### PR TITLE
refactor(config): derive sandbox settings from schemas

### DIFF
--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -1,128 +1,31 @@
 // Defines sandbox execution configuration types.
+import type { z } from "zod";
 import type { SecretInput } from "./types.secrets.js";
+import type {
+  SandboxBrowserSchema,
+  SandboxDockerSchema,
+  SandboxPruneSchema,
+} from "./zod-schema.sandbox.js";
 
-export type SandboxDockerSettings = {
-  /** Docker image to use for sandbox containers. */
-  image?: string;
-  /** Prefix for sandbox container names. */
-  containerPrefix?: string;
-  /** Container workdir mount path (default: /workspace). */
-  workdir?: string;
-  /** Run container rootfs read-only. */
-  readOnlyRoot?: boolean;
-  /** Extra tmpfs mounts for read-only containers. */
-  tmpfs?: string[];
-  /** Container network mode (bridge|none|custom). */
-  network?: string;
-  /** Container user (uid:gid). */
-  user?: string;
-  /** Drop Linux capabilities. */
-  capDrop?: string[];
-  /** Explicit environment variables for sandbox container creation and exec. */
-  env?: Record<string, string>;
-  /** Optional setup command run once after container creation (array entries are joined by newline). */
-  setupCommand?: string;
-  /** Limit container PIDs (0 = Docker default). */
-  pidsLimit?: number;
-  /** Limit container memory (e.g. 512m, 2g, or bytes as number). */
-  memory?: string | number;
-  /** Limit container memory swap (same format as memory). */
-  memorySwap?: string | number;
-  /** Limit container CPU shares (e.g. 0.5, 1, 2). */
-  cpus?: number;
-  /** GPU devices to expose via Docker --gpus (e.g. "all", "device=GPU-uuid"). */
-  gpus?: string;
-  /**
-   * Set ulimit values by name (e.g. nofile, nproc).
-   * Use "soft:hard" string, a number, or { soft, hard }.
-   */
-  ulimits?: Record<string, string | number | { soft?: number; hard?: number }>;
-  /** Seccomp profile (path or profile name). */
-  seccompProfile?: string;
-  /** AppArmor profile name. */
-  apparmorProfile?: string;
-  /** DNS servers (e.g. ["1.1.1.1", "8.8.8.8"]). */
-  dns?: string[];
-  /** Extra host mappings (e.g. ["api.local:10.0.0.2"]). */
-  extraHosts?: string[];
-  /** Additional bind mounts (host:container:mode format, e.g. ["/host/path:/container/path:rw"]). */
-  binds?: string[];
-  /**
-   * Dangerous override: allow bind mounts that target reserved container paths
-   * like /workspace or /agent.
-   */
-  dangerouslyAllowReservedContainerTargets?: boolean;
-  /**
-   * Dangerous override: allow bind mount sources outside runtime allowlisted roots
-   * (workspace + agent workspace roots).
-   */
-  dangerouslyAllowExternalBindSources?: boolean;
-  /**
-   * Dangerous override: allow Docker `network: "container:<id>"` namespace joins.
-   * Default behavior blocks container namespace joins to preserve sandbox isolation.
-   */
-  dangerouslyAllowContainerNamespaceJoin?: boolean;
-};
+export type SandboxDockerSettings = NonNullable<z.output<typeof SandboxDockerSchema>>;
 
-export type SandboxBrowserSettings = {
-  enabled?: boolean;
-  image?: string;
-  containerPrefix?: string;
-  /** Docker network for sandbox browser containers (default: openclaw-sandbox-browser). */
-  network?: string;
-  cdpPort?: number;
-  /** Optional CIDR allowlist for CDP ingress at the container edge (for example: 172.21.0.1/32). */
-  cdpSourceRange?: string;
-  vncPort?: number;
-  noVncPort?: number;
-  headless?: boolean;
-  noVncEnabled?: boolean;
+export type SandboxBrowserSettings = NonNullable<z.input<typeof SandboxBrowserSchema>> & {
   /** @deprecated Doctor-only legacy input. */
   enableNoVnc?: boolean;
-  /**
-   * Allow sandboxed sessions to target the host browser control server.
-   * Default: false.
-   */
-  allowHostControl?: boolean;
-  /**
-   * When true (default), sandboxed browser control will try to start/reattach to
-   * the sandbox browser container when a tool call needs it.
-   */
-  autoStart?: boolean;
-  /** Max time to wait for CDP to become reachable after auto-start (ms). */
-  autoStartTimeoutMs?: number;
-  /** Additional bind mounts for the browser container only. When set, replaces docker.binds for the browser container. */
-  binds?: string[];
 };
 
-export type SandboxPruneSettings = {
-  /** Prune if idle for more than N hours (0 disables). */
-  idleHours?: number;
-  /** Prune if older than N days (0 disables). */
-  maxAgeDays?: number;
-};
+export type SandboxPruneSettings = NonNullable<z.input<typeof SandboxPruneSchema>>;
 
 export type SandboxSshSettings = {
-  /** SSH target in user@host[:port] form. */
   target?: string;
-  /** SSH client command. Default: "ssh". */
   command?: string;
-  /** Absolute remote root used for per-scope workspaces. */
   workspaceRoot?: string;
-  /** Enforce host-key verification. Default: true. */
   strictHostKeyChecking?: boolean;
-  /** Allow OpenSSH host-key updates. Default: true. */
   updateHostKeys?: boolean;
-  /** Existing private key path on the host. */
   identityFile?: string;
-  /** Existing SSH certificate path on the host. */
   certificateFile?: string;
-  /** Existing known_hosts file path on the host. */
   knownHostsFile?: string;
-  /** Inline or SecretRef-backed private key contents. */
   identityData?: SecretInput;
-  /** Inline or SecretRef-backed SSH certificate contents. */
   certificateData?: SecretInput;
-  /** Inline or SecretRef-backed known_hosts contents. */
   knownHostsData?: SecretInput;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,14 +1,8 @@
 // Defines Zod schema fragments for per-agent runtime configuration.
 import { parseProviderModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { z } from "zod";
-import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
-import { isSandboxHostPathAbsolute } from "../agents/sandbox/host-paths.js";
 import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import {
@@ -31,39 +25,12 @@ import {
   TypingModeSchema,
   TtsConfigSchema,
 } from "./zod-schema.core.js";
+import {
+  SandboxBrowserSchema,
+  SandboxDockerSchema,
+  SandboxPruneSchema,
+} from "./zod-schema.sandbox.js";
 import { sensitive } from "./zod-schema.sensitive.js";
-
-function validateSandboxBindEntries(
-  binds: readonly string[] | undefined,
-  ctx: z.RefinementCtx,
-): void {
-  if (!binds) {
-    return;
-  }
-  for (let i = 0; i < binds.length; i += 1) {
-    const bind = normalizeOptionalString(binds[i]) ?? "";
-    if (!bind) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["binds", i],
-        message: "Sandbox security: bind mount entry must be a non-empty string.",
-      });
-      continue;
-    }
-
-    const parsed = splitSandboxBindSpec(bind);
-    const source = (parsed ? parsed.host : bind).trim();
-    if (!isSandboxHostPathAbsolute(source)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["binds", i],
-        message:
-          `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
-          "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
-      });
-    }
-  }
-}
 
 const AgentEntryEmbeddedAgentConfigSchema = z
   .object({
@@ -152,135 +119,6 @@ export const HeartbeatSchema = z
     validateTime(active.start, { allow24: false }, "start");
     validateTime(active.end, { allow24: true }, "end");
   })
-  .optional();
-
-const SandboxDockerSchema = z
-  .object({
-    image: z.string().optional(),
-    containerPrefix: z.string().optional(),
-    workdir: z.string().optional(),
-    readOnlyRoot: z.boolean().optional(),
-    tmpfs: z.array(z.string()).optional(),
-    network: z.string().optional(),
-    user: z.string().optional(),
-    capDrop: z.array(z.string()).optional(),
-    env: z.record(z.string(), z.string()).optional(),
-    setupCommand: z
-      .union([z.string(), z.array(z.string())])
-      .transform((value) => (Array.isArray(value) ? value.join("\n") : value))
-      .pipe(z.string())
-      .optional(),
-    pidsLimit: z.number().int().positive().optional(),
-    memory: z.union([z.string(), z.number()]).optional(),
-    memorySwap: z.union([z.string(), z.number()]).optional(),
-    cpus: z.number().positive().optional(),
-    gpus: z.string().min(1).optional(),
-    ulimits: z
-      .record(
-        z.string(),
-        z.union([
-          z.string(),
-          z.number(),
-          z
-            .object({
-              soft: z.number().int().nonnegative().optional(),
-              hard: z.number().int().nonnegative().optional(),
-            })
-            .strict(),
-        ]),
-      )
-      .optional(),
-    seccompProfile: z.string().optional(),
-    apparmorProfile: z.string().optional(),
-    dns: z.array(z.string()).optional(),
-    extraHosts: z.array(z.string()).optional(),
-    binds: z.array(z.string()).optional(),
-    dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
-    dangerouslyAllowExternalBindSources: z.boolean().optional(),
-    dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
-  })
-  .strict()
-  .superRefine((data, ctx) => {
-    validateSandboxBindEntries(data.binds, ctx);
-    const blockedNetworkReason = getBlockedNetworkModeReason({
-      network: data.network,
-      allowContainerNamespaceJoin: data.dangerouslyAllowContainerNamespaceJoin === true,
-    });
-    if (blockedNetworkReason === "host") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["network"],
-        message:
-          'Sandbox security: network mode "host" is blocked. Use "bridge" or "none" instead.',
-      });
-    }
-    if (blockedNetworkReason === "container_namespace_join") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["network"],
-        message:
-          'Sandbox security: network mode "container:*" is blocked by default. ' +
-          "Use a custom bridge network, or set dangerouslyAllowContainerNamespaceJoin=true only when you fully trust this runtime.",
-      });
-    }
-    if (normalizeLowercaseStringOrEmpty(data.seccompProfile ?? "") === "unconfined") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["seccompProfile"],
-        message:
-          'Sandbox security: seccomp profile "unconfined" is blocked. ' +
-          "Use a custom seccomp profile file or omit this setting.",
-      });
-    }
-    if (normalizeLowercaseStringOrEmpty(data.apparmorProfile ?? "") === "unconfined") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["apparmorProfile"],
-        message:
-          'Sandbox security: apparmor profile "unconfined" is blocked. ' +
-          "Use a named AppArmor profile or omit this setting.",
-      });
-    }
-  })
-  .optional();
-
-const SandboxBrowserSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    image: z.string().optional(),
-    containerPrefix: z.string().optional(),
-    network: z.string().optional(),
-    cdpPort: z.number().int().positive().optional(),
-    cdpSourceRange: z.string().optional(),
-    vncPort: z.number().int().positive().optional(),
-    noVncPort: z.number().int().positive().optional(),
-    headless: z.boolean().optional(),
-    noVncEnabled: z.boolean().optional(),
-    allowHostControl: z.boolean().optional(),
-    autoStart: z.boolean().optional(),
-    autoStartTimeoutMs: z.number().int().positive().optional(),
-    binds: z.array(z.string()).optional(),
-  })
-  .superRefine((data, ctx) => {
-    validateSandboxBindEntries(data.binds, ctx);
-    if (normalizeLowercaseStringOrEmpty(data.network ?? "") === "host") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["network"],
-        message:
-          'Sandbox security: browser network mode "host" is blocked. Use "bridge" or a custom bridge network instead.',
-      });
-    }
-  })
-  .strict()
-  .optional();
-
-const SandboxPruneSchema = z
-  .object({
-    idleHours: z.number().int().nonnegative().optional(),
-    maxAgeDays: z.number().int().nonnegative().optional(),
-  })
-  .strict()
   .optional();
 
 export const AgentContextLimitsSchema = z

--- a/src/config/zod-schema.sandbox.ts
+++ b/src/config/zod-schema.sandbox.ts
@@ -1,0 +1,165 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { z } from "zod";
+import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
+import { isSandboxHostPathAbsolute } from "../agents/sandbox/host-paths.js";
+import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
+
+function validateSandboxBindEntries(
+  binds: readonly string[] | undefined,
+  ctx: z.RefinementCtx,
+): void {
+  if (!binds) {
+    return;
+  }
+  for (let i = 0; i < binds.length; i += 1) {
+    const bind = binds[i]?.trim() ?? "";
+    if (!bind) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["binds", i],
+        message: "Sandbox security: bind mount entry must be a non-empty string.",
+      });
+      continue;
+    }
+    const parsed = splitSandboxBindSpec(bind);
+    const source = (parsed ? parsed.host : bind).trim();
+    if (!isSandboxHostPathAbsolute(source)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["binds", i],
+        message:
+          `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
+          "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
+      });
+    }
+  }
+}
+
+export const SandboxDockerSchema = z
+  .object({
+    image: z.string().optional(),
+    containerPrefix: z.string().optional(),
+    workdir: z.string().optional(),
+    readOnlyRoot: z.boolean().optional(),
+    tmpfs: z.array(z.string()).optional(),
+    network: z.string().optional(),
+    user: z.string().optional(),
+    capDrop: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    setupCommand: z
+      .union([z.string(), z.array(z.string())])
+      .transform((value) => (Array.isArray(value) ? value.join("\n") : value))
+      .pipe(z.string())
+      .optional(),
+    pidsLimit: z.number().int().positive().optional(),
+    memory: z.union([z.string(), z.number()]).optional(),
+    memorySwap: z.union([z.string(), z.number()]).optional(),
+    cpus: z.number().positive().optional(),
+    gpus: z.string().min(1).optional(),
+    ulimits: z
+      .record(
+        z.string(),
+        z.union([
+          z.string(),
+          z.number(),
+          z
+            .object({
+              soft: z.number().int().nonnegative().optional(),
+              hard: z.number().int().nonnegative().optional(),
+            })
+            .strict(),
+        ]),
+      )
+      .optional(),
+    seccompProfile: z.string().optional(),
+    apparmorProfile: z.string().optional(),
+    dns: z.array(z.string()).optional(),
+    extraHosts: z.array(z.string()).optional(),
+    binds: z.array(z.string()).optional(),
+    dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
+    dangerouslyAllowExternalBindSources: z.boolean().optional(),
+    dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    validateSandboxBindEntries(data.binds, ctx);
+    const blockedNetworkReason = getBlockedNetworkModeReason({
+      network: data.network,
+      allowContainerNamespaceJoin: data.dangerouslyAllowContainerNamespaceJoin === true,
+    });
+    if (blockedNetworkReason === "host") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["network"],
+        message:
+          'Sandbox security: network mode "host" is blocked. Use "bridge" or "none" instead.',
+      });
+    }
+    if (blockedNetworkReason === "container_namespace_join") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["network"],
+        message:
+          'Sandbox security: network mode "container:*" is blocked by default. ' +
+          "Use a custom bridge network, or set dangerouslyAllowContainerNamespaceJoin=true only when you fully trust this runtime.",
+      });
+    }
+    if (normalizeLowercaseStringOrEmpty(data.seccompProfile ?? "") === "unconfined") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["seccompProfile"],
+        message:
+          'Sandbox security: seccomp profile "unconfined" is blocked. ' +
+          "Use a custom seccomp profile file or omit this setting.",
+      });
+    }
+    if (normalizeLowercaseStringOrEmpty(data.apparmorProfile ?? "") === "unconfined") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["apparmorProfile"],
+        message:
+          'Sandbox security: AppArmor profile "unconfined" is blocked. ' +
+          "Use a named AppArmor profile or omit this setting.",
+      });
+    }
+  })
+  .optional();
+
+export const SandboxBrowserSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    image: z.string().optional(),
+    containerPrefix: z.string().optional(),
+    network: z.string().optional(),
+    cdpPort: z.number().int().positive().optional(),
+    cdpSourceRange: z.string().optional(),
+    vncPort: z.number().int().positive().optional(),
+    noVncPort: z.number().int().positive().optional(),
+    headless: z.boolean().optional(),
+    noVncEnabled: z.boolean().optional(),
+    allowHostControl: z.boolean().optional(),
+    autoStart: z.boolean().optional(),
+    autoStartTimeoutMs: z.number().int().positive().optional(),
+    binds: z.array(z.string()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    validateSandboxBindEntries(data.binds, ctx);
+    if (normalizeLowercaseStringOrEmpty(data.network ?? "") === "host") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["network"],
+        message:
+          'Sandbox security: browser network mode "host" is blocked. Use "bridge" or a custom bridge network instead.',
+      });
+    }
+  })
+  .strict()
+  .optional();
+
+export const SandboxPruneSchema = z
+  .object({
+    idleHours: z.number().int().nonnegative().optional(),
+    maxAgeDays: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+  .optional();


### PR DESCRIPTION
## Summary

- move Docker, Browser, and Prune sandbox schemas into a leaf ownership module
- derive their authoring contracts from that canonical leaf
- retain SSH as an explicit SecretInput authoring contract and preserve doctor-only `enableNoVnc`

## Why

The sandbox validator repeated large handwritten TypeScript contracts. Leaf schema ownership removes 94 production lines without introducing a config-runtime import cycle.

## Compatibility

Docker keeps its normalized string `setupCommand`, Browser retains legacy `enableNoVnc`, SSH keeps SecretInput authoring values, and resolved runtime sandbox types remain separate.

## Validation

- 126 focused config, doctor, Docker, Browser, and SSH tests
- core and all test-type shards
- Plugin SDK declaration generation
- runtime and static import-cycle guards
- full `pnpm check:changed`
- P0–P2 autoreview: scoped clean

Production diff: **+179 / −273 (net −94 LOC)**
