### PR TITLE
refactor(ui): keep one Cron editor job snapshot

### DIFF
--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -696,9 +696,9 @@ describe("cron controller", () => {
       delivery: { mode: "none" },
     });
     expect(requestPatch(call)).not.toHaveProperty("deleteAfterRun");
-    expect(state.cronEditingJobId).toBe("job-1");
+    expect(state.cronEditingJob?.id).toBe("job-1");
     expect(state.cronEditingJob?.name).toBe("Existing job");
-    expect(state.cronEditingConfigRevision).toBe("config-revision-1");
+    expect(state.cronEditingJob?.configRevision).toBe("config-revision-1");
   });
 
   it("requires a loaded config revision before form saves and toggles", async () => {
@@ -715,7 +715,7 @@ describe("cron controller", () => {
     saveState.cronForm.name = "Unsafe edit";
 
     await expect(addCronJob(saveState)).resolves.toEqual({ saved: false });
-    expect(saveState.cronEditingJobId).toBe(job.id);
+    expect(saveState.cronEditingJob?.id).toBe(job.id);
     expect(saveState.cronError).toContain("configuration revision");
     expect(request).not.toHaveBeenCalled();
 
@@ -784,9 +784,7 @@ describe("cron controller", () => {
       }),
     );
     expect(request).toHaveBeenCalledWith("cron.get", { id: staleJob.id });
-    expect(state.cronEditingJobId).toBe(staleJob.id);
     expect(state.cronEditingJob).toEqual(authoritativeJob);
-    expect(state.cronEditingConfigRevision).toBe("revision-newest");
     expect(state.cronJobs).toEqual([listedJob]);
     expect(state.cronForm.name).toBe("Authoritative name");
     expect(state.cronForm.description).toBe("third writer definition");
@@ -852,9 +850,7 @@ describe("cron controller", () => {
     expect(request).toHaveBeenCalledWith("cron.get", { id: staleJob.id });
     expect(state.cronJobs).toEqual([]);
     expect(state.cronJobsTotal).toBe(0);
-    expect(state.cronEditingJobId).toBe(authoritativeJob.id);
     expect(state.cronEditingJob).toEqual(authoritativeJob);
-    expect(state.cronEditingConfigRevision).toBe("revision-current");
     expect(state.cronForm.name).toBe("Authoritative name");
     expect(state.cronForm.description).toBe("latest definition");
 
@@ -866,7 +862,6 @@ describe("cron controller", () => {
     expect(updateRevisions).toEqual(["revision-stale", "revision-current"]);
     expect(state.cronJobs).toEqual([]);
     expect(state.cronEditingJob).toEqual(savedJob);
-    expect(state.cronEditingConfigRevision).toBe("revision-saved");
   });
 
   it("keeps a stale form paired with its frozen revision when conflict refresh fails", async () => {
@@ -912,14 +907,14 @@ describe("cron controller", () => {
     await expect(addCronJob(state)).resolves.toEqual({ saved: false });
 
     expect(state.cronForm.name).toBe("My stale edit");
-    expect(state.cronEditingConfigRevision).toBe("revision-stale");
+    expect(state.cronEditingJob?.configRevision).toBe("revision-stale");
     expect(state.cronError).toContain("could not be loaded");
 
     firstList.resolve(cronJobsListResponse([listedJob], { snapshotRevision: "newer-list" }));
     await inFlightList;
     expect(state.cronJobs).toEqual([listedJob]);
     expect(state.cronForm.name).toBe("My stale edit");
-    expect(state.cronEditingConfigRevision).toBe("revision-stale");
+    expect(state.cronEditingJob?.configRevision).toBe("revision-stale");
 
     await expect(addCronJob(state)).resolves.toEqual({ saved: false });
     expect(updateRevisions).toEqual(["revision-stale", "revision-stale"]);
@@ -960,7 +955,6 @@ describe("cron controller", () => {
 
     expect(state.cronJobs).toEqual([updatedJob]);
     expect(state.cronEditingJob).toEqual(updatedJob);
-    expect(state.cronEditingConfigRevision).toBe("revision-saved");
   });
 
   it("commits authoritative toggle state and advances an open editor revision", async () => {
@@ -1003,7 +997,6 @@ describe("cron controller", () => {
     });
     expect(state.cronJobs).toEqual([updatedJob]);
     expect(state.cronEditingJob).toEqual(updatedJob);
-    expect(state.cronEditingConfigRevision).toBe("revision-toggled");
     expect(state.cronForm.name).toBe("Unsaved rename");
 
     listResponse.resolve(cronJobsListResponse([updatedJob]));
@@ -1047,7 +1040,6 @@ describe("cron controller", () => {
 
     expect(state.cronJobs).toEqual([remainingJob]);
     expect(state.cronJobsTotal).toBe(1);
-    expect(state.cronEditingJobId).toBeNull();
     expect(state.cronEditingJob).toBeNull();
     expect(state.cronRunsJobId).toBeNull();
     expect(state.cronRuns).toEqual([]);
@@ -1127,9 +1119,7 @@ describe("cron controller", () => {
 
     startCronEdit(state, job);
 
-    expect(state.cronEditingJobId).toBe("job-9");
     expect(state.cronEditingJob).toEqual(job);
-    expect(state.cronEditingConfigRevision).toBe("config-revision-1");
     expect(state.cronRunsJobId).toBe("job-9");
     expect(state.cronForm.name).toBe("Weekly report");
     expect(state.cronForm.sessionKey).toBe("agent:ops:main");
@@ -1531,7 +1521,7 @@ describe("cron controller", () => {
       expect(state.cronJobs).toEqual(originalInventory);
       expect(state.cronCreateOpen).toBe(method === "cron.add");
       if (method === "cron.update") {
-        expect(state.cronEditingJobId).toBe(existingJob.id);
+        expect(state.cronEditingJob?.id).toBe(existingJob.id);
         expect(state.cronEditingJob?.trigger).toEqual(existingJob.trigger);
       }
     },
@@ -2160,9 +2150,7 @@ describe("cron controller", () => {
 
     cancelCronEdit(state, scenario.selectedAgentId);
 
-    expect(state.cronEditingJobId).toBeNull();
     expect(state.cronEditingJob).toBeNull();
-    expect(state.cronEditingConfigRevision).toBeNull();
     expect(state.cronForm).toEqual({
       ...DEFAULT_CRON_FORM,
       agentId: scenario.selectedAgentId,
@@ -2191,9 +2179,7 @@ describe("cron controller", () => {
     startCronEdit(state, sourceJob);
     startCronClone(state, sourceJob);
 
-    expect(state.cronEditingJobId).toBeNull();
     expect(state.cronEditingJob).toBeNull();
-    expect(state.cronEditingConfigRevision).toBeNull();
     expect(state.cronRunsJobId).toBe("job-1");
     expect(state.cronForm.name).toBe("Daily ping copy");
     expect(state.cronForm.payloadText).toBe("ping");

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -234,8 +234,6 @@ export type CronState = {
   // only the current filtered/paged table cache.
   cronEditingJob: CronJob | null;
   cronCloningJob: CronJob | null;
-  cronEditingJobId: string | null;
-  cronEditingConfigRevision: string | null;
   cronRunsJobId: string | null;
   cronRunsLoadingMore: boolean;
   cronRuns: CronRunLogEntry[];
@@ -286,8 +284,6 @@ export function createInitialCronState(
     cronFieldErrors: {},
     cronEditingJob: null,
     cronCloningJob: null,
-    cronEditingJobId: null,
-    cronEditingConfigRevision: null,
     cronRunsJobId: null,
     cronRunsLoadingMore: false,
     cronRuns: [],
@@ -774,8 +770,6 @@ function clearCronEditState(state: CronState) {
   state.cronError = null;
   state.cronEditingJob = null;
   state.cronCloningJob = null;
-  state.cronEditingJobId = null;
-  state.cronEditingConfigRevision = null;
 }
 
 function clearCronRunsPage(state: CronState) {
@@ -1156,7 +1150,7 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
 
     const editingJob = state.cronEditingJob;
     const expectedConfigRevision = editingJob
-      ? requireCronConfigRevision(state.cronEditingConfigRevision)
+      ? requireCronConfigRevision(editingJob.configRevision)
       : undefined;
     const sourceJob = editingJob ?? state.cronCloningJob;
     const sourcePayload = sourceJob ? getCronJobPayload(sourceJob) : null;
@@ -1574,8 +1568,6 @@ function setCronEditState(state: CronState, job: CronJob, form: CronFormState) {
   state.cronError = null;
   state.cronEditingJob = job;
   state.cronCloningJob = null;
-  state.cronEditingJobId = job.id;
-  state.cronEditingConfigRevision = job.configRevision ?? null;
   state.cronRunsJobId = job.id;
   state.cronForm = form;
   state.cronFieldErrors = validateCronForm(form);

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -126,7 +126,7 @@ describe("CronPage editor state sync", () => {
       jobs.resolve(inventory);
 
       await waitForCronPage(() => {
-        expect(page.cron.cronEditingJobId).toBe(job.id);
+        expect(page.cron.cronEditingJob?.id).toBe(job.id);
         expect(
           page
             .querySelector('[data-test-id="cron-detail-tab-history"]')
@@ -181,7 +181,7 @@ describe("CronPage editor state sync", () => {
     }
     const expectedJobId =
       action === "selecting another job" || action === "opening another link" ? selected.id : null;
-    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBe(expectedJobId));
+    await waitForCronPage(() => expect(page.cron.cronEditingJob?.id ?? null).toBe(expectedJobId));
     pending.resolve(linked);
     // Drain the held response and its page update before checking the user's selection.
     await pending.promise;
@@ -189,7 +189,7 @@ describe("CronPage editor state sync", () => {
       setTimeout(resolve, 0);
     });
     await page.updateComplete;
-    expect(page.cron.cronEditingJobId).toBe(expectedJobId);
+    expect(page.cron.cronEditingJob?.id ?? null).toBe(expectedJobId);
     expect(page.cron.cronError).toBeNull();
   });
 
@@ -206,7 +206,7 @@ describe("CronPage editor state sync", () => {
     page.routeSearch = "?job=removed-job";
 
     await waitForCronPage(() => expect(page.textContent).toContain("Automation no longer exists"));
-    expect(page.cron.cronEditingJobId).toBeNull();
+    expect(page.cron.cronEditingJob).toBeNull();
     expect(request.mock.calls.filter(([method]) => method === "cron.get")).toHaveLength(1);
   });
 
@@ -245,7 +245,7 @@ describe("CronPage editor state sync", () => {
       }
       await waitForCronPage(() =>
         expect(
-          destination === "a new task" ? page.cron.cronCreateOpen : page.cron.cronEditingJobId,
+          destination === "a new task" ? page.cron.cronCreateOpen : page.cron.cronEditingJob?.id,
         ).toBe(destination === "a new task" ? true : job.id),
       );
       expect(page.cron.cronError).toBeNull();
@@ -382,7 +382,7 @@ describe("CronPage editor state sync", () => {
       expect(page.querySelector('[data-test-id="cron-row-filtered-conflict-job"]')).not.toBeNull(),
     );
     (page.querySelector('[data-test-id="cron-row-filtered-conflict-job"]') as HTMLElement).click();
-    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBe(staleJob.id));
+    await waitForCronPage(() => expect(page.cron.cronEditingJob?.id).toBe(staleJob.id));
 
     page.cron.cronJobsQuery = "missing from filtered results";
     page.requestUpdate();
@@ -393,7 +393,7 @@ describe("CronPage editor state sync", () => {
     (page.querySelector('[data-test-id="cron-submit"]') as HTMLButtonElement).click();
 
     await waitForCronPage(() =>
-      expect(page.cron.cronEditingConfigRevision).toBe("revision-current"),
+      expect(page.cron.cronEditingJob?.configRevision).toBe("revision-current"),
     );
     expect(page.cron.cronEditingJob).toEqual(authoritativeJob);
     expect(request).toHaveBeenCalledWith(
@@ -413,8 +413,7 @@ describe("CronPage editor state sync", () => {
     expect(page.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull();
 
     (page.querySelector('[data-test-id="cron-back"]') as HTMLButtonElement).click();
-    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBeNull());
-    expect(page.cron.cronEditingJob).toBeNull();
+    await waitForCronPage(() => expect(page.cron.cronEditingJob).toBeNull());
     expect(page.querySelector('[data-test-id="cron-row-filtered-conflict-job"]')).toBeNull();
   });
 
@@ -698,7 +697,7 @@ describe("CronPage editor state sync", () => {
 
     await waitForCronPage(() => expect(page.querySelector(".cron-table__row")).not.toBeNull());
     (page.querySelector(".cron-table__row") as HTMLElement).click();
-    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBe("job-1"));
+    await waitForCronPage(() => expect(page.cron.cronEditingJob?.id).toBe("job-1"));
     expect(page.cron.cronRunsScope).toBe("job");
     expect(page.cron.cronForm.enabled).toBe(true);
 
@@ -731,7 +730,7 @@ describe("CronPage editor state sync", () => {
     await waitForCronPage(() => expect(findConfirmButton()).toBeDefined());
     findConfirmButton()?.click();
     await removeRequested.promise;
-    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBeNull());
+    await waitForCronPage(() => expect(page.cron.cronEditingJob).toBeNull());
     await waitForCronPage(() => expect(page.cron.cronRunsScope).toBe("all"));
   });
 

--- a/ui/src/pages/cron/view-description.test.ts
+++ b/ui/src/pages/cron/view-description.test.ts
@@ -65,8 +65,7 @@ describe("cron view saved metadata", () => {
 
       const state = createInitialCronState();
       startCronEdit(state, job);
-      expect(state.cronEditingJobId).toBe(job.id);
-      expect(state.cronEditingConfigRevision).toBe(job.configRevision);
+      expect(state.cronEditingJob).toEqual(job);
       const detail = renderCronView({ editingJob: state.cronEditingJob, form: state.cronForm });
       expect(detail.querySelector(".cron-detail-title")?.textContent).toBe(expected);
       expect(detail.querySelector<HTMLInputElement>("#cron-name")?.value).toBe(


### PR DESCRIPTION
## What Problem This Solves

The Automations editor kept separate ID and revision fields that duplicated its retained job. Every editor transition had to maintain all three values together.

## Why This Change Was Made

Use the retained job as the sole editor owner and read its revision through the existing save guard. Remove redundant test assertions where whole-job or awaited-state checks already cover the same values.

## User Impact

Behavior is unchanged. An open editor keeps its own job snapshot across filtered list refreshes, preserves its revision after failed conflict recovery, and advances it after accepted saves or toggles. The change removes eight production lines and sixteen test lines.

## Evidence

All 297 existing cases across six Cron suites and all 20 changed-file checks pass. The final edit only removes an already-awaited duplicate assertion; the same 31 page cases then pass again, with formatting and whitespace checks clean. Independent review through P2 found no issues. No visual or live Gateway change is claimed.
