### PR TITLE
test(matrix): bootstrap isolated E2EE QA drivers

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -1261,6 +1261,10 @@ async function withMatrixQaIsolatedE2eeDriverRoom<T>(
       context,
       scenarioId,
     });
+    await ensureMatrixQaE2eeOwnDeviceVerified({
+      client,
+      label: `${scenarioId} isolated driver`,
+    });
     await Promise.all([
       client.waitForJoinedMember({
         roomId,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -2154,7 +2154,23 @@ describe("matrix live qa scenarios", () => {
         };
       });
       const stop = vi.fn().mockResolvedValue(undefined);
+      const bootstrapOwnDeviceVerification = vi.fn().mockImplementation(async () => {
+        callOrder.push("bootstrap-driver");
+        return {
+          crossSigning: { published: true },
+          success: true,
+          verification: {
+            backupVersion: "1",
+            crossSigningVerified: true,
+            recoveryKeyStored: true,
+            signedByOwner: true,
+            verified: true,
+          },
+        };
+      });
       createMatrixQaE2eeScenarioClient.mockResolvedValue({
+        bootstrapOwnDeviceVerification,
+        getRecoveryKey: vi.fn().mockResolvedValue("isolated-driver-recovery-key"),
         prime: vi.fn().mockResolvedValue("driver-sync-start"),
         sendTextMessage,
         stop,
@@ -2251,6 +2267,7 @@ describe("matrix live qa scenarios", () => {
         "observer-join",
         "sut-join",
         "hard-restart",
+        "bootstrap-driver",
         "send:before",
         "restart",
         "send:after",
@@ -2272,6 +2289,9 @@ describe("matrix live qa scenarios", () => {
       });
       expect(waitGatewayAccountReady).not.toHaveBeenCalled();
       expect(stop).toHaveBeenCalledTimes(1);
+      expect(bootstrapOwnDeviceVerification).toHaveBeenCalledWith({
+        allowAutomaticCrossSigningReset: false,
+      });
       expect(createPrivateRoom).toHaveBeenCalledWith({
         encrypted: true,
         inviteUserIds: ["@observer:matrix-qa.test", "@sut:matrix-qa.test"],


### PR DESCRIPTION
## Summary
- verify fresh isolated Matrix QA driver devices before their first encrypted send
- preserve the existing hard-restart and room-join ordering
- add a contract assertion that bootstrap happens after restart and before send

## Validation
- 75/75 `extensions/qa-matrix/src/runners/contract/scenarios.test.ts` tests
- `pnpm tsgo:extensions:test`
- `pnpm lint`
- `git diff --check`

Backports the QA-side device bootstrap needed by the 2026.7.33 Matrix E2EE restart, artifact-redaction, and media-image validation scenarios.