### PR TITLE
fix(mac-gateway): stop discarding launchd stderr

### DIFF
--- a/docs/help/faq/logging-and-debugging.md
+++ b/docs/help/faq/logging-and-debugging.md
@@ -20,7 +20,7 @@ read_when:
 
     Service/supervisor logs (when the gateway runs via launchd/systemd):
 
-    - macOS launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`; stderr is suppressed).
+    - macOS launchd stdout and stderr: `~/Library/Logs/openclaw/gateway.log` (profiles use `gateway-<profile>.log`; both streams share this file, so startup failures that happen before the logger starts are recorded here too).
     - Linux: `journalctl --user -u openclaw-gateway[-<profile>].service -n 200 --no-pager`.
     - Windows: `schtasks /Query /TN "OpenClaw Gateway (<profile>)" /V /FO LIST`.
 

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -163,7 +163,8 @@ Logging:
 
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use
   `gateway-<profile>.log`)
-- launchd stderr: suppressed
+- launchd stderr: merged into the same `gateway.log` file, so startup failures
+  that happen before the logger starts are still recorded
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
   launchd-marker workaround in

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -624,7 +624,7 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, formatCliCommand("openclaw gateway restart"));
   });
 
-  it("prints macOS launchd stdout and suppressed stderr when gateway is not listening", () => {
+  it("points macOS launchd stdout and stderr at one log when gateway is not listening", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
@@ -669,7 +669,9 @@ describe("printDaemonStatus", () => {
 
     expectMockLineContains(runtime.error, "Gateway port 18789 is not listening");
     expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.log");
-    expectMockLineContains(runtime.error, "Errors: suppressed");
+    expectMockLineContains(runtime.error, "Logs (stdout and stderr):");
+    const printed = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(printed).not.toContain("suppressed");
     const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
     expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
   });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -526,8 +526,11 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       );
     } else if (process.platform === "darwin") {
       const logs = resolveGatewaySupervisorLogPaths(serviceEnv, { platform: "darwin" });
-      defaultRuntime.error(`${errorText("Logs:")} ${shortenHomePath(logs.stdoutPath)}`);
-      defaultRuntime.error(`${errorText("Errors:")} suppressed`);
+      // The plist points both launchd handles at this file, so startup crashes that
+      // never reached the logger land here too; do not advertise a separate stderr.
+      defaultRuntime.error(
+        `${errorText("Logs (stdout and stderr):")} ${shortenHomePath(logs.stdoutPath)}`,
+      );
     }
     defaultRuntime.error(
       `${errorText("Restart log:")} ${shortenHomePath(resolveGatewayRestartLogPath(serviceEnv))}`,

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -30,7 +30,7 @@ function makeTempStateDir(): string {
 }
 
 describe("readLastGatewayErrorLine", () => {
-  it("ignores stale launchd stderr when stderr is suppressed", async () => {
+  it("reads the launchd supervisor log instead of a state-dir stderr file on darwin", async () => {
     const stateDir = makeTempStateDir();
     const homeDir = makeTempStateDir();
     const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -89,8 +89,9 @@ export async function readLastGatewayErrorLine(
 ): Promise<string | null> {
   const platform = options?.platform ?? process.platform;
   const readStderr = platform !== "darwin";
-  // launchd supervisor mode combines child stderr into stdout; other platforms
-  // keep stderr as the strongest failure signal.
+  // launchd combines child stderr into stdout only because the plist points both
+  // handles at one file (buildLaunchAgentPlist); break that and darwin startup
+  // crashes stop reaching this reader. Other platforms keep stderr separate.
   const { stdoutPath, stderrPath } =
     platform === "darwin"
       ? resolveGatewaySupervisorLogPaths(env, { platform })

--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -25,7 +25,6 @@ const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 export const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 export const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
 const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
-const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 export function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
@@ -329,7 +328,10 @@ export async function writeLaunchAgentPlist({
     programArguments: prepared.programArguments,
     workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    // launchd has no stream-merge option, so both handles target one file.
+    // Diagnostics reads only stdout on darwin (readLastGatewayErrorLine);
+    // a separate stderr target would silently drop startup crash output.
+    stderrPath: stdoutPath,
     environment: prepared.inlineEnvironment,
   });
   await publishLaunchAgentPlist({ label, plistPath, contents: plist });
@@ -382,7 +384,10 @@ export async function rewriteLaunchAgentPlistForRestart({
     programArguments: prepared.programArguments,
     workingDirectory: existing.workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    // launchd has no stream-merge option, so both handles target one file.
+    // Diagnostics reads only stdout on darwin (readLastGatewayErrorLine);
+    // a separate stderr target would silently drop startup crash output.
+    stderrPath: stdoutPath,
     environment: prepared.inlineEnvironment,
   });
   const previousPlist = await fs.readFile(plistPath, "utf8").catch(() => "");

--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -328,9 +328,8 @@ export async function writeLaunchAgentPlist({
     programArguments: prepared.programArguments,
     workingDirectory,
     stdoutPath,
-    // launchd has no stream-merge option, so both handles target one file.
-    // Diagnostics reads only stdout on darwin (readLastGatewayErrorLine);
-    // a separate stderr target would silently drop startup crash output.
+    // Both handles target one file: launchd cannot merge streams, and darwin
+    // diagnostics reads only stdout (readLastGatewayErrorLine).
     stderrPath: stdoutPath,
     environment: prepared.inlineEnvironment,
   });
@@ -384,9 +383,8 @@ export async function rewriteLaunchAgentPlistForRestart({
     programArguments: prepared.programArguments,
     workingDirectory: existing.workingDirectory,
     stdoutPath,
-    // launchd has no stream-merge option, so both handles target one file.
-    // Diagnostics reads only stdout on darwin (readLastGatewayErrorLine);
-    // a separate stderr target would silently drop startup crash output.
+    // Both handles target one file: launchd cannot merge streams, and darwin
+    // diagnostics reads only stdout (readLastGatewayErrorLine).
     stderrPath: stdoutPath,
     environment: prepared.inlineEnvironment,
   });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2551,6 +2551,19 @@ describe("launchd install", () => {
     expect(plist).toContain("<integer>10</integer>");
   });
 
+  it("points launchd stderr at the stdout log so startup crashes survive", async () => {
+    const env = createDefaultLaunchdEnv();
+    await installLaunchAgent(defaultLaunchAgentFixture(env));
+
+    const plist = state.files.get(resolveLaunchAgentPlistPath(env)) ?? "";
+    const logPath = "/Users/test/Library/Logs/openclaw/gateway.log";
+    // readLastGatewayErrorLine only reads stdout on darwin, so a stderr target
+    // that is not the stdout log discards every pre-logger startup failure.
+    expect(plist).toContain(`<key>StandardOutPath</key>\n    <string>${logPath}</string>`);
+    expect(plist).toContain(`<key>StandardErrorPath</key>\n    <string>${logPath}</string>`);
+    expect(plist).not.toContain("<key>StandardErrorPath</key>\n    <string>/dev/null</string>");
+  });
+
   it("rewrites the plist before bootstrap during restart fallback", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
@@ -2571,8 +2584,9 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardInPath</key>");
     expect(plist).toContain("<key>StandardOutPath</key>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
-    expect(plist).toContain("<key>StandardErrorPath</key>");
-    expect(plist).toContain("<string>/dev/null</string>");
+    expect(plist).toContain(
+      "<key>StandardErrorPath</key>\n    <string>/Users/test/Library/Logs/openclaw/gateway.log</string>",
+    );
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>node</string>");
     expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -16,8 +16,7 @@ describe("buildPlatformRuntimeLogHints", () => {
         windowsTaskName: "OpenClaw Gateway",
       }),
     ).toEqual([
-      "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
-      "Launchd stderr (if installed): suppressed",
+      "Launchd stdout and stderr (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
       "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
     ]);
   });

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -14,8 +14,7 @@ export function buildPlatformRuntimeLogHints(params: {
     const logs = resolveGatewaySupervisorLogPaths(env, { platform });
     // Preserve the writer's path bytes; backslashes can be literal POSIX filename characters.
     return [
-      `Launchd stdout (if installed): ${logs.stdoutPath}`,
-      "Launchd stderr (if installed): suppressed",
+      `Launchd stdout and stderr (if installed): ${logs.stdoutPath}`,
       `Restart attempts: ${resolveGatewayRestartLogPath(env)}`,
     ];
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #90711. On macOS the LaunchAgent plist hard-coded `StandardErrorPath` to `/dev/null` (`src/daemon/launchd-service-files.ts`), so any gateway that died *before* its logger initialized left no trace anywhere. The operator saw a `launchctl` service in a crash loop with an empty `gateway.log`.

The failure is worse than "one log is missing", because a consumer already depends on the opposite contract. `readLastGatewayErrorLine` (`src/daemon/diagnostics.ts`) deliberately skips stderr on darwin:

```
const readStderr = platform !== "darwin";
// launchd supervisor mode combines child stderr into stdout; other platforms
// keep stderr as the strongest failure signal.
```

Nothing combined the streams. The producer discarded stderr and the consumer skipped it because it believed the producer had merged it, so darwin startup crashes fell through the gap entirely. `openclaw gateway status` also advertised `Launchd stderr (if installed): suppressed`, stating the discard as if it were intended behavior.

Real-world cost, hit on a live install today: the gateway refused to start on a SQLite schema check and crash-looped under launchd with `last exit code = 78 (EX_CONFIG)`. `gateway.log` contained nothing after the SIGTERM of the previous process, and `openclaw doctor` reported "Doctor complete". The reason was only recoverable by re-running the plist's exact `ProgramArguments` by hand with `2>&1`.

## Why This Change Was Made

The fix makes the already-documented merge real instead of adding a second log file: both plist handles now point at the resolved stdout path, so launchd itself combines the streams.

This is deliberately **not** the approach of the earlier attempt (#90828, closed unmerged). That PR routed stderr to a separate `gateway.err.log`, which created a new uncapped file and therefore a new retention-ownership question — "which restart seams own the cap" — and stalled waiting on that maintainer decision. Reusing the existing stdout log leaves supervisor-log retention byte-for-byte as it is today, so this change carries no retention decision at all. If a retention policy is chosen later it covers both streams uniformly, for free.

Because the merge is now genuine, `diagnostics.ts` needs no logic change — its darwin branch becomes correct as written. Its comment is updated to name the coupling so the plist side cannot be silently reverted.

## User Impact

macOS operators whose gateway fails to start now get the reason in `~/Library/Logs/openclaw/gateway.log` instead of silence. `openclaw gateway status` reports the real location rather than claiming stderr is suppressed. No config, no new file, no migration, no behavior change on Linux or Windows.

## Upgrade compatibility

The plist is generated content, not user data, so there is nothing to migrate. Existing installs still carry a `/dev/null` plist until a definition-writing path runs: `rewriteLaunchAgentPlistForRestart` regenerates and reloads the definition on any ordinary `openclaw gateway restart` (`src/daemon/launchd-lifecycle.ts:290-298`), and a fresh `openclaw gateway install` writes it directly. Restarts that pass `preserveDefinition` deliberately skip the rewrite, so those keep the old plist until the next definition-writing restart — which is existing behavior for every plist field, not something this change introduces.

## Evidence

Executable production change is net **-2 lines** (deleted the `LAUNCH_AGENT_STDERR_PATH` discard constant and the false status hint); the remaining additions are the two coupling comments and the regression test.

Regression test `points launchd stderr at the stdout log so startup crashes survive` asserts the `key`→`value` pairing rather than bare containment, because `StandardInPath` is also `/dev/null` and a `toContain("/dev/null")` assertion cannot distinguish the two — the pre-existing assertions had exactly that weakness.

Verified it fails on pre-fix code for the intended reason, by restoring `src/daemon/launchd-service-files.ts` from `HEAD` and re-running:

```
× launchd install > points launchd stderr at the stdout log so startup crashes survive
  → expected '<?xml version="1.0" ...' to contain '<key>StandardErrorPath</key>\n    <st…'
Tests  1 failed | 184 skipped (185)
```

With the fix restored:

```
node scripts/run-vitest.mjs src/daemon
Test Files  46 passed (46)
Tests  1500 passed | 10 skipped (1510)
```

`node scripts/check-changed.mjs` passes every lane except `plugin boundaries`, which fails on a clean checkout of `main` with zero changes:

```
compat deprecated=19 eligibleForRemoval=1 removalPending=8 removalPendingDue=0
  2026-09-08 sdk-untrusted-context-identifier-aliases owner=sdk codeRefs=6927 docRefs=62
```

That record came due 2026-09-08 and clearing it is a 6927-reference SDK compat removal needing owner judgment, so it is out of scope here and reported separately rather than bundled into this PR.

Follow-up commit `0fd6f4d991` corrects a second stale message found in review: the darwin not-listening branch of `gateway status` still printed `Errors: suppressed` (`src/cli/daemon-cli/status.print.ts`), which is precisely the path an operator reaches while investigating these startup failures. It now reports `Logs (stdout and stderr): <path>`, and the regression test asserts the word `suppressed` no longer appears. `src/commands/status-all/diagnosis.ts` needed no change — it already reads the stdout path on darwin, so it inherits the merged stream.

Re-verified after that commit: `node scripts/run-vitest.mjs src/daemon src/cli/daemon-cli` → `Test Files 74 passed (74)`, `Tests 2121 passed | 11 skipped (2132)`; `pnpm tsgo` exit 0.

Not live-verified on a fresh `openclaw gateway install`: the plist rewrite is covered at the unit boundary, and reinstalling the LaunchAgent on the operator's running gateway was not appropriate for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rTGeD4bUUEvA6vupgJt4d
