### PR TITLE
fix(media): prevent sibling sandbox attachment reads

### DIFF
--- a/docs/plugins/sdk-channel-plugins/status-and-media.md
+++ b/docs/plugins/sdk-channel-plugins/status-and-media.md
@@ -73,7 +73,13 @@ channel records with `toInboundMediaFacts(...)` from
 inbound context. When a plugin must authorize local media reads, import
 `getAgentScopedMediaLocalRoots(...)` or
 `getAgentScopedMediaLocalRootsForSources(...)` from the focused
-`openclaw/plugin-sdk/media-local-roots` subpath. The old
+`openclaw/plugin-sdk/media-local-roots` subpath. Agent-scoped roots do not grant
+the shared sandbox parent. To send a file generated in the active sandbox, pass
+its authoritative session workspace as the third argument to
+`getAgentScopedMediaLocalRoots(...)` or as `sessionWorkspaceDir` to the sources
+helper. Obtain that value from trusted host session context; never derive it
+from the requested media path. Without that context, workspace-only policy
+intentionally rejects sandbox paths. The old
 `agent-media-payload` builder/root facade is deprecated compatibility.
 
 ## Native payload shaping

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -219,7 +219,7 @@ text. Markdown wrappers, code fences, and inline prose such as
 
 Local-path behavior follows the same file-read trust model as the agent:
 
-- If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
+- If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and files generated in the active session sandbox. Files in sibling sandboxes remain inaccessible.
 - If `tools.fs.workspaceOnly` is `false`, outbound local media can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
 - Host-local sends still only allow media and supported document types (images, audio, video, PDF, Office documents including macro-enabled Excel `.xlsm`, and validated text documents such as Markdown/MD, TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match. File-type validation does not establish that an attached workbook's macros are safe to run.

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -424,11 +424,12 @@ describe("deliverMattermostReplyPayload", () => {
             path.join(stateDir, "media"),
             path.join(stateDir, "canvas"),
             path.join(stateDir, "workspace"),
-            path.join(stateDir, "sandboxes"),
             path.join(stateDir, `workspace-${agentId}`),
           ]),
         }),
       );
+      const sendOptions = sendMessage.mock.calls[0]?.[2];
+      expect(sendOptions?.mediaLocalRoots).not.toContain(path.join(stateDir, "sandboxes"));
     } finally {
       await openClawState.cleanup();
     }

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -233,6 +233,9 @@ describe("createReplyMediaPathNormalizer", () => {
         path.join("/tmp/sandboxes/session-1", "screens", "final image.png"),
         5 * 1024 * 1024,
       );
+      expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionWorkspaceDir: "/tmp/sandboxes/session-1" }),
+      );
     },
   );
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -169,11 +169,12 @@ export function createReplyMediaPathNormalizer(params: {
     return await sandboxWorkspacePromise;
   };
 
-  const resolveMediaAccessForSource = (media: string) =>
+  const resolveMediaAccessForSource = (media: string, sessionWorkspaceDir?: string) =>
     resolveAgentScopedOutboundMediaAccess({
       cfg: params.cfg,
       agentId,
       workspaceDir: params.workspaceDir,
+      ...(sessionWorkspaceDir ? { sessionWorkspaceDir } : {}),
       mediaSources: [media],
       mediaAccess: params.mediaAccess,
       workspaceMediaAccess: params.workspaceMediaAccess,
@@ -191,6 +192,7 @@ export function createReplyMediaPathNormalizer(params: {
 
   const persistLocalReplyMedia = async (
     media: string,
+    sessionWorkspaceDir?: string,
   ): Promise<{ path: string; contentType?: string }> => {
     if (!isLikelyLocalMediaSource(media)) {
       return { path: media };
@@ -207,7 +209,7 @@ export function createReplyMediaPathNormalizer(params: {
       return await cached;
     }
     const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
-      mediaAccess: resolveMediaAccessForSource(media),
+      mediaAccess: resolveMediaAccessForSource(media, sessionWorkspaceDir),
     })
       .then((saved) => ({
         ...saved,
@@ -289,7 +291,7 @@ export function createReplyMediaPathNormalizer(params: {
         }
         throw err;
       }
-      const persisted = await persistLocalReplyMedia(sandboxResolvedMedia);
+      const persisted = await persistLocalReplyMedia(sandboxResolvedMedia, sandboxWorkspace.root);
       return {
         mediaUrl: persisted.path,
         trustedLocalMedia: true,

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -16,8 +16,12 @@ function loadedConfig(config: OpenClawConfig): OpenClawConfig {
   return migratePersistedImplicitMainRoster(config).config as OpenClawConfig;
 }
 
-function getAgentScopedMediaLocalRoots(config: OpenClawConfig, agentId: string) {
-  return getAgentScopedMediaLocalRootsBase(loadedConfig(config), agentId);
+function getAgentScopedMediaLocalRoots(
+  config: OpenClawConfig,
+  agentId?: string,
+  sessionWorkspaceDir?: string,
+) {
+  return getAgentScopedMediaLocalRootsBase(loadedConfig(config), agentId, sessionWorkspaceDir);
 }
 
 function getAgentScopedMediaLocalRootsForSources(
@@ -101,11 +105,35 @@ describe("local media roots", () => {
       minLength: 4,
     },
     {
-      name: "adds the active agent workspace without re-opening broad agent state roots",
+      name: "adds the active agent workspace without re-opening broad agent or sandbox roots",
       stateDir: path.join("/tmp", "openclaw-agent-media-roots-state"),
       getRoots: () => getAgentScopedMediaLocalRoots({}, "ops"),
-      expectedContained: ["workspace-ops", "sandboxes"],
-      expectedExcluded: ["agents"],
+      expectedContained: ["workspace-ops"],
+      expectedExcluded: ["agents", "sandboxes"],
+    },
+    {
+      name: "replaces broad workspace and sandbox roots with the exact session workspace",
+      stateDir: path.join("/tmp", "openclaw-session-media-roots-state"),
+      getRoots: () =>
+        getAgentScopedMediaLocalRoots(
+          {},
+          "ops",
+          path.join("/tmp", "openclaw-session-media-roots-state", "sandboxes", "session-a"),
+        ),
+      expectedContained: ["sandboxes/session-a"],
+      expectedExcluded: ["agents", "workspace", "sandboxes"],
+    },
+    {
+      name: "does not accept the shared sandbox parent as an exact session workspace",
+      stateDir: path.join("/tmp", "openclaw-shared-sandbox-parent-state"),
+      getRoots: () =>
+        getAgentScopedMediaLocalRoots(
+          {},
+          "ops",
+          path.join("/tmp", "openclaw-shared-sandbox-parent-state", "sandboxes"),
+        ),
+      expectedContained: [],
+      expectedExcluded: ["agents", "workspace", "sandboxes"],
     },
   ] as const)("$name", ({ stateDir, getRoots, expectedContained, expectedExcluded, minLength }) => {
     expectAgentMediaRootsCase({

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -58,25 +58,38 @@ export function getDefaultMediaLocalRoots(): readonly string[] {
   return buildMediaLocalRoots(resolveStateDir(), resolveConfigDir());
 }
 
-/** Adds the active agent workspace to the default media roots without exposing all agent state. */
+/**
+ * Adds exact agent/session workspaces without exposing shared agent or sandbox roots.
+ *
+ * Callers that need to send media from a sandbox must pass the authoritative active
+ * session workspace, not a path derived from the requested media source. Omitting that
+ * context intentionally denies sandbox files under workspace-only filesystem policy.
+ */
 export function getAgentScopedMediaLocalRoots(
   cfg: OpenClawConfig,
   agentId?: string,
   sessionWorkspaceDir?: string,
 ): readonly string[] {
   const stateDir = resolveStateDir();
-  const roots = buildMediaLocalRoots(stateDir, resolveConfigDir()).filter(
-    (root) => !sessionWorkspaceDir || root !== path.join(path.resolve(stateDir), "workspace"),
-  );
+  const resolvedStateDir = path.resolve(stateDir);
+  const roots = buildMediaLocalRoots(stateDir, resolveConfigDir()).filter((root) => {
+    const resolvedRoot = path.resolve(root);
+    if (resolvedRoot === path.join(resolvedStateDir, "sandboxes")) {
+      return false;
+    }
+    return !sessionWorkspaceDir || resolvedRoot !== path.join(resolvedStateDir, "workspace");
+  });
   const normalizedAgentId = normalizeOptionalString(agentId);
-  if (!normalizedAgentId) {
-    return roots;
-  }
-  const workspaceDir = sessionWorkspaceDir ?? resolveAgentWorkspaceDir(cfg, normalizedAgentId);
+  const workspaceDir =
+    normalizeOptionalString(sessionWorkspaceDir) ??
+    (normalizedAgentId ? resolveAgentWorkspaceDir(cfg, normalizedAgentId) : undefined);
   if (!workspaceDir) {
     return roots;
   }
   const normalizedWorkspaceDir = path.resolve(workspaceDir);
+  if (normalizedWorkspaceDir === path.join(resolvedStateDir, "sandboxes")) {
+    return roots;
+  }
   if (!roots.includes(normalizedWorkspaceDir)) {
     roots.push(normalizedWorkspaceDir);
   }
@@ -106,13 +119,21 @@ export function appendLocalMediaParentRoots(
   return appended;
 }
 
-/** Resolves outbound media roots, expanding for local sources only when filesystem policy allows it. */
+/**
+ * Resolves outbound media roots, expanding for local sources only when filesystem policy allows it.
+ * Pass `sessionWorkspaceDir` from trusted session context to retain access to that exact sandbox.
+ */
 export function getAgentScopedMediaLocalRootsForSources(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   mediaSources?: readonly string[];
+  sessionWorkspaceDir?: string;
 }): readonly string[] {
-  const roots = getAgentScopedMediaLocalRoots(params.cfg, params.agentId);
+  const roots = getAgentScopedMediaLocalRoots(
+    params.cfg,
+    params.agentId,
+    params.sessionWorkspaceDir,
+  );
   if (resolveEffectiveToolFsWorkspaceOnly({ cfg: params.cfg, agentId: params.agentId })) {
     return roots;
   }

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -46,7 +46,7 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
 
     expect(Object.keys(result)).toStrictEqual(["localRoots", "readFile", "workspaceDir"]);
     expect(result.localRoots).toStrictEqual([
-      ...getDefaultMediaLocalRoots(),
+      ...getDefaultMediaLocalRoots().filter((root) => path.basename(root) !== "sandboxes"),
       "/tmp/media-workspace",
     ]);
     expect(typeof result.readFile).toBe("function");
@@ -62,7 +62,7 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
 
     expect(Object.keys(result)).toStrictEqual(["localRoots", "readFile", "workspaceDir"]);
     expect(result.localRoots).toStrictEqual([
-      ...getDefaultMediaLocalRoots(),
+      ...getDefaultMediaLocalRoots().filter((root) => path.basename(root) !== "sandboxes"),
       "/tmp/explicit-workspace",
     ]);
     expect(typeof result.readFile).toBe("function");
@@ -305,6 +305,60 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     );
     expect(loaded.buffer.toString()).toBe("generated");
     expect(workspaceReadFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects sibling sandbox media for a workspace-only agent", async () => {
+    const baseDir = tempDirs.make("workspace-only-sibling-sandbox-");
+    const stateDir = path.join(baseDir, "state");
+    const workspaceDir = path.join(baseDir, "workspace-main");
+    const siblingFile = path.join(stateDir, "sandboxes", "sibling", "secret.txt");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(path.dirname(siblingFile), { recursive: true });
+    await fs.writeFile(siblingFile, "sibling-secret");
+
+    const access = resolveAgentScopedOutboundMediaAccess({
+      cfg: {
+        agents: { list: [{ id: "main", workspace: workspaceDir }] },
+        tools: { fs: { workspaceOnly: true } },
+      } as OpenClawConfig,
+      agentId: "main",
+      workspaceDir,
+      mediaSources: [siblingFile],
+    });
+
+    await expect(
+      loadWebMediaRaw(siblingFile, buildOutboundMediaLoadOptions({ mediaAccess: access })),
+    ).rejects.toThrow(/not under an allowed directory/i);
+  });
+
+  it("allows media from the exact active session workspace", async () => {
+    const baseDir = tempDirs.make("active-sandbox-media-");
+    const stateDir = path.join(baseDir, "state");
+    const workspaceDir = path.join(baseDir, "workspace-main");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "active");
+    const activeFile = path.join(sessionWorkspaceDir, "report.txt");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(sessionWorkspaceDir, { recursive: true });
+    await fs.writeFile(activeFile, "active-report");
+
+    const access = resolveAgentScopedOutboundMediaAccess({
+      cfg: {
+        agents: { list: [{ id: "main", workspace: workspaceDir }] },
+        tools: { fs: { workspaceOnly: true } },
+      } as OpenClawConfig,
+      agentId: "main",
+      workspaceDir,
+      sessionWorkspaceDir,
+      mediaSources: [activeFile],
+    });
+
+    const loaded = await loadWebMediaRaw(
+      activeFile,
+      buildOutboundMediaLoadOptions({ mediaAccess: access }),
+    );
+    expect(loaded.buffer.toString()).toBe("active-report");
   });
 
   it("honors plugin-owned group tool policy with channel metadata", () => {

--- a/src/media/read-capability.ts
+++ b/src/media/read-capability.ts
@@ -157,6 +157,7 @@ export function resolveAgentScopedOutboundMediaAccess(
     agentId?: string;
     mediaSources?: readonly string[];
     workspaceDir?: string;
+    sessionWorkspaceDir?: string;
     mediaAccess?: OutboundMediaAccess;
     /** Workspace-bounded transport reader; sender policy remains owned by this resolver. */
     workspaceMediaAccess?: OutboundMediaAccess;
@@ -176,6 +177,7 @@ export function resolveAgentScopedOutboundMediaAccess(
       cfg: params.cfg,
       agentId: params.agentId,
       mediaSources: params.mediaSources,
+      sessionWorkspaceDir: params.sessionWorkspaceDir,
     });
   const workspaceLocalRoots = params.workspaceMediaAccess?.localRoots ?? [];
   const baseLocalRoots = mediaReadAllowed

--- a/src/plugin-sdk/media-local-roots.test.ts
+++ b/src/plugin-sdk/media-local-roots.test.ts
@@ -1,0 +1,88 @@
+// Plugin SDK media-root contract tests exercise the public helpers with the public loader.
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  getAgentScopedMediaLocalRoots,
+  getAgentScopedMediaLocalRootsForSources,
+} from "openclaw/plugin-sdk/media-local-roots";
+import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "./config-contracts.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type SandboxFixture = Awaited<ReturnType<typeof createSandboxFixture>>;
+
+async function createSandboxFixture() {
+  const baseDir = tempDirs.make("plugin-sdk-media-roots-");
+  const stateDir = path.join(baseDir, "state");
+  const agentWorkspaceDir = path.join(baseDir, "workspace-main");
+  const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "active");
+  const siblingWorkspaceDir = path.join(stateDir, "sandboxes", "sibling");
+  const activeFile = path.join(sessionWorkspaceDir, "report.txt");
+  const siblingFile = path.join(siblingWorkspaceDir, "secret.txt");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  await fs.mkdir(agentWorkspaceDir, { recursive: true });
+  await fs.mkdir(sessionWorkspaceDir, { recursive: true });
+  await fs.mkdir(siblingWorkspaceDir, { recursive: true });
+  await fs.writeFile(activeFile, "active-report");
+  await fs.writeFile(siblingFile, "sibling-secret");
+  const cfg: OpenClawConfig = {
+    agents: { list: [{ id: "main", workspace: agentWorkspaceDir }] },
+    tools: { fs: { workspaceOnly: true } },
+  };
+  return { cfg, sessionWorkspaceDir, activeFile, siblingFile };
+}
+
+async function expectActiveAllowedAndSiblingDenied(
+  fixture: SandboxFixture,
+  localRoots: readonly string[],
+) {
+  const active = await loadWebMediaRaw(fixture.activeFile, { localRoots });
+  expect(active.buffer.toString()).toBe("active-report");
+  await expect(loadWebMediaRaw(fixture.siblingFile, { localRoots })).rejects.toThrow(
+    /not under an allowed directory/i,
+  );
+}
+
+describe("plugin SDK media local roots", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("supports a fresh plugin caller using trusted active-session context", async () => {
+    const fixture = await createSandboxFixture();
+    const localRoots = getAgentScopedMediaLocalRootsForSources({
+      cfg: fixture.cfg,
+      agentId: "main",
+      mediaSources: [fixture.activeFile, fixture.siblingFile],
+      sessionWorkspaceDir: fixture.sessionWorkspaceDir,
+    });
+
+    await expectActiveAllowedAndSiblingDenied(fixture, localRoots);
+  });
+
+  it("supports an upgraded positional-helper caller using trusted active-session context", async () => {
+    const fixture = await createSandboxFixture();
+    const localRoots = getAgentScopedMediaLocalRoots(
+      fixture.cfg,
+      "main",
+      fixture.sessionWorkspaceDir,
+    );
+
+    await expectActiveAllowedAndSiblingDenied(fixture, localRoots);
+  });
+
+  it("fails closed for a legacy caller that omits active-session context", async () => {
+    const fixture = await createSandboxFixture();
+    const localRoots = getAgentScopedMediaLocalRoots(fixture.cfg, "main");
+
+    await expect(loadWebMediaRaw(fixture.activeFile, { localRoots })).rejects.toThrow(
+      /not under an allowed directory/i,
+    );
+    await expect(loadWebMediaRaw(fixture.siblingFile, { localRoots })).rejects.toThrow(
+      /not under an allowed directory/i,
+    );
+  });
+});


### PR DESCRIPTION
Closes #107972

## What Problem This Solves

Agents attach reply files through a media authorization list: a set of directories the host is allowed to read when sending an attachment. That list is a separate boundary from the filesystem tools, so `tools.fs.workspaceOnly` does not protect it.

This PR fixes a cross-sandbox read in that boundary. Agent-scoped media authorization included the shared `<stateDir>/sandboxes` parent — the parent of *every* session's sandbox workspace, not just the caller's. An agent confined to its own workspace could therefore name an absolute path into a sibling sandbox (another session's files), and the reply pipeline would read it and send it as an attachment. Reproduced end to end with `workspaceOnly=true`: the filesystem tools correctly rejected the path, but the same file sent as reply media was staged and read successfully.

The severity comes from the trust granularity. Every other sandbox code path resolves the *specific session's* workspace and constrains paths inside it (`assertSandboxPath`, `resolveSandboxContext`, inbound media staging). Outbound media authorization was the only place granting trust by parent directory — covering all sessions at once. That asymmetry is the bug.

## Why This Change Was Made

Agent-scoped media authorization now excludes the shared sandbox parent and admits only the exact active session workspace when sandbox output is being staged. Process-level recovery roots remain unchanged, and the reply pipeline carries its authoritative sandbox workspace through the shared media-access owner.

The plugin SDK guide documents the upgrade contract: sandbox media requires an authoritative active-session workspace from trusted host context, never a root derived from the requested media path. User-facing docs now distinguish active-session output from inaccessible sibling sandboxes.

Credit to @yangxiansheng for earlier work exploring the scoped-root approach.

## User Impact

Agents can continue attaching files from their own workspace and active sandbox, while files belonging to sibling sandboxes are rejected. Plugin callers using the agent-scoped media helpers must pass trusted active-session context when they need sandbox output; omission intentionally fails closed under workspace-only policy.

## Compatibility Checks

These checks were made to establish the change does not break bundled functionality:

- **Bundled extension audit:** grepped every bundled extension in `extensions/` for imports of the affected media-root helpers. Eight extensions use them (`discord`, `telegram`, `whatsapp`, `matrix`, `mattermost`, `line`, `codex`, `qa-channel`). Under this change, **none needed a production change** — their media flows either route through the core reply pipeline, which supplies the session context itself, or never touch sandbox files. The only edit was one Mattermost *test* that still asserted the removed broad root as an expectation.
- **Full extension lane:** the Mattermost extension suite passes 55 files / 858 tests, including an explicit new assertion that agent-scoped roots exclude the shared sandbox parent.
- **Signature compatibility:** the new parameter is additive and optional. Existing callers still typecheck; the only behavioral change is removal of the unsafe implicit shared-sandbox grant.
- **No config/schema/storage surface:** no configuration keys, defaults, schemas, serialized state, or migrations changed. `reply-media-paths.ts` only threads ephemeral runtime parameters during a single reply.
- **Old-code control:** the new public Plugin SDK contract suite fails 3/3 against the pre-fix merge base (old code admits sibling reads) and passes 3/3 on this head — proving the tests detect the actual authorization regression rather than mirroring the implementation.

The one intentional compatibility change: third-party plugin callers that omit trusted active-session context lose sandbox attachment access until updated. Failing closed is deliberate — preserving the legacy contract would preserve cross-sandbox read authority. The documented and tested migration is to pass the active session workspace from trusted host context.

## Evidence

- Added a regression that failed before the fix by reading a sibling marker and now rejects that path.
- Added coverage proving the exact active session workspace remains readable and the reply normalizer carries it into media authorization.
- Focused media, root, reply-normalization, Mattermost delivery, and public Plugin SDK contract suites: 93 tests passed.
- Public Plugin SDK contract coverage proves fresh and upgraded callers retain active-session attachments, sibling reads are rejected, and callers omitting trusted session context fail closed.
- Documentation checks passed: MDX validation and 12,863 internal links with zero broken links.
- Changed-file gate passed, including formatting, core and extension typechecking, lint, dependency and plugin-boundary guards, dead-export scan, import-cycle checks, and media/runtime guards.
- Fresh P0/P1 autoreview on the current change: scoped-clean at 0.95 confidence.
