### PR TITLE
refactor: reuse channel setup config writers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -687,12 +687,12 @@ extensions/matrix/src/matrix/send/chunking.ts	4
 extensions/matrix/src/matrix/send/client.ts	1
 extensions/matrix/src/matrix/send/formatting.ts	1
 extensions/matrix/src/matrix/thread-bindings.ts	2
-extensions/matrix/src/onboarding.ts	10
+extensions/matrix/src/onboarding.ts	7
 extensions/matrix/src/outbound.ts	1
 extensions/matrix/src/profile-update.ts	2
 extensions/matrix/src/setup-config.ts	6
 extensions/matrix/src/setup-contract.ts	1
-extensions/matrix/src/setup-core.ts	8
+extensions/matrix/src/setup-core.ts	5
 extensions/matrix/src/setup-dm-policy.ts	5
 extensions/matrix/src/test-runtime.ts	10
 extensions/matrix/src/tool-actions.ts	2
@@ -1063,7 +1063,7 @@ extensions/reef/src/cli.ts	6
 extensions/reef/src/doctor-durable-state.ts	2
 extensions/reef/src/legacy-key-guard.ts	1
 extensions/reef/src/registration-state.ts	3
-extensions/reef/src/setup.ts	5
+extensions/reef/src/setup.ts	3
 extensions/reef/src/state.ts	3
 extensions/reef/src/transport.ts	3
 extensions/runway/video-generation-provider.ts	1
@@ -1150,7 +1150,7 @@ extensions/slack/src/scopes.ts	2
 extensions/slack/src/secret-contract.ts	1
 extensions/slack/src/security-audit.ts	6
 extensions/slack/src/send.ts	6
-extensions/slack/src/setup-core.ts	7
+extensions/slack/src/setup-core.ts	5
 extensions/slack/src/setup-surface.ts	1
 extensions/slack/src/streaming.ts	3
 extensions/slack/src/target-parsing.ts	1

--- a/extensions/a2a/src/channel-base.ts
+++ b/extensions/a2a/src/channel-base.ts
@@ -1,4 +1,5 @@
 import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
+import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 import {
   listA2aChannelAccountIds,
   resolveA2aChannelAccount,
@@ -65,20 +66,17 @@ export function createA2aChannelPluginBase(): A2aChannelPluginBase {
           const peerName = setup.peerName?.trim();
           const peerToken = setup.peerToken?.trim();
           const advertisedUrl = setup.advertisedUrl?.trim();
-          return {
-            ...cfg,
-            channels: {
-              ...cfg.channels,
-              a2a: {
-                ...current,
-                enabled: true,
-                ...(advertisedUrl ? { advertisedUrl } : {}),
-                ...(peerName && peerToken
-                  ? { peers: { ...current.peers, [peerName]: { token: peerToken } } }
-                  : {}),
-              },
+          return patchTopLevelChannelConfigSection({
+            cfg,
+            channel: A2A_CHANNEL_ID,
+            enabled: true,
+            patch: {
+              ...(advertisedUrl ? { advertisedUrl } : {}),
+              ...(peerName && peerToken
+                ? { peers: { ...current.peers, [peerName]: { token: peerToken } } }
+                : {}),
             },
-          };
+          });
         },
       },
     }),

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -35,6 +35,7 @@ import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-run
 import { resolveLegacyInteractiveTextFallback } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 import {
   buildProbeChannelStatusSummary,
   createComputedAccountStatusAdapter,
@@ -1147,16 +1148,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           const accounts = { ...feishuCfg?.accounts };
           delete accounts[accountId];
 
-          return {
-            ...cfg,
-            channels: {
-              ...cfg.channels,
-              feishu: {
-                ...feishuCfg,
-                accounts: Object.keys(accounts).length > 0 ? accounts : undefined,
-              },
+          return patchTopLevelChannelConfigSection({
+            cfg,
+            channel: "feishu",
+            patch: {
+              accounts: Object.keys(accounts).length > 0 ? accounts : undefined,
             },
-          };
+          });
         },
         isConfigured: (account) => account.configured,
         describeAccount: (account) =>

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -9,6 +9,7 @@ import {
   normalizeAccountId,
   promptAccountId,
   promptChannelAccessConfig,
+  setSetupChannelEnabled,
   splitSetupEntries,
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
@@ -671,11 +672,5 @@ export const matrixOnboardingAdapter: ChannelSetupWizardAdapter = {
     });
   },
   dmPolicy,
-  disable: (cfg) => ({
-    ...(cfg as CoreConfig),
-    channels: {
-      ...(cfg as CoreConfig).channels,
-      matrix: { ...(cfg as CoreConfig).channels?.["matrix"], enabled: false },
-    },
-  }),
+  disable: (cfg) => setSetupChannelEnabled(cfg, channel, false),
 };

--- a/extensions/matrix/src/setup-config.ts
+++ b/extensions/matrix/src/setup-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   normalizeSecretInputString,
+  patchTopLevelChannelConfigSection,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/setup";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -128,24 +129,17 @@ export function moveSingleMatrixAccountConfigToNamedAccount(cfg: CoreConfig): Co
   for (const key of keysToMove) {
     nextAccount[key] = cloneIfObject(base[key]);
   }
-  const nextChannel = { ...base };
-  for (const key of keysToMove) {
-    delete nextChannel[key];
-  }
-
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      [channel]: {
-        ...nextChannel,
-        accounts: {
-          ...accounts,
-          [resolvedTargetAccountId]: nextAccount,
-        },
+  return patchTopLevelChannelConfigSection({
+    cfg,
+    channel,
+    clearFields: keysToMove,
+    patch: {
+      accounts: {
+        ...accounts,
+        [resolvedTargetAccountId]: nextAccount,
       },
     },
-  };
+  });
 }
 
 export function validateMatrixSetupInput(params: {

--- a/extensions/matrix/src/setup-core.ts
+++ b/extensions/matrix/src/setup-core.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   prepareScopedSetupConfig,
+  setSetupChannelEnabled,
   type ChannelSetupAdapter,
   type ChannelSetupWizardAdapter,
 } from "openclaw/plugin-sdk/setup";
@@ -52,13 +53,7 @@ export function createMatrixSetupWizardProxy(
       const promptAllowFrom = (await loadWizard()).dmPolicy?.promptAllowFrom;
       return promptAllowFrom ? await promptAllowFrom(params) : params.cfg;
     }),
-    disable: (cfg) => ({
-      ...(cfg as CoreConfig),
-      channels: {
-        ...(cfg as CoreConfig).channels,
-        matrix: { ...(cfg as CoreConfig).channels?.matrix, enabled: false },
-      },
-    }),
+    disable: (cfg) => setSetupChannelEnabled(cfg, channel, false),
   };
 }
 

--- a/extensions/msteams/src/setup-core.ts
+++ b/extensions/msteams/src/setup-core.ts
@@ -5,6 +5,7 @@ import {
   createStandardChannelSetupStatus,
   DEFAULT_ACCOUNT_ID,
   createSetupTranslator,
+  patchTopLevelChannelConfigSection,
   setSetupChannelEnabled,
   type ChannelSetupAdapter,
   type ChannelSetupWizard,
@@ -124,19 +125,12 @@ export function createMSTeamsSetupWizardBase(): Pick<
       }
 
       if (appId && appPassword && tenantId) {
-        next = {
-          ...next,
-          channels: {
-            ...next.channels,
-            msteams: {
-              ...next.channels?.msteams,
-              enabled: true,
-              appId,
-              appPassword,
-              tenantId,
-            },
-          },
-        };
+        next = patchTopLevelChannelConfigSection({
+          cfg: next,
+          channel,
+          enabled: true,
+          patch: { appId, appPassword, tenantId },
+        });
       }
 
       return { cfg: next, accountId: DEFAULT_ACCOUNT_ID };

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -258,16 +258,11 @@ export const msteamsSetupWizard: ChannelSetupWizard = {
         initialValue: false,
       });
       if (enableDelegated) {
-        next = {
-          ...next,
-          channels: {
-            ...next.channels,
-            msteams: {
-              ...next.channels?.msteams,
-              delegatedAuth: { enabled: true },
-            },
-          },
-        };
+        next = patchTopLevelChannelConfigSection({
+          cfg: next,
+          channel,
+          patch: { delegatedAuth: { enabled: true } },
+        });
         const noteDelegatedAuthFailure = async (err: unknown) => {
           await params.prompter.note(
             `Delegated auth setup failed: ${formatUnknownError(err)}\n` +

--- a/extensions/reef/src/setup.ts
+++ b/extensions/reef/src/setup.ts
@@ -1,5 +1,6 @@
 import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 import { fingerprint } from "../protocol/index.js";
 import {
   parseReefRelayUrl,
@@ -46,14 +47,7 @@ const reefSetupAdapter = {
     cfg: OpenClawConfig;
     accountId: string;
     input: Record<string, unknown>;
-  }) =>
-    ({
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        reef: { ...(cfg.channels?.reef as object), ...input },
-      },
-    }) as OpenClawConfig,
+  }) => patchTopLevelChannelConfigSection({ cfg, channel: "reef", patch: input }),
 };
 
 export const reefSetupContract = defineChannelSetupContract({

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -3,6 +3,7 @@ import { normalizeAccountId, resolveAccountEntry } from "openclaw/plugin-sdk/acc
 import { parseAllowFromEntries } from "openclaw/plugin-sdk/allow-from";
 import { createChannelDmPolicy } from "openclaw/plugin-sdk/channel-dm-policy";
 import { defineChannelSetupContract } from "openclaw/plugin-sdk/channel-setup";
+import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 import {
   createCliPathTextInput,
   createDelegatedSetupWizardProxy,
@@ -371,17 +372,7 @@ function restorePromotedSignalDefaultAccount(cfg: OpenClawConfig): OpenClawConfi
   } else {
     accounts[DEFAULT_ACCOUNT_ID] = remainingDefault;
   }
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      signal: {
-        ...signal,
-        account,
-        accounts,
-      },
-    },
-  };
+  return patchTopLevelChannelConfigSection({ cfg, channel, patch: { account, accounts } });
 }
 
 export const signalSetupAdapter: ChannelSetupAdapter<SignalSetupInput> = {

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -4,6 +4,7 @@ import {
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/channel-setup";
 import { normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 // Slack plugin module implements setup core behavior.
 import {
   createAccountScopedAllowFromSection,
@@ -74,15 +75,12 @@ function setSlackSetupIdentity(params: {
     return next;
   }
   if (params.accountId === DEFAULT_ACCOUNT_ID) {
-    const nextSlack = { ...slack };
-    delete nextSlack.postAs;
-    return {
-      ...next,
-      channels: {
-        ...next.channels,
-        slack: nextSlack,
-      },
-    } as OpenClawConfig;
+    return patchTopLevelChannelConfigSection({
+      cfg: next,
+      channel,
+      clearFields: ["postAs"],
+      patch: {},
+    });
   }
 
   const account = slack.accounts?.[params.accountId];
@@ -97,19 +95,16 @@ function setSlackSetupIdentity(params: {
   } else {
     delete nextAccount.postAs;
   }
-  return {
-    ...next,
-    channels: {
-      ...next.channels,
-      slack: {
-        ...slack,
-        accounts: {
-          ...slack.accounts,
-          [params.accountId]: nextAccount,
-        },
+  return patchTopLevelChannelConfigSection({
+    cfg: next,
+    channel,
+    patch: {
+      accounts: {
+        ...slack.accounts,
+        [params.accountId]: nextAccount,
       },
     },
-  } as OpenClawConfig;
+  });
 }
 
 function createSlackTokenCredential(params: {

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -14,6 +14,7 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
 import {
   createDelegatedSetupWizardProxy,
+  setSetupChannelEnabled,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup-runtime";
 import {
@@ -87,16 +88,7 @@ function createWhatsAppSetupWizardProxy(
     resolveShouldPromptAccountIds: (params) => params.shouldPromptAccountIds,
     credentials: [],
     delegateFinalize: true,
-    disable: (cfg) => ({
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        whatsapp: {
-          ...cfg.channels?.whatsapp,
-          enabled: false,
-        },
-      },
-    }),
+    disable: (cfg) => setSetupChannelEnabled(cfg, WHATSAPP_CHANNEL, false),
     onAccountRecorded: (accountId, options) => {
       options?.onAccountId?.(WHATSAPP_CHANNEL, accountId);
     },


### PR DESCRIPTION
## What Problem This Solves

Channel setup and account changes repeat the same root/channel object-copying logic across eight plugins. This maintainer-requested cleanup gives those writes one existing owner while preserving each plugin's account and migration policy.

## Why This Change Was Made

Use the existing setup SDK writers for 12 equivalent section updates across A2A, Feishu, Matrix, Microsoft Teams, Reef, Signal, Slack, and WhatsApp. Keep account selection, default-account promotion, field deletion, cloning, and credential decisions with their current plugin owners. Remove ten unnecessary type assertions and shrink their four existing baseline entries.

## User Impact

No intended behavior change. Setup, disabling a channel, account removal, and account promotion retain their existing config values, unknown fields, missing-versus-undefined properties, raw account keys, and unchanged-reference outcomes. The change removes 58 production code lines without new helpers or SDK exports.

## Evidence

- 2,378 differential cases compare the actual old and new writers with the unchanged SDK helpers, including field ownership, key order, and reference relationships for JSON-like config.
- 556 successful test executions across two scoped runs covering 20 distinct files, covering setup/config owners and canonical account mutation. No test changes or production test seams.
- Final changed-file checks and fresh P2 review passed; no actionable review findings.
- Normal builds passed for the baseline and retained production changes; after the final exclusion, the owning external-plugin build phase passed. The normal candidate build reported a non-enforcing UI gzip warning, 12 bytes above its budget, with no UI source changes.
- Built entry inspection exercised the actual writers. Signal and Slack add approximately 6 KiB of shared setup facade/group-access code; their lazy setup-entry wrappers alone would miss this cost. A2A, Reef, and Feishu do not add a larger loaded dependency graph on the measured entries.
