### PR TITLE
fix: keep sandboxed worktree creation isolated

### DIFF
--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -10,6 +10,7 @@ import {
   validateSessionsCreateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { resolveSandboxWorkspaceAuthority } from "../../agents/sandbox/workspace-authority.js";
 import { insideGitCheckout } from "../../agents/worktrees/git.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import { sessionEntryForkedFromParent } from "../../config/sessions/session-entry-lineage.js";
@@ -455,6 +456,26 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         requestedCwd ??
         inheritedSource?.workspace ??
         resolveAgentWorkspaceDir(cfg, target.agentId);
+      const requesterWorkspaceAuthority =
+        spawnRequesterSessionKey &&
+        sessionCreation.actor?.type === "agent" &&
+        normalizeAgentId(sessionCreation.actor.id) === target.agentId
+          ? resolveSandboxWorkspaceAuthority({
+              config: cfg,
+              agentId: target.agentId,
+              sessionKey: spawnRequesterSessionKey,
+            })
+          : undefined;
+      // A sandbox-writable source may contain command-bearing Git configuration.
+      // Keep agent-originated worktree creation local instead of letting Gateway
+      // default-base resolution fetch through repository-selected transports.
+      const effectiveWorktreeBaseRef =
+        worktreeBaseRef ??
+        (!existingTargetEntry?.worktree &&
+        requesterWorkspaceAuthority?.sandboxed === true &&
+        requesterWorkspaceAuthority.workspaceAccess === "rw"
+          ? "HEAD"
+          : undefined);
       // Git discovery permits subdirectory workspaces with an ancestor .git entry.
       if (!requestedProjectGitUrl && !insideGitCheckout(workspace)) {
         respond(
@@ -466,8 +487,8 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       }
       // Reuse validates the binding, not a selected ref that may have since disappeared.
       const resolvedBase =
-        worktreeBaseRef && !requestedProjectGitUrl && !existingTargetEntry?.worktree
-          ? await resolveSessionWorktreeBase(workspace, worktreeBaseRef, signal)
+        effectiveWorktreeBaseRef && !requestedProjectGitUrl && !existingTargetEntry?.worktree
+          ? await resolveSessionWorktreeBase(workspace, effectiveWorktreeBaseRef, signal)
           : undefined;
       if (resolvedBase && !resolvedBase.ok) {
         return respond(false, undefined, resolvedBase.error);
@@ -478,7 +499,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         pendingWorktree = {
           ...(requestedProjectGitUrl ? {} : { workspace }),
           name: requestedWorktreeName,
-          baseRef: worktreeBaseRef,
+          baseRef: effectiveWorktreeBaseRef,
           baseCommit,
           titleSource: buildDashboardSessionTitleSource({
             message: initialMessage ?? "",
@@ -526,7 +547,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
             target: lifecycleTarget,
             workspace,
             name: requestedWorktreeName,
-            baseRef: worktreeBaseRef,
+            baseRef: effectiveWorktreeBaseRef,
             checkoutCommit: baseCommit,
             label:
               explicitSessionLabel ??

--- a/src/gateway/server.sessions.create-worktree-spawn.test.ts
+++ b/src/gateway/server.sessions.create-worktree-spawn.test.ts
@@ -162,6 +162,37 @@ test("trusted same-agent worktree spawns inherit the parent's selected project",
   await expect(fs.stat(path.join(childPath, "setup-marker.txt"))).rejects.toThrow();
 });
 
+test("sandbox-originated worktree preparation does not execute repository SSH commands on the Gateway", async () => {
+  testState.agentConfig = {
+    workspace: repository,
+    sandbox: { mode: "all", workspaceAccess: "rw" },
+  };
+  const config = await getGatewayConfigModule();
+  config.clearRuntimeConfigSnapshot();
+  config.clearConfigCache();
+  const marker = path.join(state.root, "gateway-host-marker");
+  const sshCommand = path.join(state.root, "repository-ssh-command.sh");
+  await fs.writeFile(
+    sshCommand,
+    `#!/bin/sh\nprintf '%s\\n' 'executed-on-gateway' > ${JSON.stringify(marker)}\nexit 1\n`,
+    { mode: 0o755 },
+  );
+  await execFileAsync("git", ["-C", repository, "config", "core.sshCommand", sshCommand]);
+  await execFileAsync("git", [
+    "-C",
+    repository,
+    "remote",
+    "add",
+    "origin",
+    "ssh://invalid@127.0.0.1:1/does-not-exist",
+  ]);
+
+  const created = await createChild({ worktreeName: "sandbox-boundary-proof" });
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(managedWorktrees.findLiveByOwner("session", created.payload!.key)?.baseRef).toBe("HEAD");
+  await expect(fs.stat(marker)).rejects.toThrow();
+});
+
 test("keyed worktree creation reuses its recorded base after reopening the registry", async () => {
   const params = { ...parentCreateParams, cwd: repository };
   closeOpenClawStateDatabaseForTest();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a sandboxed agent creating a visible worktree could cause the Gateway to execute repository-selected transport commands while resolving the default worktree base.

## Why This Change Was Made

For same-agent spawns whose source workspace is both sandboxed and writable, an omitted base now resolves and pins the already accepted local `HEAD` before managed-worktree preparation. Trusted operator, registered-project, cross-agent, reuse, and explicit-base paths keep their existing behavior.

This is a narrow containment for implicit remote refresh. It avoids disabling legitimate repository-local Git settings or requiring a sandbox backend solely to create a worktree.

## User Impact

Sandboxed read-write agents can continue creating child worktrees normally. Those spawns no longer refresh `origin` automatically when no base is selected; they start from local `HEAD`. Users can still select an already available local or remote ref explicitly.

Other worktree creation flows are unchanged.

## Evidence

- Added a Gateway-level agent-spawn regression using a disposable SSH origin and benign marker-writing repository command.
- Before the fix, the regression observed the Gateway-host marker.
- After the fix, worktree creation succeeds, records `HEAD`, and the marker remains absent.
- `src/gateway/server.sessions.create-worktree-spawn.test.ts`: 14 passed.
- `src/gateway/server-methods/sessions-create-worktree-base.test.ts`: 6 passed.
- Core TypeScript check passed.
- Targeted formatting and diff checks passed.
