### PR TITLE
fix(chat): keep submitted images visible during history handoff

### DIFF
--- a/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import type { ChatHost } from "../pages/chat/chat-send-contract.ts";
 import {
   takeControlUiElementScreenshot,
   takeControlUiViewportScreenshot,
@@ -13,11 +14,13 @@ import {
   requireRecord,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { waitForCommittedState } from "./settle.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+const orders = ["receipt-first", "event-first"] as const;
 
 suite.define(() => {
-  it("keeps a submitted image visible through custody and canonical history loading", async () => {
+  it.each(orders)("keeps image previews through the history handoff (%s)", async (order) => {
     const proofDir = captureUiProofEnabled ? suite.artifactDir : undefined;
     const imageBytes = await readFile(path.join(process.cwd(), "ui/public/apple-touch-icon.png"));
     await suite.withPage(
@@ -95,6 +98,7 @@ suite.define(() => {
             buffer: imageBytes,
           });
           await page.getByRole("img", { name: "stable-preview.png" }).waitFor();
+          await gateway.deferNext("chat.history", { limit: 1000 });
           await gateway.deferNext("chat.send");
           await page.getByRole("button", { name: "Send message" }).click();
           const request = await gateway.waitForRequest("chat.send");
@@ -198,9 +202,30 @@ suite.define(() => {
             session: sessionInfo,
           });
           await gateway.waitForRequest("chat.history", { after: histories });
-          await expect.poll(() => page.locator(".chat-send-status").count()).toBe(0);
+          // Custody starts the canonical media read while the send acknowledgment is held.
+          await expect.poll(() => metadataRequested).toBe(true);
           await expectImageStillVisible("02-custody");
           await gateway.resolveDeferred("chat.send", { runId, status: "started" });
+          await waitForCommittedState(
+            page,
+            ({ runId: expectedRunId }) => {
+              const state = document.querySelector<HTMLElement & { state: ChatHost }>(
+                "openclaw-chat-pane",
+              )?.state;
+              return state !== undefined && state.chatRunId === expectedRunId && !state.chatSending;
+            },
+            { runId },
+          );
+          // Another session's update wakes the outbox without hydrating this transcript.
+          const wakeSessionKey = "agent:main:image-handoff-wakeup";
+          await gateway.emitGatewayEvent("sessions.changed", {
+            sessionKey: wakeSessionKey,
+            sessionId: "image-handoff-wakeup-session",
+            reason: "send",
+            hasActiveRun: true,
+            session: { key: wakeSessionKey, kind: "direct", hasActiveRun: true, status: "running" },
+          });
+          await gateway.waitForRequest("chat.history", { match: { limit: 1000 } });
 
           const canonical = {
             ...pendingInput.message,
@@ -211,11 +236,20 @@ suite.define(() => {
               idempotencyKey: `${runId}:user`,
             },
           };
-          await gateway.setMethodResponse("chat.history", {
+          const canonicalHistory = {
             ...custodyHistory,
             messages: [canonical],
             pendingInputs: { items: [], total: 0 },
-          });
+          };
+          await gateway.setMethodResponse("chat.history", canonicalHistory);
+          if (order === "receipt-first") {
+            const followups = (await gateway.getRequests("chat.history", { limit: 80 })).length;
+            await gateway.resolveDeferred("chat.history", canonicalHistory);
+            await gateway.waitForRequest("chat.history", {
+              match: { limit: 80 },
+              after: followups,
+            });
+          }
           await gateway.emitGatewayEvent("session.message", {
             sessionKey,
             sessionId,
@@ -225,6 +259,9 @@ suite.define(() => {
             message: canonical,
           });
           await page.locator('.chat-bubble[data-entry-id="accepted-image-input"]').waitFor();
+          if (order === "event-first") {
+            await gateway.resolveDeferred("chat.history", canonicalHistory);
+          }
           await expect.poll(() => metadataRequested).toBe(true);
           await expectImageStillVisible("03-canonical-metadata-loading");
           releaseMetadata();

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -148,7 +148,7 @@ describe("server-owned pending input display", () => {
     expect(remounted.chatMessages).toHaveLength(1);
   });
 
-  it.each(["pending", "consumed", "canonical", "canonical-first"])(
+  it.each(["pending", "pending-first", "consumed", "canonical", "canonical-first"])(
     "keeps a %s delivered source retired when its terminal is replayed",
     async (receipt) => {
       const host = makeChatHost({ sessionKey, currentSessionId: sessionId });
@@ -160,6 +160,8 @@ describe("server-owned pending input display", () => {
       };
       if (receipt === "canonical-first") {
         reduceChatSessionProjection(host, { type: "snapshotLoaded", messages: [canonical] });
+      } else if (receipt === "pending-first") {
+        applyChatPendingInputs(host, { items: [{ ...input, runId }], total: 1 });
       }
       const scope = await retainDeliveredUserTurn(host, {
         id: runId,
@@ -169,7 +171,10 @@ describe("server-owned pending input display", () => {
         text: "Collected input",
         createdAt: 1,
       });
-      if (receipt === "pending" || receipt === "consumed") {
+      if (receipt === "pending-first") {
+        expect(host.chatMessages).toEqual([]);
+        applyChatPendingInputs(host, { items: [], total: 0 });
+      } else if (receipt === "pending" || receipt === "consumed") {
         const inputReceipt: ChatInputReceipts[number] =
           receipt === "pending"
             ? { runId, state: receipt }
@@ -188,6 +193,26 @@ describe("server-owned pending input display", () => {
       expect(listStoredChatOutboxes(host)).toEqual([]);
     },
   );
+
+  it("keeps a local delivery fallback when custody belongs to a replaced physical session", async () => {
+    const host = makeChatHost({ sessionKey, currentSessionId: sessionId });
+    applyChatPendingInputs(host, page);
+    host.currentSessionId = "replacement-session";
+
+    await retainDeliveredUserTurn(host, {
+      id: "current-session-delivery",
+      sendRunId: input.runId,
+      sessionKey,
+      sessionId: host.currentSessionId,
+      text: "Current session input",
+      createdAt: 1,
+    });
+
+    expect(host.chatMessages).toHaveLength(1);
+    expect(host.chatMessages[0]).toMatchObject({
+      content: [{ type: "text", text: "Current session input" }],
+    });
+  });
 
   it("does not share receipt queries between panes with different provisional sources", async () => {
     const response = createDeferred<unknown>();

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -14,6 +14,7 @@ import {
   normalizeAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
+import { getChatPendingInputs } from "./chat-pending-inputs.ts";
 import {
   readDeliveredQueuedChatSendForRun,
   readQueuedMessageById,
@@ -83,6 +84,15 @@ function preserveDeliveredUserTurn(
       !state.currentSessionId ||
       submission.sessionId === state.currentSessionId
     ) {
+      // Custody may already own this source before its first delivery retention.
+      if (
+        getChatPendingInputs(state)?.page.items.some(
+          (input) => input.runId === submission.pendingRunId,
+        )
+      ) {
+        submission.pending = false;
+        return;
+      }
       admitChatSubmission(state, submission);
     }
     return;


### PR DESCRIPTION
Related: #143227, #134931

## What Problem This Solves

Fixes an issue where a submitted image disappears behind a loading placeholder when outbox history confirms delivery before the live transcript event arrives. The image has already been accepted, but canonical media metadata is still loading.

## Why This Change Was Made

Delivery retirement now recognizes when the current session's pending-input custody already owns the submitted run. It retires the retained submission before local admission can replace the displayed image. The existing local fallback remains available when custody belongs to another physical session or has not accepted the submission.

## User Impact

Submitted images remain visible while delivery moves from the local preview to canonical history, regardless of whether the history receipt or live event arrives first. This is a separate ten-line production repair discovered while validating #143227.

## Evidence

The pinned-main regression failed before the repair and passed afterward. On Linux Chromium 144, receipt-first ordering reproduced the original image detachment while event-first ordering passed; after the repair, both orders preserve the original image handle, decoded pixels, and frame continuity through metadata and image loading. The owner suite also covers replay after custody removal and the fallback for a replaced physical session.

Validation passed: 417 owner/sibling tests, 18 Linux Chromium E2E cases across four files, the full changed-file gate, and independent review through P2. [Completed Testbox run](https://github.com/openclaw/openclaw/actions/runs/34404165374). All owned Testboxes were stopped.

Before and after captures below use synthetic data with canonical metadata deliberately held. Exact-head required CI passed after one unchanged-head retry of an unrelated text-streaming frame-budget failure; source and thresholds were unchanged. Native review, prepare, and merge completed; the landed files match the reviewed patch.

![Before: accepted image disappears while canonical metadata loads](https://github.com/user-attachments/assets/72504576-a9c9-49ed-8155-80f926f35ccf)

![After: the submitted image remains visible through the same handoff](https://github.com/user-attachments/assets/356d2fee-4968-4d88-904a-bd288a500761)