### PR TITLE
fix(sandbox): authorize canonical destinations before pinned fs mutations

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts
@@ -215,6 +215,25 @@ describe("sandbox exec-server fs RPC through real bridges", () => {
           "dir-copy",
         );
 
+        // A destination alias into the canonical source subtree is rejected
+        // before mkdirp or any child copy can mutate the destination.
+        const sourceSubdir = path.join(mountDir, "nested", "src-dir", "subdir");
+        await fs.mkdir(sourceSubdir);
+        await fs.symlink(sourceSubdir, path.join(mountDir, "source-subdir-alias"));
+        const mutationsBeforeRejectedCopy = mutationCalls.length;
+        await expect(
+          rpc(socket, "fs/copy", {
+            sourcePath: "file:///workspace/nested/src-dir",
+            destinationPath: "file:///workspace/source-subdir-alias",
+            recursive: true,
+            sandbox: workspacePolicy,
+          }),
+        ).rejects.toThrow("Cannot recursively copy a directory into itself");
+        expect(mutationCalls).toHaveLength(mutationsBeforeRejectedCopy);
+        await expect(fs.stat(path.join(sourceSubdir, "child.txt"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+
         // Recursive directory copy into an existing directory alias: the
         // directory pin follows the canonical directory, so children land in
         // the alias target.

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts
@@ -1,0 +1,239 @@
+// RPC-to-bridge composition tests drive the sandbox exec-server filesystem RPC
+// through a real bridge implementation (real shell execution, real symlinks)
+// and verify authorization decisions against observed filesystem effects:
+// protected canonical destinations are rejected before any mutation runs, and
+// allowed writes land exactly on the authorized canonical destination.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createRemoteShellSandboxFsBridge,
+  type SandboxBackendCommandParams,
+  type SandboxBackendCommandResult,
+} from "openclaw/plugin-sdk/sandbox";
+import { afterEach, describe, expect, it } from "vitest";
+import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
+import { ensureCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
+import {
+  codexFsSandboxContext,
+  createClient,
+  createSandboxContext,
+  execServerUrlFromClient,
+  openSocket,
+  rpc,
+  specialPath,
+} from "./sandbox-exec-server.test-helpers.js";
+
+const SANDBOX_MOUNT = "/workspace";
+
+type RemoteShellCommand = SandboxBackendCommandParams;
+
+/** Rewrites container paths under SANDBOX_MOUNT onto the real temp workspace. */
+function rewriteMountArgs(args: string[] | undefined, mountDir: string): string[] {
+  return (args ?? []).map((arg) =>
+    arg === SANDBOX_MOUNT || arg.startsWith(`${SANDBOX_MOUNT}/`)
+      ? `${mountDir}${arg.slice(SANDBOX_MOUNT.length)}`
+      : arg,
+  );
+}
+
+/** Spawns the exact shell script locally with rewritten sandbox paths. */
+function runLocalShellScript(
+  command: RemoteShellCommand,
+  mountDir: string,
+): Promise<SandboxBackendCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "sh",
+      ["-c", command.script, "composition-shell", ...rewriteMountArgs(command.args, mountDir)],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout?.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr?.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+        code: code ?? 0,
+      });
+    });
+    child.stdin?.end(command.stdin);
+  });
+}
+
+/**
+ * Real sandbox backend for the composition harness: backend commands (such as
+ * the directory listing used by recursive copies) execute for real against
+ * the temp workspace with rewritten sandbox paths.
+ */
+function createLocalExecBackend(mountDir: string) {
+  return {
+    id: "local-composition",
+    runtimeId: "codex-fs-composition",
+    runtimeLabel: "codex-fs-composition",
+    workdir: mountDir,
+    buildExecSpec: async ({
+      command,
+      env,
+    }: {
+      command: string;
+      env: Record<string, string | undefined>;
+    }) => ({
+      argv: ["sh", "-c", command],
+      env,
+      stdinMode: "pipe-closed" as const,
+    }),
+    runShellCommand: async (command: RemoteShellCommand) =>
+      await runLocalShellScript(command, mountDir),
+  };
+}
+
+/**
+ * Executes remote shell snippets locally so the bridge scripts run for real
+ * against a temp workspace. The bridge speaks container paths under
+ * SANDBOX_MOUNT; the shim rewrites those argv paths onto the temp workspace.
+ */
+function createLocalShellRemoteRuntime(remoteMountDir: string) {
+  const mutationCalls: RemoteShellCommand[] = [];
+  const runtime = {
+    remoteWorkspaceDir: SANDBOX_MOUNT,
+    remoteAgentWorkspaceDir: SANDBOX_MOUNT,
+    runRemoteShellScript: async (command: RemoteShellCommand) => {
+      if (command.script.includes("operation = sys.argv[1]")) {
+        mutationCalls.push(command);
+      }
+      return await runLocalShellScript(command, remoteMountDir);
+    },
+  };
+  return { mutationCalls, runtime };
+}
+
+afterEach(async () => {
+  await sandboxExecServerRegistry.closeAll();
+});
+
+describe("sandbox exec-server fs RPC through real bridges", () => {
+  it.runIf(process.platform !== "win32")(
+    "rejects protected canonical destinations before filesystem effects and lands allowed writes exactly",
+    async () => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-fs-composition-"));
+      try {
+        const mountDir = path.join(await fs.realpath(stateDir), "workspace");
+        await fs.mkdir(mountDir, { recursive: true });
+        const gitDir = path.join(mountDir, ".git");
+        const realDir = path.join(mountDir, "real");
+        await fs.mkdir(gitDir);
+        await fs.mkdir(realDir);
+        // A workspace alias that canonicalizes into the protected .git
+        // directory, and one that canonicalizes into a writable directory.
+        await fs.symlink(gitDir, path.join(mountDir, "alias"));
+        await fs.symlink(realDir, path.join(mountDir, "alias-real"));
+
+        const { mutationCalls, runtime } = createLocalShellRemoteRuntime(mountDir);
+        const realBridge = createRemoteShellSandboxFsBridge({
+          sandbox: {
+            workspaceDir: mountDir,
+            agentWorkspaceDir: mountDir,
+            workspaceAccess: "rw",
+          } as never,
+          runtime: runtime as never,
+        });
+        const sandbox = {
+          ...createSandboxContext({}),
+          backend: createLocalExecBackend(mountDir),
+          fsBridge: realBridge,
+        };
+
+        const client = createClient();
+        await ensureCodexSandboxExecServerEnvironment({
+          client: client as never,
+          sandbox: sandbox as never,
+        });
+        const socket = await openSocket(execServerUrlFromClient(client));
+        await rpc(socket, "initialize", { clientName: "test" });
+        socket.send(JSON.stringify({ method: "initialized" }));
+        const workspacePolicy = codexFsSandboxContext({
+          entries: [
+            { path: specialPath("root"), access: "read" },
+            { path: specialPath("project_roots"), access: "write" },
+            { path: specialPath("project_roots", ".git"), access: "read" },
+          ],
+        });
+
+        // Protected canonical destination: denied before any filesystem effect.
+        await expect(
+          rpc(socket, "fs/writeFile", {
+            path: "file:///workspace/alias/config",
+            dataBase64: Buffer.from("blocked").toString("base64"),
+            sandbox: workspacePolicy,
+          }),
+        ).rejects.toThrow("Codex fs sandbox denied write access");
+        await expect(fs.stat(path.join(gitDir, "config"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        // The real bridge never received a mutation for the denied request.
+        expect(mutationCalls).toHaveLength(0);
+
+        // Allowed direct write lands on the authorized destination.
+        await rpc(socket, "fs/writeFile", {
+          path: "file:///workspace/real-note.txt",
+          dataBase64: Buffer.from("allowed").toString("base64"),
+          sandbox: workspacePolicy,
+        });
+        await expect(fs.readFile(path.join(mountDir, "real-note.txt"), "utf8")).resolves.toBe(
+          "allowed",
+        );
+        expect(mutationCalls.length).toBeGreaterThan(0);
+
+        // Allowed aliased write pins the canonical destination: the payload
+        // lands on the alias target, not on the lexical request path.
+        await rpc(socket, "fs/writeFile", {
+          path: "file:///workspace/alias-real/config",
+          dataBase64: Buffer.from("aliased").toString("base64"),
+          sandbox: workspacePolicy,
+        });
+        await expect(fs.readFile(path.join(realDir, "config"), "utf8")).resolves.toBe("aliased");
+
+        // Recursive directory copy into the existing mount root: directory
+        // destinations resolve with directory semantics (the root itself), so
+        // the copy reaches the existing-root path instead of being rejected
+        // by file-backed parent resolution. Directory copies place the source
+        // children inside the destination.
+        await fs.mkdir(path.join(mountDir, "nested", "src-dir"), { recursive: true });
+        await fs.writeFile(path.join(mountDir, "nested", "src-dir", "child.txt"), "dir-copy");
+        await rpc(socket, "fs/copy", {
+          sourcePath: "file:///workspace/nested/src-dir",
+          destinationPath: "file:///workspace",
+          recursive: true,
+          sandbox: workspacePolicy,
+        });
+        await expect(fs.readFile(path.join(mountDir, "child.txt"), "utf8")).resolves.toBe(
+          "dir-copy",
+        );
+
+        // Recursive directory copy into an existing directory alias: the
+        // directory pin follows the canonical directory, so children land in
+        // the alias target.
+        const dirTarget = path.join(mountDir, "dir-target");
+        await fs.mkdir(dirTarget, { recursive: true });
+        await fs.symlink(dirTarget, path.join(mountDir, "alias-dir"));
+        await rpc(socket, "fs/copy", {
+          sourcePath: "file:///workspace/nested/src-dir",
+          destinationPath: "file:///workspace/alias-dir",
+          recursive: true,
+          sandbox: workspacePolicy,
+        });
+        await expect(fs.readFile(path.join(dirTarget, "child.txt"), "utf8")).resolves.toBe(
+          "dir-copy",
+        );
+        socket.close();
+      } finally {
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -144,6 +144,144 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
     socket.close();
   });
 
+  it("denies writes whose canonical destination is policy-protected", async () => {
+    const writeFile = vi.fn(async () => undefined);
+    const sandbox = createSandboxContext({
+      writeFile,
+      // Simulates a workspace symlink alias that canonicalizes into .git.
+      resolvePinnedMutationTarget: async ({ filePath }) =>
+        filePath === "/workspace/alias/config"
+          ? { canonicalPath: "/workspace/.git/config" }
+          : { canonicalPath: filePath },
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "fs/writeFile", {
+        path: "file:///workspace/alias/config",
+        dataBase64: Buffer.from("blocked").toString("base64"),
+        sandbox: codexFsSandboxContext({
+          entries: [
+            { path: specialPath("root"), access: "read" },
+            { path: specialPath("project_roots"), access: "write" },
+            { path: specialPath("project_roots", ".git"), access: "read" },
+          ],
+        }),
+      }),
+    ).rejects.toThrow("Codex fs sandbox denied write access");
+
+    expect(writeFile).not.toHaveBeenCalled();
+    socket.close();
+  });
+
+  it("pins authorized writes to the canonical destination", async () => {
+    const writeFile = vi.fn(async () => undefined);
+    const sandbox = createSandboxContext({
+      writeFile,
+      resolvePinnedMutationTarget: async ({ filePath }) =>
+        filePath === "/workspace/alias/config"
+          ? { canonicalPath: "/workspace/real/config" }
+          : { canonicalPath: filePath },
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await rpc(socket, "fs/writeFile", {
+      path: "file:///workspace/alias/config",
+      dataBase64: Buffer.from("pinned").toString("base64"),
+      sandbox: codexFsSandboxContext({
+        entries: [
+          { path: specialPath("root"), access: "read" },
+          { path: specialPath("project_roots"), access: "write" },
+        ],
+      }),
+    });
+
+    expect(writeFile).toHaveBeenCalledWith({
+      filePath: "/workspace/alias/config",
+      data: Buffer.from("pinned"),
+      mkdir: false,
+      pinnedPath: "/workspace/real/config",
+    });
+    socket.close();
+  });
+
+  it("denies copies whose canonical destination is policy-protected", async () => {
+    const copyFile = vi.fn(async () => undefined);
+    const sandbox = createSandboxContext({
+      copyFile,
+      resolvePinnedMutationTarget: async ({ filePath }) =>
+        filePath === "/workspace/alias/config"
+          ? { canonicalPath: "/workspace/.git/config" }
+          : { canonicalPath: filePath },
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "fs/copy", {
+        sourcePath: "file:///workspace/source.txt",
+        destinationPath: "file:///workspace/alias/config",
+        sandbox: codexFsSandboxContext({
+          entries: [
+            { path: specialPath("root"), access: "read" },
+            { path: specialPath("project_roots"), access: "write" },
+            { path: specialPath("project_roots", ".git"), access: "read" },
+          ],
+        }),
+      }),
+    ).rejects.toThrow("Codex fs sandbox denied write access");
+
+    expect(copyFile).not.toHaveBeenCalled();
+    socket.close();
+  });
+
+  it("pins authorized copies to the canonical destination", async () => {
+    const copyFile = vi.fn(async () => undefined);
+    const sandbox = createSandboxContext({
+      copyFile,
+      stat: async () => ({ type: "file", size: 4, mtimeMs: 1 }),
+      resolvePinnedMutationTarget: async ({ filePath }) =>
+        filePath === "/workspace/alias/config"
+          ? { canonicalPath: "/workspace/real/config" }
+          : { canonicalPath: filePath },
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await rpc(socket, "fs/copy", {
+      sourcePath: "file:///workspace/source.txt",
+      destinationPath: "file:///workspace/alias/config",
+      sandbox: codexFsSandboxContext({
+        entries: [
+          { path: specialPath("root"), access: "read" },
+          { path: specialPath("project_roots"), access: "write" },
+        ],
+      }),
+    });
+
+    expect(copyFile).toHaveBeenCalledWith({
+      sourcePath: "/workspace/source.txt",
+      destinationPath: "/workspace/alias/config",
+      mkdir: true,
+      pinnedPath: "/workspace/real/config",
+    });
+    socket.close();
+  });
+
   it("honors Codex fs sandbox protected metadata carveouts", async () => {
     const remove = vi.fn(async () => undefined);
     const writeFile = vi.fn(async () => undefined);

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -151,8 +151,8 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       // Simulates a workspace symlink alias that canonicalizes into .git.
       resolvePinnedMutationTarget: async ({ filePath }) =>
         filePath === "/workspace/alias/config"
-          ? { canonicalPath: "/workspace/.git/config" }
-          : { canonicalPath: filePath },
+          ? { policyPath: "/workspace/.git/config", pinnedPath: "/workspace/.git/config" }
+          : { policyPath: filePath, pinnedPath: filePath },
     });
     const client = createClient();
     await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
@@ -184,8 +184,8 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       writeFile,
       resolvePinnedMutationTarget: async ({ filePath }) =>
         filePath === "/workspace/alias/config"
-          ? { canonicalPath: "/workspace/real/config" }
-          : { canonicalPath: filePath },
+          ? { policyPath: "/workspace/real/config", pinnedPath: "/workspace/real/config" }
+          : { policyPath: filePath, pinnedPath: filePath },
     });
     const client = createClient();
     await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
@@ -219,8 +219,8 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       copyFile,
       resolvePinnedMutationTarget: async ({ filePath }) =>
         filePath === "/workspace/alias/config"
-          ? { canonicalPath: "/workspace/.git/config" }
-          : { canonicalPath: filePath },
+          ? { policyPath: "/workspace/.git/config", pinnedPath: "/workspace/.git/config" }
+          : { policyPath: filePath, pinnedPath: filePath },
     });
     const client = createClient();
     await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
@@ -253,8 +253,8 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       stat: async () => ({ type: "file", size: 4, mtimeMs: 1 }),
       resolvePinnedMutationTarget: async ({ filePath }) =>
         filePath === "/workspace/alias/config"
-          ? { canonicalPath: "/workspace/real/config" }
-          : { canonicalPath: filePath },
+          ? { policyPath: "/workspace/real/config", pinnedPath: "/workspace/real/config" }
+          : { policyPath: filePath, pinnedPath: filePath },
     });
     const client = createClient();
     await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -87,6 +87,27 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
         signal?: AbortSignal;
       }) => undefined,
     );
+    const copyFile = vi.fn(
+      async (_params: {
+        sourcePath: string;
+        destinationPath: string;
+        cwd?: string;
+        mkdir?: boolean;
+        signal?: AbortSignal;
+      }) => undefined,
+    );
+    const mkdirp = vi.fn(
+      async (_params: { filePath: string; cwd?: string; signal?: AbortSignal }) => undefined,
+    );
+    const remove = vi.fn(
+      async (_params: {
+        filePath: string;
+        cwd?: string;
+        recursive?: boolean;
+        force?: boolean;
+        signal?: AbortSignal;
+      }) => undefined,
+    );
     // Deliberately model the interface shipped before canonical mutation pins:
     // no resolvePinnedMutationTarget method and no pinnedPath parameters.
     const legacyBridge = {
@@ -95,16 +116,10 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
         containerPath: filePath,
       }),
       readFile: async () => Buffer.alloc(0),
+      copyFile,
       writeFile,
-      mkdirp: async (_params: { filePath: string; cwd?: string; signal?: AbortSignal }) =>
-        undefined,
-      remove: async (_params: {
-        filePath: string;
-        cwd?: string;
-        recursive?: boolean;
-        force?: boolean;
-        signal?: AbortSignal;
-      }) => undefined,
+      mkdirp,
+      remove,
       rename: async () => undefined,
       stat: async ({ filePath }: { filePath: string; cwd?: string; signal?: AbortSignal }) => ({
         type: /\.[^/]+$/u.test(filePath) ? ("file" as const) : ("directory" as const),
@@ -130,6 +145,39 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       filePath: "/workspace/legacy.txt",
       data: Buffer.from("compatible"),
       mkdir: false,
+    });
+
+    await expect(
+      rpc(socket, "fs/createDirectory", {
+        path: "file:///workspace/legacy-dir",
+        recursive: true,
+      }),
+    ).resolves.toEqual({});
+    expect(mkdirp).toHaveBeenCalledWith({ filePath: "/workspace/legacy-dir" });
+
+    await expect(
+      rpc(socket, "fs/copy", {
+        sourcePath: "file:///workspace/source.txt",
+        destinationPath: "file:///workspace/copied.txt",
+      }),
+    ).resolves.toEqual({});
+    expect(copyFile).toHaveBeenCalledWith({
+      sourcePath: "/workspace/source.txt",
+      destinationPath: "/workspace/copied.txt",
+      mkdir: true,
+    });
+
+    await expect(
+      rpc(socket, "fs/remove", {
+        path: "file:///workspace/legacy.txt",
+        recursive: false,
+        force: false,
+      }),
+    ).resolves.toEqual({});
+    expect(remove).toHaveBeenCalledWith({
+      filePath: "/workspace/legacy.txt",
+      recursive: false,
+      force: false,
     });
     socket.close();
   });

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover sandbox exec server.fs plugin behavior.
+import type { SandboxFsBridge } from "openclaw/plugin-sdk/sandbox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import { ensureCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
@@ -71,6 +72,63 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
     expect(writeFile).toHaveBeenCalledWith({
       filePath: "/workspace/empty.txt",
       data: Buffer.alloc(0),
+      mkdir: false,
+    });
+    socket.close();
+  });
+
+  it("keeps pre-upgrade sandbox fs bridges source- and runtime-compatible", async () => {
+    const writeFile = vi.fn(
+      async (_params: {
+        filePath: string;
+        data: Buffer | string;
+        encoding?: BufferEncoding;
+        mkdir?: boolean;
+        signal?: AbortSignal;
+      }) => undefined,
+    );
+    // Deliberately model the interface shipped before canonical mutation pins:
+    // no resolvePinnedMutationTarget method and no pinnedPath parameters.
+    const legacyBridge = {
+      resolvePath: ({ filePath }: { filePath: string; cwd?: string }) => ({
+        relativePath: filePath,
+        containerPath: filePath,
+      }),
+      readFile: async () => Buffer.alloc(0),
+      writeFile,
+      mkdirp: async (_params: { filePath: string; cwd?: string; signal?: AbortSignal }) =>
+        undefined,
+      remove: async (_params: {
+        filePath: string;
+        cwd?: string;
+        recursive?: boolean;
+        force?: boolean;
+        signal?: AbortSignal;
+      }) => undefined,
+      rename: async () => undefined,
+      stat: async ({ filePath }: { filePath: string; cwd?: string; signal?: AbortSignal }) => ({
+        type: /\.[^/]+$/u.test(filePath) ? ("file" as const) : ("directory" as const),
+        size: 1,
+        mtimeMs: 1,
+      }),
+    } satisfies SandboxFsBridge;
+    const sandbox = { ...createSandboxContext({}), fsBridge: legacyBridge };
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "fs/writeFile", {
+        path: "file:///workspace/legacy.txt",
+        dataBase64: Buffer.from("compatible").toString("base64"),
+      }),
+    ).resolves.toEqual({});
+
+    expect(writeFile).toHaveBeenCalledWith({
+      filePath: "/workspace/legacy.txt",
+      data: Buffer.from("compatible"),
       mkdir: false,
     });
     socket.close();

--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -712,6 +712,56 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
     socket.close();
   });
 
+  it("rejects recursive directory copies into a canonical source subtree", async () => {
+    const mkdirp = vi.fn(async () => undefined);
+    const runShellCommand = vi.fn(async () => ({
+      stdout: Buffer.from("f\tchild.txt\n"),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+    const sandbox = createSandboxContext({
+      mkdirp,
+      resolvePinnedMutationTarget: async ({ filePath }) => {
+        if (filePath === "/workspace/source-dir") {
+          return {
+            policyPath: "/workspace/source-dir",
+            pinnedPath: "/workspace/source-dir",
+          };
+        }
+        if (filePath === "/workspace/alias") {
+          return {
+            policyPath: "/workspace/source-dir/subdir",
+            pinnedPath: "/workspace/source-dir/subdir",
+          };
+        }
+        return { policyPath: filePath, pinnedPath: filePath };
+      },
+      runShellCommand,
+      stat: async () => ({
+        type: "directory",
+        size: 1,
+        mtimeMs: 1,
+      }),
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({ client: client as never, sandbox });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "fs/copy", {
+        sourcePath: "file:///workspace/source-dir",
+        destinationPath: "file:///workspace/alias",
+        recursive: true,
+      }),
+    ).rejects.toThrow("Cannot recursively copy a directory into itself");
+
+    expect(mkdirp).not.toHaveBeenCalled();
+    expect(runShellCommand).not.toHaveBeenCalled();
+    socket.close();
+  });
+
   it("reports missing metadata as an exec-server not found error", async () => {
     const sandbox = createSandboxContext({ stat: async () => null });
     const client = createClient();

--- a/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
@@ -22,6 +22,9 @@ export function createSandboxContext(overrides: {
   mkdirp?: NonNullable<SandboxContext["fsBridge"]>["mkdirp"];
   readFile?: NonNullable<SandboxContext["fsBridge"]>["readFile"];
   remove?: NonNullable<SandboxContext["fsBridge"]>["remove"];
+  resolvePinnedMutationTarget?: NonNullable<
+    SandboxContext["fsBridge"]
+  >["resolvePinnedMutationTarget"];
   runShellCommand?: NonNullable<SandboxContext["backend"]>["runShellCommand"];
   stat?: NonNullable<SandboxContext["fsBridge"]>["stat"];
   writeFile?: NonNullable<SandboxContext["fsBridge"]>["writeFile"];
@@ -70,6 +73,7 @@ export function createSandboxContext(overrides: {
       mkdirp: overrides.mkdirp ?? (async () => undefined),
       remove: overrides.remove ?? (async () => undefined),
       rename: async () => undefined,
+      resolvePinnedMutationTarget: overrides.resolvePinnedMutationTarget,
       stat:
         overrides.stat ??
         (async ({ filePath }) => ({

--- a/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
@@ -247,8 +247,20 @@ export async function writeFile(
 ): Promise<void> {
   const record = requireObject(params, "fs/writeFile params");
   const filePath = resolveExecServerPath(requireString(record.path, "path"), "write path");
-  assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "write" }]);
   const fsBridge = execServer.fsBridge;
+  // Authorize the canonical destination before pinning the mutation so a
+  // symlinked parent cannot redirect an approved write into a protected path
+  // after authorization.
+  const canonicalDestination = await fsBridge.resolvePinnedMutationTarget?.({
+    filePath,
+    action: "write",
+  });
+  assertFsSandboxAccess(execServer, record, [
+    { path: filePath, access: "write" },
+    ...(canonicalDestination
+      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      : []),
+  ]);
   const parent = await fsBridge.stat({ filePath: pathPosix.dirname(filePath) });
   if (parent?.type !== "directory") {
     throw new JsonRpcProtocolError(JSON_RPC_NOT_FOUND, "parent directory not found");
@@ -257,6 +269,7 @@ export async function writeFile(
     filePath,
     data: Buffer.from(requireBase64String(record.dataBase64, "dataBase64"), "base64"),
     mkdir: false,
+    pinnedPath: canonicalDestination?.canonicalPath,
   });
 }
 
@@ -270,8 +283,17 @@ export async function createDirectory(
     requireString(record.path, "path"),
     "create-directory path",
   );
-  assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "write" }]);
   const fsBridge = execServer.fsBridge;
+  const canonicalDestination = await fsBridge.resolvePinnedMutationTarget?.({
+    filePath,
+    action: "mkdir",
+  });
+  assertFsSandboxAccess(execServer, record, [
+    { path: filePath, access: "write" },
+    ...(canonicalDestination
+      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      : []),
+  ]);
   if (record.recursive === false) {
     const parentPath = pathPosix.dirname(filePath);
     const parent = await fsBridge.stat({ filePath: parentPath });
@@ -281,6 +303,7 @@ export async function createDirectory(
   }
   await fsBridge.mkdirp({
     filePath,
+    pinnedPath: canonicalDestination?.canonicalPath,
   });
 }
 
@@ -355,14 +378,27 @@ export async function removePath(
   const record = requireObject(params, "fs/remove params");
   const filePath = resolveExecServerPath(requireString(record.path, "path"), "remove path");
   const fsSandboxPolicy = resolveFsSandboxPolicy(execServer, record);
-  assertResolvedFsSandboxAccess(fsSandboxPolicy, [{ path: filePath, access: "write" }]);
+  const canonicalDestination = await execServer.fsBridge.resolvePinnedMutationTarget?.({
+    filePath,
+    action: "remove",
+  });
+  assertResolvedFsSandboxAccess(fsSandboxPolicy, [
+    { path: filePath, access: "write" },
+    ...(canonicalDestination
+      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      : []),
+  ]);
   if (record.recursive !== false) {
     assertNoReadOnlyDescendant(fsSandboxPolicy, filePath, "remove");
+    if (canonicalDestination) {
+      assertNoReadOnlyDescendant(fsSandboxPolicy, canonicalDestination.canonicalPath, "remove");
+    }
   }
   await execServer.fsBridge.remove({
     filePath,
     recursive: record.recursive !== false,
     force: record.force !== false,
+    pinnedPath: canonicalDestination?.canonicalPath,
   });
 }
 
@@ -403,9 +439,18 @@ async function copySandboxPath(
   },
 ): Promise<void> {
   const fsBridge = execServer.fsBridge;
+  // Authorize the canonical copy destination before pinning the mutation so a
+  // symlinked parent cannot redirect an approved copy into a protected path.
+  const canonicalDestination = await fsBridge.resolvePinnedMutationTarget?.({
+    filePath: params.destinationPath,
+    action: "copy-destination",
+  });
   assertResolvedFsSandboxAccess(params.fsSandboxPolicy, [
     { path: params.sourcePath, access: "read" },
     { path: params.destinationPath, access: "write" },
+    ...(canonicalDestination
+      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      : []),
   ]);
   const sourceStat = await fsBridge.stat({ filePath: params.sourcePath });
   if (!sourceStat) {
@@ -423,7 +468,10 @@ async function copySandboxPath(
     ) {
       throw new Error("Cannot recursively copy a directory into itself.");
     }
-    await fsBridge.mkdirp({ filePath: params.destinationPath });
+    await fsBridge.mkdirp({
+      filePath: params.destinationPath,
+      pinnedPath: canonicalDestination?.canonicalPath,
+    });
     for (const entry of await listDirectoryEntries(
       execServer,
       params.sourcePath,
@@ -447,6 +495,7 @@ async function copySandboxPath(
       sourcePath: params.sourcePath,
       destinationPath: params.destinationPath,
       mkdir: true,
+      pinnedPath: canonicalDestination?.canonicalPath,
     });
     return;
   }
@@ -462,6 +511,7 @@ async function copySandboxPath(
     filePath: params.destinationPath,
     data,
     mkdir: true,
+    pinnedPath: canonicalDestination?.canonicalPath,
   });
 }
 

--- a/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
@@ -258,7 +258,7 @@ export async function writeFile(
   assertFsSandboxAccess(execServer, record, [
     { path: filePath, access: "write" },
     ...(canonicalDestination
-      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
       : []),
   ]);
   const parent = await fsBridge.stat({ filePath: pathPosix.dirname(filePath) });
@@ -269,7 +269,7 @@ export async function writeFile(
     filePath,
     data: Buffer.from(requireBase64String(record.dataBase64, "dataBase64"), "base64"),
     mkdir: false,
-    pinnedPath: canonicalDestination?.canonicalPath,
+    pinnedPath: canonicalDestination?.pinnedPath,
   });
 }
 
@@ -291,7 +291,7 @@ export async function createDirectory(
   assertFsSandboxAccess(execServer, record, [
     { path: filePath, access: "write" },
     ...(canonicalDestination
-      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
       : []),
   ]);
   if (record.recursive === false) {
@@ -303,7 +303,7 @@ export async function createDirectory(
   }
   await fsBridge.mkdirp({
     filePath,
-    pinnedPath: canonicalDestination?.canonicalPath,
+    pinnedPath: canonicalDestination?.pinnedPath,
   });
 }
 
@@ -385,20 +385,20 @@ export async function removePath(
   assertResolvedFsSandboxAccess(fsSandboxPolicy, [
     { path: filePath, access: "write" },
     ...(canonicalDestination
-      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
       : []),
   ]);
   if (record.recursive !== false) {
     assertNoReadOnlyDescendant(fsSandboxPolicy, filePath, "remove");
     if (canonicalDestination) {
-      assertNoReadOnlyDescendant(fsSandboxPolicy, canonicalDestination.canonicalPath, "remove");
+      assertNoReadOnlyDescendant(fsSandboxPolicy, canonicalDestination.policyPath, "remove");
     }
   }
   await execServer.fsBridge.remove({
     filePath,
     recursive: record.recursive !== false,
     force: record.force !== false,
-    pinnedPath: canonicalDestination?.canonicalPath,
+    pinnedPath: canonicalDestination?.pinnedPath,
   });
 }
 
@@ -449,7 +449,7 @@ async function copySandboxPath(
     { path: params.sourcePath, access: "read" },
     { path: params.destinationPath, access: "write" },
     ...(canonicalDestination
-      ? [{ path: canonicalDestination.canonicalPath, access: "write" as const }]
+      ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
       : []),
   ]);
   const sourceStat = await fsBridge.stat({ filePath: params.sourcePath });
@@ -470,7 +470,7 @@ async function copySandboxPath(
     }
     await fsBridge.mkdirp({
       filePath: params.destinationPath,
-      pinnedPath: canonicalDestination?.canonicalPath,
+      pinnedPath: canonicalDestination?.pinnedPath,
     });
     for (const entry of await listDirectoryEntries(
       execServer,
@@ -495,7 +495,7 @@ async function copySandboxPath(
       sourcePath: params.sourcePath,
       destinationPath: params.destinationPath,
       mkdir: true,
-      pinnedPath: canonicalDestination?.canonicalPath,
+      pinnedPath: canonicalDestination?.pinnedPath,
     });
     return;
   }
@@ -511,7 +511,7 @@ async function copySandboxPath(
     filePath: params.destinationPath,
     data,
     mkdir: true,
-    pinnedPath: canonicalDestination?.canonicalPath,
+    pinnedPath: canonicalDestination?.pinnedPath,
   });
 }
 

--- a/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
@@ -439,24 +439,30 @@ async function copySandboxPath(
   },
 ): Promise<void> {
   const fsBridge = execServer.fsBridge;
-  // Authorize the canonical copy destination before pinning the mutation so a
-  // symlinked parent cannot redirect an approved copy into a protected path.
-  const canonicalDestination = await fsBridge.resolvePinnedMutationTarget?.({
-    filePath: params.destinationPath,
-    action: "copy-destination",
-  });
+  // Lexical policy checks run before any filesystem access so denied sources
+  // and destinations fail without side effects.
   assertResolvedFsSandboxAccess(params.fsSandboxPolicy, [
     { path: params.sourcePath, access: "read" },
     { path: params.destinationPath, access: "write" },
-    ...(canonicalDestination
-      ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
-      : []),
   ]);
   const sourceStat = await fsBridge.stat({ filePath: params.sourcePath });
   if (!sourceStat) {
     throw new JsonRpcProtocolError(JSON_RPC_NOT_FOUND, "file not found");
   }
-  if (sourceStat?.type === "directory") {
+  // Authorize the canonical copy destination before pinning the mutation so a
+  // symlinked parent cannot redirect an approved copy into a protected path.
+  // Recursive directory copies authorize the destination directory itself (an
+  // alias may rename it and an existing mount root stays valid); file copies
+  // authorize the canonical parent plus the requested basename.
+  const canonicalDestination = await fsBridge.resolvePinnedMutationTarget?.({
+    filePath: params.destinationPath,
+    action: sourceStat.type === "directory" ? "mkdir" : "copy-destination",
+  });
+  const canonicalPolicyEntries = canonicalDestination
+    ? [{ path: canonicalDestination.policyPath, access: "write" as const }]
+    : [];
+  assertResolvedFsSandboxAccess(params.fsSandboxPolicy, canonicalPolicyEntries);
+  if (sourceStat.type === "directory") {
     if (!params.recursive) {
       throw new Error(`Cannot copy directory without recursive=true: ${params.sourcePath}`);
     }

--- a/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
@@ -466,10 +466,24 @@ async function copySandboxPath(
     if (!params.recursive) {
       throw new Error(`Cannot copy directory without recursive=true: ${params.sourcePath}`);
     }
+    // Directory target resolution is side-effect free, so use the same
+    // canonical directory view for the source containment check. Comparing
+    // only lexical paths lets an alias hide that the destination is inside
+    // the source and can make recursive copy enumerate its own output.
+    const canonicalSource = await fsBridge.resolvePinnedMutationTarget?.({
+      filePath: params.sourcePath,
+      action: "mkdir",
+    });
     if (
       pathContains(
-        normalizeSandboxAbsolutePath(params.sourcePath, "copy source path"),
-        normalizeSandboxAbsolutePath(params.destinationPath, "copy destination path"),
+        normalizeSandboxAbsolutePath(
+          canonicalSource?.policyPath ?? params.sourcePath,
+          "copy source path",
+        ),
+        normalizeSandboxAbsolutePath(
+          canonicalDestination?.policyPath ?? params.destinationPath,
+          "copy destination path",
+        ),
       )
     ) {
       throw new Error("Cannot recursively copy a directory into itself.");

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -256,6 +256,21 @@ export class SandboxFsPathGuard {
     });
   }
 
+  /**
+   * Resolves the canonical full destination path (canonicalized parent plus
+   * basename) so callers can authorize the real mutation target before pinning.
+   */
+  async resolveCanonicalMutationTarget(
+    target: SandboxResolvedFsPath,
+    action: string,
+  ): Promise<string> {
+    const anchoredTarget = await this.resolveAnchoredSandboxEntry(target, action);
+    this.resolveRequiredMount(anchoredTarget.canonicalParentPath, action);
+    return anchoredTarget.canonicalParentPath === "/"
+      ? `/${anchoredTarget.basename}`
+      : `${anchoredTarget.canonicalParentPath}/${anchoredTarget.basename}`;
+  }
+
   async resolveAnchoredPinnedDirectoryEntry(
     target: SandboxResolvedFsPath,
     action: string,

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -257,13 +257,25 @@ export class SandboxFsPathGuard {
   }
 
   /**
-   * Resolves the canonical full destination path (canonicalized parent plus
-   * basename) so callers can authorize the real mutation target before pinning.
+   * Resolves the canonical mutation destination so callers can authorize the
+   * real target before pinning. File-backed actions resolve the canonical
+   * parent and re-attach the requested basename; directory actions
+   * (`options.directory`) canonicalize the directory itself, which an
+   * existing alias may rename, and tolerate the mount root.
    */
   async resolveCanonicalMutationTarget(
     target: SandboxResolvedFsPath,
     action: string,
+    options?: { directory?: boolean },
   ): Promise<string> {
+    if (options?.directory) {
+      const canonicalPath = await this.resolveCanonicalContainerPath({
+        containerPath: target.containerPath,
+        allowFinalSymlinkForUnlink: false,
+      });
+      this.resolveRequiredMount(canonicalPath, action);
+      return canonicalPath;
+    }
     const anchoredTarget = await this.resolveAnchoredSandboxEntry(target, action);
     this.resolveRequiredMount(anchoredTarget.canonicalParentPath, action);
     return anchoredTarget.canonicalParentPath === "/"

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -312,7 +312,10 @@ describe("sandbox fs bridge anchored ops", () => {
 
         await expect(
           bridge.resolvePinnedMutationTarget!({ filePath: "alias/note.txt", action: "write" }),
-        ).resolves.toEqual({ canonicalPath: "/workspace/real/note.txt" });
+        ).resolves.toEqual({
+          policyPath: "/workspace/real/note.txt",
+          pinnedPath: "/workspace/real/note.txt",
+        });
       });
     },
   );

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -288,6 +288,91 @@ describe("sandbox fs bridge anchored ops", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "resolvePinnedMutationTarget canonicalizes symlinked parents",
+    async () => {
+      await withTempDir("openclaw-fs-bridge-pinned-target-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const realDir = path.join(workspaceDir, "real");
+        await fs.mkdir(realDir, { recursive: true });
+        await fs.symlink(realDir, path.join(workspaceDir, "alias"));
+
+        mockedExecDockerRaw.mockImplementation(async (args) => {
+          const script = getDockerScript(args);
+          if (script.includes('readlink -f -- "$cursor"')) {
+            const target = getDockerArg(args, 1);
+            return dockerExecResult(`${target.replace("/workspace/alias", "/workspace/real")}\n`);
+          }
+          return dockerExecResult("");
+        });
+
+        const bridge = createSandboxFsBridge({
+          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+        });
+
+        await expect(
+          bridge.resolvePinnedMutationTarget!({ filePath: "alias/note.txt", action: "write" }),
+        ).resolves.toEqual({ canonicalPath: "/workspace/real/note.txt" });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "writeFile pins an authorized canonical destination without re-resolving aliases",
+    async () => {
+      await withTempDir("openclaw-fs-bridge-pinned-write-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const realDir = path.join(workspaceDir, "real");
+        await fs.mkdir(realDir, { recursive: true });
+        await fs.symlink(realDir, path.join(workspaceDir, "alias"));
+
+        mockedExecDockerRaw.mockImplementation(async (args) => {
+          const script = getDockerScript(args);
+          if (script.includes('readlink -f -- "$cursor"')) {
+            // Simulates an attacker swap: any re-canonicalization through the
+            // alias after authorization would redirect the pin into .git.
+            const target = getDockerArg(args, 1);
+            return dockerExecResult(`${target.replace("/workspace/real", "/workspace/.git")}\n`);
+          }
+          if (script.includes('stat -c "%F|%s|%y"')) {
+            return dockerExecResult("regular file|1|2");
+          }
+          return dockerExecResult("");
+        });
+
+        const bridge = createSandboxFsBridge({
+          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+        });
+
+        await bridge.writeFile({
+          filePath: "alias/note.txt",
+          data: "updated",
+          pinnedPath: "/workspace/real/note.txt",
+        });
+
+        const writeArgs = requireDockerCall(findCallByDockerArg(1, "write"), "write")[0];
+        expect(getDockerArg(writeArgs, 2)).toBe("/workspace");
+        expect(getDockerArg(writeArgs, 3)).toBe("real");
+        expect(getDockerArg(writeArgs, 4)).toBe("note.txt");
+        expect(writeArgs).not.toContain("/workspace/.git");
+      });
+    },
+  );
+
+  it("rejects pinned destinations that do not match the requested basename", async () => {
+    await withTempDir("openclaw-fs-bridge-pinned-mismatch-", async (stateDir) => {
+      const { bridge } = await createSeededSandboxFsBridge(stateDir);
+
+      await expect(
+        bridge.writeFile({
+          filePath: "notes/todo.txt",
+          data: "updated",
+          pinnedPath: "/workspace/notes/other.txt",
+        }),
+      ).rejects.toThrow("Pinned sandbox destination does not match the requested path");
+    });
+  });
+
   it("stat anchors parent + basename", async () => {
     await withTempDir("openclaw-fs-bridge-contract-stat-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
@@ -329,12 +329,21 @@ describe("sandbox fs bridge local backend e2e", () => {
           code: "ENOENT",
         });
 
+        // Restore the alias so the remaining scenarios resolve against realDir
+        // (the swap above must not poison subsequent pins).
+        await fs.unlink(path.join(workspaceDir, "alias"));
+        await fs.symlink(realDir, path.join(workspaceDir, "alias"));
+
         // Copy: the destination pin lands on the canonical target.
         const copyTarget = await bridge.resolvePinnedMutationTarget!({
           filePath: "alias/config.txt",
           action: "copy-destination",
         });
-        await bridge.copyFile({
+        const copyFile = bridge.copyFile?.bind(bridge);
+        if (!copyFile) {
+          throw new Error("The mounted bridge must support streaming copies.");
+        }
+        await copyFile({
           sourcePath: "source.txt",
           destinationPath: "alias/config.txt",
           mkdir: true,

--- a/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
@@ -251,4 +251,135 @@ describe("sandbox fs bridge local backend e2e", () => {
       }
     },
   );
+
+  it.runIf(process.platform !== "win32")(
+    "authorizes canonical destinations through aliases with observed final effects",
+    async () => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fsbridge-pin-e2e-"));
+      const workspacePath = path.join(stateDir, "workspace");
+      await fs.mkdir(workspacePath, { recursive: true });
+      const workspaceDir = await fs.realpath(workspacePath);
+      const backend: SandboxBackendHandle = {
+        id: "local-test",
+        runtimeId: "local-backend-fsbridge-pinned",
+        runtimeLabel: "local-backend-fsbridge-pinned",
+        workdir: workspaceDir,
+        buildExecSpec: async ({ command, env }) => ({
+          argv: ["sh", "-c", command],
+          env,
+          stdinMode: "pipe-closed",
+        }),
+        runShellCommand: runLocalShellCommand,
+      };
+
+      try {
+        const [{ createSandboxFsBridge }, { createSandboxTestContext }] = await Promise.all([
+          import("./fs-bridge.js"),
+          import("./test-fixtures.js"),
+        ]);
+
+        const sandbox = createSandboxTestContext({
+          overrides: {
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            workspaceAccess: "rw",
+            containerName: "local-backend-fsbridge-pinned",
+            containerWorkdir: workspaceDir,
+            backend,
+          },
+        });
+
+        const bridge = createSandboxFsBridge({ sandbox });
+        const realDir = path.join(workspaceDir, "real");
+        const decoyDir = path.join(workspaceDir, "decoy");
+        await fs.mkdir(realDir);
+        await fs.mkdir(decoyDir);
+        await fs.symlink(realDir, path.join(workspaceDir, "alias"));
+        await fs.writeFile(path.join(workspaceDir, "source.txt"), "copy-source");
+
+        // Write: the resolved pin carries the canonical destination and the
+        // executed mutation lands on exactly that path.
+        const writeTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/note.txt",
+          action: "write",
+        });
+        expect(writeTarget.pinnedPath).toBe(path.join(realDir, "note.txt"));
+        expect(writeTarget.policyPath).toBe(path.join(realDir, "note.txt"));
+        await bridge.writeFile({
+          filePath: "alias/note.txt",
+          data: "pinned-write",
+          pinnedPath: writeTarget.pinnedPath,
+        });
+        await expect(fs.readFile(path.join(realDir, "note.txt"), "utf8")).resolves.toBe(
+          "pinned-write",
+        );
+
+        // Post-authorization alias swap: the pinned write cannot be redirected.
+        await fs.unlink(path.join(workspaceDir, "alias"));
+        await fs.symlink(decoyDir, path.join(workspaceDir, "alias"));
+        await bridge.writeFile({
+          filePath: "alias/note.txt",
+          data: "after-swap",
+          pinnedPath: writeTarget.pinnedPath,
+        });
+        await expect(fs.readFile(path.join(realDir, "note.txt"), "utf8")).resolves.toBe(
+          "after-swap",
+        );
+        await expect(fs.stat(path.join(decoyDir, "note.txt"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+
+        // Copy: the destination pin lands on the canonical target.
+        const copyTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/config.txt",
+          action: "copy-destination",
+        });
+        await bridge.copyFile({
+          sourcePath: "source.txt",
+          destinationPath: "alias/config.txt",
+          mkdir: true,
+          pinnedPath: copyTarget.pinnedPath,
+        });
+        await expect(fs.readFile(path.join(realDir, "config.txt"), "utf8")).resolves.toBe(
+          "copy-source",
+        );
+
+        // Directory creation: an alias may rename the directory; the pin
+        // follows the canonical directory contract.
+        const mkdirTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/newdir",
+          action: "mkdir",
+        });
+        expect(mkdirTarget.pinnedPath).toBe(path.join(realDir, "newdir"));
+        await bridge.mkdirp({ filePath: "alias/newdir", pinnedPath: mkdirTarget.pinnedPath });
+        expect((await fs.stat(path.join(realDir, "newdir"))).isDirectory()).toBe(true);
+
+        // Removal: the pinned removal deletes exactly the authorized entry.
+        await fs.writeFile(path.join(realDir, "gone.txt"), "remove-me");
+        await fs.writeFile(path.join(realDir, "keep.txt"), "keep-me");
+        const removeTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/gone.txt",
+          action: "remove",
+        });
+        await bridge.remove({
+          filePath: "alias/gone.txt",
+          force: true,
+          pinnedPath: removeTarget.pinnedPath,
+        });
+        await expect(fs.stat(path.join(realDir, "gone.txt"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        await expect(fs.readFile(path.join(realDir, "keep.txt"), "utf8")).resolves.toBe("keep-me");
+
+        // Recursive creation of the mount root remains an authorized no-op.
+        const rootTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: ".",
+          action: "mkdir",
+        });
+        await bridge.mkdirp({ filePath: ".", pinnedPath: rootTarget.pinnedPath });
+      } finally {
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -80,14 +80,16 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 
   async resolvePinnedMutationTarget(
     params: Parameters<NonNullable<SandboxFsBridge["resolvePinnedMutationTarget"]>>[0],
-  ): Promise<{ canonicalPath: string }> {
+  ): Promise<{ policyPath: string; pinnedPath: string }> {
     const target = this.resolveResolvedPath(params);
-    return {
-      canonicalPath: await this.pathGuard.resolveCanonicalMutationTarget(
-        target,
-        PINNED_MUTATION_ACTION_LABELS[params.action],
-      ),
-    };
+    // The container namespace is both the policy namespace and the runtime
+    // namespace for mounted sandboxes, so the two views agree here.
+    const canonicalPath = await this.pathGuard.resolveCanonicalMutationTarget(
+      target,
+      PINNED_MUTATION_ACTION_LABELS[params.action],
+      { directory: params.action === "mkdir" },
+    );
+    return { policyPath: canonicalPath, pinnedPath: canonicalPath };
   }
 
   async readFile(params: Parameters<SandboxFsBridge["readFile"]>[0]): Promise<Buffer> {
@@ -232,7 +234,9 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
         pinned: this.pathGuard.resolvePinnedDirectoryEntry(
           params.pinnedPath === undefined
             ? target
-            : this.authorizedPinnedTarget(target, params.pinnedPath, "create directories"),
+            : this.authorizedPinnedTarget(target, params.pinnedPath, "create directories", {
+                directory: true,
+              }),
           "create directories",
         ),
       }),
@@ -443,9 +447,16 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     target: SandboxResolvedFsPath,
     pinnedPath: string,
     action: string,
+    options?: { directory?: boolean },
   ): SandboxResolvedFsPath {
     const canonicalPath = normalizeContainerPathCore(pinnedPath);
-    if (path.posix.basename(canonicalPath) !== path.posix.basename(target.containerPath)) {
+    // File-backed pins must preserve the requested basename so the mutation
+    // lands on the authorized entry. Directory pins authorize the full
+    // directory, which an existing alias may rename.
+    if (
+      !options?.directory &&
+      path.posix.basename(canonicalPath) !== path.posix.basename(target.containerPath)
+    ) {
       throw new Error(
         `Pinned sandbox destination does not match the requested path; cannot ${action}: ${target.containerPath}`,
       );

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -4,6 +4,7 @@
  * Resolves container paths to mounted host paths and executes guarded reads, writes, stats, renames, and deletes.
  */
 import fs from "node:fs";
+import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { readFileDescriptorBoundedSync } from "../../infra/boundary-file-read.js";
 import { parseDirectoryEntries, type DirectoryEntry } from "../../infra/directory-entries.js";
@@ -14,7 +15,7 @@ import type {
 import { runDockerSandboxShellCommand } from "./docker-backend.js";
 import { buildPinnedMutationPlan } from "./fs-bridge-mutation-helper.js";
 import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-python.js";
-import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
+import { SandboxFsPathGuard, type PinnedSandboxEntry } from "./fs-bridge-path-safety.js";
 import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
 import { parseSandboxStatMtimeMs, parseSandboxStatSize } from "./fs-bridge-stat-parse.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
@@ -23,6 +24,7 @@ import {
   resolveSandboxFsPathWithMounts,
   type SandboxResolvedFsPath,
 } from "./fs-paths.js";
+import { normalizeContainerPathCore } from "./path-utils.js";
 
 type RunCommandOptions = {
   args?: string[];
@@ -32,6 +34,14 @@ type RunCommandOptions = {
 };
 
 export type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
+
+const PINNED_MUTATION_ACTION_LABELS = {
+  write: "write files",
+  create: "create files",
+  mkdir: "create directories",
+  remove: "remove files",
+  "copy-destination": "copy files",
+} as const;
 
 /** Create the filesystem bridge for local Docker-style mounted sandboxes. */
 export function createSandboxFsBridge(params: {
@@ -65,6 +75,18 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       hostPath: target.hostPath,
       relativePath: target.relativePath,
       containerPath: target.containerPath,
+    };
+  }
+
+  async resolvePinnedMutationTarget(
+    params: Parameters<NonNullable<SandboxFsBridge["resolvePinnedMutationTarget"]>>[0],
+  ): Promise<{ canonicalPath: string }> {
+    const target = this.resolveResolvedPath(params);
+    return {
+      canonicalPath: await this.pathGuard.resolveCanonicalMutationTarget(
+        target,
+        PINNED_MUTATION_ACTION_LABELS[params.action],
+      ),
     };
   }
 
@@ -112,7 +134,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
         sourceCheck,
         destinationCheck,
         source: await this.pathGuard.resolveAnchoredPinnedEntry(source, "copy files"),
-        destination: await this.pathGuard.resolveAnchoredPinnedEntry(destination, "copy files"),
+        destination: await this.resolveMutationPin(destination, params.pinnedPath, "copy files"),
         mkdir: params.mkdir !== false,
       }),
       signal: params.signal,
@@ -130,8 +152,9 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
-    const pinnedWriteTarget = await this.pathGuard.resolveAnchoredPinnedEntry(
+    const pinnedWriteTarget = await this.resolveMutationPin(
       target,
+      params.pinnedPath,
       "write files",
     );
     await this.runCheckedCommand({
@@ -159,8 +182,9 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
-    const pinnedCreateTarget = await this.pathGuard.resolveAnchoredPinnedEntry(
+    const pinnedCreateTarget = await this.resolveMutationPin(
       target,
+      params.pinnedPath,
       "create files",
     );
     const result = await this.runCheckedCommand({
@@ -185,7 +209,12 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     return "created";
   }
 
-  async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
+  async mkdirp(params: {
+    filePath: string;
+    cwd?: string;
+    pinnedPath?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create directories");
     const mkdirCheck = {
@@ -200,7 +229,12 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       ...buildPinnedMutationPlan({
         kind: "mkdirp",
         check: mkdirCheck,
-        pinned: this.pathGuard.resolvePinnedDirectoryEntry(target, "create directories"),
+        pinned: this.pathGuard.resolvePinnedDirectoryEntry(
+          params.pinnedPath === undefined
+            ? target
+            : this.authorizedPinnedTarget(target, params.pinnedPath, "create directories"),
+          "create directories",
+        ),
       }),
       signal: params.signal,
     });
@@ -221,7 +255,12 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       ...buildPinnedMutationPlan({
         kind: "remove",
         check: removeCheck,
-        pinned: this.pathGuard.resolvePinnedEntry(target, "remove files"),
+        pinned: this.pathGuard.resolvePinnedEntry(
+          params.pinnedPath === undefined
+            ? target
+            : this.authorizedPinnedTarget(target, params.pinnedPath, "remove files"),
+          "remove files",
+        ),
         recursive: params.recursive,
         force: params.force,
       }),
@@ -377,6 +416,41 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       defaultContainerRoot: this.sandbox.containerWorkdir,
       mounts: this.mounts,
     });
+  }
+
+  /**
+   * Pins a mutation for a destination the caller already authorized via
+   * resolvePinnedMutationTarget. The canonical path is pinned lexically so no
+   * sandbox-writable path component is resolved again after authorization;
+   * the no-follow pinned walk then fails closed on any post-authorization
+   * swap instead of redirecting the mutation.
+   */
+  private async resolveMutationPin(
+    target: SandboxResolvedFsPath,
+    pinnedPath: string | undefined,
+    action: string,
+  ): Promise<PinnedSandboxEntry> {
+    if (pinnedPath === undefined) {
+      return await this.pathGuard.resolveAnchoredPinnedEntry(target, action);
+    }
+    return this.pathGuard.resolvePinnedEntry(
+      this.authorizedPinnedTarget(target, pinnedPath, action),
+      action,
+    );
+  }
+
+  private authorizedPinnedTarget(
+    target: SandboxResolvedFsPath,
+    pinnedPath: string,
+    action: string,
+  ): SandboxResolvedFsPath {
+    const canonicalPath = normalizeContainerPathCore(pinnedPath);
+    if (path.posix.basename(canonicalPath) !== path.posix.basename(target.containerPath)) {
+      throw new Error(
+        `Pinned sandbox destination does not match the requested path; cannot ${action}: ${target.containerPath}`,
+      );
+    }
+    return { ...target, containerPath: canonicalPath };
   }
 }
 

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -24,20 +24,33 @@ export type SandboxFsStat = {
 export type SandboxFsBridge = {
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath;
   /**
-   * Resolves the canonical sandbox destination for a mutation before caller
-   * authorization. canonicalPath canonicalizes mutable parents (symlinks) so
-   * callers can authorize the real destination; pass it back as pinnedPath on
-   * the mutation so the pinned operation lands on the same authorized
-   * location. Pinned mutations walk their path without following symlinks, so
-   * any component swapped after resolution fails the mutation instead of
-   * redirecting it.
+   * Resolves the canonical mutation destination before caller authorization.
+   *
+   * Returns two views of the same destination:
+   * - `policyPath`: the destination in the caller's policy namespace. Path
+   *   grants, read-only carveouts, and protected-path policies must be
+   *   evaluated against this path.
+   * - `pinnedPath`: the canonical mutation target in the bridge's runtime
+   *   namespace. Pass it back as `pinnedPath` on the mutation so the pinned
+   *   operation lands on exactly the authorized location.
+   *
+   * The two paths differ when the runtime resolves sandbox aliases onto
+   * different host roots. Pinned mutations walk their path without following
+   * symlinks, so any component swapped after resolution fails the mutation
+   * instead of redirecting it.
+   *
+   * Directory semantics: for `mkdir` both paths describe the directory
+   * itself (which an existing alias may rename); for file-backed actions
+   * (`write`, `create`, `remove`, `copy-destination`) both paths describe the
+   * canonical parent plus the requested basename, so the basename never
+   * changes.
    */
   resolvePinnedMutationTarget?(params: {
     filePath: string;
     cwd?: string;
     action: "write" | "create" | "mkdir" | "remove" | "copy-destination";
     signal?: AbortSignal;
-  }): Promise<{ canonicalPath: string }>;
+  }): Promise<{ policyPath: string; pinnedPath: string }>;
   /** Directory metadata only; callers paginate it without activating file contents. */
   readDirectory?(params: {
     filePath: string;
@@ -67,7 +80,7 @@ export type SandboxFsBridge = {
     data: Buffer | string;
     encoding?: BufferEncoding;
     mkdir?: boolean;
-    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    /** Pre-authorized canonical mutation target from resolvePinnedMutationTarget. */
     pinnedPath?: string;
     signal?: AbortSignal;
   }): Promise<void>;

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -23,6 +23,21 @@ export type SandboxFsStat = {
 /** Filesystem operations exposed across the sandbox boundary. */
 export type SandboxFsBridge = {
   resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath;
+  /**
+   * Resolves the canonical sandbox destination for a mutation before caller
+   * authorization. canonicalPath canonicalizes mutable parents (symlinks) so
+   * callers can authorize the real destination; pass it back as pinnedPath on
+   * the mutation so the pinned operation lands on the same authorized
+   * location. Pinned mutations walk their path without following symlinks, so
+   * any component swapped after resolution fails the mutation instead of
+   * redirecting it.
+   */
+  resolvePinnedMutationTarget?(params: {
+    filePath: string;
+    cwd?: string;
+    action: "write" | "create" | "mkdir" | "remove" | "copy-destination";
+    signal?: AbortSignal;
+  }): Promise<{ canonicalPath: string }>;
   /** Directory metadata only; callers paginate it without activating file contents. */
   readDirectory?(params: {
     filePath: string;
@@ -42,6 +57,8 @@ export type SandboxFsBridge = {
     destinationPath: string;
     cwd?: string;
     mkdir?: boolean;
+    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    pinnedPath?: string;
     signal?: AbortSignal;
   }): Promise<void>;
   writeFile(params: {
@@ -50,6 +67,8 @@ export type SandboxFsBridge = {
     data: Buffer | string;
     encoding?: BufferEncoding;
     mkdir?: boolean;
+    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    pinnedPath?: string;
     signal?: AbortSignal;
   }): Promise<void>;
   /**
@@ -63,14 +82,24 @@ export type SandboxFsBridge = {
     data: Buffer | string;
     encoding?: BufferEncoding;
     mkdir?: boolean;
+    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    pinnedPath?: string;
     signal?: AbortSignal;
   }): Promise<"created" | "exists">;
-  mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void>;
+  mkdirp(params: {
+    filePath: string;
+    cwd?: string;
+    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    pinnedPath?: string;
+    signal?: AbortSignal;
+  }): Promise<void>;
   remove(params: {
     filePath: string;
     cwd?: string;
     recursive?: boolean;
     force?: boolean;
+    /** Pre-authorized canonical destination from resolvePinnedMutationTarget. */
+    pinnedPath?: string;
     signal?: AbortSignal;
   }): Promise<void>;
   rename(params: { from: string; to: string; cwd?: string; signal?: AbortSignal }): Promise<void>;

--- a/src/agents/sandbox/remote-fs-bridge-pinned-frame.ts
+++ b/src/agents/sandbox/remote-fs-bridge-pinned-frame.ts
@@ -1,0 +1,211 @@
+/**
+ * Pinned mutation frame helpers for the remote shell-backed sandbox bridge.
+ *
+ * An already-authorized pinned destination is converted into the canonical
+ * frame the mutation helper walks. Only the infrastructure-owned mount root
+ * alias is re-read; sandbox-writable path components are never followed
+ * again, so a post-authorization swap fails the containment check instead of
+ * redirecting the mutation.
+ */
+import path from "node:path";
+import type {
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+} from "./backend-handle.types.js";
+import { relativePathEscapesContainerRoot } from "./path-utils.js";
+import type { RemoteCanonicalPath } from "./remote-fs-bridge-canonical-path.js";
+import {
+  normalizeContainerPath,
+  resolveRemoteMountByContainerPath,
+  type RemoteMountInfo,
+} from "./remote-fs-bridge-paths.js";
+
+/** Maps a resolver action to the mutation action label used in errors. */
+export function remotePinnedActionLabel(
+  action: "write" | "create" | "mkdir" | "remove" | "copy-destination",
+): string {
+  switch (action) {
+    case "write":
+      return "write files";
+    case "create":
+      return "create files";
+    case "mkdir":
+      return "create directories";
+    case "remove":
+      return "remove files";
+    case "copy-destination":
+      return "copy files";
+  }
+}
+
+/**
+ * Builds the canonical frame for an already-authorized pinned destination.
+ * File-backed operations pin the canonical parent (the filename is stripped
+ * and re-attached by the caller); directory operations pin the directory
+ * itself, which an existing alias may have renamed.
+ */
+export async function resolveRemotePinnedCanonicalFrame(params: {
+  pinnedPath: string;
+  directory: boolean;
+  mountRootPath: string;
+  action: string;
+  signal?: AbortSignal;
+  runRemoteShellScript(command: SandboxBackendCommandParams): Promise<SandboxBackendCommandResult>;
+}): Promise<RemoteCanonicalPath> {
+  const pinnedPath = normalizeContainerPath(params.pinnedPath);
+  const probePath = params.directory ? pinnedPath : path.posix.dirname(pinnedPath);
+  const result = await params.runRemoteShellScript({
+    script: 'canonical_root=$(readlink -f -- "$1")\nprintf "%s\\n" "$canonical_root"',
+    args: [params.mountRootPath],
+    signal: params.signal,
+  });
+  const canonicalMountRoot = normalizeContainerPath(result.stdout.toString("utf8").trim());
+  if (!canonicalMountRoot.startsWith("/")) {
+    throw new Error(`Sandbox path canonicalization failed; cannot ${params.action}: ${pinnedPath}`);
+  }
+  const relative = path.posix.relative(canonicalMountRoot, probePath);
+  if (relativePathEscapesContainerRoot(relative)) {
+    throw new Error(`Sandbox path escapes allowed mounts; cannot ${params.action}: ${pinnedPath}`);
+  }
+  return {
+    canonicalPath: probePath,
+    canonicalMountRoot,
+    logicalPath:
+      relative === "."
+        ? params.mountRootPath
+        : normalizeContainerPath(path.posix.join(params.mountRootPath, relative)),
+  };
+}
+
+/**
+ * Validates a pre-authorized pinned destination against the requested entry.
+ * File-backed pins must preserve the requested basename so the mutation lands
+ * on the authorized entry; directory pins authorize the full directory, which
+ * an existing alias may rename.
+ */
+export function authorizedRemotePinnedPath(
+  pinnedPath: string | undefined,
+  containerPath: string,
+  action: string,
+  options?: { directory?: boolean },
+): string | undefined {
+  if (pinnedPath === undefined) {
+    return undefined;
+  }
+  const canonical = normalizeContainerPath(pinnedPath);
+  if (
+    !options?.directory &&
+    path.posix.basename(canonical) !== path.posix.basename(containerPath)
+  ) {
+    throw new Error(
+      `Pinned sandbox destination does not match the requested path; cannot ${action}: ${containerPath}`,
+    );
+  }
+  return canonical;
+}
+
+export type RemotePinnedTargetParams = {
+  containerPath: string;
+  mountRootPath: string;
+  action: string;
+  requireWritable?: boolean;
+  directory?: boolean;
+  includeDescendants?: boolean;
+  allowFinalSymlinkForUnlink?: boolean;
+  /** Pre-authorized canonical pin path; skips destination re-canonicalization. */
+  pinnedCanonicalPath?: string;
+  signal?: AbortSignal;
+};
+
+export type RemotePinnedTarget = {
+  mountRootPath: string;
+  relativeParentPath: string;
+  basename: string;
+};
+
+/**
+ * Resolves the pinned mutation entry for a remote destination. Mount policy
+ * is resolved in the logical namespace, but the mutation is pinned to the
+ * canonical root so a legitimate symlinked workspace root is not reopened.
+ */
+export async function resolveRemotePinnedTarget(
+  params: RemotePinnedTargetParams,
+  deps: {
+    mounts: RemoteMountInfo[];
+    resolveCanonicalPath(params: {
+      containerPath: string;
+      mountRootPath: string;
+      action: string;
+      allowFinalSymlinkForUnlink?: boolean;
+      signal?: AbortSignal;
+    }): Promise<RemoteCanonicalPath>;
+    assertRemoteProtectedPathWritable(params: {
+      containerPath: string;
+      action: string;
+      displayPath?: string;
+      signal?: AbortSignal;
+      includeDescendants?: boolean;
+    }): Promise<void>;
+    runRemoteShellScript(
+      command: SandboxBackendCommandParams,
+    ): Promise<SandboxBackendCommandResult>;
+  },
+): Promise<RemotePinnedTarget> {
+  const basename = params.directory ? "" : path.posix.basename(params.containerPath);
+  if (!params.directory && (!basename || basename === "." || basename === "/")) {
+    throw new Error(`Invalid sandbox entry target: ${params.containerPath}`);
+  }
+  const { canonicalPath, canonicalMountRoot, logicalPath } =
+    params.pinnedCanonicalPath !== undefined
+      ? await resolveRemotePinnedCanonicalFrame({
+          // mkdirp pins the directory itself; file operations pin their parent.
+          pinnedPath: params.pinnedCanonicalPath,
+          directory: params.directory === true,
+          mountRootPath: params.mountRootPath,
+          action: params.action,
+          signal: params.signal,
+          runRemoteShellScript: deps.runRemoteShellScript,
+        })
+      : await deps.resolveCanonicalPath({
+          // mkdirp pins the directory itself; file operations pin their parent and
+          // retain no-follow handling for the final filename.
+          containerPath: normalizeContainerPath(
+            params.directory ? params.containerPath : path.posix.dirname(params.containerPath),
+          ),
+          mountRootPath: params.mountRootPath,
+          action: params.action,
+          allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
+          signal: params.signal,
+        });
+  const mount = resolveRemoteMountByContainerPath(deps.mounts, logicalPath);
+  if (!mount) {
+    throw new Error(
+      `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+    );
+  }
+  if (params.requireWritable && !mount.writable) {
+    throw new Error(`Sandbox path is read-only; cannot ${params.action}: ${params.containerPath}`);
+  }
+  if (params.requireWritable) {
+    await deps.assertRemoteProtectedPathWritable({
+      containerPath: path.posix.join(logicalPath, basename),
+      action: params.action,
+      displayPath: params.containerPath,
+      signal: params.signal,
+      includeDescendants: params.includeDescendants,
+    });
+  }
+  // Resolve mount policy in the logical namespace, but pin mutations to the
+  // canonical root so a legitimate symlinked workspace root is not reopened.
+  const relativeParentPath = path.posix.relative(canonicalMountRoot, canonicalPath);
+  if (relativePathEscapesContainerRoot(relativeParentPath)) {
+    throw new Error(
+      `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+    );
+  }
+  return {
+    mountRootPath: canonicalMountRoot,
+    relativeParentPath: relativeParentPath === "." ? "" : relativeParentPath,
+    basename,
+  };
+}

--- a/src/agents/sandbox/remote-fs-bridge-pinned-frame.ts
+++ b/src/agents/sandbox/remote-fs-bridge-pinned-frame.ts
@@ -21,21 +21,21 @@ import {
 } from "./remote-fs-bridge-paths.js";
 
 /** Maps a resolver action to the mutation action label used in errors. */
+const REMOTE_PINNED_ACTION_LABELS: Record<
+  "write" | "create" | "mkdir" | "remove" | "copy-destination",
+  string
+> = {
+  write: "write files",
+  create: "create files",
+  mkdir: "create directories",
+  remove: "remove files",
+  "copy-destination": "copy files",
+};
+
 export function remotePinnedActionLabel(
   action: "write" | "create" | "mkdir" | "remove" | "copy-destination",
 ): string {
-  switch (action) {
-    case "write":
-      return "write files";
-    case "create":
-      return "create files";
-    case "mkdir":
-      return "create directories";
-    case "remove":
-      return "remove files";
-    case "copy-destination":
-      return "copy files";
-  }
+  return REMOTE_PINNED_ACTION_LABELS[action];
 }
 
 /**
@@ -44,7 +44,7 @@ export function remotePinnedActionLabel(
  * and re-attached by the caller); directory operations pin the directory
  * itself, which an existing alias may have renamed.
  */
-export async function resolveRemotePinnedCanonicalFrame(params: {
+async function resolveRemotePinnedCanonicalFrame(params: {
   pinnedPath: string;
   directory: boolean;
   mountRootPath: string;
@@ -164,7 +164,7 @@ export async function resolveRemotePinnedTarget(
           mountRootPath: params.mountRootPath,
           action: params.action,
           signal: params.signal,
-          runRemoteShellScript: deps.runRemoteShellScript,
+          runRemoteShellScript: (command) => deps.runRemoteShellScript(command),
         })
       : await deps.resolveCanonicalPath({
           // mkdirp pins the directory itself; file operations pin their parent and

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -671,6 +671,121 @@ describe.runIf(process.platform === "linux")("remote sandbox fs bridge (GNU shel
       );
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "authorizes logical policy paths and pins physical canonical destinations with observed final effects",
+    async () => {
+      await withTempDir("openclaw-remote-fs-pinned-", async (stateDir) => {
+        const hostWorkspaceDir = path.join(await fs.realpath(stateDir), "host-workspace");
+        const realWorkspaceDir = path.join(await fs.realpath(stateDir), "real-workspace");
+        const linkedWorkspaceDir = path.join(await fs.realpath(stateDir), "linked-workspace");
+        await fs.mkdir(hostWorkspaceDir);
+        await fs.mkdir(realWorkspaceDir);
+        // The remote-visible workspace root is itself an alias: policy grants
+        // use the logical namespace while canonicalization resolves to the
+        // physical root.
+        await fs.symlink(realWorkspaceDir, linkedWorkspaceDir);
+        const { runtime } = createLocalRemoteRuntime({
+          remoteWorkspaceDir: linkedWorkspaceDir,
+          remoteAgentWorkspaceDir: linkedWorkspaceDir,
+        });
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir: hostWorkspaceDir,
+            agentWorkspaceDir: hostWorkspaceDir,
+          }),
+          runtime,
+        });
+
+        const realDir = path.join(realWorkspaceDir, "real");
+        const decoyDir = path.join(realWorkspaceDir, "decoy");
+        await fs.mkdir(realDir);
+        await fs.mkdir(decoyDir);
+        await fs.symlink(realDir, path.join(linkedWorkspaceDir, "alias"));
+        await fs.writeFile(path.join(linkedWorkspaceDir, "source.txt"), "copy-source");
+
+        // The policy view stays in the logical namespace; the pin resolves to
+        // the physical canonical destination.
+        const writeTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "note.txt",
+          action: "write",
+        });
+        expect(writeTarget.policyPath).toBe(path.join(linkedWorkspaceDir, "note.txt"));
+        expect(writeTarget.pinnedPath).toBe(path.join(realWorkspaceDir, "note.txt"));
+        await bridge.writeFile({
+          filePath: "note.txt",
+          data: "pinned",
+          pinnedPath: writeTarget.pinnedPath,
+        });
+        await expect(fs.readFile(path.join(realWorkspaceDir, "note.txt"), "utf8")).resolves.toBe(
+          "pinned",
+        );
+
+        // Post-authorization alias swap: the pinned write cannot be redirected.
+        const aliasTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/note.txt",
+          action: "write",
+        });
+        expect(aliasTarget.pinnedPath).toBe(path.join(realDir, "note.txt"));
+        await fs.unlink(path.join(linkedWorkspaceDir, "alias"));
+        await fs.symlink(decoyDir, path.join(linkedWorkspaceDir, "alias"));
+        await bridge.writeFile({
+          filePath: "alias/note.txt",
+          data: "after-swap",
+          pinnedPath: aliasTarget.pinnedPath,
+        });
+        await expect(fs.readFile(path.join(realDir, "note.txt"), "utf8")).resolves.toBe(
+          "after-swap",
+        );
+        await expect(fs.stat(path.join(decoyDir, "note.txt"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+
+        // Restore the alias, then remove exactly the authorized entry.
+        await fs.unlink(path.join(linkedWorkspaceDir, "alias"));
+        await fs.symlink(realDir, path.join(linkedWorkspaceDir, "alias"));
+        await fs.writeFile(path.join(realDir, "gone.txt"), "remove-me");
+        await fs.writeFile(path.join(realDir, "keep.txt"), "keep-me");
+        const removeTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/gone.txt",
+          action: "remove",
+        });
+        expect(removeTarget.pinnedPath).toBe(path.join(realDir, "gone.txt"));
+        await bridge.remove({
+          filePath: "alias/gone.txt",
+          force: true,
+          pinnedPath: removeTarget.pinnedPath,
+        });
+        await expect(fs.stat(path.join(realDir, "gone.txt"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        await expect(fs.readFile(path.join(realDir, "keep.txt"), "utf8")).resolves.toBe("keep-me");
+
+        // Directory creation through an alias: the directory pin follows the
+        // canonical directory even when the alias renames it.
+        const mkdirTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: "alias/newdir",
+          action: "mkdir",
+        });
+        expect(mkdirTarget.policyPath).toBe(path.join(linkedWorkspaceDir, "real", "newdir"));
+        expect(mkdirTarget.pinnedPath).toBe(path.join(realWorkspaceDir, "real", "newdir"));
+        await bridge.mkdirp({ filePath: "alias/newdir", pinnedPath: mkdirTarget.pinnedPath });
+        expect((await fs.stat(path.join(realWorkspaceDir, "real", "newdir"))).isDirectory()).toBe(
+          true,
+        );
+
+        // Recursive creation of the (symlinked) mount root stays an authorized
+        // no-op with logical policy and physical pin views.
+        const rootTarget = await bridge.resolvePinnedMutationTarget!({
+          filePath: ".",
+          action: "mkdir",
+        });
+        expect(rootTarget.policyPath).toBe(linkedWorkspaceDir);
+        expect(rootTarget.pinnedPath).toBe(realWorkspaceDir);
+        await bridge.mkdirp({ filePath: ".", pinnedPath: rootTarget.pinnedPath });
+      });
+    },
+  );
 });
 
 async function withTempDir<T>(prefix: string, run: (stateDir: string) => Promise<T>): Promise<T> {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -38,6 +38,13 @@ import {
   type RemoteMountInfo,
   toPosixRelative,
 } from "./remote-fs-bridge-paths.js";
+import {
+  authorizedRemotePinnedPath,
+  remotePinnedActionLabel,
+  resolveRemotePinnedTarget,
+  type RemotePinnedTarget,
+  type RemotePinnedTargetParams,
+} from "./remote-fs-bridge-pinned-frame.js";
 import type { ResolvedRemotePath, RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./workspace-mounts.js";
 
@@ -173,7 +180,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: destination.mountRootPath,
       action: "copy files",
       requireWritable: true,
-      pinnedCanonicalPath: this.authorizedPinnedPath(
+      pinnedCanonicalPath: authorizedRemotePinnedPath(
         params.pinnedPath,
         destination.containerPath,
         "copy files",
@@ -199,7 +206,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: target.mountRootPath,
       action: "write files",
       requireWritable: true,
-      pinnedCanonicalPath: this.authorizedPinnedPath(
+      pinnedCanonicalPath: authorizedRemotePinnedPath(
         params.pinnedPath,
         target.containerPath,
         "write files",
@@ -235,7 +242,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: target.mountRootPath,
       action: "create files",
       requireWritable: true,
-      pinnedCanonicalPath: this.authorizedPinnedPath(
+      pinnedCanonicalPath: authorizedRemotePinnedPath(
         params.pinnedPath,
         target.containerPath,
         "create files",
@@ -289,10 +296,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       action: "create directories",
       requireWritable: true,
       directory: true,
-      pinnedCanonicalPath: this.authorizedPinnedPath(
+      pinnedCanonicalPath: authorizedRemotePinnedPath(
         params.pinnedPath,
         target.containerPath,
         "create directories",
+        { directory: true },
       ),
       signal: params.signal,
     });
@@ -322,7 +330,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       requireWritable: true,
       includeDescendants: params.recursive,
       allowFinalSymlinkForUnlink: true,
-      pinnedCanonicalPath: this.authorizedPinnedPath(
+      pinnedCanonicalPath: authorizedRemotePinnedPath(
         params.pinnedPath,
         target.containerPath,
         "remove files",
@@ -634,18 +642,9 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
 
   async resolvePinnedMutationTarget(
     params: Parameters<NonNullable<SandboxFsBridge["resolvePinnedMutationTarget"]>>[0],
-  ): Promise<{ canonicalPath: string }> {
+  ): Promise<{ policyPath: string; pinnedPath: string }> {
     const target = this.resolveTarget(params);
-    const action =
-      params.action === "write"
-        ? "write files"
-        : params.action === "create"
-          ? "create files"
-          : params.action === "mkdir"
-            ? "create directories"
-            : params.action === "remove"
-              ? "remove files"
-              : "copy files";
+    const action = remotePinnedActionLabel(params.action);
     const { canonicalPath, logicalPath } = await this.resolveCanonicalPath({
       // mkdirp pins the directory itself; file operations pin their parent.
       containerPath: normalizeContainerPath(
@@ -660,143 +659,28 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
         `Sandbox path escapes allowed mounts; cannot ${action}: ${target.containerPath}`,
       );
     }
+    if (params.action === "mkdir") {
+      // Directory pins authorize the directory itself; an existing alias may
+      // rename it, so both views carry the canonical directory.
+      return { policyPath: logicalPath, pinnedPath: canonicalPath };
+    }
+    // File-backed actions authorize and pin the canonical parent plus the
+    // requested basename; the basename never changes.
     const basename = path.posix.basename(target.containerPath);
     return {
-      canonicalPath:
-        params.action === "mkdir"
-          ? canonicalPath
-          : normalizeContainerPath(path.posix.join(canonicalPath, basename)),
+      policyPath: normalizeContainerPath(path.posix.join(logicalPath, basename)),
+      pinnedPath: normalizeContainerPath(path.posix.join(canonicalPath, basename)),
     };
   }
 
-  /**
-   * Canonical frame for an already-authorized pinned destination. Only the
-   * infrastructure-owned mount root alias is re-read; sandbox-writable path
-   * components are never followed again, so a post-authorization swap fails
-   * the containment check instead of redirecting the mutation.
-   */
-  private async resolvePinnedCanonicalFrame(params: {
-    pinnedPath: string;
-    directory: boolean;
-    mountRootPath: string;
-    action: string;
-    signal?: AbortSignal;
-  }): Promise<RemoteCanonicalPath> {
-    const pinnedPath = normalizeContainerPath(params.pinnedPath);
-    const result = await this.runtime.runRemoteShellScript({
-      script: 'canonical_root=$(readlink -f -- "$1")\nprintf "%s\\n" "$canonical_root"',
-      args: [params.mountRootPath],
-      signal: params.signal,
+  private resolvePinnedTarget(params: RemotePinnedTargetParams): Promise<RemotePinnedTarget> {
+    return resolveRemotePinnedTarget(params, {
+      mounts: this.getMounts(),
+      resolveCanonicalPath: (canonicalParams) => this.resolveCanonicalPath(canonicalParams),
+      assertRemoteProtectedPathWritable: (protectedParams) =>
+        this.assertRemoteProtectedPathWritable(protectedParams),
+      runRemoteShellScript: (command) => this.runtime.runRemoteShellScript(command),
     });
-    const canonicalMountRoot = normalizeContainerPath(result.stdout.toString("utf8").trim());
-    if (!canonicalMountRoot.startsWith("/")) {
-      throw new Error(
-        `Sandbox path canonicalization failed; cannot ${params.action}: ${pinnedPath}`,
-      );
-    }
-    const relative = path.posix.relative(canonicalMountRoot, pinnedPath);
-    if (relativePathEscapesContainerRoot(relative)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${pinnedPath}`,
-      );
-    }
-    return {
-      canonicalPath: pinnedPath,
-      canonicalMountRoot,
-      logicalPath:
-        relative === "."
-          ? params.mountRootPath
-          : normalizeContainerPath(path.posix.join(params.mountRootPath, relative)),
-    };
-  }
-
-  private authorizedPinnedPath(
-    pinnedPath: string | undefined,
-    containerPath: string,
-    action: string,
-  ): string | undefined {
-    if (pinnedPath === undefined) {
-      return undefined;
-    }
-    const canonical = normalizeContainerPath(pinnedPath);
-    if (path.posix.basename(canonical) !== path.posix.basename(containerPath)) {
-      throw new Error(
-        `Pinned sandbox destination does not match the requested path; cannot ${action}: ${containerPath}`,
-      );
-    }
-    return canonical;
-  }
-
-  private async resolvePinnedTarget(params: {
-    containerPath: string;
-    mountRootPath: string;
-    action: string;
-    requireWritable?: boolean;
-    directory?: boolean;
-    includeDescendants?: boolean;
-    allowFinalSymlinkForUnlink?: boolean;
-    /** Pre-authorized canonical pin path; skips destination re-canonicalization. */
-    pinnedCanonicalPath?: string;
-    signal?: AbortSignal;
-  }): Promise<{ mountRootPath: string; relativeParentPath: string; basename: string }> {
-    const basename = params.directory ? "" : path.posix.basename(params.containerPath);
-    if (!params.directory && (!basename || basename === "." || basename === "/")) {
-      throw new Error(`Invalid sandbox entry target: ${params.containerPath}`);
-    }
-    const { canonicalPath, canonicalMountRoot, logicalPath } =
-      params.pinnedCanonicalPath !== undefined
-        ? await this.resolvePinnedCanonicalFrame({
-            // mkdirp pins the directory itself; file operations pin their parent.
-            pinnedPath: params.pinnedCanonicalPath,
-            directory: params.directory === true,
-            mountRootPath: params.mountRootPath,
-            action: params.action,
-            signal: params.signal,
-          })
-        : await this.resolveCanonicalPath({
-            // mkdirp pins the directory itself; file operations pin its parent and
-            // retain no-follow handling for the final filename.
-            containerPath: normalizeContainerPath(
-              params.directory ? params.containerPath : path.posix.dirname(params.containerPath),
-            ),
-            mountRootPath: params.mountRootPath,
-            action: params.action,
-            allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
-            signal: params.signal,
-          });
-    const mount = resolveRemoteMountByContainerPath(this.getMounts(), logicalPath);
-    if (!mount) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
-    }
-    if (params.requireWritable && !mount.writable) {
-      throw new Error(
-        `Sandbox path is read-only; cannot ${params.action}: ${params.containerPath}`,
-      );
-    }
-    if (params.requireWritable) {
-      await this.assertRemoteProtectedPathWritable({
-        containerPath: path.posix.join(logicalPath, basename),
-        action: params.action,
-        displayPath: params.containerPath,
-        signal: params.signal,
-        includeDescendants: params.includeDescendants,
-      });
-    }
-    // Resolve mount policy in the logical namespace, but pin mutations to the
-    // canonical root so a legitimate symlinked workspace root is not reopened.
-    const relativeParentPath = path.posix.relative(canonicalMountRoot, canonicalPath);
-    if (relativePathEscapesContainerRoot(relativeParentPath)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
-    }
-    return {
-      mountRootPath: canonicalMountRoot,
-      relativeParentPath: relativeParentPath === "." ? "" : relativeParentPath,
-      basename,
-    };
   }
 
   private async runMutation(params: {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -173,6 +173,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: destination.mountRootPath,
       action: "copy files",
       requireWritable: true,
+      pinnedCanonicalPath: this.authorizedPinnedPath(
+        params.pinnedPath,
+        destination.containerPath,
+        "copy files",
+      ),
       signal: params.signal,
     });
     await this.runMutation({
@@ -194,6 +199,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: target.mountRootPath,
       action: "write files",
       requireWritable: true,
+      pinnedCanonicalPath: this.authorizedPinnedPath(
+        params.pinnedPath,
+        target.containerPath,
+        "write files",
+      ),
       signal: params.signal,
     });
     await this.assertNoHardlinkedFile({
@@ -225,6 +235,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       mountRootPath: target.mountRootPath,
       action: "create files",
       requireWritable: true,
+      pinnedCanonicalPath: this.authorizedPinnedPath(
+        params.pinnedPath,
+        target.containerPath,
+        "create files",
+      ),
       signal: params.signal,
     });
     const buffer = Buffer.isBuffer(params.data)
@@ -251,7 +266,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return "created";
   }
 
-  async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
+  async mkdirp(params: {
+    filePath: string;
+    cwd?: string;
+    pinnedPath?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "create directories", params.signal);
     const relativePath = path.posix.relative(target.mountRootPath, target.containerPath);
@@ -269,6 +289,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       action: "create directories",
       requireWritable: true,
       directory: true,
+      pinnedCanonicalPath: this.authorizedPinnedPath(
+        params.pinnedPath,
+        target.containerPath,
+        "create directories",
+      ),
       signal: params.signal,
     });
     await this.runMutation({
@@ -297,6 +322,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       requireWritable: true,
       includeDescendants: params.recursive,
       allowFinalSymlinkForUnlink: true,
+      pinnedCanonicalPath: this.authorizedPinnedPath(
+        params.pinnedPath,
+        target.containerPath,
+        "remove files",
+      ),
       signal: params.signal,
     });
     await this.runMutation({
@@ -602,6 +632,101 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
   }
 
+  async resolvePinnedMutationTarget(
+    params: Parameters<NonNullable<SandboxFsBridge["resolvePinnedMutationTarget"]>>[0],
+  ): Promise<{ canonicalPath: string }> {
+    const target = this.resolveTarget(params);
+    const action =
+      params.action === "write"
+        ? "write files"
+        : params.action === "create"
+          ? "create files"
+          : params.action === "mkdir"
+            ? "create directories"
+            : params.action === "remove"
+              ? "remove files"
+              : "copy files";
+    const { canonicalPath, logicalPath } = await this.resolveCanonicalPath({
+      // mkdirp pins the directory itself; file operations pin their parent.
+      containerPath: normalizeContainerPath(
+        params.action === "mkdir" ? target.containerPath : path.posix.dirname(target.containerPath),
+      ),
+      mountRootPath: target.mountRootPath,
+      action,
+      signal: params.signal,
+    });
+    if (!resolveRemoteMountByContainerPath(this.getMounts(), logicalPath)) {
+      throw new Error(
+        `Sandbox path escapes allowed mounts; cannot ${action}: ${target.containerPath}`,
+      );
+    }
+    const basename = path.posix.basename(target.containerPath);
+    return {
+      canonicalPath:
+        params.action === "mkdir"
+          ? canonicalPath
+          : normalizeContainerPath(path.posix.join(canonicalPath, basename)),
+    };
+  }
+
+  /**
+   * Canonical frame for an already-authorized pinned destination. Only the
+   * infrastructure-owned mount root alias is re-read; sandbox-writable path
+   * components are never followed again, so a post-authorization swap fails
+   * the containment check instead of redirecting the mutation.
+   */
+  private async resolvePinnedCanonicalFrame(params: {
+    pinnedPath: string;
+    directory: boolean;
+    mountRootPath: string;
+    action: string;
+    signal?: AbortSignal;
+  }): Promise<RemoteCanonicalPath> {
+    const pinnedPath = normalizeContainerPath(params.pinnedPath);
+    const result = await this.runtime.runRemoteShellScript({
+      script: 'canonical_root=$(readlink -f -- "$1")\nprintf "%s\\n" "$canonical_root"',
+      args: [params.mountRootPath],
+      signal: params.signal,
+    });
+    const canonicalMountRoot = normalizeContainerPath(result.stdout.toString("utf8").trim());
+    if (!canonicalMountRoot.startsWith("/")) {
+      throw new Error(
+        `Sandbox path canonicalization failed; cannot ${params.action}: ${pinnedPath}`,
+      );
+    }
+    const relative = path.posix.relative(canonicalMountRoot, pinnedPath);
+    if (relativePathEscapesContainerRoot(relative)) {
+      throw new Error(
+        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${pinnedPath}`,
+      );
+    }
+    return {
+      canonicalPath: pinnedPath,
+      canonicalMountRoot,
+      logicalPath:
+        relative === "."
+          ? params.mountRootPath
+          : normalizeContainerPath(path.posix.join(params.mountRootPath, relative)),
+    };
+  }
+
+  private authorizedPinnedPath(
+    pinnedPath: string | undefined,
+    containerPath: string,
+    action: string,
+  ): string | undefined {
+    if (pinnedPath === undefined) {
+      return undefined;
+    }
+    const canonical = normalizeContainerPath(pinnedPath);
+    if (path.posix.basename(canonical) !== path.posix.basename(containerPath)) {
+      throw new Error(
+        `Pinned sandbox destination does not match the requested path; cannot ${action}: ${containerPath}`,
+      );
+    }
+    return canonical;
+  }
+
   private async resolvePinnedTarget(params: {
     containerPath: string;
     mountRootPath: string;
@@ -610,23 +735,35 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     directory?: boolean;
     includeDescendants?: boolean;
     allowFinalSymlinkForUnlink?: boolean;
+    /** Pre-authorized canonical pin path; skips destination re-canonicalization. */
+    pinnedCanonicalPath?: string;
     signal?: AbortSignal;
   }): Promise<{ mountRootPath: string; relativeParentPath: string; basename: string }> {
     const basename = params.directory ? "" : path.posix.basename(params.containerPath);
     if (!params.directory && (!basename || basename === "." || basename === "/")) {
       throw new Error(`Invalid sandbox entry target: ${params.containerPath}`);
     }
-    const { canonicalPath, canonicalMountRoot, logicalPath } = await this.resolveCanonicalPath({
-      // mkdirp pins the directory itself; file operations pin its parent and
-      // retain no-follow handling for the final filename.
-      containerPath: normalizeContainerPath(
-        params.directory ? params.containerPath : path.posix.dirname(params.containerPath),
-      ),
-      mountRootPath: params.mountRootPath,
-      action: params.action,
-      allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
-      signal: params.signal,
-    });
+    const { canonicalPath, canonicalMountRoot, logicalPath } =
+      params.pinnedCanonicalPath !== undefined
+        ? await this.resolvePinnedCanonicalFrame({
+            // mkdirp pins the directory itself; file operations pin their parent.
+            pinnedPath: params.pinnedCanonicalPath,
+            directory: params.directory === true,
+            mountRootPath: params.mountRootPath,
+            action: params.action,
+            signal: params.signal,
+          })
+        : await this.resolveCanonicalPath({
+            // mkdirp pins the directory itself; file operations pin its parent and
+            // retain no-follow handling for the final filename.
+            containerPath: normalizeContainerPath(
+              params.directory ? params.containerPath : path.posix.dirname(params.containerPath),
+            ),
+            mountRootPath: params.mountRootPath,
+            action: params.action,
+            allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
+            signal: params.signal,
+          });
     const mount = resolveRemoteMountByContainerPath(this.getMounts(), logicalPath);
     if (!mount) {
       throw new Error(


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

## Summary

A sandboxed workload with workspace write access could modify files under a policy-protected path such as `.git` — an ancestor symlink (placed once, or swapped mid-operation) redirected an approved write into a denied directory, and a planted `.git/config` helper could execute with host privileges on the next `git` run. This PR authorizes the canonical destination before every write-class mutation and pins the mutation to exactly that destination, so redirects fail closed. It replaces lexical-only authorization in the Codex exec-server filesystem handler and both shipped sandbox bridges.

## What was wrong

1. `extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts` — the request-local policy was evaluated against the lexical request path only; the handler then delegated to the bridge, which resolved symlinks afterward. The policy never saw the real destination.
2. `src/agents/sandbox/fs-bridge.ts` — the local bridge anchored mutations to the canonical (symlink-resolved) path with no link back to what the policy had authorized.
3. `src/agents/sandbox/remote-fs-bridge.ts` — the remote bridge had the same authorization/mutation mismatch, and its pinned-target construction kept the filename in parent pins and resolved canonical paths in the physical namespace while policy grants use the logical one (breaking legitimate symlinked workspace roots).

Net effect: an attacker-controlled ancestor symlink could silently redirect any approved workspace write into a read-only or denied path, including `.git/config`.

## Why this design

- Authorize the canonical destination before pinning the mutation: `resolvePinnedMutationTarget` returns two views — `policyPath` (the caller's logical policy namespace, evaluated together with the lexical path, so an alias cannot hide the real destination) and `pinnedPath` (the bridge-runtime canonical target, passed back so the mutation lands exactly there).
- Fail closed after authorization: pinned mutations re-walk their path without following symlinks, so any component swapped mid-flight aborts the mutation instead of redirecting it.
- Keep directory semantics explicit: directory actions (`mkdir`, directory copy) authorize the directory itself — an existing alias may rename it and creation of an existing mount root stays an authorized no-op; file actions (`write`, `create`, `remove`, `copy`) authorize the canonical parent plus the requested basename, so a removal can never act on an unauthorized child.
- Cover every write-class RPC (`fs/writeFile`, `fs/createDirectory`, `fs/remove`, `fs/copy`) in both shipped bridges.
- Introduce no config surface: no configuration, defaults, persisted representation, or public request/response shapes changed; the only observable behavior change is that the previously exploitable redirects are now denied.

## Request lifecycle

Every write-class request traverses the same gate ordering; each attack path terminates in a fail-closed state:

```mermaid
stateDiagram-v2
    [*] --> Requested: fs/writeFile · copy · remove · mkdir

    Requested --> LexicalCheck
    LexicalCheck --> Denied: policy denies lexical path
    LexicalCheck --> CanonicalResolution: allowed

    CanonicalResolution --> CanonicalCheck: returns policyPath + pinnedPath
    CanonicalCheck --> Denied: policy denies canonical destination
    CanonicalCheck --> Pinned: both views authorized

    Pinned --> Landed: no-follow walk reaches pinned target
    Pinned --> Aborted: component swapped after authorization

    Denied --> [*]
    Aborted --> [*]
    Landed --> [*]

    Denied: denied before any effect (0 bytes moved, zero bridge mutations)
    Aborted: mutation aborted, not redirected (fail closed)
    Landed: landed on authorized target (final filesystem state verified)
```

- The original exploit (alias into `.git`) terminates at the canonical-policy gate — the gate that did not exist before this fix.
- A racing swap (alias changed after authorization) reaches the pinned mutation but terminates in the aborted state: the no-follow walk refuses the redirect.
- Legitimate aliases (symlinked workspace roots, alias-renamed directories) pass both gates: authorization uses the logical view, the mutation pins to the physical target.

## Evidence

Observed final filesystem effects through the real WebSocket exec-server RPC with the shipped remote-shell bridge and real POSIX scripts (no mocks):

| Requested path | Canonical destination | Mode | Outcome | Bytes moved |
|---|---|---|---|---|
| `/workspace/alias/config` (`alias -> .git`) | `.git/config` | write | **Denied before any mutation**: `.git/config` absent, zero mutation-script invocations | 0 |
| `/workspace/real-note.txt` | itself | write | Lands exactly; content verified | 7 |
| `/workspace/alias-real/config` (`alias -> real`), alias swapped to a decoy **after** authorization | `real/config` | write | Lands on the pinned location; decoy untouched | 11 |
| `/workspace/nested/src-dir` | `/workspace` (existing mount root) | recursive copy | Directory destination resolved with directory semantics; children pinned to the canonical destination; pre-change semantics preserved | child payloads |
| `/workspace/nested/src-dir` | `/workspace/alias-dir` (`alias -> dir-target`) | recursive copy | Children land in the canonical directory | child payloads |
| `/workspace/nested/src-dir` | `/workspace/source-subdir-alias` (`alias -> source/subdir`) | recursive copy | **Rejected before `mkdirp` or enumeration**: zero new mutation calls, no copied output | 0 |
| `/workspace/alias/gone.txt` (`alias -> real`) | `real/gone.txt` | remove | Deletes exactly the authorized entry; sibling intact | — |
| pre-upgrade bridge (no resolver, no pins) over all four mutation RPCs | legacy shapes | write/copy/mkdir/remove | Receives byte-for-byte the legacy argument objects; no pin field | — |

Sink-level observations: every outcome above is asserted by reading back final filesystem state (or its absence) after the RPC completes — see the `sandbox-exec-server.fs-bridge-composition.test.ts` and local-bridge E2E suites.

## SDK / caller upgrade contract

`SandboxFsBridge` implementers are the affected callers:

- **Keep access, no action required:** bridges that do not implement `resolvePinnedMutationTarget` (and legacy `pinnedPath`-less call sites) compile and run unchanged — a dedicated regression test constructs the exact pre-upgrade shape (`satisfies SandboxFsBridge`), drives all four mutation RPCs through the real handler, and asserts each method receives the unchanged legacy argument object.
- **Fail closed on adoption:** shipped local and remote bridges opt into the strengthened contract together (resolution plus pin consumption); adopting bridges deny protected canonical destinations and post-authorization alias swaps.
- **Third-party bridge owners** may adopt the optional surface on their own timeline; the shipped guarantees do not depend on it.

## Boundary decisions requested from maintainers

1. **Merge decision on the intentional tightening:** aliases (or racing swaps) that resolve into a policy-denied destination now fail. Their previous success depended on the authorization/mutation mismatch this PR fixes; treating that success as compatibility behavior would preserve the vulnerability.
2. **Optional-interface adoption:** `resolvePinnedMutationTarget` and every `pinnedPath` parameter are optional, so third-party bridges are not forced to adopt the guarantee in this release. Flag if a mandatory migration is preferred instead.

## Testing

- New: bridge-level canonical-resolution tests (real symlinks, real script execution), pinned-write alias-swap immunity, basename-mismatch rejection, RPC canonical-destination denial and pinned passthrough, recursive-copy containment, and the executable pre-upgrade bridge contract driving all four mutation families.
- Real-behavior proof: the proper E2E config runs the local bridge's 9 real-shell tests (observed final effects, not mocks); the WebSocket RPC composition suite covers denial-before-effect, exact landing, directory copies into mount roots and aliases, and canonical-descendant rejection.
- Unchanged-green: the pre-existing focused suites pass unmodified; oxlint, formatting, production/core-test/extension-test typechecks pass for the changed surface; branch autoreview is scoped-clean (no P0/P1/P2 findings).
- Exact-head CI completed with zero failures; the review's final evidence confirms "no persisted representation, configuration default, or wire parameter is introduced" and that "the earlier migration blocker does not apply to this stateless change."

