### PR TITLE
perf: avoid repeated system-message trimming

### DIFF
--- a/src/infra/system-message.ts
+++ b/src/infra/system-message.ts
@@ -2,22 +2,15 @@
 // identified without extra metadata in plain chat transcripts.
 export const SYSTEM_MARK = "⚙️";
 
-function normalizeSystemText(value: string): string {
-  return value.trim();
-}
-
 /** Return true when text already carries the system-message prefix. */
 export function hasSystemMark(text: string): boolean {
-  return normalizeSystemText(text).startsWith(SYSTEM_MARK);
+  return text.trim().startsWith(SYSTEM_MARK);
 }
 
 /** Prefix non-empty text as a system message without double-prefixing. */
 export function prefixSystemMessage(text: string): string {
-  const normalized = normalizeSystemText(text);
-  if (!normalized) {
-    return normalized;
-  }
-  if (hasSystemMark(normalized)) {
+  const normalized = text.trim();
+  if (!normalized || normalized.startsWith(SYSTEM_MARK)) {
     return normalized;
   }
   return `${SYSTEM_MARK} ${normalized}`;


### PR DESCRIPTION
## What Problem This Solves

System-message prefixing trims text, then checks the already-trimmed result through a helper that trims it again. Thread-binding intro and farewell messages pay for that redundant normalization.

## Why This Change Was Made

Trim once in prefixSystemMessage and check the normalized string directly. Inline the private one-line normalization wrapper in the public marker predicate. Preserve the exact marker bytes, whitespace trimming, empty results, idempotence, and interior message text. Seven production lines are removed; public exports and tests are unchanged.

## User Impact

Same system-marked messages with less redundant work. This is a small helper-level improvement, not a claim of faster provider turns or Gateway latency.

## Evidence

- Both complete relevant test files passed on baseline and candidate: 12 tests each.
- Independent Codex review found no actionable P0–P2 defects.
- The first validation run hit its setup deadline during the serial core-test typecheck. Its failure is retained. Recovery used the existing five stripes serially, covering all 17 canonical graphs, then the 12 pending checks and final diff check. Previously passed tests/checks were not repeated or relabeled.
- [Completed recovery and measurement run](https://github.com/openclaw/openclaw/actions/runs/34411306117): all recovery commands passed, followed by 176 real intro/farewell calls and 24 separate Unicode/prefix controls. Full literal results, input snapshots, control types, and cross-phase equality were verified. An independent audit checked the results, complete stripe coverage, strict joins, and stopped/removed container and lease.

Warm median call times in microseconds, baseline → candidate, with eight warm observations per case and process:

| Real producer case | Baseline-first pair | Candidate-first pair |
|---|---:|---:|
| Default intro | 3.998 → 2.284 | 2.696 → 2.139 |
| Intro with details | 3.747 → 1.794 | 1.864 → 1.824 |
| Prefixed farewell | 0.521 → 0.311 | 0.336 → 0.306 |
| Expired farewell | 1.263 → 0.401 | 0.456 → 0.366 |

All eight warm medians were lower, but these are small descriptive samples subject to timer/JIT noise and order effects. Absolute median gains ranged from 29.5 ns to 1.953 µs. All initial, warmup, and adverse CPU/memory observations are retained; no memory-saving or whole-Gateway claim is made.

Exact-head repository CI remains required before landing.
