### PR TITLE
fix(release): omit unpublished candidate from upgrade baselines

### DIFF
--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -834,6 +834,8 @@ jobs:
           args=(
             --requested "$REQUESTED_BASELINES"
             --fallback "$fallback_baseline"
+            --candidate-version "$CANDIDATE_VERSION"
+            --candidate-published "$CANDIDATE_PUBLISHED"
             --github-output "$GITHUB_OUTPUT"
           )
           if [[ -n "$npm_versions_json" ]]; then

--- a/scripts/resolve-upgrade-survivor-baselines.mts
+++ b/scripts/resolve-upgrade-survivor-baselines.mts
@@ -45,6 +45,21 @@ function dedupeSpecs(specs: string[]) {
   return [...new Set(normalized)];
 }
 
+function omitUnpublishedCandidateBaseline(args: Map<string, string>, specs: string[]) {
+  if (args.get("candidate-published") !== "false") {
+    return specs;
+  }
+  const candidateVersion = args.get("candidate-version");
+  if (!candidateVersion) {
+    return specs;
+  }
+  const candidateSpec = normalizeUpgradeSurvivorBaselineSpec(candidateVersion);
+  if (!candidateSpec) {
+    throw new Error(`invalid candidate version: ${candidateVersion}`);
+  }
+  return specs.filter((spec) => normalizeUpgradeSurvivorBaselineSpec(spec) !== candidateSpec);
+}
+
 function parsePositiveInteger(value: unknown, label: string) {
   const text = scalarText(value).trim();
   if (!/^[1-9]\d*$/u.test(text)) {
@@ -135,7 +150,10 @@ function resolveReleaseHistory(args: Map<string, string>) {
   const preDate = args.get("pre-date") ?? "2026-03-15T00:00:00Z";
   const publishedVersions = readPublishedVersions(args.get("npm-versions-json"));
   const releases = readStableReleases(releasesJson, publishedVersions);
-  const versions = releases.slice(0, historyCount).map((release) => release.version);
+  const versions = omitUnpublishedCandidateBaseline(
+    args,
+    releases.map((release) => release.version),
+  ).slice(0, historyCount);
   const exact = releases.find((release) => release.version === includeVersion);
   if (exact) {
     versions.push(exact.version);
@@ -162,7 +180,12 @@ function resolveLastStable(args: Map<string, string>, count: number) {
   }
   const publishedVersions = readPublishedVersions(args.get("npm-versions-json"));
   const releases = readStableReleases(releasesJson, publishedVersions);
-  return dedupeSpecs(releases.slice(0, count).map((release) => release.version));
+  return dedupeSpecs(
+    omitUnpublishedCandidateBaseline(
+      args,
+      releases.map((release) => release.version),
+    ).slice(0, count),
+  );
 }
 
 /**
@@ -175,10 +198,13 @@ function resolveAllSince(args: Map<string, string>, minimumVersion: string) {
   }
   const publishedVersions = readPublishedVersions(args.get("npm-versions-json"));
   const releases = readStableReleases(releasesJson, publishedVersions);
-  return dedupeSpecs(
-    releases
-      .map((release) => release.version)
-      .filter((version) => compareStableVersions(version, minimumVersion) >= 0),
+  return omitUnpublishedCandidateBaseline(
+    args,
+    dedupeSpecs(
+      releases
+        .map((release) => release.version)
+        .filter((version) => compareStableVersions(version, minimumVersion) >= 0),
+    ),
   );
 }
 
@@ -215,12 +241,15 @@ function resolveSupportedLines(args: Map<string, string>) {
   ) {
     throw new Error("npm extended-stable must name a published stable version when present");
   }
-  return dedupeSpecs([
-    latest,
-    previous,
-    ...(typeof extended === "string" ? [extended] : []),
-    OLDEST_SUPPORTED_UPGRADE_SURVIVOR_BASELINE,
-  ]);
+  return omitUnpublishedCandidateBaseline(
+    args,
+    dedupeSpecs([
+      latest,
+      previous,
+      ...(typeof extended === "string" ? [extended] : []),
+      OLDEST_SUPPORTED_UPGRADE_SURVIVOR_BASELINE,
+    ]),
+  );
 }
 
 /**

--- a/test/scripts/upgrade-survivor-baselines.test.ts
+++ b/test/scripts/upgrade-survivor-baselines.test.ts
@@ -270,6 +270,24 @@ console.log(JSON.stringify(process.argv[4] === "dist-tags"
     },
   );
 
+  it("omits the unpublished candidate version from expanded supported lines", () => {
+    withJsonFixture("tags.json", { latest: "2026.9.3" }, (tagsFile) => {
+      withJsonFixture("versions.json", ["2026.6.34", "2026.9.2", "2026.9.3"], (versionsFile) => {
+        expect(
+          resolveBaselines(
+            new Map([
+              ["requested", "supported-lines"],
+              ["candidate-version", "2026.9.3"],
+              ["candidate-published", "false"],
+              ["npm-dist-tags-json", tagsFile],
+              ["npm-versions-json", versionsFile],
+            ]),
+          ),
+        ).toEqual(["openclaw@2026.9.2", "openclaw@2026.6.34"]);
+      });
+    });
+  });
+
   it.each([
     {
       tags: {},
@@ -342,6 +360,36 @@ console.log(JSON.stringify(process.argv[4] === "dist-tags"
         "openclaw@2026.4.22",
         "openclaw@2026.4.23",
         "openclaw@2026.3.13-1",
+      ]);
+    });
+  });
+
+  it("preserves the release-history count when the unpublished candidate is newest", () => {
+    const releases = ["2026.9.4", "2026.9.3", "2026.9.2", "2026.9.1", "2026.8.30"].map(
+      (version, index) => ({
+        isPrerelease: false,
+        publishedAt: `2026-09-${String(5 - index).padStart(2, "0")}T00:00:00Z`,
+        tagName: `v${version}`,
+      }),
+    );
+
+    withReleaseFixture(releases, (file) => {
+      expect(
+        resolveBaselines(
+          new Map([
+            ["requested", "release-history"],
+            ["candidate-version", "2026.9.4"],
+            ["candidate-published", "false"],
+            ["releases-json", file],
+            ["history-count", "4"],
+            ["include-version", "2026.9.3"],
+          ]),
+        ),
+      ).toEqual([
+        "openclaw@2026.9.3",
+        "openclaw@2026.9.2",
+        "openclaw@2026.9.1",
+        "openclaw@2026.8.30",
       ]);
     });
   });
@@ -423,6 +471,41 @@ console.log(JSON.stringify(process.argv[4] === "dist-tags"
             "openclaw@2026.4.29",
             "openclaw@2026.4.23",
             "openclaw@2026.4.15",
+          ]);
+        },
+      );
+    });
+  });
+
+  it("preserves the last-stable count when the unpublished candidate is newest", () => {
+    const releases = ["2026.9.4", "2026.9.3", "2026.9.2", "2026.9.1", "2026.8.30"].map(
+      (version, index) => ({
+        isPrerelease: false,
+        publishedAt: `2026-09-${String(5 - index).padStart(2, "0")}T00:00:00Z`,
+        tagName: `v${version}`,
+      }),
+    );
+
+    withReleaseFixture(releases, (releasesFile) => {
+      withJsonFixture(
+        "versions.json",
+        ["2026.8.30", "2026.9.1", "2026.9.2", "2026.9.3", "2026.9.4"],
+        (versionsFile) => {
+          expect(
+            resolveBaselines(
+              new Map([
+                ["requested", "last-stable-4"],
+                ["candidate-version", "2026.9.4"],
+                ["candidate-published", "false"],
+                ["releases-json", releasesFile],
+                ["npm-versions-json", versionsFile],
+              ]),
+            ),
+          ).toEqual([
+            "openclaw@2026.9.3",
+            "openclaw@2026.9.2",
+            "openclaw@2026.9.1",
+            "openclaw@2026.8.30",
           ]);
         },
       );


### PR DESCRIPTION
## Summary

- pass candidate publication identity into upgrade-baseline expansion
- omit an unpublished candidate before applying dynamic history count limits
- preserve requested `release-history` and `last-stable` cardinality while retaining explicit baselines
- normalize raw release versions during candidate exclusion

## Release-validation evidence

Full Release Validation selected `openclaw@2026.9.3` as a published upgrade baseline for the unpublished `2026.9.3` candidate. The updater correctly returned `skipped/already-current`, so the survivor lane could not exercise a candidate update. Dynamic expansion must exclude that same-version release before applying count limits.

Failing job: https://github.com/openclaw/openclaw/actions/runs/34420249302/job/102695981279

## Test plan

- `test/scripts/upgrade-survivor-baselines.test.ts` (26 passed, including candidate-first count preservation for both counted selectors)
- `pnpm exec oxfmt --check scripts/resolve-upgrade-survivor-baselines.mts test/scripts/upgrade-survivor-baselines.test.ts`
- `pnpm exec oxlint scripts/resolve-upgrade-survivor-baselines.mts test/scripts/upgrade-survivor-baselines.test.ts`