### PR TITLE
fix(cli): reject blank directory group IDs before setup

### DIFF
--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -106,6 +106,8 @@ openclaw directory groups list --channel zalouser --query "work"
 openclaw directory groups members --channel zalouser --group-id <id>
 ```
 
+`groups members` requires a non-blank `--group-id`; empty or whitespace-only IDs fail before plugin setup or lookup.
+
 ## Related
 
 - [CLI reference](/cli)

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -225,6 +225,73 @@ describe("registerDirectoryCli", () => {
     expect(runtimeState.defaultRuntime.error).not.toHaveBeenCalled();
   });
 
+  describe("group member input", () => {
+    const listGroupMembers = vi.fn().mockResolvedValue([]);
+    const enabledConfig = {
+      channels: { slack: {} },
+      plugins: { entries: { slack: { enabled: true } } },
+    };
+
+    beforeEach(() => {
+      mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+        cfg: enabledConfig,
+        channelId: "slack",
+        plugin: { id: "slack", directory: { listGroupMembers } },
+        configChanged: true,
+      });
+      mocks.replaceConfigFile.mockImplementation(async ({ sourceConfig }) => {
+        mocks.loadConfig.mockReturnValue(sourceConfig);
+      });
+    });
+
+    it.each(["", " \t\n "])("rejects blank group ID %j before setup writes", async (groupId) => {
+      const program = new Command().name("openclaw");
+      registerDirectoryCli(program);
+
+      await expect(
+        program.parseAsync(
+          ["directory", "groups", "members", "--channel", "slack", "--group-id", groupId, "--json"],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("Missing --group-id");
+
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(listGroupMembers).not.toHaveBeenCalled();
+    });
+
+    it("keeps setup writes and trimmed group IDs for valid member lookups", async () => {
+      const program = new Command().name("openclaw");
+      registerDirectoryCli(program);
+
+      await program.parseAsync(
+        [
+          "directory",
+          "groups",
+          "members",
+          "--channel",
+          "slack",
+          "--group-id",
+          " group-1 ",
+          "--limit",
+          "5",
+          "--json",
+        ],
+        { from: "user" },
+      );
+
+      expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
+        sourceConfig: enabledConfig,
+        baseHash: "config-1",
+        writeOptions: {},
+      });
+      expect(listGroupMembers).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: "group-1", limit: 5 }),
+      );
+    });
+  });
+
   it.each([
     ["self", ["directory", "self", "--channel", "slack", "--json"]],
     ["peers", ["directory", "peers", "list", "--channel", "slack", "--json"]],
@@ -777,6 +844,11 @@ describe("registerDirectoryCli", () => {
     ["peers list", "   ", ["directory", "peers", "list", "--channel", "slack", "--limit", "   "]],
     ["groups list", "5x", ["directory", "groups", "list", "--channel", "slack", "--limit", "5x"]],
     ["groups list", "", ["directory", "groups", "list", "--channel", "slack", "--limit", ""]],
+    [
+      "group members with a blank group ID",
+      "5x",
+      ["directory", "groups", "members", "--channel", "slack", "--group-id", "", "--limit", "5x"],
+    ],
     [
       "group members",
       "5x",

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -335,6 +335,10 @@ export function registerDirectoryCli(program: Command) {
     .action((opts) =>
       runDirectoryAction(opts, async () => {
         const limit = parseLimit(opts.limit);
+        const groupId = normalizeStringifiedOptionalString(opts.groupId) ?? "";
+        if (!groupId) {
+          throw new Error("Missing --group-id");
+        }
         const resolved = await resolve({
           channel: opts.channel as string | undefined,
           account: opts.account as string | undefined,
@@ -346,10 +350,6 @@ export function registerDirectoryCli(program: Command) {
         const fn = plugin.directory?.listGroupMembers;
         if (!fn) {
           throw new Error(`Channel ${channelId} does not support group members listing`);
-        }
-        const groupId = normalizeStringifiedOptionalString(opts.groupId) ?? "";
-        if (!groupId) {
-          throw new Error("Missing --group-id");
         }
         const result = await fn({
           cfg,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `directory groups members --group-id ""` or a whitespace-only ID could run plugin setup and write configuration before reporting `Missing --group-id`.

## Why This Change Was Made

Move the existing group-ID normalization and check immediately after limit validation, before directory resolution. Valid-ID trimming, setup, lookup and error handling remain unchanged. The CLI reference documents the early rejection.

## User Impact

Invalid group-member requests fail before directory plugin installation, enablement or configuration writes. Valid commands retain their existing behavior.

## Evidence

Two regressions fail on the original code because the configuration-write boundary is reached; the same 43 tests pass after the guard move. Controls cover a valid trimmed ID with setup writes and invalid-limit precedence. All 29 changed-file checks, docs listing and independent review through P2 pass. Tests isolate configuration/provider operations; no real settings or credentials were used.
