### PR TITLE
test(ui): wait for refreshed account catalog

### DIFF
--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -707,7 +707,9 @@ suite.define(() => {
       await gateway.waitForRequest("models.list", { after: 1 });
       await trigger.click();
       await gateway.setMethodResponse("models.list", { models: [existing, published] });
+      const previousRequestCount = (await gateway.getRequests("models.list")).length;
       await trigger.click();
+      await gateway.waitForRequest("models.list", { after: previousRequestCount });
       await expect
         .poll(() => composer.locator('[data-chat-model-option="example/published"]').isVisible())
         .toBe(true);


### PR DESCRIPTION
## Summary
- synchronize the catalog reopen assertion with the `models.list` request triggered after the response change
- remove the UI E2E race that blocked two normal-CI shards in FRV run 34409752188

## Validation
- targeted UI E2E config: 11 passed, including `reads a newer account catalog on reopen without a cooldown or provider discovery`
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34409752188