### PR TITLE
fix(qa): test Teams timeout at send boundary

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -290,7 +290,6 @@ export const QA_TOOL_PROGRESS_PROMPT_RE = /tool progress( error)? qa check/i;
 export const QA_TOOL_LOOP_GLOBAL_BREAKER_PROMPT_RE = /global tool loop breaker qa check/i;
 export const QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE = /provider http 503 after tool qa check/i;
 export const QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE = /qa group visible reply tool check/i;
-export const QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE = /qa msteams ambiguous gateway timeout/i;
 export const QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE = /qa msteams thread message-tool final dedupe/i;
 export const QA_THREAD_REPLY_RECEIPT_PROMPT_RE =
   /qa thread reply receipt check[\s\S]*channel id: `([^`]+)`[\s\S]*thread id: `([^`]+)`/i;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -794,30 +794,6 @@ describe("qa mock openai server", () => {
     expect(outputItems(finalBody).some((item) => item.type === "function_call")).toBe(false);
   });
 
-  it("returns a distinct final after the ambiguous Teams message-tool send", async () => {
-    const server = await startMockServer();
-    const prompt = "qa msteams ambiguous gateway timeout. exact marker: `QA-MSTEAMS-AMBIGUOUS-504`";
-
-    const initialBody = await expectOpenAiNonStreamingResponsesJson(server, {
-      tools: [MESSAGE_TOOL],
-      input: [makeUserInput(prompt)],
-    });
-    const toolCall = outputToolCall(initialBody, "message");
-    expect(outputToolArgsFromItem(toolCall)).toEqual({
-      action: "send",
-      message: "QA-MSTEAMS-AMBIGUOUS-504",
-    });
-
-    const finalBody = await expectOpenAiNonStreamingResponsesJson(server, {
-      tools: [MESSAGE_TOOL],
-      input: [
-        makeUserInput(prompt),
-        makeToolOutputWithCallId(outputToolCallId(toolCall, "call_msteams_timeout"), "failed"),
-      ],
-    });
-    expect(outputText(finalBody)).toBe("QA-MSTEAMS-AMBIGUOUS-FINAL");
-  });
-
   it("keeps the retry-failure stranded-final fixture as text without a message tool call", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -57,7 +57,6 @@ import {
   QA_TOOL_LOOP_GLOBAL_BREAKER_PROMPT_RE,
   QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE,
   QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE,
-  QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE,
   QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE,
   QA_THREAD_REPLY_RECEIPT_PROMPT_RE,
   QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE,
@@ -1926,15 +1925,6 @@ async function buildResponsesPayload(
       });
     }
     return buildAssistantEvents("");
-  }
-  if (QA_MSTEAMS_AMBIGUOUS_TIMEOUT_PROMPT_RE.test(allInputText)) {
-    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
-      return buildToolCallEventsWithArgs("message", {
-        action: "send",
-        message: exactMarkerDirective ?? "QA-MSTEAMS-AMBIGUOUS-504",
-      });
-    }
-    return buildAssistantEvents("QA-MSTEAMS-AMBIGUOUS-FINAL");
   }
   if (QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE.test(allInputText)) {
     const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-MSTEAMS-THREAD-DEDUPE-OK";

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -257,6 +257,22 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).toContain("QA-MSTEAMS-GROUP-OK");
   });
 
+  it("proves ambiguous Teams delivery at the Gateway send boundary", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("msteams-ambiguous-gateway-timeout"));
+    const flow = JSON.stringify(scenario.execution.flow);
+
+    expect(flow).toContain("env.gateway.call('send'");
+    expect(flow).toContain("sendError.includes('504')");
+    expect(flow).toContain("matchingOutbound.length === 1");
+    expect(flow).toContain("seed proactive conversation reference");
+    expect(flow.match(/"resetTransport":true/g)).toHaveLength(1);
+    expect(flow.match(/"waitForOutbound"/g)).toHaveLength(1);
+    expect(flow).toContain("conversation:19:ambiguous-timeout@thread.tacv2");
+    expect(scenario.execution.config).toMatchObject({
+      seedMarker: "QA-MSTEAMS-CONVERSATION-READY",
+    });
+  });
+
   it("isolates scenarios that own asynchronous transport state", () => {
     const channelBaseline = requireFlowScenario(readQaScenarioById("channel-chat-baseline"));
     const subagentFanout = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));

--- a/qa/scenarios/channels/msteams-ambiguous-gateway-timeout.yaml
+++ b/qa/scenarios/channels/msteams-ambiguous-gateway-timeout.yaml
@@ -33,10 +33,10 @@ scenario:
     channel: msteams
     suiteIsolation: isolated
     isolationReason: Injects an accepted-then-504 Connector response for one outbound marker.
-    summary: Run a real Gateway and Microsoft Teams plugin against the loopback Bot Framework Connector while the mock provider produces one exact final reply.
+    summary: Call the real Gateway send RPC through the Microsoft Teams plugin while the loopback Bot Framework Connector accepts the activity and returns HTTP 504.
     config:
       expectedMarker: QA-MSTEAMS-AMBIGUOUS-504
-      finalMarker: QA-MSTEAMS-AMBIGUOUS-FINAL
+      seedMarker: QA-MSTEAMS-CONVERSATION-READY
 
 flow:
   steps:
@@ -52,17 +52,19 @@ flow:
             senderId: driver
             senderName: Teams QA Driver
             text:
-              expr: '`qa msteams ambiguous gateway timeout. exact marker: \`${config.expectedMarker}\``'
+              expr: "`qa msteams seed proactive conversation reference. reply with only this exact marker: ${config.seedMarker}`"
         - waitForOutbound:
             conversation: { id: ambiguous-timeout, kind: direct }
-            textIncludes: { ref: config.expectedMarker }
+            textIncludes: { ref: config.seedMarker }
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
-        - waitForOutbound:
-            conversation: { id: ambiguous-timeout, kind: direct }
-            textIncludes: { ref: config.finalMarker }
-            timeoutMs:
-              expr: liveTurnTimeoutMs(env, 60000)
+        - set: sendError
+          value:
+            expr: "await (async () => { try { await env.gateway.call('send', { accountId: 'default', agentId: 'qa', channel: 'msteams', idempotencyKey: randomUUID(), message: config.expectedMarker, to: 'conversation:19:ambiguous-timeout@thread.tacv2' }, { timeoutMs: liveTurnTimeoutMs(env, 60000) }); return null; } catch (error) { return String(error); } })()"
+        - assert:
+            expr: "typeof sendError === 'string' && sendError.includes('504')"
+            message:
+              expr: "`expected the accepted Teams send to surface HTTP 504; got ${String(sendError)}`"
         - set: matchingOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === 'ambiguous-timeout' && String(message.text ?? '').includes(config.expectedMarker))"
@@ -70,4 +72,4 @@ flow:
             expr: matchingOutbound.length === 1
             message:
               expr: "`expected one ambiguous Teams POST, saw ${matchingOutbound.length}; transcript=${formatTransportTranscript(state, { conversationId: 'ambiguous-timeout' })}`"
-      detailsExpr: "`accepted ambiguous Teams POST count=${matchingOutbound.length}`"
+      detailsExpr: "`accepted ambiguous Teams POST count=${matchingOutbound.length}; Gateway surfaced the Connector 504 without replay`"


### PR DESCRIPTION
## Summary

- seed and prove the native Teams conversation reference before proactive delivery
- exercise the ambiguous 504 directly at the Gateway `send` boundary
- assert the loopback Connector receives the marker exactly once
- remove the obsolete provider-driven retry fixture

## Testing

- exact live-adapter scenario: `msteams-ambiguous-gateway-timeout` (passed)
- `pnpm test extensions/qa-lab/src/scenario-catalog-channels.test.ts` (29 passed)
- `pnpm check:changed`
- autoreview: clean at P0–P2
