### PR TITLE
fix(docs): report original MDX source lines

### DIFF
--- a/scripts/check-docs-mdx.mts
+++ b/scripts/check-docs-mdx.mts
@@ -232,7 +232,8 @@ function stripFrontmatter(raw: string): string {
   const lines = raw.split(/\r?\n/u);
   for (let index = 1; index < lines.length; index += 1) {
     if (lines[index] === "---" || lines[index] === "...") {
-      return lines.slice(index + 1).join("\n");
+      // Preserve source line numbers for both MDX and component diagnostics.
+      return lines.fill("", 0, index + 1).join("\n");
     }
   }
   return raw;

--- a/test/scripts/check-docs-mdx.test.ts
+++ b/test/scripts/check-docs-mdx.test.ts
@@ -1,8 +1,90 @@
 // Check Docs Mdx tests cover check docs mdx script behavior.
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseArgs } from "../../scripts/check-docs-mdx.mts";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const checkerPath = path.resolve(import.meta.dirname, "../../scripts/check-docs-mdx.mjs");
 
 describe("scripts/check-docs-mdx", () => {
+  it.each([
+    {
+      name: "plain component",
+      prefix: "",
+      body: "<Note>\n  </Note>\n",
+      error: { type: "mintlify-mdx", line: 2, column: 3 },
+    },
+    {
+      name: "LF frontmatter",
+      prefix: "---\ntitle: Example\n---\n",
+      body: "<Note>\n  </Note>\n",
+      error: { type: "mintlify-mdx", line: 5, column: 3 },
+    },
+    {
+      name: "CRLF frontmatter",
+      prefix: "---\r\ntitle: Example\r\n---\r\n",
+      body: "<Note>\r\n  </Note>\r\n",
+      error: { type: "mintlify-mdx", line: 5, column: 3 },
+    },
+    {
+      name: "YAML document-end delimiter",
+      prefix: "---\ntitle: Example\n...\n",
+      body: "<Note>\n  </Note>\n",
+      error: { type: "mintlify-mdx", line: 5, column: 3 },
+    },
+    {
+      name: "LF MDX expression",
+      prefix: "---\ntitle: Example\n---\n",
+      body: "{\n",
+      error: { type: "mdx", line: 5, column: 1 },
+    },
+    {
+      name: "CRLF MDX expression",
+      prefix: "---\r\ntitle: Example\r\n---\r\n",
+      body: "{\r\n",
+      error: { type: "mdx", line: 5, column: 1 },
+    },
+    {
+      name: "valid LF document",
+      prefix: "---\ntitle: Example\n---\n",
+      body: "# Valid\n",
+      error: null,
+    },
+    {
+      name: "valid CRLF document",
+      prefix: "---\r\ntitle: Example\r\n---\r\n",
+      body: "# Valid\r\n",
+      error: null,
+    },
+  ])("reports original source locations for $name", ({ prefix, body, error }) => {
+    const root = createTempDir("openclaw-mdx-source-lines-");
+    const sourcePath = path.join(root, "page.mdx");
+    const reportPath = path.join(root, "report.json");
+    writeFileSync(sourcePath, prefix + body);
+
+    const result = spawnSync(
+      process.execPath,
+      [checkerPath, sourcePath, "--json-out", reportPath],
+      {
+        cwd: root,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(error ? 1 : 0);
+    expect(JSON.parse(readFileSync(reportPath, "utf8"))).toMatchObject({
+      files: 1,
+      errors: error ? [{ file: "page.mdx", ...error }] : [],
+    });
+    if (error) {
+      expect(result.stderr).toContain(`page.mdx:${error.line}:${error.column}:`);
+    }
+  });
+
   it("parses roots and output options", () => {
     expect(
       parseArgs(["docs", "README.md", "--json-out", "report.json", "--max-errors", "7"]),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where documentation errors pointed to the wrong source line when a page had YAML frontmatter. For example, a closing-tag error on line 5 was reported on line 2. MDX parser errors were affected too.

## Why This Change Was Made

Blank recognized frontmatter lines instead of removing them before validation. Both existing diagnostic paths then retain the original line positions, without separate offset calculations.

## User Impact

Terminal diagnostics and JSON reports identify the correct source lines. Delimiter recognition, body content, messages, columns and validation exit status remain unchanged.

## Evidence

Five real-CLI regression cases fail before the fix and pass afterward. All 13 focused and publishing-runtime/cache tests pass, along with all 20 changed-file checks and independent review through P2. Replaying the original four fixtures changes only the three incorrect line numbers; invalid documents still fail validation.
