### PR TITLE
test(gateway): backport Claude CLI continuity probe

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -135,6 +135,18 @@ export function resetClaudeLiveSessionsForTest(): void {
   liveSessionCreates.clear();
 }
 
+/** Closes all live Claude CLI sessions and waits briefly for their children to exit. */
+export async function closeClaudeLiveSessionsForTest(): Promise<void> {
+  const sessions = [...liveSessions.values()];
+  resetClaudeLiveSessionsForTest();
+  await Promise.all(sessions.map((session) => waitForManagedRunExit(session.managedRun)));
+}
+
+/** Returns managed-run identities for live-session continuity assertions. */
+export function getClaudeLiveSessionRunIdsForTest(): string[] {
+  return [...liveSessions.values()].map((session) => session.managedRun.runId).toSorted();
+}
+
 async function waitForManagedRunExit(managedRun: ManagedRun): Promise<void> {
   let timeout: NodeJS.Timeout | null = null;
   try {

--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -198,6 +198,45 @@ describe("gateway cli backend live helpers", () => {
     });
   });
 
+  it("builds Claude continuity prompts without revealing the hidden note", () => {
+    const { buildClaudeCliResumeContinuityProbe } = liveHelpers;
+    const memoryToken = "CLI-MEM-A1B2C3D4E5F6";
+
+    const probe = buildClaudeCliResumeContinuityProbe({
+      firstTurnNonce: "112233",
+      resumeNonce: "445566",
+      memoryToken,
+    });
+
+    expect(probe.firstTurnPrompt).toBe(
+      "Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-112233.",
+    );
+    expect(probe.resumePrompt).toBe(
+      "Do not inspect files or run tools. " +
+        "What private session note were you asked to remember earlier? " +
+        "Reply with exactly: CLI backend RESUME OK 445566 <remembered-note>.",
+    );
+    expect(probe.firstTurnPrompt).not.toContain(memoryToken);
+    expect(probe.resumePrompt).not.toContain(memoryToken);
+    expect(probe.injectedContext).toContain(memoryToken);
+    expect(probe.expectedResumeReply).toBe("CLI backend RESUME OK 445566 CLI-MEM-A1B2C3D4E5F6.");
+  });
+
+  it("finds only Claude-imported native session ids", () => {
+    const { resolveImportedClaudeCliSessionId } = liveHelpers;
+
+    expect(
+      resolveImportedClaudeCliSessionId([
+        null,
+        { __openclaw: "invalid" },
+        { __openclaw: { importedFrom: "codex-cli", cliSessionId: "wrong-provider" } },
+        { __openclaw: { importedFrom: "claude-cli", cliSessionId: 42 } },
+        { __openclaw: { importedFrom: "claude-cli", cliSessionId: "claude-session" } },
+      ]),
+    ).toBe("claude-session");
+    expect(resolveImportedClaudeCliSessionId([])).toBeUndefined();
+  });
+
   it("retries Codex CLI timeout payloads only before the final attempt", async () => {
     const { isCliBackendLiveTimeoutPayload, shouldRetryCliBackendLiveTimeout } =
       await import("./gateway-cli-backend.live-helpers.js");

--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -198,9 +198,9 @@ describe("gateway cli backend live helpers", () => {
     });
   });
 
-  it("builds Claude continuity prompts without revealing the hidden note", () => {
+  it("builds Claude continuity prompts without revealing the public label", () => {
     const { buildClaudeCliResumeContinuityProbe } = liveHelpers;
-    const memoryToken = "CLI-MEM-A1B2C3D4E5F6";
+    const memoryToken = "test-memory-token";
 
     const probe = buildClaudeCliResumeContinuityProbe({
       firstTurnNonce: "112233",
@@ -208,18 +208,15 @@ describe("gateway cli backend live helpers", () => {
       memoryToken,
     });
 
-    expect(probe.firstTurnPrompt).toBe(
-      "Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-112233.",
-    );
-    expect(probe.resumePrompt).toBe(
-      "Do not inspect files or run tools. " +
-        "What private session note were you asked to remember earlier? " +
-        "Reply with exactly: CLI backend RESUME OK 445566 <remembered-note>.",
-    );
+    expect(probe.firstTurnPrompt).toContain("public test label");
+    expect(probe.firstTurnPrompt).toContain("not a credential");
+    expect(probe.firstTurnPrompt).toContain("CLI-BACKEND-112233");
+    expect(probe.resumePrompt).toContain("public test label");
+    expect(probe.resumePrompt).toContain("CLI-RESUME-445566");
     expect(probe.firstTurnPrompt).not.toContain(memoryToken);
     expect(probe.resumePrompt).not.toContain(memoryToken);
     expect(probe.injectedContext).toContain(memoryToken);
-    expect(probe.expectedResumeReply).toBe("CLI backend RESUME OK 445566 CLI-MEM-A1B2C3D4E5F6.");
+    expect(probe.expectedResumeMarker).toBe("CLI-RESUME-445566");
   });
 
   it("finds only Claude-imported native session ids", () => {

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -73,6 +73,15 @@ export type CliBackendLiveProviderSkipDecision = {
   message: string;
 };
 
+export type ClaudeCliResumeContinuityProbe = {
+  firstTurnMarker: string;
+  firstTurnPrompt: string;
+  injectedContext: string;
+  resumePrompt: string;
+  expectedFirstReply: string;
+  expectedResumeReply: string;
+};
+
 function normalizeCliRuntimeModelTarget(raw: string | undefined): string | undefined {
   if (!raw) {
     return undefined;
@@ -270,6 +279,44 @@ export function matchesCliBackendReply(text: string, expected: string): boolean 
     normalized.includes(target) ||
     normalized.includes(targetWithoutPeriod)
   );
+}
+
+export function buildClaudeCliResumeContinuityProbe(params: {
+  firstTurnNonce: string;
+  resumeNonce: string;
+  memoryToken: string;
+}): ClaudeCliResumeContinuityProbe {
+  const firstTurnMarker = `CLI-BACKEND-${params.firstTurnNonce}`;
+  return {
+    firstTurnMarker,
+    firstTurnPrompt: `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
+    injectedContext:
+      `For this turn only, remember the private session note ${params.memoryToken} for a later turn. ` +
+      "Do not include that note in this turn's reply.",
+    resumePrompt:
+      "Do not inspect files or run tools. " +
+      "What private session note were you asked to remember earlier? " +
+      `Reply with exactly: CLI backend RESUME OK ${params.resumeNonce} <remembered-note>.`,
+    expectedFirstReply: `${firstTurnMarker}.`,
+    expectedResumeReply: `CLI backend RESUME OK ${params.resumeNonce} ${params.memoryToken}.`,
+  };
+}
+
+export function resolveImportedClaudeCliSessionId(messages: unknown[]): string | undefined {
+  for (const message of messages) {
+    const metadata =
+      typeof message === "object" && message !== null
+        ? (message as Record<string, unknown>)["__openclaw"]
+        : undefined;
+    if (typeof metadata !== "object" || metadata === null) {
+      continue;
+    }
+    const imported = metadata as { cliSessionId?: unknown; importedFrom?: unknown };
+    if (imported.importedFrom === "claude-cli" && typeof imported.cliSessionId === "string") {
+      return imported.cliSessionId;
+    }
+  }
+  return undefined;
 }
 
 export function withClaudeMcpConfigOverrides(args: string[], mcpConfigPath: string): string[] {

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -79,7 +79,7 @@ export type ClaudeCliResumeContinuityProbe = {
   injectedContext: string;
   resumePrompt: string;
   expectedFirstReply: string;
-  expectedResumeReply: string;
+  expectedResumeMarker: string;
 };
 
 function normalizeCliRuntimeModelTarget(raw: string | undefined): string | undefined {
@@ -289,16 +289,19 @@ export function buildClaudeCliResumeContinuityProbe(params: {
   const firstTurnMarker = `CLI-BACKEND-${params.firstTurnNonce}`;
   return {
     firstTurnMarker,
-    firstTurnPrompt: `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
+    firstTurnPrompt:
+      "This is a synthetic session-memory test. Remember the random public test label " +
+      "provided in runtime context; it is not a credential. " +
+      `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
     injectedContext:
-      `For this turn only, remember the private session note ${params.memoryToken} for a later turn. ` +
-      "Do not include that note in this turn's reply.",
+      `The random public test label for this session-memory test is ${params.memoryToken}. ` +
+      "Remember it for the follow-up, without including it in this turn's reply.",
     resumePrompt:
       "Do not inspect files or run tools. " +
-      "What private session note were you asked to remember earlier? " +
-      `Reply with exactly: CLI backend RESUME OK ${params.resumeNonce} <remembered-note>.`,
+      `Return exactly two whitespace-separated tokens: CLI-RESUME-${params.resumeNonce} followed by ` +
+      "the exact public test label from the earlier turn. Do not add prose.",
     expectedFirstReply: `${firstTurnMarker}.`,
-    expectedResumeReply: `CLI backend RESUME OK ${params.resumeNonce} ${params.memoryToken}.`,
+    expectedResumeMarker: `CLI-RESUME-${params.resumeNonce}`,
   };
 }
 

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -4,15 +4,26 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveCliBackendConfig, resolveCliBackendLiveTest } from "../agents/cli-backends.js";
+import {
+  __testing as cliBackendsTesting,
+  resolveCliBackendConfig,
+  resolveCliBackendLiveTest,
+} from "../agents/cli-backends.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  createMockPluginRegistry,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugin-sdk/testing.js";
 import { setTestEnvValue } from "../test-utils/env.js";
+import { resolveClaudeCliSessionFilePath } from "./cli-session-history.js";
 import {
   applyCliBackendLiveEnv,
+  buildClaudeCliResumeContinuityProbe,
   createBootstrapWorkspace,
   ensurePairedTestGatewayClientIdentity,
   getFreeGatewayPort,
@@ -23,6 +34,7 @@ import {
   resolveCliBackendLiveArgs,
   resolveCliBackendLiveModelSelection,
   resolveCliBackendLiveProviderSkipDecision,
+  resolveImportedClaudeCliSessionId,
   resolveCliModelSwitchProbeTarget,
   restoreCliBackendLiveEnv,
   shouldAllowCliBackendLiveProviderSkip,
@@ -58,6 +70,7 @@ const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
 
 const MCP_SCHEMA_PROBE_PLUGIN_ID = "mcp-schema-probe";
 const MCP_SCHEMA_PROBE_TOOL_NAME = "mcp_schema_probe_no_args";
+const CLI_CONTINUITY_PROBE_PLUGIN_ID = "cli-continuity-probe";
 
 const DEFAULT_PROVIDER = "claude-cli";
 const DEFAULT_MODEL =
@@ -315,6 +328,20 @@ describeLive("gateway live (cli backend)", () => {
       const modelSwitchTarget = enableCliModelSwitchProbe
         ? modelSelection.configModelSwitchTarget
         : undefined;
+      const sessionKey = "agent:dev:live-cli-backend";
+      const nonce = randomBytes(3).toString("hex").toUpperCase();
+      const memoryNonce = randomBytes(6).toString("hex").toUpperCase();
+      const memoryToken = `CLI-MEM-${memoryNonce}`;
+      const resumeNonce = randomBytes(3).toString("hex").toUpperCase();
+      const enableCliResumeContinuityProbe =
+        providerId === "claude-cli" && CLI_RESUME && !modelSwitchTarget;
+      const resumeContinuityProbe = enableCliResumeContinuityProbe
+        ? buildClaudeCliResumeContinuityProbe({
+            firstTurnNonce: nonce,
+            resumeNonce,
+            memoryToken,
+          })
+        : undefined;
       logCliBackendLiveStep("model-selected", {
         providerId,
         modelKey,
@@ -371,7 +398,7 @@ describeLive("gateway live (cli backend)", () => {
         : undefined;
       const useMinimalToolsProfile = providerId === "codex-cli" && !schemaProbePluginPath;
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-      const bundleMcp = backendResolved?.bundleMcp === true;
+      const bundleMcp = backendResolved?.bundleMcp === true && !resumeContinuityProbe;
       const bootstrapWorkspace = await createBootstrapWorkspace(tempDir);
       const disableMcpConfig = process.env.OPENCLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG !== "0";
       let cliArgs = baseCliArgs;
@@ -495,6 +522,41 @@ describeLive("gateway live (cli backend)", () => {
           controlUiEnabled: false,
         });
         logCliBackendLiveStep("server-started");
+        if (resumeContinuityProbe) {
+          const continuityHookRegistry = createMockPluginRegistry([
+            {
+              pluginId: CLI_CONTINUITY_PROBE_PLUGIN_ID,
+              hookName: "before_prompt_build",
+              handler: async (event: unknown, ctx: unknown) => {
+                const prompt = (event as { prompt?: unknown }).prompt;
+                const hookSessionKey = (ctx as { sessionKey?: unknown }).sessionKey;
+                if (
+                  hookSessionKey !== sessionKey ||
+                  typeof prompt !== "string" ||
+                  !prompt.includes(resumeContinuityProbe.firstTurnMarker)
+                ) {
+                  return undefined;
+                }
+                return { prependContext: resumeContinuityProbe.injectedContext };
+              },
+            },
+          ]);
+          initializeGlobalHookRunner(continuityHookRegistry);
+          // Bundled MCP capture intentionally retires a Claude child after each turn. This probe
+          // isolates the exact warm-session path while leaving production defaults untouched.
+          if (!backendResolved) {
+            throw new Error(`missing CLI backend metadata for ${providerId}`);
+          }
+          cliBackendsTesting.setDepsForTest({
+            resolveRuntimeCliBackends: () => [
+              {
+                ...backendResolved,
+                pluginId: backendResolved.pluginId ?? CLI_CONTINUITY_PROBE_PLUGIN_ID,
+                bundleMcp: false,
+              },
+            ],
+          });
+        }
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -503,10 +565,6 @@ describeLive("gateway live (cli backend)", () => {
         logCliBackendLiveStep("client-connected");
         const activeClient = client;
 
-        const sessionKey = "agent:dev:live-cli-backend";
-        const nonce = randomBytes(3).toString("hex").toUpperCase();
-        const memoryNonce = randomBytes(3).toString("hex").toUpperCase();
-        const memoryToken = `CLI-MEM-${memoryNonce}`;
         logCliBackendLiveStep("agent-request:start", { sessionKey, nonce });
         const payload = await requestWithCodexTimeoutRetry(
           providerId,
@@ -520,11 +578,13 @@ describeLive("gateway live (cli backend)", () => {
                 message:
                   providerId === "codex-cli"
                     ? `Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-${nonce}.`
-                    : enableCliModelSwitchProbe
-                      ? `Please include the token CLI-BACKEND-${nonce} in your reply.` +
-                        ` Also remember this session note for later: ${memoryToken}.` +
-                        " Do not include the note in your reply."
-                      : `Please include the token CLI-BACKEND-${nonce} in your reply.`,
+                    : resumeContinuityProbe
+                      ? resumeContinuityProbe.firstTurnPrompt
+                      : enableCliModelSwitchProbe
+                        ? `Please include the token CLI-BACKEND-${nonce} in your reply.` +
+                          ` Also remember this session note for later: ${memoryToken}.` +
+                          " Do not include the note in your reply."
+                        : `Please include the token CLI-BACKEND-${nonce} in your reply.`,
                 deliver: false,
                 timeout: timeouts.agentTimeoutSeconds,
               },
@@ -548,6 +608,11 @@ describeLive("gateway live (cli backend)", () => {
           };
           if (enableCliModelSwitchProbe) {
             expect(text.trim().length).toBeGreaterThan(0);
+          } else if (resumeContinuityProbe) {
+            expect(matchesCliBackendReply(text, resumeContinuityProbe.expectedFirstReply)).toBe(
+              true,
+            );
+            expect(text).not.toContain(memoryToken);
           } else {
             expect(text).toContain(`CLI-BACKEND-${nonce}`);
           }
@@ -612,8 +677,31 @@ describeLive("gateway live (cli backend)", () => {
             ),
           ).toBe(true);
         } else if (CLI_RESUME) {
-          const resumeNonce = randomBytes(3).toString("hex").toUpperCase();
           logCliBackendLiveStep("agent-resume:start", { sessionKey, resumeNonce });
+          if (resumeContinuityProbe) {
+            const nativeHistory = await activeClient.request<{ messages?: unknown[] }>(
+              "chat.history",
+              { sessionKey },
+            );
+            const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
+            expect(JSON.stringify(nativeHistory.messages ?? [])).toContain(memoryToken);
+            expect(cliSessionId).toBeTruthy();
+            const cliSessionFile = cliSessionId
+              ? resolveClaudeCliSessionFilePath({ cliSessionId })
+              : undefined;
+            expect(cliSessionFile).toBeTruthy();
+            if (!cliSessionFile) {
+              throw new Error("Claude CLI continuity probe could not locate its native transcript");
+            }
+            // The warm child keeps this turn in memory. Remove Claude's native transcript so
+            // --resume and raw-history reseed cannot recover the hidden note if that child is lost.
+            await fs.rm(cliSessionFile, { force: true });
+            const rawHistory = await activeClient.request<{ messages?: unknown[] }>(
+              "chat.history",
+              { sessionKey },
+            );
+            expect(JSON.stringify(rawHistory.messages ?? [])).not.toContain(memoryToken);
+          }
           const resumePayload = await requestWithCodexTimeoutRetry(
             providerId,
             "agent resume request",
@@ -626,7 +714,9 @@ describeLive("gateway live (cli backend)", () => {
                   message:
                     providerId === "codex-cli"
                       ? `Do not inspect files or run tools. Reply with exactly: CLI-RESUME-${resumeNonce}.`
-                      : `Reply with exactly: CLI backend RESUME OK ${resumeNonce}.`,
+                      : resumeContinuityProbe
+                        ? resumeContinuityProbe.resumePrompt
+                        : `Reply with exactly: CLI backend RESUME OK ${resumeNonce}.`,
                   deliver: false,
                   timeout: timeouts.agentTimeoutSeconds,
                 },
@@ -643,6 +733,10 @@ describeLive("gateway live (cli backend)", () => {
           const resumeText = extractPayloadText(resumePayload?.result);
           if (providerId === "codex-cli") {
             expect(resumeText).toContain(`CLI-RESUME-${resumeNonce}`);
+          } else if (resumeContinuityProbe) {
+            expect(
+              matchesCliBackendReply(resumeText, resumeContinuityProbe.expectedResumeReply),
+            ).toBe(true);
           } else {
             expect(
               matchesCliBackendReply(resumeText, `CLI backend RESUME OK ${resumeNonce}.`),
@@ -708,6 +802,8 @@ describeLive("gateway live (cli backend)", () => {
             await server?.close();
           }
         } finally {
+          cliBackendsTesting.resetDepsForTest();
+          resetGlobalHookRunner();
           await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
           restoreCliBackendLiveEnv(previousEnv);
           logCliBackendLiveStep("cleanup:done");

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -55,6 +55,7 @@ import {
   verifyCliCronMcpLoopbackPreflight,
   verifyCliCronMcpProbe,
 } from "./gateway-cli-backend.live-probe-helpers.js";
+import { ensureMcpLoopbackServer } from "./mcp-http.js";
 import { startGatewayServer } from "./server.js";
 import { extractPayloadText } from "./test-helpers.agent-results.js";
 
@@ -747,6 +748,13 @@ describeLive("gateway live (cli backend)", () => {
         // normal backend resolution before independently enabled image or MCP probes run.
         if (resumeContinuityProbe) {
           cliBackendsTesting.resetDepsForTest();
+          // The continuity turns intentionally bypass bundled MCP so Claude's warm child can be
+          // observed across both requests. A standalone MCP probe normally starts the loopback
+          // runtime during its first agent preparation; the combined probe performs its direct
+          // preflight first, so activate that same runtime explicitly at this phase boundary.
+          if (enableCliMcpProbe) {
+            await ensureMcpLoopbackServer();
+          }
         }
 
         if (enableCliImageProbe) {

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -9,6 +9,10 @@ import {
   resolveCliBackendConfig,
   resolveCliBackendLiveTest,
 } from "../agents/cli-backends.js";
+import {
+  closeClaudeLiveSessionsForTest,
+  getClaudeLiveSessionRunIdsForTest,
+} from "../agents/cli-runner/claude-live-session.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
@@ -20,7 +24,6 @@ import {
   resetGlobalHookRunner,
 } from "../plugin-sdk/testing.js";
 import { setTestEnvValue } from "../test-utils/env.js";
-import { resolveClaudeCliSessionFilePath } from "./cli-session-history.js";
 import {
   applyCliBackendLiveEnv,
   buildClaudeCliResumeContinuityProbe,
@@ -678,29 +681,18 @@ describeLive("gateway live (cli backend)", () => {
           ).toBe(true);
         } else if (CLI_RESUME) {
           logCliBackendLiveStep("agent-resume:start", { sessionKey, resumeNonce });
+          let expectedLiveRunIds: string[] | undefined;
+          let expectedCliSessionId: string | undefined;
           if (resumeContinuityProbe) {
             const nativeHistory = await activeClient.request<{ messages?: unknown[] }>(
               "chat.history",
               { sessionKey },
             );
-            const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
+            expectedCliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
             expect(JSON.stringify(nativeHistory.messages ?? [])).toContain(memoryToken);
-            expect(cliSessionId).toBeTruthy();
-            const cliSessionFile = cliSessionId
-              ? resolveClaudeCliSessionFilePath({ cliSessionId })
-              : undefined;
-            expect(cliSessionFile).toBeTruthy();
-            if (!cliSessionFile) {
-              throw new Error("Claude CLI continuity probe could not locate its native transcript");
-            }
-            // The warm child keeps this turn in memory. Remove Claude's native transcript so
-            // --resume and raw-history reseed cannot recover the hidden note if that child is lost.
-            await fs.rm(cliSessionFile, { force: true });
-            const rawHistory = await activeClient.request<{ messages?: unknown[] }>(
-              "chat.history",
-              { sessionKey },
-            );
-            expect(JSON.stringify(rawHistory.messages ?? [])).not.toContain(memoryToken);
+            expect(expectedCliSessionId).toBeTruthy();
+            expectedLiveRunIds = getClaudeLiveSessionRunIdsForTest();
+            expect(expectedLiveRunIds).toHaveLength(1);
           }
           const resumePayload = await requestWithCodexTimeoutRetry(
             providerId,
@@ -734,14 +726,27 @@ describeLive("gateway live (cli backend)", () => {
           if (providerId === "codex-cli") {
             expect(resumeText).toContain(`CLI-RESUME-${resumeNonce}`);
           } else if (resumeContinuityProbe) {
-            expect(
-              matchesCliBackendReply(resumeText, resumeContinuityProbe.expectedResumeReply),
-            ).toBe(true);
+            expect(resumeText).toContain(resumeContinuityProbe.expectedResumeMarker);
+            expect(resumeText).toContain(memoryToken);
+            expect(getClaudeLiveSessionRunIdsForTest()).toEqual(expectedLiveRunIds);
+            const resumedHistory = await activeClient.request<{ messages?: unknown[] }>(
+              "chat.history",
+              { sessionKey },
+            );
+            expect(resolveImportedClaudeCliSessionId(resumedHistory.messages ?? [])).toBe(
+              expectedCliSessionId,
+            );
           } else {
             expect(
               matchesCliBackendReply(resumeText, `CLI backend RESUME OK ${resumeNonce}.`),
             ).toBe(true);
           }
+        }
+
+        // The continuity turns suppress bundled MCP so Claude's warm child stays alive. Restore
+        // normal backend resolution before independently enabled image or MCP probes run.
+        if (resumeContinuityProbe) {
+          cliBackendsTesting.resetDepsForTest();
         }
 
         if (enableCliImageProbe) {
@@ -802,6 +807,7 @@ describeLive("gateway live (cli backend)", () => {
             await server?.close();
           }
         } finally {
+          await closeClaudeLiveSessionsForTest();
           cliBackendsTesting.resetDepsForTest();
           resetGlobalHookRunner();
           await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });


### PR DESCRIPTION
## Summary
- backport the warm-session continuity probe from main
- verify Claude recalls a public test label across the resumed native session
- avoid brittle exact sentence matching while strengthening session-continuity proof

## Validation
- gateway live-helper suite: 22 passed
- TypeScript and formatting checks

Fixes Full Validation run 34413637760, child run 34414129143.