### PR TITLE
fix: retain context engine resources through logical cleanup

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -4,7 +4,7 @@
 import { matchesContextOverflowMessage } from "@openclaw/ai/internal/runtime";
 import { type Mock, vi } from "vitest";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import type { ContextEngineSessionTarget } from "../../context-engine/types.js";
+import type { ContextEngine, ContextEngineSessionTarget } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
   PluginHookBeforeAgentFinalizeEvent,
@@ -750,6 +750,9 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     sleepWithAbort: mockedSleepWithAbort,
   }));
   vi.doMock("../../context-engine/registry.js", () => ({
+    hasSameContextEngineInstance: vi.fn(
+      (left: ContextEngine, right: ContextEngine) => left === right,
+    ),
     resolveContextEngine: mockedResolveContextEngine,
     resolveContextEngineOwnerPluginId: mockedResolveContextEngineOwnerPluginId,
     resolveLogicalTurnContextEngines: async () => {

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -6,10 +6,14 @@ import {
   type ContextEngineHostSupport,
 } from "../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
-import { resolveLogicalTurnContextEngines } from "../../context-engine/registry.js";
+import {
+  hasSameContextEngineInstance,
+  resolveLogicalTurnContextEngines,
+} from "../../context-engine/registry.js";
+import { disposeContextEngineSources } from "../../context-engine/registry.resources.js";
 import type { ContextEngine, ContextEngineOperation } from "../../context-engine/types.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
-import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
+import { recordAgentCleanupFailure, runAgentCleanupStep } from "../run-cleanup-timeout.js";
 
 type LogicalTurnSelectionState = "unselected" | "selected" | "started" | "disposed";
 
@@ -75,6 +79,7 @@ export async function createContextEngineLogicalTurnLease(params: {
   const resolution = await resolveLogicalTurnContextEngines(params.config, {
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
+    onCleanupFailure: recordAgentCleanupFailure,
   });
   let state: LogicalTurnSelectionState = "unselected";
   let effective = resolution.configured;
@@ -224,22 +229,27 @@ export async function createContextEngineLogicalTurnLease(params: {
         return;
       }
       state = "disposed";
-      const engines = new Set<ContextEngine>([
-        resolution.configured.engine,
-        resolution.fallback.engine,
-      ]);
+      const engines = [resolution.configured.engine, resolution.fallback.engine];
+      const distinctEngines = engines.filter((engine, index) =>
+        engines.slice(0, index).every((other) => !hasSameContextEngineInstance(engine, other)),
+      );
       // Dispose instances in parallel so their deadlines do not stack. The
       // shared helper records each failure before one-shot cleanup checks ownership.
       const disposeEngines = async () => {
         await Promise.allSettled(
-          [...engines].map((engine) =>
+          distinctEngines.map((engine) =>
             runAgentCleanupStep({
               runId,
               sessionId,
               step: "context-engine-dispose",
               log: { warn: params.warn ?? console.warn },
               cleanup: async () => {
-                await engine.dispose?.();
+                const sources = new Set(
+                  engines
+                    .filter((other) => hasSameContextEngineInstance(engine, other))
+                    .flatMap((other) => resolution.sourceResources?.get(other) ?? []),
+                );
+                await disposeContextEngineSources(engine, [...sources]);
               },
             }),
           ),

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -4,6 +4,7 @@
  * Installs targeted Vitest module mocks for tests that do not need live plugin/runtime boot.
  */
 import { vi } from "vitest";
+import type { ContextEngine } from "../../context-engine/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
@@ -127,6 +128,9 @@ export function installEmbeddedRunnerBaseE2eMocks(options?: {
     ensureContextEnginesInitialized: vi.fn(),
   }));
   vi.doMock("../../context-engine/registry.js", () => ({
+    hasSameContextEngineInstance: vi.fn(
+      (left: ContextEngine, right: ContextEngine) => left === right,
+    ),
     resolveContextEngine: vi.fn(async () => ({
       dispose: async () => undefined,
     })),

--- a/src/context-engine/registry.logical-turn-resources.test.ts
+++ b/src/context-engine/registry.logical-turn-resources.test.ts
@@ -1,0 +1,493 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createContextEngineLogicalTurnLease } from "../agents/harness/context-engine-logical-turn.js";
+import { createAgentCleanupScope } from "../agents/run-cleanup-timeout.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
+import { LegacyContextEngine } from "./legacy.js";
+import * as contextEngineRegistry from "./registry.js";
+import {
+  adoptRuntimeContextEngineRegistrations,
+  registerContextEngineInRegistry,
+  resolveLogicalTurnContextEngines,
+} from "./registry.js";
+import type { ContextEngineFactory } from "./registry.js";
+import type { ContextEngine } from "./types.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+it("captures configured registration before awaiting the fallback factory", async () => {
+  const registry = createEmptyPluginRegistry();
+  const fallbackGate = createDeferred();
+  const calls: string[] = [];
+  const factory =
+    (name: string): ContextEngineFactory =>
+    () => {
+      calls.push(name);
+      return new LegacyContextEngine();
+    };
+  registerContextEngineInRegistry(
+    registry,
+    "legacy",
+    async () => {
+      await fallbackGate.promise;
+      return new LegacyContextEngine();
+    },
+    "core",
+  );
+  registerContextEngineInRegistry(registry, "selected", factory("original"), "plugin:fixture");
+  const pending = withPluginRuntimeRegistryScope(registry, () =>
+    resolveLogicalTurnContextEngines({ plugins: { slots: { contextEngine: "selected" } } }),
+  );
+  registerContextEngineInRegistry(registry, "selected", factory("replacement"), "plugin:fixture", {
+    allowSameOwnerRefresh: true,
+  });
+  fallbackGate.resolve();
+  const resolved = await pending;
+  expect(calls).toEqual(["original"]);
+  await resolved.configured.engine.dispose?.();
+  await resolved.fallback.engine.dispose?.();
+});
+
+it.each([
+  "selection",
+  "factory",
+  "factory-tail",
+  "abort-factory-tail",
+  "dispose",
+  "dispose-tail",
+  "abort-tail",
+  "parent-abort",
+  "invalid",
+  "invalid-tail",
+  "invalid-factory-tail",
+  "factory-error",
+  "factory-cleanup-error",
+  "closing-factory",
+  "last-user",
+  "raw",
+] as const)("retains the adopted engine's native source through %s", async (mode) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "context-engine-source-"));
+  const databasePath = path.join(directory, "source.sqlite");
+  const database = new DatabaseSync(databasePath);
+  const source = new PluginRegistryInspectionResources();
+  const donor = createEmptyPluginRegistry();
+  const supplyingView = createEmptyPluginRegistry();
+  const viewSource = new PluginRegistryInspectionResources();
+  const plugin = { id: "engine-source-fixture", source: path.join(directory, "plugin.cjs") };
+  donor.plugins.push(createPluginRecord(plugin));
+  supplyingView.plugins.push(createPluginRecord(plugin));
+  if (mode !== "raw") {
+    source.attach(donor);
+  }
+  viewSource.attach(supplyingView);
+  let sourceDisposals = 0;
+  const sourceDisposed = createDeferred();
+  source.register(plugin.id, {
+    id: "native",
+    dispose() {
+      sourceDisposals++;
+      database.close();
+      sourceDisposed.resolve();
+      if (mode === "factory-cleanup-error") {
+        throw new Error("registration disposer failed");
+      }
+    },
+  });
+  const reads: number[] = [];
+  const read = () => {
+    try {
+      reads.push(Number(database.prepare("SELECT 42 AS value").get()?.value));
+    } catch {
+      reads.push(-1);
+    }
+  };
+  const factoryStarted = createDeferred();
+  const factoryGate = createDeferred();
+  const factoryTail = createDeferred();
+  const disposeStarted = createDeferred();
+  const disposeGate = createDeferred();
+  const disposeTail = createDeferred();
+  const tails: Promise<unknown>[] = [];
+  const contexts: Array<string | undefined> = [];
+  const signals: AbortSignal[] = [];
+  let engineDisposals = 0;
+  let cleanupSignal: AbortSignal | undefined;
+  let factoryWorker: Promise<void> | undefined;
+  let factoryWorkFinished = false;
+  let abortInOrigin = false;
+  class NativeEngine extends LegacyContextEngine {
+    #read = read;
+    override readonly info = {
+      id:
+        mode === "invalid" || mode === "invalid-tail" || mode === "invalid-factory-tail"
+          ? ""
+          : "native-engine",
+      name: "Native engine",
+    };
+    override async assemble(params: Parameters<ContextEngine["assemble"]>[0]) {
+      this.#read();
+      return await super.assemble(params);
+    }
+    async dispose() {
+      engineDisposals++;
+      disposeStarted.resolve();
+      // A factory's accepted background work may require disposal to let it finish.
+      if (mode !== "abort-factory-tail" && mode !== "invalid-factory-tail") {
+        factoryTail.resolve();
+      }
+      if (mode === "invalid-factory-tail") {
+        cleanupSignal = getAsyncWorkSignal();
+        await factoryWorker;
+      }
+      if (mode === "dispose" || mode === "invalid" || mode === "invalid-factory-tail") {
+        await disposeGate.promise;
+      }
+      if (mode === "dispose-tail" || mode === "invalid-tail") {
+        cleanupSignal = getAsyncWorkSignal();
+        tails.push(
+          trackAsyncWork(async () => {
+            await disposeTail.promise;
+            this.#read();
+          }),
+        );
+      }
+      this.#read();
+    }
+  }
+  const factory: ContextEngineFactory = async (context) => {
+    contexts.push(context.agentDir);
+    const signal = getAsyncWorkSignal();
+    if (signal) {
+      signals.push(signal);
+      if (mode === "abort-tail" || mode === "parent-abort") {
+        signal.addEventListener(
+          "abort",
+          () => {
+            abortInOrigin = getAsyncWorkSignal() === signal;
+            tails.push(
+              trackAsyncWork(async () => {
+                await disposeTail.promise;
+                read();
+              }),
+            );
+          },
+          { once: true },
+        );
+      }
+    }
+    factoryStarted.resolve();
+    if (mode === "factory" || mode === "closing-factory" || mode === "factory-cleanup-error") {
+      await factoryGate.promise;
+    }
+    if (mode === "factory-tail" || mode === "factory-error" || mode === "closing-factory") {
+      const tail = trackAsyncWork(async () => {
+        await factoryTail.promise;
+        read();
+      });
+      void tail.catch(() => {});
+      tails.push(tail);
+    }
+    if (mode === "abort-factory-tail" || mode === "invalid-factory-tail") {
+      if (!signal) {
+        throw new Error("Managed factory did not receive its work signal");
+      }
+      const stopped = createDeferred();
+      signal.addEventListener("abort", () => stopped.resolve(), { once: true });
+      factoryWorker = trackAsyncWork(async () => {
+        await Promise.race([stopped.promise, factoryTail.promise]);
+        read();
+        factoryWorkFinished = true;
+      });
+      tails.push(factoryWorker);
+    }
+    read();
+    if (
+      mode === "factory-error" ||
+      mode === "closing-factory" ||
+      mode === "factory-cleanup-error"
+    ) {
+      throw new Error("original factory failure");
+    }
+    return new NativeEngine();
+  };
+  source.runRegistration(plugin.id, () => {
+    registerContextEngineInRegistry(donor, "selected", factory, `plugin:${plugin.id}`);
+  });
+  const copiedView = adoptRuntimeContextEngineRegistrations(supplyingView, donor);
+  viewSource.attach(copiedView);
+  const config = { plugins: { slots: { contextEngine: "selected" } } };
+  const cleanupScope = createAgentCleanupScope();
+  const parent = new AsyncWorkScope();
+  const foreign = new AsyncWorkScope();
+  const leases: Array<Awaited<ReturnType<typeof createContextEngineLogicalTurnLease>>> = [];
+  const pending: Array<Promise<unknown>> = [];
+  const start = async () => {
+    const create = () =>
+      cleanupScope.run(() =>
+        withPluginRuntimeRegistryScope(copiedView, () =>
+          createContextEngineLogicalTurnLease({
+            identity: { runId: "fixture-run", sessionId: "fixture-session" },
+            config,
+            agentDir: path.join(directory, "staged-agent"),
+            workspaceDir: path.join(directory, "workspace"),
+            warn: () => {},
+          }),
+        ),
+      );
+    const lease = await (mode === "abort-factory-tail" || mode === "invalid-factory-tail"
+      ? create()
+      : mode === "closing-factory"
+        ? parent.run(create)
+        : parent.track(create));
+    leases.push(lease);
+    return lease;
+  };
+  const first = start();
+  pending.push(first);
+  try {
+    if (mode === "selection") {
+      await source.release();
+    }
+    await factoryStarted.promise;
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+    if (mode === "invalid" || mode === "invalid-factory-tail") {
+      await disposeStarted.promise;
+    }
+    if (mode === "last-user") {
+      await first;
+      await start();
+    }
+    if (mode !== "raw") {
+      await source.release();
+      expect.soft(database.isOpen).toBe(true);
+      expect.soft(sourceDisposals).toBe(0);
+    }
+    if (mode === "closing-factory") {
+      let parentDrained = false;
+      pending.push(
+        parent.drain().then(() => {
+          parentDrained = true;
+        }),
+      );
+      await Promise.resolve();
+      expect.soft(parentDrained).toBe(false);
+    }
+    if (mode === "invalid-factory-tail") {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect.soft(signals.every((signal) => signal.aborted)).toBe(true);
+      expect.soft(factoryWorkFinished).toBe(true);
+      expect.soft(cleanupSignal?.aborted).toBe(false);
+      factoryTail.resolve();
+      disposeGate.resolve();
+    }
+    factoryGate.resolve();
+    if (mode === "invalid") {
+      disposeGate.resolve();
+    }
+    const lease = await first;
+    expect(contexts.every((value) => value === path.join(directory, "staged-agent"))).toBe(true);
+    if (
+      mode === "factory-error" ||
+      mode === "closing-factory" ||
+      mode === "factory-cleanup-error"
+    ) {
+      expect(lease.degradedReason).toBe("original factory failure");
+      factoryTail.resolve();
+    } else if (mode === "invalid" || mode === "invalid-tail" || mode === "invalid-factory-tail") {
+      expect(lease.degradedReason).toContain("missing info.id");
+    } else {
+      await lease.engine.assemble({ sessionId: "fixture-session", messages: [] });
+    }
+    if (mode === "parent-abort") {
+      const reason = new Error("original parent abort");
+      foreign.run(() => parent.beginClose(reason));
+      expect(signals.every((signal) => signal.reason === reason)).toBe(true);
+      let foreignDrained = false;
+      pending.push(
+        foreign.drain().then(() => {
+          foreignDrained = true;
+        }),
+      );
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect.soft(foreignDrained).toBe(true);
+    }
+    vi.useFakeTimers();
+    vi.stubEnv("OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS", "25");
+    const cleanup = cleanupScope.run(() => lease.dispose());
+    pending.push(cleanup);
+    await vi.advanceTimersByTimeAsync(25);
+    await cleanup;
+    if (
+      mode === "dispose" ||
+      mode === "dispose-tail" ||
+      mode === "abort-tail" ||
+      mode === "parent-abort"
+    ) {
+      expect.soft(cleanupScope.outcome).toBe("uncertain");
+      expect.soft(database.isOpen).toBe(true);
+    }
+    if (mode === "abort-tail" || mode === "parent-abort") {
+      expect.soft(abortInOrigin).toBe(true);
+    }
+    if (mode === "last-user") {
+      expect.soft(sourceDisposals).toBe(0);
+      await leases[1]!.dispose();
+    }
+    if (mode === "dispose-tail" || mode === "invalid-tail") {
+      expect.soft(cleanupSignal?.aborted).toBe(false);
+    }
+    if (mode === "abort-factory-tail") {
+      expect.soft(cleanupScope.outcome).toBe("closed");
+      factoryTail.resolve();
+    }
+    disposeGate.resolve();
+    disposeTail.resolve();
+    const settledTails = await Promise.allSettled(tails);
+    expect.soft(settledTails.every((tail) => tail.status === "fulfilled")).toBe(true);
+    await parent.drain();
+    if (mode !== "raw") {
+      await sourceDisposed.promise;
+      expect(sourceDisposals).toBe(1);
+      expect(database.isOpen).toBe(false);
+    } else {
+      expect(database.isOpen).toBe(true);
+      expect(sourceDisposals).toBe(0);
+    }
+    if (mode === "factory-cleanup-error") {
+      expect.soft(cleanupScope.outcome).toBe("uncertain");
+    }
+    expect(reads.length).toBeGreaterThan(0);
+    expect.soft(reads.every((value) => value === 42)).toBe(true);
+    expect(engineDisposals).toBe(
+      mode === "factory-error" || mode === "closing-factory" || mode === "factory-cleanup-error"
+        ? 0
+        : mode === "last-user"
+          ? 2
+          : 1,
+    );
+    await lease.dispose();
+    const reopened = new DatabaseSync(databasePath);
+    expect(reopened.prepare("SELECT 42 AS value").get()?.value).toBe(42);
+    reopened.close();
+  } finally {
+    vi.useRealTimers();
+    factoryGate.resolve();
+    factoryTail.resolve();
+    disposeGate.resolve();
+    disposeTail.resolve();
+    await Promise.allSettled(pending);
+    await Promise.allSettled(leases.map((lease) => lease.dispose()));
+    await Promise.allSettled(tails);
+    await parent.drain();
+    await foreign.drain();
+    await source.release();
+    await viewSource.release();
+    if (database.isOpen) {
+      database.close();
+    }
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+it("disposes a shared engine once while releasing both factory source claims", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "context-engine-alias-"));
+  const database = new DatabaseSync(path.join(directory, "source.sqlite"));
+  const registry = createEmptyPluginRegistry();
+  const resources = new PluginRegistryInspectionResources();
+  resources.attach(registry);
+  const sourceDisposed = createDeferred();
+  const finishTail = createDeferred();
+  const tails: Promise<unknown>[] = [];
+  let sourceDisposals = 0;
+  let engineDisposals = 0;
+  const reads: number[] = [];
+  resources.register("fixture", {
+    id: "native",
+    dispose() {
+      sourceDisposals++;
+      database.close();
+      sourceDisposed.resolve();
+    },
+  });
+  class SharedEngine extends LegacyContextEngine {
+    #database = database;
+    async dispose() {
+      engineDisposals++;
+      tails.push(
+        trackAsyncWork(async () => {
+          await finishTail.promise;
+          try {
+            reads.push(Number(this.#database.prepare("SELECT 42 AS value").get()?.value));
+          } catch {
+            reads.push(-1);
+          }
+        }),
+      );
+    }
+  }
+  const engine = new SharedEngine();
+  resources.runRegistration("fixture", () => {
+    registerContextEngineInRegistry(registry, "legacy", () => engine, "core");
+    registerContextEngineInRegistry(registry, "selected", () => engine, "plugin:fixture");
+  });
+  const config = { plugins: { slots: { contextEngine: "selected" } } };
+  const resolution = await withPluginRuntimeRegistryScope(registry, () =>
+    resolveLogicalTurnContextEngines(config),
+  );
+  // Feed the actual acquired pair to its existing logical owner without replacing the factories.
+  const resolve = vi
+    .spyOn(contextEngineRegistry, "resolveLogicalTurnContextEngines")
+    .mockResolvedValueOnce(resolution);
+  const lease = await withPluginRuntimeRegistryScope(registry, () =>
+    createContextEngineLogicalTurnLease({
+      identity: { runId: "alias-run", sessionId: "alias-session" },
+      config,
+      warn: () => {},
+    }),
+  );
+  let cleanup: Promise<void> | undefined;
+  try {
+    await resources.release();
+    expect.soft(database.isOpen).toBe(true);
+    vi.useFakeTimers();
+    vi.stubEnv("OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS", "25");
+    cleanup = lease.dispose();
+    await vi.advanceTimersByTimeAsync(25);
+    await cleanup;
+    expect.soft(engineDisposals).toBe(1);
+    expect.soft(sourceDisposals).toBe(0);
+    finishTail.resolve();
+    await Promise.allSettled(tails);
+    await sourceDisposed.promise;
+    expect.soft(reads).toEqual([42]);
+    expect(sourceDisposals).toBe(1);
+    expect(database.isOpen).toBe(false);
+  } finally {
+    finishTail.resolve();
+    await Promise.allSettled(tails);
+    await cleanup;
+    await lease.dispose();
+    await resources.release();
+    resolve.mockRestore();
+    vi.useRealTimers();
+    if (database.isOpen) {
+      database.close();
+    }
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/context-engine/registry.resources.ts
+++ b/src/context-engine/registry.resources.ts
@@ -1,0 +1,195 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import type { ContextEngineRegistration } from "../plugins/registry-contribution-types.js";
+import {
+  getPluginRegistryInspectionResources,
+  type PluginRegistryInspectionResources,
+} from "../plugins/registry-inspection-resources.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { ResolvedContextEngineRef } from "./registry.js";
+import type { ContextEngine } from "./types.js";
+
+// Adoption copies entries by identity; the copied view's primary source is not their owner.
+const registrationSources = resolveGlobalSingleton(
+  Symbol.for("openclaw.contextEngineRegistrationSources"),
+  () => new WeakMap<ContextEngineRegistration, PluginRegistryInspectionResources>(),
+);
+
+export function recordContextEngineRegistrationSource(
+  registration: ContextEngineRegistration,
+  registry: PluginRegistry,
+): void {
+  const resources = getPluginRegistryInspectionResources(registry);
+  if (resources) {
+    registrationSources.set(registration, resources);
+  }
+}
+
+export class ContextEngineFactoryResources {
+  readonly work = new AsyncWorkScope();
+  readonly context = this.work.run(() => AsyncLocalStorage.snapshot());
+  readonly cleanupWork = new AsyncWorkScope();
+  readonly cleanupContext = this.cleanupWork.run(() => AsyncLocalStorage.snapshot());
+  private readonly parentSignal = getAsyncWorkSignal();
+  private readonly abort = () => {
+    this.context(() => this.work.beginClose(this.parentSignal?.reason));
+    this.cleanupContext(() => this.cleanupWork.beginClose(this.parentSignal?.reason));
+  };
+
+  constructor(private readonly claim: { release: () => Promise<void> }) {
+    this.parentSignal?.addEventListener("abort", this.abort, { once: true });
+    if (this.parentSignal?.aborted) {
+      this.abort();
+    }
+  }
+
+  run<T>(operation: () => T | Promise<T>): Promise<T> {
+    return this.work.track(() => this.context(operation));
+  }
+
+  runCleanup<T>(operation: () => T): T {
+    try {
+      return this.cleanupWork.run(() => this.cleanupContext(operation));
+    } finally {
+      this.context(() => this.work.beginClose());
+    }
+  }
+
+  release(): Promise<void> {
+    this.parentSignal?.removeEventListener("abort", this.abort);
+    return this.claim.release();
+  }
+}
+
+function retainContextEngineFactorySource(
+  registration: ContextEngineRegistration | undefined,
+): ContextEngineFactoryResources | undefined {
+  const claim = registration && registrationSources.get(registration)?.retain();
+  return claim ? new ContextEngineFactoryResources(claim) : undefined;
+}
+
+/** One instance may come from both factories; every source stays held through shared cleanup. */
+export async function disposeContextEngineSources(
+  engine: ContextEngine | undefined,
+  sources: readonly ContextEngineFactoryResources[],
+): Promise<void> {
+  const dispose = () => engine?.dispose?.();
+  if (sources.length === 0) {
+    await dispose();
+    return;
+  }
+  // Start instance cleanup before retiring the factory lifetime that it may need to stop.
+  const cleanup = sources[0]!.cleanupWork.track(() => sources[0]!.runCleanup(dispose));
+  for (const source of sources) {
+    source.context(() => source.work.beginClose());
+  }
+  const [engineResult] = await Promise.allSettled([cleanup]);
+  const scopes = sources.flatMap((source) => [source.work, source.cleanupWork]);
+  await AsyncWorkScope.runWhenAllIdle(
+    () => scopes,
+    () => {
+      for (const source of sources) {
+        source.cleanupContext(() => source.cleanupWork.beginClose());
+      }
+    },
+  );
+  await AsyncWorkScope.runWhenAllIdle(
+    () => scopes,
+    () =>
+      Promise.all(
+        sources.flatMap((source) => [
+          source.context(() => source.work.drain()),
+          source.cleanupContext(() => source.cleanupWork.drain()),
+        ]),
+      ),
+  );
+  const released = await Promise.allSettled(sources.map((source) => source.release()));
+  if (engineResult.status === "rejected") {
+    throw engineResult.reason;
+  }
+  for (const result of released) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+  }
+}
+
+type ContextEngineFactoryFailureCleanup = (
+  source: ContextEngineFactoryResources | undefined,
+) => void;
+
+/** Report selection separately while its admitted owner joins failed-factory cleanup. */
+export async function runContextEngineFactoryResolution<T>(
+  resolve: (abandon: ContextEngineFactoryFailureCleanup) => Promise<T>,
+  onCleanupFailure?: () => void,
+): Promise<T> {
+  const reportCleanupFailure = onCleanupFailure
+    ? AsyncLocalStorage.bind(onCleanupFailure)
+    : undefined;
+  const result = createDeferredCore<T>();
+  const failedSources: Promise<void>[] = [];
+  const abandon: ContextEngineFactoryFailureCleanup = (source) => {
+    if (source) {
+      failedSources.push(
+        disposeContextEngineSources(undefined, [source]).catch((error: unknown) => {
+          reportCleanupFailure?.();
+          console.warn(
+            `[context-engine] Failed factory resource cleanup: ${sanitizeForLog(String(error))}`,
+          );
+        }),
+      );
+    }
+  };
+  // Admit construction before either factory can escape into asynchronous work.
+  void captureAsyncWorkTracker()(async () => {
+    try {
+      result.resolve(await resolve(abandon));
+    } catch (error) {
+      result.reject(error);
+    } finally {
+      await Promise.all(failedSources);
+    }
+  }).catch(result.reject);
+  return await result.promise;
+}
+
+export function retainLogicalTurnContextEngineSources(
+  fallback: ContextEngineRegistration | undefined,
+  configured: ContextEngineRegistration | undefined,
+): {
+  fallback: ContextEngineFactoryResources | undefined;
+  configured?: ContextEngineFactoryResources;
+  configuredFailure?: { error: unknown };
+} {
+  const fallbackSource = retainContextEngineFactorySource(fallback);
+  try {
+    const configuredSource =
+      configured?.lifecycle === "runtime"
+        ? retainContextEngineFactorySource(configured)
+        : undefined;
+    return { fallback: fallbackSource, configured: configuredSource };
+  } catch (error) {
+    return { fallback: fallbackSource, configuredFailure: { error } };
+  }
+}
+
+export async function resolveContextEngineFactory(
+  source: ContextEngineFactoryResources | undefined,
+  owners: Map<ContextEngine, ContextEngineFactoryResources[]>,
+  create: () => Promise<ResolvedContextEngineRef>,
+): Promise<ResolvedContextEngineRef> {
+  const ref = await (source ? source.run(create) : create());
+  if (source) {
+    const retained = owners.get(ref.engine) ?? [];
+    retained.push(source);
+    owners.set(ref.engine, retained);
+  }
+  return ref;
+}

--- a/src/context-engine/registry.resources.ts
+++ b/src/context-engine/registry.resources.ts
@@ -13,7 +13,6 @@ import {
 } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { ResolvedContextEngineRef } from "./registry.js";
 import type { ContextEngine } from "./types.js";
 
 // Adoption copies entries by identity; the copied view's primary source is not their owner.
@@ -180,11 +179,11 @@ export function retainLogicalTurnContextEngineSources(
   }
 }
 
-export async function resolveContextEngineFactory(
+export async function resolveContextEngineFactory<T extends { engine: ContextEngine }>(
   source: ContextEngineFactoryResources | undefined,
   owners: Map<ContextEngine, ContextEngineFactoryResources[]>,
-  create: () => Promise<ResolvedContextEngineRef>,
-): Promise<ResolvedContextEngineRef> {
+  create: () => Promise<T>,
+): Promise<T> {
   const ref = await (source ? source.run(create) : create());
   if (source) {
     const retained = owners.get(ref.engine) ?? [];

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -21,6 +21,13 @@ import {
   listPersistedContextEngineQuarantines,
   recordPersistedContextEngineQuarantine,
 } from "./quarantine-health.js";
+import {
+  recordContextEngineRegistrationSource,
+  resolveContextEngineFactory,
+  retainLogicalTurnContextEngineSources,
+  runContextEngineFactoryResolution,
+  type ContextEngineFactoryResources,
+} from "./registry.resources.js";
 import type {
   BootstrapResult,
   ContextEngine,
@@ -352,7 +359,9 @@ export function registerContextEngineInRegistry(
   if (existing && opts?.allowSameOwnerRefresh !== true) {
     return { ok: false, existingOwner: existing.owner };
   }
-  registry.set(id, { factory, owner: normalizedOwner, lifecycle });
+  const registration = { factory, owner: normalizedOwner, lifecycle };
+  recordContextEngineRegistrationSource(registration, pluginRegistry);
+  registry.set(id, registration);
   return { ok: true };
 }
 
@@ -561,6 +570,7 @@ async function invokeFallbackContextEngineMethod(params: {
 export type ResolveContextEngineOptions = {
   agentDir?: string;
   workspaceDir?: string;
+  onCleanupFailure?: () => void;
 };
 
 export type ResolvedContextEngineRef = Readonly<{
@@ -574,6 +584,7 @@ export type LogicalTurnContextEngineResolution = {
   configuredId: string;
   configuredFailure?: string;
   fallback: ResolvedContextEngineRef;
+  sourceResources?: ReadonlyMap<ContextEngine, readonly ContextEngineFactoryResources[]>;
 };
 
 function resolvedContextEngineRef(params: {
@@ -592,8 +603,9 @@ function resolvedContextEngineRef(params: {
 async function resolveRawContextEngineRef(
   engineId: string,
   factoryCtx: ContextEngineFactoryContext,
+  entry: ContextEngineRegistration | undefined,
+  source: ContextEngineFactoryResources | undefined,
 ): Promise<ResolvedContextEngineRef> {
-  const entry = getContextEngines().get(engineId);
   if (!entry) {
     throw new Error(
       `Context engine "${engineId}" is not registered. ` +
@@ -603,9 +615,8 @@ async function resolveRawContextEngineRef(
   const engine = await entry.factory(factoryCtx);
   const contractError = describeResolvedContextEngineContractError(engineId, engine);
   if (contractError) {
-    await Promise.resolve((engine as ContextEngine | undefined)?.dispose?.()).catch(
-      () => undefined,
-    );
+    const dispose = () => (engine as ContextEngine | undefined)?.dispose?.();
+    await Promise.resolve(source ? source.runCleanup(dispose) : dispose()).catch(() => undefined);
     throw new Error(contractError);
   }
   const projectedEngine = wrapResolvedContextEngine(engine, {
@@ -627,51 +638,75 @@ export async function resolveLogicalTurnContextEngines(
   config?: OpenClawConfig,
   options?: ResolveContextEngineOptions,
 ): Promise<LogicalTurnContextEngineResolution> {
-  const defaultEngineId = defaultSlotIdForKey("contextEngine");
-  const slotValue = config?.plugins?.slots?.contextEngine;
-  const configuredEngineId =
-    typeof slotValue === "string" && slotValue.trim() ? slotValue.trim() : defaultEngineId;
-  const factoryCtx: ContextEngineFactoryContext = {
-    config,
-    agentDir: options?.agentDir,
-    workspaceDir: options?.workspaceDir,
-  };
-  const fallback = await resolveRawContextEngineRef(defaultEngineId, factoryCtx);
-  if (configuredEngineId === defaultEngineId) {
-    return { configured: fallback, configuredId: configuredEngineId, fallback };
-  }
-  const entry = getContextEngines().get(configuredEngineId);
-  if (!entry) {
-    return {
-      configured: fallback,
-      configuredId: configuredEngineId,
-      configuredFailure: `context engine "${configuredEngineId}" is not registered`,
-      fallback,
+  return await runContextEngineFactoryResolution(async (abandon) => {
+    const defaultEngineId = defaultSlotIdForKey("contextEngine");
+    const slotValue = config?.plugins?.slots?.contextEngine;
+    const configuredEngineId =
+      typeof slotValue === "string" && slotValue.trim() ? slotValue.trim() : defaultEngineId;
+    const factoryCtx: ContextEngineFactoryContext = {
+      config,
+      agentDir: options?.agentDir,
+      workspaceDir: options?.workspaceDir,
     };
-  }
-  if (entry.lifecycle === "readOnlyDiscovery") {
-    return {
-      configured: fallback,
-      configuredId: configuredEngineId,
-      configuredFailure: `context engine "${configuredEngineId}" is available for discovery only`,
-      fallback,
-    };
-  }
-  try {
-    const configured = await resolveRawContextEngineRef(configuredEngineId, factoryCtx);
-    return {
-      configured,
-      configuredId: configuredEngineId,
-      fallback,
-    };
-  } catch (error) {
-    return {
-      configured: fallback,
-      configuredId: configuredEngineId,
-      configuredFailure: error instanceof Error ? error.message : String(error),
-      fallback,
-    };
-  }
+    const entries = getContextEngines();
+    const fallbackEntry = entries.get(defaultEngineId);
+    const configuredEntry = entries.get(configuredEngineId);
+    const sources = retainLogicalTurnContextEngineSources(
+      fallbackEntry,
+      configuredEngineId === defaultEngineId ? undefined : configuredEntry,
+    );
+    const sourceResources = new Map<ContextEngine, ContextEngineFactoryResources[]>();
+    let fallback: ResolvedContextEngineRef;
+    try {
+      fallback = await resolveContextEngineFactory(sources.fallback, sourceResources, () =>
+        resolveRawContextEngineRef(defaultEngineId, factoryCtx, fallbackEntry, sources.fallback),
+      );
+    } catch (error) {
+      abandon(sources.fallback);
+      abandon(sources.configured);
+      throw error;
+    }
+    if (configuredEngineId === defaultEngineId) {
+      return { configured: fallback, configuredId: configuredEngineId, fallback, sourceResources };
+    }
+    if (!configuredEntry || configuredEntry.lifecycle === "readOnlyDiscovery") {
+      return {
+        configured: fallback,
+        configuredId: configuredEngineId,
+        configuredFailure: !configuredEntry
+          ? `context engine "${configuredEngineId}" is not registered`
+          : `context engine "${configuredEngineId}" is available for discovery only`,
+        fallback,
+        sourceResources,
+      };
+    }
+    try {
+      if (sources.configuredFailure) {
+        throw sources.configuredFailure.error;
+      }
+      const configured = await resolveContextEngineFactory(
+        sources.configured,
+        sourceResources,
+        () =>
+          resolveRawContextEngineRef(
+            configuredEngineId,
+            factoryCtx,
+            configuredEntry,
+            sources.configured,
+          ),
+      );
+      return { configured, configuredId: configuredEngineId, fallback, sourceResources };
+    } catch (error) {
+      abandon(sources.configured);
+      return {
+        configured: fallback,
+        configuredId: configuredEngineId,
+        configuredFailure: error instanceof Error ? error.message : String(error),
+        fallback,
+        sourceResources,
+      };
+    }
+  }, options?.onCleanupFailure);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where context-engine selection could change during an asynchronous startup, and managed registration resources could close while an engine still needed them. A logical turn spanning model candidates must retain its initial selection and database access through accepted work.

A shared engine instance could also be disposed twice, and failed-factory resource cleanup could leave one-shot cleanup incorrectly marked as complete.

## Why This Change Was Made

Resolution now captures the fallback and configured registrations, with claims on their actual registration sources, before its first await; adopted factories retain their donor source, and the logical-turn owner carries their custody. Factory and cleanup work have separate lifetimes: disposal starts before factory cancellation, cleanup remains available to accepted descendants, and source claims release after actual completion, including failed construction.

## User Impact

Turns retain a consistent engine selection through startup and cleanup. Shared instances dispose once, class instances retain their private receivers, and factory configuration and staged agent directory inputs remain unchanged.

The default 10-second cleanup reporting deadline remains intact. Work continuing after that report keeps its resources, while disposal failures mark the originating one-shot cleanup outcome uncertain without replacing the original factory error. Raw host behavior remains unchanged.

This prepares managed source ownership; whole supplying-view custody and new resolution after donor retirement remain separate prerequisites.

## Evidence

- **121 distinct tests passed**, covering selection stability, native SQLite lifetime, aliases, private receivers, parent cancellation, failed construction, invalid-instance cleanup, and raw-host controls. Original-source testing reproduced 13 failures with the raw control passing. Three additional defects found during review were independently reproduced and repaired.
- Complete changed-file checks passed, followed by focused type, lint, assertion, line-limit, formatting, and diff checks for the final ordering fix. Fresh **Codex review found no actionable P0–P2 issues**.
- The ordinary build passed in **291.1 seconds**.
- A **35.09-second compiled proof** used the emitted native full-registration API in a synthetic fixture, with actual inspection resources attached before registration. All 20 SQLite sources closed once; all 10 donor files reopened successfully. Held cleanup reported at the unchanged 10-second deadline while its donor remained usable. This fixture does not activate general managed loader or copied-view retirement behavior.

- CI caught a static type-import cycle between the registry and its resource helper. The helper now preserves its caller’s return type generically and no longer imports back from the registry. The repaired static graph, production and owning test types, lint, formatting, and fresh Codex review pass. Emitted JavaScript is identical, so the runtime and compiled proof above is unchanged.

- Full CI also exposed two shared runner test mocks missing the engine comparison export. Both fixtures now model identity for their plain engine objects. All 210 affected tests across ten files pass, with production code and existing assertions unchanged; focused checks and a fresh Codex review pass.
