### PR TITLE
test(plugins): accept MCP resolver diagnostic

### DIFF
--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -333,6 +333,7 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
     'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
     "memory prompt supplement registration missing builder",
+    "MCP server connection resolver registration missing serverName or resolve",
     "model catalog provider registration missing provider",
     "session extension registration requires namespace and description",
     "session scheduler job registration requires unique id, sessionKey, and kind",


### PR DESCRIPTION
## Summary
- recognize the MCP connection resolver registration diagnostic as an expected invalid-probe result from the published kitchen-sink fixture
- restore the candidate plugin prerelease Docker lane exposed by terminal FRV drain

## Validation
- `pnpm exec vitest run test/scripts/kitchen-sink-plugin-assertions.test.ts` (32 passed)
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34411388949/job/102667584525