### PR TITLE
fix(plugins): preserve bundled trust for dev path installs

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -456,7 +456,7 @@ For bundled workspace package names, keep the plugin id anchored in the npm name
 
 For intentional local overrides, use `plugins.load.paths` to select the plugin path. Tracked global installs can also override ordinary bundled copies, while bundled plugins from `OPENCLAW_DEV_SOURCE_ROOT` retain priority over tracked globals. See [Discovery precedence](/plugins/manifest/package-json#discovery-precedence-duplicate-plugin-ids) for the full order.
 
-An alias of the same independently validated bundled entry retains bundled provenance; a different local copy does not inherit trust from its name or allowlist entry. Checkout runners supply the development selector automatically, including for compiled plugins. See [development debugging](</help/debugging#dev-profile-%2B-dev-gateway-(--dev)>).
+A configured path or install record pointing to the host’s own bundled plugin tree retains bundled provenance, including source and compiled entries; a different local copy does not inherit trust from its name or allowlist entry. Checkout runners supply the development selector automatically, including for compiled plugins. See [development debugging](</help/debugging#dev-profile-%2B-dev-gateway-(--dev)>).
 
 Bundled-plugin trust is resolved from the source snapshot — the manifest and code on disk at load time — rather than from install metadata. A corrupted or substituted install record cannot silently widen a bundled plugin's trust surface beyond what the actual source claims.
 </Note>

--- a/src/plugins/discovery-checkout.test.ts
+++ b/src/plugins/discovery-checkout.test.ts
@@ -147,62 +147,81 @@ describe("host provenance across bundled build states", () => {
 
   it.each(
     buildStates.flatMap(({ label, built }) =>
-      aliasShapes.map((alias) => ({ label, built, alias })),
+      aliasShapes.flatMap((alias) =>
+        ["configured", "installed"].map((selection) => ({ label, built, alias, selection })),
+      ),
     ),
-  )("keeps a $alias alias bundled in a $label bundled tree", ({ built, alias }) => {
-    const stateDir = fs.realpathSync(makeTrackedTempDir("openclaw-host-provenance", tempDirs));
-    const bundledDir = fs.realpathSync(makeTrackedTempDir("openclaw-bundled-tree", tempDirs));
-    const pluginRoot = path.join(bundledDir, "hosted");
-    fs.mkdirSync(pluginRoot, { recursive: true });
-    fs.writeFileSync(
-      path.join(pluginRoot, "package.json"),
-      JSON.stringify({ name: "@openclaw/hosted", openclaw: { extensions: ["./index.ts"] } }),
-    );
-    fs.writeFileSync(
-      path.join(pluginRoot, "openclaw.plugin.json"),
-      JSON.stringify({ id: "hosted", configSchema: { type: "object" } }),
-    );
-    fs.writeFileSync(path.join(pluginRoot, "index.ts"), "export default {};\n");
-    if (built) {
-      fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
-      fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default {};\n");
-    }
-    let aliasRoot = pluginRoot;
-    if (alias.startsWith("symlink")) {
-      aliasRoot = path.join(stateDir, "linked-hosted");
-      fs.symlinkSync(pluginRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
-    }
-    const env = {
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
-      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-    };
-    withPluginCache(createPluginCache(), () => {
-      const discovery = discoverOpenClawPlugins({
-        env,
-        extraPaths: [alias.endsWith("directory") ? aliasRoot : path.join(aliasRoot, "index.ts")],
-        installRecords: {},
-      });
-      // One physical plugin must yield one candidate; a second candidate means the
-      // alias resolved a different entry point than the bundled scan did.
-      expect(discovery.candidates.filter((candidate) => candidate.idHint === "hosted")).toEqual([
-        expect.objectContaining({
+  )(
+    "keeps $selection $alias aliases bundled in a $label bundled tree",
+    ({ built, alias, selection }) => {
+      const stateDir = fs.realpathSync(makeTrackedTempDir("openclaw-host-provenance", tempDirs));
+      const bundledDir = fs.realpathSync(makeTrackedTempDir("openclaw-bundled-tree", tempDirs));
+      const pluginRoot = path.join(bundledDir, "hosted");
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({ name: "@openclaw/hosted", openclaw: { extensions: ["./index.ts"] } }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({ id: "hosted", configSchema: { type: "object" } }),
+      );
+      fs.writeFileSync(path.join(pluginRoot, "index.ts"), "export default {};\n");
+      if (built) {
+        fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
+        fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default {};\n");
+      }
+      let aliasRoot = pluginRoot;
+      if (alias.startsWith("symlink")) {
+        aliasRoot = path.join(stateDir, "linked-hosted");
+        fs.symlinkSync(pluginRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
+      }
+      const env = {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      };
+      withPluginCache(createPluginCache(), () => {
+        const discovery = discoverOpenClawPlugins({
+          env,
+          extraPaths:
+            selection === "configured"
+              ? [alias.endsWith("directory") ? aliasRoot : path.join(aliasRoot, "index.ts")]
+              : [],
+          installRecords:
+            selection === "installed"
+              ? {
+                  hosted: {
+                    source: "path",
+                    sourcePath: aliasRoot,
+                    installPath: alias.endsWith("directory")
+                      ? aliasRoot
+                      : path.join(aliasRoot, "index.ts"),
+                  },
+                }
+              : {},
+        });
+        // One physical plugin must yield one candidate; a second candidate means the
+        // alias resolved a different entry point than the bundled scan did.
+        expect(discovery.candidates.filter((candidate) => candidate.idHint === "hosted")).toEqual([
+          expect.objectContaining({
+            origin: "bundled",
+            rootDir: pluginRoot,
+            source: path.join(pluginRoot, "index.ts"),
+            ...(selection === "configured" ? { configSelected: true } : {}),
+          }),
+        ]);
+        const registry = loadPluginManifestRegistryCore({
+          env,
+          candidates: discovery.candidates,
+          installRecords: {},
+        });
+        expect(registry.plugins.find((plugin) => plugin.id === "hosted")).toMatchObject({
           origin: "bundled",
           rootDir: pluginRoot,
           source: path.join(pluginRoot, "index.ts"),
-          configSelected: true,
-        }),
-      ]);
-      const registry = loadPluginManifestRegistryCore({
-        env,
-        candidates: discovery.candidates,
-        installRecords: {},
+        });
       });
-      expect(registry.plugins.find((plugin) => plugin.id === "hosted")).toMatchObject({
-        origin: "bundled",
-        rootDir: pluginRoot,
-        source: path.join(pluginRoot, "index.ts"),
-      });
-    });
-  });
+    },
+  );
 });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1180,10 +1180,10 @@ function createPluginScanner(env: NodeJS.ProcessEnv, ownershipUid?: number | nul
     if (!stat) {
       return;
     }
-    // Origin gates entry resolution and bundled runtime privileges, so pointing
-    // plugins.load.paths at a host-owned plugin must not reclassify it.
+    // Origin gates entry resolution and bundled runtime privileges. Configured
+    // paths and install records must resolve host-owned plugins as bundled.
     const origin =
-      params.origin === "config" &&
+      (params.origin === "config" || params.origin === "global") &&
       isHostBundledPluginRoot(stat.isFile() ? path.dirname(resolved) : resolved, env)
         ? "bundled"
         : params.origin;


### PR DESCRIPTION
Related: #143190

## What Problem This Solves

Fixes an issue where users running a development checkout could see a bundled plugin rejected by trusted-plugin state APIs when its path install record resolved to a different entry than bundled discovery. With compiled output present, an installed directory alias could produce an extra `global` candidate instead of retaining bundled provenance.

## Why This Change Was Made

Apply the existing host-bundled-path classification to install-record paths before resolving their entry points, just as configured paths already do. Physical containment in the host's bundled tree remains the basis for trust; unrelated local copies remain untrusted. Extend the existing built/unbuilt alias test matrix and clarify the documented behavior.

## User Impact

Host-owned bundled plugins retain consistent provenance when referenced by path install records, avoiding false trusted-plugin state refusals caused by this discovery mismatch. This applies to direct paths and symlink aliases without granting trust based on a plugin name or install-record source alone.

## Evidence

- Before the fix, the new built-tree installed-directory cases failed for both direct and symlink aliases: discovery returned a second candidate with `origin: "global"` and an inferred compiled entry.
- After the fix, all 145 focused tests passed: `node scripts/run-vitest.mjs src/plugins/discovery-checkout.test.ts src/plugins/discovery.test.ts src/plugins/loader.trust-diagnostics.test.ts`. Existing external path-install refusal cases remain green.
- `pnpm build`, `node scripts/check-changed.mjs`, and `git diff --check` passed.
- Independent autoreview through P2 found no actionable findings.

The investigation began with a transient Codex `openSyncKeyedStore` trust refusal that cleared on a subsequent turn. This PR fixes the independently reproduced discovery defect; it does not establish why that reported turn recovered. No live Gateway was modified or restarted for validation.
