### PR TITLE
refactor(cli): narrow help context and remove unused fields

### DIFF
--- a/src/cli/account-selector-boundary.test.ts
+++ b/src/cli/account-selector-boundary.test.ts
@@ -14,7 +14,6 @@ type AccountOptions = {
 
 const context: ProgramContext = {
   programVersion: "test",
-  channelOptions: ["discord"],
   messageChannelOptions: "discord",
   agentChannelOptions: "last|discord",
 };

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -54,7 +54,6 @@ describe("buildProgram", () => {
     mockProcessOutput();
     createProgramContextMock.mockReturnValue({
       programVersion: "9.9.9-test",
-      channelOptions: ["quietchat"],
       messageChannelOptions: "quietchat",
       agentChannelOptions: "last|quietchat",
     } satisfies ProgramContext);

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -59,7 +59,6 @@ import {
 
 const testProgramContext: ProgramContext = {
   programVersion: "0.0.0-test",
-  channelOptions: [],
   messageChannelOptions: "",
   agentChannelOptions: "web",
 };

--- a/src/cli/program/context.test.ts
+++ b/src/cli/program/context.test.ts
@@ -18,7 +18,6 @@ describe("createProgramContext", () => {
     const ctx = createProgramContext();
     expect(ctx).toEqual({
       programVersion: "9.9.9-test",
-      channelOptions: ["telegram", "whatsapp"],
       messageChannelOptions: "telegram|whatsapp",
       agentChannelOptions: "last|telegram|whatsapp",
     });
@@ -30,7 +29,6 @@ describe("createProgramContext", () => {
     const ctx = createProgramContext();
     expect(ctx).toEqual({
       programVersion: "9.9.9-test",
-      channelOptions: [],
       messageChannelOptions: "",
       agentChannelOptions: "last",
     });
@@ -46,7 +44,6 @@ describe("createProgramContext", () => {
   it("reuses one channel option resolution across all getters", () => {
     resolveCliChannelOptionsMock.mockClear().mockReturnValue(["telegram"]);
     const ctx = createProgramContext();
-    expect(ctx.channelOptions).toEqual(["telegram"]);
     expect(ctx.messageChannelOptions).toBe("telegram");
     expect(ctx.agentChannelOptions).toBe("last|telegram");
     expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();

--- a/src/cli/program/context.ts
+++ b/src/cli/program/context.ts
@@ -5,7 +5,6 @@ import { resolveCliChannelOptions } from "../channel-options.js";
 /** Root CLI program context consumed by command registration and help rendering. */
 export type ProgramContext = {
   programVersion: string;
-  channelOptions: string[];
   messageChannelOptions: string;
   agentChannelOptions: string;
 };
@@ -22,9 +21,6 @@ export function createProgramContext(): ProgramContext {
 
   return {
     programVersion: VERSION,
-    get channelOptions() {
-      return getChannelOptions();
-    },
     get messageChannelOptions() {
       return getChannelOptions().join("|");
     },

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -1,7 +1,6 @@
 // Help tests cover command help generation and inherited help options.
 import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ProgramContext } from "./context.js";
 import { configureProgramHelp } from "./help.js";
 import { OpenClawCommand } from "./openclaw-command.js";
 
@@ -44,12 +43,7 @@ vi.mock("./register.subclis.js", () => ({
   getSubCliCommandsWithSubcommands: () => ["gateway"],
 }));
 
-const testProgramContext: ProgramContext = {
-  programVersion: "9.9.9-test",
-  channelOptions: ["quietchat"],
-  messageChannelOptions: "quietchat",
-  agentChannelOptions: "last|quietchat",
-};
+const testProgramContext = { programVersion: "9.9.9-test" };
 
 describe("configureProgramHelp", () => {
   let originalArgv: string[];

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -13,7 +13,6 @@ import {
   getCommanderErrorCommandNames,
   getCommanderErrorCommandPath,
 } from "./commander-parse-facts.js";
-import type { ProgramContext } from "./context.js";
 import { getCoreCliCommandsWithSubcommands } from "./core-command-descriptors.js";
 import { formatCliParseErrorOutput } from "./error-output.js";
 import { getSubCliCommandsWithSubcommands } from "./subcli-descriptors.js";
@@ -67,7 +66,7 @@ export function formatProgramHelpOutput(str: string): string {
 
 export function configureProgramHelp(
   program: Command,
-  ctx: ProgramContext,
+  ctx: { programVersion: string },
   options?: { commandsWithSubcommands?: ReadonlySet<string> },
 ) {
   const commandsWithSubcommands = new Set([

--- a/src/cli/program/program-context.test.ts
+++ b/src/cli/program/program-context.test.ts
@@ -7,7 +7,6 @@ import { getProgramContext, setProgramContext } from "./program-context.js";
 function makeCtx(version: string): ProgramContext {
   return {
     programVersion: version,
-    channelOptions: ["quietchat"],
     messageChannelOptions: "quietchat",
     agentChannelOptions: "last|quietchat",
   };

--- a/src/cli/program/register.message.test.ts
+++ b/src/cli/program/register.message.test.ts
@@ -91,7 +91,6 @@ vi.mock("./message/register.discord-admin.js", () => ({
 describe("registerMessageCommands", () => {
   const ctx: ProgramContext = {
     programVersion: "9.9.9-test",
-    channelOptions: ["telegram", "discord"],
     messageChannelOptions: "telegram|discord",
     agentChannelOptions: "last|telegram|discord",
   };

--- a/src/cli/program/root-help.ts
+++ b/src/cli/program/root-help.ts
@@ -29,12 +29,7 @@ async function buildRootHelpProgram(renderOptions?: RootHelpRenderOptions): Prom
       : [];
   configureProgramHelp(
     program,
-    {
-      programVersion: VERSION,
-      channelOptions: [],
-      messageChannelOptions: "",
-      agentChannelOptions: "",
-    },
+    { programVersion: VERSION },
     {
       commandsWithSubcommands: new Set(
         pluginDescriptors

--- a/src/cli/setup-onboard-configure-help-fast-path.ts
+++ b/src/cli/setup-onboard-configure-help-fast-path.ts
@@ -3,7 +3,6 @@ import { Command, CommanderError } from "commander";
 import { VERSION } from "../version.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { isSimpleCommandHelpInvocation } from "./argv.js";
-import type { ProgramContext } from "./program/context.js";
 import { configureProgramHelp } from "./program/help.js";
 
 type SetupOnboardConfigureHelpCommand = "setup" | "onboard" | "configure";
@@ -28,15 +27,6 @@ function resolveSetupOnboardConfigureHelpCommand(
   return SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS.has(command as SetupOnboardConfigureHelpCommand)
     ? (command as SetupOnboardConfigureHelpCommand)
     : null;
-}
-
-function createHelpContext(): ProgramContext {
-  return {
-    programVersion: VERSION,
-    channelOptions: [],
-    messageChannelOptions: "",
-    agentChannelOptions: "last",
-  };
 }
 
 async function registerHelpCommand(
@@ -67,7 +57,7 @@ export async function tryOutputSetupOnboardConfigureHelp(argv: string[]): Promis
   const program = new Command();
   program.enablePositionalOptions();
   program.exitOverride();
-  configureProgramHelp(program, createHelpContext());
+  configureProgramHelp(program, { programVersion: VERSION });
   await registerHelpCommand(program, command);
 
   try {


### PR DESCRIPTION
## What Problem This Solves

Help-only CLI paths fabricate channel context that they never read. The root program context also exposes a raw channel-options getter with no production consumer. This makes simple help rendering depend on an unnecessarily broad internal contract.

## Why This Change Was Made

Give help configuration only the version it needs, remove the unused getter, and delete fake channel fields from the two help paths and their test fixtures. Message and agent command registration keep their existing lazy, shared channel resolution. No runtime import boundary or public CLI behavior changes.

## User Impact

No intentional user-visible change. This is a maintainer-requested cleanup: 20 fewer production lines and 14 fewer test lines. It is not presented as a demonstrated speedup.

## Evidence

- 189 tests across nine whole files passed. All 29 selected checks have successful scoped proof. The first aggregate timed out during core-test typechecking after 16 checks; a bounded recovery ran the same 17 typecheck graphs through five serial canonical stripes and the 12 unstarted checks. The original failure remains recorded. [Recovery run](https://github.com/openclaw/openclaw/actions/runs/34414260936).
- Independent Codex review found no actionable findings through P2. Existing context laziness, registration, help, account-selector and cold-import coverage remains; no test case was removed.
- A fixed B0/C0/C1/B1 cohort made 48 actual root/setup/onboard/configure source-export calls. Full return values, output bytes, exits, throw flags and before/after arguments matched. [Measurement run](https://github.com/openclaw/openclaw/actions/runs/34415907524).

The call measurements were adverse: 21 of 24 individual comparisons and all eight repeat means were slower. Setup's first call was 150.59 to 208.09 ms (+38.19%) forward and 142.34 to 161.57 ms (+13.51%) in the reverse pair. Repeat means changed as follows:

| Help task | Forward | Reverse |
| --- | ---: | ---: |
| root | +6.31% | +48.12% |
| setup | +3.16% | +1.05% |
| onboard | +6.89% | +9.21% |
| configure | +26.48% | +15.39% |

There was only one first call and two repeats per task per process. Imports outside the call clocks and setup warming onboard limit interpretation; these observations are neither a proven causal regression nor evidence to discard. Whole-child wall times improved 7.69% and 4.50%, but that different boundary does not override the adverse call results. No cold CLI, Gateway, provider-latency or memory benefit is claimed. Full raw outcomes, adverse comparisons and the independent audit are retained locally; the linked runs are execution references, not a promise that the raw benchmark archive is publicly downloadable.

All measured children joined successfully, source was restored, and the task container and lease completed cleanup. No favorable rerun was used. Changelog changes are deferred to release generation.
