### PR TITLE
feat(ui): show sender identities in shared chat rail previews

### DIFF
--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -229,40 +229,56 @@ describe("conversation position rail", () => {
     }
   });
 
-  it.each(["user", "assistant"])("renders safe Markdown in %s previews", (role) => {
-    const messages = [
-      message(
-        "formatted",
-        role,
-        "**Important** *detail* `code`\n\n- [Guide](https://example.com)\n<script>alert(1)</script>",
-        1,
-      ),
-      message("next", role === "user" ? "assistant" : "user", "Next turn", 2),
-    ];
-    const props = threadProps("rail-markdown", "agent:main:markdown", messages);
-    const transcript = createTestTranscript();
-    const container = document.body.appendChild(document.createElement("div"));
-    const rerender = () => {
-      render(renderChatThread(props, transcript), container);
-      transcript.hostUpdated();
-    };
-    props.onRequestUpdate = rerender;
-    try {
-      rerender();
-      transcript.hostConnected();
-      container.querySelector<HTMLButtonElement>(".chat-position-rail__marker")!.focus();
-      const preview = container.querySelector(".chat-position-rail__preview-copy")!;
-      expect(preview.querySelector("strong")?.textContent).toBe("Important");
-      expect(preview.querySelector("em")?.textContent).toBe("detail");
-      expect(preview.querySelector("code")?.textContent).toBe("code");
-      expect(preview.querySelector("li a")?.textContent).toBe("Guide");
-      expect(preview.querySelector("script")).toBeNull();
-      expect(preview.closest("[inert]")).not.toBeNull();
-    } finally {
-      render(nothing, container);
-      transcript.hostDisconnected();
-    }
-  });
+  it.each([
+    { role: "user", senderName: undefined, label: "User message" },
+    { role: "user", senderName: "Alice Example", label: "Alice Example" },
+    { role: "assistant", senderName: "Alice Example", label: "Assistant message" },
+  ])(
+    "renders safe Markdown and attribution in $role previews ($label)",
+    ({ role, senderName, label }) => {
+      const messages = [
+        message(
+          "formatted",
+          role,
+          "**Important** *detail* `code`\n\n- [Guide](https://example.com)\n<script>alert(1)</script>",
+          1,
+        ),
+        message("next", role === "user" ? "assistant" : "user", "Next turn", 2),
+      ];
+      Object.assign(messages[0]!["__openclaw"], { senderName });
+      const props = threadProps("rail-markdown", "agent:main:markdown", messages);
+      props.userName = "Local Viewer";
+      const transcript = createTestTranscript();
+      const container = document.body.appendChild(document.createElement("div"));
+      const rerender = () => {
+        render(renderChatThread(props, transcript), container);
+        transcript.hostUpdated();
+      };
+      props.onRequestUpdate = rerender;
+      try {
+        rerender();
+        transcript.hostConnected();
+        container.querySelector<HTMLButtonElement>(".chat-position-rail__marker")!.focus();
+        const preview = container.querySelector(".chat-position-rail__preview-copy")!;
+        expect(container.querySelector(".chat-position-rail__preview-label")?.textContent).toBe(
+          label,
+        );
+        const avatar = container.querySelector(".chat-position-rail__preview .chat-author-avatar");
+        expect(avatar?.getAttribute("aria-label") ?? null).toBe(
+          role === "user" ? (senderName ?? null) : null,
+        );
+        expect(preview.querySelector("strong")?.textContent).toBe("Important");
+        expect(preview.querySelector("em")?.textContent).toBe("detail");
+        expect(preview.querySelector("code")?.textContent).toBe("code");
+        expect(preview.querySelector("li a")?.textContent).toBe("Guide");
+        expect(preview.querySelector("script")).toBeNull();
+        expect(preview.closest("[inert]")).not.toBeNull();
+      } finally {
+        render(nothing, container);
+        transcript.hostDisconnected();
+      }
+    },
+  );
 
   it("uses the visible completed answer and keeps attachment-only user landmarks", () => {
     const messages = [

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -10,6 +10,7 @@ import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import { normalizeMessage, resolveMessageRole } from "../../../lib/chat/message-normalizer.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
+import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
 import { resolveMessageDisplayMarkdown } from "./chat-message-text.ts";
 import type { ChatTranscriptSession } from "./chat-transcript-session.ts";
 
@@ -248,7 +249,13 @@ class ChatPositionRailDirective extends AsyncDirective {
       const marker = this.markerElements.get(previewId ?? "");
       if (marker) {
         const center = marker.offsetTop + marker.offsetHeight / 2 - scroller.scrollTop;
-        const description = `${preview.textContent?.trim() ?? ""}. ${t("chat.thread.positionMarkerHint")}`;
+        const label = preview
+          .querySelector(".chat-position-rail__preview-label")
+          ?.textContent?.trim();
+        const copy = preview
+          .querySelector(".chat-position-rail__preview-copy")
+          ?.textContent?.trim();
+        const description = `${label ?? ""} ${copy ?? ""}. ${t("chat.thread.positionMarkerHint")}`;
         if (marker.getAttribute("aria-description") !== description) {
           marker.setAttribute("aria-description", description);
         }
@@ -376,15 +383,17 @@ class ChatPositionRailDirective extends AsyncDirective {
       ? undefined
       : markers.find((marker) => marker.id === (interaction.hoveredId ?? interaction.focusedId));
     // Parse message content only for the open preview, even in long sessions.
-    const previewText = previewMarker
-      ? truncateUtf16Safe(
-          resolveMessageDisplayMarkdown(
-            previewMarker.message,
-            normalizeMessage(previewMarker.message),
-          ).trim(),
-          PREVIEW_LENGTH,
-        )
-      : "";
+    const previewMessage = previewMarker ? normalizeMessage(previewMarker.message) : undefined;
+    const previewSender = previewMessage?.role === "user" ? previewMessage.sender : undefined;
+    const previewLabel =
+      (previewSender ? previewMessage?.senderLabel : null) ?? previewMarker?.label;
+    const previewText =
+      previewMarker && previewMessage
+        ? truncateUtf16Safe(
+            resolveMessageDisplayMarkdown(previewMarker.message, previewMessage).trim(),
+            PREVIEW_LENGTH,
+          )
+        : "";
     const rovingId = interaction.rovingId ?? this.activeId ?? markers[0]!.id;
     const moveFocus = (event: KeyboardEvent, index: number) => {
       const nextIndex =
@@ -492,7 +501,10 @@ class ChatPositionRailDirective extends AsyncDirective {
                     class="chat-position-rail__preview"
                     aria-hidden="true"
                   >
-                    <span class="chat-position-rail__preview-label">${previewMarker.label}</span>
+                    <div class="chat-position-rail__preview-header">
+                      ${renderChatAuthorAvatar(previewSender)}
+                      <span class="chat-position-rail__preview-label">${previewLabel}</span>
+                    </div>
                     <!-- Preview links remain non-interactive; the marker owns keyboard navigation. -->
                     <div class="chat-position-rail__preview-copy" inert>
                       ${previewText ? unsafeHTML(toSanitizedMarkdownHtml(previewText, { codeBlockChrome: "none" })) : t("chat.attachments.previewUnavailable")}

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -210,10 +210,17 @@
   transform: translateY(-50%);
 }
 
+.chat-position-rail__preview-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .chat-position-rail__preview-label {
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .chat-position-rail__preview-copy {


### PR DESCRIPTION
Closes #143473

## What Problem This Solves

Today, chat position rail previews show the role label “User message,” while shared conversation transcripts can also identify the sender by name and avatar. Including that existing identity in the preview lets participants recognize who sent a turn while scanning the rail.

## Why This Change Was Made

The open preview now uses the transcript's normalized sender and existing compact author avatar, including authenticated images and initials. Messages without sender attribution keep the existing role label. Avatar initials are excluded from the marker's accessible description.

Related: #142227 and #143296 by @vyctorbrzezowski. The separate change to which turns appear on the rail is not included here.

## User Impact

Participants can recognize who sent a turn directly from its preview. Standard installations without per-message identity continue to show “User message.”

## Evidence

The sender-attribution boundary test failed on the original code and passed after the change. The focused rail and shared avatar lifecycle suites passed all 16 tests. Browser checks covered switching between two senders, an uploaded image and initials, Escape dismissal, clean accessible descriptions, opening the actual attachment, and navigation to an unattributed session.

UI production and selected test typechecks, targeted TypeScript/CSS lint, i18n verification, formatting, coercion guards, and unused-export scans passed. The combined changed check expanded into unrelated core test graphs and was stopped; the remaining UI checks were run directly.

These are inspected captures of the real Control UI with a mocked Gateway, synthetic participants, and the app's Instrument Sans font. Each desktop matrix reads left to right, top to bottom: own short/long turns without attachments, own short/long turns with attachments, the same four cases from another participant, then an unattributed session. The 390px matrices show sequential scroll samples of the existing mobile transcript, followed by the unattributed session: the rail stays hidden because that layout has insufficient side gutter.

<table>
<thead><tr><th>Scenario</th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>1440px, dark</td><td><a href="https://github.com/user-attachments/assets/024e16f3-da30-4091-97dc-384e85b352ba"><img src="https://github.com/user-attachments/assets/024e16f3-da30-4091-97dc-384e85b352ba" alt="Desktop dark before" width="500"></a></td><td><a href="https://github.com/user-attachments/assets/2c974c3c-2d00-4bea-82bd-d3495bdde479"><img src="https://github.com/user-attachments/assets/2c974c3c-2d00-4bea-82bd-d3495bdde479" alt="Desktop dark after" width="500"></a></td></tr>
<tr><td>1440px, light</td><td><a href="https://github.com/user-attachments/assets/dfe2c607-179f-42f6-8d70-16d74dd6232f"><img src="https://github.com/user-attachments/assets/dfe2c607-179f-42f6-8d70-16d74dd6232f" alt="Desktop light before" width="500"></a></td><td><a href="https://github.com/user-attachments/assets/381bff98-7ed5-4265-8caf-7e10bbb56000"><img src="https://github.com/user-attachments/assets/381bff98-7ed5-4265-8caf-7e10bbb56000" alt="Desktop light after" width="500"></a></td></tr>
<tr><td>390px, dark</td><td><a href="https://github.com/user-attachments/assets/b9b7c241-b6ce-4497-848d-838b85a0cd61"><img src="https://github.com/user-attachments/assets/b9b7c241-b6ce-4497-848d-838b85a0cd61" alt="Mobile dark baseline" width="500"></a></td><td><a href="https://github.com/user-attachments/assets/9f27b3ec-7816-49f5-9364-6892792ea465"><img src="https://github.com/user-attachments/assets/9f27b3ec-7816-49f5-9364-6892792ea465" alt="Mobile dark after" width="500"></a></td></tr>
<tr><td>390px, light</td><td><a href="https://github.com/user-attachments/assets/59c1cf2c-e43e-48d1-8b4b-d58f733c50e3"><img src="https://github.com/user-attachments/assets/59c1cf2c-e43e-48d1-8b4b-d58f733c50e3" alt="Mobile light baseline" width="500"></a></td><td><a href="https://github.com/user-attachments/assets/388e1cff-5c99-420c-b8af-6f0de116836c"><img src="https://github.com/user-attachments/assets/388e1cff-5c99-420c-b8af-6f0de116836c" alt="Mobile light after" width="500"></a></td></tr>
</tbody>
</table>

## Risk and coverage

Only the open preview resolves the sender's avatar; the shared identity normalizer, avatar resolver, loader, and transcript rendering are unchanged. The existing shared avatar tests cover asynchronous replacement and fallback behavior. No Gateway, storage, configuration, marker selection, or mobile visibility policy changes.

The visual evidence uses a mocked Gateway, not an authenticated team deployment. The supplied-source review found no actionable defects; validation was run separately. Mobile captures are layout compatibility evidence, not mobile hover proof.
