### PR TITLE
docs(gateway): lift non-family sections out of RPC method families

### DIFF
--- a/docs/gateway/protocol/rpc-methods.md
+++ b/docs/gateway/protocol/rpc-methods.md
@@ -36,7 +36,7 @@ methods. Treat this as feature discovery, not a full enumeration of
 
 ### Models and usage
 
-- `models.list` returns the runtime-allowed model catalog. See "`models.list` views" below.
+- `models.list` returns the runtime-allowed model catalog. See [`models.list` views](/gateway/protocol/operator-methods#models-list-views).
 - `usage.status` returns provider usage windows/remaining quota summaries. Clients advertising `usage-refreshing` receive an immediate `refreshing: true` placeholder on a cold cache and must refetch on a bounded schedule; other callers block for the cold provider read.
 - `usage.cost` returns aggregated cost usage summaries for a date range. Pass `agentId` for one agent, or `agentScope: "all"` to aggregate configured agents.
 - `doctor.memory.status` returns vector-memory / cached embedding readiness for the active default agent workspace. Pass `{ "probe": true }` or `{ "deep": true }` only for an explicit live embedding provider ping. Pass `{ "agentId": "agent-id" }` to scope Dreaming store stats to one agent workspace; omitting it aggregates configured Dreaming workspaces.
@@ -244,7 +244,7 @@ Outcomes are retained past the credential's own expiry.
 - `cron.runs` accepts an optional non-empty `runId` filter so clients can follow one queued manual run without racing against other history entries for the same job.
 - Skills and tools: `commands.list`, `skills.*`, `tools.catalog`, `tools.effective`, `tools.invoke`. See [Operator helper methods](/gateway/protocol/operator-methods#operator-helper-methods).
 
-### Session list bootstrap
+## Session list bootstrap
 
 Call `sessions.subscribe` with a non-empty `sessions.list` parameter object, such
 as `{ limit: 60, ownerFirst: true }`, to subscribe and load the initial roster in
@@ -277,7 +277,7 @@ exceed the shared page size. Use `nextOffset` to advance and deduplicate rows by
 session key across pages; do not derive the next offset from the displayed row
 count.
 
-### Common event families
+## Common event families
 
 - `chat`: UI chat updates such as `chat.inject` and other transcript-only chat
   events. In protocol v4, delta payloads carry `deltaText`; `message` remains
@@ -344,12 +344,12 @@ count.
 - `plugin.approval.requested` / `plugin.approval.resolved`: plugin approval
   lifecycle.
 
-### Node helper methods
+## Node helper methods
 
 Nodes may call `skills.bins` to fetch the current list of skill executables
 for auto-allow checks.
 
-### Node exec lifecycle events
+## Node exec lifecycle events
 
 Nodes report `system.run` lifecycle through the node-role `node.event` RPC with
 `event: "exec.started"`, `"exec.finished"`, or `"exec.denied"`. These are not the


### PR DESCRIPTION
## What

Two small, related fixes to `docs/gateway/protocol/rpc-methods.md`, both pre-existing on `main` and both deliberately left out of scope by #143459.

**1. Four sections were mis-nested.** #143459 turned the 15 headingless `<Accordion>` blocks under `## RPC method families` into `###` headings. That left the page with one `##` and 19 `###` children — but only 15 of those children are method families. `Session list bootstrap`, `Common event families`, `Node helper methods` and `Node exec lifecycle events` are *peers* of the families, not members of them. The page says so twice itself:

- frontmatter `summary`: "RPC method families, discovery, session list bootstrap, and event families"
- the lede: "The gateway method surface, grouped into families, **plus** the session list bootstrap, the common event families, and the node helper and exec lifecycle contracts."

They are now `##`.

**2. A dangling cross-reference.** Under "Models and usage":

```
- `models.list` returns the runtime-allowed model catalog. See "`models.list` views" below.
```

`### \`models.list\` views` is not on this page — #141055 moved it to `/gateway/protocol/operator-methods#models-list-views`. It is now a real link to that route. `.audit/check-orphan-refs.py` reports the same 1 (unrelated, false-positive) hit before and after, so nothing flagged this.

Prose is otherwise untouched: the whole diff is 5 lines.

## Anchors: neutral, measured

Ids enumerated with the repo's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`), not a slug approximation. Heading level does not feed the slug, so the id list is **identical before and after — same 23 ids, same order, 0 collisions**:

```
rpc-method-families
system-and-identity
models-and-usage
channels-and-login-helpers
plugin-management
messaging-and-logs
operator-terminal
talk-and-tts
secrets%2C-config%2C-update%2C-and-wizard
agent-and-workspace-helpers
session-control
device-pairing-and-device-tokens
node-pairing%2C-invoke%2C-and-pending-work
approval-families
control-ui-commands
automation%2C-skills%2C-and-tools
session-list-bootstrap
common-event-families
node-helper-methods
node-exec-lifecycle-events
secrets-config-update-and-wizard
node-pairing-invoke-and-pending-work
automation-skills-and-tools
```

(The three comma-bearing titles each mint an encoded/cleaned pair; both forms survive unchanged.) No `<a id>` stub is needed, and adding one would mint a duplicate authored/canonical id.

## Inbound links

`git grep -n "rpc-methods" origin/main` with no path filter: 28 hits, 26 of them fragment-bearing links plus one `docs/docs.json` nav entry and one intra-page link. `docs/gateway/protocol.md` alone carries 20 anchored links into this page (lines 51-70), including all four of the promoted sections. Every fragment used inbound is in the 23-id set above, unchanged. Other inbound pages: `docs/gateway/clients.md`, `docs/gateway/cloud-workers.md`, `docs/gateway/diagnostics.md`, `docs/gateway/opentelemetry/spans-and-events.md`, `docs/tools/screen.md`.

## Validators

Baseline measured in a detached worktree at the merge-base (`d566b83f027`), not by stashing.

| check | baseline | this branch |
| --- | --- | --- |
| `pnpm check:docs` (format:docs:check, lint:docs, lint:templates, check-mdx, check-i18n-glossary, check-links, check-config-examples) | exit 0 | exit 0 |
| `docs-link-audit --anchors` | `checked_internal_links=13085`, `broken_links=3` | `checked_internal_links=13086`, `broken_links=3` |
| `vitest.tooling` `src/scripts/docs-link-audit.test.ts` | 1 file, 1 failed / 32 passed | 1 file, 1 failed / 32 passed (identical, pre-existing) |
| `vitest.full-core-unit-src` `src/docs/` | — | 8 files, 16 tests, all pass |
| `.audit/stranded-stubs.py docs` | — | 0 suspects |
| `.audit/check-orphan-refs.py` on the page | 1 | 1 (same line 107 false positive; the `models.list` one was never detected by it) |

`+1` internal link is the new cross-reference; the 3 `--anchors` errors are the known pre-existing `/maturity/taxonomy#windows-app-node` ones. The `docs-link-audit.test.ts` failure is `expected [ 'ass-guide', 'param-ass-guide' ] to deeply equal [ 'as-s-guide', 'param-as-s-guide' ]` — an apostrophe-normalization unit test with inline fixtures, reproduced identically at the base sha.

## Other pins

- `.audit/docs-test-pins.py docs/gateway/protocol/rpc-methods.md`: **0 tests pin this page**.
- `git grep "gateway/protocol/rpc-methods" origin/main -- ':!docs/'`: no hits. Not in `RELEASE_METADATA_PATHS` in `scripts/changed-lanes.mts`.
- `.github/labeler.yml`: no glob names this page (it is matched only by the generic docs globs), so nothing to add — no new paths are created here anyway.
- `.github/CODEOWNERS`: last-match-wins simulation — no rule matches `docs/gateway/protocol/rpc-methods.md`. No maintainer-team block.

## Glossary: no entry needed

`docs/.i18n/glossary.zh-CN.json` is **untouched**, and `docs:check-i18n-glossary` passes. The new link is exempt twice over: `LIST_ITEM_LINK_RE` in `scripts/check-docs-i18n-glossary.mts` only matches a link at the *start* of a list item (this one is mid-sentence), and `isGlossaryCandidate` rejects any term containing a backtick (the label is `` `models.list` views ``). This keeps the PR off the file that conflicts on every concurrent rebase.

## Not in scope

Splitting the page. That is the next PR — real `##` boundaries are its precondition.
