### PR TITLE
test(gateway): isolate CLI announce continuity probe

### DIFF
--- a/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
@@ -249,9 +249,9 @@ export function prepareClaudeCacheProbeBackend(params: {
   };
 }
 
-async function waitFor<T>(resolve: () => T | undefined): Promise<T> {
+async function waitFor<T>(resolve: () => T | undefined | Promise<T | undefined>): Promise<T> {
   for (let attempt = 0; attempt < 480; attempt += 1) {
-    const value = resolve();
+    const value = await resolve();
     if (value !== undefined) {
       return value;
     }
@@ -347,25 +347,32 @@ export async function verifyCliBackendAnnounceOrdering({
   if (!announceEntry?.sessionId) {
     throw new Error("CLI announce probe lost its requester session");
   }
-  const announceHistory = await loadCliSessionHistoryMessages({
-    sessionTarget: await resolveSessionTranscriptRuntimeTarget({
-      agentId: "dev",
-      sessionId: announceEntry.sessionId,
-      sessionKey: announceSessionKey,
-    }),
+  const sessionTarget = await resolveSessionTranscriptRuntimeTarget({
+    agentId: "dev",
+    sessionId: announceEntry.sessionId,
+    sessionKey: announceSessionKey,
   });
-  const assistantReplies = announceHistory.flatMap((message) => {
-    const record = message as { role?: unknown; content?: unknown };
-    return record.role === "assistant"
-      ? [extractTextFromChatContent(record.content, { joinWith: "" }) ?? ""]
-      : [];
+  const { parentReplyIndex, completionReplyIndex } = await waitFor(async () => {
+    const announceHistory = await loadCliSessionHistoryMessages({ sessionTarget });
+    const assistantReplies = announceHistory.flatMap((message) => {
+      const record = message as { role?: unknown; content?: unknown };
+      return record.role === "assistant"
+        ? [extractTextFromChatContent(record.content, { joinWith: "" }) ?? ""]
+        : [];
+    });
+    const observedParentReplyIndex = assistantReplies.findIndex((reply) =>
+      reply.includes(announceParentToken),
+    );
+    const observedCompletionReplyIndex = assistantReplies.findIndex((reply) =>
+      reply.includes(announceChildToken),
+    );
+    return observedParentReplyIndex >= 0 && observedCompletionReplyIndex >= 0
+      ? {
+          parentReplyIndex: observedParentReplyIndex,
+          completionReplyIndex: observedCompletionReplyIndex,
+        }
+      : undefined;
   });
-  const parentReplyIndex = assistantReplies.findIndex((reply) =>
-    reply.includes(announceParentToken),
-  );
-  const completionReplyIndex = assistantReplies.findIndex((reply) =>
-    reply.includes(announceChildToken),
-  );
   logStep("announce-child:transcript-order", {
     runId: deliveredAnnounceChild.runId,
     parentObservedAt: announceParentObservedAt,

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -667,13 +667,6 @@ describeLive("gateway live (cli backend)", () => {
           }
         }
 
-        await verifyCliBackendAnnounceOrdering({
-          client: activeClient,
-          announceBarrier,
-          requestTimeoutMs: CLI_BACKEND_REQUEST_TIMEOUT_MS,
-          logStep: logCliBackendLiveStep,
-        });
-
         if (modelSwitchTarget) {
           const switchNonce = randomBytes(3).toString("hex").toUpperCase();
           logCliBackendLiveStep("agent-switch:start", {
@@ -979,6 +972,16 @@ describeLive("gateway live (cli backend)", () => {
             logCliBackendLiveStep("cron-mcp-probe:done");
           }
         }
+
+        // The announce probe spawns a separate CLI-backed session and can change the
+        // process-wide MCP/tool topology. Keep it after continuity and cache assertions
+        // so those probes measure consecutive turns in their owning native session.
+        await verifyCliBackendAnnounceOrdering({
+          client: activeClient,
+          announceBarrier,
+          requestTimeoutMs: CLI_BACKEND_REQUEST_TIMEOUT_MS,
+          logStep: logCliBackendLiveStep,
+        });
       } finally {
         try {
           logCliBackendLiveStep("cleanup:start");


### PR DESCRIPTION
## Summary

- run the CLI-backed announce ordering probe after continuity, cache, image, and MCP assertions
- prevent its separate session from changing process-wide tool topology between continuity turns
- wait for both parent and completion turns to become readable before asserting canonical transcript order

## Release-validation evidence

The original Full Validation failure came from interleaving the independent announce session between consecutive continuity/cache turns. Authenticated isolated Docker validation confirmed the cache lane passes after relocation. The ordinary lane then exposed that delivery metadata can become durable before the CLI transcript flushes the completion turn; the proof now waits for both entries and still requires parent-before-completion order.

Failing parent: https://github.com/openclaw/openclaw/actions/runs/34418806238

## Validation

- `pnpm test:docker:live-cli-backend:claude:cache` (passed; 1 live test, 50.8s)
- `pnpm test:docker:live-cli-backend:claude` (passed after transcript barrier; 1 live test, 35.7s)
- focused oxfmt and oxlint checks passed