### PR TITLE
refactor(signal): share native quote test inputs

### DIFF
--- a/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/extensions/signal/src/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -98,6 +98,23 @@ function hasQueuedReactionEventFor(sender: string) {
   });
 }
 
+function createSignalQuoteInput() {
+  return {
+    payloads: [
+      {
+        envelope: {
+          sourceNumber: "+15550001111",
+          sourceName: "Ada",
+          timestamp: 1700000000001,
+          dataMessage: {
+            message: "quote me",
+          },
+        },
+      },
+    ],
+  };
+}
+
 function makeBaseEnvelope(overrides: Record<string, unknown> = {}) {
   return {
     sourceNumber: "+15550001111",
@@ -163,20 +180,7 @@ describe("monitorSignalProvider tool results", () => {
   it("passes inbound Signal quote metadata to final replies", async () => {
     replyMock.mockResolvedValue({ text: "final reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -332,20 +336,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "chunked Signal reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock.mock.calls.length).toBeGreaterThan(1);
@@ -369,20 +360,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "chunked Signal reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock.mock.calls.length).toBeGreaterThan(1);
@@ -408,20 +386,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue([{ text: "first reply" }, { text: "second reply" }]);
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(2);
@@ -451,20 +416,7 @@ describe("monitorSignalProvider tool results", () => {
       );
       replyMock.mockResolvedValue([{ text: "working", ...flag }, { text: "final reply" }]);
 
-      await receiveSignalPayloads({
-        payloads: [
-          {
-            envelope: {
-              sourceNumber: "+15550001111",
-              sourceName: "Ada",
-              timestamp: 1700000000001,
-              dataMessage: {
-                message: "quote me",
-              },
-            },
-          },
-        ],
-      });
+      await receiveSignalPayloads(createSignalQuoteInput());
 
       await waitForSignalDelivery(() => {
         expect(sendMock).toHaveBeenCalledTimes(2);
@@ -494,20 +446,7 @@ describe("monitorSignalProvider tool results", () => {
       );
       replyMock.mockResolvedValue([{ text: "final reply" }, { text: "still working", ...flag }]);
 
-      await receiveSignalPayloads({
-        payloads: [
-          {
-            envelope: {
-              sourceNumber: "+15550001111",
-              sourceName: "Ada",
-              timestamp: 1700000000001,
-              dataMessage: {
-                message: "quote me",
-              },
-            },
-          },
-        ],
-      });
+      await receiveSignalPayloads(createSignalQuoteInput());
 
       await waitForSignalDelivery(() => {
         expect(sendMock).toHaveBeenCalledTimes(2);
@@ -535,20 +474,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue([{ text: "working", ...flag }]);
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -567,20 +493,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "final reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -653,20 +566,7 @@ describe("monitorSignalProvider tool results", () => {
   it("passes inbound Signal quote metadata to media replies", async () => {
     replyMock.mockResolvedValue({ text: "caption", mediaUrl: "https://example.com/reply.png" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -682,20 +582,7 @@ describe("monitorSignalProvider tool results", () => {
   it("does not attach native quote metadata for a different explicit reply target", async () => {
     replyMock.mockResolvedValue({ text: "final reply", replyToId: "1700000000999" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -708,20 +595,7 @@ describe("monitorSignalProvider tool results", () => {
   it("does not attach native quote metadata when the reply opts out of the current message", async () => {
     replyMock.mockResolvedValue({ text: "status reply", replyToCurrent: false });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -737,20 +611,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "final reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -766,20 +627,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "final reply", replyToCurrent: true });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -801,20 +649,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "final reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -838,20 +673,7 @@ describe("monitorSignalProvider tool results", () => {
     );
     replyMock.mockResolvedValue({ text: "final reply" });
 
-    await receiveSignalPayloads({
-      payloads: [
-        {
-          envelope: {
-            sourceNumber: "+15550001111",
-            sourceName: "Ada",
-            timestamp: 1700000000001,
-            dataMessage: {
-              message: "quote me",
-            },
-          },
-        },
-      ],
-    });
+    await receiveSignalPayloads(createSignalQuoteInput());
 
     await waitForSignalDelivery(() => {
       expect(sendMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Signal's native-quote tests repeated the same inbound payload in 15 places, making the scenarios harder to scan and maintain.

## Why This Change Was Made

A small local input factory replaces those identical literals. Every call creates the same fresh payload graph, while the quote expectations remain explicit in each scenario. This removes 178 net test lines without changing the monitor, test harness, or async flow.

## User Impact

No user-visible behavior change. The tests retain their quote-mode, notice, media, opt-out, and account/chat override coverage.

## Evidence

All 45 cases passed before and after with identical ordered results, including all 21 invocations affected by the 15 input sites. Expanding the factory calls reproduces the original complete source bytes and AST. Independent factory checks verify fresh object graphs, field order, descriptors, omitted properties, and mutation isolation.

Changed checks, extension test typechecking, lint, and independent P2 review passed. No runtime improvement is claimed.
