### PR TITLE
fix(gateway): allow runtime-aware environment listing from CLI

### DIFF
--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -247,7 +247,9 @@ dispatch so authorization failures have one canonical structured response:
   `projectId`, and `operator.admin` for incognito sessions or any `execNode`
   request. For non-admin callers, the handler limits `cwd` to configured agent
   workspaces; `projectId` cannot be combined with `cwd` or `execNode`.
-- `environments.list` needs `operator.read`. Session placement methods derive
+- `environments.list` needs `operator.read` for plain inventory and
+  `operator.write` when `runtimeId` requests runtime-specific command eligibility.
+  Session placement methods derive
   their scope from the requested target before schema validation:
   `sessions.dispatch` needs `operator.write` for `deviceId` and
   `operator.admin` for `profileId` or a target-less

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -925,6 +925,13 @@ describe("callGateway url resolution", () => {
   });
 
   it.each([
+    ["plain environment inventory", "environments.list", {}, ["operator.read"]],
+    [
+      "runtime-aware environment inventory",
+      "environments.list",
+      { runtimeId: "openclaw" },
+      ["operator.write"],
+    ],
     [
       "device dispatch",
       "sessions.dispatch",

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -40,6 +40,22 @@ afterEach(() => {
 });
 
 describe("method scope resolution", () => {
+  it.each(["openclaw", " "])(
+    "authorizes runtime-aware inventory %j with write scope",
+    (runtimeId) => {
+      const params = { runtimeId };
+      expect(
+        authorizeOperatorScopesForMethod("environments.list", ["operator.read"], params),
+      ).toEqual({
+        allowed: false,
+        missingScope: "operator.write",
+      });
+      expect(
+        authorizeOperatorScopesForMethod("environments.list", ["operator.write"], params),
+      ).toEqual({ allowed: true });
+    },
+  );
+
   it("requires write scope before sessions.assignOwner visibility is considered", () => {
     const params = {
       key: "agent:main:shared",

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -166,6 +166,14 @@ function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
         : undefined;
     return includeSecrets === true ? [READ_SCOPE, TALK_SECRETS_SCOPE] : [READ_SCOPE];
   }
+  if (method === "environments.list") {
+    const runtimeId =
+      params && typeof params === "object" && !Array.isArray(params) && "runtimeId" in params
+        ? params.runtimeId
+        : undefined;
+    // Match the handler: every nonempty runtime ID needs command eligibility access.
+    return typeof runtimeId === "string" && runtimeId ? [WRITE_SCOPE] : [READ_SCOPE];
+  }
   if (method === "channels.pairing.approve") {
     const bootstrapCommandOwner =
       params && typeof params === "object" && !Array.isArray(params)

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -168,7 +168,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["taskSuggestions.create", "task-suggestions", "operator.write", "<=2026.7"],
   ["taskSuggestions.accept", "task-suggestions", "operator.admin", "<=2026.7"],
   ["taskSuggestions.dismiss", "task-suggestions", "operator.write", "<=2026.7"],
-  ["environments.list", "environments", "operator.read", "2026.7"],
+  ["environments.list", "environments", "dynamic", "2026.7"],
   ["environments.status", "environments", "operator.read", "2026.7"],
   ["worktrees.list", "worktrees", "operator.read", "2026.7"],
   // Read-only git probe, but it accepts arbitrary host paths; keep it at the


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators listing environments through the CLI would receive a missing `operator.write` error when supplying `runtimeId`, even when their credentials permit that scope.

## Why This Change Was Made

Classify `environments.list` as dynamically scoped so clients request `operator.read` for plain inventory and `operator.write` for runtime-specific command eligibility. Scope selection now matches the existing handler, including nonempty whitespace runtime IDs. The handler's authorization checks, credential grants, and worker-placement behavior remain unchanged.

## User Impact

Operators with write authority can request runtime-aware environment inventory without manually constructing a write-scoped client. Plain inventory remains available with read authority.

## Evidence

- Regression tests failed before the repair because runtime-aware calls selected read scope and the shared scope authorizer accepted read-only access.
- Final focused validation passed: **346 tests across 3 files**, covering CLI scope negotiation, shared authorization, and existing environment command-authority behavior:
  ```sh
  node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts src/gateway/call.test.ts src/gateway/server-methods/environments.node-command-authority.test.ts
  ```
- Core and core-test typechecks, formatting, changed-file lint, dead-export scan, and remaining changed-check guards passed across the validation runs. The aggregate changed-check invocation was not recorded as a single successful run; final lint and remaining guards were completed separately.
- `git diff --check` passed.
- No live Gateway deployment, restart, or worker dispatch was performed for this candidate.

- Fresh pre-commit autoreview completed with no actionable P0–P2 findings.
