### PR TITLE
improve(test): reduce Gateway worktree fixture setup

### DIFF
--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { expect, onTestFinished, test, vi } from "vitest";
 import type { SessionsDeleteResult } from "../../packages/gateway-protocol/src/index.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   getRegistryWorktree,
   WorktreeRemovalContentionError,
@@ -35,15 +36,32 @@ import {
   sessionStoreEntry,
   threadBindingMocks,
 } from "./test/server-sessions.test-helpers.js";
-import {
-  initializeRemoteBackedGitWorkspace,
-  setupGatewaySessionsWorktreeTestHarness,
-} from "./test/server-sessions.worktree-fixture.js";
+import { setupGatewaySessionsWorktreeTestHarness } from "./test/server-sessions.worktree-fixture.js";
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 
-const { createSessionStoreDir, createArchiveWorktreeFixture } =
+const { createSessionStoreDir, createArchiveWorktreeFixture, initializeRemoteBackedGitWorkspace } =
   setupGatewaySessionsWorktreeTestHarness();
 const execFileAsync = promisify(execFile);
+
+test("worktree fixtures keep committed changes and remote cleanup local to each case", async () => {
+  const tempDirs = createTempDirTracker();
+  onTestFinished(tempDirs.cleanup);
+  const firstRoot = tempDirs.make("openclaw-worktree-first-");
+  const first = await initializeRemoteBackedGitWorkspace(firstRoot);
+  await fs.writeFile(path.join(first, "README.md"), "first fixture only\n");
+  await execFileAsync("git", ["-C", first, "commit", "-am", "change first fixture"]);
+  await execFileAsync("git", ["-C", first, "push"]);
+
+  const second = await initializeRemoteBackedGitWorkspace(
+    tempDirs.make("openclaw-worktree-second-"),
+  );
+  await fs.rm(firstRoot, { recursive: true, force: true });
+  await execFileAsync("git", ["-C", second, "fetch", "origin"]);
+  expect(await fs.readFile(path.join(second, "README.md"), "utf8")).toBe("base\n");
+  expect((await execFileAsync("git", ["-C", second, "show", "origin/main:README.md"])).stdout).toBe(
+    "base\n",
+  );
+});
 
 test.each(["none", "restore-failed", "placement-changed"] as const)(
   "inbound admission restores the archived worktree before opening its session (failure=%s)",

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -300,8 +300,11 @@ vi.mock("../../agents/agent-bundle-mcp-tools.js", async (importOriginal) => ({
   retireSessionMcpRuntime: bundleMcpRuntimeMocks.retireSessionMcpRuntime,
 }));
 
-export function setupGatewaySessionsHandlerTestHarness() {
-  const { getHarness, openClient, ...handlerFixture } = createGatewaySessionsTestHarness(false);
+export function setupGatewaySessionsHandlerTestHarness(setup?: GatewaySessionsSuiteSetup) {
+  const { getHarness, openClient, ...handlerFixture } = createGatewaySessionsTestHarness(
+    false,
+    setup,
+  );
   void [getHarness, openClient];
   return handlerFixture;
 }

--- a/src/gateway/test/server-sessions.worktree-fixture.ts
+++ b/src/gateway/test/server-sessions.worktree-fixture.ts
@@ -16,7 +16,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-export async function initializeRemoteBackedGitWorkspace(root: string): Promise<string> {
+async function initializeRemoteBackedGitSeed(root: string): Promise<void> {
   const workspace = path.join(root, "workspace");
   const remote = path.join(root, "remote.git");
   await fs.mkdir(workspace, { recursive: true });
@@ -35,11 +35,27 @@ export async function initializeRemoteBackedGitWorkspace(root: string): Promise<
   await execFileAsync("git", ["clone", "--bare", workspace, remote]);
   await execFileAsync("git", ["-C", workspace, "remote", "add", "origin", remote]);
   await execFileAsync("git", ["-C", workspace, "push", "-u", "origin", "main"]);
-  return await fs.realpath(workspace);
 }
 
 export function setupGatewaySessionsWorktreeTestHarness() {
-  const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+  let seedRoot: string;
+  const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness(async (makeTempDir) => {
+    seedRoot = makeTempDir("openclaw-worktree-seed-");
+    await initializeRemoteBackedGitSeed(seedRoot);
+  });
+
+  async function initializeRemoteBackedGitWorkspace(root: string): Promise<string> {
+    const workspace = path.join(root, "workspace");
+    const remote = path.join(root, "remote.git");
+    // Only pristine contents are shared. Each case owns its Git metadata, remote,
+    // and later managed worktrees; suite cleanup owns the never-mutated seed.
+    await Promise.all([
+      fs.cp(path.join(seedRoot, "workspace"), workspace, { recursive: true }),
+      fs.cp(path.join(seedRoot, "remote.git"), remote, { recursive: true }),
+    ]);
+    await execFileAsync("git", ["-C", workspace, "remote", "set-url", "origin", remote]);
+    return await fs.realpath(workspace);
+  }
 
   async function createArchiveWorktreeFixture() {
     const state = await createOpenClawTestState({
@@ -83,5 +99,9 @@ export function setupGatewaySessionsWorktreeTestHarness() {
     return { key, sessionId, storePath, transcriptScope, worktree, workspace };
   }
 
-  return { createSessionStoreDir, createArchiveWorktreeFixture };
+  return {
+    createSessionStoreDir,
+    createArchiveWorktreeFixture,
+    initializeRemoteBackedGitWorkspace,
+  };
 }


### PR DESCRIPTION
Related: #142719

## What Problem This Solves

Reduces repeated Git setup in Gateway archive, delete, and inbound-restore lifecycle tests. Each fixture previously ran eight Git commands to initialize a working repository and bare remote before exercising the behavior under test.

## Why This Change Was Made

Prepare one pristine Git seed per suite through the existing suite resource lifecycle. Copy the working repository and bare remote into each test's own state directory, then rewrite origin to that test's absolute remote path. Each test keeps independent Git metadata, worktrees, database state, and cleanup; the suite owns seed cleanup.

## User Impact

A small reduction in test setup work. Production behavior, lifecycle assertions, test scheduling, runners, concurrency, and timeouts remain unchanged. This is not a solution to the entire four-minute agent/chat group.

## Evidence

- On macOS arm64 with Node 24.16.0, pnpm 12.3.4, and Vitest 5.0.0, a same-process benchmark alternated original and candidate initializers across 20 pairs, reversing order on alternate pairs. Median setup fell from **182.50 ms to 31.50 ms** (82.7%); the candidate was faster in all 20 pairs. Median paired saving was 147.48 ms. These per-case measurements exclude cleanup and the candidate's one-time suite seed preparation.
- The original 43 lifecycle tests passed before and after the change. All 44 cases passed with the new isolation test; its final content-based assertion refinement also passed in a focused rerun. The isolation case commits and pushes a change from fixture A, creates B, deletes A, fetches B, and verifies that B's working tree and remote remain pristine.
- Validation used `node scripts/run-vitest.mjs` with the archive-worktree-lifecycle, delete-worktree-lifecycle, and inbound-worktree-writer files, `--maxWorkers=1 --reporter=verbose`.
- Changed-file checks passed, including core test typechecks, type-aware lint, formatting, dead-export scans, and applicable guards. `git diff --check` passed. Independent autoreview was scoped-clean through P2.

Full-suite speedup remains unverified: original cold/warm Vitest runs took 97.65s/89.58s; candidate runs took 140.25s and 109.17s while unrelated compiler jobs saturated the host. The paired initializer probe supports a small setup saving, not an end-to-end timing claim. A configured Blacksmith Testbox attempt stopped at missing authentication before returning a lease, so no Linux benchmark is claimed.
