### PR TITLE
fix: close node pairing fixture databases before cleanup

### DIFF
--- a/src/infra/device-pairing-node.lifecycle.test.ts
+++ b/src/infra/device-pairing-node.lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { approveDevicePairing } from "./device-pairing-approval.js";
 import {
@@ -27,8 +28,13 @@ import {
 } from "./device-pairing.js";
 
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-node-pairing-lifecycle-" });
+const databasePaths = new Set<string>();
 async function withNodePairingDir<T>(run: (baseDir: string) => Promise<T>): Promise<T> {
-  return await run(await tempDirs.make("case"));
+  const baseDir = await tempDirs.make("case");
+  databasePaths.add(
+    resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: baseDir }),
+  );
+  return await run(baseDir);
 }
 
 describe("node surface approval lifetime", () => {
@@ -36,6 +42,9 @@ describe("node surface approval lifetime", () => {
     await tempDirs.setup();
   });
   afterAll(async () => {
+    for (const databasePath of databasePaths) {
+      closeOpenClawStateDatabaseByPath(databasePath);
+    }
     await tempDirs.cleanup();
   });
 

--- a/src/infra/device-pairing-node.test.ts
+++ b/src/infra/device-pairing-node.test.ts
@@ -7,6 +7,7 @@ import {
   closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { approveDevicePairing } from "./device-pairing-approval.js";
 import { updatePairedNodeBins, updatePairedNodeSessionHost } from "./device-pairing-node-facts.js";
@@ -40,6 +41,7 @@ import {
 } from "./node-commands.js";
 
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-node-pairing-" });
+const databasePaths = new Set<string>();
 const hostStats: NodeHostStats = {
   cpuCount: 4,
   loadAverage: [1.5, 1, 0.5],
@@ -49,7 +51,11 @@ const hostStats: NodeHostStats = {
 };
 
 async function withNodePairingDir<T>(run: (baseDir: string) => Promise<T>): Promise<T> {
-  return await run(await tempDirs.make("case"));
+  const baseDir = await tempDirs.make("case");
+  databasePaths.add(
+    resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: baseDir }),
+  );
+  return await run(baseDir);
 }
 
 async function findPairedNode(nodeId: string, baseDir: string) {
@@ -77,6 +83,9 @@ describe("node surface approvals", () => {
   });
 
   afterAll(async () => {
+    for (const databasePath of databasePaths) {
+      closeOpenClawStateDatabaseByPath(databasePath);
+    }
     await tempDirs.cleanup();
   });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the node-pairing test suites removed their temporary database directories while cached SQLite handles were still open. Explicit database-reopen checks in several cases left a new handle alive at suite cleanup.

## Why This Change Was Made

Each suite records the canonical database paths belonging to its fresh case directories and closes those handles before removing the suite root. A close failure prevents directory removal. All existing test cases, assertions, and mid-case reopen checks remain unchanged.

## User Impact

No production behavior changes. Developers get correctly ordered database and filesystem cleanup in both node-pairing suites.

## Evidence

- Safe observation of all 46 existing cases found live handles and WAL files at all 39 node-suite and seven lifecycle-suite paths before directory removal; only those owned handles were closed before allowing diagnostic cleanup.
- Both full candidate suites passed all 46 cases. A separate observation confirmed all 46 paths were already closed before removal, without any diagnostic safety close.
- Extracted cleanup callbacks passed success and first/second-close-failure controls, preserving files and the original error when closing failed.
- Existing case names, order within each file, assertions, and reopen checks are preserved. Changed-file checks and independent review passed.

This proves the fixture lifetime defect; it does not attribute a historical process termination to a particular test or claim a suite speedup.
