### PR TITLE
fix(chat): keep earlier answers visible after tool continuations

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3845,7 +3845,7 @@ ui/src/pages/chat/chat-session-companion.ts	3
 ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1
-ui/src/pages/chat/chat-thread-grouping.ts	2
+ui/src/pages/chat/chat-thread-grouping.ts	1
 ui/src/pages/chat/chat-thread-items.ts	2
 ui/src/pages/chat/components/chat-audio-player.ts	1
 ui/src/pages/chat/components/chat-composer-plus-menu.ts	1

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -267,8 +267,10 @@ Absolute external `http(s)` embed URLs stay blocked by default. To let `[embed u
 In completed dashboard turns, commentary, reasoning-only messages, and tool activity
 share one **Worked for…** disclosure above the answers. Expanding it shows the
 activity in its original order; explicit answer segments and visual results stay
-visible below it. This is display grouping, not a change to stored history. Live
-turns, search results, and turns without an answer stay expanded. User messages,
+visible below it. Failed tool results after the last answer stay visible outside
+the disclosure until a later answer follows them. This is display grouping, not a
+change to stored history. Live turns, search results, and turns without an answer
+stay expanded. User messages,
 forwarded inputs, and structural markers remain boundaries for grouping.
 
 The chat transcript uses a centered readable frame aligned with the composer. Assistant and tool output stay left-aligned while your own messages stay right-aligned inside that frame. In multi-user sessions (for example a group chat relayed from a channel plugin), messages from other attributed participants render left-aligned with the author's avatar, name, and a stable per-identity color, so only the signed-in viewer's messages read as "mine". When two or more attributed participants are present, assistant replies carry a small "Replying to name" marker naming the participant whose message triggered the turn. System entries such as local slash-command output render as centered notice rows without an avatar.

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -264,6 +264,13 @@ Absolute external `http(s)` embed URLs stay blocked by default. To let `[embed u
 
 ## Chat transcript layout
 
+In completed dashboard turns, commentary, reasoning-only messages, and tool activity
+share one **Worked for…** disclosure above the answers. Expanding it shows the
+activity in its original order; explicit answer segments and visual results stay
+visible below it. This is display grouping, not a change to stored history. Live
+turns, search results, and turns without an answer stay expanded. User messages,
+forwarded inputs, and structural markers remain boundaries for grouping.
+
 The chat transcript uses a centered readable frame aligned with the composer. Assistant and tool output stay left-aligned while your own messages stay right-aligned inside that frame. In multi-user sessions (for example a group chat relayed from a channel plugin), messages from other attributed participants render left-aligned with the author's avatar, name, and a stable per-identity color, so only the signed-in viewer's messages read as "mine". When two or more attributed participants are present, assistant replies carry a small "Replying to name" marker naming the participant whose message triggered the turn. System entries such as local slash-command output render as centered notice rows without an avatar.
 
 Images and video previews in your own messages appear above any accompanying text, without a surrounding bubble background. Videos use a still frame with a play icon; select the preview to open the video in the Files panel. If a preview cannot load, the attachment card remains available. Hovering media leaves that layout unchanged, and the text keeps its normal bubble color, including any per-identity tint. Assistant videos retain their inline player.

--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChatItem } from "../../lib/chat/chat-types.ts";
+import { coalesceAgentRunFrames } from "./chat-agent-run-grouping.ts";
 import {
   assistantGroupCanOwnActiveRunStatus,
   collapseCompletedTurnWork,
+  coalesceActivityRuns,
   groupMessages,
 } from "./chat-thread-grouping.ts";
 import { buildCachedChatItems, resetChatThreadState } from "./chat-thread.ts";
@@ -232,5 +234,113 @@ describe("cached group content classification", () => {
       },
       { kind: "group", role: "assistant" },
     ]);
+  });
+});
+
+describe("explicit answer visibility across continuations", () => {
+  beforeEach(() => resetChatThreadState());
+
+  it.each([
+    { phase: "final_answer", tool: true },
+    { phase: "final_answer", tool: false },
+    { phase: "commentary", tool: true },
+    { phase: "commentary", tool: false },
+  ] as const)(
+    "preserves an answer before $phase with intervening tool=$tool",
+    ({ phase, tool }) => {
+      const signed = (text: string, messagePhase: string) => ({
+        type: "text",
+        text,
+        textSignature: JSON.stringify({ v: 1, id: text, phase: messagePhase }),
+      });
+      const messages = [
+        { role: "user", content: "Investigate", timestamp: 1, __openclaw: { runId: "run" } },
+        {
+          role: "assistant",
+          content: [signed("Substantive answer", "final_answer")],
+          timestamp: 2,
+          __openclaw: { runId: "run" },
+        },
+        ...(tool
+          ? [
+              {
+                role: "toolResult",
+                toolCallId: "call",
+                toolName: "read",
+                content: "Evidence",
+                timestamp: 3,
+                __openclaw: { runId: "run" },
+              },
+            ]
+          : []),
+        {
+          role: "assistant",
+          content: [signed("Later update", phase)],
+          timestamp: 4,
+          __openclaw: { runId: "run" },
+        },
+      ];
+      // Exercise the renderer's complete grouping pipeline, including a history reload.
+      for (const history of [messages, structuredClone(messages)]) {
+        const items = coalesceAgentRunFrames(
+          coalesceActivityRuns(
+            collapseCompletedTurnWork(cachedGroups(history), {
+              sessionKey: "agent:main:dashboard:answers",
+              runWorking: false,
+            }),
+          ),
+        );
+        const parts = items.flatMap((item) =>
+          item.kind === "agent-run-frame" ? item.parts : [item],
+        );
+        const visible = parts.flatMap((item) =>
+          item.kind === "group" ? item.messages.map(({ message }) => message) : [],
+        );
+        expect(visible).toContainEqual(messages[1]);
+        expect(visible).toContainEqual(messages.at(-1));
+        if (tool && phase === "final_answer") {
+          expect(parts.find((item) => item.kind === "work-group")).toMatchObject({
+            groups: [{ role: "tool" }],
+          });
+        }
+        if (phase === "commentary") {
+          expect(
+            parts.filter((item) => item.kind === "group" && item.role === "assistant"),
+          ).toHaveLength(2);
+        }
+      }
+    },
+  );
+
+  it("preserves mixed-phase answer text when later tools and an answer arrive", () => {
+    const answer = {
+      role: "assistant",
+      content: ["commentary", "final_answer"].map((phase) => ({
+        type: "text",
+        text: phase === "commentary" ? "Checking" : "Substantive answer",
+        textSignature: JSON.stringify({ v: 1, id: phase, phase }),
+      })),
+      timestamp: 2,
+    };
+    const items = collapseCompletedTurnWork(
+      cachedGroups([
+        { role: "user", content: "Investigate", timestamp: 1 },
+        answer,
+        {
+          role: "toolResult",
+          toolCallId: "call",
+          toolName: "read",
+          content: "Evidence",
+          timestamp: 3,
+        },
+        { role: "assistant", phase: "final_answer", content: "Later update", timestamp: 4 },
+      ]),
+      { sessionKey: "agent:main:dashboard:answers", runWorking: false },
+    );
+    expect(
+      items
+        .filter((item) => item.kind === "group")
+        .flatMap((item) => item.messages.map(({ message }) => message)),
+    ).toContainEqual(answer);
   });
 });

--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -219,8 +219,8 @@ describe("cached group content classification", () => {
 
     expect(project()).toMatchObject([
       { kind: "group", role: "user" },
-      { kind: "group", role: "assistant", messages: [{ message: preview }] },
       { kind: "work-group", groups: [{ role: "tool" }] },
+      { kind: "group", role: "assistant", messages: [{ message: preview }] },
       { kind: "group", role: "assistant" },
     ]);
 
@@ -297,20 +297,82 @@ describe("explicit answer visibility across continuations", () => {
           item.kind === "group" ? item.messages.map(({ message }) => message) : [],
         );
         expect(visible).toContainEqual(messages[1]);
-        expect(visible).toContainEqual(messages.at(-1));
-        if (tool && phase === "final_answer") {
-          expect(parts.find((item) => item.kind === "work-group")).toMatchObject({
-            groups: [{ role: "tool" }],
-          });
+        if (phase === "final_answer") {
+          expect(visible).toContainEqual(messages.at(-1));
+        } else {
+          expect(visible).not.toContainEqual(messages.at(-1));
         }
-        if (phase === "commentary") {
-          expect(
-            parts.filter((item) => item.kind === "group" && item.role === "assistant"),
-          ).toHaveLength(2);
+        const work = parts.filter((item) => item.kind === "work-group");
+        const expectedWork = [
+          ...(tool ? [messages[2]] : []),
+          ...(phase === "commentary" ? [messages.at(-1)] : []),
+        ];
+        expect(
+          work.flatMap((item) =>
+            item.groups.flatMap((group) => group.messages.map(({ message }) => message)),
+          ),
+        ).toEqual(expectedWork);
+        expect(work).toHaveLength(expectedWork.length ? 1 : 0);
+        if (expectedWork.length) {
+          expect(parts[1]?.kind).toBe("work-group");
         }
       }
     },
   );
+
+  it("collects activity on both sides of answers without crossing the next user", () => {
+    const messages = [
+      { role: "user", content: "First question", timestamp: 1 },
+      { role: "assistant", phase: "commentary", content: "Checking first", timestamp: 2 },
+      { role: "assistant", phase: "final_answer", content: "First answer", timestamp: 3 },
+      {
+        role: "toolResult",
+        toolCallId: "first",
+        toolName: "read",
+        content: "Evidence",
+        timestamp: 4,
+      },
+      { role: "assistant", phase: "final_answer", content: "Addendum", timestamp: 5 },
+      { role: "assistant", phase: "commentary", content: "Final check", timestamp: 6 },
+      {
+        role: "toolResult",
+        toolCallId: "last",
+        toolName: "read",
+        content: "Confirmed",
+        timestamp: 7,
+      },
+      { role: "user", content: "Second question", timestamp: 8 },
+      { role: "assistant", phase: "commentary", content: "Checking second", timestamp: 9 },
+      { role: "assistant", phase: "final_answer", content: "Second answer", timestamp: 10 },
+    ];
+    const snapshot = structuredClone(messages);
+    const items = collapseCompletedTurnWork(cachedGroups(messages), {
+      sessionKey: "agent:main:dashboard:answers",
+      runWorking: false,
+    });
+    expect(items.map((item) => item.kind)).toEqual([
+      "group",
+      "work-group",
+      "group",
+      "group",
+      "group",
+      "work-group",
+      "group",
+    ]);
+    const work = items.filter((item) => item.kind === "work-group");
+    expect(
+      work.map((item) =>
+        item.groups.flatMap((group) => group.messages.map(({ message }) => message)),
+      ),
+    ).toEqual([[messages[1], messages[3], messages[5], messages[6]], [messages[8]]]);
+    expect(work[0]?.durationMs).toBe(6);
+    expect(
+      items
+        .filter((item) => item.kind === "group")
+        .flatMap((item) => item.messages.map(({ message }) => message)),
+    ).toEqual([messages[0], messages[2], messages[4], messages[7], messages[9]]);
+    expect(messages).toEqual(snapshot);
+  });
 
   it("preserves mixed-phase answer text when later tools and an answer arrive", () => {
     const answer = {

--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -320,6 +320,92 @@ describe("explicit answer visibility across continuations", () => {
     },
   );
 
+  it.each(["same-run", "independent-run", "unscoped"])(
+    "keeps %s trailing activity with its presentation owner",
+    (ownership) => {
+      const messages = [
+        { role: "user", content: "Watch the queue", timestamp: 1 },
+        {
+          role: "assistant",
+          phase: "commentary",
+          content: "Checking",
+          timestamp: 2,
+          runId: "reply",
+        },
+        {
+          role: "assistant",
+          phase: "final_answer",
+          content: "Watching",
+          timestamp: 3,
+          runId: "reply",
+        },
+        ...[1, 2].flatMap((index) => {
+          const runId =
+            ownership === "unscoped"
+              ? undefined
+              : ownership === "same-run"
+                ? "reply"
+                : `wake-${index}`;
+          return [
+            {
+              role: "assistant",
+              content: [{ type: "toolCall", id: `call-${index}`, name: "read", arguments: {} }],
+              timestamp: 4 * index,
+              runId,
+            },
+            {
+              role: "toolResult",
+              toolCallId: `call-${index}`,
+              toolName: "read",
+              content: "ok",
+              timestamp: 4 * index + 1,
+              runId,
+            },
+          ];
+        }),
+      ];
+      for (const history of [messages, structuredClone(messages)]) {
+        const items = coalesceActivityRuns(
+          collapseCompletedTurnWork(
+            groupMessages(
+              history.map((message, index) => ({
+                kind: "message",
+                key: `message:${index}`,
+                message,
+              })),
+            ),
+            {
+              sessionKey: "agent:main:dashboard:answers",
+              runWorking: false,
+            },
+          ),
+        );
+        expect(items.map((item) => item.kind)).toEqual(
+          ownership === "independent-run"
+            ? ["group", "work-group", "group", "activity-run"]
+            : ["group", "work-group", "group"],
+        );
+        const work = items.filter((item) => item.kind === "work-group");
+        expect(
+          work.flatMap((item) =>
+            item.groups.flatMap((group) => group.messages.map(({ message }) => message)),
+          ),
+        ).toEqual(
+          ownership === "independent-run" ? [messages[1]] : [messages[1], ...messages.slice(3)],
+        );
+        if (ownership === "independent-run") {
+          expect(work[0]?.durationMs).toBe(2);
+        }
+        const activity = items.filter((item) => item.kind === "activity-run");
+        expect(
+          activity.flatMap((item) =>
+            item.groups.flatMap((group) => group.messages.map(({ message }) => message)),
+          ),
+        ).toEqual(ownership === "independent-run" ? messages.slice(3) : []);
+      }
+    },
+  );
+
   it("collects activity on both sides of answers without crossing the next user", () => {
     const messages = [
       { role: "user", content: "First question", timestamp: 1 },

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -1,5 +1,9 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  extractAssistantTextForPhase,
+  resolveAssistantMessagePhase,
+} from "../../../../src/shared/chat-message-content.js";
 import type { ChatItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { resolveMessageVisibleContent } from "../../lib/chat/message-visibility.ts";
@@ -21,7 +25,13 @@ function assistantMessageKind(message: unknown, visibleContent: MessageGroup["vi
   if (isKeyedAssistantStreamFallbackMessage(message)) {
     return "commentary";
   }
-  return visibleContent === "none" ? "activity" : "reply";
+  // A response can contain both phases; any explicit answer remains visible.
+  if (extractAssistantTextForPhase(message, { phase: "final_answer" })) {
+    return "final_answer";
+  }
+  return (
+    resolveAssistantMessagePhase(message) ?? (visibleContent === "none" ? "activity" : "reply")
+  );
 }
 
 function stampReplyAttribution(
@@ -210,7 +220,12 @@ function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
     return false;
   }
   const role = item.role.toLowerCase();
-  return role === "tool" || (role === "assistant" && !assistantGroupIsForwardedBoundary(item));
+  return (
+    role === "tool" ||
+    (role === "assistant" &&
+      !assistantGroupIsForwardedBoundary(item) &&
+      assistantMessageKind(item.messages[0]?.message, item.visibleContent) !== "final_answer")
+  );
 }
 
 function groupHasVisibleReplyContent(group: MessageGroup, includeText = true): boolean {
@@ -225,12 +240,15 @@ export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolea
   );
 }
 
-// History carries no final-vs-commentary marker (commentary exists only as
-// live stream segments), so the last assistant group with visible content
-// stands in for the final reply. Turns whose last content is commentary
-// merely collapse less; the visible reply is never folded away.
+// Unphased providers keep the last-visible-reply policy. Explicit commentary
+// cannot move the completed-work boundary past an already delivered answer.
 function isFinalReplyGroup(item: TurnRenderItem): boolean {
-  return item.kind === "group" && !item.isStreaming && assistantGroupCanOwnActiveRunStatus(item);
+  return (
+    item.kind === "group" &&
+    !item.isStreaming &&
+    assistantGroupCanOwnActiveRunStatus(item) &&
+    assistantMessageKind(item.messages[0]?.message, item.visibleContent) !== "commentary"
+  );
 }
 
 function turnUserMessages(turn: TurnRenderItem[]): unknown[] {

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -215,6 +215,15 @@ export type ActivityRunRenderItem = {
 
 type TurnRenderItem = RenderChatItem | StreamRunRenderItem;
 
+// User input, forwarded messages and structural markers bound presentation reordering.
+function isTurnOutputGroup(item: TurnRenderItem): item is MessageGroup {
+  return (
+    item.kind === "group" &&
+    (item.role === "assistant" || item.role === "tool") &&
+    !assistantGroupIsForwardedBoundary(item)
+  );
+}
+
 function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
   if (item.kind !== "group" || item.isStreaming || groupHasVisibleReplyContent(item, false)) {
     return false;
@@ -265,10 +274,9 @@ function turnUserMessages(turn: TurnRenderItem[]): unknown[] {
 }
 
 /**
- * Once a turn is done, its intermediate work (tool groups and assistant
- * commentary before the final reply) collapses behind one "Worked for X"
- * disclosure so the thread reads final-output-first. Live turns stay fully
- * expanded; the collapse itself is the done signal.
+ * Once a turn is done, collect its activity above the preserved answers in one
+ * "Worked for X" disclosure. Each partition retains source order without changing
+ * the stored transcript. Live turns stay expanded; structural markers stay anchored.
  */
 export function collapseCompletedTurnWork(
   items: TurnRenderItem[],
@@ -362,16 +370,26 @@ export function collapseCompletedTurnWork(
       result.push(...turn);
       continue;
     }
-    const segmentEnd = finalReplyIndex >= 0 ? finalReplyIndex - 1 : turn.length - 1;
-    let segmentStart = segmentEnd + 1;
-    for (let index = segmentEnd; index >= 0; index -= 1) {
-      const candidate = turn[index];
-      if (!candidate || !isCollapsibleWorkGroup(candidate)) {
-        break;
-      }
-      segmentStart = index;
+    // Partition the answer's output segment, including work after the last answer.
+    // Never move activity across a user, forwarded input, or structural marker.
+    let segmentStart = finalReplyIndex >= 0 ? finalReplyIndex : turn.length - 1;
+    let segmentEnd = segmentStart;
+    while (segmentStart > 0 && isTurnOutputGroup(turn[segmentStart - 1]!)) {
+      segmentStart -= 1;
     }
-    const groups = turn.slice(segmentStart, segmentEnd + 1) as MessageGroup[];
+    while (segmentEnd + 1 < turn.length && isTurnOutputGroup(turn[segmentEnd + 1]!)) {
+      segmentEnd += 1;
+    }
+    const groups: MessageGroup[] = [];
+    const answers: TurnRenderItem[] = [];
+    for (let index = segmentStart; index <= segmentEnd; index += 1) {
+      const item = turn[index]!;
+      if (index !== finalReplyIndex && isCollapsibleWorkGroup(item)) {
+        groups.push(item);
+      } else {
+        answers.push(item);
+      }
+    }
     const firstGroup = groups[0];
     if (!firstGroup) {
       result.push(...turn);
@@ -386,7 +404,10 @@ export function collapseCompletedTurnWork(
         ? boundary.timestamp
         : null;
     const startTimestamp = boundaryTimestamp == null ? firstGroup.timestamp : boundaryTimestamp;
-    const endTimestamp = terminalReply.timestamp;
+    const endTimestamp = groups.reduce(
+      (latest, group) => Math.max(latest, group.timestamp),
+      terminalReply.timestamp,
+    );
     const durationMs = endTimestamp > startTimestamp ? endTimestamp - startTimestamp : null;
     const continuationBoundary = turns[continuationTurnIndexes.get(turnIndex) ?? -1]?.[0];
     result.push(...turn.slice(0, segmentStart));
@@ -399,7 +420,7 @@ export function collapseCompletedTurnWork(
       groups,
       durationMs,
     });
-    result.push(...turn.slice(segmentEnd + 1));
+    result.push(...answers, ...turn.slice(segmentEnd + 1));
   }
   return result;
 }

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -8,6 +8,7 @@ import type { ChatItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { resolveMessageVisibleContent } from "../../lib/chat/message-visibility.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
+import { extractToolCardsCached, isToolCardError } from "../../lib/chat/tool-cards.ts";
 import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
 import { userTurnRunId } from "./chat-thread-items.ts";
 import {
@@ -384,7 +385,17 @@ export function collapseCompletedTurnWork(
     const answers: TurnRenderItem[] = [];
     for (let index = segmentStart; index <= segmentEnd; index += 1) {
       const item = turn[index]!;
-      if (index !== finalReplyIndex && isCollapsibleWorkGroup(item)) {
+      // Only a later answer can put a failed result inside completed work.
+      // Share the renderer's error classification, including structured results.
+      if (
+        index !== finalReplyIndex &&
+        isCollapsibleWorkGroup(item) &&
+        (finalReplyIndex < 0 ||
+          index < finalReplyIndex ||
+          !item.messages.some(({ message }) =>
+            extractToolCardsCached(message).some(isToolCardError),
+          ))
+      ) {
         groups.push(item);
       } else {
         answers.push(item);

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -378,7 +378,14 @@ export function collapseCompletedTurnWork(
     while (segmentStart > 0 && isTurnOutputGroup(turn[segmentStart - 1]!)) {
       segmentStart -= 1;
     }
-    while (segmentEnd + 1 < turn.length && isTurnOutputGroup(turn[segmentEnd + 1]!)) {
+    // Independent reply-less runs retain their own activity rollup, rather than
+    // becoming work for an earlier answer merely because no user spoke between them.
+    const replyRunIds = runIdsWithVisibleReplies(turn);
+    while (segmentEnd + 1 < turn.length) {
+      const next = turn[segmentEnd + 1]!;
+      if (!isTurnOutputGroup(next) || (next.runId && !replyRunIds.has(next.runId))) {
+        break;
+      }
       segmentEnd += 1;
     }
     const groups: MessageGroup[] = [];

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1150,19 +1150,85 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireWorkGroup(items[1]).groups).toHaveLength(1);
   });
 
-  it("includes work after the final reply in the same disclosure", () => {
+  it.each([
+    { name: "success", isError: false, result: { isError: false } },
+    { name: "message error", isError: true, result: { isError: true } },
+    { name: "snake-case error", isError: true, result: { is_error: true } },
+    {
+      name: "structured error",
+      isError: true,
+      result: { content: [{ type: "tool_result", isError: true, text: "boom" }] },
+    },
+    {
+      name: "inferred error",
+      isError: true,
+      result: { content: '{"status":"error","error":"boom"}' },
+    },
+    {
+      name: "explicit success overrides error-shaped output",
+      isError: false,
+      result: { isError: false, content: '{"error":"example"}' },
+    },
+  ])("keeps trailing work in the disclosure unless it failed ($name)", ({ isError, result }) => {
+    const trailing = { ...toolResult("call-2", 4_000), isError: undefined, ...result };
     const items = collapsedItems({
       messages: [
         userMessage("go", 1_000),
         toolResult("call-1", 2_000),
         assistantMessage("Done.", 3_000),
-        toolResult("call-2", 4_000),
+        trailing,
       ],
     });
 
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
-    expect(requireWorkGroup(items[1]).groups).toHaveLength(2);
-    expect(requireWorkGroup(items[1]).durationMs).toBe(3_000);
+    expect(items.map((item) => item.kind)).toEqual(
+      isError ? ["group", "work-group", "group", "group"] : ["group", "work-group", "group"],
+    );
+    const work = requireWorkGroup(items[1]);
+    expect(work.groups).toHaveLength(isError ? 1 : 2);
+    if (isError) {
+      expect(requireGroup(items[3]).messages.map(({ message }) => message)).toContain(trailing);
+    } else {
+      expect(work.durationMs).toBe(3_000);
+    }
+  });
+
+  it("collapses a trailing failure only after a subsequent answer", () => {
+    const failed = toolResult("failed", 4_000, true);
+    const messages = [
+      userMessage("go", 1_000),
+      assistantMessage("First result.", 2_000),
+      failed,
+      {
+        ...assistantMessage("Checking the failure.", 5_000),
+        content: [
+          {
+            type: "text",
+            text: "Checking the failure.",
+            textSignature: JSON.stringify({ v: 1, id: "checking", phase: "commentary" }),
+          },
+        ],
+      },
+      toolResult("supplementary", 6_000),
+    ];
+    const idle = collapsedItems({ messages });
+    expect(
+      idle
+        .filter((item) => item.kind === "group")
+        .flatMap((group) => group.messages.map(({ message }) => message)),
+    ).toContain(failed);
+    const recovered = collapsedItems({
+      messages: [...messages, assistantMessage("Recovered via another route.", 7_000)],
+    });
+    expect(
+      recovered
+        .filter((item) => item.kind === "group")
+        .flatMap((group) => group.messages.map(({ message }) => message)),
+    ).not.toContain(failed);
+    expect(
+      requireWorkGroup(recovered[1]).groups.flatMap((group) =>
+        group.messages.map(({ message }) => message),
+      ),
+    ).toContain(failed);
   });
 
   it("does not collapse across dividers", () => {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1031,9 +1031,9 @@ describe("collapseCompletedTurnWork", () => {
         ],
       });
 
-      expect(items.map((item) => item.kind)).toEqual(["group", "group", "work-group", "group"]);
-      expect(canvasBlocksIn(requireGroup(items[1]))).toHaveLength(1);
-      expect(requireWorkGroup(items[2]).groups.map((group) => group.role)).toEqual(workRoles);
+      expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group", "group"]);
+      expect(canvasBlocksIn(requireGroup(items[2]))).toHaveLength(1);
+      expect(requireWorkGroup(items[1]).groups.map((group) => group.role)).toEqual(workRoles);
       expect(messageRecord(requireGroup(items[3])).content).toBe("All done.");
     },
   );
@@ -1150,7 +1150,7 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireWorkGroup(items[1]).groups).toHaveLength(1);
   });
 
-  it("keeps work after the final reply visible", () => {
+  it("includes work after the final reply in the same disclosure", () => {
     const items = collapsedItems({
       messages: [
         userMessage("go", 1_000),
@@ -1160,8 +1160,9 @@ describe("collapseCompletedTurnWork", () => {
       ],
     });
 
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group", "group"]);
-    expect(requireGroup(items[3]).role).toBe("tool");
+    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
+    expect(requireWorkGroup(items[1]).groups).toHaveLength(2);
+    expect(requireWorkGroup(items[1]).durationMs).toBe(3_000);
   });
 
   it("does not collapse across dividers", () => {

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -292,7 +292,7 @@ describe("conversation position rail", () => {
     transcript.hostDisconnected();
   });
 
-  it("does not target a final-answer action owner folded behind dashboard work", () => {
+  it("targets the visible final answer before later dashboard commentary and tools", () => {
     const messages = [
       message("question", "user", "Inspect the design", 1),
       { ...message("final", "assistant", "Design ready", 2, "run-1"), phase: "final_answer" },
@@ -323,7 +323,7 @@ describe("conversation position rail", () => {
       landmarks = projectChatTranscript(props, session).positionMessages;
       return html``;
     });
-    expect(landmarks).toEqual([messages[0], messages[3]]);
+    expect(landmarks).toEqual([messages[0], messages[1]]);
     transcript.hostDisconnected();
   });
 });


### PR DESCRIPTION
Related: #105012

## What Problem This Solves

Fixes an issue where users reading a completed Control UI conversation would find the substantive answer hidden under “Worked for…” when later tools or a short update followed it. It also removes the confusing layout where supplementary work splits the visible answer from its addendum.

## Why This Change Was Made

Completed dashboard turns collect commentary, reasoning-only messages, and tool activity into one expandable **Worked for…** section above the answers. Explicit answer segments and visual results stay visible, in their original order. Successful work arriving after an answer joins the same disclosure rather than interrupting the answer area. Failed tool results after the last answer stay visible outside it until a later answer follows them.

This is a presentation-only partition in the existing grouping owner. Stored transcript order and native async continuation remain unchanged. User messages, forwarded inputs, and structural markers bound the reordering; live turns, search, non-dashboard conversations, and turns without answers stay expanded. Unphased providers retain the last-visible-reply fallback. Media-bearing messages remain intact.

## User Impact

Read the result below one compact work disclosure. Expand it to inspect the activity in its original order. Earlier explicit answers are never hidden just because another answer or tool result follows them. No configuration option, protocol, persistence, dependency, or model change.

## Evidence

- Desired-layout regressions against the previous PR head: **8 failed / 275 passed**. They cover activity on either side of answers, trailing commentary/tools, visual results, and user-turn boundaries.
- Focused grouping, transcript, run-frame, position-rail, and tool-outcome tests: **334 passed across 5 files**.
- Isolated Chromium with repository mock-Gateway fixtures and identical synthetic history: verified one disclosure above the substantive answer and addendum, expanded activity, and the same layout after reload. The before screenshot is from unmodified main at `ffbe841610c`; the after screenshots are from PR head `551f73d0e1d`. They use the identical synthetic conversation and viewport. This is running browser/UI proof, not authenticated-provider or production-Gateway proof.
- ClawSweeper trailing-failure regression: **5 cases failed before the fix**. Tests cover message/snake-case/structured/inferred errors, explicit success precedence, and failure → commentary → supplementary tool → subsequent answer. Isolated Chromium verified closed disclosure, error details, and reload for standalone and run-frame rendering, plus the subsequent-answer collapse case.
- Heartbeat CI regression: completed-work grouping no longer absorbs later independent reply-less runs. The existing heartbeat rollup browser test failed before this repair and passes with it; a new table covers independent runs, same-run trailing work, and unscoped history. The independent-run case fails against the original owner. Trailing-failure policy is unchanged.
- Required changed-file checks passed, including core/UI typechecks, formatting, lint, i18n verification, dead-export scans, and tooling guards.
- Fresh autoreview of the staged complete candidate through **P2**: scoped-clean, no actionable findings.
- The grouping refactor removed one type assertion; its existing safety baseline was reduced by exactly one entry. No guard was weakened.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-agent-run-grouping.test.ts ui/src/pages/chat/components/chat-position-rail.test.ts ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/chat-thread-grouping.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/components/chat-position-rail.test.ts docs/web/control-ui/chat.md config/assertion-safety-baseline.txt
git diff --check
```

### Before — main

Captured from an unmodified checkout of `main` at `ffbe841610ced9274f55c5a8ab21392481e1c995`, using the identical conversation fixture as the after screenshots. The substantive answer is hidden inside **Worked for…**, while the short addendum, later commentary, and trailing tool row remain visible. Expanding the disclosure reveals the buried answer; reloading reproduces the collapsed state.

![Before on main: substantive answer hidden while the short addendum and later activity remain visible](https://github.com/user-attachments/assets/f8f3b067-3477-492c-8165-3cb05f01374e)

### After — collapsed

One work disclosure above the complete answer and addendum.

![After: one work disclosure above all answer segments](https://github.com/user-attachments/assets/5857578f-2eb0-4785-87e1-561569f67208)

### After — expanded

The same disclosure contains commentary and tools from before and after the answer, in their original activity order.

![Expanded: all activity together above the preserved answer](https://github.com/user-attachments/assets/969dcb57-0165-4de2-a597-2ccea54eea5d)

### Trailing failures — review feedback addressed

A failed tool result after the last answer remains accessible outside the closed work disclosure. The grouping owner uses the same error classification as the tool renderer; ordinary successful activity still joins the single work section. A subsequent answer permits the failed activity to collapse again.

![Failed trailing tool stays visible outside the closed work disclosure](https://github.com/user-attachments/assets/1a767685-46f3-4178-b28e-9c6bf51aeb79)

![Opening the visible tool result shows its failure details](https://github.com/user-attachments/assets/7523a1fc-2f73-4ec6-9d6f-5ff0c8a3399e)

### Regression provenance

The regression was introduced by `5b7b2d0fe0bc` (#105012), merged July 12, 2026. Its raw parent is `02f88c209c6d541df4a8fe159525e32b3f1333ae`: the prior renderer displayed the groups directly; the change selected the last visible assistant group and folded preceding assistant/tool groups without consulting already-existing phase metadata. Raw-parent diff and current behavior were checked separately. Native async tool execution later made this ordering more common; it did not introduce the faulty collapse rule.


Production LOC for the complete PR: **+77/-20 (net +57)**; tests: **+335/-10**; docs: **+9**; one mechanical assertion-baseline adjustment. The heartbeat repair adds **net 7 production lines** in the existing grouping owner and reuses the existing visible-reply run classification.
