### PR TITLE
fix: preserve generated images after tool failures

### DIFF
--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -48,6 +48,23 @@ describe("mergeAttemptToolMediaPayloads", () => {
     ]);
   });
 
+  it("keeps earlier generated media separate from a later tool-error warning", () => {
+    expect(
+      mergeAttemptToolMediaPayloads({
+        payloads: [{ text: "Bash failed", isError: true }],
+        toolMediaUrls: ["/tmp/generated.png"],
+      }),
+    ).toEqual([
+      { text: "Bash failed", isError: true },
+      {
+        mediaUrls: ["/tmp/generated.png"],
+        mediaUrl: "/tmp/generated.png",
+        audioAsVoice: undefined,
+        trustedLocalMedia: undefined,
+      },
+    ]);
+  });
+
   it("preserves reply metadata when attaching tool media to a visible reply", () => {
     const visibleReply = setReplyPayloadMetadata(
       { text: "done" },

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -13,8 +13,8 @@ type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number
 
 /**
  * Merges media emitted by tools into the channel payloads produced by the
- * assistant turn. The first non-reasoning reply owns the media so text and
- * attachments stay together; metadata is preserved for delivery bookkeeping.
+ * assistant turn. The first successful, non-reasoning reply owns the media so
+ * text and attachments stay together; metadata is preserved for delivery bookkeeping.
  */
 export function mergeAttemptToolMediaPayloads(params: {
   payloads?: EmbeddedRunPayload[];
@@ -32,7 +32,7 @@ export function mergeAttemptToolMediaPayloads(params: {
   }
 
   const payloads = params.payloads?.length ? [...params.payloads] : [];
-  const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning);
+  const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning && !payload.isError);
   if (payloadIndex >= 0) {
     const payload = payloads[payloadIndex];
     if (


### PR DESCRIPTION
## Summary
- attach generated media only to successful, non-reasoning payloads
- keep generated media separate when the only later payload is a tool-error warning
- backport the narrow production fix from #131226 to 2026.7.33

## Validation
- 6/6 focused tool-media payload tests
- `pnpm check:test-types`
- `pnpm lint`
- `git diff --check`

This addresses the Matrix generated-image validation artifact where image generation completed, a later error payload owned the media, and no `m.image` was delivered.

## Worked on by
- CGlashu
- A28Hui
- Ayaan Zaidi
