### PR TITLE
fix(sqlite): name the repair path in schema drift failures

### DIFF
--- a/src/infra/sqlite-schema-contract.test.ts
+++ b/src/infra/sqlite-schema-contract.test.ts
@@ -77,6 +77,21 @@ describe.each([false, true])("assertSqliteSchemaContains (statement cache: %s)",
     }
   });
 
+  it("names the doctor repair path when a canonical index is missing", () => {
+    const database = createDatabase(CANONICAL_SCHEMA);
+    try {
+      database.exec("DROP INDEX idx_children_parent;");
+
+      // Operators hit this throw as gateway startup failure text, so it must
+      // name the repair owner instead of dead-ending on the drift detail.
+      expect(() => assertSqliteSchemaContains(database, "test database", CANONICAL_SCHEMA)).toThrow(
+        /missing or drifted index idx_children_parent; run openclaw doctor --fix to repair it\./,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
   it("accepts an extra non-unique index on a canonical table", () => {
     const database = createDatabase(CANONICAL_SCHEMA);
     try {

--- a/src/infra/sqlite-schema-issues.ts
+++ b/src/infra/sqlite-schema-issues.ts
@@ -121,7 +121,9 @@ export function throwSqliteSchemaMismatches(
   if (mismatches.length > shown.length) {
     shown.push(`${mismatches.length - shown.length} additional mismatch(es)`);
   }
+  // Drift is repairable by the doctor migration owner, so the throw must name it:
+  // callers surface this straight to operators, and the gateway refuses to start.
   throw new Error(
-    `SQLite schema is incomplete or noncanonical for ${databaseLabel}: ${shown.join("; ")}`,
+    `SQLite schema is incomplete or noncanonical for ${databaseLabel}: ${shown.join("; ")}; run openclaw doctor --fix to repair it.`,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

A missing or drifted canonical SQLite index aborts Gateway startup, and the failure text told operators nothing about how to fix it:

```
SQLite schema is incomplete or noncanonical for
/Users/…/.openclaw/agents/codex/agent/openclaw-agent.sqlite:
missing or drifted index idx_agent_session_nodes_active
```

That is the entire message. The Gateway then exits `78 (EX_CONFIG)` and launchd restarts it into a crash loop.

Hit on a live install today. The affected database was stamped `user_version = 19` (current), passed `pragma quick_check`, and had every other canonical index — exactly one index was absent, on a *secondary* agent that was not even in use. `openclaw doctor` ran to completion and reported "Doctor complete" without mentioning it. The repair turned out to be a single idempotent `CREATE INDEX IF NOT EXISTS`, and `openclaw doctor --fix` applied it in milliseconds ("Rebuilt canonical shared-state SQLite indexes (1)") — but nothing in the failure path said so.

The two sibling throws in `assertOpenClawAgentCurrentRuntimeSchema` (`src/state/openclaw-agent-db-schema-helpers.ts`) already end with *"run openclaw doctor --fix before using it."* The index-drift throw, which is the one that actually fires on a healthy-looking database, was the only one that dead-ended.

## Why This Change Was Made

`throwSqliteSchemaMismatches` is the single owner of this message, so naming the repair path there fixes both call sites in `sqlite-schema-contract.ts` at once and keeps the wording consistent with its siblings.

This intentionally does **not** make runtime open self-repair the index. That would be a material change to recovery semantics: both the shared state database (`repairStateSchema`) and the agent migration path (`repairAndAssertAgentSchemaGroup`) call `repairCanonicalSqliteIndexes` only inside explicit repair/migration contexts, never on a normal runtime open. Per `AGENTS.md`, same-version changes to indexing or recovery need maintainer acceptance before implementation, so that option is raised for a maintainer decision rather than taken here. See "Open question" below.

## User Impact

An operator whose Gateway will not start now gets a message that names the fix instead of only the symptom. No schema change, no persistence-semantics change, no config surface.

## Evidence

Production change is one message string plus a two-line comment.

Regression test `names the doctor repair path when a canonical index is missing` drops a canonical index and asserts both the drift detail and the remediation. Verified it fails on pre-fix code by restoring `src/infra/sqlite-schema-issues.ts` from `HEAD`:

```
× assertSqliteSchemaContains (statement cache: false) > names the doctor repair path when a canonical index is missing
× assertSqliteSchemaContains (statement cache: true)  > names the doctor repair path when a canonical index is missing
Tests  2 failed | 95 skipped (97)
```

With the fix restored:

```
node scripts/run-vitest.mjs src/infra/sqlite-schema-contract.test.ts src/infra/sqlite-index-schema.test.ts
Test Files  2 passed (2)      Tests  110 passed | 2 skipped (112)

node scripts/run-vitest.mjs src/state
Test Files  65 passed | 1 skipped (66)      Tests  956 passed | 6 skipped (962)
```

`pnpm tsgo` exits 0. `node scripts/check-changed.mjs` passes every lane except `plugin boundaries`, which fails identically on a clean checkout of `main` with zero changes (`2026-09-08 sdk-untrusted-context-identifier-aliases`, 6927 code refs) and is reported separately.

## Open question for a maintainer

Should a canonical **index** — as opposed to a table or column — be repairable during normal runtime open rather than only under `doctor --fix`? An index is a performance artifact; refusing to boot on a missing one, when the repair is idempotent and already implemented, is arguably disproportionate. It is deliberately left out of this PR because it changes recovery semantics and needs your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rTGeD4bUUEvA6vupgJt4d
