### PR TITLE
fix(docs): detect overdue mirror changes during steady edits

### DIFF
--- a/scripts/docs-mirror-freshness.mjs
+++ b/scripts/docs-mirror-freshness.mjs
@@ -83,11 +83,12 @@ function toCommitApiPath(pattern) {
   return bare;
 }
 
-async function newestWatchedCommit(watchPaths) {
+async function newestWatchedCommit(watchPaths, until = "") {
   let newest = null;
+  const untilQuery = until ? `&until=${encodeURIComponent(until)}` : "";
   for (const watchPath of watchPaths) {
     const commits = await githubJson(
-      `/repos/${SOURCE_REPO}/commits?sha=main&path=${encodeURIComponent(watchPath)}&per_page=1`,
+      `/repos/${SOURCE_REPO}/commits?sha=main&path=${encodeURIComponent(watchPath)}&per_page=1${untilQuery}`,
     );
     const head = commits[0];
     if (!head) {
@@ -98,7 +99,7 @@ async function newestWatchedCommit(watchPaths) {
       newest = { sha: head.sha, committedAt, path: watchPath };
     }
   }
-  if (!newest) {
+  if (!newest && !until) {
     throw new Error("no commits found for any watched docs path on main");
   }
   return newest;
@@ -154,18 +155,25 @@ async function main() {
     newestWatchedCommit(watchPaths),
     readMirroredSourceSha(),
   ]);
-  const ageMinutes = Math.round((Date.now() - newest.committedAt) / 60_000);
+  const now = Date.now();
+  const ageMinutes = Math.round((now - newest.committedAt) / 60_000);
   const summary = `newest docs-touching main commit ${newest.sha} (${newest.path}, ${ageMinutes}m ago); mirror at ${mirroredSha}`;
 
   if (await mirrorCoversCommit(newest.sha, mirroredSha)) {
     console.log(`docs mirror fresh: ${summary}`);
     return;
   }
-  if (ageMinutes < STALE_MINUTES) {
-    console.log(
-      `docs mirror trailing within ${STALE_MINUTES}m grace (sync in flight?): ${summary}`,
-    );
-    return;
+  let stale = newest;
+  const cutoff = now - STALE_MINUTES * 60_000;
+  if (newest.committedAt > cutoff) {
+    // Recent edits must not renew grace for older changes the mirror still lacks.
+    stale = await newestWatchedCommit(watchPaths, new Date(cutoff).toISOString());
+    if (!stale || (await mirrorCoversCommit(stale.sha, mirroredSha))) {
+      console.log(
+        `docs mirror trailing within ${STALE_MINUTES}m grace (sync in flight?): ${summary}`,
+      );
+      return;
+    }
   }
 
   const activeSyncRuns = await countActiveSyncRuns();
@@ -177,7 +185,10 @@ async function main() {
       `${activeSyncRuns} ${SYNC_WORKFLOW} run(s) already queued/in progress; not dispatching another`,
     );
   }
-  fail(`docs mirror stale for ${ageMinutes}m (threshold ${STALE_MINUTES}m): ${summary}`);
+  const staleMinutes = Math.round((now - stale.committedAt) / 60_000);
+  fail(
+    `docs mirror stale for ${staleMinutes}m (threshold ${STALE_MINUTES}m): unmirrored docs-touching main commit ${stale.sha} (${stale.path}); mirror at ${mirroredSha}`,
+  );
 }
 
 try {

--- a/test/scripts/docs-mirror-freshness.test.ts
+++ b/test/scripts/docs-mirror-freshness.test.ts
@@ -1,0 +1,192 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const script = path.resolve(import.meta.dirname, "../../scripts/docs-mirror-freshness.mjs");
+const baseSha = "a".repeat(40);
+const oldSha = "b".repeat(40);
+const newestSha = "c".repeat(40);
+
+describe("docs mirror freshness", () => {
+  it.each([
+    {
+      name: "a current mirror",
+      mirror: newestSha,
+      recentMinutes: 10,
+      old: true,
+      base: true,
+      grace: 60,
+      active: 0,
+      staleMinutes: 0,
+    },
+    {
+      name: "only recent changes",
+      mirror: baseSha,
+      recentMinutes: 10,
+      old: false,
+      base: true,
+      grace: 60,
+      active: 0,
+      staleMinutes: 0,
+    },
+    {
+      name: "an overdue change hidden by a recent edit",
+      mirror: baseSha,
+      recentMinutes: 10,
+      old: true,
+      base: true,
+      grace: 60,
+      active: 0,
+      staleMinutes: 120,
+    },
+    {
+      name: "an overdue change with recovery already active",
+      mirror: baseSha,
+      recentMinutes: 10,
+      old: true,
+      base: true,
+      grace: 60,
+      active: 1,
+      staleMinutes: 120,
+    },
+    {
+      name: "a quiet stale source",
+      mirror: baseSha,
+      recentMinutes: 90,
+      old: true,
+      base: true,
+      grace: 60,
+      active: 0,
+      staleMinutes: 90,
+    },
+    {
+      name: "the first watched change still in grace",
+      mirror: baseSha,
+      recentMinutes: 10,
+      old: false,
+      base: false,
+      grace: 60,
+      active: 0,
+      staleMinutes: 0,
+    },
+    {
+      name: "a configured longer grace period",
+      mirror: baseSha,
+      recentMinutes: 10,
+      old: true,
+      base: true,
+      grace: 180,
+      active: 0,
+      staleMinutes: 0,
+    },
+    {
+      name: "a change just inside the grace boundary",
+      mirror: oldSha,
+      recentMinutes: 59.75,
+      old: true,
+      base: true,
+      grace: 60,
+      active: 0,
+      staleMinutes: 0,
+    },
+  ])("handles $name without live network access", (scenario) => {
+    const root = createTempDir("openclaw-docs-mirror-");
+    mkdirSync(path.join(root, ".github/workflows"), { recursive: true });
+    writeFileSync(
+      path.join(root, ".github/workflows/docs-sync-publish.yml"),
+      "on:\n  push:\n    paths:\n      - watched-docs/**\n      - scripts/publish-support.mjs\n",
+    );
+    const requestsPath = path.join(root, "requests.jsonl");
+    writeFileSync(requestsPath, "");
+    const preload = path.join(root, "github-fixture.mjs");
+    writeFileSync(
+      preload,
+      `
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import { syncBuiltinESMExports } from "node:module";
+const rejectNetwork = () => { throw new Error("Unexpected network connection"); };
+net.connect = net.createConnection = net.Socket.prototype.connect = rejectNetwork;
+syncBuiltinESMExports();
+const scenario = ${JSON.stringify(scenario)};
+const now = Date.parse("2026-09-09T12:00:00Z");
+Date.now = () => now;
+const commit = (sha, minutes) => ({ sha, commit: { committer: { date: new Date(now - minutes * 60000).toISOString() } } });
+const base = scenario.base ? [commit(${JSON.stringify(baseSha)}, 360)] : [];
+const history = {
+  "watched-docs": [commit(${JSON.stringify(newestSha)}, scenario.recentMinutes), ...base],
+  "scripts/publish-support.mjs": [...(scenario.old ? [commit(${JSON.stringify(oldSha)}, 120)] : []), ...base],
+};
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(input);
+  const method = init.method ?? "GET";
+  assert.equal(url.origin, "https://api.github.com");
+  assert.equal(new Headers(init.headers).has("authorization"), false);
+  fs.appendFileSync(${JSON.stringify(requestsPath)}, JSON.stringify({ method, pathname: url.pathname, search: url.search }) + "\\n");
+  let body;
+  if (method === "GET" && url.pathname === "/repos/openclaw/openclaw/commits") {
+    assert.equal(url.searchParams.get("sha"), "main");
+    assert.equal(url.searchParams.get("per_page"), "1");
+    const entries = history[url.searchParams.get("path")];
+    assert.ok(entries, "watched paths must come from the workflow");
+    const until = url.searchParams.get("until");
+    if (until) assert.equal(Date.parse(until), now - scenario.grace * 60000);
+    body = entries.filter(entry => !until || Date.parse(entry.commit.committer.date) <= Date.parse(until)).slice(0, 1);
+  } else if (method === "GET" && url.pathname === "/repos/openclaw/docs/contents/.openclaw-sync/source.json") {
+    assert.equal(url.searchParams.get("ref"), "main");
+    body = { content: Buffer.from(JSON.stringify({ sha: scenario.mirror })).toString("base64") };
+  } else if (method === "GET" && url.pathname.startsWith("/repos/openclaw/openclaw/compare/")) {
+    const [from, to] = url.pathname.split("/").at(-1).split("...");
+    const order = ${JSON.stringify([baseSha, oldSha, newestSha])};
+    assert.ok(order.includes(from) && order.includes(to));
+    body = { status: from === to ? "identical" : order.indexOf(to) > order.indexOf(from) ? "ahead" : "behind" };
+  } else if (method === "GET" && url.pathname === "/repos/openclaw/openclaw/actions/workflows/docs-sync-publish.yml/runs") {
+    assert.equal(url.searchParams.get("per_page"), "1");
+    assert.ok(["queued", "in_progress"].includes(url.searchParams.get("status")));
+    body = { total_count: url.searchParams.get("status") === "queued" ? scenario.active : 0 };
+  } else if (method === "POST" && url.pathname === "/repos/openclaw/openclaw/actions/workflows/docs-sync-publish.yml/dispatches") {
+    assert.deepEqual(JSON.parse(init.body), { ref: "main" });
+    return new Response(null, { status: 204 });
+  } else {
+    throw new Error("Unexpected GitHub request: " + method + " " + url.pathname);
+  }
+  return Response.json(body);
+};
+`,
+    );
+
+    const result = spawnSync(process.execPath, ["--import", preload, script], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        WINDIR: process.env.WINDIR,
+        DOCS_MIRROR_STALE_MINUTES: String(scenario.grace),
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stdout + result.stderr).toBe(scenario.staleMinutes ? 1 : 0);
+    const requests = readFileSync(requestsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(requests.filter((request) => request.method === "POST")).toHaveLength(
+      scenario.staleMinutes && !scenario.active ? 1 : 0,
+    );
+    if (scenario.staleMinutes) {
+      expect(result.stderr).toContain(`docs mirror stale for ${scenario.staleMinutes}m`);
+      expect(result.stderr).toContain(
+        scenario.recentMinutes === scenario.staleMinutes ? newestSha : oldSha,
+      );
+    } else {
+      expect(result.stdout).toContain(
+        scenario.mirror === newestSha ? "docs mirror fresh:" : `within ${scenario.grace}m grace`,
+      );
+    }
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1413,6 +1413,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/ci-platform-checkout.test.ts",
         "src/scripts/ci-changed-scope.git-owner.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
+        ...(workflow === "docs-sync-publish" ? ["test/scripts/docs-mirror-freshness.test.ts"] : []),
       ],
     );
     const plans = buildVitestRunPlans(["test/scripts/ci-linux-git.test.ts"]);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where continuous documentation edits could keep the docs mirror monitor reporting that synchronization was within its grace period even while older changes remained unpublished. The monitor could also report a change as overdue just before the configured threshold because it rounded the age first.

## Why This Change Was Made

When the latest watched commit is still within grace, the existing commit lookup also checks watched history at the grace cutoff. Grace now applies only when the mirror contains that overdue history. Threshold decisions use the exact timestamp; rounded minutes remain diagnostic output. Existing recovery dispatch and active-run suppression are preserved.

## User Impact

Maintainers receive the intended stale-mirror failure and recovery attempt when older documentation changes remain missing during steady source activity. Genuinely recent changes retain the existing grace period.

## Evidence

Eight real CLI scenarios pass with fetch intercepted and network sockets blocked; three fail for the intended reasons on the original code. Controls cover a current mirror, genuine grace, quiet staleness, active recovery, missing older history, a longer configured grace, and the minute boundary. All 18 selected validation stages pass.

The GitHub List commits `until` contract was checked against its primary documentation and three bounded read-only source-repository requests, including the exact cutoff format and second boundary. No live mirror recovery or workflow dispatch was executed, and workflow settings are unchanged.

Hosted CI exposed an outdated target-list expectation: the new mirror test is correctly selected for docs-sync workflow edits. That expectation now includes it only for docs-sync, with docs-agent and strict ordering preserved. Five focused routing cases and the same eight CLI cases pass, as do all 16 checks selected for this test-only repair. Independent review found no actionable issues in either the production patch or the CI repair.
