### PR TITLE
fix(state): repair dangling Workshop review index

### DIFF
--- a/src/infra/startup-maintenance-required.ts
+++ b/src/infra/startup-maintenance-required.ts
@@ -7,6 +7,7 @@ const maintenanceReasons = {
   "agent-media": "offline media migration",
   "agent-databases-composite-primary-key": "state database schema migration",
   "audit-events-v2": "state database schema migration",
+  "legacy-workshop-review-index": "state database schema migration",
   "legacy-workspace": "workspace setup state migration",
   "legacy-session-store": "session store migration",
 } as const;

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -26,7 +26,10 @@ import {
 } from "./openclaw-state-db-schema-version.js";
 import type { DB } from "./openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
-import { OpenClawStateOwnershipError } from "./openclaw-state-ownership.js";
+import {
+  assertOpenClawStateWriteAllowed,
+  OpenClawStateOwnershipError,
+} from "./openclaw-state-ownership.js";
 import {
   getOpenClawStateRuntimeSchema,
   OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
@@ -37,6 +40,143 @@ import {
 } from "./openclaw-state-schema-publication.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 import { UpdateSchemaRefusalError } from "./openclaw-update-schema-refusal.js";
+
+const LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX =
+  "idx_skill_workshop_collection_reviews_workspace_time";
+const LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX_SQL =
+  "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)";
+
+function normalizeSqliteCatalogSql(sql: string): string {
+  return sql
+    .replace(/\s+/gu, " ")
+    .replace(/\s*([(),])\s*/gu, "$1")
+    .trim();
+}
+
+function withWritableSchema<T>(database: DatabaseSync, operation: () => T): T {
+  database.enableDefensive?.(false);
+  database.exec("PRAGMA writable_schema = ON;");
+  try {
+    return operation();
+  } finally {
+    try {
+      database.exec("PRAGMA writable_schema = OFF;");
+    } finally {
+      database.enableDefensive?.(true);
+    }
+  }
+}
+
+/** Detect only the known v15 review index left behind after its column was retired. */
+export function hasDanglingSkillWorkshopCollectionReviewIndex(database: DatabaseSync): boolean {
+  return withWritableSchema(database, () => {
+    const rawIndex = database
+      .prepare(
+        "SELECT tbl_name, rootpage, sql FROM sqlite_schema WHERE type = 'index' AND name = ?",
+      )
+      .get(LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX);
+    // SAFETY: the narrow catalog projection is validated field-by-field below.
+    const index = rawIndex as { tbl_name?: unknown; rootpage?: unknown; sql?: unknown } | undefined;
+    if (
+      index?.tbl_name !== "skill_workshop_collection_reviews" ||
+      typeof index.rootpage !== "number" ||
+      index.rootpage <= 0 ||
+      typeof index.sql !== "string" ||
+      normalizeSqliteCatalogSql(index.sql) !==
+        normalizeSqliteCatalogSql(LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX_SQL)
+    ) {
+      return false;
+    }
+    const rawColumns = database
+      .prepare("PRAGMA table_info(skill_workshop_collection_reviews)")
+      .all();
+    // SAFETY: PRAGMA table_info rows expose optional names compared as unknown values.
+    const columns = rawColumns as Array<{ name?: unknown }>;
+    return (
+      columns.some((column) => column.name === "owner_agent_id") &&
+      !columns.some((column) => column.name === "workspace_dir")
+    );
+  });
+}
+
+/**
+ * Make the known malformed index parseable, then let SQLite drop and reclaim it
+ * in the caller's transaction. A failed repair rolls both catalog edits back.
+ */
+export function repairDanglingSkillWorkshopCollectionReviewIndex(database: DatabaseSync): boolean {
+  if (!hasDanglingSkillWorkshopCollectionReviewIndex(database)) {
+    return false;
+  }
+  return withWritableSchema(database, () => {
+    database
+      .prepare("UPDATE sqlite_schema SET sql = ? WHERE type = 'index' AND name = ?")
+      .run(
+        `CREATE INDEX ${LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX} ON skill_workshop_collection_reviews(create_time DESC, review_id DESC)`,
+        LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX,
+      );
+    // SAFETY: the pragma result is treated as unknown and validated before arithmetic.
+    const row = database.prepare("PRAGMA schema_version").get() as {
+      schema_version?: unknown;
+    };
+    const schemaVersion = typeof row.schema_version === "number" ? row.schema_version : 0;
+    database.exec(`PRAGMA schema_version = ${schemaVersion + 1}; PRAGMA writable_schema = OFF;`);
+    database.exec(`DROP INDEX ${LEGACY_SKILL_WORKSHOP_COLLECTION_REVIEWS_INDEX};`);
+    return true;
+  });
+}
+
+export function repairDanglingSkillWorkshopCollectionReviewIndexChanges(
+  database: DatabaseSync,
+): string[] {
+  return repairDanglingSkillWorkshopCollectionReviewIndex(database)
+    ? ["Removed dangling legacy Skill Workshop review index"]
+    : [];
+}
+
+/** Run read-only schema admission while SQLite ignores malformed catalog rows. */
+function admitStateDatabaseWithDanglingWorkshopIndex<T>(
+  database: DatabaseSync,
+  operation: () => T,
+): T {
+  return withWritableSchema(database, operation);
+}
+
+/** Admit the schema before Doctor begins its write transaction. */
+export function admitStateDatabaseForSchemaRepair(
+  database: DatabaseSync,
+  pathname: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const danglingWorkshopIndex = hasDanglingSkillWorkshopCollectionReviewIndex(database);
+  const admit = () => {
+    assertSupportedStateSchemaVersion(database, pathname);
+    if (danglingWorkshopIndex) {
+      assertOpenClawStateWriteAllowed({ database, databasePath: pathname, env });
+    }
+  };
+  if (danglingWorkshopIndex) {
+    admitStateDatabaseWithDanglingWorkshopIndex(database, admit);
+  } else {
+    admit();
+  }
+  return danglingWorkshopIndex;
+}
+
+/** Recheck write ownership after BEGIN IMMEDIATE and before catalog mutation. */
+export function assertStateDatabaseSchemaRepairWriteAllowed(
+  database: DatabaseSync,
+  pathname: string,
+  env: NodeJS.ProcessEnv,
+  danglingWorkshopIndex: boolean,
+): void {
+  const assertAllowed = () =>
+    assertOpenClawStateWriteAllowed({ database, databasePath: pathname, env });
+  if (danglingWorkshopIndex) {
+    admitStateDatabaseWithDanglingWorkshopIndex(database, assertAllowed);
+  } else {
+    assertAllowed();
+  }
+}
 
 const STATE_V6_ADDITIVE_TABLES = [
   // v6-v12 databases may predate this former same-version lazy table.

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -21,7 +21,9 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
+import { hasDanglingSkillWorkshopCollectionReviewIndex } from "./openclaw-state-db-maintenance.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import {
   assertSupportedStateSchemaVersion,
   readStateSchemaMigrationVersion,
@@ -72,6 +74,12 @@ export function openUnpublishedStateDatabase(params: {
     () => {
       let maintenance: SqliteWalMaintenance | undefined;
       try {
+        if (hasDanglingSkillWorkshopCollectionReviewIndex(db)) {
+          throw new OpenClawStateDatabaseSchemaMigrationRequiredError(
+            "legacy-workshop-review-index",
+            params.pathname,
+          );
+        }
         assertSupportedStateSchemaVersion(db, params.pathname);
         assertStateDatabaseIntegrityBeforeMutation(db, params.pathname);
         configureSqlitePreSchemaPragmas(db, { busyTimeoutMs });

--- a/src/state/openclaw-state-db-schema-migration-required.ts
+++ b/src/state/openclaw-state-db-schema-migration-required.ts
@@ -2,7 +2,8 @@ import { StartupMaintenanceRequiredError } from "../infra/startup-maintenance-re
 
 type OpenClawStateDatabaseSchemaMigrationRequiredKind =
   | "agent-databases-composite-primary-key"
-  | "audit-events-v2";
+  | "audit-events-v2"
+  | "legacy-workshop-review-index";
 
 export class OpenClawStateDatabaseSchemaMigrationRequiredError extends StartupMaintenanceRequiredError {
   constructor(

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -30,6 +30,7 @@ import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.t
 import { isPathInside } from "../infra/path-guards.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { VERSION } from "../version.js";
@@ -43,6 +44,10 @@ import {
   FIRST_USE_STATE_TABLES,
   OPENCLAW_STATE_SCHEMA_VERSION,
 } from "./openclaw-state-db-contract.js";
+import {
+  hasDanglingSkillWorkshopCollectionReviewIndex,
+  repairDanglingSkillWorkshopCollectionReviewIndex,
+} from "./openclaw-state-db-maintenance.js";
 import { ensureGitHubPublicationSchema } from "./openclaw-state-db-schema-additive.js";
 import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
@@ -726,6 +731,58 @@ function materializeCurrentStateDatabase(stateDir: string): string {
   fs.mkdirSync(path.dirname(databasePath), { recursive: true });
   fs.copyFileSync(canonicalStateDatabaseTemplatePath, databasePath);
   return databasePath;
+}
+
+function createDanglingSkillWorkshopReviewIndex(databasePath: string): number {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(
+      "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+    );
+    const index = database
+      .prepare(
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND name = 'idx_skill_workshop_collection_reviews_workspace_time'",
+      )
+      .get() as { rootpage?: number } | undefined;
+    if (typeof index?.rootpage !== "number") {
+      throw new Error("failed to create legacy Skill Workshop review index fixture");
+    }
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    database
+      .prepare(
+        `UPDATE sqlite_schema
+            SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                         ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+          WHERE type = 'index'
+            AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+      )
+      .run();
+    const schemaVersion = readSqliteNumberPragma(database, "schema_version");
+    database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+    return index.rootpage;
+  } finally {
+    database.close();
+  }
+}
+
+function readDanglingSkillWorkshopReviewIndex(
+  databasePath: string,
+): { rootpage: number; sql: string } | undefined {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    return database
+      .prepare(
+        "SELECT rootpage, sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_skill_workshop_collection_reviews_workspace_time'",
+      )
+      .get() as { rootpage: number; sql: string } | undefined;
+  } finally {
+    database.close();
+  }
 }
 
 function downgradeWorkerPlacementsToV7(db: DatabaseSync): void {
@@ -1692,6 +1749,99 @@ describe("openclaw state database", () => {
         .prepare("SELECT review_id, backup_id FROM skill_workshop_collection_reviews")
         .get(),
     ).toEqual({ review_id: "review-v15", backup_id: "backup-v15" });
+  });
+
+  it("requires Doctor to repair the dangling v15 Workshop review index", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        `INSERT INTO skill_workshop_collection_reviews (
+           review_id, owner_agent_id, backup_id, create_time,
+           kept_names_json, written_names_json, dropped_json
+         ) VALUES ('review-preserved', 'main', 'backup-preserved', 1, '[]', '[]', '[]')`,
+      )
+      .run();
+    database.close();
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+
+    const defensiveProbe = new DatabaseSync(databasePath);
+    expect(hasDanglingSkillWorkshopCollectionReviewIndex(defensiveProbe)).toBe(true);
+    const schemaVersion = readSqliteNumberPragma(defensiveProbe, "schema_version");
+    defensiveProbe.exec(`PRAGMA schema_version = ${schemaVersion + 1};`);
+    expect(readSqliteNumberPragma(defensiveProbe, "schema_version")).toBe(schemaVersion);
+    defensiveProbe.close();
+
+    expect(() => openOpenClawStateDatabase(options)).toThrow(
+      /legacy-workshop-review-index.*openclaw doctor --fix/u,
+    );
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Removed dangling legacy Skill Workshop review index"],
+      warnings: [],
+    });
+
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        repaired
+          .prepare(
+            "SELECT review_id, backup_id FROM skill_workshop_collection_reviews WHERE review_id = 'review-preserved'",
+          )
+          .get(),
+      ).toEqual({ review_id: "review-preserved", backup_id: "backup-preserved" });
+      expect(repaired.prepare("PRAGMA integrity_check").all()).toEqual([{ integrity_check: "ok" }]);
+      expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toBeUndefined();
+    } finally {
+      repaired.close();
+    }
+    expect(() => openOpenClawStateDatabase(options)).not.toThrow();
+  });
+
+  it("does not repair a dangling Workshop index in a newer unsupported schema", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database.exec("PRAGMA writable_schema = ON;");
+    database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
+    database.exec("PRAGMA writable_schema = OFF;");
+    database.close();
+
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: [],
+      warnings: [expect.stringContaining("uses newer schema version")],
+    });
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+  });
+
+  it("rolls back dangling Workshop index reclamation and converges on retry", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const rootpage = createDanglingSkillWorkshopReviewIndex(databasePath);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    expect(() =>
+      runSqliteImmediateTransactionSync(database, () => {
+        expect(repairDanglingSkillWorkshopCollectionReviewIndex(database)).toBe(true);
+        throw new Error("injected post-reclamation failure");
+      }),
+    ).toThrow("injected post-reclamation failure");
+    database.close();
+
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toMatchObject({ rootpage });
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Removed dangling legacy Skill Workshop review index"],
+      warnings: [],
+    });
+    expect(readDanglingSkillWorkshopReviewIndex(databasePath)).toBeUndefined();
   });
 
   it("upgrades a v15 store without Workshop tables before creating their v16 schema", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -59,7 +59,9 @@ import {
   needsOpenClawStateDatabaseSchemaRepair,
 } from "./openclaw-state-db-fast-path.js";
 import {
+  admitStateDatabaseForSchemaRepair,
   assertOpenClawStateDatabaseForMaintenance,
+  assertStateDatabaseSchemaRepairWriteAllowed,
   markCurrentStateSchemaVersion,
   openClawStateMigrationAssertions,
   resolveDatabasePath,
@@ -67,6 +69,7 @@ import {
   runStateSchemaMigrationTransaction,
   writeCurrentStateSchemaMetadata,
   executeCanonicalStateSchema,
+  repairDanglingSkillWorkshopCollectionReviewIndexChanges,
 } from "./openclaw-state-db-maintenance.js";
 import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
@@ -158,14 +161,14 @@ function repairStateSchema(
   let ownershipRefused = false;
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedStateSchemaVersion(db, pathname);
+    const danglingWorkshopIndex = admitStateDatabaseForSchemaRepair(db, pathname, env);
     db.exec("PRAGMA foreign_keys = OFF;");
     const changes = runStateSchemaMigrationTransaction(
       db,
       pathname,
       () => {
-        assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
-        const applied: string[] = [];
+        assertStateDatabaseSchemaRepairWriteAllowed(db, pathname, env, danglingWorkshopIndex);
+        const applied = repairDanglingSkillWorkshopCollectionReviewIndexChanges(db);
         const previousVersion = readStateSchemaMigrationVersion(db);
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of verifyAndRepairCanonicalSqliteIndexes(

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -742,6 +742,93 @@ describe("external shared-state ownership", () => {
     }
   });
 
+  it("fences a claim made immediately before dangling Workshop index repair", () => {
+    const env = createEnv();
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const damaged = new DatabaseSync(databasePath);
+    damaged.exec(
+      "CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time ON skill_workshop_collection_reviews(review_id, create_time DESC);",
+    );
+    damaged.enableDefensive?.(false);
+    damaged.exec("PRAGMA writable_schema = ON;");
+    damaged
+      .prepare(
+        `UPDATE sqlite_schema
+            SET sql = 'CREATE INDEX idx_skill_workshop_collection_reviews_workspace_time
+                         ON skill_workshop_collection_reviews(workspace_dir, create_time DESC, review_id DESC)'
+          WHERE type = 'index'
+            AND name = 'idx_skill_workshop_collection_reviews_workspace_time'`,
+      )
+      .run();
+    const schemaVersion = damaged.prepare("PRAGMA schema_version").get() as {
+      schema_version: number;
+    };
+    damaged.exec(
+      `PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion.schema_version + 1};`,
+    );
+    damaged.close();
+
+    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
+      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
+      | undefined;
+    if (!originalExec) {
+      throw new Error("DatabaseSync.exec descriptor is unavailable");
+    }
+    let immediateTransactionCount = 0;
+    const exec = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      if (sql === "BEGIN IMMEDIATE" && ++immediateTransactionCount === 1) {
+        const claimant = new DatabaseSync(databasePath);
+        try {
+          claimant.enableDefensive?.(false);
+          claimant.exec("PRAGMA writable_schema = ON;");
+          claimant
+            .prepare(
+              `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+               VALUES (?, ?, ?)`,
+            )
+            .run(
+              STATE_SUPERVISION_KEY,
+              JSON.stringify({
+                version: 1,
+                mode: "external",
+                managerId: "race-manager",
+                claimedAt: 1,
+              }),
+              1,
+            );
+        } finally {
+          claimant.close();
+        }
+      }
+      return originalExec.call(this, sql);
+    });
+
+    try {
+      expect(() => repairOpenClawStateDatabaseSchema({ env })).toThrow(OpenClawStateOwnershipError);
+    } finally {
+      exec.mockRestore();
+    }
+    expect(immediateTransactionCount).toBe(1);
+
+    const verify = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      verify.enableDefensive?.(false);
+      verify.exec("PRAGMA writable_schema = ON;");
+      expect(
+        verify
+          .prepare("SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND name = ?")
+          .get("idx_skill_workshop_collection_reviews_workspace_time"),
+      ).toBeDefined();
+    } finally {
+      verify.close();
+    }
+  });
+
   it("fences a claim made during a canonical current-schema cold open", () => {
     const env = createEnv();
     const databasePath = openOpenClawStateDatabase({ env }).path;

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -119,19 +119,29 @@ export function inspectOpenClawStateOwnershipFromDatabase(
   databasePath: string,
   configMachineStateTableReady = false,
 ): OpenClawExternalStateOwnership | null {
-  if (!configMachineStateTableReady && !tableExists(database, "config_machine_state")) {
-    return null;
+  database.enableDefensive?.(false);
+  database.exec("PRAGMA writable_schema = ON;");
+  try {
+    if (!configMachineStateTableReady && !tableExists(database, "config_machine_state")) {
+      return null;
+    }
+    const row = database
+      .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ? LIMIT 1")
+      .get(STATE_SUPERVISION_KEY) as { value_json?: unknown } | undefined;
+    if (!row) {
+      return null;
+    }
+    if (typeof row.value_json !== "string") {
+      throw new OpenClawStateOwnershipMetadataError(databasePath, "reserved value is not text");
+    }
+    return parseExternalOwnership(row.value_json, databasePath);
+  } finally {
+    try {
+      database.exec("PRAGMA writable_schema = OFF;");
+    } finally {
+      database.enableDefensive?.(true);
+    }
   }
-  const row = database
-    .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ? LIMIT 1")
-    .get(STATE_SUPERVISION_KEY) as { value_json?: unknown } | undefined;
-  if (!row) {
-    return null;
-  }
-  if (typeof row.value_json !== "string") {
-    throw new OpenClawStateOwnershipMetadataError(databasePath, "reserved value is not text");
-  }
-  return parseExternalOwnership(row.value_json, databasePath);
 }
 
 function inspectOwnershipThroughConnection(


### PR DESCRIPTION
## Summary

- repair the exact released malformed Skill Workshop review index only through Doctor
- keep ordinary startup non-mutating and surface an actionable Doctor-required error
- validate schema and shared-state ownership before mutation, then recheck ownership under `BEGIN IMMEDIATE`
- restore SQLite defensive mode after privileged catalog inspection and make failure rollback/retry safe

## Safety properties

- newer or otherwise unrecognized schema shapes remain fail-closed and unchanged
- the malformed catalog entry is first made parseable and then removed transactionally with `DROP INDEX`
- an injected reclamation failure rolls back cleanly and a second Doctor run converges
- an ownership claim racing Doctor admission is rejected before mutation

## Validation

- `pnpm exec vitest run src/state/openclaw-state-db.test.ts src/state/openclaw-state-ownership.test.ts` — 219 passed, 1 skipped
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` — passed
- independent review identified transaction-time ownership admission and defensive-mode restoration gaps; both are fixed and regression-covered

Supersedes #142522 while preserving Jacqueline Henriksen's contribution via co-authorship.
