### PR TITLE
fix(opencode-go): attach stable session routing per turn

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -610,6 +610,60 @@ describe("opencode-go provider plugin", () => {
     expect(provider.wrapStreamFn?.({ streamFn: undefined } as never)).toBeUndefined();
   });
 
+  it("attaches a stable conversation id only to native OpenCode Go requests", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const resolveTurnState = provider.resolveTransportTurnState;
+
+    expect(
+      resolveTurnState?.({
+        provider: "opencode-go",
+        modelId: "glm-5",
+        model: {
+          provider: "opencode-go",
+          id: "glm-5",
+          api: "openai-completions",
+          baseUrl: "https://opencode.ai/zen/go/v1",
+        },
+        sessionId: "conversation-123",
+        turnId: "turn-1",
+        attempt: 1,
+        transport: "stream",
+      } as never),
+    ).toEqual({ headers: { "x-opencode-session": "conversation-123" } });
+    expect(
+      resolveTurnState?.({
+        provider: "opencode-go",
+        modelId: "glm-5",
+        model: {
+          provider: "opencode-go",
+          id: "glm-5",
+          api: "openai-completions",
+          baseUrl: "https://opencode.ai/zen/go/v1",
+          headers: { "X-OpenCode-Session": "configured-session" },
+        },
+        turnId: "turn-1",
+        attempt: 1,
+        transport: "stream",
+      } as never),
+    ).toBeUndefined();
+    expect(
+      resolveTurnState?.({
+        provider: "opencode-go",
+        modelId: "glm-5",
+        model: {
+          provider: "opencode-go",
+          id: "glm-5",
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.com/v1",
+        },
+        sessionId: "conversation-123",
+        turnId: "turn-1",
+        attempt: 1,
+        transport: "stream",
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("identifies native Anthropic stream and simple requests without tagging proxies", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     for (const testCase of [

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -115,6 +115,20 @@ export default defineSingleProviderPluginEntry({
     augmentModelCatalog: () => listOpencodeGoModelCatalogEntries(),
     ...buildProviderReplayFamilyHooks({ family: "passthrough-gemini" }),
     resolveThinkingProfile,
+    resolveTransportTurnState: (ctx) => {
+      if (!normalizeOpencodeGoBaseUrl({ api: ctx.model?.api, baseUrl: ctx.model?.baseUrl })) {
+        return undefined;
+      }
+      if (
+        Object.keys(ctx.model?.headers ?? {}).some(
+          (name) => name.toLowerCase() === "x-opencode-session",
+        )
+      ) {
+        return undefined;
+      }
+      const sessionId = ctx.sessionId?.trim() || ctx.turnId.trim();
+      return sessionId ? { headers: { "x-opencode-session": sessionId } } : undefined;
+    },
     wrapStreamFn: (ctx) => createOpencodeGoWrapper(ctx.streamFn, ctx.thinkingLevel),
     wrapSimpleCompletionStreamFn: (ctx) =>
       createOpencodeGoAttributionWrapper(ctx.streamFn, ctx.sourceApi),

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -15,7 +15,7 @@ import {
   createOpenAIProviderAcceptanceHook,
   isOpenAICompletionsThinkingEnabled,
 } from "../transports/openai-transport-shared.js";
-import { resolveOpencodeSessionHeaders } from "../transports/session-affinity.js";
+import { resolveProviderSimpleCompletionHeaders } from "../transports/provider-transport-turn-state.js";
 import {
   assignTransportErrorDetails,
   transportAbortError,
@@ -72,7 +72,7 @@ export const streamOpenAICompletions: StreamFunction<
         model,
         context,
         apiKey,
-        resolveOpencodeSessionHeaders(model, options),
+        resolveProviderSimpleCompletionHeaders(model, options),
         cacheSessionId,
         compat,
       );

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -5,7 +5,7 @@ import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import { resolveOpenAICompletionsCompat } from "../transports/openai-completions-compat.js";
 import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
-import { resolveOpencodeSessionHeaders } from "../transports/session-affinity.js";
+import { resolveProviderSimpleCompletionHeaders } from "../transports/provider-transport-turn-state.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveCacheRetention } from "./cache-retention.js";
@@ -73,7 +73,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
         model,
         context,
         apiKey,
-        resolveOpencodeSessionHeaders(model, options),
+        resolveProviderSimpleCompletionHeaders(model, options),
         cacheSessionId,
       );
     },

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Context, Model, StreamFn } from "@openclaw/llm-core";
 import OpenAI from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
@@ -36,7 +37,8 @@ import {
   type MutableAssistantOutput,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
-import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
+import { resolveProviderTransportTurnState } from "./provider-transport-turn-state.js";
+import { hasOpencodeSessionHeader, resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import {
   createWritableTransportEventStream,
   failTransportStream,
@@ -201,6 +203,16 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const turnState = resolveProviderTransportTurnState(model, {
+          sessionId: options?.sessionId,
+          turnId: randomUUID(),
+          attempt: 1,
+          transport: "stream",
+        });
+        const optionHeaders = resolveOpencodeSessionHeaders(model, options);
+        const turnHeaders = hasOpencodeSessionHeader(model, options)
+          ? undefined
+          : turnState?.headers;
         // The OpenAI SDK consumes the SSE terminal without yielding it. Observe
         // the raw body so native tool calls can distinguish clean DONE from EOF.
         const doneDetector = createSseDoneDetector();
@@ -234,7 +246,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           model,
           context,
           apiKey,
-          resolveOpencodeSessionHeaders(model, options),
+          { ...turnHeaders, ...optionHeaders },
           {
             fetch: doneDetectingFetch,
           },

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -81,7 +81,9 @@ import {
   log,
   resolveOpenAIClientBaseUrl,
 } from "./openai-transport-shared.js";
+import { resolveProviderTransportTurnState } from "./provider-transport-turn-state.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
+import { hasOpencodeSessionHeader } from "./session-affinity.js";
 import {
   createWritableTransportEventStream,
   failTransportStream,
@@ -125,36 +127,6 @@ function combineWebSocketTimeoutSignal(
     return signal;
   }
   return AbortSignal.any([signal, AbortSignal.timeout(Math.max(1, resolvedTimeoutMs))]);
-}
-
-function resolveProviderTransportTurnState(
-  model: Model,
-  params: {
-    sessionId?: string;
-    turnId: string;
-    attempt: number;
-    transport: "stream" | "websocket";
-  },
-) {
-  const normalizedProvider = model.provider.trim().toLowerCase();
-  const allowRuntimePluginLoad =
-    normalizedProvider === "openai" ||
-    normalizedProvider === "azure-openai" ||
-    normalizedProvider === "azure-openai-responses";
-  return getAiTransportHost().plugin.resolveTransportTurnState({
-    provider: model.provider,
-    modelId: model.id,
-    allowRuntimePluginLoad,
-    context: {
-      provider: model.provider,
-      modelId: model.id,
-      model,
-      sessionId: params.sessionId,
-      turnId: params.turnId,
-      attempt: params.attempt,
-      transport: params.transport,
-    },
-  });
 }
 
 export function createOpenAIResponsesClient(
@@ -224,12 +196,13 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           transport: websocketMode ? "websocket" : "stream",
         });
         const websocketSessionPolicy = websocketMode ? turnState?.websocket : undefined;
+        const hasExplicitOpencodeSession = hasOpencodeSessionHeader(model, options);
         const websocketHeaders = websocketMode
           ? buildOpenAIClientHeaders(
               model,
               context,
               options?.headers,
-              websocketSessionPolicy?.headers,
+              hasExplicitOpencodeSession ? undefined : websocketSessionPolicy?.headers,
               options?.sessionId,
               options?.cacheRetention,
             )
@@ -238,7 +211,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           model,
           context,
           options?.headers,
-          turnState?.headers,
+          hasExplicitOpencodeSession ? undefined : turnState?.headers,
           options?.sessionId,
           options?.cacheRetention,
         );

--- a/packages/ai/src/transports/provider-transport-session-headers.test.ts
+++ b/packages/ai/src/transports/provider-transport-session-headers.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApiRegistry } from "../api-registry.js";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import { streamSimpleGoogle } from "../providers/google.js";
+import { registerBuiltInApiProviders } from "../providers/register-builtins.js";
 import type { Model } from "../types.js";
 import {
   createAzureOpenAIResponsesTransportStreamFn,
@@ -197,6 +198,62 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
           expect(sessionHeader).toBe(testCase.expected);
         }
       }
+    },
+  );
+
+  it.each(["openai-completions", "openai-responses"] as const)(
+    "applies provider turn fallback through the sessionless simple-completion %s adapter",
+    async (api) => {
+      const requests: Request[] = [];
+      const captureFetch: typeof fetch = async (input, init) => {
+        requests.push(new Request(input, init));
+        return new Response(JSON.stringify({ error: { message: "request captured" } }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      };
+      configureAiTransportHost({
+        ...initialHost,
+        buildModelFetch: () => captureFetch,
+        requiresManagedTransport: () => false,
+        plugin: {
+          ...initialHost.plugin,
+          resolveProviderStream: () => undefined,
+          resolveTransportTurnState: ({ context }) => ({
+            headers: { "x-opencode-session": context.turnId },
+          }),
+        },
+      });
+      const apiRegistry = createApiRegistry();
+      registerBuiltInApiProviders(apiRegistry);
+      const sourceModel = {
+        id: "test-model",
+        name: "Test model",
+        api,
+        provider: "opencode-go",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 128,
+      } satisfies Model;
+      const model = prepareModelForSimpleCompletion({ apiRegistry, model: sourceModel });
+
+      expect(model.api).toBe(api);
+      const provider = apiRegistry.getApiProvider(model.api);
+      if (!provider) {
+        throw new Error(`No provider registered for ${api}`);
+      }
+      const stream = provider.streamSimple(
+        model,
+        { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+        { apiKey: "test-key" },
+      );
+      await stream.result();
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.headers.get("x-opencode-session")).toBeTruthy();
     },
   );
 });

--- a/packages/ai/src/transports/provider-transport-session-headers.test.ts
+++ b/packages/ai/src/transports/provider-transport-session-headers.test.ts
@@ -131,6 +131,74 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
       expect(requests[0]?.headers.get("x-opencode-session")).toBe(testCase.expected);
     }
   });
+
+  it.each(["openai-completions", "openai-responses"] as const)(
+    "applies provider turn fallback through sessionless %s requests",
+    async (api) => {
+      const requests: Request[] = [];
+      const captureFetch: typeof fetch = async (input, init) => {
+        requests.push(new Request(input, init));
+        return new Response(JSON.stringify({ error: { message: "request captured" } }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      };
+      configureAiTransportHost({
+        ...initialHost,
+        buildModelFetch: () => captureFetch,
+        plugin: {
+          ...initialHost.plugin,
+          resolveTransportTurnState: ({ context }) => ({
+            headers: { "x-opencode-session": context.turnId },
+          }),
+        },
+      });
+      const baseModel = {
+        id: "test-model",
+        name: "Test model",
+        api,
+        provider: "opencode-go",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 128,
+      } satisfies Model;
+
+      for (const testCase of [
+        { expected: "generated" },
+        { modelHeaders: { "X-OpenCode-Session": "model-session" }, expected: "model-session" },
+        { headers: { "x-opencode-session": "stream-session" }, expected: "stream-session" },
+      ] as const) {
+        const model = {
+          ...baseModel,
+          headers: "modelHeaders" in testCase ? testCase.modelHeaders : undefined,
+        };
+        const streamFn = createBoundaryAwareStreamFnForModel(model);
+        if (!streamFn) {
+          throw new Error(`No managed transport for ${api}`);
+        }
+        requests.length = 0;
+        const stream = await streamFn(
+          model,
+          { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+          {
+            apiKey: "test-key",
+            headers: "headers" in testCase ? testCase.headers : undefined,
+          },
+        );
+        await stream.result();
+        expect(requests).toHaveLength(1);
+        const sessionHeader = requests[0]?.headers.get("x-opencode-session");
+        if (testCase.expected === "generated") {
+          expect(sessionHeader).toBeTruthy();
+        } else {
+          expect(sessionHeader).toBe(testCase.expected);
+        }
+      }
+    },
+  );
 });
 
 describe("managed OpenAI Responses session headers at fetch egress", () => {

--- a/packages/ai/src/transports/provider-transport-turn-state.ts
+++ b/packages/ai/src/transports/provider-transport-turn-state.ts
@@ -1,5 +1,7 @@
-import type { Model } from "@openclaw/llm-core";
+import { randomUUID } from "node:crypto";
+import type { Model, StreamOptions } from "@openclaw/llm-core";
 import { getAiTransportHost } from "../host.js";
+import { hasOpencodeSessionHeader, resolveOpencodeSessionHeaders } from "./session-affinity.js";
 
 export function resolveProviderTransportTurnState(
   model: Model,
@@ -29,4 +31,21 @@ export function resolveProviderTransportTurnState(
       transport: params.transport,
     },
   });
+}
+
+export function resolveProviderSimpleCompletionHeaders(
+  model: Model,
+  options?: Pick<StreamOptions, "headers" | "sessionId">,
+) {
+  const optionHeaders = resolveOpencodeSessionHeaders(model, options);
+  if (hasOpencodeSessionHeader(model, { headers: optionHeaders })) {
+    return optionHeaders;
+  }
+  const turnState = resolveProviderTransportTurnState(model, {
+    sessionId: options?.sessionId,
+    turnId: randomUUID(),
+    attempt: 1,
+    transport: "stream",
+  });
+  return { ...turnState?.headers, ...optionHeaders };
 }

--- a/packages/ai/src/transports/provider-transport-turn-state.ts
+++ b/packages/ai/src/transports/provider-transport-turn-state.ts
@@ -1,0 +1,32 @@
+import type { Model } from "@openclaw/llm-core";
+import { getAiTransportHost } from "../host.js";
+
+export function resolveProviderTransportTurnState(
+  model: Model,
+  params: {
+    sessionId?: string;
+    turnId: string;
+    attempt: number;
+    transport: "stream" | "websocket";
+  },
+) {
+  const normalizedProvider = model.provider.trim().toLowerCase();
+  const allowRuntimePluginLoad =
+    normalizedProvider === "openai" ||
+    normalizedProvider === "azure-openai" ||
+    normalizedProvider === "azure-openai-responses";
+  return getAiTransportHost().plugin.resolveTransportTurnState({
+    provider: model.provider,
+    modelId: model.id,
+    allowRuntimePluginLoad,
+    context: {
+      provider: model.provider,
+      modelId: model.id,
+      model,
+      sessionId: params.sessionId,
+      turnId: params.turnId,
+      attempt: params.attempt,
+      transport: params.transport,
+    },
+  });
+}

--- a/packages/ai/src/transports/session-affinity.ts
+++ b/packages/ai/src/transports/session-affinity.ts
@@ -17,12 +17,17 @@ export function resolveOpencodeSessionHeaders(
   if (!options?.sessionId || !isOpencodeEndpoint(model.baseUrl)) {
     return options?.headers;
   }
-  if (
-    [model.headers, options.headers].some((headers) =>
-      Object.keys(headers ?? {}).some((name) => name.toLowerCase() === "x-opencode-session"),
-    )
-  ) {
+  if (hasOpencodeSessionHeader(model, options)) {
     return options.headers;
   }
   return { ...options.headers, "x-opencode-session": options.sessionId };
+}
+
+export function hasOpencodeSessionHeader(
+  model: Pick<Model, "headers">,
+  options?: Pick<StreamOptions, "headers">,
+): boolean {
+  return [model.headers, options?.headers].some((headers) =>
+    Object.keys(headers ?? {}).some((name) => name.toLowerCase() === "x-opencode-session"),
+  );
 }

--- a/src/agents/embedded-agent-runner/run-orchestrator.projection.test.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.projection.test.ts
@@ -166,6 +166,7 @@ describe("embedded retry transcript ownership", () => {
       const fetchMock = vi
         .fn<typeof fetch>()
         .mockRejectedValue(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+      vi.spyOn(getAiTransportHost().plugin, "resolveTransportTurnState").mockReturnValue(undefined);
       vi.spyOn(getAiTransportHost(), "buildModelFetch").mockReturnValue(fetchMock);
       const history = [
         { role: "user", content: "Check the results.", timestamp: 1 },


### PR DESCRIPTION
## Summary

- attach `x-opencode-session` through provider turn state for native OpenCode Go endpoints
- route the fallback through both Chat Completions and Responses transports
- preserve explicit model and request session headers ahead of generated conversation/turn identity

## Release-validation evidence

Full Release Validation run 34418806238 failed all six OpenCode Go live probes with HTTP 400 because sessionless requests lacked `x-opencode-session`. The shared provider turn-state hook now reaches both affected transports while explicit configured identity retains precedence.

Failing job: https://github.com/openclaw/openclaw/actions/runs/34418865241/job/102691864264

## Test plan

- `provider-transport-session-headers.test.ts` (14 passed; real fetch-egress coverage for both transports and explicit header precedence)
- `extensions/opencode-go/index.test.ts` (39 passed)
- `pnpm check` (passed)