### PR TITLE
improve(ci): skip unnecessary SDK guard parsing

### DIFF
--- a/scripts/check-plugin-sdk-subpath-exports.mts
+++ b/scripts/check-plugin-sdk-subpath-exports.mts
@@ -126,6 +126,10 @@ async function collectViolations(): Promise<PluginSdkViolation[]> {
 
   for (const filePath of files) {
     const sourceText = readFileSync(filePath, "utf8");
+    // Escaped module names need parsing even when the literal SDK prefix is absent.
+    if (!sourceText.includes("plugin-sdk") && !sourceText.includes("\\")) {
+      continue;
+    }
     const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
 
     function push(kind: string, node: ts.Node, specifierNode: ts.Node, specifier: string): void {


### PR DESCRIPTION
Related: #143469

## What Problem This Solves

The plugin SDK export guard constructs a TypeScript AST for every scanned file, including files that cannot contain a matching SDK import. This adds avoidable CPU work to the additional-boundaries CI job.

## Why This Change Was Made

Skip AST construction only when source contains neither the literal `plugin-sdk` marker nor a backslash. Escaped module names continue through the existing complete parser and boundary checks. Scan roots, syntax handling, diagnostics, and private/public export policy stay intact.

## User Impact

Less work in the existing guard without changing CI scheduling or application behavior. Local median command time fell from **24.9s to 20.0s**; median user CPU time fell by **26%**. Linux CI and total workflow elapsed-time savings remain unmeasured.

## Evidence

Measured on macOS arm64, Node 24.16.0, with independent frozen-lockfile dependencies and baseline `8f6cdd32d63b7b68c283a38ebf1222dd8d7711a8`:

- Same complete command: `node --import ./scripts/tsx.mjs scripts/check-plugin-sdk-subpath-exports.mts`.
- Baseline wall times: 23.92s, 24.864s, 35.784s. Candidate: 16.69s, 24.261s, 20.018s. The final four invocations reversed order: candidate, baseline, baseline, candidate. All passed. Host load was noisy; median user CPU fell from 19.695s to 14.544s.
- Temporary executable fixtures produced byte-identical exit status and all 12 diagnostics before and after: static/dynamic/CommonJS/import-equals/type imports, private inline-type runtime references, and Unicode/hex/template/line-continuation escapes. Erased private type imports remained accepted. Fixtures were removed after the comparison.
- Complete changed-file gate passed, including scripts typecheck, all unused-export scans, lint, formatting, and repository guards. `git diff --check` passed.
- Independent review through P2 was scoped-clean.
