### PR TITLE
perf(cli): reuse prepared channel setup options

### DIFF
--- a/src/cli/channels-cli-add-args.ts
+++ b/src/cli/channels-cli-add-args.ts
@@ -22,8 +22,7 @@ export const loadChannelSetupCliOptions = createLazyPromise(
   () => import("../channels/plugins/cli-add-options.js"),
 );
 
-export function getChannelSetupOptionSwitches(flags: string): string[] {
-  const option = new Option(flags);
+export function getChannelSetupOptionSwitches(option: Option): string[] {
   return [option.short, option.long].filter((flag): flag is string => Boolean(flag));
 }
 
@@ -41,11 +40,11 @@ function buildChannelSetupFlagArityMap(
   };
   for (const option of options) {
     const arity = resolveChannelSetupFlagArity(option.flags);
-    for (const flag of getChannelSetupOptionSwitches(option.flags)) {
+    for (const flag of getChannelSetupOptionSwitches(new Option(option.flags))) {
       addSwitch(flag, arity);
     }
     if (option.negatedFlags) {
-      for (const flag of getChannelSetupOptionSwitches(option.negatedFlags)) {
+      for (const flag of getChannelSetupOptionSwitches(new Option(option.negatedFlags))) {
         addSwitch(flag, "boolean");
       }
     }

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -90,21 +90,19 @@ function addChannelSetupOption(
   option: ChannelSetupCliOption,
   seenFlags: Set<string>,
 ): void {
-  const optionSwitches = getChannelSetupOptionSwitches(option.flags);
+  const prepared = command.createOption(option.flags, option.description);
+  const optionSwitches = getChannelSetupOptionSwitches(prepared);
   if (optionSwitches.some((flag) => seenFlags.has(flag))) {
     return;
   }
   optionSwitches.forEach((flag) => seenFlags.add(flag));
-  if (option.defaultValue !== undefined) {
-    command.option(option.flags, option.description, option.defaultValue);
-  } else {
-    command.option(option.flags, option.description);
-  }
+  command.addOption(prepared.makeOptionMandatory(false).default(option.defaultValue));
   if (option.negatedFlags) {
-    const negatedSwitches = getChannelSetupOptionSwitches(option.negatedFlags);
+    const negated = command.createOption(option.negatedFlags, option.description);
+    const negatedSwitches = getChannelSetupOptionSwitches(negated);
     if (!negatedSwitches.some((flag) => seenFlags.has(flag))) {
       negatedSwitches.forEach((flag) => seenFlags.add(flag));
-      command.option(option.negatedFlags, option.description);
+      command.addOption(negated.makeOptionMandatory(false).default(undefined));
     }
   }
 }
@@ -135,9 +133,7 @@ async function addChannelSetupOptions(
       ? "modern"
       : "legacy"
     : "none";
-  const seenFlags = new Set(
-    command.options.flatMap((option) => getChannelSetupOptionSwitches(option.flags)),
-  );
+  const seenFlags = new Set(command.options.flatMap(getChannelSetupOptionSwitches));
   for (const option of options) {
     addChannelSetupOption(command, option, seenFlags);
   }


### PR DESCRIPTION
## What Problem This Solves

Channel setup registration reparses flags into throwaway Commander Options to find their switches, then parses them again for registration. It also reconstructs Options that have already been registered. Larger plugin setup schemas repeat that work for every field.

## Why This Change Was Made

Use each prepared Option for both switch arbitration and registration, preserving Commander's mandatory/default/addOption sequence. Existing Options supply their own switches. Keep raw-argv arity discovery, alias precedence, lazy metadata loading and CLI-only forwarding unchanged. This removes five production lines without changing tests or introducing a new cache.

## User Impact

The verified help, defaults, negation, parsing and forwarded values are unchanged. Warm registration for the wide synthetic metadata fixture improved about 9–13%; smaller cases and initial calls were mixed or adverse. This is not a universal CLI startup or Gateway improvement claim.

## Evidence

- Independent Codex review found no actionable findings through P2, including the installed Commander 15 implementation and actual callers. A customized Option factory could observe earlier execution for rejected collisions; no such caller is present in the inspected path.
- All 68 tests in the existing channel CLI suite passed on both baseline and candidate. Formatting, syntax-focused lint and diff checks passed. The focused run did not execute every command in the 28-command discovery plan. [Required CI for this exact head](https://github.com/openclaw/openclaw/actions/runs/34419919449) subsequently completed successfully; that is separate from the focused Linux proof.
- [Isolated Linux proof](https://github.com/openclaw/openclaw/actions/runs/34418815260) captured 138 complete registration/help/parse/Option/default-source/forwarding outcomes, including 132 timed registrations. Full decoded V8 graphs match, including own undefined fields and input preservation. Real registration, metadata resolution and Commander run; only metadata/catalog data and the final channel dispatch use exact-parent fixture substitutions. No actual channel setup occurs.

| Warm registration median | Forward baseline → candidate | Reverse baseline → candidate |
| --- | ---: | ---: |
| Wide metadata | 260.06 → 237.38 µs (−8.72%) | 274.82 → 240.32 µs (−12.55%) |
| Six-field metadata | 178.26 → 115.14 µs (−35.41%) | 120.09 → 169.03 µs (+40.75%) |
| Generic control | 140.77 → 142.11 µs (+0.95%) | 143.04 → 173.10 µs (+21.01%) |

Eight warm samples per image/profile/order are descriptive. Wide first calls worsened 34.84% and 27.66%, and its reverse maximum worsened 21.98%. Overall, 10/24 warm statistics, 35/66 individual timings and 6/10 resource comparisons were adverse. MaxRSS rose 2.78% and 1.56%. All observations are retained; no memory or statistical-confidence claim.

Help generation, parsing and capture are verified outside registration clocks. The generic fixture checks helpInformation, not Commander's help-exit path. Whole-child walls improved 21.78% and 4.44%, but include other work and must not substitute for registration timing.

All children joined successfully, candidate source was restored, and the task container and lease completed cleanup. An independent audit's initial digit-camelcase expectation was corrected after reading Commander; original audit evidence remains, and neither runtime data nor product was changed or rerun. Full raw proof and the numerical audit are retained locally; the run link identifies execution. Changelog changes are deferred to release generation.

## Maintainer Review Disposition

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/143540#issuecomment-5611407405) found no actionable correctness or security defect. Its remaining concern correctly notes that these measurements do not establish an overall CLI startup improvement. That limitation is already reflected above and is retained.

The maintainer acceptance decision is limited to eliminating duplicate Option preparation, removing five production lines, and improving the measured wide-schema warm registration path in both orders. Overall startup improvement is not a claim or acceptance condition for this bounded change. Smaller-case and first-call regressions, increased RSS, and the synthetic workload limitation remain explicit; no additional favorable run or broader speedup claim is being substituted. The warning therefore does not require a source change or an overall-startup benchmark before this scoped cleanup can land.
