### PR TITLE
fix: keep run resources available through late cleanup

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.cleanup-resources.test.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.cleanup-resources.test.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { CliPluginInvocationResources } from "../../cli/plugin-invocation-resources.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetPluginLoaderTestStateForTest } from "../../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { getPluginRegistryForContext } from "../../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { createColdPluginFixture } from "../../plugins/test-helpers/cold-plugin-fixtures.js";
+import { captureAsyncWorkTracker, getAsyncWorkSignal } from "../../shared/async-work-scope.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../prepared-model-runtime.test-support.js";
+import { createAgentCleanupScope, runOwnedAgentCleanup } from "../run-cleanup-timeout.js";
+import { SessionManager } from "../sessions/session-manager.js";
+import { immediateEnqueue } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import { runEmbeddedAgent } from "./run-orchestrator.js";
+import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
+import type { RunEmbeddedAgentInternalParams } from "./run/internal-params.js";
+import type { EmbeddedAgentRunResult } from "./types.js";
+
+const loop = vi.hoisted(() =>
+  vi.fn<(input: PreparedEmbeddedRunInput) => Promise<EmbeddedAgentRunResult>>(),
+);
+vi.mock("./run-loop.js", () => ({ runPreparedEmbeddedLoop: loop }));
+
+type Registration = {
+  file: string;
+  read: () => number;
+  disposed: number;
+  close: { promise: Promise<void>; resolve: () => void };
+};
+const fixtureKey = "__openclawCandidateCleanupResources";
+
+it.each([
+  "late-success",
+  "late-failure",
+  "required-timeout",
+  "ordinary-error",
+  "parent-cancel",
+] as const)(
+  "holds the candidate's actual registry through %s cleanup and descendants",
+  async (mode) => {
+    // Direct cases rely solely on the public runner's work owner.
+    const state = await createOpenClawTestState({
+      label: "candidate-cleanup-resources",
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "25" },
+    });
+    const records = new Map<string, Registration>();
+    Object.defineProperty(globalThis, fixtureKey, {
+      configurable: true,
+      value: { records, next: 0, deferred: createDeferred },
+    });
+    const cleanupStarted = createDeferred();
+    const finishCleanup = createDeferred();
+    const cleanupSettled = createDeferred();
+    const nestedStarted = createDeferred();
+    const finishNested = createDeferred();
+    const warnings: string[] = [];
+    const cleanupScope = createAgentCleanupScope();
+    let selected: Registration | undefined;
+    let nested: Promise<number> | undefined;
+    let lateRead: number | undefined;
+    let signalAbortedAtLogicalResult: boolean | undefined;
+    let workSignal: AbortSignal | undefined;
+    let logical: Promise<EmbeddedAgentRunResult> | undefined;
+    let actualCleanup: Promise<void> | undefined;
+    let admission: ReturnType<typeof prepareSystemAgentRunAdmission> | undefined;
+    const cliResources = mode === "parent-cancel" ? new CliPluginInvocationResources() : undefined;
+    let parentSignal: AbortSignal | undefined;
+    let parentClose: Promise<void> | undefined;
+    let parentClosed = false;
+    let cancellationSawCandidate = false;
+    try {
+      const pluginRoot = state.path("provider");
+      fs.mkdirSync(pluginRoot);
+      const fixture = createColdPluginFixture({
+        rootDir: pluginRoot,
+        pluginId: "candidate-cleanup",
+        providerId: "candidate-provider",
+      });
+      fs.writeFileSync(
+        fixture.runtimeSource,
+        `module.exports = { id: "candidate-cleanup", register(api) {
+        const state = globalThis[${JSON.stringify(fixtureKey)}];
+        const label = "candidate-registration-" + (++state.next);
+        const file = require("node:path").join(__dirname, label + ".sqlite");
+        const db = new (require("node:sqlite").DatabaseSync)(file);
+        db.exec("CREATE TABLE observations (value INTEGER); INSERT INTO observations VALUES (42)");
+        const record = { file, read: () => db.prepare("SELECT value FROM observations").get().value, disposed: 0, close: state.deferred() };
+        state.records.set(label, record);
+        api.registerProvider({ id: "candidate-provider", label, auth: [] });
+        api.registerRuntimeLifecycle({ id: label, dispose() {
+          record.disposed++;
+          db.close();
+          record.close.resolve();
+        } });
+      } };`,
+      );
+      const cfg: OpenClawConfig = {
+        agents: {
+          entries: { main: { default: true, workspace: state.workspaceDir } },
+          defaults: {
+            workspace: state.workspaceDir,
+            model: "candidate-provider/candidate-model",
+            models: { "candidate-provider/candidate-model": { agentRuntime: { id: "openclaw" } } },
+          },
+        },
+        models: {
+          providers: {
+            "candidate-provider": {
+              api: "openai-completions",
+              apiKey: "synthetic-candidate-key",
+              baseUrl: "http://127.0.0.1:9/v1",
+              models: [
+                {
+                  id: "candidate-model",
+                  name: "Candidate model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          allow: [fixture.pluginId],
+          load: { paths: [fixture.rootDir] },
+          slots: { memory: "none" },
+          entries: { [fixture.pluginId]: { enabled: true } },
+        },
+      };
+      loop.mockImplementation(async (input) => {
+        const prepared = input.preparedModelRuntime;
+        if (!prepared) {
+          throw new Error("Runner did not supply its prepared candidate runtime");
+        }
+        const label = prepared.pluginRegistry?.providers.find(
+          (entry) => entry.provider.id === fixture.providerId,
+        )?.provider.label;
+        const record = label ? records.get(label) : undefined;
+        if (!record) {
+          throw new Error("Candidate did not supply its registered provider source");
+        }
+        selected = record;
+        expect(record.read()).toBe(42);
+        workSignal = getAsyncWorkSignal();
+        if (cliResources) {
+          workSignal?.addEventListener(
+            "abort",
+            () => {
+              cancellationSawCandidate = getPluginRegistryForContext() === prepared.pluginRegistry;
+            },
+            { once: true },
+          );
+        }
+        await runOwnedAgentCleanup({
+          runId: input.runParams.runId,
+          sessionId: input.runParams.sessionId,
+          oneShotCliRun: mode !== "ordinary-error",
+          ...(mode === "required-timeout" ? { settlement: "required" as const } : {}),
+          step: "candidate-fixture",
+          log: {
+            warn: (message) => {
+              warnings.push(message);
+            },
+          },
+          cleanup: () => {
+            actualCleanup = (async () => {
+              cleanupStarted.resolve();
+              await finishCleanup.promise;
+              nested = captureAsyncWorkTracker()(async () => {
+                nestedStarted.resolve();
+                await finishNested.promise;
+                return record.read();
+              });
+              void nested.catch(() => {});
+              lateRead = record.read();
+              if (mode === "late-failure" || mode === "ordinary-error") {
+                throw new Error("candidate cleanup failure");
+              }
+            })();
+            void actualCleanup.finally(() => cleanupSettled.resolve()).catch(() => {});
+            return actualCleanup;
+          },
+        });
+        return {
+          payloads: [{ text: "candidate complete" }],
+          meta: {
+            durationMs: 1,
+            stopReason: "completed",
+            agentMeta: {
+              sessionId: input.runParams.sessionId,
+              provider: input.provider,
+              model: input.modelId,
+            },
+          },
+        };
+      });
+      const runId = `candidate-cleanup-${mode}`;
+      admission = prepareSystemAgentRunAdmission(cfg, runId, "main", "candidate-cleanup-test");
+      const params: RunEmbeddedAgentInternalParams = {
+        config: cfg,
+        agentId: "main",
+        agentDir: state.agentDir(),
+        workspaceDir: state.workspaceDir,
+        sessionId: runId,
+        sessionKey: `agent:main:${runId}`,
+        runId,
+        provider: fixture.providerId,
+        model: "candidate-model",
+        prompt: "Complete the synthetic candidate",
+        timeoutMs: 5000,
+        enqueue: immediateEnqueue,
+        preparedRunAdmission: admission,
+        preparedModelRuntimeMode: "isolated-read-only",
+        sessionPersistence: "detached",
+        sessionManager: SessionManager.inMemory(state.workspaceDir),
+        oneShotCliRun: mode !== "ordinary-error",
+      };
+      logical = cleanupScope.run(() =>
+        cliResources
+          ? cliResources.run(() => {
+              parentSignal = getAsyncWorkSignal();
+              return runEmbeddedAgent(params);
+            })
+          : runEmbeddedAgent(params),
+      );
+      void logical.catch(() => {});
+      await Promise.race([
+        cleanupStarted.promise,
+        logical.then(() => {
+          throw new Error("Run completed before cleanup started");
+        }),
+      ]);
+      if (mode === "ordinary-error") {
+        finishCleanup.resolve();
+      }
+      if (mode === "required-timeout" || mode === "ordinary-error") {
+        await expect(logical.then(() => undefined)).rejects.toThrow(
+          mode === "required-timeout"
+            ? "resource replacement refused"
+            : "candidate cleanup failure",
+        );
+      } else {
+        expect((await logical).payloads?.[0]?.text).toBe("candidate complete");
+      }
+      if (!selected) {
+        throw new Error("Candidate registry source was not selected");
+      }
+      admission.close();
+      signalAbortedAtLogicalResult = workSignal?.aborted;
+      expect.soft(selected.disposed).toBe(0);
+      expect.soft(signalAbortedAtLogicalResult ?? false).toBe(false);
+      expect(cleanupScope.outcome).toBe("uncertain");
+      if (mode !== "ordinary-error") {
+        expect(
+          warnings.some((warning) => warning.includes("step=candidate-fixture timeoutMs=25")),
+        ).toBe(true);
+      }
+      if (cliResources) {
+        parentClose = withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () =>
+          cliResources.release(),
+        ).then(() => {
+          parentClosed = true;
+        });
+        await Promise.resolve();
+        expect(cancellationSawCandidate).toBe(true);
+        expect(workSignal?.reason).toBe(parentSignal?.reason);
+        expect(parentClosed).toBe(false);
+      }
+      finishCleanup.resolve();
+      await nestedStarted.promise;
+      await cleanupSettled.promise;
+      expect.soft(lateRead).toBe(42);
+      expect.soft(selected.disposed).toBe(0);
+      expect.soft(workSignal?.aborted ?? false).toBe(mode === "parent-cancel");
+      finishNested.resolve();
+      if (!nested) {
+        throw new Error("Cleanup did not start its nested work");
+      }
+      await expect(nested).resolves.toBe(42);
+      await selected.close.promise;
+      await parentClose;
+      if (cliResources) {
+        expect(parentClosed).toBe(true);
+      }
+      expect(selected.disposed).toBe(1);
+      expect(cleanupScope.outcome).toBe("uncertain");
+      if (mode === "late-failure") {
+        expect(
+          warnings.some(
+            (warning) =>
+              warning.includes("rejected after timeout") &&
+              warning.includes("candidate cleanup failure"),
+          ),
+        ).toBe(true);
+      }
+      const reopened = new DatabaseSync(selected.file, { readOnly: true });
+      try {
+        expect(reopened.prepare("SELECT value FROM observations").get()?.value).toBe(42);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      finishCleanup.resolve();
+      finishNested.resolve();
+      await Promise.allSettled([logical, actualCleanup, nested]);
+      admission?.close();
+      await parentClose;
+      await cliResources?.release();
+      await resetPreparedModelRuntimeSnapshotsForTest();
+      clearPluginMetadataLifecycleCaches();
+      resetPluginLoaderTestStateForTest();
+      loop.mockReset();
+      Reflect.deleteProperty(globalThis, fixtureKey);
+      await state.cleanup();
+    }
+  },
+);

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -1,6 +1,7 @@
 /**
  * Embedded-agent run orchestration implementation.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   createAgentLifecycleTerminalBackstop,
@@ -26,6 +27,12 @@ import {
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import {
@@ -318,261 +325,304 @@ async function runEmbeddedAgentInternal(
         runtimePluginSelections,
       };
       startupStages.mark("harness-selection");
-      // Configless direct hosts reuse one idle generation. The prepared-runtime lifecycle keeps
-      // gateway run generations in its own bounded cache so one-off paths cannot accumulate.
-      // Runtime acquisition owns its build bound before the attempt budget starts.
-      // Suspend lane-idle inference without inventing progress; Stop still cancels admission.
-      laneController.setLaneTaskDeadline({ kind: "unlimited" });
-      const preparedModelRuntimeLease = await (
-        params.preparedModelRuntimeMode === "isolated-read-only"
-          ? // Probe homes outlive only the attempt client, not independent live catalog clients.
-            acquireReadOnlyPreparedModelRuntime(preparedInput, laneController.abortSignal, "static")
-          : acquireAgentRunPreparedModelRuntime(preparedInput, {
-              retainIdleRunOwner,
-              // Turns need only configured admission facts. Full live model inventory remains
-              // available through the snapshot's lazy control-plane loader.
-              catalogMode: "static",
-              ...(params.pluginGeneration ? { pluginGeneration: params.pluginGeneration } : {}),
-              abortSignal: laneController.abortSignal,
-            })
-      ).finally(() => {
-        noteLaneTaskProgress();
-        laneController.setLaneTaskDeadline(undefined);
-      });
-      startupStages.mark("prepared-runtime");
-      const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
-      let preparedLeaseActive = true;
-      try {
-        throwIfAborted();
-        if (
-          params.pluginGeneration &&
-          preparedModelRuntimeOwnerSnapshot.metadataSnapshot !==
-            params.pluginGeneration.pluginMetadataSnapshot
-        ) {
-          throw new Error("prepared model runtime replaced the admitted plugin generation");
-        }
-        // A reload may complete while admission waits. The committed generation owns config,
-        // directories, model selection, hooks, fallbacks, and every later run projection.
-        const rebound = bindRunToPreparedModelRuntime({
-          runParams: params,
-          requestedWorkspaceResolution,
-          preparedModelRuntime: preparedModelRuntimeOwnerSnapshot,
+      const callerResult = createDeferredCore<EmbeddedAgentRunResult>();
+      const trackOwner = captureAsyncWorkTracker();
+      const parentSignal = getAsyncWorkSignal();
+      const work = new AsyncWorkScope();
+      let context = work.run(() => AsyncLocalStorage.snapshot());
+      let releasePreparedRuntime: (() => void) | undefined;
+      const runPreparedCandidate = async () => {
+        // Configless direct hosts reuse one idle generation. The prepared-runtime lifecycle keeps
+        // gateway run generations in its own bounded cache so one-off paths cannot accumulate.
+        // Runtime acquisition owns its build bound before the attempt budget starts.
+        // Suspend lane-idle inference without inventing progress; Stop still cancels admission.
+        laneController.setLaneTaskDeadline({ kind: "unlimited" });
+        const preparedModelRuntimeLease = await (
+          params.preparedModelRuntimeMode === "isolated-read-only"
+            ? // Probe homes outlive only the attempt client, not independent live catalog clients.
+              acquireReadOnlyPreparedModelRuntime(
+                preparedInput,
+                laneController.abortSignal,
+                "static",
+              )
+            : acquireAgentRunPreparedModelRuntime(preparedInput, {
+                retainIdleRunOwner,
+                // Turns need only configured admission facts. Full live model inventory remains
+                // available through the snapshot's lazy control-plane loader.
+                catalogMode: "static",
+                ...(params.pluginGeneration ? { pluginGeneration: params.pluginGeneration } : {}),
+                abortSignal: laneController.abortSignal,
+              })
+        ).finally(() => {
+          noteLaneTaskProgress();
+          laneController.setLaneTaskDeadline(undefined);
         });
-        params = rebound.runParams;
-        const workspaceResolution = rebound.workspaceResolution;
-        const repoRoot =
-          resolveSystemPromptRepoRoot({
-            config: rebound.runParams.config,
-            workspaceDir: workspaceResolution.workspaceDir,
-            cwd: rebound.runParams.cwd,
-          }) ?? null;
-        const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
-        const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
-          params.sessionId,
-          projectKey,
-        );
-        const preparedModelRuntime = Object.freeze({
-          ...preparedModelRuntimeOwnerSnapshot,
-          repoRoot,
-          projectKey,
-          activeProjectKeys,
-        });
-        const runPrepared = async () => {
-          const preparedAgentId = workspaceResolution.agentId;
-          const resolvedWorkspace = workspaceResolution.workspaceDir;
-          const agentDir = preparedModelRuntime.agentDir;
-          const progressController = createEmbeddedRunProgressController({
-            attempt: params,
-            noteLaneTaskProgress,
-            startedAtMs: started,
+        releasePreparedRuntime = () => preparedModelRuntimeLease.release();
+        startupStages.mark("prepared-runtime");
+        const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
+        let preparedLeaseActive = true;
+        try {
+          throwIfAborted();
+          if (
+            params.pluginGeneration &&
+            preparedModelRuntimeOwnerSnapshot.metadataSnapshot !==
+              params.pluginGeneration.pluginMetadataSnapshot
+          ) {
+            throw new Error("prepared model runtime replaced the admitted plugin generation");
+          }
+          // A reload may complete while admission waits. The committed generation owns config,
+          // directories, model selection, hooks, fallbacks, and every later run projection.
+          const rebound = bindRunToPreparedModelRuntime({
+            runParams: params,
+            requestedWorkspaceResolution,
+            preparedModelRuntime: preparedModelRuntimeOwnerSnapshot,
           });
-          const { notifyExecutionPhase } = progressController;
-          const emitStartupStageSummary = createEmbeddedRunStageSummaryEmitter({
-            label: "startup stages",
-            log,
-            runId: params.runId,
-            sessionId: params.sessionId,
-            tracker: startupStages,
-          });
-          params.onExecutionStarted?.({ lifecycleGeneration });
-          notifyExecutionPhase("runner_entered");
-          const canonicalWorkspace = resolveUserPath(
-            resolveAgentWorkspaceDir(preparedModelRuntime.config, preparedAgentId),
+          params = rebound.runParams;
+          const workspaceResolution = rebound.workspaceResolution;
+          const repoRoot =
+            resolveSystemPromptRepoRoot({
+              config: rebound.runParams.config,
+              workspaceDir: workspaceResolution.workspaceDir,
+              cwd: rebound.runParams.cwd,
+            }) ?? null;
+          const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
+          const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
+            params.sessionId,
+            projectKey,
           );
-          const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
-          const redactedSessionId = redactRunIdentifier(params.sessionId);
-          const redactedSessionKey = redactRunIdentifier(params.sessionKey);
-          const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
-          if (requestedWorkspaceResolution.usedFallback) {
-            log.warn(
-              `[workspace-fallback] caller=runEmbeddedAgent reason=${requestedWorkspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${preparedAgentId} workspace=${redactedWorkspace}`,
-            );
-          }
-          startupStages.mark("runtime-context");
-          notifyExecutionPhase("workspace");
-          startupStages.mark("runtime-plugins");
-          notifyExecutionPhase("runtime_plugins");
-
-          const { provider, modelId } = resolveInitialEmbeddedRunModel({
-            config: params.config,
-            agentId: workspaceResolution.agentId,
-            provider: params.provider,
-            model: params.model,
+          const preparedModelRuntime = Object.freeze({
+            ...preparedModelRuntimeOwnerSnapshot,
+            repoRoot,
+            projectKey,
+            activeProjectKeys,
           });
-          const normalizedSessionKey = params.sessionKey?.trim();
-          const modelFallbackAvailability =
-            params.modelFallbackAvailability ??
-            resolveModelFallbackAvailability({
-              cfg: params.config ?? EMPTY_EMBEDDED_AGENT_CONFIG,
-              agentId: workspaceResolution.agentId,
-              sessionKey: normalizedSessionKey,
-              hasSessionModelOverride: false,
-              modelFallbacksOverride: params.modelFallbacksOverride,
+          const runPrepared = async () => {
+            const preparedAgentId = workspaceResolution.agentId;
+            const resolvedWorkspace = workspaceResolution.workspaceDir;
+            const agentDir = preparedModelRuntime.agentDir;
+            const progressController = createEmbeddedRunProgressController({
+              attempt: params,
+              noteLaneTaskProgress,
+              startedAtMs: started,
             });
-          const fallbackConfigured = modelFallbackAvailability.kind === "active";
-          if (modelFallbackAvailability.kind === "disabled_by_model_override") {
-            log.warn(
-              `[model-fallback] configured fallbacks disabled by user model override run=${params.runId} session=${redactedSessionId}`,
+            const { notifyExecutionPhase } = progressController;
+            const emitStartupStageSummary = createEmbeddedRunStageSummaryEmitter({
+              label: "startup stages",
+              log,
+              runId: params.runId,
+              sessionId: params.sessionId,
+              tracker: startupStages,
+            });
+            params.onExecutionStarted?.({ lifecycleGeneration });
+            notifyExecutionPhase("runner_entered");
+            const canonicalWorkspace = resolveUserPath(
+              resolveAgentWorkspaceDir(preparedModelRuntime.config, preparedAgentId),
             );
-          }
-          const resolvedSessionKey = normalizedSessionKey ?? runSessionTarget.sessionKey;
-          const hookRunner = getGlobalHookRunner();
-          const hookCtx = {
-            runId: params.runId,
-            jobId: params.jobId,
-            agentId: workspaceResolution.agentId,
-            sessionKey: resolvedSessionKey,
-            sessionId: params.sessionId,
-            workspaceDir: resolvedWorkspace,
-            activeProjectKeys: [...activeProjectKeys],
-            modelProviderId: provider,
-            modelId,
-            trigger: params.trigger,
-            ...buildAgentHookContextChannelFields(params),
-            ...buildAgentHookContextIdentityFields({
-              trigger: params.trigger,
-              senderId: params.senderId,
-              chatId: params.chatId,
-              channelContext: params.channelContext,
-            }),
-          };
-          const hookResult = await runBeforeAgentReplyForTurn({
-            runId: params.runId,
-            trigger: params.trigger,
-            event: { cleanedBody: params.prompt },
-            context: hookCtx,
-            onDispatch: () =>
-              notifyExecutionPhase("before_agent_reply", { provider, model: modelId }),
-            onDeclined: () => notifyExecutionPhase("runtime_plugins", { provider, model: modelId }),
-          });
-          if (hookResult?.handled) {
-            return {
-              payloads: buildHandledBeforeAgentReplyPayloads(hookResult.reply),
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: {
-                  sessionId: params.sessionId,
-                  provider,
-                  model: modelId,
-                },
-                finalAssistantVisibleText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
-                finalAssistantRawText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
-              },
-            };
-          }
-
-          const assistantErrorTranscript =
-            params.assistantErrorTranscript ?? createAssistantErrorTranscript(params);
-          const terminal =
-            (params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd)
-              ? undefined
-              : createAgentLifecycleTerminalBackstop({
-                  runId: params.runId,
-                  sessionKey: params.sessionKey,
-                  startedAt: started,
-                  getLifecycleGeneration: () => lifecycleGeneration,
-                  resolveTerminationFields: (error) =>
-                    resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
-                  onTerminalEvent: (event) =>
-                    runBestEffortCallback({
-                      callback: () => params.onAgentEvent?.(event),
-                      label: "lifecycle agent event",
-                      log,
-                    }),
-                });
-          try {
-            let failed = true;
-            let result: EmbeddedAgentRunResult;
-            try {
-              result = await runPreparedEmbeddedLoop({
-                runParams: {
-                  ...params,
-                  assistantErrorTranscript,
-                  deferTerminalLifecycle: true,
-                  onAgentEvent: terminal
-                    ? (event) => {
-                        terminal.note(event);
-                        return params.onAgentEvent?.(event);
-                      }
-                    : params.onAgentEvent,
-                },
-                sessionAdmission,
-                contextEngineAgentId,
-                provider,
-                modelId,
-                agentDir,
-                workspaceResolution,
-                workspaceDir: resolvedWorkspace,
-                bootstrapWorkspaceDir: canonicalWorkspace,
-                isCanonicalWorkspace,
-                globalLane,
-                hookRunner,
-                hookContext: hookCtx,
-                fallbackConfigured,
-                isProbeSession,
-                resolvedSessionKey,
-                resolvedToolResultFormat,
-                startedAtMs: started,
-                startupStages,
-                emitStartupStageSummary,
-                progressController,
-                laneController,
-                lifecycleGeneration,
-                suspendForFailure,
-                preparedModelRuntime,
-              });
-              failed = Boolean(result.meta.error) || result.meta.stopReason === "error";
-            } finally {
-              // Settle the fenced error append before publishing this logical run's terminal.
-              if (!params.assistantErrorTranscript) {
-                await assistantErrorTranscript.settle(failed && !params.abortSignal?.aborted);
-              }
+            const isCanonicalWorkspace = canonicalWorkspace === resolvedWorkspace;
+            const redactedSessionId = redactRunIdentifier(params.sessionId);
+            const redactedSessionKey = redactRunIdentifier(params.sessionKey);
+            const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
+            if (requestedWorkspaceResolution.usedFallback) {
+              log.warn(
+                `[workspace-fallback] caller=runEmbeddedAgent reason=${requestedWorkspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${preparedAgentId} workspace=${redactedWorkspace}`,
+              );
             }
-            const error = result.meta.error?.message ?? terminal?.getDeferredError();
-            terminal?.emit(
-              error ? "error" : "end",
-              error ? new Error(error) : result,
-              resolveAgentLifecycleTerminalMetadata(result.meta),
+            startupStages.mark("runtime-context");
+            notifyExecutionPhase("workspace");
+            startupStages.mark("runtime-plugins");
+            notifyExecutionPhase("runtime_plugins");
+
+            const { provider, modelId } = resolveInitialEmbeddedRunModel({
+              config: params.config,
+              agentId: workspaceResolution.agentId,
+              provider: params.provider,
+              model: params.model,
+            });
+            const normalizedSessionKey = params.sessionKey?.trim();
+            const modelFallbackAvailability =
+              params.modelFallbackAvailability ??
+              resolveModelFallbackAvailability({
+                cfg: params.config ?? EMPTY_EMBEDDED_AGENT_CONFIG,
+                agentId: workspaceResolution.agentId,
+                sessionKey: normalizedSessionKey,
+                hasSessionModelOverride: false,
+                modelFallbacksOverride: params.modelFallbacksOverride,
+              });
+            const fallbackConfigured = modelFallbackAvailability.kind === "active";
+            if (modelFallbackAvailability.kind === "disabled_by_model_override") {
+              log.warn(
+                `[model-fallback] configured fallbacks disabled by user model override run=${params.runId} session=${redactedSessionId}`,
+              );
+            }
+            const resolvedSessionKey = normalizedSessionKey ?? runSessionTarget.sessionKey;
+            const hookRunner = getGlobalHookRunner();
+            const hookCtx = {
+              runId: params.runId,
+              jobId: params.jobId,
+              agentId: workspaceResolution.agentId,
+              sessionKey: resolvedSessionKey,
+              sessionId: params.sessionId,
+              workspaceDir: resolvedWorkspace,
+              activeProjectKeys: [...activeProjectKeys],
+              modelProviderId: provider,
+              modelId,
+              trigger: params.trigger,
+              ...buildAgentHookContextChannelFields(params),
+              ...buildAgentHookContextIdentityFields({
+                trigger: params.trigger,
+                senderId: params.senderId,
+                chatId: params.chatId,
+                channelContext: params.channelContext,
+              }),
+            };
+            const hookResult = await runBeforeAgentReplyForTurn({
+              runId: params.runId,
+              trigger: params.trigger,
+              event: { cleanedBody: params.prompt },
+              context: hookCtx,
+              onDispatch: () =>
+                notifyExecutionPhase("before_agent_reply", { provider, model: modelId }),
+              onDeclined: () =>
+                notifyExecutionPhase("runtime_plugins", { provider, model: modelId }),
+            });
+            if (hookResult?.handled) {
+              return {
+                payloads: buildHandledBeforeAgentReplyPayloads(hookResult.reply),
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: {
+                    sessionId: params.sessionId,
+                    provider,
+                    model: modelId,
+                  },
+                  finalAssistantVisibleText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
+                  finalAssistantRawText: hookResult.reply?.text ?? SILENT_REPLY_TOKEN,
+                },
+              };
+            }
+
+            const assistantErrorTranscript =
+              params.assistantErrorTranscript ?? createAssistantErrorTranscript(params);
+            const terminal =
+              (params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd)
+                ? undefined
+                : createAgentLifecycleTerminalBackstop({
+                    runId: params.runId,
+                    sessionKey: params.sessionKey,
+                    startedAt: started,
+                    getLifecycleGeneration: () => lifecycleGeneration,
+                    resolveTerminationFields: (error) =>
+                      resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
+                    onTerminalEvent: (event) =>
+                      runBestEffortCallback({
+                        callback: () => params.onAgentEvent?.(event),
+                        label: "lifecycle agent event",
+                        log,
+                      }),
+                  });
+            try {
+              let failed = true;
+              let result: EmbeddedAgentRunResult;
+              try {
+                result = await runPreparedEmbeddedLoop({
+                  runParams: {
+                    ...params,
+                    assistantErrorTranscript,
+                    deferTerminalLifecycle: true,
+                    onAgentEvent: terminal
+                      ? (event) => {
+                          terminal.note(event);
+                          return params.onAgentEvent?.(event);
+                        }
+                      : params.onAgentEvent,
+                  },
+                  sessionAdmission,
+                  contextEngineAgentId,
+                  provider,
+                  modelId,
+                  agentDir,
+                  workspaceResolution,
+                  workspaceDir: resolvedWorkspace,
+                  bootstrapWorkspaceDir: canonicalWorkspace,
+                  isCanonicalWorkspace,
+                  globalLane,
+                  hookRunner,
+                  hookContext: hookCtx,
+                  fallbackConfigured,
+                  isProbeSession,
+                  resolvedSessionKey,
+                  resolvedToolResultFormat,
+                  startedAtMs: started,
+                  startupStages,
+                  emitStartupStageSummary,
+                  progressController,
+                  laneController,
+                  lifecycleGeneration,
+                  suspendForFailure,
+                  preparedModelRuntime,
+                });
+                failed = Boolean(result.meta.error) || result.meta.stopReason === "error";
+              } finally {
+                // Settle the fenced error append before publishing this logical run's terminal.
+                if (!params.assistantErrorTranscript) {
+                  await assistantErrorTranscript.settle(failed && !params.abortSignal?.aborted);
+                }
+              }
+              const error = result.meta.error?.message ?? terminal?.getDeferredError();
+              terminal?.emit(
+                error ? "error" : "end",
+                error ? new Error(error) : result,
+                resolveAgentLifecycleTerminalMetadata(result.meta),
+              );
+              return result;
+            } catch (error) {
+              terminal?.emit("error", error);
+              throw error;
+            }
+          };
+          const runWithPreparedRuntime = () =>
+            withPluginRuntimeGenerationScope(preparedModelRuntime, () => {
+              context = AsyncLocalStorage.snapshot();
+              return runPrepared();
+            });
+          return params.pluginGeneration
+            ? await withPreparedModelRuntimePluginGenerationScope(
+                preparedModelRuntimeLease.pluginGeneration,
+                runWithPreparedRuntime,
+                () => (preparedLeaseActive ? preparedModelRuntimeOwnerSnapshot : undefined),
+              )
+            : await runWithPreparedRuntime();
+        } finally {
+          preparedLeaseActive = false;
+        }
+      };
+      // The lane reports its existing result while this owner retains actual cleanup work.
+      void trackOwner(async () => {
+        const closeWork = () => context(() => work.beginClose(parentSignal?.reason));
+        parentSignal?.addEventListener("abort", closeWork, { once: true });
+        if (parentSignal?.aborted) {
+          closeWork();
+        }
+        try {
+          callerResult.resolve(await work.track(runPreparedCandidate));
+        } catch (error) {
+          callerResult.reject(error);
+        } finally {
+          try {
+            await AsyncWorkScope.runWhenAllIdle(
+              () => [work],
+              () => context(() => work.drain()),
             );
-            return result;
-          } catch (error) {
-            terminal?.emit("error", error);
-            throw error;
+          } finally {
+            try {
+              releasePreparedRuntime?.();
+            } finally {
+              parentSignal?.removeEventListener("abort", closeWork);
+            }
           }
-        };
-        const runWithPreparedRuntime = () =>
-          withPluginRuntimeGenerationScope(preparedModelRuntime, runPrepared);
-        return params.pluginGeneration
-          ? await withPreparedModelRuntimePluginGenerationScope(
-              preparedModelRuntimeLease.pluginGeneration,
-              runWithPreparedRuntime,
-              () => (preparedLeaseActive ? preparedModelRuntimeOwnerSnapshot : undefined),
-            )
-          : await runWithPreparedRuntime();
-      } finally {
-        preparedLeaseActive = false;
-        preparedModelRuntimeLease.release();
-      }
+        }
+      }).catch(callerResult.reject);
+      return await callerResult.promise;
     });
   }).finally(() => {
     revokeMessageActionTurnCapability(recoveryMessageActionTurnCapability);

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../infra/errors.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 // Cleanup failures follow the originating run across nested async cleanup.
@@ -177,6 +178,7 @@ async function settleAgentCleanupStep(
       );
       return { error };
     });
+  void trackAsyncWork(() => observedCleanupPromise).catch(() => {});
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timeoutHandle = setTimeout(() => {
       timedOut = true;


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where plugin-backed agent runs could report completion or a cleanup timeout while their remaining cleanup failed with a closed database.

## Why This Change Was Made

Retain the candidate's prepared runtime until actual cleanup and its cooperating descendants settle, independently of the reported result. The existing timeout observation also remains owned through late failure reporting. Logical deadlines, transcript cleanup order, uncertainty reporting, and parent cancellation context are preserved.

## User Impact

Late cleanup can finish using its original resources without extending the visible cleanup deadline. The candidate’s resources close after its remaining work finishes. Logical-engine factory ownership remains a separate change.

## Evidence

- Original code failed five native cases with premature SQLite closure or incorrect cancellation context; the candidate passes them. Together with timeout, projection, suspension, and transcript-cleanup controls, 88 tests passed.
- Required changed-file checks completed after a fixture typing correction. Independent Codex review found no actionable P0–P2 issues. Full build passed in 300.6 seconds.
- Compiled smoke used the real runner, production lanes, a registered synthetic harness, and loopback HTTP cleanup. Late success and failure retained SQLite through nested work, disposed it once, and reopened it successfully. The explicit staged agent directory remained selected.
- The smoke joined its process tree in 2.55 seconds; source and all 12,120 build artifacts stayed unchanged. Logical-run samples were 257.9 ms and 39.8 ms, not a comparative performance benchmark.
