### PR TITLE
improve(gateway): defer worker workspace execution imports

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -36,7 +36,7 @@ import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   finalizeWorkspaceResultConflicts,
   settleStagedWorkspaceResult,
-} from "./workspace-result-finalize.js";
+} from "./workspace-result-settlement.js";
 import {
   applyStagedWorkerWorkspaceResult,
   cleanupWorkerWorkspaceResultRef,

--- a/src/gateway/worker-environments/placement-reclaim.ts
+++ b/src/gateway/worker-environments/placement-reclaim.ts
@@ -33,7 +33,7 @@ import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   finalizeWorkspaceResultConflicts,
   settleStagedWorkspaceResult,
-} from "./workspace-result-finalize.js";
+} from "./workspace-result-settlement.js";
 import {
   hasWorkerWorkspaceResultRef,
   preparedWorkerWorkspaceResultRef,

--- a/src/gateway/worker-environments/repository-workspace-mutation.ts
+++ b/src/gateway/worker-environments/repository-workspace-mutation.ts
@@ -14,7 +14,7 @@ import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-
 import {
   createWorkspaceResultJournal,
   settleStagedWorkspaceResult,
-} from "./workspace-result-finalize.js";
+} from "./workspace-result-settlement.js";
 import { workerWorkspaceResultRef } from "./workspace-result-staging.js";
 
 export function createRepositoryWorkspaceMutationService(options: {

--- a/src/gateway/worker-environments/worker-turn-failure.ts
+++ b/src/gateway/worker-environments/worker-turn-failure.ts
@@ -27,6 +27,10 @@ export type ActiveWorkerPlacement = Extract<WorkerSessionPlacementRecord, { stat
 
 export class WorkerTurnExecutionError extends Error {}
 
+export class WorkerWorkspaceReconciliationError extends Error {
+  override name = "WorkerWorkspaceReconciliationError";
+}
+
 // Journal-terminal launches get a short cleanup grace before failure is surfaced.
 // This never limits a live launch or a turn still holding its claim.
 const TERMINAL_WORKER_CLEANUP_GRACE_MS = 30_000;

--- a/src/gateway/worker-environments/worker-turn-launcher.imports.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.imports.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "vitest";
+import { findSourceImportBackedges } from "../../../test/helpers/source-import-closure.js";
+
+it.each([
+  "worker-turn-launcher.ts",
+  "placement-dispatch-pending-results.ts",
+  "placement-reclaim.ts",
+  "repository-workspace-mutation.ts",
+])("keeps %s independent of selected worker execution", (entry) => {
+  expect(
+    findSourceImportBackedges(`src/gateway/worker-environments/${entry}`, [
+      "src/gateway/worker-environments/worker-turn-execution.ts",
+      "src/gateway/worker-environments/workspace-result-finalize.ts",
+      "src/gateway/worker-environments/placement-sandbox.ts",
+    ]),
+  ).toEqual([]);
+});

--- a/src/gateway/worker-environments/worker-turn-launcher.lazy.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.lazy.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { WorkerSessionTurnClaim } from "./placement-store.js";
+
+describe("worker turn execution loading", () => {
+  let fixture: typeof import("./worker-turn-launcher.test-support.js");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    // The store, provider and cleanup must share the same module generation.
+    fixture = await import("./worker-turn-launcher.test-support.js");
+    await fixture.setupWorkerTurnLauncherTest();
+  });
+
+  afterEach(async () => {
+    vi.doUnmock("./worker-turn-execution.js");
+    vi.doUnmock("./workspace-result-finalize.js");
+    vi.doUnmock("./placement-sandbox.js");
+    vi.restoreAllMocks();
+    await fixture.cleanupWorkerTurnLauncherTest();
+    vi.resetModules();
+  });
+
+  describe.each(["worker-turn", "remote-exec"] as const)("%s", (mode) => {
+    it.each([
+      "current",
+      "revoked",
+      "claim-replaced",
+      "placement-drained",
+      "loader-failed",
+    ] as const)("retains admission and the exact claim across loading: %s", async (scenario) => {
+      fixture.seedActivePlacement(mode);
+      const claimTurn = vi.spyOn(fixture.placements, "claimTurn");
+      const loadStarted = createDeferredCore();
+      const releaseLoad = createDeferredCore();
+      const failure = new Error(`execution load ${scenario}`);
+      let revoked = false;
+      const execute = vi.fn(
+        async (params: {
+          onHandoff: () => void;
+          onTerminal?: () => void;
+          turnClaim: WorkerSessionTurnClaim;
+        }) => {
+          params.onHandoff();
+          params.onTerminal?.();
+          fixture.placements.releaseTurn(params.turnClaim);
+          return { meta: { durationMs: 1 } };
+        },
+      );
+      const load = vi.fn(async () => {
+        loadStarted.resolve();
+        await releaseLoad.promise;
+        if (scenario === "loader-failed") {
+          throw failure;
+        }
+        return mode === "remote-exec"
+          ? { executeRemoteExecTurn: execute }
+          : { executeWorkerTurn: execute };
+      });
+      const unselected = vi.fn(() => {
+        throw new Error("unselected execution loaded");
+      });
+      vi.doMock("./worker-turn-execution.js", mode === "worker-turn" ? load : unselected);
+      vi.doMock("./workspace-result-finalize.js", mode === "remote-exec" ? load : unselected);
+      const owner = await import("./worker-turn-run-owner.js");
+      const createOwner = vi.spyOn(owner, "createWorkerTurnRunOwner");
+      const environments = fixture.unusedEnvironments();
+      const provider = fixture.createWorkerSessionTurnPlacementProvider({
+        environments,
+        placements: fixture.placements,
+      });
+      const onAdmitted = vi.fn();
+      const assertCurrent = vi.fn(() => {
+        if (revoked) {
+          throw failure;
+        }
+      });
+      const runLocal = vi.fn();
+      const request = {
+        sessionId: fixture.SESSION_ID,
+        sessionKey: fixture.SESSION_KEY,
+        agentId: "main",
+        runId: "run-lazy-execution",
+      };
+      const run = provider.executeTurn(
+        request,
+        fixture.turn(request.runId),
+        runLocal,
+        onAdmitted,
+        assertCurrent,
+      );
+      const settled = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      try {
+        expect(
+          await Promise.race([
+            loadStarted.promise.then(() => "loading"),
+            settled.then(() => "settled"),
+          ]),
+        ).toBe("loading");
+        expect(load).toHaveBeenCalledOnce();
+        expect(unselected).not.toHaveBeenCalled();
+        expect(createOwner).not.toHaveBeenCalled();
+        expect(onAdmitted).not.toHaveBeenCalled();
+        expect(execute).not.toHaveBeenCalled();
+        const placement = fixture.placements.get(fixture.SESSION_ID);
+        if (placement?.state !== "active") {
+          throw new Error("expected retained active placement");
+        }
+        const claimed = claimTurn.mock.results[0];
+        if (claimed?.type !== "return") {
+          throw new Error("expected retained admission claim");
+        }
+        const retained = claimed.value;
+        expect(retained.owner).toEqual({
+          kind: mode === "remote-exec" ? "local" : "worker",
+          environmentId: placement.environmentId,
+          ownerEpoch: placement.activeOwnerEpoch,
+        });
+        expect(fixture.placements.validateTurnClaim(retained)).toBe(true);
+        let replacement: WorkerSessionTurnClaim | undefined;
+        if (scenario === "claim-replaced") {
+          fixture.placements.releaseTurn(retained);
+          replacement = fixture.placements.claimTurn({
+            ...request,
+            claimId: "replacement-claim",
+            owner: retained.owner,
+          });
+        } else if (scenario === "placement-drained") {
+          fixture.placements.startDrain({
+            sessionId: placement.sessionId,
+            environmentId: placement.environmentId,
+            ownerEpoch: placement.activeOwnerEpoch,
+            expectedGeneration: placement.generation,
+          });
+        }
+        revoked = scenario === "revoked";
+        releaseLoad.resolve();
+        if (scenario === "current") {
+          await expect(run).resolves.toEqual({ meta: { durationMs: 1 } });
+          expect(onAdmitted).toHaveBeenCalledOnce();
+          expect(execute).toHaveBeenCalledOnce();
+          expect(execute.mock.calls[0]?.[0].turnClaim).toEqual(retained);
+          expect(createOwner).toHaveBeenCalledTimes(mode === "worker-turn" ? 1 : 0);
+        } else {
+          if (scenario === "revoked") {
+            await expect(run).rejects.toBe(failure);
+          } else if (scenario === "loader-failed") {
+            await expect(run).rejects.toMatchObject({ cause: failure });
+          } else {
+            await expect(run).rejects.toThrow("placement changed while loading turn execution");
+          }
+          expect(createOwner).not.toHaveBeenCalled();
+          expect(onAdmitted).not.toHaveBeenCalled();
+          expect(execute).not.toHaveBeenCalled();
+        }
+        expect(runLocal).not.toHaveBeenCalled();
+        expect(environments.startTunnel).not.toHaveBeenCalled();
+        expect(environments.destroy).not.toHaveBeenCalled();
+        expect(fixture.placements.get(fixture.SESSION_ID)?.turnClaim?.claimId).toBe(
+          replacement?.claimId,
+        );
+      } finally {
+        releaseLoad.resolve();
+        await settled;
+      }
+    });
+  });
+
+  it("keeps local turns outside execution loading with an active interception", async () => {
+    const failure = new Error("selected execution load reached");
+    const load = vi.fn(() => {
+      throw failure;
+    });
+    vi.doMock("./worker-turn-execution.js", load);
+    vi.doMock("./workspace-result-finalize.js", load);
+    const provider = fixture.createWorkerSessionTurnPlacementProvider({
+      environments: fixture.unusedEnvironments(),
+      placements: fixture.placements,
+    });
+    const request = {
+      sessionId: fixture.SESSION_ID,
+      sessionKey: fixture.SESSION_KEY,
+      agentId: "main",
+      runId: "run-local-lazy",
+    };
+    const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+    await expect(
+      provider.executeTurn(request, fixture.turn(request.runId), runLocal),
+    ).resolves.toEqual({ meta: { durationMs: 1 } });
+    expect(runLocal).toHaveBeenCalledOnce();
+    expect(load).not.toHaveBeenCalled();
+    fixture.seedActivePlacement();
+    await expect(
+      provider.executeTurn(request, fixture.turn(request.runId), runLocal),
+    ).rejects.toMatchObject({ cause: failure });
+    expect(load).toHaveBeenCalledOnce();
+    expect(runLocal).toHaveBeenCalledOnce();
+    expect(fixture.placements.get(fixture.SESSION_ID)?.turnClaim).toBeNull();
+  });
+
+  it.each(["current", "revoked", "loader-failed"] as const)(
+    "rechecks the remote-exec placement after sandbox loading: %s",
+    async (scenario) => {
+      fixture.seedActivePlacement("remote-exec");
+      const loadStarted = createDeferredCore();
+      const releaseLoad = createDeferredCore();
+      const failure = new Error("sandbox load failed");
+      let sandboxCalls = 0;
+      vi.doMock("./placement-sandbox.js", async (importOriginal) => {
+        loadStarted.resolve();
+        await releaseLoad.promise;
+        if (scenario === "loader-failed") {
+          throw failure;
+        }
+        const actual = await importOriginal<typeof import("./placement-sandbox.js")>();
+        return {
+          ...actual,
+          createRemoteExecPlacementSandbox: (
+            params: Parameters<typeof actual.createRemoteExecPlacementSandbox>[0],
+          ) => {
+            sandboxCalls++;
+            return actual.createRemoteExecPlacementSandbox(params);
+          },
+        };
+      });
+      const environment = {
+        ...fixture.attachedEnvironment(),
+        nodeDeviceId: "fixture-node",
+        sshEndpoint: null,
+      };
+      const provider = fixture.createWorkerSessionTurnPlacementProvider({
+        environments: { ...fixture.unusedEnvironments(), get: vi.fn(() => environment) },
+        placements: fixture.placements,
+      });
+      const sandbox = provider.resolveSandbox({
+        sessionId: fixture.SESSION_ID,
+        sessionKey: fixture.SESSION_KEY,
+        agentId: "main",
+        workspaceDir: fixture.root,
+      });
+      const settled = sandbox.then(
+        () => undefined,
+        () => undefined,
+      );
+      try {
+        expect(
+          await Promise.race([
+            loadStarted.promise.then(() => "loading"),
+            settled.then(() => "settled"),
+          ]),
+        ).toBe("loading");
+        expect(sandboxCalls).toBe(0);
+        if (scenario === "revoked") {
+          const placement = fixture.placements.get(fixture.SESSION_ID);
+          if (placement?.state !== "active") {
+            throw new Error("expected active sandbox placement");
+          }
+          fixture.placements.startDrain({
+            sessionId: placement.sessionId,
+            environmentId: placement.environmentId,
+            ownerEpoch: placement.activeOwnerEpoch,
+            expectedGeneration: placement.generation,
+          });
+        }
+        releaseLoad.resolve();
+        if (scenario === "current") {
+          await expect(sandbox).resolves.toMatchObject({
+            backendId: "node",
+            placementNodeId: "fixture-node",
+          });
+          expect(sandboxCalls).toBe(1);
+        } else {
+          if (scenario === "revoked") {
+            await expect(sandbox).rejects.toThrow("changed while preparing its sandbox");
+          } else {
+            await expect(sandbox).rejects.toMatchObject({ cause: failure });
+          }
+          expect(sandboxCalls).toBe(0);
+        }
+      } finally {
+        releaseLoad.resolve();
+        await settled;
+      }
+    },
+  );
+
+  it("checks sandbox eligibility before loading with an active interception", async () => {
+    fixture.seedActivePlacement("remote-exec");
+    const failure = new Error("sandbox load reached");
+    const load = vi.fn(() => {
+      throw failure;
+    });
+    vi.doMock("./placement-sandbox.js", load);
+    const provider = fixture.createWorkerSessionTurnPlacementProvider({
+      environments: fixture.unusedEnvironments(),
+      placements: fixture.placements,
+    });
+    const request = {
+      sessionId: fixture.SESSION_ID,
+      sessionKey: fixture.SESSION_KEY,
+      agentId: "main",
+      workspaceDir: fixture.root,
+    };
+    await expect(provider.resolveSandbox({ ...request, agentId: "other" })).resolves.toBeNull();
+    expect(load).not.toHaveBeenCalled();
+    await expect(provider.resolveSandbox(request)).rejects.toMatchObject({ cause: failure });
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the reconciliation error constructor shared with the loaded thrower", async () => {
+    fixture.seedActivePlacement();
+    const { WorkerWorkspaceReconciliationError } = await import("./worker-turn-failure.js");
+    const { recoverWorkspaceBeforeTurn } = await import("./workspace-result-finalize.js");
+    const placement = fixture.placements.get(fixture.SESSION_ID);
+    if (placement?.state !== "active") {
+      throw new Error("expected active recovery placement");
+    }
+    const claim = fixture.placements.claimTurn({
+      sessionId: fixture.SESSION_ID,
+      sessionKey: fixture.SESSION_KEY,
+      agentId: "main",
+      runId: "run-load-recovery",
+      claimId: "recovery-claim",
+      owner: {
+        kind: "worker",
+        environmentId: placement.environmentId,
+        ownerEpoch: placement.activeOwnerEpoch,
+      },
+    });
+    const cause = new Error("recovery rejected");
+    const recovery = recoverWorkspaceBeforeTurn({
+      placement,
+      placements: fixture.placements,
+      turnClaim: claim,
+      workspace: { kind: "local", path: fixture.root },
+      workspaceOperations: {
+        run: async () => {
+          throw cause;
+        },
+      },
+    });
+    await expect(recovery).rejects.toBeInstanceOf(WorkerWorkspaceReconciliationError);
+    await expect(recovery).rejects.toMatchObject({ cause });
+    fixture.placements.releaseTurn(claim);
+  });
+});

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -6,10 +6,10 @@ import type {
 } from "../../agents/session-placement-admission.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { emitAgentRunStatusEvent } from "../../infra/agent-run-status-events.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { StaleWorkerBuildError } from "./admission.js";
 import { matchesWorkerPlacementTarget } from "./placement-reclaim-contract.js";
 import { placementTurnOwner, sameWorkerSessionTurnClaim } from "./placement-record.js";
-import { createRemoteExecPlacementSandbox } from "./placement-sandbox.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -27,19 +27,19 @@ import {
   waitForPendingWorkerResult,
   waitForInitialWorkerPlacement,
 } from "./worker-turn-admission.js";
-import { executeWorkerTurn } from "./worker-turn-execution.js";
 import {
   failHandedOffTurn,
   WorkerTurnExecutionError,
+  WorkerWorkspaceReconciliationError,
   type ActiveWorkerPlacement,
   type WorkerTurnEnvironmentService,
 } from "./worker-turn-failure.js";
 import { createWorkerTurnRunOwner, type ActiveWorkerTurn } from "./worker-turn-run-owner.js";
 import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
-import {
-  executeRemoteExecTurn,
-  WorkerWorkspaceReconciliationError,
-} from "./workspace-result-finalize.js";
+
+const loadWorkerTurnExecution = createLazyRuntimeModule(() => import("./worker-turn-execution.js"));
+const loadRemoteExecTurn = createLazyRuntimeModule(() => import("./workspace-result-finalize.js"));
+const loadPlacementSandbox = createLazyRuntimeModule(() => import("./placement-sandbox.js"));
 
 type ReclaimedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
 
@@ -115,6 +115,8 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
         sessionKey: placement.sessionKey,
       });
       assertCurrentPlacement("managed workspace");
+      const { createRemoteExecPlacementSandbox } = await loadPlacementSandbox();
+      assertCurrentPlacement("sandbox");
       const sandbox = await createRemoteExecPlacementSandbox({
         config: params.config,
         environments: options.environments,
@@ -316,6 +318,18 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       let handedOff = false;
       let terminalAtMs: number | undefined;
       try {
+        const execute = remoteExec
+          ? (await loadRemoteExecTurn()).executeRemoteExecTurn
+          : (await loadWorkerTurnExecution()).executeWorkerTurn;
+        // Loading retains the admitted claim; it cannot admit a replacement or
+        // register a run owner after the caller or placement has been revoked.
+        assertAdmissionCurrent();
+        if (
+          !matchesWorkerPlacementTarget(options.placements.get(turnClaim.sessionId), placement) ||
+          !options.placements.validateTurnClaim(turnClaim)
+        ) {
+          throw new Error("Worker placement changed while loading turn execution");
+        }
         if (!remoteExec) {
           activeWorkerTurn = createWorkerTurnRunOwner({
             placements: options.placements,
@@ -350,9 +364,7 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           turn,
           turnClaim,
         };
-        return remoteExec
-          ? await executeRemoteExecTurn({ ...executionParams, runLocal, assertRunCurrent })
-          : await executeWorkerTurn(executionParams);
+        return await execute({ ...executionParams, runLocal, assertRunCurrent });
       } catch (error) {
         if (error instanceof StaleWorkerBuildError) {
           await options.reconcileActivePlacement(placement.environmentId);

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -27,39 +27,32 @@ import type {
 import type { WorkerEnvironmentService } from "./service.js";
 import {
   createWorkerWorkspaceReconcileRequest,
-  sessionWorkspaceRoot,
   type WorkerSessionWorkspace,
 } from "./session-workspace.js";
 import { transferSkillResources } from "./skill-resource-transfer.js";
 import { WorkerTunnelOwnerDisconnectedError, type WorkerTunnelHandle } from "./tunnel-contract.js";
 import { latestDurableWorkspaceConflict, waitForTurnOperation } from "./worker-turn-admission.js";
 import { prepareWorkerTurnAttachments } from "./worker-turn-attachments.js";
+import { WorkerWorkspaceReconciliationError } from "./worker-turn-failure.js";
 import { resolveWorkerTurnTranscriptTarget } from "./worker-turn-transcript-target.js";
 import {
   formatWorkspaceConflictSummary,
-  projectWorkspaceResultConflict,
   WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
-  type WorkerWorkspaceResultConflict,
 } from "./workspace-conflicts.js";
 import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
 import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
-  deleteStagedWorkerWorkspaceResult,
-  isWorkerWorkspaceResultCleanupRef,
-  moveStagedWorkerWorkspaceResultToCleanup,
-  workerWorkspaceResultRef,
-} from "./workspace-result-staging.js";
+  createWorkspaceResultJournal,
+  finalizeWorkspaceResultConflicts,
+  settleStagedWorkspaceResult,
+} from "./workspace-result-settlement.js";
+import { workerWorkspaceResultRef } from "./workspace-result-staging.js";
 
 type ActiveWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "active" }>;
-type OwnedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "active" | "draining" }>;
 type RemoteExecEnvironmentService = Pick<WorkerEnvironmentService, "get" | "startTunnel"> &
   Partial<Pick<WorkerEnvironmentService, "prepareComputer">>;
-
-export class WorkerWorkspaceReconciliationError extends Error {
-  override name = "WorkerWorkspaceReconciliationError";
-}
 
 type WorkspaceConflictReport = {
   paths: string[];
@@ -101,33 +94,6 @@ function remoteExecWorkspaceFailure(executionError: unknown, reconciliationError
     // Keep the typed reconciliation failure discoverable so model fallback cannot replay the turn.
     { cause: reconciliationFailure },
   );
-}
-
-export function createWorkspaceResultJournal(params: {
-  placement: OwnedWorkerPlacement;
-  placements: WorkerSessionPlacementStore;
-  turnClaim: WorkerSessionTurnClaim;
-}) {
-  const owner = {
-    sessionId: params.placement.sessionId,
-    environmentId: params.placement.environmentId,
-    ownerEpoch: params.placement.activeOwnerEpoch,
-    placementGeneration: params.placement.generation,
-  };
-  let manifestAccepted = false;
-  return {
-    adapter: {
-      load: () => params.placements.loadWorkspaceReconciliation(owner),
-      begin: (next: Parameters<typeof params.placements.beginWorkspaceReconciliation>[1]) =>
-        params.placements.beginWorkspaceReconciliation(owner, next),
-      commit: (manifestRef: string) => {
-        params.placements.updateWorkspaceBaseManifest({ claim: params.turnClaim, manifestRef });
-        manifestAccepted = true;
-      },
-      abort: () => params.placements.abortWorkspaceReconciliation(owner),
-    },
-    wasAccepted: () => manifestAccepted,
-  };
 }
 
 export async function recoverWorkspaceBeforeTurn(params: {
@@ -582,109 +548,4 @@ export async function executeRemoteExecTurn(params: {
     }),
   ).catch(() => undefined);
   return appendWorkspaceConflict(result, workspaceConflict);
-}
-
-type WorkspaceResultFinalizationStore = Pick<
-  WorkerSessionPlacementStore,
-  | "closeWorkerTurnToolState"
-  | "completeWorkspaceResultAndReleaseTurn"
-  | "recordWorkspaceResultConflict"
->;
-
-type WorkspaceResultConflictReport = Required<WorkerWorkspaceResultConflict> | { cleared: true };
-
-export async function finalizeWorkspaceResultConflicts(params: {
-  placements: WorkspaceResultFinalizationStore;
-  turnClaim: WorkerSessionTurnClaim;
-  conflictPaths: readonly string[];
-  priorConflict: WorkerWorkspaceResultConflict | undefined;
-  stagedResultRef: string | null | undefined;
-  retainPriorConflict?: boolean;
-  report: (report: WorkspaceResultConflictReport) => Promise<void>;
-  workspace: WorkerSessionWorkspace;
-}): Promise<{
-  conflict: Required<WorkerWorkspaceResultConflict> | undefined;
-  conflictRetained: boolean;
-}> {
-  const retainedPriorConflict =
-    params.retainPriorConflict && params.conflictPaths.length === 0
-      ? params.priorConflict
-      : undefined;
-  const supersededConflict =
-    params.priorConflict &&
-    !retainedPriorConflict &&
-    (params.conflictPaths.length === 0 ||
-      params.priorConflict.stagedResultRef !== params.stagedResultRef)
-      ? params.priorConflict
-      : undefined;
-  if (
-    params.workspace.kind === "local" &&
-    supersededConflict &&
-    supersededConflict.stagedResultRef !== params.stagedResultRef
-  ) {
-    // Delete the inspectable result before replacing its last durable pointer.
-    await deleteStagedWorkerWorkspaceResult({
-      root: sessionWorkspaceRoot(params.workspace),
-      stagedResultRef: supersededConflict.stagedResultRef,
-    });
-  }
-
-  let conflict: Required<WorkerWorkspaceResultConflict> | undefined;
-  if (params.conflictPaths.length > 0) {
-    if (!params.stagedResultRef) {
-      throw new Error("Cloud workspace conflict has no staged result reference");
-    }
-    conflict = projectWorkspaceResultConflict(params.conflictPaths, params.stagedResultRef);
-    params.placements.recordWorkspaceResultConflict(params.turnClaim, conflict);
-    await params.report(conflict);
-  } else if (retainedPriorConflict) {
-    params.placements.recordWorkspaceResultConflict(params.turnClaim, retainedPriorConflict);
-  } else if (supersededConflict) {
-    params.placements.recordWorkspaceResultConflict(params.turnClaim, undefined);
-    await params.report({ cleared: true });
-  }
-
-  return { conflict, conflictRetained: conflict !== undefined };
-}
-
-type StagedWorkspaceResultSettlement = {
-  placements: WorkspaceResultFinalizationStore;
-  turnClaim: WorkerSessionTurnClaim;
-  workspace: WorkerSessionWorkspace;
-  stagedResultRef: string | null | undefined;
-  conflictRetained: boolean;
-  beforeComplete: () => Promise<void>;
-  complete?: () => WorkerSessionPlacementRecord;
-  afterComplete?: (completed: WorkerSessionPlacementRecord) => Promise<void>;
-  validateCompleted?: (completed: WorkerSessionPlacementRecord) => void;
-};
-export async function settleStagedWorkspaceResult(
-  params: StagedWorkspaceResultSettlement,
-): Promise<WorkerSessionPlacementRecord> {
-  if (params.turnClaim.owner.kind === "worker") {
-    await params.placements.closeWorkerTurnToolState(params.turnClaim);
-  }
-  const cleanupRef =
-    params.workspace.kind === "local" && params.stagedResultRef && !params.conflictRetained
-      ? isWorkerWorkspaceResultCleanupRef(params.stagedResultRef)
-        ? params.stagedResultRef
-        : await moveStagedWorkerWorkspaceResultToCleanup({
-            root: sessionWorkspaceRoot(params.workspace),
-            stagedResultRef: params.stagedResultRef,
-          })
-      : undefined;
-  await params.beforeComplete();
-  const completed = params.complete
-    ? params.complete()
-    : params.placements.completeWorkspaceResultAndReleaseTurn(params.turnClaim);
-  params.validateCompleted?.(completed);
-  await params.afterComplete?.(completed);
-  if (cleanupRef) {
-    // Cleanup refs remain discoverable after the SQLite fence disappears.
-    await deleteStagedWorkerWorkspaceResult({
-      root: sessionWorkspaceRoot(params.workspace),
-      stagedResultRef: cleanupRef,
-    }).catch(() => undefined);
-  }
-  return completed;
 }

--- a/src/gateway/worker-environments/workspace-result-settlement.ts
+++ b/src/gateway/worker-environments/workspace-result-settlement.ts
@@ -1,0 +1,149 @@
+import type {
+  WorkerSessionPlacementRecord,
+  WorkerSessionPlacementStore,
+  WorkerSessionTurnClaim,
+} from "./placement-store.js";
+import { sessionWorkspaceRoot, type WorkerSessionWorkspace } from "./session-workspace.js";
+import {
+  projectWorkspaceResultConflict,
+  type WorkerWorkspaceResultConflict,
+} from "./workspace-conflicts.js";
+import {
+  deleteStagedWorkerWorkspaceResult,
+  isWorkerWorkspaceResultCleanupRef,
+  moveStagedWorkerWorkspaceResultToCleanup,
+} from "./workspace-result-staging.js";
+
+type OwnedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "active" | "draining" }>;
+
+export function createWorkspaceResultJournal(params: {
+  placement: OwnedWorkerPlacement;
+  placements: WorkerSessionPlacementStore;
+  turnClaim: WorkerSessionTurnClaim;
+}) {
+  const owner = {
+    sessionId: params.placement.sessionId,
+    environmentId: params.placement.environmentId,
+    ownerEpoch: params.placement.activeOwnerEpoch,
+    placementGeneration: params.placement.generation,
+  };
+  let manifestAccepted = false;
+  return {
+    adapter: {
+      load: () => params.placements.loadWorkspaceReconciliation(owner),
+      begin: (next: Parameters<typeof params.placements.beginWorkspaceReconciliation>[1]) =>
+        params.placements.beginWorkspaceReconciliation(owner, next),
+      commit: (manifestRef: string) => {
+        params.placements.updateWorkspaceBaseManifest({ claim: params.turnClaim, manifestRef });
+        manifestAccepted = true;
+      },
+      abort: () => params.placements.abortWorkspaceReconciliation(owner),
+    },
+    wasAccepted: () => manifestAccepted,
+  };
+}
+
+type WorkspaceResultFinalizationStore = Pick<
+  WorkerSessionPlacementStore,
+  | "closeWorkerTurnToolState"
+  | "completeWorkspaceResultAndReleaseTurn"
+  | "recordWorkspaceResultConflict"
+>;
+
+type WorkspaceResultConflictReport = Required<WorkerWorkspaceResultConflict> | { cleared: true };
+
+export async function finalizeWorkspaceResultConflicts(params: {
+  placements: WorkspaceResultFinalizationStore;
+  turnClaim: WorkerSessionTurnClaim;
+  conflictPaths: readonly string[];
+  priorConflict: WorkerWorkspaceResultConflict | undefined;
+  stagedResultRef: string | null | undefined;
+  retainPriorConflict?: boolean;
+  report: (report: WorkspaceResultConflictReport) => Promise<void>;
+  workspace: WorkerSessionWorkspace;
+}): Promise<{
+  conflict: Required<WorkerWorkspaceResultConflict> | undefined;
+  conflictRetained: boolean;
+}> {
+  const retainedPriorConflict =
+    params.retainPriorConflict && params.conflictPaths.length === 0
+      ? params.priorConflict
+      : undefined;
+  const supersededConflict =
+    params.priorConflict &&
+    !retainedPriorConflict &&
+    (params.conflictPaths.length === 0 ||
+      params.priorConflict.stagedResultRef !== params.stagedResultRef)
+      ? params.priorConflict
+      : undefined;
+  if (
+    params.workspace.kind === "local" &&
+    supersededConflict &&
+    supersededConflict.stagedResultRef !== params.stagedResultRef
+  ) {
+    // Delete the inspectable result before replacing its last durable pointer.
+    await deleteStagedWorkerWorkspaceResult({
+      root: sessionWorkspaceRoot(params.workspace),
+      stagedResultRef: supersededConflict.stagedResultRef,
+    });
+  }
+
+  let conflict: Required<WorkerWorkspaceResultConflict> | undefined;
+  if (params.conflictPaths.length > 0) {
+    if (!params.stagedResultRef) {
+      throw new Error("Cloud workspace conflict has no staged result reference");
+    }
+    conflict = projectWorkspaceResultConflict(params.conflictPaths, params.stagedResultRef);
+    params.placements.recordWorkspaceResultConflict(params.turnClaim, conflict);
+    await params.report(conflict);
+  } else if (retainedPriorConflict) {
+    params.placements.recordWorkspaceResultConflict(params.turnClaim, retainedPriorConflict);
+  } else if (supersededConflict) {
+    params.placements.recordWorkspaceResultConflict(params.turnClaim, undefined);
+    await params.report({ cleared: true });
+  }
+
+  return { conflict, conflictRetained: conflict !== undefined };
+}
+
+type StagedWorkspaceResultSettlement = {
+  placements: WorkspaceResultFinalizationStore;
+  turnClaim: WorkerSessionTurnClaim;
+  workspace: WorkerSessionWorkspace;
+  stagedResultRef: string | null | undefined;
+  conflictRetained: boolean;
+  beforeComplete: () => Promise<void>;
+  complete?: () => WorkerSessionPlacementRecord;
+  afterComplete?: (completed: WorkerSessionPlacementRecord) => Promise<void>;
+  validateCompleted?: (completed: WorkerSessionPlacementRecord) => void;
+};
+export async function settleStagedWorkspaceResult(
+  params: StagedWorkspaceResultSettlement,
+): Promise<WorkerSessionPlacementRecord> {
+  if (params.turnClaim.owner.kind === "worker") {
+    await params.placements.closeWorkerTurnToolState(params.turnClaim);
+  }
+  const cleanupRef =
+    params.workspace.kind === "local" && params.stagedResultRef && !params.conflictRetained
+      ? isWorkerWorkspaceResultCleanupRef(params.stagedResultRef)
+        ? params.stagedResultRef
+        : await moveStagedWorkerWorkspaceResultToCleanup({
+            root: sessionWorkspaceRoot(params.workspace),
+            stagedResultRef: params.stagedResultRef,
+          })
+      : undefined;
+  await params.beforeComplete();
+  const completed = params.complete
+    ? params.complete()
+    : params.placements.completeWorkspaceResultAndReleaseTurn(params.turnClaim);
+  params.validateCompleted?.(completed);
+  await params.afterComplete?.(completed);
+  if (cleanupRef) {
+    // Cleanup refs remain discoverable after the SQLite fence disappears.
+    await deleteStagedWorkerWorkspaceResult({
+      root: sessionWorkspaceRoot(params.workspace),
+      stagedResultRef: cleanupRef,
+    }).catch(() => undefined);
+  }
+  return completed;
+}


### PR DESCRIPTION
## What Problem This Solves

Importing the worker-turn launcher eagerly loads execution implementations and their workspace-settlement dependencies before a turn passes admission.

## Why This Change Was Made

Keep workspace validation, placement authority and turn-claim cleanup in their existing owners. Load only the selected execution implementation on each recovery-loop iteration, inside the existing claim-cleanup boundary. Revalidate admission, placement and the exact claim after loading and before registering the execution owner.

Preserve the worker-specific composed admission callback through asynchronous context preparation, while remote execution retains its existing caller callback. Redispatch retains the composed callback and abort signal. Admission notification, persistence, release-before-reconciliation, pending-result custody and identity-based cleanup remain unchanged.

Move the unchanged reconciliation error constructor and workspace-settlement functions into shared leaves. Redirect the three eager settlement consumers so they do not restore the cold-import dependency path. No configuration, protocol, schema or persistence-contract changes.

## User Impact

Less execution code is loaded eagerly. No measured startup, latency or RSS improvement is claimed. Revocation, claim replacement, loader failure, rollback and recovery continue through their existing owners, without a new operator action.

## Evidence

### Current Integrated Source

- Signed head: `9ec456dcfc26775b5a871307ea972b506701668e`.
- Parents: published `6b5db794123fb767af6e80ce2aaf2734b3004881` and main integration snapshot `2700b9e34e6f79afba980dac67508af4c6eb707e`. Both ancestries are preserved; this is not replacement of the published branch.
- The ten-file residual against that main snapshot preserves its recovery loop, composed writer-admission fence and redispatch signal. Production: **+187 / -160**, net **+27**, including an unchanged 149-line settlement move. Tests: **+469 / -4**. The remaining growth implements selected lazy-loading boundaries and post-await authority checks.
- One fresh source-review invocation across **four batches**, **108 context files** and **six complete owning guides** reported **zero findings and zero abstentions**. Its native invocation and outer process completed successfully with frozen source preserved.

### Current Local Qualification

- Normal frozen install completed at the exact signed head with the repository-pinned pnpm 12.3.4 and Node 26.7.0. Native TypeScript 7.0.2, TypeScript API 6.0.3 and tsdown 0.23.0 resolved inside the isolated validation checkout.
- Normal full `pnpm build` passed in **273.777 seconds**, with all sixteen build phases completed and build metadata bound to the exact head. This is not a whole-environment cold-build or performance claim.
- The new initial-setup regression pauses the real asynchronous model-context read, changes the authoritative writer while caller and placement remain valid, and checks rejection before credentials, tunnel or worker launch plus claim release. Replacing only the composed worker callback with the raw callback failed the intended credential-call assertion; restoring the exact candidate passed. This is an **integration-regression mutant**, not a claim that the old published head had the newer asynchronous path.
- Current owner and sibling proof: **210 unique passing cases across 19 files**, zero failures and zero excluded cases. Coverage includes cold imports, recovery-loop reloads, admission and claim replacement, cancellation, detached context, error identity, ordered workspace settlement and placement resume. The focused GREEN case is included in those 210, not an additional case.
- Canonical changed checks passed against the explicit main integration snapshot: core and core-test type graphs, scoped formatting/lint, dead exports, boundaries, import cycles and store guards. The tests, full build and targeted checks exited successfully; owned processes and streams closed, and tracked source and install inputs were preserved.
- These are local owner-boundary observations. They are not live Gateway/provider, Windows, latency or RSS proof. Current-head required CI and native landing checks remain separate gates.

### Retained History And Limits

- Original proof base `008cf5d9b0a4b1dcae5517706ea06d31ec1082ff` and signed source `d90d6944c42ef023d964eeee8cec08d11ac1f930` supplied four intended baseline cold-import failures. Twenty new cases had passing observations across recorded revisions, not one final-byte twenty-case run: an initial fixture error was corrected using the actual claim return, and the affected cases were rerun. A selector-miss attempt selected zero tests and is not proof.
- Historical launcher/recovery siblings passed 83 cases. The original ordered workspace run had **30 passes and one timeout** at the unchanged 120-second deadline; its cause remains unknown.
- A matched, temporarily instrumented `--no-cache` diagnostic pair preserved staged-results -> repository -> finalize order and passed 31/31 on both baseline and candidate. The original timeout was not reproduced under those diagnostic conditions. Instrumentation was removed. A later uninstrumented published-head run passed **13 + 15 + 3 = 31**, without explaining or erasing the original timeout.
- Published `6b5db794123fb767af6e80ce2aaf2734b3004881` had successful [CI run 34424900129](https://github.com/openclaw/openclaw/actions/runs/34424900129) and normal Node 26.1.0 / Ubuntu compatibility [run 34429388774](https://github.com/openclaw/openclaw/actions/runs/34429388774), including full `pnpm build`. The declaration-restore step was skipped; no broader cold-build claim follows. These runs remain old-head evidence, not current-head CI.
- The earlier incomplete source-review attempt and all adverse receipts remain retained. The later historical clean review and the current four-batch invocation are distinct evidence, not retrospective rerating of an incomplete attempt.
