### PR TITLE
fix(sessions): keep cold prepared updates responsive

### DIFF
--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -48,6 +48,13 @@ uses the admitted handle. Coalesced callers retain their own guards. History
 eviction also uses this admission when reopening after archive materialization,
 then rereads candidate protection before preparing reclamation.
 
+Prepared session-store updates, entry replacements, and lifecycle upserts use
+the same admission for cold snapshot reads and actual commits, retaining their
+existing writer position. Warm update callbacks remain direct. Result-only
+no-op commits do not reopen a disposed handle. Native deletion and archive
+preparation still run outside the writer; the subsequent commit rechecks its
+native owner's authority after any awaited admission.
+
 Session reclamation keeps its deletion transaction on a worker connection.
 The worker opens its database under the session writer, then releases that writer
 while full integrity and foreign-key checks run on the same connection. Unrelated

--- a/src/config/sessions/session-accessor.sqlite-deletion.ts
+++ b/src/config/sessions/session-accessor.sqlite-deletion.ts
@@ -30,6 +30,7 @@ import { readSessionEntryRow } from "./session-accessor.sqlite-entry-read.js";
 import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
   type ResolvedSqliteReadScope,
 } from "./session-accessor.sqlite-scope.js";
 import type { SqliteSessionWriteOperation } from "./session-accessor.sqlite-write-operation.js";
@@ -92,8 +93,11 @@ export async function runPreparedSqliteSessionWrite<T>(
       return await runExclusiveSqliteSessionWrite(
         scope,
         async () => {
-          assertCurrent();
-          return await write.commit();
+          return await withSqliteSessionDatabase(
+            toDatabaseOptions(scope),
+            () => write.commit(),
+            assertCurrent,
+          );
         },
         operation,
       );

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -10,7 +10,6 @@ import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-n
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   isIncognitoOpenClawAgentDatabase,
-  openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
@@ -44,7 +43,11 @@ import {
   addRetainedWindowSessionReferences,
   collectSessionStateIdsForEntry,
 } from "./session-accessor.sqlite-references.js";
-import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import {
+  cloneSessionEntry,
+  getSessionKysely,
+  withSqliteSessionDatabase,
+} from "./session-accessor.sqlite-scope.js";
 import {
   parseSessionEntryJson as parseSessionEntryRow,
   sessionEntryMetadataJson,
@@ -89,10 +92,7 @@ export function shouldRemoveSessionEntry(
   ) {
     return false;
   }
-  if (removal.expectedUpdatedAt !== undefined && entry.updatedAt !== removal.expectedUpdatedAt) {
-    return false;
-  }
-  return true;
+  return removal.expectedUpdatedAt === undefined || entry.updatedAt === removal.expectedUpdatedAt;
 }
 
 function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
@@ -353,157 +353,158 @@ export async function projectSessionEntryLifecycleMutation(
     upserts: readonly SessionEntryLifecycleUpsert[];
   },
 ): Promise<ProjectedLifecycleMutation> {
-  // openclaw-agent-db.ts cache rule: keep handles within synchronous sections.
-  const removalDatabase = openOpenClawAgentDatabase(databaseOptions);
-  const store = readSessionEntryStore(removalDatabase, {
-    allowCanonicalRepair: params.allowCanonicalRepair === true,
-    sessionKeys: [
-      ...params.removals.map((removal) =>
-        removal.exactStoredKey ? removal.sessionKey : removal.sessionKey.trim(),
-      ),
-      ...params.upserts.map((upsert) => upsert.sessionKey.trim()),
-    ],
-  });
-  const removedKeysToArchive = new Set<string>();
-  const changedSessionKeys = new Set<string>();
-  const projectedRemovals: ProjectedLifecycleMutation["removals"] = [];
-  for (const removal of params.removals) {
-    const sessionKey = removal.exactStoredKey ? removal.sessionKey : removal.sessionKey.trim();
-    let entry = removal.exactStoredKey || sessionKey ? store[sessionKey] : undefined;
-    if (removal.expectedRawEntryJson !== undefined) {
-      const currentRawEntryJson = readExactSessionEntryJson(removalDatabase, sessionKey);
-      if (currentRawEntryJson !== removal.expectedRawEntryJson) {
-        throw new Error(
-          `SQLite session entry changed before raw lifecycle removal for ${sessionKey}`,
-        );
+  return withSqliteSessionDatabase(databaseOptions, async (removalDatabase) => {
+    const store = readSessionEntryStore(removalDatabase, {
+      allowCanonicalRepair: params.allowCanonicalRepair === true,
+      sessionKeys: [
+        ...params.removals.map((removal) =>
+          removal.exactStoredKey ? removal.sessionKey : removal.sessionKey.trim(),
+        ),
+        ...params.upserts.map((upsert) => upsert.sessionKey.trim()),
+      ],
+    });
+    const removedKeysToArchive = new Set<string>();
+    const changedSessionKeys = new Set<string>();
+    const projectedRemovals: ProjectedLifecycleMutation["removals"] = [];
+    for (const removal of params.removals) {
+      const sessionKey = removal.exactStoredKey ? removal.sessionKey : removal.sessionKey.trim();
+      let entry = removal.exactStoredKey || sessionKey ? store[sessionKey] : undefined;
+      if (removal.expectedRawEntryJson !== undefined) {
+        const currentRawEntryJson = readExactSessionEntryJson(removalDatabase, sessionKey);
+        if (currentRawEntryJson !== removal.expectedRawEntryJson) {
+          throw new Error(
+            `SQLite session entry changed before raw lifecycle removal for ${sessionKey}`,
+          );
+        }
+        entry = removal.expectedEntry ? cloneSessionEntry(removal.expectedEntry) : undefined;
       }
-      entry = removal.expectedEntry ? cloneSessionEntry(removal.expectedEntry) : undefined;
-    }
-    if (!shouldRemoveSessionEntry(entry, removal)) {
-      continue;
-    }
-    if (removal.expectedTranscriptSnapshot) {
-      const sessionId = entry.sessionId;
-      if (
-        !sessionId ||
-        !sqliteSessionStateDeleteSnapshotsEqual(
-          readSessionStateDeleteSnapshot(removalDatabase.db, sessionId),
-          removal.expectedTranscriptSnapshot,
-        )
-      ) {
-        // Classification happens before the lifecycle writer lane. A stale fact
-        // must become a no-op so newly live state is never archived and deleted.
+      if (!shouldRemoveSessionEntry(entry, removal)) {
         continue;
       }
+      if (removal.expectedTranscriptSnapshot) {
+        const sessionId = entry.sessionId;
+        if (
+          !sessionId ||
+          !sqliteSessionStateDeleteSnapshotsEqual(
+            readSessionStateDeleteSnapshot(removalDatabase.db, sessionId),
+            removal.expectedTranscriptSnapshot,
+          )
+        ) {
+          // Classification happens before the lifecycle writer lane. A stale fact
+          // must become a no-op so newly live state is never archived and deleted.
+          continue;
+        }
+      }
+      projectedRemovals.push({
+        // Capture each archive decision before an async builder can change its input.
+        archiveTranscript: removal.archiveRemovedTranscript === true,
+        expectedEntry: cloneSessionEntry(entry),
+        removal,
+        sessionKey,
+      });
+      if (removal.archiveRemovedTranscript === true) {
+        removedKeysToArchive.add(sessionKey);
+      }
+      changedSessionKeys.add(sessionKey);
+      delete store[sessionKey];
     }
-    projectedRemovals.push({
-      // Capture each archive decision before an async builder can change its input.
-      archiveTranscript: removal.archiveRemovedTranscript === true,
-      expectedEntry: cloneSessionEntry(entry),
-      removal,
-      sessionKey,
-    });
-    if (removal.archiveRemovedTranscript === true) {
-      removedKeysToArchive.add(sessionKey);
+    const upsertedEntries: ProjectedLifecycleMutation["upsertedEntries"] = [];
+    for (const upsert of params.upserts) {
+      const sessionKey = upsert.sessionKey.trim();
+      if (!sessionKey) {
+        continue;
+      }
+      if (
+        upsert.requiresRemovalSessionKey &&
+        !projectedRemovals.some(
+          (removal) => removal.sessionKey === upsert.requiresRemovalSessionKey?.trim(),
+        )
+      ) {
+        continue;
+      }
+      const expectedEntry = store[sessionKey] ? cloneSessionEntry(store[sessionKey]) : undefined;
+      if (upsert.resetBoundary && !expectedEntry) {
+        throw new Error(
+          `Cannot append reset boundary without an existing session row: ${sessionKey}`,
+        );
+      }
+      const entry =
+        upsert.buildEntry === undefined
+          ? upsert.entry
+          : await upsert.buildEntry({
+              currentEntry: expectedEntry ? cloneSessionEntry(expectedEntry) : undefined,
+              sessionKey,
+            });
+      if (!entry) {
+        continue;
+      }
+      const cloned = cloneSessionEntry(entry);
+      store[sessionKey] = cloned;
+      changedSessionKeys.add(sessionKey);
+      upsertedEntries.push({
+        expectedEntry,
+        sessionKey,
+        entry: cloned,
+        ...(upsert.routeContext !== undefined ? { routeContext: upsert.routeContext } : {}),
+        ...(upsert.resetBoundary ? { resetBoundary: upsert.resetBoundary } : {}),
+      });
     }
-    changedSessionKeys.add(sessionKey);
-    delete store[sessionKey];
-  }
-  const upsertedEntries: ProjectedLifecycleMutation["upsertedEntries"] = [];
-  for (const upsert of params.upserts) {
-    const sessionKey = upsert.sessionKey.trim();
-    if (!sessionKey) {
-      continue;
+    if (projectedRemovals.length === 0) {
+      return { deletePlans: [], removals: projectedRemovals, upsertedEntries };
     }
-    if (
-      upsert.requiresRemovalSessionKey &&
-      !projectedRemovals.some(
-        (removal) => removal.sessionKey === upsert.requiresRemovalSessionKey?.trim(),
-      )
-    ) {
-      continue;
-    }
-    const expectedEntry = store[sessionKey] ? cloneSessionEntry(store[sessionKey]) : undefined;
-    if (upsert.resetBoundary && !expectedEntry) {
-      throw new Error(
-        `Cannot append reset boundary without an existing session row: ${sessionKey}`,
+    // Builders can close the original handle; admit the reference snapshot again.
+    return withSqliteSessionDatabase(databaseOptions, (database) => {
+      const referencedSessionIds = collectProjectedReferencedSessionIds({
+        database,
+        excludedSessionKeys: changedSessionKeys,
+        projectedStore: store,
+      });
+      const deletePlans = projectedRemovals.flatMap(({ archiveTranscript, expectedEntry: entry }) =>
+        planSessionStateAfterEntryRemoval({
+          archiveDirectory: params.archiveDirectory,
+          archiveTranscript,
+          database,
+          entry,
+          reason: "deleted",
+          referencedSessionIds,
+        }),
       );
-    }
-    const entry =
-      upsert.buildEntry === undefined
-        ? upsert.entry
-        : await upsert.buildEntry({
-            currentEntry: expectedEntry ? cloneSessionEntry(expectedEntry) : undefined,
-            sessionKey,
-          });
-    if (!entry) {
-      continue;
-    }
-    const cloned = cloneSessionEntry(entry);
-    store[sessionKey] = cloned;
-    changedSessionKeys.add(sessionKey);
-    upsertedEntries.push({
-      expectedEntry,
-      sessionKey,
-      entry: cloned,
-      ...(upsert.routeContext !== undefined ? { routeContext: upsert.routeContext } : {}),
-      ...(upsert.resetBoundary ? { resetBoundary: upsert.resetBoundary } : {}),
+      const observedSnapshotsBySessionId = new Map(
+        projectedRemovals.flatMap(({ expectedEntry, removal }) =>
+          expectedEntry.sessionId && removal.expectedTranscriptSnapshot
+            ? [[expectedEntry.sessionId, removal.expectedTranscriptSnapshot] as const]
+            : [],
+        ),
+      );
+      for (const plan of deletePlans) {
+        const observedSnapshot = observedSnapshotsBySessionId.get(plan.sessionId);
+        if (observedSnapshot) {
+          // Keep the delete plan bound to classification, even if another process
+          // changes the transcript after the initial projection comparison.
+          plan.snapshot = observedSnapshot;
+        }
+      }
+      const plannedIds = new Set(deletePlans.map((plan) => plan.sessionId));
+      for (const sessionId of readSessionGenerationIdsForKeys(database, removedKeysToArchive)) {
+        if (plannedIds.has(sessionId)) {
+          continue;
+        }
+        const plan = planSessionStateDeleteIfUnreferenced({
+          archiveDirectory: params.archiveDirectory,
+          archiveTranscript: true,
+          database,
+          reason: "deleted",
+          referencedSessionIds,
+          sessionId,
+        });
+        if (plan) {
+          deletePlans.push(plan);
+          plannedIds.add(sessionId);
+        }
+      }
+      return { deletePlans, removals: projectedRemovals, upsertedEntries };
     });
-  }
-  if (projectedRemovals.length === 0) {
-    return { deletePlans: [], removals: projectedRemovals, upsertedEntries };
-  }
-  // openclaw-agent-db.ts cache rule: LRU eviction may close idle handles during buildEntry awaits.
-  const database = openOpenClawAgentDatabase(databaseOptions);
-  const referencedSessionIds = collectProjectedReferencedSessionIds({
-    database,
-    excludedSessionKeys: changedSessionKeys,
-    projectedStore: store,
   });
-  const deletePlans = projectedRemovals.flatMap(({ archiveTranscript, expectedEntry: entry }) =>
-    planSessionStateAfterEntryRemoval({
-      archiveDirectory: params.archiveDirectory,
-      archiveTranscript,
-      database,
-      entry,
-      reason: "deleted",
-      referencedSessionIds,
-    }),
-  );
-  const observedSnapshotsBySessionId = new Map(
-    projectedRemovals.flatMap(({ expectedEntry, removal }) =>
-      expectedEntry.sessionId && removal.expectedTranscriptSnapshot
-        ? [[expectedEntry.sessionId, removal.expectedTranscriptSnapshot] as const]
-        : [],
-    ),
-  );
-  for (const plan of deletePlans) {
-    const observedSnapshot = observedSnapshotsBySessionId.get(plan.sessionId);
-    if (observedSnapshot) {
-      // Keep the delete plan bound to classification, even if another process
-      // changes the transcript after the initial projection comparison.
-      plan.snapshot = observedSnapshot;
-    }
-  }
-  const plannedIds = new Set(deletePlans.map((plan) => plan.sessionId));
-  for (const sessionId of readSessionGenerationIdsForKeys(database, removedKeysToArchive)) {
-    if (plannedIds.has(sessionId)) {
-      continue;
-    }
-    const plan = planSessionStateDeleteIfUnreferenced({
-      archiveDirectory: params.archiveDirectory,
-      archiveTranscript: true,
-      database,
-      reason: "deleted",
-      referencedSessionIds,
-      sessionId,
-    });
-    if (plan) {
-      deletePlans.push(plan);
-      plannedIds.add(sessionId);
-    }
-  }
-  return { deletePlans, removals: projectedRemovals, upsertedEntries };
 }
 
 // Projected deletes must preserve raw session_nodes.current_session_id references for
@@ -723,12 +724,10 @@ export function deletePlannedLifecycleArtifactEntries(
   entries: readonly SessionEntryRemovalPlan[],
 ): number {
   assertPlannedLifecycleArtifactEntriesUnchanged(database, entries);
-  let removedEntries = 0;
   for (const planned of entries) {
     deleteSessionEntryRows(database, planned.sessionKey);
-    removedEntries += 1;
   }
-  return removedEntries;
+  return entries.length;
 }
 
 export function assertPlannedLifecycleArtifactEntriesUnchanged(

--- a/src/config/sessions/session-accessor.sqlite-prepared-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-prepared-admission.test.ts
@@ -1,0 +1,653 @@
+import type { ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { AgentHarness } from "../../agents/harness/types.js";
+import * as sqlite from "../../infra/node-sqlite.js";
+import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+} from "../../plugins/registry-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config.js";
+import {
+  loadSessionEntryReadOnly,
+  loadTranscriptEventsSync,
+  replaceSessionEntrySync,
+  replaceTranscriptEventsSync,
+} from "./session-accessor.js";
+import type { SessionEntryLifecycleMutationResult } from "./session-accessor.sqlite-contract.js";
+import {
+  applySessionEntryLifecycleMutation,
+  applySessionEntryReplacements,
+  applySessionStoreProjection,
+} from "./session-accessor.sqlite-projection.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+
+const hooks = vi.hoisted(() => ({
+  fork: undefined as ((child: ChildProcess) => void) | undefined,
+  afterMaterialize: undefined as (() => Promise<void>) | undefined,
+}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    fork: (...args: Parameters<typeof actual.fork>) => {
+      const child = actual.fork(...args);
+      hooks.fork?.(child);
+      return child;
+    },
+  };
+});
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    materializeSessionStateDeletePlans: async (
+      ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
+    ) => {
+      const result = await actual.materializeSessionStateDeletePlans(...args);
+      await hooks.afterMaterialize?.();
+      return result;
+    },
+  };
+});
+
+const roots = createTempDirTracker();
+const pending: Promise<unknown>[] = [];
+const releases: Array<() => void> = [];
+const realOpen = sqlite.openNodeSqliteDatabase;
+const realIntegrity = integrity.assertSqliteIntegrityInWorker;
+
+beforeEach(() => {
+  resetConfigRuntimeState();
+  const config = { session: { maintenance: { mode: "warn" as const } } };
+  setRuntimeConfigSnapshot(config, config);
+});
+
+afterEach(async () => {
+  releases.splice(0).forEach((release) => release());
+  await Promise.allSettled(pending.splice(0));
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  hooks.fork = undefined;
+  hooks.afterMaterialize = undefined;
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetConfigRuntimeState();
+  roots.cleanup();
+});
+
+function own<T>(promise: Promise<T>): Promise<T> {
+  pending.push(promise);
+  void promise.catch(() => {});
+  return promise;
+}
+
+function fixture() {
+  const root = roots.make("prepared-writer-admission-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  const input = {
+    agentId: "main",
+    env: { OPENCLAW_STATE_DIR: root },
+    sessionKey: "agent:main:prepared-admission",
+  };
+  replaceSessionEntrySync(input, { sessionId: "original", updatedAt: Date.now() });
+  const scope = resolveSqliteScope(input);
+  const options = toDatabaseOptions(scope);
+  const database = openOpenClawAgentDatabase(options);
+  return { input, scope, options, databasePath: database.path };
+}
+
+type Fixture = ReturnType<typeof fixture>;
+
+function observeAdmission(databasePath: string, hold = false) {
+  let parentChecks = 0;
+  let admissions = 0;
+  let settled = 0;
+  let forkingIntegrity = false;
+  const entered = createDeferred();
+  const release = createDeferred();
+  releases.push(() => release.resolve());
+  if (!hold) {
+    release.resolve();
+  }
+  const children: Array<{
+    closed: boolean;
+    code: number | null;
+    signal: string | null;
+    phases: integrity.SqliteIntegrityWorkerPhase[];
+    resultOk?: boolean;
+  }> = [];
+  hooks.fork = (child) => {
+    if (!forkingIntegrity) {
+      return;
+    }
+    const row = {
+      closed: false,
+      code: null as number | null,
+      signal: null as string | null,
+      phases: [] as integrity.SqliteIntegrityWorkerPhase[],
+      resultOk: undefined as boolean | undefined,
+    };
+    children.push(row);
+    child.on("message", (message: integrity.SqliteIntegrityWorkerMessage) => {
+      if ("type" in message) {
+        row.phases.push(message.phase);
+      } else {
+        row.resultOk = message.ok;
+      }
+    });
+    void own(
+      new Promise<void>((resolve) => {
+        child.once("close", (code, signal) => {
+          row.closed = true;
+          row.code = code;
+          row.signal = signal;
+          resolve();
+        });
+      }),
+    );
+  };
+  vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, options) => {
+    const database = realOpen(pathname, options);
+    if (pathname !== databasePath || options?.readOnly) {
+      return database;
+    }
+    const prepare = database.prepare.bind(database);
+    database.prepare = (sql) => {
+      const statement = prepare(sql);
+      if (sql === "PRAGMA integrity_check;") {
+        const all = statement.all.bind(statement);
+        statement.all = () => {
+          parentChecks += 1;
+          return all();
+        };
+      }
+      return statement;
+    };
+    return database;
+  });
+  vi.spyOn(integrity, "assertSqliteIntegrityInWorker").mockImplementation(async (...args) => {
+    if (args[0] !== databasePath) {
+      return await realIntegrity(...args);
+    }
+    admissions += 1;
+    let check: Promise<void>;
+    forkingIntegrity = true;
+    try {
+      check = realIntegrity(...args);
+    } finally {
+      forkingIntegrity = false;
+    }
+    entered.resolve();
+    try {
+      await Promise.all([check, release.promise]);
+    } finally {
+      settled += 1;
+    }
+  });
+  return {
+    release,
+    async expectPending(operation: Promise<unknown>) {
+      expect(
+        await Promise.race([
+          entered.promise.then(() => "child"),
+          operation.then(
+            () => "completed",
+            () => "failed",
+          ),
+        ]),
+      ).toBe("child");
+    },
+    expectHealthy(count: number) {
+      expect(parentChecks, "integrity ran on the caller thread").toBe(0);
+      expect(admissions).toBe(count);
+      expect(settled).toBe(count);
+      expect(children).toHaveLength(count);
+      for (const child of children) {
+        expect(child).toEqual({
+          closed: true,
+          code: 0,
+          signal: null,
+          resultOk: true,
+          phases: ["opening", "checking", "closing"],
+        });
+      }
+    },
+  };
+}
+
+const cases = (["whole-store", "lifecycle", "replacement"] as const).flatMap((owner) =>
+  (["warm", "cold-preparation", "cold-commit"] as const).map((mode) => ({ owner, mode })),
+);
+
+it.each(cases)(
+  "keeps $owner $mode validation and callback order inside the writer FIFO",
+  async ({ owner, mode }) => {
+    const f = fixture();
+    if (mode === "cold-preparation") {
+      expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+    }
+    const probe = observeAdmission(f.databasePath);
+    const entered = createDeferred();
+    const release = createDeferred();
+    releases.push(() => release.resolve());
+    let callbacks = 0;
+    const order: string[] = [];
+    const update = async () => {
+      callbacks += 1;
+      order.push("update");
+      entered.resolve();
+      await release.promise;
+      if (mode === "cold-commit") {
+        expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+      }
+    };
+    const operation = own<string | SessionEntryLifecycleMutationResult>(
+      owner === "whole-store"
+        ? applySessionStoreProjection({
+            storePath: f.databasePath,
+            skipMaintenance: true,
+            update: async (store) => {
+              await update();
+              store[f.input.sessionKey]!.label = "updated";
+              return { persist: true, result: "done" };
+            },
+          })
+        : owner === "replacement"
+          ? applySessionEntryReplacements({
+              storePath: f.databasePath,
+              sessionKeys: [f.input.sessionKey],
+              skipMaintenance: true,
+              update: async (entries) => {
+                await update();
+                return {
+                  replacements: entries.map(({ sessionKey, entry }) => ({
+                    sessionKey,
+                    entry: { ...entry, label: "updated" },
+                  })),
+                  result: "done",
+                };
+              },
+            })
+          : applySessionEntryLifecycleMutation({
+              storePath: f.databasePath,
+              skipMaintenance: true,
+              upserts: [
+                {
+                  sessionKey: f.input.sessionKey,
+                  buildEntry: async ({ currentEntry }) => {
+                    await update();
+                    if (!currentEntry) {
+                      throw new Error("fixture entry missing");
+                    }
+                    return { ...currentEntry, label: "updated" };
+                  },
+                },
+              ],
+            }),
+    );
+    expect(callbacks).toBe(mode === "cold-preparation" ? 0 : 1);
+    const later = own(
+      runExclusiveSqliteSessionWrite(
+        f.scope,
+        async () => {
+          order.push("later");
+          return loadSessionEntryReadOnly(f.input)?.label;
+        },
+        "session.transcript.batch",
+      ),
+    );
+    await entered.promise;
+    await yieldToEventLoop();
+    expect(order).toEqual(["update"]);
+    release.resolve();
+    await operation;
+    expect(await later).toBe("updated");
+    expect(loadSessionEntryReadOnly(f.input)).toMatchObject({
+      sessionId: "original",
+      label: "updated",
+    });
+    expect(callbacks).toBe(1);
+    expect(order).toEqual(["update", "later"]);
+    probe.expectHealthy(mode === "warm" ? 0 : 1);
+  },
+);
+
+it.each(["persist-false", "unchanged", "empty-replacements", "missing-replacement"] as const)(
+  "does not reopen a disposed handle for a $0 result-only commit",
+  async (mode) => {
+    const f = fixture();
+    const probe = observeAdmission(f.databasePath);
+    let callbacks = 0;
+    const close = () => {
+      callbacks += 1;
+      expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+    };
+    const operation =
+      mode === "persist-false" || mode === "unchanged"
+        ? applySessionStoreProjection({
+            storePath: f.databasePath,
+            skipMaintenance: true,
+            update: (store) => {
+              close();
+              if (mode === "persist-false") {
+                delete store[f.input.sessionKey];
+              }
+              return { persist: mode !== "persist-false", result: "no-op" };
+            },
+          })
+        : applySessionEntryReplacements({
+            storePath: f.databasePath,
+            sessionKeys: [
+              mode === "missing-replacement" ? "agent:main:missing" : f.input.sessionKey,
+            ],
+            skipMaintenance: true,
+            update: () => {
+              close();
+              return {
+                result: "no-op",
+                ...(mode === "missing-replacement"
+                  ? {
+                      replacements: [
+                        {
+                          sessionKey: "agent:main:missing",
+                          entry: { sessionId: "missing", updatedAt: 1 },
+                        },
+                      ],
+                    }
+                  : {}),
+              };
+            },
+          });
+    await expect(own(operation)).resolves.toBe("no-op");
+    expect(callbacks).toBe(1);
+    expect(getOpenClawAgentDatabaseIfOpen(f.options)).toBeUndefined();
+    probe.expectHealthy(0);
+    expect(loadSessionEntryReadOnly(f.input)?.sessionId).toBe("original");
+  },
+);
+
+it.each(["selection", "stale", "denied"] as const)(
+  "preserves replacement $0 error ordering across a cold commit",
+  async (mode) => {
+    const f = fixture();
+    const probe = observeAdmission(f.databasePath);
+    const denied = new Error("synthetic replacement denied");
+    const guard = vi.fn(() => {
+      throw denied;
+    });
+    const update = vi.fn(
+      (entries: Parameters<Parameters<typeof applySessionEntryReplacements>[0]["update"]>[0]) => {
+        if (mode === "stale") {
+          replaceSessionEntrySync(f.input, {
+            sessionId: "original",
+            label: "newer",
+            updatedAt: Date.now(),
+          });
+        }
+        expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+        return {
+          result: undefined,
+          replacements: entries.map(({ entry, sessionKey }) => ({
+            sessionKey: mode === "selection" ? "agent:main:outside-selection" : sessionKey,
+            entry: { ...entry, label: "uncommitted" },
+          })),
+        };
+      },
+    );
+    const work = own(
+      applySessionEntryReplacements({
+        storePath: f.databasePath,
+        sessionKeys: [f.input.sessionKey],
+        skipMaintenance: true,
+        assertCommitAllowed: guard,
+        update,
+      }),
+    );
+    if (mode === "denied") {
+      await expect(work).rejects.toBe(denied);
+    } else {
+      await expect(work).rejects.toThrow(
+        mode === "selection" ? "outside the selected key set" : "changed before replacement",
+      );
+    }
+    expect(update).toHaveBeenCalledOnce();
+    expect(guard).toHaveBeenCalledTimes(mode === "denied" ? 1 : 0);
+    probe.expectHealthy(mode === "selection" ? 0 : 1);
+    expect(loadSessionEntryReadOnly(f.input)?.label).toBe(mode === "stale" ? "newer" : undefined);
+  },
+);
+
+it("keeps lifecycle commit denial before its stale-row check after admission", async () => {
+  const f = fixture();
+  const probe = observeAdmission(f.databasePath);
+  const denied = new Error("synthetic lifecycle denied");
+  const guard = vi.fn(() => {
+    throw denied;
+  });
+  const committed = vi.fn();
+  const buildEntry = vi.fn(
+    ({ currentEntry }: { currentEntry?: import("./types.js").SessionEntry }) => {
+      replaceSessionEntrySync(f.input, {
+        sessionId: "original",
+        label: "newer",
+        updatedAt: Date.now(),
+      });
+      expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+      return { ...currentEntry!, label: "uncommitted" };
+    },
+  );
+  const work = own(
+    applySessionEntryLifecycleMutation({
+      storePath: f.databasePath,
+      skipMaintenance: true,
+      beforeCommitInTransaction: guard,
+      onLifecycleCommitted: committed,
+      upserts: [{ sessionKey: f.input.sessionKey, buildEntry }],
+    }),
+  );
+  await expect(work).rejects.toBe(denied);
+  expect(buildEntry).toHaveBeenCalledOnce();
+  expect(guard).toHaveBeenCalledOnce();
+  expect(committed).not.toHaveBeenCalled();
+  probe.expectHealthy(1);
+  expect(loadSessionEntryReadOnly(f.input)?.label).toBe("newer");
+});
+
+function seedTranscript(f: Fixture) {
+  const scope = { ...f.input, sessionId: "original" };
+  const events = [{ type: "session", id: "original", content: "retained prepared history" }];
+  expect(replaceTranscriptEventsSync(scope, events)).toBe(true);
+  return { scope, events };
+}
+
+it("reacquires post-builder references before planning lifecycle transcript deletion", async () => {
+  const f = fixture();
+  const transcript = seedTranscript(f);
+  const survivor = { ...f.input, sessionKey: "agent:main:surviving-reference" };
+  replaceSessionEntrySync(survivor, { sessionId: "survivor", updatedAt: Date.now() });
+  const probe = observeAdmission(f.databasePath);
+  const builder = vi.fn(
+    ({ currentEntry }: { currentEntry?: import("./types.js").SessionEntry }) => {
+      expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+      return { ...currentEntry!, usageFamilySessionIds: ["original"] };
+    },
+  );
+  await expect(
+    own(
+      applySessionEntryLifecycleMutation({
+        storePath: f.databasePath,
+        skipMaintenance: true,
+        removals: [{ sessionKey: f.input.sessionKey, archiveRemovedTranscript: true }],
+        upserts: [{ sessionKey: survivor.sessionKey, buildEntry: builder }],
+      }),
+    ),
+  ).resolves.toMatchObject({ removedEntries: 1, archivedTranscriptDirectories: [] });
+  expect(builder).toHaveBeenCalledOnce();
+  probe.expectHealthy(1);
+  expect(loadSessionEntryReadOnly(f.input)).toBeUndefined();
+  expect(loadSessionEntryReadOnly(survivor)?.usageFamilySessionIds).toEqual(["original"]);
+  expect(loadTranscriptEventsSync(transcript.scope)).toEqual(transcript.events);
+});
+
+it("reacquires the split lifecycle commit after real archive materialization", async () => {
+  const f = fixture();
+  const transcript = seedTranscript(f);
+  const probe = observeAdmission(f.databasePath, true);
+  let materializations = 0;
+  let preparationWriterRan = false;
+  hooks.afterMaterialize = async () => {
+    materializations += 1;
+    await runExclusiveSqliteSessionWrite(
+      f.scope,
+      async () => {
+        preparationWriterRan = true;
+      },
+      "session.transcript.batch",
+    );
+    expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+  };
+  const work = own(
+    applySessionEntryLifecycleMutation({
+      storePath: f.databasePath,
+      skipMaintenance: true,
+      removals: [{ sessionKey: f.input.sessionKey, archiveRemovedTranscript: true }],
+    }),
+  );
+  await probe.expectPending(work);
+  let laterRan = false;
+  const later = own(
+    runExclusiveSqliteSessionWrite(
+      f.scope,
+      async () => {
+        laterRan = true;
+      },
+      "session.transcript.batch",
+    ),
+  );
+  await yieldToEventLoop();
+  expect(laterRan).toBe(false);
+  expect(preparationWriterRan).toBe(true);
+  expect(loadSessionEntryReadOnly(f.input)?.sessionId).toBe("original");
+  probe.release.resolve();
+  const result = await work;
+  await later;
+  expect(materializations).toBe(1);
+  expect(result.removedEntries).toBe(1);
+  expect(result.archivedTranscriptDirectories).toHaveLength(1);
+  expect(
+    fs
+      .readdirSync(result.archivedTranscriptDirectories[0]!)
+      .some((name) => name.startsWith("original.jsonl.deleted.")),
+  ).toBe(true);
+  expect(loadSessionEntryReadOnly(f.input)).toBeUndefined();
+  expect(loadTranscriptEventsSync(transcript.scope)).toEqual([]);
+  probe.expectHealthy(1);
+});
+
+it.each([false, true])(
+  "rechecks native deletion ownership during split cold admission (revoked: %s)",
+  async (revoked) => {
+    const f = fixture();
+    replaceSessionEntrySync(f.input, {
+      sessionId: "original",
+      updatedAt: Date.now(),
+      agentHarnessId: "prepared-native",
+      lifecycleRevision: "generation-1",
+    });
+    const registry = createEmptyPluginRegistry();
+    const commit = vi.fn();
+    const rollback = vi.fn();
+    let preparationWriterRan = false;
+    const prepare = vi.fn(async () => {
+      await runExclusiveSqliteSessionWrite(
+        f.scope,
+        async () => {
+          preparationWriterRan = true;
+        },
+        "session.transcript.batch",
+      );
+      expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+    });
+    const harness: AgentHarness = {
+      id: "prepared-native",
+      label: "Prepared native test",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => {
+        throw new Error("unused test harness");
+      },
+      withSessionDeletion: async (params, run) => {
+        await prepare();
+        params.assertCurrent();
+        return await run({ commit, rollback });
+      },
+    };
+    const record = createPluginRecord({ id: "prepared-native-owner" });
+    registry.plugins.push(record);
+    registry.agentHarnesses.push({ harness, pluginId: record.id, source: "runtime" });
+    markPluginRegistryActive(registry);
+    const probe = observeAdmission(f.databasePath, true);
+    const work = own(
+      withPluginRuntimeRegistryScope(registry, () =>
+        applySessionStoreProjection({
+          storePath: f.databasePath,
+          skipMaintenance: true,
+          update: (store) => {
+            delete store[f.input.sessionKey];
+            return { persist: true, result: "deleted" };
+          },
+        }),
+      ),
+    );
+    await probe.expectPending(work);
+    let laterRan = false;
+    const later = own(
+      runExclusiveSqliteSessionWrite(
+        f.scope,
+        async () => {
+          laterRan = true;
+        },
+        "session.transcript.batch",
+      ),
+    );
+    await yieldToEventLoop();
+    expect(laterRan).toBe(false);
+    expect(preparationWriterRan).toBe(true);
+    expect(commit).not.toHaveBeenCalled();
+    if (revoked) {
+      markPluginRegistryRetired(registry);
+    }
+    probe.release.resolve();
+    if (revoked) {
+      await expect(work).rejects.toThrow("harness owner changed");
+    } else {
+      await expect(work).resolves.toBe("deleted");
+    }
+    await later;
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(commit).toHaveBeenCalledTimes(revoked ? 0 : 1);
+    expect(rollback).not.toHaveBeenCalled();
+    probe.expectHealthy(1);
+    expect(loadSessionEntryReadOnly(f.input)?.sessionId).toBe(revoked ? "original" : undefined);
+  },
+);

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -79,6 +79,7 @@ import {
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
 } from "./session-accessor.sqlite-scope.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
@@ -134,81 +135,86 @@ export async function applySessionStoreProjection<T>(params: {
   const preparedWrite = await runPreparedSqliteSessionWrite(
     resolved,
     async () => {
-      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-      const before = readSessionEntryStore(database);
-      const projected = structuredClone(before);
-      const operation = await params.update(projected);
-      if (!operation.persist) {
-        return {
-          deletedEntries: [],
-          commit: () => ({ maintenancePlans: [], result: operation.result }),
-        };
-      }
-      const lockedEntriesBefore = new Map(
-        Object.entries(before).filter(([, entry]) => entry.modelSelectionLocked === true),
-      );
-      const transitionError = resolveAgentHarnessSessionStoreTransitionError({
-        before: lockedEntriesBefore,
-        store: projected,
-      });
-      const storeError = resolveAgentHarnessSessionStoreError(projected);
-      if (transitionError || storeError) {
-        throw new Error(transitionError ?? storeError);
-      }
+      return withSqliteSessionDatabase(toDatabaseOptions(resolved), async (database) => {
+        const before = readSessionEntryStore(database);
+        const projected = structuredClone(before);
+        const operation = await params.update(projected);
+        if (!operation.persist) {
+          return {
+            deletedEntries: [],
+            commit: () => ({ maintenancePlans: [], result: operation.result }),
+          };
+        }
+        const lockedEntriesBefore = new Map(
+          Object.entries(before).filter(([, entry]) => entry.modelSelectionLocked === true),
+        );
+        const transitionError = resolveAgentHarnessSessionStoreTransitionError({
+          before: lockedEntriesBefore,
+          store: projected,
+        });
+        const storeError = resolveAgentHarnessSessionStoreError(projected);
+        if (transitionError || storeError) {
+          throw new Error(transitionError ?? storeError);
+        }
 
-      const changedKeys = uniqueStrings([...Object.keys(before), ...Object.keys(projected)]).filter(
-        (sessionKey) => !sqliteSessionEntriesEqual(before[sessionKey], projected[sessionKey]),
-      );
-      if (changedKeys.length === 0) {
-        return {
-          deletedEntries: [],
-          commit: () => ({ maintenancePlans: [], result: operation.result }),
-        };
-      }
+        const changedKeys = uniqueStrings([
+          ...Object.keys(before),
+          ...Object.keys(projected),
+        ]).filter(
+          (sessionKey) => !sqliteSessionEntriesEqual(before[sessionKey], projected[sessionKey]),
+        );
+        if (changedKeys.length === 0) {
+          return {
+            deletedEntries: [],
+            commit: () => ({ maintenancePlans: [], result: operation.result }),
+          };
+        }
 
-      const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-      const deletedOwners = changedKeys.flatMap((sessionKey) => {
-        const entry = before[sessionKey];
-        return entry && !projected[sessionKey] ? [{ entry, sessionKey }] : [];
-      });
-      return {
-        deletedEntries: deletedOwners,
-        commit: () => {
-          runOpenClawAgentWriteTransaction(
-            (transactionDb) => {
-              for (const sessionKey of changedKeys) {
-                const current = readExactSessionEntryRow(transactionDb, sessionKey)?.entry;
-                if (!sqliteSessionEntriesEqual(current, before[sessionKey])) {
-                  throw new Error(
-                    `SQLite session entry changed before store projection for ${sessionKey}`,
+        const maintenancePlans: SessionEntryMaintenancePlan[] = [];
+        const deletedOwners = changedKeys.flatMap((sessionKey) => {
+          const entry = before[sessionKey];
+          return entry && !projected[sessionKey] ? [{ entry, sessionKey }] : [];
+        });
+        return {
+          deletedEntries: deletedOwners,
+          commit: () =>
+            withSqliteSessionDatabase(toDatabaseOptions(resolved), () => {
+              runOpenClawAgentWriteTransaction(
+                (transactionDb) => {
+                  for (const sessionKey of changedKeys) {
+                    const current = readExactSessionEntryRow(transactionDb, sessionKey)?.entry;
+                    if (!sqliteSessionEntriesEqual(current, before[sessionKey])) {
+                      throw new Error(
+                        `SQLite session entry changed before store projection for ${sessionKey}`,
+                      );
+                    }
+                  }
+                  for (const sessionKey of changedKeys) {
+                    const entry = projected[sessionKey];
+                    if (entry) {
+                      writeSessionEntry(transactionDb, sessionKey, cloneSessionEntry(entry), {
+                        previousEntry: before[sessionKey] ?? null,
+                      });
+                    } else {
+                      deleteSessionEntryRows(transactionDb, sessionKey);
+                    }
+                  }
+                  maintenancePlans.push(
+                    applySessionEntryMaintenance(transactionDb, {
+                      activeSessionKey: params.activeSessionKey ?? "",
+                      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+                      skipMaintenance: params.skipMaintenance,
+                      storePath: params.storePath,
+                    }),
                   );
-                }
-              }
-              for (const sessionKey of changedKeys) {
-                const entry = projected[sessionKey];
-                if (entry) {
-                  writeSessionEntry(transactionDb, sessionKey, cloneSessionEntry(entry), {
-                    previousEntry: before[sessionKey] ?? null,
-                  });
-                } else {
-                  deleteSessionEntryRows(transactionDb, sessionKey);
-                }
-              }
-              maintenancePlans.push(
-                applySessionEntryMaintenance(transactionDb, {
-                  activeSessionKey: params.activeSessionKey ?? "",
-                  archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-                  skipMaintenance: params.skipMaintenance,
-                  storePath: params.storePath,
-                }),
+                },
+                toDatabaseOptions(resolved),
+                { operationLabel: "session.store-projection" },
               );
-            },
-            toDatabaseOptions(resolved),
-            { operationLabel: "session.store-projection" },
-          );
-          return { maintenancePlans, result: operation.result };
-        },
-      };
+              return { maintenancePlans, result: operation.result };
+            }),
+        };
+      });
     },
     "session.store-projection",
   );
@@ -319,9 +325,11 @@ export async function applySessionEntryLifecycleMutation(params: {
             }
           : {}),
         commit: () =>
-          commitProjectedLifecycleMutation(
-            materializedRemovalPlans,
-            removalArchiveMaterializationFailed,
+          withSqliteSessionDatabase(toDatabaseOptions(resolved), () =>
+            commitProjectedLifecycleMutation(
+              materializedRemovalPlans,
+              removalArchiveMaterializationFailed,
+            ),
           ),
       };
     },

--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
@@ -1,6 +1,5 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
-import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
 import type {
   SessionEntryReplacementSnapshot,
@@ -31,6 +30,7 @@ import {
   resolveSqliteScope,
   resolveSqliteTranscriptArchiveDirectory,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
 } from "./session-accessor.sqlite-scope.js";
 import { readSessionEntriesByStatus } from "./session-accessor.sqlite-status.js";
 import type { SessionEntryReplacement } from "./session-accessor.types.js";
@@ -77,208 +77,212 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
   const preparedWrite = await runPreparedSqliteSessionWrite(
     resolved,
     async () => {
-      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-      const selectedKeys = params.sessionKeys ? new Set(params.sessionKeys) : undefined;
-      const selectedStatuses = params.statuses ? new Set(params.statuses) : undefined;
-      const readLabelOwnerKeys = (db = database.db) =>
-        params.includeLabelOwners === undefined
-          ? []
-          : executeSqliteQuerySync(
-              db,
-              getSessionKysely(db)
-                .selectFrom("session_nodes")
-                .select("session_key")
-                .where("label", "=", params.includeLabelOwners)
-                .orderBy("session_key"),
-            ).rows.map((row) => row.session_key);
-      // Label owners join the read snapshot, never the caller's mutation authority.
-      // Reading only their keys avoids hydrating unrelated sessions on every rename.
-      const labelOwnerKeys = readLabelOwnerKeys();
-      const selected = selectedStatuses
-        ? readSessionEntriesByStatus(database, [...selectedStatuses], params.sessionKeys)
-        : selectedKeys
-          ? uniqueStrings([...selectedKeys, ...labelOwnerKeys]).map((sessionKey) => ({
-              sessionKey,
-            }))
-          : Object.keys(readSessionEntryStore(database)).map((sessionKey) => ({ sessionKey }));
-      const expectedRows = new Map<string, ResolvedSessionEntryRow>();
-      const entries = selected.flatMap(({ sessionKey }) => {
-        const row = readExactSessionEntryRow(database, sessionKey);
-        if (!row) {
-          if (!selectedKeys || selectedStatuses) {
-            throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
+      return withSqliteSessionDatabase(toDatabaseOptions(resolved), async (database) => {
+        const selectedKeys = params.sessionKeys ? new Set(params.sessionKeys) : undefined;
+        const selectedStatuses = params.statuses ? new Set(params.statuses) : undefined;
+        const readLabelOwnerKeys = (db = database.db) =>
+          params.includeLabelOwners === undefined
+            ? []
+            : executeSqliteQuerySync(
+                db,
+                getSessionKysely(db)
+                  .selectFrom("session_nodes")
+                  .select("session_key")
+                  .where("label", "=", params.includeLabelOwners)
+                  .orderBy("session_key"),
+              ).rows.map((row) => row.session_key);
+        // Label owners join the read snapshot, never the caller's mutation authority.
+        // Reading only their keys avoids hydrating unrelated sessions on every rename.
+        const labelOwnerKeys = readLabelOwnerKeys();
+        const selected = selectedStatuses
+          ? readSessionEntriesByStatus(database, [...selectedStatuses], params.sessionKeys)
+          : selectedKeys
+            ? uniqueStrings([...selectedKeys, ...labelOwnerKeys]).map((sessionKey) => ({
+                sessionKey,
+              }))
+            : Object.keys(readSessionEntryStore(database)).map((sessionKey) => ({ sessionKey }));
+        const expectedRows = new Map<string, ResolvedSessionEntryRow>();
+        const entries = selected.flatMap(({ sessionKey }) => {
+          const row = readExactSessionEntryRow(database, sessionKey);
+          if (!row) {
+            if (!selectedKeys || selectedStatuses) {
+              throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
+            }
+            return [];
           }
-          return [];
-        }
-        if (selectedStatuses && (!row.entry.status || !selectedStatuses.has(row.entry.status))) {
-          return [];
-        }
-        // Pair the detached entry and CAS bytes from one row; separate reads can
-        // otherwise bless stale data with a newer writer's comparison token.
-        expectedRows.set(sessionKey, row);
-        return [{ entry: cloneSessionEntry(row.entry), sessionKey }];
-      });
-      const replacementAuthorityKeys = selectedStatuses
-        ? new Set(entries.map(({ sessionKey }) => sessionKey))
-        : selectedKeys;
-      const operation = await params.update(entries);
-      const replacements = normalize(operation.replacements);
-      const claimedCanonicalKeys = new Set<string>();
-      for (const replacement of replacements) {
-        const previousSessionKeys = replacement.previousSessionKeys;
-        const canonical = previousSessionKeys !== undefined;
-        if (canonical && !replacement.sessionKey) {
-          throw new Error("Session entry replacement requires a key");
-        }
-        if (
-          canonical &&
-          [replacement.sessionKey, ...(previousSessionKeys ?? [])].some(isInternalSessionEffectsKey)
-        ) {
-          throw new Error(
-            "Session entry canonical replacement cannot target internal effects rows",
-          );
-        }
-        for (const sessionKey of [replacement.sessionKey, ...(previousSessionKeys ?? [])]) {
-          if (replacementAuthorityKeys && !replacementAuthorityKeys.has(sessionKey)) {
-            const selectionName = selectedStatuses ? "row" : "key";
+          if (selectedStatuses && (!row.entry.status || !selectedStatuses.has(row.entry.status))) {
+            return [];
+          }
+          // Pair the detached entry and CAS bytes from one row; separate reads can
+          // otherwise bless stale data with a newer writer's comparison token.
+          expectedRows.set(sessionKey, row);
+          return [{ entry: cloneSessionEntry(row.entry), sessionKey }];
+        });
+        const replacementAuthorityKeys = selectedStatuses
+          ? new Set(entries.map(({ sessionKey }) => sessionKey))
+          : selectedKeys;
+        const operation = await params.update(entries);
+        const replacements = normalize(operation.replacements);
+        const claimedCanonicalKeys = new Set<string>();
+        for (const replacement of replacements) {
+          const previousSessionKeys = replacement.previousSessionKeys;
+          const canonical = previousSessionKeys !== undefined;
+          if (canonical && !replacement.sessionKey) {
+            throw new Error("Session entry replacement requires a key");
+          }
+          if (
+            canonical &&
+            [replacement.sessionKey, ...(previousSessionKeys ?? [])].some(
+              isInternalSessionEffectsKey,
+            )
+          ) {
             throw new Error(
-              `Session entry replacement is outside the selected ${selectionName} set: ${sessionKey}`,
+              "Session entry canonical replacement cannot target internal effects rows",
             );
           }
-          if (canonical) {
-            if (claimedCanonicalKeys.has(sessionKey)) {
-              throw new Error(`Session entry replacements overlap at ${sessionKey}`);
-            }
-            claimedCanonicalKeys.add(sessionKey);
-          }
-        }
-        if (canonical) {
-          for (const previousSessionKey of previousSessionKeys) {
-            if (!expectedRows.has(previousSessionKey)) {
+          for (const sessionKey of [replacement.sessionKey, ...(previousSessionKeys ?? [])]) {
+            if (replacementAuthorityKeys && !replacementAuthorityKeys.has(sessionKey)) {
+              const selectionName = selectedStatuses ? "row" : "key";
               throw new Error(
-                `Session entry canonical projection cannot replace missing alias ${previousSessionKey}`,
+                `Session entry replacement is outside the selected ${selectionName} set: ${sessionKey}`,
               );
+            }
+            if (canonical) {
+              if (claimedCanonicalKeys.has(sessionKey)) {
+                throw new Error(`Session entry replacements overlap at ${sessionKey}`);
+              }
+              claimedCanonicalKeys.add(sessionKey);
+            }
+          }
+          if (canonical) {
+            for (const previousSessionKey of previousSessionKeys) {
+              if (!expectedRows.has(previousSessionKey)) {
+                throw new Error(
+                  `Session entry canonical projection cannot replace missing alias ${previousSessionKey}`,
+                );
+              }
             }
           }
         }
-      }
 
-      const applicable = replacements.filter(
-        (replacement) =>
-          replacement.previousSessionKeys || expectedRows.has(replacement.sessionKey),
-      );
-      if (params.requireWriteSuccess && replacements.length > 0 && applicable.length === 0) {
-        throw new Error("session entry replacements did not persist any rows");
-      }
-      if (applicable.length === 0) {
+        const applicable = replacements.filter(
+          (replacement) =>
+            replacement.previousSessionKeys || expectedRows.has(replacement.sessionKey),
+        );
+        if (params.requireWriteSuccess && replacements.length > 0 && applicable.length === 0) {
+          throw new Error("session entry replacements did not persist any rows");
+        }
+        if (applicable.length === 0) {
+          return {
+            deletedEntries: [],
+            commit: () => ({ maintenancePlans: [], result: operation.result }),
+          };
+        }
+        const mutationKeys = new Set(
+          applicable.flatMap((replacement) => [
+            replacement.sessionKey,
+            ...(replacement.previousSessionKeys ?? []),
+          ]),
+        );
+        // Read-only label owners need the same row CAS as targets: their label can
+        // change between key selection and hydration, then change back during planning.
+        const validationKeys = new Set([...mutationKeys, ...labelOwnerKeys]);
+
+        const maintenancePlans: SessionEntryMaintenancePlan[] = [];
+        const previous = new Map<string, SessionEntry>();
+        const current = new Map<string, SessionEntry>();
+        const deletedOwners = [...mutationKeys].flatMap((sessionKey) => {
+          const entry = expectedRows.get(sessionKey)?.entry;
+          return entry && !applicable.some((replacement) => replacement.sessionKey === sessionKey)
+            ? [{ entry, sessionKey }]
+            : [];
+        });
         return {
-          deletedEntries: [],
-          commit: () => ({ maintenancePlans: [], result: operation.result }),
-        };
-      }
-      const mutationKeys = new Set(
-        applicable.flatMap((replacement) => [
-          replacement.sessionKey,
-          ...(replacement.previousSessionKeys ?? []),
-        ]),
-      );
-      // Read-only label owners need the same row CAS as targets: their label can
-      // change between key selection and hydration, then change back during planning.
-      const validationKeys = new Set([...mutationKeys, ...labelOwnerKeys]);
-
-      const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-      const previous = new Map<string, SessionEntry>();
-      const current = new Map<string, SessionEntry>();
-      const deletedOwners = [...mutationKeys].flatMap((sessionKey) => {
-        const entry = expectedRows.get(sessionKey)?.entry;
-        return entry && !applicable.some((replacement) => replacement.sessionKey === sessionKey)
-          ? [{ entry, sessionKey }]
-          : [];
-      });
-      return {
-        deletedEntries: deletedOwners,
-        commit: () => {
-          const publish = runOpenClawAgentWriteTransaction(
-            (transactionDb) => {
-              // Planning can await providers or hooks. Recheck uniqueness under the
-              // write transaction so an external label claim cannot race this snapshot.
-              if (
-                params.includeLabelOwners !== undefined &&
-                JSON.stringify(readLabelOwnerKeys(transactionDb.db)) !==
-                  JSON.stringify(labelOwnerKeys)
-              ) {
-                throw new Error("SQLite session label owners changed before replacement");
-              }
-              const transactionEntries = new Map<string, SessionEntry>();
-              for (const sessionKey of validationKeys) {
-                const transactionRow = readExactSessionEntryRow(transactionDb, sessionKey);
-                const expectedRow = expectedRows.get(sessionKey);
-                if (
-                  transactionRow?.row.entry_json !== expectedRow?.row.entry_json ||
-                  !sqliteSessionEntriesEqual(transactionRow?.entry, expectedRow?.entry)
-                ) {
-                  throw new Error(
-                    `SQLite session entry changed before replacement for ${sessionKey}`,
+          deletedEntries: deletedOwners,
+          commit: () =>
+            withSqliteSessionDatabase(toDatabaseOptions(resolved), () => {
+              const publish = runOpenClawAgentWriteTransaction(
+                (transactionDb) => {
+                  // Planning can await providers or hooks. Recheck uniqueness under the
+                  // write transaction so an external label claim cannot race this snapshot.
+                  if (
+                    params.includeLabelOwners !== undefined &&
+                    JSON.stringify(readLabelOwnerKeys(transactionDb.db)) !==
+                      JSON.stringify(labelOwnerKeys)
+                  ) {
+                    throw new Error("SQLite session label owners changed before replacement");
+                  }
+                  const transactionEntries = new Map<string, SessionEntry>();
+                  for (const sessionKey of validationKeys) {
+                    const transactionRow = readExactSessionEntryRow(transactionDb, sessionKey);
+                    const expectedRow = expectedRows.get(sessionKey);
+                    if (
+                      transactionRow?.row.entry_json !== expectedRow?.row.entry_json ||
+                      !sqliteSessionEntriesEqual(transactionRow?.entry, expectedRow?.entry)
+                    ) {
+                      throw new Error(
+                        `SQLite session entry changed before replacement for ${sessionKey}`,
+                      );
+                    }
+                    if (transactionRow) {
+                      transactionEntries.set(sessionKey, transactionRow.entry);
+                    }
+                  }
+                  params.assertCommitAllowed?.();
+                  for (const replacement of applicable) {
+                    const sourceEntries = [
+                      replacement.sessionKey,
+                      ...(replacement.previousSessionKeys ?? []),
+                    ].flatMap((sessionKey) => {
+                      const entry = transactionEntries.get(sessionKey);
+                      return entry ? [{ entry, sessionKey }] : [];
+                    });
+                    const selectedBefore = sourceEntries.toSorted(
+                      (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
+                    )[0]?.entry;
+                    for (const { entry, sessionKey } of sourceEntries) {
+                      previous.set(sessionKey, entry);
+                    }
+                    writeSessionEntry(
+                      transactionDb,
+                      replacement.sessionKey,
+                      cloneSessionEntry(replacement.entry),
+                      {
+                        ...(params.consumePendingReset ? { consumePendingReset: true } : {}),
+                        previousEntry: selectedBefore ?? null,
+                      },
+                    );
+                    deleteLegacySessionEntryRows(
+                      transactionDb,
+                      [...(replacement.previousSessionKeys ?? [])],
+                      replacement.sessionKey,
+                      { rehomeMembers: selectedBefore?.sessionId === replacement.entry.sessionId },
+                    );
+                    current.set(replacement.sessionKey, replacement.entry);
+                  }
+                  maintenancePlans.push(
+                    applySessionEntryMaintenance(transactionDb, {
+                      activeSessionKey: params.activeSessionKey ?? "",
+                      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+                      skipMaintenance: params.skipMaintenance ?? true,
+                      storePath: params.storePath,
+                    }),
                   );
-                }
-                if (transactionRow) {
-                  transactionEntries.set(sessionKey, transactionRow.entry);
-                }
-              }
-              params.assertCommitAllowed?.();
-              for (const replacement of applicable) {
-                const sourceEntries = [
-                  replacement.sessionKey,
-                  ...(replacement.previousSessionKeys ?? []),
-                ].flatMap((sessionKey) => {
-                  const entry = transactionEntries.get(sessionKey);
-                  return entry ? [{ entry, sessionKey }] : [];
-                });
-                const selectedBefore = sourceEntries.toSorted(
-                  (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
-                )[0]?.entry;
-                for (const { entry, sessionKey } of sourceEntries) {
-                  previous.set(sessionKey, entry);
-                }
-                writeSessionEntry(
-                  transactionDb,
-                  replacement.sessionKey,
-                  cloneSessionEntry(replacement.entry),
-                  {
-                    ...(params.consumePendingReset ? { consumePendingReset: true } : {}),
-                    previousEntry: selectedBefore ?? null,
-                  },
-                );
-                deleteLegacySessionEntryRows(
-                  transactionDb,
-                  [...(replacement.previousSessionKeys ?? [])],
-                  replacement.sessionKey,
-                  { rehomeMembers: selectedBefore?.sessionId === replacement.entry.sessionId },
-                );
-                current.set(replacement.sessionKey, replacement.entry);
-              }
-              maintenancePlans.push(
-                applySessionEntryMaintenance(transactionDb, {
-                  activeSessionKey: params.activeSessionKey ?? "",
-                  archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-                  skipMaintenance: params.skipMaintenance ?? true,
-                  storePath: params.storePath,
-                }),
+                  return prepareSessionIdentityPublication(
+                    transactionDb,
+                    resolved.agentId,
+                    previous,
+                    current,
+                  );
+                },
+                toDatabaseOptions(resolved),
+                { operationLabel: "session.entry-replacements" },
               );
-              return prepareSessionIdentityPublication(
-                transactionDb,
-                resolved.agentId,
-                previous,
-                current,
-              );
-            },
-            toDatabaseOptions(resolved),
-            { operationLabel: "session.entry-replacements" },
-          );
-          publish();
-          return { maintenancePlans, result: operation.result };
-        },
-      };
+              publish();
+              return { maintenancePlans, result: operation.result };
+            }),
+        };
+      });
     },
     "session.entry-replacements",
   );


### PR DESCRIPTION
Related: #143379, #143451

## What Problem This Solves

Fixes an issue where prepared session updates and cleanup could run full database integrity validation on the Gateway thread when a cached connection was cold or closed during an awaited callback. The affected owners include session replacements used by `sessions.patch`, lifecycle updates and internal cleanup, and the legacy SDK whole-store update surface.

## Why This Change Was Made

These existing acquisition points now use the asynchronous database owner while retaining their current writer-queue positions. Actual commits reacquire after awaited preparation; result-only store/replacement commits remain lazy. Native deletion and archive preparation stay outside the writer, with native-owner authority checked again after cold commit admission. Snapshot comparisons, callback order, and transaction/publication boundaries remain intact. Integration with the operation-label change in #143451 preserves the required owner category across both prepared writer phases.

## User Impact

Cold prepared updates perform their full integrity and foreign-key checks in the existing read-only child process. Warm callbacks remain direct, validation is retained, and stale or revoked operations still fail before mutation.

## Evidence

- Original-source reproduction: all three owners performed caller-thread integrity checks for cold preparation and cold commit; warm controls performed no new check. Real SQLite persistence, callback-once, and FIFO checks passed before the initial regression assertion.
- Exact strengthened regression replay before subsequent type/style-only test cleanup: six intended cold failures, three warm passes on the original source.
- Integrated candidate: 98 focused tests passed across prepared admission, entry admission, native deletion, replacement comparisons, handle lifecycle, lifecycle admission, maintenance, and writer operation-label diagnostics. Cold tests require healthy real-child completion and joined close; warm and result-only no-op paths require no new child.
- Changed-file checks, production/test typechecking, targeted documentation checks, and fresh independent review passed. The existing 700-line limit remains intact.
- Linux built-CLI proof passed on the pre-integration feature head `1f7201bfa4578905d3cbab759acd225acde1da15` with Node 24.19.0 and pnpm 12.3.4: full build, health, session creation without a turn, label patch, `sessions.describe` readback preserving identity, deletion, repeated missing deletion, and health. All eight CLI/Gateway owners and the build owner joined native extinction and released. The Testbox is stopped. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/34412040987); command exit 0 and collected artifact hashes were verified independently of the workflow's lease lifecycle.
- The conflict-driven integration onto main preserves the reviewed cold-admission behavior and main's required operation labels. Its fresh focused proof, independent review, and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34418420880) passed at `30dc1f3cb564f69da1536a959cbad381cca993d1`, including both Windows lanes. The earlier Linux flow and prior CI attempts remain evidence for their recorded pre-integration head.

The small synthetic fixtures establish validation placement and ownership. They do not establish a production latency ratio or attribution of a historical slow-write event.
