### PR TITLE
refactor(channels): reuse normalized setup catalog metadata

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2356,7 +2356,7 @@ src/commands/backup-restore.ts	1
 src/commands/backup-schedule.ts	1
 src/commands/backup-verify.ts	2
 src/commands/channel-setup/config-compatibility.ts	2
-src/commands/channel-setup/discovery.ts	10
+src/commands/channel-setup/discovery.ts	8
 src/commands/channel-test-registry.ts	2
 src/commands/channels/add-wizard.ts	1
 src/commands/channels/add.ts	2

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -1,13 +1,16 @@
 // Channel setup discovery tests cover visible setup choices from bundled, installed, and trusted catalog sources.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginAutoEnableResult } from "../../config/plugin-auto-enable.js";
+import { makeCatalogEntry, makeMeta } from "../../flows/channel-setup.test-helpers.js";
 import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
 
 const listPluginContributionIds = vi.hoisted(() =>
   vi.fn((_index?: unknown, _contribution?: unknown, _options?: unknown): string[] => []),
 );
 const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((): unknown[] => []));
-const listChatChannels = vi.hoisted(() => vi.fn((): Array<Record<string, string>> => []));
+const listChatChannels = vi.hoisted(() =>
+  vi.fn<typeof import("../../channels/chat-meta.js").listChatChannels>(() => []),
+);
 const applyPluginAutoEnable = vi.hoisted(() =>
   vi.fn<(args: { config: unknown; env?: NodeJS.ProcessEnv }) => PluginAutoEnableResult>(
     ({ config }) => ({
@@ -34,6 +37,10 @@ vi.mock("../../channels/plugins/catalog.js", () => ({
 
 vi.mock("../../channels/chat-meta.js", () => ({
   listChatChannels: () => listChatChannels(),
+}));
+
+vi.mock("../../secrets/channel-env-vars.js", () => ({
+  getChannelEnvVars: () => [],
 }));
 
 import { listManifestInstalledChannelIds, resolveChannelSetupEntries } from "./discovery.js";
@@ -130,29 +137,41 @@ describe("listManifestInstalledChannelIds", () => {
     expect(resolved.entries.map((entry) => entry.id)).toEqual(["telegram"]);
   });
 
-  it("preserves bundled channel display metadata when installed setup plugins omit it", () => {
+  it("preserves source precedence and catalog metadata across setup views", () => {
     listChatChannels.mockReturnValue([
-      {
-        id: "telegram",
-        label: "Telegram",
-        selectionLabel: "Telegram",
-        docsPath: "/channels/telegram",
-        blurb: "bot token",
-      },
+      makeMeta("telegram", "Telegram", { blurb: "bot token" }),
+      makeMeta("matrix", "Matrix"),
+    ]);
+    const bundledCatalog = makeCatalogEntry("matrix", "Catalog Matrix");
+    const installedCatalog = makeCatalogEntry("installed-chat", "Installed Chat", {
+      meta: makeMeta("installed-chat", "Installed Chat", {
+        aliases: ["installed"],
+        detailLabel: "Installed Chat Bot",
+        selectionDocsPrefix: "",
+      }),
+    });
+    const installableCatalog = makeCatalogEntry("installable-chat", "Installable Chat");
+    listPluginContributionIds.mockReturnValue(["matrix", "installed-chat"]);
+    listChannelPluginCatalogEntries.mockReturnValue([
+      makeCatalogEntry("telegram", "Catalog Telegram"),
+      bundledCatalog,
+      installedCatalog,
+      installableCatalog,
     ]);
 
     const resolved = resolveChannelSetupEntries({
-      cfg: {} as never,
+      cfg: {},
       installedPlugins: [
         {
           id: "telegram",
           meta: {
             id: "telegram",
+            selectionLabel: "Telegram setup",
           },
         } as never,
       ],
       workspaceDir: "/tmp/workspace",
-      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+      env: { OPENCLAW_HOME: "/tmp/home" },
     });
 
     expect(resolved).toStrictEqual({
@@ -162,16 +181,22 @@ describe("listManifestInstalledChannelIds", () => {
           meta: {
             id: "telegram",
             label: "Telegram",
-            selectionLabel: "Telegram",
+            selectionLabel: "Telegram setup",
             blurb: "bot token",
             docsPath: "/channels/telegram",
           },
         },
+        { id: "matrix", meta: makeMeta("matrix", "Matrix") },
+        { id: "installed-chat", meta: installedCatalog.meta },
+        { id: "installable-chat", meta: installableCatalog.meta },
       ],
-      installedCatalogEntries: [],
-      installableCatalogEntries: [],
-      installedCatalogById: new Map(),
-      installableCatalogById: new Map(),
+      installedCatalogEntries: [bundledCatalog, installedCatalog],
+      installableCatalogEntries: [installableCatalog],
+      installedCatalogById: new Map([
+        ["matrix", bundledCatalog],
+        ["installed-chat", installedCatalog],
+      ]),
+      installableCatalogById: new Map([["installable-chat", installableCatalog]]),
     });
   });
 });

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -144,28 +144,9 @@ export function resolveChannelSetupEntries(params: {
       }),
     );
   }
-  for (const entry of installedCatalogEntries) {
+  for (const entry of [...installedCatalogEntries, ...installableCatalogEntries]) {
     if (!metaById.has(entry.id)) {
-      metaById.set(
-        entry.id,
-        normalizeChannelMeta({
-          id: entry.id as ChannelChoice,
-          meta: entry.meta,
-          existing: metaById.get(entry.id),
-        }),
-      );
-    }
-  }
-  for (const entry of installableCatalogEntries) {
-    if (!metaById.has(entry.id)) {
-      metaById.set(
-        entry.id,
-        normalizeChannelMeta({
-          id: entry.id as ChannelChoice,
-          meta: entry.meta,
-          existing: metaById.get(entry.id),
-        }),
-      );
+      metaById.set(entry.id, entry.meta);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Channel setup normalized catalog metadata while building its installed and installable buckets, then repeated that same work in two separate display-list loops. The second pass could never supply an existing fallback because it ran only for missing display entries.

## Why This Change Was Made

One ordered loop now reuses the already-normalized catalog records. Built-in metadata, loaded-plugin overrides, catalog filtering and the separate installed/installable maps retain their existing owners and precedence. This removes 19 production lines and two unnecessary type assertions; the assertion baseline shrinks by exactly those two assertions.

## User Impact

No user-visible behavior changes. Setup keeps the same labels, fallbacks, display order and installation choices with less duplicate processing.

## Evidence

The extended existing fixture passes before and after the refactor. It covers partial loaded metadata, built-in/catalog collisions, installed and installable entries, optional metadata, display order, and both lookup maps. All 76 owner and sibling cases pass, along with all 30 selected validation stages. The first full check required the expected assertion-baseline reduction from 10 to 8; the final full check passes with that exact shrink. No runtime import, configuration or storage changes.
