### PR TITLE
refactor(codex): derive plugin config contracts from schemas

### DIFF
--- a/extensions/codex/src/app-server/config-contracts.shared.ts
+++ b/extensions/codex/src/app-server/config-contracts.shared.ts
@@ -1,0 +1,39 @@
+export type OpenClawExecMode = "deny" | "allowlist" | "ask" | "auto" | "full";
+export type OpenClawExecSecurity = "deny" | "allowlist" | "full";
+export type OpenClawExecAsk = "off" | "on-miss" | "always";
+export type OpenClawExecApprovalFloorsForCodexAppServer = {
+  security?: OpenClawExecSecurity;
+  ask?: OpenClawExecAsk;
+};
+export type OpenClawExecPolicyForCodexAppServer = {
+  mode: OpenClawExecMode;
+  security: OpenClawExecSecurity;
+  ask: OpenClawExecAsk;
+  touched: boolean;
+};
+export type OpenClawExecPolicy = OpenClawExecPolicyForCodexAppServer;
+
+export type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "env";
+export type CodexPluginDestructivePolicy = boolean | "auto" | "ask";
+export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "ask";
+
+export const CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
+export type CodexPluginMarketplaceName = string;
+
+export type ResolvedCodexPluginPolicy = {
+  configKey: string;
+  marketplaceName: CodexPluginMarketplaceName;
+  pluginName: string;
+  enabled: boolean;
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+};
+
+export type ResolvedCodexPluginsPolicy = {
+  configured: boolean;
+  enabled: boolean;
+  allowAllPlugins: boolean;
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+  pluginPolicies: ResolvedCodexPluginPolicy[];
+};

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -1,31 +1,26 @@
 import type { ProviderAuthAliasLookupParams } from "openclaw/plugin-sdk/agent-runtime";
-import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
-import type { z } from "zod";
+import type { CodexAppServerCommandSource } from "./config-contracts.shared.js";
+import type { ParsedCodexPluginConfig, ParsedCodexSupervisionEndpoint } from "./config-parsing.js";
 import type { CodexApprovalPolicy, CodexServiceTier, JsonObject } from "./protocol.js";
-import type {
-  codexDiscoveryConfigSchema,
-  codexSessionCatalogConfigSchema,
-} from "./session-discovery-config.js";
+
+export {
+  CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN,
+  type CodexAppServerCommandSource,
+  type CodexPluginDestructiveApprovalMode,
+  type CodexPluginMarketplaceName,
+  type OpenClawExecApprovalFloorsForCodexAppServer,
+  type OpenClawExecMode,
+  type OpenClawExecPolicy,
+  type OpenClawExecPolicyForCodexAppServer,
+  type ResolvedCodexPluginPolicy,
+  type ResolvedCodexPluginsPolicy,
+} from "./config-contracts.shared.js";
 
 export type CodexAppServerTransportMode = "stdio" | "websocket" | "unix";
 export type CodexAppServerHomeScope = "agent" | "user";
 export type CodexAppServerPolicyMode = "yolo" | "guardian";
 export type CodexAppServerConnectionClass = "local-loopback" | "remote";
 export type CodexAppServerRemoteAppsSubstrate = "preconfigured";
-export type OpenClawExecMode = "deny" | "allowlist" | "ask" | "auto" | "full";
-export type OpenClawExecSecurity = "deny" | "allowlist" | "full";
-export type OpenClawExecAsk = "off" | "on-miss" | "always";
-export type OpenClawExecApprovalFloorsForCodexAppServer = {
-  security?: OpenClawExecSecurity;
-  ask?: OpenClawExecAsk;
-};
-export type OpenClawExecPolicyForCodexAppServer = {
-  mode: OpenClawExecMode;
-  security: OpenClawExecSecurity;
-  ask: OpenClawExecAsk;
-  touched: boolean;
-};
-export type OpenClawExecPolicy = OpenClawExecPolicyForCodexAppServer;
 export type ProviderAuthAliasConfig = NonNullable<ProviderAuthAliasLookupParams>["config"];
 export type CodexAppServerDefaultPolicy = {
   mode: CodexAppServerPolicyMode;
@@ -40,34 +35,13 @@ export type CodexAppServerApprovalPolicySource = "config" | "env" | "requirement
 export type CodexAppServerEffectiveApprovalPolicy = CodexApprovalPolicy;
 export type CodexAppServerSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 export type CodexAppServerApprovalsReviewer = "user" | "auto_review" | "guardian_subagent";
-export type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "env";
 export type CodexManagedCommandOrder = "package-first" | "desktop-first";
 export type CodexDynamicToolsLoading = "searchable" | "direct";
-export type CodexPluginDestructivePolicy = boolean | "auto" | "ask";
-export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "ask";
 
 export const CODEX_PLUGINS_MARKETPLACE_NAME = "openai-curated";
 export const CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME = "workspace-directory";
-export const CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
-export type CodexPluginMarketplaceName = string;
 
-export type CodexComputerUseConfig = {
-  enabled?: boolean;
-  autoInstall?: boolean;
-  marketplaceDiscoveryTimeoutMs?: number;
-  liveTestTimeoutMs?: number;
-  toolCallTimeoutMs?: number;
-  healthCheckEnabled?: boolean;
-  healthCheckIntervalMinutes?: number;
-  pluginCacheMode?: "shared" | "independent";
-  strictReadiness?: boolean;
-  autoRepair?: boolean;
-  marketplaceSource?: string;
-  marketplacePath?: string;
-  marketplaceName?: string;
-  pluginName?: string;
-  mcpServerName?: string;
-};
+export type CodexComputerUseConfig = NonNullable<CodexPluginConfig["computerUse"]>;
 
 export type ResolvedCodexComputerUseConfig = {
   enabled: boolean;
@@ -87,92 +61,16 @@ export type ResolvedCodexComputerUseConfig = {
   marketplaceName?: string;
 };
 
-type CodexPluginEntryConfig = {
-  enabled?: boolean;
-  marketplaceName?: string;
-  pluginName?: string;
-  allow_destructive_actions?: CodexPluginDestructivePolicy;
-};
+export type CodexSupervisionEndpoint = ParsedCodexSupervisionEndpoint;
 
-type CodexPluginsConfig = {
-  enabled?: boolean;
-  allow_all_plugins?: boolean;
-  allow_destructive_actions?: CodexPluginDestructivePolicy;
-  plugins?: Record<string, CodexPluginEntryConfig>;
-};
-
-export type CodexSupervisionEndpoint =
-  | {
-      id?: string;
-      label?: string;
-      transport?: "stdio-proxy";
-      command?: string;
-      args?: string[];
-      cwd?: string;
-    }
-  | {
-      id?: string;
-      label?: string;
-      transport: "websocket";
-      url: string;
-      authTokenEnv?: string;
-    };
-
-type CodexSupervisionConfig = {
-  enabled?: boolean;
-  endpoints?: CodexSupervisionEndpoint[];
-  allowRawTranscripts?: boolean;
-  allowWriteControls?: boolean;
-};
-
-type CodexAppServerExperimentalConfig = {
-  sandboxExecServer?: boolean;
-};
-
-type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
-type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
-type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
-type CodexAppServerNetworkProxyMode = "limited" | "full";
-
-export type CodexAppServerNetworkProxyConfig = {
-  enabled?: boolean;
-  profileName?: string;
-  baseProfile?: CodexAppServerNetworkProxyBaseProfile;
-  mode?: CodexAppServerNetworkProxyMode;
-  domains?: Record<string, CodexAppServerNetworkProxyDomainPermission>;
-  unixSockets?: Record<string, CodexAppServerNetworkProxyUnixSocketPermission>;
-  proxyUrl?: string;
-  socksUrl?: string;
-  enableSocks5?: boolean;
-  enableSocks5Udp?: boolean;
-  allowUpstreamProxy?: boolean;
-  allowLocalBinding?: boolean;
-  dangerouslyAllowNonLoopbackProxy?: boolean;
-  dangerouslyAllowAllUnixSockets?: boolean;
-};
+export type CodexAppServerNetworkProxyConfig = NonNullable<
+  NonNullable<CodexPluginConfig["appServer"]>["networkProxy"]
+>;
 
 export type ResolvedCodexAppServerNetworkProxyConfig = {
   profileName: string;
   configFingerprint: string;
   configPatch: JsonObject;
-};
-
-export type ResolvedCodexPluginPolicy = {
-  configKey: string;
-  marketplaceName: CodexPluginMarketplaceName;
-  pluginName: string;
-  enabled: boolean;
-  allowDestructiveActions: boolean;
-  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
-};
-
-export type ResolvedCodexPluginsPolicy = {
-  configured: boolean;
-  enabled: boolean;
-  allowAllPlugins: boolean;
-  allowDestructiveActions: boolean;
-  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
-  pluginPolicies: ResolvedCodexPluginPolicy[];
 };
 
 export type CodexAppServerStartOptions = {
@@ -224,34 +122,4 @@ export type CodexModelBackedReviewerContext = {
   codexArgs?: readonly string[];
 };
 
-export type CodexPluginConfig = {
-  codexDynamicToolsLoading?: CodexDynamicToolsLoading;
-  codexDynamicToolsExclude?: string[];
-  sessionCatalog?: z.infer<typeof codexSessionCatalogConfigSchema>;
-  discovery?: z.infer<typeof codexDiscoveryConfigSchema>;
-  computerUse?: CodexComputerUseConfig;
-  codexPlugins?: CodexPluginsConfig;
-  supervision?: CodexSupervisionConfig;
-  appServer?: {
-    mode?: CodexAppServerPolicyMode;
-    transport?: CodexAppServerTransportMode;
-    homeScope?: CodexAppServerHomeScope;
-    command?: string;
-    args?: string[] | string;
-    url?: string;
-    authToken?: SecretInput;
-    headers?: Record<string, SecretInput>;
-    clearEnv?: string[];
-    remoteWorkspaceRoot?: string;
-    codeModeOnly?: boolean;
-    loopDetectionPreToolUseRelay?: boolean;
-    requestTimeoutMs?: number;
-    approvalPolicy?: CodexAppServerApprovalPolicy;
-    sandbox?: CodexAppServerSandboxMode;
-    approvalsReviewer?: CodexAppServerApprovalsReviewer;
-    serviceTier?: CodexServiceTier | null;
-    networkProxy?: CodexAppServerNetworkProxyConfig;
-    defaultWorkspaceDir?: string;
-    experimental?: CodexAppServerExperimentalConfig;
-  };
-};
+export type CodexPluginConfig = ParsedCodexPluginConfig;

--- a/extensions/codex/src/app-server/config-parsing.ts
+++ b/extensions/codex/src/app-server/config-parsing.ts
@@ -5,13 +5,12 @@ import { z } from "zod";
 import {
   CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN,
   type CodexAppServerCommandSource,
-  type CodexPluginConfig,
   type CodexPluginDestructiveApprovalMode,
   type CodexPluginDestructivePolicy,
   type CodexPluginMarketplaceName,
   type ResolvedCodexPluginPolicy,
   type ResolvedCodexPluginsPolicy,
-} from "./config-contracts.js";
+} from "./config-contracts.shared.js";
 import { normalizeCodexServiceTier } from "./config-utils.js";
 import {
   codexDiscoveryConfigSchema,
@@ -189,7 +188,15 @@ const codexPluginConfigSchema = z
   })
   .strict();
 
-export function readCodexPluginConfig(value: unknown): CodexPluginConfig {
+export type ParsedCodexSupervisionEndpoint = z.infer<typeof codexSupervisionEndpointSchema>;
+export type ParsedCodexPluginConfig = Omit<
+  z.infer<typeof codexPluginConfigSchema>,
+  "codexPlugins"
+> & {
+  codexPlugins?: z.infer<typeof codexPluginsConfigSchema>;
+};
+
+export function readCodexPluginConfig(value: unknown): ParsedCodexPluginConfig {
   const appServer = asNullableRecord(asNullableRecord(value)?.appServer);
   if (appServer?.approvalPolicy === "untrusted") {
     throw new Error(

--- a/extensions/codex/src/app-server/config-utils.ts
+++ b/extensions/codex/src/app-server/config-utils.ts
@@ -7,7 +7,7 @@ import {
   normalizeOptionalString as readNonEmptyString,
   parseBooleanValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { OpenClawExecAsk, OpenClawExecSecurity } from "./config-contracts.js";
+import type { OpenClawExecAsk, OpenClawExecSecurity } from "./config-contracts.shared.js";
 import type { CodexServiceTier } from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET_SYMBOL = Symbol.for("openclaw.codexAppServerStartOptionsKeySecret");


### PR DESCRIPTION
## Summary

- derive Codex app-server configuration contracts from the schemas that parse them
- isolate shared policy contracts in a leaf module so parser and contract ownership stay acyclic
- preserve the separately validated `codexPlugins` compatibility overlay

## Why

The parser and public contract file independently described the same plugin, supervision, Computer Use, and network-proxy configuration. Making the parser schemas authoritative removes 86 production lines and prevents those contracts from drifting.

## Compatibility

Runtime parsing is unchanged. Supported package exports remain unchanged, `codexPlugins` keeps its dedicated validation path, and shared policy constants/types now live below both parser and contract modules.

## Validation

- 388 focused config, security, migration, and app-server tests
- extension production and test typechecks
- Plugin SDK declaration generation
- runtime and static import-cycle guards
- full `pnpm check:changed`
- P0–P2 autoreview: scoped clean

Production diff: **+71 / −157 (net −86 LOC)**
