### PR TITLE
refactor(doctor): share session migration validation

### DIFF
--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -3349,27 +3349,84 @@ describe("runDoctorSessionSqlite", () => {
     ).not.toHaveProperty("sessionFile");
   });
 
-  it("validates missing SQLite rows without creating the agent database", async () => {
-    const store = createLegacyStore();
+  it.each([
+    ["missing row", undefined, 0, false, "sqlite_entry_missing", 0, 0],
+    ["different session", "other", 2, false, "sqlite_entry_mismatch", 0, 0],
+    ["short transcript", "session-1", 1, false, "sqlite_transcript_count_mismatch", 1, 0],
+    ["matching transcript", "session-1", 2, false, undefined, 1, 2],
+    ["longer transcript", "session-1", 3, false, "sqlite_transcript_count_mismatch", 1, 0],
+    ["missing source", "session-1", 2, true, undefined, 1, 2],
+  ] as const)(
+    "validates a %s against SQLite",
+    async (
+      _name,
+      sessionId,
+      eventCount,
+      missingSource,
+      issueCode,
+      validatedEntries,
+      validatedTranscriptEvents,
+    ) => {
+      const events = [
+        { type: "session", id: "session-1", version: 3 },
+        {
+          type: "message",
+          id: "one",
+          parentId: null,
+          message: { role: "user", content: "source" },
+        },
+        {
+          type: "message",
+          id: "two",
+          parentId: "one",
+          message: { role: "assistant", content: "later" },
+        },
+      ];
+      const store = createLegacyStore({
+        transcriptLines: events.slice(0, 2).map((event) => JSON.stringify(event)),
+      });
+      if (sessionId) {
+        await importSqliteSessionRows({
+          agentId: "main",
+          env: store.env,
+          sessionKey: "agent:main:main",
+          storePath: store.storePath,
+          entry: { sessionId, updatedAt: 2000 },
+          readTranscriptEvents: (append) => events.slice(0, eventCount).forEach(append),
+        });
+      }
+      if (missingSource) {
+        fs.rmSync(store.transcriptPath);
+      }
 
-    const report = await runDoctorSessionSqlite({
-      env: store.env,
-      mode: "validate",
-      store: store.storePath,
-    });
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "validate",
+        store: store.storePath,
+      });
 
-    expect(report.totals).toMatchObject({
-      issues: 1,
-      sqliteEntries: 0,
-      validatedEntries: 0,
-      validatedTranscriptEvents: 0,
-    });
-    expect(report.targets[0]?.issues[0]).toMatchObject({
-      code: "sqlite_entry_missing",
-      sessionKey: "agent:main:main",
-    });
-    expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
-  });
+      const expectedIssueCodes = [
+        ...(issueCode ? [issueCode] : []),
+        ...(sessionId === "session-1" && !missingSource ? ["active_sqlite_transcript_jsonl"] : []),
+      ];
+      expect(report.totals).toMatchObject({
+        issues: expectedIssueCodes.length,
+        sqliteEntries: sessionId ? 1 : 0,
+        validatedEntries,
+        validatedTranscriptEvents,
+      });
+      expect(report.targets[0]?.issues.map((issue) => issue.code)).toEqual(expectedIssueCodes);
+      if (issueCode) {
+        expect(report.targets[0]?.issues[0]?.sessionKey).toBe("agent:main:main");
+      }
+      expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(Boolean(sessionId));
+      if (eventCount === 3) {
+        const imported = await importLegacyStore(store);
+        expect(imported.targets[0]?.issues).toEqual([]);
+        expect(fs.existsSync(store.transcriptPath)).toBe(false);
+      }
+    },
+  );
 
   it("writes a migration manifest with planned and completed archive moves", async () => {
     const store = createLegacyStore();

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -384,11 +384,16 @@ async function inspectOrMigrateTarget(params: {
       countLegacyTranscript(record, report);
     }
   } else {
-    validateLegacySessionRecords(params.target, records, report);
+    validateLegacySessionRecords(params.target, records, report, "validate");
   }
   let validationPassed = false;
   if (params.mode === "import" && blockingIssueCount(report) === 0) {
-    validationPassed = validateImportedTargetBeforeArchive(params.target, records, report);
+    validationPassed = validateLegacySessionRecords(
+      params.target,
+      records,
+      report,
+      "before-archive",
+    );
     updateMigrationManifestTarget(
       params.activeRun,
       createMigrationTargetInput(params.target),
@@ -809,12 +814,13 @@ function markAlreadyMigratedTranscript(
   return true;
 }
 
-function validateImportedTargetBeforeArchive(
+function validateLegacySessionRecords(
   target: SessionStoreTarget,
   records: readonly LegacySessionRecord[],
   report: DoctorSessionSqliteTargetReport,
+  purpose: "validate" | "before-archive",
 ): boolean {
-  if (records.length === 0) {
+  if (purpose === "before-archive" && records.length === 0) {
     return true;
   }
   const issueCountBeforeValidation = report.issues.length;
@@ -827,17 +833,22 @@ function validateImportedTargetBeforeArchive(
     return false;
   }
   for (const record of records) {
-    validateImportedRecordBeforeArchive(record, report, validation.snapshot);
+    validateLegacySessionRecord(record, report, validation.snapshot, purpose);
   }
   return report.issues.length === issueCountBeforeValidation;
 }
 
-function validateImportedRecordBeforeArchive(
+function validateLegacySessionRecord(
   record: LegacySessionRecord,
   report: DoctorSessionSqliteTargetReport,
   snapshot: ReadOnlySqliteValidationSnapshot,
+  purpose: "validate" | "before-archive",
 ): void {
-  const normalizedKey = record.sessionKey;
+  const beforeArchive = purpose === "before-archive";
+  // Import preserves aliases until canonical repair; standalone validation compares canonical keys.
+  const normalizedKey = beforeArchive
+    ? record.sessionKey
+    : normalizeStoreSessionKey(record.sessionKey);
   const sqliteSessionId = snapshot.sessionIdsBySessionKey.get(normalizedKey);
   if (!sqliteSessionId) {
     report.issues.push({
@@ -855,8 +866,15 @@ function validateImportedRecordBeforeArchive(
     });
     return;
   }
+  if (!beforeArchive) {
+    report.validatedEntries += 1;
+  }
   const result = countTranscriptEvents(record);
   if (result.status === "missing") {
+    if (!beforeArchive) {
+      report.validatedTranscriptEvents +=
+        snapshot.transcriptEventCountsBySessionId.get(record.entry.sessionId) ?? 0;
+    }
     return;
   }
   if (result.status !== "ok") {
@@ -870,13 +888,20 @@ function validateImportedRecordBeforeArchive(
     return;
   }
   const sqliteEvents = snapshot.transcriptEventCountsBySessionId.get(record.entry.sessionId) ?? 0;
-  const expectedEvents = record.recovery?.events ?? result.events;
-  if (sqliteEvents < expectedEvents) {
+  // Verified import may retain later history and repair source rows; validation compares the raw count.
+  const expectedEvents = beforeArchive ? (record.recovery?.events ?? result.events) : result.events;
+  if (beforeArchive ? sqliteEvents < expectedEvents : sqliteEvents !== expectedEvents) {
     report.issues.push({
       code: "sqlite_transcript_count_mismatch",
-      message: `SQLite transcript has ${sqliteEvents} events; verified import expects ${expectedEvents}.`,
+      message: beforeArchive
+        ? `SQLite transcript has ${sqliteEvents} events; verified import expects ${expectedEvents}.`
+        : `SQLite transcript has ${sqliteEvents} events; source has ${result.events}.`,
       sessionKey: record.sessionKey,
     });
+    return;
+  }
+  if (!beforeArchive) {
+    report.validatedTranscriptEvents += sqliteEvents;
   }
 }
 
@@ -1223,86 +1248,6 @@ async function archiveImportedLegacySessionStores(
   }
 }
 
-function validateLegacySessionRecords(
-  target: SessionStoreTarget,
-  records: readonly LegacySessionRecord[],
-  report: DoctorSessionSqliteTargetReport,
-): void {
-  const validation = readOnlySqliteValidationSnapshot(target);
-  if (!validation.ok) {
-    report.issues.push({
-      code: "sqlite_read_failed",
-      message: `SQLite validation read failed: ${String(validation.error)}`,
-    });
-    return;
-  }
-  for (const record of records) {
-    validateLegacySessionRecord(record, report, validation.snapshot);
-  }
-}
-
-function validateLegacySessionRecord(
-  record: LegacySessionRecord,
-  report: DoctorSessionSqliteTargetReport,
-  snapshot: ReadOnlySqliteValidationSnapshot,
-): void {
-  const normalizedKey = normalizeStoreSessionKey(record.sessionKey);
-  const sqliteSessionId = snapshot.sessionIdsBySessionKey.get(normalizedKey);
-  if (!sqliteSessionId) {
-    report.issues.push({
-      code: "sqlite_entry_missing",
-      message: `SQLite entry is missing for ${normalizedKey}.`,
-      sessionKey: record.sessionKey,
-    });
-    return;
-  }
-  if (sqliteSessionId !== record.entry.sessionId) {
-    report.issues.push({
-      code: "sqlite_entry_mismatch",
-      message: `SQLite sessionId ${sqliteSessionId} does not match ${record.entry.sessionId}.`,
-      sessionKey: record.sessionKey,
-    });
-    return;
-  }
-  report.validatedEntries += 1;
-  validateTranscriptEventCount(record, report, snapshot);
-}
-
-function validateTranscriptEventCount(
-  record: LegacySessionRecord,
-  report: DoctorSessionSqliteTargetReport,
-  snapshot: ReadOnlySqliteValidationSnapshot,
-): void {
-  const result = countTranscriptEvents(record);
-  if (result.status === "missing") {
-    const migratedEvents = countAlreadyMigratedTranscriptEventsForValidate(snapshot, record);
-    if (migratedEvents !== undefined) {
-      report.validatedTranscriptEvents += migratedEvents;
-    }
-    return;
-  }
-  if (result.status !== "ok") {
-    if (!hasSessionIssue(report, "transcript_malformed", record.sessionKey)) {
-      report.issues.push({
-        code: "transcript_malformed",
-        message: result.message,
-        sessionKey: record.sessionKey,
-      });
-    }
-    return;
-  }
-  const sqliteEvents = snapshot.transcriptEventCountsBySessionId.get(record.entry.sessionId) ?? 0;
-  if (sqliteEvents !== result.events) {
-    report.issues.push({
-      code: "sqlite_transcript_count_mismatch",
-      message: `SQLite transcript has ${sqliteEvents} events; source has ${result.events}.`,
-      sessionKey: record.sessionKey,
-    });
-    return;
-  }
-  report.validatedTranscriptEvents += sqliteEvents;
-}
-
 function hasSessionIssue(
   report: DoctorSessionSqliteTargetReport,
   code: string,
@@ -1319,17 +1264,6 @@ function countAlreadyMigratedTranscriptEventsForImport(
     return undefined;
   }
   const normalizedKey = record.sessionKey;
-  if (snapshot.sessionIdsBySessionKey.get(normalizedKey) !== record.entry.sessionId) {
-    return undefined;
-  }
-  return snapshot.transcriptEventCountsBySessionId.get(record.entry.sessionId) ?? 0;
-}
-
-function countAlreadyMigratedTranscriptEventsForValidate(
-  snapshot: ReadOnlySqliteValidationSnapshot,
-  record: LegacySessionRecord,
-): number | undefined {
-  const normalizedKey = normalizeStoreSessionKey(record.sessionKey);
   if (snapshot.sessionIdsBySessionKey.get(normalizedKey) !== record.entry.sessionId) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Maintaining Doctor's legacy-session migration checks required keeping two validation paths aligned. This maintainer-requested refactor reduces that duplication while preserving the different acceptance rules for import and standalone validation.

## Why This Change Was Made

Use one internal validator with explicit before-archive and standalone-validation purposes. Import keeps exact legacy keys and accepts transcript counts at or above the repaired source count; standalone validation normalizes keys and requires an exact raw source count. Missing-source handling, diagnostic text and ordering, counters, snapshot reads, and migration/archive ordering remain unchanged.

## User Impact

No user-visible behavior change. The complete change removes 64 production code lines and adds 57 test lines, for 7 fewer maintained code lines. It does not change schemas, persistence, retention, locking, configuration, or recovery behavior.

## Evidence

Migration compatibility: the canonical importer (`src/config/sessions/session-accessor.sqlite-import.ts`), schema definitions, manifest/archive publication owners, and all durable writes are unchanged. The shared validator preserves exact imported keys, the empty-import no-read shortcut, recovered-count lower bounds, standalone normalized keys and exact counts, missing-source counters, and diagnostic ordering. The tests below exercise those contracts through isolated real legacy files and SQLite stores; the full suites also cover import, restore, recovery and shared-store behavior. No stored-data-model migration is introduced.

- The focused preservation matrix and existing malformed/repaired-history cases passed against the original production code (10 tests).
- Both full Doctor session-SQLite suites passed (251 tests), and the complete changed gate passed. These preceded a test-only correction restoring the original issue-count and diagnostic-session-key assertions; production is unchanged.
- The final six-case matrix passed after that correction, covering missing rows, mismatched session identity, shorter/equal/longer history, and missing source files. The longer-history case also proves standalone rejection followed by successful import.
- Fresh managed Codex autoreview of the final source and tests found no actionable issues through P2. Formatting and diff checks passed.
