### PR TITLE
fix: retain prepared speech overrides until host cleanup

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -68,7 +68,7 @@ These operations retain managed registrations and preserve raw host ownership.
 Configured fallback catalogs stay separate from direct preference and override
 lookups. Returned audio buffers outlive registration disposal; standard TTS
 transcodes and saves those completed buffers after releasing the provider. The
-separate synchronous speech lookup and request-preparation APIs keep their
+separate synchronous speech lookup and directive-parsing APIs keep their
 existing caller lifetime; streaming speech is not part of this finite operation.
 
 Streaming speech owns its provider registrations until stream cleanup finishes.
@@ -79,6 +79,15 @@ EOF or a read error releases registrations automatically. Stream cancellation
 and explicit release start source cancellation and provider cleanup before
 joining both, including tracked producer work. Release also handles an unopened
 stream. Existing raw host registrations keep their host lifetime.
+
+`api.runtime.tts.prepareTtsRequest(...)` can return opaque provider overrides for
+later synthesis. Preparation retains borrowed managed registrations
+until the SDK host closes, even if the original inspection is released first.
+Repeated preparation from the same source shares the host claim. Raw loader and
+Gateway registrations keep their existing lifetime and cache reuse; preparation
+does not create a fresh registration for each utterance. The host joins tracked
+preparation work before releasing its claims, including work started by a failed
+projection.
 
 For `image_generate`, `music_generate`, and `video_generate` tools prepared from an owned inspection,
 resources remain held through preflight and, once accepted, through generation, media saving, and

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -466,9 +466,11 @@ function prepareCapabilityProviderLoad<K extends CapabilityProviderRegistryKey>(
 
 function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
   params: Parameters<typeof prepareCapabilityProviderLoad<K>>[0],
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
 ): PluginRegistry[K] {
-  const load = prepareCapabilityProviderLoad(params);
+  const load = prepareCapabilityProviderLoad(params, onSelectedRegistry);
   const registry = load.loadedRegistry ?? resolveRuntimePluginRegistry(load.resolveLoadOptions());
+  onSelectedRegistry?.(registry);
   const { entries, pluginIds } = load.fallback(registry);
   if (pluginIds.length === 0) {
     return entries;
@@ -482,13 +484,14 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
   return entries.length > 0 ? mergeCapabilityProviderEntries(entries, captured) : captured;
 }
 
-export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegistryKey>(params: {
-  key: K;
-  providerId: string;
-  cfg?: OpenClawConfig;
-}): CapabilityProviderFor<K> | undefined {
-  const resolution = preparePluginCapabilityProviderLookup(params);
-  return resolution.resolve(resolution.load ? loadCapabilityProviderEntries(resolution.load) : []);
+export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegistryKey>(
+  params: { key: K; providerId: string; cfg?: OpenClawConfig },
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
+): CapabilityProviderFor<K> | undefined {
+  const resolution = preparePluginCapabilityProviderLookup(params, onSelectedRegistry);
+  return resolution.resolve(
+    resolution.load ? loadCapabilityProviderEntries(resolution.load, onSelectedRegistry) : [],
+  );
 }
 
 export function preparePluginCapabilityProviderLookup<K extends CapabilityProviderRegistryKey>(
@@ -664,13 +667,14 @@ export function preparePluginCapabilityProviderResolution<K extends CapabilityPr
   };
 }
 
-export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
-  key: K;
-  cfg?: OpenClawConfig;
-  additionalProviderIds?: readonly string[];
-}): CapabilityProviderFor<K>[] {
-  const resolution = preparePluginCapabilityProviderResolution(params);
-  return resolution.resolve(resolution.load ? loadCapabilityProviderEntries(resolution.load) : []);
+export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(
+  params: { key: K; cfg?: OpenClawConfig; additionalProviderIds?: readonly string[] },
+  onSelectedRegistry?: (registry: PluginRegistry | undefined) => void,
+): CapabilityProviderFor<K>[] {
+  const resolution = preparePluginCapabilityProviderResolution(params, onSelectedRegistry);
+  return resolution.resolve(
+    resolution.load ? loadCapabilityProviderEntries(resolution.load, onSelectedRegistry) : [],
+  );
 }
 
 export function prepareMediaCapabilityProviders(params: {

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -10,9 +10,7 @@ import type { PluginRuntimeTaskFlows, PluginRuntimeTaskRuns } from "./runtime-ta
 
 type TtsRuntimeApi = typeof import("../../tts/runtime-api.js");
 type ListSpeechVoices = TtsRuntimeApi["listSpeechVoices"];
-type PrepareTtsRequest = (
-  ...args: Parameters<TtsRuntimeApi["prepareTtsRequest"]>
-) => Promise<ReturnType<TtsRuntimeApi["prepareTtsRequest"]>>;
+type PrepareTtsRequest = TtsRuntimeApi["prepareTtsRequest"];
 type TextToSpeech = typeof import("../../tts/tts.js").textToSpeech;
 type TextToSpeechStream = TtsRuntimeApi["textToSpeechStream"];
 type TextToSpeechTelephony = TtsRuntimeApi["textToSpeechTelephony"];

--- a/src/tts/tts-request.preparation-resources.test.ts
+++ b/src/tts/tts-request.preparation-resources.test.ts
@@ -1,0 +1,397 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+
+function createPreparationFixture() {
+  const dir = makePluginLoaderTempDir();
+  const id = "native-speech-preparation";
+  const key = `__openclaw_speech_preparation_${path.basename(dir)}`;
+  const connections: Array<{
+    database: DatabaseSync;
+    disposals: number;
+    cleanups: number;
+    opaque: { voiceId: string };
+  }> = [];
+  const callbacks: {
+    onMetadata?: () => void;
+    onProjection?: () => void;
+    onDispose?: () => Promise<void>;
+    trackTail?: boolean;
+  } = {};
+  const tailResume = createDeferredCore();
+  const tails: Promise<void>[] = [];
+  const consumedVoices: string[] = [];
+  const state = { connections, callbacks, tailResume, tails, consumedVoices, trackAsyncWork, dir };
+  Object.defineProperty(globalThis, key, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const database = new DatabaseSync(require("node:path").join(state.dir, "preparation-" + state.connections.length + ".sqlite"));
+  database.exec("CREATE TABLE fixture(value INTEGER); INSERT INTO fixture VALUES(42)");
+  const read = () => database.prepare("SELECT value FROM fixture").get().value;
+  const connection = { database, disposals: 0, cleanups: 0,
+    opaque: { get voiceId() { return "voice-" + read(); } } };
+  state.connections.push(connection);
+  api.lifecycle.registerRuntimeLifecycle({ id: "speech-preparation-resource",
+    async dispose() { await state.callbacks.onDispose?.(); read(); connection.disposals++; database.close(); },
+    cleanup() { read(); connection.cleanups++; database.close(); }
+  });
+  api.registerSpeechProvider({
+    get id() { state.callbacks.onMetadata?.(); read(); return ${JSON.stringify(id)}; },
+    aliases: [${JSON.stringify(`${id}-alias`)}], label: "Native speech preparation",
+    resolveConfig() { read(); return {}; },
+    isConfigured() { read(); return true; },
+    parseDirectiveToken({ key }) {
+      if (key !== "voice") return { handled: false };
+      read();
+      if (state.callbacks.trackTail) {
+        state.tails.push(state.trackAsyncWork(async () => { await state.tailResume.promise; read(); }));
+      }
+      return { handled: true, get overrides() {
+        state.callbacks.onProjection?.(); read(); return { voiceSettings: connection.opaque };
+      } };
+    },
+    async synthesize() { throw new Error("Buffered fixture synthesis is unused"); },
+    async synthesizeTelephony(request) {
+      read(); state.consumedVoices.push(request.providerOverrides.voiceSettings.voiceId);
+      return { audioBuffer: Buffer.from([42, 0]), sampleRate: 8000, outputFormat: "pcm" };
+    }
+  });
+} };`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({ id, contracts: { speechProviders: [id] }, configSchema: { type: "object" } }),
+  );
+  const cfg: OpenClawConfig = {
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+    tts: { provider: id, providers: { [id]: {} }, modelOverrides: { allowProvider: true } },
+  };
+  const host = new LegacyPluginSdkResourceHost();
+  const runtime = createPluginRuntime();
+  const text = `Hello [[tts:provider=${id}-alias voice=fixture]]`;
+  return {
+    cfg,
+    id,
+    host,
+    runtime,
+    state,
+    prepare: () => runtime.tts.prepareTtsRequest({ cfg, text }),
+    withEnvironment: (run: () => Promise<void>) =>
+      withEnvAsync(
+        {
+          OPENCLAW_HOME: dir,
+          OPENCLAW_STATE_DIR: dir,
+          OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+          OPENCLAW_TTS_PREFS: path.join(dir, "prefs.json"),
+        },
+        () => host.run(run),
+      ),
+    async cleanup() {
+      tailResume.resolve();
+      await Promise.allSettled(tails);
+      await host.close();
+      for (const { database } of connections) {
+        if (database.isOpen) {
+          database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("async speech preparation resources", () => {
+  it("reuses registrations and preserves opaque overrides for synthesis after inspection retirement", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        try {
+          const prepared = await withPluginRuntimeRegistryScope(inspection.registry, async () => {
+            const first = await fixture.prepare();
+            for (let index = 0; index < 3; index++) {
+              const next = await fixture.prepare();
+              expect(
+                next.directives.overrides.providerOverrides?.[fixture.id]?.voiceSettings ===
+                  first.directives.overrides.providerOverrides?.[fixture.id]?.voiceSettings,
+              ).toBe(true);
+            }
+            return first;
+          });
+          expect(fixture.state.connections.length).toBe(1);
+          await inspection.release();
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+          expect(
+            prepared.directives.overrides.providerOverrides?.[fixture.id]?.voiceSettings ===
+              fixture.state.connections[0]?.opaque,
+          ).toBe(true);
+          const result = await fixture.runtime.tts.textToSpeechTelephony({
+            cfg: prepared.cfg,
+            text: prepared.directives.cleanedText,
+            overrides: prepared.directives.overrides,
+          });
+          expect(result.success).toBe(true);
+          expect(fixture.state.consumedVoices).toEqual(["voice-42"]);
+          await fixture.host.close();
+          expect(fixture.state.connections.every((entry) => !entry.database.isOpen)).toBe(true);
+          expect(fixture.state.connections.every((entry) => entry.disposals === 1)).toBe(true);
+        } finally {
+          await inspection.release();
+        }
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("retains the selected source before provider metadata can retire its inspection", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        let retirement: Promise<void> | undefined;
+        fixture.state.callbacks.onMetadata = () => {
+          retirement ??= inspection.release();
+        };
+        try {
+          const prepared = await withPluginRuntimeRegistryScope(
+            inspection.registry,
+            fixture.prepare,
+          );
+          await retirement;
+          expect(prepared.directives.hasDirective).toBe(true);
+          expect(fixture.state.connections[0]?.opaque.voiceId).toBe("voice-42");
+          await fixture.host.close();
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        } finally {
+          await inspection.release();
+        }
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("owns failed projection cleanup until asynchronous disposal finishes", async () => {
+    const fixture = createPreparationFixture();
+    const disposeResume = createDeferredCore();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        let retirement: Promise<void> | undefined;
+        fixture.state.callbacks.onDispose = () => disposeResume.promise;
+        fixture.state.callbacks.onProjection = () => {
+          retirement ??= inspection.release();
+          throw new Error("speech directive projection failed");
+        };
+        try {
+          await expect(
+            withPluginRuntimeRegistryScope(inspection.registry, fixture.prepare),
+          ).rejects.toThrow("speech directive projection failed");
+          let closed = false;
+          const closing = fixture.host.close().then(() => {
+            closed = true;
+          });
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(closed).toBe(false);
+          disposeResume.resolve();
+          await closing;
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        } finally {
+          disposeResume.resolve();
+          await retirement;
+          await inspection.release();
+        }
+      });
+    } finally {
+      disposeResume.resolve();
+      await fixture.cleanup();
+    }
+  });
+
+  it("keeps failed projection resources alive through its tracked directive tail", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        let retirement: Promise<void> | undefined;
+        fixture.state.callbacks.trackTail = true;
+        fixture.state.callbacks.onProjection = () => {
+          retirement ??= inspection.release();
+          throw new Error("speech directive projection failed");
+        };
+        try {
+          await expect(
+            withPluginRuntimeRegistryScope(inspection.registry, fixture.prepare).then(
+              () => undefined,
+            ),
+          ).rejects.toThrow("speech directive projection failed");
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+          let closed = false;
+          const closing = fixture.host.close().then(() => {
+            closed = true;
+          });
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(closed).toBe(false);
+          fixture.state.tailResume.resolve();
+          await Promise.all(fixture.state.tails);
+          await closing;
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        } finally {
+          fixture.state.tailResume.resolve();
+          await Promise.allSettled(fixture.state.tails);
+          await retirement;
+          await inspection.release();
+        }
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("rejects projection when its SDK host closes during preparation", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        let closing: Promise<void> | undefined;
+        fixture.state.callbacks.onProjection = () => {
+          closing ??= fixture.host.close();
+        };
+        try {
+          await expect(
+            withPluginRuntimeRegistryScope(inspection.registry, fixture.prepare),
+          ).rejects.toThrow("Plugin SDK resource host is closed");
+          await closing;
+          await inspection.release();
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        } finally {
+          await inspection.release();
+        }
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("joins tracked directive work before closing borrowed SQLite resources", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        const inspection = await acquirePluginRegistryForInspection({ config: fixture.cfg });
+        fixture.state.callbacks.trackTail = true;
+        try {
+          await withPluginRuntimeRegistryScope(inspection.registry, fixture.prepare);
+          expect(fixture.state.tails.length).toBe(1);
+          await inspection.release();
+          let closed = false;
+          const closing = fixture.host.close().then(() => {
+            closed = true;
+          });
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(closed).toBe(false);
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+          fixture.state.tailResume.resolve();
+          await Promise.all(fixture.state.tails);
+          await closing;
+          expect(fixture.state.connections[0]?.disposals).toBe(1);
+        } finally {
+          fixture.state.tailResume.resolve();
+          await Promise.allSettled(fixture.state.tails);
+          await inspection.release();
+        }
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it.each(["active", "cold"] as const)(
+    "preserves %s raw registration lifetime and cache reuse",
+    async (mode) => {
+      const fixture = createPreparationFixture();
+      try {
+        await fixture.withEnvironment(async () => {
+          useNoBundledPlugins();
+          const registry =
+            mode === "active" ? loadPluginRegistryHandle({ config: fixture.cfg }) : undefined;
+          for (let index = 0; index < 4; index++) {
+            const result = await withPluginRuntimeRegistryScope(registry, fixture.prepare);
+            expect(result.directives.hasDirective).toBe(true);
+          }
+          expect(fixture.state.connections.length).toBe(1);
+          await fixture.host.close();
+          expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+          expect(fixture.state.connections[0]?.disposals).toBe(0);
+          if (registry) {
+            const lifecycle = registry.runtimeLifecycles.find(
+              (entry) => entry.lifecycle.id === "speech-preparation-resource",
+            );
+            await lifecycle?.lifecycle.cleanup?.({ reason: "restart" });
+            expect(fixture.state.connections[0]?.cleanups).toBe(1);
+          }
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it("rejects new preparation after the SDK host closes", async () => {
+    const fixture = createPreparationFixture();
+    try {
+      await fixture.withEnvironment(async () => {
+        useNoBundledPlugins();
+        await fixture.host.close();
+        await expect(fixture.prepare().then(() => undefined)).rejects.toThrow(
+          "Plugin SDK resource host is closed",
+        );
+        expect(fixture.state.connections.length).toBe(0);
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});

--- a/src/tts/tts-request.ts
+++ b/src/tts/tts-request.ts
@@ -1,6 +1,14 @@
 import type { OpenClawConfig, TtsConfig } from "../config/types.js";
 import { mergeDeep } from "../infra/deep-merge.js";
+import {
+  resolvePluginCapabilityProvider,
+  resolvePluginCapabilityProviders,
+} from "../plugins/capability-provider-runtime.js";
+import { getLegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import { getPluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
 import { parseTtsDirectives } from "./directives.js";
+import { createSpeechProviderRegistry } from "./provider-registry-core.js";
 import { canonicalizeSpeechProviderId, getSpeechProvider } from "./provider-registry.js";
 import type {
   SpeechProviderOverrides,
@@ -16,24 +24,49 @@ type PreparedTtsRequest = {
 };
 
 /** Merge a surface TTS override and resolve its inline synthesis directives. */
-export function prepareTtsRequest(params: {
+export async function prepareTtsRequest(params: {
   cfg: OpenClawConfig;
   override?: TtsConfig;
   text: string;
-}): PreparedTtsRequest {
-  const cfg = params.override
-    ? {
-        ...params.cfg,
-        tts: mergeDeep(params.cfg.tts ?? {}, params.override) as TtsConfig,
+}): Promise<PreparedTtsRequest> {
+  const host = getLegacyPluginSdkResourceHost();
+  return await host.track(() => {
+    const retained = new Set<
+      NonNullable<ReturnType<typeof getPluginRegistryInspectionResources>>
+    >();
+    const retain = (registry: PluginRegistry | undefined) => {
+      host.assertOpen();
+      const source = registry && getPluginRegistryInspectionResources(registry);
+      if (source && !retained.has(source)) {
+        // Failed projections can also leave tracked work using this registration.
+        host.adopt(source, source.retain());
+        retained.add(source);
       }
-    : params.cfg;
-  const config = resolveTtsConfig(cfg);
-  const directives = parseTtsDirectives(params.text, config.modelOverrides, {
-    cfg,
-    providerConfigs: config.providerConfigs,
-    preferredProviderId: resolveTtsProvider(config, resolveTtsPrefsPath(config)),
+    };
+    const registry = createSpeechProviderRegistry({
+      getProvider: (providerId, cfg) =>
+        resolvePluginCapabilityProvider({ key: "speechProviders", providerId, cfg }, retain),
+      listProviders: (cfg) =>
+        resolvePluginCapabilityProviders({ key: "speechProviders", cfg }, retain),
+    });
+    const cfg = params.override
+      ? {
+          ...params.cfg,
+          tts: mergeDeep(params.cfg.tts ?? {}, params.override) as TtsConfig,
+        }
+      : params.cfg;
+    const config = resolveTtsConfig(cfg);
+    const directives = parseTtsDirectives(params.text, config.modelOverrides, {
+      cfg,
+      get providers() {
+        return registry.listSpeechProviders(cfg);
+      },
+      providerConfigs: config.providerConfigs,
+      preferredProviderId: resolveTtsProvider(config, resolveTtsPrefsPath(config), registry),
+    });
+    host.assertOpen();
+    return { cfg, directives };
   });
-  return { cfg, directives };
 }
 
 export function resolveExplicitTtsOverrides(params: {

--- a/src/tts/tts-runtime-routing.test.ts
+++ b/src/tts/tts-runtime-routing.test.ts
@@ -93,7 +93,7 @@ describe("TTS runtime native voice-note routing", () => {
     expect(hint).not.toContain("[[tts:");
   });
 
-  it("prepares deep-merged surface config and directive inputs", () => {
+  it("prepares deep-merged surface config and directive inputs", async () => {
     const cfg: OpenClawConfig = {
       tts: {
         provider: "mock",
@@ -107,7 +107,7 @@ describe("TTS runtime native voice-note routing", () => {
       },
     };
 
-    const prepared = prepareTtsRequest({
+    const prepared = await prepareTtsRequest({
       cfg,
       override: {
         modelOverrides: { allowProvider: true },
@@ -143,8 +143,8 @@ describe("TTS runtime native voice-note routing", () => {
     });
   });
 
-  it("sanitizes blocked override keys while preparing TTS config", () => {
-    const prepared = prepareTtsRequest({
+  it("sanitizes blocked override keys while preparing TTS config", async () => {
+    const prepared = await prepareTtsRequest({
       cfg: {
         tts: {
           provider: "mock",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugins preparing speech through `api.runtime.tts.prepareTtsRequest(...)` could receive overrides that stopped working after the original plugin inspection was released. VoiceCall and Discord prepare requests separately from synthesis, so an override can still be needed after preparation returns. A preparation that failed while projecting directive metadata could also leave background work accessing SQLite after its registration resources had closed.

## Why This Change Was Made

The public async preparation facade now retains selected managed registration sources in the existing SDK resource host before provider callbacks run, preserving opaque override objects and allowing host shutdown to join tracked work before disposal, including work started by failed projections. Claims use existing per-source deduplication and preserve canonical raw loading, cache reuse, and the public Promise signature without creating a fresh registration per utterance.

## User Impact

Plugins can use prepared overrides in subsequent synthesis after releasing the originating inspection. Provider-owned nested values retain their identity and stay usable for the SDK host's lifetime. Repeated preparation reuses its registration source rather than accumulating registrations for each utterance.

Failed preparations may also retain a selected managed source until the SDK host closes. Raw registrations retain their existing caller or process lifetime, and public synchronous directive and lookup helpers remain unchanged.

Accounting for registrations copied from a managed donor remains a separate prerequisite; this PR does not claim to repair donor provenance.

## Evidence

- Original production bytes reproduced six ownership failures while two raw lifetime/cache controls passed. A combined projection-failure and pending-work regression also reproduced premature SQLite closure before the final repair.
- **264 unique tests passed**, including native preparation, buffered/Talk/Telephony resource tests, provider selection, SDK ownership, directives, and VoiceCall consumers. Required changed-file checks and affected follow-up checks passed.
- Fresh full-candidate **Codex review** reported no actionable P0–P2 findings. `pnpm build` passed in **304.75 seconds**; its non-fatal UI gzip report was seven bytes over budget, with no UI or budget changes.
- **Four compiled public-API probes passed:** 19 preparation attempts and three Telephony calls, three real PCM/WAV roundtrips, and six SQLite stores closed and reopened. All processes exited; 11,392 artifact hashes remained unchanged, with **no TypeScript source fallback**.
