### PR TITLE
test: reuse source transforms in cron output cases

### DIFF
--- a/src/cli/cron-output.process.test.ts
+++ b/src/cli/cron-output.process.test.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+// Reuse temporary source transforms while each child keeps its own scenario state.
+const childTempDir = useAutoCleanupTempDirTracker(afterAll).make("openclaw-cron-child-tmp-");
 const summaryBytes = 128 * 1024;
 const sentinel = "\nEND-CRON-SUMMARY\n";
 const summary = "x".repeat(summaryBytes - sentinel.length) + sentinel;
@@ -87,8 +89,9 @@ describe("cron process output", () => {
         ...process.env,
         OPENCLAW_STATE_DIR: path.join(root, "state"),
         OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
-        TMPDIR: root,
-        TSX_DISABLE_CACHE: "1",
+        TMPDIR: childTempDir,
+        TEMP: childTempDir,
+        TMP: childTempDir,
         NODE_DISABLE_COMPILE_CACHE: "1",
         NO_COLOR: "1",
       };


### PR DESCRIPTION
## What Problem This Solves

Six cron-output process cases explicitly disabled TSX caching and gave each child a new temporary root. They repeatedly transformed the same source graph, taking about 35–36 seconds for the complete file.

## Why This Change Was Made

Use the existing cleanup tracker to keep a temporary transform cache for the file, then remove it after every child has finished. Each case keeps separate state/configuration and a fresh Node process. TMPDIR/TEMP/TMP bind the temporary directory on both platform families; Node's separate compile cache remains disabled.

Retain all six cases in their original order: successful/failed waits, queued/not-due admission, run history and human lookup failure. Commander, CLI actions, runtime output and finalization remain real; the existing synthetic Gateway RPC responses, 128-KiB summary/sentinel, 256-KiB buffer, deadlines and all assertions are unchanged. No production, dependency, worker or sharding change. One test file, +6/−3 lines.

## User Impact

Faster CLI output coverage while retaining the regression detector for truncated piped JSON and truthful exit codes.

## Evidence

| Complete six-case invocation | Time |
| --- | ---: |
| Original | 36.18s |
| Candidate with temporary scratch audit | 11.96s |
| Restored original | 34.78s |
| Final candidate without audit | 10.34s |

All positive runs passed in the original order with the same physical dependencies, Node 24.19.0/pnpm 12.3.4, and a newly empty benchmark temporary base. Timings include the normal wrapper, preparation and cleanup. Final peak command RSS was approximately 369 MB.

Twelve boundary snapshots found an empty shared root initially, then 550 TSX cache files retaining their sizes/mtimes across later cases. Only TSX paths persisted at those observed boundaries; the root was removed after cleanup. The audited candidate includes 56ms of observer work. No diagnostic instrumentation is committed.

Regression sensitivity was also checked by temporarily restoring the two premature exits that #133661 replaced. Both cache-disabled and cache-enabled fixtures still failed on truncated JSON at position 65,536, after the original exit-code and signal guards passed. An additional diagnostic run moved the existing history case first to populate the cache: the subsequent warm wait cases ran in 0.691/0.705s against unchanged cache files and still detected the same truncation. Other four cases passed. Production bytes and the original test order were restored before final validation; no counterfactual code is retained.

Required changed-file checks and independent P2 review passed. These are controlled POSIX results; no Windows performance gain or full-main CI saving is claimed.
