### PR TITLE
refactor(config): derive agent config from schema

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,21 +1,19 @@
-import type { FastMode } from "@openclaw/normalization-core/string-coerce";
+import type { z } from "zod";
 // Defines agent routing, model, and runtime configuration types.
 import type { ChatType } from "../channels/chat-type.js";
 import type {
   AgentContextLimitsConfig,
   AgentDefaultsConfig,
   AgentModelEntryConfig,
-  AgentModelPolicyConfig,
-  EmbeddedAgentExecutionContract,
-  SubagentDelegationMode,
 } from "./types.agent-defaults.js";
-import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
+import type { AgentSandboxConfig } from "./types.agents-shared.js";
 import type { DmScope, GroupScope, HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { MemorySearchConfig } from "./types.memory.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { SkillsLimitsConfig } from "./types.skills.js";
 import type { AgentToolsConfig } from "./types.tools.js";
 import type { TtsConfig } from "./types.tts.js";
+import type { AgentEntryBaseSchema } from "./zod-schema.agent-entry-base.js";
 
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
@@ -81,94 +79,30 @@ export type AgentAcpBinding = {
 
 export type AgentBinding = AgentRouteBinding | AgentAcpBinding;
 
-export type AgentConfig = {
-  id: string;
+export type AgentConfig = z.input<typeof AgentEntryBaseSchema> & {
   /** @deprecated Raw legacy list compatibility only; canonical agents.entries rejects this key. */
   default?: boolean;
-  name?: string;
-  /** Optional human-authored agent description. */
-  description?: string;
-  workspace?: string;
-  /** Working directory for agent reply runs; overrides agents.defaults.cwd. */
-  cwd?: string;
-  agentDir?: string;
-  model?: AgentModelConfig;
-  /** Optional per-agent model for short internal tasks such as generated session titles. */
-  utilityModel?: string;
   /**
    * @deprecated Legacy raw config accepted only by doctor/migration repair.
    * Normal schema parsing rejects this key; use per-model agentRuntime instead.
    */
   agentRuntime?: AgentModelEntryConfig["agentRuntime"];
-  /** Per-model metadata overrides for this agent. */
-  models?: Record<string, AgentModelEntryConfig>;
-  /** Per-agent model override policy. Replaces the default policy when allow is present. */
-  modelPolicy?: AgentModelPolicyConfig;
   /** @deprecated Legacy per-agent compaction config is kept for raw doctor migration/repair. */
   compaction?: AgentDefaultsConfig["compaction"];
-  /** Optional per-agent default thinking level (overrides agents.defaults.thinkingDefault). */
-  thinkingDefault?: AgentDefaultsConfig["thinkingDefault"];
-  /** Optional per-agent default verbosity level. */
-  verboseDefault?: "off" | "on" | "full";
-  /** Optional per-agent tool progress detail mode. */
-  toolProgressDetail?: AgentDefaultsConfig["toolProgressDetail"];
-  /** Optional per-agent default reasoning visibility. */
-  reasoningDefault?: "on" | "off" | "stream";
-  /** Optional per-agent default for fast mode. */
-  fastModeDefault?: FastMode;
-  /** Optional per-agent bootstrap/context injection mode override. */
-  contextInjection?: AgentDefaultsConfig["contextInjection"];
-  /** Optional per-agent max chars for each injected bootstrap file. */
-  bootstrapMaxChars?: AgentDefaultsConfig["bootstrapMaxChars"];
-  /** Optional per-agent max total chars across injected bootstrap files. */
-  bootstrapTotalMaxChars?: AgentDefaultsConfig["bootstrapTotalMaxChars"];
-  /** Optional per-agent experimental flags. Omitted fields inherit agents.defaults.experimental. */
-  experimental?: AgentDefaultsConfig["experimental"];
-  /** Optional allowlist of skills for this agent; omitting it inherits agents.defaults.skills when set, and an explicit list replaces defaults instead of merging. */
-  skills?: string[];
-  /** Per-agent overrides for the shared top-level memory configuration. */
   memory?: {
     search?: MemorySearchConfig;
   };
-  /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;
-  /** Optional per-agent typing start policy. */
   typingMode?: AgentDefaultsConfig["typingMode"];
-  /** Optional per-agent TTS overrides, deep-merged over top-level tts. */
-  /** Per-agent TTS overrides. prefsPath remains scoped because agents may use distinct preference stores. */
   tts?: TtsConfig & { prefsPath?: string };
-  /** Optional per-agent skills subsystem overrides. */
   skillsLimits?: Pick<SkillsLimitsConfig, "maxSkillsPromptChars">;
-  /** Optional per-agent overrides for selected context/token-heavy limits. */
   contextLimits?: AgentContextLimitsConfig;
-  /** Optional per-agent heartbeat overrides. */
   heartbeat?: Omit<NonNullable<AgentDefaultsConfig["heartbeat"]>, "agentId">;
   identity?: IdentityConfig;
   groupChat?: Omit<GroupChatConfig, "visibleReplies">;
-  subagents?: {
-    /** Prompt-only guidance for how strongly this agent should delegate work. */
-    delegationMode?: SubagentDelegationMode;
-    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any configured target. */
-    allowAgents?: string[];
-    /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
-    model?: AgentModelConfig;
-    /** Per-agent default thinking level for spawned sub-agents. */
-    thinking?: string;
-    /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
-    requireAgentId?: boolean;
-  };
-  /** Optional per-agent embedded OpenClaw overrides. */
-  embeddedAgent?: {
-    /** Optional per-agent execution contract override. */
-    executionContract?: EmbeddedAgentExecutionContract;
-  };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
-  /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
-  params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
-  /** Optional runtime descriptor for this agent. */
-  runtime?: AgentRuntimeConfig;
 };
 
 export type AgentEntryConfig = Omit<AgentConfig, "id">;

--- a/src/config/zod-schema.agent-entry-base.ts
+++ b/src/config/zod-schema.agent-entry-base.ts
@@ -1,0 +1,107 @@
+import { parseProviderModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { z } from "zod";
+import { AgentModelSchema } from "./zod-schema.agent-model.js";
+
+const AgentRuntimePolicySchema = z
+  .object({
+    id: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+const AgentModelRuntimeEntrySchema = z
+  .object({
+    alias: z.string().optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
+    agentRuntime: AgentRuntimePolicySchema,
+    codeMode: z.boolean().optional(),
+    streaming: z.boolean().optional(),
+  })
+  .strict();
+
+export const AgentModelMapSchema = z
+  .record(z.string(), AgentModelRuntimeEntrySchema)
+  .superRefine((models, ctx) => {
+    for (const [ref, entry] of Object.entries(models)) {
+      if (entry.codeMode !== undefined && (ref.includes("*") || !parseProviderModelRef(ref))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [ref, "codeMode"],
+          message:
+            "Code Mode requires an exact provider/model entry; wildcard and bare model keys are not supported.",
+        });
+      }
+    }
+  });
+
+export const AgentModelPolicySchema = z
+  .object({
+    allow: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const AgentRuntimeAcpSchema = z
+  .object({
+    agent: z.string().optional(),
+    backend: z.string().optional(),
+    mode: z.enum(["persistent", "oneshot"]).optional(),
+    cwd: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+const AgentRuntimeSchema = z
+  .union([
+    z.object({ type: z.literal("embedded") }).strict(),
+    z.object({ type: z.literal("acp"), acp: AgentRuntimeAcpSchema }).strict(),
+  ])
+  .optional();
+
+const AgentEntryEmbeddedAgentConfigSchema = z
+  .object({
+    executionContract: z.union([z.literal("default"), z.literal("strict-agentic")]).optional(),
+  })
+  .strict()
+  .optional();
+
+export const AgentEntryBaseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    workspace: z.string().optional(),
+    cwd: z.string().optional(),
+    agentDir: z.string().optional(),
+    model: AgentModelSchema.optional(),
+    utilityModel: z.string().optional(),
+    models: AgentModelMapSchema.optional(),
+    modelPolicy: AgentModelPolicySchema.optional(),
+    thinkingDefault: z
+      .enum(["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max", "ultra"])
+      .optional(),
+    verboseDefault: z.enum(["off", "on", "full"]).optional(),
+    toolProgressDetail: z.enum(["explain", "raw"]).optional(),
+    reasoningDefault: z.enum(["on", "off", "stream"]).optional(),
+    fastModeDefault: z.union([z.boolean(), z.literal("auto")]).optional(),
+    contextInjection: z
+      .union([z.literal("always"), z.literal("continuation-skip"), z.literal("never")])
+      .optional(),
+    bootstrapMaxChars: z.number().int().positive().optional(),
+    bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    experimental: z.object({ localModelLean: z.boolean().optional() }).strict().optional(),
+    skills: z.array(z.string()).optional(),
+    subagents: z
+      .object({
+        delegationMode: z.enum(["suggest", "prefer"]).optional(),
+        allowAgents: z.array(z.string()).optional(),
+        model: AgentModelSchema.optional(),
+        thinking: z.string().optional(),
+        requireAgentId: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    embeddedAgent: AgentEntryEmbeddedAgentConfigSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
+    runtime: AgentRuntimeSchema,
+  })
+  .strict();

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,5 +1,4 @@
 // Defines Zod schema fragments for per-agent runtime configuration.
-import { parseProviderModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { z } from "zod";
@@ -13,6 +12,7 @@ import {
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { MANAGED_GITHUB_PROFILE_ID_PATTERN } from "./github-identity-profile-id.js";
 import { LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS } from "./web-search-legacy-provider-keys.js";
+import { AgentEntryBaseSchema } from "./zod-schema.agent-entry-base.js";
 import { AgentModelSchema, AgentToolModelSchema } from "./zod-schema.agent-model.js";
 import {
   GroupChatSchema,
@@ -32,11 +32,7 @@ import {
 } from "./zod-schema.sandbox.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
-const AgentEntryEmbeddedAgentConfigSchema = z
-  .object({
-    executionContract: z.union([z.literal("default"), z.literal("strict-agentic")]).optional(),
-  })
-  .strict();
+export { AgentModelMapSchema, AgentModelPolicySchema } from "./zod-schema.agent-entry-base.js";
 
 const AgentTtsConfigSchema = TtsConfigSchema.unwrap()
   .extend({ prefsPath: z.string().optional() })
@@ -707,134 +703,24 @@ export const MemorySearchSchema = z
   .optional();
 export { AgentModelSchema, AgentToolModelSchema };
 
-const AgentRuntimeAcpSchema = z
-  .object({
-    agent: z.string().optional(),
-    backend: z.string().optional(),
-    mode: z.enum(["persistent", "oneshot"]).optional(),
-    cwd: z.string().optional(),
-  })
-  .strict()
-  .optional();
-
-const AgentRuntimeSchema = z
-  .union([
-    z
-      .object({
-        type: z.literal("embedded"),
-      })
-      .strict(),
-    z
-      .object({
-        type: z.literal("acp"),
-        acp: AgentRuntimeAcpSchema,
-      })
-      .strict(),
-  ])
-  .optional();
-
-const AgentRuntimePolicySchema = z
-  .object({
-    id: z.string().optional(),
-  })
-  .strict()
-  .optional();
-
-const AgentModelRuntimeEntrySchema = z
-  .object({
-    alias: z.string().optional(),
-    params: z.record(z.string(), z.unknown()).optional(),
-    agentRuntime: AgentRuntimePolicySchema,
-    codeMode: z.boolean().optional(),
-    streaming: z.boolean().optional(),
-  })
-  .strict();
-
-export const AgentModelMapSchema = z
-  .record(z.string(), AgentModelRuntimeEntrySchema)
-  .superRefine((models, ctx) => {
-    for (const [ref, entry] of Object.entries(models)) {
-      // Runtime policy supports wildcard rows; Code Mode resolves exact models.
-      // Reject an authored override that would otherwise be silently ignored.
-      if (entry.codeMode !== undefined && (ref.includes("*") || !parseProviderModelRef(ref))) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [ref, "codeMode"],
-          message:
-            "Code Mode requires an exact provider/model entry; wildcard and bare model keys are not supported.",
-        });
-      }
-    }
-  });
-
-export const AgentModelPolicySchema = z
-  .object({
-    allow: z.array(z.string()).optional(),
-  })
-  .strict();
-
-export const AgentEntrySchema = z
-  .object({
-    id: z.string(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    workspace: z.string().optional(),
-    cwd: z.string().optional(),
-    agentDir: z.string().optional(),
-    model: AgentModelSchema.optional(),
-    utilityModel: z.string().optional(),
-    models: AgentModelMapSchema.optional(),
-    modelPolicy: AgentModelPolicySchema.optional(),
-    thinkingDefault: z
-      .enum(["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max", "ultra"])
-      .optional(),
-    verboseDefault: z.enum(["off", "on", "full"]).optional(),
-    toolProgressDetail: z.enum(["explain", "raw"]).optional(),
-    reasoningDefault: z.enum(["on", "off", "stream"]).optional(),
-    fastModeDefault: z.union([z.boolean(), z.literal("auto")]).optional(),
-    contextInjection: z
-      .union([z.literal("always"), z.literal("continuation-skip"), z.literal("never")])
-      .optional(),
-    bootstrapMaxChars: z.number().int().positive().optional(),
-    bootstrapTotalMaxChars: z.number().int().positive().optional(),
-    experimental: z
-      .object({
-        localModelLean: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    skills: z.array(z.string()).optional(),
-    memory: z
-      .object({
-        search: MemorySearchSchema,
-      })
-      .strict()
-      .optional(),
-    humanDelay: HumanDelaySchema.optional(),
-    typingMode: TypingModeSchema.optional(),
-    tts: AgentTtsConfigSchema,
-    skillsLimits: AgentSkillsLimitsSchema,
-    contextLimits: AgentContextLimitsSchema,
-    heartbeat: HeartbeatSchema,
-    identity: IdentitySchema,
-    groupChat: GroupChatSchema.unwrap().omit({ visibleReplies: true }).optional(),
-    subagents: z
-      .object({
-        delegationMode: z.enum(["suggest", "prefer"]).optional(),
-        allowAgents: z.array(z.string()).optional(),
-        model: AgentModelSchema.optional(),
-        thinking: z.string().optional(),
-        requireAgentId: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    embeddedAgent: AgentEntryEmbeddedAgentConfigSchema.optional(),
-    sandbox: AgentSandboxSchema,
-    params: z.record(z.string(), z.unknown()).optional(),
-    tools: AgentToolsSchema,
-    runtime: AgentRuntimeSchema,
-  })
-  .strict();
+export const AgentEntrySchema = AgentEntryBaseSchema.extend({
+  memory: z
+    .object({
+      search: MemorySearchSchema,
+    })
+    .strict()
+    .optional(),
+  humanDelay: HumanDelaySchema.optional(),
+  typingMode: TypingModeSchema.optional(),
+  tts: AgentTtsConfigSchema,
+  skillsLimits: AgentSkillsLimitsSchema,
+  contextLimits: AgentContextLimitsSchema,
+  heartbeat: HeartbeatSchema,
+  identity: IdentitySchema,
+  groupChat: GroupChatSchema.unwrap().omit({ visibleReplies: true }).optional(),
+  sandbox: AgentSandboxSchema,
+  tools: AgentToolsSchema,
+}).strict();
 
 export const ToolsSchema = z
   .object({


### PR DESCRIPTION
## Summary

- derive the aligned `AgentConfig` fields from a canonical leaf `AgentEntryBaseSchema`
- compose the runtime `AgentEntrySchema` from that same leaf owner
- retain explicit overlays for complex config-boundary fields and doctor-only legacy inputs

## Why

`AgentConfig` repeated schema-owned agent entry fields by hand. A leaf schema owner removes 73 production lines while keeping both runtime and static import topology acyclic.

## Compatibility

The released memory, TTS, heartbeat, identity, group-chat, tools, and sandbox contracts remain explicit. Legacy `default`, `agentRuntime`, and `compaction` fields remain available to doctor migrations.

## Validation

- 118 focused config, agent, and runtime-schema tests
- core and all test-type shards
- Plugin SDK declaration generation
- runtime and static import-cycle guards
- full `pnpm check:changed`
- P0–P2 autoreview: scoped clean

Production diff: **+132 / −205 (net −73 LOC)**
