### PR TITLE
fix(heartbeat): isolated heartbeat runs leak bundle MCP child processes until Gateway restart

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -381,6 +381,7 @@ export async function runCliFallbackCandidate(
             taskSuggestionDeliveryMode: turn.followupRun.run.taskSuggestionDeliveryMode,
             // Heartbeat ambient routes are never implicit message recipients.
             ...(turn.isHeartbeat ? { requireExplicitMessageTarget: true } : {}),
+            cleanupBundleMcpOnRunEnd: turn.opts?.cleanupBundleMcpOnRunEnd,
             silentReplyPromptMode: turn.followupRun.run.silentReplyPromptMode,
             allowEmptyAssistantReplyAsSilent: turn.followupRun.run.allowEmptyAssistantReplyAsSilent,
             extraSystemPromptStatic: turn.followupRun.run.extraSystemPromptStatic,

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -205,6 +205,7 @@ export async function runEmbeddedFallbackCandidate(
         // Heartbeat ambient routes are delivery context, never implicit message recipients.
         // Omit false so subagent sessions keep their downstream default.
         ...(turn.isHeartbeat ? { requireExplicitMessageTarget: true } : {}),
+        cleanupBundleMcpOnRunEnd: turn.opts?.cleanupBundleMcpOnRunEnd,
         silentReplyPromptMode: turn.followupRun.run.silentReplyPromptMode,
         suppressNextUserMessagePersistence: params.suppressQueuedUserPersistenceForCandidate,
         onUserMessagePersisted: params.notifyUserMessagePersisted,

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -37,6 +37,7 @@ import type {
   FallbackRunnerParams,
   EmbeddedAgentParams,
 } from "./agent-runner-execution.test-support.js";
+import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import {
   createReplyOperation,
   hasReplyOperationExecutionStarted,
@@ -836,6 +837,64 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     expectMockCallArgFields(state.runEmbeddedAgentMock, 0, "heartbeat embedded run params", {
       trigger: "heartbeat",
       requireExplicitMessageTarget: true,
+    });
+  });
+
+  it("forwards bundle MCP retirement to isolated heartbeat embedded runs", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("anthropic", "claude", initialFallbackAttemptOptions(params)),
+      provider: "anthropic",
+      model: "claude",
+      attempts: [],
+    }));
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "HEARTBEAT_OK" }],
+      meta: {},
+    });
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const opts: InternalGetReplyOptions = { isHeartbeat: true, cleanupBundleMcpOnRunEnd: true };
+    const params = createMinimalRunAgentTurnParams({ opts });
+    params.isHeartbeat = true;
+
+    await executeAgentTurn(params);
+
+    expectMockCallArgFields(
+      state.runEmbeddedAgentMock,
+      0,
+      "isolated heartbeat embedded run params",
+      {
+        trigger: "heartbeat",
+        cleanupBundleMcpOnRunEnd: true,
+      },
+    );
+  });
+
+  it("forwards bundle MCP retirement to isolated heartbeat CLI runs", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "sonnet-4.6", initialFallbackAttemptOptions(params)),
+      provider: "claude-cli",
+      model: "sonnet-4.6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "sonnet-4.6";
+    const opts: InternalGetReplyOptions = { isHeartbeat: true, cleanupBundleMcpOnRunEnd: true };
+    const params = createMinimalRunAgentTurnParams({ followupRun, opts });
+    params.isHeartbeat = true;
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    await executeAgentTurn(params);
+
+    expectMockCallArgFields(state.runCliAgentMock, 0, "isolated heartbeat CLI run params", {
+      trigger: "heartbeat",
+      cleanupBundleMcpOnRunEnd: true,
     });
   });
 

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -44,6 +44,8 @@ type InternalReplySessionOptions = {
   /** First dispatch only: admission created this exact pinned session before reply initialization. */
   newlyCreatedSessionId?: string;
   onDeliberateSilentTerminalReply?: () => void;
+  /** Retire the run's bundle MCP runtime at settlement. Set by one-shot isolated runs (isolated heartbeats) whose session ID is never reused. */
+  cleanupBundleMcpOnRunEnd?: boolean;
   /** Defers the child-completion wake until the visible waiting status is delivered. */
   onPendingContinuation?: (settlement?: PendingContinuationSettlement) => void;
   onSessionPrepared?: (binding: ReplySessionBinding) => void;

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -96,6 +96,9 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
       replyOptions: withReplySystemEventContext<InternalGetReplyOptions>(
         {
           isHeartbeat: true,
+          // Isolated heartbeats mint a fresh session ID per run, so nothing later
+          // reuses this run's bundle MCP runtime; retire it at settlement.
+          ...(prepared.run.kind === "isolated" ? { cleanupBundleMcpOnRunEnd: true } : {}),
           replyConversation: prepareReplyConversation({
             ctx: heartbeatContext,
             sessionEntry: suppressOriginatingContext ? undefined : prepared.conversationEntry,

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -259,6 +259,15 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     });
   });
 
+  it("retires the bundle MCP runtime only for isolated heartbeat runs", async () => {
+    // Isolated runs mint a fresh session ID per heartbeat, so nothing reuses the runtime.
+    const isolatedOpts = await runDefaultsHeartbeat({ isolatedSession: true });
+    expectReplyOptions(isolatedOpts, { isHeartbeat: true, cleanupBundleMcpOnRunEnd: true });
+
+    const sharedOpts = await runDefaultsHeartbeat({});
+    expectReplyOptions(sharedOpts, { isHeartbeat: true, cleanupBundleMcpOnRunEnd: undefined });
+  });
+
   it("uses isolated session key when isolatedSession is enabled", async () => {
     await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
       const cfg: OpenClawConfig = {

--- a/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
@@ -1,0 +1,480 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+
+/**
+ * Live product proof for #143381: an isolated heartbeat run mints a fresh
+ * session ID, so its bundle MCP stdio runtime is never reused. Before the fix
+ * nothing retired it, and every heartbeat left one MCP child process alive.
+ *
+ * The proof counts fixture MCP child processes around forced heartbeat runs on
+ * a built Gateway. Variant labeling comes from the environment so the same
+ * test can record the pre-fix (main) and fixed behavior.
+ */
+
+const MODEL_REF = "mock-openai/gpt-5.6-luna";
+const RESPONSE_TEXT = "HEARTBEAT_OK";
+const HEARTBEAT_RUNS = 3;
+const SETTLE_MS = 5_000;
+const TEST_TIMEOUT_MS = 600_000;
+const VARIANT =
+  process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF_VARIANT === "main" ? "main" : "fixed";
+// Shared heartbeats keep one persistent session runtime; isolated ones mint a
+// session per run and must retire it. Both live here so the control stays adjacent.
+const SESSION_MODE =
+  process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF_SESSION === "shared" ? "shared" : "isolated";
+const LABEL = SESSION_MODE === "shared" ? "shared" : VARIANT;
+const PROOF_OUT_DIR = process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF_OUT;
+
+const execFileAsync = promisify(execFile);
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    await cleanup();
+  }
+});
+
+type CronJob = {
+  agentId?: string;
+  declarationKey?: string;
+  enabled: boolean;
+  id: string;
+  payload: { kind: string };
+};
+type CronRunEntry = { error?: string; runId?: string; status?: string };
+type ProofCount = { stage: string; count: number; pids: number[]; at: string };
+
+function writeTextResponse(response: ServerResponse, text: string): void {
+  const message = {
+    type: "message",
+    id: `hb-mcp-retire-${randomUUID()}`,
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  writeOpenAiResponsesSse(response, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: `hb-mcp-retire-response-${randomUUID()}`,
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    },
+  ]);
+}
+
+async function startMockProvider() {
+  let responsesRequests = 0;
+  const server = createServer((request, response) => {
+    void (async () => {
+      let body = "";
+      for await (const chunk of request) {
+        body += String(chunk);
+      }
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: "gpt-5.6-luna", object: "model" }] }));
+        return;
+      }
+      if (request.method === "POST" && request.url === "/v1/embeddings") {
+        const inputs = JSON.parse(body) as { input?: string | string[] };
+        const texts = Array.isArray(inputs.input) ? inputs.input : [inputs.input ?? ""];
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            object: "list",
+            model: "text-embedding-3-small",
+            data: texts.map((_text, index) => ({
+              object: "embedding",
+              index,
+              embedding: Array.from({ length: 64 }, (_slot, dimension) =>
+                dimension === 0 ? 1 : 0,
+              ),
+            })),
+            usage: { prompt_tokens: 1, total_tokens: 1 },
+          }),
+        );
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      responsesRequests += 1;
+      writeTextResponse(response, RESPONSE_TEXT);
+    })().catch((error: unknown) => {
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock provider did not bind a loopback port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    get responsesRequests() {
+      return responsesRequests;
+    },
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+/** Writes a minimal stdio MCP server whose cmdline carries a unique marker. */
+async function writeMcpProbeScript(repoRoot: string, marker: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-mcp-probe-"));
+  cleanups.push(() => fs.rm(dir, { recursive: true, force: true }));
+  const require = createRequire(path.join(repoRoot, "package.json"));
+  const mcpUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/mcp.js")).href;
+  const stdioUrl = pathToFileURL(require.resolve("@modelcontextprotocol/sdk/server/stdio.js")).href;
+  const scriptPath = path.join(dir, `${marker}.mjs`);
+  await fs.writeFile(
+    scriptPath,
+    [
+      `const { McpServer } = await import(${JSON.stringify(mcpUrl)});`,
+      `const { StdioServerTransport } = await import(${JSON.stringify(stdioUrl)});`,
+      `const server = new McpServer({ name: ${JSON.stringify(marker)}, version: "1.0.0" });`,
+      `server.registerTool("leak_probe_ping", { description: "Heartbeat MCP leak probe" }, async () => ({`,
+      `  content: [{ type: "text", text: "pong:" + process.pid }],`,
+      `}));`,
+      `await server.connect(new StdioServerTransport());`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return scriptPath;
+}
+
+/** Counts live processes whose cmdline carries the probe marker (pgrep excludes itself). */
+async function countProbeProcesses(marker: string): Promise<{ count: number; pids: number[] }> {
+  const pattern = `[${marker[0]}]${marker.slice(1)}`;
+  try {
+    const { stdout } = await execFileAsync("pgrep", ["-f", pattern]);
+    const pids = stdout
+      .split("\n")
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter((pid) => Number.isFinite(pid));
+    return { count: pids.length, pids };
+  } catch (error) {
+    // pgrep exits 1 when nothing matches.
+    if (typeof error === "object" && error && (error as { code?: unknown }).code === 1) {
+      return { count: 0, pids: [] };
+    }
+    throw error;
+  }
+}
+
+type GatewayLogSource = { workspaceDir: string; tempRoot: string };
+
+async function readLogFiles(gateway: GatewayLogSource): Promise<Map<string, string>> {
+  const logsDir = path.join(gateway.workspaceDir, "logs");
+  const names = (await fs.readdir(logsDir).catch(() => [])).filter((name) => name.endsWith(".log"));
+  const files = [
+    ...names.toSorted().map((name) => path.join(logsDir, name)),
+    path.join(gateway.tempRoot, "gateway.stdout.log"),
+    path.join(gateway.tempRoot, "gateway.stderr.log"),
+  ];
+  const entries = await Promise.all(
+    files.map(async (file) => [file, await fs.readFile(file, "utf8").catch(() => "")] as const),
+  );
+  return new Map(entries);
+}
+
+function redact(text: string, replacements: Array<[string, string]>): string {
+  let out = text;
+  for (const [needle, label] of replacements) {
+    if (needle) {
+      out = out.replaceAll(needle, label);
+    }
+  }
+  return out
+    .replace(/(token|secret|apiKey|api_key|authorization)(["'=: ]+)[^\s"',}]+/gi, "$1$2<redacted>")
+    .replace(/Bearer\s+\S+/g, "Bearer <redacted>")
+    .replace(/\/(?:home|Users)\/[^/\s"'│]+/g, "<home>")
+    .replaceAll(os.hostname(), "<host>");
+}
+
+describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
+  "Isolated heartbeat bundle MCP runtime retirement product proof",
+  () => {
+    it(
+      `retires the isolated heartbeat MCP stdio child after each run (${LABEL})`,
+      { timeout: TEST_TIMEOUT_MS },
+      async () => {
+        const repoRoot = process.cwd();
+        const marker = `hb-mcp-leak-probe-${randomUUID().slice(0, 8)}`;
+        const scriptPath = await writeMcpProbeScript(repoRoot, marker);
+        const provider = await startMockProvider();
+        cleanups.push(() => provider.stop());
+
+        const counts: ProofCount[] = [];
+        const record = async (stage: string) => {
+          const probe = await countProbeProcesses(marker);
+          const entry = { stage, ...probe, at: new Date().toISOString() };
+          counts.push(entry);
+          console.log(JSON.stringify({ phase: "hb-mcp-count", variant: LABEL, ...entry }));
+          return entry;
+        };
+
+        await record("before-gateway-start");
+        const gatewayOwner = createQaGatewayChild();
+        cleanups.push(() => stopQaGatewayFixture(gatewayOwner));
+        const gateway = await gatewayOwner.start({
+          repoRoot,
+          // Built Gateway: source-mode tsx startup alone exceeds the QA child's
+          // 120 s listen deadline on a cold checkout.
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: ["dist/index.js"],
+            cwd: repoRoot,
+            usePackagedPlugins: true,
+          },
+          providerBaseUrl: `${provider.baseUrl}/v1`,
+          providerMode: "mock-openai",
+          primaryModel: MODEL_REF,
+          alternateModel: MODEL_REF,
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          runtimeEnvPatch: { OPENCLAW_SKIP_CHANNELS: "1" },
+          mutateConfig: (config) => ({
+            ...config,
+            logging: { ...config.logging, level: "debug" },
+            models: config.models
+              ? {
+                  ...config.models,
+                  providers: Object.fromEntries(
+                    Object.entries(config.models.providers ?? {}).map(([id, entry]) => [
+                      id,
+                      { ...entry, timeoutSeconds: 30 },
+                    ]),
+                  ),
+                }
+              : config.models,
+            mcp: {
+              ...config.mcp,
+              servers: {
+                ...config.mcp?.servers,
+                leakprobe: { command: process.execPath, args: [scriptPath], transport: "stdio" },
+              },
+            },
+            agents: {
+              ...config.agents,
+              defaults: {
+                ...config.agents?.defaults,
+                // 24h cadence: only the forced cron.run wakes below execute, so
+                // every count maps to one known heartbeat run.
+                heartbeat: {
+                  every: "24h",
+                  isolatedSession: SESSION_MODE === "isolated",
+                  target: "none",
+                  lightContext: true,
+                },
+              },
+            },
+          }),
+        });
+        await record("after-gateway-start");
+
+        // The system-owned monitor appears once cron reconciles at startup.
+        let monitor: CronJob | undefined;
+        const listDeadline = Date.now() + 60_000;
+        while (!monitor && Date.now() < listDeadline) {
+          const listed = (await gateway.call(
+            "cron.list",
+            { includeDisabled: true },
+            { timeoutMs: 15_000 },
+          )) as { jobs: CronJob[] };
+          monitor = listed.jobs.find(
+            (job) => job.payload.kind === "heartbeat" && (job.agentId ?? "qa") === "qa",
+          );
+          if (!monitor) {
+            await sleep(500);
+          }
+        }
+        if (!monitor) {
+          throw new Error("system-owned qa heartbeat monitor was not listed");
+        }
+        console.log(JSON.stringify({ phase: "hb-mcp-monitor", monitor }));
+
+        const heartbeatStatuses: Array<{
+          run: number;
+          runId: string;
+          status?: string;
+          error?: string;
+          providerRequests: number;
+        }> = [];
+        for (let run = 1; run <= HEARTBEAT_RUNS; run += 1) {
+          const requestsBefore = provider.responsesRequests;
+          const forced = (await gateway.call(
+            "cron.run",
+            { id: monitor.id, mode: "force" },
+            { timeoutMs: 15_000 },
+          )) as { ok: boolean; enqueued: boolean; runId: string };
+          expect(forced).toMatchObject({ ok: true, runId: expect.any(String) });
+          let entry: CronRunEntry | undefined;
+          let peak = { count: 0, pids: [] as number[] };
+          const runDeadline = Date.now() + 120_000;
+          while (!entry && Date.now() < runDeadline) {
+            // Sample while the run is live: the child must exist mid-run for a
+            // later zero to mean "retired" rather than "never spawned".
+            const live = await countProbeProcesses(marker);
+            if (live.count > peak.count) {
+              peak = live;
+            }
+            const history = (await gateway.call(
+              "cron.runs",
+              { id: monitor.id, runId: forced.runId, limit: 1 },
+              { timeoutMs: 15_000 },
+            )) as { entries: CronRunEntry[] };
+            entry = history.entries.find((candidate) => candidate.runId === forced.runId);
+            if (!entry) {
+              await sleep(100);
+            }
+          }
+          counts.push({
+            stage: `during-heartbeat-${run}-peak`,
+            ...peak,
+            at: new Date().toISOString(),
+          });
+          console.log(JSON.stringify({ phase: "hb-mcp-count", variant: LABEL, ...counts.at(-1) }));
+          const status = {
+            run,
+            runId: forced.runId,
+            status: entry?.status,
+            error: entry?.error,
+            providerRequests: provider.responsesRequests - requestsBefore,
+          };
+          heartbeatStatuses.push(status);
+          console.log(JSON.stringify({ phase: "hb-mcp-heartbeat", variant: LABEL, ...status }));
+          expect(status.status).toBe("ok");
+          expect(status.providerRequests).toBeGreaterThan(0);
+          await sleep(SETTLE_MS);
+          await record(`after-heartbeat-${run}`);
+        }
+
+        const logs = await readLogFiles(gateway);
+        const replacements: Array<[string, string]> = [
+          [gateway.tempRoot, "<tempRoot>"],
+          [gateway.workspaceDir, "<workspaceDir>"],
+          [scriptPath, "<probeScript>"],
+          [repoRoot, "<repoRoot>"],
+          [os.homedir(), "<home>"],
+        ];
+        const interesting = /leakprobe|leak_probe|bundle-mcp|heartbeat|agent cleanup/i;
+        const excerpts = [...logs]
+          .map(([file, text]) => ({
+            file: redact(file, replacements),
+            lines: text
+              .split("\n")
+              .filter((line) => interesting.test(line))
+              .map((line) => redact(line, replacements)),
+          }))
+          .filter((entry) => entry.lines.length > 0);
+
+        const packageVersion = (
+          JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8")) as {
+            version?: string;
+          }
+        ).version;
+        const gitHead = (
+          await execFileAsync("git", ["rev-parse", "--short", "HEAD"], { cwd: repoRoot }).catch(
+            () => ({ stdout: "unknown" }),
+          )
+        ).stdout.trim();
+        const gatewayVersion = `${packageVersion ?? "unknown"}@${gitHead}`;
+
+        await stopQaGatewayFixture(gatewayOwner);
+        await sleep(1_000);
+        await record("after-gateway-stop");
+
+        const proof = {
+          variant: LABEL,
+          build: VARIANT,
+          sessionMode: SESSION_MODE,
+          issue: 143381,
+          marker,
+          counts: counts.map(({ stage, count }) => ({ stage, count })),
+          countsDetailed: counts,
+          heartbeatStatuses,
+          gatewayVersion,
+          timestamps: { startedAt: counts[0]?.at, finishedAt: new Date().toISOString() },
+        };
+        console.log(`HB_MCP_RETIRE_PROOF ${JSON.stringify(proof)}`);
+        if (PROOF_OUT_DIR) {
+          await fs.mkdir(PROOF_OUT_DIR, { recursive: true });
+          await fs.writeFile(
+            path.join(PROOF_OUT_DIR, `proof-${LABEL}.json`),
+            `${JSON.stringify(proof, null, 2)}\n`,
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(PROOF_OUT_DIR, `gateway-log-excerpts-${LABEL}.txt`),
+            excerpts.map((entry) => `### ${entry.file}\n${entry.lines.join("\n")}\n`).join("\n"),
+            "utf8",
+          );
+        }
+
+        const afterRuns = counts.filter((entry) => entry.stage.startsWith("after-heartbeat-"));
+        const peaks = counts.filter((entry) => entry.stage.startsWith("during-heartbeat-"));
+        expect(afterRuns).toHaveLength(HEARTBEAT_RUNS);
+        expect(peaks).toHaveLength(HEARTBEAT_RUNS);
+        for (const entry of peaks) {
+          expect(
+            entry.count,
+            `${entry.stage} should observe the MCP child mid-run`,
+          ).toBeGreaterThan(0);
+        }
+        if (SESSION_MODE === "shared") {
+          // One persistent runtime serves every shared run: same child, never retired mid-life.
+          const sharedPid = peaks[0]?.pids[0];
+          expect(sharedPid).toBeDefined();
+          for (const entry of [...peaks, ...afterRuns]) {
+            expect(entry.pids, `${entry.stage} should reuse the shared MCP child`).toEqual([
+              sharedPid,
+            ]);
+          }
+        } else if (VARIANT === "fixed") {
+          for (const entry of afterRuns) {
+            expect(entry.count, `${entry.stage} should retire the MCP child`).toBe(0);
+          }
+        } else {
+          for (const [index, entry] of afterRuns.entries()) {
+            expect(entry.count, `${entry.stage} should leak one child per run`).toBe(index + 1);
+          }
+        }
+        expect(counts.at(-1)?.count, "gateway shutdown must reap every probe").toBe(0);
+      },
+    );
+  },
+);

--- a/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
@@ -85,6 +85,15 @@ function writeTextResponse(response: ServerResponse, text: string): void {
 
 async function startMockProvider() {
   let responsesRequests = 0;
+  // Each model request waits here until the test releases it, so the run stays
+  // live while the fixture child is observed; a later zero then means retired.
+  let releaseResponse: () => void = () => {};
+  let responseGate = Promise.resolve();
+  const holdNextResponse = () => {
+    responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+  };
   const server = createServer((request, response) => {
     void (async () => {
       let body = "";
@@ -121,6 +130,7 @@ async function startMockProvider() {
         return;
       }
       responsesRequests += 1;
+      await responseGate;
       writeTextResponse(response, RESPONSE_TEXT);
     })().catch((error: unknown) => {
       if (!response.headersSent) {
@@ -142,7 +152,10 @@ async function startMockProvider() {
     get responsesRequests() {
       return responsesRequests;
     },
+    holdNextResponse,
+    releaseResponse: () => releaseResponse(),
     stop: async () => {
+      releaseResponse();
       server.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
@@ -218,9 +231,11 @@ function redact(text: string, replacements: Array<[string, string]>): string {
       out = out.replaceAll(needle, label);
     }
   }
+  // Bearer credentials first: the generic key/value pass would otherwise
+  // consume the scheme word and leave the token behind it intact.
   return out
-    .replace(/(token|secret|apiKey|api_key|authorization)(["'=: ]+)[^\s"',}]+/gi, "$1$2<redacted>")
     .replace(/Bearer\s+\S+/g, "Bearer <redacted>")
+    .replace(/(token|secret|apiKey|api_key|authorization)(["'=: ]+)[^\s"',}]+/gi, "$1$2<redacted>")
     .replace(/\/(?:home|Users)\/[^/\s"'│]+/g, "<home>")
     .replaceAll(os.hostname(), "<host>");
 }
@@ -336,18 +351,33 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
         }> = [];
         for (let run = 1; run <= HEARTBEAT_RUNS; run += 1) {
           const requestsBefore = provider.responsesRequests;
+          provider.holdNextResponse();
           const forced = (await gateway.call(
             "cron.run",
             { id: monitor.id, mode: "force" },
             { timeoutMs: 15_000 },
           )) as { ok: boolean; enqueued: boolean; runId: string };
           expect(forced).toMatchObject({ ok: true, runId: expect.any(String) });
-          let entry: CronRunEntry | undefined;
+          // The model request is held open until the fixture child is observed,
+          // so the run cannot start and retire between two samples. The child
+          // must exist mid-run for a later zero to mean "retired" rather than
+          // "never spawned".
           let peak = { count: 0, pids: [] as number[] };
+          const observeDeadline = Date.now() + 60_000;
+          while (
+            Date.now() < observeDeadline &&
+            (peak.count === 0 || provider.responsesRequests === requestsBefore)
+          ) {
+            const live = await countProbeProcesses(marker);
+            if (live.count > peak.count) {
+              peak = live;
+            }
+            await sleep(100);
+          }
+          provider.releaseResponse();
+          let entry: CronRunEntry | undefined;
           const runDeadline = Date.now() + 120_000;
           while (!entry && Date.now() < runDeadline) {
-            // Sample while the run is live: the child must exist mid-run for a
-            // later zero to mean "retired" rather than "never spawned".
             const live = await countProbeProcesses(marker);
             if (live.count > peak.count) {
               peak = live;

--- a/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
@@ -234,7 +234,7 @@ function redact(text: string, replacements: Array<[string, string]>): string {
   // Bearer credentials first: the generic key/value pass would otherwise
   // consume the scheme word and leave the token behind it intact.
   return out
-    .replace(/Bearer\s+\S+/g, "Bearer <redacted>")
+    .replace(/bearer\s+\S+/gi, "Bearer <redacted>")
     .replace(/(token|secret|apiKey|api_key|authorization)(["'=: ]+)[^\s"',}]+/gi, "$1$2<redacted>")
     .replace(/\/(?:home|Users)\/[^/\s"'│]+/g, "<home>")
     .replaceAll(os.hostname(), "<host>");

--- a/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts
@@ -26,7 +26,8 @@ import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 const MODEL_REF = "mock-openai/gpt-5.6-luna";
 const RESPONSE_TEXT = "HEARTBEAT_OK";
 const HEARTBEAT_RUNS = 3;
-const SETTLE_MS = 5_000;
+// Bounded wait for post-run process state; a matching sample returns at once.
+const SETTLE_TIMEOUT_MS = 30_000;
 const TEST_TIMEOUT_MS = 600_000;
 const VARIANT =
   process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF_VARIANT === "main" ? "main" : "fixed";
@@ -54,7 +55,8 @@ type CronJob = {
   payload: { kind: string };
 };
 type CronRunEntry = { error?: string; runId?: string; status?: string };
-type ProofCount = { stage: string; count: number; pids: number[]; at: string };
+type ProbeCount = { count: number; pids: number[] };
+type ProofCount = ProbeCount & { stage: string; at: string };
 
 function writeTextResponse(response: ServerResponse, text: string): void {
   const message = {
@@ -190,7 +192,7 @@ async function writeMcpProbeScript(repoRoot: string, marker: string) {
 }
 
 /** Counts live processes whose cmdline carries the probe marker (pgrep excludes itself). */
-async function countProbeProcesses(marker: string): Promise<{ count: number; pids: number[] }> {
+async function countProbeProcesses(marker: string): Promise<ProbeCount> {
   const pattern = `[${marker[0]}]${marker.slice(1)}`;
   try {
     const { stdout } = await execFileAsync("pgrep", ["-f", pattern]);
@@ -254,12 +256,38 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
         cleanups.push(() => provider.stop());
 
         const counts: ProofCount[] = [];
-        const record = async (stage: string) => {
-          const probe = await countProbeProcesses(marker);
-          const entry = { stage, ...probe, at: new Date().toISOString() };
+        const record = async (stage: string, probe?: ProbeCount) => {
+          const entry = {
+            stage,
+            ...(probe ?? (await countProbeProcesses(marker))),
+            at: new Date().toISOString(),
+          };
           counts.push(entry);
           console.log(JSON.stringify({ phase: "hb-mcp-count", variant: LABEL, ...entry }));
           return entry;
+        };
+        // Run settlement is not a process-closure barrier: the agent cleanup
+        // step can return on its reporting timeout while the child is still
+        // tearing down. Poll for the expected state instead of sampling once
+        // after a fixed delay; the deadline sample is recorded as-is so the
+        // assertions below judge whatever state the wait left behind.
+        const settle = async (stage: string, isExpected: (probe: ProbeCount) => boolean) => {
+          const deadline = Date.now() + SETTLE_TIMEOUT_MS;
+          let probe = await countProbeProcesses(marker);
+          while (!isExpected(probe) && Date.now() < deadline) {
+            await sleep(100);
+            probe = await countProbeProcesses(marker);
+          }
+          return record(stage, probe);
+        };
+        // The shared control keeps its first child for every run; the fixed
+        // isolated build retires it; the main baseline keeps one child per run.
+        let sharedPid: number | undefined;
+        const expectedAfterRun = (run: number) => (probe: ProbeCount) => {
+          if (SESSION_MODE === "shared") {
+            return probe.pids.length === 1 && probe.pids[0] === sharedPid;
+          }
+          return probe.count === (VARIANT === "fixed" ? 0 : run);
         };
 
         await record("before-gateway-start");
@@ -392,6 +420,7 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
               await sleep(100);
             }
           }
+          sharedPid ??= peak.pids[0];
           counts.push({
             stage: `during-heartbeat-${run}-peak`,
             ...peak,
@@ -409,8 +438,7 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
           console.log(JSON.stringify({ phase: "hb-mcp-heartbeat", variant: LABEL, ...status }));
           expect(status.status).toBe("ok");
           expect(status.providerRequests).toBeGreaterThan(0);
-          await sleep(SETTLE_MS);
-          await record(`after-heartbeat-${run}`);
+          await settle(`after-heartbeat-${run}`, expectedAfterRun(run));
         }
 
         const logs = await readLogFiles(gateway);
@@ -445,8 +473,7 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
         const gatewayVersion = `${packageVersion ?? "unknown"}@${gitHead}`;
 
         await stopQaGatewayFixture(gatewayOwner);
-        await sleep(1_000);
-        await record("after-gateway-stop");
+        await settle("after-gateway-stop", (probe) => probe.count === 0);
 
         const proof = {
           variant: LABEL,
@@ -487,7 +514,6 @@ describe.runIf(process.env.OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF === "1")(
         }
         if (SESSION_MODE === "shared") {
           // One persistent runtime serves every shared run: same child, never retired mid-life.
-          const sharedPid = peaks[0]?.pids[0];
           expect(sharedPid).toBeDefined();
           for (const entry of [...peaks, ...afterRuns]) {
             expect(entry.pids, `${entry.stage} should reuse the shared MCP child`).toEqual([


### PR DESCRIPTION
Closes #143381

## What Problem This Solves

Fixes an issue where operators running an agent heartbeat with `isolatedSession: true` and stdio MCP servers would accumulate one full set of MCP child processes per heartbeat run. The processes stayed resident until a Gateway restart, growing to hundreds of idle children and many gigabytes of RSS over a few hours, unless the operator discovered the opt-in `mcp.sessionIdleTtlMs` reaper.

## Why This Change Was Made

Isolated heartbeats mint a fresh session ID for every run, so the bundle MCP runtime built for that run is never reused, yet nothing retired it. Isolated cron runs already retire their runtime through the existing one-shot `cleanupBundleMcpOnRunEnd` settlement step; this change carries that same flag from the heartbeat runner through the reply pipeline (embedded and CLI candidates) so isolated heartbeat runs retire their exact runtime at settlement. Shared (non-isolated) heartbeats are unchanged and keep the persistent main-session runtime. Active leases are preserved through the existing deferred-retirement path.

## User Impact

Heartbeat runs with `isolatedSession: true` no longer leak stdio MCP child processes. Process count returns to baseline after each run without configuring an idle TTL or restarting the Gateway.

## Evidence

**Real Gateway proof** (`test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts`, opt-in with `OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF=1`): a built Gateway child (`dist/index.js`, `2026.9.3@f8a06baad7e`) with `agents.defaults.heartbeat = { isolatedSession: true, target: "none", lightContext: true }`, a loopback mock Responses provider, and one stdio MCP server (`mcp.servers.leakprobe`, a tiny `@modelcontextprotocol/sdk` script with a unique marker in its path). Three heartbeats are forced through `cron.run { mode: "force" }` on the Gateway's heartbeat monitor job; each reaches `status: "ok"` (via `cron.runs`) and each run's model request advertises the probe tool, so the MCP server really was connected. MCP child processes are counted with `pgrep -f <marker>` before, during (peak), and after each run. The after-run and after-stop samples poll `pgrep` for the variant's expected state (isolated fixed: 0 children; shared: the first run's PID; `main` baseline: one child per run) with a 30 s bound instead of sampling once after a fixed delay, since run settlement is not a process-closure barrier; the deadline sample is recorded as-is so the assertions still judge the real state. Re-run at `b5e33ef9f14` on the `aa1bc7daefc` build: isolated peaks 1/1/1 with 0 after every run, shared PID unchanged across all three runs, 0 after Gateway stop; retirement was observed within about 60 ms of `cron.runs` reporting `ok`.

| MCP children (peak during run / after run) | `main`, isolated (runner file at `9601bb22f39`) | this branch, isolated | this branch, shared (`isolatedSession: false`) |
| --- | --- | --- | --- |
| after Gateway start | 0 | 0 | 0 |
| heartbeat 1 | 1 / **1** | 1 / **0** | 1 / 1 |
| heartbeat 2 | 2 / **2** | 1 / **0** | 1 / 1 |
| heartbeat 3 | 3 / **3** | 1 / **0** | 1 / 1 |
| after Gateway stop | 0 | 0 | 0 |

On `main` the three leaked children are the same three PIDs across every later stage (one new child per run, none reclaimed until the Gateway exits); with the fix each isolated run spawns one child and it is gone before the next run. The shared-session control on the fixed build keeps a single child with the same PID through all three runs and reaps it only at Gateway stop, so persistent-session MCP runtimes stay usable and are not retired by this change. The redacted Gateway log shows every isolated heartbeat dispatching under a fresh `sessionId` for the same `agent:qa:main:heartbeat` key, which is why the per-run runtime can never be reused:

```text
message queued: sessionId=d5ced400-… sessionKey=agent:qa:main:heartbeat source=dispatch queueDepth=1 sessionState=idle
session state: sessionId=d5ced400-… sessionKey=agent:qa:main:heartbeat prev=processing new=idle reason="run_completed" queueDepth=0
message queued: sessionId=4fe95eb7-… sessionKey=agent:qa:main:heartbeat source=dispatch queueDepth=1 sessionState=idle
```

Recorded counts (PIDs are the fixture children on this machine):

```text
# proof-main.json (2026.9.3@a293a8dcb0a, sessionMode=isolated)
before-gateway-start: 0
after-gateway-start: 0
during-heartbeat-1-peak: 1 pids=[908239]
after-heartbeat-1: 1 pids=[908239]
during-heartbeat-2-peak: 2 pids=[908239, 908284]
after-heartbeat-2: 2 pids=[908239, 908284]
during-heartbeat-3-peak: 3 pids=[908239, 908284, 908330]
after-heartbeat-3: 3 pids=[908239, 908284, 908330]
after-gateway-stop: 0
heartbeats: run 1: ok, run 2: ok, run 3: ok

# proof-fixed.json (2026.9.3@a293a8dcb0a, sessionMode=isolated)
before-gateway-start: 0
after-gateway-start: 0
during-heartbeat-1-peak: 1 pids=[877501]
after-heartbeat-1: 0
during-heartbeat-2-peak: 1 pids=[877557]
after-heartbeat-2: 0
during-heartbeat-3-peak: 1 pids=[877591]
after-heartbeat-3: 0
after-gateway-stop: 0
heartbeats: run 1: ok, run 2: ok, run 3: ok

# proof-shared.json (2026.9.3@a293a8dcb0a, sessionMode=shared)
before-gateway-start: 0
after-gateway-start: 0
during-heartbeat-1-peak: 1 pids=[879131]
after-heartbeat-1: 1 pids=[879131]
during-heartbeat-2-peak: 1 pids=[879131]
after-heartbeat-2: 1 pids=[879131]
during-heartbeat-3-peak: 1 pids=[879131]
after-heartbeat-3: 1 pids=[879131]
after-gateway-stop: 0
heartbeats: run 1: ok, run 2: ok, run 3: ok
```

Reproduce on a built checkout: `OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF=1 OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_HEARTBEAT_MCP_RETIRE_PROOF_SESSION=isolated node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/heartbeat-mcp-runtime-retire.product-proof.e2e.test.ts` (set `..._SESSION=shared` for the control; `..._VARIANT=main` only labels a build made with the runner file at `main`).

Method notes: the heartbeat cadence is set to `24h` so only the forced runs execute and every count maps to one known run; the fixture provider holds each model reply until the test has observed the fixture child, so a later zero means "retired", not "never spawned" and the sample cannot race a fast run; `cron.runs` confirms each run's `status: "ok"`. The proof test is parameterized (`..._VARIANT=fixed|main` labels the build, `..._SESSION=isolated|shared`), writes `proof-<label>.json` with per-stage PIDs and redacted Gateway log excerpts, and was run three times on this machine (Linux, Node 24.18) against dist builds of this branch and of this branch with the runner file at `main`. Successful bundle-MCP retirement emits no log line, so the process counts plus the advertised probe tool are the evidence.

**Regression tests**
- `src/infra/heartbeat-runner.model-override.test.ts` ("retires the bundle MCP runtime only for isolated heartbeat runs") fails on `main` with `expected undefined to deeply equal true` and passes with the fix; the shared-heartbeat half proves the flag stays unset for persistent sessions.
- `src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts` covers forwarding through both the embedded and CLI run candidates.
- Focused suites: 16/16 heartbeat runner cases and 33/33 lifecycle cases pass.

**Checks**: `node scripts/check-changed.mjs` passed on the fix (lint, formatting, core typecheck, core test typecheck shards, boundary and guard scripts); `autoreview` (Codex, P2, branch vs `origin/main`) scoped-clean on the fix. Two further autoreview rounds on the proof test found three P2s (Bearer redaction order, a peak-sample race against a fast run, and case-sensitive Bearer matching); all three are fixed and the three variants were rerun with the corrected test before the counts above were recorded. The proof test typechecks with zero diagnostics.

