### PR TITLE
improve(model-catalog): avoid duplicate manifest planning during preparation

### DIFF
--- a/src/agents/model-catalog.planning.test.ts
+++ b/src/agents/model-catalog.planning.test.ts
@@ -1,0 +1,128 @@
+import { normalizeModelCatalogProviderRows } from "@openclaw/model-catalog-core/model-catalog-normalize";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
+import { finalizePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { buildPreparedModelCatalogSnapshot, loadManifestModelCatalog } from "./model-catalog.js";
+import type { ModelRegistry } from "./sessions/index.js";
+
+vi.mock("../model-catalog/index.js", { spy: true });
+vi.mock("@openclaw/model-catalog-core/model-catalog-normalize", { spy: true });
+const augment = vi.hoisted(() => vi.fn(async () => []));
+vi.mock("../plugins/provider-runtime.runtime.js", () => ({
+  augmentModelCatalogWithProviderPlugins: augment,
+}));
+
+function fixture(discovery: "static" | "runtime", ...modelIds: string[]) {
+  return finalizePluginMetadataSnapshot(
+    createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "catalog-fixture",
+          origin: "bundled",
+          providers: ["catalog-fixture"],
+          modelCatalog: {
+            providers: {
+              "catalog-fixture": {
+                api: "openai-responses",
+                models: modelIds.map((id) => ({ id, name: id })),
+              },
+            },
+            discovery: { "catalog-fixture": discovery },
+          },
+        },
+      ],
+    }),
+  );
+}
+
+async function build(
+  params: { config: OpenClawConfig; metadataSnapshot: PluginMetadataSnapshot },
+  observed: string[] = [],
+) {
+  return await buildPreparedModelCatalogSnapshot({
+    ...params,
+    agentDir: "/tmp/model-catalog-planning-test",
+    authCredentials: {},
+    readOnly: true,
+    modelRegistry: {
+      getAll: () => observed.map((id) => ({ provider: "catalog-fixture", id, name: id })),
+    } as ModelRegistry,
+  });
+}
+
+describe("prepared catalog planning and declaration cache", () => {
+  beforeEach(() => {
+    augment.mockClear();
+    vi.mocked(planEffectiveModelCatalogRows).mockReset();
+    vi.mocked(normalizeModelCatalogProviderRows).mockReset();
+  });
+
+  it.each([
+    { warm: false, prepare: true, observed: [] },
+    { warm: false, prepare: true, observed: ["allowed"] },
+    { warm: true, prepare: true, observed: [] },
+    { warm: true, prepare: true, observed: ["allowed"] },
+    { warm: true, prepare: false, observed: [] },
+  ])(
+    "plans manifest rows once without expanding entitlement (warm=$warm, prepare=$prepare, observed=$observed)",
+    async ({ warm, prepare, observed }) => {
+      const config: OpenClawConfig = {
+        plugins: { enabled: false },
+        models: { catalogRefresh: { enabled: false } },
+      };
+      const metadataSnapshot = fixture("runtime", "allowed", "denied");
+      const params = { config, metadataSnapshot };
+      const declared = warm ? loadManifestModelCatalog(params) : undefined;
+      await withPluginRuntimeGenerationScope({ metadataSnapshot }, async () => {
+        vi.mocked(planEffectiveModelCatalogRows).mockClear();
+        vi.mocked(normalizeModelCatalogProviderRows).mockClear();
+        if (prepare) {
+          const snapshot = await build(params, observed);
+          for (const rows of [snapshot.entries, snapshot.routeVariants]) {
+            expect(rows.map((row) => row.id)).toEqual(observed);
+            expect(rows.every((row) => row.provider === "catalog-fixture")).toBe(true);
+          }
+        }
+        const firstRead = loadManifestModelCatalog(params);
+        expect(firstRead.map((row) => row.id)).toEqual(["allowed", "denied"]);
+        expect(loadManifestModelCatalog(params)).toBe(firstRead);
+        if (warm) {
+          expect(firstRead).toBe(declared);
+        }
+        expect(augment).not.toHaveBeenCalled();
+        expect(planEffectiveModelCatalogRows).toHaveBeenCalledTimes(prepare ? 1 : 0);
+        const normalizations = vi.mocked(normalizeModelCatalogProviderRows).mock.results;
+        expect(
+          normalizations.map(({ type, value }) => (type === "return" ? value.length : type)),
+        ).toEqual(prepare ? [2] : []);
+      });
+    },
+  );
+
+  it("keeps the old declaration cache when replacement planning fails", async () => {
+    const config: OpenClawConfig = { plugins: { enabled: false } };
+    const initial = fixture("static", "initial");
+    const replacement = fixture("static", "replacement");
+    const planningError = new Error("catalog planning failed");
+    const originalRows = loadManifestModelCatalog({ config, metadataSnapshot: initial });
+    const params = { config, metadataSnapshot: replacement };
+    await withPluginRuntimeGenerationScope({ metadataSnapshot: replacement }, async () => {
+      vi.mocked(planEffectiveModelCatalogRows).mockImplementationOnce(() => {
+        throw planningError;
+      });
+      await expect(build(params)).rejects.toBe(planningError);
+      expect(loadManifestModelCatalog({ config, metadataSnapshot: initial })).toBe(originalRows);
+      const snapshot = await build(params);
+      expect(snapshot.entries.map((row) => row.id)).toEqual(["replacement"]);
+      const replacementRows = loadManifestModelCatalog(params);
+      expect(replacementRows.map((row) => row.id)).toEqual(["replacement"]);
+      expect(replacementRows).not.toBe(originalRows);
+      expect(loadManifestModelCatalog(params)).toBe(replacementRows);
+      expect(originalRows.map((row) => row.id)).toEqual(["initial"]);
+    });
+  });
+});

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -101,19 +101,37 @@ describe("prepared model catalog builder", () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([]);
   });
 
-  it.each(["static", "refreshable", "runtime"] as const)(
-    "keeps replace publication closed to %s manifest and augmented inventory",
-    async (discovery) => {
+  it.each(
+    (["static", "refreshable", "runtime"] as const).flatMap((discovery) =>
+      [false, true].map((warmCache) => ({ discovery, warmCache })),
+    ),
+  )(
+    "keeps replace publication closed to $discovery inventory (warm cache=$warmCache)",
+    async ({ discovery, warmCache }) => {
       mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([
         { provider: "manifest-provider", id: "augmented-only", name: "Augmented" },
       ]);
-      const snapshot = await build({
-        config: { models: { mode: "replace", providers: {} } },
-        metadataSnapshot: providerManifestSnapshot({
-          provider: "manifest-provider",
-          discovery,
-          modelIds: ["manifest-only"],
+      const config: OpenClawConfig = { models: { catalogRefresh: { enabled: false } } };
+      const manifest = providerManifestSnapshot({
+        provider: "manifest-provider",
+        discovery,
+        modelIds: ["manifest-only"],
+      });
+      if (warmCache) {
+        expect(loadManifestModelCatalog({ config, metadataSnapshot: manifest })).toHaveLength(1);
+      }
+      config.models = { ...config.models, mode: "replace", providers: {} };
+      expect(
+        loadManifestModelCatalog({
+          config,
+          get metadataSnapshot() {
+            throw new Error("replace must not resolve manifest metadata");
+          },
         }),
+      ).toEqual([]);
+      const snapshot = await build({
+        config,
+        metadataSnapshot: manifest,
         readOnly: false,
         includeProviderPluginAugmentation: true,
       });
@@ -249,29 +267,6 @@ describe("prepared model catalog builder", () => {
 
     expect(snapshot.entries.map((entry) => entry.id)).toEqual(["model-a", "model-b"]);
     expect(snapshot.entries.every((entry) => entry.providerOrder === undefined)).toBe(true);
-  });
-
-  it("keeps account-denied runtime models out of the prepared catalog", async () => {
-    const config: OpenClawConfig = { plugins: { enabled: false } };
-    const runtimeManifest = providerManifestSnapshot({
-      provider: "openai",
-      discovery: "runtime",
-      modelIds: ["gpt-5.5", "gpt-5.6"],
-    });
-
-    const declaredManifestModels = loadManifestModelCatalog({
-      config,
-      metadataSnapshot: runtimeManifest,
-    });
-    expect(declaredManifestModels.map((entry) => entry.id)).toEqual(["gpt-5.5", "gpt-5.6"]);
-
-    const snapshot = await build({ config, metadataSnapshot: runtimeManifest });
-
-    expect(snapshot.entries).toEqual([]);
-    expect(snapshot.routeVariants).toEqual([]);
-    expect(loadManifestModelCatalog({ config, metadataSnapshot: runtimeManifest })).toBe(
-      declaredManifestModels,
-    );
   });
 
   it("carries manifest capability metadata into the prepared catalog", async () => {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -124,7 +124,7 @@ describe("prepared model catalog builder", () => {
       expect(
         loadManifestModelCatalog({
           config,
-          get metadataSnapshot() {
+          get metadataSnapshot(): never {
             throw new Error("replace must not resolve manifest metadata");
           },
         }),

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -199,18 +199,29 @@ export function loadManifestModelCatalog(params: {
           env: params.env ?? process.env,
           allowWorkspaceScopedCurrent: params.workspaceDir === undefined,
         }));
-  if (!resolvedSnapshot) {
+  return resolvedSnapshot ? loadManifestModelCatalogRows(params.config, resolvedSnapshot) : [];
+}
+
+function loadManifestModelCatalogRows(
+  config: OpenClawConfig,
+  snapshot: PluginMetadataSnapshot,
+  preparedPlan?: ReturnType<typeof planEffectiveModelCatalogRows>,
+): ModelCatalogEntry[] {
+  // Prepared builds also enter here directly; replace must precede cached-row publication.
+  if (config.models?.mode === "replace") {
     return [];
   }
-  const cached = manifestModelCatalogCache.get(params.config);
-  if (cached?.snapshot === resolvedSnapshot) {
+  const cached = manifestModelCatalogCache.get(config);
+  if (cached?.snapshot === snapshot) {
     return cached.rows;
   }
-  const plugins = resolveEligibleManifestCatalogPlugins(resolvedSnapshot, params.config);
-  const plan = planEffectiveModelCatalogRows({
-    registry: { plugins },
-    config: params.config,
-  });
+  const plugins = resolveEligibleManifestCatalogPlugins(snapshot, config);
+  const plan =
+    preparedPlan ??
+    planEffectiveModelCatalogRows({
+      registry: { plugins },
+      config,
+    });
   const providerOrderByKey = new Map<string, number>();
   for (const plugin of plugins) {
     for (const [provider, providerCatalog] of Object.entries(
@@ -232,7 +243,7 @@ export function loadManifestModelCatalog(params: {
     }
     return entry;
   });
-  manifestModelCatalogCache.set(params.config, { snapshot: resolvedSnapshot, rows });
+  manifestModelCatalogCache.set(config, { snapshot, rows });
   return rows;
 }
 
@@ -274,11 +285,17 @@ export async function buildPreparedModelCatalogSnapshot(
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
     logStage("catalog-deps-ready");
     const entries = params.modelRegistry.getAll();
-    const declaredManifestModels = loadManifestModelCatalog({
+    const manifestPlan = planEffectiveModelCatalogRows({
+      registry: {
+        plugins: resolveEligibleManifestCatalogPlugins(manifestMetadataSnapshot, cfg),
+      },
       config: cfg,
-      env,
-      metadataSnapshot: manifestMetadataSnapshot,
     });
+    const declaredManifestModels = loadManifestModelCatalogRows(
+      cfg,
+      manifestMetadataSnapshot,
+      manifestPlan,
+    );
     logStage("registry-read", `entries=${entries.length}`);
 
     const shouldSuppressBuiltInModel = buildShouldSuppressBuiltInModelCore({ config: cfg });
@@ -317,15 +334,8 @@ export async function buildPreparedModelCatalogSnapshot(
     });
     models.splice(0, models.length, ...orderedRegistryModels);
     mergeCatalogRouteVariants(routeVariants, orderedRegistryModels);
-    const supplementalManifestPlan = planEffectiveModelCatalogRows({
-      registry: {
-        plugins: resolveEligibleManifestCatalogPlugins(manifestMetadataSnapshot, cfg),
-      },
-      config: cfg,
-      selection: "supplemental",
-    });
     const dynamicManifestKeys = new Set(
-      supplementalManifestPlan.entries.flatMap((entry) =>
+      manifestPlan.entries.flatMap((entry) =>
         entry.discovery === "runtime" || entry.discovery === "refreshable"
           ? entry.rows.map((row) => buildModelCatalogMergeKey(row.provider, row.id))
           : [],
@@ -333,7 +343,7 @@ export async function buildPreparedModelCatalogSnapshot(
     );
     const runtimeDiscoveryProviders = new Set([
       ...observedProviders,
-      ...supplementalManifestPlan.entries.flatMap((entry) =>
+      ...manifestPlan.entries.flatMap((entry) =>
         entry.discovery === "runtime" || entry.discovery === "refreshable"
           ? [normalizeProviderId(entry.provider)]
           : [],

--- a/test/tsconfig/tsconfig.core.test.agents-other.json
+++ b/test/tsconfig/tsconfig.core.test.agents-other.json
@@ -4,8 +4,10 @@
     "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-agents-other.tsbuildinfo"
   },
   "include": [
-    "../../src/agents/**/*.test.ts",
-    "../../src/agents/**/*.test.tsx"
+    "../../src/agents/*/**/*.test.ts",
+    "../../src/agents/*/**/*.test.tsx",
+    "../../src/agents/model-catalog.test.ts",
+    "../../src/agents/model-catalog.planning.test.ts"
   ],
   "exclude": [
     "../../node_modules",
@@ -13,8 +15,6 @@
     "../../**/dist/**",
     "../../src/agents/command/**/*.test.ts",
     "../../src/agents/command/**/*.test.tsx",
-    "../../src/agents/*.test.ts",
-    "../../src/agents/*.test.tsx",
     "../../src/agents/tools/**/*.test.ts",
     "../../src/agents/tools/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.agents-root.json
+++ b/test/tsconfig/tsconfig.core.test.agents-root.json
@@ -16,6 +16,8 @@
     "../../src/agents/code-mode*.test.ts",
     "../../src/agents/code-mode*.test.tsx",
     "../../src/agents/tool-search*.test.ts",
-    "../../src/agents/tool-search*.test.tsx"
+    "../../src/agents/tool-search*.test.tsx",
+    "../../src/agents/model-catalog.test.ts",
+    "../../src/agents/model-catalog.planning.test.ts"
   ]
 }


### PR DESCRIPTION
## What Problem This Solves

Cold model-catalog preparation plans the same manifest twice within one build:
once for declared rows and again for runtime/refreshable exclusion facts.
This maintainer-requested change removes that duplicate work.

## User Impact

Cold preparation uses one planner call instead of two. Warm prepared builds
still use one; public cached declaration reads use zero. Model availability,
configured modes, ordering and route capabilities remain unchanged.

No attributable latency, RSS, retained-memory or Gateway-startup improvement
is claimed. There is no new configuration, dependency, persistence schema,
public API or retained cache.

## Why This Change Was Made

The prepared-catalog owner creates one complete transient manifest plan and
passes it to the existing declaration-cache projection. That same plan's entries
supply runtime/refreshable facts; the cache still retains only snapshot and rows.
Both public and private entry points reject replace-mode declarations before
cache publication. Public cached-array identity and the previous cache after
failed replacement planning are preserved.

The signed main integrations preserve upstream provider selection/augmentation,
document-helper removal, prepared-runtime ownership, the UI dependency refresh
and unrelated test-shard exclusions. The planner and its public exports are
unchanged.

Compared with integration snapshot
`0ac8a700e43efceef73d92fe8e50b185819e38ad`, the change is six paths:
production **+31/-21**, tests **+173/-37**, test-project configuration **+6/-4**.
The production growth separates the existing cache projection from public
metadata resolution so the prepared plan can be reused without widening cache
contents or bypassing replace mode. Both catalog tests belong to agents-other
and are excluded from agents-root; compiler options and the root cap are unchanged.

A memory-reclamation fixture is also adapted to the integrated main's SQLite
worker-request contract. It observes the real request entry point, retains the
real required authorizer and assertions, starts foreground work in the captured
writer context, and awaits database closure. No memory production code is changed.
The later main integration retains the generic request-result signature and
forwards that type explicitly through the real request call; runtime logic and
assertions are unchanged.

## Evidence

Current signed head: `66e1852b19b3a5557654dd6ce6c5c10d2319b6a0`.
It follows the signed merge of the previously published `d322f2c` and the
integration snapshot above, with one scoped generic-type forwarding correction.
Both hosted and main ancestry are preserved.

### Current Candidate

Fresh proof on the final head, using Node 26.7.0 and the unchanged owned install:

- The canonical state-logging type graph passed through
  `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.state-logging.json --builders 1`
  in 2.183 seconds.
- Scoped memory-fixture formatting/lint and `git diff --check` passed.
- TypeScript 6.0.3 emitted byte-identical fixture JavaScript for this head and
  `d322f2c`. This is emission parity, not a replacement for the semantic type
  graph above or a new runtime run.
- All 193 install inputs matched the retained installation. Nine bound
  source/type inputs remained stable, the tracked tree stayed clean, and all
  check processes and streams closed.

The intervening merge `a235d0e` failed that graph with TS2345 because the wrapped
request inferred `unknown`. The explicit `<Result>` forwarding fixed the exact
type error. That failed receipt remains RED; no passing runtime result is
invented for it.

Retained exact-`d322f2c` proof: normal **`pnpm build` passed in 344.895 seconds**
with matching build information, then **25/25 tests passed, zero skipped**
(nine admission-race, one memory-reclamation and fifteen reuse cases).
The memory plugin was rebuilt before those tests through the normal built-first
loader. State-logging types, six-path formatting and scoped lint also passed.
These local owner-boundary results remain attributed to `d322f2c`, not rerated
as a final-head build or runtime run. They are not authenticated-provider or
live-Gateway proof.

The earlier `7bffac8` catalog qualification remains historical proof:
149/149 cases, a normal 236.770-second build, core boundary/core types and both
canonical agent shards passed. It covered cold/warm planning, entitlement,
replace exclusion, identity/error replacement, membership, ordering and prepared
lifetimes. Those tests were not rerun or added to the current 25-case count.
Native compiler 7.0.2, TypeScript API 6.0.3 and tsdown 0.23.0 were resolved in
the owned validation checkout.

### Review

The retained catalog integration review was one fresh source-review invocation
across six batches. It returned native exit 1 with one P2 alleging that both
catalog tests were included in both compiler shards.
That finding was rejected after reading the actual **root exclude** and
**other include** arrays and expanding the configs with TypeScript 6.0.3:
neither catalog root belongs to agents-root; both belong to agents-other.
Removing the root exclusions would create the alleged overlap.

The raw adverse report is preserved, not called clean or rerated to exit 0.
The accepted disposition found no remaining actionable source finding.
One individual batch lacked the planner facade; the full review input and
direct owner/facade/planner inspection covered it. Upstream owner changes were
retained without adding compatibility paths or expanding this change.

The subsequent memory-fixture adaptation and generic-type integration were
independently inspected against the actual worker-request/reclamation owners and
retained assertions. The runtime proof belongs to `d322f2c`; the final-head
emission parity and semantic type result above qualify the type-only follow-up.

Exact-head hosted CI for the newly published integrated head is pending
verification. The earlier successful CI below is historical, not qualification
of this head. Native current-head artifact refresh, hosted gates, preparation
and merge remain separate requirements.

<details>
<summary>Historical regression, review and measurement limits</summary>

[CI run 34757690248](https://github.com/openclaw/openclaw/actions/runs/34757690248)
failed on the synthetic merge of `7bffac8` and `4aff70f`.
The integrated main had changed the SQLite worker-request contract while the
memory fixture still observed the old entry point. The current test-only
adaptation addresses that demonstrated integration failure; the old failed run
is not rerated. An earlier local build interrupted by an allocation observer
also remains incomplete, not a Discord source defect or a successful build.

The residual optimization's original-source cold cases failed as intended:
expected one planner call, observed two; ten controls passed. Its RED02 receipt
also records `indexStable:false` and `nativeComplete:false`; the index writer
and cause are unknown. Those assertions are behavioral RED evidence, not a
fully native-qualified RED run. Later normalizer assertions were not reached
in the failing cases. The residual candidate then passed 49 catalog and 18
sibling cases, 67 unique cases; those are not added to the later 149.

The first residual review returned native 0 but contained an explicit
batch-scope abstention and was not accepted as a complete review. The corrected
whole-input invocation completed three passes without findings. A later
five-pass review covered the test-shard correction. These older raw results and
dispositions remain historical, not substitutes for the integrated review above.

[CI run 34531362226](https://github.com/openclaw/openclaw/actions/runs/34531362226)
on `a765728` failed the root-count boundary and core-test-types-1.
Moving the two catalog roots between existing shards repaired the demonstrated
root-cap issue. The separate compiler job's original cause remains unknown;
neither that routing correction nor the throwing getter's erased `: never`
annotation is asserted to explain it. The annotation had its own TypeScript
contract RED/GREEN and 49/49 runtime proof.
[CI run 34588032364](https://github.com/openclaw/openclaw/actions/runs/34588032364)
then succeeded on `771ef568` with 110 successful and 17 skipped jobs, including
core-test-types-1 and the required gate. That run is not current-head CI.

The earlier `8782cb1` implementation had 52 passing cases and
[successful CI](https://github.com/openclaw/openclaw/actions/runs/34426784738).
Its duplicate-key review allegation was rejected by direct producer evidence:
repeated merge keys were already conflicting and selection excluded them.
That older implementation and its reviews do not qualify the current residual.

The earlier ABBA comparison used 33 cases per leg, 132 passing executions, not
132 distinct cases. It showed **no attributable latency or RSS improvement**.
The values and closure facts were recovered from retained execution-transcript
records after the original raw per-sample artifacts were lost. No benchmark
was rerun for this integration, and no current performance result is inferred.
The [earlier ClawSweeper review](https://github.com/openclaw/openclaw/pull/143502#issuecomment-5610356837)
and its subsequent revisions remain head- and time-qualified review evidence,
not an independent merge approval.

</details>
