### PR TITLE
fix(release): accept Bun built-in module specifiers

### DIFF
--- a/scripts/lib/plugin-package-dependencies.mts
+++ b/scripts/lib/plugin-package-dependencies.mts
@@ -26,6 +26,7 @@ export function packageNameFromSpecifier(specifier: string) {
     typeof specifier !== "string" ||
     specifier.startsWith(".") ||
     specifier.startsWith("/") ||
+    specifier.startsWith("bun:") ||
     specifier.startsWith("node:") ||
     specifier.startsWith("#")
   ) {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1151,6 +1151,27 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     }
   });
 
+  it("accepts Bun built-in modules without npm dependency declarations", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writePackageFile(packageRoot, "package.json", {
+        version: "2026.9.9",
+        dependencies: {},
+      });
+      mkdirSync(join(packageRoot, "dist"), { recursive: true });
+      writeFileSync(
+        join(packageRoot, "dist", "bun-sqlite-library.js"),
+        'import { Database } from "bun:sqlite";\nconst { dlopen } = require("bun:ffi");\nexport { Database, dlopen };\n',
+        "utf8",
+      );
+
+      expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toStrictEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   const companionSource = 'const voice = require("@discordjs/voice");\nexport { voice };\n';
   const companionOwnership = {
     chunks: {

--- a/test/scripts/plugin-package-dependencies.test.ts
+++ b/test/scripts/plugin-package-dependencies.test.ts
@@ -27,6 +27,7 @@ describe("scripts/lib/plugin-package-dependencies.mts", () => {
     expect(packageNameFromSpecifier("plain-pkg/subpath")).toBe("plain-pkg");
     expect(packageNameFromSpecifier("@scope")).toBeNull();
     expect(packageNameFromSpecifier("@scope/")).toBeNull();
+    expect(packageNameFromSpecifier("bun:sqlite")).toBeNull();
     expect(packageNameFromSpecifier("node:fs")).toBeNull();
     expect(packageNameFromSpecifier("./local")).toBeNull();
     expect(packageNameFromSpecifier("/absolute")).toBeNull();


### PR DESCRIPTION
## Summary

- classify bun: module specifiers as runtime built-ins instead of npm package names
- prevent npm release verification and ownership auditing from demanding impossible package.json declarations
- cover bun:sqlite and bun:ffi through the packed-root dependency verifier

## Release evidence

This fixes the first failing leaf in npm preflight run 34409795774 and the matching npm qualification failure in Full Release Validation run 34409752188. The candidate legitimately imports Bun built-ins, but trusted tooling only excluded node: specifiers.

## Validation

- pnpm exec vitest run test/scripts/plugin-package-dependencies.test.ts test/openclaw-npm-postpublish-verify.test.ts (168 passed)
- pnpm check:changed