### PR TITLE
test(matrix): keep state_after fault injection in place

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/runtime.ts
@@ -956,6 +956,7 @@ export async function runMatrixQaLive(params: {
                 driverUserId: provisioning.driver.userId,
                 faultProxyObserver: harness.recording,
                 faultProxyTargetBaseUrl: harness.upstreamBaseUrl,
+                installFaultRule: (rule) => harness.recording.installFaultRule(rule),
                 interruptTransport: async () => {
                   writeMatrixQaProgress(`transport interrupt start ${scenario.id}`);
                   const measuredInterrupt = await measureMatrixQaStep(async () => {

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -1381,43 +1381,25 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
   if (!context.restartGatewayAfterStateMutation) {
     throw new Error("Matrix E2EE state_after QA scenario requires hard gateway restart support");
   }
+  if (!context.installFaultRule) {
+    throw new Error("Matrix E2EE state_after QA scenario requires in-place fault injection");
+  }
   const accountId = context.sutAccountId ?? "sut";
-  const configPath = requireMatrixQaGatewayConfigPath(context);
-  const originalAccountConfig = await readMatrixQaGatewayMatrixAccount({
-    accountId,
-    configPath,
-  });
-  const proxy = await startMatrixQaFaultProxy({
-    targetBaseUrl: context.faultProxyTargetBaseUrl ?? context.baseUrl,
-    ...context.faultProxyObserver,
-    rules: [buildSyncStateAfterMissingEncryptionFaultRule(context.sutAccessToken)],
-  });
-  let gatewayPatched = false;
+  const faultRule = context.installFaultRule(
+    buildSyncStateAfterMissingEncryptionFaultRule(context.sutAccessToken),
+  );
   try {
-    await context.restartGatewayAfterStateMutation(
-      async () => {
-        await patchMatrixQaGatewayMatrixAccount({
-          accountId,
-          accountPatch: {
-            homeserver: proxy.baseUrl,
-            network: {
-              dangerouslyAllowPrivateNetwork: true,
-            },
-          },
-          configPath,
-        });
-        gatewayPatched = true;
-      },
-      {
-        timeoutMs: context.timeoutMs,
-        waitAccountId: accountId,
-      },
-    );
+    // Keep the configured homeserver URL stable so the Matrix client reuses
+    // its existing crypto identity while every post-restart /sync crosses the fault rule.
+    await context.restartGatewayAfterStateMutation(async () => undefined, {
+      timeoutMs: context.timeoutMs,
+      waitAccountId: accountId,
+    });
     const result = await runMatrixQaE2eeTopLevelScenario(context, {
       scenarioId: "matrix-e2ee-state-after-missing-encryption",
       tokenPrefix: "MATRIX_QA_E2EE_STATE_AFTER",
     });
-    const stateAfterHits = proxy
+    const stateAfterHits = faultRule
       .hits()
       .filter((hit) => hit.ruleId === MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID);
     if (stateAfterHits.length > 0) {
@@ -1428,7 +1410,7 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
     return {
       artifacts: {
         driverEventId: result.driverEventId,
-        faultProxyBaseUrl: proxy.baseUrl,
+        faultProxyBaseUrl: context.baseUrl,
         reply: result.reply,
         roomKey: result.roomKey,
         roomId: result.roomId,
@@ -1440,30 +1422,13 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
         `encrypted room key: ${result.roomKey}`,
         `encrypted room id: ${result.roomId}`,
         `driver event: ${result.driverEventId}`,
-        `fault proxy: ${proxy.baseUrl}`,
+        `fault proxy: ${context.baseUrl}`,
         `state_after sync opt-in hits: ${stateAfterHits.length}`,
         ...buildMatrixReplyDetails("E2EE state_after reply", result.reply),
       ].join("\n"),
     };
   } finally {
-    if (gatewayPatched) {
-      await context
-        .restartGatewayAfterStateMutation(
-          async () => {
-            await replaceMatrixQaGatewayMatrixAccount({
-              accountConfig: originalAccountConfig,
-              accountId,
-              configPath,
-            });
-          },
-          {
-            timeoutMs: context.timeoutMs,
-            waitAccountId: accountId,
-          },
-        )
-        .catch(() => undefined);
-    }
-    await proxy.stop().catch(() => undefined);
+    faultRule.remove();
   }
 }
 

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -2,7 +2,11 @@
 import { randomUUID } from "node:crypto";
 import { createMatrixQaClient, type MatrixQaRoomObserver } from "../../substrate/client.js";
 import type { MatrixQaObservedEvent } from "../../substrate/events.js";
-import type { MatrixQaFaultProxyObserver } from "../../substrate/fault-proxy.js";
+import type {
+  MatrixQaFaultProxyObserver,
+  MatrixQaFaultProxyRule,
+  MatrixQaFaultProxyRuleHandle,
+} from "../../substrate/fault-proxy.js";
 import { createMatrixQaRoomObserver } from "../../substrate/sync.js";
 import type { MatrixQaProvisionedTopology } from "../../substrate/topology.js";
 import { resolveMatrixQaScenarioRoomId } from "./scenario-catalog.js";
@@ -26,6 +30,7 @@ export type MatrixQaScenarioContext = {
   driverUserId: string;
   faultProxyObserver?: MatrixQaFaultProxyObserver;
   faultProxyTargetBaseUrl?: string;
+  installFaultRule?: (rule: MatrixQaFaultProxyRule) => MatrixQaFaultProxyRuleHandle;
   observedEvents: MatrixQaObservedEvent[];
   observerAccessToken: string;
   observerDeviceId?: string;

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -1128,13 +1128,12 @@ describe("matrix live qa scenarios", () => {
           },
         },
       });
-      const proxyStop = vi.fn().mockResolvedValue(undefined);
-      const proxyHits = vi.fn().mockReturnValue([]);
-      startMatrixQaFaultProxy.mockResolvedValue({
-        baseUrl: "http://127.0.0.1:39879",
-        hits: proxyHits,
-        stop: proxyStop,
-      });
+      const faultRuleRemove = vi.fn();
+      const faultRuleHits = vi.fn().mockReturnValue([]);
+      const installFaultRule = vi.fn((_rule: unknown) => ({
+        hits: faultRuleHits,
+        remove: faultRuleRemove,
+      }));
       let replyToken = "";
       const driverStop = vi.fn().mockResolvedValue(undefined);
       const driverClient = {
@@ -1171,6 +1170,7 @@ describe("matrix live qa scenarios", () => {
           OPENCLAW_CONFIG_PATH: gatewayConfigPath,
           PATH: process.env.PATH,
         },
+        installFaultRule,
         outputDir,
         restartGatewayAfterStateMutation,
         sutAccountId: "sut",
@@ -1225,44 +1225,39 @@ describe("matrix live qa scenarios", () => {
         "http://127.0.0.1:28008/",
       );
       expect(restoredConfig.channels.matrix.accounts.sut.network).toEqual({ existing: true });
-      expect(restartGatewayAfterStateMutation).toHaveBeenCalledTimes(2);
-      expect(proxyStop).toHaveBeenCalledTimes(1);
+      expect(restartGatewayAfterStateMutation).toHaveBeenCalledTimes(1);
+      expect(faultRuleRemove).toHaveBeenCalledTimes(1);
 
-      const proxyArgs = mockObjectArg(startMatrixQaFaultProxy, "startMatrixQaFaultProxy") as {
-        rules: Array<{
-          match: (params: {
-            bearerToken?: string;
-            headers: Record<string, string>;
-            method: string;
-            path: string;
-            search: string;
-          }) => boolean;
-          mutateResponse: (params: {
-            request: unknown;
-            response: {
+      const faultRule = installFaultRule.mock.calls[0]?.[0] as {
+        match: (params: {
+          bearerToken?: string;
+          headers: Record<string, string>;
+          method: string;
+          path: string;
+          search: string;
+        }) => boolean;
+        mutateResponse: (params: {
+          request: unknown;
+          response: {
+            body: Buffer;
+            headers: Headers;
+            status: number;
+          };
+        }) =>
+          | {
               body: Buffer;
               headers: Headers;
               status: number;
-            };
-          }) =>
-            | {
-                body: Buffer;
-                headers: Headers;
-                status: number;
-              }
-            | Promise<{
-                body: Buffer;
-                headers: Headers;
-                status: number;
-              }>;
-        }>;
-        targetBaseUrl?: unknown;
+            }
+          | Promise<{
+              body: Buffer;
+              headers: Headers;
+              status: number;
+            }>;
       };
-      const [faultRule] = proxyArgs.rules;
       if (!faultRule) {
         throw new Error("expected Matrix QA fault proxy rule");
       }
-      expect(proxyArgs.targetBaseUrl).toBe("http://127.0.0.1:28008/");
       expect(
         faultRule.match({
           bearerToken: "sut-token",

--- a/extensions/qa-matrix/src/substrate/fault-proxy.test.ts
+++ b/extensions/qa-matrix/src/substrate/fault-proxy.test.ts
@@ -195,6 +195,40 @@ describe("Matrix QA fault proxy", () => {
     ]);
   });
 
+  it("installs and removes scenario-local rules without changing the proxy origin", async () => {
+    const target = await startTargetServer();
+    proxy = await startMatrixQaFaultProxy({ targetBaseUrl: target.baseUrl, rules: [] });
+    const baseUrl = proxy.baseUrl;
+    const handle = proxy.installRule({
+      id: "scenario-local-sync-fault",
+      match: (proxyRequest) =>
+        proxyRequest.path === "/_matrix/client/v3/sync" && proxyRequest.bearerToken === "sut-token",
+      response: () => ({ body: { errcode: "M_QA_FAULT" }, status: 503 }),
+    });
+
+    const faulted = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync`, {
+      headers: { authorization: "Bearer sut-token" },
+    });
+    expect(faulted.status).toBe(503);
+    expect(proxy.baseUrl).toBe(baseUrl);
+    expect(handle.hits()).toEqual([
+      {
+        method: "GET",
+        path: "/_matrix/client/v3/sync",
+        ruleId: "scenario-local-sync-fault",
+      },
+    ]);
+
+    handle.remove();
+    handle.remove();
+    const forwarded = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync`, {
+      headers: { authorization: "Bearer sut-token" },
+    });
+    expect(forwarded.status).toBe(200);
+    expect(handle.hits()).toHaveLength(1);
+    expect(proxy.hits()).toHaveLength(1);
+  });
+
   it("rejects oversized forwarded request bodies before contacting the target", async () => {
     const target = await startTargetServer();
     proxy = await startMatrixQaFaultProxy({

--- a/extensions/qa-matrix/src/substrate/fault-proxy.ts
+++ b/extensions/qa-matrix/src/substrate/fault-proxy.ts
@@ -82,11 +82,34 @@ export type MatrixQaFaultProxyHit = {
   ruleId: string;
 };
 
+export type MatrixQaFaultProxyRuleHandle = {
+  hits(): MatrixQaFaultProxyHit[];
+  remove(): void;
+};
+
 export type MatrixQaFaultProxy = {
   baseUrl: string;
   hits(): MatrixQaFaultProxyHit[];
+  installRule(rule: MatrixQaFaultProxyRule): MatrixQaFaultProxyRuleHandle;
   stop(): Promise<void>;
 };
+
+type MatrixQaRegisteredFaultProxyRule = {
+  registrationId: number;
+  rule: MatrixQaFaultProxyRule;
+};
+
+type MatrixQaRegisteredFaultProxyHit = MatrixQaFaultProxyHit & {
+  registrationId: number;
+};
+
+function toMatrixQaFaultProxyHit(hit: MatrixQaRegisteredFaultProxyHit): MatrixQaFaultProxyHit {
+  return {
+    method: hit.method,
+    path: hit.path,
+    ruleId: hit.ruleId,
+  };
+}
 
 function normalizeHeaderValue(value: string | string[] | undefined) {
   if (Array.isArray(value)) {
@@ -327,7 +350,12 @@ export async function startMatrixQaFaultProxy(
   const targetBaseUrl = new URL(params.targetBaseUrl);
   const maxRequestBytes = params.maxRequestBytes ?? DEFAULT_FAULT_PROXY_REQUEST_MAX_BYTES;
   const maxResponseBytes = params.maxResponseBytes ?? DEFAULT_FAULT_PROXY_RESPONSE_MAX_BYTES;
-  const hits: MatrixQaFaultProxyHit[] = [];
+  let nextRuleRegistrationId = 0;
+  const registeredRules: MatrixQaRegisteredFaultProxyRule[] = params.rules.map((rule) => ({
+    registrationId: nextRuleRegistrationId++,
+    rule,
+  }));
+  const hits: MatrixQaRegisteredFaultProxyHit[] = [];
   const server = createServer((req, res) => {
     void (async () => {
       let observedRequest: MatrixQaFaultProxyRequest | undefined;
@@ -348,11 +376,13 @@ export async function startMatrixQaFaultProxy(
         observedRequest = request;
         const context = params.createExchangeContext?.(request);
         observedContext = context;
-        const rule = params.rules.find((candidate) => candidate.match(request));
-        if (rule) {
+        const registeredRule = registeredRules.find((candidate) => candidate.rule.match(request));
+        const rule = registeredRule?.rule;
+        if (rule && registeredRule) {
           hits.push({
             method: request.method,
             path: request.path,
+            registrationId: registeredRule.registrationId,
             ruleId: rule.id,
           });
           if (rule.response) {
@@ -435,7 +465,27 @@ export async function startMatrixQaFaultProxy(
 
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
-    hits: () => [...hits],
+    hits: () => hits.map(toMatrixQaFaultProxyHit),
+    installRule(rule) {
+      const registrationId = nextRuleRegistrationId++;
+      const registeredRule = { registrationId, rule };
+      registeredRules.push(registeredRule);
+      let removed = false;
+      return {
+        hits: () =>
+          hits.filter((hit) => hit.registrationId === registrationId).map(toMatrixQaFaultProxyHit),
+        remove() {
+          if (removed) {
+            return;
+          }
+          removed = true;
+          const index = registeredRules.indexOf(registeredRule);
+          if (index !== -1) {
+            registeredRules.splice(index, 1);
+          }
+        },
+      };
+    },
     stop: async () => {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => {

--- a/extensions/qa-matrix/src/substrate/recording-proxy.ts
+++ b/extensions/qa-matrix/src/substrate/recording-proxy.ts
@@ -5,6 +5,8 @@ import {
   startMatrixQaFaultProxy,
   type MatrixQaFaultProxyExchange,
   type MatrixQaFaultProxyObserver,
+  type MatrixQaFaultProxyRule,
+  type MatrixQaFaultProxyRuleHandle,
 } from "./fault-proxy.js";
 
 const MATRIX_QA_RECORDING_PROFILE = "matrix-qa-v1";
@@ -109,6 +111,7 @@ export type MatrixQaRecordingProxy = MatrixQaFaultProxyObserver & {
     scenarioIds: string[];
     substrate: MatrixQaRouteStateManifest["substrate"];
   }): MatrixQaRouteStateManifest;
+  installFaultRule(rule: MatrixQaFaultProxyRule): MatrixQaFaultProxyRuleHandle;
   records(): MatrixQaRecordedExchange[];
   setScenarioId(scenarioId: string): void;
   stop(): Promise<void>;
@@ -712,6 +715,7 @@ export async function startMatrixQaRecordingProxy(params: {
         substrate,
       };
     },
+    installFaultRule: (rule) => proxy.installRule(rule),
     records: () =>
       structuredClone(
         records


### PR DESCRIPTION
## Summary
- add scenario-scoped fault rules to the existing Matrix recording proxy
- keep the configured homeserver URL stable across the state_after restart
- remove the scoped rule after the scenario without a second gateway restart

## Validation
- 81/81 focused fault-proxy and scenario tests
- `pnpm tsgo:extensions:test`
- `pnpm lint`
- `git diff --check`

Backports the in-place fault-injection contract needed by the 2026.7.33 `matrix-e2ee-state-after-missing-encryption` validation scenario.
