### PR TITLE
refactor(gateway): remove unused no-op heartbeat config parameter

### DIFF
--- a/src/gateway/server-runtime-service-shared.ts
+++ b/src/gateway/server-runtime-service-shared.ts
@@ -1,6 +1,5 @@
 // Shared Gateway runtime service helpers.
 // Supplies minimal service handles for tests and reduced startup paths.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 
 export type GatewayRuntimeServiceLogger = {
@@ -16,6 +15,6 @@ export type GatewayRuntimeServiceLogger = {
 export function createNoopHeartbeatRunner(): HeartbeatRunner {
   return {
     stop: () => {},
-    updateConfig: (_cfg: OpenClawConfig) => {},
+    updateConfig: () => {},
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The no-op heartbeat runner declares a configuration parameter it never uses, making the inert implementation look configuration-dependent.

## Why This Change Was Made

This requested cleanup removes that unused parameter and its type-only import. The `HeartbeatRunner` annotation, real runner interface, callers, both no-op methods, and existing test assertions remain unchanged.

## User Impact

No intended user-visible change. The no-op method's JavaScript arity changes from one to zero; callers can still pass configuration through the unchanged typed interface.

## Evidence

- 45 tests passed across the same two whole Gateway suites before and after the change, with no failures or skips.
- 28 changed checks passed, including three Knip scans with zero findings.
- P3 autoreview completed with no actionable findings.
- Validation was local on Linux; no CI or performance result is claimed.
