### PR TITLE
perf(tests): overlap independent CLI cleanup processes

### DIFF
--- a/src/cli/one-shot-exit.cleanup.process.test.ts
+++ b/src/cli/one-shot-exit.cleanup.process.test.ts
@@ -1,24 +1,30 @@
-import { spawnSync } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { expect, it } from "vitest";
+import { it } from "vitest";
+import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
 
-it.each([
+it.concurrent.for([
   { mode: "automatic", exitCode: 0, disposed: true },
   { mode: "requested", exitCode: 7, disposed: false },
   { mode: "deferred", exitCode: 7, disposed: false },
   { mode: "failure", exitCode: 9, disposed: false },
   { mode: "worker", exitCode: 0, disposed: true },
-])("preserves native cleanup and the $mode exit policy", ({ mode, exitCode, disposed }) => {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-cleanup-exit-"));
-  const databasePath = path.join(directory, "observations.sqlite");
-  const exitPath = path.join(directory, "exit.json");
-  const oneShotExitUrl = new URL("./one-shot-exit.ts", import.meta.url).href;
-  const cleanupUrl = new URL("./runtime-cleanup.ts", import.meta.url).href;
-  const runtimeUrl = new URL("../runtime.ts", import.meta.url).href;
-  const script = `
+])(
+  "preserves native cleanup and the $mode exit policy",
+  async ({ mode, exitCode, disposed }, { expect, signal, onTestFinished }) => {
+    const fixture = createFixtureLifetime();
+    onTestFinished(() => fixture.cleanup());
+    await fixture.run(async () => {
+      const directory = fixture.createTempDir("openclaw-cli-cleanup-exit-");
+      const databasePath = path.join(directory, "observations.sqlite");
+      const exitPath = path.join(directory, "exit.json");
+      const oneShotExitUrl = new URL("./one-shot-exit.ts", import.meta.url).href;
+      const cleanupUrl = new URL("./runtime-cleanup.ts", import.meta.url).href;
+      const runtimeUrl = new URL("../runtime.ts", import.meta.url).href;
+      const script = `
     import fs from "node:fs";
     import { DatabaseSync } from "node:sqlite";
     import { setTimeout as delay } from "node:timers/promises";
@@ -70,53 +76,57 @@ it.each([
     finalizationReturnedBeforeCleanup = database.isOpen;
   `;
 
-  try {
-    const result = spawnSync(
-      process.execPath,
-      [
-        "--disable-warning=ExperimentalWarning",
-        "--import",
-        "tsx",
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        encoding: "utf8",
-        env: {
-          PATH: process.env.PATH,
-          SystemRoot: process.env.SystemRoot,
-          HOME: directory,
-          USERPROFILE: directory,
-          TERM: "dumb",
-          NODE_DISABLE_COMPILE_CACHE: "1",
-          TSX_DISABLE_CACHE: "1",
-        },
-        timeout: 20_000,
-      },
-    );
-    expect(result.error).toBeUndefined();
-    expect(result.signal).toBeNull();
-    expect(result.status).toBe(exitCode);
-    expect(JSON.parse(result.stdout)).toEqual({ mode, outcome: "recorded" });
-    expect(result.stderr).toContain("CLI cleanup timed out: native-write after 5000ms");
-    expect(JSON.parse(fs.readFileSync(exitPath, "utf8"))).toEqual({
-      code: exitCode,
-      disposals: disposed ? 1 : 0,
-      nativeOpen: !disposed,
-      returnedBeforeCleanup: true,
-      finalizationReturnedBeforeCleanup: mode !== "automatic",
-      reportedErrors: mode === "failure" ? 1 : 0,
-    });
-    const database = new DatabaseSync(databasePath, { readOnly: true });
-    try {
-      expect(database.prepare("SELECT value FROM observations ORDER BY value").all()).toEqual(
-        (disposed ? [42, 99] : [42]).map((value) => ({ value })),
+      let child: ChildProcess | undefined;
+      const result = await fixture.track(
+        runNodeScript(
+          [
+            "--disable-warning=ExperimentalWarning",
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "--eval",
+            script,
+          ],
+          {
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            HOME: directory,
+            USERPROFILE: directory,
+            TERM: "dumb",
+            NODE_DISABLE_COMPILE_CACHE: "1",
+            TSX_DISABLE_CACHE: "1",
+          },
+          20_000,
+          {
+            signal,
+            maxBuffer: 1024 * 1024,
+            onReady: (startedChild) => {
+              child = startedChild;
+            },
+          },
+        ),
       );
-    } finally {
-      database.close();
-    }
-  } finally {
-    fs.rmSync(directory, { recursive: true, force: true });
-  }
-});
+      expect(result.error).toBeUndefined();
+      expect(child?.signalCode).toBeNull();
+      expect(result.status).toBe(exitCode);
+      expect(JSON.parse(result.stdout)).toEqual({ mode, outcome: "recorded" });
+      expect(result.stderr).toContain("CLI cleanup timed out: native-write after 5000ms");
+      expect(JSON.parse(fs.readFileSync(exitPath, "utf8"))).toEqual({
+        code: exitCode,
+        disposals: disposed ? 1 : 0,
+        nativeOpen: !disposed,
+        returnedBeforeCleanup: true,
+        finalizationReturnedBeforeCleanup: mode !== "automatic",
+        reportedErrors: mode === "failure" ? 1 : 0,
+      });
+      const database = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        expect(database.prepare("SELECT value FROM observations ORDER BY value").all()).toEqual(
+          (disposed ? [42, 99] : [42]).map((value) => ({ value })),
+        );
+      } finally {
+        database.close();
+      }
+    });
+  },
+);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five independent CLI cleanup process tests ran serially, adding a roughly 27-second delay floor while checking real cleanup and exit behavior.

## Why This Change Was Made

Run those five cases concurrently through the existing managed Node-process and fixture-lifetime helpers. Each case owns its child, output, temporary directory, cancellation signal, assertions, and cleanup. Preserve the native child program, real five-second reporting grace, six-second disposer, twenty-second command deadline, and every exit/output/SQLite oracle. The native child signal is checked separately from the helper’s normalized status.

## User Impact

No production behavior change. The test refactor adds 10 lines and reduces the time spent waiting for independent cleanup timers. It changes no global worker, CI, routing, or timeout settings.

## Evidence

One matched local whole-file pair completed in 29.052 seconds before and 8.020 seconds after, with all five cases passing. Both runs used one worker, file parallelism disabled, and maxConcurrency 5. Observed child overlap rose from one to five; sampled process-tree peak RSS rose by about 412 MiB. No task-owned child births or fixture roots remained at join. This is a local file-level measurement, not a full-suite, CI, or universal speed claim.

All native template/argv/environment and output, exit-file, and SQLite assertions are preserved. The relevant one-shot and managed-helper suites passed 56 tests; mapped checks and independent review passed. Earlier exploratory measurements had differing automatically selected worker settings and were excluded from the matched timing claim.
