### PR TITLE
fix: retain model catalog resources through projections

### DIFF
--- a/src/agents/prepared-model-catalog.resources.test.ts
+++ b/src/agents/prepared-model-catalog.resources.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
+import { expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { withPreparedModelCatalogOwner } from "./prepared-model-catalog.js";
+import { acquireReadOnlyPreparedModelRuntime } from "./prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+
+const selectedSource = vi.hoisted(() => ({
+  input: undefined as PreparedModelRuntimeInput | undefined,
+}));
+
+// Select an existing managed publication without enabling configured producer disposal.
+vi.mock("./prepared-model-runtime.js", async (importOriginal) => {
+  const runtime = await importOriginal<typeof import("./prepared-model-runtime.js")>();
+  return {
+    ...runtime,
+    prepareModelRuntimeSnapshot: (input: PreparedModelRuntimeInput) =>
+      runtime.prepareModelRuntimeSnapshot(selectedSource.input ?? input),
+    acquirePreparedModelRuntimeSnapshot: (input: PreparedModelRuntimeInput) =>
+      runtime.acquirePreparedModelRuntimeSnapshot(selectedSource.input ?? input),
+  };
+});
+
+it.each([
+  { outcome: "complete", releaseBeforeCallback: false },
+  { outcome: "reject", releaseBeforeCallback: false },
+  { outcome: "complete", releaseBeforeCallback: true },
+])(
+  "keeps SQLite through catalog projection ($outcome, releaseBeforeCallback=$releaseBeforeCallback)",
+  async ({ outcome, releaseBeforeCallback }) => {
+    await withOpenClawTestState({ label: "catalog-projection-resources" }, async (state) => {
+      const pluginId = "catalog-projection-provider";
+      const pluginRoot = state.path("plugin");
+      const emptyBundled = state.path("empty-bundled");
+      fs.mkdirSync(pluginRoot);
+      fs.mkdirSync(emptyBundled);
+      const fixture = createColdPluginFixture({
+        rootDir: pluginRoot,
+        pluginId,
+        providerId: pluginId,
+        manifest: { channels: [], channelConfigs: {}, providerAuthChoices: [] },
+      });
+      const key = `__catalog_projection_${path.basename(state.root)}`;
+      const connections: Array<{ file: string; database: DatabaseSync; disposals: number }> = [];
+      Object.defineProperty(globalThis, key, { configurable: true, value: connections });
+      fs.writeFileSync(
+        fixture.runtimeSource,
+        `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    const connections = globalThis[${JSON.stringify(key)}];
+    const file = ${JSON.stringify(state.root)} + "/registration-" + connections.length + ".sqlite";
+    const database = new DatabaseSync(file);
+    database.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+    const connection = { file, database, disposals: 0 };
+    connections.push(connection);
+    api.lifecycle.registerRuntimeLifecycle({ id: "database", dispose() {
+      connection.disposals++;
+      database.close();
+    } });
+    api.registerProvider({
+      id: ${JSON.stringify(pluginId)}, label: "Fixture provider", auth: [],
+      normalizeModelId: () => String(database.prepare("SELECT value FROM answer").get().value),
+    });
+  },
+};
+`,
+      );
+      const config: OpenClawConfig = {
+        agents: { defaults: { workspace: state.workspaceDir } },
+        plugins: {
+          load: { paths: [pluginRoot] },
+          slots: { memory: "none" },
+          entries: { [pluginId]: { enabled: true } },
+        },
+      };
+      const input: PreparedModelRuntimeInput = {
+        config,
+        agentId: "main",
+        agentDir: state.agentDir("main"),
+        workspaceDir: state.workspaceDir,
+        readOnly: true,
+        loadRuntimePlugins: true,
+        skipCredentials: true,
+        runtimePluginSelections: [{ provider: pluginId, modelId: "model", agentId: "main" }],
+      };
+      await withEnvAsync(
+        { OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundled, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+        async () => {
+          await resetPreparedModelRuntimeSnapshotsForTest();
+          clearPluginMetadataLifecycleCaches();
+          const entered = createDeferredCore();
+          const resume = createDeferredCore();
+          const failure = new Error("catalog projection failed");
+          let first: Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>> | undefined;
+          let replacement: typeof first;
+          let projection: Promise<string[]> | undefined;
+          try {
+            first = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            expect(connections).toHaveLength(1);
+            const original = expectDefined(connections[0], "original provider registration");
+            selectedSource.input = input;
+            projection = withPreparedModelCatalogOwner(input, async (snapshot) => {
+              const normalize = expectDefined(
+                snapshot.pluginRegistry?.providers.find(({ provider }) => provider.id === pluginId)
+                  ?.provider.normalizeModelId,
+                "registered catalog hook",
+              );
+              entered.resolve();
+              await resume.promise;
+              const row = normalize({ provider: pluginId, modelId: "model" });
+              if (outcome === "reject") {
+                throw failure;
+              }
+              return [String(row)];
+            });
+            const result = projection.then(
+              (rows) => ({ rows }),
+              (error: unknown) => ({ error }),
+            );
+            if (releaseBeforeCallback) {
+              first.release();
+            }
+            await Promise.race([
+              entered.promise,
+              projection.then(() => {
+                throw new Error("Projection did not enter the published owner");
+              }),
+            ]);
+            if (!releaseBeforeCallback) {
+              first.release();
+            }
+            replacement = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
+            expect(connections).toHaveLength(2);
+            const successor = expectDefined(connections[1], "replacement provider registration");
+            expect(original.database.isOpen).toBe(true);
+            resume.resolve();
+            expect(await result).toEqual(
+              outcome === "reject" ? { error: failure } : { rows: ["42"] },
+            );
+            await expect.poll(() => original.disposals).toBe(1);
+            expect(original.database.isOpen).toBe(false);
+            expect(successor.database.isOpen).toBe(true);
+            const reopened = new DatabaseSync(original.file, { readOnly: true });
+            try {
+              expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+            } finally {
+              reopened.close();
+            }
+            replacement.release();
+            await expect.poll(() => successor.disposals).toBe(1);
+          } finally {
+            resume.resolve();
+            await Promise.allSettled([projection]);
+            selectedSource.input = undefined;
+            first?.release();
+            replacement?.release();
+            await resetPreparedModelRuntimeSnapshotsForTest();
+            clearPluginMetadataLifecycleCaches();
+            resetPluginLoaderTestStateForTest();
+            cleanupPluginLoaderFixturesForTest();
+            for (const connection of connections) {
+              if (connection.database.isOpen) {
+                connection.database.close();
+              }
+            }
+            Reflect.deleteProperty(globalThis, key);
+          }
+        },
+      );
+    });
+  },
+);

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   refreshStaleCatalog: vi.fn(),
   isFullCatalog: vi.fn(),
   releaseSnapshot: vi.fn(),
+  releasePublishedSnapshot: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -54,6 +55,10 @@ vi.mock("./prepared-model-runtime.js", () => {
     preparedModelRuntimeConfigsMatch: (left: object, right: object) =>
       JSON.stringify(left) === JSON.stringify(right),
     prepareModelRuntimeSnapshot: (...args: unknown[]) => mocks.prepareSnapshot(...args),
+    acquirePreparedModelRuntimeSnapshot: async (...args: unknown[]) => ({
+      snapshot: await mocks.prepareSnapshot(...args),
+      release: mocks.releasePublishedSnapshot,
+    }),
     refreshPreparedModelRuntimeCatalog: (...args: unknown[]) => mocks.refreshStaleCatalog(...args),
   };
 });
@@ -113,6 +118,78 @@ describe("prepared model catalog access", () => {
     mocks.refreshStaleCatalog.mockReset();
     mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
+    mocks.releasePublishedSnapshot.mockReset();
+  });
+
+  it.each([
+    { readOnly: true, rejectProjection: false },
+    { readOnly: true, rejectProjection: true },
+    { readOnly: false, rejectProjection: false },
+    { readOnly: false, rejectProjection: true },
+  ])(
+    "retains a published owner through projection (readOnly=$readOnly, reject=$rejectProjection)",
+    async ({ readOnly, rejectProjection }) => {
+      const entered = createDeferred();
+      const resume = createDeferred();
+      const failure = new Error("projection failed");
+      mocks.prepareSnapshot.mockResolvedValue(fullSnapshot);
+      const result = withPreparedModelCatalogOwner({ readOnly }, async (snapshot) => {
+        entered.resolve();
+        await resume.promise;
+        expect(mocks.releasePublishedSnapshot).not.toHaveBeenCalled();
+        if (rejectProjection) {
+          throw failure;
+        }
+        return snapshot.modelCatalog.entries;
+      });
+      const outcome = rejectProjection
+        ? expect(result).rejects.toBe(failure)
+        : expect(result).resolves.toBe(fullSnapshot.modelCatalog.entries);
+      await entered.promise;
+      expect(mocks.releasePublishedSnapshot).not.toHaveBeenCalled();
+      resume.resolve();
+      await outcome;
+      expect(mocks.releasePublishedSnapshot).toHaveBeenCalledOnce();
+      expect(mocks.activateSnapshot).not.toHaveBeenCalled();
+      expect(mocks.loadSnapshot).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains a published owner while an explicitly requested catalog refresh fails", async () => {
+    const entered = createDeferred();
+    const resume = createDeferred();
+    const failure = new Error("catalog refresh failed");
+    const snapshot = { ...fullSnapshot, loadFullModelCatalog: vi.fn() };
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+    mocks.refreshStaleCatalog.mockImplementation(async () => {
+      entered.resolve();
+      await resume.promise;
+      expect(mocks.releasePublishedSnapshot).not.toHaveBeenCalled();
+      throw failure;
+    });
+    const project = vi.fn();
+    const result = withPreparedModelCatalogOwner({ refreshFullCatalog: true }, project);
+    const outcome = expect(result).rejects.toBe(failure);
+    await entered.promise;
+    expect(mocks.releasePublishedSnapshot).not.toHaveBeenCalled();
+    resume.resolve();
+    await outcome;
+    expect(project).not.toHaveBeenCalled();
+    expect(mocks.releasePublishedSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("releases a published claim rejected by the exact config policy", async () => {
+    mocks.prepareSnapshot.mockResolvedValue({
+      ...fullSnapshot,
+      config: { agents: { defaults: { model: "openai/old" } } },
+    });
+    const project = vi.fn();
+    await expect(withPreparedModelCatalogOwner({}, project)).rejects.toBeInstanceOf(
+      PreparedModelCatalogConfigReplacedError,
+    );
+    expect(project).not.toHaveBeenCalled();
+    expect(mocks.releasePublishedSnapshot).toHaveBeenCalledOnce();
+    expect(mocks.activateSnapshot).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -25,6 +25,7 @@ import {
 import { isPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  acquirePreparedModelRuntimeSnapshot,
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -63,6 +64,16 @@ export type GetPublishedPreparedModelCatalogOwnerParams = Omit<
 >;
 
 type PreparedModelCatalogConfigPolicy = "exact" | "published";
+type PreparedModelCatalogOwner = {
+  snapshot: PreparedModelRuntimeSnapshot;
+  release?: () => void;
+};
+
+async function preparePublishedCatalogOwner(
+  input: PreparedModelRuntimeInput,
+): Promise<PreparedModelCatalogOwner> {
+  return { snapshot: await prepareModelRuntimeSnapshot(input) };
+}
 
 async function materializeRequestedModelCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
@@ -234,15 +245,17 @@ export function getPreparedModelCatalogSnapshot(
 async function resolveReadOnlyPublishedModelCatalogOwner(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
-): Promise<PreparedModelRuntimeSnapshot | undefined> {
+  preparePublishedOwner = preparePublishedCatalogOwner,
+): Promise<PreparedModelCatalogOwner | undefined> {
   const { activationFull, full } = resolveInputs(params);
   const fullCandidates =
     activationFull.workspaceDir === full.workspaceDir ? [full] : [full, activationFull];
   for (const candidate of fullCandidates) {
     try {
       // Full lifecycle owners include provider augmentation omitted by read-only fallback builds.
-      const prepared = await prepareModelRuntimeSnapshot(candidate);
-      if (!acceptsPreparedSnapshotConfig(prepared, candidate, configPolicy)) {
+      const prepared = await preparePublishedOwner(candidate);
+      if (!acceptsPreparedSnapshotConfig(prepared.snapshot, candidate, configPolicy)) {
+        prepared.release?.();
         throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
       }
       return prepared;
@@ -258,12 +271,17 @@ async function resolveReadOnlyPublishedModelCatalogOwner(
 async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
-): Promise<{ snapshot: PreparedModelRuntimeSnapshot; release?: () => void }> {
+  preparePublishedOwner = preparePublishedCatalogOwner,
+): Promise<PreparedModelCatalogOwner> {
   const { activationExact, activationFull, exact } = resolveInputs(params);
   if (params.readOnly) {
-    const prepared = await resolveReadOnlyPublishedModelCatalogOwner(params, configPolicy);
+    const prepared = await resolveReadOnlyPublishedModelCatalogOwner(
+      params,
+      configPolicy,
+      preparePublishedOwner,
+    );
     if (prepared) {
-      return { snapshot: prepared };
+      return prepared;
     }
     const lease = await acquireReadOnlyPreparedModelRuntime(activationExact);
     if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationExact, configPolicy)) {
@@ -273,10 +291,11 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
     return lease;
   }
   try {
-    const preparedExact = await prepareModelRuntimeSnapshot(exact);
-    if (acceptsPreparedSnapshotConfig(preparedExact, exact, configPolicy)) {
-      return { snapshot: preparedExact };
+    const preparedExact = await preparePublishedOwner(exact);
+    if (acceptsPreparedSnapshotConfig(preparedExact.snapshot, exact, configPolicy)) {
+      return preparedExact;
     }
+    preparedExact.release?.();
   } catch (error) {
     if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
       throw error;
@@ -311,6 +330,7 @@ async function withPreparedModelCatalogOwnerPolicy<T>(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
   read: (snapshot: PreparedModelRuntimeSnapshot) => T | Promise<T>,
+  preparePublishedOwner = preparePublishedCatalogOwner,
 ): Promise<T> {
   // Ordinary reads stay passive; explicit refresh keeps its existing writable default.
   const request = {
@@ -323,6 +343,7 @@ async function withPreparedModelCatalogOwnerPolicy<T>(
   const { snapshot, release } = await resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
     request,
     configPolicy,
+    preparePublishedOwner,
   );
   try {
     // Only published owners expose generation caches; temporary reads use their prepared facts.
@@ -334,7 +355,7 @@ async function withPreparedModelCatalogOwnerPolicy<T>(
             request.readOnly,
             request.refreshFullCatalog,
           );
-    // Projection must finish before a temporary lease retires its liveness predicate.
+    // Projection must finish before releasing the selected generation's resources.
     return await read(owner);
   } finally {
     release?.();
@@ -385,7 +406,7 @@ export async function loadProviderScopedThinkingCatalog(params: {
 }): Promise<ModelCatalogEntry[]> {
   const request = { ...params, readOnly: true };
   const publishedOwner = getPreparedModelCatalogOwnerSnapshot(request);
-  const owner = await resolveReadOnlyPublishedModelCatalogOwner(request, "exact");
+  const owner = (await resolveReadOnlyPublishedModelCatalogOwner(request, "exact"))?.snapshot;
   const catalog = owner
     ? (publishedOwner ? await materializeRequestedModelCatalog(owner, true, undefined) : owner)
         .modelCatalog
@@ -417,12 +438,17 @@ export async function loadProviderScopedThinkingCatalog(params: {
   return entries;
 }
 
-/** Keeps the exact catalog owner alive through an asynchronous read. */
+/** Retains published or temporary catalog resources through an asynchronous read. */
 export async function withPreparedModelCatalogOwner<T>(
   params: LoadPreparedModelCatalogParams,
   read: (snapshot: PreparedModelRuntimeSnapshot) => T | Promise<T>,
 ): Promise<T> {
-  return await withPreparedModelCatalogOwnerPolicy(params, "exact", read);
+  return await withPreparedModelCatalogOwnerPolicy(
+    params,
+    "exact",
+    read,
+    acquirePreparedModelRuntimeSnapshot,
+  );
 }
 
 /** Resolves the lifecycle owner for an exact caller-supplied config. */

--- a/src/agents/prepared-model-runtime.published-owner.ts
+++ b/src/agents/prepared-model-runtime.published-owner.ts
@@ -4,12 +4,26 @@ import {
   preparedModelRuntimeConfigsMatch,
   resolvePublishedOwner,
 } from "./prepared-model-runtime.owner.js";
+import { retainPreparedModelRuntimeGenerationResources } from "./prepared-model-runtime.resources.js";
 import type {
   PreparedModelRuntimeInput,
+  PreparedModelRuntimeLease,
   PreparedModelRuntimeOwner,
   PreparedModelRuntimeReplacement,
   PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.types.js";
+
+export function retainPublishedModelRuntimeOwner(
+  owner: PreparedModelRuntimeOwner,
+  snapshot: PreparedModelRuntimeSnapshot,
+): PreparedModelRuntimeLease {
+  const pluginGeneration = owner.pluginGeneration;
+  if (!pluginGeneration) {
+    throw new Error("Published model runtime has no plugin generation");
+  }
+  const claim = retainPreparedModelRuntimeGenerationResources(pluginGeneration);
+  return { snapshot, pluginGeneration, release: () => claim?.release() };
+}
 
 type PublishedModelRuntimeContext = {
   captureLifetime(): () => void;

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -50,17 +50,17 @@ import {
   notifyPreparedModelRuntimePublication,
   resetPreparedModelRuntimePublicationListenersForTest,
 } from "./prepared-model-runtime.publication-events.js";
-import { projectPublishedModelRuntimeOwner } from "./prepared-model-runtime.published-owner.js";
+import {
+  projectPublishedModelRuntimeOwner,
+  retainPublishedModelRuntimeOwner,
+} from "./prepared-model-runtime.published-owner.js";
 import {
   isPreparedModelRuntimeOwnerInRefreshScope,
   listConfiguredRefreshInputs,
   resolveSafeRefreshAgentIds,
   updateOwnersForScopedRefresh,
 } from "./prepared-model-runtime.refresh-scope.js";
-import {
-  closeEphemeralPreparedModelRuntimeResources,
-  retainPreparedModelRuntimeGenerationResources,
-} from "./prepared-model-runtime.resources.js";
+import { closeEphemeralPreparedModelRuntimeResources } from "./prepared-model-runtime.resources.js";
 import { PreparedModelRuntimeOwnerRetention } from "./prepared-model-runtime.retention.js";
 import type {
   PreparedModelRuntimeCatalogMode,
@@ -175,14 +175,18 @@ export async function loadPreparedModelRuntimeSnapshot(
 export async function acquirePublishedPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeLease> {
-  return await loadPreparedModelRuntimeOwner(rawInput, (owner, snapshot) => {
-    const pluginGeneration = owner.pluginGeneration;
-    if (!pluginGeneration) {
-      throw new Error("Published model runtime has no plugin generation");
-    }
-    const claim = retainPreparedModelRuntimeGenerationResources(pluginGeneration);
-    return { snapshot, pluginGeneration, release: () => claim?.release() };
-  });
+  return await loadPreparedModelRuntimeOwner(rawInput, retainPublishedModelRuntimeOwner);
+}
+
+/** Retains the selected publication without activating an unpublished owner. */
+export async function acquirePreparedModelRuntimeSnapshot(
+  rawInput: PreparedModelRuntimeInput,
+): Promise<PreparedModelRuntimeLease> {
+  return await projectPublishedModelRuntimeOwner(
+    rawInput,
+    preparedModelRuntimeLeaseContext,
+    retainPublishedModelRuntimeOwner,
+  );
 }
 
 async function loadPreparedModelRuntimeOwner<T>(


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Resolves a resource-lifetime gap in finite catalog projections used by local CLI and TUI model lists. Synthetic SQLite tests demonstrate a managed publication’s connection closing while its asynchronous projection is still held.

This is preparation for broader managed-runtime ownership. It does not enable general physical disposal of configured registrations.

## Why This Change Was Made

Finite reads acquire the exact existing publication before its snapshot crosses an await. They retain resources through materialization and the awaited callback, releasing them on success, failure, or config rejection. Acquisition reuses existing generation-retention logic shared with BTW.

Passive lookup, exact config matching, explicit refresh intent, fallback selection, and stale-result rejection remain unchanged. Bare snapshot aliases keep their existing contract; fresh standalone activation and pending-publication handoff remain separate work.

## User Impact

Finite projections can safely consume managed publications. The actual model-list projector still rejects replaced publications, and ordinary reads retain their passive discovery and activation policy.

## Evidence

- Three native SQLite regressions fail originally for early closure and pass with the fix, including release before the callback’s first microtask. Final release closes once and persisted data reopens successfully.
- 90 focused and sibling tests pass, covering catalog policy, BTW cleanup, CLI projection, and model-list freshness fences. All required changed-file checks pass; independent Codex review found no actionable issues.
- Normal build passes in 261.29 seconds. It reports a nonfatal UI startup gzip warning of 42 bytes over budget; no UI or guard changes are included.
- Two compiled probes pass: managed passive acquisition with SQLite replacement, and the actual finite model-list flow with stale-result rejection. All 11,833 sealed artifacts remain unchanged. Combined managed-source callback coverage uses the maintained native input adapter; the compiled model-list flow uses normal standalone publication.
- Observed passive acquisition: 0.148 ms; warm model-list projections: 1.84/1.35 ms. These are individual timings, not a statistical speedup claim.
