### PR TITLE
improve(test): remove minute-long triage timeout wait

### DIFF
--- a/src/infra/update-managed-service-handoff-boundary.test-support.ts
+++ b/src/infra/update-managed-service-handoff-boundary.test-support.ts
@@ -21,6 +21,7 @@ import {
 import {
   createManagedServiceCancellationPreload,
   createManagedServiceLaunchdClockPreload,
+  prepareManagedServiceTriageClockPreload,
   createManagedServiceUpdaterFixtureScript,
   createManagedServiceManagerFixtureScript,
   type ManagedServiceCommandTiming,
@@ -347,6 +348,15 @@ export function createManagedServiceManagerBoundary({
       let helperEnv = options?.repair
         ? await prepareManagedRepairSpawnEnv(root, childEnv)
         : childEnv;
+      const triageDeadlinePath = path.join(root, "triage-deadline.json");
+      if (options?.triageHang) {
+        helperEnv = await prepareManagedServiceTriageClockPreload(
+          { root, scriptPath, statePath },
+          commandFixture.triageCommandArgv,
+          String(generated.triageInputPath),
+          helperEnv,
+        );
+      }
       if (options?.launchdTeardown?.clockEachCommandMs || options?.recoveryClockAdvanceMs) {
         const preloadPath = path.join(root, "launchd-clock-preload.cjs");
         await fs.writeFile(
@@ -662,6 +672,9 @@ export function createManagedServiceManagerBoundary({
         >,
         sentinel: readRestartSentinelPayload({ OPENCLAW_STATE_DIR: root }),
         log: await fs.readFile(String(generated.logPath), "utf8"),
+        ...(options?.triageHang
+          ? { triageDeadline: JSON.parse(await fs.readFile(triageDeadlinePath, "utf8")) }
+          : {}),
         savedFailure,
         sensitiveFilesRemoved: (
           await Promise.all((generated.sensitivePaths as string[]).map(pathExists))

--- a/src/infra/update-managed-service-handoff-command.test-support.ts
+++ b/src/infra/update-managed-service-handoff-command.test-support.ts
@@ -179,7 +179,7 @@ export function createManagedServiceCommandFixture(params: {
             ...(options?.triageHang
               ? [
                   `const { spawn } = require("node:child_process");`,
-                  `const triageDescendantPid = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }).pid;`,
+                  `const triageDescendantPid = spawn(process.execPath, ["-e", ${JSON.stringify(`require("node:fs").writeFileSync(${JSON.stringify(path.join(root, "triage-descendant-ready"))}, String(process.pid)); setInterval(() => {}, 1000);`)}], { stdio: "ignore" }).pid;`,
                   `${managedServiceStateUpdateScript(statePath, "state.triageDescendantPid = triageDescendantPid")};`,
                   `setInterval(() => {}, 1000);`,
                 ]

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { TriageUpdateFailure } from "../commands/triage-update.js";
 import { buildRestartSentinelRow, parseRestartSentinelEnvelope } from "./restart-sentinel-store.js";
 import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
@@ -76,6 +78,7 @@ export type ManagedServiceManagerBoundaryResult = {
   sentinel: unknown;
   log: string;
   commandTimings: ManagedServiceCommandTiming[];
+  triageDeadline?: { requestedMs: number; descendantPid: number };
   savedFailure: { path: string; mode: number; contents: TriageUpdateFailure } | null;
   sensitiveFilesRemoved: boolean;
 };
@@ -501,6 +504,63 @@ export function createManagedServiceCancellationPreload(params: {
       return child;
     };
   }`;
+}
+
+export async function prepareManagedServiceTriageClockPreload(
+  params: { root: string; scriptPath: string; statePath: string },
+  triageCommandArgv: string[],
+  triageInputPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<NodeJS.ProcessEnv> {
+  const preloadPath = path.join(params.root, "triage-clock-preload.cjs");
+  const commandArgv = [...triageCommandArgv, "--update-result", triageInputPath];
+  // Only the generated helper advances its diagnostic timer. The installed
+  // command, its descendant, recovery, and lease clocks stay native.
+  const source = `if (process.argv[1] === ${JSON.stringify(params.scriptPath)}) {
+    const fs = require("node:fs");
+    const children = require("node:child_process");
+    const spawn = children.spawn;
+    const setTimeout = global.setTimeout;
+    const clearTimeout = global.clearTimeout;
+    const polls = new Map();
+    let diagnostic;
+    let captured = false;
+    children.spawn = (command, args, options) => {
+      const child = spawn(command, args, options);
+      if (command === ${JSON.stringify(commandArgv[0])} &&
+          (args.at(-1) === ${JSON.stringify(JSON.stringify(commandArgv))} ||
+           JSON.stringify(args.slice(-${commandArgv.length - 1})) === ${JSON.stringify(JSON.stringify(commandArgv.slice(1)))})) {
+        diagnostic = child;
+        child.once("close", () => { diagnostic = undefined; });
+      }
+      return child;
+    };
+    global.clearTimeout = (timer) => {
+      clearInterval(polls.get(timer));
+      polls.delete(timer);
+      return clearTimeout(timer);
+    };
+    global.setTimeout = (callback, delay, ...args) => {
+      const timer = setTimeout(callback, delay, ...args);
+      if (!diagnostic || delay !== 60_000) return timer;
+      if (captured) throw new Error("duplicate diagnostic deadline");
+      captured = true;
+      const poll = setInterval(() => {
+        if (!fs.existsSync(${JSON.stringify(path.join(params.root, "triage-descendant-ready"))})) return;
+        const descendantPid = Number(fs.readFileSync(${JSON.stringify(path.join(params.root, "triage-descendant-ready"))}, "utf8"));
+        const state = JSON.parse(fs.readFileSync(${JSON.stringify(params.statePath)}, "utf8"));
+        if (state.triageDescendantPid !== descendantPid) return;
+        process.kill(descendantPid, 0);
+        global.clearTimeout(timer);
+        fs.writeFileSync(${JSON.stringify(path.join(params.root, "triage-deadline.json"))}, JSON.stringify({ requestedMs: delay, descendantPid }));
+        callback.apply(timer, args);
+      }, 5);
+      polls.set(timer, poll);
+      return timer;
+    };
+  }`;
+  await fs.writeFile(preloadPath, source);
+  return { ...env, NODE_OPTIONS: `${env.NODE_OPTIONS ?? ""} --require ${preloadPath}`.trim() };
 }
 
 export function createManagedServiceLaunchdClockPreload(params: {

--- a/src/infra/update-managed-service-handoff-triage.test-support.ts
+++ b/src/infra/update-managed-service-handoff-triage.test-support.ts
@@ -57,6 +57,7 @@ export function registerManagedUpdateHandoffTriageTests(
         log: helperLog,
         savedFailure,
         sensitiveFilesRemoved,
+        triageDeadline,
       } = await runManagedServiceManagerBoundary("systemd", {
         ...options,
         updaterExitCode: 7,
@@ -127,6 +128,11 @@ export function registerManagedUpdateHandoffTriageTests(
       expect(helperLog).toContain("update triage could not complete");
       if (options.triageHang) {
         expect(typeof state.triageDescendantPid).toBe("number");
+        expect(triageDeadline).toEqual({
+          requestedMs: 60_000,
+          descendantPid: state.triageDescendantPid,
+        });
+        expect(helperLog).toContain("verified recovery command exceeded its update timeout");
         await expect.poll(() => isPidAlive(Number(state.triageDescendantPid))).toBe(false);
       }
     },


### PR DESCRIPTION
Related: #143469

## What Problem This Solves

The managed-service update integration test spends a full minute waiting for a deliberately hung diagnostic command. The test needs to prove timeout handling and real descendant cleanup; that fixed wait adds about 60 seconds to the infrastructure CI lane.

## Why This Change Was Made

Use a test-only preload scoped to the generated helper and exact diagnostic invocation. It captures the original 60,000ms timer and invokes its unchanged callback after a real descendant reports readiness and its PID agrees with committed fixture state. Native timer cancellation and callback receiver behavior remain intact; other subprocesses and clocks remain native.

The test still checks the original failure artifact, recovery, redaction, sensitive-file removal, and actual descendant death. It additionally verifies the requested 60,000ms deadline and the original timeout diagnostic. Production code and deadlines are unchanged. Preload setup lives with the existing lifecycle test helpers.

## User Impact

The same timeout case fell from **62.084s to 1.984s** locally, saving **60.1 seconds**. The final helper organization reran it in 1.894s. This removes incidental waiting from existing coverage; Linux CI and total workflow elapsed-time savings remain unmeasured.

## Evidence

Measured on macOS arm64, Node 24.16.0, with independent frozen-lockfile dependencies and baseline `8f6cdd32d63b7b68c283a38ebf1222dd8d7711a8`:

- Baseline and candidate used `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts` with the same focused timeout selection. The selected case passed before and after; Vitest duration fell from 70.03s to 10.15s. The case comparison excludes separate runtime-artifact preparation.
- All four related cases passed again after the final helper move: hung triage, nonzero triage exit, missing triage, and stalled recovery cleanup. Final Vitest duration was 23.27s under host load, with the timeout case taking 1.894s.
- A temporary mutation of the original timeout diagnostic made the accelerated test fail at the intended callback assertion in about two seconds, while keeping real process cleanup intact. Production source was restored byte-for-byte afterward.
- Complete changed-file gate passed, including core test typechecks, all unused-export scans, scoped lint, formatting, and repository guards. The existing file-size limit is satisfied without suppressions. `git diff --check` passed.
- Fresh independent review through P2 was scoped-clean.
