### PR TITLE
fix(feishu): reject replayed webhook callbacks with stale signed timestamps

### DIFF
--- a/docs/channels/feishu/setup.md
+++ b/docs/channels/feishu/setup.md
@@ -40,3 +40,14 @@ The wizard also asks for the API domain (Feishu vs Lark) and the group policy. I
 OpenClaw durably queues authenticated `im.message.receive_v1` and `drive.notice.comment_add_v1` envelopes before agent dispatch. In webhook mode, the durable `200` carries `x-openclaw-delivery-accepted: durable`; verification challenges, non-durable event types, and error responses omit the marker, so reverse proxies can require it to distinguish durable acceptance from a generic `200`. Pending or retryable events survive a Gateway restart, remain serialized per chat or document, and use Feishu's event ID to suppress duplicate queue entries while the active or retained completion record exists.
 
 If a WebSocket event cannot be persisted after bounded retries, OpenClaw closes that socket and forces a fresh authenticated connection instead of continuing past an uncommitted turn. Other Feishu event types, including reactions and VC meeting invitations, use their normal event paths and do not receive this durable-queue guarantee.
+
+## Webhook delivery window
+
+Feishu signs each webhook delivery at send time, so a captured signed callback stays validly signed forever. Webhook mode therefore rejects any signed callback whose `x-lark-request-timestamp` is more than one hour before or after the Gateway host's clock, before the body is parsed. This is a replay defense: it works together with the per-message replay guard (24-hour window) so a re-delivered signed callback cannot re-trigger the same action.
+
+Practical consequences:
+
+- Keep the Gateway host clock synchronized (NTP). A host clock drifting more than one hour from Feishu's servers rejects fresh deliveries.
+- Feishu deliveries are signed when they are sent, so ordinary redeliveries carry fresh timestamps and are unaffected.
+- WebSocket mode is not affected by this window.
+- There is no configuration key for this window; it is intentionally fixed.

--- a/docs/channels/feishu/troubleshooting.md
+++ b/docs/channels/feishu/troubleshooting.md
@@ -67,6 +67,13 @@ provides `vc +meeting-join`.
 The official `lark-cli` VC agent skill currently marks meeting-bot actions as a limited beta. If the tool returns `ErrNotInGray` or error code `20017`, the app or tenant has not been enabled for that beta; use the early-access guidance in the linked skill before troubleshooting ordinary scope grants.
 </Warning>
 
+### Webhook callbacks rejected with 401 Invalid signature
+
+1. Check the Gateway host clock: webhook mode rejects signed callbacks whose timestamp is more than one hour from the server clock (before or after). Verify NTP sync and that the system time is correct.
+2. Confirm the configured `encryptKey` matches the app's Encrypt Key in Feishu Open Platform / Lark Developer.
+3. Verify the webhook URL path and port match the `channels.feishu.webhook*` configuration.
+4. Check logs: `openclaw logs --follow` for repeated signature failures from unexpected senders.
+
 ### QR setup does not react in the Feishu mobile app
 
 1. Rerun setup: `openclaw channels login --channel feishu`

--- a/extensions/feishu/src/feishu-ingress.test.ts
+++ b/extensions/feishu/src/feishu-ingress.test.ts
@@ -125,7 +125,7 @@ async function withQueue<T>(fn: (queue: FeishuIngressQueue, stateDir: string) =>
 }
 
 function signWebhookBody(rawBody: string, encryptKey: string): Record<string, string> {
-  const timestamp = "1711111111";
+  const timestamp = Math.floor(Date.now() / 1000).toString();
   const nonce = "feishu-ingress-test";
   return {
     "content-type": "application/json",

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -49,6 +49,12 @@ type MonitorTransportParams = {
 
 const FEISHU_WEBHOOK_ACCEPTED_HEADER = "x-openclaw-delivery-accepted";
 const FEISHU_WEBHOOK_ACCEPTED_VALUE = "durable";
+// Feishu signs each delivery at send time, so a captured signed callback stays
+// validly signed forever. Reject deliveries whose signed timestamp is too far
+// from the local clock: generous enough for provider retries and host clock
+// skew, far shorter than the 24h persistent dedup TTL that otherwise guards
+// synthetic card-action replay.
+const FEISHU_WEBHOOK_TIMESTAMP_MAX_SKEW_MS = 60 * 60_000;
 const FEISHU_WS_RECONNECT_INITIAL_DELAY_MS = 1_000;
 const FEISHU_WS_RECONNECT_MAX_DELAY_MS = 30_000;
 const FEISHU_WS_LOG_ERROR_MAX_LENGTH = 500;
@@ -91,6 +97,16 @@ function parseFeishuWebhookPayload(rawBody: string): Record<string, unknown> | n
   }
 }
 
+function isFeishuWebhookTimestampFresh(timestamp: string): boolean {
+  const parsed = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(parsed)) {
+    return false;
+  }
+  // Feishu signs with second-level timestamps; tolerate millisecond values too.
+  const timestampMs = parsed < 1e12 ? parsed * 1000 : parsed;
+  return Math.abs(Date.now() - timestampMs) <= FEISHU_WEBHOOK_TIMESTAMP_MAX_SKEW_MS;
+}
+
 function isFeishuWebhookSignatureValid(params: {
   headers: http.IncomingHttpHeaders;
   rawBody: string;
@@ -108,6 +124,10 @@ function isFeishuWebhookSignatureValid(params: {
   const nonce = Array.isArray(nonceHeader) ? nonceHeader[0] : nonceHeader;
   const signature = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
   if (!timestamp || !nonce || !signature) {
+    return false;
+  }
+
+  if (!isFeishuWebhookTimestampFresh(timestamp)) {
     return false;
   }
 

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -362,6 +362,36 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("accepts signed callbacks near the timestamp skew window edge", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "skew-window-edge",
+        path: "/hook-e2e-skew-window-edge",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = { type: "url_verification", challenge: "challenge-token" };
+        const rawBody = JSON.stringify(payload);
+        const response = await fetch(url, {
+          method: "POST",
+          headers: signFeishuPayload({
+            encryptKey: "encrypt_key",
+            rawBody,
+            timestamp: (Math.floor(Date.now() / 1000) - 3_300).toString(),
+          }),
+          body: rawBody,
+        });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ challenge: "challenge-token" });
+      },
+    );
+  });
+
   it("accepts signed non-challenge events and reaches the dispatcher", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
     const statusSink = vi.fn();

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildWebhookConfig,
   getFreePort,
+  signFeishuPayload,
   withRunningWebhookMonitor,
 } from "./monitor.webhook.test-helpers.js";
 
@@ -431,5 +432,67 @@ describe("Feishu webhook security hardening", () => {
 
     feishuWebhookRateLimiter.isRateLimited("/feishu-rate-limit-stale:fresh", now + 60_001);
     expect(feishuWebhookRateLimiter.size()).toBe(1);
+  });
+
+  it("rejects correctly signed callbacks with a stale timestamp", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "stale-timestamp",
+        path: "/hook-stale-timestamp",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = { type: "url_verification", challenge: "challenge-token" };
+        const headers = signFeishuPayload({
+          encryptKey: "encrypt_key",
+          rawBody: JSON.stringify(payload),
+          timestamp: (Math.floor(Date.now() / 1000) - 7_200).toString(),
+        });
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.text()).toBe("Invalid signature");
+      },
+    );
+  });
+
+  it("rejects correctly signed callbacks with a far-future timestamp", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "future-timestamp",
+        path: "/hook-future-timestamp",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = { type: "url_verification", challenge: "challenge-token" };
+        const headers = signFeishuPayload({
+          encryptKey: "encrypt_key",
+          rawBody: JSON.stringify(payload),
+          timestamp: (Math.floor(Date.now() / 1000) + 7_200).toString(),
+        });
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.text()).toBe("Invalid signature");
+      },
+    );
   });
 });

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -39,7 +39,7 @@ export function signFeishuPayload(params: {
   timestamp?: string;
   nonce?: string;
 }): Record<string, string> {
-  const timestamp = params.timestamp ?? "1711111111";
+  const timestamp = params.timestamp ?? Math.floor(Date.now() / 1000).toString();
   const nonce = params.nonce ?? "nonce-test";
   const signature = crypto
     .createHash("sha256")


### PR DESCRIPTION
## Problem

Feishu webhook signature verification authenticated requests purely by their
signature (`sha256(timestamp + nonce + encryptKey + body)`) with no check on
the signed timestamp's age. Feishu signs each delivery at send time, so a
captured signed callback stays validly signed forever.

Card-action callbacks are excluded from durable event admission and replay
protection is handled downstream: synthetic card commands are deduplicated by
a stable `card-action-<token>` key with a 24h persistent TTL. That gate
already blocks replays inside the TTL window (including across restarts),
but once the entry expires, replaying a captured callback re-authenticated and
re-dispatched the same command — for quick-button and unrecognized-envelope
card actions, which carry no expiry of their own.

## Fix

Reject callbacks whose signed `x-lark-request-timestamp` is more than one
hour from the local clock (symmetric: stale or far-future), inside
`isFeishuWebhookSignatureValid`, before any JSON parsing:

- hardcoded `FEISHU_WEBHOOK_TIMESTAMP_MAX_SKEW_MS` (1h) — generous enough for
  provider retries and host clock skew, far shorter than the 24h dedup TTL, so
  auth + dedup together close replay with no gap;
- second-level Feishu timestamps normalized by magnitude (values < 1e12 treated
  as seconds, otherwise milliseconds).

No config keys, no default changes, no schema changes, no public API changes.

## Tests

- regression: correctly signed callbacks with a stale (−2h) or far-future (+2h)
  timestamp are rejected with 401 before parsing;
- acceptance: a correctly signed callback near the window edge (−55 min) still
  completes the `url_verification` challenge end-to-end;
- webhook test helpers now sign with fresh timestamps instead of a hardcoded
  stale one;
- full extension suite passes (102 files / 2051 tests).