### PR TITLE
fix(ci): reconcile omitted empty FRV inputs

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -730,6 +730,7 @@ function exactKeys(value: unknown, keys: string[]): value is Record<string, unkn
 export function dispatchInputsDigest(inputs: DispatchInputs): string {
   const wireInputs = Object.fromEntries(
     Object.keys(inputs)
+      .filter((key) => String(inputs[key]) !== "")
       .toSorted()
       .map((key) => [key, String(inputs[key])]),
   );

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -238,7 +238,8 @@ module.exports = async () => {
   const accepted = JSON.parse(fs.readFileSync(${JSON.stringify(acceptedRunPath)}, "utf8"));
   const inputs = { ...accepted.inputs, ...${JSON.stringify(options.witnessInputs ?? {})} };
   const canonicalInputs = JSON.stringify(Object.fromEntries(
-    Object.entries(inputs).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
+    Object.entries(inputs).filter(([, value]) => String(value) !== "")
+      .sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
       .map(([key, value]) => [key, String(value)]),
   ));
   const witness = {
@@ -699,12 +700,12 @@ function dispatchedInputs(args: string[]): Record<string, string> {
 }
 
 describe("full-release-validation-at-sha", () => {
-  it("normalizes full wire inputs without depending on key order or Boolean event representation", () => {
+  it("normalizes GitHub witness inputs without depending on omitted blanks, order, or Boolean representation", () => {
     expect(dispatchInputsDigest({ text: "a=b\n$()", count: 3, flag: false, empty: "" })).toBe(
       dispatchInputsDigest({ empty: "", flag: "false", count: "3", text: "a=b\n$()" }),
     );
     expect(dispatchInputsDigest({ flag: true })).not.toBe(dispatchInputsDigest({ flag: false }));
-    expect(dispatchInputsDigest({ flag: "" })).not.toBe(dispatchInputsDigest({}));
+    expect(dispatchInputsDigest({ flag: "" })).toBe(dispatchInputsDigest({}));
   });
 
   it("parses release validation dispatch args", () => {


### PR DESCRIPTION
## Summary

- normalize FRV dispatch witness digests the same way GitHub records `workflow_dispatch` inputs
- omit empty-string inputs from the retained-request digest comparison
- update the dispatch fixture and regression coverage for GitHub's omitted-empty behavior

## Release impact

The SHA-pinned helper currently dispatches all declared inputs, including empty strings. GitHub omits those empty values from `event.inputs`, so the workflow's sealed witness cannot match the retained request and the helper refuses to adopt an otherwise exact run. This blocks trusted Full Release Validation dispatches.

Observed on beta validation run https://github.com/openclaw/openclaw/actions/runs/34408047774. The expected digest matched the workflow witness only after removing the ten empty-string inputs.

## Testing

- `pnpm exec vitest run test/scripts/full-release-validation-at-sha.test.ts` (160 passed)
- `pnpm exec oxfmt --check scripts/full-release-validation-at-sha.mts test/scripts/full-release-validation-at-sha.test.ts`
- `git diff --check`
