### PR TITLE
fix(release): accept memory preparation probe diagnostic

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -182,6 +182,9 @@ describe("qa scenario catalog", () => {
     expect(config?.allowedAdversarialDiagnostics).toContain(
       "model catalog provider registration missing provider",
     );
+    expect(config?.allowedAdversarialDiagnostics).toContain(
+      "memory prompt preparation registration missing prepare function",
+    );
     expect(
       config?.requiredAdversarialDiagnostics?.every((entry) => typeof entry === "string"),
     ).toBe(true);

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -99,6 +99,7 @@ scenario:
         - "http route registration missing or invalid auth: /kitchen-sink/http-route"
         - "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider"
         - "trusted tool policy registration requires id, description, and evaluate()"
+        - memory prompt preparation registration missing prepare function
         - memory prompt supplement registration missing builder
         - model catalog provider registration missing provider
         - node invoke policy registration missing commands

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -332,6 +332,7 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
     "plugin must declare contracts.tools for: kitchen-sink-tool",
     'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
+    "memory prompt preparation registration missing prepare function",
     "memory prompt supplement registration missing builder",
     "MCP server connection resolver registration missing serverName or resolve",
     "model catalog provider registration missing provider",

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -311,7 +311,10 @@ describe("kitchen-sink plugin assertions", () => {
 
   it("accepts published full-surface installs with stable diagnostic canaries", () => {
     const result = runAssertInstalled({
-      diagnostics: diagnosticErrors(REQUIRED_FULL_DIAGNOSTIC_CANARIES),
+      diagnostics: diagnosticErrors([
+        ...REQUIRED_FULL_DIAGNOSTIC_CANARIES,
+        "memory prompt preparation registration missing prepare function",
+      ]),
     });
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- accept the intentional invalid `registerMemoryPromptPreparation` probe emitted by `@openclaw/kitchen-sink@0.3.0`
- keep the live QA scenario diagnostic contract aligned with the Docker prerelease assertion
- cover both assertion and scenario-catalog paths

## Validation
- `pnpm exec vitest run test/scripts/kitchen-sink-plugin-assertions.test.ts extensions/qa-lab/src/scenario-catalog.openai-live.test.ts` (37 passed)
- `pnpm exec oxfmt --check scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs qa/scenarios/plugins/kitchen-sink-live-openai.yaml test/scripts/kitchen-sink-plugin-assertions.test.ts extensions/qa-lab/src/scenario-catalog.openai-live.test.ts`