### PR TITLE
fix: retain background compaction state through disposal

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -86,6 +86,11 @@ Every time OpenClaw runs a model prompt, the context engine participates at four
 
 Engines can also implement an optional `maintain()` method for transcript maintenance (safe rewrites via `runtimeContext.rewriteTranscriptEntries()`) after bootstrap, a successful turn, or compaction. Set `info.turnMaintenanceMode: "background"` to run it as deferred work instead of blocking the reply.
 
+When queued budget compaction accepts background maintenance, it keeps the prepared
+runtime alive through maintenance, coalesced reruns, and engine disposal. Acceptance
+does not mean cleanup has finished. Return asynchronous work from engine methods
+and `dispose()` so the host can join it before releasing their resources.
+
 For the bundled non-ACP Codex harness, OpenClaw applies the same lifecycle by projecting assembled context into Codex developer instructions and the current turn prompt. Codex still owns its native thread history and native compactor.
 
 ### Subagent lifecycle (optional)

--- a/src/agents/embedded-agent-runner/compact.queued-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.queued-resources.test.ts
@@ -1,0 +1,244 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { PluginRegistryInspectionResources } from "../../plugins/registry-inspection-resources.js";
+import { createPluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry, resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
+import { createPluginRuntime } from "../../plugins/runtime/index.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { closePreparedModelRuntimeSnapshots } from "../prepared-model-runtime.lifecycle.js";
+import { compactEmbeddedAgentSession } from "./compact.queued.js";
+import { waitForDeferredTurnMaintenanceForSession } from "./context-engine-maintenance.js";
+
+// Exercise the managed producer at the existing input boundary without enabling RUN disposal.
+vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../prepared-model-runtime.js")>();
+  return {
+    ...actual,
+    acquireAgentRunPreparedModelRuntime: (
+      input: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[0],
+      options: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[1],
+    ) =>
+      actual.acquireReadOnlyPreparedModelRuntime(
+        {
+          ...input,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [
+            { provider: "queued-resource-fixture", modelId: "model", agentId: "main" },
+          ],
+        },
+        options?.abortSignal,
+        "static",
+      ),
+  };
+});
+
+it("keeps an actual prepared registration alive through queued engine maintenance and disposal", async () => {
+  await withOpenClawTestState(
+    { prefix: "openclaw-queued-registration-", layout: "split" },
+    async (state) => {
+      const pluginId = "queued-resource-fixture";
+      const pluginRoot = state.path("plugin");
+      const key = `__queued_resources_${path.basename(state.root)}`;
+      const bridge = {
+        entered: createDeferredCore(),
+        resume: createDeferredCore(),
+        disposalEntered: createDeferredCore(),
+        finishDisposal: createDeferredCore(),
+        closed: createDeferredCore(),
+        connections: [] as Array<{ file: string; db: DatabaseSync; disposals: number }>,
+        values: [] as unknown[],
+      };
+      Object.defineProperty(globalThis, key, { configurable: true, value: bridge });
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.mkdirSync(state.workspaceDir, { recursive: true });
+      fs.mkdirSync(state.agentDir(), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: pluginId,
+          version: "1.0.0",
+          openclaw: { extensions: ["./index.cjs"] },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({ id: pluginId, providers: [pluginId], configSchema: { type: "object" } }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "index.cjs"),
+        `
+const { DatabaseSync } = require('node:sqlite');
+module.exports = { id: '${pluginId}', register(api) {
+  const bridge = globalThis[${JSON.stringify(key)}];
+  const file = ${JSON.stringify(state.root)} + '/registration-' + bridge.connections.length + '.sqlite';
+  const db = new DatabaseSync(file);
+  db.exec('CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES(42)');
+  const connection = { file, db, disposals: 0 };
+  bridge.connections.push(connection);
+  api.lifecycle.registerRuntimeLifecycle({ id: 'database', dispose() { connection.disposals++; db.close(); bridge.closed.resolve(); } });
+  api.registerProvider({ id: '${pluginId}', label: 'Queued fixture', auth: [] });
+  api.registerContextEngine('${pluginId}', () => ({
+    info: { id: '${pluginId}', name: 'Queued fixture', ownsCompaction: true, turnMaintenanceMode: 'background' },
+    ingest: async () => ({ ingested: false }),
+    assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+    compact: async () => { throw new Error('Expected deferred maintenance'); },
+    async maintain() { bridge.entered.resolve(); await bridge.resume.promise; bridge.values.push(db.prepare('SELECT value FROM answer').get().value); return { changed: false, bytesFreed: 0, rewrittenEntries: 0 }; },
+    async dispose() { bridge.disposalEntered.resolve(); await bridge.finishDisposal.promise; bridge.values.push(db.prepare('SELECT value FROM answer').get().value); },
+  }));
+} };
+`,
+      );
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: state.workspaceDir, model: { primary: `${pluginId}/model` } },
+        },
+        models: {
+          providers: {
+            [pluginId]: {
+              api: "openai-completions",
+              apiKey: "synthetic-fixture",
+              baseUrl: "https://fixture.invalid/v1",
+              models: [
+                {
+                  id: "model",
+                  name: "Model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          allow: [pluginId],
+          load: { paths: [pluginRoot] },
+          slots: { memory: "none", contextEngine: pluginId },
+          entries: { [pluginId]: { enabled: true } },
+        },
+      };
+      await state.writeConfig(config);
+      const donor = createPluginRegistry({
+        runtime: createPluginRuntime(),
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+        activateGlobalSideEffects: false,
+      });
+      const source = new PluginRegistryInspectionResources();
+      source.attach(donor.registry);
+      const record = createPluginRecord({
+        id: pluginId,
+        source: path.join(pluginRoot, "index.cjs"),
+      });
+      donor.registry.plugins.push(record);
+      const api = donor.createApi(record, { config, registrationMode: "full" });
+      const file = state.path("donor.sqlite");
+      const db = new DatabaseSync(file);
+      db.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+      const registration = { file, db, disposals: 0 };
+      bridge.connections.push(registration);
+      source.runRegistration(pluginId, () => {
+        api.lifecycle.registerRuntimeLifecycle({
+          id: "donor-database",
+          dispose() {
+            registration.disposals++;
+            db.close();
+          },
+        });
+        api.registerContextEngine(pluginId, () => ({
+          info: {
+            id: pluginId,
+            name: "Runtime donor",
+            ownsCompaction: true,
+            turnMaintenanceMode: "background",
+          },
+          ingest: async () => ({ ingested: false }),
+          assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+          compact: async () => {
+            throw new Error("Expected deferred maintenance");
+          },
+          async maintain() {
+            bridge.entered.resolve();
+            await bridge.resume.promise;
+            bridge.values.push(db.prepare("SELECT value FROM answer").get()?.value);
+            return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+          },
+          async dispose() {
+            bridge.disposalEntered.resolve();
+            await bridge.finishDisposal.promise;
+            bridge.values.push(db.prepare("SELECT value FROM answer").get()?.value);
+          },
+        }));
+      });
+      setActivePluginRegistry(donor.registry);
+      const target = {
+        agentId: "main",
+        sessionId: "queued-registration",
+        sessionKey: "agent:main:queued-registration",
+        storePath: state.path("sessions.sqlite"),
+      };
+      await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: Date.now() });
+      try {
+        const result = await compactEmbeddedAgentSession({
+          ...target,
+          sessionTarget: target,
+          sessionFile: target.sessionKey,
+          workspaceDir: state.workspaceDir,
+          agentDir: state.agentDir(),
+          config,
+          provider: pluginId,
+          model: "model",
+          trigger: "budget",
+          deferOwningContextEngineCompaction: true,
+          enqueue: async (task) => await task(),
+        });
+        expect(result).toMatchObject({ ok: true, compacted: false });
+        await bridge.entered.promise;
+        await source.release();
+        expect(bridge.connections).toHaveLength(2);
+        expect.soft(registration.db.isOpen).toBe(true);
+        bridge.resume.resolve();
+        await bridge.disposalEntered.promise;
+        expect.soft(registration.db.isOpen).toBe(true);
+        expect.soft(registration.disposals).toBe(0);
+        bridge.finishDisposal.resolve();
+        await waitForDeferredTurnMaintenanceForSession(target.sessionKey);
+        await bridge.closed.promise;
+        await vi.waitFor(() =>
+          expect(bridge.connections.every((connection) => connection.disposals === 1)).toBe(true),
+        );
+        expect(bridge.values).toEqual([42, 42]);
+        expect(registration.disposals).toBe(1);
+        expect(registration.db.isOpen).toBe(false);
+        const reopened = new DatabaseSync(registration.file, { readOnly: true });
+        try {
+          expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        bridge.resume.resolve();
+        bridge.finishDisposal.resolve();
+        await waitForDeferredTurnMaintenanceForSession(target.sessionKey);
+        await closePreparedModelRuntimeSnapshots();
+        await source.release();
+        resetPluginRuntimeStateForTest();
+        clearPluginMetadataLifecycleCaches();
+        for (const connection of bridge.connections) {
+          if (connection.db.isOpen) {
+            connection.db.close();
+          }
+        }
+        Reflect.deleteProperty(globalThis, key);
+      }
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -132,6 +132,7 @@ async function deferOwningContextEngineBudgetCompaction(params: {
   contextEngine: ContextEngine;
   contextEngineRuntimeContext: ContextEngineRuntimeContext;
   contextEngineRuntimeSettings: ContextEngineRuntimeSettings;
+  onDeferredMaintenance: (completion: Promise<void>) => void;
 }): Promise<EmbeddedAgentCompactResult> {
   let deferredScheduled = false;
   let deferredScheduleFailure: unknown;
@@ -148,8 +149,9 @@ async function deferOwningContextEngineBudgetCompaction(params: {
       config: params.compactParams.config,
       contextEngineAgentId: params.compactParams.contextEngineAgentId,
       disposeDeferredContextEngineAfterMaintenance: true,
-      onDeferredMaintenance: () => {
+      onDeferredMaintenance: (completion) => {
         deferredScheduled = true;
+        params.onDeferredMaintenance(completion);
       },
       onDeferredMaintenanceFailure: (error) => {
         deferredScheduleFailure = error;
@@ -388,6 +390,7 @@ async function compactEmbeddedAgentSessionImpl(
     ),
     agentDir: lease.snapshot.agentDir,
   };
+  let deferredCompletion: Promise<void> | undefined;
   const run = async () => {
     ensureContextEnginesInitialized();
     const contextEngine = await resolveContextEngine(preparedParams.config, {
@@ -408,8 +411,9 @@ async function compactEmbeddedAgentSessionImpl(
         resolvedWorkspaceDir,
         lease.snapshot,
         contextEngineSessionKey,
-        () => {
+        (completion) => {
           disposeContextEngineOnExit = false;
+          deferredCompletion = completion;
         },
       );
     } finally {
@@ -422,7 +426,11 @@ async function compactEmbeddedAgentSessionImpl(
     assertQueuedCompactionPreparationActive(params, host);
     return await withPluginRuntimeGenerationScope(lease.snapshot, run);
   } finally {
-    lease.release();
+    if (deferredCompletion) {
+      void deferredCompletion.then(lease.release, lease.release);
+    } else {
+      lease.release();
+    }
   }
 }
 
@@ -435,7 +443,7 @@ async function compactResolvedContextEngine(
   resolvedWorkspaceDir: string,
   preparedModelRuntime: PreparedModelRuntimeSnapshot,
   contextEngineSessionKey: string | undefined,
-  releaseContextEngineOwnership: () => void,
+  transferContextEngineOwnership: (completion: Promise<void>) => void,
 ): Promise<EmbeddedAgentCompactResult> {
   const runtimeTarget = params.sessionTarget;
   const lockedHarnessRuntime = resolveSessionPinnedHarnessId(params.sessionEntry);
@@ -662,17 +670,14 @@ async function compactResolvedContextEngine(
     contextEngine.info.turnMaintenanceMode === "background" &&
     typeof contextEngine.maintain === "function"
   ) {
-    const deferredResult = await deferOwningContextEngineBudgetCompaction({
+    return await deferOwningContextEngineBudgetCompaction({
       compactParams: preparedParams,
       contextEngineSessionKey,
       contextEngine,
       contextEngineRuntimeContext,
       contextEngineRuntimeSettings,
+      onDeferredMaintenance: transferContextEngineOwnership,
     });
-    if (deferredResult.ok) {
-      releaseContextEngineOwnership();
-    }
-    return deferredResult;
   }
   return await executeQueuedContextEngineCompaction({
     params,

--- a/src/agents/embedded-agent-runner/context-engine-maintenance-work.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance-work.ts
@@ -1,0 +1,56 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ContextEngine } from "../../context-engine/types.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import type { createSessionMaintenanceOwner } from "../session-maintenance/coordinator.js";
+import { log } from "./logger.js";
+
+/** Maintenance owns cooperating descendants through the operation's actual settlement. */
+export async function runContextEngineMaintenanceWork(
+  run: () => Promise<void>,
+  signal: AbortSignal,
+): Promise<void> {
+  const work = new AsyncWorkScope();
+  const context = work.run(() => AsyncLocalStorage.snapshot());
+  // Accepted background work follows maintenance shutdown, not foreground completion.
+  const cancel = () => context(() => work.beginClose(signal.reason));
+  signal.addEventListener("abort", cancel, { once: true });
+  if (signal.aborted) {
+    cancel();
+  }
+  try {
+    await work.track(run);
+  } finally {
+    try {
+      // Normal completion must not abort work that returned an early result.
+      await AsyncWorkScope.runWhenAllIdle(
+        () => [work],
+        () => context(() => work.drain()),
+      );
+    } finally {
+      signal.removeEventListener("abort", cancel);
+    }
+  }
+}
+
+export async function disposeDeferredMaintenanceContextEngine(
+  params: {
+    contextEngine: ContextEngine;
+    runInContext: ReturnType<typeof AsyncLocalStorage.snapshot>;
+  },
+  maintenance: Pick<ReturnType<typeof createSessionMaintenanceOwner>, "run" | "signal">,
+): Promise<void> {
+  try {
+    await params.runInContext(() =>
+      maintenance.run(() =>
+        runContextEngineMaintenanceWork(async () => {
+          await params.contextEngine.dispose?.();
+        }, maintenance.signal),
+      ),
+    );
+  } catch (err) {
+    log.warn("context engine dispose failed after deferred maintenance", {
+      errorMessage: formatErrorMessage(err),
+    });
+  }
+}

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.resources.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.resources.test.ts
@@ -1,0 +1,328 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import type { ContextEngine } from "../../context-engine/types.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import {
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "../../tasks/task-runtime.test-helpers.js";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import {
+  runContextEngineMaintenance,
+  waitForDeferredTurnMaintenanceForSession,
+} from "./context-engine-maintenance.js";
+
+const unchanged = { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+
+function engine(maintain: NonNullable<ContextEngine["maintain"]>): ContextEngine {
+  return {
+    info: { id: "resource-test", name: "Resource test", turnMaintenanceMode: "background" },
+    ingest: async () => ({ ingested: false }),
+    assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+    compact: async () => ({ ok: true, compacted: false }),
+    maintain,
+  };
+}
+
+it("keeps SIGTERM cancellation attached through actual engine disposal", async () => {
+  await withResources(async (db, schedule) => {
+    const context = new AsyncLocalStorage<string>();
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const cancelled = vi.fn();
+    const disposed = vi.fn();
+    const keepTestProcessAlive = () => {};
+    process.on("SIGTERM", keepTestProcessAlive);
+    let lifecycleSignal: AbortSignal | undefined;
+    const contextEngine = engine(async ({ abortSignal }) => {
+      lifecycleSignal = abortSignal;
+      return unchanged;
+    });
+    contextEngine.dispose = async () => {
+      const signal = getAsyncWorkSignal();
+      if (!signal) {
+        throw new Error("expected disposer work signal");
+      }
+      signal.addEventListener("abort", () => cancelled(context.getStore(), signal.reason), {
+        once: true,
+      });
+      entered.resolve();
+      await release.promise;
+      disposed(db.prepare("SELECT value FROM probe").get()?.value);
+    };
+    try {
+      await context.run("disposer", () => schedule(contextEngine));
+      await entered.promise;
+      context.run("unrelated", () => process.emit("SIGTERM", "SIGTERM"));
+      expect(lifecycleSignal?.aborted).toBe(true);
+      expect(cancelled).toHaveBeenCalledExactlyOnceWith("disposer", lifecycleSignal?.reason);
+      release.resolve();
+      await waitForDeferredTurnMaintenanceForSession("agent:main:maintenance-resources");
+      expect(disposed).toHaveBeenCalledExactlyOnceWith(42);
+    } finally {
+      release.resolve();
+      await waitForDeferredTurnMaintenanceForSession("agent:main:maintenance-resources");
+      process.off("SIGTERM", keepTestProcessAlive);
+    }
+  });
+});
+
+async function withResources(
+  run: (
+    db: DatabaseSync,
+    schedule: (contextEngine: ContextEngine) => Promise<void>,
+  ) => Promise<void>,
+) {
+  await withStateDirEnv("openclaw-maintenance-resources-", async ({ stateDir }) => {
+    resetCommandQueueStateForTest();
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+    const db = new DatabaseSync(path.join(stateDir, "registration.sqlite"));
+    db.exec("CREATE TABLE probe(value INTEGER); INSERT INTO probe VALUES (42)");
+    const pending: Promise<void>[] = [];
+    const schedule = async (contextEngine: ContextEngine) => {
+      await runContextEngineMaintenance({
+        contextEngine,
+        sessionId: "resources",
+        sessionKey: "agent:main:maintenance-resources",
+        sessionFile: path.join(stateDir, "session.jsonl"),
+        reason: "turn",
+        disposeDeferredContextEngineAfterMaintenance: true,
+        onDeferredMaintenance: (promise) => {
+          pending.push(promise);
+        },
+      });
+    };
+    try {
+      await run(db, schedule);
+    } finally {
+      await Promise.allSettled(pending);
+      db.close();
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+    }
+  });
+}
+
+it.each(["maintenance", "disposal"] as const)(
+  "joins actual %s descendants before maintenance completion",
+  async (phase) => {
+    await withStateDirEnv("openclaw-maintenance-tail-", async ({ stateDir }) => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      const db = new DatabaseSync(path.join(stateDir, "registration.sqlite"));
+      db.exec("CREATE TABLE probe(value INTEGER); INSERT INTO probe VALUES (42)");
+      const release = createDeferredCore();
+      const entered = createDeferredCore();
+      let tail: Promise<unknown> | undefined;
+      let completion: Promise<void> | undefined;
+      let returned = false;
+      const startTail = () => {
+        tail = trackAsyncWork(async () => {
+          entered.resolve();
+          await release.promise;
+          return db.prepare("SELECT value FROM probe").get()?.value;
+        });
+        void tail.catch(() => {});
+      };
+      const contextEngine = engine(async () => {
+        if (phase === "maintenance") {
+          startTail();
+        }
+        return unchanged;
+      });
+      const dispose = vi.fn(async () => {
+        if (phase === "disposal") {
+          startTail();
+        }
+      });
+      contextEngine.dispose = dispose;
+      try {
+        await runContextEngineMaintenance({
+          contextEngine,
+          sessionId: "tail",
+          sessionKey: "agent:main:maintenance-tail",
+          sessionFile: path.join(stateDir, "session.jsonl"),
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+          onDeferredMaintenance: (promise) => {
+            completion = promise.then(() => {
+              returned = true;
+              db.close();
+            });
+          },
+        });
+        await entered.promise;
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect.soft(returned).toBe(false);
+        if (phase === "maintenance") {
+          expect.soft(dispose).not.toHaveBeenCalled();
+        }
+        release.resolve();
+        await expect(tail).resolves.toBe(42);
+        await completion;
+        expect(dispose).toHaveBeenCalledOnce();
+      } finally {
+        release.resolve();
+        await Promise.allSettled([...(tail ? [tail] : []), ...(completion ? [completion] : [])]);
+        if (!returned) {
+          db.close();
+        }
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+      }
+    });
+  },
+);
+
+it("joins disposal of a superseded queued engine before reporting the active maintenance settled", async () => {
+  await withResources(async (db, schedule) => {
+    const context = new AsyncLocalStorage<string>();
+    const contexts: Array<string | undefined> = [];
+    const releaseActive = createDeferredCore();
+    const activeStarted = createDeferredCore();
+    const releaseDisposal = createDeferredCore();
+    const disposalStarted = createDeferredCore();
+    const finalRan = createDeferredCore();
+    const disposed = vi.fn();
+    const active = engine(async () => {
+      contexts.push(context.getStore());
+      activeStarted.resolve();
+      await releaseActive.promise;
+      return unchanged;
+    });
+    const superseded = engine(async () => unchanged);
+    superseded.dispose = async () => {
+      contexts.push(context.getStore());
+      disposalStarted.resolve();
+      await releaseDisposal.promise;
+      disposed(db.prepare("SELECT value FROM probe").get()?.value);
+    };
+    const latest = engine(async () => {
+      contexts.push(context.getStore());
+      finalRan.resolve();
+      return unchanged;
+    });
+    let allSettled = false;
+    let joined: Promise<void> | undefined;
+    try {
+      await context.run("active", () => schedule(active));
+      await activeStarted.promise;
+      await context.run("superseded", () => schedule(superseded));
+      await context.run("latest", () => schedule(latest));
+      await disposalStarted.promise;
+      joined = waitForDeferredTurnMaintenanceForSession("agent:main:maintenance-resources").then(
+        () => {
+          allSettled = true;
+        },
+      );
+      releaseActive.resolve();
+      await finalRan.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect.soft(allSettled).toBe(false);
+      releaseDisposal.resolve();
+      await joined;
+      expect(disposed).toHaveBeenCalledExactlyOnceWith(42);
+      expect(contexts).toEqual(["active", "superseded", "latest"]);
+    } finally {
+      releaseActive.resolve();
+      releaseDisposal.resolve();
+      await joined;
+    }
+  });
+});
+
+it.each(["parent completion", "gateway restart"] as const)(
+  "keeps accepted maintenance independent of %s",
+  async (mode) => {
+    await withResources(async (db, schedule) => {
+      const parent = new AsyncWorkScope();
+      const context = new AsyncLocalStorage<string>();
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const cancelled = vi.fn();
+      let tail: Promise<unknown> | undefined;
+      let maintenanceSignal: AbortSignal | undefined;
+      let parentClosed = false;
+      let closing: Promise<void> | undefined;
+      let cancellationCheckpoint: Promise<void> | undefined;
+      let checkpointPassed = false;
+      try {
+        await context.run("admitted", () =>
+          parent.track(() =>
+            schedule(
+              engine(async ({ abortSignal }) => {
+                maintenanceSignal = abortSignal;
+                const signal = getAsyncWorkSignal();
+                if (!signal) {
+                  throw new Error("expected maintenance work cancellation");
+                }
+                signal.addEventListener(
+                  "abort",
+                  () => {
+                    cancelled(context.getStore(), signal.reason);
+                    cancellationCheckpoint = waitForDeferredTurnMaintenanceForSession(
+                      "agent:main:maintenance-resources",
+                    ).then(() => {
+                      checkpointPassed = true;
+                    });
+                  },
+                  { once: true },
+                );
+                tail = trackAsyncWork(async () => {
+                  entered.resolve();
+                  await release.promise;
+                  return db.prepare("SELECT value FROM probe").get()?.value;
+                });
+                return unchanged;
+              }),
+            ),
+          ),
+        );
+        await entered.promise;
+        closing = context
+          .run("unrelated", () => parent.drain())
+          .then(() => {
+            parentClosed = true;
+          });
+        await vi.waitFor(() => expect(parentClosed).toBe(true));
+        expect.soft(maintenanceSignal?.aborted).toBe(false);
+        expect.soft(cancelled).not.toHaveBeenCalled();
+        if (mode === "gateway restart") {
+          context.run("unrelated", () => markGatewayRestartDraining());
+          expect(maintenanceSignal?.aborted).toBe(true);
+          expect(cancelled).toHaveBeenCalledExactlyOnceWith("admitted", maintenanceSignal?.reason);
+          await vi.waitFor(() => expect(checkpointPassed).toBe(true));
+        }
+        release.resolve();
+        await expect(tail).resolves.toBe(42);
+      } finally {
+        release.resolve();
+        await tail;
+        await closing;
+        await parent.drain();
+        await cancellationCheckpoint;
+        resetGatewayWorkAdmission();
+      }
+    });
+  },
+);

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -1,6 +1,7 @@
 /**
  * Schedules and runs deferred context-engine turn maintenance.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
@@ -48,6 +49,10 @@ import {
 } from "../session-maintenance/coordinator.js";
 import { SessionManager } from "../sessions/index.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
+import {
+  disposeDeferredMaintenanceContextEngine,
+  runContextEngineMaintenanceWork,
+} from "./context-engine-maintenance-work.js";
 import { log } from "./logger.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 import { resolveRuntimeTranscriptReadTarget } from "./transcript-runtime-state.js";
@@ -84,11 +89,14 @@ type ContextEngineMaintenanceParams = {
 type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
   contextEngine: ContextEngine;
   sessionKey: string;
+  runInContext: ReturnType<typeof AsyncLocalStorage.snapshot>;
   disposeContextEngineAfterMaintenance?: boolean;
   onScheduleFailure?: (error: unknown) => void;
 };
 
 type DeferredTurnMaintenanceRunState = {
+  maintenance: ReturnType<typeof createSessionMaintenanceOwner>;
+  pendingDisposals: Set<Promise<void>>;
   promise: Promise<void>;
   rerunRequested: boolean;
   activeContextEngine: ContextEngine;
@@ -116,18 +124,6 @@ function unregisterDeferredTurnMaintenanceAbortSignalHandlers(
     processLike.off(signal, handler);
   }
   state.cleanupHandlers.clear();
-}
-
-async function disposeDeferredMaintenanceContextEngine(
-  contextEngine: ContextEngine,
-): Promise<void> {
-  try {
-    await contextEngine.dispose?.();
-  } catch (err) {
-    log.warn("context engine dispose failed after deferred maintenance", {
-      errorMessage: formatErrorMessage(err),
-    });
-  }
 }
 
 function createDeferredTurnMaintenanceAbortSignal(params?: {
@@ -484,7 +480,12 @@ function scheduleDeferredTurnMaintenance(
       ) &&
       !hasSameContextEngineInstance(supersededParams.contextEngine, latestParams.contextEngine)
     ) {
-      void disposeDeferredMaintenanceContextEngine(supersededParams.contextEngine);
+      const disposal = disposeDeferredMaintenanceContextEngine(
+        supersededParams,
+        activeRun.maintenance,
+      );
+      activeRun.pendingDisposals.add(disposal);
+      void disposal.finally(() => activeRun.pendingDisposals.delete(disposal));
     }
     return activeRun.promise;
   }
@@ -552,17 +553,23 @@ function scheduleDeferredTurnMaintenance(
   let runPromise: Promise<void>;
   try {
     runPromise = enqueueCommandInLane(lane, () =>
-      maintenance.run(() =>
-        runDeferredTurnMaintenanceWorker({
-          ...params,
-          abortSignal: maintenance.signal,
-          assertActive: () => {
-            maintenance.assertCurrent();
-            params.assertActive?.();
-          },
-          sessionKey,
-          runId: task.runId!,
-        }),
+      params.runInContext(() =>
+        maintenance.run(() =>
+          runContextEngineMaintenanceWork(
+            () =>
+              runDeferredTurnMaintenanceWorker({
+                ...params,
+                abortSignal: maintenance.signal,
+                assertActive: () => {
+                  maintenance.assertCurrent();
+                  params.assertActive?.();
+                },
+                sessionKey,
+                runId: task.runId!,
+              }),
+            maintenance.signal,
+          ),
+        ),
       ),
     );
   } catch (err) {
@@ -575,7 +582,6 @@ function scheduleDeferredTurnMaintenance(
   const cleanupDeferredTurnMaintenance = () =>
     maintenance.run(async () => {
       releaseProcessOwner();
-      schedulerAbort.dispose();
       const current = activeDeferredTurnMaintenanceRuns.get(sessionKey);
       if (current !== state) {
         return;
@@ -592,7 +598,7 @@ function scheduleDeferredTurnMaintenance(
           current.activeContextEngine,
         );
         if (!rerunSharesActiveEngine && current.disposeActiveContextEngineAfterMaintenance) {
-          await disposeDeferredMaintenanceContextEngine(current.activeContextEngine);
+          await disposeDeferredMaintenanceContextEngine(params, maintenance);
         }
         const nextParams =
           rerunSharesActiveEngine && current.disposeActiveContextEngineAfterMaintenance
@@ -601,7 +607,7 @@ function scheduleDeferredTurnMaintenance(
         // Disposal can await a lifecycle rotation. Retired work cannot mint a fresh rerun.
         if (maintenance.signal.aborted) {
           if (nextParams.disposeContextEngineAfterMaintenance) {
-            await disposeDeferredMaintenanceContextEngine(nextParams.contextEngine);
+            await disposeDeferredMaintenanceContextEngine(nextParams, maintenance);
           }
           return;
         }
@@ -609,14 +615,14 @@ function scheduleDeferredTurnMaintenance(
         maintenance.releaseWrites();
         const scheduledRerun = scheduleDeferredTurnMaintenance(nextParams);
         if (!scheduledRerun && nextParams.disposeContextEngineAfterMaintenance) {
-          await disposeDeferredMaintenanceContextEngine(nextParams.contextEngine);
+          await disposeDeferredMaintenanceContextEngine(nextParams, maintenance);
         } else {
           await scheduledRerun;
         }
         return;
       }
       if (current.disposeActiveContextEngineAfterMaintenance) {
-        await disposeDeferredMaintenanceContextEngine(current.activeContextEngine);
+        await disposeDeferredMaintenanceContextEngine(params, maintenance);
       }
       if (
         discardedRerunParams?.disposeContextEngineAfterMaintenance &&
@@ -625,21 +631,36 @@ function scheduleDeferredTurnMaintenance(
           current.activeContextEngine,
         )
       ) {
-        await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
+        await disposeDeferredMaintenanceContextEngine(discardedRerunParams, maintenance);
       }
     });
+  const pendingDisposals = new Set<Promise<void>>();
   const trackedPromise = maintenance.track(
-    runPromise
-      .catch((err: unknown) => {
-        params.onScheduleFailure?.(err);
-        cancelFailedTask(err);
-      })
-      .then(cleanupDeferredTurnMaintenance, async (error: unknown) => {
-        await cleanupDeferredTurnMaintenance();
-        throw error;
-      }),
+    (async () => {
+      try {
+        await runPromise
+          .catch((err: unknown) => {
+            params.onScheduleFailure?.(err);
+            cancelFailedTask(err);
+          })
+          .then(cleanupDeferredTurnMaintenance, async (error: unknown) => {
+            await cleanupDeferredTurnMaintenance();
+            throw error;
+          });
+      } finally {
+        try {
+          while (pendingDisposals.size > 0) {
+            await Promise.all(pendingDisposals);
+          }
+        } finally {
+          schedulerAbort.dispose();
+        }
+      }
+    })(),
   );
   const state: DeferredTurnMaintenanceRunState = {
+    maintenance,
+    pendingDisposals,
     promise: trackedPromise,
     rerunRequested: false,
     activeContextEngine: params.contextEngine,
@@ -689,6 +710,7 @@ export async function runContextEngineMaintenance(
         ...params,
         contextEngine,
         sessionKey,
+        runInContext: AsyncLocalStorage.snapshot(),
         disposeContextEngineAfterMaintenance: params.disposeDeferredContextEngineAfterMaintenance,
         onScheduleFailure: params.onDeferredMaintenanceFailure,
       });


### PR DESCRIPTION
Related: #140674.

## What Problem This Solves

Resolves a problem where accepted background compaction can release its prepared runtime before maintenance, reruns or engine disposal finish. Cancellation during disposal can also lose its signal handler or wait on the operation's own write owner.

## Why This Change Was Made

Transfer the existing prepared lease to the accepted maintenance completion promise. Include worker and disposer descendants, superseded queued-engine disposal and coalesced reruns in that completion. Capture source and maintenance-writer context at the operation boundary, and keep cancellation attached until final disposal.

Accepted background work follows its existing maintenance lifetime. Normal foreground completion does not cancel it. The existing task-ID marker release point and write-release ordering stay intact so a parent cannot clear or block its rerun's owner. No schema, configuration, public API, timeout-policy or RUN producer-activation changes.

## User Impact

Background compaction can finish and clean up using its original resources after its foreground acknowledgement. Shutdown cancellation continues to reach a disposer that is still running.

## Evidence

Original maintenance fails three actual-tail regressions. The original queued-compaction source also closes SQLite before the real managed primary/runtime-donor path can finish maintenance and disposal. The final native composition passes 40 cases, covering retained sources, reruns, normal foreground completion, cancellation, transcript ownership and disposal. Earlier broader sibling coverage overlaps and is not added to that count.

Affected checks and final proportional checks pass. Fresh full-candidate Codex review through P2 is clean. The ordinary build passed in 322.72 seconds; the existing line limit was preserved by moving the cohesive disposer operation into its work helper.

Compiled runtime proof passed in 3.00 seconds across normal operation, cancellation during disposal and restart. Foreground acknowledgements took 131.42, 7.40 and 6.68 milliseconds. All 11,390 artifacts and six source files stayed unchanged; 3,896 resolved files used no application source fallback, and all processes exited.

Compiled proof exercises actual queued compaction and maintenance with its normal raw registration owner, plus separate managed read-only SQLite close/reopen. The combined managed primary/donor path is maintained native proof using the existing acquisition input seam. SIGTERM was a synthetic event inside the test child, never a signal to an operator process. These are correctness timings, not a speedup benchmark or a claim of general RUN disposal activation.
