### PR TITLE
fix(tooling): join memory profiler children within cleanup deadlines

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -21,6 +21,7 @@ type ManagedProcessGroupChild = {
   signalCode?: string | null;
 };
 type ManagedProcessGroupOptions = {
+  deadlineAt?: number;
   errorPolicy: ManagedProcessGroupErrorPolicy;
   inspectLeaderWhenNoGroup?: boolean;
   platform?: NodeJS.Platform;
@@ -202,6 +203,7 @@ export function terminateManagedChild(
 export function inspectManagedProcessGroup(
   child: ManagedProcessGroupChild,
   {
+    deadlineAt,
     errorPolicy,
     inspectLeaderWhenNoGroup = false,
     platform = process.platform,
@@ -223,7 +225,7 @@ export function inspectManagedProcessGroup(
   try {
     process.kill(-pid, 0);
     if (platform === "linux" && (child.exitCode != null || child.signalCode != null)) {
-      if (isLinuxZombieProcessGroup(pid)) {
+      if (isLinuxZombieProcessGroup(pid, deadlineAt)) {
         return "dead";
       }
       // The group may be reaped while ps runs. Recheck kernel existence without
@@ -256,7 +258,16 @@ export function inspectManagedProcessGroup(
   }
 }
 
-function isLinuxZombieProcessGroup(pid: number): boolean {
+function isLinuxZombieProcessGroup(pid: number, deadlineAt?: number): boolean {
+  const timeout =
+    deadlineAt === undefined
+      ? PROCESS_GROUP_DRAIN_TIMEOUT_MS
+      : Math.min(PROCESS_GROUP_DRAIN_TIMEOUT_MS, Math.floor(deadlineAt - Date.now()));
+  // Snapshot work shares its owner's deadline. Exhaustion is not death, and
+  // timeout: 0 would silently remove Node's subprocess timeout.
+  if (timeout <= 0) {
+    return false;
+  }
   // Detached children lead their own session. Linux kill(0) includes zombies,
   // which cannot write or respond to signals while awaiting their parent's reap.
   // Enumerate threads (-L): a process row reports only the group leader's state,
@@ -264,7 +275,7 @@ function isLinuxZombieProcessGroup(pid: number): boolean {
   const result = spawnSync("ps", ["-s", String(pid), "-L", "-o", "pgid=,state="], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
-    timeout: PROCESS_GROUP_DRAIN_TIMEOUT_MS,
+    timeout,
     killSignal: "SIGKILL",
   });
   const zombie = new RegExp(`^\\s*${pid}\\s+Z\\s*$`, "u");
@@ -291,19 +302,22 @@ export async function waitForManagedProcessGroupExit(
     pollIntervalMs?: number;
   },
 ): Promise<boolean> {
-  const deadlineAt = Date.now() + timeoutMs;
+  const deadlineAt = Math.min(Date.now() + timeoutMs, groupOptions.deadlineAt ?? Infinity);
+  const boundedGroupOptions = { ...groupOptions, deadlineAt };
   while (Date.now() < deadlineAt) {
-    if (inspectManagedProcessGroup(child, groupOptions) !== "live") {
+    if (inspectManagedProcessGroup(child, boundedGroupOptions) !== "live") {
       return true;
     }
-    const waitMs = clampPollToDeadline
-      ? Math.min(pollIntervalMs, deadlineAt - Date.now())
-      : pollIntervalMs;
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    const waitMs = clampPollToDeadline ? Math.min(pollIntervalMs, remainingMs) : pollIntervalMs;
     await new Promise((resolve) => {
       setTimeout(resolve, waitMs);
     });
   }
-  return inspectManagedProcessGroup(child, groupOptions) !== "live";
+  return inspectManagedProcessGroup(child, boundedGroupOptions) !== "live";
 }
 
 /** Run a child command while forwarding termination signals to its process group. */
@@ -518,9 +532,15 @@ async function finalizeManagedChild(
   // Nested wrappers own detached groups. Let them forward the signal before
   // killing their leader, then join inherited pipes as well as our own group.
   // Normal exit has no grace period: surviving group members are a failure.
+  const startedAt = Date.now();
+  const forceDelay = signal ? forceKillDelayMs : 0;
   const termination =
     !signal &&
-    inspectManagedProcessGroup(child, { errorPolicy: "indeterminate", platform }) === "dead"
+    inspectManagedProcessGroup(child, {
+      deadlineAt: startedAt + forceDelay + PROCESS_GROUP_DRAIN_TIMEOUT_MS,
+      errorPolicy: "indeterminate",
+      platform,
+    }) === "dead"
       ? { processTreeState: "terminated" }
       : terminateManagedChild(child, signal ?? "SIGKILL", { platform, runTaskkill });
   if (platform === "win32" && termination?.processTreeState !== "terminated") {
@@ -531,16 +551,29 @@ async function finalizeManagedChild(
       "indeterminate",
     );
   }
-  const forceAt = Date.now() + (signal ? forceKillDelayMs : 0);
+  // POSIX probes share the original budget; Windows retains its existing
+  // post-taskkill drainage allowance.
+  const forceAt = (platform === "win32" ? Date.now() : startedAt) + forceDelay;
   const deadline = forceAt + PROCESS_GROUP_DRAIN_TIMEOUT_MS;
   let forced = !signal || platform === "win32";
   let groupState: "dead" | "indeterminate" | "live" = "indeterminate";
   while (true) {
+    const exited = child.exitCode !== null || child.signalCode !== null;
+    // A snapshot cannot spend drainage time before escalation is due. Forced
+    // leader-exit cleanup skips snapshot work but still checks kernel existence.
+    const probeDeadline = forced
+      ? deadline
+      : forceKillOnLeaderExit && exited
+        ? Math.min(forceAt, Date.now())
+        : forceAt;
     groupState =
       platform === "win32"
         ? "dead"
-        : inspectManagedProcessGroup(child, { errorPolicy: "indeterminate", platform });
-    const exited = child.exitCode !== null || child.signalCode !== null;
+        : inspectManagedProcessGroup(child, {
+            deadlineAt: probeDeadline,
+            errorPolicy: "indeterminate",
+            platform,
+          });
     const pipesClosed = [child.stdout, child.stderr].every((pipe) => !pipe || pipe.closed);
     if (groupState === "dead" && exited && pipesClosed) {
       onTerminated();
@@ -568,7 +601,7 @@ async function finalizeManagedChild(
       break;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, Math.min(PROCESS_GROUP_POLL_MS, deadline - now));
+      setTimeout(resolve, Math.min(PROCESS_GROUP_POLL_MS, (forced ? deadline : forceAt) - now));
     });
   }
   // Stop owning pipe handles only after recording failure; never disguise an

--- a/scripts/profile-extension-memory.mts
+++ b/scripts/profile-extension-memory.mts
@@ -13,7 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
-import pMap from "p-map";
+import pMap, { pMapSkip } from "p-map";
 import {
   ensureExtensionMemoryBuild,
   findBuiltExtensionMemoryEntries,
@@ -21,6 +21,7 @@ import {
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
 import { appendBoundedTail } from "./lib/bounded-output-tail.mjs";
 import { formatErrorMessage } from "./lib/error-format.mts";
+import { hasUnjoinedWork, inspectManagedProcessGroup } from "./lib/managed-child-process.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 
 const DEFAULT_CONCURRENCY = 6;
@@ -44,16 +45,21 @@ type RunCaseResult = {
   timedOut: boolean;
 };
 type CaseChild = ChildProcessByStdio<null, Readable, Readable>;
+type ActiveCase = {
+  stop: (signal: NodeJS.Signals) => void;
+  completion: Promise<RunCaseResult>;
+};
 
 const PARENT_SIGNAL_EXIT_CODES = new Map<ParentSignal, number>([
   ["SIGHUP", 129],
   ["SIGINT", 130],
   ["SIGTERM", 143],
 ]);
-const activeCaseChildren = new Map<CaseChild, number>();
+const activeCases = new Set<ActiveCase>();
 const parentSignalHandlers = new Map<ParentSignal, () => void>();
 let parentSignalHandlersInstalled = false;
 let parentSignalShutdownStarted = false;
+let parentSignalShutdown: Promise<void> | undefined;
 
 function defaultJsonReportPath(): string {
   return path.join(
@@ -204,10 +210,34 @@ function summarizeStderr(stderr: string, lines = 8, maxChars = STDERR_PREVIEW_MA
   )}`;
 }
 
+function describeCaseFailure(result: RunCaseResult, errors: Error[] = []): string {
+  const limit = Math.floor(STDERR_PREVIEW_MAX_CHARS / (errors.length + 2));
+  return [
+    `${result.name}: code=${result.code}, signal=${result.signal}, timedOut=${result.timedOut}`,
+    result.stderr,
+    ...errors.map(formatErrorMessage),
+  ]
+    .map((part) => summarizeStderr(part, 8, limit))
+    .filter(Boolean)
+    .join("; ");
+}
+
+function summarizeCase(result: RunCaseResult) {
+  const status = result.timedOut ? "timeout" : result.error || result.code !== 0 ? "fail" : "ok";
+  return {
+    status,
+    code: result.code,
+    signal: result.signal,
+    error: result.error ?? (status === "ok" ? null : describeCaseFailure(result)),
+    maxRssMb: result.maxRssMb,
+    stderrPreview: summarizeStderr(result.stderr),
+  };
+}
+
 /**
  * Runs one import scenario in a child process and captures bounded output plus RSS.
  */
-export async function runCase({
+export function runCase({
   repoRoot,
   env,
   hookPath,
@@ -230,82 +260,204 @@ export async function runCase({
     options: SpawnOptionsWithStdioTuple<"ignore", "pipe", "pipe">,
   ) => CaseChild;
 }): Promise<RunCaseResult> {
-  return await new Promise<RunCaseResult>((resolve) => {
-    const child = spawnImpl(
-      process.execPath,
-      ["--import", hookPath, "--input-type=module", "--eval", body],
-      {
-        cwd: repoRoot,
-        detached: process.platform !== "win32",
-        env,
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    trackActiveCaseChild(child, shutdownGraceMs);
-
-    let stdout = createOutputCapture();
-    let stderr = createOutputCapture();
-    let stderrRssTail = "";
-    let maxRssMb: number | null = null;
-    let timedOut = false;
-    let settled = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      signalChildProcessTree(child, "SIGKILL");
-    }, timeoutMs);
-    timer.unref?.();
-
-    function settle(result: RunCaseResult): void {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      untrackActiveCaseChild(child);
-      resolve(result);
+  if (parentSignalShutdownStarted) {
+    return Promise.reject(new Error("Profiling interrupted by parent signal"));
+  }
+  let child: CaseChild | undefined;
+  let stdout = createOutputCapture();
+  let stderr = createOutputCapture();
+  let stderrRssTail = "";
+  let maxRssMb: number | null = null;
+  let timedOut = false;
+  let closed = false;
+  let code: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let failure: Error | undefined;
+  const errors: Error[] = [];
+  let parentStopDeadline: number | undefined;
+  let killDeadline: number | undefined;
+  let registrationError: Error | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let wake!: () => void;
+  const outcome = new Promise<void>((resolve) => {
+    wake = resolve;
+  });
+  const recordFailure = (error: unknown) => {
+    const next = error instanceof Error ? error : new Error(formatErrorMessage(error));
+    errors.push(next);
+    failure = failure
+      ? new AggregateError([failure, next], `${failure.message}; ${next.message}`)
+      : next;
+  };
+  const sendSignal = (requested: NodeJS.Signals, deadlineAt = Date.now() + shutdownGraceMs) => {
+    if (!child || (requested === "SIGKILL" && killDeadline !== undefined)) {
+      return;
     }
-
-    child.stdout.setEncoding("utf8").on("data", (chunk) => {
-      stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_MAX_CHARS);
-    });
-    child.stderr.setEncoding("utf8").on("data", (chunk) => {
-      const rssScan = scanMaxRssMb(stderrRssTail, chunk, maxRssMb);
-      stderrRssTail = rssScan.tail;
-      maxRssMb = rssScan.maxRssMb;
-      stderr = appendBoundedTail(stderr, chunk, OUTPUT_CAPTURE_MAX_CHARS);
-    });
-    child.on("error", (error) => {
+    if (requested === "SIGKILL") {
+      killDeadline = deadlineAt;
+    }
+    try {
+      signalChildProcessTree(child, requested);
+    } catch (error) {
+      recordFailure(error);
+    }
+  };
+  const stop = (requested: NodeJS.Signals) => {
+    if (parentStopDeadline === undefined) {
+      parentStopDeadline = Date.now() + shutdownGraceMs;
+      if (killDeadline === undefined) {
+        sendSignal(requested);
+      }
+    } else if (requested === "SIGKILL") {
+      sendSignal(requested);
+    }
+    // A failed signal or missing exit event must still enter bounded case finalization.
+    wake();
+  };
+  const fullyClosed = (deadlineAt: number) =>
+    closed && child !== undefined && !childProcessTreeIsAlive(child, deadlineAt);
+  const waitForClosure = async (deadline: number, graceful = false) => {
+    while (!fullyClosed(deadline)) {
+      if (graceful && killDeadline !== undefined) {
+        break;
+      }
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, Math.min(50, remainingMs));
+      });
+    }
+  };
+  // Publish the completion before installing signal handlers or spawning. The parent
+  // joins this same promise, including finally, and the case never awaits the parent.
+  const completion = Promise.resolve()
+    .then(async () => {
+      if (registrationError !== undefined) {
+        throw registrationError;
+      }
+      if (parentSignalShutdownStarted) {
+        throw new Error("Profiling interrupted by parent signal");
+      }
+      child = spawnImpl(
+        process.execPath,
+        ["--import", hookPath, "--input-type=module", "--eval", body],
+        {
+          cwd: repoRoot,
+          detached: process.platform !== "win32",
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let cleanupError: Error | undefined;
+      try {
+        try {
+          child.on("error", (error) => {
+            recordFailure(error);
+            wake();
+          });
+          // Exit starts cleanup even when descendants still hold the output pipes.
+          child.once("exit", (exitCode, exitSignal) => {
+            code = exitCode;
+            signal = exitSignal;
+            wake();
+          });
+          child.once("close", (exitCode, exitSignal) => {
+            code = exitCode;
+            signal = exitSignal;
+            closed = true;
+            wake();
+          });
+          child.stdout.setEncoding("utf8").on("data", (chunk) => {
+            stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_MAX_CHARS);
+          });
+          child.stderr.setEncoding("utf8").on("data", (chunk) => {
+            const rssScan = scanMaxRssMb(stderrRssTail, chunk, maxRssMb);
+            stderrRssTail = rssScan.tail;
+            maxRssMb = rssScan.maxRssMb;
+            stderr = appendBoundedTail(stderr, chunk, OUTPUT_CAPTURE_MAX_CHARS);
+          });
+          timer = setTimeout(() => {
+            timedOut = true;
+            wake();
+          }, timeoutMs);
+          timer.unref?.();
+        } catch (error) {
+          recordFailure(error);
+          wake();
+        }
+        await outcome;
+        clearTimeout(timer);
+        if (child.pid) {
+          // Charge the preliminary snapshot to cleanup too; it cannot earn a
+          // fresh drainage allowance after consuming the current phase.
+          const cleanupDeadline =
+            killDeadline ?? (parentStopDeadline ?? Date.now()) + shutdownGraceMs;
+          if (parentStopDeadline !== undefined && killDeadline === undefined) {
+            await waitForClosure(parentStopDeadline, true);
+          }
+          if (timedOut || !fullyClosed(killDeadline ?? parentStopDeadline ?? cleanupDeadline)) {
+            sendSignal("SIGKILL", cleanupDeadline);
+          }
+          const deadlineAt = killDeadline ?? cleanupDeadline;
+          await waitForClosure(deadlineAt);
+          if (!fullyClosed(deadlineAt)) {
+            cleanupError = Object.assign(
+              new Error(
+                `${name} cleanup could not verify child, process group, and output closure`,
+              ),
+              { code: "EPROCESSGROUP_CLEANUP_FAILED", processTreeState: "indeterminate" },
+            );
+          }
+        }
+      } finally {
+        clearTimeout(timer);
+        if (!closed) {
+          for (const stream of [child.stdout, child.stderr]) {
+            try {
+              stream.destroy();
+            } catch (error) {
+              recordFailure(error);
+            }
+          }
+        }
+      }
       const stderrText = formatCapturedOutput(stderr);
-      settle({
+      const result: RunCaseResult = {
         name,
-        code: null,
-        signal: null,
+        code,
+        signal,
         timedOut,
-        error: formatErrorMessage(error),
+        error: null,
         stdout: formatCapturedOutput(stdout),
         stderr: stderrText,
         maxRssMb: maxRssMb ?? parseMaxRssMb(stderrText),
-      });
-    });
-    child.on("close", (code, signal) => {
-      void (async () => {
-        if (timedOut) {
-          await waitForChildProcessTreeExit(child, shutdownGraceMs);
-        }
-        const stderrText = formatCapturedOutput(stderr);
-        settle({
-          name,
-          code,
-          signal,
+      };
+      if (cleanupError) {
+        const message = describeCaseFailure(result, [...errors, cleanupError]);
+        // Keep the cleanup tag for HOME retention and terminal evidence even without
+        // an Error event. Structured primary errors remain intact in the aggregate.
+        Object.assign(cleanupError, {
+          message,
+          exitCode: code,
+          exitSignal: signal,
           timedOut,
-          error: null,
-          stdout: formatCapturedOutput(stdout),
-          stderr: stderrText,
-          maxRssMb: maxRssMb ?? parseMaxRssMb(stderrText),
+          stderrPreview: summarizeStderr(stderrText),
         });
-      })();
-    });
-  });
+        throw failure ? new AggregateError([failure, cleanupError], message) : cleanupError;
+      }
+      result.error = failure ? describeCaseFailure(result, errors) : null;
+      return result;
+    })
+    .finally(() => untrackActiveCase(owner));
+  const owner = { stop, completion };
+  try {
+    trackActiveCase(owner);
+  } catch (error) {
+    registrationError = error instanceof Error ? error : new Error(formatErrorMessage(error));
+  }
+  return completion;
 }
 
 function signalChildProcessTree(child: CaseChild, signal: NodeJS.Signals): void {
@@ -313,50 +465,38 @@ function signalChildProcessTree(child: CaseChild, signal: NodeJS.Signals): void 
     try {
       process.kill(-child.pid, signal);
       return;
-    } catch {
-      child.kill(signal);
-      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+        return;
+      }
+      // The POSIX spawn owns a detached group; signaling just its leader cannot replace it.
+      throw error;
     }
   }
   child.kill(signal);
 }
 
-async function waitForChildProcessTreeExit(child: CaseChild, timeoutMs: number): Promise<boolean> {
-  if (process.platform === "win32" || typeof child.pid !== "number") {
-    return true;
-  }
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!childProcessTreeIsAlive(child)) {
-      return true;
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
-    });
-  }
-  return !childProcessTreeIsAlive(child);
-}
-
-function childProcessTreeIsAlive(child: CaseChild): boolean {
+function childProcessTreeIsAlive(child: CaseChild, deadlineAt: number): boolean {
   if (typeof child.pid !== "number") {
     return false;
   }
-  try {
-    process.kill(-child.pid, 0);
-    return true;
-  } catch (error) {
-    return error instanceof Error && "code" in error && error.code === "EPERM";
-  }
+  return (
+    inspectManagedProcessGroup(child, {
+      deadlineAt,
+      errorPolicy: "indeterminate",
+      inspectLeaderWhenNoGroup: true,
+    }) !== "dead"
+  );
 }
 
-function trackActiveCaseChild(child: CaseChild, shutdownGraceMs: number): void {
-  activeCaseChildren.set(child, shutdownGraceMs);
+function trackActiveCase(owner: ActiveCase): void {
+  activeCases.add(owner);
   installParentSignalHandlers();
 }
 
-function untrackActiveCaseChild(child: CaseChild): void {
-  activeCaseChildren.delete(child);
-  if (activeCaseChildren.size === 0) {
+function untrackActiveCase(owner: ActiveCase): void {
+  activeCases.delete(owner);
+  if (activeCases.size === 0) {
     removeParentSignalHandlers();
   }
 }
@@ -393,31 +533,30 @@ function removeInstalledParentSignalHandlers(): void {
 
 function handleParentSignal(signal: ParentSignal): void {
   if (parentSignalShutdownStarted) {
-    for (const child of activeCaseChildren.keys()) {
-      signalChildProcessTree(child, "SIGKILL");
+    for (const owner of activeCases) {
+      owner.stop("SIGKILL");
     }
     return;
   }
   parentSignalShutdownStarted = true;
-  void cleanupActiveCaseChildrenForParentSignal(signal);
+  parentSignalShutdown = cleanupActiveCaseChildrenForParentSignal(signal);
 }
 
 async function cleanupActiveCaseChildrenForParentSignal(signal: ParentSignal): Promise<void> {
-  const children = [...activeCaseChildren.entries()];
-  for (const [child] of children) {
-    signalChildProcessTree(child, signal);
+  const owners = [...activeCases];
+  for (const owner of owners) {
+    owner.stop(signal);
   }
-  await Promise.all(
-    children.map(([child, shutdownGraceMs]) => waitForChildProcessTreeExit(child, shutdownGraceMs)),
-  );
-  for (const [child] of children) {
-    if (childProcessTreeIsAlive(child)) {
-      signalChildProcessTree(child, "SIGKILL");
+  const outcomes = await Promise.allSettled(owners.map((owner) => owner.completion));
+  for (const outcome of outcomes) {
+    if (outcome.status === "rejected") {
+      console.error(`[extension-memory] ${formatErrorMessage(outcome.reason)}`);
+    } else if (summarizeCase(outcome.value).status !== "ok") {
+      console.error(
+        `[extension-memory] ${outcome.value.error ?? describeCaseFailure(outcome.value)}`,
+      );
     }
   }
-  await Promise.all(
-    children.map(([child, shutdownGraceMs]) => waitForChildProcessTreeExit(child, shutdownGraceMs)),
-  );
   removeInstalledParentSignalHandlers();
   process.exit(PARENT_SIGNAL_EXIT_CODES.get(signal) ?? 1);
 }
@@ -485,6 +624,7 @@ async function main(): Promise<void> {
     LANG: process.env.LANG ?? "C.UTF-8",
   };
 
+  const runErrors: unknown[] = [];
   try {
     const baseline = await runCase({
       repoRoot,
@@ -509,36 +649,50 @@ async function main(): Promise<void> {
           timeoutMs: options.combinedTimeoutMs,
         });
 
+    const mapperErrors: unknown[] = [];
     const results = await pMap(
       selectedEntries,
       async (next) => {
-        const result = await runCase({
-          repoRoot,
-          env,
-          hookPath,
-          name: next.dir,
-          body: buildImportBody([next.file], "IMPORTED"),
-          timeoutMs: options.timeoutMs,
-        });
-        const entry = {
-          dir: next.dir,
-          file: next.file,
-          status: result.timedOut ? "timeout" : result.code === 0 ? "ok" : "fail",
-          maxRssMb: result.maxRssMb,
-          deltaFromBaselineMb:
-            result.maxRssMb !== null && baseline.maxRssMb !== null
-              ? result.maxRssMb - baseline.maxRssMb
-              : null,
-          stderrPreview: summarizeStderr(result.stderr),
-        };
+        if (mapperErrors.length > 0 || parentSignalShutdownStarted) {
+          return pMapSkip;
+        }
+        try {
+          const result = await runCase({
+            repoRoot,
+            env,
+            hookPath,
+            name: next.dir,
+            body: buildImportBody([next.file], "IMPORTED"),
+            timeoutMs: options.timeoutMs,
+          });
+          const entry = {
+            dir: next.dir,
+            file: next.file,
+            ...summarizeCase(result),
+            deltaFromBaselineMb:
+              result.maxRssMb !== null && baseline.maxRssMb !== null
+                ? result.maxRssMb - baseline.maxRssMb
+                : null,
+          };
 
-        const status = result.timedOut ? "timeout" : result.code === 0 ? "ok" : "fail";
-        const rss = result.maxRssMb === null ? "n/a" : `${result.maxRssMb.toFixed(1)} MB`;
-        console.log(`[extension-memory] ${next.dir}: ${status} ${rss}`);
-        return entry;
+          const rss = result.maxRssMb === null ? "n/a" : `${result.maxRssMb.toFixed(1)} MB`;
+          console.log(`[extension-memory] ${next.dir}: ${entry.status} ${rss}`);
+          return entry;
+        } catch (error) {
+          // p-map rejects before active mappers join. Fulfill failures, stop new admission,
+          // then propagate every error only after all admitted case owners have settled.
+          mapperErrors.push(error);
+          return pMapSkip;
+        }
       },
-      { concurrency: options.concurrency, stopOnError: true },
+      { concurrency: options.concurrency, stopOnError: false },
     );
+    if (parentSignalShutdownStarted) {
+      mapperErrors.push(new Error("Profiling interrupted by parent signal"));
+    }
+    if (mapperErrors.length > 0) {
+      throw new AggregateError(mapperErrors, mapperErrors.map(formatErrorMessage).join("; "));
+    }
 
     results.sort((a, b) => a.dir.localeCompare(b.dir));
     const top = results
@@ -550,16 +704,12 @@ async function main(): Promise<void> {
       generatedAt: new Date().toISOString(),
       repoRoot,
       selectedExtensions: selectedEntries.map((entry) => entry.dir),
-      baseline: {
-        status: baseline.timedOut ? "timeout" : baseline.code === 0 ? "ok" : "fail",
-        maxRssMb: baseline.maxRssMb,
-      },
+      baseline: summarizeCase(baseline),
       combined:
         combined === null
           ? null
           : {
-              status: combined.timedOut ? "timeout" : combined.code === 0 ? "ok" : "fail",
-              maxRssMb: combined.maxRssMb,
+              ...summarizeCase(combined),
               stderrPreview: summarizeStderr(combined.stderr, 12),
             },
       counts: {
@@ -597,14 +747,14 @@ async function main(): Promise<void> {
 
     const failures = [];
     if (report.baseline.status !== "ok") {
-      failures.push(`baseline import ${report.baseline.status}`);
+      failures.push(`baseline import ${report.baseline.status}: ${report.baseline.error}`);
     }
     if (report.baseline.maxRssMb === null) {
       failures.push("baseline import did not report RSS");
     }
     if (report.combined !== null) {
       if (report.combined.status !== "ok") {
-        failures.push(`combined import ${report.combined.status}`);
+        failures.push(`combined import ${report.combined.status}: ${report.combined.error}`);
       }
       if (report.combined.maxRssMb === null) {
         failures.push("combined import did not report RSS");
@@ -612,7 +762,7 @@ async function main(): Promise<void> {
     }
     for (const result of report.results) {
       if (result.status !== "ok") {
-        failures.push(`${result.dir} import ${result.status}`);
+        failures.push(`${result.dir} import ${result.status}: ${result.error}`);
       }
       if (result.maxRssMb === null) {
         failures.push(`${result.dir} import did not report RSS`);
@@ -624,8 +774,27 @@ async function main(): Promise<void> {
       }
       process.exitCode = 1;
     }
-  } finally {
-    rmSync(tmpHome, { recursive: true, force: true });
+  } catch (error) {
+    runErrors.push(error);
+  }
+  // The signal owner retains the exit status and must finish its snapshot's cleanup.
+  if (parentSignalShutdown) {
+    await parentSignalShutdown;
+    return;
+  }
+  if (runErrors.some(hasUnjoinedWork)) {
+    console.error(
+      `[extension-memory] retained temporary home after unverified cleanup: ${tmpHome}`,
+    );
+  } else {
+    try {
+      rmSync(tmpHome, { recursive: true, force: true });
+    } catch (error) {
+      runErrors.push(error);
+    }
+  }
+  if (runErrors.length > 0) {
+    throw new AggregateError(runErrors, runErrors.map(formatErrorMessage).join("; "));
   }
 }
 

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -695,6 +695,8 @@ setInterval(() => {}, 1_000);
     policy?: Parameters<typeof inspectManagedProcessGroup>[1]["errorPolicy"];
     platform?: NodeJS.Platform;
     running?: boolean;
+    remainingMs?: number;
+    snapshotTimeoutMs?: number;
   }>([
     { snapshot: "empty", afterSnapshot: "ESRCH", expected: "dead" },
     { snapshot: "live", afterSnapshot: "ESRCH", expected: "dead" },
@@ -721,8 +723,46 @@ setInterval(() => {}, 1_000);
     { snapshot: "empty", afterSnapshot: "EIO", expected: "dead" },
     { snapshot: "zombie", afterSnapshot: null, platform: "darwin", expected: "live" },
     { snapshot: "zombie", afterSnapshot: null, running: true, expected: "live" },
+    {
+      snapshot: "zombie",
+      afterSnapshot: null,
+      remainingMs: 20,
+      snapshotTimeoutMs: 20,
+      expected: "dead",
+    },
+    {
+      snapshot: "zombie",
+      afterSnapshot: null,
+      remainingMs: 10_000,
+      snapshotTimeoutMs: 5_000,
+      expected: "dead",
+    },
+    {
+      snapshot: "zombie-leader",
+      afterSnapshot: null,
+      remainingMs: 20,
+      snapshotTimeoutMs: 20,
+      expected: "live",
+    },
+    {
+      snapshot: "failed",
+      afterSnapshot: "ESRCH",
+      remainingMs: 20,
+      snapshotTimeoutMs: 20,
+      expected: "dead",
+    },
+    { snapshot: "zombie", afterSnapshot: null, remainingMs: 0, expected: "live" },
+    { snapshot: "zombie", afterSnapshot: null, remainingMs: -1, expected: "live" },
+    { snapshot: "zombie", afterSnapshot: "ESRCH", remainingMs: 0, expected: "dead" },
+    {
+      snapshot: "zombie",
+      afterSnapshot: "EPERM",
+      remainingMs: 0,
+      policy: "indeterminate",
+      expected: "indeterminate",
+    },
   ])(
-    "checks current group state after $snapshot snapshot ($afterSnapshot, $policy, $platform, $running)",
+    "checks current group state after $snapshot snapshot ($afterSnapshot, $policy, $platform, $running, budget $remainingMs)",
     ({
       snapshot,
       afterSnapshot,
@@ -730,10 +770,19 @@ setInterval(() => {}, 1_000);
       policy = "alive-on-eperm",
       platform = "linux",
       running,
+      remainingMs,
+      snapshotTimeoutMs = 5_000,
     }) => {
       let inspected = false;
+      let probes = 0;
+      const clock =
+        remainingMs === undefined ? undefined : vi.spyOn(Date, "now").mockReturnValue(1_000);
       const kill = vi.spyOn(process, "kill").mockImplementation(() => {
-        if (inspected && afterSnapshot) {
+        probes += 1;
+        if (
+          (inspected || (remainingMs !== undefined && remainingMs <= 0 && probes > 1)) &&
+          afterSnapshot
+        ) {
           throw Object.assign(new Error("group lookup failed"), { code: afterSnapshot });
         }
         return true;
@@ -767,16 +816,31 @@ setInterval(() => {}, 1_000);
           };
         });
       try {
+        const options = {
+          errorPolicy: policy,
+          platform,
+          ...(remainingMs === undefined ? {} : { deadlineAt: Date.now() + remainingMs }),
+        };
         expect(
           inspectManagedProcessGroup(
             { pid: 12345, exitCode: running ? null : 0, signalCode: null },
-            { errorPolicy: policy, platform },
+            options,
           ),
         ).toBe(expected);
-        expect(ps).toHaveBeenCalledTimes(platform === "linux" && !running ? 1 : 0);
+        const snapshotExpected =
+          platform === "linux" && !running && (remainingMs === undefined || remainingMs > 0);
+        expect(ps).toHaveBeenCalledTimes(snapshotExpected ? 1 : 0);
+        if (snapshotExpected) {
+          expect(ps).toHaveBeenCalledWith(
+            "ps",
+            ["-s", "12345", "-L", "-o", "pgid=,state="],
+            expect.objectContaining({ timeout: snapshotTimeoutMs, killSignal: "SIGKILL" }),
+          );
+        }
       } finally {
         ps.mockRestore();
         kill.mockRestore();
+        clock?.mockRestore();
       }
     },
   );
@@ -795,6 +859,119 @@ setInterval(() => {}, 1_000);
     } finally {
       kill.mockRestore();
     }
+  });
+
+  it.each([
+    "waiter",
+    "normal exit",
+    "zombie normal exit",
+    "graceful abort",
+    "force on leader exit",
+  ] as const)("includes Linux snapshot work in the %s deadline", (mode) => {
+    const dir = createTempDir("openclaw-managed-probe-deadline-");
+    // Deliberately failed mock cleanup owns its claim separately from real fixture jobs.
+    createVitestResourceOwner(dir);
+    const script = path.join(dir, "controller.mjs");
+    fs.writeFileSync(
+      script,
+      `
+import assert from "node:assert/strict";
+import cp from "node:child_process";
+import { EventEmitter } from "node:events";
+import { syncBuiltinESMExports } from "node:module";
+const mode = ${JSON.stringify(mode)};
+let now = 1_000, live = true;
+const probes = [], signals = [];
+const child = Object.assign(new EventEmitter(), {
+  pid: 12345, exitCode: 0, signalCode: null,
+  stdin: null, stdout: null, stderr: null,
+  kill() { throw new Error("must signal the owned group"); },
+});
+Date.now = () => now;
+process.kill = (pid, signal) => {
+  assert.equal(pid, -child.pid);
+  if (!live) throw Object.assign(new Error("group gone"), { code: "ESRCH" });
+  if (signal !== 0) {
+    signals.push({ signal, at: now });
+    if (signal === "SIGKILL" && mode !== "normal exit") {
+      live = false;
+      child.exitCode = null;
+      child.signalCode = "SIGKILL";
+      child.emit("exit", null, "SIGKILL");
+      child.emit("close", null, "SIGKILL");
+    }
+  }
+  return true;
+};
+cp.spawn = () => child;
+cp.spawnSync = (bin, args, options) => {
+  assert.equal(bin, "ps");
+  assert.ok(args.includes("-L"));
+  assert.ok(Number.isInteger(options.timeout) && options.timeout > 0);
+  probes.push({ at: now, timeout: options.timeout });
+  if (mode === "zombie normal exit") {
+    now += 1;
+    return { pid: 12346, output: [], status: 0, signal: null, stdout: "12345 Z\\n", stderr: "" };
+  }
+  now += options.timeout;
+  return { pid: 12346, output: [], status: null, signal: "SIGKILL",
+    stdout: "", stderr: "", error: Object.assign(new Error("snapshot timed out"), { code: "ETIMEDOUT" }) };
+};
+syncBuiltinESMExports();
+const { runManagedCommand, waitForManagedProcessGroupExit } =
+  await import(${JSON.stringify(pathToFileURL(path.resolve("scripts/lib/managed-child-process.mts")).href)});
+const started = now;
+let outcome;
+if (mode === "waiter") {
+  outcome = await waitForManagedProcessGroupExit(child, 20, {
+    errorPolicy: "indeterminate", platform: "linux", clampPollToDeadline: true, pollIntervalMs: 1,
+  });
+} else {
+  const abort = new AbortController();
+  outcome = await runManagedCommand({
+    bin: "mocked-owned-child", platform: "linux", shell: false, stdio: "ignore",
+    requireProcessTreeExit: true, signal: abort.signal, abortKillGraceMs: 100,
+    ...(mode === "force on leader exit" ? {
+      timeoutMs: 0, timeoutKillGraceMs: 100, timeoutForceKillOnLeaderExit: true,
+    } : {}),
+    onReady() {
+      if (mode === "normal exit" || mode === "zombie normal exit") {
+        child.emit("exit", 0, null);
+        child.emit("close", 0, null);
+      } else if (mode === "graceful abort") abort.abort();
+    },
+  }).catch(error => error.code);
+}
+console.log(JSON.stringify({ mode, elapsed: now - started, outcome, probes, signals }));
+if (mode === "waiter") {
+  assert.equal(outcome, false, "budget exhaustion must not establish death");
+  assert.ok(now - started <= 20, "terminal probe must not refresh the waiter's allowance");
+  assert.equal(probes.length, 1);
+} else if (mode === "normal exit") {
+  assert.equal(outcome, "EPROCESSGROUP_CLEANUP_FAILED");
+  assert.ok(now - started <= 5_000, "preliminary snapshot must be charged to finalization");
+  assert.ok(signals.some(entry => entry.signal === "SIGKILL"));
+} else if (mode === "zombie normal exit") {
+  assert.equal(outcome, 0, "completed zombie-only group remains a successful normal exit");
+  assert.deepEqual(signals, []);
+  assert.ok(probes.length > 0);
+} else {
+  const forceBudget = mode === "graceful abort" ? 100 : 0;
+  assert.equal(outcome, mode === "graceful abort" ? "ABORT_ERR" : "ETIMEDOUT");
+  const forced = signals.find(entry => entry.signal === "SIGKILL");
+  assert.ok(forced && forced.at - started <= forceBudget, "snapshot must not delay escalation");
+  assert.equal(live, false);
+}
+`,
+    );
+    const result = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir },
+      timeout: 10_000,
+      killSignal: "SIGKILL",
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
   });
 
   it("signals the direct child when process-group ownership is disabled", () => {

--- a/test/scripts/process-fixture-cleanup.test.ts
+++ b/test/scripts/process-fixture-cleanup.test.ts
@@ -34,8 +34,9 @@ async function captureFixture(owner: (typeof fixtures)[number]["owner"]) {
   vi.resetModules();
   const bodies = new Map<string, () => Promise<void>>();
   const register = (name: string, body: () => Promise<void>) => bodies.set(name, body);
+  const collectSuite = (_name: string, body: () => void) => body();
   vi.doMock("vitest", () => ({
-    describe: (_name: string, body: () => void) => body(),
+    describe: Object.assign(collectSuite, { runIf: () => collectSuite }),
     it: Object.assign(register, { each: () => () => {}, runIf: () => register, skip: register }),
     expect,
     vi,

--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -14,8 +14,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough, Transform } from "node:stream";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  hasUnjoinedWork,
   inspectManagedProcessGroup,
   waitForManagedProcessGroupExit,
 } from "../../scripts/lib/managed-child-process.mts";
@@ -464,11 +465,467 @@ describe("scripts/profile-extension-memory", () => {
     expect(Date.now() - startedAt).toBeLessThan(1000);
     expect(result).toMatchObject({
       code: null,
-      error: "spawn denied",
+      error: "spawn-error: code=null, signal=null, timedOut=false; spawn denied",
       name: "spawn-error",
       signal: null,
       timedOut: false,
     });
+  });
+
+  it.runIf(process.platform !== "win32").each([
+    ...["mapper failure", "unverified group", "parent signal", "home deletion failure"].map(
+      (scenario) => ({
+        name: `settles admitted mappers and stops admission on ${scenario}`,
+        scenario,
+        signalFailureCase: null as string | null,
+      }),
+    ),
+    {
+      name: "parent shutdown joins delayed case closure before exit",
+      scenario: "delayed parent close",
+      signalFailureCase: null,
+    },
+    {
+      name: "bounds Linux snapshots across initial and final case cleanup probes",
+      scenario: "linux cleanup deadline",
+      signalFailureCase: null,
+    },
+    {
+      name: "bounds Linux snapshots by parent escalation and final drainage",
+      scenario: "linux parent deadline",
+      signalFailureCase: null,
+    },
+    ...["baseline", "combined", "a-held"].map((signalFailureCase) => ({
+      name: `reports signal failure after verified cleanup for ${signalFailureCase}`,
+      scenario: "settled signal failure",
+      signalFailureCase,
+    })),
+  ])("$name", ({ scenario, signalFailureCase }) => {
+    const unverifiedGroup = scenario === "unverified group";
+    const delayedParentClose = scenario === "delayed parent close";
+    const linuxDeadline = scenario.startsWith("linux ");
+    const parentSignal =
+      scenario === "parent signal" || delayedParentClose || scenario === "linux parent deadline";
+    const homeDeletionFailure = scenario === "home deletion failure";
+    const signalFailure = scenario === "settled signal failure";
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-mappers-"));
+    const journalPath = path.join(root, "journal.json");
+    const preloadPath = path.join(root, "spawn-fixture.mjs");
+    const reportPath = path.join(root, "report.json");
+    let home: string | undefined;
+    try {
+      for (const id of ["a-held", "b-error", "c-unused"]) {
+        const dir = path.join(root, "dist", "extensions", id);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(path.join(dir, "index.js"), "export {};\n");
+      }
+      writeFileSync(
+        preloadPath,
+        [
+          "import cp from 'node:child_process';",
+          "import { EventEmitter } from 'node:events';",
+          "import fs, { existsSync, writeFileSync } from 'node:fs';",
+          "import { syncBuiltinESMExports } from 'node:module';",
+          "import { PassThrough } from 'node:stream';",
+          "let home, finishHeld, homeDuringClose, failedPid;",
+          "const started = [], closed = [], signals = [], live = new Map();",
+          "let now = 1_000;",
+          "const probes = [], signalTimes = [];",
+          `if (${linuxDeadline}) {`,
+          "  Object.defineProperty(process, 'platform', { value: 'linux' });",
+          "  Date.now = () => now;",
+          "  cp.spawnSync = (bin, args, options) => {",
+          "    if (bin !== 'ps' || !args.includes('-L') || !(options.timeout > 0))",
+          "      throw new Error('expected a positive, thread-aware snapshot budget');",
+          "    probes.push({ at: now, timeout: options.timeout });",
+          "    now += options.timeout;",
+          "    return { pid: 12346, output: [], status: null, signal: 'SIGKILL',",
+          "      stdout: '', stderr: '', error: Object.assign(new Error('snapshot timed out'), { code: 'ETIMEDOUT' }) };",
+          "  };",
+          "}",
+          "const remove = fs.rmSync;",
+          "fs.rmSync = (target, options) => {",
+          `  if (${homeDeletionFailure} && target === home)`,
+          "    throw Object.assign(new Error('home cleanup denied'), { code: 'EACCES' });",
+          "  return remove(target, options);",
+          "};",
+          "process.on('exit', () => writeFileSync(" + JSON.stringify(journalPath) + ",",
+          "  JSON.stringify({ home, pending: live.size > 0, started, closed, signals, signalTimes, probes, elapsed: now - 1_000, homeDuringClose, homeExists: existsSync(home) })));",
+          "process.kill = (pid, signal) => {",
+          `  if (${signalFailure} && pid === -failedPid && live.has(-pid)) {`,
+          "    if (signal === 0) return true;",
+          "    signals.push([pid, signal]); live.delete(-pid);",
+          "    throw Object.assign(new Error('group signal failed after exit'), { code: 'EIO' });",
+          "  }",
+          `  if (${parentSignal} && live.has(-pid)) {`,
+          "    if (signal === 0) return true;",
+          "    signals.push([pid, signal]);",
+          "    signalTimes.push({ pid, signal, at: now });",
+          `    if (!${linuxDeadline} && pid === -2147483646 && signal === 'SIGTERM')`,
+          "      throw Object.assign(new Error('group signal failed'), { code: 'EIO' });",
+          "    const finish = live.get(-pid);",
+          `    if (${delayedParentClose || linuxDeadline}) finish(signal); else queueMicrotask(() => finish(signal));`,
+          "    return true;",
+          "  }",
+          `  if (${linuxDeadline} && live.has(-pid)) {`,
+          "    if (signal !== 0) {",
+          "      signals.push([pid, signal]); signalTimes.push({ pid, signal, at: now });",
+          "    }",
+          "    return true;",
+          "  }",
+          `  if (${unverifiedGroup} && pid === -2147483646)`,
+          "    throw Object.assign(new Error('inspection denied'), { code: 'EPERM' });",
+          "  throw Object.assign(new Error('missing group'), { code: 'ESRCH' });",
+          "};",
+          "cp.spawn = (_command, args, options) => {",
+          "  home = options.env.HOME;",
+          "  const body = args.at(-1);",
+          "  const name = body.includes('IMPORTED_ALL') ? 'combined' :",
+          "    body.match(/\\/(a-held|b-error|c-unused)\\//)?.[1] ?? 'baseline';",
+          "  started.push(name);",
+          `  if (name === 'b-error' && !${parentSignal} && !${signalFailure}) {`,
+          "    setImmediate(() => finishHeld());",
+          "    throw new Error('mapper spawn failed');",
+          "  }",
+          "  const child = Object.assign(new EventEmitter(), {",
+          "    pid: { 'a-held': 2147483646, 'b-error': 2147483645, 'c-unused': 2147483644,",
+          "      baseline: 2147483643, combined: 2147483642 }[name],",
+          "    exitCode: null, signalCode: null,",
+          "    stdout: new PassThrough(), stderr: new PassThrough(), kill: () => true,",
+          "  });",
+          `  if (name === ${JSON.stringify(signalFailureCase)}) failedPid = child.pid;`,
+          "  let finished = false;",
+          "  const finish = (signal = null) => {",
+          "    if (finished) return;",
+          "    finished = true;",
+          `    if (child.pid !== failedPid && !(${linuxDeadline} && name === 'a-held')) live.delete(child.pid);`,
+          "    child.exitCode = signal ? null : 0; child.signalCode = signal;",
+          "    child.emit('exit', child.exitCode, signal);",
+          "    const close = () => {",
+          "      if (name === 'a-held') homeDuringClose = existsSync(home);",
+          "      child.stderr.end('primary stderr for ' + name + '\\n__OPENCLAW_MAX_RSS_KB__=2048\\n');",
+          "      child.stdout.end(); closed.push(name);",
+          "      child.emit('close', child.exitCode, signal);",
+          "    };",
+          // Separate group disappearance from pipe closure without timing-based sleeps.
+          `    if (${delayedParentClose} && name !== 'baseline') setImmediate(close);`,
+          "    else close();",
+          "  };",
+          "  live.set(child.pid, finish);",
+          `  if (name === 'a-held' && !${signalFailure}) finishHeld = finish;`,
+          `  else if (${parentSignal} && name === 'b-error') queueMicrotask(() => process.emit('SIGTERM'));`,
+          "  else queueMicrotask(finish);",
+          "  return child;",
+          "};",
+          "syncBuiltinESMExports();",
+        ].join("\n"),
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          TSX_PRELOAD,
+          "--import",
+          preloadPath,
+          SCRIPT_PATH,
+          ...(signalFailureCase === "combined" ? [] : ["--skip-combined"]),
+          "--concurrency",
+          "2",
+          "--json",
+          reportPath,
+        ],
+        {
+          cwd: root,
+          env: { ...process.env, TSX_TSCONFIG_PATH: SOURCE_TSCONFIG_PATH },
+          encoding: "utf8",
+          timeout: 10_000,
+          killSignal: "SIGKILL",
+        },
+      );
+      const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+      home = journal.home;
+      expect(result.status, result.stderr).toBe(parentSignal ? 143 : 1);
+      expect(journal.pending).toBe(linuxDeadline);
+      expect(journal.started).toEqual([
+        "baseline",
+        ...(signalFailureCase === "combined" ? ["combined"] : []),
+        "a-held",
+        "b-error",
+        ...(signalFailure ? ["c-unused"] : []),
+      ]);
+      if (parentSignal) {
+        if (!linuxDeadline) {
+          expect(result.stderr).toContain("group signal failed");
+        }
+        expect(journal.signals).toContainEqual([-2147483645, "SIGTERM"]);
+        expect(journal.signals).toContainEqual([-2147483646, "SIGKILL"]);
+        if (delayedParentClose) {
+          expect(journal.closed).toEqual(expect.arrayContaining(journal.started));
+          expect(result.stderr).toContain("primary stderr for a-held");
+        }
+      } else if (signalFailure) {
+        const report = JSON.parse(readFileSync(reportPath, "utf8"));
+        const failed =
+          signalFailureCase === "baseline"
+            ? report.baseline
+            : signalFailureCase === "combined"
+              ? report.combined
+              : report.results.find((entry: { dir: string }) => entry.dir === "a-held");
+        expect(failed).toMatchObject({
+          status: "fail",
+          code: 0,
+          signal: null,
+          error: expect.stringContaining("group signal failed after exit"),
+          stderrPreview: expect.stringContaining(`primary stderr for ${signalFailureCase}`),
+        });
+        expect(result.stderr).toContain("group signal failed after exit");
+        expect(result.stderr).toContain(`primary stderr for ${signalFailureCase}`);
+        expect(journal.homeExists).toBe(false);
+      } else {
+        expect(result.stderr).toContain("mapper spawn failed");
+        expect(journal.homeExists).toBe(unverifiedGroup || homeDeletionFailure || linuxDeadline);
+        if (unverifiedGroup) {
+          expect(result.stderr).toMatch(/cleanup/i);
+        }
+        if (homeDeletionFailure) {
+          expect(result.stderr).toContain("mapper spawn failed; home cleanup denied");
+        }
+      }
+      if (linuxDeadline) {
+        expect(result.stderr).toMatch(/cleanup/i);
+        expect(journal.homeExists).toBe(true);
+        expect(journal.elapsed).toBeLessThanOrEqual(parentSignal ? 2_000 : 1_000);
+        expect(journal.probes.length).toBeGreaterThan(0);
+        expect(
+          journal.probes.every(
+            (probe: { timeout: number }) => probe.timeout > 0 && probe.timeout <= 1_000,
+          ),
+        ).toBe(true);
+        if (parentSignal) {
+          const forced = journal.signalTimes.find(
+            (entry: { pid: number; signal: string }) =>
+              entry.pid === -2147483646 && entry.signal === "SIGKILL",
+          );
+          expect(forced?.at).toBeLessThanOrEqual(2_000);
+        }
+      }
+      expect(journal.homeDuringClose).toBe(true);
+    } finally {
+      // These CLI fixtures model children in memory; no native descendant owns the home.
+      if (home) {
+        rmSync(home, { recursive: true, force: true });
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "cleans descendants after an ordinary leader exit before resolving the case",
+    async () => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-exit-"));
+      const hookPath = path.join(root, "rss-hook.mjs");
+      const descendantPidPath = path.join(root, "descendant.pid");
+      let cleanup = async () => rmSync(root, { recursive: true, force: true });
+      await runQaGatewayFixture(
+        async () => {
+          writeFileSync(hookPath, "", "utf8");
+          const descendantScript = [
+            "import { writeFileSync } from 'node:fs';",
+            "setInterval(() => {}, 1000);",
+            `writeFileSync(${JSON.stringify(descendantPidPath)}, String(process.pid));`,
+            "process.send('ready');",
+          ].join("\n");
+          const body = [
+            "import { spawn } from 'node:child_process';",
+            `const child = spawn(process.execPath, ['--input-type=module', '--eval', ${JSON.stringify(descendantScript)}],`,
+            "  { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });",
+            "child.once('message', () => { child.disconnect(); child.unref(); });",
+          ].join("\n");
+          const result = await runCase({
+            body,
+            env: process.env,
+            hookPath,
+            name: "ordinary-exit-descendant",
+            repoRoot: root,
+            shutdownGraceMs: 1_000,
+            timeoutMs: 5_000,
+            spawnImpl: (command, args, options) => {
+              const child = spawn(command, args, options);
+              const closed = new Promise<void>((resolve) => {
+                child.once("close", () => resolve());
+              });
+              cleanup = () => cleanupProfileFixture(root, child, closed, descendantPidPath);
+              return child;
+            },
+          });
+          const descendantPid = await waitForPidFile(descendantPidPath, 5_000);
+          expect(result).toMatchObject({ code: 0, error: null, signal: null, timedOut: false });
+          expect(isProcessAlive(descendantPid)).toBe(false);
+        },
+        () => cleanup(),
+      );
+    },
+  );
+
+  describe.runIf(process.platform !== "win32")("unverified timeout cleanup", () => {
+    it.each(["alive", "EPERM", "EIO"] as const)(
+      "rejects when the owned group is %s after SIGKILL",
+      async (groupState) => {
+        const child = Object.assign(new EventEmitter(), {
+          pid: 2_147_483_647,
+          exitCode: null,
+          signalCode: null as NodeJS.Signals | null,
+          stdout: new PassThrough(),
+          stderr: new PassThrough(),
+          kill: vi.fn(() => true),
+        });
+        const signal = vi.spyOn(process, "kill").mockImplementation((pid, requestedSignal) => {
+          expect(pid).toBe(-child.pid);
+          if (requestedSignal === 0) {
+            if (groupState !== "alive") {
+              throw Object.assign(new Error(`group inspection failed: ${groupState}`), {
+                code: groupState,
+              });
+            }
+            return true;
+          }
+          expect(requestedSignal).toBe("SIGKILL");
+          queueMicrotask(() => {
+            child.signalCode = "SIGKILL";
+            child.stdout.end();
+            child.stderr.end();
+            child.emit("close", null, "SIGKILL");
+          });
+          return true;
+        });
+        try {
+          await expect(
+            runCase({
+              body: "",
+              env: process.env,
+              hookPath: "unused-hook.mjs",
+              name: "unverified-cleanup",
+              repoRoot: process.cwd(),
+              shutdownGraceMs: 0,
+              timeoutMs: 5,
+              spawnImpl: (() => child) as unknown as typeof spawn,
+            }),
+          ).rejects.toThrow(/cleanup/i);
+        } finally {
+          signal.mockRestore();
+        }
+      },
+    );
+  });
+
+  it.runIf(process.platform !== "win32").each(["EIO", "EPERM"])(
+    "preserves %s group-signal and primary failures alongside unverified cleanup",
+    async (errorCode) => {
+      const primary = new Error("case failed");
+      const groupSignalError = Object.assign(new Error("group signal failed"), { code: errorCode });
+      const child = Object.assign(new EventEmitter(), {
+        pid: 2_147_483_647,
+        exitCode: 1,
+        signalCode: null,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        kill: vi.fn(() => {
+          throw new Error("leader fallback must not replace the group error");
+        }),
+      });
+      const signal = vi.spyOn(process, "kill").mockImplementation((pid, requestedSignal) => {
+        expect(pid).toBe(-child.pid);
+        if (requestedSignal === 0) {
+          throw Object.assign(new Error("inspection failed"), { code: errorCode });
+        }
+        expect(requestedSignal).toBe("SIGKILL");
+        throw groupSignalError;
+      });
+      try {
+        const result = runCase({
+          body: "",
+          env: process.env,
+          hookPath: "unused-hook.mjs",
+          name: "failed-group-signal",
+          repoRoot: process.cwd(),
+          shutdownGraceMs: 0,
+          timeoutMs: 30_000,
+          spawnImpl: (() => {
+            queueMicrotask(() => {
+              child.emit("error", primary);
+              child.stdout.end();
+              child.stderr.end();
+              child.emit("close", 1, null);
+            });
+            return child;
+          }) as unknown as typeof spawn,
+        });
+        await expect(result).rejects.toMatchObject({
+          errors: [
+            expect.objectContaining({ errors: [primary, groupSignalError] }),
+            expect.objectContaining({ code: "EPROCESSGROUP_CLEANUP_FAILED" }),
+          ],
+        });
+        expect(child.kill).not.toHaveBeenCalled();
+      } finally {
+        signal.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32").each([
+    { label: "nonzero exit", code: 23, signal: null },
+    { label: "signal exit", code: null, signal: "SIGTERM" as const },
+  ])("cleanup preserves terminal evidence without an error event: $label", async (outcome) => {
+    const child = Object.assign(new EventEmitter(), {
+      pid: 2_147_483_647,
+      exitCode: outcome.code,
+      signalCode: outcome.signal,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: vi.fn(() => true),
+    });
+    const signal = vi.spyOn(process, "kill").mockImplementation((pid, requestedSignal) => {
+      expect(pid).toBe(-child.pid);
+      expect([0, "SIGKILL"]).toContain(requestedSignal);
+      return true;
+    });
+    try {
+      const failure: unknown = await runCase({
+        body: "",
+        env: process.env,
+        hookPath: "unused-hook.mjs",
+        name: "terminal-without-error-event",
+        repoRoot: process.cwd(),
+        shutdownGraceMs: 0,
+        timeoutMs: 30_000,
+        spawnImpl: (() => {
+          queueMicrotask(() => {
+            child.stderr.end(`${"x".repeat(160_000)}\nprimary import diagnostic\n`);
+            child.stdout.end();
+            child.emit("exit", outcome.code, outcome.signal);
+            child.emit("close", outcome.code, outcome.signal);
+          });
+          return child;
+        }) as unknown as typeof spawn,
+      }).then(
+        () => {
+          throw new Error("unverified cleanup resolved unexpectedly");
+        },
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      if (!(failure instanceof Error)) {
+        throw new Error("missing cleanup failure");
+      }
+      expect(hasUnjoinedWork(failure)).toBe(true);
+      expect(failure.message).toMatch(outcome.signal ? /SIGTERM/u : /\b23\b/u);
+      expect(failure.message).toContain("primary import diagnostic");
+      expect(failure.message).toMatch(/cleanup/i);
+      expect(failure.message.length).toBeLessThan(10_000);
+    } finally {
+      signal.mockRestore();
+    }
   });
 
   it.runIf(process.platform !== "win32")(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers profiling plugin memory could see the command finish or its temporary HOME disappear while admitted child work was still running. Parent interruption could also exit before case finalizers joined, and cleanup failures could hide the original child failure.

Linux process-group inspection introduced a related timing problem: a synchronous snapshot could consume five seconds outside a shorter cleanup phase, delaying escalation or renewing the effective cleanup allowance.

## Why This Change Was Made

The profiler now owns each case through one completion promise, stops new admission on failure or parent interruption, and joins admitted cases before reporting or removing HOME. Unverified cleanup retains HOME and reports bounded primary and cleanup diagnostics together.

The existing process-group inspector accepts an optional absolute deadline. Its callers share their existing escalation and drainage deadlines with snapshot work, including initial and terminal probes. Expired snapshots do not prove death or invoke an unbounded zero-timeout subprocess. The omitted inspector deadline retains the existing five-second default.

This keeps the existing process-group owner and parser rather than introducing another supervision subsystem. The lifecycle repair preserves the profiler's SIGKILL timeout, bounded UTF-8/RSS capture, and Windows behavior; no public configuration or unrelated caller migration is added. The subsequent test-only correction makes the cleanup fixture's mocked `describe.runIf` return its existing collector, matching Vitest's collection behavior without changing assertions or production code.

## User Impact

Intended behavior: profiler completion means its admitted work has settled; interruption and cleanup errors remain visible; temporary inputs are retained when cleanup cannot be verified. Linux snapshots must fit the phase that owns them.

This is a lifecycle-correctness repair, not evidence of lower memory consumption or a change to memory thresholds.

## Evidence

- Original proof base: `af58a779d3e51071857e65e4ed6b0fcd6d092ce8`.
- Original tested source: `4086c13f4e80ceb86900d9f68041b26833491cad`.
- Publication base: `8642c68b6b9f6ee42fa91641dd8656fcf0a617a9`.
- Original publication head: `4312dea131238ccecd263114af45eb3f22becbd7`.
- Current signed head: `f9755c55b9a00a6d0889def3805fe0649f8e42cb`.
- The original rebase preserved the exact patch and all four changed files. Relevant owner, helper, and harness inputs matched the original proof base. Those original test and review results remain historical proof, separate from the subsequent collector-only correction and current-head CI.
- Exact-head [CI run 34447081118](https://github.com/openclaw/openclaw/actions/runs/34447081118) completed successfully for `f9755c55b9a00a6d0889def3805fe0649f8e42cb`.
- The collector regression used the full existing seven-case file in its original order: before the correction, **three passed and four failed**; after the correction, **seven passed, zero failed, zero skipped**. The native runs exited and closed with their expected codes, owned groups were absent, and temporary/worker directories were empty. Formatting, scoped lint, and whitespace checks passed. Only the two-line-addition/one-line-removal collector correction was committed; production bytes were unchanged.
- Earlier owner-boundary regressions covered ordinary leader exit with a surviving descendant, mapper admission and joining, parent-signal fanout, visible signal/cleanup errors, and HOME deletion failures.
- The exact candidate passed the grouped full-file run: **135 passed, 1 skipped, 2 files**, in 106.63 seconds including the wrapper. The existing Linux-only reap case is skipped on macOS. Source and test hashes were unchanged throughout the run, and worker generations were absent afterward.
- Before the deadline production edits, the helper selection produced **11 intended assertion failures, 17 passes, and 70 skips**. The profiler selection produced **2 intended assertion failures and 36 skips**. Across the 15 additions, 13 regression cases failed and both controls passed; 15 existing controls also passed. No import, setup, or watchdog failure was counted as regression RED.
- The controlled clocks showed waiter/finalizer snapshot work consuming 10 seconds, normal profiler cleanup consuming 15 seconds, and parent cleanup consuming 20 seconds beyond their owned phase budgets.
- Scoped source and test lint, formatting, and whitespace checks pass for the current four files. Independent source review accepted the deadline amendment.
- The earlier read-only review remains historical evidence. A fresh whole-committed-scope review emitted **three raw P2 rows**; they are retained with the disposition below, not relabeled as a zero-finding review.

Review disposition:

- The proposed POSIX escaped-descendant premise was not established within this change's ordinary owned-descendant contract. No new supervision mechanism or production edit was justified by that premise.
- The Windows descendant-closure gap predates this change. **Windows descendant closure proof** remains a named follow-up; POSIX observations do not qualify Windows.
- Diagnostic output loss remains **unproven on the tested canonical invocation**. The continuously drained native control passed. The paused-reader experiment stopped during prefill before descendant startup, not at a truncation assertion, so it is not qualifying RED. A bounded native observation showed that write returning after reader release; it does not establish universal blocking or loss-free output. **Profiler diagnostic output completion across supported stream/runtime modes** remains a named follow-up.
- The failed experimental test delta and raw review/probe evidence were preserved privately. Only that experimental delta was removed; exact committed test and production hashes were restored, and the worktree was clean at the current head. No production fix, new test run, or review rerating followed the disposition.

This PR is open for review, not a draft. The exact-head CI result is passing; native maintainer review/prepare and landing gates remain separate. No merge approval is claimed.

Qualifying RED commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts -t 'checks current group state|includes Linux snapshot work'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/profile-extension-memory.test.ts -t 'bounds Linux snapshots'
```

Passing exact-candidate whole-file command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/profile-extension-memory.test.ts
```

Known limits: the deadline regressions use controlled Linux snapshots and clocks on macOS. Native Linux and Windows qualification, broad repository checks, and any measured memory improvement are not established by this evidence.

Production delta remains +202 net lines across the profiler and shared helper; +40 belongs to the deadline amendment. The growth supplies joined case ownership, bounded error projection, and deadline propagation through existing owners. Original tests were +634 net lines; the subsequent collector-only correction adds one net test line.
