### PR TITLE
refactor(tests): share image resource acquisition setup

### DIFF
--- a/src/media-understanding/image.resources.test.ts
+++ b/src/media-understanding/image.resources.test.ts
@@ -250,6 +250,22 @@ module.exports = { id: ${JSON.stringify(id)}, register(api) {
   };
 }
 
+function acquireFixtureRuntime(fixture: ReturnType<typeof nativeImageFixture>, modelId: string) {
+  return acquireReadOnlyPreparedModelRuntime(
+    {
+      config: fixture.config,
+      agentId: "main",
+      agentDir: fixture.agentDir,
+      workspaceDir: fixture.dir,
+      loadRuntimePlugins: true,
+      skipCredentials: true,
+      runtimePluginSelections: [{ provider: fixture.id, modelId }],
+    },
+    undefined,
+    "static",
+  );
+}
+
 afterEach(async () => {
   vi.useRealTimers();
   await closePreparedModelRuntimeSnapshots();
@@ -286,19 +302,7 @@ it.each(["timeout", "cancellation", "late-rejection"] as const)(
             ),
           ).toEqual({ ok: true });
           setActivePluginRegistry(donor.registry);
-          const acquired = await acquireReadOnlyPreparedModelRuntime(
-            {
-              config: fixture.config,
-              agentId: "main",
-              agentDir: fixture.agentDir,
-              workspaceDir: fixture.dir,
-              loadRuntimePlugins: true,
-              skipCredentials: true,
-              runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-            },
-            undefined,
-            "static",
-          );
+          const acquired = await acquireFixtureRuntime(fixture, "image-model");
           lease = acquired;
           expect(fixture.state.connections).toHaveLength(2);
           const [donorConnection, primary] = fixture.state.connections;
@@ -387,19 +391,7 @@ it("releases only its borrow while the supplying generation remains open", async
   try {
     await fixture.environment(async () => {
       useNoBundledPlugins();
-      const lease = await acquireReadOnlyPreparedModelRuntime(
-        {
-          config: fixture.config,
-          agentId: "main",
-          agentDir: fixture.agentDir,
-          workspaceDir: fixture.dir,
-          loadRuntimePlugins: true,
-          skipCredentials: true,
-          runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-        },
-        undefined,
-        "static",
-      );
+      const lease = await acquireFixtureRuntime(fixture, "image-model");
       try {
         fixture.state.finish.resolve();
         expect(
@@ -428,19 +420,7 @@ it("leaves a raw supplied registry with its caller", async () => {
       useNoBundledPlugins();
       const raw = loadPluginRegistryHandle({ config: fixture.config });
       setActivePluginRegistry(raw);
-      const lease = await acquireReadOnlyPreparedModelRuntime(
-        {
-          config: fixture.config,
-          agentId: "main",
-          agentDir: fixture.agentDir,
-          workspaceDir: fixture.dir,
-          loadRuntimePlugins: true,
-          skipCredentials: true,
-          runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-        },
-        undefined,
-        "static",
-      );
+      const lease = await acquireFixtureRuntime(fixture, "image-model");
       try {
         fixture.state.finish.resolve();
         const snapshot = { ...lease.snapshot, pluginRegistry: raw };
@@ -466,19 +446,7 @@ it.each(["setup", "retry"] as const)(
     try {
       await fixture.environment(async () => {
         useNoBundledPlugins();
-        const lease = await acquireReadOnlyPreparedModelRuntime(
-          {
-            config: fixture.config,
-            agentId: "main",
-            agentDir: fixture.agentDir,
-            workspaceDir: fixture.dir,
-            loadRuntimePlugins: true,
-            skipCredentials: true,
-            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-          },
-          undefined,
-          "static",
-        );
+        const lease = await acquireFixtureRuntime(fixture, "image-model");
         let closing: Promise<void> | undefined;
         let outcome: Promise<unknown> | undefined;
         try {
@@ -532,19 +500,7 @@ it.each(["parent", "normal", "admitted-tail"] as const)(
     try {
       await fixture.environment(async () => {
         useNoBundledPlugins();
-        const lease = await acquireReadOnlyPreparedModelRuntime(
-          {
-            config: fixture.config,
-            agentId: "main",
-            agentDir: fixture.agentDir,
-            workspaceDir: fixture.dir,
-            loadRuntimePlugins: true,
-            skipCredentials: true,
-            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-          },
-          undefined,
-          "static",
-        );
+        const lease = await acquireFixtureRuntime(fixture, "image-model");
         const parent = new AsyncWorkScope();
         let result: Promise<unknown> | undefined;
         let closing: Promise<void> | undefined;
@@ -627,19 +583,7 @@ it.each(["success", "failure", "timeout"] as const)(
     try {
       await fixture.environment(async () => {
         useNoBundledPlugins();
-        const lease = await acquireReadOnlyPreparedModelRuntime(
-          {
-            config: fixture.config,
-            agentId: "main",
-            agentDir: fixture.agentDir,
-            workspaceDir: fixture.dir,
-            loadRuntimePlugins: true,
-            skipCredentials: true,
-            runtimePluginSelections: [{ provider: fixture.id, modelId: "image-model" }],
-          },
-          undefined,
-          "static",
-        );
+        const lease = await acquireFixtureRuntime(fixture, "image-model");
         const parent = new AsyncWorkScope();
         let outcome: Promise<unknown> | undefined;
         let closing: Promise<void> | undefined;
@@ -731,19 +675,7 @@ it.each(["open", "resolved", "fallback"] as const)(
     try {
       await fixture.environment(async () => {
         useNoBundledPlugins();
-        const lease = await acquireReadOnlyPreparedModelRuntime(
-          {
-            config: fixture.config,
-            agentId: "main",
-            agentDir: fixture.agentDir,
-            workspaceDir: fixture.dir,
-            loadRuntimePlugins: true,
-            skipCredentials: true,
-            runtimePluginSelections: [{ provider: fixture.id, modelId: fixture.request.model }],
-          },
-          undefined,
-          "static",
-        );
+        const lease = await acquireFixtureRuntime(fixture, fixture.request.model);
         const parent = new AsyncWorkScope();
         const read = () =>
           fixture.state.connections[0]!.database.prepare("SELECT value FROM proof").get()?.value;


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The image resource-lifetime suite repeats the same prepared-runtime acquisition setup in seven scenarios, making its lifecycle assertions harder to distinguish from boilerplate.

## Why This Change Was Made

Use one private synchronous helper to forward the unchanged acquisition arguments to the real runtime. Each caller still supplies its explicit model ID and owns the same lease, assertions, and cleanup. No runtime mock or new lifecycle owner is introduced.

## User Impact

No user-visible behavior changes. This removes 68 net test lines while retaining every resource-lifetime scenario.

## Evidence

The complete image resource suite passed before and after: 16 tests, zero skips, identical ordered names and results. Expanding the seven helper calls reconstructs the original file's parser tokens. A bounded control of the actual helper source confirms fresh options, retained config and Promise identity, synchronous invocation, and unchanged ambient scope. The mapped changed-file gate and fresh independent P2 review passed. No full-suite runtime improvement is claimed.
