### PR TITLE
refactor(discord): remove duplicate presence-event test

### DIFF
--- a/extensions/discord/src/monitor/presence-events.test.ts
+++ b/extensions/discord/src/monitor/presence-events.test.ts
@@ -74,17 +74,6 @@ describe("resolveDiscordOnlinePresenceEvent", () => {
     ).toBeNull();
   });
 
-  it("requires the caller to classify an availability transition", () => {
-    expect(
-      resolveDiscordOnlinePresenceEvent({
-        config,
-        data: presence("online"),
-        availabilityKind: null,
-        nowMs: 1_000,
-      }),
-    ).toBeNull();
-  });
-
   it("honors immutable user allowlists, bot exclusion, and cooldown", () => {
     const base = {
       data: presence("online"),


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

This maintainer-requested test audit found a Discord presence-event test that repeats existing coverage without protecting a distinct behavior.

## Why This Change Was Made

Remove the duplicate caller-classification case. The retained unchanged-online case uses the same fresh online/null/1000 input and additionally covers idle status. Caller classification and listener lifecycle coverage remain unchanged.

## User Impact

No runtime behavior changes. This removes 11 test lines and one redundant case; all imports, fixtures, remaining cases, and assertions are preserved.

## Evidence

- Full `presence-events.test.ts` through the owning Discord configuration: 4 passed, 0 skipped.
- All 19 selected changed-file checks passed, with no retries.
- Targeted formatting and diff checks passed.
- Fresh P2 review completed scoped-clean with no findings under the current review policy.

This is focused local proof, not a full-repository test run or live Discord/Gateway validation.
