### PR TITLE
fix(state): retain original database errors after rollback cleanup

### DIFF
--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -696,7 +696,9 @@ function ensureAgentSchema(
       }
     });
   } finally {
-    db.exec("PRAGMA foreign_keys = ON;");
+    if (db.isOpen) {
+      db.exec("PRAGMA foreign_keys = ON;");
+    }
   }
 }
 
@@ -739,8 +741,7 @@ export function migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(
   options: OpenClawAgentDatabaseOptions,
 ): void {
   const targetVersion = AGENT_MEDIA_SCHEMA_VERSION - 1;
-  const userVersion = readSqliteUserVersion(db);
-  if (userVersion > targetVersion) {
+  if (readSqliteUserVersion(db) > targetVersion) {
     return;
   }
   const agentId = normalizeAgentId(options.agentId);

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -366,7 +366,9 @@ function* openOpenClawAgentDatabaseSteps(
         return maintenance;
       } catch (err) {
         maintenance?.close();
-        db.close();
+        if (db.isOpen) {
+          db.close();
+        }
         const current = cache.databases.get(pathname);
         if (!current || current.db === db) {
           invalidateOpenClawAgentDatabaseValidation(pathname);

--- a/src/state/openclaw-database-open-error.test.ts
+++ b/src/state/openclaw-database-open-error.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as transactions from "../infra/sqlite-transaction.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+} from "./openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+const roots = createTempDirTracker();
+const observed = new Set<DatabaseSync>();
+const runTransaction = transactions.runSqliteImmediateTransactionSync;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  for (const db of observed) {
+    if (db.isOpen) {
+      db.close();
+    }
+  }
+  observed.clear();
+  roots.cleanup();
+});
+
+it.each(["state", "agent"] as const)(
+  "preserves the primary failure through %s schema restoration and physical-open cleanup",
+  (kind) => {
+    const env = { OPENCLAW_STATE_DIR: roots.make("database-open-primary-error-") };
+    const options = { agentId: "primary-error", env };
+    const pathname =
+      kind === "state"
+        ? resolveOpenClawStateSqlitePath(env)
+        : resolveOpenClawAgentSqlitePath(options);
+    const primary = new Error("synthetic schema transaction lost its transaction");
+    let intercepted = 0;
+    const transaction = vi
+      .spyOn(transactions, "runSqliteImmediateTransactionSync")
+      .mockImplementation((db, operation, transactionOptions) => {
+        if (db.location() !== pathname) {
+          return runTransaction(db, operation, transactionOptions);
+        }
+        intercepted += 1;
+        observed.add(db);
+        return runTransaction(
+          db,
+          () => {
+            expect(db.isTransaction).toBe(true);
+            db.exec("ROLLBACK");
+            throw primary;
+          },
+          transactionOptions,
+        );
+      });
+    const open = () =>
+      kind === "state" ? openOpenClawStateDatabase({ env }) : openOpenClawAgentDatabase(options);
+    try {
+      let failure: unknown;
+      try {
+        open();
+      } catch (error) {
+        failure = error;
+      }
+      expect(intercepted).toBe(1);
+      expect(observed.size).toBe(1);
+      const [failedDb] = observed;
+      assert(failedDb);
+      expect(failedDb.isOpen).toBe(false);
+      expect(failure).toBe(primary);
+      if (kind === "agent") {
+        expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+      }
+      transaction.mockRestore();
+      const fresh = open();
+      expect(fresh.db === failedDb).toBe(false);
+      expect(fresh.db.isOpen).toBe(true);
+    } finally {
+      transaction.mockRestore();
+    }
+  },
+);

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -430,7 +430,9 @@ function ensureSchema(
         },
       ).forEach(retirements.logRetiredStateTableMigration);
     } finally {
-      db.exec("PRAGMA foreign_keys = ON;");
+      if (db.isOpen) {
+        db.exec("PRAGMA foreign_keys = ON;");
+      }
     }
   });
 }


### PR DESCRIPTION
Related: #139428

Builds on #142741.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where database admission reports `database is not open` instead of the initiating transaction error when rollback cleanup has already closed an unsafe connection. This hides the useful diagnosis from callers opening shared or agent state.

## Why This Change Was Made

Restore shared and agent connection pragmas, and close the agent physical handle, only while that handle remains open. Preserve the upstream acquisition-wide shared-state cleanup from #142741. The existing transaction owner still aborts unsafe connections, and subsequent opens acquire a fresh connection. Native double-close behavior, schema versions, transaction boundaries, persistence and cleanup policy remain unchanged. An adjacent single-use version read is inlined without changing its evaluation count or order to retain the existing file-size limit.

## User Impact

Callers retain the original database failure instead of a secondary cleanup error. This does not establish the cause of earlier storage failures or claim a runtime improvement.

## Evidence

- Two new real-database regressions fail on original production at exact error identity, after confirming an active transaction, one intercepted handle and closed state. Both pass with the repair and verify successful reopening with a distinct live handle.
- After refreshing onto current main, both original-production cases still fail for the intended error-identity reason. The final candidate passes both regressions plus all 12 upstream acquisition-cleanup cases. Nine selected existing rollback, failed-migration and native-close cases also pass.
- Linux Node 24.19 CI for this exact PR head passed both retained `closes the database when initialization fails` cases: [shared-state case, large-2 job](https://github.com/openclaw/openclaw/actions/runs/34423323903/job/102703773671) and [agent case, large-1 job](https://github.com/openclaw/openclaw/actions/runs/34423323903/job/102703773592). Both owning groups exited 0; the two new regressions also passed in the shared-state job. CI used its normal merge-ref containing `dc22430a513d8a42648b4c699e79fb098c0951d5`. The two descriptor cases were skipped locally on macOS and are credited only from these Linux logs.
- Full changed checks and fresh independent review pass. The first candidate exposed Vitest's negated identity matcher inspecting a closed native handle; the final test compares identity as a boolean without weakening the oracle. The initial file-size gate failure was corrected without changing its limit.
- No host disk-pressure test or quota attribution. Changes add 90 test lines and five net production lines; all existing assertions and tests remain.
