### PR TITLE
fix(runtime): re-exec under an available supported Node before refusing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY node-version.mjs ./
 COPY node-sqlite.mjs ./
 COPY node-runtime-update.mjs ./
+COPY node-runtime-recovery.mjs ./
 COPY openclaw.mjs ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
@@ -277,6 +278,7 @@ COPY --from=runtime-assets --chown=node:node /app/patches ./patches
 COPY --from=runtime-assets --chown=node:node /app/node-version.mjs .
 COPY --from=runtime-assets --chown=node:node /app/node-sqlite.mjs .
 COPY --from=runtime-assets --chown=node:node /app/node-runtime-update.mjs .
+COPY --from=runtime-assets --chown=node:node /app/node-runtime-recovery.mjs .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -31,6 +31,10 @@ Arguments, working directory, environment, standard streams, and exit status are
 preserved. Commands with an exact process-identity requirement cannot use this
 recovery.
 
+Runtime discovery uses the environment inherited when the CLI starts, before
+OpenClaw loads any `.env` file. Configure version-manager roots in your shell environment;
+workspace `.env` values cannot select a Node executable for recovery.
+
 Recovery ignores relative PATH entries and runtimes that resolve inside the
 current working directory, unless an absolute PATH entry explicitly names their
 directory. On Windows, the service reader honors recorded code pages and Unicode

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -42,7 +42,10 @@ manager metadata inside the current working directory are rejected.
 
 Recovery ignores relative PATH entries and runtimes that resolve inside the
 current working directory, unless an absolute PATH entry explicitly names their
-directory. On Windows, the service reader honors recorded code pages and Unicode
+directory. OpenClaw's own private recovery directory is also allowed, so cached
+runtime reuse and the installation offer work when you launch from your home
+directory. This exception does not extend to other in-home executables or manager
+roots. On Windows, the service reader honors recorded code pages and Unicode
 byte-order marks. If the current Node build cannot decode a service script safely,
 OpenClaw prints the code page and continues searching other sources. Unsupported
 OEM pages such as CP850 are skipped rather than guessed. CP949 is also skipped:

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -21,7 +21,17 @@ Upgrade Node before updating OpenClaw to avoid SQLite TEXT truncation. See [Node
 
 ### Update from the CLI
 
-If you run `openclaw` with an incompatible Node.js in an interactive terminal, the CLI offers:
+If you run `openclaw` with an incompatible Node.js, startup first checks for an
+already available compatible runtime: the private OpenClaw runtime, the Node
+recorded in the managed Gateway service, Node on PATH, then nvm, fnm, Volta, and
+Homebrew defaults. Each candidate must pass the same SQLite capability checks as
+normal startup. The first passing runtime retries the original command without
+prompting, including non-interactive Doctor commands launched by older updaters.
+Arguments, working directory, environment, standard streams, and exit status are
+preserved. Commands with an exact process-identity requirement cannot use this
+recovery.
+
+If none is available and you are in an interactive terminal, the CLI offers:
 
 ```text
 Update NodeJS: Y/N [N]:

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -35,6 +35,11 @@ Runtime discovery uses the environment inherited when the CLI starts, before
 OpenClaw loads any `.env` file. Configure version-manager roots in your shell environment;
 workspace `.env` values cannot select a Node executable for recovery.
 
+Home-relative service and version-manager paths expand `~` against inherited
+`HOME` or `USERPROFILE`. Service paths use that home even when `OPENCLAW_HOME`
+selects a different private-runtime home. Bare relative paths and service or
+manager metadata inside the current working directory are rejected.
+
 Recovery ignores relative PATH entries and runtimes that resolve inside the
 current working directory, unless an absolute PATH entry explicitly names their
 directory. On Windows, the service reader honors recorded code pages and Unicode

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -31,6 +31,16 @@ Arguments, working directory, environment, standard streams, and exit status are
 preserved. Commands with an exact process-identity requirement cannot use this
 recovery.
 
+Recovery ignores relative PATH entries and runtimes that resolve inside the
+current working directory, unless an absolute PATH entry explicitly names their
+directory. On Windows, the service reader honors recorded code pages and Unicode
+byte-order marks. If the current Node build cannot decode a service script safely,
+OpenClaw prints the code page and continues searching other sources. Unsupported
+OEM pages such as CP850 are skipped rather than guessed. CP949 is also skipped:
+Node's ICU `euc-kr` decoder silently misdecodes UHC extension characters. Neither
+case probes the service executable; recovery continues with PATH and the other
+available runtime sources.
+
 If none is available and you are in an interactive terminal, the CLI offers:
 
 ```text

--- a/node-runtime-recovery.d.mts
+++ b/node-runtime-recovery.d.mts
@@ -1,9 +1,13 @@
 export function consumeLauncherRootOptionToken(args: string[], index: number): number;
 export function isForegroundGmailRunInvocation(argv: string[]): boolean;
 export function isNativeHookRelayInvocation(argv: string[]): boolean;
-export function isUsableNode(nodePath: string, options?: { allowCwd?: boolean }): boolean;
+export function isUsableNode(
+  nodePath: string,
+  options?: { allowCwd?: boolean; env?: NodeJS.ProcessEnv },
+): boolean;
 export function runRespawnedChild(command: string, args: string[], env: NodeJS.ProcessEnv): true;
 export function recoverNodeRuntime(options?: {
   homeDir?: string;
   allowInstall?: boolean;
+  env?: NodeJS.ProcessEnv;
 }): Promise<boolean>;

--- a/node-runtime-recovery.d.mts
+++ b/node-runtime-recovery.d.mts
@@ -1,0 +1,9 @@
+export function consumeLauncherRootOptionToken(args: string[], index: number): number;
+export function isForegroundGmailRunInvocation(argv: string[]): boolean;
+export function isNativeHookRelayInvocation(argv: string[]): boolean;
+export function isUsableNode(nodePath: string): boolean;
+export function runRespawnedChild(command: string, args: string[], env: NodeJS.ProcessEnv): true;
+export function recoverNodeRuntime(options?: {
+  homeDir?: string;
+  allowInstall?: boolean;
+}): Promise<boolean>;

--- a/node-runtime-recovery.d.mts
+++ b/node-runtime-recovery.d.mts
@@ -1,7 +1,7 @@
 export function consumeLauncherRootOptionToken(args: string[], index: number): number;
 export function isForegroundGmailRunInvocation(argv: string[]): boolean;
 export function isNativeHookRelayInvocation(argv: string[]): boolean;
-export function isUsableNode(nodePath: string): boolean;
+export function isUsableNode(nodePath: string, options?: { allowCwd?: boolean }): boolean;
 export function runRespawnedChild(command: string, args: string[], env: NodeJS.ProcessEnv): true;
 export function recoverNodeRuntime(options?: {
   homeDir?: string;

--- a/node-runtime-recovery.d.mts
+++ b/node-runtime-recovery.d.mts
@@ -4,11 +4,11 @@ export function isNativeHookRelayInvocation(argv: string[]): boolean;
 export function resolveRecoveryPath(
   value: string | null | undefined,
   homeDir?: string | null,
-  options?: { allowMissing?: boolean; allowCwd?: boolean },
+  options?: { allowMissing?: boolean; allowCwd?: boolean; trustedRoot?: string },
 ): string | null;
 export function isUsableNode(
   nodePath: string,
-  options?: { allowCwd?: boolean; env?: NodeJS.ProcessEnv },
+  options?: { allowCwd?: boolean; trustedRoot?: string; env?: NodeJS.ProcessEnv },
 ): boolean;
 export function runRespawnedChild(command: string, args: string[], env: NodeJS.ProcessEnv): true;
 export function recoverNodeRuntime(options?: {

--- a/node-runtime-recovery.d.mts
+++ b/node-runtime-recovery.d.mts
@@ -1,6 +1,11 @@
 export function consumeLauncherRootOptionToken(args: string[], index: number): number;
 export function isForegroundGmailRunInvocation(argv: string[]): boolean;
 export function isNativeHookRelayInvocation(argv: string[]): boolean;
+export function resolveRecoveryPath(
+  value: string | null | undefined,
+  homeDir?: string | null,
+  options?: { allowMissing?: boolean; allowCwd?: boolean },
+): string | null;
 export function isUsableNode(
   nodePath: string,
   options?: { allowCwd?: boolean; env?: NodeJS.ProcessEnv },

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -44,8 +44,7 @@ export const consumeLauncherRootOptionToken = (args, index) => {
   return 0;
 };
 
-// Mirror the entry's foreground Gmail policy before any built modules can load.
-// A compile-cache wrapper would kill its owner before descendant cleanup finishes.
+// Mirror the entry's foreground Gmail policy: a wrapper would kill that run before descendant cleanup finishes.
 export const isForegroundGmailRunInvocation = (argv) => {
   const args = argv.slice(2);
   const commandPath = [];
@@ -76,10 +75,7 @@ export const runRespawnedChild = (command, args, env) => {
     env,
   });
   const listeners = new Map();
-  // This intentionally overlaps with src/entry.compile-cache.ts; keep the
-  // respawn supervision behavior in sync until the launcher can share TS code.
-  // Give the child a moment to honor forwarded signals, then exit the wrapper so
-  // a child that ignores SIGTERM cannot keep the launcher alive indefinitely.
+  // Keep signal forwarding and bounded shutdown in sync with src/entry.compile-cache.ts.
   let signalExitTimer = null;
   let signalForceKillTimer = null;
   let signalHardExitTimer = null;
@@ -192,9 +188,7 @@ function readSmallFile(filename, encoding = "utf8") {
   }
 }
 
-// Numeric mappings are owned by src/infra/windows-encoding.ts; use WHATWG
-// labels here, plus the Windows UTF/ISO page IDs, without loading that graph.
-// Skip CP850 (no ICU decoder) and CP949 (ICU silently corrupts UHC); never guess.
+// Match windows-encoding.ts labels; skip CP850 (no decoder) and CP949 (corrupts UHC).
 const WINDOWS_SERVICE_CODEPAGE_LABELS = {
   437: "cp437",
   720: "cp720",
@@ -329,8 +323,7 @@ export function resolveRecoveryPath(
   const paths = /^(?:[a-zA-Z]:[\\/]|\\\\)/.test(expanded) ? path.win32 : path;
   const absolute = paths.resolve(expanded);
   const cwd = realNodePath(process.cwd()) ?? process.cwd();
-  // OpenClaw owns this private recovery root even when the user launches from HOME.
-  // Only private recovery passes it; symlinks into cwd outside it remain excluded.
+  // Trust only the private recovery root when launching from HOME; reject other cwd symlinks.
   const trusted =
     trustedRoot && path.isAbsolute(trustedRoot) && isPathWithin(absolute, trustedRoot);
   const excluded = (filename) =>
@@ -469,17 +462,16 @@ function managedServiceNode(homeDir, env) {
     index += consumed;
   }
   const suffix = profile && profile.toLowerCase() !== "default" ? profile : "";
-  const serviceHome = homeDir;
   let command;
   if (process.platform === "darwin") {
-    if (!serviceHome) {
+    if (!homeDir) {
       return null;
     }
     const label = env.OPENCLAW_LAUNCHD_LABEL?.trim() || `ai.openclaw.${suffix || "gateway"}`;
     if (!/^[A-Za-z0-9._-]+$/.test(label)) {
       return null;
     }
-    const text = readSmallFile(path.join(serviceHome, "Library", "LaunchAgents", `${label}.plist`));
+    const text = readSmallFile(path.join(homeDir, "Library", "LaunchAgents", `${label}.plist`));
     const array = text?.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/)?.[1];
     const recordedArgs = [...(array || "").matchAll(/<string>([^<]*)<\/string>/g)].map(
       ([, value]) =>
@@ -494,7 +486,7 @@ function managedServiceNode(homeDir, env) {
       recordedArgs[wrapperIndex + 1]?.endsWith(`${label}.env`);
     command = recordedArgs[generatedWrapper ? wrapperIndex + 2 : 0];
   } else if (process.platform === "linux") {
-    if (!serviceHome) {
+    if (!homeDir) {
       return null;
     }
     const name =
@@ -503,7 +495,7 @@ function managedServiceNode(homeDir, env) {
       return null;
     }
     const filename = name.endsWith(".service") ? name : `${name}.service`;
-    const text = readSmallFile(path.join(serviceHome, ".config", "systemd", "user", filename));
+    const text = readSmallFile(path.join(homeDir, ".config", "systemd", "user", filename));
     const service = text?.split(/^\s*\[Service\]\s*$/m)[1]?.split(/^\s*\[/m)[0];
     const executable = service?.match(/^\s*ExecStart=\s*(?:"((?:[^"\\]|\\.)*)"|(\S+))/m);
     command = (executable?.[1] ?? executable?.[2])?.replace(/\\(.)/g, "$1");
@@ -514,12 +506,12 @@ function managedServiceNode(homeDir, env) {
     }
     const stateDir = resolveRecoveryPath(
       env.OPENCLAW_STATE_DIR?.trim() ||
-        (serviceHome && path.join(serviceHome, `.openclaw${suffix ? `-${suffix}` : ""}`)),
-      serviceHome,
+        (homeDir && path.join(homeDir, `.openclaw${suffix ? `-${suffix}` : ""}`)),
+      homeDir,
     );
     const filename = resolveRecoveryPath(
       env.OPENCLAW_TASK_SCRIPT?.trim() || (stateDir && path.join(stateDir, scriptName)),
-      serviceHome,
+      homeDir,
     );
     const text = readWindowsServiceScript(filename);
     command = text && windowsServiceNode(text);
@@ -573,9 +565,7 @@ function resolveNvmDefault(root) {
   return null;
 }
 
-// Only inherited environment roots are trusted like PATH; dotenv values must never
-// select an executable. Relative/cwd candidates remain excluded except when an
-// inherited absolute PATH directory explicitly opts into cwd.
+// Discovery uses inherited roots; dotenv must never select an executable.
 function* availableNodeCandidates(homeDir, env) {
   yield [managedServiceNode(homeDir, env), "managed Gateway service"];
   const pathKey =
@@ -588,22 +578,21 @@ function* availableNodeCandidates(homeDir, env) {
       yield [path.join(directory, binary), "PATH"];
     }
   }
-  const managerHome = homeDir;
-  for (const candidate of new Set([env.NVM_DIR, managerHome && path.join(managerHome, ".nvm")])) {
-    const root = resolveRecoveryPath(candidate, managerHome);
+  for (const candidate of new Set([env.NVM_DIR, homeDir && path.join(homeDir, ".nvm")])) {
+    const root = resolveRecoveryPath(candidate, homeDir);
     if (root) {
       yield [resolveNvmDefault(root), "nvm default"];
     }
   }
   for (const candidate of new Set([
     env.FNM_DIR,
-    managerHome && path.join(managerHome, ".fnm"),
-    managerHome && path.join(managerHome, ".local", "share", "fnm"),
-    ...(process.platform === "darwin" && managerHome
-      ? [path.join(managerHome, "Library", "Application Support", "fnm")]
+    homeDir && path.join(homeDir, ".fnm"),
+    homeDir && path.join(homeDir, ".local", "share", "fnm"),
+    ...(process.platform === "darwin" && homeDir
+      ? [path.join(homeDir, "Library", "Application Support", "fnm")]
       : []),
   ])) {
-    const root = resolveRecoveryPath(candidate, managerHome);
+    const root = resolveRecoveryPath(candidate, homeDir);
     if (root) {
       yield [
         path.join(
@@ -617,11 +606,8 @@ function* availableNodeCandidates(homeDir, env) {
       ];
     }
   }
-  for (const candidate of new Set([
-    env.VOLTA_HOME,
-    managerHome && path.join(managerHome, ".volta"),
-  ])) {
-    const root = resolveRecoveryPath(candidate, managerHome);
+  for (const candidate of new Set([env.VOLTA_HOME, homeDir && path.join(homeDir, ".volta")])) {
+    const root = resolveRecoveryPath(candidate, homeDir);
     if (!root) {
       continue;
     }

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -326,7 +326,7 @@ export function isUsableNode(nodePath, { allowCwd = false } = {}) {
   ) {
     return false;
   }
-  if (!allowCwd && isCwdNode(resolved)) {
+  if (!allowCwd && (isCwdNode(nodePath) || isCwdNode(resolved))) {
     return false;
   }
   const env = { NODE_NO_WARNINGS: "1" };
@@ -498,6 +498,9 @@ function resolveNvmDefault(root) {
   return null;
 }
 
+// Absolute roots from PATH and manager env vars are user configuration and trusted
+// like PATH; anything relative or under cwd is never probed. The explicit absolute
+// PATH directory opt-in below retains its cwd exception.
 function* availableNodeCandidates(homeDir) {
   yield [managedServiceNode(homeDir), "managed Gateway service"];
   const pathKey =
@@ -604,7 +607,7 @@ export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {})
       // Only an explicitly named PATH directory may opt into cwd executables.
       const allowCwd =
         source === "PATH" && realNodePath(path.dirname(candidate)) === path.dirname(realPath);
-      if (!allowCwd && isCwdNode(realPath)) {
+      if (!allowCwd && (isCwdNode(candidate) || isCwdNode(realPath))) {
         continue;
       }
       seen.add(realPath);

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -1,6 +1,6 @@
 // Startup-only recovery; this module cannot depend on dist or installed packages.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -180,9 +180,13 @@ export const runRespawnedChild = (command, args, env) => {
 };
 
 function readSmallFile(filename, encoding = "utf8") {
+  const resolved = resolveRecoveryPath(filename);
+  if (!resolved) {
+    return null;
+  }
   try {
-    const info = statSync(filename);
-    return info.isFile() && info.size <= 65_536 ? readFileSync(filename, encoding) : null;
+    const info = statSync(resolved);
+    return info.isFile() && info.size <= 65_536 ? readFileSync(resolved, encoding) : null;
   } catch {
     return null;
   }
@@ -307,26 +311,74 @@ function realNodePath(filename) {
   }
 }
 
-function isCwdNode(nodePath) {
-  const cwd = realNodePath(process.cwd()) ?? process.cwd();
+function isCwdPath(nodePath, cwd) {
   const relative = path.relative(cwd, nodePath);
   return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 }
 
+// Match daemon/paths.ts home expansion without resolving relative inputs against cwd.
+export function resolveRecoveryPath(
+  value,
+  homeDir,
+  { allowMissing = false, allowCwd = false } = {},
+) {
+  const expanded = value?.trim().replace(/^~(?=$|[\\/])/, () => homeDir ?? "~");
+  if (!expanded || !path.isAbsolute(expanded)) {
+    return null;
+  }
+  const paths = /^(?:[a-zA-Z]:[\\/]|\\\\)/.test(expanded) ? path.win32 : path;
+  const absolute = paths.resolve(expanded);
+  const cwd = realNodePath(process.cwd()) ?? process.cwd();
+  if (!allowCwd && isCwdPath(absolute, cwd)) {
+    return null;
+  }
+  if (!allowCwd) {
+    // A final symlink can hide a workspace-owned intermediate directory.
+    for (let prefix = paths.dirname(absolute); ;) {
+      const real = realNodePath(prefix);
+      if (real && isCwdPath(real, cwd)) {
+        return null;
+      }
+      const parent = paths.dirname(prefix);
+      if (parent === prefix) {
+        break;
+      }
+      prefix = parent;
+    }
+  }
+  let existing = absolute;
+  const missing = [];
+  for (;;) {
+    const real = realNodePath(existing);
+    if (real) {
+      const resolved = paths.resolve(real, ...missing);
+      return path.isAbsolute(resolved) && (allowCwd || !isCwdPath(resolved, cwd)) ? resolved : null;
+    }
+    if (!allowMissing) {
+      return null;
+    }
+    // An existing dangling symlink or unreadable path is not a creatable suffix.
+    try {
+      lstatSync(existing);
+      return null;
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        return null;
+      }
+    }
+    const parent = paths.dirname(existing);
+    if (parent === existing) {
+      return null;
+    }
+    missing.unshift(paths.basename(existing));
+    existing = parent;
+  }
+}
+
 // Do not pass preload hooks, native-library overrides, or application secrets to probes.
 export function isUsableNode(nodePath, { allowCwd = false, env = process.env } = {}) {
-  if (!path.isAbsolute(nodePath)) {
-    return false;
-  }
-  const resolved = realNodePath(nodePath);
-  if (
-    !resolved ||
-    !path.isAbsolute(resolved) ||
-    !/^node(?:\.exe)?$/i.test(path.basename(resolved))
-  ) {
-    return false;
-  }
-  if (!allowCwd && (isCwdNode(nodePath) || isCwdNode(resolved))) {
+  const resolved = resolveRecoveryPath(nodePath, undefined, { allowCwd });
+  if (!resolved || !/^node(?:\.exe)?$/i.test(path.basename(resolved))) {
     return false;
   }
   const probeEnv = { NODE_NO_WARNINGS: "1" };
@@ -408,9 +460,12 @@ function managedServiceNode(homeDir, env) {
     index += consumed;
   }
   const suffix = profile && profile.toLowerCase() !== "default" ? profile : "";
-  const serviceHome = env.HOME?.trim() || env.USERPROFILE?.trim() || homeDir;
+  const serviceHome = homeDir;
   let command;
   if (process.platform === "darwin") {
+    if (!serviceHome) {
+      return null;
+    }
     const label = env.OPENCLAW_LAUNCHD_LABEL?.trim() || `ai.openclaw.${suffix || "gateway"}`;
     if (!/^[A-Za-z0-9._-]+$/.test(label)) {
       return null;
@@ -430,6 +485,9 @@ function managedServiceNode(homeDir, env) {
       recordedArgs[wrapperIndex + 1]?.endsWith(`${label}.env`);
     command = recordedArgs[generatedWrapper ? wrapperIndex + 2 : 0];
   } else if (process.platform === "linux") {
+    if (!serviceHome) {
+      return null;
+    }
     const name =
       env.OPENCLAW_SYSTEMD_UNIT?.trim() || `openclaw-gateway${suffix ? `-${suffix}` : ""}`;
     if (!/^[A-Za-z0-9._@-]+$/.test(name)) {
@@ -445,10 +503,15 @@ function managedServiceNode(homeDir, env) {
     if (/[/\\]|\.\./.test(scriptName)) {
       return null;
     }
-    const stateDir =
+    const stateDir = resolveRecoveryPath(
       env.OPENCLAW_STATE_DIR?.trim() ||
-      path.join(serviceHome, `.openclaw${suffix ? `-${suffix}` : ""}`);
-    const filename = env.OPENCLAW_TASK_SCRIPT?.trim() || path.join(stateDir, scriptName);
+        (serviceHome && path.join(serviceHome, `.openclaw${suffix ? `-${suffix}` : ""}`)),
+      serviceHome,
+    );
+    const filename = resolveRecoveryPath(
+      env.OPENCLAW_TASK_SCRIPT?.trim() || (stateDir && path.join(stateDir, scriptName)),
+      serviceHome,
+    );
     const text = readWindowsServiceScript(filename);
     command = text && windowsServiceNode(text);
   }
@@ -459,8 +522,12 @@ function managedServiceNode(homeDir, env) {
 }
 
 function directoryNames(directory) {
+  const resolved = resolveRecoveryPath(directory);
+  if (!resolved) {
+    return [];
+  }
   try {
-    return readdirSync(directory).toSorted().slice(0, 256);
+    return readdirSync(resolved).toSorted().slice(0, 256);
   } catch {
     return [];
   }
@@ -512,20 +579,22 @@ function* availableNodeCandidates(homeDir, env) {
       yield [path.join(directory, binary), "PATH"];
     }
   }
-  const managerHome = env.HOME?.trim() || env.USERPROFILE?.trim() || homeDir;
-  for (const root of new Set([env.NVM_DIR, path.join(managerHome, ".nvm")])) {
+  const managerHome = homeDir;
+  for (const candidate of new Set([env.NVM_DIR, managerHome && path.join(managerHome, ".nvm")])) {
+    const root = resolveRecoveryPath(candidate, managerHome);
     if (root) {
       yield [resolveNvmDefault(root), "nvm default"];
     }
   }
-  for (const root of new Set([
+  for (const candidate of new Set([
     env.FNM_DIR,
-    path.join(managerHome, ".fnm"),
-    path.join(managerHome, ".local", "share", "fnm"),
-    ...(process.platform === "darwin"
+    managerHome && path.join(managerHome, ".fnm"),
+    managerHome && path.join(managerHome, ".local", "share", "fnm"),
+    ...(process.platform === "darwin" && managerHome
       ? [path.join(managerHome, "Library", "Application Support", "fnm")]
       : []),
   ])) {
+    const root = resolveRecoveryPath(candidate, managerHome);
     if (root) {
       yield [
         path.join(
@@ -539,7 +608,11 @@ function* availableNodeCandidates(homeDir, env) {
       ];
     }
   }
-  for (const root of new Set([env.VOLTA_HOME, path.join(managerHome, ".volta")])) {
+  for (const candidate of new Set([
+    env.VOLTA_HOME,
+    managerHome && path.join(managerHome, ".volta"),
+  ])) {
+    const root = resolveRecoveryPath(candidate, managerHome);
     if (!root) {
       continue;
     }
@@ -590,28 +663,39 @@ export async function recoverNodeRuntime({
     return false;
   }
   // userInfo reads the account home without consulting the mutable process environment.
-  const osHome = env.HOME?.trim() || env.USERPROFILE?.trim() || os.userInfo().homedir;
-  const configuredHome = env.OPENCLAW_HOME?.trim() || osHome;
-  const recoveryHome =
-    homeDir ?? path.resolve(configuredHome.replace(/^~(?=$|[\\/])/, () => osHome));
+  const inheritedHome = env.HOME?.trim() || env.USERPROFILE?.trim();
+  let accountHome;
+  if (!inheritedHome || /^~(?=$|[\\/])/.test(inheritedHome)) {
+    try {
+      accountHome = os.userInfo().homedir;
+    } catch {
+      // Containers may have no account record; independent PATH discovery still works.
+    }
+  }
+  const osHome = resolveRecoveryPath(inheritedHome || accountHome, accountHome, {
+    allowMissing: true,
+  });
+  const recoveryHome = resolveRecoveryPath(
+    homeDir ?? (env.OPENCLAW_HOME?.trim() || osHome),
+    osHome,
+    { allowMissing: true },
+  );
   const { resolveUpdatedNodeRuntime } = await import("./node-runtime-update.mjs");
-  let nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false, env });
+  let nodePath = recoveryHome
+    ? await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false, env })
+    : null;
   let reason = "cached OpenClaw runtime";
   const currentNode = realNodePath(process.execPath);
   if (!nodePath) {
     const seen = new Set([currentNode]);
-    for (const [candidate, source] of availableNodeCandidates(recoveryHome, env)) {
-      if (!candidate || !path.isAbsolute(candidate)) {
-        continue;
-      }
-      const realPath = realNodePath(candidate);
-      if (!realPath || !path.isAbsolute(realPath) || seen.has(realPath)) {
-        continue;
-      }
+    for (const [candidate, source] of availableNodeCandidates(osHome, env)) {
       // Only an explicitly named PATH directory may opt into cwd executables.
-      const allowCwd =
-        source === "PATH" && realNodePath(path.dirname(candidate)) === path.dirname(realPath);
-      if (!allowCwd && (isCwdNode(candidate) || isCwdNode(realPath))) {
+      const target = source === "PATH" ? realNodePath(candidate) : null;
+      const allowCwd = Boolean(
+        target && realNodePath(path.dirname(candidate)) === path.dirname(target),
+      );
+      const realPath = resolveRecoveryPath(candidate, undefined, { allowCwd });
+      if (!realPath || seen.has(realPath)) {
         continue;
       }
       seen.add(realPath);
@@ -622,7 +706,7 @@ export async function recoverNodeRuntime({
       }
     }
   }
-  if (!nodePath && allowInstall) {
+  if (!nodePath && allowInstall && recoveryHome) {
     nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { env });
     reason = "private OpenClaw runtime";
   }

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -311,8 +311,8 @@ function realNodePath(filename) {
   }
 }
 
-function isCwdPath(nodePath, cwd) {
-  const relative = path.relative(cwd, nodePath);
+function isPathWithin(filename, directory) {
+  const relative = path.relative(directory, filename);
   return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 }
 
@@ -320,7 +320,7 @@ function isCwdPath(nodePath, cwd) {
 export function resolveRecoveryPath(
   value,
   homeDir,
-  { allowMissing = false, allowCwd = false } = {},
+  { allowMissing = false, allowCwd = false, trustedRoot } = {},
 ) {
   const expanded = value?.trim().replace(/^~(?=$|[\\/])/, () => homeDir ?? "~");
   if (!expanded || !path.isAbsolute(expanded)) {
@@ -329,14 +329,23 @@ export function resolveRecoveryPath(
   const paths = /^(?:[a-zA-Z]:[\\/]|\\\\)/.test(expanded) ? path.win32 : path;
   const absolute = paths.resolve(expanded);
   const cwd = realNodePath(process.cwd()) ?? process.cwd();
-  if (!allowCwd && isCwdPath(absolute, cwd)) {
+  // OpenClaw owns this private recovery root even when the user launches from HOME.
+  // Only private recovery passes it; symlinks into cwd outside it remain excluded.
+  const trusted =
+    trustedRoot && path.isAbsolute(trustedRoot) && isPathWithin(absolute, trustedRoot);
+  const excluded = (filename) =>
+    !allowCwd && isPathWithin(filename, cwd) && !(trusted && isPathWithin(filename, trustedRoot));
+  if (excluded(absolute)) {
     return null;
   }
   if (!allowCwd) {
     // A final symlink can hide a workspace-owned intermediate directory.
     for (let prefix = paths.dirname(absolute); ;) {
+      if (trusted && !isPathWithin(prefix, trustedRoot)) {
+        break;
+      }
       const real = realNodePath(prefix);
-      if (real && isCwdPath(real, cwd)) {
+      if (real && excluded(real)) {
         return null;
       }
       const parent = paths.dirname(prefix);
@@ -352,7 +361,7 @@ export function resolveRecoveryPath(
     const real = realNodePath(existing);
     if (real) {
       const resolved = paths.resolve(real, ...missing);
-      return path.isAbsolute(resolved) && (allowCwd || !isCwdPath(resolved, cwd)) ? resolved : null;
+      return path.isAbsolute(resolved) && !excluded(resolved) ? resolved : null;
     }
     if (!allowMissing) {
       return null;
@@ -376,8 +385,8 @@ export function resolveRecoveryPath(
 }
 
 // Do not pass preload hooks, native-library overrides, or application secrets to probes.
-export function isUsableNode(nodePath, { allowCwd = false, env = process.env } = {}) {
-  const resolved = resolveRecoveryPath(nodePath, undefined, { allowCwd });
+export function isUsableNode(nodePath, { allowCwd = false, trustedRoot, env = process.env } = {}) {
+  const resolved = resolveRecoveryPath(nodePath, undefined, { allowCwd, trustedRoot });
   if (!resolved || !/^node(?:\.exe)?$/i.test(path.basename(resolved))) {
     return false;
   }
@@ -674,15 +683,23 @@ export async function recoverNodeRuntime({
   }
   const osHome = resolveRecoveryPath(inheritedHome || accountHome, accountHome, {
     allowMissing: true,
+    allowCwd: true,
   });
   const recoveryHome = resolveRecoveryPath(
     homeDir ?? (env.OPENCLAW_HOME?.trim() || osHome),
     osHome,
-    { allowMissing: true },
+    { allowMissing: true, allowCwd: true },
   );
+  const recoveryPath = recoveryHome && path.join(recoveryHome, ".openclaw");
+  const recoveryRoot =
+    recoveryPath &&
+    resolveRecoveryPath(recoveryPath, undefined, {
+      allowMissing: true,
+      trustedRoot: recoveryPath,
+    });
   const { resolveUpdatedNodeRuntime } = await import("./node-runtime-update.mjs");
-  let nodePath = recoveryHome
-    ? await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false, env })
+  let nodePath = recoveryRoot
+    ? await resolveUpdatedNodeRuntime(recoveryRoot, { allowInstall: false, env })
     : null;
   let reason = "cached OpenClaw runtime";
   const currentNode = realNodePath(process.execPath);
@@ -706,8 +723,8 @@ export async function recoverNodeRuntime({
       }
     }
   }
-  if (!nodePath && allowInstall && recoveryHome) {
-    nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { env });
+  if (!nodePath && allowInstall && recoveryRoot) {
+    nodePath = await resolveUpdatedNodeRuntime(recoveryRoot, { env });
     reason = "private OpenClaw runtime";
   }
   if (!nodePath) {

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -1,0 +1,468 @@
+// Startup-only recovery; this module cannot depend on dist or installed packages.
+import { spawn, spawnSync } from "node:child_process";
+import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  detectCurrentSqliteCapabilities,
+  nodeRuntimeFailure,
+  SQLITE_CAPABILITY_PROBE,
+} from "./node-sqlite.mjs";
+
+const LAUNCHER_ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
+const LAUNCHER_ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level", "--container"]);
+export const isNativeHookRelayInvocation = (argv) => argv[2] === "hooks" && argv[3] === "relay";
+
+const isLauncherRootOptionValueToken = (arg) => {
+  if (!arg || arg === "--") {
+    return false;
+  }
+  if (!arg.startsWith("-")) {
+    return true;
+  }
+  return /^-\d+(?:\.\d+)?$/.test(arg);
+};
+
+export const consumeLauncherRootOptionToken = (args, index) => {
+  const arg = args[index];
+  if (!arg) {
+    return 0;
+  }
+  if (LAUNCHER_ROOT_BOOLEAN_FLAGS.has(arg)) {
+    return 1;
+  }
+  if (
+    arg.startsWith("--profile=") ||
+    arg.startsWith("--log-level=") ||
+    arg.startsWith("--container=")
+  ) {
+    return 1;
+  }
+  if (LAUNCHER_ROOT_VALUE_FLAGS.has(arg)) {
+    return isLauncherRootOptionValueToken(args[index + 1]) ? 2 : 1;
+  }
+  return 0;
+};
+
+// Mirror the entry's foreground Gmail policy before any built modules can load.
+// A compile-cache wrapper would kill its owner before descendant cleanup finishes.
+export const isForegroundGmailRunInvocation = (argv) => {
+  const args = argv.slice(2);
+  const commandPath = [];
+  for (let index = 0; index < args.length && commandPath.length < 3; index += 1) {
+    const consumed = consumeLauncherRootOptionToken(args, index);
+    if (consumed > 0) {
+      index += consumed - 1;
+    } else if (!args[index] || args[index].startsWith("-")) {
+      break;
+    } else {
+      commandPath.push(args[index]);
+    }
+  }
+  return commandPath.join(" ") === "webhooks gmail run";
+};
+
+const respawnSignals =
+  process.platform === "win32"
+    ? ["SIGTERM", "SIGINT", "SIGBREAK"]
+    : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
+const respawnSignalExitGraceMs = 1_000;
+const respawnSignalForceKillGraceMs = 1_000;
+const respawnSignalHardExitGraceMs = 1_000;
+
+export const runRespawnedChild = (command, args, env) => {
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    env,
+  });
+  const listeners = new Map();
+  // This intentionally overlaps with src/entry.compile-cache.ts; keep the
+  // respawn supervision behavior in sync until the launcher can share TS code.
+  // Give the child a moment to honor forwarded signals, then exit the wrapper so
+  // a child that ignores SIGTERM cannot keep the launcher alive indefinitely.
+  let signalExitTimer = null;
+  let signalForceKillTimer = null;
+  let signalHardExitTimer = null;
+  let firstForwardedSignal = null;
+  let hardKillBackstopStarted = false;
+  const detach = () => {
+    for (const [signal, listener] of listeners) {
+      process.off(signal, listener);
+    }
+    listeners.clear();
+    if (signalExitTimer) {
+      clearTimeout(signalExitTimer);
+      signalExitTimer = null;
+    }
+    if (signalForceKillTimer) {
+      clearTimeout(signalForceKillTimer);
+      signalForceKillTimer = null;
+    }
+    if (signalHardExitTimer) {
+      clearTimeout(signalHardExitTimer);
+      signalHardExitTimer = null;
+    }
+  };
+  const forceKillChild = () => {
+    try {
+      child.kill(process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+    } catch {
+      // Best-effort shutdown fallback.
+    }
+  };
+  const requestChildTermination = () => {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Best-effort shutdown fallback.
+    }
+    signalForceKillTimer = setTimeout(() => {
+      hardKillBackstopStarted = true;
+      forceKillChild();
+      signalHardExitTimer = setTimeout(() => {
+        process.exit(1);
+      }, respawnSignalHardExitGraceMs);
+      signalHardExitTimer.unref?.();
+    }, respawnSignalForceKillGraceMs);
+    signalForceKillTimer.unref?.();
+  };
+  const scheduleParentExit = (signal) => {
+    firstForwardedSignal ??= signal;
+    if (signalExitTimer) {
+      return;
+    }
+    signalExitTimer = setTimeout(() => {
+      requestChildTermination();
+    }, respawnSignalExitGraceMs);
+    signalExitTimer.unref?.();
+  };
+  for (const signal of respawnSignals) {
+    const listener = () => {
+      try {
+        child.kill(signal);
+      } catch {
+        // Best-effort signal forwarding.
+      }
+      scheduleParentExit(signal);
+    };
+    try {
+      process.on(signal, listener);
+      listeners.set(signal, listener);
+    } catch {
+      // Unsupported signal on this platform.
+    }
+  }
+  child.once("exit", (code, signal) => {
+    detach();
+    if (signal) {
+      const forwardedSignalExitCode =
+        !hardKillBackstopStarted && signal === firstForwardedSignal
+          ? signal === "SIGINT"
+            ? 130
+            : signal === "SIGTERM"
+              ? 143
+              : undefined
+          : undefined;
+      process.exit(forwardedSignalExitCode ?? 1);
+    }
+    process.exit(code ?? 1);
+  });
+  child.once("error", (error) => {
+    detach();
+    process.stderr.write(
+      `[openclaw] Failed to respawn launcher: ${
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      }\n`,
+    );
+    process.exit(1);
+  });
+  return true;
+};
+
+function readSmallFile(filename) {
+  try {
+    const info = statSync(filename);
+    return info.isFile() && info.size <= 65_536 ? readFileSync(filename, "utf8") : null;
+  } catch {
+    return null;
+  }
+}
+
+function realNodePath(filename) {
+  try {
+    return realpathSync(filename);
+  } catch {
+    return null;
+  }
+}
+
+// Do not pass preload hooks, native-library overrides, or application secrets to probes.
+export function isUsableNode(nodePath) {
+  if (!realNodePath(nodePath)) {
+    return false;
+  }
+  const env = { NODE_NO_WARNINGS: "1" };
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^(SystemRoot|WINDIR|TEMP|TMP|TMPDIR)$/i.test(key)) {
+      env[key] = value;
+    }
+  }
+  const result = spawnSync(
+    nodePath,
+    [
+      "-e",
+      `const probe = ${SQLITE_CAPABILITY_PROBE}; process.stdout.write(JSON.stringify({ version: process.versions.node, probe }));`,
+    ],
+    {
+      encoding: "utf8",
+      env,
+      timeout: 5_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 65_536,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  try {
+    const details = JSON.parse(result.stdout);
+    return result.status === 0 && !nodeRuntimeFailure(details.version, details.probe);
+  } catch {
+    return false;
+  }
+}
+
+function managedServiceNode(homeDir) {
+  const env = process.env;
+  let profile = env.OPENCLAW_PROFILE?.trim();
+  const args = process.argv.slice(2);
+  for (let index = 0; index < args.length;) {
+    const consumed = consumeLauncherRootOptionToken(args, index);
+    if (!consumed) {
+      break;
+    }
+    if (args[index] === "--dev") {
+      profile = "dev";
+    } else if (args[index] === "--profile") {
+      profile = args[index + 1];
+    } else if (args[index].startsWith("--profile=")) {
+      profile = args[index].slice("--profile=".length);
+    }
+    index += consumed;
+  }
+  const suffix = profile && profile.toLowerCase() !== "default" ? profile : "";
+  const serviceHome = env.HOME?.trim() || env.USERPROFILE?.trim() || homeDir;
+  let command;
+  if (process.platform === "darwin") {
+    const label = env.OPENCLAW_LAUNCHD_LABEL?.trim() || `ai.openclaw.${suffix || "gateway"}`;
+    if (!/^[A-Za-z0-9._-]+$/.test(label)) {
+      return null;
+    }
+    const text = readSmallFile(path.join(serviceHome, "Library", "LaunchAgents", `${label}.plist`));
+    const array = text?.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/)?.[1];
+    const recordedArgs = [...(array || "").matchAll(/<string>([^<]*)<\/string>/g)].map(
+      ([, value]) =>
+        value.replace(
+          /&(amp|lt|gt|quot|apos);/g,
+          (_, name) => ({ amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" })[name],
+        ),
+    );
+    const wrapperIndex = recordedArgs[0] === "/bin/sh" ? 1 : 0;
+    const generatedWrapper =
+      recordedArgs[wrapperIndex]?.endsWith(`${label}-env-wrapper.sh`) &&
+      recordedArgs[wrapperIndex + 1]?.endsWith(`${label}.env`);
+    command = recordedArgs[generatedWrapper ? wrapperIndex + 2 : 0];
+  } else if (process.platform === "linux") {
+    const name =
+      env.OPENCLAW_SYSTEMD_UNIT?.trim() || `openclaw-gateway${suffix ? `-${suffix}` : ""}`;
+    if (!/^[A-Za-z0-9._@-]+$/.test(name)) {
+      return null;
+    }
+    const filename = name.endsWith(".service") ? name : `${name}.service`;
+    const text = readSmallFile(path.join(serviceHome, ".config", "systemd", "user", filename));
+    const service = text?.split(/^\s*\[Service\]\s*$/m)[1]?.split(/^\s*\[/m)[0];
+    const executable = service?.match(/^\s*ExecStart=\s*(?:"((?:[^"\\]|\\.)*)"|(\S+))/m);
+    command = (executable?.[1] ?? executable?.[2])?.replace(/\\(.)/g, "$1");
+  } else if (process.platform === "win32") {
+    const scriptName = env.OPENCLAW_TASK_SCRIPT_NAME?.trim() || "gateway.cmd";
+    if (/[/\\]|\.\./.test(scriptName)) {
+      return null;
+    }
+    const stateDir =
+      env.OPENCLAW_STATE_DIR?.trim() ||
+      path.join(serviceHome, `.openclaw${suffix ? `-${suffix}` : ""}`);
+    const filename = env.OPENCLAW_TASK_SCRIPT?.trim() || path.join(stateDir, scriptName);
+    const text = readSmallFile(filename);
+    command = text?.match(/^\s*@?"([^"]*\\node\.exe)"(?:\s|$)/im)?.[1];
+  }
+  // Service definitions are data. Never execute a shell, service wrapper, or manager shim.
+  return command && path.isAbsolute(command) && /^node(?:\.exe)?$/i.test(path.basename(command))
+    ? command
+    : null;
+}
+
+function directoryNames(directory) {
+  try {
+    return readdirSync(directory).toSorted().slice(0, 256);
+  } catch {
+    return [];
+  }
+}
+
+function resolveNvmDefault(root) {
+  let alias = readSmallFile(path.join(root, "alias", "default"))?.trim();
+  for (let depth = 0; alias && depth < 8; depth += 1) {
+    if (/^v?\d+(?:\.\d+){0,2}$/.test(alias) || ["node", "stable"].includes(alias)) {
+      const prefix = alias.replace(/^v/, "");
+      const version = directoryNames(path.join(root, "versions", "node"))
+        .filter((name) => /^v\d+\.\d+\.\d+$/.test(name))
+        .filter(
+          (name) =>
+            ["node", "stable"].includes(alias) ||
+            name === `v${prefix}` ||
+            name.startsWith(`v${prefix}.`),
+        )
+        .toSorted((a, b) => b.localeCompare(a, "en", { numeric: true }))[0];
+      return version ? path.join(root, "versions", "node", version, "bin", "node") : null;
+    }
+    if (alias === "lts/*") {
+      const versions = directoryNames(path.join(root, "alias", "lts"))
+        .map((name) => readSmallFile(path.join(root, "alias", "lts", name))?.trim())
+        .filter((value) => value && /^v?\d+\.\d+\.\d+$/.test(value))
+        .toSorted((a, b) => b.localeCompare(a, "en", { numeric: true }));
+      alias = versions[0];
+    } else if (/^(?:lts\/)?[A-Za-z0-9_-]+$/.test(alias)) {
+      alias = readSmallFile(path.join(root, "alias", alias))?.trim();
+    } else {
+      return null;
+    }
+  }
+  return null;
+}
+
+function* availableNodeCandidates(homeDir) {
+  yield [managedServiceNode(homeDir), "managed Gateway service"];
+  const pathKey =
+    process.platform === "win32"
+      ? Object.keys(process.env).find((key) => key.toUpperCase() === "PATH") || "PATH"
+      : "PATH";
+  const binary = process.platform === "win32" ? "node.exe" : "node";
+  for (const directory of (process.env[pathKey] || "").split(path.delimiter)) {
+    if (directory) {
+      yield [path.resolve(directory, binary), "PATH"];
+    }
+  }
+  const managerHome = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || homeDir;
+  for (const root of new Set([process.env.NVM_DIR, path.join(managerHome, ".nvm")])) {
+    if (root) {
+      yield [resolveNvmDefault(root), "nvm default"];
+    }
+  }
+  for (const root of new Set([
+    process.env.FNM_DIR,
+    path.join(managerHome, ".fnm"),
+    path.join(managerHome, ".local", "share", "fnm"),
+    ...(process.platform === "darwin"
+      ? [path.join(managerHome, "Library", "Application Support", "fnm")]
+      : []),
+  ])) {
+    if (root) {
+      yield [
+        path.join(
+          root,
+          "aliases",
+          "default",
+          ...(process.platform === "win32" ? [] : ["bin"]),
+          binary,
+        ),
+        "fnm default",
+      ];
+    }
+  }
+  for (const root of new Set([process.env.VOLTA_HOME, path.join(managerHome, ".volta")])) {
+    if (!root) {
+      continue;
+    }
+    try {
+      const version = JSON.parse(readSmallFile(path.join(root, "tools", "user", "platform.json")))
+        ?.node?.runtime;
+      if (typeof version === "string" && /^\d+\.\d+\.\d+$/.test(version)) {
+        yield [
+          path.join(
+            root,
+            "tools",
+            "image",
+            "node",
+            version,
+            ...(process.platform === "win32" ? [] : ["bin"]),
+            binary,
+          ),
+          "Volta default",
+        ];
+      }
+    } catch {
+      // Missing or incomplete manager metadata does not select a runtime.
+    }
+  }
+  for (const major of [26, 24]) {
+    for (const prefix of ["/opt/homebrew", "/usr/local"]) {
+      if (process.platform === "darwin" || process.platform === "linux") {
+        yield [path.join(prefix, "opt", `node@${major}`, "bin", "node"), `Homebrew node@${major}`];
+      }
+    }
+  }
+}
+
+/** Recover only at CLI startup, before reading config or state. */
+export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {}) {
+  if (
+    process.versions.bun ||
+    process.env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1" ||
+    !process.argv[1] ||
+    isForegroundGmailRunInvocation(process.argv) ||
+    (process.platform !== "win32" && isNativeHookRelayInvocation(process.argv)) ||
+    !nodeRuntimeFailure(process.versions.node, detectCurrentSqliteCapabilities())
+  ) {
+    return false;
+  }
+  const osHome = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || os.homedir();
+  const configuredHome = process.env.OPENCLAW_HOME?.trim() || osHome;
+  const recoveryHome =
+    homeDir ?? path.resolve(configuredHome.replace(/^~(?=$|[\\/])/, () => osHome));
+  const { resolveUpdatedNodeRuntime } = await import("./node-runtime-update.mjs");
+  let nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false });
+  let reason = "cached OpenClaw runtime";
+  const currentNode = realNodePath(process.execPath);
+  if (!nodePath) {
+    const seen = new Set([currentNode]);
+    for (const [candidate, source] of availableNodeCandidates(recoveryHome)) {
+      const realPath = candidate && realNodePath(candidate);
+      if (!realPath || seen.has(realPath)) {
+        continue;
+      }
+      seen.add(realPath);
+      if (isUsableNode(realPath)) {
+        nodePath = realPath;
+        reason = source;
+        break;
+      }
+    }
+  }
+  if (!nodePath && allowInstall) {
+    nodePath = await resolveUpdatedNodeRuntime(recoveryHome);
+    reason = "private OpenClaw runtime";
+  }
+  if (!nodePath) {
+    return false;
+  }
+  const env = { ...process.env, OPENCLAW_NODE_UPDATE_RESPAWNED: "1" };
+  process.stderr.write(
+    `openclaw: Retrying with ${JSON.stringify(nodePath)} (${reason}; current Node failed runtime admission).\n`,
+  );
+  runRespawnedChild(
+    nodePath,
+    [...process.execArgv, process.argv[1], ...process.argv.slice(2)],
+    env,
+  );
+  // The original CLI must not continue while the replacement owns the invocation.
+  return await new Promise(() => {});
+}

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -179,13 +179,124 @@ export const runRespawnedChild = (command, args, env) => {
   return true;
 };
 
-function readSmallFile(filename) {
+function readSmallFile(filename, encoding = "utf8") {
   try {
     const info = statSync(filename);
-    return info.isFile() && info.size <= 65_536 ? readFileSync(filename, "utf8") : null;
+    return info.isFile() && info.size <= 65_536 ? readFileSync(filename, encoding) : null;
   } catch {
     return null;
   }
+}
+
+// Numeric mappings are owned by src/infra/windows-encoding.ts; use WHATWG
+// labels here, plus the Windows UTF/ISO page IDs, without loading that graph.
+// Skip CP850 (no ICU decoder) and CP949 (ICU silently corrupts UHC); never guess.
+const WINDOWS_SERVICE_CODEPAGE_LABELS = {
+  437: "cp437",
+  720: "cp720",
+  737: "cp737",
+  775: "cp775",
+  850: "cp850",
+  852: "cp852",
+  855: "cp855",
+  857: "cp857",
+  858: "cp858",
+  860: "cp860",
+  861: "cp861",
+  862: "cp862",
+  863: "cp863",
+  865: "cp865",
+  866: "ibm866",
+  869: "cp869",
+  874: "windows-874",
+  932: "shift_jis",
+  936: "gbk",
+  949: "euc-kr",
+  950: "big5",
+  1200: "utf-16le",
+  1201: "utf-16be",
+  1250: "windows-1250",
+  1251: "windows-1251",
+  1252: "windows-1252",
+  1253: "windows-1253",
+  1254: "windows-1254",
+  1255: "windows-1255",
+  1256: "windows-1256",
+  1257: "windows-1257",
+  1258: "windows-1258",
+  28591: "iso-8859-1",
+  28592: "iso-8859-2",
+  28593: "iso-8859-3",
+  28594: "iso-8859-4",
+  28595: "iso-8859-5",
+  28596: "iso-8859-6",
+  28597: "iso-8859-7",
+  28598: "iso-8859-8",
+  28599: "iso-8859-9",
+  28600: "iso-8859-10",
+  28603: "iso-8859-13",
+  28604: "iso-8859-14",
+  28605: "iso-8859-15",
+  28606: "iso-8859-16",
+  38598: "iso-8859-8-i",
+  54936: "gb18030",
+  65001: "utf-8",
+};
+
+function readWindowsServiceScript(filename) {
+  let buffer = readSmallFile(filename, null);
+  if (!buffer) {
+    return null;
+  }
+  let codePage = 65001;
+  if (buffer[0] === 0xff && buffer[1] === 0xfe) {
+    codePage = 1200;
+  } else if (buffer[0] === 0xfe && buffer[1] === 0xff) {
+    codePage = 1201;
+  } else {
+    if (buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf) {
+      buffer = buffer.subarray(3);
+    }
+    let end = buffer.indexOf(0x0a);
+    const preamble = /^@chcp (\d+) >nul\s*$/.exec(
+      buffer.subarray(0, end < 0 ? buffer.length : end).toString("latin1"),
+    );
+    if (preamble) {
+      codePage = Number(preamble[1]);
+      buffer = buffer.subarray(end < 0 ? buffer.length : end + 1);
+      end = buffer.indexOf(0x0a);
+    }
+    const marker = /^@rem openclaw-launcher-encoding=(\S+)\s*$/.exec(
+      buffer.subarray(0, end < 0 ? buffer.length : end).toString("latin1"),
+    );
+    if (marker) {
+      if (!preamble) {
+        const label = marker[1].toLowerCase();
+        const numeric = /^cp(\d+)$/.exec(label);
+        codePage = numeric
+          ? Number(numeric[1])
+          : Number(
+              Object.entries(WINDOWS_SERVICE_CODEPAGE_LABELS).find(
+                ([, value]) => value === label,
+              )?.[0],
+            );
+      }
+      buffer = buffer.subarray(end < 0 ? buffer.length : end + 1);
+    }
+  }
+  const label = WINDOWS_SERVICE_CODEPAGE_LABELS[codePage];
+  try {
+    if (label && codePage !== 850 && codePage !== 949) {
+      const decoder = new TextDecoder(label, { fatal: true });
+      return decoder.decode(buffer);
+    }
+  } catch {
+    // A missing decoder or invalid byte sequence must not select a guessed path.
+  }
+  process.stderr.write(
+    `openclaw: service script uses code page ${Number.isFinite(codePage) ? codePage : "unknown"}; not decodable here\n`,
+  );
+  return null;
 }
 
 function realNodePath(filename) {
@@ -196,9 +307,26 @@ function realNodePath(filename) {
   }
 }
 
+function isCwdNode(nodePath) {
+  const cwd = realNodePath(process.cwd()) ?? process.cwd();
+  const relative = path.relative(cwd, nodePath);
+  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
 // Do not pass preload hooks, native-library overrides, or application secrets to probes.
-export function isUsableNode(nodePath) {
-  if (!realNodePath(nodePath)) {
+export function isUsableNode(nodePath, { allowCwd = false } = {}) {
+  if (!path.isAbsolute(nodePath)) {
+    return false;
+  }
+  const resolved = realNodePath(nodePath);
+  if (
+    !resolved ||
+    !path.isAbsolute(resolved) ||
+    !/^node(?:\.exe)?$/i.test(path.basename(resolved))
+  ) {
+    return false;
+  }
+  if (!allowCwd && isCwdNode(resolved)) {
     return false;
   }
   const env = { NODE_NO_WARNINGS: "1" };
@@ -208,7 +336,7 @@ export function isUsableNode(nodePath) {
     }
   }
   const result = spawnSync(
-    nodePath,
+    resolved,
     [
       "-e",
       `const probe = ${SQLITE_CAPABILITY_PROBE}; process.stdout.write(JSON.stringify({ version: process.versions.node, probe }));`,
@@ -229,6 +357,37 @@ export function isUsableNode(nodePath) {
   } catch {
     return false;
   }
+}
+
+function windowsServiceNode(text) {
+  for (const line of text.split(/\r?\n/)) {
+    const command = line.trimStart().replace(/^@/, "");
+    let executable = "";
+    let quoted = false;
+    // Mirror quoteCmdScriptArg: other Windows path backslashes stay literal.
+    for (let index = 0; index < command.length; index += 1) {
+      const char = command[index];
+      if (char === "\\" && command[index + 1] === '"') {
+        executable += '"';
+        index += 1;
+      } else if (char === '"') {
+        quoted = !quoted;
+      } else if (/\s/.test(char) && !quoted) {
+        break;
+      } else {
+        executable += char;
+      }
+    }
+    executable = executable.replace(/\^!/g, "!").replace(/%%/g, "%");
+    if (
+      !quoted &&
+      path.win32.isAbsolute(executable) &&
+      /^node\.exe$/i.test(path.win32.basename(executable))
+    ) {
+      return executable;
+    }
+  }
+  return null;
 }
 
 function managedServiceNode(homeDir) {
@@ -291,8 +450,8 @@ function managedServiceNode(homeDir) {
       env.OPENCLAW_STATE_DIR?.trim() ||
       path.join(serviceHome, `.openclaw${suffix ? `-${suffix}` : ""}`);
     const filename = env.OPENCLAW_TASK_SCRIPT?.trim() || path.join(stateDir, scriptName);
-    const text = readSmallFile(filename);
-    command = text?.match(/^\s*@?"([^"]*\\node\.exe)"(?:\s|$)/im)?.[1];
+    const text = readWindowsServiceScript(filename);
+    command = text && windowsServiceNode(text);
   }
   // Service definitions are data. Never execute a shell, service wrapper, or manager shim.
   return command && path.isAbsolute(command) && /^node(?:\.exe)?$/i.test(path.basename(command))
@@ -347,8 +506,8 @@ function* availableNodeCandidates(homeDir) {
       : "PATH";
   const binary = process.platform === "win32" ? "node.exe" : "node";
   for (const directory of (process.env[pathKey] || "").split(path.delimiter)) {
-    if (directory) {
-      yield [path.resolve(directory, binary), "PATH"];
+    if (path.isAbsolute(directory)) {
+      yield [path.join(directory, binary), "PATH"];
     }
   }
   const managerHome = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || homeDir;
@@ -435,12 +594,21 @@ export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {})
   if (!nodePath) {
     const seen = new Set([currentNode]);
     for (const [candidate, source] of availableNodeCandidates(recoveryHome)) {
-      const realPath = candidate && realNodePath(candidate);
-      if (!realPath || seen.has(realPath)) {
+      if (!candidate || !path.isAbsolute(candidate)) {
+        continue;
+      }
+      const realPath = realNodePath(candidate);
+      if (!realPath || !path.isAbsolute(realPath) || seen.has(realPath)) {
+        continue;
+      }
+      // Only an explicitly named PATH directory may opt into cwd executables.
+      const allowCwd =
+        source === "PATH" && realNodePath(path.dirname(candidate)) === path.dirname(realPath);
+      if (!allowCwd && isCwdNode(realPath)) {
         continue;
       }
       seen.add(realPath);
-      if (isUsableNode(realPath)) {
+      if (isUsableNode(realPath, { allowCwd })) {
         nodePath = realPath;
         reason = source;
         break;

--- a/node-runtime-recovery.mjs
+++ b/node-runtime-recovery.mjs
@@ -314,7 +314,7 @@ function isCwdNode(nodePath) {
 }
 
 // Do not pass preload hooks, native-library overrides, or application secrets to probes.
-export function isUsableNode(nodePath, { allowCwd = false } = {}) {
+export function isUsableNode(nodePath, { allowCwd = false, env = process.env } = {}) {
   if (!path.isAbsolute(nodePath)) {
     return false;
   }
@@ -329,10 +329,10 @@ export function isUsableNode(nodePath, { allowCwd = false } = {}) {
   if (!allowCwd && (isCwdNode(nodePath) || isCwdNode(resolved))) {
     return false;
   }
-  const env = { NODE_NO_WARNINGS: "1" };
-  for (const [key, value] of Object.entries(process.env)) {
+  const probeEnv = { NODE_NO_WARNINGS: "1" };
+  for (const [key, value] of Object.entries(env)) {
     if (/^(SystemRoot|WINDIR|TEMP|TMP|TMPDIR)$/i.test(key)) {
-      env[key] = value;
+      probeEnv[key] = value;
     }
   }
   const result = spawnSync(
@@ -343,7 +343,7 @@ export function isUsableNode(nodePath, { allowCwd = false } = {}) {
     ],
     {
       encoding: "utf8",
-      env,
+      env: probeEnv,
       timeout: 5_000,
       killSignal: "SIGKILL",
       maxBuffer: 65_536,
@@ -390,8 +390,7 @@ function windowsServiceNode(text) {
   return null;
 }
 
-function managedServiceNode(homeDir) {
-  const env = process.env;
+function managedServiceNode(homeDir, env) {
   let profile = env.OPENCLAW_PROFILE?.trim();
   const args = process.argv.slice(2);
   for (let index = 0; index < args.length;) {
@@ -498,29 +497,29 @@ function resolveNvmDefault(root) {
   return null;
 }
 
-// Absolute roots from PATH and manager env vars are user configuration and trusted
-// like PATH; anything relative or under cwd is never probed. The explicit absolute
-// PATH directory opt-in below retains its cwd exception.
-function* availableNodeCandidates(homeDir) {
-  yield [managedServiceNode(homeDir), "managed Gateway service"];
+// Only inherited environment roots are trusted like PATH; dotenv values must never
+// select an executable. Relative/cwd candidates remain excluded except when an
+// inherited absolute PATH directory explicitly opts into cwd.
+function* availableNodeCandidates(homeDir, env) {
+  yield [managedServiceNode(homeDir, env), "managed Gateway service"];
   const pathKey =
     process.platform === "win32"
-      ? Object.keys(process.env).find((key) => key.toUpperCase() === "PATH") || "PATH"
+      ? Object.keys(env).find((key) => key.toUpperCase() === "PATH") || "PATH"
       : "PATH";
   const binary = process.platform === "win32" ? "node.exe" : "node";
-  for (const directory of (process.env[pathKey] || "").split(path.delimiter)) {
+  for (const directory of (env[pathKey] || "").split(path.delimiter)) {
     if (path.isAbsolute(directory)) {
       yield [path.join(directory, binary), "PATH"];
     }
   }
-  const managerHome = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || homeDir;
-  for (const root of new Set([process.env.NVM_DIR, path.join(managerHome, ".nvm")])) {
+  const managerHome = env.HOME?.trim() || env.USERPROFILE?.trim() || homeDir;
+  for (const root of new Set([env.NVM_DIR, path.join(managerHome, ".nvm")])) {
     if (root) {
       yield [resolveNvmDefault(root), "nvm default"];
     }
   }
   for (const root of new Set([
-    process.env.FNM_DIR,
+    env.FNM_DIR,
     path.join(managerHome, ".fnm"),
     path.join(managerHome, ".local", "share", "fnm"),
     ...(process.platform === "darwin"
@@ -540,7 +539,7 @@ function* availableNodeCandidates(homeDir) {
       ];
     }
   }
-  for (const root of new Set([process.env.VOLTA_HOME, path.join(managerHome, ".volta")])) {
+  for (const root of new Set([env.VOLTA_HOME, path.join(managerHome, ".volta")])) {
     if (!root) {
       continue;
     }
@@ -575,10 +574,14 @@ function* availableNodeCandidates(homeDir) {
 }
 
 /** Recover only at CLI startup, before reading config or state. */
-export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {}) {
+export async function recoverNodeRuntime({
+  homeDir,
+  allowInstall = false,
+  env = process.env,
+} = {}) {
   if (
     process.versions.bun ||
-    process.env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1" ||
+    env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1" ||
     !process.argv[1] ||
     isForegroundGmailRunInvocation(process.argv) ||
     (process.platform !== "win32" && isNativeHookRelayInvocation(process.argv)) ||
@@ -586,17 +589,18 @@ export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {})
   ) {
     return false;
   }
-  const osHome = process.env.HOME?.trim() || process.env.USERPROFILE?.trim() || os.homedir();
-  const configuredHome = process.env.OPENCLAW_HOME?.trim() || osHome;
+  // userInfo reads the account home without consulting the mutable process environment.
+  const osHome = env.HOME?.trim() || env.USERPROFILE?.trim() || os.userInfo().homedir;
+  const configuredHome = env.OPENCLAW_HOME?.trim() || osHome;
   const recoveryHome =
     homeDir ?? path.resolve(configuredHome.replace(/^~(?=$|[\\/])/, () => osHome));
   const { resolveUpdatedNodeRuntime } = await import("./node-runtime-update.mjs");
-  let nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false });
+  let nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { allowInstall: false, env });
   let reason = "cached OpenClaw runtime";
   const currentNode = realNodePath(process.execPath);
   if (!nodePath) {
     const seen = new Set([currentNode]);
-    for (const [candidate, source] of availableNodeCandidates(recoveryHome)) {
+    for (const [candidate, source] of availableNodeCandidates(recoveryHome, env)) {
       if (!candidate || !path.isAbsolute(candidate)) {
         continue;
       }
@@ -611,7 +615,7 @@ export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {})
         continue;
       }
       seen.add(realPath);
-      if (isUsableNode(realPath, { allowCwd })) {
+      if (isUsableNode(realPath, { allowCwd, env })) {
         nodePath = realPath;
         reason = source;
         break;
@@ -619,21 +623,19 @@ export async function recoverNodeRuntime({ homeDir, allowInstall = false } = {})
     }
   }
   if (!nodePath && allowInstall) {
-    nodePath = await resolveUpdatedNodeRuntime(recoveryHome);
+    nodePath = await resolveUpdatedNodeRuntime(recoveryHome, { env });
     reason = "private OpenClaw runtime";
   }
   if (!nodePath) {
     return false;
   }
-  const env = { ...process.env, OPENCLAW_NODE_UPDATE_RESPAWNED: "1" };
   process.stderr.write(
     `openclaw: Retrying with ${JSON.stringify(nodePath)} (${reason}; current Node failed runtime admission).\n`,
   );
-  runRespawnedChild(
-    nodePath,
-    [...process.execArgv, process.argv[1], ...process.argv.slice(2)],
-    env,
-  );
+  runRespawnedChild(nodePath, [...process.execArgv, process.argv[1], ...process.argv.slice(2)], {
+    ...env,
+    OPENCLAW_NODE_UPDATE_RESPAWNED: "1",
+  });
   // The original CLI must not continue while the replacement owns the invocation.
   return await new Promise(() => {});
 }

--- a/node-runtime-update.d.mts
+++ b/node-runtime-update.d.mts
@@ -1,1 +1,4 @@
-export function resolveUpdatedNodeRuntime(homeDir: string): Promise<string | null>;
+export function resolveUpdatedNodeRuntime(
+  homeDir: string,
+  options?: { allowInstall?: boolean },
+): Promise<string | null>;

--- a/node-runtime-update.d.mts
+++ b/node-runtime-update.d.mts
@@ -1,4 +1,4 @@
 export function resolveUpdatedNodeRuntime(
-  homeDir: string,
+  recoveryRoot: string,
   options?: { allowInstall?: boolean; env?: NodeJS.ProcessEnv },
 ): Promise<string | null>;

--- a/node-runtime-update.d.mts
+++ b/node-runtime-update.d.mts
@@ -1,4 +1,4 @@
 export function resolveUpdatedNodeRuntime(
   homeDir: string,
-  options?: { allowInstall?: boolean },
+  options?: { allowInstall?: boolean; env?: NodeJS.ProcessEnv },
 ): Promise<string | null>;

--- a/node-runtime-update.mjs
+++ b/node-runtime-update.mjs
@@ -36,20 +36,20 @@ function confirmNodeUpdate() {
 
 /** Returns a verified private runtime, or null when recovery was declined/unavailable. */
 export async function resolveUpdatedNodeRuntime(
-  homeDir,
+  recoveryRoot,
   { allowInstall = true, env = process.env } = {},
 ) {
   if (env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1") {
     return null;
   }
+  const privatePaths = { allowMissing: true, trustedRoot: recoveryRoot };
   const prefix = resolveRecoveryPath(
-    path.join(homeDir, ".openclaw", "tools", "cli-node"),
-    homeDir,
-    { allowMissing: true },
+    path.join(recoveryRoot, "tools", "cli-node"),
+    undefined,
+    privatePaths,
   );
   const nodeRoot =
-    prefix &&
-    resolveRecoveryPath(path.join(prefix, "tools", "node"), homeDir, { allowMissing: true });
+    prefix && resolveRecoveryPath(path.join(prefix, "tools", "node"), undefined, privatePaths);
   if (!prefix || !nodeRoot) {
     return null;
   }
@@ -59,7 +59,7 @@ export async function resolveUpdatedNodeRuntime(
       : path.join(nodeRoot, "bin", "node");
 
   // An earlier explicit opt-in is durable, but an incompatible cache is never trusted.
-  if (isUsableNode(nodePath, { env })) {
+  if (isUsableNode(nodePath, { env, trustedRoot: recoveryRoot })) {
     return nodePath;
   }
   if (
@@ -104,7 +104,7 @@ export async function resolveUpdatedNodeRuntime(
       ]
     : [installer, "--node-only", "--prefix", prefix];
   const result = spawnSync(command, args, { stdio: "inherit", env });
-  if (result.status !== 0 || !isUsableNode(nodePath, { env })) {
+  if (result.status !== 0 || !isUsableNode(nodePath, { env, trustedRoot: recoveryRoot })) {
     process.stderr.write(
       "openclaw: Node.js update failed; install a compatible Node.js manually.\n",
     );

--- a/node-runtime-update.mjs
+++ b/node-runtime-update.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import { isUsableNode } from "./node-runtime-recovery.mjs";
+import { isUsableNode, resolveRecoveryPath } from "./node-runtime-recovery.mjs";
 
 function canInstallPrivateNode() {
   if (!["x64", "arm64"].includes(process.arch)) {
@@ -42,8 +42,17 @@ export async function resolveUpdatedNodeRuntime(
   if (env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1") {
     return null;
   }
-  const prefix = path.join(homeDir, ".openclaw", "tools", "cli-node");
-  const nodeRoot = path.join(prefix, "tools", "node");
+  const prefix = resolveRecoveryPath(
+    path.join(homeDir, ".openclaw", "tools", "cli-node"),
+    homeDir,
+    { allowMissing: true },
+  );
+  const nodeRoot =
+    prefix &&
+    resolveRecoveryPath(path.join(prefix, "tools", "node"), homeDir, { allowMissing: true });
+  if (!prefix || !nodeRoot) {
+    return null;
+  }
   const nodePath =
     process.platform === "win32"
       ? path.join(nodeRoot, "node.exe")

--- a/node-runtime-update.mjs
+++ b/node-runtime-update.mjs
@@ -35,8 +35,11 @@ function confirmNodeUpdate() {
 }
 
 /** Returns a verified private runtime, or null when recovery was declined/unavailable. */
-export async function resolveUpdatedNodeRuntime(homeDir, { allowInstall = true } = {}) {
-  if (process.env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1") {
+export async function resolveUpdatedNodeRuntime(
+  homeDir,
+  { allowInstall = true, env = process.env } = {},
+) {
+  if (env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1") {
     return null;
   }
   const prefix = path.join(homeDir, ".openclaw", "tools", "cli-node");
@@ -47,14 +50,14 @@ export async function resolveUpdatedNodeRuntime(homeDir, { allowInstall = true }
       : path.join(nodeRoot, "bin", "node");
 
   // An earlier explicit opt-in is durable, but an incompatible cache is never trusted.
-  if (isUsableNode(nodePath)) {
+  if (isUsableNode(nodePath, { env })) {
     return nodePath;
   }
   if (
     !allowInstall ||
     !process.stdin.isTTY ||
     !process.stderr.isTTY ||
-    process.env.CI ||
+    env.CI ||
     process.argv.some((arg) => ["--non-interactive", "--json", "--yes"].includes(arg)) ||
     !canInstallPrivateNode()
   ) {
@@ -74,7 +77,7 @@ export async function resolveUpdatedNodeRuntime(homeDir, { allowInstall = true }
     new URL(windows ? "./scripts/install.ps1" : "./scripts/install-cli.sh", import.meta.url),
   );
   const command = windows
-    ? (await import("./scripts/windows-cmd-helpers.mjs")).resolveWindowsPowerShellPath()
+    ? (await import("./scripts/windows-cmd-helpers.mjs")).resolveWindowsPowerShellPath(env)
     : process.platform === "darwin"
       ? "/bin/bash"
       : "bash";
@@ -91,8 +94,8 @@ export async function resolveUpdatedNodeRuntime(homeDir, { allowInstall = true }
         nodeRoot,
       ]
     : [installer, "--node-only", "--prefix", prefix];
-  const result = spawnSync(command, args, { stdio: "inherit" });
-  if (result.status !== 0 || !isUsableNode(nodePath)) {
+  const result = spawnSync(command, args, { stdio: "inherit", env });
+  if (result.status !== 0 || !isUsableNode(nodePath, { env })) {
     process.stderr.write(
       "openclaw: Node.js update failed; install a compatible Node.js manually.\n",
     );

--- a/node-runtime-update.mjs
+++ b/node-runtime-update.mjs
@@ -1,30 +1,9 @@
 // This module must run on unsupported Node versions, before importing dist or dependencies.
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import { nodeRuntimeFailure, SQLITE_CAPABILITY_PROBE } from "./node-sqlite.mjs";
-
-function isUsableNode(nodePath) {
-  if (!existsSync(nodePath)) {
-    return false;
-  }
-  const result = spawnSync(
-    nodePath,
-    [
-      "-e",
-      `const probe = ${SQLITE_CAPABILITY_PROBE}; process.stdout.write(JSON.stringify({ version: process.versions.node, probe }));`,
-    ],
-    { encoding: "utf8", timeout: 10_000, windowsHide: true },
-  );
-  try {
-    const details = JSON.parse(result.stdout);
-    return result.status === 0 && !nodeRuntimeFailure(details.version, details.probe);
-  } catch {
-    return false;
-  }
-}
+import { isUsableNode } from "./node-runtime-recovery.mjs";
 
 function canInstallPrivateNode() {
   if (!["x64", "arm64"].includes(process.arch)) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -62,7 +62,6 @@ const ensureSupportedRuntimeVersion = async () => {
   const canRunDiagnostics = canRunOpenClawNodeDiagnostics(process.versions.node, probe.available);
   const diagnosticExemption = unsupportedCommand === "diagnostic" && canRunDiagnostics;
   await recoverNodeRuntime({
-    homeDir: resolveLauncherHomeDir(),
     allowInstall: !diagnosticExemption,
   });
   if (!diagnosticExemption) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 
-import { spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { access } from "node:fs/promises";
 import module from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  consumeLauncherRootOptionToken,
+  isForegroundGmailRunInvocation,
+  isNativeHookRelayInvocation,
+  recoverNodeRuntime,
+  runRespawnedChild,
+} from "./node-runtime-recovery.mjs";
 import {
   canRunOpenClawNodeDiagnostics,
   classifyUnsupportedNodeCommand,
@@ -55,31 +61,12 @@ const ensureSupportedRuntimeVersion = async () => {
   const unsupportedCommand = classifyUnsupportedNodeCommand(process.argv);
   const canRunDiagnostics = canRunOpenClawNodeDiagnostics(process.versions.node, probe.available);
   const diagnosticExemption = unsupportedCommand === "diagnostic" && canRunDiagnostics;
+  await recoverNodeRuntime({
+    homeDir: resolveLauncherHomeDir(),
+    allowInstall: !diagnosticExemption,
+  });
   if (!diagnosticExemption) {
     process.stderr.write(`openclaw: ${failure}\n`);
-  }
-  // These invocations have an exact-PID contract and cannot acquire a wrapper process.
-  if (
-    !isForegroundGmailRunInvocation(process.argv) &&
-    !(process.platform !== "win32" && isNativeHookRelayInvocation(process.argv))
-  ) {
-    const { resolveUpdatedNodeRuntime } = await import("./node-runtime-update.mjs");
-    const nodePath = await resolveUpdatedNodeRuntime(resolveLauncherHomeDir(), {
-      allowInstall: !diagnosticExemption,
-    });
-    if (nodePath) {
-      const env = { ...process.env, OPENCLAW_NODE_UPDATE_RESPAWNED: "1" };
-      const pathKey =
-        process.platform === "win32"
-          ? (await import("./scripts/windows-cmd-helpers.mjs")).resolvePathEnvKey(env)
-          : "PATH";
-      env[pathKey] = `${path.dirname(nodePath)}${path.delimiter}${env[pathKey] ?? ""}`;
-      return runRespawnedChild(
-        nodePath,
-        [...process.execArgv, process.argv[1], ...process.argv.slice(2)],
-        env,
-      );
-    }
   }
   if (diagnosticExemption) {
     return false;
@@ -101,7 +88,6 @@ const ensureSupportedRuntimeVersion = async () => {
 const isNodeCompileCacheDisabled = () => process.env.NODE_DISABLE_COMPILE_CACHE !== undefined;
 const isNodeCompileCacheRequested = () =>
   Boolean(process.env.NODE_COMPILE_CACHE) && !isNodeCompileCacheDisabled();
-const isNativeHookRelayInvocation = (argv) => argv[2] === "hooks" && argv[3] === "relay";
 const sanitizeCompileCachePathSegment = (value) => {
   const normalized = value.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
   return normalized.length > 0 ? normalized : "unknown";
@@ -136,123 +122,6 @@ const resolvePackagedCompileCacheDirectory = () => {
     version,
     sanitizeCompileCachePathSegment(installMarker),
   );
-};
-
-const respawnSignals =
-  process.platform === "win32"
-    ? ["SIGTERM", "SIGINT", "SIGBREAK"]
-    : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
-const respawnSignalExitGraceMs = 1_000;
-const respawnSignalForceKillGraceMs = 1_000;
-const respawnSignalHardExitGraceMs = 1_000;
-
-const runRespawnedChild = (command, args, env) => {
-  const child = spawn(command, args, {
-    stdio: "inherit",
-    env,
-  });
-  const listeners = new Map();
-  // This intentionally overlaps with src/entry.compile-cache.ts; keep the
-  // respawn supervision behavior in sync until the launcher can share TS code.
-  // Give the child a moment to honor forwarded signals, then exit the wrapper so
-  // a child that ignores SIGTERM cannot keep the launcher alive indefinitely.
-  let signalExitTimer = null;
-  let signalForceKillTimer = null;
-  let signalHardExitTimer = null;
-  let firstForwardedSignal = null;
-  let hardKillBackstopStarted = false;
-  const detach = () => {
-    for (const [signal, listener] of listeners) {
-      process.off(signal, listener);
-    }
-    listeners.clear();
-    if (signalExitTimer) {
-      clearTimeout(signalExitTimer);
-      signalExitTimer = null;
-    }
-    if (signalForceKillTimer) {
-      clearTimeout(signalForceKillTimer);
-      signalForceKillTimer = null;
-    }
-    if (signalHardExitTimer) {
-      clearTimeout(signalHardExitTimer);
-      signalHardExitTimer = null;
-    }
-  };
-  const forceKillChild = () => {
-    try {
-      child.kill(process.platform === "win32" ? "SIGTERM" : "SIGKILL");
-    } catch {
-      // Best-effort shutdown fallback.
-    }
-  };
-  const requestChildTermination = () => {
-    try {
-      child.kill("SIGTERM");
-    } catch {
-      // Best-effort shutdown fallback.
-    }
-    signalForceKillTimer = setTimeout(() => {
-      hardKillBackstopStarted = true;
-      forceKillChild();
-      signalHardExitTimer = setTimeout(() => {
-        process.exit(1);
-      }, respawnSignalHardExitGraceMs);
-      signalHardExitTimer.unref?.();
-    }, respawnSignalForceKillGraceMs);
-    signalForceKillTimer.unref?.();
-  };
-  const scheduleParentExit = (signal) => {
-    firstForwardedSignal ??= signal;
-    if (signalExitTimer) {
-      return;
-    }
-    signalExitTimer = setTimeout(() => {
-      requestChildTermination();
-    }, respawnSignalExitGraceMs);
-    signalExitTimer.unref?.();
-  };
-  for (const signal of respawnSignals) {
-    const listener = () => {
-      try {
-        child.kill(signal);
-      } catch {
-        // Best-effort signal forwarding.
-      }
-      scheduleParentExit(signal);
-    };
-    try {
-      process.on(signal, listener);
-      listeners.set(signal, listener);
-    } catch {
-      // Unsupported signal on this platform.
-    }
-  }
-  child.once("exit", (code, signal) => {
-    detach();
-    if (signal) {
-      const forwardedSignalExitCode =
-        !hardKillBackstopStarted && signal === firstForwardedSignal
-          ? signal === "SIGINT"
-            ? 130
-            : signal === "SIGTERM"
-              ? 143
-              : undefined
-          : undefined;
-      process.exit(forwardedSignalExitCode ?? 1);
-    }
-    process.exit(code ?? 1);
-  });
-  child.once("error", (error) => {
-    detach();
-    process.stderr.write(
-      `[openclaw] Failed to respawn launcher: ${
-        error instanceof Error ? (error.stack ?? error.message) : String(error)
-      }\n`,
-    );
-    process.exit(1);
-  });
-  return true;
 };
 
 const respawnWithoutCompileCacheIfNeeded = () => {
@@ -402,8 +271,6 @@ const isBareRootHelpInvocation = (argv) =>
   argv.length === 3 && (argv[2] === "--help" || argv[2] === "-h");
 
 const LAUNCHER_HELP_FLAGS = new Set(["-h", "--help"]);
-const LAUNCHER_ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
-const LAUNCHER_ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level", "--container"]);
 const LAUNCHER_PRECOMPUTED_COMMAND_HELP = {
   browser: { command: "browser", metadataKey: "browserHelpText" },
   secrets: { command: "secrets", metadataKey: "secretsHelpText" },
@@ -418,55 +285,6 @@ const LAUNCHER_PRECOMPUTED_SUBCOMMAND_HELP = new Set([
   "sessions",
   "tasks",
 ]);
-
-const isLauncherRootOptionValueToken = (arg) => {
-  if (!arg || arg === "--") {
-    return false;
-  }
-  if (!arg.startsWith("-")) {
-    return true;
-  }
-  return /^-\d+(?:\.\d+)?$/.test(arg);
-};
-
-const consumeLauncherRootOptionToken = (args, index) => {
-  const arg = args[index];
-  if (!arg) {
-    return 0;
-  }
-  if (LAUNCHER_ROOT_BOOLEAN_FLAGS.has(arg)) {
-    return 1;
-  }
-  if (
-    arg.startsWith("--profile=") ||
-    arg.startsWith("--log-level=") ||
-    arg.startsWith("--container=")
-  ) {
-    return 1;
-  }
-  if (LAUNCHER_ROOT_VALUE_FLAGS.has(arg)) {
-    return isLauncherRootOptionValueToken(args[index + 1]) ? 2 : 1;
-  }
-  return 0;
-};
-
-// Mirror the entry's foreground Gmail policy before any built modules can load.
-// A compile-cache wrapper would kill its owner before descendant cleanup finishes.
-const isForegroundGmailRunInvocation = (argv) => {
-  const args = argv.slice(2);
-  const commandPath = [];
-  for (let index = 0; index < args.length && commandPath.length < 3; index += 1) {
-    const consumed = consumeLauncherRootOptionToken(args, index);
-    if (consumed > 0) {
-      index += consumed - 1;
-    } else if (!args[index] || args[index].startsWith("-")) {
-      break;
-    } else {
-      commandPath.push(args[index]);
-    }
-  }
-  return commandPath.join(" ") === "webhooks gmail run";
-};
 
 const hasLauncherContainerTarget = (argv) => {
   if (normalizeLauncherMetadataValue(process.env.OPENCLAW_CONTAINER)) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node-sqlite.mjs",
     "node-version.mjs",
     "node-runtime-update.mjs",
+    "node-runtime-recovery.mjs",
     "openclaw.mjs",
     "pnpm-workspace.yaml",
     "README.md",

--- a/scripts/check-duplicates.mts
+++ b/scripts/check-duplicates.mts
@@ -23,6 +23,7 @@ const targets = [
   "skills",
   "config",
   "node-runtime-update.mjs",
+  "node-runtime-recovery.mjs",
   "node-sqlite.mjs",
   "node-version.mjs",
   "openclaw.mjs",

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -18,6 +18,7 @@ COPY openclaw.mjs ./
 COPY node-version.mjs ./
 COPY node-sqlite.mjs ./
 COPY node-runtime-update.mjs ./
+COPY node-runtime-recovery.mjs ./
 COPY ui/package.json ./ui/package.json
 COPY packages ./packages
 COPY extensions ./extensions

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -964,8 +964,10 @@ export async function runCli(
   options: {
     additionalStartupTrace?: ReturnType<typeof createGatewayDispatchStartupTrace>;
     retainConsoleRoutingUntilProcessExit?: boolean;
+    runtimeRecoveryEnv?: NodeJS.ProcessEnv;
   } = {},
 ) {
+  const runtimeRecoveryEnv = options.runtimeRecoveryEnv ?? { ...process.env };
   const originalArgv = normalizeWindowsArgv(argv);
   const builtInMachineOutput = resolveBuiltInMachineOutput(originalArgv);
   return await withConsoleLogsRoutedToStderrForJson(
@@ -975,6 +977,7 @@ export async function runCli(
         try {
           return await runCliWithPreparedOutputMode(originalArgv, {
             ...options,
+            runtimeRecoveryEnv,
             builtInMachineOutput,
             harnessCleanup,
           });
@@ -1027,6 +1030,7 @@ async function runCliWithPreparedOutputMode(
     additionalStartupTrace?: ReturnType<typeof createGatewayDispatchStartupTrace>;
     builtInMachineOutput: boolean;
     harnessCleanup?: CliHarnessCleanup;
+    runtimeRecoveryEnv: NodeJS.ProcessEnv;
   },
 ) {
   const startupTrace = createGatewayDispatchStartupTrace(originalArgv, "cli.main");
@@ -1111,7 +1115,13 @@ async function runCliWithPreparedOutputMode(
   // Enforce the minimum supported runtime before gateway selection can read or recover config.
   const { assertSupportedRuntime, isCurrentRuntimeSupported } =
     await import("../infra/runtime-guard.js");
-  await assertSupportedRuntime(undefined, undefined, normalizedArgv);
+  await assertSupportedRuntime(
+    undefined,
+    undefined,
+    normalizedArgv,
+    true,
+    options.runtimeRecoveryEnv,
+  );
 
   if (
     !isHelpOrVersionInvocation &&

--- a/src/cli/update-cli/update-command-repair-isolation.test-support.ts
+++ b/src/cli/update-cli/update-command-repair-isolation.test-support.ts
@@ -143,6 +143,7 @@ export async function writeRepairCandidate(candidate: string, configChange: bool
     "node-version.mjs",
     "node-sqlite.mjs",
     "node-runtime-update.mjs",
+    "node-runtime-recovery.mjs",
     "package.json",
   ]) {
     await fs.copyFile(path.join(process.cwd(), file), path.join(candidate, file));

--- a/src/commands/doctor-config-preflight.process.test-support.ts
+++ b/src/commands/doctor-config-preflight.process.test-support.ts
@@ -107,6 +107,7 @@ export function createSourceRuntime(root: string): string {
     "node-version.mjs",
     "node-sqlite.mjs",
     "node-runtime-update.mjs",
+    "node-runtime-recovery.mjs",
     "package.json",
     "tsconfig.json",
   ]) {

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -112,8 +112,9 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   currentFile: string;
   installRoot: string;
   compileCacheDir?: string;
+  env?: NodeJS.ProcessEnv;
 }): OpenClawCompileCacheRespawnPlan | undefined {
-  const env = process.env;
+  const env = params.env ?? process.env;
   const argv = process.argv;
   const platform = process.platform;
   if (isForegroundGmailRunArgv(argv) || shouldKeepNativeHookRelayInProcess(argv, platform)) {
@@ -145,12 +146,14 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
 export async function respawnWithoutOpenClawCompileCacheIfNeeded(params: {
   currentFile: string;
   installRoot: string;
+  env?: NodeJS.ProcessEnv;
   prepareWriteError?: () => Promise<(message: string) => void | Promise<void>>;
 }): Promise<boolean> {
   const plan = buildOpenClawCompileCacheRespawnPlan({
     currentFile: params.currentFile,
     installRoot: params.installRoot,
     compileCacheDir: getCompileCacheDir?.(),
+    env: params.env,
   });
   if (!plan) {
     return false;

--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -12,6 +12,7 @@ describe("entry run-main boundary", () => {
 
     expect(runCli).toHaveBeenCalledWith(["node", "openclaw", "status"], {
       additionalStartupTrace: expect.any(Object),
+      runtimeRecoveryEnv: expect.any(Object),
       retainConsoleRoutingUntilProcessExit: true,
     });
   });

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -34,6 +34,9 @@ import { ensureOpenClawExecMarkerOnProcess } from "./infra/openclaw-exec-env.js"
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { defaultRuntime } from "./runtime.js";
 
+// Recovery must not select executables from workspace/global dotenv values.
+const inheritedRuntimeEnv = { ...process.env };
+
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.mjs" },
@@ -129,6 +132,7 @@ if (
   if (earlyProfile.ok && earlyProfile.profile) {
     applyCliProfileEnv({ profile: earlyProfile.profile });
   }
+  const startupEnv = { ...process.env };
   const { assertSupportedRuntime, isCurrentRuntimeSupported } =
     await import("./infra/runtime-guard.js");
   if (!isCurrentRuntimeSupported()) {
@@ -136,12 +140,13 @@ if (
     loadCliDotEnv({ quiet: true });
     await configureGatewayStartupTraceConsoleFormatting(gatewayEntryStartupTrace);
   }
-  await assertSupportedRuntime(undefined, undefined, process.argv, false);
+  await assertSupportedRuntime(undefined, undefined, process.argv, false, inheritedRuntimeEnv);
   gatewayEntryStartupTrace.mark("bootstrap");
 
   const waitingForCompileCacheRespawn = await respawnWithoutOpenClawCompileCacheIfNeeded({
     currentFile: entryFile,
     installRoot,
+    env: startupEnv,
     prepareWriteError: async () => {
       // The child environment was already snapshotted. Load dotenv only to format
       // the parent trace; command-specific dotenv ordering remains child-owned.
@@ -164,7 +169,7 @@ if (
     }
 
     async function ensureCliRespawnReady(): Promise<boolean> {
-      const plan = buildCliRespawnPlan();
+      const plan = buildCliRespawnPlan({ env: startupEnv });
       if (!plan) {
         return false;
       }
@@ -179,7 +184,7 @@ if (
 
     if (!(await ensureCliRespawnReady())) {
       // Only the final child emits the diagnostic warning; parents still enforce admission.
-      await assertSupportedRuntime(undefined, undefined, process.argv);
+      await assertSupportedRuntime(undefined, undefined, process.argv, true, inheritedRuntimeEnv);
       const parsedContainer = parseCliContainerArgs(process.argv);
       if (!parsedContainer.ok) {
         await writeCapturedCliArgumentError(parsedContainer.error);
@@ -312,6 +317,7 @@ export async function runMainOrRootHelp(
       commandStarted = true;
       await runCli(argv, {
         additionalStartupTrace: gatewayEntryStartupTrace,
+        runtimeRecoveryEnv: inheritedRuntimeEnv,
         // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
         retainConsoleRoutingUntilProcessExit: true,
       });

--- a/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
@@ -62,6 +62,7 @@ async function fixture(mode: "source" | "package" | "external-plugin" = "source"
   await write(packageRoot, "node-version.mjs", "export const supported = true;");
   await write(packageRoot, "node-sqlite.mjs", "export const probe = true;");
   await write(packageRoot, "node-runtime-update.mjs", "export const update = true;");
+  await write(packageRoot, "node-runtime-recovery.mjs", "export const recovery = true;");
   await write(packageRoot, "scripts/preinstall.mjs", "export {};\n");
   await write(
     packageRoot,

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -44,6 +44,7 @@ const BOOTSTRAP_LAUNCHER_FILES = [
   "node-version.mjs",
   "node-sqlite.mjs",
   "node-runtime-update.mjs",
+  "node-runtime-recovery.mjs",
 ];
 const READ_CONCURRENCY = 16;
 const IGNORED_PLUGIN_DIRECTORIES = new Set(["node_modules", "src", "test", "tests"]);

--- a/src/gateway/worker-environments/node-enrollment.test.ts
+++ b/src/gateway/worker-environments/node-enrollment.test.ts
@@ -122,6 +122,10 @@ describe("worker node enrollment", () => {
         path.join(packageRoot, "node-runtime-update.mjs"),
         "export const update = true;",
       ),
+      fs.writeFile(
+        path.join(packageRoot, "node-runtime-recovery.mjs"),
+        "export const recovery = true;",
+      ),
       fs.writeFile(path.join(packageRoot, "dist/entry.js"), "export const ready = true;"),
       fs.writeFile(
         path.join(packageRoot, "dist/build-info.json"),

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   type SpawnSyncReturns,
 } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
@@ -67,7 +68,7 @@ const windowsPath = {
   isAbsolute: path.win32.isAbsolute.bind(path.win32),
   basename: path.win32.basename.bind(path.win32),
   dirname: path.win32.dirname.bind(path.win32),
-  relative: path.win32.relative.bind(path.win32),
+  relative: (from: string, to: string) => path.win32.relative(from, to).replaceAll("\\", path.sep),
 };
 const exitSentinel = new Error("replacement exited");
 let child: ChildProcess;
@@ -159,6 +160,226 @@ async function expectRecoveryStarted(home: string) {
 }
 
 describe("runtime recovery discovery", () => {
+  it.each([
+    { name: "expands the Windows service state directory against home", source: "home" },
+    { name: "never reads competing cwd tilde service metadata", source: "competing" },
+    { name: "rejects a relative Windows service state directory", source: "relative" },
+    { name: "expands an explicit Windows task script against home", source: "home-script" },
+    { name: "rejects an explicit Windows task script under cwd", source: "cwd-script" },
+    { name: "rejects a Windows task script resolving under cwd", source: "symlink-script" },
+    { name: "rejects a task script through a cwd-owned parent", source: "parent-script" },
+  ])("$name", async ({ source }) => {
+    await withRecoveryHome(async (root) => {
+      const state = source === "relative" ? "state" : "~/x";
+      const home = path.join(root, "daemon $& home");
+      const cwd = path.join(root, "checkout");
+      await fs.mkdir(home);
+      await fs.mkdir(cwd);
+      const installedNode = await writeFixture(path.join(root, "installed", "node.exe"));
+      const workspaceNode = await writeFixture(path.join(root, "sibling", "node.exe"));
+      const homeScript = path.join(home, "x", "gateway.cmd");
+      const competingScript = path.join(cwd, state, "gateway.cmd");
+      const writeScript = async (filename: string, node: string) => {
+        await fs.mkdir(path.dirname(filename), { recursive: true });
+        await fs.writeFile(
+          filename,
+          encodeWindowsLauncherScript({
+            format: "cmd",
+            content: buildTaskScript({ programArguments: [node, "/fixture/entry.js", "gateway"] }),
+          }),
+        );
+      };
+      await writeScript(homeScript, installedNode);
+      if (source !== "home") {
+        await writeScript(competingScript, workspaceNode);
+      }
+      const scriptLink = path.join(root, "gateway.cmd");
+      const outsideScript = path.join(root, "outside-gateway.cmd");
+      const parentLink = path.join(root, "cwd-alias");
+      if (source === "symlink-script") {
+        await fs.symlink(competingScript, scriptLink);
+      } else if (source === "parent-script") {
+        await fs.rename(competingScript, outsideScript);
+        await fs.symlink(outsideScript, competingScript);
+        await fs.symlink(cwd, parentLink, "junction");
+      }
+      const scriptOverride =
+        source === "home-script"
+          ? "~/x/gateway.cmd"
+          : source === "cwd-script"
+            ? competingScript
+            : source === "symlink-script"
+              ? scriptLink
+              : source === "parent-script"
+                ? path.join(parentLink, state, "gateway.cmd")
+                : undefined;
+      const report = path.join(root, "discovery.json");
+      const driver = await writeFixture(
+        path.join(root, "discover.mjs"),
+        `
+        import childProcess from "node:child_process";
+        import { EventEmitter } from "node:events";
+        import fs from "node:fs";
+        import path from "node:path";
+        import { syncBuiltinESMExports } from "node:module";
+        Object.defineProperty(process, "platform", { value: "win32" });
+        Object.defineProperty(process.versions, "node", { value: "20.0.0" });
+        const result = { reads: [], probes: [] };
+        const readFileSync = fs.readFileSync;
+        fs.readFileSync = (filename, ...args) => {
+          result.reads.push(path.resolve(String(filename)));
+          return readFileSync(filename, ...args);
+        };
+        childProcess.spawnSync = (command) => {
+          result.probes.push(command);
+          return { status: [${JSON.stringify(installedNode)}, ${JSON.stringify(workspaceNode)}].includes(command) ? 0 : 1,
+            stdout: JSON.stringify({ version: "24.19.0", probe: { available: true, version: "3.53.4", text: true, blob: true, json: true } }) };
+        };
+        childProcess.spawn = (command) => {
+          result.selected = command;
+          const child = new EventEmitter();
+          child.kill = () => true;
+          setImmediate(() => child.emit("exit", 23, null));
+          return child;
+        };
+        process.on("exit", () => fs.writeFileSync(${JSON.stringify(report)}, JSON.stringify(result)));
+        syncBuiltinESMExports();
+        const { recoverNodeRuntime } = await import(${JSON.stringify(new URL("../../node-runtime-recovery.mjs", import.meta.url).href)});
+        await recoverNodeRuntime();
+      `,
+      );
+      const { spawnSync } =
+        await vi.importActual<typeof import("node:child_process")>("node:child_process");
+      const result = spawnSync(process.execPath, [driver, "doctor", "--fix", "--non-interactive"], {
+        cwd,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          OPENCLAW_HOME: path.join(root, "private-home"),
+          OPENCLAW_STATE_DIR: state,
+          OPENCLAW_TASK_SCRIPT: scriptOverride,
+          OPENCLAW_TASK_SCRIPT_NAME: undefined,
+          PATH: "",
+          NVM_DIR: undefined,
+          FNM_DIR: undefined,
+          VOLTA_HOME: undefined,
+          NODE_OPTIONS: undefined,
+        },
+        encoding: "utf8",
+        timeout: 30_000,
+      });
+      const observed = JSON.parse(await fs.readFile(report, "utf8"));
+      expect(observed.reads).not.toContain(competingScript);
+      expect(observed.reads).not.toContain(scriptLink);
+      expect(observed.reads).not.toContain(outsideScript);
+      expect(observed.probes).not.toContain(workspaceNode);
+      if (["home", "competing", "home-script"].includes(source)) {
+        expect(result.status, result.stderr).toBe(23);
+        expect(observed.reads).toContain(homeScript);
+        expect(observed.selected).toBe(installedNode);
+      } else {
+        expect(result.status, result.stderr).toBe(0);
+        expect(observed.selected).toBeUndefined();
+      }
+    });
+  });
+
+  it("never probes fnm through a cwd-owned parent directory", async () => {
+    await withRecoveryHome(async (home) => {
+      const cwd = path.join(home, "checkout");
+      const candidate = await writeFixture(path.join(home, "outside", "node"));
+      await fs.mkdir(path.join(cwd, "bin"), { recursive: true });
+      await fs.symlink(candidate, path.join(cwd, "bin", "node"));
+      const aliases = path.join(home, ".fnm", "aliases");
+      await fs.mkdir(aliases, { recursive: true });
+      await fs.symlink(cwd, path.join(aliases, "default"), "junction");
+      vi.spyOn(process, "cwd").mockReturnValue(cwd);
+
+      expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+      expect(mocks.probe.mock.calls.map(([file]) => file)).not.toContain(candidate);
+      expect(mocks.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([true, false])("recovers without an OS account record (HOME=%s)", async (hasHome) => {
+    await withRecoveryHome(async (home) => {
+      const candidate = await writeFixture(path.join(home, "bin", "node"));
+      const account = vi.spyOn(os, "userInfo").mockImplementation(() => {
+        throw new Error("OS account record unavailable");
+      });
+      if (!hasHome) {
+        vi.stubEnv("HOME", undefined);
+        vi.stubEnv("USERPROFILE", undefined);
+      }
+      mocks.admissible.add(candidate);
+      await expect(
+        Promise.race([
+          recoverNodeRuntime({ homeDir: home }),
+          vi.waitFor(() => {
+            expect(mocks.spawn).toHaveBeenCalledOnce();
+          }),
+        ]),
+      ).resolves.toBeUndefined();
+      expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+      expect(account).toHaveBeenCalledTimes(hasHome ? 0 : 1);
+    });
+  });
+
+  it.each(["nvm", "fnm", "Volta"])("expands the %s manager root against home", async (manager) => {
+    await withRecoveryHome(async (home) => {
+      const root = path.join(home, "custom-manager");
+      let candidate: string;
+      if (manager === "nvm") {
+        candidate = await writeFixture(path.join(root, "versions/node/v24.19.0/bin/node"));
+        await writeFixture(path.join(root, "alias/default"), "24");
+        vi.stubEnv("NVM_DIR", "~/custom-manager");
+      } else if (manager === "fnm") {
+        candidate = await writeFixture(path.join(root, "aliases/default/bin/node"));
+        vi.stubEnv("FNM_DIR", "~/custom-manager");
+      } else {
+        candidate = await writeFixture(path.join(root, "tools/image/node/24.19.0/bin/node"));
+        await writeFixture(
+          path.join(root, "tools/user/platform.json"),
+          JSON.stringify({ node: { runtime: "24.19.0" } }),
+        );
+        vi.stubEnv("VOLTA_HOME", "~/custom-manager");
+      }
+      mocks.admissible.add(candidate);
+      await expectRecoveryStarted(home);
+      expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+    });
+  });
+
+  it.each(["HOME", "USERPROFILE", "OPENCLAW_HOME"])(
+    "expands inherited %s before private discovery",
+    async (key) => {
+      await withRecoveryHome(async (home) => {
+        const candidate = await writeFixture(
+          path.join(home, "custom-home/.openclaw/tools/cli-node/tools/node/bin/node"),
+        );
+        vi.spyOn(os, "userInfo").mockReturnValue({
+          homedir: home,
+          username: "fixture",
+          uid: 1000,
+          gid: 1000,
+          shell: null,
+        });
+        vi.stubEnv("OPENCLAW_HOME", undefined);
+        vi.stubEnv("USERPROFILE", undefined);
+        if (key === "USERPROFILE") {
+          vi.stubEnv("HOME", undefined);
+        }
+        vi.stubEnv(key, "~/custom-home");
+        mocks.admissible.add(candidate);
+
+        void recoverNodeRuntime();
+        await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+        expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+      });
+    },
+  );
+
   it("uses inherited PATH and probe settings after process env changes", async () => {
     await withRecoveryHome(async (home) => {
       const inheritedNode = await writeFixture(path.join(home, "inherited/bin/node"));
@@ -298,6 +519,28 @@ describe("runtime recovery discovery", () => {
 
       await expectRecoveryStarted(home);
 
+      expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("(PATH;"));
+    });
+  });
+
+  it("keeps PATH discovery after rejecting a service executable's cwd parent", async () => {
+    await withRecoveryHome(async (home) => {
+      const cwd = path.join(home, "checkout");
+      const candidate = await writeFixture(path.join(home, "outside", "node"));
+      await fs.mkdir(cwd);
+      await fs.symlink(candidate, path.join(cwd, "node"));
+      const alias = path.join(home, "service-alias");
+      await fs.symlink(cwd, alias, "junction");
+      await writeFixture(
+        path.join(home, ".config/systemd/user/openclaw-gateway.service"),
+        `[Service]\nExecStart="${path.join(alias, "node").replaceAll("\\", "\\\\")}" /fixture/entry.js gateway\n`,
+      );
+      vi.spyOn(process, "cwd").mockReturnValue(cwd);
+      vi.stubEnv("PATH", path.dirname(candidate));
+      mocks.admissible.add(candidate);
+
+      await expectRecoveryStarted(home);
       expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("(PATH;"));
     });

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -240,6 +240,27 @@ describe("runtime recovery discovery", () => {
     });
   });
 
+  it("never probes an nvm symlink under cwd pointing outside cwd", async () => {
+    await withRecoveryHome(async (home) => {
+      const cwd = path.join(home, "untrusted-checkout");
+      const root = path.join(cwd, ".nvm");
+      const candidate = path.join(root, "versions/node/v24.19.0/bin/node");
+      const target = await writeFixture(path.join(home, "outside/bin/node"));
+      await writeFixture(path.join(root, "alias/default"), "24");
+      await fs.mkdir(path.dirname(candidate), { recursive: true });
+      await fs.symlink(target, candidate);
+      vi.spyOn(process, "cwd").mockReturnValue(cwd);
+      vi.stubEnv("NVM_DIR", root);
+      vi.stubEnv("PATH", "");
+
+      expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+      const probed = mocks.probe.mock.calls.map(([file]) => file);
+      expect(probed).not.toContain(candidate);
+      expect(probed).not.toContain(target);
+      expect(mocks.spawn).not.toHaveBeenCalled();
+    });
+  });
+
   it("allows an absolute PATH entry explicitly naming the cwd", async () => {
     await withRecoveryHome(async (home) => {
       const cwd = path.join(home, "explicit-bin");

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -160,6 +160,75 @@ async function expectRecoveryStarted(home: string) {
 }
 
 describe("runtime recovery discovery", () => {
+  it.each(["HOME", "OPENCLAW_HOME"])(
+    "reuses a private runtime when cwd equals %s",
+    async (homeVariable) => {
+      await withRecoveryHome(async (home) => {
+        const candidate = await writeFixture(
+          path.join(home, ".openclaw/tools/cli-node/tools/node/bin/node"),
+        );
+        vi.stubEnv("OPENCLAW_HOME", homeVariable === "OPENCLAW_HOME" ? home : undefined);
+        if (homeVariable === "OPENCLAW_HOME") {
+          vi.stubEnv("HOME", path.dirname(home));
+        }
+        vi.stubEnv("PATH", "");
+        vi.spyOn(process, "cwd").mockReturnValue(home);
+        mocks.admissible.add(candidate);
+
+        void recoverNodeRuntime();
+        await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+        expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+        expect(mocks.probe.mock.calls.map(([file]) => file)).toEqual([candidate]);
+      });
+    },
+  );
+
+  it.each(["none", "executable", "parent", "root"])(
+    "rejects workspace and manager Nodes from HOME (private symlink escape=%s)",
+    async (privateEscape) => {
+      await withRecoveryHome(async (home) => {
+        vi.stubEnv("OPENCLAW_HOME", undefined);
+        vi.stubEnv("PATH", ".");
+        vi.spyOn(process, "cwd").mockReturnValue(home);
+        const workspaceNode = await writeFixture(path.join(home, "node"));
+        const managerNode = await writeFixture(
+          path.join(home, ".nvm/versions/node/v24.19.0/bin/node"),
+        );
+        const plantedNodes = [workspaceNode, managerNode, await fs.realpath(process.execPath)];
+        await writeFixture(path.join(home, ".nvm/alias/default"), "24");
+        if (privateEscape !== "none") {
+          const privateNode = path.join(home, ".openclaw/tools/cli-node/tools/node/bin/node");
+          if (privateEscape === "root") {
+            const workspaceRoot = path.join(home, "workspace-state");
+            plantedNodes.push(
+              await writeFixture(path.join(workspaceRoot, "tools/cli-node/tools/node/bin/node")),
+            );
+            await fs.symlink(workspaceRoot, path.join(home, ".openclaw"), "junction");
+          } else if (privateEscape === "executable") {
+            await fs.mkdir(path.dirname(privateNode), { recursive: true });
+            await fs.symlink(workspaceNode, privateNode);
+          } else {
+            const workspaceTools = path.join(home, "workspace-tools");
+            const redirectedNode = path.join(workspaceTools, "cli-node/tools/node/bin/node");
+            await fs.mkdir(path.dirname(redirectedNode), { recursive: true });
+            await fs.symlink(process.execPath, redirectedNode);
+            await fs.mkdir(path.join(home, ".openclaw"));
+            await fs.symlink(workspaceTools, path.join(home, ".openclaw/tools"), "junction");
+          }
+        }
+        mocks.admissible.add(workspaceNode);
+        mocks.admissible.add(managerNode);
+
+        expect(await recoverNodeRuntime()).toBe(false);
+        const probed = mocks.probe.mock.calls.map(([file]) => file);
+        for (const planted of plantedNodes) {
+          expect(probed).not.toContain(planted);
+        }
+        expect(mocks.spawn).not.toHaveBeenCalled();
+      });
+    },
+  );
+
   it.each([
     { name: "expands the Windows service state directory against home", source: "home" },
     { name: "never reads competing cwd tilde service metadata", source: "competing" },

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -1,0 +1,402 @@
+import {
+  ChildProcess,
+  type SpawnOptions,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { isUsableNode, recoverNodeRuntime } from "../../node-runtime-recovery.mjs";
+import { SQLITE_CAPABILITY_PROBE } from "../../node-sqlite.mjs";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+
+const mocks = vi.hoisted(() => ({
+  currentAdmitted: false,
+  admissible: new Set<string>(),
+  virtualPaths: new Map<string, string>(),
+  probe:
+    vi.fn<
+      (
+        file: string,
+        args: string[],
+        options: SpawnSyncOptionsWithStringEncoding,
+      ) => SpawnSyncReturns<string>
+    >(),
+  spawn: vi.fn<(file: string, args: string[], options: SpawnOptions) => ChildProcess>(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: mocks.spawn,
+  spawnSync: mocks.probe,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    realpathSync: (filename: string) =>
+      mocks.virtualPaths.get(filename) ?? actual.realpathSync(filename),
+  };
+});
+vi.mock("../../node-sqlite.mjs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../node-sqlite.mjs")>()),
+  detectCurrentSqliteCapabilities: () => ({
+    available: true,
+    version: "3.51.3",
+    text: mocks.currentAdmitted,
+    blob: true,
+    json: true,
+  }),
+}));
+
+const originalArgv = process.argv;
+const originalExecArgv = process.execArgv;
+const hostPlatform = process.platform;
+const exitSentinel = new Error("replacement exited");
+let child: ChildProcess;
+let exitSpy: MockInstance<typeof process.exit>;
+let stderrSpy: MockInstance<typeof process.stderr.write>;
+
+beforeEach(() => {
+  mockProcessPlatform("linux");
+  mocks.currentAdmitted = false;
+  mocks.admissible.clear();
+  mocks.virtualPaths.clear();
+  mocks.probe.mockReset();
+  mocks.spawn.mockReset();
+  mocks.probe.mockImplementation((filename) => ({
+    pid: 100,
+    status: 0,
+    signal: null,
+    output: [],
+    stdout: JSON.stringify({
+      version: "24.19.0",
+      probe: {
+        available: true,
+        version: "3.51.3",
+        text: mocks.admissible.has(filename),
+        blob: true,
+        json: true,
+      },
+    }),
+    stderr: "",
+  }));
+  child = new ChildProcess();
+  mocks.spawn.mockReturnValue(child);
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw exitSentinel;
+  });
+  stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  process.argv = [
+    process.execPath,
+    "/fixture/dist/index.js",
+    "doctor",
+    "--non-interactive",
+    "--fix",
+  ];
+  process.execArgv = [];
+  vi.stubEnv("CI", "1");
+  for (const key of [
+    "OPENCLAW_NODE_UPDATE_RESPAWNED",
+    "OPENCLAW_PROFILE",
+    "OPENCLAW_LAUNCHD_LABEL",
+    "OPENCLAW_SYSTEMD_UNIT",
+  ]) {
+    vi.stubEnv(key, undefined);
+  }
+});
+
+afterEach(() => {
+  if (child.listenerCount("exit")) {
+    expect(() => child.emit("exit", 0, null)).toThrow(exitSentinel);
+  }
+  process.argv = originalArgv;
+  process.execArgv = originalExecArgv;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+async function writeFixture(filename: string, text = "") {
+  await fs.mkdir(path.dirname(filename), { recursive: true });
+  await fs.writeFile(filename, text);
+  return filename;
+}
+
+async function withRecoveryHome(run: (home: string) => Promise<void>) {
+  await withTempDir("openclaw-node-recovery-", async (directory) => {
+    const home = await fs.realpath(directory);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("PATH", path.join(home, "bin"));
+    vi.stubEnv("NVM_DIR", path.join(home, ".nvm"));
+    vi.stubEnv("FNM_DIR", path.join(home, ".fnm"));
+    vi.stubEnv("VOLTA_HOME", path.join(home, ".volta"));
+    await run(home);
+  });
+}
+
+async function expectRecoveryStarted(home: string) {
+  void recoverNodeRuntime({ homeDir: home });
+  await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+}
+
+describe("runtime recovery discovery", () => {
+  it.each([
+    [0, "cached OpenClaw runtime"],
+    [1, "managed Gateway service"],
+    [2, "PATH"],
+    [3, "nvm default"],
+    [4, "fnm default"],
+    [5, "Volta default"],
+    [6, "Homebrew node@26"],
+    [7, "Homebrew node@24"],
+  ] as const)("selects the first admissible runtime: %s %s", async (index, source) => {
+    await withRecoveryHome(async (home) => {
+      const candidates = await Promise.all(
+        [
+          ".openclaw/tools/cli-node/tools/node/bin/node",
+          "service/bin/node",
+          "bin/node",
+          ".nvm/versions/node/v24.19.0/bin/node",
+          ".fnm/aliases/default/bin/node",
+          ".volta/tools/image/node/24.19.0/bin/node",
+          "brew26/bin/node",
+          "brew24/bin/node",
+        ].map((relative) => writeFixture(path.join(home, relative))),
+      );
+      await writeFixture(
+        path.join(home, ".config/systemd/user/openclaw-gateway.service"),
+        `[Service]\nExecStart="${expectDefined(candidates[1], "service candidate").replaceAll("\\", "\\\\")}" /fixture/dist/index.js gateway run\n`,
+      );
+      await writeFixture(path.join(home, ".nvm/alias/default"), "lts/test\n");
+      await writeFixture(path.join(home, ".nvm/alias/lts/test"), "24\n");
+      await writeFixture(
+        path.join(home, ".volta/tools/user/platform.json"),
+        JSON.stringify({ node: { runtime: "24.19.0" } }),
+      );
+      for (const prefix of ["/opt/homebrew", "/usr/local"]) {
+        mocks.virtualPaths.set(
+          path.join(prefix, "opt", "node@26", "bin", "node"),
+          expectDefined(candidates[6], "Node 26 candidate"),
+        );
+        mocks.virtualPaths.set(
+          path.join(prefix, "opt", "node@24", "bin", "node"),
+          expectDefined(candidates[7], "Node 24 candidate"),
+        );
+      }
+      for (const candidate of candidates.slice(index)) {
+        mocks.admissible.add(candidate);
+      }
+
+      await expectRecoveryStarted(home);
+
+      expect(mocks.probe.mock.calls.map(([filename]) => filename)).toEqual(
+        candidates.slice(0, index + 1),
+      );
+      expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidates[index]);
+      expect(stderrSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(`(${source}; current Node failed runtime admission)`),
+      );
+    });
+  });
+
+  it.each(["direct", "shell wrapper", "executable wrapper"])(
+    "finds the profiled launchd runtime through a %s command",
+    async (form) => {
+      mockProcessPlatform("darwin");
+      await withRecoveryHome(async (home) => {
+        const candidate = await writeFixture(path.join(home, "service & runtime/bin/node"));
+        mocks.admissible.add(candidate);
+        process.argv = [
+          process.execPath,
+          "/fixture/openclaw.mjs",
+          "--profile",
+          "fixture",
+          "doctor",
+        ];
+        const wrapper = path.join(home, "service-env/ai.openclaw.fixture-env-wrapper.sh");
+        const envFile = path.join(home, "service-env/ai.openclaw.fixture.env");
+        const prefix =
+          form === "direct"
+            ? []
+            : form === "shell wrapper"
+              ? ["/bin/sh", wrapper, envFile]
+              : [wrapper, envFile];
+        const args = [...prefix, candidate, "/fixture/dist/index.js", "gateway"];
+        await writeFixture(
+          path.join(home, "Library/LaunchAgents/ai.openclaw.fixture.plist"),
+          `<key>ProgramArguments</key><array>${args.map((arg) => `<string>${arg.replaceAll("&", "&amp;")}</string>`).join("")}</array>`,
+        );
+
+        await expectRecoveryStarted(home);
+
+        expect(mocks.probe.mock.calls.map(([filename]) => filename)).toEqual([candidate]);
+        expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+      });
+    },
+  );
+
+  it("ignores PATH aliases for the running executable and probes each other binary once", async () => {
+    await withRecoveryHome(async (home) => {
+      await fs.mkdir(path.join(home, "bin"));
+      if (hostPlatform === "win32") {
+        mocks.virtualPaths.set(path.join(home, "bin/node"), await fs.realpath(process.execPath));
+      } else {
+        await fs.symlink(process.execPath, path.join(home, "bin/node"));
+      }
+      const replacement = await writeFixture(path.join(home, "replacement/bin/node"));
+      const alternate = path.join(home, "alternate/bin/node");
+      await fs.mkdir(path.dirname(alternate), { recursive: true });
+      if (hostPlatform === "win32") {
+        mocks.virtualPaths.set(alternate, replacement);
+      } else {
+        await fs.symlink(replacement, alternate);
+      }
+      vi.stubEnv(
+        "PATH",
+        [path.join(home, "bin"), path.dirname(alternate), path.dirname(replacement)].join(
+          path.delimiter,
+        ),
+      );
+
+      expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+
+      expect(mocks.probe.mock.calls.filter(([filename]) => filename === replacement)).toHaveLength(
+        1,
+      );
+      expect(mocks.probe.mock.calls.some(([filename]) => filename === process.execPath)).toBe(
+        false,
+      );
+      expect(mocks.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(["already admitted", "replacement child"])(
+    "does not discover for an %s",
+    async (reason) => {
+      await withRecoveryHome(async (home) => {
+        const candidate = await writeFixture(path.join(home, "bin/node"));
+        mocks.admissible.add(candidate);
+        mocks.currentAdmitted = reason === "already admitted";
+        if (reason === "replacement child") {
+          vi.stubEnv("OPENCLAW_NODE_UPDATE_RESPAWNED", "1");
+        }
+
+        expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+        expect(mocks.probe).not.toHaveBeenCalled();
+        expect(mocks.spawn).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it.each([
+    ["webhooks", "gmail", "run"],
+    ["--profile", "fixture", "webhooks", "gmail", "run"],
+    ["webhooks", "--log-level=debug", "gmail", "--no-color", "run"],
+    ["hooks", "relay", "--relay-id", "fixture"],
+  ])("keeps exact-PID invocation %j in its original process", async (...args) => {
+    await withRecoveryHome(async (home) => {
+      const candidate = await writeFixture(path.join(home, "bin/node"));
+      mocks.admissible.add(candidate);
+      process.argv = [process.execPath, "/fixture/openclaw.mjs", ...args];
+
+      expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+      expect(mocks.probe).not.toHaveBeenCalled();
+      expect(mocks.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([0, 7])(
+    "preserves the invocation and propagates replacement exit %s",
+    async (exitCode) => {
+      await withRecoveryHome(async (home) => {
+        const candidate = await writeFixture(path.join(home, "bin/node"));
+        mocks.admissible.add(candidate);
+        process.execArgv = ["--trace-warnings"];
+        vi.stubEnv("OPENCLAW_TEST_VALUE", "preserved");
+        vi.stubEnv("NODE_OPTIONS", "--no-warnings");
+        const originalEnv = { ...process.env };
+        const originalCwd = process.cwd();
+
+        await expectRecoveryStarted(home);
+
+        expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
+          candidate,
+          ["--trace-warnings", "/fixture/dist/index.js", "doctor", "--non-interactive", "--fix"],
+          { stdio: "inherit", env: { ...originalEnv, OPENCLAW_NODE_UPDATE_RESPAWNED: "1" } },
+        );
+        expect(process.cwd()).toBe(originalCwd);
+        expect(exitSpy).not.toHaveBeenCalled();
+        expect(() => child.emit("exit", exitCode, null)).toThrow(exitSentinel);
+        expect(exitSpy).toHaveBeenCalledExactlyOnceWith(exitCode);
+      });
+    },
+  );
+});
+
+describe("candidate admission probe", () => {
+  it("runs only the shared bounded probe with a sanitized environment", async () => {
+    await withRecoveryHome(async (home) => {
+      const candidate = await writeFixture(path.join(home, "bin/node"));
+      mocks.admissible.add(candidate);
+      for (const key of [
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        "LD_PRELOAD",
+        "DYLD_INSERT_LIBRARIES",
+        "OPENCLAW_TEST_SECRET",
+      ]) {
+        vi.stubEnv(key, "synthetic-untrusted-value");
+      }
+      vi.stubEnv("SystemRoot", "/fixture/windows");
+      vi.stubEnv("TMPDIR", path.join(home, "tmp"));
+
+      expect(isUsableNode(candidate)).toBe(true);
+
+      expect(mocks.probe).toHaveBeenCalledOnce();
+      const [, args, options] = expectDefined(mocks.probe.mock.calls[0], "runtime probe call");
+      expect(args).toEqual(["-e", expect.stringContaining(SQLITE_CAPABILITY_PROBE)]);
+      expect(options).toMatchObject({
+        timeout: 5_000,
+        maxBuffer: 65_536,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        env: {
+          NODE_NO_WARNINGS: "1",
+          SystemRoot: "/fixture/windows",
+          TMPDIR: path.join(home, "tmp"),
+        },
+      });
+      expect(
+        Object.keys(options.env ?? {}).every((key) =>
+          /^(SystemRoot|WINDIR|TEMP|TMP|TMPDIR|NODE_NO_WARNINGS)$/i.test(key),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it.each(["timeout", "malformed response", "failed exit"])("rejects %s", async (failure) => {
+    await withRecoveryHome(async (home) => {
+      const candidate = await writeFixture(path.join(home, "bin/node"));
+      mocks.admissible.add(candidate);
+      mocks.probe.mockReturnValue({
+        pid: 100,
+        status: failure === "timeout" ? null : failure === "failed exit" ? 1 : 0,
+        signal: failure === "timeout" ? "SIGTERM" : null,
+        output: [],
+        stdout:
+          failure === "malformed response"
+            ? "not JSON"
+            : JSON.stringify({
+                version: "24.19.0",
+                probe: { available: true, version: "3.51.3", text: true, blob: true, json: true },
+              }),
+        stderr: "",
+      });
+
+      expect(isUsableNode(candidate)).toBe(false);
+    });
+  });
+});

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -10,11 +10,14 @@ import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { isUsableNode, recoverNodeRuntime } from "../../node-runtime-recovery.mjs";
 import { SQLITE_CAPABILITY_PROBE } from "../../node-sqlite.mjs";
+import { buildTaskScript } from "../daemon/schtasks-layout.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { encodeWindowsLauncherScript } from "./windows-launcher-encoding.js";
 
 const mocks = vi.hoisted(() => ({
   currentAdmitted: false,
+  encoding: "utf-8",
   admissible: new Set<string>(),
   virtualPaths: new Map<string, string>(),
   probe:
@@ -51,10 +54,21 @@ vi.mock("../../node-sqlite.mjs", async (importOriginal) => ({
     json: true,
   }),
 }));
+vi.mock("./windows-encoding.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./windows-encoding.js")>()),
+  resolveWindowsOemEncoding: () => mocks.encoding,
+  resolveWindowsOemCodePage: () => 437,
+}));
 
 const originalArgv = process.argv;
 const originalExecArgv = process.execArgv;
 const hostPlatform = process.platform;
+const windowsPath = {
+  isAbsolute: path.win32.isAbsolute.bind(path.win32),
+  basename: path.win32.basename.bind(path.win32),
+  dirname: path.win32.dirname.bind(path.win32),
+  relative: path.win32.relative.bind(path.win32),
+};
 const exitSentinel = new Error("replacement exited");
 let child: ChildProcess;
 let exitSpy: MockInstance<typeof process.exit>;
@@ -63,6 +77,7 @@ let stderrSpy: MockInstance<typeof process.stderr.write>;
 beforeEach(() => {
   mockProcessPlatform("linux");
   mocks.currentAdmitted = false;
+  mocks.encoding = "utf-8";
   mocks.admissible.clear();
   mocks.virtualPaths.clear();
   mocks.probe.mockReset();
@@ -104,6 +119,7 @@ beforeEach(() => {
     "OPENCLAW_PROFILE",
     "OPENCLAW_LAUNCHD_LABEL",
     "OPENCLAW_SYSTEMD_UNIT",
+    "OPENCLAW_TASK_SCRIPT",
   ]) {
     vi.stubEnv(key, undefined);
   }
@@ -143,6 +159,151 @@ async function expectRecoveryStarted(home: string) {
 }
 
 describe("runtime recovery discovery", () => {
+  it.each([
+    ["unquoted", "C:\\Node24\\node.exe", "utf-8", false, "cmd"],
+    ["quoted", "C:\\Program Files\\Node24\\node.exe", "utf-8", false, "cmd"],
+    ["cmd escapes", "C:\\Tools\\100% ready!\\node.exe", "utf-8", false, "cmd"],
+    ["GBK marker", "C:\\Node 隆\\node.exe", "gbk", false, "cmd"],
+    ["legacy GBK marker", "C:\\Node 隆\\node.exe", "gbk", false, "marker-only"],
+    ["UTF-8 BOM", "C:\\Node café\\node.exe", "utf-8", false, "utf8-bom"],
+    ["UTF-16 LE BOM", "C:\\Node café\\node.exe", "utf-8", false, "utf16le-bom"],
+    ["UTF-16 BE BOM", "C:\\Node café\\node.exe", "utf-8", false, "utf16be-bom"],
+    ["Big5 marker", "C:\\Node 文\\node.exe", "big5", false, "cmd"],
+    ["CP866 marker", "C:\\Node Я\\node.exe", "cp866", false, "cmd"],
+    ["CP1258 marker", "C:\\Node Đ\\node.exe", "windows-1258", false, "cmd"],
+    ["OEM marker", "C:\\Node café\\node.exe", "cp850", true, "cmd"],
+    ["UHC marker", "C:\\Node 똠이\\node.exe", "euc-kr", true, "cmd"],
+  ] as const)(
+    "reads the Windows writer's %s service executable",
+    async (_label, candidate, encoding, skip, format) => {
+      await withRecoveryHome(async (home) => {
+        const script = path.join(home, "gateway.cmd");
+        mocks.encoding = encoding;
+        const content = buildTaskScript({
+          programArguments: [candidate, "C:\\OpenClaw\\dist\\index.js", "gateway"],
+        });
+        let bytes = encodeWindowsLauncherScript({
+          format: format.startsWith("utf16") ? "vbs" : "cmd",
+          content,
+        });
+        if (format === "marker-only") {
+          bytes = bytes.subarray(bytes.indexOf(0x0a) + 1);
+        } else if (format === "utf8-bom") {
+          bytes = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), bytes]);
+        } else if (format === "utf16be-bom") {
+          bytes = bytes.swap16();
+        }
+        await fs.writeFile(script, bytes);
+        mockProcessPlatform("win32");
+        vi.spyOn(path, "isAbsolute").mockImplementation(windowsPath.isAbsolute);
+        vi.spyOn(path, "basename").mockImplementation(windowsPath.basename);
+        vi.spyOn(path, "dirname").mockImplementation(windowsPath.dirname);
+        vi.spyOn(path, "relative").mockImplementation(windowsPath.relative);
+        vi.stubEnv("OPENCLAW_TASK_SCRIPT", script);
+        vi.stubEnv("PATH", "");
+        mocks.virtualPaths.set(candidate, candidate);
+        mocks.admissible.add(candidate);
+
+        if (skip) {
+          expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+          expect(mocks.probe).not.toHaveBeenCalled();
+          expect(mocks.spawn).not.toHaveBeenCalled();
+          expect(stderrSpy).toHaveBeenCalledExactlyOnceWith(
+            `openclaw: service script uses code page ${encoding === "euc-kr" ? 949 : 850}; not decodable here\n`,
+          );
+          const fallback = await writeFixture(path.join(home, "fallback/bin/node.exe"));
+          vi.stubEnv("PATH", path.dirname(fallback));
+          mocks.admissible.add(fallback);
+          await expectRecoveryStarted(home);
+          expect(mocks.probe.mock.calls.map(([file]) => file)).toEqual([fallback]);
+          expect(mocks.spawn.mock.calls[0]?.[0]).toBe(fallback);
+        } else {
+          await expectRecoveryStarted(home);
+          expect(mocks.probe.mock.calls.map(([file]) => file)).toEqual([candidate]);
+          expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+        }
+      });
+    },
+  );
+
+  it.each([".", "bin", ""])("never probes cwd Node through relative PATH %j", async (entry) => {
+    await withRecoveryHome(async (home) => {
+      const cwd = path.join(home, "untrusted-checkout");
+      await fs.mkdir(cwd);
+      const candidate = await writeFixture(path.resolve(cwd, entry || ".", "node"));
+      vi.spyOn(process, "cwd").mockReturnValue(cwd);
+      vi.stubEnv("PATH", entry);
+
+      expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+      expect(mocks.probe.mock.calls.map(([file]) => file)).not.toContain(candidate);
+      expect(mocks.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows an absolute PATH entry explicitly naming the cwd", async () => {
+    await withRecoveryHome(async (home) => {
+      const cwd = path.join(home, "explicit-bin");
+      const candidate = await writeFixture(path.join(cwd, "node"));
+      vi.spyOn(process, "cwd").mockReturnValue(cwd);
+      vi.stubEnv("PATH", cwd);
+      mocks.admissible.add(candidate);
+      await writeFixture(
+        path.join(home, ".config/systemd/user/openclaw-gateway.service"),
+        `[Service]\nExecStart="${candidate.replaceAll("\\", "\\\\")}" /fixture/dist/index.js gateway\n`,
+      );
+
+      await expectRecoveryStarted(home);
+
+      expect(mocks.spawn.mock.calls[0]?.[0]).toBe(candidate);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("(PATH;"));
+    });
+  });
+
+  it.each(["private", "service", "nvm", "fnm", "Volta", "Homebrew"])(
+    "never probes a %s runtime resolving into cwd",
+    async (source) => {
+      await withRecoveryHome(async (home) => {
+        const cwd = path.join(home, "untrusted-checkout");
+        const candidate = await writeFixture(path.join(cwd, "node"));
+        vi.spyOn(process, "cwd").mockReturnValue(cwd);
+        vi.stubEnv("PATH", "");
+        const paths = {
+          private: path.join(home, ".openclaw/tools/cli-node/tools/node/bin/node"),
+          service: path.join(home, "service/bin/node"),
+          nvm: path.join(home, ".nvm/versions/node/v24.19.0/bin/node"),
+          fnm: path.join(home, ".fnm/aliases/default/bin/node"),
+          Volta: path.join(home, ".volta/tools/image/node/24.19.0/bin/node"),
+          Homebrew: path.join("/opt/homebrew", "opt/node@26/bin/node"),
+        };
+        for (const [name, alias] of Object.entries(paths)) {
+          if (name === source) {
+            mocks.virtualPaths.set(alias, candidate);
+          }
+        }
+        await writeFixture(
+          path.join(home, ".config/systemd/user/openclaw-gateway.service"),
+          `[Service]\nExecStart="${paths.service.replaceAll("\\", "\\\\")}" /fixture/dist/index.js gateway\n`,
+        );
+        await writeFixture(path.join(home, ".nvm/alias/default"), "24");
+        await fs.mkdir(path.dirname(path.dirname(paths.nvm)), { recursive: true });
+        await writeFixture(
+          path.join(home, ".volta/tools/user/platform.json"),
+          JSON.stringify({ node: { runtime: "24.19.0" } }),
+        );
+
+        expect(await recoverNodeRuntime({ homeDir: home })).toBe(false);
+        const probed = mocks.probe.mock.calls.map(([file]) => file);
+        expect(probed).not.toContain(candidate);
+        for (const [name, alias] of Object.entries(paths)) {
+          if (name === source) {
+            expect(probed).not.toContain(alias);
+          }
+        }
+        expect(mocks.spawn).not.toHaveBeenCalled();
+      });
+    },
+  );
+
   it.each([
     [0, "cached OpenClaw runtime"],
     [1, "managed Gateway service"],
@@ -337,6 +498,17 @@ describe("runtime recovery discovery", () => {
 });
 
 describe("candidate admission probe", () => {
+  it("never probes a non-Node symlink target", async () => {
+    await withRecoveryHome(async (home) => {
+      const target = await writeFixture(path.join(home, "another-executable"));
+      const alias = path.join(home, "bin/node");
+      mocks.virtualPaths.set(alias, target);
+
+      expect(isUsableNode(alias)).toBe(false);
+      expect(mocks.probe).not.toHaveBeenCalled();
+    });
+  });
+
   it("runs only the shared bounded probe with a sanitized environment", async () => {
     await withRecoveryHome(async (home) => {
       const candidate = await writeFixture(path.join(home, "bin/node"));

--- a/src/infra/node-runtime-recovery.test.ts
+++ b/src/infra/node-runtime-recovery.test.ts
@@ -159,6 +159,29 @@ async function expectRecoveryStarted(home: string) {
 }
 
 describe("runtime recovery discovery", () => {
+  it("uses inherited PATH and probe settings after process env changes", async () => {
+    await withRecoveryHome(async (home) => {
+      const inheritedNode = await writeFixture(path.join(home, "inherited/bin/node"));
+      const workspaceNode = await writeFixture(path.join(home, "workspace/bin/node"));
+      const env = { ...process.env, PATH: path.dirname(inheritedNode), TEMP: home };
+      vi.stubEnv("PATH", path.dirname(workspaceNode));
+      vi.stubEnv("TEMP", path.join(home, "workspace"));
+      vi.stubEnv("FNM_DIR", path.join(home, "workspace-fnm"));
+      mocks.admissible.add(inheritedNode);
+      mocks.admissible.add(workspaceNode);
+
+      void recoverNodeRuntime({ homeDir: home, env });
+      await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+
+      expect(mocks.probe.mock.calls.map(([file]) => file)).toEqual([inheritedNode]);
+      expect(mocks.probe.mock.calls[0]?.[2].env).toMatchObject({ TEMP: home });
+      expect(mocks.spawn.mock.calls[0]?.[2].env).toEqual({
+        ...env,
+        OPENCLAW_NODE_UPDATE_RESPAWNED: "1",
+      });
+    });
+  });
+
   it.each([
     ["unquoted", "C:\\Node24\\node.exe", "utf-8", false, "cmd"],
     ["quoted", "C:\\Program Files\\Node24\\node.exe", "utf-8", false, "cmd"],

--- a/src/infra/node-runtime-update.test.ts
+++ b/src/infra/node-runtime-update.test.ts
@@ -7,7 +7,7 @@ import { resolveUpdatedNodeRuntime } from "../../node-runtime-update.mjs";
 import { withTempDir } from "../test-utils/temp-dir.js";
 
 const mocks = vi.hoisted(() => ({
-  exists: vi.fn<(value: string) => boolean>(),
+  realpath: vi.fn<(value: string) => string>(),
   spawn:
     vi.fn<
       (
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
 }));
 vi.mock("node:fs", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:fs")>()),
-  existsSync: mocks.exists,
+  realpathSync: mocks.realpath,
 }));
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
@@ -70,7 +70,12 @@ it.each([
       }
     `,
     );
-    mocks.exists.mockImplementation((value) => value === candidate);
+    mocks.realpath.mockImplementation((value) => {
+      if (value === candidate) {
+        return value;
+      }
+      throw new Error("missing candidate");
+    });
     mocks.spawn.mockImplementation((_file, args, options) =>
       childProcess.spawnSync(
         process.execPath,
@@ -81,7 +86,7 @@ it.each([
 
     expect(await resolveUpdatedNodeRuntime(home)).toBe(lossless ? candidate : null);
     expect(mocks.spawn).toHaveBeenCalledOnce();
-    expect(mocks.spawn.mock.calls[0]?.[2].timeout).toBe(10_000);
+    expect(mocks.spawn.mock.calls[0]?.[2].timeout).toBe(5_000);
     const result = mocks.spawn.mock.results[0];
     if (result?.type !== "return") {
       throw new Error("Runtime probe did not return");

--- a/src/infra/node-runtime-update.test.ts
+++ b/src/infra/node-runtime-update.test.ts
@@ -7,7 +7,6 @@ import { resolveUpdatedNodeRuntime } from "../../node-runtime-update.mjs";
 import { withTempDir } from "../test-utils/temp-dir.js";
 
 const mocks = vi.hoisted(() => ({
-  realpath: vi.fn<(value: string) => string>(),
   spawn:
     vi.fn<
       (
@@ -16,10 +15,6 @@ const mocks = vi.hoisted(() => ({
         options: SpawnSyncOptionsWithStringEncoding,
       ) => SpawnSyncReturns<string>
     >(),
-}));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("node:fs")>()),
-  realpathSync: mocks.realpath,
 }));
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
@@ -41,12 +36,15 @@ it.each([
   vi.stubEnv("NODE_OPTIONS", undefined);
   const childProcess =
     await vi.importActual<typeof import("node:child_process")>("node:child_process");
-  await withTempDir("openclaw-node-recovery-", async (home) => {
+  await withTempDir("openclaw-node-recovery-", async (directory) => {
+    const home = await fs.realpath(directory);
     const nodeRoot = path.join(home, ".openclaw", "tools", "cli-node", "tools", "node");
     const candidate =
       process.platform === "win32"
         ? path.join(nodeRoot, "node.exe")
         : path.join(nodeRoot, "bin", "node");
+    await fs.mkdir(path.dirname(candidate), { recursive: true });
+    await fs.writeFile(candidate, "synthetic runtime; the probe uses the current Node");
     const preload = path.join(home, "binding.mjs");
     await fs.writeFile(
       preload,
@@ -70,12 +68,6 @@ it.each([
       }
     `,
     );
-    mocks.realpath.mockImplementation((value) => {
-      if (value === candidate) {
-        return value;
-      }
-      throw new Error("missing candidate");
-    });
     mocks.spawn.mockImplementation((_file, args, options) =>
       childProcess.spawnSync(
         process.execPath,

--- a/src/infra/node-runtime-update.test.ts
+++ b/src/infra/node-runtime-update.test.ts
@@ -76,7 +76,9 @@ it.each([
       ),
     );
 
-    expect(await resolveUpdatedNodeRuntime(home)).toBe(lossless ? candidate : null);
+    expect(await resolveUpdatedNodeRuntime(path.join(home, ".openclaw"))).toBe(
+      lossless ? candidate : null,
+    );
     expect(mocks.spawn).toHaveBeenCalledOnce();
     expect(mocks.spawn.mock.calls[0]?.[2].timeout).toBe(5_000);
     const result = mocks.spawn.mock.results[0];

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -215,6 +215,7 @@ export async function assertSupportedRuntime(
   details: RuntimeDetails = detectRuntime(),
   argv?: readonly string[],
   emitDiagnosticWarning = true,
+  recoveryEnv?: NodeJS.ProcessEnv,
 ): Promise<void> {
   if (runtimeSatisfies(details)) {
     const note =
@@ -230,10 +231,10 @@ export async function assertSupportedRuntime(
     }
     return;
   }
-  // CLI entrypoints supply argv; later checks and sealed workers retain their runtime.
-  if (details.kind === "node" && argv) {
+  // Only startup callers with a pre-dotenv snapshot may select another runtime.
+  if (details.kind === "node" && argv && recoveryEnv) {
     const { recoverNodeRuntime } = await import("../../node-runtime-recovery.mjs");
-    await recoverNodeRuntime();
+    await recoverNodeRuntime({ env: recoveryEnv });
   }
   if (
     details.kind === "node" &&

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -230,6 +230,11 @@ export async function assertSupportedRuntime(
     }
     return;
   }
+  // CLI entrypoints supply argv; later checks and sealed workers retain their runtime.
+  if (details.kind === "node" && argv) {
+    const { recoverNodeRuntime } = await import("../../node-runtime-recovery.mjs");
+    await recoverNodeRuntime();
+  }
   if (
     details.kind === "node" &&
     canRunOpenClawNodeDiagnostics(details.version, details.hasNodeSqlite) &&

--- a/test/openclaw-launcher-version.e2e.test.ts
+++ b/test/openclaw-launcher-version.e2e.test.ts
@@ -37,6 +37,10 @@ async function makeLauncherVersionFixture(
     path.resolve(process.cwd(), "node-runtime-update.mjs"),
     path.join(fixtureRoot, "node-runtime-update.mjs"),
   );
+  await fs.copyFile(
+    path.resolve(process.cwd(), "node-runtime-recovery.mjs"),
+    path.join(fixtureRoot, "node-runtime-recovery.mjs"),
+  );
   await fs.mkdir(path.join(fixtureRoot, "dist"), { recursive: true });
   await fs.writeFile(
     path.join(fixtureRoot, "package.json"),

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -211,7 +211,7 @@ describe("openclaw launcher", () => {
           const realpath = fs.realpathSync;
           fs.realpathSync = (filename, ...options) => {
             const file = String(filename);
-            if (path.basename(file) === "node" && file !== process.execPath && file !== ${JSON.stringify(nodePath)}) {
+            if (path.basename(file) === "node" && file !== process.execPath && file !== ${JSON.stringify(nodePath)} && !fs.statSync(file).isDirectory()) {
               throw Object.assign(new Error("runtime absent from fixture"), { code: "ENOENT" });
             }
             return realpath(filename, ...options);

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -247,12 +247,12 @@ describe("openclaw launcher", () => {
           'if (process.env.OPENCLAW_NODE_UPDATE_RESPAWNED !== "1") throw new Error("legacy lifecycle loaded"); export function completePendingPackageLifecycle() {}',
         );
       }
-      const run = (input: string, args = ["status"], env: NodeJS.ProcessEnv = {}) =>
+      const run = (input: string, args = ["status"], env: NodeJS.ProcessEnv = {}, cwd = root) =>
         spawnSync(
           process.execPath,
           ["--import", pathToFileURL(preload).href, path.join(root, "openclaw.mjs"), ...args],
           {
-            cwd: root,
+            cwd,
             env: {
               ...launcherEnv(),
               HOME: home,
@@ -268,6 +268,49 @@ describe("openclaw launcher", () => {
         );
       return { root, home, nodePath, installLog, run };
     }
+
+    it.each(
+      ["HOME", "OPENCLAW_HOME"].flatMap((homeVariable) =>
+        ["cached", "install", "decline", "non-interactive"].map((mode) => ({
+          homeVariable,
+          mode,
+        })),
+      ),
+    )(
+      "preserves $mode private recovery when cwd equals $homeVariable",
+      async ({ homeVariable, mode }) => {
+        const fixture = await prepareRecovery({
+          cached: mode === "cached",
+          tty: mode !== "non-interactive",
+        });
+        const result = fixture.run(
+          mode === "install" ? "y\n" : "n\n",
+          ["status"],
+          {
+            HOME: homeVariable === "HOME" ? fixture.home : fixture.root,
+            OPENCLAW_HOME: homeVariable === "OPENCLAW_HOME" ? fixture.home : undefined,
+            PATH: "",
+          },
+          fixture.home,
+        );
+        const recovered = mode === "cached" || mode === "install";
+        expect(result.status, result.stderr).toBe(recovered ? 17 : 1);
+        expect(result.stderr.includes("Update NodeJS: Y/N")).toBe(
+          mode === "install" || mode === "decline",
+        );
+        if (recovered) {
+          expect(JSON.parse(result.stdout)).toMatchObject({
+            recovered: true,
+            cwd: await fs.realpath(fixture.home),
+          });
+        } else {
+          expect(result.stderr).toContain("nvm install");
+        }
+        if (mode !== "install") {
+          await expect(fs.stat(fixture.installLog)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      },
+    );
 
     it("accepts Yes before pending lifecycle imports, installs only Node, and retries exact arguments", async () => {
       const fixture = await prepareRecovery({ pendingLifecycle: true });

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -176,7 +176,7 @@ describe("openclaw launcher", () => {
       } = {},
     ) {
       const root = await makeLauncherFixture(fixtureRoots);
-      const home = path.join(root, "home with spaces");
+      const home = makeTempDir(fixtureRoots, "openclaw-launcher-home with spaces-");
       const nodePath = path.join(
         home,
         ".openclaw",
@@ -187,7 +187,6 @@ describe("openclaw launcher", () => {
         "bin",
         "node",
       );
-      await fs.mkdir(home);
       if (params.cached) {
         await fs.mkdir(path.dirname(nodePath), { recursive: true });
         await fs.symlink(process.execPath, nodePath);

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -25,6 +25,10 @@ async function makeLauncherFixture(fixtureRoots: string[]): Promise<string> {
     path.join(fixtureRoot, "node-runtime-update.mjs"),
   );
   await fs.copyFile(
+    path.resolve(process.cwd(), "node-runtime-recovery.mjs"),
+    path.join(fixtureRoot, "node-runtime-recovery.mjs"),
+  );
+  await fs.copyFile(
     path.resolve(process.cwd(), "node-sqlite.mjs"),
     path.join(fixtureRoot, "node-sqlite.mjs"),
   );
@@ -205,6 +209,14 @@ describe("openclaw launcher", () => {
           }
           Object.defineProperty(process.stdin, "isTTY", { value: ${params.tty ?? true} });
           Object.defineProperty(process.stderr, "isTTY", { value: ${params.tty ?? true} });
+          const realpath = fs.realpathSync;
+          fs.realpathSync = (filename, ...options) => {
+            const file = String(filename);
+            if (path.basename(file) === "node" && file !== process.execPath && file !== ${JSON.stringify(nodePath)}) {
+              throw Object.assign(new Error("runtime absent from fixture"), { code: "ENOENT" });
+            }
+            return realpath(filename, ...options);
+          };
           const original = childProcess.spawnSync;
           childProcess.spawnSync = (command, args, options) => {
             if (command !== ${JSON.stringify(process.platform === "darwin" ? "/bin/bash" : "bash")}) return original(command, args, options);
@@ -224,7 +236,7 @@ describe("openclaw launcher", () => {
         path.join(root, "dist", "entry.js"),
         `
         if (!process.getBuiltinModule?.("node:sqlite")) throw new Error("native diagnostic reader loaded without node:sqlite");
-        process.stdout.write(JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd(), path: process.env.PATH }));
+        process.stdout.write(JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd(), path: process.env.PATH, recovered: process.env.OPENCLAW_NODE_UPDATE_RESPAWNED === "1" }));
         process.exitCode = 17;
       `,
       );
@@ -271,8 +283,9 @@ describe("openclaw launcher", () => {
         args,
         cwd: fixture.root,
         path: expect.any(String),
+        recovered: true,
       });
-      expect(output.path.split(path.delimiter)[0]).toBe(path.dirname(fixture.nodePath));
+      expect(output.path).toBe(process.env.PATH);
       expect(JSON.parse(await fs.readFile(fixture.installLog, "utf8"))).toEqual({
         command: process.platform === "darwin" ? "/bin/bash" : "bash",
         args: [
@@ -347,9 +360,7 @@ describe("openclaw launcher", () => {
       const result = fixture.run("", args);
       expect(result.status, result.stderr).toBe(17);
       expect(result.stderr).not.toContain("Update NodeJS:");
-      expect(JSON.parse(result.stdout).path.split(path.delimiter)[0]).toBe(
-        path.dirname(fixture.nodePath),
-      );
+      expect(JSON.parse(result.stdout)).toMatchObject({ path: process.env.PATH, recovered: true });
       await expect(fs.stat(fixture.installLog)).rejects.toMatchObject({ code: "ENOENT" });
     });
 

--- a/test/scripts/node-runtime-recovery.built-cli.e2e.test.ts
+++ b/test/scripts/node-runtime-recovery.built-cli.e2e.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -60,3 +61,128 @@ it("recovers legacy dist/index.js Doctor before refusing its unsupported Node", 
   });
   expect(result.stderr).not.toContain("Upgrade Node and re-run");
 }, 60_000);
+
+it.each([
+  { name: "rejects workspace NVM_DIR before probing a sibling executable", source: "workspace" },
+  { name: "honors inherited NVM_DIR without forwarding workspace roots", source: "inherited" },
+  { name: "rejects workspace PATH before runtime discovery", source: "path" },
+  { name: "checks launcher admission before loading workspace dotenv", source: "launcher" },
+  { name: "keeps workspace roots out of compile-cache respawns", source: "compile-cache" },
+  { name: "keeps workspace roots out of startup-environment respawns", source: "startup-env" },
+])(
+  "$name",
+  async ({ source }) => {
+    const instance = await createOpenClawTestInstance({ name: `runtime-env-${source}` });
+    instances.push(instance);
+    const workspace = path.join(instance.homeDir, "checkout");
+    const manager = path.join(instance.homeDir, "sibling-nvm");
+    const bin = path.join(manager, "versions/node/v24.19.0/bin");
+    const node = path.join(bin, "node");
+    const workspaceFnm = path.join(instance.homeDir, "workspace-fnm");
+    await fs.mkdir(workspace);
+    await fs.mkdir(bin, { recursive: true });
+    await fs.mkdir(path.join(manager, "alias"));
+    await fs.writeFile(path.join(manager, "alias/default"), "24");
+    await fs.writeFile(node, "synthetic executable; process boundary is instrumented");
+    await fs.writeFile(
+      path.join(workspace, ".env"),
+      `${source === "path" ? "PATH" : "NVM_DIR"}=${source === "path" ? bin : manager}\nFNM_DIR=${workspaceFnm}\n`,
+    );
+    const report = path.join(instance.homeDir, "runtime-env-report.json");
+    const preload = path.join(instance.homeDir, "runtime-env-preload.mjs");
+    const startupRespawn = source === "compile-cache" || source === "startup-env";
+    await fs.writeFile(
+      preload,
+      `import childProcess from "node:child_process";
+     import { EventEmitter } from "node:events";
+     import fs from "node:fs";
+     import { syncBuiltinESMExports } from "node:module";
+     const result = { probes: [] };
+     Object.defineProperty(process.versions, "node", { value: ${JSON.stringify(startupRespawn ? "22.23.2" : "20.0.0")} });
+     if (process.versions.node.startsWith("20.")) {
+       const getBuiltinModule = process.getBuiltinModule;
+       process.getBuiltinModule = (name) => name === "node:sqlite" ? undefined : getBuiltinModule(name);
+     }
+     childProcess.spawnSync = (command) => {
+       result.probes.push(command);
+       return {
+         status: command === ${JSON.stringify(node)} ? 0 : 1,
+         stdout: JSON.stringify({ version: "24.19.0", probe: { available: true, version: "3.53.4", text: true, blob: true, json: true } }),
+       };
+     };
+     childProcess.spawn = (command, args, options) => {
+       result.child = { command, args, nvm: options.env.NVM_DIR, fnm: options.env.FNM_DIR,
+         marker: options.env.OPENCLAW_NODE_UPDATE_RESPAWNED,
+         cacheMarker: options.env.OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED,
+         startupMarker: options.env.OPENCLAW_NODE_OPTIONS_READY };
+       const child = new EventEmitter();
+       child.kill = () => true;
+       setImmediate(() => child.emit("exit", 23, null));
+       return child;
+     };
+     process.on("exit", () => fs.writeFileSync(${JSON.stringify(report)}, JSON.stringify({
+       ...result, loadedNvm: process.env.NVM_DIR, loadedPath: process.env.PATH,
+     })));
+     syncBuiltinESMExports();`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(preload).href,
+        path.resolve(source === "launcher" ? "openclaw.mjs" : "dist/entry.js"),
+        ...(startupRespawn ? ["update", "status"] : ["doctor", "--non-interactive", "--fix"]),
+      ],
+      {
+        cwd: workspace,
+        env: {
+          ...instance.env,
+          HOME: instance.homeDir,
+          PATH: "",
+          NVM_DIR: source === "inherited" ? manager : undefined,
+          FNM_DIR: undefined,
+          VOLTA_HOME: undefined,
+          NODE_OPTIONS: undefined,
+          NODE_DISABLE_COMPILE_CACHE: source === "compile-cache" ? undefined : "1",
+          NODE_COMPILE_CACHE:
+            source === "compile-cache" ? path.join(instance.homeDir, "compile-cache") : undefined,
+          OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED: undefined,
+          OPENCLAW_NODE_UPDATE_RESPAWNED: undefined,
+          OPENCLAW_NODE_OPTIONS_READY: undefined,
+          OPENCLAW_NO_RESPAWN: startupRespawn ? undefined : "1",
+        },
+        encoding: "utf8",
+        timeout: 30_000,
+      },
+    );
+    const observed = JSON.parse(await fs.readFile(report, "utf8"));
+    if (source === "inherited") {
+      expect(result.status, result.stdout + result.stderr).toBe(23);
+      expect(observed.probes).toContain(node);
+      expect(observed.child).toMatchObject({ command: node, nvm: manager, marker: "1" });
+      expect(observed.child.fnm).toBeUndefined();
+    } else {
+      expect(observed.probes).not.toContain(node);
+      expect(observed.loadedNvm).toBe(
+        source === "path" || source === "launcher" ? undefined : manager,
+      );
+      if (startupRespawn) {
+        expect(result.status, result.stdout + result.stderr).toBe(23);
+        expect(observed.child.nvm).toBeUndefined();
+        expect(observed.child.fnm).toBeUndefined();
+        if (source === "compile-cache") {
+          expect(observed.child.cacheMarker).toBe("1");
+        } else if (process.platform === "win32") {
+          expect(observed.child.args).toContain("--stack-size=8192");
+        } else {
+          expect(observed.child.startupMarker).toBe("1");
+        }
+      } else {
+        expect(result.status, result.stdout + result.stderr).toBe(1);
+        expect(observed.child).toBeUndefined();
+      }
+    }
+    expect(observed.loadedPath).toBe("");
+  },
+  60_000,
+);

--- a/test/scripts/node-runtime-recovery.built-cli.e2e.test.ts
+++ b/test/scripts/node-runtime-recovery.built-cli.e2e.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, expect, it } from "vitest";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../helpers/openclaw-test-instance.js";
+
+const instances: OpenClawTestInstance[] = [];
+afterEach(async () => {
+  await Promise.all(instances.splice(0).map((instance) => instance.cleanup()));
+});
+
+it("recovers legacy dist/index.js Doctor before refusing its unsupported Node", async () => {
+  const instance = await createOpenClawTestInstance({ name: "legacy-doctor-node-recovery" });
+  instances.push(instance);
+  const bin = path.join(instance.homeDir, "supported", "bin");
+  const node = path.join(bin, process.platform === "win32" ? "node.exe" : "node");
+  await fs.mkdir(bin, { recursive: true });
+  await fs.writeFile(node, "synthetic runtime; execution is mocked");
+  const preload = path.join(instance.homeDir, "unsupported-node.mjs");
+  const calls = path.join(instance.homeDir, "reexec.json");
+  await fs.writeFile(
+    preload,
+    `import childProcess from "node:child_process";
+     import { EventEmitter } from "node:events";
+     import fs from "node:fs";
+     import { syncBuiltinESMExports } from "node:module";
+     Object.defineProperty(process.versions, "node", { value: "22.23.2" });
+     Object.defineProperty(process, "execPath", { value: ${JSON.stringify(path.join(instance.homeDir, "legacy", "node"))} });
+     process.env.PATH = ${JSON.stringify(bin)};
+     childProcess.spawnSync = (command, args) => ({
+       status: command === ${JSON.stringify(node)} && args[0] === "-e" ? 0 : 1,
+       stdout: JSON.stringify({ version: "24.19.0", probe: { available: true, version: "3.53.4", text: true, blob: true, json: true } }),
+     });
+     childProcess.spawn = (command, args, options) => {
+       fs.writeFileSync(${JSON.stringify(calls)}, JSON.stringify({ command, args, stdio: options.stdio, marker: options.env.OPENCLAW_NODE_UPDATE_RESPAWNED }));
+       const child = new EventEmitter();
+       child.kill = () => true;
+       setImmediate(() => child.emit("exit", 23, null));
+       return child;
+     };
+     syncBuiltinESMExports();`,
+  );
+  instance.env.NODE_OPTIONS = `--import=${pathToFileURL(preload).href}`;
+  delete instance.env.OPENCLAW_NODE_UPDATE_RESPAWNED;
+  const result = await instance.cli(["doctor", "--non-interactive", "--fix"]);
+  expect(result.code, result.stdout + result.stderr).toBe(23);
+  expect(JSON.parse(await fs.readFile(calls, "utf8"))).toMatchObject({
+    command: node,
+    args: [
+      expect.stringMatching(/dist[/\\]index\.(?:m?js)$/),
+      "doctor",
+      "--non-interactive",
+      "--fix",
+    ],
+    stdio: "inherit",
+    marker: "1",
+  });
+  expect(result.stderr).not.toContain("Upgrade Node and re-run");
+}, 60_000);

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2482,6 +2482,7 @@ describe("scripts/test-projects changed-target routing", () => {
         forwardedArgs: [
           "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
           "test/scripts/mcp-channels-seed.built-cli.e2e.test.ts",
+          "test/scripts/node-runtime-recovery.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
         ],


### PR DESCRIPTION
Refs #140465

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users upgrading from an older OpenClaw release would fail during target Doctor and lose Gateway availability when the recorded service runtime was unsupported, even though a compatible Node was already installed. The 2026.7.1-2 updater invokes the target through `dist/index.js`, so launcher-only recovery cannot reach this path.

## Why This Change Was Made

Share dependency-free startup recovery between `openclaw.mjs` and CLI runtime admission. Try the previously installed private runtime, the recorded managed Gateway Node, another Node on PATH, then nvm/fnm/Volta defaults and Homebrew Node 26/24 prefixes. Candidates must pass the existing SQLite capability admission through a bounded, sanitized `node -e` probe.

Reuse the launcher's child supervision to retry the same script and arguments, retaining cwd, environment, standard streams, and exit status. A marker prevents rediscovery in the child; exact-PID Gmail and native hook-relay invocations retain their exclusions. Already-admitted runtimes do not search. Existing installation offers, diagnostic exemptions, and refusal behavior remain the fallback. Include the shared module in package, Docker, and worker-bootstrap artifacts.

## User Impact

Older updaters can finish Doctor using an already available compatible Node without prompting or a manual runtime switch. Runtime discovery does not install Node unattended or rewrite service definitions. Release-note context: recover update Doctor when the old updater chooses an incompatible service Node despite a compatible installed runtime.

Recorded-service discovery reads canonical service files and OpenClaw's generated launchd wrappers. Arbitrary custom wrappers and systemd drop-ins are not interpreted. Native Windows and version-manager installations were not live-tested in this lane.

## Evidence

- The built `dist/index.js doctor --non-interactive --fix` regression failed before integration: admission exited 1 instead of reaching the replacement process. It passes after integration and propagates replacement exit 23.
- Focused runtime, entry, and CLI orchestration tests: 468 passed, including snapshot isolation, absolute/cwd path guards, and writer-produced Windows cases. Launcher and built-entrypoint suite: 111 passed, 1 existing real-Bun skip. Worker-bootstrap suites: 62 passed.
- All typecheck lanes and scoped core/script/root-test lint passed. Full `check-changed` reached lint, then the declaration-isolation guard rejected the nested worktree because module lookup reached an ancestor install. The guard was left intact; clean-checkout CI remains required.
- `pnpm build` passed. The requested Docker packer and tarball integrity/import checks passed.
- Live matrix cell `2026.7.1-2-node22-service`: old updater launched target Doctor under Node 22.23.2; recovery selected PATH's Node 24.19.0. Both Doctor processes exited 0, update exited 0, Gateway restarted on Node 24, HTTP/RPC and synthetic chat passed, and no manual recovery was required. HTTP downtime was 84.278 seconds (sampling bounds 83.278–85.283 seconds).
- Tested candidate SHA-256: `16cb1c2c9302817b955e8a551ef19b96453b1d4265413142aaca60b2e3e59d8c`; installed build and RPC reported commit `cb22822127654e2fc2cc26e3529fbb4519abb8ea`. That is the recorded Linux PATH-discovery live proof. The subsequent PATH hardening and Windows-reader repairs are covered by the focused tests; this is not a new native-Windows live run.
- Initial CI exposed an E2E routing expectation that needed the new test filename. Both affected routing cases pass after the one-line correction, and `checks-node-compact-small-31` is green on `0e6ddc245fb30af39cda4d4b1d41aeea228d3aef`.

- Before these review repairs, relative PATH probes and generated unquoted/escaped and encoded Windows cases failed; the prior path/Windows repair passed 127 focused tests. The earlier terminal-panel CI failure passed on its one authorized rerun. Exact-head CI is green on `9618a0c75f3ea5d232a5d6e8ff951999cfedbc6c` ([run 34420851845](https://github.com/openclaw/openclaw/actions/runs/34420851845)), verified with `node scripts/watch-pr-ci.mjs 143464 9618a0c75f3ea5d232a5d6e8ff951999cfedbc6c`. All UI shards passed without a rerun on this head.

## Review notes

Current repair head: `b0a2a3d771a20af4963467d04fdbac27baea5611`.

`OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs` passed completely on tree `6c56654593cfdc55f01b4fcee0fa92a046af78ee`, which exactly matches the committed tree: all typechecks, guards, unused-export scans, lint, and zero runtime import cycles. Blacksmith Testbox [run 34445790621](https://github.com/openclaw/openclaw/actions/runs/34445790621) returned exit 0; its owned lease and source capsule were cleaned up. The backing Actions run can show cancellation after successful one-shot cleanup; the delegated command result is succeeded. `git diff --check` passed. Fresh PR CI and ClawSweeper review are pending on this head.

### HOME invocation recovery

The accepted HOME-cwd regression is repaired at the shared recovery owner. Resolving HOME or OPENCLAW_HOME as metadata no longer rejects a normal home-directory launch. The canonical effective home plus literal `.openclaw` is validated before accepting its realpath, and the resulting recovery root is computed once and passed through private cache lookup, install-path validation, and both capability probes. OPENCLAW_HOME keeps its existing base-home meaning; the private installation stays beneath `.openclaw/tools/cli-node`.

Only private recovery receives this root exemption. Relative paths, workspace dotenv values, service/manager candidates beneath cwd, and root/intermediate/executable symlinks into cwd outside the owned subtree remain excluded. The existing explicit absolute-PATH directory exception remains unchanged. A local autoreview found the initial root-level symlink promotion issue; its added regression failed before the correction and passes now. Fresh autoreview is scoped-clean at P0/P1.

Before this repair, the new cached-runtime unit cases failed for both HOME and OPENCLAW_HOME (`expected ... to be called once, but got 0 times`): **2 failed, 3 controls passed**. Launcher proof had **6 failed, 2 controls passed**: cached/install cases exited 1 instead of replacement exit 17, and decline cases never displayed the offer. The new root-symlink test also failed against the initial repair because a workspace Node was probed. Final focused proof: **76 recovery/updater tests passed; 114 launcher/version tests passed, with one existing real-Bun skip**. These tests exercise cache reuse, accepted/declined installation offers, non-interactive refusal, and workspace/manager/root/intermediate/executable escape rejection.

No persisted state, install records, configuration schema, SQLite schema, retention/recovery semantics, or migration changes. The existing Linux Docker upgrade cell remains the recorded live proof; native Windows and actual version-manager installations were not live-tested in this round.

### Earlier review history

Patch-identical rebase: `7cc250fe578cbae3485f7c66816a57d4e964e4b9` → `21d24232701f2c108baf1ce14ddf986096c2880d`, onto main `f4d1a1fdf84a6c2df91e2d78570964fff5302677`. All seven `git range-diff` entries are `=`, and the aggregate patch is byte-identical after removing blob IDs and hunk offsets. No conflict resolution or semantic patch change was needed. This base includes #143666, which repairs the shared-main real-Gateway fixture that blocked the previous CI run. Fresh exact-head [CI run 34442970535](https://github.com/openclaw/openclaw/actions/runs/34442970535) failed in [checks-ui-e2e (4/7)](https://github.com/openclaw/openclaw/actions/runs/34442970535/job/102761784356). The unrelated mocked-browser case `Control UI Ask OpenClaw panel toggle mocked Gateway E2E > opens OpenClaw from Home and the palette and reuses the persisted session id` failed at `ui/src/e2e/custodian-panel-toggle.e2e.test.ts:154:50`: `TimeoutError: locator.waitFor: Timeout 30000ms exceeded`, waiting for `locator('openclaw-assistant-panel').getByText('Channel repaired.')` after the palette click. This file and its browser flow are outside this PR's delta. The shard had 304 passing tests and one failure. Per the landing order, no CI rerun or native landing was dispatched. ClawSweeper's push dispatch succeeded, but its durable review still targets the previous head; the freshness poll was stopped when CI blocked landing.

`OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs` passed in full on this exact source tree (`52c311726678bc688203ecff359b39307dc6e9b1`): all typechecks, guards, unused-export scans, lint, and zero runtime import cycles. Blacksmith Testbox [run 34440426892](https://github.com/openclaw/openclaw/actions/runs/34440426892) returned exit 0; its owned lease and source capsule were cleaned up. The backing Actions run can show cancellation after successful one-shot cleanup; the delegated command result is succeeded. `git diff --check` passed.

Data-model compatibility verified for this head: no persisted state, install records, configuration schema, SQLite schema, or retention/recovery semantics change. No migration is required. The new root recovery module reads existing service/manager metadata and re-executes the original invocation; the existing private-runtime layout is unchanged. The recorded 2026.7.1-2 Linux upgrade cell completed Doctor/update and restored Gateway HTTP/RPC/chat without manual recovery. Later path and dotenv repairs have the instrumented process-boundary proof described below.

The 13 Windows writer-fixture cases are: unquoted executable, quoted executable, cmd percent/exclamation escapes, GBK marker, legacy GBK marker, UTF-8 BOM, UTF-16 LE BOM, UTF-16 BE BOM, Big5 marker, CP866 marker, CP1258 marker, CP850 skip, and CP949/UHC skip. Native Windows installation and real version-manager installations were not live-tested.

Path canonicalization repair head: `7cc250fe578cbae3485f7c66816a57d4e964e4b9`. Fresh autoreview is scoped-clean at P0/P1.

The accepted Windows service-path finding is fixed by one dependency-free canonicalization helper. It expands leading `~` against the correct inherited home, rejects bare relative paths before resolving them, and checks lexical paths, existing parent-directory realpaths, and final realpaths against cwd before metadata reads or executable probes. Service and manager paths use daemon HOME/USERPROFILE; OPENCLAW_HOME selects only the private-runtime home. Explicit task-script overrides use the same expansion and rejection rules. The launcher no longer pre-resolves a relative private-home setting before recovery can reject it.

The same helper protects service files, version-manager roots/alias files/manifests, directory enumeration, and private installation destinations. Missing private destinations validate their existing ancestors without treating dangling links or unreadable paths as creatable directories. Account-home lookup remains optional so inherited HOME or independent PATH recovery works for container UIDs without account records. Invalid service candidates are rejected before deduplication, preserving later valid PATH discovery and its explicit absolute-directory cwd exception.

Child-process tests use real files, the canonical Windows service writer, and a separate invocation cwd. They prove that `OPENCLAW_STATE_DIR=~/x` selects the daemon-home service despite a different OPENCLAW_HOME, competing `cwd/~/x/gateway.cmd` is never read/probed, relative state paths are rejected, and explicit task-script and intermediate-directory symlink cases are rejected before reads or probes. Additional cases cover nvm/fnm/Volta and HOME/USERPROFILE/OPENCLAW_HOME expansion, intermediate-directory rejection, container account lookup, and PATH fallback. Probes and replacement spawning are instrumented; this is not native Windows installation proof.

Against the original committed recovery modules, the new path suite had **15 failures and 2 passing controls**. All **17 cases pass** after the fix. The broader focused suite passes **468 tests**, and launcher/built-entrypoint suites pass **111 tests with one existing real-Bun skip**. No assertions or baselines were weakened; obsolete executable-only filesystem mocks were replaced with real fixtures or corrected to preserve directories. All typecheck lanes and scoped lint passed. Full `check-changed` again stopped at the documented ancestor-install declaration-isolation guard during full lint; `git diff --check` passed. The earlier Linux upgrade cell remains the recorded installed-runtime proof.

Dotenv-boundary repair head: `711e0d77f8ead0d6f6707a8619b3d2cf817b3723`. Fresh autoreview is scoped-clean at P0/P1.

Before the dotenv repair, exact-head CI was green on `e7e5fa0968b7ba9a95e197749112cf5c76ad7f80` ([run 34424261112](https://github.com/openclaw/openclaw/actions/runs/34424261112)), verified with `node scripts/watch-pr-ci.mjs 143464 e7e5fa0968b7ba9a95e197749112cf5c76ad7f80`. The launcher check and all UI shards passed without reruns on this head.

The first hardening CI run exposed four launcher-fixture failures: the fixture's synthetic home was nested under its invocation cwd and contained an outside-pointing Node symlink. The fixture now creates its home in a separate tracked temporary directory, retaining spaces in the path, all assertions, and cleanup ownership. The four failures were reproduced locally; the corrected launcher and version suites pass 104 tests with one existing real-Bun skip. The fixture-only changed-file checks pass in full, and its autoreview is scoped-clean at P0/P1.

The earlier rejection of the manager-root provenance finding was incorrect. Inherited environment settings are trusted like PATH, but `src/entry.ts` loads workspace dotenv before runtime admission, and the existing filter admits `NVM_DIR`, `FNM_DIR`, and `VOLTA_HOME`. Those values could select a sibling executable outside cwd. The accepted P1 is fixed at startup ownership: entry captures the inherited environment before dotenv, threads it through both admission calls and run-main, and recovery uses it for every discovery root, private runtime, sanitized probe setting, and replacement-child environment. Legacy run-main captures its environment before its own dotenv phase. Both startup respawn paths also receive pre-dotenv settings so a child cannot recategorize workspace values as inherited. The dotenv filter remains unchanged; application code can still use permitted dotenv values.

Security boundary proof runs the actual built entrypoint with instrumented process spawning and a real workspace `.env`. These test names cover the behavior:

- `rejects workspace NVM_DIR before probing a sibling executable`
- `honors inherited NVM_DIR without forwarding workspace roots`
- `rejects workspace PATH before runtime discovery`
- `checks launcher admission before loading workspace dotenv`
- `keeps workspace roots out of compile-cache respawns`
- `keeps workspace roots out of startup-environment respawns`
- `uses inherited PATH and probe settings after process env changes`

Before the repair, the built-entry suite had four failures: workspace NVM reached the probe, both respawn cases reached it, and inherited NVM recovery forwarded workspace FNM. The separate mutable-PATH regression also failed, selecting the changed PATH instead of the snapshot. The real workspace-PATH control already passed because the existing filter blocks PATH; launcher ordering is likewise a preserved control. All seven named boundary cases now pass. `pnpm build` passed; all changed-file guards and typechecks passed before the documented ancestor-install lint guard, and scoped lint and `git diff --check` passed. The recorded Linux Docker cell remains the real installed-Node upgrade proof, not a new-head live run. Native Windows and real version-manager installations remain outside live coverage.

The accepted PATH finding is fixed at the shared probe boundary: candidates must be absolute before and after realpath, and must resolve to `node` or `node.exe`. Cwd-resolved executables are rejected unless an absolute PATH directory explicitly selects them. Other discovery sources cannot inherit that exception.

The Windows reader now parses the canonical task writer's quoted, unquoted, and escaped executable tokens. It honors recorded code-page metadata, legacy marker-only files, and Unicode BOMs using built-in `TextDecoder`; it imports neither dist nor a codec dependency.

Maintainer decision: CP850 and CP949 are intentionally skipped with `service script uses code page N; not decodable here`, followed by the remaining discovery sources. ICU has no CP850 decoder, and its `euc-kr` decoder silently corrupts genuine UHC bytes even with fatal decoding. These cases must never guess or probe the service executable.

| Writer-produced fixture | Result |
|---|---|
| Quoted, unquoted, percent/exclamation escaping | Discovered |
| GBK and legacy marker-only GBK | Discovered |
| Big5, CP866, CP1258 | Discovered |
| UTF-8 BOM, UTF-16 LE/BE BOM | Discovered |
| CP850 and genuine CP949/UHC | Note printed, no service probe, PATH fallback succeeds |

Proof scope: the recorded Linux Docker upgrade exercises PATH discovery through legacy `dist/index.js`; the new path restrictions and Windows reader have unit proof, including fixtures produced by the actual service writer. Native Windows and real version-manager installations were not live-tested.

Data-model compatibility: no persisted-state, store, install-record, or configuration-schema change. Recovery reads existing metadata and redirects the invocation; the package ships one new root module. No migration is required.

Validation commands:

```sh
node scripts/run-vitest.mjs src/infra/node-runtime-recovery.test.ts src/infra/node-runtime-update.test.ts src/infra/runtime-guard.test.ts src/entry.run-main.test.ts src/entry.compile-cache.test.ts src/entry.respawn-diagnostics.test.ts src/cli/run-main.exit.test.ts src/cli/run-main.profile-env.test.ts
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/scripts/node-runtime-recovery.built-cli.e2e.test.ts test/openclaw-launcher.e2e.test.ts test/openclaw-launcher-version.e2e.test.ts
node scripts/run-vitest.mjs src/gateway/worker-environments/node-bootstrap-artifact.test.ts src/gateway/worker-environments/node-enrollment.test.ts
node scripts/check-changed.mjs
node scripts/package-openclaw-for-docker.mjs --skip-build --allow-unreleased-changelog --output-dir .local/l19/package --output-name openclaw-current.tgz
/bin/bash .local/l19/launch.sh 2026.7.1-2 2026.7.1 2026.7.1-2-node22-service 22 openclaw-current.tgz
```
