### PR TITLE
fix(ui): clarify global model defaults and agent scope

### DIFF
--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -196,7 +196,7 @@ suite.define(() => {
         const failedScripts: string[] = [];
         const startupScripts: string[] = [];
         const settingsScripts: string[] = [];
-        const providerCopy = "Model providers with auth, plan, quota, and cost data.";
+        const providerCopy = "Providers and credentials for the selected agent.";
         // Keep each cold-boot document alive through the final assertions: replacing
         // an observed document cancels its idle imports and creates test-owned failures.
         for (const pathname of ["new", "chat", "settings/model-providers"]) {
@@ -777,7 +777,7 @@ suite.define(() => {
           routeId: route,
         });
         if (route === "model-providers") {
-          await page.getByRole("heading", { name: "Defaults", exact: true }).waitFor();
+          await page.getByRole("heading", { name: "Global defaults", exact: true }).waitFor();
         }
 
         const titleDescriptionPairs = page.locator(

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -112,7 +112,8 @@ const enSettings = {
   modelProviders: {
     title: "Configured providers",
     configureModels: "Configure Models",
-    subtitle: "Model providers with auth, plan, quota, and cost data.",
+    subtitle:
+      "Inspect providers and credentials for the selected agent. The agent selector does not change global defaults.",
     updated: "Updated {time}",
     refreshing: "Refreshing…",
     disconnected: "Connect to the gateway to see configured model providers.",
@@ -228,8 +229,9 @@ const enSettings = {
       saved: "Provider {provider} added.",
     },
     defaults: {
-      title: "Defaults",
-      subtitle: "Applies across all providers and models where applicable.",
+      title: "Global defaults",
+      subtitle:
+        "Model and behavior defaults for all agents. Agent-specific settings override these defaults. View each agent's model in Agents → Overview.",
       primary: "Model",
       utility: "Utility Model",
       utilityHelpLabel: "About the utility model",
@@ -248,12 +250,12 @@ const enSettings = {
       retryDiscover: "Retry",
       thinkingHelpLabel: "About thinking defaults",
       thinkingHelp:
-        "Sets the default for new sessions when no session-specific thinking level is set. OpenClaw maps unsupported levels to the closest option supported by the selected model.",
+        "Sets the global default for new sessions when no session-specific thinking level is set. OpenClaw maps unsupported levels to the closest option supported by the selected model.",
       thinkingDefaultHelp:
         "Uses the selected model's thinking policy instead of saving a global thinking override.",
       fastModeHelpLabel: "About fast mode defaults",
       fastModeHelp:
-        "Sets the default for new sessions. Auto starts in fast mode and returns to standard mode after the model's configured interval; On and Off keep that behavior fixed.",
+        "Sets the global default for new sessions. Auto starts in fast mode and returns to standard mode after the model's configured interval; On and Off keep that behavior fixed.",
       fastModeDefaultHelp:
         "Uses the selected model's fast-mode policy. Unlike Auto, Default does not enable fast mode by itself.",
       saved: "Defaults saved.",

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -112,8 +112,7 @@ const enSettings = {
   modelProviders: {
     title: "Configured providers",
     configureModels: "Configure Models",
-    subtitle:
-      "Inspect providers and credentials for the selected agent. The agent selector does not change global defaults.",
+    subtitle: "Providers and credentials for the selected agent.",
     updated: "Updated {time}",
     refreshing: "Refreshing…",
     disconnected: "Connect to the gateway to see configured model providers.",

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -235,7 +235,7 @@ describe("ModelProvidersPage agent scope", () => {
     expect(agentSelection.set).toHaveBeenCalledWith("writer");
     expect(agentSelection.setScope).not.toHaveBeenCalled();
     expect(page.querySelector(".page-subtitle")?.textContent).toContain(
-      "Inspect providers and credentials for the selected agent. The agent selector does not change global defaults.",
+      "Providers and credentials for the selected agent.",
     );
   });
 

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -234,6 +234,9 @@ describe("ModelProvidersPage agent scope", () => {
 
     expect(agentSelection.set).toHaveBeenCalledWith("writer");
     expect(agentSelection.setScope).not.toHaveBeenCalled();
+    expect(page.querySelector(".page-subtitle")?.textContent).toContain(
+      "Inspect providers and credentials for the selected agent. The agent selector does not change global defaults.",
+    );
   });
 
   it("links the page subtitle to the model providers guide", async () => {

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -227,7 +227,7 @@ describe("renderModelProviders", () => {
     document.body.replaceChildren();
   });
 
-  it("renders one Defaults section with the five default rows and canonical values", () => {
+  it("renders global defaults with agent override precedence and canonical values", () => {
     const onThinkingChange = vi.fn();
     const onFastModeChange = vi.fn();
     const container = mount(
@@ -241,9 +241,9 @@ describe("renderModelProviders", () => {
 
     const behavior = container.querySelector("#settings-model-behavior");
     expect(behavior).not.toBeNull();
-    expect(text(container.querySelector(".settings-section__heading"))).toBe("Defaults");
+    expect(text(container.querySelector(".settings-section__heading"))).toBe("Global defaults");
     expect(text(container.querySelector(".settings-section__desc"))).toBe(
-      "Applies across all providers and models where applicable.",
+      "Model and behavior defaults for all agents. Agent-specific settings override these defaults. View each agent's model in Agents → Overview.",
     );
     expect(
       [...container.querySelectorAll(".model-providers__defaults .settings-row")].map((entry) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting an agent in Models settings could mistake the displayed global model for that agent's model override.

## Why This Change Was Made

Label the existing section “Global defaults,” explain that agent-specific settings override it, and point to Agents → Overview. The short page subtitle identifies provider and credential inspection as the selected-agent scope. Thinking and Fast Mode help now also name their global scope.

## User Impact

Users can identify which settings apply globally and where to inspect an agent's effective model. Save targets, agent overrides, and credential probing keep their existing behavior.

## Evidence

- The served baseline showed the global model under “Defaults” while a different agent model remained visible in Overview.
- Updated regression assertions fail on baseline wording. All 111 focused and sibling tests passed; all 78 affected tests passed again after the final wording change.
- The existing settings-layout browser checks pass with the updated subtitle and Global defaults heading.
- Formatting, typed lint, relevant ratchets, targeted style checks, and locale baseline/verification pass.
- Independent real-browser checks on the packaged candidate confirm global Model, Thinking, and Fast Mode saves, unchanged agent overrides, inherited model readback, and selected-agent credential probing without model calls.
- All 21 exposed locales retain their selection and readable current English fallback, with translated surrounding UI. Generated translations remain owned by the post-merge locale process.
- Matched phone captures confirm the page title and scope explanation remain visible. Existing phone-header control overlap and Escape behavior are retained as separate baseline findings.

Fixes #142429. Thanks @schjonhaug for the report.
