### PR TITLE
fix(docs): repair dead docs anchors emitted from source code

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.errors.ts
+++ b/extensions/browser/src/browser/routes/agent.act.errors.ts
@@ -25,6 +25,6 @@ export function browserEvaluateDisabledMessage(action: "wait" | "evaluate"): str
     action === "wait"
       ? "wait --fn is disabled by config (browser.evaluateEnabled=false)."
       : "act:evaluate is disabled by config (browser.evaluateEnabled=false).",
-    "Docs: /gateway/configuration#browser-openclaw-managed-browser",
+    "Docs: /tools/browser/configuration#configuration",
   ].join("\n");
 }

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -485,7 +485,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
             `This can leak conversation context between users.\n\n` +
             `Fix: Add to your OpenClaw config:\n` +
             `session:\n  dmScope: "per-channel-peer"\n\n` +
-            `Docs: https://docs.openclaw.ai/concepts/session#secure-dm-mode`;
+            `Docs: https://docs.openclaw.ai/concepts/session#dm-isolation`;
 
           sendDm({
             api,

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -183,7 +183,7 @@ export async function handleBashChatCommand(params: {
     return buildDisabledCommandReply({
       label: "bash",
       configKey: "bash",
-      docsUrl: "https://docs.openclaw.ai/tools/slash-commands#config",
+      docsUrl: "https://docs.openclaw.ai/tools/slash-commands#configuration",
     });
   }
 

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1638,7 +1638,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Reason: session override");
     expect(normalized).not.toContain("This session is pinned");
     expect(normalized).not.toContain(
-      "Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
+      "Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-strictness",
     );
   });
 

--- a/src/commands/channels/status-config-format.ts
+++ b/src/commands/channels/status-config-format.ts
@@ -135,7 +135,7 @@ export async function formatConfigChannelsStatusLines(
 
   lines.push("");
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: ${formatDocsLink("/cli/status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
   );
   return lines;
 }

--- a/src/commands/channels/status.runtime.ts
+++ b/src/commands/channels/status.runtime.ts
@@ -218,7 +218,7 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
     lines.push("");
   }
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: ${formatDocsLink("/cli/status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
   );
   return lines;
 }

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -39,7 +39,7 @@ import {
 } from "./doctor-state-integrity.test-support.js";
 
 const WORKSPACE_BACKUP_TIP =
-  "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended";
+  "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended-private";
 
 describe("workspace backup tip", () => {
   it("recognizes direct, deeply nested, and symlinked Git workspaces without duplicate tips", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1472,7 +1472,7 @@ export function collectWorkspaceBackupTip(workspaceDir: string): string | null {
   if (!resolvedWorkspaceDir || findGitRoot(resolvedWorkspaceDir)) {
     return null;
   }
-  return "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended";
+  return "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended-private";
 }
 
 /** Emits the workspace backup tip when applicable. */

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -227,7 +227,7 @@ describe("status.command-sections", () => {
       "  Session selected: deepseek/deepseek-v4-flash",
       "  Reason: session override",
       "  Clear with: /model default",
-      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
+      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-strictness",
     ]);
   });
 
@@ -263,7 +263,7 @@ describe("status.command-sections", () => {
       "  Session selected: ollama/qwen3.6-blue:35b-a3b",
       "  Reason: fallback selected",
       "  Action: check provider availability or retry with /model",
-      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
+      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-strictness",
     ]);
   });
 

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -402,7 +402,7 @@ export function buildStatusModelSelectionLines(params: {
       `  Session selected: ${selected}`,
       reasonLine,
       clearLine,
-      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
+      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-strictness",
     );
   }
   if (mismatches.length > limit) {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -869,7 +869,7 @@ describe("CORE_HEALTH_CHECKS", () => {
         createDeps({
           async collectWorkspaceSuggestionNotes(): Promise<readonly string[]> {
             return [
-              "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended",
+              "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended-private",
               "Memory system not found in workspace.",
             ];
           },
@@ -896,7 +896,7 @@ describe("CORE_HEALTH_CHECKS", () => {
         checkId: "core/doctor/workspace-suggestions",
         severity: "info",
         message:
-          "Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended",
+          "Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended-private",
       }),
     );
     expect(findings).toContainEqual(

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -43,7 +43,7 @@ export async function startGatewayTailscaleExposure(params: {
         `external Tailscale Funnel for port ${params.port} remains active only for plugin-authenticated webhook routes; Gateway-authenticated routes reject its unattributable ingress. ` +
           "First configure a durable gateway password (gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD) and set gateway.auth.mode=password, " +
           "then run `openclaw config set gateway.tailscale.mode funnel` and `openclaw config unset gateway.tailscale.preserveFunnel`; " +
-          "see https://docs.openclaw.ai/gateway/tailscale#public-internet-funnel--shared-password",
+          "see https://docs.openclaw.ai/gateway/tailscale#public-internet-funnel-%2B-shared-password",
       );
       return null;
     }

--- a/ui/src/components/login-gate-feedback.ts
+++ b/ui/src/components/login-gate-feedback.ts
@@ -238,7 +238,7 @@ export function resolveLoginFailureFeedback(
       kind: "origin-not-allowed",
       rawError,
       docsHref:
-        "https://docs.openclaw.ai/web/control-ui#debuggingtesting-dev-server--remote-gateway",
+        "https://docs.openclaw.ai/web/control-ui/development#debugging%2Ftesting%3A-dev-server-%2B-remote-gateway",
       titleKey: "login.failure.origin.title",
       summaryKey: "login.failure.origin.summary",
       stepKeys: [
@@ -254,7 +254,7 @@ export function resolveLoginFailureFeedback(
       kind: "protocol-mismatch",
       rawError,
       docsHref:
-        "https://docs.openclaw.ai/web/control-ui#debuggingtesting-dev-server--remote-gateway",
+        "https://docs.openclaw.ai/web/control-ui/development#debugging%2Ftesting%3A-dev-server-%2B-remote-gateway",
       titleKey: "login.failure.protocol.title",
       summaryKey: "login.failure.protocol.summary",
       refreshAction: { label: t("login.failure.protocol.refresh") },


### PR DESCRIPTION
## What Problem This Solves

Nine anchored documentation links are written in **source code** — browser error payloads, a Tlon security DM, chat command replies, CLI status tips, doctor tips, a Gateway Tailscale warning, and two Control UI login-failure hints. Every one of them points at a fragment that the target docs page no longer publishes, so a user who follows the link lands on a page that scrolls nowhere.

`scripts/docs-link-audit.mjs` cannot see any of them: it walks the `docs/` tree only. A `docs.openclaw.ai` URL written in `src/`, `extensions/`, `ui/`, `scripts/`, or a workflow is completely unchecked today.

This is the **second and third** defect of this class found by hand this week. One of the earlier ones was an auto-response that closed GitHub issues while pointing at a dead FAQ anchor.

## Why This Change Was Made

Each replacement targets a fragment the docs page actually publishes today, enumerated with the repo's own `parseDocsDocument` (`scripts/lib/docs-markdown.mjs`) rather than a slug approximation. No docs page was edited, and no heading was invented to make a code string resolve.

| # | Code site | Old target | New target | Evidence |
|---|-----------|-----------|-----------|----------|
| 1 | `extensions/browser/src/browser/routes/agent.act.errors.ts:28` | `/gateway/configuration#browser-openclaw-managed-browser` | `/tools/browser/configuration#configuration` | Heading `### \`browser\` (openclaw-managed browser)` was deleted from `docs/gateway/configuration.md` in `3ed06c6f368` (2026-02-11). The code line was written two months later (`251ac7ff857`, 2026-04-10), so it never resolved. The message is about `browser.evaluateEnabled=false`; that key is documented at `docs/tools/browser/configuration.md:19`, under `## Configuration`. |
| 2 | `extensions/tlon/src/monitor/index.ts:488` | `/concepts/session#secure-dm-mode` | `/concepts/session#dm-isolation` | `git log -S secure-dm-mode -- docs/` is empty: the id never existed. The warning tells the operator to set `session.dmScope: "per-channel-peer"`; that is exactly `## DM isolation` on the **same page** (`docs/concepts/session.md:*`), including the `dmScope` value table. |
| 3 | `src/auto-reply/reply/bash-command.ts:186` | `/tools/slash-commands#config` | `/tools/slash-commands#configuration` | Straight heading rename: `5976f148326` (2026-05-31) changed `## Config` → `## Configuration`. The link was added `01211937fcc` (2026-01-18), while `## Config` still existed. `docs/install/updating.md:195` already links the new spelling. |
| 4 | `src/commands/channels/status-config-format.ts:138` | `/cli#status` | `/cli/status` | `/cli` was split into per-command pages (`docs/cli/index.md` + `docs/cli/<cmd>.md`). `docs/cli/status.md` is the page for `openclaw status`, and documents `--deep` (lines 14, 23) — which is the link text. The index publishes **no** per-command `<a id>` stub, so there is no live fragment to aim at; the parent route is the correct target. |
| 5 | `src/commands/channels/status.runtime.ts:221` | `/cli#status` | `/cli/status` | Same string, same reasoning. |
| 6 | `src/commands/doctor-state-integrity.ts:1475` | `/concepts/agent-workspace#git-backup-recommended` | `/concepts/agent-workspace#git-backup-recommended-private` | The heading is `## Git backup (recommended, private)` (`docs/concepts/agent-workspace.md:130`); the id is `git-backup-recommended-private`. The code slug simply dropped `-private`. `docs/install/backups.md:383` already links the full id. |
| 7 | `src/commands/status.command-sections.ts:405` | `/concepts/models#selection-source-and-fallback-behavior` | `/concepts/models#selection-source-and-fallback-strictness` | Heading renamed to `## Selection source and fallback strictness` in `f7d7148cf04` (`docs/concepts/models.md:71`). |
| 8 | `src/gateway/server-tailscale.ts:46` | `/gateway/tailscale#public-internet-funnel--shared-password` | `/gateway/tailscale#public-internet-funnel-%2B-shared-password` | The heading is `### Public internet (Funnel + shared password)`. The code hand-slugged the `+` into a second `-`. The new spelling is byte-identical to the one `docs/gateway/stable-https-url.md:14` already uses for the same section. |
| 9 | `ui/src/components/login-gate-feedback.ts:241,257` | `/web/control-ui#debuggingtesting-dev-server--remote-gateway` | `/web/control-ui/development#debugging%2Ftesting%3A-dev-server-%2B-remote-gateway` | The code slug dropped `/`, `:` and `+` and was never a published id. `/web/control-ui` has since been split; `docs/web/control-ui/development.md:100` holds `## Debugging/testing: dev server + remote Gateway`. The new URL is copied verbatim from the index's own preserved stub (`docs/web/control-ui.md:101`), which links to exactly that target. |

### Repair choice, per the two options

- **Renamed / re-slugged, content still on the same page** — 2, 3, 6, 7, 8. Pointed at the live id.
- **Content moved to another page by a split** — 1, 4, 5, 9. Pointed at the page that now owns it. For 4 and 5 there is no fragment because `docs/cli/index.md` publishes no per-command stub and the whole child page is the `status` command; for 9 the child page's own heading id is used, in the exact spelling the index stub already points to.

No anchor was invented, and `docs/` is untouched (`git diff HEAD~1 HEAD -- docs/` is empty).

### Left alone deliberately

- `CHANGELOG.md:25601` (`/tools/thinking#fast-mode-fast`) — history, not a live link.
- `src/scripts/docs-link-audit.test.ts:337` (`/index#missing`) — a deliberate negative fixture for the audit itself.
- `scripts/docs-i18n/localized_links_test.go:39-40` (`/gateway/configuration#hooks`) — a synthetic input/expectation pair proving the link localizer *preserves* fragments. It is not a link anyone follows; rewriting it would weaken nothing and change nothing. (For the record, `/gateway/configuration` does publish `set-up-webhooks-hooks`.)
- `src/tui/gateway-chat.connection.test.ts:413` and `src/infra/node-sqlite.ts:97` — checker false positives, not docs links: `wss://remote.example/gateway#resume` is a WebSocket URL and `oven-sh/bun#40005` is a GitHub issue shorthand.

## Proposed systemic fix (not implemented here)

**Yes — `docs-link-audit` should grow a non-docs scanning mode, and it should gate CI.** Concretely:

- A `--code` (or `--external-trees`) mode that walks everything **outside** `docs/` — `src/`, `extensions/`, `ui/`, `packages/`, `scripts/`, `apps/`, `.github/`, `.agents/` — for two shapes: absolute `https://docs.openclaw.ai/<route>[#frag]` URLs, and bare anchored docs routes (`/<route>#<frag>`) as used by `formatDocsLink()` and plain message strings.
- It should reuse the existing `buildAuditIndex` / `resolveRoute` / `resolveDocsFragment` machinery so redirects in `docs/docs.json` and both the canonical (`mintSlug`) and cleaned (`cleanMintId`) id spellings are honoured — that is what makes it trustworthy rather than another slug approximation.
- Route-only checking matters as much as fragment checking: a `docs.openclaw.ai/<gone-page>` in an error message is the same defect without the `#`.
- **Noise control is the design problem, not detection.** A naive regex produces mostly false positives (see the three above). The mode needs: an exclusion list for fixtures and history (`CHANGELOG.md`, `*.snap`, the audit's own test), trailing sentence-punctuation stripping, and a rule that a route which resolves to no docs page is *reported separately* rather than silently skipped — the current hand-rolled checker's silent `continue` is exactly where a dead **route** would hide.
- It should also cover repo-relative `docs/<path>.md#frag` references (as in `CONTRIBUTING.md:78`, `apps/macos/AGENTS.md:16`, `src/plugin-sdk/plugin-entry.ts:1`, `taxonomy.yaml:3454`). I checked that class by hand for this PR: 10 such references, **0 dead**. It is cheap to keep it that way.
- Lane wiring is the other half. `scripts/changed-lanes.mts` selects `check-docs` on `docs/**` changes; this PR touches no docs and therefore **does not run the docs lane at all**. A code-anchor check has to be selected by *code* paths (or run repo-wide on a schedule), otherwise it will never see the very PRs that introduce these strings — which is how all three of this week's defects got in.

## User Impact

Nine user-facing documentation links now land on the section they promise instead of the top of an unrelated page. The most consequential are the Tlon multi-user DM security warning, the Gateway Tailscale Funnel warning, and the two Control UI login-failure hints — all of which appear precisely when a user is stuck and needs the doc.

No behaviour changes beyond the link text; the surrounding messages are untouched.

## Evidence

**Detection.** A checker was written for this hunt (`git grep` for anchored docs routes outside `docs/`, then resolve each page with the repo's own `parseDocsDocument`). Baseline on this branch's merge-base (`d566b83f027`): **21 dead of 152 checked**. After this change: **0 dead in production code**; the only remaining hits are the CHANGELOG entry, the two deliberate test fixtures, and two regex false positives listed above.

I did not take that list on trust. A widened re-implementation (uppercase route segments allowed, `docs.json` redirects followed, `<route>/index.mdx` and `<route>/README.md` page shapes added, trailing sentence punctuation stripped, unresolvable routes *reported* instead of skipped) was run as a cross-check and found **no additional dead anchors in production code** — it did surface 194 route-shaped strings that are not docs links, all of which I classified. A separate pass over repo-relative `docs/**.md#frag` references found 10 such references and 0 dead.

**Tests.** Four test files pinned the old strings; each was updated to its production counterpart so the assertion keeps pinning the real message rather than a stale literal:

- `src/commands/status.command-sections.test.ts` (2 sites)
- `src/flows/doctor-core-checks.test.ts` (2 sites)
- `src/commands/doctor-state-integrity.test.ts` (1 site)
- `src/auto-reply/status.test.ts` (1 site — a `not.toContain` cross-surface guard asserting the chat status message does *not* carry the CLI's docs line)

Run with the repo's own project selector (`scripts/test-projects.mts`), which picks the right vitest config per file:

```
src/auto-reply/status.test.ts                    Test Files 1 passed (1)   Tests 82 passed
src/commands/status.command-sections.test.ts     Test Files 1 passed (1)   Tests 28 passed
src/commands/doctor-state-integrity.test.ts      Test Files 1 passed (1)   Tests 24 passed
src/flows/doctor-core-checks.test.ts             Test Files 1 passed (1)   Tests 20 passed
[test] passed 4 Vitest shards
```

Plus the suites around each changed production file:

```
ui/src/components/login-gate.test.ts                     1 passed (1)   31 tests
src/gateway/server-tailscale.test.ts (+ -upgrade)        2 passed (2)
src/commands/channels.config-only-status-output.test.ts  } 3 passed (3)
src/commands/status-runtime-shared.test.ts               }
src/status/status-text.test.ts                           }
src/auto-reply/reply/commands-gating.test.ts             } 2 passed (2)
src/auto-reply/reply/commands-bash-alias.test.ts         }
```

File counts were checked against the number of files intended in every run — no "No test files found" green or red was accepted as a result.

**Docs gate.** `docs/` is unchanged, so `scripts/changed-lanes.mts` does not select the docs lane for this PR (lanes selected: `core, coreTests, ui, extensions, extensionTests`). Run anyway for the record, and unchanged from base:

```
node scripts/docs-link-audit.mjs            checked_internal_links=12813  broken_links=0
node scripts/docs-link-audit.mjs --anchors  checked_internal_links=13085  broken_links=3
  -> the 3 known pre-existing /maturity/taxonomy#windows-app-node errors
```

**Repo gate.** `node scripts/check-changed.mjs`: 11 of 12 lanes ok (conflict markers, max-lines ratchet, assertion SAFETY ratchet, changelog attributions, doctor deprecation registry, extension wildcard re-exports, plugin-sdk wildcard re-exports, extension test core imports, duplicate scan target coverage, dependency pin guard, format changed files). `oxfmt --check` clean on all 13 changed files.

**Pre-existing failures, reproduced at the merge-base** (`git worktree add --detach` at `d566b83f027` with `node_modules` symlinked; no `git stash` was used at any point):

- `src/plugins/doctor-contract-declarations.test.ts` — `Cannot find package '@noble/hashes/sha2.js'` from `extensions/reef/protocol/canonical.ts`. Identical failure at base.
- `extensions/browser/src/browser/server.agent-contract-core.test.ts` — `Cannot find package 'yargs-parser'` from `extensions/browser/src/browser/chrome-mcp-options.ts`. Identical failure and identical counts (1 failed | 33 skipped) at base.

Both are local dependency-install gaps in this checkout, not regressions; CI installs these packages.

**CODEOWNERS.** None of the 13 changed paths matches a rule in `.github/CODEOWNERS` (checked with last-match-wins semantics against the secops and release-manager blocks). No maintainer team is required.

## Follow-up worth filing separately (not done here)

`docs/AGENTS.md` requires an `<a id>` stub when a heading is renamed, so published links keep resolving. Three of the fixes above exist because that did not happen:

- `docs/tools/slash-commands.md` — `## Config` → `## Configuration` left no `<a id="config" />`.
- `docs/concepts/models.md` — `…fallback behavior` → `…fallback strictness` left no stub.
- `docs/cli/index.md` — the `/cli` split preserved no per-command ids (`#status` and its siblings), unlike `docs/gateway/configuration.md` and `docs/web/control-ui.md`, which both carry full "Where each section moved" stub lists.

Adding those stubs is a docs-tree change that would pull in the docs and i18n-glossary lanes, so it is deliberately kept out of this code-only PR.
