### PR TITLE
test: reuse prepared entry for CLI JSON failure coverage

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -2,11 +2,13 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Command, CommanderError } from "commander";
 import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
 import {
   CLI_PROCESS_DEADLOCK_GUARD_MS,
   formatCliProcessFailure,
@@ -97,6 +99,7 @@ registerHooks({
 
 async function runCliProcess(params: {
   args: string[];
+  entry?: URL;
   config?: Record<string, unknown>;
   env?: NodeJS.ProcessEnv;
   forbidTlsImport?: boolean;
@@ -121,6 +124,7 @@ async function runCliProcess(params: {
   const expectedExitCode = params.expectedExitCode ?? 0;
   const exit = await runCliProcessChild({
     nodeArgs: [
+      // Prepared entrypoints still load source-checkout plugins; keep the same TSX loader.
       "--import",
       "tsx",
       // Node runs later sync customization hooks first. Install test guards after
@@ -132,7 +136,7 @@ async function runCliProcess(params: {
       ...(params.failRunMainImport
         ? ["--import", pathToFileURL(fixture.failRunMainImportPath).href]
         : []),
-      "src/entry.ts",
+      params.entry ? fileURLToPath(params.entry) : "src/entry.ts",
       ...params.args,
     ],
     env: {
@@ -353,6 +357,7 @@ describe("models list JSON failure process output", () => {
   )("renders $name as one clean canonical JSON document", async ({ provider, message, env }) => {
     const result = await runCliProcess({
       args: ["models", "list", "--provider", provider, "--json"],
+      entry: resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cli),
       config: {},
       env,
       expectedExitCode: 1,


### PR DESCRIPTION
## What Problem This Solves

Four CLI JSON-error process tests repeatedly cold-load the core CLI from TypeScript. Their complete invocation took 79–95 seconds in adjacent source baselines, despite checking the parser's output and exit behavior rather than source startup.

## Why This Change Was Made

Let those four cases use the existing invocation-owned prepared CLI entry. Keep the original TSX preload for source-checkout plugins, along with every other argument, environment value, process deadline, and output/exit assertion. Source-specific help, TLS guards, forced import failure, tracing/respawn, and backup cases keep their original entrypoint.

This is one test-file change: +7/-2 lines, zero production changes, no new tests, and no sharding or caching policy changes.

## User Impact

Faster CLI JSON process coverage with the same real parser and plugin catalog. No application behavior changes.

## Evidence

- Complete four-case original/candidate/restored-original commands: **95.166 / 55.581 / 78.623 seconds**, all four cases passing each time. The candidate is 29–42% faster, including its 3.624-second compilation, verification, and cleanup. Same physical dependencies and Node 24.20.0/pnpm 12.3.4.
- All **28 existing tests** in the file passed in 88.249 seconds, including the source-specific cases. Required changed checks passed; independent P2 review found no actionable issues.
- Positive controls ran the real `models list --all --json` through source/prepared entries in both route-first and Commander modes. All returned the same **244 nonempty canonical model identities** and local-cache notice using isolated config/home/state and the same checkout inventory. Diagnostic controls recorded zero fetch, HTTP(S), or TCP attempts; only verified TSX parent-process IPC was permitted.
- An initial variant without TSX was rejected because it made source-plugin loading slower. The final change retains the original preload. Diagnostic controls were separated when a combined two-command test exceeded its outer budget; production and committed test deadlines were never increased. Temporary diagnostic code is absent from the final diff.

The measurements establish a focused test improvement, not a promise that every CI run finishes within eight minutes.
