### PR TITLE
fix(release): include default survivor companions

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2411,6 +2411,9 @@ jobs:
           if [[ "$PREPARE_ONLY" == "true" ]]; then
             # Shared artifacts serve both release-path and plugin prerelease consumers.
             # Plan their union here without expanding either child's execution scope.
+            if [[ -z "$OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS" ]]; then
+              export OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS="base legacy-operator-state"
+            fi
             preparation_lanes="$(node --input-type=module <<'NODE'
           import { allReleasePathLanes } from "./.release-harness/scripts/lib/docker-e2e-scenarios.mts";
           import { createPluginPrereleaseTestPlan } from "./.release-harness/scripts/lib/plugin-prerelease-test-plan.mts";

--- a/test/scripts/release-candidate-plan.test.ts
+++ b/test/scripts/release-candidate-plan.test.ts
@@ -24,6 +24,7 @@ type Plan = ReturnType<typeof resolveDockerE2ePlan>["plan"];
 function runPlanningStep(
   releaseProfile: "beta" | "stable" | "full",
   mode: "prepare" | "release" | "targeted",
+  upgradeSurvivorScenarios = mode === "targeted" ? "" : "reported-issues",
 ) {
   const root = tempDirs.make("openclaw-candidate-plan-");
   const output = join(root, "github-output");
@@ -44,7 +45,7 @@ function runPlanningStep(
       OPENCLAW_DOCKER_ALL_TIMINGS: "0",
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: "",
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: "",
-      OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: mode === "targeted" ? "" : "reported-issues",
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: upgradeSurvivorScenarios,
     },
   });
   return {
@@ -90,5 +91,11 @@ describe("shared release candidate preparation", () => {
     const { plan } = runPlanningStep("full", "targeted");
     expect(plan.lanes.map((lane) => lane.name)).toEqual(["npm-onboard-channel-agent"]);
     expect(plan.requiredPrepublishPluginPackages).toEqual(["@openclaw/codex"]);
+  });
+
+  it("prepares the default non-soak survivor companion packages", () => {
+    const { plan } = runPlanningStep("beta", "prepare", "");
+
+    expect(plan.requiredPrepublishPluginPackages).toContain("@openclaw/duckduckgo-plugin");
   });
 });


### PR DESCRIPTION
## Summary
- make shared candidate preparation default to the same base + legacy-operator-state survivor scenarios used by non-soak current-source release checks
- include `@openclaw/duckduckgo-plugin` in the reusable prepublish registry before candidate consumers validate it
- add regression coverage for an empty scenario input

## Validation
- `pnpm exec vitest run test/scripts/release-candidate-plan.test.ts` (5 passed)
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34411533627/job/102668688689