### PR TITLE
refactor(plugin-sdk): compact reply payload case matrices

### DIFF
--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -56,37 +56,17 @@ describe("ask_user question option indices", () => {
 
 describe("isReasoningReplyPayload", () => {
   it.each([
-    { name: "flagged", payload: { text: "Visible", isReasoning: true }, expected: true },
-    { name: "prefix", payload: { text: "  \n Thinking\n_hidden_" }, expected: true },
-    {
-      name: "legacy animated prefix",
-      payload: { text: "Thinking...\n\n_hidden_" },
-      expected: true,
-    },
-    { name: "legacy prefix", payload: { text: "  \n Reasoning:\n_hidden_" }, expected: true },
-    { name: "blockquote", payload: { text: "> Thinking\n> _hidden_" }, expected: true },
-    {
-      name: "visible prose starting with thinking",
-      payload: { text: "Thinking... this is the answer" },
-      expected: false,
-    },
-    {
-      name: "visible exact thinking label",
-      payload: { text: "Thinking..." },
-      expected: false,
-    },
-    {
-      name: "visible thinking status line",
-      payload: { text: "Thinking...\nI'll check that now" },
-      expected: false,
-    },
-    {
-      name: "mid-message mention",
-      payload: { text: "Intro\nThinking: visible discussion" },
-      expected: false,
-    },
-    { name: "missing text", payload: {}, expected: false },
-  ])("$name", ({ payload, expected }) => {
+    ["flagged", { text: "Visible", isReasoning: true }, true],
+    ["prefix", { text: "  \n Thinking\n_hidden_" }, true],
+    ["legacy animated prefix", { text: "Thinking...\n\n_hidden_" }, true],
+    ["legacy prefix", { text: "  \n Reasoning:\n_hidden_" }, true],
+    ["blockquote", { text: "> Thinking\n> _hidden_" }, true],
+    ["visible prose starting with thinking", { text: "Thinking... this is the answer" }, false],
+    ["visible exact thinking label", { text: "Thinking..." }, false],
+    ["visible thinking status line", { text: "Thinking...\nI'll check that now" }, false],
+    ["mid-message mention", { text: "Intro\nThinking: visible discussion" }, false],
+    ["missing text", {}, false],
+  ])("%s", (_name, payload, expected) => {
     expect(isReasoningReplyPayload(payload)).toBe(expected);
   });
 });
@@ -664,39 +644,41 @@ describe("TTS supplement payload helpers", () => {
 });
 
 describe("resolveOutboundMediaUrls", () => {
-  it.each([
-    {
-      name: "prefers mediaUrls over the legacy single-media field",
-      payload: {
-        mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
-        mediaUrl: "https://example.com/legacy.png",
-      },
-      expected: ["https://example.com/a.png", "https://example.com/b.png"],
-    },
-    {
-      name: "falls back to the legacy single-media field",
-      payload: {
-        mediaUrl: "https://example.com/legacy.png",
-      },
-      expected: ["https://example.com/legacy.png"],
-    },
-    {
-      name: "falls back to the legacy single-media field when plural entries are blank",
-      payload: {
-        mediaUrls: ["   "],
-        mediaUrl: "https://example.com/legacy.png",
-      },
-      expected: ["https://example.com/legacy.png"],
-    },
-    {
-      name: "preserves raw plural entries and duplicates when one attachment is valid",
-      payload: {
-        mediaUrls: ["   ", " https://example.com/a.png ", " https://example.com/a.png "],
-        mediaUrl: "https://example.com/legacy.png",
-      },
-      expected: ["   ", " https://example.com/a.png ", " https://example.com/a.png "],
-    },
-  ])("$name", ({ payload, expected }) => {
+  it.each<[name: string, payload: { mediaUrls?: string[]; mediaUrl?: string }, expected: string[]]>(
+    [
+      [
+        "prefers mediaUrls over the legacy single-media field",
+        {
+          mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+          mediaUrl: "https://example.com/legacy.png",
+        },
+        ["https://example.com/a.png", "https://example.com/b.png"],
+      ],
+      [
+        "falls back to the legacy single-media field",
+        {
+          mediaUrl: "https://example.com/legacy.png",
+        },
+        ["https://example.com/legacy.png"],
+      ],
+      [
+        "falls back to the legacy single-media field when plural entries are blank",
+        {
+          mediaUrls: ["   "],
+          mediaUrl: "https://example.com/legacy.png",
+        },
+        ["https://example.com/legacy.png"],
+      ],
+      [
+        "preserves raw plural entries and duplicates when one attachment is valid",
+        {
+          mediaUrls: ["   ", " https://example.com/a.png ", " https://example.com/a.png "],
+          mediaUrl: "https://example.com/legacy.png",
+        },
+        ["   ", " https://example.com/a.png ", " https://example.com/a.png "],
+      ],
+    ],
+  )("%s", (_name, payload, expected) => {
     const mediaUrls = resolveOutboundMediaUrls(payload);
     expect(mediaUrls).toEqual(expected);
     if (payload.mediaUrls?.some((mediaUrl) => mediaUrl.trim())) {
@@ -736,107 +718,62 @@ describe("hasOutboundMedia", () => {
 
 describe("hasOutboundText", () => {
   it.each([
-    {
-      name: "checks raw text presence by default",
-      payload: { text: "hello" },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "treats whitespace-only text as present by default",
-      payload: { text: "   " },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "returns false when text is missing",
-      payload: {},
-      options: undefined,
-      expected: false,
-    },
-    {
-      name: "can trim whitespace-only text",
-      payload: { text: "   " },
-      options: { trim: true },
-      expected: false,
-    },
-    {
-      name: "keeps non-empty trimmed text",
-      payload: { text: " hi " },
-      options: { trim: true },
-      expected: true,
-    },
-  ])("$name", ({ payload, options, expected }) => {
+    ["checks raw text presence by default", { text: "hello" }, undefined, true],
+    ["treats whitespace-only text as present by default", { text: "   " }, undefined, true],
+    ["returns false when text is missing", {}, undefined, false],
+    ["can trim whitespace-only text", { text: "   " }, { trim: true }, false],
+    ["keeps non-empty trimmed text", { text: " hi " }, { trim: true }, true],
+  ])("%s", (_name, payload, options, expected) => {
     expect(hasOutboundText(payload, options)).toBe(expected);
   });
 });
 
 describe("hasOutboundReplyContent", () => {
   it.each([
-    {
-      name: "detects text content",
-      payload: { text: "hello" },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "detects media content",
-      payload: { mediaUrl: "https://example.com/a.png" },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "returns false when text and media are both missing",
-      payload: {},
-      options: undefined,
-      expected: false,
-    },
-    {
-      name: "can ignore whitespace-only text",
-      payload: { text: "   " },
-      options: { trimText: true },
-      expected: false,
-    },
-    {
-      name: "still reports content when trimmed text is blank but media exists",
-      payload: { text: "   ", mediaUrls: ["https://example.com/a.png"] },
-      options: { trimText: true },
-      expected: true,
-    },
-    {
-      name: "detects presentation-only content",
-      payload: {
+    ["detects text content", { text: "hello" }, undefined, true],
+    ["detects media content", { mediaUrl: "https://example.com/a.png" }, undefined, true],
+    ["returns false when text and media are both missing", {}, undefined, false],
+    ["can ignore whitespace-only text", { text: "   " }, { trimText: true }, false],
+    [
+      "still reports content when trimmed text is blank but media exists",
+      { text: "   ", mediaUrls: ["https://example.com/a.png"] },
+      { trimText: true },
+      true,
+    ],
+    [
+      "detects presentation-only content",
+      {
         text: "   ",
         presentation: {
           blocks: [{ type: "buttons", buttons: [{ label: "Approve", value: "approve" }] }],
         },
       },
-      options: { trimText: true },
-      expected: true,
-    },
-    {
-      name: "detects interactive-only content",
-      payload: {
+      { trimText: true },
+      true,
+    ],
+    [
+      "detects interactive-only content",
+      {
         interactive: {
           blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
         },
       },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "detects channel data-only content",
-      payload: { channelData: { webchat: { cardId: "card-1" } } },
-      options: undefined,
-      expected: true,
-    },
-    {
-      name: "ignores empty rich payload fields",
-      payload: { presentation: { blocks: [] }, interactive: { blocks: [] }, channelData: {} },
-      options: undefined,
-      expected: false,
-    },
-  ])("$name", ({ payload, options, expected }) => {
+      undefined,
+      true,
+    ],
+    [
+      "detects channel data-only content",
+      { channelData: { webchat: { cardId: "card-1" } } },
+      undefined,
+      true,
+    ],
+    [
+      "ignores empty rich payload fields",
+      { presentation: { blocks: [] }, interactive: { blocks: [] }, channelData: {} },
+      undefined,
+      false,
+    ],
+  ])("%s", (_name, payload, options, expected) => {
     expect(hasOutboundReplyContent(payload, options)).toBe(expected);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Plugin SDK reply-payload suite repeats object property names across homogeneous helper matrices, obscuring the actual outbound edge cases.

## Why This Change Was Made

Compacts four matrices into positional tuples, retaining explicit optional-media typing and preserving every reasoning, media, text, and rich-content case.

## User Impact

No user-visible behavior changes. Maintainers get unchanged outbound payload coverage with 63 fewer test lines.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/reply-payload.test.ts` — 80 passed
- `node scripts/check-changed.mjs` — passed, including Plugin SDK surface and native services graphs
- P3 autoreview — clean, 0.99

