### PR TITLE
fix: retain isolated completion state through cleanup

### DIFF
--- a/src/agents/harness/isolated-completion.native-auth.test.ts
+++ b/src/agents/harness/isolated-completion.native-auth.test.ts
@@ -15,6 +15,8 @@ import {
 const { createPluginMetadataSnapshot, makeRegistry } =
   await import("../../config/plugin-auto-enable.test-helpers.js");
 
+const { AsyncWorkScope } = await import("../../shared/async-work-scope.js");
+
 beforeEach(resetIsolatedCompletionTestState);
 
 describe("runIsolatedCompletion native authorization", () => {
@@ -426,7 +428,15 @@ describe("runIsolatedCompletion native authorization", () => {
       runIsolatedCompletionV2,
     });
 
-    await runIsolatedCompletion(isolatedRequest());
+    const parent = new AsyncWorkScope();
+    try {
+      await parent.run(() => runIsolatedCompletion(isolatedRequest()));
+    } finally {
+      await AsyncWorkScope.runWhenAllIdle(
+        () => [parent],
+        () => parent.drain(),
+      );
+    }
 
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledOnce();
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(

--- a/src/agents/isolated-completion-work.ts
+++ b/src/agents/isolated-completion-work.ts
@@ -1,0 +1,57 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import type { PreparedModelRuntimeLease } from "./prepared-model-runtime.js";
+
+/** Retains isolated completion resources through admitted setup and transport cleanup. */
+export async function runWithIsolatedCompletionResources<T>(
+  run: (
+    acceptLease: (lease: PreparedModelRuntimeLease) => void,
+    captureWorkContext: () => void,
+  ) => Promise<T>,
+): Promise<T> {
+  const result = createDeferredCore<T>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  void trackOwner(async () => {
+    const work = new AsyncWorkScope();
+    let lease: PreparedModelRuntimeLease | undefined;
+    let runInContext = work.run(() => AsyncLocalStorage.snapshot());
+    const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
+    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
+    if (parentSignal?.aborted) {
+      closeFromParent();
+    }
+    try {
+      result.resolve(
+        await work.track(() =>
+          run(
+            (acquired) => {
+              lease = acquired;
+            },
+            () => {
+              runInContext = AsyncLocalStorage.snapshot();
+            },
+          ),
+        ),
+      );
+    } catch (error) {
+      result.reject(error);
+    } finally {
+      try {
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => runInContext(() => work.drain()),
+        );
+      } finally {
+        parentSignal?.removeEventListener("abort", closeFromParent);
+        lease?.release();
+      }
+    }
+  }).catch(result.reject);
+  return await result.promise;
+}

--- a/src/agents/isolated-completion.resources.test.ts
+++ b/src/agents/isolated-completion.resources.test.ts
@@ -1,0 +1,343 @@
+import fs from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { getAiTransportHost } from "@openclaw/ai";
+import { expect, it, vi } from "vitest";
+import { writeOpenAiResponsesSse } from "../../test/helpers/openai-responses-sse.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  createColdPluginFixture,
+  createColdPluginHermeticEnv,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { createSyncSuiteTempRootTracker } from "../plugins/test-helpers/fs-fixtures.js";
+import { getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime-snapshots.js";
+import { runIsolatedCompletion } from "./isolated-completion.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import { ModelRegistry } from "./sessions/model-registry.js";
+
+it.each(["overlap", "callback-tail", "cancel-tail", "auth-tail", "auth-failure"] as const)(
+  "retains standalone isolated completion resources through %s",
+  async (mode) => {
+    const roots = createSyncSuiteTempRootTracker("isolated-completion-resources");
+    const root = fs.realpathSync(roots.makeTempDir());
+    const providerDir = path.join(root, "provider");
+    fs.mkdirSync(providerDir);
+    const fixture = createColdPluginFixture({
+      rootDir: providerDir,
+      pluginId: "isolated-resource-fixture",
+      providerId: "isolated-resource-provider",
+    });
+    const workStarted = createDeferred();
+    const finishWork = createDeferred();
+    const actualWork: Promise<unknown>[] = [];
+    const authFailure = new Error("fixture runtime auth unavailable");
+    const callbackFailure = new Error("fixture response callback failed");
+    const cancelFailure = new Error("fixture stream cancellation failed");
+    let authCalls = 0;
+    let authWorkSignal: AbortSignal | undefined;
+    let authWorkFinished = false;
+    let normalDrainRegistryMatches: boolean | undefined;
+    const globalKey = `__isolatedAuthWork_${path.basename(root)}`;
+    Object.defineProperty(globalThis, globalKey, {
+      configurable: true,
+      value: () => {
+        if (++authCalls !== 1) {
+          return;
+        }
+        if (mode === "auth-tail" || mode === "auth-failure") {
+          authWorkSignal = getAsyncWorkSignal();
+          const selectedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+          authWorkSignal?.addEventListener(
+            "abort",
+            () => {
+              normalDrainRegistryMatches =
+                getPluginRuntimeGatewayRequestScope()?.pluginRegistry === selectedRegistry;
+            },
+            { once: true },
+          );
+          const pending = trackAsyncWork(async () => {
+            workStarted.resolve();
+            await finishWork.promise;
+            authWorkSignal?.throwIfAborted();
+            authWorkFinished = true;
+          });
+          actualWork.push(pending);
+          void pending.catch(() => {});
+          if (mode === "auth-failure") {
+            throw authFailure;
+          }
+        }
+      },
+    });
+    fs.writeFileSync(
+      fixture.runtimeSource,
+      `module.exports = { id: ${JSON.stringify(fixture.pluginId)}, register(api) {
+        api.registerProvider({
+          id: ${JSON.stringify(fixture.providerId)}, label: "Isolated resources", auth: [],
+          async prepareRuntimeAuth() { globalThis[${JSON.stringify(globalKey)}](); }
+        });
+      } };`,
+    );
+    const requests: ServerResponse[] = [];
+    const arrivals = [createDeferred(), createDeferred(), createDeferred()];
+    let finishing = false;
+    const finishResponse = (response: ServerResponse, index: number) => {
+      if (response.destroyed || response.writableEnded) {
+        return;
+      }
+      writeOpenAiResponsesSse(response, [
+        {
+          id: "isolated-response",
+          object: "chat.completion.chunk",
+          model: "isolated-model",
+          choices: [{ index: 0, delta: { content: `reply-${index}` }, finish_reason: "stop" }],
+        },
+      ]);
+    };
+    const server = createServer((request, response) => {
+      request.resume();
+      const index = requests.push(response) - 1;
+      arrivals[index]?.resolve();
+      if (finishing) {
+        finishResponse(response, index);
+      }
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+    const calls: Promise<unknown>[] = [];
+    const spies: Array<{ mockRestore(): void }> = [];
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Isolated completion fixture has no TCP port");
+      }
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { workspace: root, model: `${fixture.providerId}/isolated-model` } },
+        models: {
+          providers: {
+            [fixture.providerId]: {
+              api: "openai-completions",
+              apiKey: "synthetic-isolated-key",
+              baseUrl: `http://127.0.0.1:${address.port}/v1`,
+              models: [
+                {
+                  id: "isolated-model",
+                  name: "Isolated model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          load: { paths: [fixture.rootDir] },
+          slots: { memory: "none" },
+          entries: { [fixture.pluginId]: { enabled: true } },
+        },
+      };
+      await withEnvAsync(
+        {
+          ...createColdPluginHermeticEnv(root, { bundledPluginsDir: roots.makeTempDir() }),
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: path.join(root, "state"),
+        },
+        async () => {
+          expect(getAsyncWorkSignal()).toBeUndefined();
+          const create = vi.spyOn(ModelRegistry, "create");
+          const fork = vi.spyOn(ModelRegistry.prototype, "fork");
+          spies.push(create, fork);
+          if (mode === "callback-tail" || mode === "cancel-tail") {
+            const { configureAiTransportRuntimeHost } =
+              await import("./ai-transport-runtime-host.js");
+            configureAiTransportRuntimeHost();
+            const pluginHost = getAiTransportHost().plugin;
+            const wrap = pluginHost.wrapSimpleCompletionStream;
+            let responses = 0;
+            spies.push(
+              vi.spyOn(pluginHost, "wrapSimpleCompletionStream").mockImplementation((params) => {
+                const stream = wrap(params) ?? params.context.streamFn;
+                return (model, context, options) =>
+                  stream(model, context, {
+                    ...options,
+                    onResponse: async (response, responseModel) => {
+                      await options?.onResponse?.(response, responseModel);
+                      if (++responses !== 1) {
+                        return;
+                      }
+                      if (mode === "cancel-tail") {
+                        throw callbackFailure;
+                      }
+                      workStarted.resolve();
+                      const pending = finishWork.promise;
+                      actualWork.push(pending);
+                      await pending;
+                    },
+                  });
+              }),
+            );
+            if (mode === "cancel-tail") {
+              const realFetch = globalThis.fetch;
+              let wrapped = false;
+              spies.push(
+                vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+                  const response = await realFetch(...args);
+                  if (wrapped || !response.url.startsWith(`http://127.0.0.1:${address.port}/`)) {
+                    return response;
+                  }
+                  wrapped = true;
+                  const reader = response.body?.getReader();
+                  if (!reader) {
+                    throw new Error("Isolated fixture response has no body");
+                  }
+                  return new Response(
+                    new ReadableStream<Uint8Array>({
+                      async pull(controller) {
+                        const { value, done } = await reader.read();
+                        if (done) {
+                          controller.close();
+                        } else {
+                          controller.enqueue(value);
+                        }
+                      },
+                      async cancel(reason) {
+                        workStarted.resolve();
+                        const pending = (async () => {
+                          try {
+                            await finishWork.promise;
+                            throw cancelFailure;
+                          } finally {
+                            await reader.cancel(reason);
+                          }
+                        })();
+                        actualWork.push(pending);
+                        return await pending;
+                      },
+                    }),
+                    { status: response.status, headers: response.headers },
+                  );
+                }),
+              );
+            }
+          }
+          const start = (signal?: AbortSignal) => {
+            const pending = runIsolatedCompletion({
+              config: cfg,
+              provider: fixture.providerId,
+              model: "isolated-model",
+              agentId: "main",
+              agentHarnessRuntimeOverride: "openclaw",
+              systemPrompt: "Return a short reply.",
+              prompt: "Fixture input",
+              timeoutMs: 10_000,
+              abortSignal: signal,
+            });
+            calls.push(pending);
+            return pending;
+          };
+          const waitForRequest = (index: number, call: Promise<unknown>) =>
+            Promise.race([
+              arrivals[index]!.promise,
+              call.then(() => {
+                throw new Error("Completion ended before the expected provider request");
+              }),
+            ]);
+          const abortReason = new Error("fixture isolated caller aborted");
+          const controller = new AbortController();
+          const first = start(mode === "callback-tail" ? controller.signal : undefined);
+          if (mode === "auth-failure") {
+            await expect(first).rejects.toBe(authFailure);
+            await workStarted.promise;
+            expect(requests).toHaveLength(0);
+          } else {
+            await waitForRequest(0, first);
+            if (mode !== "overlap") {
+              finishResponse(requests[0]!, 0);
+              if (mode === "callback-tail" || mode === "cancel-tail") {
+                await Promise.race([
+                  workStarted.promise,
+                  first.then(() => {
+                    throw new Error("Completion ended before its accepted work started");
+                  }),
+                ]);
+              }
+              if (mode === "callback-tail") {
+                controller.abort(abortReason);
+                await expect(first).rejects.toBe(abortReason);
+              } else if (mode === "cancel-tail") {
+                await expect(first).rejects.toMatchObject({ code: "output-rejected" });
+              } else {
+                await expect(first).resolves.toMatchObject({ text: "reply-0" });
+                await workStarted.promise;
+              }
+            }
+          }
+          if (mode === "auth-tail" || mode === "auth-failure") {
+            expect.soft(authWorkSignal?.aborted ?? false).toBe(false);
+          }
+          const firstBuilds = create.mock.calls.length;
+          expect(firstBuilds).toBeGreaterThan(0);
+          const secondIndex = mode === "auth-failure" ? 0 : 1;
+          const second = start();
+          await waitForRequest(secondIndex, second);
+          expect.soft(create.mock.calls.length).toBe(firstBuilds);
+          expect(fork.mock.calls.length).toBe(2);
+          expect(fork.mock.calls[0]![0] === fork.mock.calls[1]![0]).toBe(false);
+          finishWork.resolve();
+          await Promise.allSettled(actualWork);
+          if (mode === "auth-tail" || mode === "auth-failure") {
+            expect.soft(authWorkFinished).toBe(true);
+          }
+          if (mode === "overlap") {
+            finishResponse(requests[0]!, 0);
+            await expect(first).resolves.toMatchObject({ text: "reply-0" });
+          }
+          finishResponse(requests[secondIndex]!, secondIndex);
+          await expect(second).resolves.toMatchObject({ text: `reply-${secondIndex}` });
+          const thirdIndex = secondIndex + 1;
+          const third = start();
+          await waitForRequest(thirdIndex, third);
+          expect(create.mock.calls.length).toBe(firstBuilds + 1);
+          finishResponse(requests[thirdIndex]!, thirdIndex);
+          await expect(third).resolves.toMatchObject({ text: `reply-${thirdIndex}` });
+          if (authWorkSignal) {
+            expect(normalDrainRegistryMatches).toBe(true);
+          }
+        },
+      );
+    } finally {
+      finishWork.resolve();
+      finishing = true;
+      requests.forEach(finishResponse);
+      await Promise.allSettled(calls);
+      await Promise.allSettled(actualWork);
+      for (const spy of spies) {
+        spy.mockRestore();
+      }
+      await resetPreparedModelRuntimeSnapshotsForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      clearPluginMetadataLifecycleCaches();
+      resetPluginLoaderTestStateForTest();
+      Reflect.deleteProperty(globalThis, globalKey);
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      roots.cleanup();
+    }
+  },
+);

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -15,6 +15,12 @@ import {
 
 // The shared fixture must register mocks before other runtime modules load.
 const { createDeferred } = await import("../../test/helpers/promise.js");
+const { AsyncLocalStorage } = await import("node:async_hooks");
+const { createEmptyPluginRegistry } = await import("../plugins/registry-empty.js");
+const { getPluginRuntimeGatewayRequestScope, withPluginRuntimeRegistryScope } =
+  await import("../plugins/runtime/gateway-request-scope.js");
+const { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } =
+  await import("../shared/async-work-scope.js");
 const { validateAgentRunDelegatedAuthority } = await import("../infra/agent-run-registry.js");
 const { mintSecretSentinel } = await import("../secrets/sentinel.js");
 const { getAdmittedRunDelegatedAuthority } = await import("./admitted-run-context.js");
@@ -612,5 +618,121 @@ describe("runIsolatedCompletion", () => {
       model: "gemini-3.1-flash-preview",
       owner: { kind: "cli", id: "google-gemini-cli" },
     });
+  });
+});
+
+describe("isolated completion work ownership", () => {
+  it.each(["acquisition", "host-auth"] as const)(
+    "owns %s descendants and preserves parent cancellation context",
+    async (stage) => {
+      const parent = new AsyncWorkScope();
+      const caller = new AbortController();
+      const callerReason = new Error("isolated caller cancelled");
+      const parentReason = new Error("isolated parent closing");
+      const callerRegistry = createEmptyPluginRegistry();
+      const selectedRegistry = createEmptyPluginRegistry();
+      const foreignRegistry = createEmptyPluginRegistry();
+      Object.assign(preparedModelRuntime, { pluginRegistry: selectedRegistry });
+      let cancellationRegistryMatches = false;
+      const entered = createDeferred();
+      const finishSetup = createDeferred();
+      const finishTail = createDeferred();
+      const tails: Promise<unknown>[] = [];
+      let observedReason: unknown;
+      let cancellationScopeMatches = false;
+      const pause = async () => {
+        const signal = getAsyncWorkSignal();
+        if (!signal) {
+          throw new Error("Setup did not inherit its actual work owner");
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            observedReason = signal.reason;
+            cancellationScopeMatches = getAsyncWorkSignal() === signal;
+            cancellationRegistryMatches =
+              getPluginRuntimeGatewayRequestScope()?.pluginRegistry ===
+              (stage === "acquisition" ? callerRegistry : selectedRegistry);
+            tails.push(trackAsyncWork(() => finishTail.promise));
+          },
+          { once: true },
+        );
+        entered.resolve();
+        await finishSetup.promise;
+      };
+      if (stage === "acquisition") {
+        mocks.acquireAgentRunPreparedModelRuntime.mockImplementationOnce(async () => {
+          await pause();
+          return { snapshot: preparedModelRuntime, release: releaseRuntimeLease };
+        });
+      } else {
+        mocks.prepareSimpleCompletionModel.mockImplementationOnce(async () => {
+          await pause();
+          return {
+            model: { provider: "openai", id: "gpt-test", api: "openai-responses" },
+            auth: { apiKey: "synthetic-key", mode: "api-key", source: "test" },
+          };
+        });
+      }
+      const dispatch = vi.fn(async () => ({
+        assistant: isolatedAssistant([{ type: "text", text: "done" }]),
+      }));
+      registerIsolatedHarness({ runIsolatedCompletionV2: dispatch });
+      const completion = withPluginRuntimeRegistryScope(callerRegistry, () =>
+        parent.run(() =>
+          runIsolatedCompletion({
+            ...isolatedRequest(),
+            abortSignal: caller.signal,
+          }),
+        ),
+      );
+      let drained = false;
+      let drainage: Promise<void> | undefined;
+      try {
+        await Promise.race([
+          entered.promise,
+          completion.then(() => {
+            throw new Error("Completion ended before setup entered");
+          }),
+        ]);
+        caller.abort(callerReason);
+        withPluginRuntimeRegistryScope(foreignRegistry, () => parent.beginClose(parentReason));
+        expect.soft(cancellationRegistryMatches).toBe(true);
+        expect.soft(observedReason).toBe(parentReason);
+        expect.soft(cancellationScopeMatches).toBe(true);
+        drainage = parent.drain().then(() => {
+          drained = true;
+        });
+        finishSetup.resolve();
+        await expect(completion).rejects.toBe(callerReason);
+        expect(dispatch).not.toHaveBeenCalled();
+        expect.soft(releaseRuntimeLease).not.toHaveBeenCalled();
+        expect.soft(drained).toBe(false);
+        finishTail.resolve();
+        await drainage;
+        expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+      } finally {
+        finishSetup.resolve();
+        finishTail.resolve();
+        await Promise.allSettled([completion, ...tails]);
+        await drainage;
+        await parent.drain();
+      }
+    },
+  );
+
+  it("does not begin setup through a captured closed parent", async () => {
+    const parent = new AsyncWorkScope();
+    registerIsolatedHarness({
+      runIsolatedCompletionV2: vi.fn(async () => ({
+        assistant: isolatedAssistant([{ type: "text", text: "done" }]),
+      })),
+    });
+    const invoke = parent.run(() =>
+      AsyncLocalStorage.bind(() => runIsolatedCompletion(isolatedRequest())),
+    );
+    await parent.drain();
+    await expect(invoke()).rejects.toThrow("Async work scope is closed");
+    expect(mocks.acquireAgentRunPreparedModelRuntime).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -27,6 +27,7 @@ import type {
   AgentHarnessIsolatedCompletionParamsV2,
   AgentHarnessIsolatedCompletionResult,
 } from "./harness/types.js";
+import { runWithIsolatedCompletionResources } from "./isolated-completion-work.js";
 import { ensureAuthProfileStore } from "./model-auth.js";
 import {
   isCliRuntimeAliasForProvider,
@@ -34,6 +35,7 @@ import {
 } from "./model-runtime-aliases.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  type PreparedModelRuntimeLease,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.js";
 import {
@@ -398,6 +400,16 @@ async function prepareHostAuthorization(params: {
 export async function runIsolatedCompletion(
   params: RunIsolatedCompletionParams,
 ): Promise<IsolatedCompletionResult> {
+  return await runWithIsolatedCompletionResources((acceptLease, captureWorkContext) =>
+    runIsolatedCompletionOwned(params, acceptLease, captureWorkContext),
+  );
+}
+
+async function runIsolatedCompletionOwned(
+  params: RunIsolatedCompletionParams,
+  acceptLease: (lease: PreparedModelRuntimeLease) => void,
+  captureWorkContext: () => void,
+): Promise<IsolatedCompletionResult> {
   // Snapshot caller choices and validators before admission yields; callbacks expire on close.
   const input = {
     ...params,
@@ -447,9 +459,11 @@ export async function runIsolatedCompletion(
       ],
     },
   );
+  acceptLease(lease);
   try {
     assertCurrent();
     const run = async (): Promise<IsolatedCompletionResult> => {
+      captureWorkContext();
       // A new admission owns config and directories; the caller keeps its explicit route and profile.
       const context = {
         config: lease.snapshot.config,
@@ -724,6 +738,5 @@ export async function runIsolatedCompletion(
     return result;
   } finally {
     closed = true;
-    lease.release();
   }
 }


### PR DESCRIPTION
Related: #140674.

## What Problem This Solves

Resolves a problem where an isolated model completion can release its prepared runtime after reporting a result or cancellation while accepted auth or transport cleanup is still running.

## Why This Change Was Made

Start work ownership before runtime acquisition and setup, retain the selected lease through actual cooperating work, and release it after drainage. Parent cancellation and normal drainage restore the captured runtime context. Normal completion lets accepted auth work finish before closing its signal.

A small ownership helper keeps this lifecycle separate from the existing policy code. Input snapshots, authority checks, model/profile/harness/CLI selection, and result/error behavior remain unchanged. No public API, configuration, dependency or producer-activation change.

## User Impact

Isolated completions keep their current result and cancellation behavior while retaining the original runtime through cleanup. This also prevents overlapping calls from rebuilding a generation that still has an active user.

## Evidence

Original production fails seven ownership/context cases while 31 controls pass. An intermediate implementation fails four cases, showing why normal completion must not abort accepted auth work and why cancellation must restore the admitted context. The final candidate passes all 89 owner and caller tests across six files.

The complete affected checks, fresh full-candidate Codex review through P2, and ordinary build pass. The new helper preserves the original policy body and keeps the existing file limit without a baseline exception. The build took 249.73 seconds.

Compiled plain-Node proof uses the actual isolated-completion entry, a synthetic provider and real loopback HTTP. Standalone auth-tail, callback-abort and foreign-context parent-cancellation scenarios pass in 2.17 seconds overall. Each makes three HTTP requests and observes two actual base generations: overlapping work reuses the retained generation, and a later call rebuilds after cleanup. All 12,119 artifact hashes and five source hashes remain unchanged, with no application source fallback; all processes exit and synthetic state is removed.

One probe initially assumed the second call's physical release coincided with its logical result. Joining that control call's actual cleanup fixed the assertion; the tested first calls remain standalone, and no product change or delay was added. Timings are correctness observations, not a speedup benchmark. General RUN SQLite disposal and real vendor execution are separate from this proof.

The final rebase includes the landed Anthropic cancellation repair and preserves all five validated code/test files byte-for-byte.
