### PR TITLE
fix(update): report the built runtime instead of the unbuilt source version

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -617,15 +617,18 @@ function readLauncherJson(relativePath) {
 }
 
 function resolveLauncherVersion() {
-  const packageJson = readLauncherJson("./package.json");
-  const packageVersion = normalizeLauncherMetadataValue(packageJson?.version);
-  if (packageVersion) {
-    return packageVersion;
-  }
+  // Report what is built, not what the source says: resolveLauncherCommit already
+  // prefers dist provenance, so reading package.json first pairs a source version
+  // with a built commit and hides a checkout that pulled without rebuilding.
   const buildInfo = readLauncherJson("./dist/build-info.json");
   const buildVersion = normalizeLauncherMetadataValue(buildInfo?.version);
   if (buildVersion) {
     return buildVersion;
+  }
+  const packageJson = readLauncherJson("./package.json");
+  const packageVersion = normalizeLauncherMetadataValue(packageJson?.version);
+  if (packageVersion) {
+    return packageVersion;
   }
   return normalizeLauncherMetadataValue(process.env.OPENCLAW_BUNDLED_VERSION) ?? "0.0.0";
 }

--- a/src/commands/status.update.test.ts
+++ b/src/commands/status.update.test.ts
@@ -55,6 +55,50 @@ describe("resolveUpdateAvailability", () => {
     });
   });
 
+  it("reports a stale build when dist was built from a different commit", () => {
+    const update = buildUpdate({
+      installKind: "git",
+      git: {
+        root: "/tmp/repo",
+        sha: "abc123456789",
+        tag: null,
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+        builtSha: "def987654321",
+      },
+    });
+
+    // Pulling without rebuilding keeps the old dist running, which is invisible
+    // from HEAD alone and is exactly what a failed update leaves behind.
+    expect(formatUpdateOneLiner(update)).toContain(
+      "stale build (running def98765, run pnpm build)",
+    );
+  });
+
+  it("stays quiet when the built commit matches HEAD", () => {
+    const update = buildUpdate({
+      installKind: "git",
+      git: {
+        root: "/tmp/repo",
+        sha: "abc123456789",
+        tag: null,
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+        builtSha: "abc123456789",
+      },
+    });
+
+    expect(formatUpdateOneLiner(update)).not.toContain("stale build");
+  });
+
   it("flags registry update when latest version is newer", () => {
     const latestVersion = nextMajorVersion(VERSION);
     const update = buildUpdate({

--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -199,6 +199,11 @@ export function formatUpdateOneLiner(update: UpdateCheckResult): string {
     if (update.git.fetchOk === false) {
       parts.push("fetch failed");
     }
+    // A checkout that pulled but never rebuilt keeps executing the previous dist,
+    // so report the built commit rather than letting HEAD imply what is running.
+    if (update.git.builtSha && update.git.sha && update.git.builtSha !== update.git.sha) {
+      parts.push(`stale build (running ${update.git.builtSha.slice(0, 8)}, run pnpm build)`);
+    }
     appendRegistryUpdateSummary();
   } else {
     parts.push(update.packageManager !== "unknown" ? update.packageManager : "pkg");

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -21,6 +21,7 @@ import {
   fetchNpmPackageTargetStatus,
   type NpmMetadataCommandRunner,
 } from "./update-check-package-target.js";
+import { readBuiltRuntimeCommit } from "./update-git-runtime.js";
 import { updateInstallRootsMatch } from "./update-install-root.js";
 import type { UpdateFetchFailure } from "./update-run-record.js";
 
@@ -40,6 +41,7 @@ type GitUpdateStatus = {
   ahead: number | null;
   behind: number | null;
   fetchOk: boolean | null;
+  builtSha?: string | null;
   countsCached?: true;
   stale?: UpdateFetchFailure;
   error?: string;
@@ -430,6 +432,7 @@ async function checkGitUpdateStatus(params: {
     ahead: parsed ? Number(parsed[1]) : null,
     behind: parsed ? Number(parsed[2]) : null,
     fetchOk,
+    builtSha: await readBuiltRuntimeCommit(root),
   };
 }
 

--- a/src/infra/update-git-runtime.test.ts
+++ b/src/infra/update-git-runtime.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readBuiltRuntimeCommit } from "./update-git-runtime.js";
+
+const roots: string[] = [];
+
+async function createRoot(): Promise<string> {
+  // Resolve the temp root: macOS reports /var while prod resolvers return /private/var.
+  const root = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-built-commit-")),
+  );
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("readBuiltRuntimeCommit", () => {
+  it("reads the commit the dist was built from", async () => {
+    const root = await createRoot();
+    await fs.mkdir(path.join(root, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "dist", "build-info.json"),
+      JSON.stringify({ version: "2026.8.1", commit: "1623683f478b1e4a2e3d5632585f006ea142e08c" }),
+    );
+
+    expect(await readBuiltRuntimeCommit(root)).toBe("1623683f478b1e4a2e3d5632585f006ea142e08c");
+  });
+
+  it("returns null when the checkout has no build", async () => {
+    // Source-only checkouts must not be reported as running a stale build.
+    expect(await readBuiltRuntimeCommit(await createRoot())).toBeNull();
+  });
+
+  it("returns null when build provenance omits the commit", async () => {
+    const root = await createRoot();
+    await fs.mkdir(path.join(root, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "dist", "build-info.json"),
+      JSON.stringify({ version: "2026.8.1" }),
+    );
+
+    expect(await readBuiltRuntimeCommit(root)).toBeNull();
+  });
+});

--- a/src/infra/update-git-runtime.ts
+++ b/src/infra/update-git-runtime.ts
@@ -42,6 +42,16 @@ export async function collectGitRuntimeErrors(params: GitRuntimeIdentity): Promi
       ];
 }
 
+/**
+ * Commit the checkout's dist was built from, or null when no build exists.
+ * Comparing it to HEAD is how callers detect a checkout that pulled but never
+ * rebuilt, which otherwise runs old code while reporting the new source version.
+ */
+export async function readBuiltRuntimeCommit(root: string): Promise<string | null> {
+  const buildInfo = await tryReadJson(path.join(root, "dist", "build-info.json"));
+  return normalizeNullableString(asNullableRecord(buildInfo)?.commit);
+}
+
 export async function readBuiltGatewayBuildId(root: string): Promise<string | null> {
   const buildInfo = await tryReadJson(path.join(root, "dist", "build-info.json"));
   const buildId = normalizeNullableString(asNullableRecord(buildInfo)?.buildId);

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -83,6 +83,18 @@ describe("version resolution", () => {
     });
   });
 
+  it("reports the built version when dist lags the source package version", async () => {
+    await withVersionFixtureDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "2026.9.2" });
+      await writeJsonFixture(root, "build-info.json", { version: "2026.8.1" });
+      const moduleUrl = await ensureModuleFixture(root);
+      // A git checkout that pulled but never rebuilt still executes the old dist,
+      // so reporting the source version hides the stale runtime from operators.
+      expect(readVersionFromPackageJsonForModuleUrl(moduleUrl)).toBe("2026.9.2");
+      expect(resolveVersionFromModuleUrl(moduleUrl)).toBe("2026.8.1");
+    });
+  });
+
   it("reads the bounded immutable build id from generated provenance", async () => {
     await withVersionFixtureDir(async (root) => {
       const moduleUrl = await ensureModuleFixture(root);

--- a/src/version.ts
+++ b/src/version.ts
@@ -91,9 +91,12 @@ export function readBuildIdFromBuildInfoForModuleUrl(moduleUrl: string): string 
 }
 
 export function resolveVersionFromModuleUrl(moduleUrl: string): string | null {
+  // build-info.json records the version this artifact was built from, so it wins:
+  // a git checkout whose source moved ahead of dist must not report the unbuilt
+  // source version. Source runs have no build-info and fall back to package.json.
   return (
-    readVersionFromPackageJsonForModuleUrl(moduleUrl) ||
-    readVersionFromBuildInfoForModuleUrl(moduleUrl)
+    readVersionFromBuildInfoForModuleUrl(moduleUrl) ||
+    readVersionFromPackageJsonForModuleUrl(moduleUrl)
   );
 }
 

--- a/test/openclaw-launcher-version.e2e.test.ts
+++ b/test/openclaw-launcher-version.e2e.test.ts
@@ -11,6 +11,7 @@ const buildCommit = "1234567890abcdef1234567890abcdef12345678";
 
 type LauncherVersionFixtureOptions = {
   buildCommit?: string;
+  buildVersion?: string;
   checkout?: "directory" | "linked";
   packageCommit?: string;
   pendingLifecycle?: "complete" | "fail";
@@ -56,7 +57,10 @@ async function makeLauncherVersionFixture(
   if (options.buildCommit) {
     await fs.writeFile(
       path.join(fixtureRoot, "dist", "build-info.json"),
-      JSON.stringify({ version: packageVersion, commit: options.buildCommit }),
+      JSON.stringify({
+        version: options.buildVersion ?? packageVersion,
+        commit: options.buildCommit,
+      }),
     );
   }
 
@@ -131,6 +135,21 @@ describe("openclaw launcher version provenance", () => {
       expect(result.stderr).toBe("");
     },
   );
+
+  it("reports the built version when the source package version moved ahead", async () => {
+    const fixtureRoot = await makeLauncherVersionFixture(fixtureRoots, {
+      buildCommit,
+      buildVersion: "2026.8.1",
+    });
+
+    // The launcher answers bare --version before the runtime entry loads, so a
+    // checkout that pulled without rebuilding must not report the unbuilt version.
+    const result = runLauncherVersion(fixtureRoot);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(`OpenClaw 2026.8.1 (${buildCommit.slice(0, 7)})\n`);
+    expect(result.stderr).toBe("");
+  });
 
   it.each(["--version", "-V", "-v"])(
     "reports the packaged build for the %s fast path without importing the runtime",


### PR DESCRIPTION
## What Problem This Solves

A git-mode install that pulls but never rebuilds keeps executing the previous `dist/`. Every surface an operator would check to notice that reported the opposite.

`openclaw --version` resolved the version from the **source** `package.json` while the commit came from the **build**:

```
resolveVersionFromModuleUrl = readVersionFromPackageJson(...) || readVersionFromBuildInfo(...)
```

Observed on a live install: the machine printed `OpenClaw 2026.9.2 (1623683)` while actually running a build stamped `{"version":"2026.8.1","commit":"1623683f…"}`. The version half came from source, the commit half from the build, and `2026.9.2` had never been compiled. `openclaw status` reported `git main @ <HEAD>` with no indication that `dist/` was six days behind it.

This is not a cosmetic mismatch. The repo already detects the exact condition — `collectGitRuntimeErrors` compares `build-info.commit`, `.buildstamp.head` and `.runtime-postbuildstamp.head` against the expected SHA, and `verifyGitUpdateRecovery` returns `runtime-verification-failed` — but only inside the update path. When an update aborts at its dirty-tree precondition it writes that verdict to a support file and stops; nothing tells the operator, and the version string then actively contradicts it. On the install that prompted this, that combination hid a stale runtime for six days until a plugin failed to load against a module its build predated.

## Why This Change Was Made

Two minimal changes, both reusing what already exists:

**Version precedence.** `build-info.json` records the version the running artifact was actually built from, so it now wins. Both readers were already present and exported; only the `||` order changed. Source runs (`tsx`, `pnpm dev`) have no reachable `build-info.json` and still fall back to `package.json`, and published packages ship `dist/build-info.json` alongside a matching `package.json`, so neither case changes. No test pinned the old precedence — the existing one covers "falls back to build-info when package metadata is unavailable", which still holds.

**Launcher precedence.** The package executable `openclaw.mjs` answers bare `--version`/`-V`/`-v` and exits *before* the runtime entry loads, so it never reaches the resolver above. Its `resolveLauncherVersion()` read `package.json` first while `resolveLauncherCommit()` already preferred `dist/build-info.json` — which is exactly how a stale build printed a source version paired with a built commit (`OpenClaw 2026.9.2 (1623683)`). Both halves now agree.

**Status visibility.** `GitUpdateStatus` already carried `root` and `sha`, so detecting staleness needed only a built-commit read (`readBuiltRuntimeCommit`, added next to the existing `readBuiltGatewayBuildId`) and a comparison.

The status check deliberately compares the built commit to HEAD rather than reusing `collectGitRuntimeErrors` wholesale. That helper also fails on a missing `dist/entry.js` and on Control UI asset health, which would flag every developer running from source as "stale". Comparing commits reports only the real condition, and stays silent when no build exists.

## The version string is not only cosmetic

`VERSION` is derived from this resolver and is stamped into persisted state and compared at two decision points, so the wrong value had consequences beyond display:

- `src/state/openclaw-state-db-fast-path.ts:86` returns `metadata?.app_version === VERSION` to decide whether startup repairs can be skipped ("app_version commits only after this release's repairs; same-build writes are canonical"). Under the old precedence a dist built at `2026.8.1`, sitting in a checkout whose `package.json` read `2026.9.2`, reported `2026.9.2` — so against a database already stamped `2026.9.2` by a genuine build, the stale runtime **matched and skipped startup repairs it had never run**. Reporting the built version makes that comparison fail, which falls through to the full repair path; a false negative here only does more work.
- `src/commands/doctor-gateway-health.ts:68` compares the gateway version against the CLI's `VERSION`; a stale CLI now correctly reports the mismatch instead of hiding it.
- `src/infra/sqlite-user-version.ts:39` builds the diagnostic identity `OpenClaw ${VERSION} (${commit})`. That is the exact string #115008 reported as unable to identify the stale build; it is now truthful.

Nothing gates a migration on the version *string* — the schema decisions key off `user_version` — so no migration behavior changes.

## User Impact

`openclaw --version` now reports the version actually executing. `openclaw status` gains a `stale build (running <commit>, run pnpm build)` marker on the update row when `dist/` was built from a different commit than HEAD. Nothing changes for npm installs, source runs, or checkouts whose build is current. No config surface, no new files.

## Evidence

```
node scripts/run-vitest.mjs src/version.test.ts                  Tests  17 passed (17)
node scripts/run-vitest.mjs src/commands/status.update.test.ts   Tests  17 passed (17)
node scripts/run-vitest.mjs src/commands/status.update-channel.test.ts \
  src/commands/status.update-ledger.test.ts src/infra/update-check.test.ts
                                                                 Tests  30 passed (30)
pnpm tsgo                                                        exit 0
```

New tests:

- `reports the built version when dist lags the source package version` — pins the real-world shape (source `2026.9.2`, build `2026.8.1`) and asserts the built version wins while `readVersionFromPackageJsonForModuleUrl` still sees the source value.
- `reports a stale build when dist was built from a different commit`
- `stays quiet when the built commit matches HEAD` — guards against the false-positive mode described above.
- `test/openclaw-launcher-version.e2e.test.ts` gains `reports the built version when the source package version moved ahead`, with deliberately differing package and build versions. Verified failing on pre-fix code: `expected 'OpenClaw 1.2.3-test (1234567)' to be 'OpenClaw 2026.8.1 (1234567)'`.
- `src/infra/update-git-runtime.test.ts` covers `readBuiltRuntimeCommit`, pinning the null results (no `dist/`, provenance without a commit) that keep source-only checkouts from being reported stale.

`node scripts/check-changed.mjs` passes every lane except `plugin boundaries`, which fails identically on a clean checkout of `main` with zero changes (`2026-09-08 sdk-untrusted-context-identifier-aliases`, 6927 code refs) and is reported separately.

## Follow-up not taken here

`openclaw doctor` still does not run the stale-runtime check at all; this PR only reaches `status` and `--version`. Wiring `collectGitRuntimeErrors` into a doctor check (with the source-run false positives handled) is the natural next step and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rTGeD4bUUEvA6vupgJt4d
