### PR TITLE
test(browser): allow tab index propagation

### DIFF
--- a/extensions/browser/chrome-extension/tab-creation.test-support.ts
+++ b/extensions/browser/chrome-extension/tab-creation.test-support.ts
@@ -51,7 +51,9 @@ export async function assertRelayTabCreation(params: {
       const tabs = await extensionPage.evaluate(async () => await chrome.tabs.query({}));
       return { tabs, newTabs: tabs.filter((tab) => !existingTabs.some((e) => e.id === tab.id)) };
     };
-    await expect.poll(async () => (await queryNewTabs()).newTabs.length).toBe(1);
+    await expect
+      .poll(async () => (await queryNewTabs()).newTabs.length, { timeout: 10_000 })
+      .toBe(1);
     const { tabs, newTabs } = await queryNewTabs();
     const unchanged = await Promise.all(
       existingPages.map(


### PR DESCRIPTION
## Summary
- give the Chrome tab-index poll an explicit 10-second budget
- preserve the helper intent that Playwright page creation may precede `chrome.tabs` indexing
- remove the extension bootstrap E2E race seen in FRV run 34409752188

## Validation
- `pnpm test:e2e:browser-extension` (1 passed under real Chromium)
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34409752188