### PR TITLE
fix(ui): align chat actions and keep copy confirmation green

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -931,6 +931,7 @@ img.chat-avatar.chat-avatar--logo {
 
 .chat-copy-btn__icon-copy,
 .chat-copy-btn__icon-check {
+  display: flex;
   position: absolute;
   top: 0;
   left: 0;
@@ -957,10 +958,28 @@ img.chat-avatar.chat-avatar--logo {
   color: var(--danger);
 }
 
-.chat-copy-btn[data-copy-state="copied"] {
+.chat-copy-btn[data-copy-state="copied"],
+.chat-group
+  :is(.chat-group-footer-actions, .chat-message-actions-row)
+  button[data-copy-state="copied"] {
+  opacity: 1;
   border-color: var(--ok-subtle);
   background: var(--ok-subtle);
   color: var(--ok);
+}
+
+/* The check is the visible confirmation; retain the live status for assistive
+   technology and the footer's transient-feedback disclosure. */
+.chat-group .chat-copy-btn[data-copy-state="copied"] + [data-copy-feedback] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .chat-copy-btn:focus-visible,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the chat footer copy and reply icons were vertically misaligned. Successful copying also added a visible “Copied!” label and changed the green check to the accent color on hover.

## Why This Change Was Made

Center the copy/check SVG layers with flex layout, keep success styling authoritative over footer hover styling, and visually hide only the chat success status. The accessible live status, clipboard lifecycle, reset timers, and visible failure feedback remain intact.

## User Impact

Aligned chat actions and quiet, consistently green copy confirmation without expanding the footer. No Gateway, configuration, or clipboard transport changes.

## Evidence

- Chromium, real Control UI `/chat` route with deterministic mocked Gateway history and real browser clipboard. No production Gateway or personal data.
- Desktop `1440×900` and mobile `390×844`; both typical and wrapped, formatted content.
- Actual reply/copy SVG center delta: **1px before → 0px after** in all four combinations.
- Success color stays `rgb(34, 197, 94)` and opacity `1` both idle and hovered. “Copied!” remains accessible without visible layout width; reset and visible denied-copy feedback pass.
- Empty/loading: N/A, completed-message footer actions do not exist there. Error state is included at both viewports.
- Baseline: `7818177bf0bedc8a35e3cf666824c20e643dad66`. Candidate CSS blob: `c31e68340947aeacd4a3cd11d96263dfadb78e04`; recordings match the proposed stylesheet.
- Browser recordings and all paired screenshots inspected; generated media is not committed.

### Before/after videos

**1440x900 — before**

https://github.com/user-attachments/assets/3b47622a-b66c-4287-be1d-a9e7d53387c6

**1440x900 — after**

https://github.com/user-attachments/assets/7a5fdf10-b122-4b59-8c03-1a72c7b949b1

**390x844 — before**

https://github.com/user-attachments/assets/aa9bae31-be06-4aaf-a6f2-15c182b66dac

**390x844 — after**

https://github.com/user-attachments/assets/f2919b2c-14f2-43ce-a030-91f020c8ef13

### Screenshots

| State | Viewport | Before | After |
| --- | --- | --- | --- |
| typical-idle | 1440x900 | ![Before typical-idle](https://github.com/user-attachments/assets/a0f960a8-b1b9-4bdc-8039-c60718ad6d36) | ![After typical-idle](https://github.com/user-attachments/assets/74985be1-d307-4c35-b922-e051d15a27a7) |
| typical-copied-hover | 1440x900 | ![Before typical-copied-hover](https://github.com/user-attachments/assets/ab5563fa-8db7-42bb-a15a-5b8762d43511) | ![After typical-copied-hover](https://github.com/user-attachments/assets/d71cdb7e-d783-4075-9257-a6a4fc716e6a) |
| content-heavy-idle | 1440x900 | ![Before content-heavy-idle](https://github.com/user-attachments/assets/48c365c2-ed29-4b17-8145-da20c39df22f) | ![After content-heavy-idle](https://github.com/user-attachments/assets/61e5572c-635f-44aa-a172-20da037e5101) |
| content-heavy-copied-hover | 1440x900 | ![Before content-heavy-copied-hover](https://github.com/user-attachments/assets/5cc5128c-9385-4b6a-9ea1-c927bb8f15e1) | ![After content-heavy-copied-hover](https://github.com/user-attachments/assets/49cbfe4d-e65e-4ff4-8b46-a0082eaff46a) |
| error | 1440x900 | ![Before error](https://github.com/user-attachments/assets/2cba19b8-178a-42f1-91be-9aa5bb2815db) | ![After error](https://github.com/user-attachments/assets/a5d6b443-5588-4f23-9b38-a3b7b75e6926) |
| typical-idle | 390x844 | ![Before typical-idle](https://github.com/user-attachments/assets/0806b526-a61c-4cd6-87b3-887637aa9315) | ![After typical-idle](https://github.com/user-attachments/assets/1d9bf403-129f-45b4-bdc0-0c6d54821272) |
| typical-copied-hover | 390x844 | ![Before typical-copied-hover](https://github.com/user-attachments/assets/29ded02d-d9cc-4fe6-bfaa-1737a7fe8c3d) | ![After typical-copied-hover](https://github.com/user-attachments/assets/30ba8be4-c8bc-4a2f-914b-185632adbc82) |
| content-heavy-idle | 390x844 | ![Before content-heavy-idle](https://github.com/user-attachments/assets/b24c5a09-df84-4dfc-89c5-b54d796f0e2b) | ![After content-heavy-idle](https://github.com/user-attachments/assets/daf9268a-db58-4e23-ad1f-d1958f61a2d8) |
| content-heavy-copied-hover | 390x844 | ![Before content-heavy-copied-hover](https://github.com/user-attachments/assets/69ad90f9-ff89-4c4b-901d-5d08eb5bcfdb) | ![After content-heavy-copied-hover](https://github.com/user-attachments/assets/2792388f-ba79-457b-919a-f311f4054e5c) |
| error | 390x844 | ![Before error](https://github.com/user-attachments/assets/797cb87d-e03b-48d0-bb7c-a66e57a501b4) | ![After error](https://github.com/user-attachments/assets/7cfdc654-725a-4f0b-9a05-43386cb6dacf) |

### Validation

- `node scripts/check-changed.mjs`: passed (repo-pinned pnpm 12.3.4).
- Focused bundled browser lane: **29 tests passed** across `chat-flow.clipboard.e2e.test.ts` and `chat-message-actions.e2e.test.ts`, including a fresh UI build.
- `node --import tsx .artifacts/chat-copy-proof.mts before` / `after`: passed all visual, clipboard, reset, and failure assertions.
- Independent autoreview: scoped-clean through P2, no actionable findings.
- `git diff --check`: passed.

## Worked on by

- Patrick Erichsen (@Patrick-Erichsen)
