### PR TITLE
test: reuse TSX transforms across update output cases

### DIFF
--- a/src/cli/update-finalization-output.process.test.ts
+++ b/src/cli/update-finalization-output.process.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { listUpdateRuns } from "../infra/update-run-ledger.js";
@@ -14,6 +14,8 @@ import {
 } from "./cli-process-child.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+// Keep source transforms reusable across fresh children; each case still owns its state.
+const childTempDir = useAutoCleanupTempDirTracker(afterAll).make("openclaw-update-child-tmp-");
 const fixture = fileURLToPath(
   new URL("./update-finalization-output.test-support.ts", import.meta.url),
 );
@@ -140,7 +142,7 @@ describe.each(["repair", "finalize"])("update %s process output", (command) => {
           XDG_CACHE_HOME: path.join(root, "xdg-cache"),
           XDG_STATE_HOME: path.join(root, "xdg-state"),
           XDG_RUNTIME_DIR: path.join(root, "xdg-runtime"),
-          TMPDIR: root,
+          TMPDIR: childTempDir,
           NODE_DISABLE_COMPILE_CACHE: "1",
           NO_COLOR: "1",
           TERM: "dumb",


### PR DESCRIPTION
## What Problem This Solves

The 16 update-output process cases gave each child a new temporary directory. On Linux/macOS, that also gave TSX a new transform cache, so every fresh child recompiled the same source. Controlled full-file runs took about 268–272 seconds.

## Why This Change Was Made

Keep the child temporary base alive for the test file using the existing tracked cleanup helper. TSX can reuse its existing source/content/options/version-keyed code and maps; each child still evaluates its own modules and scenario replacements.

Each case retains its own home, config, state, workspace, XDG paths, logs, ports and process. Source stubs, TSX, the anti-deadlock worker setting, explicit waits, deadlines and all assertions are unchanged. The shared directory is removed after all cases finish. No production code, persistent cache, new option, extra worker or shard change.

## User Impact

Faster update CLI output coverage with the same native failure, cleanup, borrowed-work and output contracts. The diff is one test file, +4/-2 lines.

## Evidence

| Variant | Complete 16-case command |
| --- | ---: |
| Original | 272.37s |
| Shared file-owned temporary base | 91.58s |
| Restored original | 267.84s |

All 16 cases passed in the same order each time. These are complete invocation timings, including setup and cleanup. Final uninstrumented validation passed all 16 in **85.86s**. Same physical dependencies, Node 24.19.0/pnpm 12.3.4; peak RSS remains approximately 2.28 GB.

- The first candidate case still paid for cold loading; ordinary later cases took roughly 1.7–1.9 seconds instead of 12–16 seconds. Deliberate waits remain.
- Temporary before/after audits covered all 16 cases. The directory began empty; the first 1,320 TSX files retained their sizes/mtimes, with five additional cache files on a later scenario. No non-TSX paths persisted at the observed case boundaries, and the shared root was absent after cleanup. Audit overhead of 281 ms is included in the middle measurement; diagnostic code is not committed.
- Pinned dependency source confirms cached transforms do not cache evaluated runtime state. Other identified temporary consumers use PID-specific or randomized paths with their own cleanup; the full scenario matrix passed.
- Required changed checks and independent P2 review passed. This is POSIX cache attribution: Node uses different temp variables on Windows, so no Windows speedup is claimed.

Exact-head [CI 34417358636](https://github.com/openclaw/openclaw/actions/runs/34417358636) passed in **5m44s**. The Linux changed-test shard passed all 16 cases in **85.57s**, including preparation and cleanup; ordinary warm cases were 1.8–2.3s. This is the scoped PR run, not a new full-main benchmark. Windows was not selected by the existing filters.
