### PR TITLE
test: reuse source transforms in proxy exit cases

### DIFF
--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { defaultRuntime, ExitError } from "../runtime.js";
 import {
   exitCliAfterOutput,
@@ -10,6 +11,8 @@ import {
 
 const successfulRun = async () => {};
 const ignoreError = () => {};
+// Fresh proxy children share only temporary source transforms, not module state.
+const proxyChildTempDir = useAutoCleanupTempDirTracker(afterAll).make("openclaw-proxy-child-tmp-");
 
 function spyOnExit(onExit?: (code: number) => void) {
   const exited = createDeferred();
@@ -489,7 +492,9 @@ describe("one-shot CLI exit", () => {
       ...process.env,
       OPENCLAW_STATE_DIR: "/dev/null",
       OPENCLAW_CONFIG_PATH: "/dev/null",
-      TSX_DISABLE_CACHE: "1",
+      TMPDIR: proxyChildTempDir,
+      TEMP: proxyChildTempDir,
+      TMP: proxyChildTempDir,
       NODE_DISABLE_COMPILE_CACHE: "1",
     };
     delete env.VITEST;


### PR DESCRIPTION
## What Problem This Solves

The four real proxy-command exit cases explicitly disabled TSX's transform cache. Three refusal cases each recompiled the same source graph, so the complete 36-test file took about 30 seconds locally.

## Why This Change Was Made

Use the existing temporary-directory tracker to give these children a file-owned transform cache and remove the explicit cache bypass. Bind all platform temp variables to that directory and remove it after the file finishes. The first proxy child still compiles cold; subsequent children reuse code/maps and evaluate their modules afresh.

Preserve the real Commander/proxy action, native processes, JSON/help and exit assertions, state/config locators, Node compile-cache setting, deadlines and all 36 tests. Other child environments are unchanged. No production, dependency, worker or shard change.

## User Impact

Faster coverage for truthful CLI failure/help exits. The same file also retains native large-pipe, terminal-output and finalization checks. This is test infrastructure only: one test file, +7/−2 lines, zero production changes.

## Evidence

| Complete 36-case invocation | Time |
| --- | ---: |
| Original | 29.78s |
| Candidate with temporary cache audit | 15.19s |
| Restored original | 29.40s |
| Final candidate without audit | 14.91s |

All cases passed in the original order, with the same dependencies and Node 24.19.0/pnpm 12.3.4. The benchmark temporary base started empty each time; timings include the normal wrapper, preparation and cleanup. The final first proxy case took 8.224s; subsequent cases took 1.010s, 1.130s and 0.198s.

Eight before/after snapshots found an initially empty cache root, then 819 TSX files whose sizes and mtimes remained unchanged. Only TSX paths persisted at those boundaries, and the root was removed after cleanup. The 56ms observer cost is included in the audited candidate; diagnostic code is not committed. Pinned TSX source confirms content/source/options/version-keyed transforms do not retain evaluated application state.

Peak command RSS rose from 392–409 MB in the original runs to 469 MB in the final candidate, an observed 60–77 MB increase. These are controlled local POSIX timings, not aggregate process-tree memory or a full-main CI speed claim. TEMP/TMP preserve directory ownership on Windows, but no Windows speed measurement is claimed.

Independent P2 review is scoped-clean; required changed-file types, guards, dead-export checks and scoped lint passed. All local test/reviewer processes joined and temporary directories were cleaned.

Exact-head [CI 34419164898](https://github.com/openclaw/openclaw/actions/runs/34419164898) passed in **6m38s**. The Linux shard passed all 36 tests in **15.19s**, including the wrapper; the first proxy case took 7.424s and later cases 1.332s, 1.283s and 0.255s. Windows was not selected by the existing filters.
