### PR TITLE
fix: retain image provider state through request cleanup

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -90,6 +90,13 @@ An already accepted task keeps its captured resources until its work settles.
 Raw prepared registries retain their existing host lifetime; this does not enable
 automatic physical disposal for all prepared runtimes.
 
+When model-backed image understanding reports request timeout or cancellation,
+its prepared runtime borrow stays held until the actual provider operation and
+tracked transport cleanup settle.
+Supplied managed snapshots retain their original prepared resources, including
+adopted donors; raw snapshots keep their caller-owned lifetime. A timeout reports
+an unfinished request, not completed resource cleanup.
+
 Executable CLI command registration also uses an owned, uncached registry. Its
 resources remain available through asynchronous registration, command actions,
 and their tracked cleanup, then `dispose()` runs. Closing command preparation

--- a/src/agents/prepared-model-runtime.resources.ts
+++ b/src/agents/prepared-model-runtime.resources.ts
@@ -5,6 +5,7 @@ import { capturePreparedModelRuntimeLifetime } from "./prepared-model-runtime.li
 import type {
   PreparedModelRuntimePluginGeneration,
   PreparedModelRuntimeResourceClaim,
+  PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.types.js";
 import {
   acquireAgentRuntimePluginRegistry,
@@ -44,10 +45,14 @@ class PreparedRegistryResources {
     return this.acquired.primaryRegistry;
   }
 
-  retain(): PreparedModelRuntimeResourceClaim {
+  assertOpen(): void {
     if (this.closed) {
       throw new Error("Prepared plugin registry resources have been released");
     }
+  }
+
+  retain(): PreparedModelRuntimeResourceClaim {
+    this.assertOpen();
     const claim = this.acquired.resources.retain();
     this.claims++;
     let released = false;
@@ -159,6 +164,18 @@ export function retainPreparedModelRuntimeGenerationResources(
   generation: PreparedModelRuntimePluginGeneration | undefined,
 ): PreparedModelRuntimeResourceClaim | undefined {
   return generation && state.generations.get(generation)?.retain();
+}
+
+/** Borrow the immutable view's prepared owner, including its adopted donor registrations. */
+export function retainPreparedModelRuntimeSnapshotResources(
+  snapshot: Pick<PreparedModelRuntimeSnapshot, "pluginRegistry">,
+): (PreparedModelRuntimeResourceClaim & { assertOpen: () => void }) | undefined {
+  const resources = snapshot.pluginRegistry && state.registries.get(snapshot.pluginRegistry);
+  if (!resources) {
+    return undefined;
+  }
+  const claim = resources.retain();
+  return { release: claim.release, assertOpen: () => resources.assertOpen() };
 }
 
 /** Fence owned views before joining builds or the callers that still hold physical claims. */

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -12,6 +12,7 @@ import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
 } from "../agents/prepared-model-runtime.js";
+import { retainPreparedModelRuntimeSnapshotResources } from "../agents/prepared-model-runtime.resources.js";
 import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
 import { applyPreparedRuntimeAuthToModel } from "../agents/provider-request-config.js";
 import { protectPreparedProviderRuntimeAuth } from "../agents/provider-runtime-auth-protection.js";
@@ -52,7 +53,10 @@ type PreparedImageRuntime = {
   model: Model;
 };
 
-type ResolvedImageRuntime = PreparedImageRuntime & { release: () => void };
+type ImageRuntimeResources = {
+  release: () => void;
+  assertResourcesOpen?: () => void;
+};
 
 const resolvedImageRuntimeContexts = new WeakMap<Model, ResolvedImageRuntimeContext>();
 
@@ -215,7 +219,8 @@ async function prepareResolvedImageRuntime(
 
 export async function resolveImageRuntime(
   params: ImageRuntimeParams,
-): Promise<ResolvedImageRuntime> {
+  onAcquired: (resources: ImageRuntimeResources) => void,
+): Promise<PreparedImageRuntime> {
   const resolvedRef = normalizeModelRef(params.provider, params.model);
   const workspaceDir =
     params.workspaceDir ??
@@ -225,12 +230,12 @@ export async function resolveImageRuntime(
     ...(params.profile ? { authProfileId: params.profile } : {}),
     ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
   };
-  // Borrow a supplied generation; only direct calls acquire and release a new lease.
-  const preparedRuntimeLease = params.preparedModelRuntime
-    ? {
-        snapshot: params.preparedModelRuntime as PreparedModelRuntimeSnapshot,
-        release: () => {},
-      }
+  const suppliedSnapshot = params.preparedModelRuntime as PreparedModelRuntimeSnapshot | undefined;
+  const suppliedClaim = suppliedSnapshot
+    ? retainPreparedModelRuntimeSnapshotResources(suppliedSnapshot)
+    : undefined;
+  const preparedRuntimeLease = suppliedSnapshot
+    ? { snapshot: suppliedSnapshot, release: () => suppliedClaim?.release() }
     : await acquireAgentRunPreparedModelRuntime(
         {
           agentDir: params.agentDir,
@@ -249,65 +254,57 @@ export async function resolveImageRuntime(
         // The request already chose a model; full inventory discovery must stay outside setup.
         { catalogMode: "static", abortSignal: params.signal },
       );
-  let leaseRetained = false;
-  const retainLease = (resolved: PreparedImageRuntime): ResolvedImageRuntime => {
-    leaseRetained = true;
-    return { ...resolved, release: preparedRuntimeLease.release };
+  // The operation owns release before setup can leave asynchronous cleanup behind.
+  onAcquired({
+    release: preparedRuntimeLease.release,
+    ...(suppliedClaim ? { assertResourcesOpen: suppliedClaim.assertOpen } : {}),
+  });
+  params.signal?.throwIfAborted();
+  const preparedRuntime = preparedRuntimeLease.snapshot;
+  const preparedWorkspaceDir = preparedRuntime.workspaceDir ?? runtimeParams.workspaceDir;
+  const preparedParams: ImageRuntimeParams = {
+    ...runtimeParams,
+    agentDir: preparedRuntime.agentDir,
+    cfg: preparedRuntime.config,
+    preparedModelRuntime: preparedRuntime,
+    ...(preparedWorkspaceDir ? { workspaceDir: preparedWorkspaceDir } : {}),
   };
-  try {
+  // Media request types carry this agent-owned handle opaquely to avoid importing the agent
+  // runtime graph into provider contracts. This is the sole boundary that consumes its stores.
+  const preparedStores = preparedRuntime.createStores() as Required<
+    Pick<NonNullable<Parameters<typeof resolveModelAsync>[4]>, "authStorage" | "modelRegistry">
+  >;
+  const resolveOptions = {
+    allowBundledStaticCatalogFallback: true,
+    ...preparedStores,
+    preparedModelRuntime: preparedRuntime,
+    skipAgentDiscovery: true,
+    ...(preparedParams.workspaceDir ? { workspaceDir: preparedParams.workspaceDir } : {}),
+    ...authProfileOptions,
+  };
+  return await withPluginRuntimeGenerationScope(preparedRuntime, async () => {
+    const resolved = await resolveModelAsync(
+      resolvedRef.provider,
+      resolvedRef.model,
+      preparedParams.agentDir,
+      preparedParams.cfg,
+      resolveOptions,
+    );
+    // Setup may have closed during model lookup; do not start auth for a late result.
     params.signal?.throwIfAborted();
-    const preparedRuntime = preparedRuntimeLease.snapshot;
-    const preparedWorkspaceDir = preparedRuntime.workspaceDir ?? runtimeParams.workspaceDir;
-    const preparedParams: ImageRuntimeParams = {
-      ...runtimeParams,
-      agentDir: preparedRuntime.agentDir,
-      cfg: preparedRuntime.config,
-      preparedModelRuntime: preparedRuntime,
-      ...(preparedWorkspaceDir ? { workspaceDir: preparedWorkspaceDir } : {}),
-    };
-    // Media request types carry this agent-owned handle opaquely to avoid importing the agent
-    // runtime graph into provider contracts. This is the sole boundary that consumes its stores.
-    const preparedStores = preparedRuntime.createStores() as Required<
-      Pick<NonNullable<Parameters<typeof resolveModelAsync>[4]>, "authStorage" | "modelRegistry">
-    >;
-    const resolveOptions = {
-      allowBundledStaticCatalogFallback: true,
-      ...preparedStores,
-      preparedModelRuntime: preparedRuntime,
-      skipAgentDiscovery: true,
-      ...(preparedParams.workspaceDir ? { workspaceDir: preparedParams.workspaceDir } : {}),
-      ...authProfileOptions,
-    };
-    return await withPluginRuntimeGenerationScope(preparedRuntime, async () => {
-      const resolved = await resolveModelAsync(
-        resolvedRef.provider,
-        resolvedRef.model,
-        preparedParams.agentDir,
-        preparedParams.cfg,
-        resolveOptions,
-      );
-      // Setup may have closed during model lookup; do not start auth for a late result.
-      params.signal?.throwIfAborted();
-      const model = requireImageCapableModel({
-        model: resolved.model,
-        resolvedProvider: resolvedRef.provider,
-        resolvedModel: resolvedRef.model,
-        requestedProvider: params.provider,
-        requestedModel: params.model,
-      });
-      return retainLease(
-        await prepareResolvedImageRuntime(
-          preparedParams,
-          preparedRuntime,
-          model,
-          resolved.authStorage,
-          resolved.modelRegistry,
-        ),
-      );
+    const model = requireImageCapableModel({
+      model: resolved.model,
+      resolvedProvider: resolvedRef.provider,
+      resolvedModel: resolvedRef.model,
+      requestedProvider: params.provider,
+      requestedModel: params.model,
     });
-  } finally {
-    if (!leaseRetained) {
-      preparedRuntimeLease.release();
-    }
-  }
+    return await prepareResolvedImageRuntime(
+      preparedParams,
+      preparedRuntime,
+      model,
+      resolved.authStorage,
+      resolved.modelRegistry,
+    );
+  });
 }

--- a/src/media-understanding/image.resources.test.ts
+++ b/src/media-understanding/image.resources.test.ts
@@ -1,0 +1,833 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, expect, it, vi } from "vitest";
+import { getSessionMcpRequestSignal } from "../agents/agent-bundle-mcp-request-context.js";
+import * as minimaxVlm from "../agents/minimax-vlm.js";
+import * as modelAuth from "../agents/model-auth.js";
+import { acquireReadOnlyPreparedModelRuntime } from "../agents/prepared-model-runtime.js";
+import { closePreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.lifecycle.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerContextEngineInRegistry } from "../context-engine/registry.js";
+import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { getPluginRegistryForContext } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  getPluginRuntimeGenerationRegistry,
+  withPluginRuntimeGenerationScope,
+} from "../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { describeImagesWithModelCore, describeImageWithModelCore } from "./image.js";
+
+function nativeImageFixture(
+  reject = false,
+  modelRef: { provider: string; model: string; input?: Array<"text" | "image"> } = {
+    provider: "image-description-native",
+    model: "image-model",
+  },
+) {
+  const dir = makePluginLoaderTempDir();
+  const id = modelRef.provider;
+  const stateKey = `__image_description_${path.basename(dir)}`;
+  const connections: Array<{
+    database: DatabaseSync;
+    dbPath: string;
+    registry: PluginRegistry;
+    disposals: number;
+    lateReads: number;
+    cleanupReads: number;
+  }> = [];
+  const cancellation: {
+    signal?: AbortSignal;
+    cleanupSignal?: AbortSignal;
+    registry?: PluginRegistry;
+    afterRegistry?: PluginRegistry;
+    failure?: unknown;
+  } = {};
+  const state = {
+    connections,
+    started: createDeferredCore(),
+    finish: createDeferredCore(),
+    settled: createDeferredCore(),
+    setupStarted: createDeferredCore(),
+    resumeSetup: createDeferredCore(),
+    holdSetup: false,
+    holdSetupTail: false,
+    rejectSetup: false,
+    finishSetupTail: createDeferredCore(),
+    setupTailSettled: createDeferredCore(),
+    setupTailReads: 0,
+    reasoningOnly: false,
+    calls: 0,
+    setupReads: 0,
+    watchCancellation: false,
+    holdWork: false,
+    cancellation,
+    cleanupStarted: createDeferredCore(),
+    finishCleanup: createDeferredCore(),
+    finishWork: createDeferredCore(),
+    workSettled: createDeferredCore(),
+    trackWork: trackAsyncWork,
+    readSignal: getSessionMcpRequestSignal,
+    readGeneration: getPluginRuntimeGenerationRegistry,
+    createStream: createAssistantMessageEventStream,
+    readRegistry: getPluginRegistryForContext,
+    databasePath: () => path.join(dir, `provider-${connections.length}.sqlite`),
+  };
+  Object.defineProperty(globalThis, stateKey, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(stateKey)}];
+  const dbPath = state.databasePath();
+  const database = new DatabaseSync(dbPath);
+  database.exec("CREATE TABLE proof (value INTEGER); INSERT INTO proof VALUES (42)");
+  const connection = { database, dbPath, registry: state.readRegistry(), disposals: 0, lateReads: 0, cleanupReads: 0 };
+  state.connections.push(connection);
+  const read = () => database.prepare("SELECT value FROM proof").get().value;
+  api.lifecycle.registerRuntimeLifecycle({ id: "native-image", dispose() {
+    connection.disposals++;
+    database.close();
+  }});
+  api.registerProvider({
+    id: ${JSON.stringify(id)}, label: "Native image", auth: [],
+    async prepareRuntimeAuth() {
+      if (state.holdSetupTail) {
+        void state.trackWork(async () => {
+          await state.finishSetupTail.promise;
+          read();
+          state.setupTailReads++;
+        }).then(() => state.setupTailSettled.resolve(), (error) => {
+          state.cancellation.failure = error;
+          state.setupTailSettled.resolve();
+        });
+      }
+      if (state.holdSetup) {
+        read();
+        state.setupStarted.resolve();
+        await state.resumeSetup.promise;
+        read();
+        state.setupReads++;
+      }
+      if (state.rejectSetup) throw new Error("synthetic setup failure");
+    },
+    createStreamFn() {
+      return async (model) => {
+        read();
+        if (state.watchCancellation) {
+          const signal = state.cancellation.signal = state.readSignal();
+          const cancel = () => {
+            state.cancellation.cleanupSignal = state.readSignal();
+            state.cancellation.registry = state.readGeneration();
+            void state.trackWork(async () => {
+              state.cleanupStarted.resolve();
+              await state.finishCleanup.promise;
+              read();
+              connection.cleanupReads++;
+              state.cancellation.afterRegistry = state.readGeneration();
+            }).catch((error) => { state.cancellation.failure = error; });
+          };
+          signal?.addEventListener("abort", cancel, { once: true });
+          if (signal?.aborted) cancel();
+        }
+        if (state.holdWork) {
+          void state.trackWork(async () => { await state.finishWork.promise; read(); })
+            .then(() => state.workSettled.resolve(), (error) => {
+              state.cancellation.failure = error;
+              state.workSettled.resolve();
+            });
+        }
+        state.calls++;
+        state.started.resolve();
+        try {
+          await state.finish.promise;
+          const value = read();
+          connection.lateReads++;
+          if (${reject}) throw new Error("synthetic late image failure");
+          const stream = state.createStream();
+          stream.push({ type: "done", reason: "stop", message: {
+            role: "assistant", content: state.reasoningOnly
+              ? [{ type: "thinking", thinking: "synthetic reasoning", thinkingSignature: "reasoning_content" }]
+              : [{ type: "text", text: "native image " + value }],
+            api: model.api, provider: model.provider, model: model.id,
+            stopReason: "stop", timestamp: 0,
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }
+          }});
+          stream.end();
+          return stream;
+        } finally { state.settled.resolve(); }
+      };
+    },
+  });
+}};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      providers: [id],
+      configSchema: { type: "object", properties: {}, additionalProperties: false },
+    }),
+  );
+  const config: OpenClawConfig = {
+    models: {
+      providers: {
+        [id]: {
+          api: "openai-responses",
+          baseUrl: "https://image-fixture.invalid/v1",
+          apiKey: "synthetic-fixture",
+          models: [
+            {
+              id: modelRef.model,
+              name: "Image model",
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              input: modelRef.input ?? ["text", "image"],
+              contextWindow: 8192,
+              maxTokens: 1024,
+            },
+          ],
+        },
+      },
+    },
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const agentDir = path.join(dir, "agent");
+  return {
+    dir,
+    id,
+    config,
+    agentDir,
+    state,
+    request: {
+      cfg: config,
+      agentDir,
+      workspaceDir: dir,
+      provider: id,
+      model: modelRef.model,
+      buffer: Buffer.from("synthetic image"),
+      mime: "image/png",
+      fileName: "image.png",
+      timeoutMs: 1000,
+    },
+    environment: <T>(run: () => Promise<T>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: path.join(dir, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+        },
+        run,
+      ),
+    cleanup() {
+      state.finish.resolve();
+      state.resumeSetup.resolve();
+      state.finishCleanup.resolve();
+      state.finishWork.resolve();
+      state.finishSetupTail.resolve();
+      for (const connection of connections) {
+        if (connection.database.isOpen) {
+          connection.database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, stateKey);
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await closePreparedModelRuntimeSnapshots();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it.each(["timeout", "cancellation", "late-rejection"] as const)(
+  "retains the supplied generation and adopted donor after %s reports",
+  async (mode) => {
+    const fixture = nativeImageFixture(mode === "late-rejection");
+    try {
+      await fixture.environment(async () => {
+        useNoBundledPlugins();
+        const donor = await acquirePluginRegistryForInspection({ config: fixture.config });
+        const parent = new AsyncWorkScope();
+        const abort = new AbortController();
+        let lease: Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>> | undefined;
+        let closing: Promise<void> | undefined;
+        let outcome: Promise<unknown> | undefined;
+        try {
+          expect(
+            registerContextEngineInRegistry(
+              donor.registry,
+              fixture.id,
+              () => ({
+                info: { id: fixture.id, name: "Native donor" },
+                ingest: async () => ({ ingested: false }),
+                assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+                compact: async () => ({ ok: true, compacted: false }),
+              }),
+              `plugin:${fixture.id}`,
+              { lifecycle: "runtime" },
+            ),
+          ).toEqual({ ok: true });
+          setActivePluginRegistry(donor.registry);
+          const acquired = await acquireReadOnlyPreparedModelRuntime(
+            {
+              config: fixture.config,
+              agentId: "main",
+              agentDir: fixture.agentDir,
+              workspaceDir: fixture.dir,
+              loadRuntimePlugins: true,
+              skipCredentials: true,
+              runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+            },
+            undefined,
+            "static",
+          );
+          lease = acquired;
+          expect(fixture.state.connections).toHaveLength(2);
+          const [donorConnection, primary] = fixture.state.connections;
+          expect(acquired.snapshot.pluginRegistry).not.toBe(primary!.registry);
+          expect(acquired.snapshot.pluginRegistry?.contextEngines.get(fixture.id)).toBe(
+            donor.registry.contextEngines.get(fixture.id),
+          );
+          vi.useFakeTimers();
+          outcome = parent
+            .track(() =>
+              describeImageWithModelCore({
+                ...fixture.request,
+                preparedModelRuntime: acquired.snapshot,
+                timeoutMs: 25,
+                signal: abort.signal,
+              }),
+            )
+            .catch((error: unknown) => error);
+          await Promise.race([
+            fixture.state.started.promise,
+            outcome.then(() => {
+              throw new Error("Image description settled before invoking its provider");
+            }),
+          ]);
+          if (mode === "timeout") {
+            await vi.advanceTimersByTimeAsync(25);
+          } else {
+            abort.abort(new Error("synthetic image cancellation"));
+          }
+          expect(await outcome).toEqual(
+            expect.objectContaining({
+              message:
+                mode === "timeout"
+                  ? expect.stringContaining("image description request timed out")
+                  : "synthetic image cancellation",
+            }),
+          );
+          acquired.release();
+          await donor.release();
+          closing = closePreparedModelRuntimeSnapshots();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(primary!.database.isOpen).toBe(true);
+          expect(donorConnection!.database.isOpen).toBe(true);
+          expect(primary!.disposals).toBe(0);
+          expect(donorConnection!.disposals).toBe(0);
+          await expect(
+            describeImageWithModelCore({
+              ...fixture.request,
+              preparedModelRuntime: acquired.snapshot,
+            }),
+          ).rejects.toThrow(/resources have been released/);
+          fixture.state.finish.resolve();
+          await fixture.state.settled.promise;
+          await parent.drain();
+          await closing;
+          expect(primary!.lateReads).toBe(1);
+          for (const connection of fixture.state.connections) {
+            expect(connection.disposals).toBe(1);
+            expect(connection.database.isOpen).toBe(false);
+            const reopened = new DatabaseSync(connection.dbPath, { readOnly: true });
+            try {
+              expect(reopened.prepare("SELECT value FROM proof").get()?.value).toBe(42);
+            } finally {
+              reopened.close();
+            }
+          }
+        } finally {
+          abort.abort();
+          fixture.state.finish.resolve();
+          await outcome;
+          await parent.drain();
+          lease?.release();
+          await donor.release();
+          await closing;
+          vi.useRealTimers();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  },
+);
+
+it("releases only its borrow while the supplying generation remains open", async () => {
+  const fixture = nativeImageFixture();
+  try {
+    await fixture.environment(async () => {
+      useNoBundledPlugins();
+      const lease = await acquireReadOnlyPreparedModelRuntime(
+        {
+          config: fixture.config,
+          agentId: "main",
+          agentDir: fixture.agentDir,
+          workspaceDir: fixture.dir,
+          loadRuntimePlugins: true,
+          skipCredentials: true,
+          runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+        },
+        undefined,
+        "static",
+      );
+      try {
+        fixture.state.finish.resolve();
+        expect(
+          await describeImageWithModelCore({
+            ...fixture.request,
+            preparedModelRuntime: lease.snapshot,
+          }),
+        ).toMatchObject({ text: "native image 42" });
+        expect(fixture.state.connections[0]!.database.isOpen).toBe(true);
+        expect(fixture.state.connections[0]!.disposals).toBe(0);
+      } finally {
+        lease.release();
+        await closePreparedModelRuntimeSnapshots();
+      }
+      expect(fixture.state.connections[0]!.disposals).toBe(1);
+    });
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+it("leaves a raw supplied registry with its caller", async () => {
+  const fixture = nativeImageFixture();
+  try {
+    await fixture.environment(async () => {
+      useNoBundledPlugins();
+      const raw = loadPluginRegistryHandle({ config: fixture.config });
+      setActivePluginRegistry(raw);
+      const lease = await acquireReadOnlyPreparedModelRuntime(
+        {
+          config: fixture.config,
+          agentId: "main",
+          agentDir: fixture.agentDir,
+          workspaceDir: fixture.dir,
+          loadRuntimePlugins: true,
+          skipCredentials: true,
+          runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+        },
+        undefined,
+        "static",
+      );
+      try {
+        fixture.state.finish.resolve();
+        const snapshot = { ...lease.snapshot, pluginRegistry: raw };
+        expect(
+          await describeImageWithModelCore({ ...fixture.request, preparedModelRuntime: snapshot }),
+        ).toMatchObject({ text: "native image 42" });
+        expect(fixture.state.connections[0]!.disposals).toBe(0);
+        expect(fixture.state.connections[0]!.database.isOpen).toBe(true);
+      } finally {
+        lease.release();
+        await closePreparedModelRuntimeSnapshots();
+      }
+    });
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+it.each(["setup", "retry"] as const)(
+  "refuses new provider work after process close during %s",
+  async (phase) => {
+    const fixture = nativeImageFixture();
+    try {
+      await fixture.environment(async () => {
+        useNoBundledPlugins();
+        const lease = await acquireReadOnlyPreparedModelRuntime(
+          {
+            config: fixture.config,
+            agentId: "main",
+            agentDir: fixture.agentDir,
+            workspaceDir: fixture.dir,
+            loadRuntimePlugins: true,
+            skipCredentials: true,
+            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+          },
+          undefined,
+          "static",
+        );
+        let closing: Promise<void> | undefined;
+        let outcome: Promise<unknown> | undefined;
+        try {
+          fixture.state.holdSetup = phase === "setup";
+          fixture.state.reasoningOnly = phase === "retry";
+          outcome = describeImageWithModelCore({
+            ...fixture.request,
+            preparedModelRuntime: lease.snapshot,
+          }).catch((error: unknown) => error);
+          const entered = phase === "setup" ? fixture.state.setupStarted : fixture.state.started;
+          await Promise.race([
+            entered.promise,
+            outcome.then(() => {
+              throw new Error("Image request settled before the held phase");
+            }),
+          ]);
+          lease.release();
+          closing = closePreparedModelRuntimeSnapshots();
+          expect(fixture.state.connections[0]!.database.isOpen).toBe(true);
+          fixture.state.resumeSetup.resolve();
+          fixture.state.finish.resolve();
+          expect(await outcome).toEqual(
+            expect.objectContaining({
+              message: "Prepared plugin registry resources have been released",
+            }),
+          );
+          await closing;
+          expect(fixture.state.calls).toBe(phase === "setup" ? 0 : 1);
+          expect(fixture.state.setupReads).toBe(phase === "setup" ? 1 : 0);
+          expect(fixture.state.connections[0]!.lateReads).toBe(phase === "setup" ? 0 : 1);
+          expect(fixture.state.connections[0]!.disposals).toBe(1);
+        } finally {
+          fixture.state.resumeSetup.resolve();
+          fixture.state.finish.resolve();
+          await outcome;
+          lease.release();
+          await closing;
+          await closePreparedModelRuntimeSnapshots();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  },
+);
+
+it.each(["parent", "normal", "admitted-tail"] as const)(
+  "preserves MCP cancellation and cleanup context during %s closure",
+  async (mode) => {
+    const fixture = nativeImageFixture();
+    try {
+      await fixture.environment(async () => {
+        useNoBundledPlugins();
+        const lease = await acquireReadOnlyPreparedModelRuntime(
+          {
+            config: fixture.config,
+            agentId: "main",
+            agentDir: fixture.agentDir,
+            workspaceDir: fixture.dir,
+            loadRuntimePlugins: true,
+            skipCredentials: true,
+            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+          },
+          undefined,
+          "static",
+        );
+        const parent = new AsyncWorkScope();
+        let result: Promise<unknown> | undefined;
+        let closing: Promise<void> | undefined;
+        try {
+          fixture.state.watchCancellation = true;
+          fixture.state.holdWork = mode === "admitted-tail";
+          result = parent.track(() =>
+            withPluginRuntimeGenerationScope(lease.snapshot, () =>
+              describeImageWithModelCore({
+                ...fixture.request,
+                preparedModelRuntime: lease.snapshot,
+              }),
+            ),
+          );
+          await Promise.race([
+            fixture.state.started.promise,
+            result.then(() => {
+              throw new Error("Provider did not enter before reporting its result");
+            }),
+          ]);
+          if (mode === "parent") {
+            const reason = new Error("synthetic parent close");
+            withPluginRuntimeGenerationScope(
+              {
+                metadataSnapshot: lease.snapshot.metadataSnapshot,
+                pluginRegistry: createEmptyPluginRegistry(),
+              },
+              () => parent.beginClose(reason),
+            );
+            expect(fixture.state.cancellation.signal?.aborted).toBe(true);
+            expect(fixture.state.cancellation.signal?.reason).toBe(reason);
+          } else {
+            fixture.state.finish.resolve();
+            expect(await result).toMatchObject({ text: "native image 42" });
+            if (mode === "admitted-tail") {
+              expect(fixture.state.cancellation.signal?.aborted).toBe(false);
+              fixture.state.finishWork.resolve();
+              await fixture.state.workSettled.promise;
+            }
+          }
+          await fixture.state.cleanupStarted.promise;
+          expect(fixture.state.cancellation.cleanupSignal?.aborted).toBe(true);
+          expect(fixture.state.cancellation.cleanupSignal?.reason).toBe(
+            fixture.state.cancellation.signal?.reason,
+          );
+          expect(fixture.state.cancellation.registry).toBe(lease.snapshot.pluginRegistry);
+          lease.release();
+          closing = closePreparedModelRuntimeSnapshots();
+          expect(fixture.state.connections[0]!.database.isOpen).toBe(true);
+          fixture.state.finish.resolve();
+          expect(await result).toMatchObject({ text: "native image 42" });
+          fixture.state.finishCleanup.resolve();
+          await parent.drain();
+          await closing;
+          expect(fixture.state.cancellation.failure).toBeUndefined();
+          expect(fixture.state.cancellation.afterRegistry).toBe(lease.snapshot.pluginRegistry);
+          expect(fixture.state.connections[0]!.cleanupReads).toBe(1);
+          expect(fixture.state.connections[0]!.disposals).toBe(1);
+        } finally {
+          fixture.state.finish.resolve();
+          fixture.state.finishWork.resolve();
+          fixture.state.finishCleanup.resolve();
+          await result;
+          await parent.drain();
+          lease.release();
+          await closing;
+          await closePreparedModelRuntimeSnapshots();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  },
+);
+
+it.each(["success", "failure", "timeout"] as const)(
+  "retains native resources through auth descendants after setup %s",
+  async (mode) => {
+    const fixture = nativeImageFixture();
+    try {
+      await fixture.environment(async () => {
+        useNoBundledPlugins();
+        const lease = await acquireReadOnlyPreparedModelRuntime(
+          {
+            config: fixture.config,
+            agentId: "main",
+            agentDir: fixture.agentDir,
+            workspaceDir: fixture.dir,
+            loadRuntimePlugins: true,
+            skipCredentials: true,
+            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
+          },
+          undefined,
+          "static",
+        );
+        const parent = new AsyncWorkScope();
+        let outcome: Promise<unknown> | undefined;
+        let closing: Promise<void> | undefined;
+        try {
+          fixture.state.holdSetup = true;
+          fixture.state.holdSetupTail = true;
+          fixture.state.rejectSetup = mode === "failure";
+          fixture.state.finish.resolve();
+          vi.useFakeTimers();
+          outcome = parent
+            .track(() =>
+              describeImageWithModelCore({
+                ...fixture.request,
+                preparedModelRuntime: lease.snapshot,
+                timeoutMs: 25,
+              }),
+            )
+            .catch((error: unknown) => error);
+          await Promise.race([
+            fixture.state.setupStarted.promise,
+            outcome.then(() => {
+              throw new Error("Setup did not enter the auth hook");
+            }),
+          ]);
+          if (mode === "timeout") {
+            await vi.advanceTimersByTimeAsync(25);
+            expect(await outcome).toEqual(
+              expect.objectContaining({
+                message: expect.stringContaining("image description setup timed out"),
+              }),
+            );
+          }
+          fixture.state.resumeSetup.resolve();
+          const result = await outcome;
+          if (mode === "success") {
+            expect(result).toMatchObject({ text: "native image 42" });
+          } else if (mode === "failure") {
+            expect(result).toEqual(expect.objectContaining({ message: "synthetic setup failure" }));
+          }
+          // Let the auth callback return after its deadline while its descendant is still held.
+          await vi.advanceTimersByTimeAsync(0);
+          expect(fixture.state.setupReads).toBe(1);
+          expect(fixture.state.calls).toBe(mode === "success" ? 1 : 0);
+          lease.release();
+          closing = closePreparedModelRuntimeSnapshots();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(fixture.state.connections[0]!.database.isOpen).toBe(true);
+          fixture.state.finishSetupTail.resolve();
+          await fixture.state.setupTailSettled.promise;
+          await parent.drain();
+          await closing;
+          expect(fixture.state.cancellation.failure).toBeUndefined();
+          expect(fixture.state.setupTailReads).toBe(1);
+          expect(fixture.state.connections[0]!.disposals).toBe(1);
+          const reopened = new DatabaseSync(fixture.state.connections[0]!.dbPath, {
+            readOnly: true,
+          });
+          try {
+            expect(reopened.prepare("SELECT value FROM proof").get()?.value).toBe(42);
+          } finally {
+            reopened.close();
+          }
+        } finally {
+          fixture.state.resumeSetup.resolve();
+          fixture.state.finishSetupTail.resolve();
+          await outcome;
+          await parent.drain();
+          lease.release();
+          await closing;
+          vi.useRealTimers();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  },
+);
+
+it.each(["open", "resolved", "fallback"] as const)(
+  "fences MiniMax image admission while the managed owner is %s",
+  async (mode) => {
+    const fixture = nativeImageFixture(false, {
+      provider: "minimax",
+      model: "MiniMax-VL-01",
+      input: mode === "fallback" ? ["text"] : ["text", "image"],
+    });
+    const entered = createDeferredCore();
+    const resume = createDeferredCore();
+    try {
+      await fixture.environment(async () => {
+        useNoBundledPlugins();
+        const lease = await acquireReadOnlyPreparedModelRuntime(
+          {
+            config: fixture.config,
+            agentId: "main",
+            agentDir: fixture.agentDir,
+            workspaceDir: fixture.dir,
+            loadRuntimePlugins: true,
+            skipCredentials: true,
+            runtimePluginSelections: [{ provider: fixture.id, modelId: fixture.request.model }],
+          },
+          undefined,
+          "static",
+        );
+        const parent = new AsyncWorkScope();
+        const read = () =>
+          fixture.state.connections[0]!.database.prepare("SELECT value FROM proof").get()?.value;
+        const request = vi
+          .spyOn(minimaxVlm, "minimaxUnderstandImage")
+          .mockImplementation(async () => {
+            expect(read()).toBe(42);
+            if (mode === "resolved") {
+              entered.resolve();
+              await resume.promise;
+              expect(read()).toBe(42);
+            }
+            return "native MiniMax image";
+          });
+        const originalAuth = modelAuth.resolveApiKeyForProviderCore;
+        const auth =
+          mode === "fallback"
+            ? vi
+                .spyOn(modelAuth, "resolveApiKeyForProviderCore")
+                .mockImplementation(async (...args) => {
+                  entered.resolve();
+                  await resume.promise;
+                  return await originalAuth(...args);
+                })
+            : undefined;
+        let outcome: Promise<unknown> | undefined;
+        let closing: Promise<void> | undefined;
+        try {
+          outcome = parent
+            .track(() =>
+              describeImagesWithModelCore({
+                ...fixture.request,
+                preparedModelRuntime: lease.snapshot,
+                images: [fixture.request, fixture.request],
+              }),
+            )
+            .catch((error: unknown) => error);
+          if (mode !== "open") {
+            await Promise.race([
+              entered.promise,
+              outcome.then(() => {
+                throw new Error("MiniMax did not enter the held boundary");
+              }),
+            ]);
+            lease.release();
+            closing = closePreparedModelRuntimeSnapshots();
+            expect(read()).toBe(42);
+            resume.resolve();
+            expect(await outcome).toEqual(
+              expect.objectContaining({
+                message: "Prepared plugin registry resources have been released",
+              }),
+            );
+          } else {
+            expect(await outcome).toMatchObject({
+              text: "Image 1:\nnative MiniMax image\n\nImage 2:\nnative MiniMax image",
+            });
+          }
+          expect(request).toHaveBeenCalledTimes(mode === "open" ? 2 : mode === "resolved" ? 1 : 0);
+          await parent.drain();
+          lease.release();
+          await closing;
+          await closePreparedModelRuntimeSnapshots();
+          expect(fixture.state.connections[0]!.disposals).toBe(1);
+          const reopened = new DatabaseSync(fixture.state.connections[0]!.dbPath, {
+            readOnly: true,
+          });
+          try {
+            expect(reopened.prepare("SELECT value FROM proof").get()?.value).toBe(42);
+          } finally {
+            reopened.close();
+          }
+        } finally {
+          resume.resolve();
+          await outcome;
+          await parent.drain();
+          lease.release();
+          await closing;
+          request.mockRestore();
+          auth?.mockRestore();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  },
+);

--- a/src/media-understanding/image.runtime-timeout.test.ts
+++ b/src/media-understanding/image.runtime-timeout.test.ts
@@ -485,7 +485,7 @@ describe("describeImageWithModelCore", () => {
     expect(options.timeoutMs).toBe(25);
   });
 
-  it("releases the prepared runtime when a provider ignores caller cancellation", async () => {
+  it("retains the prepared runtime until an aborted provider actually settles", async () => {
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({
         api: "openai-responses",
@@ -495,7 +495,11 @@ describe("describeImageWithModelCore", () => {
         baseUrl: "https://api.openai.com/v1",
       })),
     });
-    completeMock.mockImplementation(() => new Promise(() => {}));
+    const completion = createDeferred();
+    completeMock.mockImplementation(async () => {
+      await completion.promise;
+      throw new Error("late provider failure");
+    });
     const controller = new AbortController();
     const result = describeImageWithModelCore({
       cfg: {},
@@ -510,12 +514,17 @@ describe("describeImageWithModelCore", () => {
       signal: controller.signal,
     });
 
-    await vi.waitFor(() => expect(completeMock).toHaveBeenCalledOnce());
-    const assertion = expect(result).rejects.toThrow("caller cancelled provider request");
-    controller.abort(new Error("caller cancelled provider request"));
-    await assertion;
+    try {
+      await vi.waitFor(() => expect(completeMock).toHaveBeenCalledOnce());
+      const assertion = expect(result).rejects.toThrow("caller cancelled provider request");
+      controller.abort(new Error("caller cancelled provider request"));
+      await assertion;
 
-    expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce();
+      expect(releasePreparedModelRuntimeMock).not.toHaveBeenCalled();
+    } finally {
+      completion.resolve();
+    }
+    await vi.waitFor(() => expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce());
   });
 
   it("keeps the full configured timeout for provider requests after slow setup", async () => {

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -5,6 +5,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { attachModelProviderRequestTransport } from "../agents/provider-request-config.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import {
   API_KEY_FIELD,
   SET_RUNTIME_API_KEY_FIELD,
@@ -503,19 +504,27 @@ describe("describeImageWithModelCore", () => {
       content: [{ type: "text", text: "workspace ok" }],
     });
 
-    const result = await describeImageWithModelCore({
-      cfg: {},
-      agentId: "vision-agent",
-      agentDir: "/tmp/openclaw-agent",
-      workspaceDir: "/tmp/openclaw-workspace",
-      provider: "google",
-      model: "gemini-2.5-flash",
-      buffer: Buffer.from("png-bytes"),
-      fileName: "image.png",
-      mime: "image/png",
-      prompt: "Describe the image.",
-      timeoutMs: 1000,
-    });
+    const owner = new AsyncWorkScope();
+    let result: Awaited<ReturnType<typeof describeImageWithModelCore>>;
+    try {
+      result = await owner.track(() =>
+        describeImageWithModelCore({
+          cfg: {},
+          agentId: "vision-agent",
+          agentDir: "/tmp/openclaw-agent",
+          workspaceDir: "/tmp/openclaw-workspace",
+          provider: "google",
+          model: "gemini-2.5-flash",
+          buffer: Buffer.from("png-bytes"),
+          fileName: "image.png",
+          mime: "image/png",
+          prompt: "Describe the image.",
+          timeoutMs: 1000,
+        }),
+      );
+    } finally {
+      await owner.drain();
+    }
 
     expect(result.text).toBe("workspace ok");
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -24,6 +25,8 @@ import {
 import { isSecretRef } from "../config/types.secrets.js";
 import { complete } from "../llm/stream.js";
 import type { AssistantMessage, Context, Model, ProviderStreamOptions } from "../llm/types.js";
+import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { getResolvedImageRuntimeContext, resolveImageRuntime } from "./image-model-runtime.js";
 import type {
   ImageDescriptionRequest,
@@ -194,6 +197,7 @@ async function describeImagesWithMinimax(params: {
   allowPrivateNetwork?: boolean;
   request?: ModelProviderRequestTransportOverrides;
   signal?: AbortSignal;
+  assertResourcesOpen?: () => void;
 }): Promise<ImagesDescriptionResult> {
   const responses: string[] = [];
   // MiniMax VLM handles its own outbound fetch, so unwrap only at this final handoff.
@@ -206,6 +210,7 @@ async function describeImagesWithMinimax(params: {
     // One MiniMax request is issued per image, so cancellation must gate every
     // iteration or a dead run can continue buying calls after the first image.
     params.signal?.throwIfAborted();
+    params.assertResourcesOpen?.();
     const prompt =
       params.images.length > 1
         ? `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length} independently.`
@@ -413,166 +418,196 @@ async function describeImagesWithModelInternal(
   params: ImagesDescriptionRequest,
   options: { onPayload?: ProviderStreamOptions["onPayload"] } = {},
 ): Promise<ImagesDescriptionResult> {
-  const prompt = params.prompt ?? "Describe the image.";
-  params.signal?.throwIfAborted();
-  const startedAtMs = Date.now();
-  const controller = new AbortController();
-  const requestSignal = params.signal
-    ? AbortSignal.any([params.signal, controller.signal])
-    : controller.signal;
-  const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
-  const allowPrivateNetwork = resolveConfiguredProviderAllowPrivateNetwork(
-    params.cfg,
-    params.provider,
-  );
-  let runtimeValue: string;
-  let model: Model | undefined;
-  let releaseRuntime: (() => void) | undefined;
-  const resolutionTask = resolveImageRuntime({ ...params, signal: requestSignal });
-
-  try {
-    const resolved = await withImageDescriptionTimeout({
-      controller,
-      signal: params.signal,
-      timeoutMs: configuredTimeoutMs,
-      createTimeoutError: (timeoutMs) =>
-        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
-      task: resolutionTask,
-    });
-    runtimeValue = resolved.runtimeValue;
-    model = resolved.model;
-    releaseRuntime = resolved.release;
-  } catch (err) {
-    // The setup timeout does not cancel catalog preparation. If it wins the race, release any
-    // generation that resolves afterward instead of abandoning its retained lease.
-    void resolutionTask.then(
-      (late) => late.release(),
-      () => undefined,
-    );
-    params.signal?.throwIfAborted();
-    if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
-      throw err;
+  const reported = createDeferredCore<ImagesDescriptionResult>();
+  const parentSignal = getAsyncWorkSignal();
+  // Admit drainage before setup; reporting a deadline does not settle provider work.
+  void trackAsyncWork(async () => {
+    const work = new AsyncWorkScope();
+    const runInScope = work.run(() => AsyncLocalStorage.snapshot());
+    const closeWork = () => runInScope(() => work.beginClose(parentSignal?.reason));
+    parentSignal?.addEventListener("abort", closeWork, { once: true });
+    if (parentSignal?.aborted) {
+      closeWork();
     }
-    const fallback = await withImageDescriptionTimeout({
-      controller,
-      signal: params.signal,
-      timeoutMs: configuredTimeoutMs,
-      createTimeoutError: (timeoutMs) =>
-        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
-      task: resolveMinimaxVlmFallbackRuntime(params),
-    });
-    return await describeImagesWithMinimax({
-      runtimeValue: fallback.runtimeValue,
-      provider: params.provider,
-      modelId: params.model,
-      modelBaseUrl: fallback.modelBaseUrl,
-      prompt,
-      timeoutMs: params.timeoutMs,
-      images: params.images,
-      allowPrivateNetwork,
-      signal: params.signal,
-    });
-  }
-
-  const apiKey = runtimeValue;
-  try {
-    params.signal?.throwIfAborted();
-    const setupDurationMs = Date.now() - startedAtMs;
-
-    if (isMinimaxVlmModel(model.provider, model.id)) {
-      return await describeImagesWithMinimax({
-        runtimeValue,
-        provider: model.provider,
-        modelId: model.id,
-        modelBaseUrl: model.baseUrl,
-        prompt,
-        timeoutMs: params.timeoutMs,
-        images: params.images,
-        request: getModelProviderRequestTransport(model),
-        signal: params.signal,
-      });
-    }
-
-    const resolvedRuntimeContext = getResolvedImageRuntimeContext(model);
-    // Prepared auth may carry sentinel-protected request headers. Resolve them only at this
-    // final direct-completion boundary so provider SDKs never receive sentinel placeholders.
-    const requestModel = unwrapModelHeaderSentinelsForProviderEgress(
-      model,
-      "image description provider request",
-    );
-    const providerStreamFn = registerProviderStreamForModel({
-      model: requestModel,
-      cfg: resolvedRuntimeContext?.cfg ?? params.cfg,
-      agentDir: resolvedRuntimeContext?.agentDir ?? params.agentDir,
-      wrapProviderStream: true,
-      ...(resolvedRuntimeContext?.workspaceDir
-        ? { workspaceDir: resolvedRuntimeContext.workspaceDir }
-        : params.workspaceDir
-          ? { workspaceDir: params.workspaceDir }
-          : {}),
-    });
-
-    const context = buildImageContext(prompt, params.images, {
-      promptInUserContent: shouldPlaceImagePromptInUserContent(model),
-    });
-
-    const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
-    const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
-      params.signal?.throwIfAborted();
-      const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);
-      const timeoutMs = configuredTimeoutMs;
-      const headers = buildImageRequestHeaders(requestModel);
-      const streamOptions = {
-        apiKey,
-        maxTokens,
-        signal: requestSignal,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        ...(headers ? { headers } : {}),
-        ...(payloadHandler ? { onPayload: payloadHandler } : {}),
-      };
-      const task: Promise<AssistantMessage> = providerStreamFn
-        ? (async () =>
-            await (await providerStreamFn(requestModel, context, streamOptions)).result())()
-        : complete(requestModel, context, streamOptions);
-      return await withImageDescriptionTimeout({
-        controller,
-        signal: params.signal,
-        timeoutMs,
-        createTimeoutError: (requestTimeoutMs) =>
-          buildImageDescriptionTimeoutError({
-            phase: "request",
-            timeoutMs: requestTimeoutMs,
-            setupDurationMs,
-          }),
-        task,
-      });
-    };
-
-    const message = await completeImage();
+    let releaseRuntime: (() => void) | undefined;
+    let assertResourcesOpen: (() => void) | undefined;
     try {
-      const text = coerceImageAssistantText({
-        message,
-        provider: model.provider,
-        model: model.id,
-      });
-      return { text, model: model.id };
-    } catch (err) {
-      if (!isImageModelNoTextError(err) || !hasImageReasoningOnlyResponse(message)) {
-        throw err;
-      }
-    }
+      reported.resolve(
+        await work.track(async () => {
+          const prompt = params.prompt ?? "Describe the image.";
+          params.signal?.throwIfAborted();
+          const startedAtMs = Date.now();
+          const controller = new AbortController();
+          const requestSignal = params.signal
+            ? AbortSignal.any([params.signal, controller.signal])
+            : controller.signal;
+          const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
+          const allowPrivateNetwork = resolveConfiguredProviderAllowPrivateNetwork(
+            params.cfg,
+            params.provider,
+          );
+          let runtimeValue: string;
+          let model: Model | undefined;
+          const resolutionTask = work.track(() =>
+            resolveImageRuntime({ ...params, signal: requestSignal }, (resources) => {
+              releaseRuntime = resources.release;
+              assertResourcesOpen = resources.assertResourcesOpen;
+            }),
+          );
 
-    params.signal?.throwIfAborted();
-    const retryMessage = await completeImage(disableReasoningForImageRetryPayload);
-    const text = coerceImageAssistantText({
-      message: retryMessage,
-      provider: model.provider,
-      model: model.id,
-    });
-    return { text, model: model.id };
-  } finally {
-    releaseRuntime?.();
-  }
+          try {
+            const resolved = await withImageDescriptionTimeout({
+              controller,
+              signal: params.signal,
+              timeoutMs: configuredTimeoutMs,
+              createTimeoutError: (timeoutMs) =>
+                buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+              task: resolutionTask,
+            });
+            runtimeValue = resolved.runtimeValue;
+            model = resolved.model;
+          } catch (err) {
+            params.signal?.throwIfAborted();
+            if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
+              throw err;
+            }
+            const fallback = await withImageDescriptionTimeout({
+              controller,
+              signal: params.signal,
+              timeoutMs: configuredTimeoutMs,
+              createTimeoutError: (timeoutMs) =>
+                buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+              task: work.track(() => resolveMinimaxVlmFallbackRuntime(params)),
+            });
+            return await describeImagesWithMinimax({
+              assertResourcesOpen,
+              runtimeValue: fallback.runtimeValue,
+              provider: params.provider,
+              modelId: params.model,
+              modelBaseUrl: fallback.modelBaseUrl,
+              prompt,
+              timeoutMs: params.timeoutMs,
+              images: params.images,
+              allowPrivateNetwork,
+              signal: params.signal,
+            });
+          }
+
+          const apiKey = runtimeValue;
+          params.signal?.throwIfAborted();
+          assertResourcesOpen?.();
+          const setupDurationMs = Date.now() - startedAtMs;
+
+          if (isMinimaxVlmModel(model.provider, model.id)) {
+            return await describeImagesWithMinimax({
+              assertResourcesOpen,
+              runtimeValue,
+              provider: model.provider,
+              modelId: model.id,
+              modelBaseUrl: model.baseUrl,
+              prompt,
+              timeoutMs: params.timeoutMs,
+              images: params.images,
+              request: getModelProviderRequestTransport(model),
+              signal: params.signal,
+            });
+          }
+
+          const resolvedRuntimeContext = getResolvedImageRuntimeContext(model);
+          // Prepared auth may carry sentinel-protected request headers. Resolve them only at this
+          // final direct-completion boundary so provider SDKs never receive sentinel placeholders.
+          const requestModel = unwrapModelHeaderSentinelsForProviderEgress(
+            model,
+            "image description provider request",
+          );
+          const providerStreamFn = registerProviderStreamForModel({
+            model: requestModel,
+            cfg: resolvedRuntimeContext?.cfg ?? params.cfg,
+            agentDir: resolvedRuntimeContext?.agentDir ?? params.agentDir,
+            wrapProviderStream: true,
+            ...(resolvedRuntimeContext?.workspaceDir
+              ? { workspaceDir: resolvedRuntimeContext.workspaceDir }
+              : params.workspaceDir
+                ? { workspaceDir: params.workspaceDir }
+                : {}),
+          });
+
+          const context = buildImageContext(prompt, params.images, {
+            promptInUserContent: shouldPlaceImagePromptInUserContent(model),
+          });
+
+          const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
+          const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
+            params.signal?.throwIfAborted();
+            assertResourcesOpen?.();
+            const payloadHandler = composeImageDescriptionPayloadHandlers(
+              onPayload,
+              options.onPayload,
+            );
+            const timeoutMs = configuredTimeoutMs;
+            const headers = buildImageRequestHeaders(requestModel);
+            const streamOptions = {
+              apiKey,
+              maxTokens,
+              signal: requestSignal,
+              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+              ...(headers ? { headers } : {}),
+              ...(payloadHandler ? { onPayload: payloadHandler } : {}),
+            };
+            const task: Promise<AssistantMessage> = work.track(() =>
+              providerStreamFn
+                ? (async () =>
+                    await (await providerStreamFn(requestModel, context, streamOptions)).result())()
+                : complete(requestModel, context, streamOptions),
+            );
+            return await withImageDescriptionTimeout({
+              controller,
+              signal: params.signal,
+              timeoutMs,
+              createTimeoutError: (requestTimeoutMs) =>
+                buildImageDescriptionTimeoutError({
+                  phase: "request",
+                  timeoutMs: requestTimeoutMs,
+                  setupDurationMs,
+                }),
+              task,
+            });
+          };
+
+          const message = await completeImage();
+          try {
+            const text = coerceImageAssistantText({
+              message,
+              provider: model.provider,
+              model: model.id,
+            });
+            return { text, model: model.id };
+          } catch (err) {
+            if (!isImageModelNoTextError(err) || !hasImageReasoningOnlyResponse(message)) {
+              throw err;
+            }
+          }
+
+          params.signal?.throwIfAborted();
+          const retryMessage = await completeImage(disableReasoningForImageRetryPayload);
+          const text = coerceImageAssistantText({
+            message: retryMessage,
+            provider: model.provider,
+            model: model.id,
+          });
+          return { text, model: model.id };
+        }),
+      );
+    } catch (error) {
+      reported.reject(error);
+    } finally {
+      await work.runWhenIdle(() => undefined);
+      await runInScope(() => work.drain());
+      parentSignal?.removeEventListener("abort", closeWork);
+      releaseRuntime?.();
+    }
+  }).catch((error: unknown) => reported.reject(error));
+  return await reported.promise;
 }
 
 function toImagesDescriptionRequest(params: ImageDescriptionRequest): ImagesDescriptionRequest {


### PR DESCRIPTION
Related: #140674.

## What Problem This Solves

Resolves a problem where image requests can close plugin databases while timed-out setup, provider calls, or cleanup are still running. Supplied prepared runtimes also need to retain the original provider and any adopted donor registrations through the request.

## Why This Change Was Made

Transfer resource ownership immediately after acquisition, before asynchronous model and auth setup. Keep the existing caller deadlines while tracking the actual setup and provider work separately, then release after cooperating cleanup settles. Supplied managed snapshots retain their exact prepared owner, including donors; raw snapshots retain their existing caller ownership.

Closed managed sources refuse new generic and MiniMax calls, including retries and each image in a MiniMax batch. The private early handoff removes competing failed-setup and late-result release paths. No public SDK fields, configuration, schema, dependency, producer-activation or timeout-policy changes.

## User Impact

Image requests keep their existing cancellation and timeout behavior while allowing already accepted work to finish using the correct retained resources. Cleanup closes each owned database once after the final user.

## Evidence

Sixteen native SQLite cases cover timeout, cancellation, late rejection, supplied and raw owners, adopted donors, setup descendants, cleanup, and closed-source admission. Original code reproduces five ownership failures with two controls. Review found two further defects in the intermediate implementation—failed setup releasing before its descendants and MiniMax missing per-image closure checks—and both have failing-before, passing-after regressions.

Focused Image, timeout, auth-profile and provider/tool suites pass. Complete affected checks, proportional checks after the final narrow fence change, and fresh full-candidate Codex review through P2 pass. The ordinary build passed in 254.76 seconds; its nonfatal UI gzip warning of 20 bytes over the threshold is recorded, with no UI or budget changes.

The actual compiled public SDK and compiled runtime producer passed together in 6.42 seconds. A successful request took 83.88 milliseconds; the unchanged 1-second timeout reported at 1.004 seconds. After replacement, the original provider and donor databases stayed usable through late work. Closed-source admission was refused, all three fixture databases closed exactly once and reopened with their expected values, and the successor received no calls.

All seven source hashes and 11,683 build artifact hashes stayed unchanged; the plain-Node process and descendants exited. The proof uses synthetic SQLite stores and a valid PNG, without application source fallback, external credentials, a real provider or a production Gateway. Timings are individual correctness observations, not a comparative performance claim.
