### PR TITLE
refactor(signal): exercise real inbound orchestration in tests

### DIFF
--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -41,44 +41,14 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
     "openclaw/plugin-sdk/channel-inbound",
   );
-  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  const { createSignalPreparedDispatchRunner } = await import("./event-handler.test-harness.js");
   return {
     ...actual,
-    runChannelInboundEvent: async (params: RunParams) => {
-      const input = await params.adapter.ingest(params.raw);
-      if (!input) {
-        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
-      }
-      const eventClass = (await params.adapter.classify?.(input)) ?? {
-        kind: "message" as const,
-        canStartAgentTurn: true,
-      };
-      const preflight = (await params.adapter.preflight?.(input, eventClass)) ?? {};
-      const resolved = await params.adapter.resolveTurn(
-        input,
-        eventClass,
-        "kind" in preflight ? { admission: preflight } : preflight,
-      );
-      if (!("route" in resolved) || !("delivery" in resolved)) {
-        throw new Error("expected assembled Signal channel turn plan");
-      }
-      const result = await actual.runPreparedInboundReply({
-        channel: resolved.channel,
-        accountId: resolved.accountId,
-        routeSessionKey: resolved.route.sessionKey,
-        storePath: "/tmp/openclaw/signal-sessions.json",
-        ctxPayload: resolved.ctxPayload,
-        recordInboundSession: recordInboundSessionMock,
-        afterRecord: resolved.afterRecord,
-        record: resolved.record,
-        history: resolved.history,
-        admission: resolved.admission,
-        botLoopProtection: resolved.botLoopProtection,
-        runDispatch: async () => await dispatchInboundMessageMock({ ctx: resolved.ctxPayload }),
-      });
-      await params.adapter.onFinalize?.(result);
-      return result;
-    },
+    runChannelInboundEvent: createSignalPreparedDispatchRunner(
+      actual.runChannelInboundEvent,
+      recordInboundSessionMock,
+      async (resolved) => await dispatchInboundMessageMock({ ctx: resolved.ctxPayload }),
+    ),
   };
 });
 

--- a/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
+++ b/extensions/signal/src/monitor/event-handler.ingress-lifecycle.test.ts
@@ -53,48 +53,18 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
     "openclaw/plugin-sdk/channel-inbound",
   );
-  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  const { createSignalPreparedDispatchRunner } = await import("./event-handler.test-harness.js");
   return {
     ...actual,
-    runChannelInboundEvent: async (params: RunParams) => {
-      const input = await params.adapter.ingest(params.raw);
-      if (!input) {
-        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
-      }
-      const eventClass = (await params.adapter.classify?.(input)) ?? {
-        kind: "message" as const,
-        canStartAgentTurn: true,
-      };
-      const preflight = (await params.adapter.preflight?.(input, eventClass)) ?? {};
-      const resolved = await params.adapter.resolveTurn(
-        input,
-        eventClass,
-        "kind" in preflight ? { admission: preflight } : preflight,
-      );
-      if (!("route" in resolved) || !("delivery" in resolved)) {
-        throw new Error("expected assembled Signal channel turn plan");
-      }
-      const result = await actual.runPreparedInboundReply({
-        channel: resolved.channel,
-        accountId: resolved.accountId,
-        routeSessionKey: resolved.route.sessionKey,
-        storePath: "/tmp/openclaw/signal-sessions.json",
-        ctxPayload: resolved.ctxPayload,
-        recordInboundSession: recordInboundSessionMock,
-        afterRecord: resolved.afterRecord,
-        record: resolved.record,
-        history: resolved.history,
-        admission: resolved.admission,
-        botLoopProtection: resolved.botLoopProtection,
-        runDispatch: async () =>
-          await dispatchInboundMessageMock({
-            ctx: resolved.ctxPayload,
-            replyOptions: resolved.replyOptions,
-          }),
-      });
-      await params.adapter.onFinalize?.(result);
-      return result;
-    },
+    runChannelInboundEvent: createSignalPreparedDispatchRunner(
+      actual.runChannelInboundEvent,
+      recordInboundSessionMock,
+      async (resolved) =>
+        await dispatchInboundMessageMock({
+          ctx: resolved.ctxPayload,
+          replyOptions: resolved.replyOptions,
+        }),
+    ),
   };
 });
 

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -54,47 +54,17 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
     "openclaw/plugin-sdk/channel-inbound",
   );
-  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  const { createSignalPreparedDispatchRunner } = await import("./event-handler.test-harness.js");
   return {
     ...actual,
-    runChannelInboundEvent: async (params: RunParams) => {
-      const input = await params.adapter.ingest(params.raw);
-      if (!input) {
-        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
-      }
-      const eventClass = (await params.adapter.classify?.(input)) ?? {
-        kind: "message" as const,
-        canStartAgentTurn: true,
-      };
-      const preflight = (await params.adapter.preflight?.(input, eventClass)) ?? {};
-      const resolved = await params.adapter.resolveTurn(
-        input,
-        eventClass,
-        "kind" in preflight ? { admission: preflight } : preflight,
-      );
-      if (!("route" in resolved) || !("delivery" in resolved)) {
-        throw new Error("expected assembled Signal channel turn plan");
-      }
-      const result = await actual.runPreparedInboundReply({
-        channel: resolved.channel,
-        accountId: resolved.accountId,
-        routeSessionKey: resolved.route.sessionKey,
-        storePath: "/tmp/openclaw/signal-sessions.json",
-        ctxPayload: resolved.ctxPayload,
-        recordInboundSession: async () => {},
-        afterRecord: resolved.afterRecord,
-        record: resolved.record,
-        history: resolved.history,
-        admission: resolved.admission,
-        botLoopProtection: resolved.botLoopProtection,
-        runDispatch: async () => {
-          capturedCtx = resolved.ctxPayload as SignalMsgContext;
-          return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
-        },
-      });
-      await params.adapter.onFinalize?.(result);
-      return result;
-    },
+    runChannelInboundEvent: createSignalPreparedDispatchRunner(
+      actual.runChannelInboundEvent,
+      async () => {},
+      async (resolved) => {
+        capturedCtx = resolved.ctxPayload as SignalMsgContext;
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      },
+    ),
   };
 });
 

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -82,44 +82,14 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
     "openclaw/plugin-sdk/channel-inbound",
   );
-  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  const { createSignalPreparedDispatchRunner } = await import("./event-handler.test-harness.js");
   return {
     ...actual,
-    runChannelInboundEvent: async (params: RunParams) => {
-      const input = await params.adapter.ingest(params.raw);
-      if (!input) {
-        return { admission: { kind: "drop" as const, reason: "ingest-null" }, dispatched: false };
-      }
-      const eventClass = (await params.adapter.classify?.(input)) ?? {
-        kind: "message" as const,
-        canStartAgentTurn: true,
-      };
-      const preflight = (await params.adapter.preflight?.(input, eventClass)) ?? {};
-      const resolved = await params.adapter.resolveTurn(
-        input,
-        eventClass,
-        "kind" in preflight ? { admission: preflight } : preflight,
-      );
-      if (!("route" in resolved) || !("delivery" in resolved)) {
-        throw new Error("expected assembled Signal channel turn plan");
-      }
-      const result = await actual.runPreparedInboundReply({
-        channel: resolved.channel,
-        accountId: resolved.accountId,
-        routeSessionKey: resolved.route.sessionKey,
-        storePath: "/tmp/openclaw/signal-sessions.json",
-        ctxPayload: resolved.ctxPayload,
-        recordInboundSession: recordInboundSessionMock,
-        afterRecord: resolved.afterRecord,
-        record: resolved.record,
-        history: resolved.history,
-        admission: resolved.admission,
-        botLoopProtection: resolved.botLoopProtection,
-        runDispatch: async () => await dispatchInboundMessageMock({ ctx: resolved.ctxPayload }),
-      });
-      await params.adapter.onFinalize?.(result);
-      return result;
-    },
+    runChannelInboundEvent: createSignalPreparedDispatchRunner(
+      actual.runChannelInboundEvent,
+      recordInboundSessionMock,
+      async (resolved) => await dispatchInboundMessageMock({ ctx: resolved.ctxPayload }),
+    ),
   };
 });
 

--- a/extensions/signal/src/monitor/event-handler.test-harness.ts
+++ b/extensions/signal/src/monitor/event-handler.test-harness.ts
@@ -1,4 +1,10 @@
 // Signal plugin module implements event handler harness behavior.
+import type {
+  ChannelInboundEventRunnerParams,
+  ChannelInboundTurnPlan,
+  PreparedInboundReply,
+  runChannelInboundEvent,
+} from "openclaw/plugin-sdk/channel-inbound";
 import type { SignalEventHandlerDeps, SignalReactionMessage } from "./event-handler.types.js";
 
 export function createBaseSignalEventHandlerDeps(
@@ -53,4 +59,43 @@ export function createSignalReceiveEvent(envelopeOverrides: Record<string, unkno
       },
     }),
   };
+}
+
+export function createSignalPreparedDispatchRunner(
+  run: typeof runChannelInboundEvent,
+  recordInboundSession: PreparedInboundReply<unknown>["recordInboundSession"],
+  dispatch: (plan: ChannelInboundTurnPlan) => Promise<unknown>,
+) {
+  return async (params: ChannelInboundEventRunnerParams<unknown, unknown>) =>
+    await run({
+      ...params,
+      adapter: {
+        ...params.adapter,
+        resolveTurn: async (...args) => {
+          const resolved = await params.adapter.resolveTurn(...args);
+          if (!("route" in resolved) || !("delivery" in resolved)) {
+            throw new Error("expected assembled Signal channel turn plan");
+          }
+          return {
+            channel: resolved.channel,
+            accountId: resolved.accountId,
+            routeSessionKey: resolved.route.sessionKey,
+            storePath: "/tmp/openclaw/signal-sessions.json",
+            ctxPayload: resolved.ctxPayload,
+            recordInboundSession,
+            afterRecord: resolved.afterRecord,
+            record: resolved.record,
+            history: resolved.history,
+            admission: resolved.admission,
+            botLoopProtection: resolved.botLoopProtection,
+            runDispatch: async () => await dispatch(resolved),
+            runDispatchLifecycle: {
+              turnAdoptionLifecycle: resolved.replyOptions?.turnAdoptionLifecycle,
+              // The mock acquires no dispatcher resources; Signal's outer flush settles skips.
+              onDispatchSkipped: () => {},
+            },
+          };
+        },
+      },
+    });
 }


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four Signal test suites replayed inbound orchestration in their mocks, so they could miss behavior owned by the real runner, including finalization when dispatch fails.

## Why This Change Was Made

Use the real inbound runner through one local test adapter that preserves each suite's existing session-recording and dispatch sinks. The adapter retains the captured adoption lifecycle; Signal's outer flush continues to settle skipped claims. This removes 75 net test/support lines without changing production code.

## User Impact

No user-visible behavior change. Signal tests now exercise the actual orchestration path while retaining their control-lane, retry, mention and ingress-ownership assertions.

## Evidence

All 65 existing cases passed before and after, with identical ordered case results and unchanged assertions/hooks outside the four mock definitions. Another 50 core orchestration cases and five Signal partial-delivery cases passed.

Temporary sensitivity controls verified that the real runner finalizes a failed dispatch once and preserves its original error even if finalization also rejects. The old replay failed that same control because it never finalized. A separate control verified skipped dispatch, exact mapped lifecycle binding and settlement by the real outer owner. Temporary controls were removed after verification.

Changed checks, including extension typechecks and lint, passed. Independent review found no actionable P2-or-higher issues. No runtime improvement is claimed.
