### PR TITLE
fix(release): qualify frozen Telegram failure recovery

### DIFF
--- a/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
+++ b/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 const PARTIAL_FAILURE_RECOVERY_SCENARIO = "telegram-partial-failure-recovery";
 const SETTLED_EMPTY_RESPONSE_SCENARIO = "telegram-empty-response-after-write-recovery";
 const PROGRESS_TOOL_VISIBILITY_SCENARIO = "telegram-progress-tool-visibility";
+const PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO = "telegram-provider-failure-before-output";
 
 function readSource(sourceRoot: string, relativePath: string): string | undefined {
   try {
@@ -44,11 +45,21 @@ export function isPreProgressToolVisibilityTarget(sourceRoot: string): boolean {
   );
 }
 
+export function isPreProviderFailureBeforeOutputTarget(sourceRoot: string): boolean {
+  return (
+    readSource(sourceRoot, "qa/scenarios/channels/telegram-provider-failure-before-output.yaml") ===
+    undefined
+  );
+}
+
 export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): string[] {
   return [
     ...(isPrePartialFailureRecoveryTarget(sourceRoot) ? [PARTIAL_FAILURE_RECOVERY_SCENARIO] : []),
     ...(isPreSettledEmptyResponseTarget(sourceRoot) ? [SETTLED_EMPTY_RESPONSE_SCENARIO] : []),
     ...(isPreProgressToolVisibilityTarget(sourceRoot) ? [PROGRESS_TOOL_VISIBILITY_SCENARIO] : []),
+    ...(isPreProviderFailureBeforeOutputTarget(sourceRoot)
+      ? [PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO]
+      : []),
   ];
 }
 

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   isPrePartialFailureRecoveryTarget,
   isPreProgressToolVisibilityTarget,
+  isPreProviderFailureBeforeOutputTarget,
   isPreSettledEmptyResponseTarget,
   resolveFrozenTelegramScenarioOmissions,
 } from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
@@ -461,6 +462,19 @@ describe("package Telegram live Docker E2E", () => {
     expect(isPreProgressToolVisibilityTarget(root)).toBe(false);
   });
 
+  it("omits provider-failure recovery until the frozen source owns its scenario", () => {
+    const root = mkTempRoot();
+    const scenario = path.join(
+      root,
+      "qa/scenarios/channels/telegram-provider-failure-before-output.yaml",
+    );
+
+    expect(isPreProviderFailureBeforeOutputTarget(root)).toBe(true);
+    mkdirSync(path.dirname(scenario), { recursive: true });
+    writeFileSync(scenario, "id: telegram-provider-failure-before-output\n");
+    expect(isPreProviderFailureBeforeOutputTarget(root)).toBe(false);
+  });
+
   it("combines only the unsupported frozen Telegram scenario contracts", () => {
     const root = mkTempRoot();
     const writeOwner = (relativePath: string, source: string) => {
@@ -479,11 +493,13 @@ describe("package Telegram live Docker E2E", () => {
       "telegram-partial-failure-recovery",
       "telegram-empty-response-after-write-recovery",
       "telegram-progress-tool-visibility",
+      "telegram-provider-failure-before-output",
     ]);
     writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-empty-response-after-write-recovery",
       "telegram-progress-tool-visibility",
+      "telegram-provider-failure-before-output",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
@@ -491,10 +507,18 @@ describe("package Telegram live Docker E2E", () => {
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-progress-tool-visibility",
+      "telegram-provider-failure-before-output",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-progress-tool-visibility.yaml",
       "id: telegram-progress-tool-visibility\n",
+    );
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
+      "telegram-provider-failure-before-output",
+    ]);
+    writeOwner(
+      "qa/scenarios/channels/telegram-provider-failure-before-output.yaml",
+      "id: telegram-provider-failure-before-output\n",
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- source-qualify the current-only Telegram provider-failure recovery scenario
- omit it only when the frozen target does not own the scenario contract
- keep explicit scenario requests unchanged

## Validation
- npm Telegram tooling suite: 53 passed
- lint and formatting checks

Fixes Full Validation run 34413637760, child run 34415759531.