### PR TITLE
refactor(hooks): consolidate source precedence policy

### DIFF
--- a/src/hooks/policy.test.ts
+++ b/src/hooks/policy.test.ts
@@ -78,14 +78,19 @@ describe("hook policy", () => {
       expect(resolved[0]?.hook.source).toBe("openclaw-managed");
     });
 
-    it("keeps later workspace entries for the same source/name", () => {
-      const first = makeHookEntry("shared", "openclaw-workspace");
-      const second = makeHookEntry("shared", "openclaw-workspace");
-      second.hook.handlerPath = "/tmp/openclaw-workspace/shared/handler-2.js";
+    it.each([
+      ["openclaw-bundled", 0],
+      ["openclaw-plugin", 0],
+      ["openclaw-managed", 1],
+      ["openclaw-workspace", 1],
+    ] as const)("preserves the duplicate winner for %s", (source, winner) => {
+      const first = makeHookEntry("shared", source);
+      const second = makeHookEntry("shared", source);
+      second.hook.handlerPath = `/tmp/${source}/shared/handler-2.js`;
 
       const resolved = resolveHookEntries([first, second]);
       expect(resolved).toHaveLength(1);
-      expect(resolved[0]?.hook.handlerPath).toContain("handler-2");
+      expect(resolved[0]).toBe([first, second][winner]);
     });
   });
 });

--- a/src/hooks/policy.ts
+++ b/src/hooks/policy.ts
@@ -11,55 +11,18 @@ type HookEnableState = {
   reason?: HookEnableStateReason;
 };
 
-type HookSourcePolicy = {
-  precedence: number;
-  trustedLocalCode: boolean;
-  defaultEnableMode: "default-on" | "explicit-opt-in";
-  canOverride: HookSource[];
-  canBeOverriddenBy: HookSource[];
-};
-
 type HookResolutionCollision<T> = {
   name: string;
   kept: T;
   ignored: T;
 };
 
-const HOOK_SOURCE_POLICIES: Record<HookSource, HookSourcePolicy> = {
-  "openclaw-bundled": {
-    precedence: 10,
-    trustedLocalCode: true,
-    defaultEnableMode: "default-on",
-    canOverride: ["openclaw-bundled"],
-    canBeOverriddenBy: ["openclaw-managed", "openclaw-plugin"],
-  },
-  "openclaw-plugin": {
-    precedence: 20,
-    trustedLocalCode: true,
-    defaultEnableMode: "default-on",
-    canOverride: ["openclaw-bundled", "openclaw-plugin"],
-    canBeOverriddenBy: ["openclaw-managed"],
-  },
-  "openclaw-managed": {
-    precedence: 30,
-    trustedLocalCode: true,
-    defaultEnableMode: "default-on",
-    canOverride: ["openclaw-bundled", "openclaw-managed", "openclaw-plugin"],
-    canBeOverriddenBy: ["openclaw-managed"],
-  },
-  "openclaw-workspace": {
-    precedence: 40,
-    trustedLocalCode: true,
-    defaultEnableMode: "explicit-opt-in",
-    canOverride: ["openclaw-workspace"],
-    canBeOverriddenBy: ["openclaw-workspace"],
-  },
+const HOOK_SOURCE_PRECEDENCE: Record<HookSource, number> = {
+  "openclaw-bundled": 10,
+  "openclaw-plugin": 20,
+  "openclaw-managed": 30,
+  "openclaw-workspace": 40,
 };
-
-/** Resolve source trust, precedence, default enablement, and override rules. */
-function getHookSourcePolicy(source: HookSource): HookSourcePolicy {
-  return HOOK_SOURCE_POLICIES[source];
-}
 
 /** Resolve explicit per-hook config by hook key. */
 export function resolveHookConfig(
@@ -94,21 +57,11 @@ export function resolveHookEnableState(params: {
     return { enabled: false, reason: "disabled in config" };
   }
 
-  const sourcePolicy = getHookSourcePolicy(entry.hook.source);
-  if (sourcePolicy.defaultEnableMode === "explicit-opt-in" && hookConfig?.enabled !== true) {
+  if (entry.hook.source === "openclaw-workspace" && hookConfig?.enabled !== true) {
     return { enabled: false, reason: "workspace hook (disabled by default)" };
   }
 
   return { enabled: true };
-}
-
-function canOverrideHook(candidate: HookPolicyEntry, existing: HookPolicyEntry): boolean {
-  const candidatePolicy = getHookSourcePolicy(candidate.hook.source);
-  const existingPolicy = getHookSourcePolicy(existing.hook.source);
-  return (
-    candidatePolicy.canOverride.includes(existing.hook.source) &&
-    existingPolicy.canBeOverriddenBy.includes(candidate.hook.source)
-  );
 }
 
 /** Merge hook entries by name using source precedence and override policy. */
@@ -122,8 +75,7 @@ export function resolveHookEntries<T extends HookPolicyEntry>(
     .map((entry, index) => ({ entry, index }))
     .toSorted((a, b) => {
       const precedenceDelta =
-        getHookSourcePolicy(a.entry.hook.source).precedence -
-        getHookSourcePolicy(b.entry.hook.source).precedence;
+        HOOK_SOURCE_PRECEDENCE[a.entry.hook.source] - HOOK_SOURCE_PRECEDENCE[b.entry.hook.source];
       return precedenceDelta !== 0 ? precedenceDelta : a.index - b.index;
     });
 
@@ -134,9 +86,13 @@ export function resolveHookEntries<T extends HookPolicyEntry>(
       merged.set(entry.hook.name, entry);
       continue;
     }
-    // Source policy is asymmetric: higher precedence alone is not enough unless
-    // both source policies agree the candidate may replace the existing hook.
-    if (canOverrideHook(entry, existing)) {
+    // Precedence orders sources, but workspace code is isolated and bundled/plugin ties keep the first entry.
+    const sameSource = entry.hook.source === existing.hook.source;
+    if (
+      entry.hook.source === "openclaw-workspace"
+        ? sameSource
+        : !sameSource || entry.hook.source === "openclaw-managed"
+    ) {
       merged.set(entry.hook.name, entry);
       continue;
     }


### PR DESCRIPTION
Closes #143438

## What Problem This Solves

Hook source precedence is maintained twice: the merge sorts candidates by source, while two override lists repeat that ordering and encode tie/workspace exceptions separately.

## Why This Change Was Made

Keep precedence in one map and express the existing exceptions directly in the resolver. Remove the unused trust metadata and duplicate policy lookup. Production shrinks by 39 code lines; extending the existing duplicate-winner test costs five lines, for 34 fewer maintained code lines.

## User Impact

No behavior change. Bundled/plugin duplicates retain the first entry; managed/workspace duplicates retain the last. Workspace hooks cannot shadow non-workspace hooks and still require opt-in. Plugin hooks retain plugin-owned enablement. Selected objects, result order, and collision callbacks are preserved.

## Evidence

- 87 focused policy, selection, discovery, status, and loader tests pass.
- Original/candidate policy functions agree on 37,449 source/name sequences of length zero through five, observing winner identity, result order, collision order, and input preservation; 192 enablement configurations also agree.
- The complete changed-code gate passes, including typechecks, lint, dead exports, import cycles, and repository guards.
- Independent P0–P2 review found no actionable issues. No live Gateway run is claimed.
