### PR TITLE
fix(channels): preserve labels for unloaded plugins

### DIFF
--- a/src/channels/plugins/manifest-channel-plugin.types.ts
+++ b/src/channels/plugins/manifest-channel-plugin.types.ts
@@ -14,6 +14,8 @@ export type ManifestChannelPlugin = {
     id: string;
     label: string;
     selectionLabel: string;
+    detailLabel?: string;
+    systemImage?: string;
     docsPath: string;
     blurb: string;
     preferOver?: readonly string[];

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -14,6 +14,7 @@ import {
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
 } from "../../plugins/loader.test-fixtures.js";
+import type { PluginPackageChannel } from "../../plugins/package-manifest.types.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import {
   rebasePluginMetadataSnapshotManifestRegistry,
@@ -25,6 +26,7 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
+import { buildChannelUiCatalog } from "./catalog.js";
 import {
   listReadOnlyChannelPluginsForConfig,
   resolveReadOnlyChannelPluginsForConfig,
@@ -107,6 +109,10 @@ function writeExternalSetupChannelPlugin(
     manifestChannelConfig?: boolean;
     manifestChannelDescription?: string;
     manifestChannelLabel?: string;
+    packagePresentation?: Pick<
+      PluginPackageChannel,
+      "label" | "blurb" | "selectionLabel" | "detailLabel" | "systemImage"
+    >;
     setupRequiresRuntime?: boolean;
     setupChannelId?: string;
   } = {},
@@ -132,6 +138,7 @@ function writeExternalSetupChannelPlugin(
           ...(setupEntry ? { setupEntry: "./setup-entry.cjs" } : {}),
           channel: {
             id: channelId,
+            ...options.packagePresentation,
             configuredState: { env: { anyOf: ["EXTERNAL_CHAT_TOKEN"] } },
           },
         },
@@ -654,17 +661,84 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
-  it("uses package channel metadata without loading setup or full runtime", () => {
-    const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin();
-    const plugins = listReadOnlyChannelPluginsForConfig(
-      createExternalChannelTestConfig({ pluginDir }),
-      {
-        env: { ...process.env },
-        includePersistedAuthState: false,
-      },
-    );
+  it.each([
+    { name: "package detail", manifestOverride: false, secondary: "detail" },
+    { name: "manifest primary override", manifestOverride: true, secondary: "detail" },
+    { name: "selection fallback", manifestOverride: false, secondary: "selection" },
+    { name: "primary fallback", manifestOverride: false, secondary: "primary" },
+  ] as const)(
+    "uses $name metadata without loading setup or full runtime",
+    ({ manifestOverride, secondary }) => {
+      const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
+        manifestChannelConfig: manifestOverride,
+        manifestChannelLabel: "Manifest Chat",
+        manifestChannelDescription: "Manifest description",
+        packagePresentation: {
+          label: " Package Chat ",
+          blurb: " Package description ",
+          selectionLabel: secondary === "primary" ? " " : " Package Chat (picker) ",
+          detailLabel: secondary === "detail" ? " Package Chat Bot " : " ",
+          systemImage: secondary === "detail" ? " bubble.left " : " ",
+        },
+      });
+      const plugins = listReadOnlyChannelPluginsForConfig(
+        createExternalChannelTestConfig({ pluginDir }),
+        { env: { ...process.env }, includePersistedAuthState: false },
+      );
+      const catalog = buildChannelUiCatalog(plugins);
+      const label = manifestOverride ? "Manifest Chat" : "Package Chat";
+      const selectionLabel = secondary === "primary" ? label : "Package Chat (picker)";
 
-    expect(pluginIds(plugins)).toContain("external-chat");
+      expect(plugins.find((entry) => entry.id === "external-chat")?.meta).toMatchObject({
+        label,
+        blurb: manifestOverride ? "Manifest description" : "Package description",
+        selectionLabel,
+      });
+      expect(catalog.byId["external-chat"]).toEqual({
+        id: "external-chat",
+        label,
+        detailLabel: secondary === "detail" ? "Package Chat Bot" : selectionLabel,
+        ...(secondary === "detail" ? { systemImage: "bubble.left" } : {}),
+      });
+      expect(fs.existsSync(setupMarker)).toBe(false);
+      expect(fs.existsSync(fullMarker)).toBe(false);
+    },
+  );
+
+  it("keeps package presentation on its declared channel", () => {
+    const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
+      manifestChannelIds: ["external-chat", "sibling-chat"],
+      manifestChannelConfig: true,
+      packagePresentation: {
+        selectionLabel: "Package Chat (picker)",
+        detailLabel: "Package Chat Bot",
+        systemImage: "bubble.left",
+      },
+    });
+    const plugins = listReadOnlyChannelPluginsForConfig(
+      createExternalChannelTestConfig({
+        pluginDir,
+        channels: {
+          "external-chat": { token: "configured" },
+          "sibling-chat": { token: "configured" },
+        },
+      }),
+      { includePersistedAuthState: false },
+    );
+    const catalog = buildChannelUiCatalog(plugins);
+    expect([catalog.byId["external-chat"], catalog.byId["sibling-chat"]]).toEqual([
+      {
+        id: "external-chat",
+        label: "External Chat Manifest",
+        detailLabel: "Package Chat Bot",
+        systemImage: "bubble.left",
+      },
+      {
+        id: "sibling-chat",
+        label: "External Chat Manifest",
+        detailLabel: "External Chat Manifest",
+      },
+    ]);
     expect(fs.existsSync(setupMarker)).toBe(false);
     expect(fs.existsSync(fullMarker)).toBe(false);
   });

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -237,6 +237,11 @@ function createManifestChannelPlugin(params: {
   if (!isSafeManifestChannelId(params.channelId)) {
     return undefined;
   }
+  // Package presentation describes one channel, even when the plugin owns several.
+  const packageChannel =
+    params.record.packageChannel?.id === params.channelId
+      ? params.record.packageChannel
+      : undefined;
   const catalogMeta =
     params.record.channelCatalogMeta?.id === params.channelId
       ? params.record.channelCatalogMeta
@@ -268,6 +273,8 @@ function createManifestChannelPlugin(params: {
     channelConfig?.description ?? catalogMeta?.blurb,
     params.record.description || "",
   );
+  const detailLabel = normalizeManifestText(packageChannel?.detailLabel, "");
+  const systemImage = normalizeManifestText(packageChannel?.systemImage, "");
   const commands = normalizeChannelCommandDefaults(
     channelConfig?.commands ?? catalogMeta?.commands,
   );
@@ -276,7 +283,9 @@ function createManifestChannelPlugin(params: {
     meta: {
       id: params.channelId,
       label,
-      selectionLabel: label,
+      selectionLabel: normalizeManifestText(packageChannel?.selectionLabel, label) || label,
+      ...(detailLabel ? { detailLabel } : {}),
+      ...(systemImage ? { systemImage } : {}),
       docsPath: `/channels/${encodeURIComponent(params.channelId)}`,
       blurb,
       ...(channelConfig?.preferOver?.length


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where configured plugins could lose their declared channel subtitle before their runtime loaded. The Channels page could show “Open details” instead of the plugin's description. Static catalog output also dropped selection labels and icon metadata.

## Why This Change Was Made

Project the three existing presentation fields from normalized package metadata into the read-only adapter, only for the package's declared channel. Keep primary label/description overrides and loaded-plugin precedence intact. The broader metadata builder is not used because it also projects policy fields.

## User Impact

Configured channels retain their declared presentation without loading plugin runtime or setup code. The change adds eleven production lines and changes no channel policy or configuration contract. Icon metadata is restored in the catalog; no current Control UI icon-rendering defect is claimed.

## Evidence

Four real adapter/catalog regressions fail before the fix and pass afterward, with all 67 tests and 33 changed-file checks passing. Independent review through P2 is clean.

The synthetic screenshots replay actual recorded before/after catalog output through the unchanged Channels view: “Open details” becomes “Package Chat Bot.” The corrected capture has no page errors; its first attempt stopped on an incomplete mock pairing response, fixed only in the capture script. No live Gateway or real operator data was used.

![Before: synthetic catalog output loses the plugin detail label](https://github.com/user-attachments/assets/1af8471e-4b70-4298-8666-1481e7cff8ed)

![After: synthetic catalog output preserves Package Chat Bot](https://github.com/user-attachments/assets/9181aec1-0476-41e5-9ec8-1f2d45aee938)