### PR TITLE
refactor: unify missing-command ownership resolution

### DIFF
--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -5,12 +5,9 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
-import {
-  resolveManifestCommandAliasOwnerInRegistry,
-  resolveManifestToolOwnerInRegistry,
-  type PluginManifestCommandAliasRecord,
-  type PluginManifestCommandAliasRegistry,
-  type PluginManifestToolOwnerRecord,
+import type {
+  PluginManifestCommandAliasRecord,
+  PluginManifestToolOwnerRecord,
 } from "../plugins/manifest-command-aliases.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { isSimpleCommandHelpInvocation } from "./argv.js";
@@ -129,21 +126,17 @@ export function resolveMissingPluginCommandMessage(
   pluginId: string,
   config?: OpenClawConfig,
   options?: {
-    registry?: PluginManifestCommandAliasRegistry;
     resolveCommandAliasOwner?: (params: {
       command: string | undefined;
       config?: OpenClawConfig;
-      registry?: PluginManifestCommandAliasRegistry;
     }) => PluginManifestCommandAliasRecord | undefined;
     resolveToolOwner?: (params: {
       toolName: string | undefined;
       config?: OpenClawConfig;
-      registry?: PluginManifestCommandAliasRegistry;
     }) => PluginManifestToolOwnerRecord | undefined;
     resolveCliCommandSurfaceOwner?: (params: {
       command: string | undefined;
       config?: OpenClawConfig;
-      registry?: PluginManifestCommandAliasRegistry;
     }) => string | undefined;
   },
 ): string | null {
@@ -158,16 +151,10 @@ export function resolveMissingPluginCommandMessage(
           .map((entry) => normalizeOptionalLowercaseString(entry))
           .filter(Boolean)
       : [];
-  const commandAlias = options?.registry
-    ? resolveManifestCommandAliasOwnerInRegistry({
-        command: normalizedPluginId,
-        registry: options.registry,
-      })
-    : options?.resolveCommandAliasOwner?.({
-        command: normalizedPluginId,
-        config,
-        ...(options?.registry ? { registry: options.registry } : {}),
-      });
+  const commandAlias = options?.resolveCommandAliasOwner?.({
+    command: normalizedPluginId,
+    config,
+  });
   const parentPluginId = commandAlias?.pluginId;
   if (parentPluginId) {
     if (allow.length > 0 && !allow.includes(parentPluginId)) {
@@ -218,22 +205,12 @@ export function resolveMissingPluginCommandMessage(
     return null;
   }
 
-  const toolOwner = options?.registry
-    ? resolveManifestToolOwnerInRegistry({
-        toolName: normalizedPluginId,
-        registry: options.registry,
-      })
-    : options?.resolveToolOwner?.({
-        toolName: normalizedPluginId,
-        config,
-        ...(options?.registry ? { registry: options.registry } : {}),
-      });
+  const toolOwner = options?.resolveToolOwner?.({
+    toolName: normalizedPluginId,
+    config,
+  });
   if (toolOwner) {
-    // Apply plugins.allow / plugins.entries[X].enabled to the owning plugin so
-    // a disabled/denied plugin's manifest-declared tool name does not get a
-    // false attribution. The runtime resolver
-    // (resolveManifestToolOwner) already filters by control-plane availability,
-    // but pure-registry callers and any future ones still need this guard.
+    // Availability metadata does not override the owning plugin's allowlist or disablement.
     const ownerEnabled =
       config?.plugins?.entries?.[toolOwner.pluginId]?.enabled !== false &&
       (allow.length === 0 || allow.includes(toolOwner.pluginId));
@@ -263,18 +240,10 @@ export function resolveMissingPluginCommandMessage(
     if (parentPluginId && allow.includes(parentPluginId)) {
       return null;
     }
-    const cliCommandSurfaceOwner = options?.resolveCliCommandSurfaceOwner
-      ? options.resolveCliCommandSurfaceOwner({
-          command: normalizedPluginId,
-          config,
-          ...(options?.registry ? { registry: options.registry } : {}),
-        })
-      : options?.registry
-        ? resolveManifestCommandAliasOwnerInRegistry({
-            command: normalizedPluginId,
-            registry: options.registry,
-          })?.pluginId
-        : undefined;
+    const cliCommandSurfaceOwner = options?.resolveCliCommandSurfaceOwner?.({
+      command: normalizedPluginId,
+      config,
+    });
     const normalizedCliCommandSurfaceOwner =
       normalizeOptionalLowercaseString(cliCommandSurfaceOwner);
     if (!normalizedCliCommandSurfaceOwner) {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,6 +1,10 @@
 // Run main tests cover CLI main entrypoint behavior and process error handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
+import {
+  resolveManifestCommandAliasOwnerInRegistry,
+  resolveManifestToolOwnerInRegistry,
+  type PluginManifestCommandAliasRegistry,
+} from "../plugins/manifest-command-aliases.js";
 import {
   resolveGatewayCatalogCommandPath,
   resolveGatewayRunPreBootstrapOptions,
@@ -418,6 +422,15 @@ describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
   });
 });
 
+function commandResolvers(registry: PluginManifestCommandAliasRegistry) {
+  return {
+    resolveCommandAliasOwner: ({ command }: { command: string | undefined }) =>
+      resolveManifestCommandAliasOwnerInRegistry({ command, registry }),
+    resolveToolOwner: ({ toolName }: { toolName: string | undefined }) =>
+      resolveManifestToolOwnerInRegistry({ toolName, registry }),
+  };
+}
+
 describe("resolveMissingPluginCommandMessage", () => {
   it("explains plugins.allow misses for a bundled plugin command", () => {
     expect(
@@ -428,7 +441,7 @@ describe("resolveMissingPluginCommandMessage", () => {
             allow: ["quietchat"],
           },
         },
-        { registry: browserCommandAliasRegistry },
+        commandResolvers(browserCommandAliasRegistry),
       ),
     ).toBe(
       'The `openclaw browser` command is unavailable because `plugins.allow` excludes "browser". Add "browser" to `plugins.allow` if you want that bundled plugin CLI surface.',
@@ -476,9 +489,7 @@ describe("resolveMissingPluginCommandMessage", () => {
     const message = resolveMissingPluginCommandMessage(
       "dreaming",
       {},
-      {
-        registry: memoryCoreCommandAliasRegistry,
-      },
+      commandResolvers(memoryCoreCommandAliasRegistry),
     );
     expect(message).toBe(
       '"dreaming" is a runtime slash command (/dreaming), not a CLI command. It is provided by the "memory-core" plugin. Use `openclaw memory` for related CLI operations, or `/dreaming` in a chat session.',
@@ -493,9 +504,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["memory-core"],
         },
       },
-      {
-        registry: memoryCoreCommandAliasRegistry,
-      },
+      commandResolvers(memoryCoreCommandAliasRegistry),
     );
     expect(message).toContain("runtime slash command");
     expect(message).not.toContain("plugins.allow");
@@ -509,9 +518,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["dreaming"],
         },
       },
-      {
-        registry: memoryCoreCommandAliasRegistry,
-      },
+      commandResolvers(memoryCoreCommandAliasRegistry),
     );
     expect(message).toBe(
       '"dreaming" is not a plugin; it is a command provided by the "memory-core" plugin. Add "memory-core" to `plugins.allow` instead of "dreaming".',
@@ -522,16 +529,14 @@ describe("resolveMissingPluginCommandMessage", () => {
     const message = resolveMissingPluginCommandMessage(
       "voicecall",
       {},
-      {
-        registry: {
-          plugins: [
-            {
-              id: "voice-call",
-              commandAliases: [{ name: "voicecall" }],
-            },
-          ],
-        },
-      },
+      commandResolvers({
+        plugins: [
+          {
+            id: "voice-call",
+            commandAliases: [{ name: "voicecall" }],
+          },
+        ],
+      }),
     );
 
     expect(message).toContain('"voice-call" plugin');
@@ -543,7 +548,7 @@ describe("resolveMissingPluginCommandMessage", () => {
     const message = resolveMissingPluginCommandMessage(
       "workboard",
       {},
-      { registry: workboardCommandAliasRegistry },
+      commandResolvers(workboardCommandAliasRegistry),
     );
 
     expect(message).toBe(
@@ -563,16 +568,14 @@ describe("resolveMissingPluginCommandMessage", () => {
           },
         },
       },
-      {
-        registry: {
-          plugins: [
-            {
-              id: "voice-call",
-              commandAliases: [{ name: "voicecall" }],
-            },
-          ],
-        },
-      },
+      commandResolvers({
+        plugins: [
+          {
+            id: "voice-call",
+            commandAliases: [{ name: "voicecall" }],
+          },
+        ],
+      }),
     );
 
     expect(message).toBeNull();
@@ -590,9 +593,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           },
         },
       },
-      {
-        registry: memoryCoreCommandAliasRegistry,
-      },
+      commandResolvers(memoryCoreCommandAliasRegistry),
     );
     expect(message).toContain("plugins.entries.memory-core.enabled=false");
     expect(message).not.toContain("runtime slash command");
@@ -606,7 +607,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["memory-wiki"],
         },
       },
-      { registry: memoryWikiCommandAliasRegistry },
+      commandResolvers(memoryWikiCommandAliasRegistry),
     );
     expect(message).toBeNull();
   });
@@ -619,7 +620,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["quietchat"],
         },
       },
-      { registry: memoryWikiCommandAliasRegistry },
+      commandResolvers(memoryWikiCommandAliasRegistry),
     );
     expect(message).toContain('"memory-wiki"');
     expect(message).toContain("plugins.allow");
@@ -633,7 +634,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["lossless-claw"],
         },
       },
-      { registry: losslessClawToolRegistry },
+      commandResolvers(losslessClawToolRegistry),
     );
     if (message === null) {
       throw new Error("expected missing plugin command message");
@@ -644,9 +645,11 @@ describe("resolveMissingPluginCommandMessage", () => {
   });
 
   it("matches agent tool names case-insensitively", () => {
-    const message = resolveMissingPluginCommandMessage("LCM_Recent", undefined, {
-      registry: losslessClawToolRegistry,
-    });
+    const message = resolveMissingPluginCommandMessage(
+      "LCM_Recent",
+      undefined,
+      commandResolvers(losslessClawToolRegistry),
+    );
     if (message === null) {
       throw new Error("expected missing plugin command message");
     }
@@ -662,7 +665,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["quietchat"],
         },
       },
-      { registry: losslessClawToolRegistry },
+      commandResolvers(losslessClawToolRegistry),
     );
     expect(message).toBeNull();
   });
@@ -695,7 +698,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["quietchat"],
         },
       },
-      { registry: losslessClawToolRegistry },
+      commandResolvers(losslessClawToolRegistry),
     );
     expect(message).toBeNull();
   });
@@ -710,7 +713,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           },
         },
       },
-      { registry: losslessClawToolRegistry },
+      commandResolvers(losslessClawToolRegistry),
     );
     // entries.<id>.enabled = false on the OWNING plugin invalidates the
     // plugin-tool attribution. With no allow filter on the bare name the


### PR DESCRIPTION
## What Problem This Solves

Missing-command diagnostics have two ownership-resolution paths: resolver callbacks used by runtime, and a registry option used only by tests. The second path duplicates policy plumbing and makes the tests exercise a different interface from the real callers.

## Why This Change Was Made

Remove the unused registry option and its alternate branches. Tests now pass the existing pure registry lookups through the same resolver callbacks that production uses. Keep normalized callback arguments, callback order and binding, explicit undefined config fields, short circuits, allowlist/disablement rules, messages, and ExpectedCliError behavior unchanged.

The diff removes 31 production lines and adds three test lines overall. It also removes a runtime import of a lightweight lookup module; this is not claimed to remove a heavy startup graph.

## User Impact

No intended user-visible behavior change. Missing-command messages and plugin ownership decisions remain the same, with one internal resolution interface to maintain. This is a code cleanup, not a demonstrated CLI speedup.

## Evidence

- 62 focused tests and seven selected real exit cases passed, plus a full candidate build in the earlier [normal validation run](https://github.com/openclaw/openclaw/actions/runs/34397504999).
- Independent Codex review found no actionable P0–P2 defects.
- Both independent baseline/candidate source checkouts completed frozen installation and full builds. The candidate passed the seven remaining supplemental guards.
- [Built-CLI Testbox run](https://github.com/openclaw/openclaw/actions/runs/34405547044): 60 fresh actual `openclaw.mjs` processes, covering runtime slash, disabled alias, and allowlist-excluded owner diagnostics. Every invocation returned the exact expected exit code, full stderr, and empty stdout. Complete source/build manifests were verified before and after the cohort; both task containers and the lease were stopped. An independent audit reconciled all 71 setup/CLI outcomes and output bytes. Compiled binaries were not downloaded for a second independent rehash.

The timing results are mixed. Candidate-minus-baseline median wall changes, keeping the two orders separate:

| Case | Baseline then candidate | Candidate then baseline |
|---|---:|---:|
| Runtime slash | +29.69% | −20.58% |
| Disabled alias | +4.36% | +1.02% |
| Excluded owner | −8.30% | +18.27% |

Four of six medians were slower. CPU results were similarly mixed, and all warmup/adverse observations are retained. These small samples do not establish a speedup or a causal regression; no Gateway or memory-saving claim is made. The earlier local staging refusal ran zero targets and was kept separate from this completed cohort.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34407357675) passed: 29 jobs succeeded and 17 were scope-skipped. Native review, preparation, and merge completed; landed as `e8e41ad2dd4a1d3dca90468215d3c27bf1c1d61f`.
