### PR TITLE
fix(test): close token store database before fixture removal

### DIFF
--- a/src/gateway/auth-token-store-ref.test.ts
+++ b/src/gateway/auth-token-store-ref.test.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readSecretStoreValue, writeSecretStoreEntry } from "../secrets/store/secret-store.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import { provisionGatewayTokenStoreRef } from "./auth-token-store-ref.js";
 
@@ -23,6 +25,9 @@ describe("provisionGatewayTokenStoreRef", () => {
   });
 
   afterEach(() => {
+    closeOpenClawStateDatabaseByPath(
+      resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir }),
+    );
     fs.rmSync(stateDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where gateway token-store tests remove their temporary SQLite files while the cached database handles remain open. Those handles can outlive the fixture in a shared test worker.

## Why This Change Was Made

Close the exact fixture-owned shared-state database through the existing canonical path resolver before removing its directory. A close error remains visible and prevents removal. All four cases, inputs and assertions stay unchanged; production code is untouched.

## User Impact

Test-only lifecycle repair. The token-store fixtures release their own database resources before cleanup without closing unrelated fixtures.

## Evidence

- A bounded local observation found one naturally opened handle still open immediately before the original unlink in each of the four cases. The repaired teardown closed all four before unlink, without an additional diagnostic safety close.
- All four uninstrumented cases passed through `node scripts/run-vitest.mjs src/gateway/auth-token-store-ref.test.ts`; their ordered identities and original case bodies are unchanged.
- An injected close-error control propagated the error, skipped removal and preserved the temporary root.
- Scoped `check-changed` and independent P2 review passed. Proof used local Node 26.8.1; this does not attribute any historical Linux worker kill to these fixtures.
