### PR TITLE
fix(cli): preserve update diagnostics when history is unavailable

### DIFF
--- a/docs/cli/update/status-and-history.md
+++ b/docs/cli/update/status-and-history.md
@@ -47,6 +47,11 @@ gets a separate `runId`.
 
 `openclaw update --json` includes `runId` and the `run` record. `openclaw update status --json`
 includes `activeRun` when a run is active and `lastRun` when history exists.
+If history cannot be read or classified, status still shows update availability
+and runtime findings. Human output explains that run status is unavailable;
+JSON includes `runStatusError` and omits the run fields. This does not mean
+there are no active or past runs, and status does not repair the underlying state.
+
 When the active row has been inactive for more than 30 minutes and its recorded
 driver is verifiably dead, status also reports `abandonedRun` with its `runId`
 and reconciliation `rule`. Status remains read-only: the stored row stays in

--- a/src/cli/update-cli/status.test.ts
+++ b/src/cli/update-cli/status.test.ts
@@ -1,14 +1,20 @@
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as runtimeGuard from "../../infra/runtime-guard.js";
 import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
   createUpdateRun,
+  findActiveUpdateRun,
+  finishUpdateRun,
   getUpdateRun,
+  listUpdateRuns,
   recordUpdateRunPhase,
 } from "../../infra/update-run-ledger.js";
 import { ABANDONED_UPDATE_RUN_MS } from "../../infra/update-run-timeouts.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { updateStatusCommand } from "./status.js";
 
 const runtime = vi.hoisted(() => ({
@@ -38,9 +44,6 @@ vi.mock("../../runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../runtime.js")>()),
   defaultRuntime: runtime,
 }));
-vi.mock("../../config/config.js", () => ({
-  readSourceConfigBestEffort: async () => ({}),
-}));
 vi.mock("../../infra/update-check.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../infra/update-check.js")>()),
   checkUpdateStatus: async () => ({
@@ -60,10 +63,95 @@ const tempDirs = createTempDirTracker();
 beforeEach(() => {
   vi.clearAllMocks();
   service.readCommand.mockResolvedValue(null);
-  vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-update-status-"));
+  const stateDir = tempDirs.make("openclaw-update-status-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
 });
 
 describe("update status Node runtime findings", () => {
+  it.each(
+    [true, false].flatMap((json) => [
+      { json, stored: true, sqliteVersion: "3.51.2", unavailable: true },
+      { json, stored: false, sqliteVersion: "3.51.2", unavailable: false },
+      { json, stored: true, sqliteVersion: "3.51.3", unavailable: false },
+    ]),
+  )(
+    "preserves diagnostics with stored=$stored SQLite $sqliteVersion (JSON: $json)",
+    async ({ json, stored, sqliteVersion, unavailable }) => {
+      const recorded = stored ? createUpdateRun({ trigger: "cli" }) : undefined;
+      closeOpenClawStateDatabaseForTest();
+      vi.resetModules();
+      const sqlitePrototype: {
+        prepare: (this: DatabaseSync, sql: string) => ReturnType<DatabaseSync["prepare"]>;
+      } = DatabaseSync.prototype;
+      const realPrepare = sqlitePrototype.prepare;
+      const prepare = vi
+        .spyOn(DatabaseSync.prototype, "prepare")
+        .mockImplementation(function (this: DatabaseSync, sql) {
+          return realPrepare.call(
+            this,
+            sql === "SELECT sqlite_version() AS version"
+              ? `SELECT '${sqliteVersion}' AS version`
+              : sql,
+          );
+        });
+      const freshGuard = await import("../../infra/runtime-guard.js");
+      vi.spyOn(freshGuard, "detectRuntime").mockReturnValue({
+        kind: "node",
+        version: process.versions.node,
+        execPath: "/fixture/node",
+        pathEnv: "/fixture",
+        hasNodeSqlite: true,
+        sqliteVersion,
+        sqliteProbe: {
+          available: true,
+          version: sqliteVersion,
+          text: true,
+          blob: true,
+          json: true,
+        },
+      });
+      const command = await import("./status.js");
+      const ledger = await import("../../infra/update-run-ledger.js");
+      if (unavailable) {
+        expect(() => ledger.findActiveUpdateRun()).toThrow(
+          "SQLite support is unavailable or unsafe",
+        );
+      }
+      await expect(command.updateStatusCommand({ json })).resolves.toBeUndefined();
+      if (json) {
+        const result = runtime.writeJson.mock.lastCall?.[0];
+        expect(result).toHaveProperty("availability");
+        expect(Boolean(result?.runStatusError)).toBe(unavailable);
+        if (sqliteVersion === "3.51.2") {
+          expect(result?.runtimeFindings).toEqual([
+            expect.objectContaining({
+              severity: "error",
+              message: expect.stringContaining("SQLite 3.51.2"),
+              fixHint: expect.stringContaining("nvm install 26"),
+            }),
+          ]);
+        }
+        expect(result?.activeRun).toEqual(unavailable ? undefined : recorded);
+        expect(result?.lastRun).toEqual(unavailable ? undefined : recorded);
+        expect(result).not.toHaveProperty("abandonedRun");
+      } else {
+        const output = runtime.log.mock.calls.flat().join("\n");
+        expect(output).toContain("OpenClaw update status");
+        expect(output.includes("Update run status unavailable:")).toBe(unavailable);
+        if (sqliteVersion === "3.51.2") {
+          expect(output).toContain("SQLite 3.51.2");
+          expect(output).toContain("nvm install 26");
+        }
+      }
+      if (!stored) {
+        expect(prepare).not.toHaveBeenCalled();
+      }
+      prepare.mockRestore();
+      expect(recorded && ledger.getUpdateRun(recorded.runId)).toEqual(recorded);
+    },
+  );
+
   it.each(["cli", "service"])(
     "renders admitted %s runtime information without a missing hint",
     async (source) => {
@@ -173,6 +261,47 @@ afterEach(() => {
 });
 
 describe("update status abandoned-run reporting", () => {
+  it.each([true, false])(
+    "does not publish partial history when the latest terminal row is unreadable (JSON: %s)",
+    async (json) => {
+      const now = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      const active = createUpdateRun({ trigger: "cli" });
+      vi.mocked(Date.now).mockReturnValue(now + 1);
+      const latest = createUpdateRun({ trigger: "cli" });
+      finishUpdateRun(latest.runId, { status: "succeeded" });
+      closeOpenClawStateDatabaseForTest();
+      const database = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      try {
+        database
+          .prepare("UPDATE update_runs SET origin_json = ? WHERE run_id = ?")
+          .run("not-json", latest.runId);
+      } finally {
+        database.close();
+      }
+      expect(findActiveUpdateRun()).toEqual(active);
+      expect(() => listUpdateRuns({ limit: 1 })).toThrow();
+
+      await updateStatusCommand({ json });
+
+      if (json) {
+        const result = runtime.writeJson.mock.lastCall?.[0];
+        expect(result?.runStatusError).toEqual(expect.any(String));
+        expect(result).toHaveProperty("availability");
+        for (const field of ["activeRun", "lastRun", "staleRun", "abandonedRun"]) {
+          expect(result).not.toHaveProperty(field);
+        }
+      } else {
+        const output = runtime.log.mock.calls.flat().join("\n");
+        expect(output).toContain("OpenClaw update status");
+        expect(output).toContain("Update run status unavailable:");
+        expect(output).not.toContain(active.runId);
+      }
+      expect(getUpdateRun(active.runId)).toEqual(active);
+      expect(() => listUpdateRuns({ limit: 1 })).toThrow();
+    },
+  );
+
   it.each([true, false])(
     "gives explicit recovery guidance for stale identityless history (JSON: %s)",
     async (json) => {

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -9,6 +9,7 @@ import {
   resolveUpdateAvailability,
 } from "../../commands/status.update.js";
 import { readSourceConfigBestEffort } from "../../config/config.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import {
   normalizeUpdateChannel,
   resolveUpdateChannelDisplay,
@@ -23,6 +24,28 @@ import { renderUpdateRunReport } from "../../infra/update-run-report.js";
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { parseTimeoutMsOrExit, resolveUpdateRoot, type UpdateStatusOptions } from "./shared.js";
+
+function readUpdateRunStatus() {
+  try {
+    const activeRun = findActiveUpdateRun();
+    const lastRun = listUpdateRuns({ limit: 1 })[0];
+    const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
+    const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
+    return {
+      ...(activeRun ? { activeRun } : {}),
+      ...(lastRun ? { lastRun } : {}),
+      ...(staleGuidance && activeRun
+        ? { staleRun: { runId: activeRun.runId, guidance: staleGuidance } }
+        : {}),
+      ...(abandonment && activeRun
+        ? { abandonedRun: { runId: activeRun.runId, rule: abandonment } }
+        : {}),
+    };
+  } catch (error) {
+    // History is optional diagnostic context; an unavailable read is not an empty ledger.
+    return { runStatusError: formatErrorMessage(error) };
+  }
+}
 
 /** Print update status in JSON or table form for scripts and humans. */
 export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<void> {
@@ -63,10 +86,7 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
 
   const updateAvailability = resolveUpdateAvailability(update);
 
-  const activeRun = findActiveUpdateRun();
-  const lastRun = listUpdateRuns({ limit: 1 })[0];
-  const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
-  const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
+  const runStatus = readUpdateRunStatus();
 
   if (opts.json) {
     defaultRuntime.writeJson({
@@ -79,14 +99,7 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
       },
       availability: updateAvailability,
       ...(runtimeFindings.length > 0 ? { runtimeFindings } : {}),
-      ...(activeRun ? { activeRun } : {}),
-      ...(lastRun ? { lastRun } : {}),
-      ...(staleGuidance && activeRun
-        ? { staleRun: { runId: activeRun.runId, guidance: staleGuidance } }
-        : {}),
-      ...(abandonment && activeRun
-        ? { abandonedRun: { runId: activeRun.runId, rule: abandonment } }
-        : {}),
+      ...runStatus,
     });
     return;
   }
@@ -138,24 +151,30 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
   );
   defaultRuntime.log("");
 
-  const run = activeRun ?? lastRun;
-  if (run) {
-    if (staleGuidance) {
-      defaultRuntime.log(`Update ${run.runId}: ${staleGuidance}`);
-    }
-    if (abandonment) {
-      defaultRuntime.log(
-        "Abandoned update detected; the Gateway will reconcile its recorded outcome. Run openclaw update repair to reconcile it now.",
-      );
-    }
-    const report = renderUpdateRunReport(run);
-    if (!abandonment && !staleGuidance) {
-      defaultRuntime.log(report.headline);
-    }
-    for (const line of report.lines) {
-      defaultRuntime.log(line);
-    }
+  if ("runStatusError" in runStatus) {
+    defaultRuntime.log(theme.warn(`Update run status unavailable: ${runStatus.runStatusError}`));
     defaultRuntime.log("");
+  } else {
+    const { activeRun, lastRun, staleRun, abandonedRun } = runStatus;
+    const run = activeRun ?? lastRun;
+    if (run) {
+      if (staleRun) {
+        defaultRuntime.log(`Update ${run.runId}: ${staleRun.guidance}`);
+      }
+      if (abandonedRun) {
+        defaultRuntime.log(
+          "Abandoned update detected; the Gateway will reconcile its recorded outcome. Run openclaw update repair to reconcile it now.",
+        );
+      }
+      const report = renderUpdateRunReport(run);
+      if (!abandonedRun && !staleRun) {
+        defaultRuntime.log(report.headline);
+      }
+      for (const line of report.lines) {
+        defaultRuntime.log(line);
+      }
+      defaultRuntime.log("");
+    }
   }
 
   const updateHint = formatUpdateAvailableHint(update);

--- a/src/state/openclaw-state-db-table-retirements.ts
+++ b/src/state/openclaw-state-db-table-retirements.ts
@@ -82,13 +82,6 @@ CREATE TABLE commitments (${RETIRED_COMMITMENTS_COLUMNS_SQL.slice(1, -1)}
 ${RETIRED_COMMITMENTS_BASE_INDEXES_SQL}
 `;
 
-const RETIRED_COMMITMENTS_INDEX_FINGERPRINTS = new Map(
-  getCanonicalSqliteNamedIndexContracts(RETIRED_COMMITMENTS_SCHEMA_SQL).map(
-    ({ fingerprint, name }) => [name, JSON.stringify(fingerprint)],
-  ),
-);
-const RETIRED_COMMITMENTS_INDEX_NAMES = [...RETIRED_COMMITMENTS_INDEX_FINGERPRINTS.keys()];
-
 const RETIRED_COMMITMENTS_ADDITIVE_COLUMNS = [
   "commitments.account_id",
   "commitments.recipient_id",
@@ -113,30 +106,40 @@ const RETIRED_COMMITMENTS_ADDITIVE_COLUMNS = [
   "commitments.expired_at_ms",
 ] as const;
 
-const RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
-  // These defaults shipped as independent same-version additive repairs, so
-  // supported databases may mix canonical and defaulted definitions. The
-  // surrounding exact-object check still rejects every other schema change.
-  allowedColumnDefinitions: {
-    "commitments.attempts": ["attempts INTEGER NOT NULL DEFAULT 0"],
-    "commitments.confidence": ["confidence REAL NOT NULL DEFAULT 0"],
-    "commitments.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
-    "commitments.dedupe_key": ["dedupe_key TEXT NOT NULL DEFAULT ''"],
-    "commitments.due_timezone": ["due_timezone TEXT NOT NULL DEFAULT 'UTC'"],
-    "commitments.kind": ["kind TEXT NOT NULL DEFAULT 'followup'"],
-    "commitments.reason": ["reason TEXT NOT NULL DEFAULT ''"],
-    "commitments.sensitivity": ["sensitivity TEXT NOT NULL DEFAULT 'normal'"],
-    "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
-    "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
-  },
-  allowedMissingColumns: RETIRED_COMMITMENTS_ADDITIVE_COLUMNS,
-  allowedMissingIndexes: RETIRED_COMMITMENTS_INDEX_NAMES,
-};
+function deriveRetiredCommitmentsContract() {
+  // Derivation opens guarded SQLite. Diagnostics must be importable before that
+  // capability is available; the canonical schema cache owns reuse after admission.
+  const indexFingerprints = new Map(
+    getCanonicalSqliteNamedIndexContracts(RETIRED_COMMITMENTS_SCHEMA_SQL).map(
+      ({ fingerprint, name }) => [name, JSON.stringify(fingerprint)],
+    ),
+  );
+  const compatibility: SqliteSchemaCompatibility = {
+    // These defaults shipped as independent same-version additive repairs, so
+    // supported databases may mix canonical and defaulted definitions. The
+    // surrounding exact-object check still rejects every other schema change.
+    allowedColumnDefinitions: {
+      "commitments.attempts": ["attempts INTEGER NOT NULL DEFAULT 0"],
+      "commitments.confidence": ["confidence REAL NOT NULL DEFAULT 0"],
+      "commitments.created_at_ms": ["created_at_ms INTEGER NOT NULL DEFAULT 0"],
+      "commitments.dedupe_key": ["dedupe_key TEXT NOT NULL DEFAULT ''"],
+      "commitments.due_timezone": ["due_timezone TEXT NOT NULL DEFAULT 'UTC'"],
+      "commitments.kind": ["kind TEXT NOT NULL DEFAULT 'followup'"],
+      "commitments.reason": ["reason TEXT NOT NULL DEFAULT ''"],
+      "commitments.sensitivity": ["sensitivity TEXT NOT NULL DEFAULT 'normal'"],
+      "commitments.source": ["source TEXT NOT NULL DEFAULT 'unknown'"],
+      "commitments.suggested_text": ["suggested_text TEXT NOT NULL DEFAULT ''"],
+    },
+    allowedMissingColumns: RETIRED_COMMITMENTS_ADDITIVE_COLUMNS,
+    allowedMissingIndexes: [...indexFingerprints.keys()],
+  };
+  return { indexFingerprints, compatibility };
+}
 
 function hasSupportedRetiredCommitmentsSchema(
   db: DatabaseSync,
   schemaSql: string,
-  compatibility: SqliteSchemaCompatibility,
+  { compatibility, indexFingerprints }: ReturnType<typeof deriveRetiredCommitmentsContract>,
 ): boolean {
   if (collectSqliteSchemaIssues(db, schemaSql, compatibility).length > 0) {
     return false;
@@ -156,7 +159,7 @@ function hasSupportedRetiredCommitmentsSchema(
     (object) =>
       object.type === "index" &&
       JSON.stringify(collectSqliteNamedIndexContract(db, object.name)) ===
-        RETIRED_COMMITMENTS_INDEX_FINGERPRINTS.get(object.name),
+        indexFingerprints.get(object.name),
   );
 }
 
@@ -168,7 +171,7 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
     db,
     "retired OpenClaw commitments schema",
     RETIRED_COMMITMENTS_SCHEMA_SQL,
-    RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
+    deriveRetiredCommitmentsContract().compatibility,
   );
   throw new Error(
     "Retired OpenClaw commitments schema has unsupported additional indexes; refusing destructive migration.",
@@ -176,17 +179,10 @@ function assertRecognizedRetiredCommitmentsSchema(db: DatabaseSync): void {
 }
 
 export function hasRecognizedRetiredCommitmentsSchema(db: DatabaseSync): boolean {
+  const contract = deriveRetiredCommitmentsContract();
   return (
-    hasSupportedRetiredCommitmentsSchema(
-      db,
-      RETIRED_COMMITMENTS_SCHEMA_SQL,
-      RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
-    ) ||
-    hasSupportedRetiredCommitmentsSchema(
-      db,
-      SHIPPED_RETIRED_COMMITMENTS_SCHEMA_SQL,
-      RETIRED_COMMITMENTS_SCHEMA_COMPATIBILITY,
-    )
+    hasSupportedRetiredCommitmentsSchema(db, RETIRED_COMMITMENTS_SCHEMA_SQL, contract) ||
+    hasSupportedRetiredCommitmentsSchema(db, SHIPPED_RETIRED_COMMITMENTS_SCHEMA_SQL, contract)
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw update status` could lose runtime repair findings when SQLite was rejected by the runtime guard or saved update history was unreadable. An eager schema fingerprint calculation could fail during module loading, before the command could report those findings.

## Why This Change Was Made

Retired-schema fingerprints are now derived when schema recognition needs them, using the same canonical SQL, cache and compatibility checks. The CLI treats reading and classifying run history as one fallible diagnostic section. If that section fails, it reports `runStatusError` and omits partial run fields while retaining update availability, runtime findings and the final update hint.

SQLite safety checks, accepted schema layouts, migration decisions and stored records are unchanged. An unavailable history report is distinct from an empty history, and the status command does not repair state.

## User Impact

Users can still see useful runtime and update guidance when optional run history is unavailable. Human output labels the failure; JSON includes `runStatusError` rather than presenting an incomplete active/latest-run snapshot.

## Evidence

The final regression fixture has six intended failures before the repair and 19 passing cases afterward. It covers cold imports, missing and healthy state, unsafe-reader rejection, and a malformed latest row after a valid active-row read. Across the final status suite, SQLite/update siblings and selected retirement controls, 725 distinct cases pass in 11 files.

Tests use real config and ledger readers with isolated state and a healthy SQLite engine whose version query is intercepted. Runtime capability facts and external observations are synthetic. This proves the guarded reader and command boundary without operating an unsafe runtime or live updater.

The 29-stage changed check passed before a final test-only receiver annotation; production and documentation bytes are identical. The final annotation passed lint, affected test types, formatting and all 19 status cases. Independent review found no actionable issues through P2. No casts, lint suppressions or weakened checks were added.
