### PR TITLE
fix(agents): keep announcement tests within their own fixture

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.test.ts
@@ -1,6 +1,6 @@
 // Subagent announce flow tests cover the seam-level orchestration between wait
 // outcomes, requester lookup, delivery, and cleanup.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeSessionDeliveryState } from "../../../utils/delivery-context.shared.js";
 import type { EmbeddedAgentQueueMessageOutcome } from "../../embedded-agent-runner/runs.js";
 import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
@@ -20,8 +20,10 @@ const agentSpy = vi.fn(async (_req: AgentCallRequest): Promise<AgentCallResponse
 const sessionsDeleteSpy = vi.fn((_req: AgentCallRequest) => undefined);
 const callGatewayMock = vi.fn(async (_request: unknown) => ({}));
 const loadSessionStoreMock = vi.fn((_storePath: string) => ({}));
-const resolveAgentIdFromSessionKeyMock = vi.fn((sessionKey: string) => {
-  return sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main";
+const resolveAgentIdFromSessionKeyMock = vi.fn<
+  typeof import("./subagent-announce.runtime.js").resolveAgentIdFromSessionKey
+>((sessionKey, configuredDefaultAgentId) => {
+  return sessionKey?.match(/^agent:([^:]+)/)?.[1] ?? configuredDefaultAgentId ?? "main";
 });
 const resolveStorePathMock = vi.fn((_store: unknown, _options: unknown) => "/tmp/sessions.json");
 const resolveMainSessionKeyMock = vi.fn((_cfg: unknown) => "agent:main:main");
@@ -219,6 +221,7 @@ vi.mock("../registry/subagent-registry-read.js", () => subagentRegistryRuntimeMo
 vi.mock("../registry/subagent-registry-runtime.js", () => subagentRegistryRuntimeMock);
 import { defaultRuntime } from "../../../runtime.js";
 import { applySubagentWaitOutcome } from "./subagent-announce-output.js";
+import { testing as outputTesting } from "./subagent-announce-output.test-support.js";
 import { runSubagentAnnounceFlow } from "./subagent-announce.js";
 
 function requireQueuedMessageCall() {
@@ -319,6 +322,24 @@ describe("subagent announce seam flow", () => {
     subagentRegistryRuntimeMock.replaceSubagentRunAfterSteer.mockReturnValue(true);
     subagentRegistryRuntimeMock.resolveRequesterForChildSession.mockReset();
     subagentRegistryRuntimeMock.resolveRequesterForChildSession.mockReturnValue(null);
+    outputTesting.setDepsForTest({
+      callGateway: callGatewayMock as typeof import("./subagent-announce.runtime.js").callGateway,
+      getRuntimeConfig: () => mockConfig,
+      readSubagentSessionEntry: (storePath, sessionKey) =>
+        (
+          loadSessionStoreMock(storePath) as Record<
+            string,
+            ReturnType<typeof import("./subagent-announce.runtime.js").readSubagentSessionEntry>
+          >
+        )[sessionKey],
+      readSessionMessagesAsync: async () => [],
+      resolveAgentIdFromSessionKey: resolveAgentIdFromSessionKeyMock,
+      resolveSessionStorePathCore: resolveStorePathMock,
+    });
+  });
+
+  afterEach(() => {
+    outputTesting.setDepsForTest();
   });
 
   it("suppresses ANNOUNCE_SKIP delivery while still deleting the child session", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/142935

<details>
<summary>Additional instructions</summary>

**Maintainer edits:** This is a same-repository branch in `openclaw/openclaw`.
Maintainer edits use repository write permissions; the fork-only
**Allow edits from maintainers** checkbox does not apply.

</details>

## What Problem This Solves

Resolves a problem where announcement flow tests can read output dependencies
outside the active fixture instead of the mocks reset for that case.

## Why This Change Was Made

Bind all six existing output dependencies after the fixture resets, read mutable
config and session-store state at call time, and restore captured defaults after
each case. The resolver mock uses the existing owner signature and handles
nullish keys and an optional configured default without a binding cast.

All existing cases, assertions, deadlines, and production behavior are unchanged.

This is a maintainer-requested standalone fixture repair under an explicit
exception to CONTRIBUTING's test/CI-only PR restriction.

## User Impact

Test-only fixture ownership repair. There is no end-user runtime change.

## Evidence

- Investigation trigger:
  https://github.com/openclaw/openclaw/actions/runs/34332078165/job/102478508606
  This failed job triggered the investigation; it is not historical cause proof.
- One uninstrumented owner-and-output-sibling invocation passed all 85 tests:
  16 announcement flow cases and 69 output cases.
- After correcting the resolver mock's signature and nullish-key handling, a
  focused owner invocation passed all 16 cases. The unchanged sibling was not
  repeated.
- The selected agents core-test typecheck, targeted formatting/lint, and
  applicable changed-file guards completed successfully. The initial typecheck
  failure and its focused correction are retained separately.
- A separately retained synthetic dependency-retention experiment failed at the
  original delivered/retryable boundary before binding and passed all 16 owner
  cases after binding. No private observer or sentinel is part of this patch.
- Final independent scoped review found no actionable issues.

This proves fixture dependency ownership, not the historical CI loader cause,
CI parity, a known flake, or recovery of the previously failing CI run.
