### PR TITLE
test: avoid cold source SDK loading in MCP coverage

### DIFF
--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -20,7 +20,10 @@ import {
   triageMaintenanceRuntimeEntrypoints,
 } from "../../src/infra/triage-runtime.test-support.ts";
 import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runtime.test-support.ts";
-import { publishedSdkBridgeEntrypoints } from "../../src/plugins/loader-sdk-bridge-artifacts.test-support.ts";
+import {
+  mcpProviderCatalogEntrypoint,
+  publishedSdkBridgeEntrypoints,
+} from "../../src/plugins/loader-sdk-bridge-artifacts.test-support.ts";
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
 import {
   agentDatabaseHeldRuntimeEntrypoint,
@@ -41,6 +44,7 @@ export const vitestWorkerBuildEntries = {
       codeModeDescriptionRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
       ...publishedSdkBridgeEntrypoints,
+      mcpProviderCatalogEntrypoint,
       ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(gatewayDirectStopEntrypoints),
       stateDirGatewayFixtureEntrypoint,

--- a/src/mcp/plugin-tools-registration.test.ts
+++ b/src/mcp/plugin-tools-registration.test.ts
@@ -3,14 +3,18 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createCompiledSdkHost } from "../plugins/compiled-sdk-host.test-support.js";
 import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import { mcpProviderCatalogEntrypoint } from "../plugins/loader-sdk-bridge-artifacts.test-support.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
   writePlugin,
 } from "../plugins/loader.test-fixtures.js";
+import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import { markPluginRegistryActive } from "../plugins/registry-lifecycle.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { acquireStandalonePluginToolRegistry } from "../plugins/tools.js";
@@ -19,6 +23,20 @@ import { createCodexSupervisionToolsMcpServer } from "./codex-supervision-tools-
 import { createToolsMcpServer, serveRegisteredToolsMcpServer } from "./tools-stdio-server.js";
 
 let sequence = 0;
+const sdkHostDirs = createTempDirTracker();
+let sdkHost: string | undefined;
+let beforeLoad: ReturnType<typeof getPluginModuleLoaderStats>;
+beforeAll(() => {
+  sdkHost = createCompiledSdkHost(mcpProviderCatalogEntrypoint, (prefix) =>
+    sdkHostDirs.make(prefix),
+  );
+});
+beforeEach(() => {
+  if (sdkHost) {
+    vi.stubEnv("OPENCLAW_DEV_SOURCE_ROOT", sdkHost);
+  }
+  beforeLoad = getPluginModuleLoaderStats();
+});
 function nativePlugin(options: { failDisposal?: boolean; abortSdk?: boolean } = {}) {
   useNoBundledPlugins();
   const key = `__mcp_registration_native_${sequence++}`;
@@ -117,10 +135,21 @@ module.exports = { id: "mcp-native", register(api) {
 }
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  resetPluginLoaderTestStateForTest();
+  try {
+    if (sdkHost) {
+      const afterLoad = getPluginModuleLoaderStats();
+      expect(afterLoad.nativeHits).toBeGreaterThan(beforeLoad.nativeHits);
+      expect(afterLoad.sourceTransformForced).toBe(beforeLoad.sourceTransformForced);
+      expect(afterLoad.sourceTransformFallbacks).toBe(beforeLoad.sourceTransformFallbacks);
+    }
+  } finally {
+    vi.restoreAllMocks();
+    resetPluginLoaderTestStateForTest();
+    vi.unstubAllEnvs();
+  }
 });
 afterAll(cleanupPluginLoaderFixturesForTest);
+afterAll(sdkHostDirs.cleanup);
 
 function causes(error: unknown): unknown[] {
   if (error instanceof AggregateError) {

--- a/src/plugins/compiled-sdk-host.test-support.ts
+++ b/src/plugins/compiled-sdk-host.test-support.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+
+/** Keep native SDK consumers on the invocation's verified, current-source graph. */
+export function createCompiledSdkHost(
+  entrypoint: Parameters<typeof resolveRuntimeWorkerUrl>[0],
+  makeTempDir: (prefix: string) => string,
+): string | undefined {
+  const artifact = fileURLToPath(resolveRuntimeWorkerUrl(entrypoint));
+  // Standalone and watch-mode Vitest deliberately retain source declarations.
+  if (path.extname(artifact) !== ".js") {
+    return undefined;
+  }
+  const hostRoot = makeTempDir("openclaw-sdk-host-");
+  fs.cpSync(path.dirname(path.dirname(artifact)), path.join(hostRoot, "dist"), {
+    recursive: true,
+  });
+  fs.copyFileSync(
+    path.resolve(import.meta.dirname, "../../package.json"),
+    path.join(hostRoot, "package.json"),
+  );
+  fs.mkdirSync(path.join(hostRoot, "src"));
+  fs.mkdirSync(path.join(hostRoot, "extensions"));
+  fs.symlinkSync(path.resolve("node_modules"), path.join(hostRoot, "node_modules"), "junction");
+  return hostRoot;
+}

--- a/src/plugins/loader-sdk-bridge-artifacts.test-support.ts
+++ b/src/plugins/loader-sdk-bridge-artifacts.test-support.ts
@@ -1,5 +1,10 @@
 // Published plugin compatibility uses the same compiled SDK graph as native execution.
 const currentModuleUrl = import.meta.url;
+export const mcpProviderCatalogEntrypoint = {
+  currentModuleUrl,
+  sourceWorkerName: "../plugin-sdk/provider-catalog-runtime",
+  distWorkerPath: "plugin-sdk/provider-catalog-runtime.js",
+} as const;
 export const publishedSdkBridgeEntrypoints = [
   {
     currentModuleUrl,

--- a/src/plugins/loader.native-module-loader.test.ts
+++ b/src/plugins/loader.native-module-loader.test.ts
@@ -1,10 +1,9 @@
 /** Verifies plugin loader behavior for native module loading and resolver hooks. */
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { createCompiledSdkHost } from "./compiled-sdk-host.test-support.js";
 import { publishedSdkBridgeEntrypoints } from "./loader-sdk-bridge-artifacts.test-support.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { resetPluginCache } from "./plugin-cache.js";
@@ -199,20 +198,9 @@ describe("createPluginModuleLoader", () => {
   it("loads published pre-split SDK bridge imports (doctor repair, WhatsApp ack, Slack render)", () => {
     const pluginRoot = writePreSplitSdkBridgeConsumerFixture();
     const [entrypoint] = publishedSdkBridgeEntrypoints;
-    const artifact = fileURLToPath(resolveRuntimeWorkerUrl(entrypoint));
-    const hasCompiledSdk = path.extname(artifact) === ".js";
+    const hostRoot = createCompiledSdkHost(entrypoint, (prefix) => tempDirs.make(prefix));
+    const hasCompiledSdk = hostRoot !== undefined;
     if (hasCompiledSdk) {
-      const hostRoot = tempDirs.make("openclaw-sdk-bridge-host-");
-      fs.cpSync(path.dirname(path.dirname(artifact)), path.join(hostRoot, "dist"), {
-        recursive: true,
-      });
-      fs.copyFileSync(
-        path.resolve(import.meta.dirname, "../../package.json"),
-        path.join(hostRoot, "package.json"),
-      );
-      fs.mkdirSync(path.join(hostRoot, "src"));
-      fs.mkdirSync(path.join(hostRoot, "extensions"));
-      fs.symlinkSync(path.resolve("node_modules"), path.join(hostRoot, "node_modules"), "junction");
       vi.stubEnv("OPENCLAW_DEV_SOURCE_ROOT", hostRoot);
       vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(hostRoot, "extensions"));
     } else {


### PR DESCRIPTION
## What Problem This Solves

The MCP registration-ownership test spends roughly 52 seconds loading the source SDK through Jiti before it exercises its native resources. The complete seven-case command took 65–72 seconds locally; main CI reported 50 seconds in its first case alone.

## Why This Change Was Made

Reuse the test runner's existing verified build of current source for the real provider-catalog SDK entry. Extract the existing compiled-SDK host fixture so MCP and the published-SDK loader test share its setup. Each MCP case still imports the real SDK during registration and exercises its original transport, cancellation, SQLite lifetime, and disposal assertions. Additional loader counters require native loading without source-transform fallback.

The host is tracked and removed after the file; loader state and the temporary environment setting are restored between cases. Standalone/watch execution retains the existing source path. This changes test preparation only, with no production loader, API, dependency, configuration option, timeout, or shard change.

## User Impact

Faster native MCP coverage without replacing the SDK or lifecycle behavior with mocks. The private compiler gains only one input and one output. Peak RSS remains approximately 2.28 GB; no memory improvement is claimed. Production LOC is unchanged; tests/support are +68/-18 and the build-entry list is +5/-1.

## Evidence

| Source-only checkout | Complete seven-case command | Test result |
| --- | ---: | --- |
| Original | 64.89s | 7 passed |
| Compiled SDK fixture | 14.21s | 7 passed |
| Restored original | 71.95s | 7 passed |

These timings include compilation, host creation/copy, verification, and cleanup, with identical physical dependencies and Node 24.19.0/pnpm 12.3.4. The candidate's first case took 556 ms and its cancellation case 12 ms. Compiler samples were 4.449/3.493/3.649 seconds; their variance is not a separate compiler-speed claim.

- Root validation after the final method-binding correction: all 10 MCP and published native-loader cases passed in 23.79 seconds.
- Standalone source-declaration branch: the existing published-SDK bridge case passed; two other cases were deliberately excluded by its focused filter.
- CPU profiling attributed the original cost to Jiti resolution/stack work and Babel in the native SDK graph. A simpler conditional import was tested and rejected because it merely moved 52 seconds to another case.
- All changed checks passed, including core/script typechecking, lint, and build-entry guards. Managed independent P2 review is clean. The broader shared build graph runs in the PR's required CI. Existing path filters did not select Windows; no Windows result is claimed for this patch.
