### PR TITLE
perf(logging): avoid copying owned diagnostic arrays

### DIFF
--- a/src/logging/code-mode-diagnostic.ts
+++ b/src/logging/code-mode-diagnostic.ts
@@ -23,16 +23,14 @@ export function logCodeModeDiagnostic(
     return;
   }
   const bounded = Object.fromEntries(
-    Object.entries(fields).map(([key, value]) => [
-      key,
-      Array.isArray(value)
-        ? [...new Set(value.map((name) => name.slice(0, MAX_NAME_LENGTH)))]
-            .toSorted((left, right) => left.localeCompare(right))
-            .slice(0, MAX_NAMES)
-        : typeof value === "string"
-          ? value.slice(0, MAX_NAME_LENGTH)
-          : value,
-    ]),
+    Object.entries(fields).map(([key, value]) => {
+      if (Array.isArray(value)) {
+        const names = [...new Set(value.map((name) => name.slice(0, MAX_NAME_LENGTH)))];
+        names.sort((left, right) => left.localeCompare(right));
+        return [key, names.slice(0, MAX_NAMES)];
+      }
+      return [key, typeof value === "string" ? value.slice(0, MAX_NAME_LENGTH) : value];
+    }),
   );
   log.info(
     redactToolPayloadText(`code-mode diagnostic ${JSON.stringify({ boundary, ...bounded })}`),


### PR DESCRIPTION
## What Problem This Solves

Opt-in code-mode diagnostics copy each freshly allocated, deduplicated name array again before sorting it. That extra copy has no ownership purpose and adds work to diagnostic formatting.

## Why This Change Was Made

Name the formatter-owned array and sort it in place. Keep the same truncation-before-deduplication, locale ordering, 24-name cap, scalar handling, field order and final redaction. Caller arrays remain untouched. The explicit array branch also removes the nested conditional; production code shrinks by two lines. No rules, config or tests change.

## User Impact

Diagnostic output is unchanged. The change removes an intermediate array, with modest component-level median improvements in the measured larger cases. It does not establish faster Gateway or provider turns.

## Evidence

- Independent Codex review found no actionable findings through P2.
- The whole existing OpenAI stream-wrapper suite passed all 38 tests on baseline and candidate. Formatting, diff checks and targeted root-config syntax lint passed. Full type-aware checks and the other guards in the 28-command discovery plan remain pending CI; the focused run does not claim those passed.
- [Isolated Linux proof](https://github.com/openclaw/openclaw/actions/runs/34416307621) ran 220 actual diagnostic calls and 36 controls in fixed B0/C0/C1/B1 order, using real redaction. Full log bytes, before/after input graphs and return/throw outcomes match. Coverage includes truncation collisions, Unicode ties, empty values, multiple arrays and flag disable/reenable behavior.

| Warm median | Forward baseline → candidate | Reverse baseline → candidate |
| --- | ---: | ---: |
| Deduplicated surface | 10.244 → 9.9185 µs (−3.18%) | 9.603 → 9.5225 µs (−0.84%) |
| Three arrays | 13.145 → 13.1445 µs (effectively flat) | 13.5805 → 12.3785 µs (−8.85%) |
| Large capped list | 18.725 → 17.498 µs (−6.55%) | 18.520 → 17.748 µs (−4.17%) |

Results are mixed: 2/10 warm medians, 5/10 means, 7/10 maxima and 51/110 individual wall comparisons worsened. The large-list forward mean and maximum increased 4.68% and 34.14%; deduplicated-surface means increased 11.89% and 1.08% despite lower medians. Only eight warm samples per case/image/order were collected. Initial, warmup, adverse and negative heap-delta observations remain retained; this is descriptive evidence, not a uniform or statistically established speedup or memory claim.

All children joined successfully, candidate source was restored, and the task container and Testbox lease completed cleanup. No favorable rerun was used. The linked run is an execution reference; full raw data and the independent numerical audit are retained locally. Changelog changes are deferred to release generation.
