### PR TITLE
fix: retain PDF provider state through cancelled work

### DIFF
--- a/src/agents/tools/pdf-tool.native-providers.test.ts
+++ b/src/agents/tools/pdf-tool.native-providers.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import * as preparedModelRuntime from "../prepared-model-runtime.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import {
@@ -203,10 +204,18 @@ describe("PDF tool native provider paths", () => {
         }),
       );
 
-      const result = await tool.execute("t1", {
-        prompt: "summarize",
-        pdf: "/tmp/doc.pdf",
-      });
+      const work = new AsyncWorkScope();
+      let result: Awaited<ReturnType<typeof tool.execute>>;
+      try {
+        result = await work.track(() =>
+          tool.execute("t1", {
+            prompt: "summarize",
+            pdf: "/tmp/doc.pdf",
+          }),
+        );
+      } finally {
+        await work.drain();
+      }
 
       expect(geminiSpy).toHaveBeenCalledWith(
         expect.objectContaining({ modelId: "gemini-2.5-pro" }),

--- a/src/agents/tools/pdf-tool.resources.test.ts
+++ b/src/agents/tools/pdf-tool.resources.test.ts
@@ -1,0 +1,448 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate } from "node:timers/promises";
+import { afterAll, afterEach, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { Model } from "../../llm/types.js";
+import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
+import * as pdfExtract from "../../media/pdf-extract.js";
+import * as webMedia from "../../media/web-media.js";
+import { loadPluginRegistryHandle } from "../../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../../plugins/loader.test-fixtures.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import {
+  getPluginRuntimeGenerationRegistry,
+  withPluginRuntimeGenerationScope,
+} from "../../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope, trackAsyncWork } from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { getSessionMcpRequestSignal } from "../agent-bundle-mcp-request-context.js";
+import * as modelAuth from "../model-auth.js";
+import * as preparedRuntime from "../prepared-model-runtime.js";
+import { closePreparedModelRuntimeSnapshots } from "../prepared-model-runtime.lifecycle.js";
+import { createPdfTool } from "./pdf-tool.js";
+import { FAKE_PDF_MEDIA } from "./pdf-tool.test-support.js";
+
+type Connection = {
+  database: DatabaseSync;
+  dbPath: string;
+  disposals: number;
+  lateReads: number;
+  cleanupReads: number;
+};
+
+function nativePdfFixture() {
+  const dir = makePluginLoaderTempDir();
+  const id = "pdf-resource-fixture";
+  const stateKey = `__pdf_resources_${path.basename(dir)}`;
+  const connections: Connection[] = [];
+  const cancellation: {
+    signal?: AbortSignal;
+    cleanupSignal?: AbortSignal;
+    registry?: PluginRegistry;
+    afterRegistry?: PluginRegistry;
+    failure?: unknown;
+  } = {};
+  const state = {
+    connections,
+    started: createDeferredCore(),
+    finish: createDeferredCore(),
+    settled: createDeferredCore(),
+    cleanupStarted: createDeferredCore(),
+    finishCleanup: createDeferredCore(),
+    finishSetupTail: createDeferredCore(),
+    holdCreation: true,
+    reject: false,
+    watchCancellation: false,
+    cancellation,
+    async stream(model: Model, read: () => number, connection: Connection) {
+      read();
+      if (state.watchCancellation) {
+        const signal = (cancellation.signal = getSessionMcpRequestSignal());
+        const cancel = () => {
+          cancellation.cleanupSignal = getSessionMcpRequestSignal();
+          cancellation.registry = getPluginRuntimeGenerationRegistry();
+          void trackAsyncWork(async () => {
+            state.cleanupStarted.resolve();
+            await state.finishCleanup.promise;
+            read();
+            connection.cleanupReads++;
+            cancellation.afterRegistry = getPluginRuntimeGenerationRegistry();
+          }).catch((error: unknown) => {
+            cancellation.failure = error;
+          });
+        };
+        signal?.addEventListener("abort", cancel, { once: true });
+        if (signal?.aborted) {
+          cancel();
+        }
+      }
+      const stream = createAssistantMessageEventStream();
+      const produce = async () => {
+        state.started.resolve();
+        try {
+          await state.finish.promise;
+          const value = read();
+          connection.lateReads++;
+          if (state.reject) {
+            throw new Error("synthetic late PDF failure");
+          }
+          stream.push({
+            type: "done",
+            reason: "stop",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: `PDF value ${value}` }],
+              api: model.api,
+              provider: model.provider,
+              model: model.id,
+              stopReason: "stop",
+              timestamp: 0,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+            },
+          });
+          stream.end();
+        } finally {
+          state.settled.resolve();
+        }
+      };
+      if (state.holdCreation) {
+        await produce();
+      } else {
+        void produce().catch((error: unknown) => {
+          cancellation.failure = error;
+          stream.end();
+        });
+      }
+      return stream;
+    },
+    databasePath: () => path.join(dir, `provider-${connections.length}.sqlite`),
+  };
+  Object.defineProperty(globalThis, stateKey, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(stateKey)}];
+  const dbPath = state.databasePath();
+  const database = new DatabaseSync(dbPath);
+  database.exec("CREATE TABLE proof (value INTEGER); INSERT INTO proof VALUES (42)");
+  const connection = { database, dbPath, disposals: 0, lateReads: 0, cleanupReads: 0 };
+  state.connections.push(connection);
+  const read = () => database.prepare("SELECT value FROM proof").get().value;
+  api.lifecycle.registerRuntimeLifecycle({ id: "native-pdf", dispose() {
+    connection.disposals++;
+    database.close();
+  }});
+  api.registerProvider({ id: ${JSON.stringify(id)}, label: "Native PDF fixture", auth: [],
+    createStreamFn() { return (model) => state.stream(model, read, connection); }
+  });
+}};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      providers: [id],
+      configSchema: { type: "object", properties: {}, additionalProperties: false },
+    }),
+  );
+  const config: OpenClawConfig = {
+    agents: { defaults: { pdfModel: { primary: `${id}/pdf-model` } } },
+    models: {
+      providers: {
+        [id]: {
+          api: "openai-responses",
+          baseUrl: "https://pdf-fixture.invalid/v1",
+          apiKey: "synthetic-fixture",
+          models: [
+            {
+              id: "pdf-model",
+              name: "PDF model",
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              input: ["text", "image"],
+              contextWindow: 8192,
+              maxTokens: 1024,
+            },
+          ],
+        },
+      },
+    },
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const agentDir = path.join(dir, "agent");
+  const parent = new AsyncWorkScope();
+  let lease: Awaited<ReturnType<typeof preparedRuntime.acquireReadOnlyPreparedModelRuntime>>;
+  let outcome: Promise<unknown> | undefined;
+  return {
+    dir,
+    config,
+    agentDir,
+    state,
+    parent,
+    async run(test: () => Promise<void>) {
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_HOME: dir,
+            OPENCLAW_STATE_DIR: path.join(dir, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+          },
+          async () => {
+            useNoBundledPlugins();
+            vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue(FAKE_PDF_MEDIA);
+            vi.spyOn(pdfExtract, "extractPdfContent").mockResolvedValue({
+              text: "Synthetic PDF text",
+              images: [],
+            });
+            lease = await preparedRuntime.acquireReadOnlyPreparedModelRuntime(
+              {
+                config,
+                agentId: "main",
+                agentDir,
+                workspaceDir: dir,
+                loadRuntimePlugins: true,
+                skipCredentials: true,
+                runtimePluginSelections: [{ provider: id, modelId: "pdf-model" }],
+              },
+              undefined,
+              "static",
+            );
+            try {
+              await test();
+            } finally {
+              state.finish.resolve();
+              state.finishCleanup.resolve();
+              state.finishSetupTail.resolve();
+              await outcome;
+              await parent.drain();
+              lease.release();
+              await closePreparedModelRuntimeSnapshots();
+            }
+          },
+        );
+      } finally {
+        for (const connection of connections) {
+          if (connection.database.isOpen) {
+            connection.database.close();
+          }
+        }
+        Reflect.deleteProperty(globalThis, stateKey);
+      }
+    },
+    get lease() {
+      return lease;
+    },
+    execute(options: { signal?: AbortSignal; supplied?: boolean; raw?: PluginRegistry } = {}) {
+      const snapshot = options.raw
+        ? { ...lease.snapshot, pluginRegistry: options.raw }
+        : lease.snapshot;
+      const tool = createPdfTool({
+        config,
+        agentDir,
+        workspaceDir: dir,
+        ...(options.supplied !== false ? { preparedModelRuntime: snapshot } : {}),
+      });
+      if (!tool) {
+        throw new Error("PDF fixture tool was unavailable");
+      }
+      outcome = parent
+        .track(() =>
+          withPluginRuntimeGenerationScope(snapshot, () =>
+            tool.execute(
+              "pdf-fixture",
+              { pdf: "https://pdf-fixture.invalid/document.pdf" },
+              options.signal,
+            ),
+          ),
+        )
+        .catch((error: unknown) => error);
+      return outcome;
+    },
+    async assertClosed() {
+      await parent.drain();
+      await closePreparedModelRuntimeSnapshots();
+      for (const connection of connections) {
+        expect(connection.disposals).toBe(1);
+        expect(connection.database.isOpen).toBe(false);
+        const reopened = new DatabaseSync(connection.dbPath, { readOnly: true });
+        try {
+          expect(reopened.prepare("SELECT value FROM proof").get()?.value).toBe(42);
+        } finally {
+          reopened.close();
+        }
+      }
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closePreparedModelRuntimeSnapshots();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it("retains a supplied runtime before the first PDF download awaits", async () => {
+  const fixture = nativePdfFixture();
+  await fixture.run(async () => {
+    const downloading = createDeferredCore();
+    const finishDownload = createDeferredCore();
+    vi.mocked(webMedia.loadWebMediaRaw).mockImplementationOnce(async () => {
+      downloading.resolve();
+      await finishDownload.promise;
+      return FAKE_PDF_MEDIA;
+    });
+    try {
+      const result = fixture.execute();
+      await downloading.promise;
+      fixture.lease.release();
+      await setImmediate();
+      expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+      finishDownload.resolve();
+      fixture.state.finish.resolve();
+      expect(await result).toMatchObject({ details: { text: "PDF value 42", native: false } });
+      await fixture.assertClosed();
+    } finally {
+      finishDownload.resolve();
+    }
+  });
+});
+
+it.each(["creation", "result", "late-rejection"] as const)(
+  "keeps PDF provider resources until cancelled %s work actually settles",
+  async (mode) => {
+    const fixture = nativePdfFixture();
+    await fixture.run(async () => {
+      fixture.state.holdCreation = mode !== "result";
+      fixture.state.reject = mode === "late-rejection";
+      const abort = new AbortController();
+      const result = fixture.execute({ signal: abort.signal });
+      await Promise.race([
+        fixture.state.started.promise,
+        result.then(() => {
+          throw new Error("PDF provider never started");
+        }),
+      ]);
+      abort.abort(new Error("synthetic PDF cancellation"));
+      expect(await result).toMatchObject({ message: "synthetic PDF cancellation" });
+      fixture.lease.release();
+      await setImmediate();
+      expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+      expect(fixture.state.connections[0]?.disposals).toBe(0);
+      fixture.state.finish.resolve();
+      await fixture.state.settled.promise;
+      await fixture.assertClosed();
+      expect(fixture.state.connections[0]?.lateReads).toBe(1);
+    });
+  },
+);
+
+it.each(["normal", "parent"] as const)(
+  "drains PDF cleanup with its captured %s context",
+  async (mode) => {
+    const fixture = nativePdfFixture();
+    await fixture.run(async () => {
+      fixture.state.watchCancellation = true;
+      const result = fixture.execute();
+      await Promise.race([
+        fixture.state.started.promise,
+        result.then(() => {
+          throw new Error("PDF provider never started");
+        }),
+      ]);
+      if (mode === "parent") {
+        const reason = new Error("synthetic parent shutdown");
+        withPluginRuntimeGenerationScope(
+          {
+            metadataSnapshot: fixture.lease.snapshot.metadataSnapshot,
+            pluginRegistry: createEmptyPluginRegistry(),
+          },
+          () => fixture.parent.beginClose(reason),
+        );
+        expect(fixture.state.cancellation.signal?.reason).toBe(reason);
+      } else {
+        fixture.state.finish.resolve();
+        expect(await result).toMatchObject({ details: { text: "PDF value 42" } });
+      }
+      await setImmediate();
+      expect(fixture.state.cancellation.signal?.aborted).toBe(true);
+      await fixture.state.cleanupStarted.promise;
+      expect(fixture.state.cancellation.cleanupSignal?.aborted).toBe(true);
+      expect(fixture.state.cancellation.registry).toBe(fixture.lease.snapshot.pluginRegistry);
+      fixture.lease.release();
+      expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+      fixture.state.finish.resolve();
+      expect(await result).toMatchObject({ details: { text: "PDF value 42" } });
+      fixture.state.finishCleanup.resolve();
+      await fixture.assertClosed();
+      expect(fixture.state.cancellation.failure).toBeUndefined();
+      expect(fixture.state.cancellation.afterRegistry).toBe(fixture.lease.snapshot.pluginRegistry);
+      expect(fixture.state.connections[0]?.cleanupReads).toBe(1);
+    });
+  },
+);
+
+it("adopts a default runtime before failed auth setup leaves a descendant", async () => {
+  const fixture = nativePdfFixture();
+  await fixture.run(async () => {
+    vi.spyOn(preparedRuntime, "acquireAgentRunPreparedModelRuntime").mockResolvedValueOnce(
+      fixture.lease,
+    );
+    let failure: unknown;
+    let reads = 0;
+    vi.spyOn(modelAuth, "getApiKeyForModelCore").mockImplementationOnce(async () => {
+      void trackAsyncWork(async () => {
+        await fixture.state.finishSetupTail.promise;
+        expect(
+          fixture.state.connections[0]?.database.prepare("SELECT value FROM proof").get()?.value,
+        ).toBe(42);
+        reads++;
+      }).catch((error: unknown) => {
+        failure = error;
+      });
+      throw new Error("synthetic PDF setup failure");
+    });
+    expect(await fixture.execute({ supplied: false })).toMatchObject({
+      message: expect.stringContaining("synthetic PDF setup failure"),
+    });
+    await setImmediate();
+    expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+    fixture.state.finishSetupTail.resolve();
+    await fixture.assertClosed();
+    expect(reads).toBe(1);
+    expect(failure).toBeUndefined();
+  });
+});
+
+it("leaves raw supplied registry disposal to its owner", async () => {
+  const fixture = nativePdfFixture();
+  await fixture.run(async () => {
+    const raw = loadPluginRegistryHandle({ config: fixture.config });
+    fixture.state.finish.resolve();
+    expect(await fixture.execute({ raw })).toMatchObject({ details: { text: "PDF value 42" } });
+    await fixture.parent.drain();
+    const rawConnection = fixture.state.connections.at(-1);
+    expect(rawConnection?.lateReads).toBe(1);
+    expect(rawConnection?.disposals).toBe(0);
+    expect(rawConnection?.database.isOpen).toBe(true);
+  });
+});

--- a/src/agents/tools/pdf-tool.runtime-abort.test.ts
+++ b/src/agents/tools/pdf-tool.runtime-abort.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import * as preparedModelRuntime from "../prepared-model-runtime.js";
 import { createEmptyPluginMetadataSnapshot } from "../test-helpers/embedded-agent-runner-e2e-mocks.js";
 import { createPdfToolInfraStub, withTempPdfAgentDir } from "./pdf-tool.test-support.js";
@@ -86,14 +87,15 @@ describe("PDF tool prepared-runtime cancellation", () => {
     });
   });
 
-  it("releases the runtime when a generic provider ignores cancellation", async () => {
+  it("reports cancellation while retaining the runtime until the generic provider settles", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       const { release } = await stubPdfToolInfra(agentDir, { provider: "openai" });
       vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
         text: "extractable text",
         images: [],
       });
-      completeMock.mockImplementationOnce(() => new Promise(() => {}));
+      const completion = createDeferredCore<never>();
+      completeMock.mockImplementationOnce(() => completion.promise);
       const cfg = {
         agents: { defaults: { pdfModel: { primary: "openai/gpt-5.4-mini" } } },
       } as OpenClawConfig;
@@ -115,7 +117,9 @@ describe("PDF tool prepared-runtime cancellation", () => {
       controller.abort(new Error("PDF provider cancelled"));
       await assertion;
 
-      expect(release).toHaveBeenCalledOnce();
+      expect(release).not.toHaveBeenCalled();
+      completion.reject(new Error("late provider failure"));
+      await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
     });
   });
 });

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -3,6 +3,7 @@
  *
  * Loads local/web PDFs, extracts pages/text, and analyzes them with native or fallback media-understanding models.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -19,6 +20,12 @@ import {
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { resolveModelAsync } from "../embedded-agent-runner/model.js";
@@ -28,6 +35,7 @@ import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
 } from "../prepared-model-runtime.js";
+import { retainPreparedModelRuntimeSnapshotResources } from "../prepared-model-runtime.resources.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
 import { optionalFiniteNumberSchema } from "../schema/typebox.js";
@@ -155,6 +163,9 @@ async function runPdfPrompt(params: {
   pageNumbers?: number[];
   getExtractions: () => Promise<PdfExtractedContent[]>;
   signal?: AbortSignal;
+  work: AsyncWorkScope;
+  onAcquired: (release: () => void) => void;
+  assertResourcesOpen?: () => void;
 }): Promise<{
   text: string;
   provider: string;
@@ -164,208 +175,197 @@ async function runPdfPrompt(params: {
 }> {
   const requestedCfg = applyImageModelConfigDefaults(params.cfg, params.pdfModelConfig);
 
-  let preparedRuntimeLease: Pick<
-    Awaited<ReturnType<typeof acquireAgentRunPreparedModelRuntime>>,
-    "snapshot" | "release"
-  >;
-  if (params.preparedModelRuntime) {
-    preparedRuntimeLease = { snapshot: params.preparedModelRuntime, release: () => {} };
-  } else {
-    const acquireRuntime = acquireAgentRunPreparedModelRuntime({
-      agentDir: params.agentDir,
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      config: requestedCfg ?? {},
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  let preparedRuntime = params.preparedModelRuntime;
+  if (!preparedRuntime) {
+    const acquireRuntime = params.work.track(async () => {
+      const lease = await acquireAgentRunPreparedModelRuntime({
+        agentDir: params.agentDir,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        config: requestedCfg ?? {},
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      });
+      // The execution owns even a late acquisition before setup can admit cleanup work.
+      params.onAcquired(lease.release);
+      return lease.snapshot;
     });
-    try {
-      preparedRuntimeLease = params.signal
-        ? await abortable(params.signal, acquireRuntime)
-        : await acquireRuntime;
-    } catch (error) {
-      if (params.signal?.aborted) {
-        void acquireRuntime.then(
-          (late) => late.release(),
-          () => undefined,
-        );
-      }
-      throw error;
-    }
+    preparedRuntime = params.signal
+      ? await abortable(params.signal, acquireRuntime)
+      : await acquireRuntime;
   }
-
-  try {
-    params.signal?.throwIfAborted();
-    const preparedRuntime = preparedRuntimeLease.snapshot;
-    const runtimeAgentDir = preparedRuntime.agentDir;
-    const runtimeWorkspaceDir = preparedRuntime.workspaceDir ?? params.workspaceDir;
-    const preparedStores = preparedRuntime.createStores();
-    const committedPdfModelConfig = resolvePdfModelConfigForTool({
-      cfg: preparedRuntime.config,
-      agentDir: runtimeAgentDir,
-      ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
-    });
-    if (!committedPdfModelConfig) {
-      throw new ToolInputError("No PDF model configured in the active runtime generation.");
+  params.signal?.throwIfAborted();
+  params.assertResourcesOpen?.();
+  const runtimeAgentDir = preparedRuntime.agentDir;
+  const runtimeWorkspaceDir = preparedRuntime.workspaceDir ?? params.workspaceDir;
+  const preparedStores = preparedRuntime.createStores();
+  const committedPdfModelConfig = resolvePdfModelConfigForTool({
+    cfg: preparedRuntime.config,
+    agentDir: runtimeAgentDir,
+    ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
+  });
+  if (!committedPdfModelConfig) {
+    throw new ToolInputError("No PDF model configured in the active runtime generation.");
+  }
+  const effectiveCfg = applyImageModelConfigDefaults(
+    preparedRuntime.config,
+    committedPdfModelConfig,
+  );
+  let nativePdfs: Array<{ base64: string; filename: string }> | undefined;
+  let extractionCache: PdfExtractedContent[] | null = null;
+  const getExtractions = async (): Promise<PdfExtractedContent[]> => {
+    if (!extractionCache) {
+      extractionCache = await params.getExtractions();
     }
-    const effectiveCfg = applyImageModelConfigDefaults(
-      preparedRuntime.config,
-      committedPdfModelConfig,
-    );
-    let nativePdfs: Array<{ base64: string; filename: string }> | undefined;
-    let extractionCache: PdfExtractedContent[] | null = null;
-    const getExtractions = async (): Promise<PdfExtractedContent[]> => {
-      if (!extractionCache) {
-        extractionCache = await params.getExtractions();
-      }
-      return extractionCache;
-    };
+    return extractionCache;
+  };
 
-    const result = await runWithImageModelFallback({
-      cfg: effectiveCfg,
-      modelOverride: params.modelOverride,
-      abortSignal: params.signal,
-      run: async (provider, modelId) => {
-        // Static snapshots serve configured models through prepared facts; a fresh registry can be empty.
-        const resolved = await resolveModelAsync(provider, modelId, runtimeAgentDir, effectiveCfg, {
-          allowBundledStaticCatalogFallback: true,
-          ...preparedStores,
-          preparedModelRuntime: preparedRuntime,
-          skipAgentDiscovery: true,
-          ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
-        });
-        if (resolved.error || !resolved.model) {
-          throw new Error(resolved.error ?? `Unknown model: ${provider}/${modelId}`);
+  const result = await runWithImageModelFallback({
+    cfg: effectiveCfg,
+    modelOverride: params.modelOverride,
+    abortSignal: params.signal,
+    run: async (provider, modelId) => {
+      // Static snapshots serve configured models through prepared facts; a fresh registry can be empty.
+      const resolved = await resolveModelAsync(provider, modelId, runtimeAgentDir, effectiveCfg, {
+        allowBundledStaticCatalogFallback: true,
+        ...preparedStores,
+        preparedModelRuntime: preparedRuntime,
+        skipAgentDiscovery: true,
+        ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
+      });
+      if (resolved.error || !resolved.model) {
+        throw new Error(resolved.error ?? `Unknown model: ${provider}/${modelId}`);
+      }
+      const modelRuntime = getModelRegistryRuntime(resolved.modelRegistry);
+      const model = bindModelLlmRuntime(
+        applySecretRefHeaderSentinels(resolved.model, effectiveCfg),
+        modelRuntime.llmRuntime,
+      );
+      const apiKey = await resolveModelRuntimeApiKey({
+        model,
+        cfg: effectiveCfg,
+        agentDir: runtimeAgentDir,
+        authStorage: resolved.authStorage,
+      });
+
+      if (providerSupportsNativePdf(provider)) {
+        if (params.password) {
+          throw new Error(
+            `password is not supported with native PDF providers (${provider}/${modelId}). Remove password, or use a non-native model for encrypted PDFs.`,
+          );
         }
-        const modelRuntime = getModelRegistryRuntime(resolved.modelRegistry);
-        const model = bindModelLlmRuntime(
-          applySecretRefHeaderSentinels(resolved.model, effectiveCfg),
-          modelRuntime.llmRuntime,
-        );
-        const apiKey = await resolveModelRuntimeApiKey({
+        if (params.pageNumbers && params.pageNumbers.length > 0) {
+          throw new Error(
+            `pages is not supported with native PDF providers (${provider}/${modelId}). Remove pages, or use a non-native model for page filtering.`,
+          );
+        }
+
+        // Encode only native requests, once across retries, after checking cancellation.
+        params.signal?.throwIfAborted();
+        params.assertResourcesOpen?.();
+        const pdfs = (nativePdfs ??= params.pdfBuffers.map(({ buffer, filename }) => ({
+          base64: buffer.toString("base64"),
+          filename,
+        })));
+
+        if (provider === "anthropic") {
+          const text = await anthropicAnalyzePdf({
+            apiKey,
+            modelId,
+            prompt: params.prompt,
+            pdfs,
+            maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
+            baseUrl: model.baseUrl,
+            requestConfig: {
+              headers: model.headers,
+              request: getModelProviderRequestTransport(model),
+            },
+            signal: params.signal,
+          });
+          return { text, provider, model: modelId, native: true };
+        }
+
+        if (provider === "google") {
+          const text = await geminiAnalyzePdf({
+            apiKey,
+            modelId,
+            prompt: params.prompt,
+            pdfs,
+            baseUrl: model.baseUrl,
+            requestConfig: {
+              headers: model.headers,
+              request: getModelProviderRequestTransport(model),
+            },
+            signal: params.signal,
+          });
+          return { text, provider, model: modelId, native: true };
+        }
+      }
+
+      // Provider hooks may own request preparation such as managed preset reloads.
+      // Registration alone is insufficient when a built-in API already owns dispatch.
+      const providerStreamFn = withPluginRuntimeGenerationScope(preparedRuntime, () =>
+        registerProviderStreamForModel({
           model,
           cfg: effectiveCfg,
           agentDir: runtimeAgentDir,
-          authStorage: resolved.authStorage,
-        });
+          wrapProviderStream: true,
+          apiRegistry: modelRuntime.apiRegistry,
+          ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
+        }),
+      );
 
-        if (providerSupportsNativePdf(provider)) {
-          if (params.password) {
-            throw new Error(
-              `password is not supported with native PDF providers (${provider}/${modelId}). Remove password, or use a non-native model for encrypted PDFs.`,
-            );
-          }
-          if (params.pageNumbers && params.pageNumbers.length > 0) {
-            throw new Error(
-              `pages is not supported with native PDF providers (${provider}/${modelId}). Remove pages, or use a non-native model for page filtering.`,
-            );
-          }
-
-          // Encode only native requests, once across retries, after checking cancellation.
-          params.signal?.throwIfAborted();
-          const pdfs = (nativePdfs ??= params.pdfBuffers.map(({ buffer, filename }) => ({
-            base64: buffer.toString("base64"),
-            filename,
-          })));
-
-          if (provider === "anthropic") {
-            const text = await anthropicAnalyzePdf({
-              apiKey,
-              modelId,
-              prompt: params.prompt,
-              pdfs,
-              maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
-              baseUrl: model.baseUrl,
-              requestConfig: {
-                headers: model.headers,
-                request: getModelProviderRequestTransport(model),
-              },
-              signal: params.signal,
-            });
-            return { text, provider, model: modelId, native: true };
-          }
-
-          if (provider === "google") {
-            const text = await geminiAnalyzePdf({
-              apiKey,
-              modelId,
-              prompt: params.prompt,
-              pdfs,
-              baseUrl: model.baseUrl,
-              requestConfig: {
-                headers: model.headers,
-                request: getModelProviderRequestTransport(model),
-              },
-              signal: params.signal,
-            });
-            return { text, provider, model: modelId, native: true };
-          }
-        }
-
-        // Provider hooks may own request preparation such as managed preset reloads.
-        // Registration alone is insufficient when a built-in API already owns dispatch.
-        const providerStreamFn = withPluginRuntimeGenerationScope(preparedRuntime, () =>
-          registerProviderStreamForModel({
-            model,
-            cfg: effectiveCfg,
-            agentDir: runtimeAgentDir,
-            wrapProviderStream: true,
-            apiRegistry: modelRuntime.apiRegistry,
-            ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
-          }),
-        );
-
-        const extractions = await getExtractions();
-        const completeExtraction = async (context: Context) => {
-          // A run cancelled mid-dispatch must not buy another provider call.
-          params.signal?.throwIfAborted();
-          const streamOptions = {
-            apiKey,
-            maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
-            signal: params.signal,
-          };
-          const completion = providerStreamFn
-            ? (async () => await (await providerStreamFn(model, context, streamOptions)).result())()
-            : complete(model, context, streamOptions);
-          return params.signal ? await abortable(params.signal, completion) : await completion;
+      const extractions = await getExtractions();
+      const completeExtraction = async (context: Context) => {
+        // A run cancelled mid-dispatch must not buy another provider call.
+        params.signal?.throwIfAborted();
+        params.assertResourcesOpen?.();
+        const streamOptions = {
+          apiKey,
+          maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
+          signal: params.signal,
         };
-        const hasImages = extractions.some((e) => e.images.length > 0);
-        if (hasImages && !model.input?.includes("image")) {
-          const hasText = extractions.some((e) => e.text.trim().length > 0);
-          if (!hasText) {
-            throw new Error(
-              `Model ${provider}/${modelId} does not support images and PDF has no extractable text.`,
-            );
-          }
-          const textOnlyExtractions: PdfExtractedContent[] = extractions.map((e) => ({
-            text: e.text,
-            images: [],
-          }));
-          const context = buildPdfExtractionContext(params.prompt, textOnlyExtractions, model);
-          const message = await completeExtraction(context);
-          const text = coercePdfAssistantText({ message, provider, model: modelId });
-          return { text, provider, model: modelId, native: false };
+        const completion = params.work.track(() =>
+          providerStreamFn
+            ? (async () => await (await providerStreamFn(model, context, streamOptions)).result())()
+            : complete(model, context, streamOptions),
+        );
+        return params.signal ? await abortable(params.signal, completion) : await completion;
+      };
+      const hasImages = extractions.some((e) => e.images.length > 0);
+      if (hasImages && !model.input?.includes("image")) {
+        const hasText = extractions.some((e) => e.text.trim().length > 0);
+        if (!hasText) {
+          throw new Error(
+            `Model ${provider}/${modelId} does not support images and PDF has no extractable text.`,
+          );
         }
-
-        const context = buildPdfExtractionContext(params.prompt, extractions, model);
+        const textOnlyExtractions: PdfExtractedContent[] = extractions.map((e) => ({
+          text: e.text,
+          images: [],
+        }));
+        const context = buildPdfExtractionContext(params.prompt, textOnlyExtractions, model);
         const message = await completeExtraction(context);
         const text = coercePdfAssistantText({ message, provider, model: modelId });
         return { text, provider, model: modelId, native: false };
-      },
-    });
+      }
 
-    return {
-      text: result.result.text,
-      provider: result.result.provider,
-      model: result.result.model,
-      native: result.result.native,
-      attempts: result.attempts.map((a) => ({
-        provider: a.provider,
-        model: a.model,
-        error: a.error,
-      })),
-    };
-  } finally {
-    preparedRuntimeLease.release();
-  }
+      const context = buildPdfExtractionContext(params.prompt, extractions, model);
+      const message = await completeExtraction(context);
+      const text = coercePdfAssistantText({ message, provider, model: modelId });
+      return { text, provider, model: modelId, native: false };
+    },
+  });
+
+  return {
+    text: result.result.text,
+    provider: result.result.provider,
+    model: result.result.model,
+    native: result.result.native,
+    attempts: result.attempts.map((a) => ({
+      provider: a.provider,
+      model: a.model,
+      error: a.error,
+    })),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -428,214 +428,269 @@ export function createPdfTool(options?: {
     'Analyze PDF(s): Anthropic/Google native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only).';
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
+  const executePdf = async (
+    args: unknown,
+    signal: AbortSignal | undefined,
+    work: AsyncWorkScope,
+    onAcquired: (release: () => void) => void,
+    assertResourcesOpen: (() => void) | undefined,
+  ): Promise<Awaited<ReturnType<AnyAgentTool["execute"]>>> => {
+    const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+
+    // MARK: - Normalize pdf + pdfs input
+    const pdfInputs = resolvePdfInputs(record);
+
+    // Enforce max PDFs cap
+    if (pdfInputs.length > DEFAULT_MAX_PDFS) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Too many PDFs: ${pdfInputs.length} provided, maximum is ${DEFAULT_MAX_PDFS}. Please reduce the number.`,
+          },
+        ],
+        details: {
+          error: "too_many_pdfs",
+          count: pdfInputs.length,
+          max: DEFAULT_MAX_PDFS,
+        },
+      };
+    }
+
+    const { prompt: promptRaw, modelOverride } = resolvePromptAndModelOverride(
+      record,
+      DEFAULT_PROMPT,
+    );
+    const maxBytesMb =
+      readFiniteNumberParam(record, "maxBytesMb", {
+        min: 0,
+        minExclusive: true,
+        message: "maxBytesMb must be greater than 0",
+      }) ?? configuredMaxBytesMb;
+    const maxBytes = Math.floor(maxBytesMb * 1024 * 1024);
+
+    // Parse page range
+    const pagesRaw = normalizeOptionalString(record.pages);
+    const pageNumbers = pagesRaw ? parsePageRange(pagesRaw, configuredMaxPages) : undefined;
+    const password = typeof record.password === "string" ? record.password : undefined;
+
+    const pdfModelConfig =
+      registrationPdfModelConfig ??
+      resolvePdfModelConfigForTool({
+        cfg: options?.config,
+        agentDir,
+        workspaceDir: options?.workspaceDir,
+        authStore: options?.authProfileStore,
+      });
+    if (!pdfModelConfig) {
+      throw new ToolInputError("No PDF model configured.");
+    }
+
+    const sandboxConfig = resolveMediaToolSandboxConfig(
+      options?.sandbox,
+      options?.fsPolicy?.workspaceOnly,
+    );
+
+    // MARK: - Load each PDF
+    const loadedPdfs: Array<{
+      buffer: Buffer;
+      filename: string;
+      resolvedPath: string;
+      rewrittenFrom?: string;
+    }> = [];
+
+    for (const pdfRaw of pdfInputs) {
+      // Stop before starting the next sequential download when the run was
+      // aborted, so a dead run cannot keep pulling remote PDFs.
+      signal?.throwIfAborted();
+      const trimmed = normalizeMediaReferenceSource(pdfRaw);
+      const refInfo = classifyMediaReferenceSource(trimmed);
+      const { isHttpUrl } = refInfo;
+
+      if (refInfo.hasUnsupportedScheme) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Unsupported PDF reference: ${pdfRaw}. Use a file path, file:// URL, or http(s) URL.`,
+            },
+          ],
+          details: { error: "unsupported_pdf_reference", pdf: pdfRaw },
+        };
+      }
+
+      if (sandboxConfig && isHttpUrl) {
+        throw new Error("Sandboxed PDF tool does not allow remote URLs.");
+      }
+
+      const resolvedPdf = (() => {
+        if (sandboxConfig) {
+          return trimmed;
+        }
+        if (trimmed.startsWith("~")) {
+          return resolveUserPath(trimmed);
+        }
+        return trimmed;
+      })();
+
+      const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
+        input: resolvedPdf,
+        isDataUrl: false,
+        workspaceDir: options?.workspaceDir,
+        sandbox: sandboxConfig,
+        rootOptions: {
+          workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+        },
+      });
+      if (resolvedPath === null) {
+        throw new Error("PDF reference resolved without a path.");
+      }
+
+      const media = sandboxConfig
+        ? await loadWebMediaRaw(resolvedPath, {
+            maxBytes,
+            sandboxValidated: true,
+            readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
+          })
+        : await loadWebMediaRaw(resolvedPath, {
+            maxBytes,
+            localRoots,
+            ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+            ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
+            ssrfPolicy: remoteMediaSsrfPolicy,
+            // Forward the run abort signal into the fetch layer so an abort
+            // mid-download disconnects the in-flight socket.
+            ...(signal ? { requestInit: { signal } } : {}),
+          });
+
+      if (media.kind !== "document") {
+        // Check MIME type more specifically
+        const ct = normalizeLowercaseStringOrEmpty(media.contentType);
+        if (!ct.includes("pdf") && !ct.includes("application/pdf")) {
+          throw new Error(`Expected PDF but got ${media.contentType ?? media.kind}: ${pdfRaw}`);
+        }
+      }
+
+      const filename =
+        media.fileName ??
+        (isHttpUrl
+          ? (new URL(trimmed).pathname.split("/").pop() ?? "document.pdf")
+          : "document.pdf");
+
+      loadedPdfs.push({
+        buffer: media.buffer,
+        filename,
+        resolvedPath,
+        ...(rewrittenFrom ? { rewrittenFrom } : {}),
+      });
+    }
+
+    const getExtractions = async (): Promise<PdfExtractedContent[]> => {
+      const extractedAll: PdfExtractedContent[] = [];
+      for (const pdf of loadedPdfs) {
+        // Extraction is sequential and can be CPU-heavy. Do not start the next
+        // document after the owning agent run has been cancelled.
+        signal?.throwIfAborted();
+        const extracted = await extractPdfContent({
+          buffer: pdf.buffer,
+          maxPages: configuredMaxPages,
+          maxPixels: PDF_MAX_PIXELS,
+          minTextChars: PDF_MIN_TEXT_CHARS,
+          ...(password ? { password } : {}),
+          pageNumbers,
+          config: options?.config,
+        });
+        extractedAll.push(extracted);
+      }
+      return extractedAll;
+    };
+
+    // Do not issue a paid PDF-model call for an already-aborted run.
+    signal?.throwIfAborted();
+    const result = await runPdfPrompt({
+      work,
+      onAcquired,
+      assertResourcesOpen,
+      signal,
+      cfg: options?.config,
+      agentId: options?.agentId,
+      agentDir,
+      ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+      ...(options?.preparedModelRuntime
+        ? { preparedModelRuntime: options.preparedModelRuntime }
+        : {}),
+      pdfModelConfig,
+      modelOverride,
+      prompt: promptRaw,
+      pdfBuffers: loadedPdfs,
+      ...(password ? { password } : {}),
+      pageNumbers,
+      getExtractions,
+    });
+
+    const singlePdf = loadedPdfs.length === 1 ? loadedPdfs.at(0) : undefined;
+    const pdfDetails = singlePdf
+      ? {
+          pdf: singlePdf.resolvedPath,
+          ...(singlePdf.rewrittenFrom ? { rewrittenFrom: singlePdf.rewrittenFrom } : {}),
+        }
+      : {
+          pdfs: loadedPdfs.map((p) =>
+            Object.assign(
+              { pdf: p.resolvedPath },
+              p.rewrittenFrom ? { rewrittenFrom: p.rewrittenFrom } : {},
+            ),
+          ),
+        };
+
+    return buildTextToolResult(result, { native: result.native, ...pdfDetails });
+  };
+
   return {
     label: "PDF",
     name: "pdf",
     description,
     parameters: PdfToolSchema,
     execute: async (_toolCallId, args, signal) => {
-      const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-
-      // MARK: - Normalize pdf + pdfs input
-      const pdfInputs = resolvePdfInputs(record);
-
-      // Enforce max PDFs cap
-      if (pdfInputs.length > DEFAULT_MAX_PDFS) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Too many PDFs: ${pdfInputs.length} provided, maximum is ${DEFAULT_MAX_PDFS}. Please reduce the number.`,
-            },
-          ],
-          details: { error: "too_many_pdfs", count: pdfInputs.length, max: DEFAULT_MAX_PDFS },
-        };
-      }
-
-      const { prompt: promptRaw, modelOverride } = resolvePromptAndModelOverride(
-        record,
-        DEFAULT_PROMPT,
-      );
-      const maxBytesMb =
-        readFiniteNumberParam(record, "maxBytesMb", {
-          min: 0,
-          minExclusive: true,
-          message: "maxBytesMb must be greater than 0",
-        }) ?? configuredMaxBytesMb;
-      const maxBytes = Math.floor(maxBytesMb * 1024 * 1024);
-
-      // Parse page range
-      const pagesRaw = normalizeOptionalString(record.pages);
-      const pageNumbers = pagesRaw ? parsePageRange(pagesRaw, configuredMaxPages) : undefined;
-      const password = typeof record.password === "string" ? record.password : undefined;
-
-      const pdfModelConfig =
-        registrationPdfModelConfig ??
-        resolvePdfModelConfigForTool({
-          cfg: options?.config,
-          agentDir,
-          workspaceDir: options?.workspaceDir,
-          authStore: options?.authProfileStore,
-        });
-      if (!pdfModelConfig) {
-        throw new ToolInputError("No PDF model configured.");
-      }
-
-      const sandboxConfig = resolveMediaToolSandboxConfig(
-        options?.sandbox,
-        options?.fsPolicy?.workspaceOnly,
-      );
-
-      // MARK: - Load each PDF
-      const loadedPdfs: Array<{
-        buffer: Buffer;
-        filename: string;
-        resolvedPath: string;
-        rewrittenFrom?: string;
-      }> = [];
-
-      for (const pdfRaw of pdfInputs) {
-        // Stop before starting the next sequential download when the run was
-        // aborted, so a dead run cannot keep pulling remote PDFs.
-        signal?.throwIfAborted();
-        const trimmed = normalizeMediaReferenceSource(pdfRaw);
-        const refInfo = classifyMediaReferenceSource(trimmed);
-        const { isHttpUrl } = refInfo;
-
-        if (refInfo.hasUnsupportedScheme) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Unsupported PDF reference: ${pdfRaw}. Use a file path, file:// URL, or http(s) URL.`,
-              },
-            ],
-            details: { error: "unsupported_pdf_reference", pdf: pdfRaw },
-          };
+      const reported = createDeferredCore<Awaited<ReturnType<AnyAgentTool["execute"]>>>();
+      const parentSignal = getAsyncWorkSignal();
+      void trackAsyncWork(async () => {
+        const work = new AsyncWorkScope();
+        const runInScope = work.run(() => AsyncLocalStorage.snapshot());
+        const closeWork = () => runInScope(() => work.beginClose(parentSignal?.reason));
+        parentSignal?.addEventListener("abort", closeWork, { once: true });
+        if (parentSignal?.aborted) {
+          closeWork();
         }
-
-        if (sandboxConfig && isHttpUrl) {
-          throw new Error("Sandboxed PDF tool does not allow remote URLs.");
-        }
-
-        const resolvedPdf = (() => {
-          if (sandboxConfig) {
-            return trimmed;
-          }
-          if (trimmed.startsWith("~")) {
-            return resolveUserPath(trimmed);
-          }
-          return trimmed;
-        })();
-
-        const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
-          input: resolvedPdf,
-          isDataUrl: false,
-          workspaceDir: options?.workspaceDir,
-          sandbox: sandboxConfig,
-          rootOptions: {
-            workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
-          },
-        });
-        if (resolvedPath === null) {
-          throw new Error("PDF reference resolved without a path.");
-        }
-
-        const media = sandboxConfig
-          ? await loadWebMediaRaw(resolvedPath, {
-              maxBytes,
-              sandboxValidated: true,
-              readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
-            })
-          : await loadWebMediaRaw(resolvedPath, {
-              maxBytes,
-              localRoots,
-              ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-              ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
-              ssrfPolicy: remoteMediaSsrfPolicy,
-              // Forward the run abort signal into the fetch layer so an abort
-              // mid-download disconnects the in-flight socket.
-              ...(signal ? { requestInit: { signal } } : {}),
-            });
-
-        if (media.kind !== "document") {
-          // Check MIME type more specifically
-          const ct = normalizeLowercaseStringOrEmpty(media.contentType);
-          if (!ct.includes("pdf") && !ct.includes("application/pdf")) {
-            throw new Error(`Expected PDF but got ${media.contentType ?? media.kind}: ${pdfRaw}`);
-          }
-        }
-
-        const filename =
-          media.fileName ??
-          (isHttpUrl
-            ? (new URL(trimmed).pathname.split("/").pop() ?? "document.pdf")
-            : "document.pdf");
-
-        loadedPdfs.push({
-          buffer: media.buffer,
-          filename,
-          resolvedPath,
-          ...(rewrittenFrom ? { rewrittenFrom } : {}),
-        });
-      }
-
-      const getExtractions = async (): Promise<PdfExtractedContent[]> => {
-        const extractedAll: PdfExtractedContent[] = [];
-        for (const pdf of loadedPdfs) {
-          // Extraction is sequential and can be CPU-heavy. Do not start the next
-          // document after the owning agent run has been cancelled.
-          signal?.throwIfAborted();
-          const extracted = await extractPdfContent({
-            buffer: pdf.buffer,
-            maxPages: configuredMaxPages,
-            maxPixels: PDF_MAX_PIXELS,
-            minTextChars: PDF_MIN_TEXT_CHARS,
-            ...(password ? { password } : {}),
-            pageNumbers,
-            config: options?.config,
-          });
-          extractedAll.push(extracted);
-        }
-        return extractedAll;
-      };
-
-      // Do not issue a paid PDF-model call for an already-aborted run.
-      signal?.throwIfAborted();
-      const result = await runPdfPrompt({
-        signal,
-        cfg: options?.config,
-        agentId: options?.agentId,
-        agentDir,
-        ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-        ...(options?.preparedModelRuntime
-          ? { preparedModelRuntime: options.preparedModelRuntime }
-          : {}),
-        pdfModelConfig,
-        modelOverride,
-        prompt: promptRaw,
-        pdfBuffers: loadedPdfs,
-        ...(password ? { password } : {}),
-        pageNumbers,
-        getExtractions,
-      });
-
-      const singlePdf = loadedPdfs.length === 1 ? loadedPdfs.at(0) : undefined;
-      const pdfDetails = singlePdf
-        ? {
-            pdf: singlePdf.resolvedPath,
-            ...(singlePdf.rewrittenFrom ? { rewrittenFrom: singlePdf.rewrittenFrom } : {}),
-          }
-        : {
-            pdfs: loadedPdfs.map((p) =>
-              Object.assign(
-                { pdf: p.resolvedPath },
-                p.rewrittenFrom ? { rewrittenFrom: p.rewrittenFrom } : {},
+        let releaseRuntime: (() => void) | undefined;
+        try {
+          const suppliedClaim = options?.preparedModelRuntime
+            ? retainPreparedModelRuntimeSnapshotResources(options.preparedModelRuntime)
+            : undefined;
+          releaseRuntime = suppliedClaim?.release;
+          reported.resolve(
+            await work.track(() =>
+              executePdf(
+                args,
+                signal,
+                work,
+                (release) => {
+                  releaseRuntime = release;
+                },
+                suppliedClaim?.assertOpen,
               ),
             ),
-          };
-
-      return buildTextToolResult(result, { native: result.native, ...pdfDetails });
+          );
+        } catch (error) {
+          reported.reject(error);
+        } finally {
+          await work.runWhenIdle(() => undefined);
+          await runInScope(() => work.drain());
+          parentSignal?.removeEventListener("abort", closeWork);
+          releaseRuntime?.();
+        }
+      }).catch((error: unknown) => reported.reject(error));
+      return await reported.promise;
     },
   };
 }


### PR DESCRIPTION
Related: #140674. Uses the prepared-owner helper from #143403.

## What Problem This Solves

Resolves a problem where PDF requests can release plugin databases while a cancelled provider call or setup cleanup is still running. A supplied prepared runtime also needs to remain alive while the tool downloads its documents.

## Why This Change Was Made

Own supplied resources before the first download, and transfer default acquisition into that same execution owner before asynchronous setup. Track actual stream creation, completion and cooperating cleanup beneath the existing abort race, then release after drainage.

The normal PDF operation stays separate from its small lifetime wrapper. Default acquisition still happens once after loading and before fallback. Native provider routing, extraction, filesystem checks, model/auth selection and existing timeouts are unchanged. Raw supplied registries retain their caller lifetime; no general RUN/configured disposal is enabled.

## User Impact

Cancelled PDF requests preserve their current response behavior while accepted work can finish using its original state. Supplied managed runtimes retain their original provider and adopted donor resources through the operation.

## Evidence

Original production reproduces eight ownership failures with two passing controls. Final native and sibling validation covers 120 distinct PDF cases. Two existing release assertions now join actual cleanup before checking release; their model, routing and output assertions remain intact.

Affected types, lint, all three Knip scans and remaining guards pass, with fresh proportional checks after fixture-only lint corrections. Full-candidate Codex review through P2 is clean. The ordinary build passed in 269.29 seconds, including 152 public SDK subpaths.

Compiled proof uses the actual public agent-harness tool factory and PDF tool, a real generated PDF, bundled document extraction and a native SQLite-backed provider. After cancellation and replacement, the old source remains usable for late work; both sources close once and reopen successfully. The proof passed in 2.45 seconds with all 11,688 artifact hashes unchanged, 3,799 resolved files, no application source fallback and all processes joined.

Single synthetic samples: cold PDF execution 75.00 milliseconds and cancellation response 13.83 milliseconds. Five failed fixture configurations are preserved; correcting the fixture's agent entry, syntax and provider/extractor scope required no application change. This is a built-checkout proof, not installed-package or real-vendor coverage, and the timings are not a comparative benchmark.

Only the PDF commit was rebased after its Image dependency landed; all four validated source files remain byte-identical.
