### PR TITLE
fix(release): support frozen Anthropic cache candidates

### DIFF
--- a/scripts/e2e/anthropic-cache-live.mts
+++ b/scripts/e2e/anthropic-cache-live.mts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import type { Context, Message, Model, StreamFn, Tool } from "@openclaw/ai";
 import { bindsClaudeThinkingPrefix, streamAnthropic } from "@openclaw/ai/internal/anthropic";
-import { createAnthropicMessagesTransportStreamFn } from "@openclaw/ai/transports";
 import { Type } from "typebox";
 import { startMockAnthropic } from "./lib/anthropic-cache/mock-provider.mts";
+import { loadAnthropicTransportStream } from "./lib/anthropic-cache/transport-loader.mts";
 
 // Docker runs this with native Node so the imports resolve to the installed
 // candidate packages, without the checkout's TypeScript source aliases.
@@ -245,10 +245,22 @@ try {
     (_model, context, options) => streamAnthropic(MODEL, context, options),
     apiKey,
   );
-  await runLane("managed-transport", createAnthropicMessagesTransportStreamFn(), apiKey);
-  mock?.assertComplete();
+  const managedTransport = await loadAnthropicTransportStream();
+  if (managedTransport) {
+    await runLane("managed-transport", managedTransport, apiKey);
+  } else {
+    process.stdout.write(
+      `${JSON.stringify({
+        lane: "managed-transport",
+        mode: mockMode ? "mock" : "live",
+        status: "not-applicable",
+        reason: "candidate-package-does-not-export-anthropic-transports",
+      })}\n`,
+    );
+  }
+  mock?.assertComplete(managedTransport ? 8 : 4);
   process.stdout.write(
-    `Anthropic transient runtime-context cache regression passed (${mockMode ? "mock" : "live"}, 8 requests).\n`,
+    `Anthropic transient runtime-context cache regression passed (${mockMode ? "mock" : "live"}, ${managedTransport ? 8 : 4} requests).\n`,
   );
 } finally {
   await mock?.close();

--- a/scripts/e2e/lib/anthropic-cache/mock-provider.mts
+++ b/scripts/e2e/lib/anthropic-cache/mock-provider.mts
@@ -95,8 +95,12 @@ export async function startMockAnthropic() {
       server.close();
       await once(server, "close");
     },
-    assertComplete() {
-      assert.equal(requests, 8, "expected eight installed-builder HTTP requests");
+    assertComplete(expectedRequests = 8) {
+      assert.equal(
+        requests,
+        expectedRequests,
+        `expected ${expectedRequests} installed-builder HTTP requests`,
+      );
     },
   };
 }

--- a/scripts/e2e/lib/anthropic-cache/transport-loader.mts
+++ b/scripts/e2e/lib/anthropic-cache/transport-loader.mts
@@ -1,0 +1,28 @@
+import type { StreamFn } from "@openclaw/ai";
+
+type AnthropicTransportModule = typeof import("@openclaw/ai/transports");
+type AnthropicTransportImporter = () => Promise<AnthropicTransportModule>;
+
+function isMissingTransportExport(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ERR_PACKAGE_PATH_NOT_EXPORTED" &&
+    error.message.includes("@openclaw/ai") &&
+    error.message.includes("transports")
+  );
+}
+
+export async function loadAnthropicTransportStream(
+  importer: AnthropicTransportImporter = () => import("@openclaw/ai/transports"),
+): Promise<StreamFn | undefined> {
+  try {
+    const module = await importer();
+    return module.createAnthropicMessagesTransportStreamFn();
+  } catch (error) {
+    if (isMissingTransportExport(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/test/scripts/anthropic-cache-mock-provider.test.ts
+++ b/test/scripts/anthropic-cache-mock-provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { startMockAnthropic } from "../../scripts/e2e/lib/anthropic-cache/mock-provider.mts";
+
+async function sendRequests(baseUrl: string, count: number) {
+  for (let index = 0; index < count; index += 1) {
+    const response = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: true,
+        messages: [{ role: "user", content: `request-${index}` }],
+      }),
+    });
+    expect(response.ok).toBe(true);
+    await response.text();
+  }
+}
+
+describe("startMockAnthropic", () => {
+  it.each([4, 8])("accepts exactly %i selected-lane requests", async (expectedRequests) => {
+    const mock = await startMockAnthropic();
+    try {
+      await sendRequests(mock.baseUrl, expectedRequests);
+      expect(() => mock.assertComplete(expectedRequests)).not.toThrow();
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("rejects a provider-only count when both lanes were selected", async () => {
+    const mock = await startMockAnthropic();
+    try {
+      await sendRequests(mock.baseUrl, 4);
+      expect(() => mock.assertComplete(8)).toThrow("expected 8 installed-builder HTTP requests");
+    } finally {
+      await mock.close();
+    }
+  });
+});

--- a/test/scripts/anthropic-cache-transport-loader.test.ts
+++ b/test/scripts/anthropic-cache-transport-loader.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadAnthropicTransportStream } from "../../scripts/e2e/lib/anthropic-cache/transport-loader.mts";
+
+describe("loadAnthropicTransportStream", () => {
+  it("loads the managed transport when the candidate exports it", async () => {
+    const stream = vi.fn();
+    const factory = vi.fn(() => stream);
+
+    await expect(
+      loadAnthropicTransportStream(
+        async () =>
+          ({
+            createAnthropicMessagesTransportStreamFn: factory,
+          }) as never,
+      ),
+    ).resolves.toBe(stream);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it("returns undefined only for the frozen candidate's missing package export", async () => {
+    const error = Object.assign(
+      new Error("Package subpath './transports' is not defined by exports in @openclaw/ai"),
+      { code: "ERR_PACKAGE_PATH_NOT_EXPORTED" },
+    );
+
+    await expect(
+      loadAnthropicTransportStream(async () => {
+        throw error;
+      }),
+    ).resolves.toBe(undefined);
+  });
+
+  it("does not hide unrelated import failures", async () => {
+    const error = Object.assign(new Error("unexpected loader failure"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+
+    await expect(
+      loadAnthropicTransportStream(async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary
- load the managed Anthropic transport only when the installed candidate exports it
- keep the provider cache-reuse proof mandatory for frozen candidates
- fail on every import error except the exact missing package export

## Validation
- 3 focused loader tests
- full 8-request mock cache lane

Fixes Full Validation run 34413637760, child run 34415759531.