### PR TITLE
improve(ui): stack local author name below avatar

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2185,11 +2185,24 @@ async function createChatPickerScenario(
     "Inspect this session.",
     "The current state is available in the session controls.",
   );
+  const dashboardHistory = summaryHistory.map((message, index) =>
+    index === 0
+      ? {
+          ...message,
+          __openclaw: {
+            senderId: selfProfile.id,
+            senderIdentity: { type: "profile", id: selfProfile.id },
+            senderName: selfProfile.displayName,
+          },
+        }
+      : message,
+  );
   const fixtureHistories: Partial<Record<NonNullable<CliOptions["fixture"]>, unknown[]>> = {
     approval: buildApprovalChatHistory(baseTime),
     attachments: buildChatAttachmentHistory(baseTime),
     avatars: buildAvatarChatHistory(baseTime),
     "code-fences": buildCodeFenceChatHistory(baseTime),
+    dashboards: dashboardHistory,
     "update-blocked": buildCancelledChatHistory(baseTime),
   };
   const historyMessages = fixture
@@ -2397,7 +2410,7 @@ async function createChatPickerScenario(
         },
       },
       "agent:main:dashboard:release-health": {
-        messages: summaryHistory,
+        messages: dashboardHistory,
       },
       "agent:main:home-server": { messages: summaryHistory },
       "agent:main:cloud-refactor": { messages: summaryHistory },
@@ -2416,6 +2429,9 @@ async function createChatPickerScenario(
       {
         self: true,
         id: selfProfile.id,
+        ...(fixture === "dashboards"
+          ? { identity: { type: "profile" as const, id: selfProfile.id } }
+          : {}),
         name: selfProfile.displayName ?? undefined,
         email: selfProfile.emails[0],
         avatarUrl: `/api/users/${selfProfile.id}/avatar`,

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -452,14 +452,16 @@ suite.define(() => {
     expect(revealedTouchHeight).toBeGreaterThan(restingTouchHeight ?? 0);
 
     await page.setViewportSize({ height: 760, width: 1180 });
-    // Own-message footer: the always-visible name must stay put when hover
-    // reveals the timestamp, which slots in to its left (right-aligned row).
+    // Own-message identity stays attached to the gutter avatar while the
+    // timestamp reveals below the bubble inside the reserved turn gap.
     const ownGroup = userGroups.first();
-    const ownName = ownGroup.locator(".chat-sender-name");
+    const ownName = ownGroup.locator(".chat-group-author__name");
+    const ownAvatar = ownGroup.locator(".chat-group-author .chat-avatar-slot");
     const ownBubble = ownGroup.locator(".chat-bubble");
     await page.mouse.move(0, 0);
     await expect(ownGroup.locator(".chat-group-timestamp")).toHaveCSS("opacity", "0");
     const restingNameBox = await ownName.boundingBox();
+    const ownAvatarBox = await ownAvatar.boundingBox();
     const ownBubbleBox = await ownBubble.boundingBox();
     await ownGroup.hover();
     const ownTimestamp = ownGroup.locator(".chat-group-timestamp");
@@ -468,12 +470,16 @@ suite.define(() => {
     const hoveredNameBox = await ownName.boundingBox();
     const timestampBox = await ownTimestamp.boundingBox();
     expect(hoveredNameBox?.x).toBe(restingNameBox?.x);
-    expect((restingNameBox?.x ?? 0) + (restingNameBox?.width ?? 0)).toBeCloseTo(
+    expect((restingNameBox?.x ?? 0) + (restingNameBox?.width ?? 0) / 2).toBeCloseTo(
+      (ownAvatarBox?.x ?? 0) + (ownAvatarBox?.width ?? 0) / 2,
+      0,
+    );
+    expect((timestampBox?.x ?? 0) + (timestampBox?.width ?? 0)).toBeCloseTo(
       (ownBubbleBox?.x ?? 0) + (ownBubbleBox?.width ?? 0),
       0,
     );
-    expect((timestampBox?.x ?? 0) + (timestampBox?.width ?? 0)).toBeLessThan(
-      hoveredNameBox?.x ?? 0,
+    expect(timestampBox?.y ?? 0).toBeGreaterThanOrEqual(
+      (ownBubbleBox?.y ?? 0) + (ownBubbleBox?.height ?? 0),
     );
 
     const footerOrder = await peerGroup
@@ -720,16 +726,18 @@ suite.define(() => {
       await expect(page.locator(".agent-chat__composer-combobox textarea")).toHaveValue("");
       const status = group.locator(".chat-send-status");
       await expect(status).toHaveText("· Not sent · Retry");
-      const footerLineCenters = await group
-        .locator(".chat-sender-name, .chat-send-status")
+      const identityAndStatus = await group
+        .locator(".chat-group-author__name, .chat-send-status")
         .evaluateAll((elements) =>
           elements.map((element) => {
             const rect = element.getBoundingClientRect();
-            return rect.top + rect.height / 2;
+            return { height: rect.height, left: rect.left, top: rect.top };
           }),
         );
-      expect(footerLineCenters).toHaveLength(2);
-      expect(footerLineCenters[0]).toBeCloseTo(footerLineCenters[1] ?? 0, 0);
+      expect(identityAndStatus).toHaveLength(2);
+      expect(identityAndStatus[0]?.height).toBeGreaterThan(0);
+      expect(identityAndStatus[1]?.height).toBeGreaterThan(0);
+      expect(identityAndStatus[1]?.left ?? 0).toBeLessThan(identityAndStatus[0]?.left ?? 0);
       expect(
         await group
           .locator(".chat-bubble")

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -365,6 +365,8 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
         ? "workspace-conflict"
         : "other";
   const avatarPlacement = opts.avatarPlacement ?? "gutter";
+  const hasStackedUserAuthor =
+    normalizedRole === "user" && !isPeerGroup && avatarPlacement === "gutter";
 
   // Aggregate usage/cost/model across all messages in the group
   const meta = extractGroupMeta(group, opts.contextWindow ?? null);
@@ -450,6 +452,12 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             group.sender,
           )
       : nothing;
+  const placedAvatar = hasStackedUserAuthor
+    ? html`<div class="chat-group-author">
+        ${avatar}
+        <span class="chat-group-author__name" title=${who}>${who}</span>
+      </div>`
+    : avatar;
 
   return html`
     <div
@@ -457,11 +465,13 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
         opts.latestAssistant ? " chat-group--latest-assistant" : ""
       }${isPeerGroup ? " chat-group--peer" : ""}${
         isForwarded ? " chat-group--forwarded" : ""
-      }${senderHue === null ? "" : " chat-group--sender-tint"}"
+      }${hasStackedUserAuthor ? " chat-group--stacked-author" : ""}${
+        senderHue === null ? "" : " chat-group--sender-tint"
+      }"
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
-      ${inlineUserAvatar ? nothing : avatar}
+      ${inlineUserAvatar ? nothing : placedAvatar}
       <div class="chat-group-messages">
         ${isForwarded ? renderForwardedAttribution(group, opts) : nothing}
         ${
@@ -490,7 +500,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                 index,
                 {
                   ...opts,
-                  avatar: inlineUserAvatar && index === lastMessageIndex ? avatar : undefined,
+                  avatar: inlineUserAvatar && index === lastMessageIndex ? placedAvatar : undefined,
                 },
                 prepared,
               )}
@@ -549,7 +559,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                         isPeerGroup && group.sender?.identity?.type === "profile"
                           ? personActivityLink(group.sender.identity.id, opts.personActivity, who)
                           : null,
-                        "chat-sender-name",
+                        `chat-sender-name${
+                          hasStackedUserAuthor ? " chat-sender-name--stacked-author-footer" : ""
+                        }`,
                       )
                 }
                 ${renderChatSendStatus(sendFailure, opts)}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2451,6 +2451,49 @@ describe("grouped chat rendering", () => {
     },
   );
 
+  it("stacks the local user name under a gutter avatar", () => {
+    const container = document.createElement("div");
+    render(
+      renderMessageGroup(
+        createMessageGroup({ role: "user", content: "hello", timestamp: 1000 }, "user", {
+          key: "local-user",
+          senderLabel: "Alice Example",
+          sender: {
+            id: "profile_123",
+            name: "Alice Example",
+            identity: { type: "profile", id: "profile_123" },
+          },
+          messages: [
+            {
+              key: "local-message",
+              message: { role: "user", content: "hello", timestamp: 1000 },
+            },
+          ],
+          timestamp: 1000,
+        }),
+        {
+          showReasoning: true,
+          showToolCalls: true,
+          assistantName: "OpenClaw",
+          avatarPlacement: "gutter",
+          userId: "profile_123",
+          userName: "Alice Example",
+        },
+      ),
+      container,
+    );
+
+    const group = container.querySelector(".chat-group");
+    expect(group?.classList.contains("chat-group--stacked-author")).toBe(true);
+    expect(group?.querySelector(".chat-group-author__name")?.textContent).toContain(
+      "Alice Example",
+    );
+    expect(group?.querySelector(".chat-group-author .chat-avatar.user")).not.toBeNull();
+    expect(group?.querySelector(".chat-sender-name--stacked-author-footer")?.textContent).toContain(
+      "Alice Example",
+    );
+  });
+
   it("falls back to initials when a user avatar image fails", async () => {
     const container = document.createElement("div");
     const message = { role: "user", content: "hello", timestamp: 1000 };

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -80,9 +80,55 @@
   justify-content: start;
 }
 
-.chat-group.chat-group--with-footer > :is(.chat-avatar, .chat-avatar-slot) {
+.chat-group.chat-group--with-footer > :is(.chat-avatar, .chat-avatar-slot, .chat-group-author) {
   grid-column: var(--chat-group-avatar-column);
   grid-row: 1;
+}
+
+/* Keep the local author's identity attached to their avatar instead of
+   spending a persistent row below the bubble. The hover metadata still uses
+   the reserved turn gap, so timestamps and actions remain reachable. */
+.chat-group--stacked-author {
+  position: relative;
+  grid-template-rows: auto;
+  padding-bottom: calc(var(--chat-turn-gap) - var(--chat-footer-row-offset));
+}
+
+.chat-group-author {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
+.chat-group-author > :is(.chat-avatar, .chat-avatar-slot) {
+  align-self: center;
+  margin-bottom: 0;
+}
+
+.chat-group-author__name {
+  display: block;
+  width: calc(var(--chat-avatar-column) + 8px);
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 14px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-group--stacked-author > .chat-group-footer {
+  position: absolute;
+  right: var(--chat-avatar-gutter);
+  bottom: 1px;
+  width: var(--chat-message-column-max);
+}
+
+.chat-sender-name--stacked-author-footer {
+  display: none;
 }
 
 .chat-group.chat-group--with-footer > .chat-group-messages {
@@ -1052,13 +1098,15 @@ img.chat-avatar.chat-avatar--logo {
   display: contents;
 }
 
-.chat-message-avatar-anchor > :is(.chat-avatar, .chat-avatar-slot) {
+.chat-message-avatar-anchor > :is(.chat-avatar, .chat-avatar-slot, .chat-group-author) {
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: calc(100% + var(--chat-avatar-gap));
 }
 
-.chat-group--peer .chat-message-avatar-anchor > :is(.chat-avatar, .chat-avatar-slot) {
+.chat-group--peer
+  .chat-message-avatar-anchor
+  > :is(.chat-avatar, .chat-avatar-slot, .chat-group-author) {
   inset-inline-start: auto;
   inset-inline-end: calc(100% + var(--chat-avatar-gap));
 }
@@ -1298,8 +1346,22 @@ img.chat-avatar.chat-avatar--logo {
     margin-inline: 0;
   }
 
-  .chat-group :is(.chat-avatar, .chat-avatar-slot) {
+  .chat-group :is(.chat-avatar, .chat-avatar-slot, .chat-group-author) {
     display: none;
+  }
+
+  .chat-group--stacked-author {
+    position: static;
+    grid-template-rows: auto auto;
+  }
+
+  .chat-group--stacked-author > .chat-group-footer {
+    position: static;
+    width: 100%;
+  }
+
+  .chat-sender-name--stacked-author-footer {
+    display: inline;
   }
 
   /* Peer names carry identity when narrow rows have no avatar column. */


### PR DESCRIPTION
## Summary

- stack the signed-in user's name below their gutter avatar on desktop
- reclaim the persistent footer row while keeping timestamp and actions in the reserved turn gap
- retain footer identity on narrow and touch layouts, and keep peer-message attribution unchanged
- add an attributed dashboards mock example for visual review

## Why

Signed-in user turns currently show the avatar beside the message and repeat the name below the bubble. Attaching the name to the avatar removes a dedicated identity row and saves about 26px on sufficiently tall turns.

## Testing

- `node scripts/run-vitest.mjs run --config ui/vitest.config.ts ui/src/pages/chat/components/chat-message.test.ts --reporter=dot`
- `OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-attributed-identity.e2e.test.ts`
- `pnpm tsgo:ui`
- `pnpm exec stylelint --config config/stylelint.config.mjs ui/src/styles/chat/grouped.css`
- `git diff --check origin/main`

## Worked on by

- @RomneyDa
