### PR TITLE
docs: split THREAT-MODEL-ATLAS threat catalog by ATLAS tactic

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -2148,6 +2148,38 @@
     "target": "威胁模型"
   },
   {
+    "source": "Reconnaissance (AML.TA0002)",
+    "target": "侦察（AML.TA0002）"
+  },
+  {
+    "source": "Initial access (AML.TA0004)",
+    "target": "初始访问（AML.TA0004）"
+  },
+  {
+    "source": "Execution (AML.TA0005)",
+    "target": "执行（AML.TA0005）"
+  },
+  {
+    "source": "Persistence (AML.TA0006)",
+    "target": "持久化（AML.TA0006）"
+  },
+  {
+    "source": "Defense evasion (AML.TA0007)",
+    "target": "防御规避（AML.TA0007）"
+  },
+  {
+    "source": "Discovery (AML.TA0008)",
+    "target": "发现（AML.TA0008）"
+  },
+  {
+    "source": "Collection and exfiltration (AML.TA0009, AML.TA0010)",
+    "target": "收集与外传（AML.TA0009、AML.TA0010）"
+  },
+  {
+    "source": "Impact (AML.TA0011)",
+    "target": "影响（AML.TA0011）"
+  },
+  {
     "source": "Timezones",
     "target": "时区"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2611,6 +2611,14 @@
                   "security/network-proxy",
                   "security/formal-verification",
                   "security/THREAT-MODEL-ATLAS",
+                  "security/THREAT-MODEL-ATLAS/reconnaissance",
+                  "security/THREAT-MODEL-ATLAS/initial-access",
+                  "security/THREAT-MODEL-ATLAS/execution",
+                  "security/THREAT-MODEL-ATLAS/persistence",
+                  "security/THREAT-MODEL-ATLAS/defense-evasion",
+                  "security/THREAT-MODEL-ATLAS/discovery",
+                  "security/THREAT-MODEL-ATLAS/collection-and-exfiltration",
+                  "security/THREAT-MODEL-ATLAS/impact",
                   "security/CONTRIBUTING-THREAT-MODEL"
                 ]
               },

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -111,299 +111,18 @@ Out-of-scope reports and false-positive patterns (public internet exposure, prom
 
 ## 3. Threat analysis by ATLAS tactic
 
-### 3.1 Reconnaissance (AML.TA0002)
+The threat catalog is split by ATLAS tactic. Each page below holds the full attribute table for every threat in that tactic. The risk matrix in section 5 and the recommendations summary in section 6 index across all of them, and the ATLAS technique mapping in section 7.1 lists which threats implement each technique.
 
-#### T-RECON-001: Agent endpoint discovery
-
-| Attribute               | Value                                                                |
-| ----------------------- | -------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0006 - Active Scanning                                          |
-| **Description**         | Attacker scans for exposed OpenClaw gateway endpoints                |
-| **Attack vector**       | Network scanning, Shodan queries, DNS enumeration                    |
-| **Affected components** | Gateway, exposed API endpoints                                       |
-| **Current mitigations** | Tailscale auth option, bind to loopback by default                   |
-| **Residual risk**       | Medium - public gateways discoverable                                |
-| **Recommendations**     | Document secure deployment, add rate limiting on discovery endpoints |
-
-#### T-RECON-002: Channel integration probing
-
-| Attribute               | Value                                                              |
-| ----------------------- | ------------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0006 - Active Scanning                                        |
-| **Description**         | Attacker probes messaging channels to identify AI-managed accounts |
-| **Attack vector**       | Sending test messages, observing response patterns                 |
-| **Affected components** | All channel integrations                                           |
-| **Current mitigations** | None specific                                                      |
-| **Residual risk**       | Low - limited value from discovery alone                           |
-| **Recommendations**     | Consider response timing randomization                             |
-
----
-
-### 3.2 Initial access (AML.TA0004)
-
-#### T-ACCESS-001: Pairing code interception
-
-| Attribute               | Value                                                                                                 |
-| ----------------------- | ----------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                                             |
-| **Description**         | Attacker intercepts a pairing code during the pairing window (1h DM/generic pairing, 5m node pairing) |
-| **Attack vector**       | Shoulder surfing, network sniffing, social engineering                                                |
-| **Affected components** | Device pairing system                                                                                 |
-| **Current mitigations** | 1h TTL (DM/generic pairing), 5m TTL (node pairing); codes sent via the existing channel               |
-| **Residual risk**       | Medium - pairing window exploitable                                                                   |
-| **Recommendations**     | Reduce pairing window, add a confirmation step                                                        |
-
-#### T-ACCESS-002: AllowFrom spoofing
-
-| Attribute               | Value                                                                                                                                                                                                                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                                                                                                                                                                                                                                                                                   |
-| **Description**         | Attacker spoofs an allowed sender identity on a channel                                                                                                                                                                                                                                                                                     |
-| **Attack vector**       | Channel-dependent - phone number spoofing, username impersonation                                                                                                                                                                                                                                                                           |
-| **Affected components** | Per-channel AllowFrom validation                                                                                                                                                                                                                                                                                                            |
-| **Current mitigations** | Channel-specific identity verification; graded identifier-authentication gate uses `min(entry, subject)` over `verified > asserted > unverified > mutable` with exact match provenance and default minimum `asserted` (#123782/#123793). Channels declare per-identifier strength; security audit warns on inert mutable entries (#131129). |
-| **Residual risk**       | Medium - some channels remain vulnerable to spoofing                                                                                                                                                                                                                                                                                        |
-| **Recommendations**     | Continue per-channel `verified` adoption and downstream strength mappers; document channel-specific risks                                                                                                                                                                                                                                   |
-
-#### T-ACCESS-003: Token theft
-
-| Attribute               | Value                                                              |
-| ----------------------- | ------------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                          |
-| **Description**         | Attacker steals authentication tokens from config/credential files |
-| **Attack vector**       | Malware, unauthorized device access, config backup exposure        |
-| **Affected components** | Channel/provider credential storage, config storage                |
-| **Current mitigations** | File permissions                                                   |
-| **Residual risk**       | High - tokens stored in plaintext on disk                          |
-| **Recommendations**     | Implement token encryption at rest, add token rotation             |
-
----
-
-### 3.3 Execution (AML.TA0005)
-
-#### T-EXEC-001: Direct prompt injection
-
-| Attribute               | Value                                                                                                                                                                                                                                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                                                                                                                                                                                                                                                     |
-| **Description**         | Attacker sends crafted prompts to manipulate agent behavior                                                                                                                                                                                                                                      |
-| **Attack vector**       | Channel messages containing adversarial instructions                                                                                                                                                                                                                                             |
-| **Affected components** | Agent LLM, all input surfaces                                                                                                                                                                                                                                                                    |
-| **Current mitigations** | Pattern detection, external content wrapping, and frontier-model robustness (2026 crowdsourced arena: 0.5% ASR on Claude Opus 4.5, 8.5% on Gemini 2.5 Pro, scored on execution plus concealment); treated as out-of-scope for vulnerability reports absent a boundary bypass (see `SECURITY.md`) |
-| **Residual risk**       | Model-tier dependent - low single-digit ASR against organic attacks on recommended frontier models, but adaptive attackers still exceed 80% against state-of-the-art defenses, and smaller/older models remain markedly easier to steer                                                          |
-| **Recommendations**     | Output validation and user confirmation for sensitive actions, layered on top of existing detection                                                                                                                                                                                              |
-
-#### T-EXEC-002: Indirect prompt injection
-
-| Attribute               | Value                                                                                                                                                                                                              |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0051.001 - LLM Prompt Injection: Indirect                                                                                                                                                                     |
-| **Description**         | Attacker embeds malicious instructions in fetched content                                                                                                                                                          |
-| **Attack vector**       | Malicious URLs, poisoned emails, compromised webhooks                                                                                                                                                              |
-| **Affected components** | `web_fetch`, email ingestion, external data sources                                                                                                                                                                |
-| **Current mitigations** | Content wrapping with random-boundary XML-style markers, homoglyph/special-token normalization, a security notice, and frontier-model robustness (see T-EXEC-001)                                                  |
-| **Residual risk**       | Model-tier dependent - recommended frontier models largely hold the wrapper boundary, but it remains soft guidance an adaptive attacker can erode; scope tool policy and sandboxing to the blast radius you accept |
-| **Recommendations**     | Separate execution contexts for wrapped content                                                                                                                                                                    |
-
-#### T-EXEC-003: Tool argument injection
-
-| Attribute               | Value                                                        |
-| ----------------------- | ------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                 |
-| **Description**         | Attacker manipulates tool arguments through prompt injection |
-| **Attack vector**       | Crafted prompts that influence tool parameter values         |
-| **Affected components** | All tool invocations                                         |
-| **Current mitigations** | Exec approvals for dangerous commands                        |
-| **Residual risk**       | High - relies on user judgment                               |
-| **Recommendations**     | Argument validation, parameterized tool calls                |
-
-#### T-EXEC-004: Exec approval bypass
-
-| Attribute               | Value                                                                                                                                                                             |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                                                                                                                |
-| **Description**         | Attacker crafts commands that bypass the approval allowlist                                                                                                                       |
-| **Attack vector**       | Command obfuscation, alias exploitation, path manipulation                                                                                                                        |
-| **Affected components** | `src/infra/exec-approvals*.ts`, command allowlist                                                                                                                                 |
-| **Current mitigations** | Allowlist + ask mode, plus command normalization (dispatch-wrapper unwrapping, inline-eval detection, shell-chain analysis)                                                       |
-| **Residual risk**       | High - normalization narrows but does not eliminate obfuscation bypass; parity-only findings between exec paths are treated as hardening, not vulnerabilities (see `SECURITY.md`) |
-| **Recommendations**     | Continue expanding command-normalization coverage against new obfuscation techniques                                                                                              |
-
----
-
-### 3.4 Persistence (AML.TA0006)
-
-#### T-PERSIST-001: Malicious skill installation
-
-| Attribute               | Value                                                                                                                     |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0010.001 - Supply Chain Compromise: AI Software                                                                      |
-| **Description**         | Attacker publishes a malicious skill to ClawHub                                                                           |
-| **Attack vector**       | Create account, publish skill with hidden malicious code                                                                  |
-| **Affected components** | ClawHub, skill loading, agent execution                                                                                   |
-| **Current mitigations** | GitHub account age verification, static pattern/AST-adjacent scanning, LLM-based agentic risk review, VirusTotal scanning |
-| **Residual risk**       | High - detection layers exist but skills still run with agent privileges and no execution sandboxing                      |
-| **Recommendations**     | Skill execution sandboxing, expanded community review                                                                     |
-
-#### T-PERSIST-002: Skill update poisoning
-
-| Attribute               | Value                                                                   |
-| ----------------------- | ----------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0010.001 - Supply Chain Compromise: AI Software                    |
-| **Description**         | Attacker compromises a popular skill and pushes a malicious update      |
-| **Attack vector**       | Account compromise, social engineering of skill owner                   |
-| **Affected components** | ClawHub versioning, auto-update flows                                   |
-| **Current mitigations** | Version fingerprinting, moderation/scanning re-run on new versions      |
-| **Residual risk**       | High - auto-updates may pull malicious versions before review completes |
-| **Recommendations**     | Update signing, rollback capability, version pinning                    |
-
-#### T-PERSIST-003: Agent configuration tampering
-
-| Attribute               | Value                                                           |
-| ----------------------- | --------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0010.002 - Supply Chain Compromise: Data                   |
-| **Description**         | Attacker modifies agent configuration to persist access         |
-| **Attack vector**       | Config file modification, settings injection                    |
-| **Affected components** | Agent config, tool policies                                     |
-| **Current mitigations** | File permissions                                                |
-| **Residual risk**       | Medium - requires local access                                  |
-| **Recommendations**     | Config integrity verification, audit logging for config changes |
-
----
-
-### 3.5 Defense evasion (AML.TA0007)
-
-#### T-EVADE-001: Moderation pattern bypass
-
-| Attribute               | Value                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                    |
-| **Description**         | Attacker crafts skill content to evade ClawHub moderation checks                      |
-| **Attack vector**       | Unicode homoglyphs, encoding tricks, dynamic loading                                  |
-| **Affected components** | ClawHub moderation/scanning pipeline                                                  |
-| **Current mitigations** | Static pattern rules, AST-adjacent code scanning, LLM agentic-risk review, VirusTotal |
-| **Residual risk**       | Medium - novel obfuscation can still slip past layered heuristics                     |
-| **Recommendations**     | Continue expanding the pattern/behavioral corpus as new evasions are found            |
-
-#### T-EVADE-002: Content wrapper escape
-
-| Attribute               | Value                                                                                                         |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                                            |
-| **Description**         | Attacker crafts content that escapes the external-content wrapper context                                     |
-| **Attack vector**       | Tag manipulation, context confusion, instruction override                                                     |
-| **Affected components** | External content wrapping                                                                                     |
-| **Current mitigations** | Random-boundary XML-style markers + security notice, plus homoglyph/whitespace-variant marker-spoof detection |
-| **Residual risk**       | Medium - novel escapes discovered regularly                                                                   |
-| **Recommendations**     | Output-side validation in addition to input-side wrapping                                                     |
-
----
-
-### 3.6 Discovery (AML.TA0008)
-
-#### T-DISC-001: Tool enumeration
-
-| Attribute               | Value                                                 |
-| ----------------------- | ----------------------------------------------------- |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access             |
-| **Description**         | Attacker enumerates available tools through prompting |
-| **Attack vector**       | "What tools do you have?" style queries               |
-| **Affected components** | Agent tool registry                                   |
-| **Current mitigations** | None specific                                         |
-| **Residual risk**       | Low - tools are generally documented                  |
-| **Recommendations**     | Consider tool visibility controls                     |
-
-#### T-DISC-002: Session data extraction
-
-| Attribute               | Value                                                   |
-| ----------------------- | ------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access               |
-| **Description**         | Attacker extracts sensitive data from session context   |
-| **Attack vector**       | "What did we discuss?" queries, context probing         |
-| **Affected components** | Session transcripts, context window                     |
-| **Current mitigations** | Session isolation per sender (`agent:channel:peer` key) |
-| **Residual risk**       | Medium - within-session data is accessible by design    |
-| **Recommendations**     | Sensitive-data redaction in context                     |
-
----
-
-### 3.7 Collection and exfiltration (AML.TA0009, AML.TA0010)
-
-#### T-EXFIL-001: Data theft via web_fetch
-
-| Attribute               | Value                                                                            |
-| ----------------------- | -------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0009 - Collection                                                           |
-| **Description**         | Attacker exfiltrates data by instructing the agent to send it to an external URL |
-| **Attack vector**       | Prompt injection causing the agent to POST data to an attacker server            |
-| **Affected components** | `web_fetch` tool                                                                 |
-| **Current mitigations** | SSRF blocking for internal/private networks (DNS pinning + IP blocking)          |
-| **Residual risk**       | High - arbitrary external URLs remain permitted                                  |
-| **Recommendations**     | URL allowlisting, data-classification awareness                                  |
-
-#### T-EXFIL-002: Unauthorized message sending
-
-| Attribute               | Value                                                                |
-| ----------------------- | -------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0009 - Collection                                               |
-| **Description**         | Attacker causes the agent to send messages containing sensitive data |
-| **Attack vector**       | Prompt injection causing the agent to message the attacker           |
-| **Affected components** | Message tool, channel integrations                                   |
-| **Current mitigations** | Outbound messaging gating                                            |
-| **Residual risk**       | Medium - gating may be bypassed                                      |
-| **Recommendations**     | Explicit confirmation for new recipients                             |
-
-#### T-EXFIL-003: Credential harvesting
-
-| Attribute               | Value                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0009 - Collection                                                                                                                                  |
-| **Description**         | Malicious skill harvests credentials from the agent context                                                                                             |
-| **Attack vector**       | Skill code reads environment variables, config files                                                                                                    |
-| **Affected components** | Skill execution environment                                                                                                                             |
-| **Current mitigations** | ClawHub credential-pattern scanning (hardcoded secrets, credential env access paired with network sends); no execution sandboxing for skills at runtime |
-| **Residual risk**       | Critical - skills run with agent privileges                                                                                                             |
-| **Recommendations**     | Skill execution sandboxing, credential isolation                                                                                                        |
-
----
-
-### 3.8 Impact (AML.TA0011)
-
-#### T-IMPACT-001: Unauthorized command execution
-
-| Attribute               | Value                                                                                                |
-| ----------------------- | ---------------------------------------------------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                                                                 |
-| **Description**         | Attacker executes arbitrary commands on the user system                                              |
-| **Attack vector**       | Prompt injection combined with exec approval bypass                                                  |
-| **Affected components** | Bash tool, command execution                                                                         |
-| **Current mitigations** | Exec approvals, Docker sandbox option (default runtime backend)                                      |
-| **Residual risk**       | Critical - host execution possible when sandbox is disabled                                          |
-| **Recommendations**     | Improve approval UX; sandbox-off deployments remain a deliberate operator choice, documented as such |
-
-#### T-IMPACT-002: Resource exhaustion (DoS)
-
-| Attribute               | Value                                              |
-| ----------------------- | -------------------------------------------------- |
-| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity               |
-| **Description**         | Attacker exhausts API credits or compute resources |
-| **Attack vector**       | Automated message flooding, expensive tool calls   |
-| **Affected components** | Gateway, agent sessions, API provider              |
-| **Current mitigations** | None                                               |
-| **Residual risk**       | High - no per-sender rate limiting                 |
-| **Recommendations**     | Per-sender rate limits, cost budgets               |
-
-#### T-IMPACT-003: Reputation damage
-
-| Attribute               | Value                                                       |
-| ----------------------- | ----------------------------------------------------------- |
-| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                        |
-| **Description**         | Attacker causes the agent to send harmful/offensive content |
-| **Attack vector**       | Prompt injection causing inappropriate responses            |
-| **Affected components** | Output generation, channel messaging                        |
-| **Current mitigations** | LLM provider content policies                               |
-| **Residual risk**       | Medium - provider filters are imperfect                     |
-| **Recommendations**     | Output filtering layer, user controls                       |
+| ATLAS tactic                                         | Threats                                        | Page                                                                                    |
+| ---------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Reconnaissance (AML.TA0002)                          | T-RECON-001, T-RECON-002                       | [Reconnaissance](/security/THREAT-MODEL-ATLAS/reconnaissance)                           |
+| Initial access (AML.TA0004)                          | T-ACCESS-001, T-ACCESS-002, T-ACCESS-003       | [Initial access](/security/THREAT-MODEL-ATLAS/initial-access)                           |
+| Execution (AML.TA0005)                               | T-EXEC-001, T-EXEC-002, T-EXEC-003, T-EXEC-004 | [Execution](/security/THREAT-MODEL-ATLAS/execution)                                     |
+| Persistence (AML.TA0006)                             | T-PERSIST-001, T-PERSIST-002, T-PERSIST-003    | [Persistence](/security/THREAT-MODEL-ATLAS/persistence)                                 |
+| Defense evasion (AML.TA0007)                         | T-EVADE-001, T-EVADE-002                       | [Defense evasion](/security/THREAT-MODEL-ATLAS/defense-evasion)                         |
+| Discovery (AML.TA0008)                               | T-DISC-001, T-DISC-002                         | [Discovery](/security/THREAT-MODEL-ATLAS/discovery)                                     |
+| Collection and exfiltration (AML.TA0009, AML.TA0010) | T-EXFIL-001, T-EXFIL-002, T-EXFIL-003          | [Collection and exfiltration](/security/THREAT-MODEL-ATLAS/collection-and-exfiltration) |
+| Impact (AML.TA0011)                                  | T-IMPACT-001, T-IMPACT-002, T-IMPACT-003       | [Impact](/security/THREAT-MODEL-ATLAS/impact)                                           |
 
 ---
 
@@ -552,6 +271,41 @@ T-EXEC-002 → T-EXFIL-001 → External exfiltration
 ---
 
 _This threat model is a living document. Report security issues to `security@openclaw.ai` or see the [Trust page](https://trust.openclaw.ai)._
+
+## Where each section moved
+
+Every heading from the previous single-page version keeps its anchor here, so an existing link such as `/security/THREAT-MODEL-ATLAS#t-exec-002-indirect-prompt-injection` still resolves. Each entry points at the page that now holds the content.
+
+- <a id="3.1-reconnaissance-(aml.ta0002)" /><a id="3-1-reconnaissance-aml-ta0002" />[3.1 Reconnaissance (AML.TA0002)](/security/THREAT-MODEL-ATLAS/reconnaissance)
+- <a id="t-recon-001%3A-agent-endpoint-discovery" /><a id="t-recon-001-agent-endpoint-discovery" />[T-RECON-001: Agent endpoint discovery](/security/THREAT-MODEL-ATLAS/reconnaissance#t-recon-001-agent-endpoint-discovery)
+- <a id="t-recon-002%3A-channel-integration-probing" /><a id="t-recon-002-channel-integration-probing" />[T-RECON-002: Channel integration probing](/security/THREAT-MODEL-ATLAS/reconnaissance#t-recon-002-channel-integration-probing)
+- <a id="3.2-initial-access-(aml.ta0004)" /><a id="3-2-initial-access-aml-ta0004" />[3.2 Initial access (AML.TA0004)](/security/THREAT-MODEL-ATLAS/initial-access)
+- <a id="t-access-001%3A-pairing-code-interception" /><a id="t-access-001-pairing-code-interception" />[T-ACCESS-001: Pairing code interception](/security/THREAT-MODEL-ATLAS/initial-access#t-access-001-pairing-code-interception)
+- <a id="t-access-002%3A-allowfrom-spoofing" /><a id="t-access-002-allowfrom-spoofing" />[T-ACCESS-002: AllowFrom spoofing](/security/THREAT-MODEL-ATLAS/initial-access#t-access-002-allowfrom-spoofing)
+- <a id="t-access-003%3A-token-theft" /><a id="t-access-003-token-theft" />[T-ACCESS-003: Token theft](/security/THREAT-MODEL-ATLAS/initial-access#t-access-003-token-theft)
+- <a id="3.3-execution-(aml.ta0005)" /><a id="3-3-execution-aml-ta0005" />[3.3 Execution (AML.TA0005)](/security/THREAT-MODEL-ATLAS/execution)
+- <a id="t-exec-001%3A-direct-prompt-injection" /><a id="t-exec-001-direct-prompt-injection" />[T-EXEC-001: Direct prompt injection](/security/THREAT-MODEL-ATLAS/execution#t-exec-001-direct-prompt-injection)
+- <a id="t-exec-002%3A-indirect-prompt-injection" /><a id="t-exec-002-indirect-prompt-injection" />[T-EXEC-002: Indirect prompt injection](/security/THREAT-MODEL-ATLAS/execution#t-exec-002-indirect-prompt-injection)
+- <a id="t-exec-003%3A-tool-argument-injection" /><a id="t-exec-003-tool-argument-injection" />[T-EXEC-003: Tool argument injection](/security/THREAT-MODEL-ATLAS/execution#t-exec-003-tool-argument-injection)
+- <a id="t-exec-004%3A-exec-approval-bypass" /><a id="t-exec-004-exec-approval-bypass" />[T-EXEC-004: Exec approval bypass](/security/THREAT-MODEL-ATLAS/execution#t-exec-004-exec-approval-bypass)
+- <a id="3.4-persistence-(aml.ta0006)" /><a id="3-4-persistence-aml-ta0006" />[3.4 Persistence (AML.TA0006)](/security/THREAT-MODEL-ATLAS/persistence)
+- <a id="t-persist-001%3A-malicious-skill-installation" /><a id="t-persist-001-malicious-skill-installation" />[T-PERSIST-001: Malicious skill installation](/security/THREAT-MODEL-ATLAS/persistence#t-persist-001-malicious-skill-installation)
+- <a id="t-persist-002%3A-skill-update-poisoning" /><a id="t-persist-002-skill-update-poisoning" />[T-PERSIST-002: Skill update poisoning](/security/THREAT-MODEL-ATLAS/persistence#t-persist-002-skill-update-poisoning)
+- <a id="t-persist-003%3A-agent-configuration-tampering" /><a id="t-persist-003-agent-configuration-tampering" />[T-PERSIST-003: Agent configuration tampering](/security/THREAT-MODEL-ATLAS/persistence#t-persist-003-agent-configuration-tampering)
+- <a id="3.5-defense-evasion-(aml.ta0007)" /><a id="3-5-defense-evasion-aml-ta0007" />[3.5 Defense evasion (AML.TA0007)](/security/THREAT-MODEL-ATLAS/defense-evasion)
+- <a id="t-evade-001%3A-moderation-pattern-bypass" /><a id="t-evade-001-moderation-pattern-bypass" />[T-EVADE-001: Moderation pattern bypass](/security/THREAT-MODEL-ATLAS/defense-evasion#t-evade-001-moderation-pattern-bypass)
+- <a id="t-evade-002%3A-content-wrapper-escape" /><a id="t-evade-002-content-wrapper-escape" />[T-EVADE-002: Content wrapper escape](/security/THREAT-MODEL-ATLAS/defense-evasion#t-evade-002-content-wrapper-escape)
+- <a id="3.6-discovery-(aml.ta0008)" /><a id="3-6-discovery-aml-ta0008" />[3.6 Discovery (AML.TA0008)](/security/THREAT-MODEL-ATLAS/discovery)
+- <a id="t-disc-001%3A-tool-enumeration" /><a id="t-disc-001-tool-enumeration" />[T-DISC-001: Tool enumeration](/security/THREAT-MODEL-ATLAS/discovery#t-disc-001-tool-enumeration)
+- <a id="t-disc-002%3A-session-data-extraction" /><a id="t-disc-002-session-data-extraction" />[T-DISC-002: Session data extraction](/security/THREAT-MODEL-ATLAS/discovery#t-disc-002-session-data-extraction)
+- <a id="3.7-collection-and-exfiltration-(aml.ta0009%2C-aml.ta0010)" /><a id="3-7-collection-and-exfiltration-aml-ta0009-aml-ta0010" />[3.7 Collection and exfiltration (AML.TA0009, AML.TA0010)](/security/THREAT-MODEL-ATLAS/collection-and-exfiltration)
+- <a id="t-exfil-001%3A-data-theft-via-web_fetch" /><a id="t-exfil-001-data-theft-via-web_fetch" />[T-EXFIL-001: Data theft via web_fetch](/security/THREAT-MODEL-ATLAS/collection-and-exfiltration#t-exfil-001-data-theft-via-web_fetch)
+- <a id="t-exfil-002%3A-unauthorized-message-sending" /><a id="t-exfil-002-unauthorized-message-sending" />[T-EXFIL-002: Unauthorized message sending](/security/THREAT-MODEL-ATLAS/collection-and-exfiltration#t-exfil-002-unauthorized-message-sending)
+- <a id="t-exfil-003%3A-credential-harvesting" /><a id="t-exfil-003-credential-harvesting" />[T-EXFIL-003: Credential harvesting](/security/THREAT-MODEL-ATLAS/collection-and-exfiltration#t-exfil-003-credential-harvesting)
+- <a id="3.8-impact-(aml.ta0011)" /><a id="3-8-impact-aml-ta0011" />[3.8 Impact (AML.TA0011)](/security/THREAT-MODEL-ATLAS/impact)
+- <a id="t-impact-001%3A-unauthorized-command-execution" /><a id="t-impact-001-unauthorized-command-execution" />[T-IMPACT-001: Unauthorized command execution](/security/THREAT-MODEL-ATLAS/impact#t-impact-001-unauthorized-command-execution)
+- <a id="t-impact-002%3A-resource-exhaustion-(dos)" /><a id="t-impact-002-resource-exhaustion-dos" />[T-IMPACT-002: Resource exhaustion (DoS)](/security/THREAT-MODEL-ATLAS/impact#t-impact-002-resource-exhaustion-dos)
+- <a id="t-impact-003%3A-reputation-damage" /><a id="t-impact-003-reputation-damage" />[T-IMPACT-003: Reputation damage](/security/THREAT-MODEL-ATLAS/impact#t-impact-003-reputation-damage)
 
 ## Related
 

--- a/docs/security/THREAT-MODEL-ATLAS/collection-and-exfiltration.md
+++ b/docs/security/THREAT-MODEL-ATLAS/collection-and-exfiltration.md
@@ -1,0 +1,47 @@
+---
+summary: "OpenClaw collection and exfiltration threats (AML.TA0009, AML.TA0010): T-EXFIL-001, T-EXFIL-002, T-EXFIL-003"
+title: "Collection and exfiltration (AML.TA0009, AML.TA0010)"
+read_when:
+  - Reviewing collection and exfiltration threats against an OpenClaw deployment
+  - Working on mitigations for T-EXFIL-001, T-EXFIL-002, T-EXFIL-003
+---
+
+Threats in the collection and exfiltration tactic (AML.TA0009, AML.TA0010) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-EXFIL-001: Data theft via web_fetch
+
+| Attribute               | Value                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0009 - Collection                                                           |
+| **Description**         | Attacker exfiltrates data by instructing the agent to send it to an external URL |
+| **Attack vector**       | Prompt injection causing the agent to POST data to an attacker server            |
+| **Affected components** | `web_fetch` tool                                                                 |
+| **Current mitigations** | SSRF blocking for internal/private networks (DNS pinning + IP blocking)          |
+| **Residual risk**       | High - arbitrary external URLs remain permitted                                  |
+| **Recommendations**     | URL allowlisting, data-classification awareness                                  |
+
+## T-EXFIL-002: Unauthorized message sending
+
+| Attribute               | Value                                                                |
+| ----------------------- | -------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0009 - Collection                                               |
+| **Description**         | Attacker causes the agent to send messages containing sensitive data |
+| **Attack vector**       | Prompt injection causing the agent to message the attacker           |
+| **Affected components** | Message tool, channel integrations                                   |
+| **Current mitigations** | Outbound messaging gating                                            |
+| **Residual risk**       | Medium - gating may be bypassed                                      |
+| **Recommendations**     | Explicit confirmation for new recipients                             |
+
+## T-EXFIL-003: Credential harvesting
+
+| Attribute               | Value                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0009 - Collection                                                                                                                                  |
+| **Description**         | Malicious skill harvests credentials from the agent context                                                                                             |
+| **Attack vector**       | Skill code reads environment variables, config files                                                                                                    |
+| **Affected components** | Skill execution environment                                                                                                                             |
+| **Current mitigations** | ClawHub credential-pattern scanning (hardcoded secrets, credential env access paired with network sends); no execution sandboxing for skills at runtime |
+| **Residual risk**       | Critical - skills run with agent privileges                                                                                                             |
+| **Recommendations**     | Skill execution sandboxing, credential isolation                                                                                                        |

--- a/docs/security/THREAT-MODEL-ATLAS/defense-evasion.md
+++ b/docs/security/THREAT-MODEL-ATLAS/defense-evasion.md
@@ -1,0 +1,35 @@
+---
+summary: "OpenClaw defense evasion threats (AML.TA0007): T-EVADE-001, T-EVADE-002"
+title: "Defense evasion (AML.TA0007)"
+read_when:
+  - Reviewing defense evasion threats against an OpenClaw deployment
+  - Working on mitigations for T-EVADE-001, T-EVADE-002
+---
+
+Threats in the defense evasion tactic (AML.TA0007) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-EVADE-001: Moderation pattern bypass
+
+| Attribute               | Value                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                    |
+| **Description**         | Attacker crafts skill content to evade ClawHub moderation checks                      |
+| **Attack vector**       | Unicode homoglyphs, encoding tricks, dynamic loading                                  |
+| **Affected components** | ClawHub moderation/scanning pipeline                                                  |
+| **Current mitigations** | Static pattern rules, AST-adjacent code scanning, LLM agentic-risk review, VirusTotal |
+| **Residual risk**       | Medium - novel obfuscation can still slip past layered heuristics                     |
+| **Recommendations**     | Continue expanding the pattern/behavioral corpus as new evasions are found            |
+
+## T-EVADE-002: Content wrapper escape
+
+| Attribute               | Value                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                                            |
+| **Description**         | Attacker crafts content that escapes the external-content wrapper context                                     |
+| **Attack vector**       | Tag manipulation, context confusion, instruction override                                                     |
+| **Affected components** | External content wrapping                                                                                     |
+| **Current mitigations** | Random-boundary XML-style markers + security notice, plus homoglyph/whitespace-variant marker-spoof detection |
+| **Residual risk**       | Medium - novel escapes discovered regularly                                                                   |
+| **Recommendations**     | Output-side validation in addition to input-side wrapping                                                     |

--- a/docs/security/THREAT-MODEL-ATLAS/discovery.md
+++ b/docs/security/THREAT-MODEL-ATLAS/discovery.md
@@ -1,0 +1,35 @@
+---
+summary: "OpenClaw discovery threats (AML.TA0008): T-DISC-001, T-DISC-002"
+title: "Discovery (AML.TA0008)"
+read_when:
+  - Reviewing discovery threats against an OpenClaw deployment
+  - Working on mitigations for T-DISC-001, T-DISC-002
+---
+
+Threats in the discovery tactic (AML.TA0008) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-DISC-001: Tool enumeration
+
+| Attribute               | Value                                                 |
+| ----------------------- | ----------------------------------------------------- |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access             |
+| **Description**         | Attacker enumerates available tools through prompting |
+| **Attack vector**       | "What tools do you have?" style queries               |
+| **Affected components** | Agent tool registry                                   |
+| **Current mitigations** | None specific                                         |
+| **Residual risk**       | Low - tools are generally documented                  |
+| **Recommendations**     | Consider tool visibility controls                     |
+
+## T-DISC-002: Session data extraction
+
+| Attribute               | Value                                                   |
+| ----------------------- | ------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access               |
+| **Description**         | Attacker extracts sensitive data from session context   |
+| **Attack vector**       | "What did we discuss?" queries, context probing         |
+| **Affected components** | Session transcripts, context window                     |
+| **Current mitigations** | Session isolation per sender (`agent:channel:peer` key) |
+| **Residual risk**       | Medium - within-session data is accessible by design    |
+| **Recommendations**     | Sensitive-data redaction in context                     |

--- a/docs/security/THREAT-MODEL-ATLAS/execution.md
+++ b/docs/security/THREAT-MODEL-ATLAS/execution.md
@@ -1,0 +1,59 @@
+---
+summary: "OpenClaw execution threats (AML.TA0005): T-EXEC-001, T-EXEC-002, T-EXEC-003, T-EXEC-004"
+title: "Execution (AML.TA0005)"
+read_when:
+  - Reviewing execution threats against an OpenClaw deployment
+  - Working on mitigations for T-EXEC-001, T-EXEC-002, T-EXEC-003, T-EXEC-004
+---
+
+Threats in the execution tactic (AML.TA0005) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-EXEC-001: Direct prompt injection
+
+| Attribute               | Value                                                                                                                                                                                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                                                                                                                                                                                                                                                     |
+| **Description**         | Attacker sends crafted prompts to manipulate agent behavior                                                                                                                                                                                                                                      |
+| **Attack vector**       | Channel messages containing adversarial instructions                                                                                                                                                                                                                                             |
+| **Affected components** | Agent LLM, all input surfaces                                                                                                                                                                                                                                                                    |
+| **Current mitigations** | Pattern detection, external content wrapping, and frontier-model robustness (2026 crowdsourced arena: 0.5% ASR on Claude Opus 4.5, 8.5% on Gemini 2.5 Pro, scored on execution plus concealment); treated as out-of-scope for vulnerability reports absent a boundary bypass (see `SECURITY.md`) |
+| **Residual risk**       | Model-tier dependent - low single-digit ASR against organic attacks on recommended frontier models, but adaptive attackers still exceed 80% against state-of-the-art defenses, and smaller/older models remain markedly easier to steer                                                          |
+| **Recommendations**     | Output validation and user confirmation for sensitive actions, layered on top of existing detection                                                                                                                                                                                              |
+
+## T-EXEC-002: Indirect prompt injection
+
+| Attribute               | Value                                                                                                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0051.001 - LLM Prompt Injection: Indirect                                                                                                                                                                     |
+| **Description**         | Attacker embeds malicious instructions in fetched content                                                                                                                                                          |
+| **Attack vector**       | Malicious URLs, poisoned emails, compromised webhooks                                                                                                                                                              |
+| **Affected components** | `web_fetch`, email ingestion, external data sources                                                                                                                                                                |
+| **Current mitigations** | Content wrapping with random-boundary XML-style markers, homoglyph/special-token normalization, a security notice, and frontier-model robustness (see T-EXEC-001)                                                  |
+| **Residual risk**       | Model-tier dependent - recommended frontier models largely hold the wrapper boundary, but it remains soft guidance an adaptive attacker can erode; scope tool policy and sandboxing to the blast radius you accept |
+| **Recommendations**     | Separate execution contexts for wrapped content                                                                                                                                                                    |
+
+## T-EXEC-003: Tool argument injection
+
+| Attribute               | Value                                                        |
+| ----------------------- | ------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0051.000 - LLM Prompt Injection: Direct                 |
+| **Description**         | Attacker manipulates tool arguments through prompt injection |
+| **Attack vector**       | Crafted prompts that influence tool parameter values         |
+| **Affected components** | All tool invocations                                         |
+| **Current mitigations** | Exec approvals for dangerous commands                        |
+| **Residual risk**       | High - relies on user judgment                               |
+| **Recommendations**     | Argument validation, parameterized tool calls                |
+
+## T-EXEC-004: Exec approval bypass
+
+| Attribute               | Value                                                                                                                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0043 - Craft Adversarial Data                                                                                                                                                |
+| **Description**         | Attacker crafts commands that bypass the approval allowlist                                                                                                                       |
+| **Attack vector**       | Command obfuscation, alias exploitation, path manipulation                                                                                                                        |
+| **Affected components** | `src/infra/exec-approvals*.ts`, command allowlist                                                                                                                                 |
+| **Current mitigations** | Allowlist + ask mode, plus command normalization (dispatch-wrapper unwrapping, inline-eval detection, shell-chain analysis)                                                       |
+| **Residual risk**       | High - normalization narrows but does not eliminate obfuscation bypass; parity-only findings between exec paths are treated as hardening, not vulnerabilities (see `SECURITY.md`) |
+| **Recommendations**     | Continue expanding command-normalization coverage against new obfuscation techniques                                                                                              |

--- a/docs/security/THREAT-MODEL-ATLAS/impact.md
+++ b/docs/security/THREAT-MODEL-ATLAS/impact.md
@@ -1,0 +1,47 @@
+---
+summary: "OpenClaw impact threats (AML.TA0011): T-IMPACT-001, T-IMPACT-002, T-IMPACT-003"
+title: "Impact (AML.TA0011)"
+read_when:
+  - Reviewing impact threats against an OpenClaw deployment
+  - Working on mitigations for T-IMPACT-001, T-IMPACT-002, T-IMPACT-003
+---
+
+Threats in the impact tactic (AML.TA0011) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-IMPACT-001: Unauthorized command execution
+
+| Attribute               | Value                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                                                                 |
+| **Description**         | Attacker executes arbitrary commands on the user system                                              |
+| **Attack vector**       | Prompt injection combined with exec approval bypass                                                  |
+| **Affected components** | Bash tool, command execution                                                                         |
+| **Current mitigations** | Exec approvals, Docker sandbox option (default runtime backend)                                      |
+| **Residual risk**       | Critical - host execution possible when sandbox is disabled                                          |
+| **Recommendations**     | Improve approval UX; sandbox-off deployments remain a deliberate operator choice, documented as such |
+
+## T-IMPACT-002: Resource exhaustion (DoS)
+
+| Attribute               | Value                                              |
+| ----------------------- | -------------------------------------------------- |
+| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity               |
+| **Description**         | Attacker exhausts API credits or compute resources |
+| **Attack vector**       | Automated message flooding, expensive tool calls   |
+| **Affected components** | Gateway, agent sessions, API provider              |
+| **Current mitigations** | None                                               |
+| **Residual risk**       | High - no per-sender rate limiting                 |
+| **Recommendations**     | Per-sender rate limits, cost budgets               |
+
+## T-IMPACT-003: Reputation damage
+
+| Attribute               | Value                                                       |
+| ----------------------- | ----------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                        |
+| **Description**         | Attacker causes the agent to send harmful/offensive content |
+| **Attack vector**       | Prompt injection causing inappropriate responses            |
+| **Affected components** | Output generation, channel messaging                        |
+| **Current mitigations** | LLM provider content policies                               |
+| **Residual risk**       | Medium - provider filters are imperfect                     |
+| **Recommendations**     | Output filtering layer, user controls                       |

--- a/docs/security/THREAT-MODEL-ATLAS/initial-access.md
+++ b/docs/security/THREAT-MODEL-ATLAS/initial-access.md
@@ -1,0 +1,47 @@
+---
+summary: "OpenClaw initial access threats (AML.TA0004): T-ACCESS-001, T-ACCESS-002, T-ACCESS-003"
+title: "Initial access (AML.TA0004)"
+read_when:
+  - Reviewing initial access threats against an OpenClaw deployment
+  - Working on mitigations for T-ACCESS-001, T-ACCESS-002, T-ACCESS-003
+---
+
+Threats in the initial access tactic (AML.TA0004) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-ACCESS-001: Pairing code interception
+
+| Attribute               | Value                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                                             |
+| **Description**         | Attacker intercepts a pairing code during the pairing window (1h DM/generic pairing, 5m node pairing) |
+| **Attack vector**       | Shoulder surfing, network sniffing, social engineering                                                |
+| **Affected components** | Device pairing system                                                                                 |
+| **Current mitigations** | 1h TTL (DM/generic pairing), 5m TTL (node pairing); codes sent via the existing channel               |
+| **Residual risk**       | Medium - pairing window exploitable                                                                   |
+| **Recommendations**     | Reduce pairing window, add a confirmation step                                                        |
+
+## T-ACCESS-002: AllowFrom spoofing
+
+| Attribute               | Value                                                                                                                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                                                                                                                                                                                                                                                                                   |
+| **Description**         | Attacker spoofs an allowed sender identity on a channel                                                                                                                                                                                                                                                                                     |
+| **Attack vector**       | Channel-dependent - phone number spoofing, username impersonation                                                                                                                                                                                                                                                                           |
+| **Affected components** | Per-channel AllowFrom validation                                                                                                                                                                                                                                                                                                            |
+| **Current mitigations** | Channel-specific identity verification; graded identifier-authentication gate uses `min(entry, subject)` over `verified > asserted > unverified > mutable` with exact match provenance and default minimum `asserted` (#123782/#123793). Channels declare per-identifier strength; security audit warns on inert mutable entries (#131129). |
+| **Residual risk**       | Medium - some channels remain vulnerable to spoofing                                                                                                                                                                                                                                                                                        |
+| **Recommendations**     | Continue per-channel `verified` adoption and downstream strength mappers; document channel-specific risks                                                                                                                                                                                                                                   |
+
+## T-ACCESS-003: Token theft
+
+| Attribute               | Value                                                              |
+| ----------------------- | ------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                          |
+| **Description**         | Attacker steals authentication tokens from config/credential files |
+| **Attack vector**       | Malware, unauthorized device access, config backup exposure        |
+| **Affected components** | Channel/provider credential storage, config storage                |
+| **Current mitigations** | File permissions                                                   |
+| **Residual risk**       | High - tokens stored in plaintext on disk                          |
+| **Recommendations**     | Implement token encryption at rest, add token rotation             |

--- a/docs/security/THREAT-MODEL-ATLAS/persistence.md
+++ b/docs/security/THREAT-MODEL-ATLAS/persistence.md
@@ -1,0 +1,47 @@
+---
+summary: "OpenClaw persistence threats (AML.TA0006): T-PERSIST-001, T-PERSIST-002, T-PERSIST-003"
+title: "Persistence (AML.TA0006)"
+read_when:
+  - Reviewing persistence threats against an OpenClaw deployment
+  - Working on mitigations for T-PERSIST-001, T-PERSIST-002, T-PERSIST-003
+---
+
+Threats in the persistence tactic (AML.TA0006) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-PERSIST-001: Malicious skill installation
+
+| Attribute               | Value                                                                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0010.001 - Supply Chain Compromise: AI Software                                                                      |
+| **Description**         | Attacker publishes a malicious skill to ClawHub                                                                           |
+| **Attack vector**       | Create account, publish skill with hidden malicious code                                                                  |
+| **Affected components** | ClawHub, skill loading, agent execution                                                                                   |
+| **Current mitigations** | GitHub account age verification, static pattern/AST-adjacent scanning, LLM-based agentic risk review, VirusTotal scanning |
+| **Residual risk**       | High - detection layers exist but skills still run with agent privileges and no execution sandboxing                      |
+| **Recommendations**     | Skill execution sandboxing, expanded community review                                                                     |
+
+## T-PERSIST-002: Skill update poisoning
+
+| Attribute               | Value                                                                   |
+| ----------------------- | ----------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0010.001 - Supply Chain Compromise: AI Software                    |
+| **Description**         | Attacker compromises a popular skill and pushes a malicious update      |
+| **Attack vector**       | Account compromise, social engineering of skill owner                   |
+| **Affected components** | ClawHub versioning, auto-update flows                                   |
+| **Current mitigations** | Version fingerprinting, moderation/scanning re-run on new versions      |
+| **Residual risk**       | High - auto-updates may pull malicious versions before review completes |
+| **Recommendations**     | Update signing, rollback capability, version pinning                    |
+
+## T-PERSIST-003: Agent configuration tampering
+
+| Attribute               | Value                                                           |
+| ----------------------- | --------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0010.002 - Supply Chain Compromise: Data                   |
+| **Description**         | Attacker modifies agent configuration to persist access         |
+| **Attack vector**       | Config file modification, settings injection                    |
+| **Affected components** | Agent config, tool policies                                     |
+| **Current mitigations** | File permissions                                                |
+| **Residual risk**       | Medium - requires local access                                  |
+| **Recommendations**     | Config integrity verification, audit logging for config changes |

--- a/docs/security/THREAT-MODEL-ATLAS/reconnaissance.md
+++ b/docs/security/THREAT-MODEL-ATLAS/reconnaissance.md
@@ -1,0 +1,35 @@
+---
+summary: "OpenClaw reconnaissance threats (AML.TA0002): T-RECON-001, T-RECON-002"
+title: "Reconnaissance (AML.TA0002)"
+read_when:
+  - Reviewing reconnaissance threats against an OpenClaw deployment
+  - Working on mitigations for T-RECON-001, T-RECON-002
+---
+
+Threats in the reconnaissance tactic (AML.TA0002) of the [MITRE ATLAS](https://atlas.mitre.org/) framework. Each entry lists the ATLAS technique, attack vector, affected components, current mitigations, residual risk, and recommendations.
+
+The trust boundaries and data flows these threats cross are defined in the [threat model index](/security/THREAT-MODEL-ATLAS), which also holds the risk matrix, the recommendations summary, and the ATLAS technique mapping.
+
+## T-RECON-001: Agent endpoint discovery
+
+| Attribute               | Value                                                                |
+| ----------------------- | -------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0006 - Active Scanning                                          |
+| **Description**         | Attacker scans for exposed OpenClaw gateway endpoints                |
+| **Attack vector**       | Network scanning, Shodan queries, DNS enumeration                    |
+| **Affected components** | Gateway, exposed API endpoints                                       |
+| **Current mitigations** | Tailscale auth option, bind to loopback by default                   |
+| **Residual risk**       | Medium - public gateways discoverable                                |
+| **Recommendations**     | Document secure deployment, add rate limiting on discovery endpoints |
+
+## T-RECON-002: Channel integration probing
+
+| Attribute               | Value                                                              |
+| ----------------------- | ------------------------------------------------------------------ |
+| **ATLAS ID**            | AML.T0006 - Active Scanning                                        |
+| **Description**         | Attacker probes messaging channels to identify AI-managed accounts |
+| **Attack vector**       | Sending test messages, observing response patterns                 |
+| **Affected components** | All channel integrations                                           |
+| **Current mitigations** | None specific                                                      |
+| **Residual risk**       | Low - limited value from discovery alone                           |
+| **Recommendations**     | Consider response timing randomization                             |


### PR DESCRIPTION
## What

Splits the `docs/security/THREAT-MODEL-ATLAS.md` threat catalog into eight child pages, one per MITRE ATLAS tactic. The index stays at the same URL.

**Why this page splits well.** A threat model is often one argument with a shared trust-boundary premise that later sections depend on, and splitting that kind of page hurts. This one is not that shape. Section 3 is an *atlas*: 22 independent threat entries with a uniform attribute schema (ATLAS ID, description, attack vector, affected components, current mitigations, residual risk, recommendations). Each entry is read on its own. The shared premise — scope, the five trust boundaries, and the data-flow table — **stays on the index**, and every child links back to it in its lede.

| | Before | After |
| --- | --- | --- |
| Index | 45,871 chars, 51 headings | 24,328 chars |
| Largest unit | section 3 alone: 29,379 chars, 22 tables | `execution.md`: 8,644 chars |

Children (chars): `reconnaissance` 2,579 · `initial-access` 6,191 · `execution` 8,644 · `persistence` 4,026 · `defense-evasion` 3,119 · `discovery` 2,307 · `collection-and-exfiltration` 4,498 · `impact` 3,576.

Sections 1, 2, 4, 5, 6, 7 and `## Related` stay on the index byte-for-byte. The risk matrix, recommendations summary, and ATLAS technique mapping all index *across* the threats, so they belong on the index rather than in any one child.

## CODEOWNERS — this PR touches secops-owned files

`/docs/security/` (`.github/CODEOWNERS:52`) is a **directory** rule, so it recurses. Simulated last-match-wins with working controls, all passing:

| Control | Expected | Got |
| --- | --- | --- |
| `docs/security/network-proxy.md` | owned | owned via L52 |
| `docs/gateway/security/index.md` | owned | owned via L58 |
| `docs/gateway/authentication.md` (file-exact) | owned | owned via L53 |
| `docs/gateway/authentication/overview.md` | **unowned** (file-exact does not recurse) | unowned |
| `docs/start/why-openclaw.md` | unowned | unowned |
| `docs/reference/RELEASING.md` | release-managers | release-managers via L59 |

The new children resolve to `@openclaw/openclaw-secops` via that same L52 directory rule, so the split does **not** move security content out from under its ownership rule and **no CODEOWNERS change is needed**.

Owned files in this PR (all `@openclaw/openclaw-secops`): `docs/security/THREAT-MODEL-ATLAS.md` and the eight new `docs/security/THREAT-MODEL-ATLAS/*.md`. `docs/docs.json` and `docs/.i18n/glossary.zh-CN.json` are unowned.

## Losslessness, proven

The eight children — heading levels restored (`##` → `####`), frontmatter and ledes removed, tactic heading re-prepended — reassemble with the captured `---` seams into a byte-identical copy of the original:

```
origin/main sha256: a1df29ab2f9822a1fb7292a9de347e751d326b9850ee378bb2fe5c6f17644407
rebuilt     sha256: a1df29ab2f9822a1fb7292a9de347e751d326b9850ee378bb2fe5c6f17644407
BYTE IDENTICAL: True
```

Reassembly reads the actual committed child files, not an in-memory intermediate. Separately verified that the index's retained regions equal `origin/main` with the section-3 body removed (`EQUAL: True`), so the only index changes are the two added regions: a 13-line lede + navigation table under `## 3.`, and the 35-line `## Where each section moved` block.

- Fences: 4 → 4, matched one-for-one on info string + body sha256.
- Table rows: 283 → 293 (+10 = the new 8-row navigation table plus its header and delimiter).
- Words: 3,938 → 5,060 (grew only).
- The page has **no** intra-page `](#anchor)` links, so no link rewrites were needed and byte-identity of the final tree holds with no exceptions.

## Anchors

Enumerated with the repo's own `parseDocsDocument`, never a slug approximation. Every heading here mints **both** an encoded and a cleaned id (the `.`, `:`, `,` and `()` left after slugification), so 50 headings + `## Related` produce **101 ids**.

- **41 stay self-published** by headings the index still carries (sections 1, 2, 2.1–2.2, 3, 4–4.3, 5–5.2, 6–6.3, 7–7.3, Related). These are deliberately *not* stubbed, which would be a duplicate authored/canonical id.
- **60 belong to the 30 moved headings** (8 tactic + 22 threat) and are authored `<a id>` stubs on the index, both spellings, e.g.:

```
- <a id="t-access-002%3A-allowfrom-spoofing" /><a id="t-access-002-allowfrom-spoofing" />[T-ACCESS-002: AllowFrom spoofing](/security/THREAT-MODEL-ATLAS/initial-access#t-access-002-allowfrom-spoofing)
```

Verified: **0 of 101 pre-split ids missing** after the split, and `COLLISIONS:[]` on the index and on all eight children. Threat-heading ids are unchanged by the `####` → `##` promotion because ids derive from heading text, not level. The page contains no MDX components, so no verbatim-marker ids are involved.

## Uppercase filename

The page is the only uppercase-named doc in `docs/security/`, and `docs/` has **no** uppercase directories today — `docs/security/THREAT-MODEL-ATLAS/` is the first. Checked before creating it: the route `security/THREAT-MODEL-ATLAS` appears only in `docs/docs.json` nav and in four inbound prose links, none with a fragment; `scripts/lib/docs-redirects.mjs` has no entry for it. The directory has to match the parent page name for the parent/child route relationship, and **child filenames follow the existing lowercase-kebab convention** (`docs/start/why-openclaw/provenance.md`), not the parent's casing.

## Validators

`pnpm check:docs` — **exit 0** (format, `lint:docs`, `lint:templates`, mdx, i18n-glossary, links, config-examples). markdownlint via the config's own globs: 0 issues in 1,258 files.

| Check | Result |
| --- | --- |
| `docs-link-audit.mjs --anchors` | 3 errors — identical set to baseline |
| `vitest.tooling` `docs-link-audit.test.ts` | 1 file, 1 failed / 32 passed — identical at baseline |
| `vitest.full-core-unit-src` `src/docs/` | 8 files, 16 tests, all pass |
| `stranded-stubs.py docs` | 0 suspects |
| `check-orphan-refs.py` (index + 8 children) | 1 directional ref, resolved |

Baseline measured in a detached worktree at the merge-base `df76050` with `node_modules` symlinked, not by stashing. Both known failures reproduce there unchanged:

- The 3 anchor errors are all `#windows-app-node` in `maturity/scorecard.md` and `maturity/taxonomy.md` — files this PR does not touch.
- The `docs-link-audit` failure is `preserves Mint component targets for raw component apostrophes` (`['ass-guide']` vs `['as-s-guide']`) — unrelated to this page, which has no components and no apostrophes in headings.

The one orphan-ref hit is "Each page below" in my new lede, referring to the navigation table directly beneath it on the same page. **This is the entire prose diff**: two added ledes on the index (the section-3 lede and the `## Where each section moved` preamble) plus one lede per child. No original prose was reworded, reordered, or removed.

## Pins

`docs-test-pins.py` reports **0 tests** pin this page. An independent `git grep -n "THREAT-MODEL-ATLAS" origin/main` with no path filter returns 6 hits, all classified:

| Hit | Kind | Effect |
| --- | --- | --- |
| `docs/docs.json:2613` | nav | updated; 8 child routes added after the parent |
| `docs/security/CONTRIBUTING-THREAT-MODEL.md:9,82` | prose link | bare route, still resolves |
| `docs/security/formal-verification.md:125` | prose link | bare route, still resolves |
| `docs/security/incident-response.md:57` | prose link | bare route, still resolves |
| `docs/start/why-openclaw/provenance.md:24` | prose link | bare route, still resolves |

No inbound link uses a fragment, so nothing depended on a moved anchor. Also grepped `scripts/` for hard-coded path allowlists (`RELEASE_METADATA_PATHS` in `changed-lanes.mts` and similar): this page is in none.

## Glossary

`check-docs-i18n-glossary.mts` gates the `title:` of every changed English doc, so the eight child titles each needed a source entry. All eight reuse the existing heading text (ATLAS tactic names) — no vocabulary was coined. Inserted **beside the parent's existing `"Threat model"` entry** rather than appended at the end, so concurrent splits touch different regions of the file and merge cleanly. 1,131 → 1,139 entries, 0 duplicate sources.

The 30 stub bullets did **not** need entries: `LIST_ITEM_LINK_RE` requires the link at the start of the list item, and these begin with the `<a id>` stubs. The navigation table is a table, not list items, so it is not gated either.

## Pre-existing gap, not fixed here

`.github/labeler.yml` has no glob matching `docs/security/**` — its `security` label covers `docs/cli/security.md`, `docs/gateway/security/**`, and `security/**` (a top-level directory that does not exist). So `docs/security/THREAT-MODEL-ATLAS.md` was **never** labelled, and the new children are unmatched for the same pre-existing reason. This split does not create the gap and does not widen it, so per program policy it is reported rather than fixed here.

## Ledger findings

Closes `r3-0737` (51 headings / 49,201 chars, above the 40-heading split signal) and the split half of `r3-0738` (explanation + reference + roadmap mixed).

Left open deliberately, as each needs a content change this content-preserving split must not make: `r3-0739` (undated `1.0-draft`, missing R-001, R-008 misfiled under P2, unlinked citations), `r3-2289` (no scannable threat index on the first screen — partly eased by the new navigation table, but the risk matrix is still at section 5), `r3-2290` (200–331 char prose cells in attribute tables), `r3-2291`/`r3-2292`/`r3-2296` (missing reciprocal Related links), `r3-0740`/`r3-0923` (Security nav group naming and ordering).
