### PR TITLE
fix(qa): detect native Slack exec progress

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -734,7 +734,12 @@ describe("Slack live QA runtime helpers", () => {
                     ? "🛠️ Exec"
                     : testCase.toolProgress === "standalone"
                       ? `🛠️ Exec\n\`\`\`\n${outputMarker}\n\`\`\``
-                      : `🛠️ Exec ${toolMarker}`,
+                      : testCase.id === "slack-progress-commentary-omitted"
+                        ? commentaryMarker
+                        : `🛠️ Exec ${toolMarker}`,
+                ...(testCase.id === "slack-progress-commentary-omitted"
+                  ? { blockText: [`• *Exec* — sleep 5`] }
+                  : {}),
                 ts: testCase.toolProgress === "draft" ? "1.500000" : "1.750000",
               },
             ]),

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -106,9 +106,17 @@ function isSlackSafeExecSummary(message: { text: string }) {
   return /^(?:🛠️|:hammer_and_wrench:) Exec$/u.test(message.text.trim());
 }
 
-function hasSlackExecHeader(message: { text: string }) {
+function hasSlackExecHeader(message: { blockText?: string[]; text: string }) {
   // Full output includes the runtime's command-derived label after the Exec glyph.
-  return /^(?:🛠️|:hammer_and_wrench:) \S.*$/u.test(message.text.split(/\r?\n/u)[0]?.trim() ?? "");
+  if (/^(?:🛠️|:hammer_and_wrench:) \S.*$/u.test(message.text.split(/\r?\n/u)[0]?.trim() ?? "")) {
+    return true;
+  }
+  // Compact progress cards keep the native tool row in Block Kit while their
+  // fallback text remains a generic status headline. Command-derived suffixes
+  // can be truncated, so identify the row by its stable native label.
+  return (message.blockText ?? []).some((text) =>
+    text.split(/\r?\n/u).some((line) => /^• \*Exec\* — \S/u.test(line.trim())),
+  );
 }
 
 function slackMarkerEnvelope(text: string, marker: string) {


### PR DESCRIPTION
## Summary

- recognize Slack native Block Kit `Exec` rows as tool-progress evidence
- keep generic fallback commentary from hiding a valid native progress surface
- add a regression case matching the maturity failure

## Testing

- `pnpm test extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` (62 passed)
- `pnpm check:changed`
- autoreview: clean at P0–P2
