### PR TITLE
feat(ui): reveal chat widget actions on hover and focus

### DIFF
--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -8,7 +8,7 @@ import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/inde
 import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
 import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
-import { takeControlUiElementScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -254,6 +254,7 @@ suite.define(() => {
       });
     }
 
+    await page.setViewportSize({ width: 1440, height: 900 });
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
     const previewBubble = page.locator(".chat-bubble", { has: preview });
     const widgetActions = preview.locator("[data-widget-actions]");
@@ -265,16 +266,68 @@ suite.define(() => {
           .evaluate((element) => getComputedStyle(element).padding),
       )
       .toBe("0px");
+    await page.mouse.move(0, 0);
+    await expect
+      .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("0");
+    const restingWidth = await preview.evaluate((element) => element.getBoundingClientRect().width);
+    const pin = preview.getByRole("button", { name: "Pin to dashboard" });
+    const more = preview.getByRole("button", { name: "Widget actions", exact: true });
+    await pin.focus();
+    await pin.hover();
+    // Hover keeps the toolbar visible after keyboard focus leaves it.
+    await page.locator(".agent-chat__composer-combobox textarea").focus();
+    await expect
+      .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    const geometry = await preview.evaluate((element) => {
+      const box = element.getBoundingClientRect();
+      const pinBox = element.querySelector("[data-pin-widget]")!.getBoundingClientRect();
+      const panelBox = element
+        .querySelector(".chat-tool-card__preview-panel")!
+        .getBoundingClientRect();
+      return {
+        gap: pinBox.left - box.right,
+        top: pinBox.top - box.top,
+        width: box.width,
+        panelWidth: panelBox.width,
+      };
+    });
+    expect(geometry.gap).toBeGreaterThan(0);
+    expect(geometry.top).toBe(0);
+    expect(geometry.width).toBe(restingWidth);
+    expect(geometry.panelWidth).toBe(restingWidth);
+    const pinBox = (await pin.boundingBox())!;
+    await page.mouse.move(pinBox.x - geometry.gap / 2, pinBox.y + pinBox.height / 2);
+    await page.mouse.move(pinBox.x + pinBox.width / 2, pinBox.y + pinBox.height / 2);
+    await expect
+      .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    await page.mouse.move(0, 0);
+    await pin.focus();
+    await page.keyboard.press("Tab");
+    await expect
+      .poll(() => more.evaluate((element) => element.matches(":focus-visible")))
+      .toBe(true);
+    await expect
+      .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    await page.keyboard.press("Enter");
+    await expect.poll(() => preview.locator("wa-dropdown[open]").count()).toBe(1);
+    await page.keyboard.press("Escape");
+    await page.setViewportSize({ width: 800, height: 900 });
     await expect
       .poll(() =>
         preview.evaluate((element) => {
-          const actions = element.querySelector(".chat-tool-card__preview-actions");
-          return actions
-            ? actions.getBoundingClientRect().bottom <= element.getBoundingClientRect().top
-            : false;
+          const box = element.getBoundingClientRect();
+          const actions = element.querySelector("[data-widget-actions]")!.getBoundingClientRect();
+          return actions.left >= box.left && actions.right <= box.right && actions.top >= box.top;
         }),
       )
       .toBe(true);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await pin.focus();
+    await pin.hover();
     await expect
       .poll(() =>
         preview
@@ -289,7 +342,7 @@ suite.define(() => {
         .toBe("1");
       await writeFile(
         path.join(suite.artifactDir, "workboard-pin", "01-pin-hover.png"),
-        await takeControlUiElementScreenshot(page, previewBubble, [preview]),
+        await takeControlUiViewportScreenshot(page, previewBubble, [preview]),
       );
     }
     await preview.getByRole("button", { name: "Pin to dashboard" }).click();
@@ -307,7 +360,7 @@ suite.define(() => {
     if (recordProof) {
       await writeFile(
         path.join(suite.artifactDir, "workboard-pin", "02-pinned.png"),
-        await takeControlUiElementScreenshot(page, previewBubble, [preview]),
+        await takeControlUiViewportScreenshot(page, previewBubble, [preview]),
       );
     }
     await gateway.setMethodResponse("board.get", pinnedBoardSnapshot);

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -283,11 +283,16 @@ suite.define(() => {
     const geometry = await preview.evaluate((element) => {
       const box = element.getBoundingClientRect();
       const pinBox = element.querySelector("[data-pin-widget]")!.getBoundingClientRect();
+      const moreBox = element
+        .querySelector(".chat-tool-card__widget-actions-trigger")!
+        .getBoundingClientRect();
       const panelBox = element
         .querySelector(".chat-tool-card__preview-panel")!
         .getBoundingClientRect();
       return {
         gap: pinBox.left - box.right,
+        actionLeftOffset: moreBox.left - pinBox.left,
+        actionVerticalGap: moreBox.top - pinBox.bottom,
         top: pinBox.top - box.top,
         box: { x: box.x, y: box.y, width: box.width, height: box.height },
         panelWidth: panelBox.width,
@@ -295,6 +300,8 @@ suite.define(() => {
     });
     expect(geometry.gap).toBeGreaterThan(0);
     expect(geometry.top).toBe(0);
+    expect(geometry.actionLeftOffset).toBe(0);
+    expect(geometry.actionVerticalGap).toBeGreaterThan(0);
     expect(geometry.box).toEqual(restingBox);
     expect(geometry.panelWidth).toBe(restingBox.width);
     const pinBox = (await pin.boundingBox())!;
@@ -468,6 +475,22 @@ suite.define(() => {
     await page.locator(".board-session-surface").waitFor();
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
     const pin = preview.getByRole("button", { name: "Pin to dashboard" });
+    await expect
+      .poll(() =>
+        preview
+          .locator("[data-widget-actions]")
+          .evaluate((element) => getComputedStyle(element).opacity),
+      )
+      .toBe("0.6");
+    await expect
+      .poll(() =>
+        pin.evaluate((element) => {
+          const box = element.getBoundingClientRect();
+          const thread = element.closest(".chat-thread")!.getBoundingClientRect();
+          return box.top >= thread.top;
+        }),
+      )
+      .toBe(true);
     await pin.focus();
     await pin.click();
 

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -270,7 +270,7 @@ suite.define(() => {
     await expect
       .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
       .toBe("0");
-    const restingWidth = await preview.evaluate((element) => element.getBoundingClientRect().width);
+    const restingBox = (await preview.boundingBox())!;
     const pin = preview.getByRole("button", { name: "Pin to dashboard" });
     const more = preview.getByRole("button", { name: "Widget actions", exact: true });
     await pin.focus();
@@ -289,14 +289,14 @@ suite.define(() => {
       return {
         gap: pinBox.left - box.right,
         top: pinBox.top - box.top,
-        width: box.width,
+        box: { x: box.x, y: box.y, width: box.width, height: box.height },
         panelWidth: panelBox.width,
       };
     });
     expect(geometry.gap).toBeGreaterThan(0);
     expect(geometry.top).toBe(0);
-    expect(geometry.width).toBe(restingWidth);
-    expect(geometry.panelWidth).toBe(restingWidth);
+    expect(geometry.box).toEqual(restingBox);
+    expect(geometry.panelWidth).toBe(restingBox.width);
     const pinBox = (await pin.boundingBox())!;
     await page.mouse.move(pinBox.x - geometry.gap / 2, pinBox.y + pinBox.height / 2);
     await page.mouse.move(pinBox.x + pinBox.width / 2, pinBox.y + pinBox.height / 2);
@@ -315,16 +315,23 @@ suite.define(() => {
     await page.keyboard.press("Enter");
     await expect.poll(() => preview.locator("wa-dropdown[open]").count()).toBe(1);
     await page.keyboard.press("Escape");
-    await page.setViewportSize({ width: 800, height: 900 });
-    await expect
-      .poll(() =>
-        preview.evaluate((element) => {
-          const box = element.getBoundingClientRect();
-          const actions = element.querySelector("[data-widget-actions]")!.getBoundingClientRect();
-          return actions.left >= box.left && actions.right <= box.right && actions.top >= box.top;
-        }),
-      )
-      .toBe(true);
+    for (const width of [796, 794, 390]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expect
+        .poll(() =>
+          preview.evaluate((element) => {
+            const box = element.getBoundingClientRect();
+            const actions = element.querySelector("[data-widget-actions]")!.getBoundingClientRect();
+            const thread = element.closest(".chat-thread")!;
+            const edge =
+              thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
+            return edge - box.right >= 40
+              ? actions.left >= box.right && actions.right <= edge && actions.top === box.top
+              : actions.right <= box.right && actions.bottom === box.top;
+          }),
+        )
+        .toBe(true);
+    }
     await page.setViewportSize({ width: 1440, height: 900 });
     await pin.focus();
     await pin.hover();
@@ -461,7 +468,7 @@ suite.define(() => {
     await page.locator(".board-session-surface").waitFor();
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
     const pin = preview.getByRole("button", { name: "Pin to dashboard" });
-    await preview.hover();
+    await pin.focus();
     await pin.click();
 
     await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
@@ -470,6 +477,7 @@ suite.define(() => {
     expect(await toast.textContent()).toContain("Could not pin to dashboard. Try again.");
     expect(await pin.isEnabled()).toBe(true);
     await page.mouse.move(0, 0);
+    await pin.focus();
     await pin.hover();
     const hint = page.locator("wa-tooltip[open]");
     await hint.locator('[part="body"]').waitFor({ state: "visible" });

--- a/ui/src/pages/chat/components/chat-tool-cards.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.browser.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../../styles.css";
 import "../../../styles/chat.ts";
 import { renderToolCard } from "./chat-tool-cards.ts";
+import { renderToolPreview } from "./widget-card.ts";
 
 let container: HTMLDivElement | undefined;
 afterEach(() => {
@@ -52,5 +53,69 @@ describe.runIf("__vitest_browser__" in globalThis)("narrow tool activity rows", 
     ).find((element) => element.textContent === "Yield")!;
     expect(label).toBeDefined();
     expect(label.scrollWidth).toBe(label.clientWidth);
+  });
+});
+
+describe.runIf("__vitest_browser__" in globalThis)("widget action placement", () => {
+  it("mounts and rerenders during resize delivery without observer loop errors", async () => {
+    container = document.body.appendChild(document.createElement("div"));
+    container.className = "chat-thread";
+    container.style.cssText = "width: 420px; height: 300px";
+    const errors: string[] = [];
+    const recordError = (event: ErrorEvent) => {
+      if (event.message.includes("ResizeObserver loop")) {
+        errors.push(event.message);
+      }
+    };
+    window.addEventListener("error", recordError);
+    const draw = () =>
+      render(
+        renderToolPreview(
+          {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            url: "about:blank",
+            sandbox: "strict",
+          },
+          "chat_message",
+          { rawText: "Widget details" },
+        ),
+        container!,
+      );
+    let rerenderObserver: ResizeObserver | undefined;
+    try {
+      draw();
+      const preview = container.querySelector<HTMLElement>(".chat-tool-card__preview")!;
+      preview.style.width = "400px";
+      const actions = preview.querySelector<HTMLElement>("[data-widget-actions]")!;
+      await vi.waitFor(() =>
+        expect(actions.getBoundingClientRect().bottom).toBe(preview.getBoundingClientRect().top),
+      );
+      expect(errors).toEqual([]);
+
+      let rerendered = false;
+      rerenderObserver = new ResizeObserver(() => {
+        rerenderObserver?.disconnect();
+        container!.style.width = "480px";
+        draw();
+        rerendered = true;
+      });
+      rerenderObserver.observe(preview);
+      await vi.waitFor(() => {
+        expect(rerendered).toBe(true);
+        expect(actions.getBoundingClientRect().left).toBe(preview.getBoundingClientRect().right);
+      });
+      expect(errors).toEqual([]);
+
+      container.style.width = "420px";
+      await vi.waitFor(() =>
+        expect(actions.getBoundingClientRect().bottom).toBe(preview.getBoundingClientRect().top),
+      );
+      expect(errors).toEqual([]);
+    } finally {
+      rerenderObserver?.disconnect();
+      window.removeEventListener("error", recordError);
+    }
   });
 });

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -524,6 +524,33 @@ function handleWidgetExportAction(
     });
 }
 
+function widgetActionsPlacementRef() {
+  let observer: ResizeObserver | undefined;
+  return (element: Element | undefined) => {
+    observer?.disconnect();
+    observer = undefined;
+    if (!(element instanceof HTMLElement) || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    observer = new ResizeObserver(() => {
+      const thread = element.closest<HTMLElement>(".chat-thread");
+      const actions = element.querySelector<HTMLElement>("[data-widget-actions]");
+      if (!thread || !actions) {
+        return;
+      }
+      observer?.observe(thread);
+      observer?.observe(actions);
+      const clipRight =
+        thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
+      element.toggleAttribute(
+        "data-widget-actions-inside",
+        element.getBoundingClientRect().right + actions.getBoundingClientRect().width > clipRight,
+      );
+    });
+    observer.observe(element);
+  };
+}
+
 function renderWidgetActions(preview: CanvasToolPreview, hasRawDetails: boolean) {
   const canExportImage = !preview.mcpApp && isInternalCanvasEntryUrl(preview.url);
   if (!canExportImage && !hasRawDetails) {
@@ -650,6 +677,7 @@ function renderWidgetCard(
         </div>`;
   return html`
     <div
+      ${actions !== nothing ? ref(widgetActionsPlacementRef()) : nothing}
       class="chat-tool-card__preview"
       data-content-kind=${contentKind}
       ?data-has-widget-actions=${actions !== nothing}

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -541,7 +541,6 @@ function widgetActionsPlacementRef() {
       const clipRight =
         thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
       const availableWidth = clipRight - element.getBoundingClientRect().right;
-      element.style.setProperty("--widget-actions-space", `${Math.max(0, availableWidth)}px`);
       element.toggleAttribute("data-widget-actions-above", availableWidth < 40);
     });
     observer.observe(element);

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -534,18 +534,15 @@ function widgetActionsPlacementRef() {
     }
     observer = new ResizeObserver(() => {
       const thread = element.closest<HTMLElement>(".chat-thread");
-      const actions = element.querySelector<HTMLElement>("[data-widget-actions]");
-      if (!thread || !actions) {
+      if (!thread) {
         return;
       }
       observer?.observe(thread);
-      observer?.observe(actions);
       const clipRight =
         thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
-      element.toggleAttribute(
-        "data-widget-actions-inside",
-        element.getBoundingClientRect().right + actions.getBoundingClientRect().width > clipRight,
-      );
+      const availableWidth = clipRight - element.getBoundingClientRect().right;
+      element.style.setProperty("--widget-actions-space", `${Math.max(0, availableWidth)}px`);
+      element.toggleAttribute("data-widget-actions-above", availableWidth < 40);
     });
     observer.observe(element);
   };

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -526,24 +526,34 @@ function handleWidgetExportAction(
 
 function widgetActionsPlacementRef() {
   let observer: ResizeObserver | undefined;
+  let frame: number | undefined;
   return (element: Element | undefined) => {
     observer?.disconnect();
     observer = undefined;
+    if (frame !== undefined) {
+      cancelAnimationFrame(frame);
+      frame = undefined;
+    }
     if (!(element instanceof HTMLElement) || typeof ResizeObserver === "undefined") {
       return;
     }
-    observer = new ResizeObserver(() => {
+    // Lit refs can run during resize delivery. Register both connected targets
+    // in the next frame so the shallower thread cannot trigger a loop error.
+    frame = requestAnimationFrame(() => {
+      frame = undefined;
       const thread = element.closest<HTMLElement>(".chat-thread");
       if (!thread) {
         return;
       }
-      observer?.observe(thread);
-      const clipRight =
-        thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
-      const availableWidth = clipRight - element.getBoundingClientRect().right;
-      element.toggleAttribute("data-widget-actions-above", availableWidth < 40);
+      observer = new ResizeObserver(() => {
+        const clipRight =
+          thread.getBoundingClientRect().left + thread.clientLeft + thread.clientWidth;
+        const availableWidth = clipRight - element.getBoundingClientRect().right;
+        element.toggleAttribute("data-widget-actions-above", availableWidth < 40);
+      });
+      observer.observe(element);
+      observer.observe(thread);
     });
-    observer.observe(element);
   };
 }
 

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -854,10 +854,9 @@
   top: 0;
   left: 100%;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
   width: max-content;
-  max-width: var(--widget-actions-space);
   gap: 4px;
   padding-left: 4px;
 }
@@ -877,6 +876,7 @@
 .chat-virtual-row:has(
   .chat-tool-card__preview:hover,
   .chat-tool-card__preview:focus-within,
+  .chat-tool-card__preview[data-widget-actions-above],
   .chat-tool-card__widget-actions[open]
 ) {
   content-visibility: visible;
@@ -898,31 +898,15 @@
   font-size: calc(13px * var(--control-ui-text-scale));
 }
 
-.chat-tool-card__widget-actions-trigger,
-.chat-tool-card__widget-action {
-  width: 28px;
-  height: 28px;
-  min-height: 28px;
+.chat-tool-card__preview[data-widget-actions-above] .chat-tool-card__preview-actions {
+  top: auto;
+  bottom: 100%;
+  left: auto;
+  right: 0;
+  flex-direction: row;
   padding: 0;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 76%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--card) 88%, transparent);
-  box-shadow: var(--shadow-sm);
-  color: var(--muted);
-}
-
-.chat-tool-card__widget-actions-trigger:hover,
-.chat-tool-card__widget-actions-trigger:focus-visible,
-.chat-tool-card__widget-action:hover,
-.chat-tool-card__widget-action:focus-visible {
-  color: var(--text);
-  background: var(--bg-hover);
-}
-
-.chat-tool-card__widget-actions-trigger svg,
-.chat-tool-card__widget-action svg {
-  width: 16px;
-  height: 16px;
+  opacity: 0.6;
+  pointer-events: auto;
 }
 
 [data-widget-actions] {
@@ -938,27 +922,16 @@
   pointer-events: auto;
 }
 
-/* Match inline image actions: touch keeps content controls directly reachable. */
+/* Touch keeps actions reachable; focus, hover, and an open menu reveal them. */
 @media (hover: none) {
   [data-widget-actions] {
-    opacity: 1;
+    opacity: 0.6;
     pointer-events: auto;
   }
 
   .chat-virtual-row:has(.chat-tool-card__preview[data-has-widget-actions]) {
     content-visibility: visible;
   }
-}
-
-.chat-tool-card__preview[data-widget-actions-above] .chat-tool-card__preview-actions {
-  top: auto;
-  bottom: 100%;
-  left: auto;
-  right: 0;
-  max-width: none;
-  padding: 0 0 4px;
-  border-radius: var(--radius-sm);
-  background: var(--bg);
 }
 
 .chat-tool-card__widget-action[data-pinned] {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -838,7 +838,6 @@
 }
 
 .chat-tool-card__preview[data-has-widget-actions] {
-  margin-top: 40px;
   overflow: visible;
 }
 
@@ -852,11 +851,12 @@
 .chat-tool-card__preview-actions {
   position: absolute;
   z-index: 2;
-  top: -34px;
-  right: 0;
+  top: 0;
+  left: 100%;
   display: flex;
   align-items: center;
   gap: 4px;
+  padding-left: 6px;
 }
 
 .chat-tool-card__preview-panel {
@@ -869,9 +869,13 @@
   flex-shrink: 0;
 }
 
-/* Chromium can retain a skipped row's pre-menu geometry. Fully lay out the
-   active widget row so closing its top-layer menu cannot move the disclosure. */
-.chat-virtual-row:has(.chat-tool-card__widget-actions[open]) {
+/* Keep outside actions reachable and avoid restoring stale row geometry when
+   the active widget's top-layer menu closes. */
+.chat-virtual-row:has(
+  .chat-tool-card__preview:hover,
+  .chat-tool-card__preview:focus-within,
+  .chat-tool-card__widget-actions[open]
+) {
   content-visibility: visible;
 }
 
@@ -919,13 +923,37 @@
 }
 
 [data-widget-actions] {
-  opacity: 0.45;
+  opacity: 0;
+  pointer-events: none;
   transition: opacity 120ms ease-out;
 }
 
 .chat-tool-card__preview:hover [data-widget-actions],
-.chat-tool-card__preview:focus-within [data-widget-actions] {
+.chat-tool-card__preview:focus-within [data-widget-actions],
+[data-widget-actions]:has(.chat-tool-card__widget-actions[open]) {
   opacity: 1;
+  pointer-events: auto;
+}
+
+/* Match inline image actions: touch keeps content controls directly reachable. */
+@media (hover: none) {
+  [data-widget-actions] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .chat-virtual-row:has(
+    .chat-tool-card__preview[data-has-widget-actions]:not([data-widget-actions-inside])
+  ) {
+    content-visibility: visible;
+  }
+}
+
+.chat-tool-card__preview[data-widget-actions-inside] .chat-tool-card__preview-actions {
+  left: auto;
+  right: 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
 }
 
 .chat-tool-card__widget-action[data-pinned] {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -854,9 +854,12 @@
   top: 0;
   left: 100%;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  width: max-content;
+  max-width: var(--widget-actions-space);
   gap: 4px;
-  padding-left: 6px;
+  padding-left: 4px;
 }
 
 .chat-tool-card__preview-panel {
@@ -942,16 +945,18 @@
     pointer-events: auto;
   }
 
-  .chat-virtual-row:has(
-    .chat-tool-card__preview[data-has-widget-actions]:not([data-widget-actions-inside])
-  ) {
+  .chat-virtual-row:has(.chat-tool-card__preview[data-has-widget-actions]) {
     content-visibility: visible;
   }
 }
 
-.chat-tool-card__preview[data-widget-actions-inside] .chat-tool-card__preview-actions {
+.chat-tool-card__preview[data-widget-actions-above] .chat-tool-card__preview-actions {
+  top: auto;
+  bottom: 100%;
   left: auto;
   right: 0;
+  max-width: none;
+  padding: 0 0 4px;
   border-radius: var(--radius-sm);
   background: var(--bg);
 }


### PR DESCRIPTION
Closes #143539

## What Problem This Solves

Chat widgets currently show Pin and More in a separate row above their content. This improvement removes the reserved row and keeps secondary controls quiet while reading.

## Why This Change Was Made

When at least 40px is available to the right, Pin and More form a vertical column outside the widget, aligned to its top. Pin is above More. With less space, the controls become a horizontal row immediately above the widget. Both placements are absolute overlays and preserve the widget's width and position.

The outside desktop column appears on hover or keyboard focus. Narrow-pane and touch controls remain reachable at 60% opacity; interacting with them or opening More reveals them fully. Tapping outside restores the muted state. Both buttons use the existing icon/ghost button radius, border, background, and sizing consistently in light and dark themes. Placement observation starts in the next animation frame, after the preview is attached, and pending initialization is canceled when its ref is retired. This prevents resize-delivery errors when widgets mount or rerender.

## User Impact

Widgets retain their full content width and no longer reserve a separate action row. The narrow first-widget case keeps Pin below the conversation header, where it can be clicked. Canvas HTML and inline MCP App widgets share this behavior. Pin, keyboard navigation, image export, raw details, and the open More menu remain available.

## Evidence

Current desktop: Pin above More, with the menu closed and open. Current mobile: muted at rest and fully visible after tapping More. Captions are included in each image; historical baselines below are explicitly labeled **Before this PR**.

<table>
<tr><th>Desktop light</th><th>Desktop dark</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee"><img src="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee" alt="Current — desktop light, hover: Pin above More" width="680"></a><br><a href="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee">Current — desktop light, hover: Pin above More</a></td><td><a href="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b"><img src="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b" alt="Current — desktop dark, hover: Pin above More" width="680"></a><br><a href="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b">Current — desktop dark, hover: Pin above More</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/d96135f5-a82b-4f22-bf99-ae8cad1585f9"><img src="https://github.com/user-attachments/assets/d96135f5-a82b-4f22-bf99-ae8cad1585f9" alt="Current — desktop light, More menu open" width="680"></a><br><a href="https://github.com/user-attachments/assets/d96135f5-a82b-4f22-bf99-ae8cad1585f9">Current — desktop light, More menu open</a></td><td><a href="https://github.com/user-attachments/assets/660389a1-a2f9-4467-b0ef-d18b0d8dd125"><img src="https://github.com/user-attachments/assets/660389a1-a2f9-4467-b0ef-d18b0d8dd125" alt="Current — desktop dark, More menu open" width="680"></a><br><a href="https://github.com/user-attachments/assets/660389a1-a2f9-4467-b0ef-d18b0d8dd125">Current — desktop dark, More menu open</a></td></tr>
</table>

Mobile at rest and after tapping More:

<table>
<tr><th>Mobile: muted at rest</th><th>Mobile: active after tap</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/3183bafe-edb2-44c3-bc85-e2ea7fdce599"><img src="https://github.com/user-attachments/assets/3183bafe-edb2-44c3-bc85-e2ea7fdce599" alt="Current — mobile light, muted at rest (60%)" width="680"></a><br><a href="https://github.com/user-attachments/assets/3183bafe-edb2-44c3-bc85-e2ea7fdce599">Current — mobile light, muted at rest (60%)</a></td><td><a href="https://github.com/user-attachments/assets/77154e8c-5894-481d-abae-c6c5bcda2184"><img src="https://github.com/user-attachments/assets/77154e8c-5894-481d-abae-c6c5bcda2184" alt="Current — mobile light, active after tap (100%)" width="680"></a><br><a href="https://github.com/user-attachments/assets/77154e8c-5894-481d-abae-c6c5bcda2184">Current — mobile light, active after tap (100%)</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/7b9557ad-a565-405d-b37d-0bcfc52a987e"><img src="https://github.com/user-attachments/assets/7b9557ad-a565-405d-b37d-0bcfc52a987e" alt="Current — mobile dark, muted at rest (60%)" width="680"></a><br><a href="https://github.com/user-attachments/assets/7b9557ad-a565-405d-b37d-0bcfc52a987e">Current — mobile dark, muted at rest (60%)</a></td><td><a href="https://github.com/user-attachments/assets/199eee6f-2351-48cf-89be-08d4c356c5c2"><img src="https://github.com/user-attachments/assets/199eee6f-2351-48cf-89be-08d4c356c5c2" alt="Current — mobile dark, active after tap (100%)" width="680"></a><br><a href="https://github.com/user-attachments/assets/199eee6f-2351-48cf-89be-08d4c356c5c2">Current — mobile dark, active after tap (100%)</a></td></tr>
</table>

Historical before/after comparison. The old reserved row is in the left column; this is a comparison between versions, not a hover shift.

<table>
<tr><th>Before this PR</th><th>Current: hover</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/11e68423-932b-44a5-8d0a-b0944adc584b"><img src="https://github.com/user-attachments/assets/11e68423-932b-44a5-8d0a-b0944adc584b" alt="Before this PR — light: old reserved action row" width="680"></a><br><a href="https://github.com/user-attachments/assets/11e68423-932b-44a5-8d0a-b0944adc584b">Before this PR — light: old reserved action row</a></td><td><a href="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee"><img src="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee" alt="Current — desktop light, hover: Pin above More" width="680"></a><br><a href="https://github.com/user-attachments/assets/2b0e1045-114a-4e7b-bc8f-581b231296ee">Current — desktop light, hover: Pin above More</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/e80a8104-b2e8-4015-a979-6f238c0c4144"><img src="https://github.com/user-attachments/assets/e80a8104-b2e8-4015-a979-6f238c0c4144" alt="Before this PR — dark: old reserved action row" width="680"></a><br><a href="https://github.com/user-attachments/assets/e80a8104-b2e8-4015-a979-6f238c0c4144">Before this PR — dark: old reserved action row</a></td><td><a href="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b"><img src="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b" alt="Current — desktop dark, hover: Pin above More" width="680"></a><br><a href="https://github.com/user-attachments/assets/0be5a637-af09-490d-b3b1-cac489a72c5b">Current — desktop dark, hover: Pin above More</a></td></tr>
</table>

Complete resting-state matrix (four scenarios per image):

<table>
<tr><th>Before this PR</th><th>Current</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/a43e11c4-deb3-4b15-896e-62fd302da0f2"><img src="https://github.com/user-attachments/assets/a43e11c4-deb3-4b15-896e-62fd302da0f2" alt="Before 1440px light: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/a43e11c4-deb3-4b15-896e-62fd302da0f2">Before 1440px light: own turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/de8e0da8-ead6-421a-b5b3-9d9cfad40ac6"><img src="https://github.com/user-attachments/assets/de8e0da8-ead6-421a-b5b3-9d9cfad40ac6" alt="Current 1440px light: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/de8e0da8-ead6-421a-b5b3-9d9cfad40ac6">Current 1440px light: own turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/f2365c35-8fbe-46ca-a5c3-dd00d023bc32"><img src="https://github.com/user-attachments/assets/f2365c35-8fbe-46ca-a5c3-dd00d023bc32" alt="Before 1440px light: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/f2365c35-8fbe-46ca-a5c3-dd00d023bc32">Before 1440px light: peer turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/0cf0484d-649b-4130-bc18-78392cc62ea8"><img src="https://github.com/user-attachments/assets/0cf0484d-649b-4130-bc18-78392cc62ea8" alt="Current 1440px light: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/0cf0484d-649b-4130-bc18-78392cc62ea8">Current 1440px light: peer turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/d8c2984a-5410-4540-9586-2591724d0739"><img src="https://github.com/user-attachments/assets/d8c2984a-5410-4540-9586-2591724d0739" alt="Before 1440px dark: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/d8c2984a-5410-4540-9586-2591724d0739">Before 1440px dark: own turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/9c39ad39-b972-47a5-8a85-21fc59ed2877"><img src="https://github.com/user-attachments/assets/9c39ad39-b972-47a5-8a85-21fc59ed2877" alt="Current 1440px dark: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/9c39ad39-b972-47a5-8a85-21fc59ed2877">Current 1440px dark: own turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/08949d24-15e6-45f5-ac6e-5daac681609e"><img src="https://github.com/user-attachments/assets/08949d24-15e6-45f5-ac6e-5daac681609e" alt="Before 1440px dark: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/08949d24-15e6-45f5-ac6e-5daac681609e">Before 1440px dark: peer turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/56cac4ff-4b61-4546-b67f-d5ef4cffee12"><img src="https://github.com/user-attachments/assets/56cac4ff-4b61-4546-b67f-d5ef4cffee12" alt="Current 1440px dark: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/56cac4ff-4b61-4546-b67f-d5ef4cffee12">Current 1440px dark: peer turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/0c75eb43-eb71-428e-8036-2bd4c76317a4"><img src="https://github.com/user-attachments/assets/0c75eb43-eb71-428e-8036-2bd4c76317a4" alt="Before 390px light: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/0c75eb43-eb71-428e-8036-2bd4c76317a4">Before 390px light: own turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/1880d144-1e6b-46f9-9d40-a1d04a57f071"><img src="https://github.com/user-attachments/assets/1880d144-1e6b-46f9-9d40-a1d04a57f071" alt="Current 390px light: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/1880d144-1e6b-46f9-9d40-a1d04a57f071">Current 390px light: own turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/b314080f-f0f6-4c88-adef-7e17ff8f062e"><img src="https://github.com/user-attachments/assets/b314080f-f0f6-4c88-adef-7e17ff8f062e" alt="Before 390px light: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/b314080f-f0f6-4c88-adef-7e17ff8f062e">Before 390px light: peer turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/da52833d-3be9-4665-b6ab-33a95a9e9c93"><img src="https://github.com/user-attachments/assets/da52833d-3be9-4665-b6ab-33a95a9e9c93" alt="Current 390px light: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/da52833d-3be9-4665-b6ab-33a95a9e9c93">Current 390px light: peer turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/6da04499-2700-406b-9fb8-5df7101b0e52"><img src="https://github.com/user-attachments/assets/6da04499-2700-406b-9fb8-5df7101b0e52" alt="Before 390px dark: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/6da04499-2700-406b-9fb8-5df7101b0e52">Before 390px dark: own turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/edfe512e-e60c-45d9-aff6-6c5cc58697e6"><img src="https://github.com/user-attachments/assets/edfe512e-e60c-45d9-aff6-6c5cc58697e6" alt="Current 390px dark: own turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/edfe512e-e60c-45d9-aff6-6c5cc58697e6">Current 390px dark: own turn, short and long text, with and without attachment</a></td></tr>
<tr><td><a href="https://github.com/user-attachments/assets/1ae2ee05-7713-4f5d-bdf5-0f5916e55b25"><img src="https://github.com/user-attachments/assets/1ae2ee05-7713-4f5d-bdf5-0f5916e55b25" alt="Before 390px dark: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/1ae2ee05-7713-4f5d-bdf5-0f5916e55b25">Before 390px dark: peer turn, short and long text, with and without attachment</a></td><td><a href="https://github.com/user-attachments/assets/5b07aeba-4356-4a8c-8b63-3cb4b8f93ebf"><img src="https://github.com/user-attachments/assets/5b07aeba-4356-4a8c-8b63-3cb4b8f93ebf" alt="Current 390px dark: peer turn, short and long text, with and without attachment" width="680"></a><br><a href="https://github.com/user-attachments/assets/5b07aeba-4356-4a8c-8b63-3cb4b8f93ebf">Current 390px dark: peer turn, short and long text, with and without attachment</a></td></tr>
</table>


Validation:

- Final commit `4e3b0b91324e3ebfe3eb0b65a90661767408b4d3`: all 13 hosted UI E2E shards passed; [shard 7/13](https://github.com/openclaw/openclaw/actions/runs/34570317075/job/103171030875) confirms all 8 session-dashboard tests pass.
- [Final-head CI passed all selected gates](https://github.com/openclaw/openclaw/actions/runs/34570317075), including types, formatting, i18n, guards, dead-export scans and lint. The final local changed-file rerun also completed successfully, including types, formatting, i18n, guards, all three dead-export scans, lint and styles.
- The focused Chromium renderer tests pass (2/2). The new regression fails on the original observer implementation with a resize-delivery error and passes after the lifecycle repair, including rerendering during resize delivery and resizing the containing thread.
- Existing flows verify vertical desktop ordering, unchanged widget geometry, keyboard access, and a visible/clickable Pin in the first widget of a narrow dashboard conversation. The original failing narrow-column case was reproduced before the horizontal fallback was applied.
- Browser probes verify the exact cutoff: 40px gives an external vertical column; 39px gives the horizontal top overlay. Both buttons are clickable, with unchanged widget geometry.
- Mobile interaction verifies 60% at rest, 100% with More open, and 60% after tapping outside, plus working raw details and Pin.
- The 32-case matrix covers 1440/390px, light/dark, own/peer shared-session turns, one-line/five-line text, and attachment/no attachment. Captures use real application fonts and were inspected.

## Risk and coverage

The above-widget row intentionally overlays existing space. Its 36px height keeps both controls inside the narrow first-widget conversation tested here, without reserving layout height. The tests retain real clicks and the existing request, error-toast, tooltip, enabled-state, and private-detail assertions. No forced clicks or longer timeouts were introduced.

The final local session-dashboard run passed 5/8 tests, including both Pin paths and failure recovery, but timed out in three Workboard scenarios while the host was under heavy CPU and memory pressure. The identical final source passed all 8 tests in hosted CI; the three scenarios completed there in 0.9–1.5 seconds. No tests or timeouts were weakened.

Browser evidence uses Chromium with a mocked Gateway; Canvas HTML and inline MCP App paths are both exercised. On the earlier commit `cd7a3ecd52b2`, hosted CI [attempt 2 passed without a code change](https://github.com/openclaw/openclaw/actions/runs/34429212692/attempts/2) after one failed-job rerun: [checks-ui-e2e (11/13)](https://github.com/openclaw/openclaw/actions/runs/34429212692/job/103020862925) and [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34429212692/job/103023435830) both succeeded. Attempt 1 timed out waiting for “Plugin ready” after Matrix installation restarted the Gateway. This flow does not render widgets or exercise Pin/More. Source review identified a request/acknowledgment race covered by the later upstream repair [#143671 by @steipete](https://github.com/openclaw/openclaw/pull/143671). The old log does not reveal the exact acknowledgment ordering; the successful retry confirms that the same code can pass. No product or test changes were needed for that earlier CI follow-up.

