### PR TITLE
fix(update): preserve unchanged already-current no-op

### DIFF
--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -152,7 +152,7 @@ export async function convergeUpdatePlugins(params: {
         });
       }
 
-      if (postCorePluginUpdate) {
+      if (postCorePluginUpdate && (!params.coreAlreadyCurrent || postCorePluginUpdate.changed)) {
         // Both package paths release the plugin lease before Doctor; the parent
         // owns the service boundary after package and network work has finished.
         const completedPluginUpdate = await completePostCorePluginUpdate({

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -9,18 +9,22 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const validConfigSnapshot = {
+  path: "/tmp/openclaw.json",
+  exists: true,
+  raw: "{}",
   valid: true,
   parsed: {},
   config: {},
   runtimeConfig: {},
   sourceConfig: {},
+  resolved: {},
   warnings: [],
   issues: [],
   legacyIssues: [],
 };
 
 const successfulPluginUpdate = {
-  status: "ok",
+  status: "ok" as const,
   changed: true,
   sync: {
     changed: false,
@@ -160,12 +164,14 @@ vi.mock("./update-command-post-core.js", async (importOriginal) => ({
   writePostCorePluginUpdateResultFile: vi.fn(async () => undefined),
 }));
 
+import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import { updateFinalizeCommand } from "./update-command-finalize.js";
 import {
   completePostCorePluginUpdate,
   runUpdateFinalizationDoctorInFreshProcess,
 } from "./update-command-fresh-doctor.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import { resumePostCoreUpdate } from "./update-command-resume.js";
 
 function expectLifecycleBoundary(preLeaseEvent: string): void {
@@ -197,6 +203,44 @@ describe("update plugin lifecycle lease boundaries", () => {
     vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
     vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
     vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
+  });
+
+  it("keeps an unchanged already-current update on the no-op path", async () => {
+    vi.mocked(updatePluginsAfterCoreUpdate).mockResolvedValueOnce({
+      ...successfulPluginUpdate,
+      changed: false,
+    });
+
+    const result = await convergeUpdatePlugins({
+      coreAlreadyCurrent: true,
+      result: {
+        status: "skipped",
+        mode: "npm",
+        root: "/tmp/openclaw",
+        reason: "already-current",
+        before: { version: "2026.9.3" },
+        after: { version: "2026.9.3" },
+        steps: [],
+        durationMs: 1,
+      },
+      root: "/tmp/openclaw",
+      installKindChanged: false,
+      configSnapshot: validConfigSnapshot,
+      requestedChannel: null,
+      storedChannel: null,
+      channel: "stable",
+      downgradeRisk: false,
+      opts: {},
+      preUpdatePluginInstallRecords: {},
+      startedAt: 1,
+      updateStepTimeoutMs: 1_000,
+    });
+
+    expect(completePostCorePluginUpdate).not.toHaveBeenCalled();
+    expect(result.resultWithPostUpdate).toMatchObject({
+      status: "skipped",
+      reason: "already-current",
+    });
   });
 
   it.each(["copied", "live"] as const)(


### PR DESCRIPTION
## Summary
- skip redundant fresh-process plugin/config completion when the core is already current and plugin convergence made no changes
- preserve real plugin errors and changed-plugin completion behavior
- prevent an immediately repeated candidate update from failing on the prior unfenced updater state-schema publication grace window

## Validation
- `pnpm exec vitest run src/cli/update-cli/update-command-post-update.test.ts` (32 passed)
- `pnpm exec vitest run src/cli/update-cli/update-command-lifecycle.test.ts` (7 passed)
- `pnpm check:changed`

Release evidence: https://github.com/openclaw/openclaw/actions/runs/34409791635/job/102664977910