### PR TITLE
feat(android): adapt flat large-screen navigation

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -56,7 +56,11 @@ truncated patches, stopped workspaces, and unavailable repositories are identifi
 in the viewer. Switching conversation or Gateway closes the review; safe fold
 layout changes preserve the opening.
 
-## Foldable layout
+## Large-screen and foldable layout
+
+Without an intersecting separator, tablet and desktop windows at least 840 dp
+wide and 320 dp tall keep a 360 dp sidebar beside the active page. The sidebar
+follows the reading direction. Narrower or shorter windows use the modal sidebar.
 
 With a full-height vertical separator reported by AndroidX WindowManager, the
 main app places its sidebar on the reading-direction start plane and the active
@@ -64,12 +68,13 @@ page on the other plane. Both use the reported bounds, including off-center
 hinges. The sidebar remains visible after selecting a page or session.
 
 Book panes require at least 280 dp for the sidebar, 320 dp for the active page,
-and 320 dp of height. Onboarding and layouts without a supported split use the
+and 320 dp of height, even when the window is narrower than 840 dp.
+Onboarding and layouts without a supported split use the
 largest rectangular region clear of separating folds and fully occluding hinges.
 Equal regions prefer the top, then the reading-direction start side. Opening
 the keyboard does not select a different fallback region for this outer host.
-Without an intersecting separator, the app keeps its full-window layout and
-modal sidebar.
+Width-based sidebars require the entire host to be clear of separating folds
+and fully occluding hinges; they never subdivide a reduced fallback region.
 
 In Chat, a full-width horizontal separator can place the conversation header,
 transcript, and status above the hinge and the same composer below it. Each

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareContent.kt
@@ -19,7 +19,7 @@ import androidx.window.layout.DisplayFeature
 internal fun FoldAwareContent(
   features: List<DisplayFeature>,
   modifier: Modifier = Modifier,
-  bookPanesEnabled: Boolean = false,
+  sidebarPanesEnabled: Boolean = false,
   tabletopEnabled: Boolean = false,
   content: @Composable (FoldContentBounds) -> Unit,
 ) {
@@ -34,12 +34,12 @@ internal fun FoldAwareContent(
       // current window offset even when an ancestor moves without changing our constraints.
       val origin = coordinates?.positionInWindow()?.round() ?: IntOffset.Zero
       val host = IntRect(origin, IntSize(width, height))
-      val book = if (bookPanesEnabled) bookPaneBounds(host, features, layoutDirection, density) else null
+      val sidebar = if (sidebarPanesEnabled) sidebarPaneBounds(host, features, layoutDirection, density) else null
       val tabletop = if (tabletopEnabled) tabletopPaneBounds(host, features, layoutDirection) else null
       val fallback = foldSafeRegion(host, features, layoutDirection)
-      val pane = if (book != null || tabletop != null) host else fallback
-      val localBook = book?.let { BookPaneBounds(it.start.translate(-origin), it.end.translate(-origin)) }
-      val bounds = FoldContentBounds(localBook, tabletop, fallback.translate(-origin).takeIf { tabletop != null })
+      val pane = if (sidebar != null || tabletop != null) host else fallback
+      val localSidebar = sidebar?.let { SidebarPaneBounds(it.start.translate(-origin), it.end.translate(-origin)) }
+      val bounds = FoldContentBounds(localSidebar, tabletop, fallback.translate(-origin).takeIf { tabletop != null })
       // One subcomposition keeps the screen alive while deciding its mode from current host bounds.
       subcompose(Unit) {
         Box(Modifier.recalculateWindowInsets().clipToBounds()) { content(bounds) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -151,11 +151,11 @@ fun ShellScreen(
     FoldAwareContent(
       features = features,
       modifier = modifier.background(ClawTheme.colors.canvas),
-      bookPanesEnabled = !commandOpen && pendingTrust == null,
+      sidebarPanesEnabled = !commandOpen && pendingTrust == null,
       tabletopEnabled = nav.activeTab == Tab.Chat && !commandOpen && pendingTrust == null,
     ) { foldBounds ->
-      val bookPanes = foldBounds.book
-      val permanentSidebar = bookPanes != null
+      val sidebarPanes = foldBounds.sidebar
+      val permanentSidebar = sidebarPanes != null
       // Mode changes discard modal operations and their drag state, not the two content slots.
       val sidebarDrawerState = key(permanentSidebar) { rememberDrawerState(initialValue = DrawerValue.Closed) }
       var sidebarRowDragging by remember(sidebarDrawerState) { mutableStateOf(false) }
@@ -249,7 +249,7 @@ fun ShellScreen(
       Box(modifier = Modifier.fillMaxSize().background(ClawTheme.colors.canvas)) {
         SidebarNavigationShell(
           drawerState = sidebarDrawerState,
-          bookPanes = bookPanes,
+          sidebarPanes = sidebarPanes,
           sidebarBand = foldBounds.sidebarBand,
           gesturesEnabled = !sidebarRowDragging,
           drawerContent = {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarShell.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarShell.kt
@@ -27,18 +27,30 @@ import androidx.compose.ui.unit.dp
 import androidx.window.layout.DisplayFeature
 import androidx.window.layout.FoldingFeature
 
-internal data class BookPaneBounds(
+internal data class SidebarPaneBounds(
   val start: IntRect,
   val end: IntRect,
 )
 
 /** Physical window rectangles. Partial or additional separators retain the root safety fallback. */
-internal fun bookPaneBounds(
+internal fun sidebarPaneBounds(
   host: IntRect,
   features: List<DisplayFeature>,
   direction: LayoutDirection,
   density: Density,
-): BookPaneBounds? {
+): SidebarPaneBounds? {
+  with(density) {
+    if (host.height < 320.dp.roundToPx()) return null
+    // Width alone may split only the whole safe host, never a reduced fold fallback.
+    if (host.width >= 840.dp.roundToPx() && foldSafeRegion(host, features, direction) == host) {
+      val sidebarWidth = 360.dp.roundToPx()
+      return if (direction == LayoutDirection.Ltr) {
+        SidebarPaneBounds(host.copy(right = host.left + sidebarWidth), host.copy(left = host.left + sidebarWidth))
+      } else {
+        SidebarPaneBounds(host.copy(left = host.right - sidebarWidth), host.copy(right = host.right - sidebarWidth))
+      }
+    }
+  }
   val separator =
     features.filterIsInstance<FoldingFeature>().singleOrNull {
       (it.isSeparating || it.occlusionType == FoldingFeature.OcclusionType.FULL) &&
@@ -48,12 +60,10 @@ internal fun bookPaneBounds(
     } ?: return null
   val left = host.copy(right = separator.bounds.left)
   val right = host.copy(left = separator.bounds.right)
-  val panes = if (direction == LayoutDirection.Ltr) BookPaneBounds(left, right) else BookPaneBounds(right, left)
+  val panes = if (direction == LayoutDirection.Ltr) SidebarPaneBounds(left, right) else SidebarPaneBounds(right, left)
   with(density) {
     // Reserve a usable navigation header and a phone-width destination, not a fixed drawer width.
-    if (panes.start.width < 280.dp.roundToPx() || panes.end.width < 320.dp.roundToPx() ||
-      host.height < 320.dp.roundToPx()
-    ) {
+    if (panes.start.width < 280.dp.roundToPx() || panes.end.width < 320.dp.roundToPx()) {
       return null
     }
   }
@@ -64,7 +74,7 @@ internal fun bookPaneBounds(
 @Composable
 internal fun SidebarNavigationShell(
   drawerState: DrawerState,
-  bookPanes: BookPaneBounds? = null,
+  sidebarPanes: SidebarPaneBounds? = null,
   sidebarBand: IntRect? = null,
   gesturesEnabled: Boolean = true,
   drawerContent: @Composable () -> Unit,
@@ -75,7 +85,7 @@ internal fun SidebarNavigationShell(
 
   ModalNavigationDrawer(
     drawerState = drawerState,
-    gesturesEnabled = bookPanes == null && gesturesEnabled,
+    gesturesEnabled = sidebarPanes == null && gesturesEnabled,
     drawerContent = {
       // Discard predictive-Back mechanics, never the destination's layout ancestry.
       key(drawerState) {
@@ -97,7 +107,7 @@ internal fun SidebarNavigationShell(
               .testTag("sidebar-drawer"),
         ) {
           // The closed empty sheet retains real measured anchors in permanent mode.
-          if (bookPanes == null) sidebar()
+          if (sidebarPanes == null) sidebar()
         }
       }
     },
@@ -107,20 +117,20 @@ internal fun SidebarNavigationShell(
         content = {
           // Keep the focused destination attached to the same parents across mode changes.
           Box(Modifier.recalculateWindowInsets().clipToBounds()) { content() }
-          if (bookPanes != null) {
+          if (sidebarPanes != null) {
             Box(Modifier.recalculateWindowInsets().clipToBounds().testTag("sidebar-permanent")) { sidebar() }
           }
         },
         modifier = Modifier.fillMaxSize(),
       ) { measurables, constraints ->
-        val destinationBounds = bookPanes?.end ?: IntRect(0, 0, constraints.maxWidth, constraints.maxHeight)
+        val destinationBounds = sidebarPanes?.end ?: IntRect(0, 0, constraints.maxWidth, constraints.maxHeight)
         val destinationPlaceable =
           measurables[0].measure(Constraints.fixed(destinationBounds.width, destinationBounds.height))
         val sidebarPlaceable =
-          bookPanes?.let { measurables[1].measure(Constraints.fixed(it.start.width, it.start.height)) }
+          sidebarPanes?.let { measurables[1].measure(Constraints.fixed(it.start.width, it.start.height)) }
         layout(constraints.maxWidth, constraints.maxHeight) {
           destinationPlaceable.place(destinationBounds.left, destinationBounds.top)
-          bookPanes?.let { sidebarPlaceable?.place(it.start.left, it.start.top) }
+          sidebarPanes?.let { sidebarPlaceable?.place(it.start.left, it.start.top) }
         }
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/TabletopLayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/TabletopLayout.kt
@@ -11,7 +11,7 @@ internal data class TabletopPaneBounds(
 )
 
 internal data class FoldContentBounds(
-  val book: BookPaneBounds?,
+  val sidebar: SidebarPaneBounds?,
   val tabletop: TabletopPaneBounds?,
   val sidebarBand: IntRect?,
 )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareContentTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -16,6 +18,7 @@ import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -23,6 +26,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.layout.DisplayFeature
@@ -38,6 +43,143 @@ import org.robolectric.annotation.Config
 @Config(minSdk = 34, maxSdk = 34, qualifiers = "w1000dp-h1000dp-mdpi")
 class FoldAwareContentTest {
   @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  @Config(qualifiers = "w1800dp-h1000dp-hdpi")
+  fun sidebarAllocationUsesRealConstraintsDensityAndCompletePhysicalFoldSafety() {
+    var width by mutableStateOf(1000.dp)
+    var height by mutableStateOf(800.dp)
+    var origin by mutableStateOf(IntOffset(150, 75))
+    var direction by mutableStateOf(LayoutDirection.Ltr)
+    var features by mutableStateOf(emptyList<DisplayFeature>())
+    var starts = 0
+    var disposals = 0
+    composeRule.setContent {
+      CompositionLocalProvider(LocalLayoutDirection provides direction) {
+        Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+          FoldAwareContent(
+            features,
+            Modifier.absoluteOffset { origin }.size(width, height),
+            sidebarPanesEnabled = true,
+          ) { bounds ->
+            SidebarNavigationShell(
+              drawerState = rememberDrawerState(DrawerValue.Closed),
+              sidebarPanes = bounds.sidebar,
+              drawerContent = { Box(Modifier.fillMaxSize()) },
+            ) {
+              var draft by remember { mutableStateOf("") }
+              DisposableEffect(Unit) {
+                starts++
+                onDispose { disposals++ }
+              }
+              Box(Modifier.fillMaxSize().testTag("destination")) {
+                BasicTextField(draft, { draft = it }, Modifier.testTag("editor"))
+              }
+            }
+          }
+        }
+      }
+    }
+    assertEquals("Exercise non-mdpi pixel rounding", 1.5f, composeRule.density.density, 0f)
+    val editor = composeRule.onNodeWithTag("editor")
+    editor.performTextReplacement("retained allocation draft")
+    val editorId = editor.fetchSemanticsNode().id
+
+    fun physicalBounds(tag: String): IntRect {
+      val bounds = composeRule.onNodeWithTag(tag).getUnclippedBoundsInRoot()
+      return with(composeRule.density) {
+        IntRect(bounds.left.roundToPx(), bounds.top.roundToPx(), bounds.right.roundToPx(), bounds.bottom.roundToPx())
+      }
+    }
+
+    fun verify(
+      sidebar: IntRect?,
+      destination: IntRect,
+    ) {
+      assertEquals("Actual destination for $width x $height, $direction, $features", destination, physicalBounds("destination"))
+      if (sidebar == null) {
+        composeRule.onNodeWithTag("sidebar-permanent").assertDoesNotExist()
+      } else {
+        composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+        assertEquals(sidebar, physicalBounds("sidebar-permanent"))
+      }
+      editor.assertTextEquals("retained allocation draft")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      assertEquals(1, starts)
+      assertEquals(0, disposals)
+    }
+    val sizes =
+      listOf(
+        Triple(360.dp, 800.dp, false),
+        Triple(600.dp, 800.dp, false),
+        Triple(839.dp, 800.dp, false),
+        Triple((1259f / 1.5f).dp, 800.dp, false),
+        Triple(840.dp, 800.dp, true),
+        Triple(1000.dp, 800.dp, true),
+        Triple(1600.dp, 800.dp, true),
+        Triple(1000.dp, 319.dp, false),
+        Triple(1000.dp, 320.dp, true),
+      )
+    for ((nextWidth, nextHeight, permanent) in sizes) {
+      composeRule.runOnIdle {
+        width = nextWidth
+        height = nextHeight
+      }
+      val host = with(composeRule.density) { IntRect(origin, IntSize(nextWidth.roundToPx(), nextHeight.roundToPx())) }
+      verify(
+        if (permanent) host.copy(right = host.left + 540) else null,
+        if (permanent) host.copy(left = host.left + 540) else host,
+      )
+    }
+    composeRule.runOnIdle {
+      width = 1000.dp
+      height = 800.dp
+    }
+    val host = IntRect(150, 75, 1650, 1275)
+    val flat = host.copy(right = 690) to host.copy(left = 690)
+    val book = host.copy(right = 750) to host.copy(left = 780)
+    val cases =
+      listOf(
+        emptyList<DisplayFeature>() to flat,
+        listOf(testFold(Rect(750, 0, 780, 1500), separating = false, state = FoldingFeature.State.FLAT)) to flat,
+        listOf(testFold(Rect(-40, -40, -20, -20))) to flat,
+        listOf(testFold(Rect(1650, 0, 1650, 1500))) to flat,
+        listOf(testFold(Rect(750, 0, 780, 1500))) to book,
+        listOf(testFold(Rect(750, 0, 780, 1500), state = FoldingFeature.State.FLAT)) to book,
+        listOf(testFold(Rect(750, 0, 780, 1500), separating = false, occlusion = FoldingFeature.OcclusionType.FULL)) to book,
+        listOf(testFold(Rect(600, 0, 600, 1500))) to (host.copy(right = 600) to host.copy(left = 600)),
+        listOf(testFold(Rect(750, 75, 780, 300))) to (null to host.copy(top = 300)),
+        listOf(testFold(Rect(750, 0, 780, 1500)), testFold(Rect(1200, 0, 1230, 1500))) to (null to host.copy(right = 750)),
+        listOf(testFold(Rect(150, 675, 1650, 705))) to (null to host.copy(bottom = 675)),
+        listOf(testFold(Rect(360, 0, 390, 1500))) to (null to host.copy(left = 390)),
+      )
+    for ((folds, expected) in cases) {
+      composeRule.runOnIdle { features = folds }
+      verify(expected.first, expected.second)
+    }
+    // A valid book split retains the 280dp/320dp minima even below the width breakpoint.
+    composeRule.runOnIdle {
+      width = 600.dp
+      height = 320.dp
+      features = listOf(testFold(Rect(570, 0, 570, 1500)))
+    }
+    verify(IntRect(150, 75, 570, 555), IntRect(570, 75, 1050, 555))
+    composeRule.runOnIdle { height = 319.dp }
+    verify(null, IntRect(570, 75, 1050, 554))
+    composeRule.runOnIdle {
+      width = 1000.dp
+      height = 800.dp
+      features = emptyList()
+      direction = LayoutDirection.Rtl
+    }
+    verify(host.copy(left = 1110), host.copy(right = 1110))
+    composeRule.runOnIdle { origin = IntOffset(173, 97) }
+    verify(IntRect(1133, 97, 1673, 1297), IntRect(173, 97, 1133, 1297))
+    composeRule.runOnIdle { features = listOf(testFold(Rect(750, 0, 780, 1500))) }
+    verify(IntRect(780, 97, 1673, 1297), IntRect(173, 97, 750, 1297))
+    composeRule.runOnIdle { origin = IntOffset(150, 75) }
+    verify(book.second, book.first)
+  }
 
   @Test
   fun movingHostAndRtlPlaceOneLiveEditorInPhysicalWindowCoordinates() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
@@ -258,7 +258,7 @@ class RootScreenFoldTest {
   @Config(qualifiers = "w1000dp-h650dp-mdpi")
   @GraphicsMode(GraphicsMode.Mode.NATIVE)
   fun expandedWidthRoundTripPreservesAnOffTailLogicalGlyphAndExplicitFollowing() {
-    val text = (1..40).joinToString("\n") { "Reading point $it: this earlier response must remain readable while navigation changes beside it." }
+    val text = (1..80).joinToString("\n") { "Reading point $it: this earlier response must remain readable while navigation changes beside it." }
     withRoot(
       completed = true,
       destination = HomeDestination.Chat,
@@ -303,9 +303,14 @@ class RootScreenFoldTest {
       }
       val transcript = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex))
       transcript.performScrollToNode(hasText(text))
-      val initialText = renderedText(text).first
+      val (initialText, initialLayout) = renderedText(text)
       val initialClip = transcript.fetchSemanticsNode().boundsInRoot
-      assertTrue("The reader fixture must span the viewport", initialText.size.height > initialClip.height * 2)
+      assertTrue(
+        "The reader fixture must span the viewport: node=${initialText.size}, layout=${initialLayout.size}, " +
+          "lineCount=${initialLayout.lineCount}, viewport=$initialClip, " +
+          "density=${initialLayout.layoutInput.density.density}, fontScale=${initialLayout.layoutInput.density.fontScale}",
+        initialText.size.height > initialClip.height * 2,
+      )
       val towardInterior = if (initialText.positionInRoot.y < initialClip.top) 100f else -100f
       transcript.performTouchInput { swipeWithVelocity(center, center + Offset(0f, towardInterior), endVelocity = 0f) }
       composeRule.waitForIdle()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/RootScreenFoldTest.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.closeNodeRuntimeTestFixture
+import ai.openclaw.app.gateway.GatewayEndpoint
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
@@ -19,19 +20,27 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
@@ -57,14 +66,22 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeWithVelocity
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -80,8 +97,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import org.junit.After
@@ -97,6 +117,7 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
 import org.robolectric.util.ReflectionHelpers
 import java.util.Collections
 import java.util.UUID
@@ -112,6 +133,7 @@ class RootScreenFoldTest {
   private lateinit var backDispatcher: OnBackPressedDispatcher
   private lateinit var focusManager: FocusManager
   private var direction by mutableStateOf(LayoutDirection.Ltr)
+  private var viewportWidth by mutableStateOf(800.dp)
 
   @Before
   @SuppressLint("RestrictedApi") // Use WindowManager's own decorator boundary, not a production test hook.
@@ -149,10 +171,37 @@ class RootScreenFoldTest {
   }
 
   @Test
+  @Config(qualifiers = "w1000dp-h1000dp-mdpi")
+  fun flatExpandedWindowShowsPermanentSidebar() {
+    withRoot(completed = true, destination = HomeDestination.Chat, width = 1000.dp) {
+      emit(emptyList())
+      assertEquals("The mdpi fixture must expose a 1000dp window", 1000, view.width)
+      val composer = composeRule.onNodeWithTag("chat-composer-surface").assertIsDisplayed()
+      val sidebar = composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+      assertTrue("The destination must remain beside the sidebar", windowBounds(composer).left >= windowBounds(sidebar).right)
+      composeRule.onNodeWithContentDescription("Show Sidebar").assertDoesNotExist()
+      val editor = composeRule.onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("chat-composer-surface")))
+      editor.performClick().performTextReplacement("Expanded window draft")
+      editor.assertIsFocused().assertTextEquals("Expanded window draft")
+      composeRule
+        .onNode(hasText("Settings") and hasAnyAncestor(hasTestTag("sidebar-permanent")))
+        .performScrollTo()
+        .performTouchInput { click() }
+      composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
+      sidebar.assertIsDisplayed()
+      composeRule.onNodeWithTag("sidebar-open-settings").assertDoesNotExist()
+    }
+  }
+
+  @Test
   fun onboardingActionsAvoidTheHingeAndKeepDraftFocusAndBackNavigation() {
     withRoot(completed = false) {
       // No WindowLayoutInfo emission yet: onboarding must render normally.
       val action = composeRule.onNodeWithText("Continue").assertIsDisplayed()
+      resize(1000.dp)
+      action.assertIsDisplayed()
+      composeRule.onNodeWithTag("sidebar-permanent").assertDoesNotExist()
+      resize(800.dp)
       val original = windowBounds(action)
       val hinge = Rect(original.centerX() - 10, 0, original.centerX() + 10, view.height)
       assertTrue("The baseline action must cross the future hinge", Rect.intersects(original, hinge))
@@ -176,6 +225,136 @@ class RootScreenFoldTest {
   }
 
   @Test
+  fun gatewayTrustSuppressesExpandedNavigationUntilThePromptCloses() {
+    lateinit var pending: MutableStateFlow<NodeRuntime.GatewayTrustPrompt?>
+    withRoot(
+      completed = true,
+      width = 1000.dp,
+      configureRuntime = { pending = ReflectionHelpers.getField(it, "_pendingGatewayTrust") },
+    ) {
+      composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+      composeRule.runOnIdle {
+        pending.value =
+          NodeRuntime.GatewayTrustPrompt(
+            endpoint = GatewayEndpoint(stableId = "test-gateway", name = "Test gateway", host = "gateway.test", port = 443),
+            fingerprintSha256 = "ab".repeat(32),
+            auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null),
+          )
+      }
+      for (width in listOf(840.dp, 839.dp, 1000.dp)) {
+        resize(width)
+        composeRule.onNodeWithText("Trust this gateway?").assertIsDisplayed()
+        composeRule.onNodeWithTag("sidebar-permanent").assertDoesNotExist()
+      }
+      composeRule.runOnIdle { pending.value = null }
+      composeRule.onNodeWithText("Trust this gateway?").assertDoesNotExist()
+      composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+      composeRule.onNodeWithContentDescription("Search settings").performTouchInput { click() }
+      composeRule.onNodeWithContentDescription("Close search").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w1000dp-h650dp-mdpi")
+  @GraphicsMode(GraphicsMode.Mode.NATIVE)
+  fun expandedWidthRoundTripPreservesAnOffTailLogicalGlyphAndExplicitFollowing() {
+    val text = (1..40).joinToString("\n") { "Reading point $it: this earlier response must remain readable while navigation changes beside it." }
+    withRoot(
+      completed = true,
+      destination = HomeDestination.Chat,
+      configureRuntime = { runtime ->
+        val controller = ReflectionHelpers.getField<ChatController>(runtime, "chat")
+        val original =
+          ReflectionHelpers.getField<suspend (String, String, String?) -> String>(controller, "requestGatewayForGateway")
+        val requester: suspend (String, String, String?) -> String = { gatewayId, method, params ->
+          val response = original(gatewayId, method, params)
+          if (method == "chat.history") {
+            val history = Json.parseToJsonElement(response).jsonObject
+            val messages =
+              history.getValue("messages").jsonArray.mapIndexed { index, message ->
+                if (index == 12) JsonObject(message.jsonObject + ("content" to JsonPrimitive(text))) else message
+              }
+            JsonObject(history + ("messages" to JsonArray(messages))).toString()
+          } else {
+            response
+          }
+        }
+        ReflectionHelpers.setField(controller, "requestGatewayForGateway", requester)
+      },
+    ) { model ->
+      composeRule.runOnIdle { model.refreshChat() }
+      composeRule.waitUntil {
+        composeRule.runOnIdle {
+          !model.chatHistoryLoading.value && model.chatMessages.value.size >= 24 &&
+            model.chatMessages.value.any { message ->
+              message.role == "assistant" && message.content.any { it.type == "text" && it.text == text }
+            }
+        }
+      }
+      composeRule.runOnIdle {
+        val syntheticMessages =
+          model.chatMessages.value.filter { message ->
+            message.role == "assistant" && message.content.any { it.type == "text" && it.text == text }
+          }
+        assertEquals("Load exactly one complete synthetic earlier response before scrolling", 1, syntheticMessages.size)
+        val syntheticMessage = syntheticMessages.single()
+        assertEquals(text, syntheticMessage.content.single().text)
+        assertFalse("The synthetic earlier response must not be truncated", syntheticMessage.truncated)
+      }
+      val transcript = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex))
+      transcript.performScrollToNode(hasText(text))
+      val initialText = renderedText(text).first
+      val initialClip = transcript.fetchSemanticsNode().boundsInRoot
+      assertTrue("The reader fixture must span the viewport", initialText.size.height > initialClip.height * 2)
+      val towardInterior = if (initialText.positionInRoot.y < initialClip.top) 100f else -100f
+      transcript.performTouchInput { swipeWithVelocity(center, center + Offset(0f, towardInterior), endVelocity = 0f) }
+      composeRule.waitForIdle()
+      composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+      val clip = transcript.fetchSemanticsNode().boundsInRoot
+      val before = renderedText(text)
+      val character =
+        text.indices.first { index ->
+          val glyph = before.second.getBoundingBox(index).translate(before.first.positionInRoot)
+          !text[index].isWhitespace() && glyph.width > 0f && glyph.height > 0f &&
+            glyph.top >= clip.top && glyph.bottom <= clip.bottom
+        }
+      val originalGlyph = before.second.getBoundingBox(character).translate(before.first.positionInRoot)
+      assertTrue("Read inside the old response, not its beginning or the live tail", character > 0 && character < text.lastIndex)
+      val relativeY = originalGlyph.top - clip.top
+      val session = model.chatSessionKey.value
+      val messages = model.chatMessages.value
+      for (width in listOf(840.dp, 1000.dp, 839.dp, 800.dp)) {
+        resize(width)
+        val currentClip = transcript.fetchSemanticsNode().boundsInRoot
+        val after = renderedText(text)
+        val glyph = after.second.getBoundingBox(character).translate(after.first.positionInRoot)
+        assertEquals(text, after.second.layoutInput.text.text)
+        assertEquals(session, model.chatSessionKey.value)
+        assertEquals("Resizing must not replace or append history", messages, model.chatMessages.value)
+        if (width == 840.dp) {
+          assertTrue("The sidebar must narrow the real transcript", currentClip.width < clip.width)
+          assertTrue("The same paragraph must actually reflow", after.second.lineCount > before.second.lineCount)
+        }
+        assertEquals("Keep the same logical reading point after reflow at $width", currentClip.top + relativeY, glyph.top, 1f)
+        assertTrue(
+          "The retained glyph must be fully visible at $width: $glyph inside $currentClip",
+          glyph.width > 0f && glyph.height > 0f &&
+            glyph.left >= currentClip.left && glyph.right <= currentClip.right &&
+            glyph.top >= currentClip.top && glyph.bottom <= currentClip.bottom,
+        )
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+      }
+      composeRule.onNodeWithContentDescription("Jump to latest").performClick()
+      composeRule.onNodeWithContentDescription("Jump to latest").assertDoesNotExist()
+      for (width in listOf(1000.dp, 800.dp)) {
+        resize(width)
+        composeRule.onNodeWithContentDescription("Jump to latest").assertDoesNotExist()
+        assertEquals(0f, transcript.fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange].value(), 0f)
+      }
+    }
+  }
+
+  @Test
   fun authenticatedSettingsKeepSearchDraftAndReturnRouteAcrossFoldChanges() {
     withRoot(completed = true) {
       composeRule.onNodeWithContentDescription("Search settings").performClick()
@@ -189,6 +368,13 @@ class RootScreenFoldTest {
         search.assertTextEquals("Appearance").assertIsFocused()
         assertEquals(editorId, search.fetchSemanticsNode().id)
         if (features.isNotEmpty()) assertClearOfHinge(search, hinge)
+      }
+      emit(emptyList())
+      for (width in listOf(840.dp, 1000.dp, 839.dp, 800.dp, 1000.dp)) {
+        resize(width)
+        search.assertTextEquals("Appearance").assertIsFocused()
+        assertEquals(editorId, search.fetchSemanticsNode().id)
+        composeRule.onNodeWithTag("sidebar-permanent").assertDoesNotExist()
       }
       composeRule.onNodeWithContentDescription("Close search").performClick()
       composeRule.onNodeWithTag("sidebar-search-toggle").assertIsDisplayed()
@@ -556,6 +742,28 @@ class RootScreenFoldTest {
       composeRule.runOnIdle { backDispatcher.onBackPressed() }
       editor.assertIsDisplayed().assertTextEquals("Keep this draftbf")
       assertEquals("Keep editor focus through both reparentings", listOf(true, true), focusedAfterMove)
+      editor.performTextInputSelection(TextRange(0, 4))
+      for (width in listOf(840.dp, 1000.dp, 839.dp, 800.dp)) {
+        resize(width)
+        editor.assertIsFocused().assertTextEquals("Keep this draftbf")
+        assertEquals(editorId, editor.fetchSemanticsNode().id)
+        assertEquals(TextRange(0, 4), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+        if (width >= 840.dp) {
+          val sidebar = composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+          val bounds = windowBounds(sidebar)
+          for (bottom in listOf(320, 0)) {
+            keyboard(bottom)
+            assertEquals("IME must not change navigation allocation", bounds, windowBounds(sidebar))
+            editor.assertIsFocused().assertTextEquals("Keep this draftbf")
+            assertEquals(TextRange(0, 4), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+          }
+        } else {
+          composeRule.onNodeWithContentDescription("Show Sidebar").assertIsDisplayed()
+          composeRule.onNodeWithTag("sidebar-permanent").assertDoesNotExist()
+        }
+      }
+      composeRule.onRoot().performKeyInput { pressKey(Key.Z) }
+      editor.assertTextEquals("z this draftbf")
     }
   }
 
@@ -589,6 +797,15 @@ class RootScreenFoldTest {
       assertEquals(editorId, editor.fetchSemanticsNode().id)
       composeRule.onRoot().performKeyInput { pressKey(Key.F) }
       editor.assertTextContains("Unsaved brf")
+      editor.performTextInputSelection(TextRange(8, 11))
+      for (width in listOf(840.dp, 839.dp, 1000.dp, 800.dp)) {
+        resize(width)
+        editor.assertIsFocused().assertTextContains("Unsaved brf")
+        assertEquals(editorId, editor.fetchSemanticsNode().id)
+        assertEquals(TextRange(8, 11), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      }
+      composeRule.onRoot().performKeyInput { pressKey(Key.Z) }
+      editor.assertTextContains("Unsaved z")
       composeRule.runOnIdle {
         assertEquals("Layout changes must not save the draft", savedName, model.displayName.value)
         backDispatcher.onBackPressed()
@@ -607,6 +824,10 @@ class RootScreenFoldTest {
       emit(fold)
       editor.assertIsNotFocused()
       emit(emptyList())
+      editor.assertIsNotFocused()
+      resize(1000.dp)
+      editor.assertIsNotFocused()
+      resize(800.dp)
       editor.assertIsNotFocused()
       editor.performClick().performTextReplacement("Do not refocus")
       composeRule.runOnIdle { focusManager.clearFocus() }
@@ -632,6 +853,16 @@ class RootScreenFoldTest {
       emit(emptyList())
       editor.assertIsFocused()
       search.assertIsNotFocused()
+      resize(1000.dp)
+      editor.assertIsFocused()
+      search.assertIsNotFocused()
+      search.performClick().assertIsFocused()
+      resize(800.dp)
+      search.assertIsNotDisplayed().assertIsNotFocused()
+      editor.assertIsNotFocused()
+      resize(1000.dp)
+      search.assertIsNotFocused()
+      editor.assertIsNotFocused()
     }
   }
 
@@ -663,6 +894,17 @@ class RootScreenFoldTest {
       search.assertTextContains("retained search").assertIsDisplayed()
       assertEquals(editorId, search.fetchSemanticsNode().id)
       assertEquals("Keep search focus through the book and RTL transitions", listOf(true, true), focusedAfterMove)
+      search.performClick().performTextInputSelection(TextRange(9, 15))
+      resize(1000.dp)
+      search.assertIsFocused().assertTextContains("retained search")
+      assertEquals(TextRange(9, 15), search.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+      assertTrue("RTL navigation must use the physical right side", windowBounds(search).left >= 640)
+      resize(800.dp)
+      search.assertIsNotDisplayed().assertIsNotFocused()
+      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+      search.assertIsDisplayed().assertTextContains("retained search")
+      assertEquals(editorId, search.fetchSemanticsNode().id)
+      assertEquals(TextRange(9, 15), search.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
     }
   }
 
@@ -693,6 +935,21 @@ class RootScreenFoldTest {
           .config[SemanticsProperties.VerticalScrollAxisRange]
           .value(),
       )
+      emit(emptyList())
+      for (width in listOf(1000.dp, 800.dp, 840.dp, 800.dp)) {
+        resize(width)
+        if (width < 840.dp) composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        composeRule.onNodeWithText("Android QA").assertIsDisplayed()
+        assertEquals(
+          "Expanded sidebar state must survive width changes",
+          scroll,
+          composeRule
+            .onNode(sidebarScroll)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.VerticalScrollAxisRange]
+            .value(),
+        )
+      }
       emit(listOf(testFold(hinge)))
       assertEquals(
         scroll,
@@ -721,69 +978,74 @@ class RootScreenFoldTest {
   }
 
   @Test
-  fun bookModeCancelsOpeningAndClosingDrawerAnimationsWithoutStrandingBack() {
-    withRoot(completed = true) {
-      val hinge = Rect(400, 0, 420, view.height)
-      Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
-      composeRule.mainClock.autoAdvance = false
-      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
-      composeRule.mainClock.advanceTimeBy(32)
-      emit(listOf(testFold(hinge)))
-      composeRule.mainClock.autoAdvance = true
-      composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
-      composeRule.onNodeWithContentDescription("Close navigation menu").assertDoesNotExist()
-      composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
-      composeRule.runOnIdle { backDispatcher.onBackPressed() }
-      composeRule.onNodeWithContentDescription("Search settings").assertDoesNotExist()
-      emit(emptyList())
-      composeRule.onNodeWithTag("sidebar-open-overview").performClick()
-      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
-      composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
-      composeRule.mainClock.autoAdvance = false
-      composeRule.onNodeWithTag("sidebar-close").performClick()
-      composeRule.mainClock.advanceTimeBy(32)
-      emit(listOf(testFold(hinge)))
-      composeRule.mainClock.autoAdvance = true
-      composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
-      composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
-      Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
-      composeRule.onNode(hasText("Home") and hasAnyAncestor(hasTestTag("sidebar-permanent"))).performTouchInput { click() }
-      composeRule.onNodeWithTag("chat-composer-surface").assertIsDisplayed()
-      emit(emptyList())
-      composeRule.runOnIdle { backDispatcher.onBackPressed() }
-      composeRule.onNodeWithTag("sidebar-open-overview").assertIsDisplayed()
+  fun permanentModeCancelsOpeningAndClosingDrawerAnimationsWithoutStrandingBack() {
+    withRoot(completed = true) { model ->
+      for (expandedWindow in listOf(false, true)) {
+        composeRule.runOnIdle { model.requestHomeDestination(HomeDestination.Settings) }
+        composeRule.waitForIdle()
+        Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        composeRule.mainClock.advanceTimeBy(32)
+        setPermanentSidebar(expandedWindow, visible = true)
+        composeRule.mainClock.autoAdvance = true
+        composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Close navigation menu").assertDoesNotExist()
+        composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
+        composeRule.runOnIdle { backDispatcher.onBackPressed() }
+        composeRule.onNodeWithContentDescription("Search settings").assertDoesNotExist()
+        setPermanentSidebar(expandedWindow, visible = false)
+        composeRule.onNodeWithTag("sidebar-open-overview").performClick()
+        composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onNodeWithTag("sidebar-close").performClick()
+        composeRule.mainClock.advanceTimeBy(32)
+        setPermanentSidebar(expandedWindow, visible = true)
+        composeRule.mainClock.autoAdvance = true
+        composeRule.onNodeWithTag("sidebar-permanent").assertIsDisplayed()
+        composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
+        Settings.Global.putFloat(view.context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+        composeRule.onNode(hasText("Home") and hasAnyAncestor(hasTestTag("sidebar-permanent"))).performTouchInput { click() }
+        composeRule.onNodeWithTag("chat-composer-surface").assertIsDisplayed()
+        setPermanentSidebar(expandedWindow, visible = false)
+        composeRule.runOnIdle { backDispatcher.onBackPressed() }
+        composeRule.onNodeWithTag("sidebar-open-overview").assertIsDisplayed()
+      }
     }
   }
 
   @Test
-  fun bookInterruptsPredictiveDrawerBackWithoutInterceptingPaneTapsOrRouteBack() {
+  fun permanentModeInterruptsPredictiveDrawerBackWithoutInterceptingPaneTapsOrRouteBack() {
     withRoot(completed = true) {
-      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
-      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
-      composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
-      composeRule.runOnIdle {
-        backDispatcher.dispatchOnBackStarted(BackEventCompat(0f, 300f, 0f, BackEventCompat.EDGE_LEFT))
-        backDispatcher.dispatchOnBackProgressed(BackEventCompat(80f, 300f, 0.4f, BackEventCompat.EDGE_LEFT))
+      for (expandedWindow in listOf(false, true)) {
+        composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Close navigation menu").assertIsDisplayed()
+        composeRule.runOnIdle {
+          backDispatcher.dispatchOnBackStarted(BackEventCompat(0f, 300f, 0f, BackEventCompat.EDGE_LEFT))
+          backDispatcher.dispatchOnBackProgressed(BackEventCompat(80f, 300f, 0.4f, BackEventCompat.EDGE_LEFT))
+        }
+        setPermanentSidebar(expandedWindow, visible = true)
+        composeRule.runOnIdle { backDispatcher.dispatchOnBackCancelled() }
+        val inactiveSheet = composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
+        assertTrue("The inactive sheet must retain real measured anchors", windowBounds(inactiveSheet).width() > 0)
+        composeRule.onNodeWithContentDescription("Close navigation menu").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Open profile").performTouchInput { click() }
+        composeRule.onNodeWithText("Save Profile").assertIsDisplayed()
+        composeRule.runOnIdle { backDispatcher.onBackPressed() }
+        composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
+        setPermanentSidebar(expandedWindow, visible = false)
+        composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+        composeRule.runOnIdle {
+          backDispatcher.dispatchOnBackStarted(BackEventCompat(0f, 300f, 0f, BackEventCompat.EDGE_LEFT))
+          backDispatcher.dispatchOnBackProgressed(BackEventCompat(80f, 300f, 0.4f, BackEventCompat.EDGE_LEFT))
+          backDispatcher.onBackPressed()
+        }
+        composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
+        composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
       }
-      emit(listOf(testFold(Rect(400, 0, 420, view.height))))
-      composeRule.runOnIdle { backDispatcher.dispatchOnBackCancelled() }
-      val inactiveSheet = composeRule.onNodeWithTag("sidebar-drawer").assertIsNotDisplayed()
-      assertTrue("The inactive sheet must retain real measured anchors", windowBounds(inactiveSheet).width() > 0)
-      composeRule.onNodeWithContentDescription("Close navigation menu").assertDoesNotExist()
-      composeRule.onNodeWithContentDescription("Open profile").performTouchInput { click() }
-      composeRule.onNodeWithText("Save Profile").assertIsDisplayed()
-      composeRule.runOnIdle { backDispatcher.onBackPressed() }
-      composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
-      emit(emptyList())
-      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
-      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
-      composeRule.runOnIdle {
-        backDispatcher.dispatchOnBackStarted(BackEventCompat(0f, 300f, 0f, BackEventCompat.EDGE_LEFT))
-        backDispatcher.dispatchOnBackProgressed(BackEventCompat(80f, 300f, 0.4f, BackEventCompat.EDGE_LEFT))
-        backDispatcher.onBackPressed()
-      }
-      composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
-      composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
     }
   }
 
@@ -808,27 +1070,29 @@ class RootScreenFoldTest {
   }
 
   @Test
-  fun bookTransitionCancelsHeldSidebarDragAndRestoresFlatDrawerGestures() {
+  fun permanentTransitionCancelsHeldSidebarDragAndRestoresCompactDrawerGestures() {
     withRoot(completed = true) { model ->
-      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
-      val order = model.sidebarPageOrder.value
-      composeRule.onNode(hasText("Home") and hasAnyAncestor(hasTestTag("sidebar-drawer"))).performTouchInput {
-        down(center)
-        advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
-        moveBy(Offset(0f, 1f))
+      for (expandedWindow in listOf(false, true)) {
+        composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        val order = model.sidebarPageOrder.value
+        composeRule.onNode(hasText("Home") and hasAnyAncestor(hasTestTag("sidebar-drawer"))).performTouchInput {
+          down(center)
+          advanceEventTime(viewConfiguration.longPressTimeoutMillis + 1L)
+          moveBy(Offset(0f, 1f))
+        }
+        setPermanentSidebar(expandedWindow, visible = true)
+        composeRule.onRoot().performTouchInput {
+          moveBy(Offset(0f, 130f))
+          up()
+        }
+        composeRule.runOnIdle { assertEquals("A stale drag must not reorder the new host", order, model.sidebarPageOrder.value) }
+        setPermanentSidebar(expandedWindow, visible = false)
+        composeRule.onNodeWithTag("sidebar-open-settings").performClick()
+        composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
+        composeRule.onNodeWithTag("sidebar-drawer").performTouchInput { swipeLeft() }
+        composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
+        composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
       }
-      emit(listOf(testFold(Rect(400, 0, 420, view.height))))
-      composeRule.onRoot().performTouchInput {
-        moveBy(Offset(0f, 130f))
-        up()
-      }
-      composeRule.runOnIdle { assertEquals("A stale drag must not reorder the new host", order, model.sidebarPageOrder.value) }
-      emit(emptyList())
-      composeRule.onNodeWithTag("sidebar-open-settings").performClick()
-      composeRule.onNodeWithTag("sidebar-close").assertIsDisplayed()
-      composeRule.onNodeWithTag("sidebar-drawer").performTouchInput { swipeLeft() }
-      composeRule.onNodeWithTag("sidebar-close").assertIsNotDisplayed()
-      composeRule.onNodeWithContentDescription("Search settings").assertIsDisplayed()
     }
   }
 
@@ -907,6 +1171,7 @@ class RootScreenFoldTest {
   private fun withRoot(
     completed: Boolean,
     destination: HomeDestination = HomeDestination.Settings,
+    width: Dp = 800.dp,
     configureRuntime: (NodeRuntime) -> Unit = {},
     verify: (MainViewModel) -> Unit,
   ) {
@@ -922,6 +1187,7 @@ class RootScreenFoldTest {
       models.put("root-fold", model)
       ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(model, "runtimeRef").value = runtime
       if (completed) model.requestHomeDestination(destination)
+      viewportWidth = width
       composeRule.setContent {
         val activity = requireNotNull(LocalActivity.current)
         view = LocalView.current
@@ -929,13 +1195,19 @@ class RootScreenFoldTest {
         backDispatcher = requireNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
         LaunchedEffect(activity) { WindowCompat.setDecorFitsSystemWindows(activity.window, false) }
         CompositionLocalProvider(LocalLayoutDirection provides direction) {
-          RootScreen(model)
+          Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {
+            Box(Modifier.width(viewportWidth).fillMaxHeight().testTag("root-viewport")) {
+              RootScreen(model)
+            }
+          }
         }
       }
       composeRule.waitForIdle()
       val rootId = composeRule.onRoot().fetchSemanticsNode().id
       val host = composeRule.onNode(SemanticsMatcher("original activity content root") { it.id == rootId })
       val originalRoot = host.getUnclippedBoundsInRoot()
+      val viewportBounds = composeRule.onNodeWithTag("root-viewport").getUnclippedBoundsInRoot()
+      assertEquals(width, viewportBounds.right - viewportBounds.left)
       verify(model)
       assertEquals("Only the pane may move, never the window host", originalRoot, host.getUnclippedBoundsInRoot())
     } finally {
@@ -945,6 +1217,53 @@ class RootScreenFoldTest {
         closeNodeRuntimeTestFixture(runtime)
       }
     }
+  }
+
+  private fun resize(width: Dp) {
+    val viewport = composeRule.onNodeWithTag("root-viewport")
+    val id = viewport.fetchSemanticsNode().id
+    val before = viewport.getUnclippedBoundsInRoot()
+    composeRule.runOnIdle { viewportWidth = width }
+    if (!composeRule.mainClock.autoAdvance) composeRule.mainClock.advanceTimeBy(32)
+    val after = viewport.getUnclippedBoundsInRoot()
+    assertEquals("Resize must change real parent constraints", width, after.right - after.left)
+    assertEquals(before.left, after.left)
+    assertEquals(before.top, after.top)
+    assertEquals(before.bottom - before.top, after.bottom - after.top)
+    assertEquals("Resize must not replace the mounted host", id, viewport.fetchSemanticsNode().id)
+  }
+
+  private fun setPermanentSidebar(
+    expandedWindow: Boolean,
+    visible: Boolean,
+  ) {
+    if (expandedWindow) {
+      resize(if (visible) 1000.dp else 800.dp)
+    } else {
+      emit(if (visible) listOf(testFold(Rect(400, 0, 420, view.height))) else emptyList())
+    }
+  }
+
+  private fun keyboard(bottom: Int) {
+    composeRule.runOnIdle {
+      ViewCompat.dispatchApplyWindowInsets(
+        view,
+        WindowInsetsCompat
+          .Builder()
+          .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 24))
+          .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, bottom))
+          .setVisible(WindowInsetsCompat.Type.ime(), bottom > 0)
+          .build(),
+      )
+    }
+    composeRule.waitForIdle()
+  }
+
+  private fun renderedText(text: String): Pair<SemanticsNode, TextLayoutResult> {
+    val node = composeRule.onNodeWithText(text, useUnmergedTree = true)
+    val layouts = mutableListOf<TextLayoutResult>()
+    node.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+    return node.fetchSemanticsNode() to layouts.single()
   }
 
   private fun windowBounds(node: SemanticsNodeInteraction): Rect {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Android keeps navigation behind the compact drawer on wide, flat windows even when there is room for a permanent sidebar. This makes navigation unnecessarily indirect on large screens and resized desktop windows.

## Why This Change Was Made

Extend the existing sidebar allocation to flat hosts at least 840dp wide and 320dp tall, using a 360dp sidebar at logical start only when the entire host is fold-safe. Preserve existing book-fold geometry and minimum sizes, including valid book layouts below 840dp, along with compact navigation and onboarding, search, and trust suppression.

This is Android-only: no dependencies, configuration, manifests, ViewModels, shared code, iOS code, or database schemas change in the incremental feature diff. The seven-file diff is production +34/-24 (net +10), tests +543/-77 (net +466), and documentation +9/-4 (net +5); production growth implements the flat-window allocation in the existing owner.

## User Impact

Qualifying wide windows keep navigation visible beside the current destination. The change preserves the existing destination, composer, sidebar-scroll, and reader owners as the layout allocation changes. Compact and obstructed windows retain the existing fold-safe layouts. The current tablet fixture provides partial same-session keyboard, draft/cursor, rotation, and Back observations below; desktop resizing and full state-retention acceptance remain pending.

## Evidence

### Current candidate

- Candidate: `1e971aa7fbe1b7c553c4abd143629c159012abc6`, based on fixed main commit `9e9944cdd90af1631af8d8575dc05c9430430769`.
- Both feature commits were rebased with verified signatures. The only conflict was `apps/android/README.md`: main's **Review changes** section is preserved verbatim, followed by this change's **Large-screen and foldable layout** heading and introduction. The seven-file incremental diff is unchanged in size. Range-diff shows only the README context movement; the fixture follow-up is patch-equivalent. `git diff --check` passed.
- **Local locale parity PASS on September 11, 2026:** `node --import ./scripts/tsx.mjs scripts/control-ui-i18n.ts check` completed with exit 0. All 20 locales were clean, with zero fallback keys/pairs and 89 raw-copy baseline entries. This is current-candidate local parity, not hosted CI.
- **Helper suite blocked before collection:** `node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts` exited 1 during startup with `TypeError: defineCacheKeyGenerator is not a function`. The candidate declares Vitest 5.0.0, but the shared dependency installation resolves Vitest 4.1.11. **Zero tests were collected or executed.** This is a dependency/bootstrap failure, not an executed helper-test or Android-code verdict. No retry or dependency installation was performed.
- **Current local Robolectric PASS on September 11, 2026:** `:app:testPlayDebugUnitTest` executed the focused `ai.openclaw.app.ui.FoldAwareContentTest` (3 tests) and `ai.openclaw.app.ui.RootScreenFoldTest` (21 tests): **24 tests, zero failures, errors or skips**. The run used the retained API 34 artifact with Robolectric's offline local resolver, Gradle flags `--offline --no-daemon --no-parallel --max-workers=2`. These are current-candidate JVM results, not native OS acceptance.
- **Current APK build and identity PASS:** `:app:assemblePlayDebug` completed with exit 0. The 136,562,930-byte debug APK has SHA-256 `6bc9d6cd76619773b11877291c50c491ead3b48ae88196d912aa9f4fc40f7449`, built from exact candidate `1e971aa7fbe1b7c553c4abd143629c159012abc6`, tree `bebfe175e7db6b3a36aea3d081431d5607ebef48`. All 40,936 tracked source files matched before and after the run; both source manifests have SHA-256 `dfe994dc397a973a052c7113f8c9f63e951b12b3425a4bf112cb51e58fd7dc47`. APK signature verification passed; signer certificate SHA-256 is `bfafb64fde0183f3a9ffd967b347511ea06679df513034fd306ece627068ba26`. This exact APK was subsequently verified and exercised in the bounded tablet run below.
- **Current tablet partial native proof on September 11, 2026; overall run FAILED:** the API 36 ARM64 emulator received one data-preserving update from the verified historical APK. The installed base APK's guest SHA-256 matched the current candidate before one cold DEBUG fixture launch. Serialized cursor readbacks acknowledged `13 -> 12 -> 11 -> 10 -> 9`, then an observed soft-key `x` produced `task4leftxtail`. With the IME open, native rotation changed 1280x800dp to 800x1280dp and back at unchanged 320dpi; insertion markers produced `task4leftxytail` and `task4leftxyztail` without editor retaps or cursor repair. Back once hid the IME while preserving the draft and focused app. All four PNGs were visually reviewed: readable drafts, wide permanent sidebar -> collapsed portrait navigation -> wide restoration, IME visible in the first three and absent after Back, with no incoherent overlap observed. This is same-session fixture evidence from a layout-only run with modem/GNSS simulators disabled, not full native acceptance.
- **September 11 networking shutdown failure and skipped postflight:** after all four captures, the owned networking simulator exited 1 during requested shutdown; its log reported inability to process shutdown signals, a busy loop, and forceful termination. The emulator exited 0; ADB terminated with SIGTERM. All owned children, claims, and the collector joined or released, but final port and foreign-resource postflight checks were skipped after the failure. **That run remains FAILED; no native clean pass is claimed for it.** Sealed receipt SHA-256: `4b0a14b7620025aacef7ee5a7f6b8918bf51cf33859c6da8cb7320271523cb13`; event-stream SHA-256: `3e33266345db6c51b0f18bf1f01fbcb872c044a1dff686f1724b8332e70ed907`. No automatic retry followed.
- **Shutdown-only continuation COMPLETE on September 13, 2026:** from 18:46:51.917 to 18:47:31.722 UTC, on the unchanged candidate, the networking simulator exited naturally with raw/managed exit 0 and no signal or error, 601 ms after the QEMU stop request. QEMU exited 0; ADB received the expected SIGTERM. All 21 gates passed, including all planned postflight checks: port absence, protected-resource identities, retained AVD configuration, SDK references and resource accounting. All 283 commands, owned services, owner claims, collector and verification stream joined or released. There were **zero installs, UI actions, PNG captures or retries**. Receipt SHA-256: `67820be6efc034d00e03e4ff349ab0de09e1a64a2f7ef271ab55c3a9572ee037`; event-stream SHA-256: `ab8a37134614604f77f3adc0a1a84c64c67a806f23d4d97215c28ee374762828`. This separate continuation proves shutdown and postflight only; it does not retroactively pass the September 11 run or repeat its UI checks.
- **Desktop-entry observation COMPLETE on September 13, 2026; eligibility UNPROVEN:** from 19:14:11.870 to 19:15:02.040 UTC, the installed base APK matched the current candidate before one cold DEBUG fixture launch and one Meta+Ctrl+Down chord. The chord exited 0, but asynchronous input injection is not entry proof. Pre/post observations retained the same focused task, user and display in fullscreen at 2560x1600 pixels and unchanged 320dpi. Both PNGs were visually reviewed: fullscreen app, with no visible desktop caption, handle or window menu. No same-task freeform entry was observed. This is **UNPROVEN in this fixture/image, not an unsupported-platform verdict**; the DEBUG fixture hides status bars, so an absent fullscreen handle alone cannot establish eligibility. All 23 gates and planned postflight checks passed; the networking simulator exited naturally 0 without a signal, QEMU exited 0, and ADB received the expected SIGTERM. All 431 commands, owned services, claims, collector and verification stream joined or released. There were zero installs or retries. Receipt SHA-256: `83eb61c55e8ded52cf21eeafd664e93d36c345bd695a5b3e12a6d9f05ba31b1e`; event-stream SHA-256: `16383f8c6c1d43feee316db7939e106902d0118cd4a1f87bf0201448c787902d`. Pre/post PNG SHA-256: `3f5d4f0d9a0a0a76107186fe0054947a588f49372bfa1ff60547cf6057b1dbdc` / `3b1c8984e99541aa61555e87019c3c4cdd131bcdec9ea51fc9eec464b9386099`. This observation does not prove desktop resizing or close the remaining acceptance gaps.
- **Current exact-head hosted CI SUCCESS on September 13, 2026:** [CI run 34774579927](https://github.com/openclaw/openclaw/actions/runs/34774579927) completed successfully at candidate `1e971aa7fbe1b7c553c4abd143629c159012abc6`. All **10 selected jobs passed**; the other 24 job records were skipped. This is scoped CI success, not proof of the remaining native acceptance.
- **Prior exact-head hosted CI SKIPPED:** [CI run 34583629062](https://github.com/openclaw/openclaw/actions/runs/34583629062) completed as **skipped** for the draft PR on September 11, 2026, at 09:19:45 UTC. That historical result remains skipped, not a hosted CI pass.
- **Pending for this candidate:** the remaining native acceptance below. No fresh bot-review result or merge-readiness claim is made.

### Historical evidence: 87619

The following retained results belong to `87619efe16935ac10d1c0ffba11a6997e831541b` and its original review base, `14c5ab4e39783a02f8fd7a721f5dde4291673dc0`. They are historical evidence, not results for the current rebased candidate.

- **Historical baseline RED:** `flatExpandedWindowShowsPermanentSidebar` failed on the original review base at 1000dp with no display features because `sidebar-permanent` was not displayed.
- **Historical six-job Android CI PASS at 87619:** [CI run 34376020789](https://github.com/openclaw/openclaw/actions/runs/34376020789) passed Play tests, third-party tests, Wear tests, four-module ktlint, Play build, and Wear build. Completed logs verify that exact checkout. Both phone unit-test tasks and the Wear unit-test task executed; builds cover both phone variants, benchmark, Wear, and wear-shared, with the applicable lint checks.
- **Historical fixture failure and repair:** [earlier CI run 34364324718](https://github.com/openclaw/openclaw/actions/runs/34364324718), at `357d1e56dd7b5bf6b94f832fa7ade9ac62a8144a`, failed both phone lanes at the reader fixture's viewport-height precondition, before resizing. The follow-up expands the same synthetic response from 40 to 80 lines and adds measured-layout diagnostics. The height condition and subsequent resize, logical-glyph, history, and follow-mode assertions are unchanged. Both phone lanes passed at historical head 87619.
- **Historical JVM coverage:** width and height boundaries, RTL, density and moving origins, harmless and obstructing fold features, and real constraint changes on one mounted root with retained user state and off-tail reading position. These are JVM results, not native desktop, fold, RTL, IME, rotation, or retention acceptance.
- **Historical independent review:** review of the seven-file change and fixture-only follow-up completed with no confirmed actionable P0-P2 findings. Those retained dispositions are not a fresh review of the rebased candidate or a fresh bot-review claim.
- **Historical overall CI failure:** run 34376020789 completed with **failure** on September 9, 2026, at 17:08:50 UTC. Its only failed jobs were `control-ui-i18n` (catalog fallback baseline drift outside the Android change) and the aggregate `openclaw/ci-gate`. The six Android passes were not an all-CI-green result. The current local locale-parity pass above does not retroactively change that run.
- **Historical APK at 87619:** the debug APK has SHA-256 `ea35e191a8c9a11a1b94a36f65e87ea87c5956608e22d2b9ad1c99339f6ffc86`. It is not a build of the current candidate.
- **Historical static flat-window observation at 87619:** one inspected native OS fixture PNG shows a permanent left sidebar beside chat at 1280x800dp (2560x1600 pixels). PNG SHA-256: `5ee30f6e1a8c9b1fd18afa45c119c16c87de2efba2ada474c71efee46f598e1e`. This is a single-session static layout observation, not desktop-caption resizing, fold/unfold, RTL, IME, rotation, cursor/reader retention, or before/after proof. Earlier cross-shutdown installed-package durability uncertainty remains unresolved.

### Remaining acceptance

**NOT MERGE-READY.** Exact-head scoped CI passed all 10 selected jobs; the focused JVM tests and APK build also passed. The September 11 tablet interaction observations remain partial evidence from a FAILED run. The September 13 shutdown-only continuation separately completed clean networking shutdown and full postflight; it does not retroactively pass the earlier run or establish additional UI behavior. The separate single-chord desktop observation completed but remained fullscreen; desktop entry is UNPROVEN in this fixture/image. Precise logical-glyph/reader retention still needs manual proof; current-client cursor readbacks are non-atomic observations, not a broader lifecycle guarantee. Actual desktop/freeform task resizing, fold/unfold, RTL, process recreation, cross-shutdown durability, baseline-versus-candidate before/after proof, and iPad acceptance remain unproved. The prior durability uncertainty is not resolved by these bounded runs. No additional tests, builds, boots, or retries were run to prepare this body update.

Punchcard-Session: cobalt-brook-valley-xq
