### PR TITLE
fix(qa): isolate health CLI scenarios

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -194,7 +194,7 @@ describe("qa scenario catalog", () => {
 
   it("keeps the audited parallel script allowlist exact", () => {
     const expected =
-      "active-talk-agent-run-status agent-run-identity-inspection cached-health-snapshot-boundaries channel-health-monitor-lifecycle diagnostic-events-boundary gateway-loopback-lan-access gateway-rpc-account-health gateway-smoke gateway-ssh-tunnels gateway-stability-runtime gateway-support-export gateway-tls-pinning gateway-websocket-protocol-contracts logging-file-boundary mcp-gateway-connect-startup-retry mcp-plugin-tools-call otel-generation-config-watcher qa-otel-smoke remote-log-tailing subagent-lineage-inspection tui-command-surfaces-pty tui-editor-input-pty tui-entrypoints-pty tui-gateway-boundary-pty tui-local-runtime-recovery-pty tui-local-shell-pty tui-pty-evidence-producer-contract tui-session-management-pty tui-streaming-tool-cards-pty tui-terminal-safety-pty voice-call-cli-rpc-agent-tool webchat-auto-tts".split(
+      "active-talk-agent-run-status agent-run-identity-inspection channel-health-monitor-lifecycle diagnostic-events-boundary gateway-loopback-lan-access gateway-smoke gateway-ssh-tunnels gateway-stability-runtime gateway-support-export gateway-tls-pinning gateway-websocket-protocol-contracts logging-file-boundary mcp-gateway-connect-startup-retry mcp-plugin-tools-call otel-generation-config-watcher qa-otel-smoke remote-log-tailing subagent-lineage-inspection tui-command-surfaces-pty tui-editor-input-pty tui-entrypoints-pty tui-gateway-boundary-pty tui-local-runtime-recovery-pty tui-local-shell-pty tui-pty-evidence-producer-contract tui-session-management-pty tui-streaming-tool-cards-pty tui-terminal-safety-pty voice-call-cli-rpc-agent-tool webchat-auto-tts".split(
         " ",
       );
     const marked = readQaScenarioPack().scenarios.filter(
@@ -209,6 +209,12 @@ describe("qa scenario catalog", () => {
       parallelSafe: true,
       allowBlockedEvidence: true,
     });
+    for (const scenarioId of ["cached-health-snapshot-boundaries", "gateway-rpc-account-health"]) {
+      expect(readQaScenarioById(scenarioId).execution).toMatchObject({
+        kind: "script",
+        parallelSafe: false,
+      });
+    }
   });
 
   it("rejects invalid provider metadata at the catalog boundary", () => {

--- a/qa/scenarios/observability/cached-health-snapshot-boundaries.yaml
+++ b/qa/scenarios/observability/cached-health-snapshot-boundaries.yaml
@@ -25,7 +25,9 @@ scenario:
     - test/e2e/qa-lab/runtime/cached-health-snapshot-boundaries.ts
   execution:
     kind: script
-    parallelSafe: true
+    # This proof launches the repository CLI, whose stale-dist guard may rebuild
+    # shared runtime artifacts. Keep it in the suite's exclusive script phase.
+    parallelSafe: false
     path: test/e2e/qa-lab/runtime/cached-health-snapshot-boundaries.ts
     summary: Exercises the production health handler cache boundary and crosses a real authenticated Gateway plugin-tool invocation.
     args:

--- a/qa/scenarios/observability/gateway-rpc-account-health.yaml
+++ b/qa/scenarios/observability/gateway-rpc-account-health.yaml
@@ -23,7 +23,9 @@ scenario:
     - test/e2e/qa-lab/runtime/gateway-rpc-account-health.ts
   execution:
     kind: script
-    parallelSafe: true
+    # This proof launches the repository CLI, whose stale-dist guard may rebuild
+    # shared runtime artifacts. Keep it in the suite's exclusive script phase.
+    parallelSafe: false
     path: test/e2e/qa-lab/runtime/gateway-rpc-account-health.ts
     summary: Starts a real QA bus and CLI Gateway child, performs authenticated health and status RPCs, and patches one account through config CAS and hot reload.
     args:


### PR DESCRIPTION
## Summary

- move both repo-CLI health scenarios out of the parallel script phase
- prevent concurrent stale-dist rebuilds from contending on the shared artifact lock
- guard their exclusive scheduler metadata in the scenario catalog

## Testing

- `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts` (121 passed)
- `pnpm check:changed`
- autoreview: clean at P0–P2
