### PR TITLE
refactor(tests): share Discord REST runtime spies

### DIFF
--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -123,6 +123,10 @@ function dispatchRequest(dispatcher: unknown, origin: string): void {
   target.dispatch({ origin, path: "/", method: "GET" }, {});
 }
 
+function createRuntimeSpies() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+}
+
 function installUndiciRuntimeDeps(): void {
   const runtime = createMockUndiciRuntime();
   class Pool {
@@ -186,11 +190,7 @@ describe("resolveDiscordRestFetch", () => {
   }
 
   it("uses undici proxy fetch when a proxy URL is configured", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
     proxyAgentSpy.mockClear();
     const fetcher = resolveDiscordRestFetch("http://127.0.0.1:8080", runtime);
@@ -212,11 +212,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("uses undici proxy fetch when the configured proxy is a DNS host", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
     proxyAgentSpy.mockClear();
     const fetcher = resolveDiscordRestFetch("http://mitm-proxy:8080", runtime);
@@ -231,11 +227,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("uses undici proxy fetch when proxy URL is arbitrary DNS", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
@@ -254,11 +246,7 @@ describe("resolveDiscordRestFetch", () => {
     vi.stubEnv("https_proxy", "https://127.0.0.1:8443");
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
     vi.stubEnv("OPENCLAW_PROXY_CA_FILE", caFile);
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("https://127.0.0.1:8443", runtime);
@@ -274,11 +262,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("falls back to global fetch when proxy URL is invalid", () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     const fetcher = resolveDiscordRestFetch("bad-proxy", runtime);
 
     expect(fetcher).toBe(fetch);
@@ -287,11 +271,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("uses undici proxy fetch when proxy URL is a non-loopback IP", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("http://10.0.0.10:8080", runtime);
@@ -305,11 +285,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("uses undici proxy fetch when the proxy URL is IPv6 loopback", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch("http://[::1]:8080", runtime);
@@ -323,11 +299,7 @@ describe("resolveDiscordRestFetch", () => {
   });
 
   it("uses undici Agent with IPv4-first lookup when no discord proxy URL is configured", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch(undefined, runtime);
@@ -357,11 +329,7 @@ describe("resolveDiscordRestFetch", () => {
     vi.stubEnv("https_proxy", "https://proxy.example:8443");
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
     vi.stubEnv("OPENCLAW_PROXY_CA_FILE", caFile);
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch(undefined, runtime);
@@ -399,11 +367,7 @@ describe("resolveDiscordRestFetch", () => {
 
   it("falls back to direct REST fetch when env proxy options are invalid", async () => {
     vi.stubEnv("https_proxy", "bad-proxy");
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch(undefined, runtime);
@@ -429,11 +393,7 @@ describe("resolveDiscordRestFetch", () => {
   it("uses debug proxy env when no discord proxy URL is configured", async () => {
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "http://127.0.0.1:7777");
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as const;
+    const runtime = createRuntimeSpies();
     undiciFetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
     const fetcher = resolveDiscordRestFetch(undefined, runtime);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Eleven Discord REST proxy tests repeat the same three runtime spies, adding boilerplate around their proxy and logging assertions.

## Why This Change Was Made

Create fresh log, error, and exit spies through one private local helper at the original allocation sites. The helper preserves the sparse runtime shape and nonthrowing exit behavior; every proxy scenario and independent assertion remains unchanged.

## User Impact

No user-visible behavior changes. This removes 40 net test lines without removing test cases or assertions.

## Evidence

The full REST proxy suite and proxy request-client sibling passed before and after: 16 tests, zero skips, with identical ordered names and results. Inlining all 11 helper calls reconstructs the original file's parser tokens, accounting only for formatter-removed trailing commas. Separate controls confirm fresh spies, independent call histories, the same three own keys, and unchanged exit behavior. The mapped changed-file gate and fresh independent P2 review passed. No full-suite runtime improvement is claimed.
