### PR TITLE
fix(qa): tolerate Telegram observation ordering

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -273,6 +273,26 @@ describe("qa scenario catalog channel contracts", () => {
     });
   });
 
+  it("keeps Telegram semantic receipts and compaction previews order-independent", () => {
+    const semantic = requireFlowScenario(
+      readQaScenarioById("telegram-semantic-formatting-boundaries"),
+    );
+    const compaction = requireFlowScenario(
+      readQaScenarioById("telegram-claude-cli-compaction-final-priority"),
+    );
+    const semanticFlow = JSON.stringify(semantic.execution.flow);
+    const compactionFlow = JSON.stringify(compaction.execution.flow);
+
+    expect(semanticFlow).toContain(
+      "received.some((message) => String(message.botApiMessageId) === String(receipt.messageId))",
+    );
+    expect(semanticFlow).not.toContain("received.at(-1)?.botApiMessageId");
+    expect(compactionFlow).toContain('"minimumPreviewEvents":2');
+    expect(compactionFlow).toContain("config.commentaryOne");
+    expect(compactionFlow).toContain("config.commentaryTwo");
+    expect(compactionFlow).toContain("Compacting context");
+  });
+
   it("isolates scenarios that own asynchronous transport state", () => {
     const channelBaseline = requireFlowScenario(readQaScenarioById("channel-chat-baseline"));
     const subagentFanout = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));

--- a/qa/scenarios/channels/telegram-claude-cli-compaction-final-priority.yaml
+++ b/qa/scenarios/channels/telegram-claude-cli-compaction-final-priority.yaml
@@ -182,7 +182,7 @@ flow:
             sinceCursor: { ref: startCursor }
             finalTextIncludes: { ref: config.finalMarker }
             finalSettleMs: 1500
-            minimumPreviewEvents: 3
+            minimumPreviewEvents: 2
             timeoutMs: 90000
           saveAs: sequence
         - set: turnEvents

--- a/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
+++ b/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
@@ -153,7 +153,7 @@ flow:
                 value:
                   expr: "received.map(({ contentType, text, entities }) => ({ contentType, text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
               - assert:
-                  expr: "String(received.at(-1)?.botApiMessageId) === String(receipt.messageId) && JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)"
+                  expr: "received.some((message) => String(message.botApiMessageId) === String(receipt.messageId)) && JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)"
                   message:
                     expr: "JSON.stringify({ case: fixture.id, expected: fixture.expectedChunks, observed: actual.map((message, index) => ({ contentType: message.contentType, text: message.text === fixture.expectedChunks[index]?.text ? message.text : message.text.replace(/\\S/gu, '?'), nonWhitespaceRedacted: message.text !== fixture.expectedChunks[index]?.text, entities: message.entities.map((entity) => ({ offset: entity.offset, length: entity.length, type: entity.type['@type'], expectedTypePayload: JSON.stringify(entity.type) === JSON.stringify(fixture.expectedChunks[index]?.entities.find((expected) => expected.offset === entity.offset && expected.length === entity.length)?.type) })) })) })"
               - set: proofs


### PR DESCRIPTION
## Summary

- accept the matching Telegram receipt regardless of later observer events
- require the two commentary previews while continuing to prove compaction and final ordering
- guard both scenario contracts in the catalog tests

## Testing

- `pnpm test extensions/qa-lab/src/scenario-catalog-channels.test.ts` (29 passed)
- `pnpm check:changed`
- autoreview: clean at P0–P2
