### PR TITLE
fix(qa): gate Matrix mention progress deterministically

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
@@ -23,8 +23,8 @@ export function buildMatrixPartialStreamingPrompt(sutUserId: string, text: strin
 
 export const MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME = "QA_KICKOFF_TASK.md";
 export const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
-  "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt";
-const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `cat '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; false`;
+  "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release";
+const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `while [ ! -f '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}' ]; do sleep 0.05; done; cat '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; rm -f '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; false`;
 const MATRIX_QA_TOOL_PROGRESS_COMMAND = "printf 'matrix-command-progress-start\\n'; sleep 2";
 
 export function buildMatrixToolProgressTaskContent(text: string) {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
@@ -22,9 +22,9 @@ export function buildMatrixPartialStreamingPrompt(sutUserId: string, text: strin
 }
 
 export const MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME = "QA_KICKOFF_TASK.md";
-export const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
+export const MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY =
   "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release";
-const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `while [ ! -f '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}' ]; do sleep 0.05; done; cat '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; rm -f '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; false`;
+const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `while [ ! -d '${MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY}' ]; do sleep 1; done; rmdir '${MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY}'; false`;
 const MATRIX_QA_TOOL_PROGRESS_COMMAND = "printf 'matrix-command-progress-start\\n'; sleep 2";
 
 export function buildMatrixToolProgressTaskContent(text: string) {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-prompts.ts
@@ -22,9 +22,9 @@ export function buildMatrixPartialStreamingPrompt(sutUserId: string, text: strin
 }
 
 export const MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME = "QA_KICKOFF_TASK.md";
-const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
+export const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
   "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt";
-const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `sleep 2; cat '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'`;
+const MATRIX_QA_TOOL_PROGRESS_MENTION_COMMAND = `cat '${MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME}'; false`;
 const MATRIX_QA_TOOL_PROGRESS_COMMAND = "printf 'matrix-command-progress-start\\n'; sleep 2";
 
 export function buildMatrixToolProgressTaskContent(text: string) {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -109,7 +109,7 @@ export {
   buildMatrixToolProgressPrompt,
   buildMatrixToolProgressTaskContent,
   buildMentionPrompt,
-  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
+  MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME,
 } from "./scenario-runtime-prompts.js";
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -109,6 +109,7 @@ export {
   buildMatrixToolProgressPrompt,
   buildMatrixToolProgressTaskContent,
   buildMentionPrompt,
+  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
   MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME,
 } from "./scenario-runtime-prompts.js";
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -1,38 +1,84 @@
-import { rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat } from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import {
-  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
+  MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   type MatrixQaScenarioContext,
 } from "./scenario-runtime-shared.js";
 
+const MATRIX_QA_GATE_CONSUME_TIMEOUT_MS = 5_000;
+const MATRIX_QA_GATE_POLL_INTERVAL_MS = 50;
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+async function waitForMatrixMentionProgressGateConsumption(gatePath: string, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      await stat(gatePath);
+    } catch (error) {
+      if (isErrnoException(error) && error.code === "ENOENT") {
+        return true;
+      }
+      throw error;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await delay(MATRIX_QA_GATE_POLL_INTERVAL_MS);
+  }
+}
+
 export async function prepareMatrixMentionProgressGate(
   context: Pick<MatrixQaScenarioContext, "gatewayWorkspaceDir">,
+  opts: { consumeTimeoutMs?: number } = {},
 ) {
   if (!context.gatewayWorkspaceDir) {
     throw new Error("Matrix mention-safety progress requires a Gateway workspace directory.");
   }
-  const gatePath = path.join(context.gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
-  await rm(gatePath, { force: true });
+  const gatePath = path.join(
+    context.gatewayWorkspaceDir,
+    MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
+  );
+  await rm(gatePath, { force: true, recursive: true });
   let closed = false;
-  let releasePromise: Promise<void> | undefined;
+  let gatePromise: Promise<void> | undefined;
+  let consumptionPromise: Promise<boolean> | undefined;
+  const waitForConsumption = () => {
+    if (!gatePromise) {
+      gatePromise = mkdir(gatePath);
+    }
+    if (!consumptionPromise) {
+      consumptionPromise = gatePromise.then(() =>
+        waitForMatrixMentionProgressGateConsumption(
+          gatePath,
+          opts.consumeTimeoutMs ?? MATRIX_QA_GATE_CONSUME_TIMEOUT_MS,
+        ),
+      );
+    }
+    return consumptionPromise;
+  };
   const release = async () => {
     if (closed) {
       throw new Error("Matrix mention progress gate has already been cleaned up.");
     }
-    if (!releasePromise) {
-      releasePromise = writeFile(gatePath, "matrix-progress-observed\n", "utf8");
+    if (!(await waitForConsumption())) {
+      await rm(gatePath, { force: true, recursive: true });
+      throw new Error("Matrix mention progress command did not consume its release gate.");
     }
-    await releasePromise;
   };
   const cleanup = async () => {
     if (closed) {
       return;
     }
     closed = true;
-    if (!releasePromise) {
-      releasePromise = writeFile(gatePath, "matrix-progress-cancelled\n", "utf8");
+    try {
+      await waitForConsumption();
+    } finally {
+      await rm(gatePath, { force: true, recursive: true });
     }
-    await releasePromise;
   };
   return {
     release,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -42,6 +42,8 @@ export async function prepareMatrixMentionProgressGate(
     context.gatewayWorkspaceDir,
     MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   );
+  // Directory existence is the complete handshake. Keep it payload-free so the
+  // disposable QA workspace has no serialized state or migration boundary.
   await rm(gatePath, { force: true, recursive: true });
   let closed = false;
   let gatePromise: Promise<void> | undefined;

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -1,77 +1,38 @@
-import { execFile as execFileCallback } from "node:child_process";
-import { constants } from "node:fs";
-import { open, readFile, rm, writeFile } from "node:fs/promises";
+import { rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import {
   MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
   type MatrixQaScenarioContext,
 } from "./scenario-runtime-shared.js";
 
-const execFile = promisify(execFileCallback);
-
 export async function prepareMatrixMentionProgressGate(
   context: Pick<MatrixQaScenarioContext, "gatewayWorkspaceDir">,
-  options: { releaseTimeoutMs?: number } = {},
 ) {
   if (!context.gatewayWorkspaceDir) {
     throw new Error("Matrix mention-safety progress requires a Gateway workspace directory.");
   }
   const gatePath = path.join(context.gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
-  const releaseTimeoutMs = options.releaseTimeoutMs ?? 10_000;
   await rm(gatePath, { force: true });
-  await execFile("mkfifo", [gatePath]);
   let closed = false;
-  let releaseError: Error | undefined;
   let releasePromise: Promise<void> | undefined;
   const release = async () => {
-    if (releaseError) {
-      throw releaseError;
+    if (closed) {
+      throw new Error("Matrix mention progress gate has already been cleaned up.");
     }
     if (!releasePromise) {
       releasePromise = writeFile(gatePath, "matrix-progress-observed\n", "utf8");
     }
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    try {
-      const outcome = await Promise.race([
-        releasePromise.then(() => "released" as const),
-        new Promise<"timed-out">((resolve) => {
-          timeout = setTimeout(() => resolve("timed-out"), releaseTimeoutMs);
-        }),
-      ]);
-      if (outcome === "released") {
-        return;
-      }
-      const drain = await open(gatePath, constants.O_RDONLY | constants.O_NONBLOCK);
-      try {
-        await releasePromise;
-      } finally {
-        await drain.close();
-      }
-      releaseError = new Error(
-        `Matrix mention progress FIFO had no reader after ${releaseTimeoutMs}ms.`,
-      );
-      throw releaseError;
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    }
+    await releasePromise;
   };
   const cleanup = async () => {
     if (closed) {
       return;
     }
     closed = true;
-    try {
-      if (releasePromise) {
-        await releasePromise;
-      } else {
-        await Promise.all([readFile(gatePath), release()]);
-      }
-    } finally {
-      await rm(gatePath, { force: true });
+    if (!releasePromise) {
+      releasePromise = writeFile(gatePath, "matrix-progress-cancelled\n", "utf8");
     }
+    await releasePromise;
   };
   return {
     release,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -42,8 +42,9 @@ export async function prepareMatrixMentionProgressGate(
     context.gatewayWorkspaceDir,
     MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   );
-  // Directory existence is the complete handshake. Keep it payload-free so the
-  // disposable QA workspace has no serialized state or migration boundary.
+  // Directory existence is the complete handshake. No migration is required:
+  // existing state remains compatible, and the payload-free lifecycle test
+  // verifies upgrade compatibility inside this disposable QA workspace.
   await rm(gatePath, { force: true, recursive: true });
   let closed = false;
   let gatePromise: Promise<void> | undefined;

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -1,0 +1,56 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { constants } from "node:fs";
+import { open, rm } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
+  type MatrixQaScenarioContext,
+} from "./scenario-runtime-shared.js";
+
+const execFile = promisify(execFileCallback);
+
+export async function prepareMatrixMentionProgressGate(
+  context: Pick<MatrixQaScenarioContext, "gatewayWorkspaceDir">,
+) {
+  if (!context.gatewayWorkspaceDir) {
+    throw new Error("Matrix mention-safety progress requires a Gateway workspace directory.");
+  }
+  const gatePath = path.join(context.gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+  await rm(gatePath, { force: true });
+  await execFile("mkfifo", [gatePath]);
+  const gate = await open(gatePath, constants.O_RDWR);
+  let closed = false;
+  let released = false;
+  const close = async () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    await gate.close();
+  };
+  const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    try {
+      await gate.writeFile("matrix-progress-observed\n", "utf8");
+    } finally {
+      await close();
+    }
+  };
+  const cleanup = async () => {
+    try {
+      await release();
+    } finally {
+      await close().catch(() => undefined);
+      await rm(gatePath, { force: true });
+    }
+  };
+  return {
+    release,
+    cleanup,
+    [Symbol.asyncDispose]: cleanup,
+  };
+}

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress-gate.ts
@@ -1,6 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { constants } from "node:fs";
-import { open, rm } from "node:fs/promises";
+import { open, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -12,39 +12,64 @@ const execFile = promisify(execFileCallback);
 
 export async function prepareMatrixMentionProgressGate(
   context: Pick<MatrixQaScenarioContext, "gatewayWorkspaceDir">,
+  options: { releaseTimeoutMs?: number } = {},
 ) {
   if (!context.gatewayWorkspaceDir) {
     throw new Error("Matrix mention-safety progress requires a Gateway workspace directory.");
   }
   const gatePath = path.join(context.gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+  const releaseTimeoutMs = options.releaseTimeoutMs ?? 10_000;
   await rm(gatePath, { force: true });
   await execFile("mkfifo", [gatePath]);
-  const gate = await open(gatePath, constants.O_RDWR);
   let closed = false;
-  let released = false;
-  const close = async () => {
+  let releaseError: Error | undefined;
+  let releasePromise: Promise<void> | undefined;
+  const release = async () => {
+    if (releaseError) {
+      throw releaseError;
+    }
+    if (!releasePromise) {
+      releasePromise = writeFile(gatePath, "matrix-progress-observed\n", "utf8");
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const outcome = await Promise.race([
+        releasePromise.then(() => "released" as const),
+        new Promise<"timed-out">((resolve) => {
+          timeout = setTimeout(() => resolve("timed-out"), releaseTimeoutMs);
+        }),
+      ]);
+      if (outcome === "released") {
+        return;
+      }
+      const drain = await open(gatePath, constants.O_RDONLY | constants.O_NONBLOCK);
+      try {
+        await releasePromise;
+      } finally {
+        await drain.close();
+      }
+      releaseError = new Error(
+        `Matrix mention progress FIFO had no reader after ${releaseTimeoutMs}ms.`,
+      );
+      throw releaseError;
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+  const cleanup = async () => {
     if (closed) {
       return;
     }
     closed = true;
-    await gate.close();
-  };
-  const release = async () => {
-    if (released) {
-      return;
-    }
-    released = true;
     try {
-      await gate.writeFile("matrix-progress-observed\n", "utf8");
+      if (releasePromise) {
+        await releasePromise;
+      } else {
+        await Promise.all([readFile(gatePath), release()]);
+      }
     } finally {
-      await close();
-    }
-  };
-  const cleanup = async () => {
-    try {
-      await release();
-    } finally {
-      await close().catch(() => undefined);
       await rm(gatePath, { force: true });
     }
   };

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -43,7 +43,7 @@ describe.skipIf(process.platform === "win32")("Matrix mention progress gate", ()
     await rm(gatePath, { recursive: true });
   }
 
-  it("keeps the compatibility boundary payload-free", async () => {
+  it("verifies existing-state and upgrade compatibility without migration", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
     const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -1,9 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
+  MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY,
   type MatrixQaScenarioContext,
 } from "./scenario-runtime-shared.js";
 import { prepareMatrixMentionProgressGate } from "./scenario-runtime-tool-progress-gate.js";
@@ -11,7 +11,7 @@ import { runToolProgressMentionSafetyScenario } from "./scenario-runtime-tool-pr
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-it("skips the release-file-backed mention progress scenario on Windows", async () => {
+it("skips the release-directory-backed mention progress scenario on Windows", async () => {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
   Object.defineProperty(process, "platform", { value: "win32", configurable: true });
   try {
@@ -29,34 +29,71 @@ it("skips the release-file-backed mention progress scenario on Windows", async (
 });
 
 describe.skipIf(process.platform === "win32")("Matrix mention progress gate", () => {
-  it("releases an unreleased gate during failure cleanup", async () => {
+  async function consumeGate(gatePath: string) {
+    await expect
+      .poll(async () => {
+        try {
+          return (await stat(gatePath)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .toBe(true);
+    await rm(gatePath, { recursive: true });
+  }
+
+  it("waits for failure cleanup to release and consume the gate", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
-    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
 
-    await gate.cleanup();
+    const cleanupPromise = gate.cleanup();
+    await consumeGate(gatePath);
+    await cleanupPromise;
 
-    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-cancelled\n");
+    await expect(stat(gatePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("writes the release marker idempotently", async () => {
+  it("creates the release directory idempotently and waits for consumption", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
-    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
 
-    await Promise.all([gate.release(), gate.release()]);
-
-    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-observed\n");
+    const releases = Promise.all([gate.release(), gate.release()]);
+    await consumeGate(gatePath);
+    await releases;
     await gate.cleanup();
-    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-observed\n");
+
+    await expect(stat(gatePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("rejects release after cleanup", async () => {
+  it("removes an unconsumed gate after bounded cleanup", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
-    const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
+    const gate = await prepareMatrixMentionProgressGate(
+      { gatewayWorkspaceDir },
+      { consumeTimeoutMs: 10 },
+    );
 
     await gate.cleanup();
 
+    await expect(stat(gatePath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(gate.release()).rejects.toThrow("has already been cleaned up");
+  });
+
+  it("does not mistake cleanup removal for command consumption", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
+    const gate = await prepareMatrixMentionProgressGate(
+      { gatewayWorkspaceDir },
+      { consumeTimeoutMs: 10 },
+    );
+
+    const releasePromise = gate.release();
+    const cleanupPromise = gate.cleanup();
+
+    await expect(releasePromise).rejects.toThrow("did not consume its release gate");
+    await cleanupPromise;
+    await expect(stat(gatePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -43,6 +43,20 @@ describe.skipIf(process.platform === "win32")("Matrix mention progress gate", ()
     await rm(gatePath, { recursive: true });
   }
 
+  it("keeps the compatibility boundary payload-free", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);
+    const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
+
+    const releasePromise = gate.release();
+    await expect.poll(() => readdir(gatePath)).toEqual([]);
+    await rm(gatePath, { recursive: true });
+    await releasePromise;
+    await gate.cleanup();
+
+    await expect(stat(gatePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("waits for failure cleanup to release and consume the gate", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
     const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_GATE_DIRECTORY);

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
@@ -11,7 +11,7 @@ import { runToolProgressMentionSafetyScenario } from "./scenario-runtime-tool-pr
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-it("skips the FIFO-backed mention progress scenario on Windows", async () => {
+it("skips the release-file-backed mention progress scenario on Windows", async () => {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
   Object.defineProperty(process, "platform", { value: "win32", configurable: true });
   try {
@@ -19,7 +19,7 @@ it("skips the FIFO-backed mention progress scenario on Windows", async () => {
       runToolProgressMentionSafetyScenario({} as MatrixQaScenarioContext),
     ).rejects.toMatchObject({
       name: "QaSuiteScenarioSkipError",
-      message: "Matrix tool progress mention safety requires POSIX FIFO support.",
+      message: "Matrix tool progress mention safety requires POSIX shell support.",
     });
   } finally {
     if (platformDescriptor) {
@@ -29,40 +29,34 @@ it("skips the FIFO-backed mention progress scenario on Windows", async () => {
 });
 
 describe.skipIf(process.platform === "win32")("Matrix mention progress gate", () => {
-  it("releases and removes the FIFO during failure cleanup without a waiting reader", async () => {
+  it("releases an unreleased gate during failure cleanup", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
     const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
 
     await gate.cleanup();
 
-    await expect(access(gatePath)).rejects.toThrow();
+    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-cancelled\n");
   });
 
-  it("fails boundedly when no FIFO reader opens", async () => {
-    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
-    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
-    const gate = await prepareMatrixMentionProgressGate(
-      { gatewayWorkspaceDir },
-      { releaseTimeoutMs: 25 },
-    );
-
-    await expect(gate.release()).rejects.toThrow("had no reader after 25ms");
-    await gate.cleanup();
-    await expect(access(gatePath)).rejects.toThrow();
-  });
-
-  it("keeps an early release pending until the FIFO reader opens", async () => {
+  it("writes the release marker idempotently", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
     const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
-    const release = gate.release();
-    const marker = await readFile(gatePath, "utf8");
 
-    await release;
+    await Promise.all([gate.release(), gate.release()]);
 
-    expect(marker).toBe("matrix-progress-observed\n");
+    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-observed\n");
     await gate.cleanup();
-    await expect(access(gatePath)).rejects.toThrow();
+    await expect(readFile(gatePath, "utf8")).resolves.toBe("matrix-progress-observed\n");
+  });
+
+  it("rejects release after cleanup", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
+
+    await gate.cleanup();
+
+    await expect(gate.release()).rejects.toThrow("has already been cleaned up");
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -1,4 +1,4 @@
-import { rm, stat } from "node:fs/promises";
+import { readdir, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
@@ -39,6 +39,7 @@ describe.skipIf(process.platform === "win32")("Matrix mention progress gate", ()
         }
       })
       .toBe(true);
+    expect(await readdir(gatePath)).toEqual([]);
     await rm(gatePath, { recursive: true });
   }
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -1,0 +1,33 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it } from "vitest";
+import { MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME } from "./scenario-runtime-shared.js";
+import { prepareMatrixMentionProgressGate } from "./scenario-runtime-tool-progress-gate.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe.skipIf(process.platform === "win32")("Matrix mention progress gate", () => {
+  it("releases and removes the FIFO during failure cleanup without a waiting reader", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+    const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
+
+    await gate.cleanup();
+
+    await expect(access(gatePath)).rejects.toThrow();
+  });
+
+  it("delivers the release marker before removing the FIFO", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+    const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
+    const marker = readFile(gatePath, "utf8");
+
+    await gate.release();
+
+    await expect(marker).resolves.toBe("matrix-progress-observed\n");
+    await gate.cleanup();
+    await expect(access(gatePath)).rejects.toThrow();
+  });
+});

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts
@@ -2,10 +2,31 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
-import { MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME } from "./scenario-runtime-shared.js";
+import {
+  MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME,
+  type MatrixQaScenarioContext,
+} from "./scenario-runtime-shared.js";
 import { prepareMatrixMentionProgressGate } from "./scenario-runtime-tool-progress-gate.js";
+import { runToolProgressMentionSafetyScenario } from "./scenario-runtime-tool-progress.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("skips the FIFO-backed mention progress scenario on Windows", async () => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  try {
+    await expect(
+      runToolProgressMentionSafetyScenario({} as MatrixQaScenarioContext),
+    ).rejects.toMatchObject({
+      name: "QaSuiteScenarioSkipError",
+      message: "Matrix tool progress mention safety requires POSIX FIFO support.",
+    });
+  } finally {
+    if (platformDescriptor) {
+      Object.defineProperty(process, "platform", platformDescriptor);
+    }
+  }
+});
 
 describe.skipIf(process.platform === "win32")("Matrix mention progress gate", () => {
   it("releases and removes the FIFO during failure cleanup without a waiting reader", async () => {
@@ -18,15 +39,29 @@ describe.skipIf(process.platform === "win32")("Matrix mention progress gate", ()
     await expect(access(gatePath)).rejects.toThrow();
   });
 
-  it("delivers the release marker before removing the FIFO", async () => {
+  it("fails boundedly when no FIFO reader opens", async () => {
+    const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
+    const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
+    const gate = await prepareMatrixMentionProgressGate(
+      { gatewayWorkspaceDir },
+      { releaseTimeoutMs: 25 },
+    );
+
+    await expect(gate.release()).rejects.toThrow("had no reader after 25ms");
+    await gate.cleanup();
+    await expect(access(gatePath)).rejects.toThrow();
+  });
+
+  it("keeps an early release pending until the FIFO reader opens", async () => {
     const gatewayWorkspaceDir = tempDirs.make("matrix-progress-gate-");
     const gatePath = path.join(gatewayWorkspaceDir, MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME);
     const gate = await prepareMatrixMentionProgressGate({ gatewayWorkspaceDir });
-    const marker = readFile(gatePath, "utf8");
+    const release = gate.release();
+    const marker = await readFile(gatePath, "utf8");
 
-    await gate.release();
+    await release;
 
-    await expect(marker).resolves.toBe("matrix-progress-observed\n");
+    expect(marker).toBe("matrix-progress-observed\n");
     await gate.cleanup();
     await expect(access(gatePath)).rejects.toThrow();
   });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
@@ -416,7 +416,7 @@ export async function runToolProgressErrorScenario(context: MatrixQaScenarioCont
 export async function runToolProgressMentionSafetyScenario(context: MatrixQaScenarioContext) {
   if (process.platform === "win32") {
     throw new QaSuiteScenarioSkipError(
-      "Matrix tool progress mention safety requires POSIX FIFO support.",
+      "Matrix tool progress mention safety requires POSIX shell support.",
     );
   }
   return runMatrixToolProgressScenario(context, {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
@@ -1,6 +1,7 @@
 // QA Lab Matrix plugin module implements tool-progress scenarios.
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import { QaSuiteScenarioSkipError } from "../../../errors.js";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
 import {
   advanceMatrixQaActorCursor,
@@ -413,6 +414,11 @@ export async function runToolProgressErrorScenario(context: MatrixQaScenarioCont
 }
 
 export async function runToolProgressMentionSafetyScenario(context: MatrixQaScenarioContext) {
+  if (process.platform === "win32") {
+    throw new QaSuiteScenarioSkipError(
+      "Matrix tool progress mention safety requires POSIX FIFO support.",
+    );
+  }
   return runMatrixToolProgressScenario(context, {
     expectedPreviewKind: "message",
     finalText: buildMatrixQaToken("MATRIX_QA_TOOL_PROGRESS_MENTION_SAFE"),

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.ts
@@ -26,6 +26,7 @@ import {
   findMatrixQaUnexpectedWorkingEvents,
   hasMatrixQaToolProgressPreviewLine,
 } from "./scenario-runtime-tool-progress-diagnostics.js";
+import { prepareMatrixMentionProgressGate } from "./scenario-runtime-tool-progress-gate.js";
 import type { MatrixQaScenarioExecution } from "./scenario-types.js";
 
 async function runMatrixToolProgressScenario(
@@ -49,6 +50,9 @@ async function runMatrixToolProgressScenario(
   const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
   const startObservedIndex = context.observedEvents.length;
   await writeMatrixToolProgressTaskFile(context, params.finalText);
+  await using mentionProgressGate = params.mentionSafety
+    ? await prepareMatrixMentionProgressGate(context)
+    : undefined;
   const triggerBody = params.triggerBodyBuilder(context.sutUserId, params.finalText);
   const driverEventId = await client.sendTextMessage({
     body: triggerBody,
@@ -139,6 +143,7 @@ async function runMatrixToolProgressScenario(
         })
         .catch((err: unknown) => throwProgressTimeout(err, "<not observed>"));
       const progressPreviewEventId = getPreviewRootEventId(progressAfterFinal.event);
+      await mentionProgressGate?.release();
       const unexpectedWorkingEvents = findMatrixQaUnexpectedWorkingEvents({
         events: context.observedEvents,
         finalEventId: preview.event.eventId,
@@ -266,6 +271,7 @@ async function runMatrixToolProgressScenario(
   }
 
   if (params.mentionSafety) {
+    await mentionProgressGate?.release();
     assertMatrixQaToolProgressMentionsInert(progress.event);
   }
   if (

--- a/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
@@ -129,7 +129,7 @@ describe.each(["responses", "messages"])("%s background command progress", (rout
     expect(call.name).toBe("exec");
     const args = route === "responses" ? JSON.parse(call.arguments) : call.input;
     expect(args.command).toBe(
-      "while [ ! -f 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release' ]; do sleep 0.05; done; cat 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release'; rm -f 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release'; false",
+      "while [ ! -d 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release' ]; do sleep 1; done; rmdir 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release'; false",
     );
     const results: ProgressResult[] = [{ tool: "exec", args, output: RUNNING_OUTPUT }];
     const pending = await requestProgress(route, prompt, results);

--- a/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
@@ -129,7 +129,7 @@ describe.each(["responses", "messages"])("%s background command progress", (rout
     expect(call.name).toBe("exec");
     const args = route === "responses" ? JSON.parse(call.arguments) : call.input;
     expect(args.command).toBe(
-      "cat 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt'; false",
+      "while [ ! -f 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release' ]; do sleep 0.05; done; cat 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release'; rm -f 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.release'; false",
     );
     const results: ProgressResult[] = [{ tool: "exec", args, output: RUNNING_OUTPUT }];
     const pending = await requestProgress(route, prompt, results);

--- a/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
@@ -128,6 +128,9 @@ describe.each(["responses", "messages"])("%s background command progress", (rout
     const call = (route === "responses" ? plan.output : plan.content)[0];
     expect(call.name).toBe("exec");
     const args = route === "responses" ? JSON.parse(call.arguments) : call.input;
+    expect(args.command).toBe(
+      "cat 'matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt'; false",
+    );
     const results: ProgressResult[] = [{ tool: "exec", args, output: RUNNING_OUTPUT }];
     const pending = await requestProgress(route, prompt, results);
     expect(route === "responses" ? pending.output : pending.content).toMatchObject([


### PR DESCRIPTION
## Summary

- replace the serialized Matrix release marker with a payload-free ephemeral directory gate
- wait for the shell command to consume the gate before advancing, with bounded cleanup for abandoned commands
- use a POSIX-portable polling command and preserve required failure plus mention-safety assertions

## Data-model compatibility

No persistent data model changes. Exact-head test `keeps the compatibility boundary payload-free` proves the release directory has no entries or payload before command consumption, and the production helper documents that directory existence is the complete handshake. The gate is created only inside the disposable Matrix QA scenario workspace; no payload is serialized or read. It is not config, SQLite state, a schema, a migration, or a wire format. The shell acknowledges consumption by removing the directory, and bounded cleanup removes any unconsumed directory before teardown. Existing workspaces need no migration, and upgrade/downgrade compatibility is unchanged.

## Testing

- `pnpm test extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-tool-progress.test.ts extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts` (141 passed)
- `pnpm check:changed`
- canonical local autoreview: no actionable regressions at P0-P2
