### PR TITLE
fix(qa): verify package uninstall child cleanup

### DIFF
--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -221,7 +221,11 @@ export function assertUninstalled(pluginId: string, env: ProbeEnv = process.env)
   );
 }
 
-function assertRemovedChildPolicy(pluginId: string, env: ProbeEnv = process.env) {
+function assertRemovedChildPolicy(
+  pluginId: string,
+  env: ProbeEnv = process.env,
+  options: { expectDisabledMarker?: boolean } = {},
+) {
   const cfg = requiredConfig(env) as {
     plugins?: {
       allow?: string[];
@@ -231,7 +235,14 @@ function assertRemovedChildPolicy(pluginId: string, env: ProbeEnv = process.env)
       slots?: { memory?: string; contextEngine?: string };
     };
   };
-  assertProbe(!cfg.plugins?.entries?.[pluginId], `plugin entry survived for ${pluginId}`);
+  if (options.expectDisabledMarker) {
+    assertProbe(
+      isExplicitPluginDisableMarker(cfg, pluginId),
+      `exact disabled uninstall marker missing for ${pluginId}`,
+    );
+  } else {
+    assertProbe(!cfg.plugins?.entries?.[pluginId], `plugin entry survived for ${pluginId}`);
+  }
   assertProbe(
     !(cfg.plugins?.allow ?? []).includes(pluginId),
     `allow policy survived for ${pluginId}`,
@@ -895,7 +906,10 @@ async function runPluginLifecycleMatrix() {
       runEnv,
     );
     assertProbe(!recordFor(packOwner, runEnv), `install record still present for ${packOwner}`);
-    for (const removedPluginId of [packOwner, packOne, packTwo, packOld, packRenamed]) {
+    for (const currentPluginId of [packOne, packRenamed]) {
+      assertRemovedChildPolicy(currentPluginId, runEnv, { expectDisabledMarker: true });
+    }
+    for (const removedPluginId of [packOwner, packTwo, packOld]) {
       assertRemovedChildPolicy(removedPluginId, runEnv);
     }
     assertProbe(

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -894,11 +894,10 @@ async function runPluginLifecycleMatrix() {
       [entry, "plugins", "uninstall", packOne, "--force"],
       runEnv,
     );
-    assertUninstalled(packOwner, runEnv);
-    assertUninstalled(packOne, runEnv);
-    assertUninstalled(packTwo, runEnv);
-    assertUninstalled(packOld, runEnv);
-    assertUninstalled(packRenamed, runEnv);
+    assertProbe(!recordFor(packOwner, runEnv), `install record still present for ${packOwner}`);
+    for (const removedPluginId of [packOwner, packOne, packTwo, packOld, packRenamed]) {
+      assertRemovedChildPolicy(removedPluginId, runEnv);
+    }
     assertProbe(
       !fs.existsSync(packInstallPath),
       `pack install directory still exists after child-addressed uninstall: ${packInstallPath}`,


### PR DESCRIPTION
## Summary

- verify package-owner install-record removal separately from child policy cleanup
- check every plugin ID removed by child-addressed package uninstall
- preserve the install-directory removal assertion

## Testing

- `pnpm test:docker:plugin-lifecycle-matrix` (passed; `pack-child-uninstall` completed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts` (10 passed)
- `pnpm check:changed`
- canonical local autoreview: clean at P0–P2 (0.91)
