### PR TITLE
test(plugins): complete bundled-dir mock

### DIFF
--- a/src/plugins/bundled-package-channel-metadata.test.ts
+++ b/src/plugins/bundled-package-channel-metadata.test.ts
@@ -6,6 +6,7 @@ import { cleanupTempDirs, makeTempDir as makeTempRepoRoot } from "../../test/hel
 import { writeJsonFile } from "../../test/helpers/temp-repo.js";
 
 vi.mock("./bundled-dir.js", () => ({
+  isPluginInPackageBundledRoots: vi.fn(() => false),
   resolveBundledPluginsDir: vi.fn(),
   resolveSourceCheckoutDependencyDiagnostic: vi.fn(() => null),
 }));


### PR DESCRIPTION
## Summary
- add the newly required `isPluginInPackageBundledRoots` export to the bundled-dir test mock
- restore the agentic plugin prerelease lane blocked in FRV run 34409752188

## Validation
- `pnpm exec vitest run src/plugins/bundled-package-channel-metadata.test.ts` (3 passed)
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34409752188