### PR TITLE
fix(usage): preserve the selected session owner in details

### DIFF
--- a/docs/gateway/protocol/rpc-methods.md
+++ b/docs/gateway/protocol/rpc-methods.md
@@ -45,6 +45,7 @@ methods. Treat this as feature discovery, not a full enumeration of
   Both usage methods accept `mode: "specific"` with an IANA `timeZone` for DST-aware calendar-day boundaries and buckets. `utcOffset` remains supported for older clients and as a fallback when the Gateway runtime does not recognize the requested zone.
 - `sessions.usage.timeseries` returns timeseries usage for one session.
 - `sessions.usage.logs` returns usage log entries for one session.
+  Both detail methods accept the selected row's `key` and optional `agentId`. Preserve both fields when opening details for an unqualified key such as `global`.
 
 ### Channels and login helpers
 

--- a/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
@@ -14,12 +14,18 @@ import {
 import { discoverAllSessions, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
 import type { AssistantMessage } from "../../llm/types.js";
 import type { SessionsUsageResult } from "../../shared/usage-types.js";
+import { SYSTEM_AGENT_ID } from "../../system-agent/agent-id.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { usageHandlers } from "./usage.js";
 
-it.each([undefined, "agent:opus:slack:dm", "global"])(
-  "keeps independent same-id transcripts with opus store key %s through the real usage handler",
-  async (opusKey) => {
+it.each([
+  { owner: "opus", key: undefined },
+  { owner: "opus", key: "agent:opus:slack:dm" },
+  { owner: "opus", key: "global" },
+  { owner: SYSTEM_AGENT_ID, key: `agent:${SYSTEM_AGENT_ID}:usage` },
+])(
+  "keeps independent same-id transcripts with $owner store key $key through the real usage handler",
+  async ({ owner, key: opusKey }) => {
     const state = await createOpenClawTestState({ label: "usage-owner-integration" });
     try {
       await state.writeConfig({
@@ -29,7 +35,7 @@ it.each([undefined, "agent:opus:slack:dm", "global"])(
       const config = getRuntimeConfig();
       const sessionId = "shared-usage-session";
       const mainKey = "agent:main:telegram:dm";
-      for (const agentId of ["main", "opus"]) {
+      for (const agentId of ["main", owner]) {
         const key = agentId === "main" ? mainKey : opusKey;
         const scope = {
           agentId,
@@ -59,17 +65,15 @@ it.each([undefined, "agent:opus:slack:dm", "global"])(
       const projected = loadCombinedSessionStoreForGatewayCore(config);
       expect(projected.targetsBySessionKey.get(mainKey)?.agentId).toBe("main");
       if (opusKey) {
-        expect(projected.targetsBySessionKey.get(opusKey)?.agentId).toBe("opus");
+        expect(projected.targetsBySessionKey.get(opusKey)?.agentId).toBe(owner);
       }
       const respond = vi.fn();
-      await expectDefined(
-        usageHandlers["sessions.usage"],
-        "usage handler",
-      )({
+      const request = {
         params: { agentScope: "all", range: "all", limit: 50 },
         context: { getRuntimeConfig: () => config },
         respond,
-      } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
+      } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0];
+      await expectDefined(usageHandlers["sessions.usage"], "usage handler")(request);
       expect(respond).toHaveBeenCalledOnce();
       const [ok, payload] = expectDefined(respond.mock.calls[0], "usage response");
       expect(ok).toBe(true);
@@ -78,9 +82,48 @@ it.each([undefined, "agent:opus:slack:dm", "global"])(
       expect(result.sessions.map(({ key, agentId }) => ({ key, agentId }))).toEqual(
         expect.arrayContaining([
           { key: mainKey, agentId: "main" },
-          { key: opusKey ?? `agent:opus:${sessionId}`, agentId: "opus" },
+          { key: opusKey ?? `agent:${owner}:${sessionId}`, agentId: owner },
         ]),
       );
+      if (opusKey) {
+        const selected = expectDefined(
+          result.sessions.find((session) => session.agentId === owner),
+          "selected usage owner",
+        );
+        for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"] as const) {
+          for (const explicitOwner of owner === SYSTEM_AGENT_ID ? [false, true] : [true]) {
+            const detail = vi.fn();
+            await expectDefined(
+              usageHandlers[method],
+              "usage detail handler",
+            )({
+              ...request,
+              params: {
+                key: selected.key,
+                ...(explicitOwner ? { agentId: selected.agentId } : {}),
+              },
+              respond: detail,
+            });
+            const [detailOk, detailPayload, detailError] = expectDefined(
+              detail.mock.calls[0],
+              "usage detail response",
+            );
+            if (owner === SYSTEM_AGENT_ID && explicitOwner) {
+              expect(detailOk).toBe(false);
+              expect(detailError).toMatchObject({ message: `Unknown agent id "${owner}"` });
+            } else {
+              expect.soft(detailOk, method).toBe(true);
+              if (detailOk) {
+                expect(detailPayload, method).toMatchObject(
+                  method === "sessions.usage.logs"
+                    ? { logs: [expect.objectContaining({ content: `${owner} turn` })] }
+                    : { sessionId },
+                );
+              }
+            }
+          }
+        }
+      }
     } finally {
       await state.cleanup();
     }

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -52,11 +52,25 @@ import {
 import { assertValidParams } from "./validation.js";
 
 function resolveSessionUsageFileOrRespond(
-  key: string,
+  params: { key?: unknown; agentId?: unknown } | undefined,
+  detail: "timeseries" | "logs",
   respond: RespondFn,
   config: OpenClawConfig,
-): (NonNullable<ReturnType<typeof resolveSessionUsageTarget>> & { config: OpenClawConfig }) | null {
-  const sessionOwner = resolveRequestedSessionAgentId(config, key);
+) {
+  const key = normalizeOptionalString(params?.key);
+  if (!key) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `key is required for ${detail}`),
+    );
+    return null;
+  }
+  const sessionOwner = resolveRequestedSessionAgentId(
+    config,
+    key,
+    normalizeOptionalString(params?.agentId),
+  );
   if (!sessionOwner.ok) {
     respond(false, undefined, sessionOwner.error);
     return null;
@@ -75,7 +89,7 @@ function resolveSessionUsageFileOrRespond(
     );
     return null;
   }
-  return { config, ...resolved };
+  return { config, key, ...resolved };
 }
 
 function resolveUsageDateRangeOrRespond(
@@ -329,21 +343,16 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, result, undefined);
   },
   "sessions.usage.timeseries": async ({ respond, params, context }) => {
-    const key = normalizeOptionalString(params?.key) ?? null;
-    if (!key) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "key is required for timeseries"),
-      );
-      return;
-    }
-
-    const resolved = resolveSessionUsageFileOrRespond(key, respond, context.getRuntimeConfig());
+    const resolved = resolveSessionUsageFileOrRespond(
+      params,
+      "timeseries",
+      respond,
+      context.getRuntimeConfig(),
+    );
     if (!resolved) {
       return;
     }
-    const { config, entry, agentId, sessionId, sessionFile } = resolved;
+    const { config, key, entry, agentId, sessionId, sessionFile } = resolved;
 
     const timeseries = await loadSessionUsageTimeSeries({
       sessionId,
@@ -366,18 +375,17 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, timeseries, undefined);
   },
   "sessions.usage.logs": async ({ respond, params, context }) => {
-    const key = normalizeOptionalString(params?.key) ?? null;
-    if (!key) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "key is required for logs"));
-      return;
-    }
-
     const limit =
       typeof params?.limit === "number" && Number.isFinite(params.limit)
         ? Math.min(params.limit, 1000)
         : 200;
 
-    const resolved = resolveSessionUsageFileOrRespond(key, respond, context.getRuntimeConfig());
+    const resolved = resolveSessionUsageFileOrRespond(
+      params,
+      "logs",
+      respond,
+      context.getRuntimeConfig(),
+    );
     if (!resolved) {
       return;
     }

--- a/ui/src/lib/sessions/usage.test.ts
+++ b/ui/src/lib/sessions/usage.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
-import {
-  buildSessionUsageDateParams,
-  requestSessionUsage,
-  requestSessionUsageContextWeight,
-} from "./usage.ts";
+import { buildSessionUsageDateParams, requestSessionUsage } from "./usage.ts";
 
 describe("buildSessionUsageDateParams", () => {
   afterEach(() => {
@@ -38,7 +34,7 @@ describe("requestSessionUsage", () => {
   ])("scopes selected context for $key without an all-agent request", async ({ key, agentId }) => {
     const request = vi.fn().mockResolvedValue({ sessions: [] });
     const signal = new AbortController().signal;
-    await requestSessionUsageContextWeight(
+    await requestSessionUsage(
       { request } as never,
       {
         startDate: "2026-07-01",
@@ -47,8 +43,7 @@ describe("requestSessionUsage", () => {
         timeZone: "utc",
         agentId,
       },
-      key,
-      signal,
+      { key, includeContextWeight: true, signal },
     );
     expect(request).toHaveBeenCalledWith(
       "sessions.usage",

--- a/ui/src/lib/sessions/usage.ts
+++ b/ui/src/lib/sessions/usage.ts
@@ -4,6 +4,8 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 
 type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
 
+export type SessionUsageTarget = { key: string; agentId?: string };
+
 export type SessionUsageQuery = {
   startDate: string;
   endDate: string;
@@ -59,35 +61,21 @@ export function requestSessionUsage(
     : client.request<SessionsUsageResult>("sessions.usage", params);
 }
 
-export async function requestSessionUsageContextWeight(
-  client: SessionRequestClient,
-  query: SessionUsageQuery,
-  key: string,
-  signal: AbortSignal,
-) {
-  const result = await requestSessionUsage(client, query, {
-    key,
-    includeContextWeight: true,
-    signal,
-  });
-  return result.sessions[0]?.contextWeight;
-}
-
 export function requestSessionUsageTimeSeries(
   client: SessionRequestClient,
-  key: string,
+  target: SessionUsageTarget,
 ): Promise<SessionUsageTimeSeries | null> {
   return client
-    .request<SessionUsageTimeSeries | undefined>("sessions.usage.timeseries", { key })
+    .request<SessionUsageTimeSeries | undefined>("sessions.usage.timeseries", target)
     .then((result) => result ?? null);
 }
 
 export function requestSessionUsageLogs(
   client: SessionRequestClient,
-  key: string,
+  target: SessionUsageTarget,
 ): Promise<{ logs?: unknown }> {
   return client.request<{ logs?: unknown }>("sessions.usage.logs", {
-    key,
+    ...target,
     limit: 1000,
   });
 }

--- a/ui/src/pages/usage/detail-controller.ts
+++ b/ui/src/pages/usage/detail-controller.ts
@@ -1,3 +1,4 @@
+import { parseAgentSessionKeyParts } from "@openclaw/session-url-contract";
 import type { ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
@@ -8,30 +9,49 @@ import {
 } from "../../components/panel-refresh-status.ts";
 import { isGatewayAvailable } from "../../lib/gateway-availability.ts";
 import {
-  requestSessionUsageContextWeight,
+  requestSessionUsage,
   requestSessionUsageLogs,
   requestSessionUsageTimeSeries,
   type SessionUsageQuery,
+  type SessionUsageTarget,
 } from "../../lib/sessions/usage.ts";
 import type { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { failUsageDetailRefresh } from "./detail-refresh.ts";
 import { createUsageRequest } from "./request.ts";
 import type { SessionLogEntry, UsageSessionEntry } from "./types.ts";
 
+function sameUsageTarget(a: SessionUsageTarget | undefined, b: SessionUsageTarget): boolean {
+  return a?.key === b.key && a.agentId === b.agentId;
+}
+
 function createUsageDetailRequest<T>(
   host: ReactiveControllerHost,
   gateway: GatewayPageController,
-  request: (client: GatewayBrowserClient, key: string, signal: AbortSignal) => Promise<T>,
+  request: (
+    client: GatewayBrowserClient,
+    target: SessionUsageTarget,
+    signal: AbortSignal,
+  ) => Promise<T>,
+  resolveTarget: (key: string) => SessionUsageTarget,
   canLoad?: (key: string) => boolean,
 ) {
-  let value: { sessionKey: string; data: T } | null = null;
+  let value: { target: SessionUsageTarget; data?: T } | null = null;
   let status = createPanelRefreshStatus();
   let pending: Promise<void> | null = null;
   let generation = 0;
   const task = createUsageRequest(host, {
-    task: async ([client, sessionKey]: readonly [GatewayBrowserClient, string], { signal }) => ({
-      sessionKey,
-      data: await request(client, sessionKey, signal),
+    task: async (
+      [client, target]: readonly [GatewayBrowserClient, SessionUsageTarget],
+      { signal },
+    ) => ({
+      target,
+      // Qualified keys can name disk-backed owners outside the configured roster.
+      // Keep key-only wire routing while retaining the full local target identity.
+      data: await request(
+        client,
+        parseAgentSessionKeyParts(target.key.trim()) ? { key: target.key } : target,
+        signal,
+      ),
     }),
     onComplete: (result) => {
       pending = null;
@@ -41,8 +61,8 @@ function createUsageDetailRequest<T>(
     onError: (error) => {
       pending = null;
       const failure = failUsageDetailRefresh(status, error, gateway.snapshot);
-      if (failure.clearData) {
-        value = null;
+      if (failure.clearData && value) {
+        delete value.data;
       }
       status = failure.status;
     },
@@ -68,9 +88,11 @@ function createUsageDetailRequest<T>(
     },
     async recover(sessionKey: string, loadInitial = false): Promise<void> {
       const current = generation;
+      const target = resolveTarget(sessionKey);
       await pending;
       if (
         current === generation &&
+        sameUsageTarget(target, resolveTarget(sessionKey)) &&
         gateway.snapshot &&
         isGatewayAvailable(gateway.snapshot) &&
         (status.awaitingGateway || status.error !== null || (loadInitial && !status.hasLoaded))
@@ -78,23 +100,29 @@ function createUsageDetailRequest<T>(
         void this.load(sessionKey);
       }
     },
-    load(sessionKey: string): Promise<void> {
+    load(sessionKey: string, refresh = true): Promise<void> {
       const client = gateway.client;
       if (!client || !gateway.connected) {
         return Promise.resolve();
       }
       const enabled = Boolean(sessionKey) && canLoad?.(sessionKey) !== false;
-      if (value?.sessionKey !== sessionKey || !enabled) {
-        value = null;
+      const target = resolveTarget(sessionKey);
+      const sameTarget = sameUsageTarget(value?.target, target);
+      if (!sameTarget || !enabled) {
+        value = enabled ? { target } : null;
         status = createPanelRefreshStatus();
       }
       if (!enabled) {
         cancel();
         return Promise.resolve();
       }
+      // Routine overview refresh retains matching details, but never another owner's data.
+      if (!refresh && sameTarget) {
+        return pending ?? Promise.resolve();
+      }
       status = beginPanelRefresh(status);
       generation += 1;
-      return (pending = task.run([client, sessionKey]));
+      return (pending = task.run([client, target]));
     },
     cancel,
     clear() {
@@ -116,28 +144,49 @@ export class UsageDetailsController {
     query: () => SessionUsageQuery,
     sessions: () => UsageSessionEntry[],
   ) {
-    this.timeSeries = createUsageDetailRequest(host, gateway, requestSessionUsageTimeSeries);
-    this.sessionLogs = createUsageDetailRequest(host, gateway, async (client, key) => {
-      const payload = await requestSessionUsageLogs(client, key);
-      // SAFETY: sessions.usage.logs returns entries normalized by the Gateway's loadSessionLogs.
-      return Array.isArray(payload.logs) ? (payload.logs as SessionLogEntry[]) : null;
-    });
+    const resolveTarget = (key: string): SessionUsageTarget => {
+      const agentId = sessions().find((session) => session.key === key)?.agentId ?? query().agentId;
+      return { key, ...(agentId ? { agentId } : {}) };
+    };
+    this.timeSeries = createUsageDetailRequest(
+      host,
+      gateway,
+      requestSessionUsageTimeSeries,
+      resolveTarget,
+    );
+    this.sessionLogs = createUsageDetailRequest(
+      host,
+      gateway,
+      async (client, target) => {
+        const payload = await requestSessionUsageLogs(client, target);
+        // SAFETY: sessions.usage.logs returns entries normalized by the Gateway's loadSessionLogs.
+        return Array.isArray(payload.logs) ? (payload.logs as SessionLogEntry[]) : null;
+      },
+      resolveTarget,
+    );
     this.contextWeight = createUsageDetailRequest(
       host,
       gateway,
-      (client, key, signal) => {
-        const params = query();
-        const agentId =
-          sessions().find((session) => session.key === key)?.agentId ?? params.agentId;
-        return requestSessionUsageContextWeight(client, { ...params, agentId }, key, signal);
+      async (client, target, signal) => {
+        const result = await requestSessionUsage(
+          client,
+          { ...query(), agentId: target.agentId },
+          {
+            key: target.key,
+            includeContextWeight: true,
+            signal,
+          },
+        );
+        return result.sessions[0]?.contextWeight;
       },
+      resolveTarget,
       (key) => sessions().some((session) => session.key === key && session.hasContextWeight),
     );
   }
 
-  load(sessionKey: string): void {
-    void this.timeSeries.load(sessionKey);
-    void this.sessionLogs.load(sessionKey);
+  load(sessionKey: string, refreshAll = true): void {
+    void this.timeSeries.load(sessionKey, refreshAll);
+    void this.sessionLogs.load(sessionKey, refreshAll);
     void this.contextWeight.load(sessionKey);
   }
 

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -35,6 +35,122 @@ function contextWeight(name: string): NonNullable<UsageSessionEntry["contextWeig
 }
 
 describe("UsagePage detail requests", () => {
+  it.each([
+    { key: "global", agentId: "opus", needsOwnerHint: true },
+    { key: "agent:openclaw:usage", agentId: "openclaw", needsOwnerHint: false },
+  ])(
+    "routes every selected $key detail through its listed agent",
+    async ({ key, agentId, needsOwnerHint }) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      const session = {
+        key,
+        agentId,
+        sessionId: `${agentId}-instance`,
+        hasContextWeight: true,
+        usage: snapshot.result.totals,
+      };
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              { ...session, ...(params?.key ? { contextWeight: contextWeight(agentId) } : {}) },
+            ],
+          };
+        }
+        if (method === "sessions.usage.logs") {
+          return { logs: [{ timestamp: 1, role: "user", content: `${agentId} turn` }] };
+        }
+        return method === "usage.cost" ? snapshot.costSummary : { providers: [], points: [] };
+      });
+      const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.textContent).toContain(`${agentId} turn`));
+
+      for (const method of ["sessions.usage", "sessions.usage.timeseries", "sessions.usage.logs"]) {
+        const detail = request.mock.calls.find(([name, params]) => name === method && params?.key);
+        expect.soft(detail?.[1], method).toMatchObject({ key });
+        if (needsOwnerHint) {
+          expect.soft(detail?.[1], method).toHaveProperty("agentId", agentId);
+        } else {
+          expect.soft(detail?.[1], method).not.toHaveProperty("agentId");
+        }
+      }
+    },
+  );
+
+  it.each(["manual", "automatic"])(
+    "retires old-owner details and pending recovery during %s overview refresh",
+    async (refresh) => {
+      const snapshot = cacheSnapshot("sessions", "fresh");
+      const retired = deferred<SessionUsageTimeSeries>();
+      let agentId = "main";
+      let holdMain = false;
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "sessions.usage") {
+          return {
+            ...snapshot.result,
+            sessions: [
+              { key: "global", agentId, label: `${agentId} global`, usage: snapshot.result.totals },
+            ],
+          };
+        }
+        if (method === "sessions.usage.logs" || method === "sessions.usage.timeseries") {
+          if (params?.agentId === "opus") {
+            throw new Error("Opus details unavailable");
+          }
+          if (holdMain) {
+            return retired.promise;
+          }
+          return method === "sessions.usage.logs"
+            ? { logs: [{ timestamp: 1, role: "user", content: "Main turn" }] }
+            : { sessionId: "main-instance", points: [] };
+        }
+        return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const context = contextWithClient(client);
+      const page = await createPage(client, true, context);
+      await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.waitFor(() => expect(page.textContent).toContain("Main turn"));
+      expect(page.details.timeSeries.data?.sessionId).toBe("main-instance");
+
+      holdMain = true;
+      const oldLoad = page.details.timeSeries.load("global");
+      context.setGatewaySnapshot({ suspensionPhase: "draining" });
+      context.setGatewaySnapshot({ suspensionPhase: "accepting" });
+      agentId = "opus";
+      if (refresh === "manual") {
+        refreshButton(page).click();
+      } else {
+        await page.loadUsage();
+      }
+      await vi.waitFor(() =>
+        expect(page.querySelector(".session-bar-selection")?.textContent).toContain("opus global"),
+      );
+      expect.soft(page.details.timeSeries.data).toBeNull();
+      expect.soft(page.details.sessionLogs.data).toBeNull();
+      retired.resolve({ sessionId: "retired-main", points: [] });
+      await oldLoad;
+      await vi.waitFor(() => {
+        expect(page.details.timeSeries.loading).toBe(false);
+        expect(page.details.sessionLogs.loading).toBe(false);
+      });
+      expect.soft(page.details.timeSeries.data).toBeNull();
+      expect.soft(page.details.sessionLogs.data).toBeNull();
+      expect.soft(page.details.timeSeries.status.error).toBe("Opus details unavailable");
+      expect.soft(page.details.sessionLogs.status.error).toBe("Opus details unavailable");
+      for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+        const ownerRequests = request.mock.calls.filter(
+          ([name, params]) => name === method && params?.agentId === "opus",
+        );
+        expect.soft(ownerRequests, method).toHaveLength(1);
+      }
+    },
+  );
+
   it("releases hydrated export reports after download while the page stays mounted", async () => {
     class ExportReport {
       name = "exported-context";
@@ -371,7 +487,6 @@ describe("UsagePage detail requests", () => {
     delete contextParams.agentScope;
     expect(firstContext[1]).toEqual({
       ...contextParams,
-      agentId: "main",
       key: keys[0],
       limit: 1,
       includeContextWeight: true,

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -165,11 +165,7 @@ class UsagePage extends OpenClawLightDomElement {
           this.usageSelectedSessions.length === 1 ? this.usageSelectedSessions[0] : undefined;
         if (sessionKey) {
           // Manual intent belongs to this request's selection, never a later poll or selection.
-          if (value.refreshSessionKey === sessionKey) {
-            this.details.load(sessionKey);
-          } else {
-            void this.details.contextWeight.load(sessionKey);
-          }
+          this.details.load(sessionKey, value.refreshSessionKey === sessionKey);
         }
       } else {
         this.applyUsageError(snapshot.error.cause);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a session in the All-agent Usage view would see missing-owner errors instead of its timeline and conversation when the session used a raw key such as `global`. An overview refresh could also keep details from the previous agent when another agent acquired that same raw key.

## Why This Change Was Made

The detail controller now carries the selected session's key and agent through requests, retained results, and recovery. Raw keys send their owner to the existing Gateway resolver. Qualified keys keep their existing key-only routing, including system sessions outside the configured roster. Automatic refresh retains matching details and replaces them when ownership changes; manual refresh still refreshes all details.

Both Gateway detail methods share key validation and owner resolution, and a single-use context-weight forwarding helper is removed. Existing authorization, key bytes, selection behavior, and storage semantics are preserved.

## User Impact

Users can inspect the correct timeline, conversation, and available context weight for the selected agent's session, including system sessions. Stale responses cannot replace a successor owner's details.

## Evidence

The original Gateway regression and three mounted UI regressions fail on the original production code. A separate system-session control proves why qualified requests must remain key-only. The final owner and sibling suites pass 94 distinct cases across six files, and all 32 selected validation stages pass. Independent review found no actionable issues through P2.

The before/after images use the same synthetic session and mock Gateway response policy in a source-built Control UI. Before, actual key-only detail requests produce missing-owner errors; after, the emitted owner-aware requests render the timeline and conversation. This is isolated browser and Gateway fixture proof, without live operator data. All full images were inspected before upload.

![Before: selected session details fail with a missing owner](https://github.com/user-attachments/assets/e3717f5f-a982-4c49-ae5c-3b9a640e18cb)

![After: the selected session timeline loads](https://github.com/user-attachments/assets/aa578996-1f01-4726-be4b-d661e313b049)

![After: the selected session conversation loads](https://github.com/user-attachments/assets/0fd6a06f-4e5a-4439-841b-7ad0d564a8e3)