### PR TITLE
fix: retain model setup resources through asynchronous work

### DIFF
--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
 /**
  * Simple completion runtime preparation.
@@ -16,6 +17,12 @@ import {
 } from "../plugins/provider-hook-runtime.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
@@ -449,6 +456,7 @@ async function acquirePreparedSimpleCompletionRuntime(
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
   runtimePluginSelections: readonly AgentHarnessPluginSelection[],
+  onAcquired?: (release: () => void) => void,
 ): Promise<{ context: PreparedSimpleCompletionResolverContext; release: () => void }> {
   const config = params.cfg ?? {};
   const agentId = params.agentId ?? resolveDefaultAgentId(config);
@@ -478,6 +486,8 @@ async function acquirePreparedSimpleCompletionRuntime(
             : {}),
         },
       );
+  const release = () => lease?.release();
+  onAcquired?.(release);
   const preparedModelRuntime = params.preparedModelRuntime ?? lease!.snapshot;
   const workspaceDir =
     params.workspaceDir ?? preparedModelRuntime.workspaceDir ?? requestedWorkspaceDir;
@@ -488,9 +498,11 @@ async function acquirePreparedSimpleCompletionRuntime(
       modelResolver: params.modelResolver,
       agentRuntimeId: params.agentRuntimeId,
     });
-    return { context, release: () => lease?.release() };
+    return { context, release };
   } catch (error) {
-    lease?.release();
+    if (!onAcquired) {
+      release();
+    }
     throw error;
   }
 }
@@ -590,20 +602,38 @@ export async function acquireSimpleCompletionModelForAgent(
       return { error: `No model configured for agent ${params.agentId}.` };
     }
   }
-  const runtime = await acquirePreparedSimpleCompletionRuntime(
-    {
-      ...params,
-      agentDir: selection.agentDir,
-      pluginMetadataSnapshot: metadataSnapshot,
-    },
-    [{ provider: selection.provider, modelId: selection.modelId }],
-  );
-  let transferred = false;
-  try {
+  const result = createDeferredCore<AcquiredSimpleCompletionModelForAgent>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  const work = new AsyncWorkScope();
+  let runInContext = work.run(() => AsyncLocalStorage.snapshot());
+  let releaseRuntime: (() => void) | undefined;
+  let setupSettled = false;
+  let callerReleased = true;
+  const releaseWhenUnused = () => {
+    if (setupSettled && callerReleased) {
+      const release = releaseRuntime;
+      releaseRuntime = undefined;
+      release?.();
+    }
+  };
+  const prepare = async () => {
+    const runtime = await acquirePreparedSimpleCompletionRuntime(
+      {
+        ...params,
+        agentDir: selection.agentDir,
+        pluginMetadataSnapshot: metadataSnapshot,
+      },
+      [{ provider: selection.provider, modelId: selection.modelId }],
+      (release) => {
+        releaseRuntime = release;
+      },
+    );
     const prepared = await withPluginRuntimeGenerationScope(
       runtime.context.preparedModelRuntime,
-      () =>
-        prepareSimpleCompletionModelCore(
+      () => {
+        runInContext = AsyncLocalStorage.snapshot();
+        return prepareSimpleCompletionModelCore(
           {
             cfg: params.cfg,
             agentId: params.agentId,
@@ -620,19 +650,47 @@ export async function acquireSimpleCompletionModelForAgent(
             bindAuthOwner: params.bindAuthOwner,
           },
           runtime.context,
-        ),
+        );
+      },
     );
     if ("error" in prepared) {
       return { ...prepared, selection };
     }
-    const acquired = { ...prepared, selection, release: runtime.release };
-    transferred = true;
-    return acquired;
-  } finally {
-    if (!transferred) {
-      runtime.release();
+    callerReleased = false;
+    return {
+      ...prepared,
+      selection,
+      release: () => {
+        callerReleased = true;
+        releaseWhenUnused();
+      },
+    };
+  };
+  // Host work includes setup only; host close releases adopted model claims after drainage.
+  void trackOwner(async () => {
+    const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
+    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
+    if (parentSignal?.aborted) {
+      closeFromParent();
     }
-  }
+    try {
+      result.resolve(await work.track(prepare));
+    } catch (error) {
+      result.reject(error);
+    } finally {
+      try {
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => runInContext(() => work.drain()),
+        );
+      } finally {
+        parentSignal?.removeEventListener("abort", closeFromParent);
+        setupSettled = true;
+        releaseWhenUnused();
+      }
+    }
+  }).catch(result.reject);
+  return await result.promise;
 }
 
 export { completeWithPreparedSimpleCompletionModel } from "./simple-completion-execution.js";

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { DatabaseSync } from "node:sqlite";
 import { getAiTransportHost } from "@openclaw/ai";
 import { expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -16,9 +17,11 @@ import {
   prepareModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "../../agents/prepared-model-runtime.js";
+import * as preparedRuntimes from "../../agents/prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared-model-runtime.test-support.js";
 import { AuthStorage } from "../../agents/sessions/auth-storage.js";
 import { ModelRegistry } from "../../agents/sessions/model-registry.js";
+import { acquireSimpleCompletionModelForAgent } from "../../agents/simple-completion-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { bindModelLlmRuntime, getModelLlmRuntime } from "../../llm/model-runtime-binding.js";
 import {
@@ -26,7 +29,11 @@ import {
   extractAssistantText,
   prepareSimpleCompletionModelForAgent,
 } from "../../plugin-sdk/simple-completion-runtime.js";
-import { AsyncWorkScope, getAsyncWorkSignal } from "../../shared/async-work-scope.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { LegacyPluginSdkResourceHost } from "../legacy-sdk-resource-host.js";
 import { resetPluginLoaderTestStateForTest } from "../loader.test-fixtures.js";
@@ -39,6 +46,10 @@ import { createSyncSuiteTempRootTracker } from "../test-helpers/fs-fixtures.js";
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 
 it.each([
+  "setup-success",
+  "setup-error",
+  "sdk-setup-error",
+  "sdk-setup-close",
   "overlap",
   "config",
   "auth",
@@ -63,6 +74,8 @@ it.each([
 ] as const)("keeps completion ownership coherent: %s", async (testCase) => {
   const sdk = testCase.startsWith("sdk-");
   const mode = testCase.replace(/^sdk-/, "");
+  const setupMode = mode.startsWith("setup-");
+  const setupKey = "__openclawCompletionSetupProof";
   const anthropicReadCancel = mode === "anthropic-read-cancel";
   const roots = createSyncSuiteTempRootTracker("runtime-llm-prepared-owner");
   const root = fs.realpathSync(roots.makeTempDir());
@@ -77,7 +90,17 @@ it.each([
     `module.exports = {
       id: ${JSON.stringify(fixture.pluginId)},
       register(api) {
-        api.registerProvider({ id: ${JSON.stringify(fixture.providerId)}, label: "Lease fixture", auth: [] });
+        const setup = globalThis[${JSON.stringify(setupKey)}];
+        if (setup) {
+          const file = require("node:path").join(__dirname, "setup-" + (++setup.count) + ".sqlite");
+          const db = new (require("node:sqlite").DatabaseSync)(file);
+          db.exec("CREATE TABLE observations (value INTEGER); INSERT INTO observations VALUES (42)");
+          const record = { file, disposed: 0, read: () => db.prepare("SELECT value FROM observations").get().value, close: setup.deferred() };
+          api.registerRuntimeLifecycle({ id: "setup-db", dispose() { record.disposed++; db.close(); record.close.resolve(); } });
+          api.registerProvider({ id: ${JSON.stringify(fixture.providerId)}, label: "Lease fixture", auth: [], prepareRuntimeAuth: () => setup.run(record) });
+        } else {
+          api.registerProvider({ id: ${JSON.stringify(fixture.providerId)}, label: "Lease fixture", auth: [] });
+        }
       },
     };`,
   );
@@ -392,6 +415,111 @@ it.each([
           }),
         ]);
       try {
+        if (setupMode) {
+          type SetupRecord = {
+            file: string;
+            disposed: number;
+            read: () => number;
+            close: ReturnType<typeof createDeferred>;
+          };
+          let record: SetupRecord | undefined;
+          let setupTail: Promise<void> | undefined;
+          let calls = 0;
+          // Use the real already-managed read-only producer; RUN activation is separate.
+          transportSpies.push(
+            vi
+              .spyOn(preparedRuntimes, "acquireAgentRunPreparedModelRuntime")
+              .mockImplementation((runtimeInput, options) =>
+                preparedRuntimes.acquireReadOnlyPreparedModelRuntime(
+                  runtimeInput,
+                  options?.abortSignal,
+                  options?.catalogMode ?? "static",
+                ),
+              ),
+          );
+          Object.defineProperty(globalThis, setupKey, {
+            configurable: true,
+            value: {
+              count: 0,
+              deferred: createDeferred,
+              run: async (source: SetupRecord) => {
+                if (++calls === 1) {
+                  record = source;
+                  setupTail = captureAsyncWorkTracker()(async () => {
+                    workStarted.resolve();
+                    await finishWork.promise;
+                    expect(source.read()).toBe(42);
+                  });
+                  void setupTail.catch(() => {});
+                  if (mode === "setup-error") {
+                    throw new Error("fixture setup failure");
+                  }
+                }
+                return {};
+              },
+            },
+          });
+          const host = sdkHosts[0];
+          const first =
+            mode === "setup-success"
+              ? acquireSimpleCompletionModelForAgent({ cfg, agentId: "main" }).then((acquired) => {
+                  if ("error" in acquired) {
+                    throw new Error(acquired.error);
+                  }
+                  acquired.release();
+                })
+              : sdk
+                ? host
+                    .run(() => prepareSimpleCompletionModelForAgent({ cfg, agentId: "main" }))
+                    .then(() => undefined)
+                : start(0).then(() => undefined);
+          pending.push(first);
+          await Promise.race([
+            workStarted.promise,
+            first.then(() => {
+              throw new Error("Setup did not start its real descendant");
+            }),
+          ]);
+          if (mode === "setup-error") {
+            await expect(first).rejects.toThrow("fixture setup failure");
+            expect(requests).toHaveLength(0);
+          } else if (sdk || mode === "setup-success") {
+            await first;
+          } else {
+            await waitForRequest(0, first);
+            finish(requests[0]!, 0);
+            await first;
+          }
+          if (!record || !setupTail) {
+            throw new Error("Missing setup source or descendant");
+          }
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect.soft(record.disposed).toBe(0);
+          let hostClosed = false;
+          const closing = sdk
+            ? host.close().then(() => {
+                hostClosed = true;
+              })
+            : undefined;
+          await Promise.resolve();
+          if (sdk) {
+            expect.soft(hostClosed).toBe(false);
+          }
+          finishWork.resolve();
+          await setupTail;
+          await closing;
+          await record.close.promise;
+          expect(record.disposed).toBe(1);
+          const reopened = new DatabaseSync(record.file, { readOnly: true });
+          try {
+            expect(reopened.prepare("SELECT value FROM observations").get()?.value).toBe(42);
+          } finally {
+            reopened.close();
+          }
+          return;
+        }
         if (sdk) {
           const [firstHost, secondHost, thirdHost, foreignHost] = sdkHosts;
           await foreignHost.close();
@@ -802,6 +930,7 @@ it.each([
           });
         }
       } finally {
+        Reflect.deleteProperty(globalThis, setupKey);
         finishPrepare.resolve();
         finishWork.resolve();
         finishing = true;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where provider authentication setup can leave asynchronous work using a prepared runtime after model preparation fails or its caller releases the result. With a managed plugin registration, that can close its database before the remaining work finishes.

## Why This Change Was Made

Model acquisition now owns setup and its admitted descendants from the moment it acquires the runtime. It releases the runtime only after setup finishes and any successful caller releases its claim. SDK host work covers setup rather than the returned lease's lifetime, preserving shutdown order without making host close wait on itself.

## User Impact

Provider setup work keeps access to its runtime through completion or failure. Model selection, authentication policy, public SDK contracts, and the current managed-runtime activation rules remain unchanged.

## Evidence

- Original-source regression: three managed SQLite cases fail because disposal occurs before a held authentication descendant reads its database. All now pass; the SDK shutdown success control remains green. These tests use an input adapter returning a real already-managed runtime, without enabling managed RUN acquisition.
- 440 focused and sibling tests pass, including public SDK, model execution, capability CLI, approval classification, and exec review controls.
- Changed-scope guards, types, dead-code scans, lint, and import-cycle checks pass. Fresh independent Codex review found no actionable P0–P2 findings.
- Full build passes in 245 seconds. A plain Node child exercises the compiled public SDK with a cold provider, held authentication HTTP work, and four real loopback model completions after setup drainage. It verifies generation reuse, host-close ordering, and eventual fresh acquisition; the child exits in 1.77 seconds with source and 12,129 build artifacts unchanged.
- Compiled proof keeps current raw RUN acquisition unchanged; it does not claim managed registration disposal. The build emitted a separate 21-byte UI startup gzip budget warning without failing.
