### PR TITLE
fix(triage): prevent Claude startup hooks from blocking repair

### DIFF
--- a/docs/cli/triage.md
+++ b/docs/cli/triage.md
@@ -17,6 +17,8 @@ openclaw triage
 
 In an interactive terminal, triage starts the first directly launchable agent on `PATH` in this detection order: Claude Code (`claude`), Codex (`codex`), OpenCode (`opencode`), then Pi (`pi`). An explicit `openclaw triage` invocation prints the selected agent and passes a bounded repair prompt directly, without a picker or launch confirmation. The agent uses its existing authentication, sandbox, and approval settings.
 
+Claude Code starts with `--safe-mode`, which disables custom hooks, plugins, and project instructions while retaining authentication and built-in tools. This prevents project startup hooks, such as dependency installation, from delaying the repair prompt. Printed manual commands use Claude's normal customization settings.
+
 Choose a particular agent with `--agent`, or collect diagnostics without starting one with `--json` or `--non-interactive`:
 
 ```bash

--- a/docs/cli/triage.md
+++ b/docs/cli/triage.md
@@ -17,7 +17,7 @@ openclaw triage
 
 In an interactive terminal, triage starts the first directly launchable agent on `PATH` in this detection order: Claude Code (`claude`), Codex (`codex`), OpenCode (`opencode`), then Pi (`pi`). An explicit `openclaw triage` invocation prints the selected agent and passes a bounded repair prompt directly, without a picker or launch confirmation. The agent uses its existing authentication, sandbox, and approval settings.
 
-Claude Code starts with `--safe-mode`, which disables custom hooks, plugins, and project instructions while retaining authentication and built-in tools. This prevents project startup hooks, such as dependency installation, from delaying the repair prompt. Printed manual commands use Claude's normal customization settings.
+Claude Code starts with `--safe-mode`, which disables custom hooks, plugins, skills, MCP servers, and project instructions while retaining authentication and built-in tools. This prevents project startup hooks, such as dependency installation, from delaying the repair prompt. Direct launch requires Claude Code 2.1.169 or newer; when the installed CLI does not advertise safe-mode support, triage prints a manual handoff instead. Printed manual commands use Claude's normal customization settings, including plugins and MCP servers.
 
 Choose a particular agent with `--agent`, or collect diagnostics without starting one with `--json` or `--non-interactive`:
 

--- a/src/cli/update-cli/update-command-triage.test.ts
+++ b/src/cli/update-cli/update-command-triage.test.ts
@@ -627,6 +627,7 @@ describe("update failure triage boundary", () => {
             path.join(bin, "claude"),
             `#!${process.execPath}\n` +
               `const fs = require("node:fs");\n` +
+              `if (process.argv.includes("--help")) { process.stdout.write("--safe-mode\\n"); process.exit(0); }\n` +
               `fs.appendFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({\n` +
               `  cwd: fs.realpathSync(process.cwd()),\n` +
               `  home: process.env.HOME,\n` +

--- a/src/cli/update-cli/update-command-triage.test.ts
+++ b/src/cli/update-cli/update-command-triage.test.ts
@@ -637,7 +637,7 @@ describe("update failure triage boundary", () => {
               `  nodeOptions: process.env.NODE_OPTIONS,\n` +
               `  updateInProgress: process.env.OPENCLAW_UPDATE_IN_PROGRESS,\n` +
               `  released: fs.existsSync(${JSON.stringify(releasedPath)}),\n` +
-              `  prompt: process.argv[2],\n` +
+              `  prompt: process.argv.at(-1),\n` +
               `}) + "\\n");\n` +
               `process.exitCode = ${agentExitCode};\n`,
             { mode: 0o700 },

--- a/src/commands/triage-claude.ts
+++ b/src/commands/triage-claude.ts
@@ -1,0 +1,21 @@
+import { runUtf8CommandWithTimeout } from "../process/exec.js";
+
+export async function claudeAdvertisesSafeMode(params: {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  cwd?: string;
+}): Promise<boolean> {
+  const help = await runUtf8CommandWithTimeout([...params.argv, "--help"], {
+    env: params.env,
+    ...(params.cwd ? { cwd: params.cwd } : {}),
+    timeoutMs: 10_000,
+    killProcessTree: true,
+    outputCapture: "tail",
+    maxOutputBytes: 64 * 1024,
+  });
+  return (
+    help.termination === "exit" &&
+    help.code === 0 &&
+    `${help.stdout}\n${help.stderr}`.includes("--safe-mode")
+  );
+}

--- a/src/commands/triage-claude.ts
+++ b/src/commands/triage-claude.ts
@@ -1,21 +1,29 @@
 import { runUtf8CommandWithTimeout } from "../process/exec.js";
 
-export async function claudeAdvertisesSafeMode(params: {
+type ClaudeSafeModeProbeResult = { ok: true; supported: boolean } | { ok: false; error: unknown };
+
+export async function probeClaudeSafeMode(params: {
   argv: string[];
   env: NodeJS.ProcessEnv;
   cwd?: string;
-}): Promise<boolean> {
-  const help = await runUtf8CommandWithTimeout([...params.argv, "--help"], {
-    env: params.env,
-    ...(params.cwd ? { cwd: params.cwd } : {}),
-    timeoutMs: 10_000,
-    killProcessTree: true,
-    outputCapture: "tail",
-    maxOutputBytes: 64 * 1024,
-  });
-  return (
-    help.termination === "exit" &&
-    help.code === 0 &&
-    `${help.stdout}\n${help.stderr}`.includes("--safe-mode")
-  );
+}): Promise<ClaudeSafeModeProbeResult> {
+  try {
+    const help = await runUtf8CommandWithTimeout([...params.argv, "--help"], {
+      env: params.env,
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      timeoutMs: 10_000,
+      killProcessTree: true,
+      outputCapture: "tail",
+      maxOutputBytes: 64 * 1024,
+    });
+    return {
+      ok: true,
+      supported:
+        help.termination === "exit" &&
+        help.code === 0 &&
+        `${help.stdout}\n${help.stderr}`.includes("--safe-mode"),
+    };
+  } catch (error) {
+    return { ok: false, error };
+  }
 }

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -175,6 +175,31 @@ describe("triage external recovery handoff", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run without safe mode:"));
   });
 
+  it("redacts a rejected Claude capability probe and prints the manual handoff", async () => {
+    mocks.resolveExecutablePath.mockImplementation((binary: string) =>
+      binary === "claude" ? "/usr/local/bin/claude" : undefined,
+    );
+    mocks.runUtf8CommandWithTimeout.mockRejectedValue(
+      new Error(`missing interpreter; Authorization: Bearer ${secret}`),
+    );
+    const runtime = createTriageRuntime();
+
+    await withOpenClawTestState({ layout: "split" }, async () => {
+      await withTriageTerminal(true, async () => {
+        await expect(triageCommand(runtime, { noExport: true })).rejects.toMatchObject({ code: 1 });
+      });
+    });
+
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to check Claude safe-mode support: missing interpreter"),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run manually:"));
+    expect(JSON.stringify([runtime.error.mock.calls, runtime.log.mock.calls])).not.toContain(
+      secret,
+    );
+  });
+
   it("reports a missing explicit agent without falling back to an available agent", async () => {
     mocks.resolveExecutablePath.mockImplementation((agent: string) =>
       agent === "claude" ? "/usr/local/bin/claude" : undefined,

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   collectDoctorFindings: vi.fn(),
   writeDiagnosticSupportExport: vi.fn(),
   resolveExecutablePath: vi.fn(),
+  runUtf8CommandWithTimeout: vi.fn(),
   spawn: vi.fn(),
 }));
 
@@ -32,6 +33,10 @@ vi.mock("../logging/diagnostic-support-export.js", () => ({
 vi.mock("../infra/executable-path.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/executable-path.js")>()),
   resolveExecutablePath: mocks.resolveExecutablePath,
+}));
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runUtf8CommandWithTimeout: mocks.runUtf8CommandWithTimeout,
 }));
 
 const agents = ["claude", "codex", "opencode", "pi"] as const;
@@ -70,6 +75,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.collectDoctorFindings.mockResolvedValue([]);
   mocks.resolveExecutablePath.mockImplementation((agent: string) => `/usr/local/bin/${agent}`);
+  mocks.runUtf8CommandWithTimeout.mockImplementation(async (argv, options) => {
+    if (argv.at(-1) === "--help") {
+      return { stdout: "--safe-mode", stderr: "", code: 0, termination: "exit" };
+    }
+    const actual = await vi.importActual<typeof import("../process/exec.js")>("../process/exec.js");
+    return await actual.runUtf8CommandWithTimeout(argv, options);
+  });
   mocks.spawn.mockImplementation(() => {
     const child = new EventEmitter();
     queueMicrotask(() => child.emit("exit", 0, null));

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -100,7 +100,11 @@ describe("triage external recovery handoff", () => {
     });
     expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
       `/usr/local/bin/${agent}`,
-      agent === "opencode" ? ["--prompt", expect.any(String)] : [expect.any(String)],
+      agent === "claude"
+        ? ["--safe-mode", expect.any(String)]
+        : agent === "opencode"
+          ? ["--prompt", expect.any(String)]
+          : [expect.any(String)],
       expect.objectContaining({ stdio: "inherit" }),
     );
   });
@@ -185,7 +189,7 @@ describe("triage external recovery handoff", () => {
       );
       expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
         "/usr/local/bin/claude",
-        [expect.any(String)],
+        ["--safe-mode", expect.any(String)],
         expect.objectContaining({
           cwd: state.workspaceDir,
           stdio: "inherit",
@@ -196,7 +200,7 @@ describe("triage external recovery handoff", () => {
           }),
         }),
       );
-      const prompt = String(mocks.spawn.mock.calls[0]?.[1]?.[0]);
+      const prompt = String(mocks.spawn.mock.calls[0]?.[1]?.[1]);
       expect(prompt).toContain("injected-doctor-failure");
       expect(prompt).toContain("2026.8.25");
       expect(prompt).toContain("2026.8.26");
@@ -266,7 +270,7 @@ describe("triage external recovery handoff", () => {
 
         expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
           "/usr/local/bin/claude",
-          [expect.stringContaining("injected-doctor-failure")],
+          ["--safe-mode", expect.stringContaining("injected-doctor-failure")],
           expect.objectContaining({ cwd: state.workspaceDir, stdio: "inherit" }),
         );
         const output = JSON.stringify([runtime.log.mock.calls, runtime.error.mock.calls]);

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -146,6 +146,35 @@ describe("triage external recovery handoff", () => {
     },
   );
 
+  it("prints a manual handoff instead of launching Claude without safe-mode support", async () => {
+    mocks.resolveExecutablePath.mockImplementation((binary: string) =>
+      binary === "claude" ? "/usr/local/bin/claude" : undefined,
+    );
+    mocks.runUtf8CommandWithTimeout.mockResolvedValue({
+      stdout: "Usage: claude [options]",
+      stderr: "",
+      code: 0,
+      termination: "exit",
+    });
+    const runtime = createTriageRuntime();
+
+    await withOpenClawTestState({ layout: "split" }, async () => {
+      await withTriageTerminal(true, async () => {
+        await expect(triageCommand(runtime, { noExport: true })).rejects.toMatchObject({ code: 1 });
+      });
+    });
+
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.runUtf8CommandWithTimeout).toHaveBeenCalledWith(
+      ["/usr/local/bin/claude", "--help"],
+      expect.objectContaining({ timeoutMs: 10_000, killProcessTree: true }),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Claude Code 2.1.169 or newer is required"),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run without safe mode:"));
+  });
+
   it("reports a missing explicit agent without falling back to an available agent", async () => {
     mocks.resolveExecutablePath.mockImplementation((agent: string) =>
       agent === "claude" ? "/usr/local/bin/claude" : undefined,

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -169,9 +169,7 @@ describe("triage external recovery handoff", () => {
       ["/usr/local/bin/claude", "--help"],
       expect.objectContaining({ timeoutMs: 10_000, killProcessTree: true }),
     );
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Claude Code 2.1.169 or newer is required"),
-    );
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Claude Code 2.1.169+"));
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run without safe mode:"));
   });
 

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   runUpdateRepairLoop: vi.fn(),
   agentExecCommand: vi.fn(),
   resolveExecutablePath: vi.fn(),
+  runUtf8CommandWithTimeout: vi.fn(),
   spawn: vi.fn(),
 }));
 
@@ -59,6 +60,11 @@ vi.mock("./doctor-lint.js", () => ({
 vi.mock("../infra/executable-path.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/executable-path.js")>()),
   resolveExecutablePath: mocks.resolveExecutablePath,
+}));
+
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runUtf8CommandWithTimeout: mocks.runUtf8CommandWithTimeout,
 }));
 
 vi.mock("../cli/gateway-rpc.js", () => ({
@@ -100,6 +106,14 @@ describe("triageCommand", () => {
       finalValidation: { ok: true, score: 0, summary: "Doctor lint reports no errors." },
     });
     mocks.resolveExecutablePath.mockReturnValue(undefined);
+    mocks.runUtf8CommandWithTimeout.mockImplementation(async (argv, options) => {
+      if (argv.at(-1) === "--help") {
+        return { stdout: "--safe-mode", stderr: "", code: 0, termination: "exit" };
+      }
+      const actual =
+        await vi.importActual<typeof import("../process/exec.js")>("../process/exec.js");
+      return await actual.runUtf8CommandWithTimeout(argv, options);
+    });
     mocks.spawn.mockImplementation(() => {
       const child = new EventEmitter();
       queueMicrotask(() => child.emit("exit", 0, null));
@@ -1015,6 +1029,33 @@ describe("triageCommand", () => {
     } else {
       expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(exitCode);
     }
+  });
+
+  it("prints a manual handoff instead of launching Claude without safe-mode support", async () => {
+    mocks.resolveExecutablePath.mockImplementation((binary: string) =>
+      binary === "claude" ? "/usr/local/bin/claude" : undefined,
+    );
+    mocks.runUtf8CommandWithTimeout.mockResolvedValue({
+      stdout: "Usage: claude [options]",
+      stderr: "",
+      code: 0,
+      termination: "exit",
+    });
+    const runtime = createTriageRuntime();
+
+    await withTriageTerminal(true, async () => {
+      await expect(triageCommand(runtime, { noExport: true })).rejects.toMatchObject({ code: 1 });
+    });
+
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.runUtf8CommandWithTimeout).toHaveBeenCalledWith(
+      ["/usr/local/bin/claude", "--help"],
+      expect.objectContaining({ timeoutMs: 10_000, killProcessTree: true }),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Claude Code 2.1.169 or newer is required"),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run without safe mode:"));
   });
 
   it("reports a failed launch without trying another installed agent", async () => {

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -1031,33 +1031,6 @@ describe("triageCommand", () => {
     }
   });
 
-  it("prints a manual handoff instead of launching Claude without safe-mode support", async () => {
-    mocks.resolveExecutablePath.mockImplementation((binary: string) =>
-      binary === "claude" ? "/usr/local/bin/claude" : undefined,
-    );
-    mocks.runUtf8CommandWithTimeout.mockResolvedValue({
-      stdout: "Usage: claude [options]",
-      stderr: "",
-      code: 0,
-      termination: "exit",
-    });
-    const runtime = createTriageRuntime();
-
-    await withTriageTerminal(true, async () => {
-      await expect(triageCommand(runtime, { noExport: true })).rejects.toMatchObject({ code: 1 });
-    });
-
-    expect(mocks.spawn).not.toHaveBeenCalled();
-    expect(mocks.runUtf8CommandWithTimeout).toHaveBeenCalledWith(
-      ["/usr/local/bin/claude", "--help"],
-      expect.objectContaining({ timeoutMs: 10_000, killProcessTree: true }),
-    );
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Claude Code 2.1.169 or newer is required"),
-    );
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Run without safe mode:"));
-  });
-
   it("reports a failed launch without trying another installed agent", async () => {
     mocks.resolveExecutablePath.mockImplementation((binary: string) => `/usr/local/bin/${binary}`);
     mocks.spawn.mockImplementation(() => {

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -926,7 +926,7 @@ describe("triageCommand", () => {
       expect(prompt).toContain('Repair A&B at 100%: ! "quoted"');
       expect(prompt).toContain("\n");
       expect(command).toBe(nodeSource === "current" ? currentNode : pathNode);
-      expect(argv).toEqual([entrypoint, prompt]);
+      expect(argv).toEqual([entrypoint, "--safe-mode", prompt]);
       expect(options?.stdio).toBe("inherit");
       expect(options?.shell).not.toBe(true);
       expect(options?.windowsHide).not.toBe(true);
@@ -998,7 +998,7 @@ describe("triageCommand", () => {
     const promptPath = String(runtime.log.mock.calls[0]?.[0]).replace("Debugging prompt: ", "");
     expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
       `/usr/local/bin/${agent}`,
-      [await fs.readFile(promptPath, "utf8")],
+      [...(agent === "claude" ? ["--safe-mode"] : []), await fs.readFile(promptPath, "utf8")],
       {
         stdio: "inherit",
         env: {

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -463,7 +463,13 @@ export async function triageCommand(
       return;
     }
     runtime.log(`Starting ${handoff.agent}; use --agent <name> to select another coding agent.`);
-    const args = handoff.agent === "opencode" ? ["--prompt", prompt] : [prompt];
+    // Project startup hooks can block the repair prompt before Claude's first turn.
+    const args =
+      handoff.agent === "claude"
+        ? ["--safe-mode", prompt]
+        : handoff.agent === "opencode"
+          ? ["--prompt", prompt]
+          : [prompt];
     // Artifact I/O can outlive the admitted update attempt. Recheck its exact
     // owner immediately before handing control to a local coding agent.
     if (!isCurrent()) {

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -462,6 +462,34 @@ export async function triageCommand(
       }
       return;
     }
+    if (handoff.agent === "claude" && !automatic) {
+      const { runUtf8CommandWithTimeout } = await import("../process/exec.js");
+      const help = await runUtf8CommandWithTimeout(
+        [handoff.program.command, ...handoff.program.leadingArgv, "--help"],
+        {
+          env: targetEnv,
+          ...agentOptions,
+          timeoutMs: 10_000,
+          killProcessTree: true,
+          outputCapture: "tail",
+          maxOutputBytes: 64 * 1024,
+        },
+      );
+      if (!isCurrent()) {
+        return;
+      }
+      if (
+        help.termination !== "exit" ||
+        help.code !== 0 ||
+        !`${help.stdout}\n${help.stderr}`.includes("--safe-mode")
+      ) {
+        runtime.error(
+          "Installed Claude does not advertise --safe-mode; Claude Code 2.1.169 or newer is required for direct triage launch.",
+        );
+        runtime.log(`Run without safe mode: ${suggestedCommands[0]}`);
+        exitCliAfterOutput(runtime, 1);
+      }
+    }
     runtime.log(`Starting ${handoff.agent}; use --agent <name> to select another coding agent.`);
     // Project startup hooks can block the repair prompt before Claude's first turn.
     const args =

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -463,26 +463,16 @@ export async function triageCommand(
       return;
     }
     if (handoff.agent === "claude" && !automatic) {
-      const { runUtf8CommandWithTimeout } = await import("../process/exec.js");
-      const help = await runUtf8CommandWithTimeout(
-        [handoff.program.command, ...handoff.program.leadingArgv, "--help"],
-        {
-          env: targetEnv,
-          ...agentOptions,
-          timeoutMs: 10_000,
-          killProcessTree: true,
-          outputCapture: "tail",
-          maxOutputBytes: 64 * 1024,
-        },
-      );
+      const { claudeAdvertisesSafeMode } = await import("./triage-claude.js");
+      const supportsSafeMode = await claudeAdvertisesSafeMode({
+        argv: [handoff.program.command, ...handoff.program.leadingArgv],
+        env: targetEnv,
+        ...agentOptions,
+      });
       if (!isCurrent()) {
         return;
       }
-      if (
-        help.termination !== "exit" ||
-        help.code !== 0 ||
-        !`${help.stdout}\n${help.stderr}`.includes("--safe-mode")
-      ) {
+      if (!supportsSafeMode) {
         runtime.error(
           "Installed Claude does not advertise --safe-mode; Claude Code 2.1.169 or newer is required for direct triage launch.",
         );

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -463,17 +463,15 @@ export async function triageCommand(
       return;
     }
     if (handoff.agent === "claude" && !automatic) {
-      const { claudeAdvertisesSafeMode } = await import("./triage-claude.js");
-      let supportsSafeMode: boolean;
-      try {
-        supportsSafeMode = await claudeAdvertisesSafeMode({
-          argv: [handoff.program.command, ...handoff.program.leadingArgv],
-          env: targetEnv,
-          ...agentOptions,
-        });
-      } catch (error) {
+      const { probeClaudeSafeMode } = await import("./triage-claude.js");
+      const probe = await probeClaudeSafeMode({
+        argv: [handoff.program.command, ...handoff.program.leadingArgv],
+        env: targetEnv,
+        ...agentOptions,
+      });
+      if (!probe.ok) {
         runtime.error(
-          `Failed to check Claude safe-mode support: ${triageCollectionError(error, redaction)}`,
+          `Failed to check Claude safe-mode support: ${triageCollectionError(probe.error, redaction)}`,
         );
         runtime.log(`Run manually: ${suggestedCommands[0]}`);
         exitCliAfterOutput(runtime, 1);
@@ -481,16 +479,13 @@ export async function triageCommand(
       if (!isCurrent()) {
         return;
       }
-      if (!supportsSafeMode) {
-        runtime.error(
-          "Installed Claude does not advertise --safe-mode; Claude Code 2.1.169 or newer is required for direct triage launch.",
-        );
+      if (!probe.supported) {
+        runtime.error("Claude --safe-mode unavailable; update to Claude Code 2.1.169+.");
         runtime.log(`Run without safe mode: ${suggestedCommands[0]}`);
         exitCliAfterOutput(runtime, 1);
       }
     }
     runtime.log(`Starting ${handoff.agent}; use --agent <name> to select another coding agent.`);
-    // Project startup hooks can block the repair prompt before Claude's first turn.
     const args =
       handoff.agent === "claude"
         ? ["--safe-mode", prompt]

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -464,11 +464,20 @@ export async function triageCommand(
     }
     if (handoff.agent === "claude" && !automatic) {
       const { claudeAdvertisesSafeMode } = await import("./triage-claude.js");
-      const supportsSafeMode = await claudeAdvertisesSafeMode({
-        argv: [handoff.program.command, ...handoff.program.leadingArgv],
-        env: targetEnv,
-        ...agentOptions,
-      });
+      let supportsSafeMode: boolean;
+      try {
+        supportsSafeMode = await claudeAdvertisesSafeMode({
+          argv: [handoff.program.command, ...handoff.program.leadingArgv],
+          env: targetEnv,
+          ...agentOptions,
+        });
+      } catch (error) {
+        runtime.error(
+          `Failed to check Claude safe-mode support: ${triageCollectionError(error, redaction)}`,
+        );
+        runtime.log(`Run manually: ${suggestedCommands[0]}`);
+        exitCliAfterOutput(runtime, 1);
+      }
       if (!isCurrent()) {
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw triage`, including failed-update recovery, launches Claude Code but appears not to submit its repair prompt when the current project's startup hooks block. In the reported case, a dependency-install hook delayed the first prompt for ten minutes before timing out; the prompt itself was passed correctly.

## Why This Change Was Made

Interactive Claude handoffs now use `--safe-mode`, matching automatic triage. Recovery starts without project hooks, plugins, or project instructions while retaining Claude's authentication, built-in tools, and permission settings. The session remains interactive and receives the original positional prompt. Documentation explains this behavior.

## User Impact

Operators can reach Claude's repair turn without waiting for unrelated project setup. Other supported agents keep their existing launch behavior.

## Evidence

- Original session evidence confirmed a 600-second startup-hook timeout followed by the unchanged repair prompt.
- Regression proof: original launch arguments fail eight assertions; the fix passes all 60 focused triage and recovery tests, including Windows shim and sibling-agent coverage.
- Real Claude probes verified that safe mode skips a synthetic startup hook and that an interactive Clack-to-Claude handoff displays and answers its positional prompt without manual submission.
- Production and test typechecks, focused lint, documentation checks, formatting, and diff checks pass. Independent autoreview is scoped-clean at P0.
- `check:changed` stops on an unrelated, unchanged compatibility record whose removal deadline has expired (`sdk-untrusted-context-identifier-aliases`).
