### PR TITLE
fix(google-meet): clean up audio when Chrome startup fails

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -506,7 +506,6 @@ extensions/google-meet/src/cli-space-commands.ts	3
 extensions/google-meet/src/meet-api.ts	1
 extensions/google-meet/src/plugin-registration.ts	1
 extensions/google-meet/src/transports/chrome-create.ts	4
-extensions/google-meet/src/transports/chrome.ts	2
 extensions/google-meet/src/transports/google-meet-platform-adapter.ts	1
 extensions/google/cli-backend-auth.runtime.ts	1
 extensions/google/cli-backend-isolated-auth.runtime.ts	5

--- a/docs/plugins/google-meet/transports.md
+++ b/docs/plugins/google-meet/transports.md
@@ -137,7 +137,7 @@ SoX is licensed `LGPL-2.0-only AND GPL-2.0-only`; BlackHole is GPL-3.0. If you b
 
 ### Chrome
 
-Opens the Meet URL through OpenClaw browser control and joins as the signed-in OpenClaw browser profile. Before launch, the plugin checks or provisions the host's native virtual-audio backend and then runs any configured audio bridge health/startup command. For local Chrome, pick the profile with `browser.defaultProfile`; `chrome.browserProfile` is passed to `chrome-node` hosts instead.
+Opens the Meet URL through OpenClaw browser control and joins as the signed-in OpenClaw browser profile. For talk-back modes, the plugin checks or provisions the host's native virtual-audio backend before browser work. Local Chrome also runs any configured audio bridge health command at this point; `chrome-node` runs that check on the node when starting its bridge. The talk-back bridge starts only after browser health confirms virtual input/output audio routing. For local Chrome, pick the profile with `browser.defaultProfile`; `chrome.browserProfile` is passed to `chrome-node` hosts instead.
 
 ```bash
 openclaw googlemeet join https://meet.google.com/abc-defg-hij --transport chrome
@@ -145,6 +145,8 @@ openclaw googlemeet join https://meet.google.com/abc-defg-hij --transport chrome
 ```
 
 Chrome mic/speaker audio routes through the local OpenClaw audio bridge. If the native backend is unavailable, the join fails with a setup error instead of joining without an audio path.
+
+If startup fails after OpenClaw acquires a command-pair audio bridge, it attempts to stop that bridge before rolling back a tab opened by the failed join. This startup cleanup leaves reused or adopted tabs, including `chrome.launch: false` sessions, untouched. Node cleanup targets the returned bridge ID; if node startup fails before returning an ID, the Gateway cannot guarantee remote bridge cleanup. External bridge commands manage their own process lifecycle.
 
 ### Twilio
 

--- a/extensions/google-meet/src/transports/chrome-startup.test.ts
+++ b/extensions/google-meet/src/transports/chrome-startup.test.ts
@@ -1,0 +1,178 @@
+import { PassThrough } from "node:stream";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { resolveGoogleMeetConfig } from "../config.js";
+import { MEET_URL, MEET_URL_EN, testBridgeProcess } from "../test-support/fixtures.test-helpers.js";
+import { launchChromeMeet, launchChromeMeetOnNode } from "./chrome.js";
+
+const processes = vi.hoisted(() => ({ spawn: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: processes.spawn,
+}));
+
+describe("Google Meet startup ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("retains required commands on local command-pair handles", () => {
+    type Bridge = Extract<
+      NonNullable<Awaited<ReturnType<typeof launchChromeMeet>>["audioBridge"]>,
+      { type: "command-pair" }
+    >;
+    expectTypeOf<Bridge["inputCommand"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<Bridge["outputCommand"]>().toEqualTypeOf<string[]>();
+  });
+
+  it.each(
+    (["chrome", "chrome-node"] as const).flatMap((transport) =>
+      (["opened", "reused", "launch-disabled"] as const).map((ownership) => ({
+        transport,
+        ownership,
+      })),
+    ),
+  )(
+    "reclaims $transport audio after failed startup with an $ownership tab",
+    async ({ transport, ownership }) => {
+      const events: string[] = [];
+      const children: ReturnType<typeof testBridgeProcess>[] = [];
+      const nodeStops: Array<{ action: string; bridgeId?: string }> = [];
+      const tab = { targetId: "owned-tab", title: "Meet", url: MEET_URL_EN };
+      let tabExists = ownership !== "opened";
+      let inspections = 0;
+      processes.spawn.mockImplementation((command: string) => {
+        events.push(`spawn:${command}`);
+        const child = testBridgeProcess({ stdin: new PassThrough(), stdout: new PassThrough() });
+        child.kill.mockImplementation((signal?: NodeJS.Signals) => {
+          events.push(`kill:${command}`);
+          child.killed = true;
+          child.signalCode = signal ?? "SIGTERM";
+          child.emit("exit", null, child.signalCode);
+          child.emit("close", null, child.signalCode);
+          return true;
+        });
+        children.push(child);
+        return child;
+      });
+      const browser = async (request: { path: string }) => {
+        events.push(`browser:${request.path}`);
+        if (request.path === "/tabs") {
+          return { tabs: tabExists ? [tab] : [] };
+        }
+        if (request.path === "/tabs/open") {
+          tabExists = true;
+          return tab;
+        }
+        if (request.path === "/act") {
+          if (inspections++ > 0) {
+            return { result: JSON.stringify({ departed: true, urlMatched: true }) };
+          }
+          return {
+            result: JSON.stringify({
+              inCall: true,
+              micMuted: false,
+              audioInputRouted: true,
+              audioOutputRouted: true,
+              url: MEET_URL_EN,
+            }),
+          };
+        }
+        return { ok: true };
+      };
+      const runtime = {
+        gateway: {
+          isAvailable: async () => true,
+          request: async (_method: string, params: { path: string }) => browser(params),
+        },
+        nodes: {
+          list: async () => ({
+            nodes: [
+              {
+                nodeId: "node-1",
+                connected: true,
+                commands: ["googlemeet.chrome", "browser.proxy"],
+              },
+            ],
+          }),
+          invoke: async ({
+            command,
+            params,
+          }: {
+            command: string;
+            params: { action: string; path: string; bridgeId?: string };
+          }) => {
+            if (command === "browser.proxy") {
+              return { payload: { result: await browser(params) } };
+            }
+            events.push(`node:${params.action}`);
+            if (params.action === "stop") {
+              nodeStops.push({ action: params.action, bridgeId: params.bridgeId });
+            }
+            return {
+              payload:
+                params.action === "start"
+                  ? { bridgeId: "bridge-1", audioBridge: { type: "node-command-pair" } }
+                  : {},
+            };
+          },
+        },
+        system: {
+          runCommandWithTimeout: async () => {
+            events.push("audio:prepare");
+            return { code: 0, stdout: "BlackHole 2ch", stderr: "" };
+          },
+        },
+      } as unknown as PluginRuntime;
+      const launch = transport === "chrome" ? launchChromeMeet : launchChromeMeetOnNode;
+      await expect(
+        launch({
+          runtime,
+          config: resolveGoogleMeetConfig({
+            chrome: {
+              audioInputCommand: ["capture"],
+              audioOutputCommand: ["play"],
+              waitForInCallMs: 1,
+              launch: ownership !== "launch-disabled",
+            },
+            realtime: { voiceProvider: "missing-meeting-test-provider" },
+          }),
+          fullConfig: {},
+          mode: "bidi",
+          meetingSessionId: "startup-owner",
+          url: MEET_URL,
+          logger: { debug() {}, info() {}, warn() {}, error() {} },
+        }),
+      ).rejects.toThrow(/provider/i);
+
+      expect(events.filter((event) => event.startsWith("node:"))).toEqual(
+        transport === "chrome-node"
+          ? ["node:stopByUrl", "node:setup", "node:start", "node:stop"]
+          : [],
+      );
+      expect(nodeStops).toEqual(
+        transport === "chrome-node" ? [{ action: "stop", bridgeId: "bridge-1" }] : [],
+      );
+      expect(events.filter((event) => event.startsWith("spawn:"))).toEqual(
+        transport === "chrome" ? ["spawn:play", "spawn:capture"] : [],
+      );
+      expect(children.every((child) => child.kill.mock.calls.length === 1)).toBe(true);
+      expect(events.filter((event) => event === "browser:/tabs")).toHaveLength(
+        ownership === "opened" ? 2 : 1,
+      );
+      expect(events.includes("browser:/tabs/owned-tab")).toBe(ownership === "opened");
+      if (ownership === "opened") {
+        const cleanupIndex = events.findIndex(
+          (event) => event.startsWith("kill:") || event === "node:stop",
+        );
+        expect(cleanupIndex).toBeGreaterThan(-1);
+        expect(cleanupIndex).toBeLessThan(events.lastIndexOf("browser:/tabs"));
+      }
+      expect(events.indexOf("browser:/act")).toBeLessThan(
+        events.indexOf(transport === "chrome" ? "spawn:play" : "node:start"),
+      );
+    },
+  );
+});

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -1,27 +1,21 @@
-// Google Meet plugin module implements chrome behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
-  createMeetingRealtimeEngineBindings,
-  createLocalMeetingRealtimeAudioTransport,
-  createNodeMeetingRealtimeAudioTransport,
   leaveMeetingWithBrowser,
-  openMeetingWithBrowser,
   readMeetingTranscriptWithBrowser,
   recoverMeetingBrowserTab,
   resolveLocalMeetingBrowserRequest,
   MeetingPlatformAdapter,
-  startMeetingAgentRealtimeEngine,
-  startMeetingRealtimeEngine,
   type MeetingBrowserRequestCaller,
-  type MeetingRealtimeAudioEngineHandle,
 } from "openclaw/plugin-sdk/meeting-runtime";
-import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
-import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveTranscriptsConfig } from "openclaw/plugin-sdk/transcripts";
 import type { GoogleMeetConfig, GoogleMeetMode } from "../config.js";
 import { callBrowserProxyOnNode, resolveChromeNode } from "./chrome-browser-proxy.js";
 import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./google-meet-platform-adapter.js";
-import { GOOGLE_MEET_NODE_COMMAND } from "./google-meet-platform-constants.js";
+import {
+  GOOGLE_MEET_BROWSER_NODE_ADAPTER,
+  GOOGLE_MEET_NODE_COMMAND,
+} from "./google-meet-platform-constants.js";
 import type {
   GoogleMeetBrowserTab,
   GoogleMeetChromeHealth,
@@ -29,225 +23,39 @@ import type {
   GoogleMeetTranscriptSnapshot,
 } from "./types.js";
 
-type ChromeRealtimeAudioBridgeHandle = MeetingRealtimeAudioEngineHandle & {
-  inputCommand: string[];
-  outputCommand: string[];
-};
-type MeetingAudioBackend = "blackhole-2ch" | "pipewire-pulse";
-type MeetingAudioRuntime = {
-  backend: MeetingAudioBackend;
-  deviceLabel: string;
-  inputCommand: string[];
-  outputCommand: string[];
-};
+const chromeTransport = MeetingPlatformAdapter.createChromeTransportWithExternalAudio<
+  GoogleMeetConfig,
+  GoogleMeetMode,
+  GoogleMeetChromeHealth,
+  GoogleMeetTranscriptSnapshot
+>({
+  browserNodeAdapter: GOOGLE_MEET_BROWSER_NODE_ADAPTER,
+  isRealtimeRouteReady: (mode, health) =>
+    !MeetingPlatformAdapter.isTalkBackMode(mode) ||
+    MeetingPlatformAdapter.isRealtimeRouteReady(mode, health),
+  isTalkBackMode: MeetingPlatformAdapter.isTalkBackMode,
+  meetingLabel: "Google Meet",
+  nodeCommandName: GOOGLE_MEET_NODE_COMMAND,
+  platform: GOOGLE_MEET_PLATFORM_ADAPTER,
+  preserveTrackedBrowserOnEngineFailure: false,
+  startupFailurePolicy: "owned",
+  runtime: MeetingPlatformAdapter.createChromeRuntimeBindings(),
+});
 
-type ChromeNodeRealtimeAudioBridgeHandle = MeetingRealtimeAudioEngineHandle & {
-  type: "node-command-pair";
-  nodeId: string;
-  bridgeId: string;
-};
+export const assertGoogleMeetAudioAvailable = chromeTransport.assertAudioDeviceAvailable;
+export const launchChromeMeetOnNode = chromeTransport.launchOnNode;
+
+export async function launchChromeMeet(
+  params: Parameters<typeof chromeTransport.launchInChrome>[0],
+): ReturnType<typeof chromeTransport.launchInChrome> {
+  const result = await chromeTransport.launchInChrome(params);
+  return { ...result, audioBridge: result.audioBridge };
+}
 
 function shouldCaptureCaptions(mode: GoogleMeetMode, fullConfig?: OpenClawConfig): boolean {
   return (
     mode === "transcribe" || !fullConfig || resolveTranscriptsConfig(fullConfig.transcripts).enabled
   );
-}
-
-async function prepareGoogleMeetAudioRuntime(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  timeoutMs: number;
-}): Promise<MeetingAudioRuntime> {
-  const audio = MeetingPlatformAdapter.resolveAudioRuntimeForFormat({
-    backend: params.config.chrome.audioBackend,
-    bufferBytes: params.config.chrome.audioBufferBytes,
-    format: params.config.chrome.audioFormat,
-    inputCommand: params.config.chrome.audioInputCommandOverride,
-    outputCommand: params.config.chrome.audioOutputCommandOverride,
-  });
-  await MeetingPlatformAdapter.ensureAudioBackend({
-    backend: audio.backend,
-    timeoutMs: params.timeoutMs,
-    run: async (argv, timeoutMs) => {
-      const result = await params.runtime.system.runCommandWithTimeout(argv, { timeoutMs });
-      return { ...result, code: result.code ?? 1 };
-    },
-  });
-  return audio;
-}
-
-export async function assertGoogleMeetAudioAvailable(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  timeoutMs: number;
-}): Promise<void> {
-  await prepareGoogleMeetAudioRuntime(params);
-}
-
-export async function launchChromeMeet(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  fullConfig: OpenClawConfig;
-  meetingSessionId: string;
-  requesterSessionKey?: string;
-  mode: GoogleMeetMode;
-  url: string;
-  logger: RuntimeLogger;
-}): Promise<{
-  launched: boolean;
-  audioBackend?: MeetingAudioBackend;
-  audioBridge?:
-    | { type: "external-command" }
-    | ({ type: "command-pair" } & ChromeRealtimeAudioBridgeHandle);
-  browser?: GoogleMeetChromeHealth;
-  tab?: GoogleMeetBrowserTab;
-}> {
-  let audio: MeetingAudioRuntime | undefined;
-  const checkRealtimeAudioPrerequisites = async () => {
-    if (!MeetingPlatformAdapter.isTalkBackMode(params.mode)) {
-      return;
-    }
-    audio = await prepareGoogleMeetAudioRuntime({
-      runtime: params.runtime,
-      config: params.config,
-      timeoutMs: Math.min(params.config.chrome.joinTimeoutMs, 10_000),
-    });
-
-    if (params.config.chrome.audioBridgeHealthCommand) {
-      const health = await params.runtime.system.runCommandWithTimeout(
-        params.config.chrome.audioBridgeHealthCommand,
-        { timeoutMs: params.config.chrome.joinTimeoutMs },
-      );
-      if (health.code !== 0) {
-        throw new Error(
-          `Chrome audio bridge health check failed: ${health.stderr || health.stdout || health.code}`,
-        );
-      }
-    }
-  };
-
-  const startRealtimeAudioBridge = async (): Promise<
-    | { type: "external-command" }
-    | ({ type: "command-pair" } & ChromeRealtimeAudioBridgeHandle)
-    | undefined
-  > => {
-    if (!MeetingPlatformAdapter.isTalkBackMode(params.mode)) {
-      return undefined;
-    }
-    if (params.config.chrome.audioBridgeCommand) {
-      if (params.mode === "agent") {
-        throw new Error(
-          "Chrome agent mode requires chrome.audioInputCommand and chrome.audioOutputCommand so OpenClaw can run STT and regular TTS directly.",
-        );
-      }
-      const bridge = await params.runtime.system.runCommandWithTimeout(
-        params.config.chrome.audioBridgeCommand,
-        { timeoutMs: params.config.chrome.joinTimeoutMs },
-      );
-      if (bridge.code !== 0) {
-        throw new Error(
-          `failed to start Chrome audio bridge: ${bridge.stderr || bridge.stdout || bridge.code}`,
-        );
-      }
-      return { type: "external-command" };
-    }
-    if (!params.config.chrome.audioInputCommand || !params.config.chrome.audioOutputCommand) {
-      throw new Error(
-        "Chrome talk-back mode requires chrome.audioInputCommand and chrome.audioOutputCommand, or chrome.audioBridgeCommand for an external bridge.",
-      );
-    }
-    if (!audio) {
-      throw new Error("Google Meet audio backend was not prepared.");
-    }
-    const transport = createLocalMeetingRealtimeAudioTransport({
-      inputCommand: audio.inputCommand,
-      outputCommand: audio.outputCommand,
-      audioFormat: params.config.chrome.audioFormat,
-      bargeInInputCommand: params.config.chrome.bargeInInputCommand,
-      bargeInRmsThreshold: params.config.chrome.bargeInRmsThreshold,
-      bargeInPeakThreshold: params.config.chrome.bargeInPeakThreshold,
-      bargeInCooldownMs: params.config.chrome.bargeInCooldownMs,
-      logger: params.logger,
-      logScope: GOOGLE_MEET_PLATFORM_ADAPTER.logScope,
-    });
-    const bindings = createMeetingRealtimeEngineBindings({
-      platform: GOOGLE_MEET_PLATFORM_ADAPTER,
-      ...params,
-    });
-    const engine =
-      params.mode === "agent"
-        ? await startMeetingAgentRealtimeEngine({
-            config: params.config,
-            fullConfig: params.fullConfig,
-            runtime: params.runtime,
-            platform: bindings.platform,
-            meetingSessionId: params.meetingSessionId,
-            requesterSessionKey: params.requesterSessionKey,
-            transport,
-            logger: params.logger,
-            consultAgent: bindings.consultAgent,
-          })
-        : await startMeetingRealtimeEngine({
-            config: {
-              ...params.config,
-              realtime: { ...params.config.realtime, strategy: "bidi" },
-            },
-            fullConfig: params.fullConfig,
-            runtime: params.runtime,
-            ...bindings,
-            meetingSessionId: params.meetingSessionId,
-            requesterSessionKey: params.requesterSessionKey,
-            transport,
-            logger: params.logger,
-          });
-    return {
-      type: "command-pair",
-      inputCommand: audio.inputCommand,
-      outputCommand: audio.outputCommand,
-      ...engine,
-    };
-  };
-
-  await checkRealtimeAudioPrerequisites();
-
-  const result = await openOrRecoverMeetWithBrowser({
-    callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
-    config: params.config,
-    captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
-    locationLabel: "in local Chrome",
-    meetingSessionId: params.meetingSessionId,
-    mode: params.mode,
-    url: params.url,
-  });
-  const shouldStartRealtimeBridge = MeetingPlatformAdapter.isRealtimeRouteReady(
-    params.mode,
-    result.browser,
-  );
-  const audioBridge = shouldStartRealtimeBridge ? await startRealtimeAudioBridge() : undefined;
-  return { ...result, audioBackend: audio?.backend, audioBridge };
-}
-
-function parseNodeStartResult(raw: unknown): {
-  launched?: boolean;
-  bridgeId?: string;
-  audioBackend?: MeetingAudioBackend;
-  audioBridge?: { type?: string; outputGeneration?: boolean };
-  browser?: GoogleMeetChromeHealth;
-} {
-  const value =
-    raw && typeof raw === "object" && "payload" in raw
-      ? (raw as { payload?: unknown }).payload
-      : raw;
-  if (!value || typeof value !== "object") {
-    throw new Error("Google Meet node returned an invalid start result.");
-  }
-  return value as {
-    launched?: boolean;
-    bridgeId?: string;
-    audioBackend?: MeetingAudioBackend;
-    audioBridge?: { type?: string; outputGeneration?: boolean };
-    browser?: GoogleMeetChromeHealth;
-  };
 }
 
 type ChromeBrowserRouteParams = {
@@ -337,49 +145,6 @@ export async function readChromeMeetTranscript(
   });
 }
 
-async function openOrRecoverMeetWithBrowser(params: {
-  callBrowser: MeetingBrowserRequestCaller;
-  locationLabel: string;
-  config: GoogleMeetConfig;
-  captureCaptions: boolean;
-  mode: GoogleMeetMode;
-  meetingSessionId: string;
-  url: string;
-}): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth; tab?: GoogleMeetBrowserTab }> {
-  if (!params.config.chrome.launch) {
-    const recovered = await recoverMeetingBrowserTab({
-      adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-      allowSessionAdoption: true,
-      autoJoin: params.config.chrome.autoJoin,
-      callBrowser: params.callBrowser,
-      captureCaptions: params.captureCaptions,
-      config: params.config.chrome,
-      locationLabel: params.locationLabel,
-      meetingSessionId: params.meetingSessionId,
-      mode: params.mode,
-      requestedMeetingUrl: params.url,
-      trackedMeetingUrl: params.url,
-      trackedTargetId: undefined,
-    });
-    return {
-      launched: false,
-      browser: recovered.browser,
-      tab: recovered.targetId ? { targetId: recovered.targetId, openedByPlugin: false } : undefined,
-    };
-  }
-  return await openMeetingWithBrowser({
-    adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser: params.callBrowser,
-    config: params.config.chrome,
-    session: {
-      captureCaptions: params.captureCaptions,
-      mode: params.mode,
-      meetingSessionId: params.meetingSessionId,
-      url: params.url,
-    },
-  });
-}
-
 export async function recoverCurrentMeetTab(
   params: Omit<ChromeBrowserRouteParams, "nodeId"> & {
     fullConfig?: OpenClawConfig;
@@ -430,202 +195,5 @@ export async function recoverCurrentMeetTab(
       trackedMeetingUrl: params.trackedMeetingUrl,
       trackedTargetId: params.trackedTargetId,
     })),
-  };
-}
-
-export async function launchChromeMeetOnNode(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  fullConfig: OpenClawConfig;
-  meetingSessionId: string;
-  requesterSessionKey?: string;
-  mode: GoogleMeetMode;
-  url: string;
-  logger: RuntimeLogger;
-}): Promise<{
-  nodeId: string;
-  launched: boolean;
-  audioBackend?: MeetingAudioBackend;
-  audioBridge?:
-    | { type: "external-command" }
-    | ({ type: "node-command-pair" } & ChromeNodeRealtimeAudioBridgeHandle);
-  browser?: GoogleMeetChromeHealth;
-  tab?: GoogleMeetBrowserTab;
-}> {
-  const nodeId = await resolveChromeNode({
-    runtime: params.runtime,
-    requestedNode: params.config.chromeNode.node,
-  });
-  try {
-    await params.runtime.nodes.invoke({
-      nodeId,
-      command: GOOGLE_MEET_NODE_COMMAND,
-      params: {
-        action: "stopByUrl",
-        url: params.url,
-        mode: params.mode,
-      },
-      timeoutMs: 5_000,
-    });
-  } catch (error) {
-    params.logger.debug?.(
-      `[google-meet] node bridge cleanup before join ignored: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  }
-  const setup = MeetingPlatformAdapter.isTalkBackMode(params.mode)
-    ? parseNodeStartResult(
-        await params.runtime.nodes.invoke({
-          nodeId,
-          command: GOOGLE_MEET_NODE_COMMAND,
-          params: {
-            action: "setup",
-            audioBackend: params.config.chrome.audioBackend,
-            audioFormat: params.config.chrome.audioFormat,
-            audioBufferBytes: params.config.chrome.audioBufferBytes,
-            ...(params.config.chrome.audioInputCommandOverride
-              ? { audioInputCommand: params.config.chrome.audioInputCommandOverride }
-              : {}),
-            ...(params.config.chrome.audioOutputCommandOverride
-              ? { audioOutputCommand: params.config.chrome.audioOutputCommandOverride }
-              : {}),
-          },
-          timeoutMs: 12_000,
-        }),
-      )
-    : undefined;
-  const browserControl = await openOrRecoverMeetWithBrowser({
-    callBrowser: chromeNodeBrowserRequest(params.runtime, nodeId),
-    locationLabel: "on the selected Chrome node",
-    config: params.config,
-    captureCaptions: shouldCaptureCaptions(params.mode, params.fullConfig),
-    mode: params.mode,
-    meetingSessionId: params.meetingSessionId,
-    url: params.url,
-  });
-  // launch:false explicitly delegates call state to an already-open session.
-  // Browser-managed joins require explicit unmuted health before node audio starts.
-  if (
-    MeetingPlatformAdapter.isTalkBackMode(params.mode) &&
-    !MeetingPlatformAdapter.isRealtimeRouteReady(params.mode, browserControl.browser)
-  ) {
-    return {
-      nodeId,
-      launched: browserControl.launched,
-      audioBackend: setup?.audioBackend,
-      browser: browserControl.browser,
-      tab: browserControl.tab,
-    };
-  }
-  const raw = await params.runtime.nodes.invoke({
-    nodeId,
-    command: GOOGLE_MEET_NODE_COMMAND,
-    params: {
-      action: "start",
-      url: params.url,
-      mode: params.mode,
-      launch: false,
-      browserProfile: params.config.chrome.browserProfile,
-      joinTimeoutMs: params.config.chrome.joinTimeoutMs,
-      audioBackend: params.config.chrome.audioBackend,
-      audioFormat: params.config.chrome.audioFormat,
-      audioBufferBytes: params.config.chrome.audioBufferBytes,
-      ...(params.config.chrome.audioInputCommandOverride
-        ? { audioInputCommand: params.config.chrome.audioInputCommandOverride }
-        : {}),
-      ...(params.config.chrome.audioOutputCommandOverride
-        ? { audioOutputCommand: params.config.chrome.audioOutputCommandOverride }
-        : {}),
-      audioBridgeCommand: params.config.chrome.audioBridgeCommand,
-      audioBridgeHealthCommand: params.config.chrome.audioBridgeHealthCommand,
-    },
-    timeoutMs: addTimerTimeoutGraceMs(params.config.chrome.joinTimeoutMs) ?? 1,
-  });
-  const result = parseNodeStartResult(raw);
-  if (result.audioBridge?.type === "node-command-pair") {
-    if (!result.bridgeId) {
-      throw new Error("Google Meet node did not return an audio bridge id.");
-    }
-    const transport = createNodeMeetingRealtimeAudioTransport({
-      runtime: params.runtime,
-      nodeId,
-      bridgeId: result.bridgeId,
-      audioFormat: params.config.chrome.audioFormat,
-      logger: params.logger,
-      commandName: GOOGLE_MEET_NODE_COMMAND,
-      logScope: GOOGLE_MEET_PLATFORM_ADAPTER.logScope,
-      logPrefix: params.mode === "agent" ? "node agent" : "node",
-    });
-    Reflect.set(
-      transport,
-      Symbol.for("openclaw.internal.meeting-node-output-generation.v1"),
-      result.audioBridge.outputGeneration === true,
-    );
-    const bindings = createMeetingRealtimeEngineBindings({
-      platform: GOOGLE_MEET_PLATFORM_ADAPTER,
-      ...params,
-    });
-    const engine =
-      params.mode === "agent"
-        ? await startMeetingAgentRealtimeEngine({
-            config: params.config,
-            fullConfig: params.fullConfig,
-            runtime: params.runtime,
-            platform: bindings.platform,
-            meetingSessionId: params.meetingSessionId,
-            requesterSessionKey: params.requesterSessionKey,
-            logPrefix: "node",
-            transport,
-            logger: params.logger,
-            consultAgent: bindings.consultAgent,
-          })
-        : await startMeetingRealtimeEngine({
-            config: {
-              ...params.config,
-              realtime: { ...params.config.realtime, strategy: "bidi" },
-            },
-            fullConfig: params.fullConfig,
-            runtime: params.runtime,
-            ...bindings,
-            meetingSessionId: params.meetingSessionId,
-            requesterSessionKey: params.requesterSessionKey,
-            logPrefix: "node",
-            talkSessionId: `google-meet:${params.meetingSessionId}:${result.bridgeId}:node-realtime`,
-            talkContext: { nodeId, bridgeId: result.bridgeId },
-            transport,
-            logger: params.logger,
-          });
-    const bridge: ChromeNodeRealtimeAudioBridgeHandle = {
-      type: "node-command-pair",
-      nodeId,
-      bridgeId: result.bridgeId,
-      ...engine,
-    };
-    return {
-      nodeId,
-      launched: browserControl.launched || result.launched === true,
-      audioBackend: result.audioBackend ?? setup?.audioBackend,
-      audioBridge: bridge,
-      browser: browserControl.browser ?? result.browser,
-      tab: browserControl.tab,
-    };
-  }
-  if (result.audioBridge?.type === "external-command") {
-    return {
-      nodeId,
-      launched: browserControl.launched || result.launched === true,
-      audioBackend: result.audioBackend ?? setup?.audioBackend,
-      audioBridge: { type: "external-command" },
-      browser: browserControl.browser ?? result.browser,
-      tab: browserControl.tab,
-    };
-  }
-  return {
-    nodeId,
-    launched: browserControl.launched || result.launched === true,
-    audioBackend: result.audioBackend ?? setup?.audioBackend,
-    browser: browserControl.browser ?? result.browser,
-    tab: browserControl.tab,
   };
 }

--- a/src/meeting-bot/chrome-transport-types.ts
+++ b/src/meeting-bot/chrome-transport-types.ts
@@ -1,0 +1,117 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
+import type { createMeetingRealtimeEngineBindings } from "./agent-consult.js";
+import type { MeetingAudioBackendSelection } from "./audio-backend.js";
+import type {
+  MeetingBrowserJoinSession,
+  MeetingPlatformAdapter,
+  MeetingPlatformRuntimeMetadata,
+} from "./platform-adapter-contract.js";
+import type { startMeetingAgentRealtimeEngine } from "./realtime-agent-engine.js";
+import type {
+  startMeetingRealtimeEngine,
+  MeetingRealtimeAudioEngineHandle,
+  MeetingRealtimeEngineConfig,
+} from "./realtime-engine.js";
+import type { createLocalMeetingRealtimeAudioTransport } from "./realtime-local-audio-transport.js";
+import type { createNodeMeetingRealtimeAudioTransport } from "./realtime-node-audio-transport.js";
+import type { MeetingBrowserHealth, MeetingTranscriptSnapshot } from "./session-types.js";
+
+export type MeetingChromeTransportConfig = MeetingRealtimeEngineConfig & {
+  chrome: MeetingRealtimeEngineConfig["chrome"] & {
+    audioBackend: MeetingAudioBackendSelection;
+    audioBridgeCommand?: string[];
+    audioBridgeHealthCommand?: string[];
+    audioBufferBytes: number;
+    audioInputCommand?: string[];
+    audioInputCommandOverride?: string[];
+    audioOutputCommand?: string[];
+    audioOutputCommandOverride?: string[];
+    autoJoin: boolean;
+    bargeInCooldownMs: number;
+    bargeInInputCommand?: string[];
+    bargeInPeakThreshold: number;
+    bargeInRmsThreshold: number;
+    browserProfile?: string;
+    guestName: string;
+    joinTimeoutMs: number;
+    launch: boolean;
+    reuseExistingTab: boolean;
+    waitForInCallMs: number;
+  };
+  chromeNode: { node?: string };
+  realtime: MeetingRealtimeEngineConfig["realtime"] & {
+    agentId?: string;
+    toolPolicy: Parameters<
+      typeof createMeetingRealtimeEngineBindings
+    >[0]["config"]["realtime"]["toolPolicy"];
+  };
+};
+
+type MeetingBrowserNodeAdapter = Pick<
+  MeetingPlatformAdapter<unknown, string, MeetingBrowserHealth, MeetingTranscriptSnapshot>,
+  "displayName" | "nodeCommandName" | "nodeConfigPath"
+>;
+
+export type MeetingChromeTransportOptions<
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+  Transcript extends MeetingTranscriptSnapshot,
+> = {
+  browserNodeAdapter: MeetingBrowserNodeAdapter;
+  isRealtimeRouteReady(mode: Mode, health: Health | undefined): boolean;
+  isTalkBackMode(mode: Mode): boolean;
+  meetingLabel: string;
+  nodeCommandName: string;
+  platform: Pick<
+    MeetingPlatformAdapter<MeetingBrowserJoinSession<Mode>, Mode, Health, Transcript>,
+    "browser" | "browserLabel" | "urls" | "nodeCommandName" | "nodeConfigPath"
+  > &
+    MeetingPlatformRuntimeMetadata;
+  preserveTrackedBrowserOnEngineFailure: boolean;
+  // Limit rollback to resources acquired by this attempt; existing platform policy is the default.
+  startupFailurePolicy?: "rollback" | "owned";
+  runtime: {
+    createBindings: typeof createMeetingRealtimeEngineBindings;
+    createLocalAudioTransport: typeof createLocalMeetingRealtimeAudioTransport;
+    createNodeAudioTransport: typeof createNodeMeetingRealtimeAudioTransport;
+    startAgentRealtimeEngine: typeof startMeetingAgentRealtimeEngine;
+    startRealtimeEngine: typeof startMeetingRealtimeEngine;
+  };
+};
+
+export type CommandPairAudioBridge = MeetingRealtimeAudioEngineHandle & { type: "command-pair" };
+export type ExternalAudioBridge = { type: "external-command" };
+
+export type MeetingChromeLaunchParams<Config, Mode extends string> = {
+  runtime: PluginRuntime;
+  config: Config;
+  fullConfig: OpenClawConfig;
+  meetingSessionId: string;
+  requesterSessionKey?: string;
+  mode: Mode;
+  trackedTargetId?: string;
+  url: string;
+  logger: RuntimeLogger;
+};
+
+export type NodeAudioBridge = MeetingRealtimeAudioEngineHandle & {
+  type: "node-command-pair";
+  nodeId: string;
+  bridgeId: string;
+};
+
+export type MeetingChromeRecoveryParams<Config, Mode extends string> = {
+  runtime: PluginRuntime;
+  config: Config;
+  fullConfig?: OpenClawConfig;
+  meetingSessionId?: string;
+  mode: Mode;
+  nodeId?: string;
+  readOnly?: boolean;
+  trackedMeetingUrl?: string;
+  trackedTargetId?: string;
+  transport: "chrome" | "chrome-node";
+  timeoutMs?: number;
+  url?: string;
+};

--- a/src/meeting-bot/chrome-transport.test.ts
+++ b/src/meeting-bot/chrome-transport.test.ts
@@ -145,6 +145,21 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
 
   it("preserves the platform rollback ownership rule for tracked calls", async () => {
     const dispose = vi.fn(async () => {});
+    const engine = {
+      providerId: "openai",
+      speak: vi.fn(),
+      getHealth: vi.fn(),
+      stop: vi.fn(async () => {}),
+    };
+    const startAgent = vi
+      .fn(async () => engine)
+      .mockRejectedValueOnce(new Error("realtime startup failed"));
+    const createBindings = vi.fn(() => ({
+      platform: { displayName: "Test", logScope: "[test]", sessionIdPrefix: "test" },
+      consultAgent: vi.fn(),
+      tools: [],
+      handleToolCall: vi.fn(),
+    }));
     const transport = createMeetingChromeTransport<
       TestConfig,
       TestMode,
@@ -159,12 +174,7 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
       platform,
       preserveTrackedBrowserOnEngineFailure: testCase.preserveTrackedBrowserOnEngineFailure,
       runtime: {
-        createBindings: vi.fn(() => ({
-          platform: { displayName: "Test", logScope: "[test]", sessionIdPrefix: "test" },
-          consultAgent: vi.fn(),
-          tools: [],
-          handleToolCall: vi.fn(),
-        })) as unknown as typeof createMeetingRealtimeEngineBindings,
+        createBindings: createBindings as unknown as typeof createMeetingRealtimeEngineBindings,
         createLocalAudioTransport: vi.fn(() => ({
           clearOutput: vi.fn(),
           dispose,
@@ -175,9 +185,7 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
         })) as unknown as typeof createLocalMeetingRealtimeAudioTransport,
         createNodeAudioTransport:
           vi.fn() as unknown as typeof createNodeMeetingRealtimeAudioTransport,
-        startAgentRealtimeEngine: vi.fn(async () => {
-          throw new Error("realtime startup failed");
-        }) as unknown as typeof startMeetingAgentRealtimeEngine,
+        startAgentRealtimeEngine: startAgent,
         startRealtimeEngine: vi.fn() as unknown as typeof startMeetingRealtimeEngine,
       },
     });
@@ -191,18 +199,18 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
       },
     } as unknown as PluginRuntime;
 
-    await expect(
+    const launch = () =>
       transport.launchInChrome({
         config,
         fullConfig: { transcripts: { enabled: false } } as OpenClawConfig,
         logger,
         meetingSessionId: "session-1",
-        mode: "agent",
+        mode: "agent" as const,
         runtime,
         trackedTargetId: "tracked-tab",
         url: "https://example.test/meeting",
-      }),
-    ).rejects.toThrow("realtime startup failed");
+      });
+    await expect(launch()).rejects.toThrow("realtime startup failed");
 
     expect(dispose).toHaveBeenCalledOnce();
     expect(browserMocks.open).toHaveBeenCalledWith(
@@ -211,6 +219,17 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
       }),
     );
     expect(browserMocks.leave).toHaveBeenCalledTimes(testCase.expectedLeaves);
+    const bindingFailure = new Error("meeting binding failed");
+    createBindings.mockImplementationOnce(() => {
+      throw bindingFailure;
+    });
+    dispose.mockRejectedValueOnce(new Error("cleanup failed"));
+    await expect(launch()).rejects.toBe(bindingFailure);
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(browserMocks.leave).toHaveBeenCalledTimes(testCase.expectedLeaves * 2);
+    const recovered = await launch();
+    expect(recovered.audioBridge).toEqual({ type: "command-pair", ...engine });
+    expect(recovered.audioBridge?.providerId).toBe("openai");
   });
 
   it("enables output generations when the node host advertises support", async () => {
@@ -283,6 +302,7 @@ describe.each(cases)("$name Chrome transport parity", (testCase) => {
     });
 
     expect(result.audioBridge?.type).toBe("node-command-pair");
+    expect(result.audioBridge?.providerId).toBe("openai");
     expect(runtime.nodes.invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         params: expect.objectContaining({

--- a/src/meeting-bot/chrome-transport.ts
+++ b/src/meeting-bot/chrome-transport.ts
@@ -2,12 +2,10 @@ import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coer
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
 import { resolveTranscriptsConfig } from "../transcripts/config.js";
-import type { createMeetingRealtimeEngineBindings } from "./agent-consult.js";
 import {
   ensureMeetingAudioBackend,
   resolveMeetingAudioRuntimeForFormat,
   type MeetingAudioBackend,
-  type MeetingAudioBackendSelection,
   type MeetingAudioRuntime,
 } from "./audio-backend.js";
 import { openMeetingWithBrowser, recoverMeetingBrowserTab } from "./browser-controller.js";
@@ -19,97 +17,41 @@ import {
 } from "./browser-session-control.js";
 import { parseMeetingChromeNodeResult } from "./chrome-node-result.js";
 import type {
-  MeetingBrowserJoinSession,
-  MeetingBrowserRequestCaller,
-  MeetingPlatformAdapter,
-  MeetingPlatformRuntimeMetadata,
-} from "./platform-adapter-contract.js";
-import type { startMeetingAgentRealtimeEngine } from "./realtime-agent-engine.js";
-import type {
-  startMeetingRealtimeEngine,
-  MeetingRealtimeAudioEngineHandle,
-  MeetingRealtimeEngineConfig,
-} from "./realtime-engine.js";
-import type { createLocalMeetingRealtimeAudioTransport } from "./realtime-local-audio-transport.js";
-import type { createNodeMeetingRealtimeAudioTransport } from "./realtime-node-audio-transport.js";
+  CommandPairAudioBridge,
+  ExternalAudioBridge,
+  MeetingChromeLaunchParams,
+  MeetingChromeRecoveryParams,
+  NodeAudioBridge,
+  MeetingChromeTransportConfig,
+  MeetingChromeTransportOptions,
+} from "./chrome-transport-types.js";
+import type { MeetingBrowserRequestCaller } from "./platform-adapter-contract.js";
+import type { MeetingRealtimeAudioEngineHandle } from "./realtime-engine.js";
 import type {
   MeetingBrowserHealth,
   MeetingBrowserTab,
   MeetingTranscriptSnapshot,
 } from "./session-types.js";
 
-export type MeetingChromeTransportConfig = MeetingRealtimeEngineConfig & {
-  chrome: MeetingRealtimeEngineConfig["chrome"] & {
-    audioBackend: MeetingAudioBackendSelection;
-    audioBufferBytes: number;
-    audioInputCommand: string[];
-    audioInputCommandOverride?: string[];
-    audioOutputCommand: string[];
-    audioOutputCommandOverride?: string[];
-    autoJoin: boolean;
-    bargeInCooldownMs: number;
-    bargeInInputCommand?: string[];
-    bargeInPeakThreshold: number;
-    bargeInRmsThreshold: number;
-    browserProfile?: string;
-    guestName: string;
-    joinTimeoutMs: number;
-    launch: boolean;
-    reuseExistingTab: boolean;
-    waitForInCallMs: number;
-  };
-  chromeNode: { node?: string };
-  realtime: MeetingRealtimeEngineConfig["realtime"] & {
-    agentId?: string;
-    toolPolicy: Parameters<
-      typeof createMeetingRealtimeEngineBindings
-    >[0]["config"]["realtime"]["toolPolicy"];
-  };
-};
+export type {
+  MeetingChromeTransportConfig,
+  MeetingChromeTransportOptions,
+} from "./chrome-transport-types.js";
 
-type MeetingBrowserNodeAdapter = Pick<
-  MeetingPlatformAdapter<unknown, string, MeetingBrowserHealth, MeetingTranscriptSnapshot>,
-  "displayName" | "nodeCommandName" | "nodeConfigPath"
->;
-
-export type MeetingChromeTransportOptions<
-  Mode extends string,
-  Health extends MeetingBrowserHealth,
-  Transcript extends MeetingTranscriptSnapshot,
-> = {
-  browserNodeAdapter: MeetingBrowserNodeAdapter;
-  isRealtimeRouteReady(mode: Mode, health: Health | undefined): boolean;
-  isTalkBackMode(mode: Mode): boolean;
-  meetingLabel: string;
-  nodeCommandName: string;
-  platform: MeetingPlatformAdapter<MeetingBrowserJoinSession<Mode>, Mode, Health, Transcript> &
-    MeetingPlatformRuntimeMetadata;
-  preserveTrackedBrowserOnEngineFailure: boolean;
-  runtime: {
-    createBindings: typeof createMeetingRealtimeEngineBindings;
-    createLocalAudioTransport: typeof createLocalMeetingRealtimeAudioTransport;
-    createNodeAudioTransport: typeof createNodeMeetingRealtimeAudioTransport;
-    startAgentRealtimeEngine: typeof startMeetingAgentRealtimeEngine;
-    startRealtimeEngine: typeof startMeetingRealtimeEngine;
-  };
-};
-
-export function createMeetingChromeTransport<
+function createMeetingChromeTransportWithAudioPolicy<
   Config extends MeetingChromeTransportConfig,
   Mode extends string,
   Health extends MeetingBrowserHealth,
   Transcript extends MeetingTranscriptSnapshot,
->(options: MeetingChromeTransportOptions<Mode, Health, Transcript>) {
-  type LocalAudioBridge = MeetingRealtimeAudioEngineHandle & {
-    type: "command-pair";
-  };
-
-  type NodeAudioBridge = MeetingRealtimeAudioEngineHandle & {
-    type: "node-command-pair";
-    nodeId: string;
-    bridgeId: string;
-  };
-
+  LocalBridge extends CommandPairAudioBridge,
+  ExternalBridge extends ExternalAudioBridge,
+>(
+  options: MeetingChromeTransportOptions<Mode, Health, Transcript>,
+  audioBridge: {
+    local(engine: MeetingRealtimeAudioEngineHandle, audio: MeetingAudioRuntime): LocalBridge;
+    external?: () => ExternalBridge;
+  },
+) {
   async function openOrRecoverMeeting(params: {
     callBrowser: MeetingBrowserRequestCaller;
     config: Config;
@@ -168,6 +110,12 @@ export function createMeetingChromeTransport<
     if (!params.tab) {
       return;
     }
+    if (
+      options.startupFailurePolicy === "owned" &&
+      (!params.config.chrome.launch || !params.tab.openedByPlugin)
+    ) {
+      return;
+    }
     const result = await leaveMeetingWithBrowser({
       adapter: options.platform,
       callBrowser: params.callBrowser,
@@ -218,18 +166,35 @@ export function createMeetingChromeTransport<
     await prepareAudioRuntime(params);
   }
 
-  async function startLocalAudioBridge(params: {
-    runtime: PluginRuntime;
-    config: Config;
-    fullConfig: OpenClawConfig;
-    meetingSessionId: string;
-    requesterSessionKey?: string;
-    mode: Mode;
-    logger: RuntimeLogger;
-    audio: MeetingAudioRuntime;
-  }): Promise<LocalAudioBridge | undefined> {
+  async function startLocalAudioBridge(
+    params: MeetingChromeLaunchParams<Config, Mode> & { audio: MeetingAudioRuntime },
+  ): Promise<LocalBridge | ExternalBridge | undefined> {
     if (!options.isTalkBackMode(params.mode)) {
       return undefined;
+    }
+    if (audioBridge.external) {
+      if (params.config.chrome.audioBridgeCommand) {
+        if (params.mode === "agent") {
+          throw new Error(
+            "Chrome agent mode requires chrome.audioInputCommand and chrome.audioOutputCommand so OpenClaw can run STT and regular TTS directly.",
+          );
+        }
+        const bridge = await params.runtime.system.runCommandWithTimeout(
+          params.config.chrome.audioBridgeCommand,
+          { timeoutMs: params.config.chrome.joinTimeoutMs },
+        );
+        if (bridge.code !== 0) {
+          throw new Error(
+            `failed to start Chrome audio bridge: ${bridge.stderr || bridge.stdout || bridge.code}`,
+          );
+        }
+        return audioBridge.external();
+      }
+      if (!params.config.chrome.audioInputCommand || !params.config.chrome.audioOutputCommand) {
+        throw new Error(
+          "Chrome talk-back mode requires chrome.audioInputCommand and chrome.audioOutputCommand, or chrome.audioBridgeCommand for an external bridge.",
+        );
+      }
     }
     const transport = options.runtime.createLocalAudioTransport({
       inputCommand: params.audio.inputCommand,
@@ -242,11 +207,11 @@ export function createMeetingChromeTransport<
       logger: params.logger,
       logScope: options.platform.logScope,
     });
-    const bindings = options.runtime.createBindings({
-      platform: options.platform,
-      ...params,
-    });
     try {
+      const bindings = options.runtime.createBindings({
+        platform: options.platform,
+        ...params,
+      });
       const engine =
         params.mode === "agent"
           ? await options.runtime.startAgentRealtimeEngine({
@@ -273,27 +238,17 @@ export function createMeetingChromeTransport<
               transport,
               logger: params.logger,
             });
-      return { type: "command-pair", ...engine };
+      return audioBridge.local(engine, params.audio);
     } catch (error) {
       await transport.dispose().catch(() => {});
       throw error;
     }
   }
 
-  async function launchInChrome(params: {
-    runtime: PluginRuntime;
-    config: Config;
-    fullConfig: OpenClawConfig;
-    meetingSessionId: string;
-    requesterSessionKey?: string;
-    mode: Mode;
-    trackedTargetId?: string;
-    url: string;
-    logger: RuntimeLogger;
-  }): Promise<{
+  async function launchInChrome(params: MeetingChromeLaunchParams<Config, Mode>): Promise<{
     launched: boolean;
     audioBackend?: MeetingAudioBackend;
-    audioBridge?: LocalAudioBridge;
+    audioBridge?: LocalBridge | ExternalBridge;
     browser?: Health;
     tab?: MeetingBrowserTab;
   }> {
@@ -304,6 +259,17 @@ export function createMeetingChromeTransport<
           timeoutMs: Math.min(params.config.chrome.joinTimeoutMs, 10_000),
         })
       : undefined;
+    if (audio && audioBridge.external && params.config.chrome.audioBridgeHealthCommand) {
+      const health = await params.runtime.system.runCommandWithTimeout(
+        params.config.chrome.audioBridgeHealthCommand,
+        { timeoutMs: params.config.chrome.joinTimeoutMs },
+      );
+      if (health.code !== 0) {
+        throw new Error(
+          `Chrome audio bridge health check failed: ${health.stderr || health.stdout || health.code}`,
+        );
+      }
+    }
     const callBrowser = await resolveLocalMeetingBrowserRequest(params.runtime);
     const result = await openOrRecoverMeeting({
       callBrowser,
@@ -369,21 +335,11 @@ export function createMeetingChromeTransport<
       `${options.meetingLabel} node returned an invalid start result.`,
     );
 
-  async function launchOnNode(params: {
-    runtime: PluginRuntime;
-    config: Config;
-    fullConfig: OpenClawConfig;
-    meetingSessionId: string;
-    requesterSessionKey?: string;
-    mode: Mode;
-    trackedTargetId?: string;
-    url: string;
-    logger: RuntimeLogger;
-  }): Promise<{
+  async function launchOnNode(params: MeetingChromeLaunchParams<Config, Mode>): Promise<{
     nodeId: string;
     launched: boolean;
     audioBackend?: MeetingAudioBackend;
-    audioBridge?: NodeAudioBridge;
+    audioBridge?: NodeAudioBridge | ExternalBridge;
     browser?: Health;
     tab?: MeetingBrowserTab;
   }> {
@@ -454,6 +410,8 @@ export function createMeetingChromeTransport<
         tab: browser.tab,
       };
     }
+    let startedBridgeId: string | undefined;
+    let audioTransport: ReturnType<typeof options.runtime.createNodeAudioTransport> | undefined;
     try {
       const raw = await params.runtime.nodes.invoke({
         nodeId,
@@ -474,6 +432,12 @@ export function createMeetingChromeTransport<
           audioBackend: params.config.chrome.audioBackend,
           audioFormat: params.config.chrome.audioFormat,
           audioBufferBytes: params.config.chrome.audioBufferBytes,
+          ...(audioBridge.external
+            ? {
+                audioBridgeCommand: params.config.chrome.audioBridgeCommand,
+                audioBridgeHealthCommand: params.config.chrome.audioBridgeHealthCommand,
+              }
+            : {}),
         },
         timeoutMs: addTimerTimeoutGraceMs(params.config.chrome.joinTimeoutMs) ?? 1,
       });
@@ -485,11 +449,15 @@ export function createMeetingChromeTransport<
           audioBackend: result.audioBackend ?? audioSetup?.audioBackend,
           browser: browser.browser ?? result.browser,
           tab: browser.tab,
+          ...(audioBridge.external && result.audioBridge?.type === "external-command"
+            ? { audioBridge: audioBridge.external() }
+            : {}),
         };
       }
       if (!result.bridgeId) {
         throw new Error(`${options.meetingLabel} node did not return an audio bridge id.`);
       }
+      startedBridgeId = result.bridgeId;
       const transport = options.runtime.createNodeAudioTransport({
         runtime: params.runtime,
         nodeId,
@@ -500,6 +468,7 @@ export function createMeetingChromeTransport<
         logScope: options.platform.logScope,
         logPrefix: params.mode === "agent" ? "node agent" : "node",
       });
+      audioTransport = transport;
       Reflect.set(
         transport,
         Symbol.for("openclaw.internal.meeting-node-output-generation.v1"),
@@ -509,42 +478,36 @@ export function createMeetingChromeTransport<
         platform: options.platform,
         ...params,
       });
-      let engine: MeetingRealtimeAudioEngineHandle;
-      try {
-        engine =
-          params.mode === "agent"
-            ? await options.runtime.startAgentRealtimeEngine({
-                config: params.config,
-                fullConfig: params.fullConfig,
-                runtime: params.runtime,
-                platform: bindings.platform,
-                meetingSessionId: params.meetingSessionId,
-                requesterSessionKey: params.requesterSessionKey,
-                logPrefix: "node",
-                transport,
-                logger: params.logger,
-                consultAgent: bindings.consultAgent,
-              })
-            : await options.runtime.startRealtimeEngine({
-                config: {
-                  ...params.config,
-                  realtime: { ...params.config.realtime, strategy: "bidi" },
-                },
-                fullConfig: params.fullConfig,
-                runtime: params.runtime,
-                ...bindings,
-                meetingSessionId: params.meetingSessionId,
-                requesterSessionKey: params.requesterSessionKey,
-                logPrefix: "node",
-                talkSessionId: `${options.platform.id}:${params.meetingSessionId}:${result.bridgeId}:node-realtime`,
-                talkContext: { nodeId, bridgeId: result.bridgeId },
-                transport,
-                logger: params.logger,
-              });
-      } catch (error) {
-        await transport.dispose().catch(() => {});
-        throw error;
-      }
+      const engine =
+        params.mode === "agent"
+          ? await options.runtime.startAgentRealtimeEngine({
+              config: params.config,
+              fullConfig: params.fullConfig,
+              runtime: params.runtime,
+              platform: bindings.platform,
+              meetingSessionId: params.meetingSessionId,
+              requesterSessionKey: params.requesterSessionKey,
+              logPrefix: "node",
+              transport,
+              logger: params.logger,
+              consultAgent: bindings.consultAgent,
+            })
+          : await options.runtime.startRealtimeEngine({
+              config: {
+                ...params.config,
+                realtime: { ...params.config.realtime, strategy: "bidi" },
+              },
+              fullConfig: params.fullConfig,
+              runtime: params.runtime,
+              ...bindings,
+              meetingSessionId: params.meetingSessionId,
+              requesterSessionKey: params.requesterSessionKey,
+              logPrefix: "node",
+              talkSessionId: `${options.platform.id}:${params.meetingSessionId}:${result.bridgeId}:node-realtime`,
+              talkContext: { nodeId, bridgeId: result.bridgeId },
+              transport,
+              logger: params.logger,
+            });
       return {
         nodeId,
         launched: browser.launched || result.launched === true,
@@ -559,14 +522,28 @@ export function createMeetingChromeTransport<
         tab: browser.tab,
       };
     } catch (error) {
-      await params.runtime.nodes
-        .invoke({
-          nodeId,
-          command: options.nodeCommandName,
-          params: { action: "stopByUrl", url: params.url, mode: params.mode },
-          timeoutMs: 5_000,
-        })
-        .catch(() => {});
+      await audioTransport?.dispose().catch(() => {});
+      if (options.startupFailurePolicy === "owned") {
+        if (!audioTransport && startedBridgeId) {
+          await params.runtime.nodes
+            .invoke({
+              nodeId,
+              command: options.nodeCommandName,
+              params: { action: "stop", bridgeId: startedBridgeId },
+              timeoutMs: 5_000,
+            })
+            .catch(() => {});
+        }
+      } else {
+        await params.runtime.nodes
+          .invoke({
+            nodeId,
+            command: options.nodeCommandName,
+            params: { action: "stopByUrl", url: params.url, mode: params.mode },
+            timeoutMs: 5_000,
+          })
+          .catch(() => {});
+      }
       if (!options.preserveTrackedBrowserOnEngineFailure || !params.trackedTargetId) {
         await rollbackBrowserJoin({
           callBrowser,
@@ -581,20 +558,7 @@ export function createMeetingChromeTransport<
     }
   }
 
-  async function recoverCurrentTab(params: {
-    runtime: PluginRuntime;
-    config: Config;
-    fullConfig?: OpenClawConfig;
-    meetingSessionId?: string;
-    mode: Mode;
-    nodeId?: string;
-    readOnly?: boolean;
-    trackedMeetingUrl?: string;
-    trackedTargetId?: string;
-    transport: "chrome" | "chrome-node";
-    timeoutMs?: number;
-    url?: string;
-  }) {
+  async function recoverCurrentTab(params: MeetingChromeRecoveryParams<Config, Mode>) {
     const nodeId =
       params.transport === "chrome-node"
         ? (params.nodeId ??
@@ -703,4 +667,46 @@ export function createMeetingChromeTransport<
     readTranscript,
     recoverCurrentTab,
   };
+}
+
+export function createMeetingChromeTransport<
+  Config extends MeetingChromeTransportConfig,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+  Transcript extends MeetingTranscriptSnapshot,
+>(options: MeetingChromeTransportOptions<Mode, Health, Transcript>) {
+  return createMeetingChromeTransportWithAudioPolicy<
+    Config,
+    Mode,
+    Health,
+    Transcript,
+    CommandPairAudioBridge,
+    never
+  >(options, {
+    local: (engine) => ({ type: "command-pair", ...engine }),
+  });
+}
+
+export function createMeetingChromeTransportWithExternalAudio<
+  Config extends MeetingChromeTransportConfig,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+  Transcript extends MeetingTranscriptSnapshot,
+>(options: MeetingChromeTransportOptions<Mode, Health, Transcript>) {
+  return createMeetingChromeTransportWithAudioPolicy<
+    Config,
+    Mode,
+    Health,
+    Transcript,
+    CommandPairAudioBridge & Pick<MeetingAudioRuntime, "inputCommand" | "outputCommand">,
+    ExternalAudioBridge
+  >(options, {
+    local: (engine, audio) => ({
+      type: "command-pair",
+      inputCommand: audio.inputCommand,
+      outputCommand: audio.outputCommand,
+      ...engine,
+    }),
+    external: () => ({ type: "external-command" }),
+  });
 }

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { formatErrorMessage } from "../infra/errors.js";
 import { ensureMeetingAudioBackend, resolveMeetingAudioRuntimeForFormat } from "./audio-backend.js";
-import { createMeetingChromeTransport } from "./chrome-transport.js";
+import {
+  createMeetingChromeTransport,
+  createMeetingChromeTransportWithExternalAudio,
+} from "./chrome-transport.js";
 import { createMeetingConfiguredNodeHost } from "./configured-node-host.js";
 import { isMeetingRealtimeRouteReady, isMeetingTalkBackMode } from "./meeting-modes.js";
 import type {
@@ -383,6 +386,7 @@ function createMeetingPlatformAdapter<
 export const MeetingPlatformAdapter = {
   create: createMeetingPlatformAdapter,
   createChromeTransport: createMeetingChromeTransport,
+  createChromeTransportWithExternalAudio: createMeetingChromeTransportWithExternalAudio,
   createChromeRuntimeBindings: createMeetingChromeRuntimeBindings,
   createPluginChromeTransport: createMeetingPluginChromeTransport,
   createPluginConfigSchema: createMeetingPluginConfigSchema,


### PR DESCRIPTION
Closes #143388

## What Problem This Solves

Fixes an issue where users joining Google Meet through Chrome could leave newly started audio processes or a node audio bridge running when provider setup failed. The join failed before the session received the handles needed to clean those resources up.

## Why This Change Was Made

Google Meet now uses the existing shared Chrome launch owner for local and node sessions. That owner retains resources until it either hands a working bridge to the session or cleans up a failed start, including failures while constructing agent bindings. External audio commands remain supported through a typed factory.

Google cleanup stops the exact returned node bridge and only rolls back a browser tab opened by that attempt. Reused tabs and `chrome.launch: false` retain their existing ownership; Teams and Zoom retain their existing browser and node fallback policies.

## User Impact

Failed provider startup releases the audio resources that OpenClaw just created and preserves the original error. Successful joins, external bridges, transcripts, node selection, and recovery continue through their existing contracts, with one shared launch implementation.

If a node start fails before returning a bridge ID, this change cannot identify that remote resource and does not add URL-wide cleanup for Google Meet.

## Evidence

The original source fails all six Google cleanup regressions and two shared binding-cleanup assertions. The candidate passed 212 focused Google/shared/Teams/Zoom cases; the final startup fixture rerun passed all seven cases after lint-only brace changes. All four TypeScript lanes pass. Independent P0–P2 review found no actionable issues; the later contract extraction has byte-identical executable output, and its type/docs changes were separately reviewed. Browser, node, and process boundaries are synthetic; no live meeting is claimed.

The full changed-file gate passed, including all four typecheck lanes, dead-export scans, lint, boundaries, and runtime-cycle guards. `pnpm build` also passed, including declaration generation, Plugin SDK exports, and package/UI build checks. All eight changed/new source files match the final verified snapshot.
