### PR TITLE
fix(qa): scope Matrix progress mock to current turn

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -753,6 +753,62 @@ describe("qa mock openai server", () => {
     expect(body).not.toContain("older-progress-target.txt");
   });
 
+  it("uses the current tool-progress turn output for a hidden final marker", async () => {
+    const server = await startMockServer();
+    const currentPrompt =
+      "Tool progress QA check: call the read tool exactly once on `QA_KICKOFF_TASK.md` before answering. The only valid final marker is inside that file.";
+    const final = await expectResponsesJson<{
+      output: Array<{ content?: Array<{ text?: string }> }>;
+    }>(server, {
+      stream: false,
+      input: [
+        makeUserInput(
+          "Tool progress QA check: read `stale-progress-target.txt`, then reply exactly `STALE_PROGRESS_OK`.",
+        ),
+        {
+          type: "function_call_output",
+          call_id: "call_stale_progress_read",
+          output: JSON.stringify({ text: "stale turn" }),
+        },
+        makeUserInput(currentPrompt),
+        makeUserInput(TEST_RUNTIME_CONTEXT_CARRIER),
+        {
+          type: "function_call_output",
+          call_id: "call_current_progress_read",
+          output: JSON.stringify({
+            text: "Matrix tool progress QA task.\nReply with only this exact marker and no other text:\nCURRENT_PROGRESS_OK",
+          }),
+        },
+      ],
+    });
+
+    expect(final.output[0]?.content?.[0]?.text).toBe("CURRENT_PROGRESS_OK");
+  });
+
+  it("does not recover tool-progress directives from an earlier user turn", async () => {
+    const server = await startMockServer();
+    const response = await postResponses(server, {
+      stream: true,
+      input: [
+        makeUserInput(
+          "Tool progress QA check: read `stale-progress-target.txt`, then reply exactly `STALE_PROGRESS_OK`.",
+        ),
+        {
+          type: "function_call_output",
+          call_id: "call_stale_progress_read",
+          output: JSON.stringify({ text: "stale turn" }),
+        },
+        makeUserInput("Summarize the current turn in one short sentence."),
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).not.toContain('"name":"read"');
+    expect(body).not.toContain("stale-progress-target.txt");
+    expect(body).not.toContain("STALE_PROGRESS_OK");
+  });
+
   it("prefers path-like refs over generic quoted keys in prompts", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1127,6 +1127,26 @@ function extractLastMatchingUserText(texts: string[], pattern: RegExp) {
   return "";
 }
 
+function findCurrentScenarioUserTurn(input: ResponsesInputItem[], pattern: RegExp) {
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (item.role !== "user" || !Array.isArray(item.content)) {
+      continue;
+    }
+    const text = extractInputText(item.content);
+    if (!text || isInternalRuntimeContextCarrierText(text)) {
+      continue;
+    }
+    if (pattern.test(text)) {
+      return { index, text };
+    }
+    if (!isToolOutputContinuationText(text)) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 function extractExactReplyDirective(text: string) {
   const backtickedMatch = extractLastCapture(text, /reply(?: with)? exactly\s+`([^`]+)`/i);
   if (backtickedMatch) {
@@ -2162,14 +2182,21 @@ async function buildResponsesPayload(
   const canCallSessionsYield =
     hasDeclaredTool(body, "sessions_yield") ||
     QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE.test(allInputText);
-  const buildToolProgressReadEvents = (pattern: RegExp) => {
-    const toolProgressPrompt = extractLastMatchingUserText(extractAllUserTexts(input), pattern);
+  const toolProgressTurn = findCurrentScenarioUserTurn(input, /tool progress(?: error)? qa check/i);
+  const toolProgressPrompt = toolProgressTurn?.text ?? "";
+  const toolProgressInput = toolProgressTurn ? input.slice(toolProgressTurn.index) : [];
+  const toolProgressToolOutput = extractToolOutput(toolProgressInput);
+  const toolProgressToolJson = parseToolOutputJson(toolProgressToolOutput);
+  const toolProgressDirectiveText =
+    typeof toolProgressToolJson?.text === "string"
+      ? toolProgressToolJson.text
+      : toolProgressToolOutput;
+  const buildToolProgressReadEvents = () => {
     return buildToolCallEventsWithArgs("read", {
       path: readTargetFromPrompt(toolProgressPrompt || prompt || allInputText),
     });
   };
-  const buildToolProgressExecEvents = (pattern: RegExp) => {
-    const toolProgressPrompt = extractLastMatchingUserText(extractAllUserTexts(input), pattern);
+  const buildToolProgressExecEvents = () => {
     const command = execCommandFromToolProgressPrompt(toolProgressPrompt || prompt || allInputText);
     return command ? buildToolCallEventsWithArgs("exec", { command }) : null;
   };
@@ -2477,25 +2504,30 @@ async function buildResponsesPayload(
       },
     ]);
   }
-  const toolProgressReplyDirective = exactReplyDirective ?? exactMarkerDirective;
-  if (QA_TOOL_PROGRESS_ERROR_PROMPT_RE.test(allInputText) && toolProgressReplyDirective) {
-    if (!toolOutput) {
-      return buildToolProgressReadEvents(QA_TOOL_PROGRESS_ERROR_PROMPT_RE);
+  const toolProgressReplyDirective =
+    extractExactReplyDirective(toolProgressPrompt) ??
+    extractExactMarkerDirective(toolProgressPrompt) ??
+    extractExactReplyDirective(toolProgressDirectiveText) ??
+    extractExactMarkerDirective(toolProgressDirectiveText);
+  if (QA_TOOL_PROGRESS_ERROR_PROMPT_RE.test(toolProgressPrompt)) {
+    if (!toolProgressToolOutput) {
+      return buildToolProgressReadEvents();
     }
-    return buildAssistantEvents(
-      hasToolErrorOutput(toolJson, toolOutput)
-        ? toolProgressReplyDirective
-        : "BUG-TOOL-DID-NOT-FAIL",
-    );
-  }
-  if (QA_TOOL_PROGRESS_PROMPT_RE.test(allInputText) && toolProgressReplyDirective) {
-    if (!toolOutput) {
-      return (
-        buildToolProgressExecEvents(QA_TOOL_PROGRESS_PROMPT_RE) ??
-        buildToolProgressReadEvents(QA_TOOL_PROGRESS_PROMPT_RE)
+    if (toolProgressReplyDirective) {
+      return buildAssistantEvents(
+        hasToolErrorOutput(toolProgressToolJson, toolProgressToolOutput)
+          ? toolProgressReplyDirective
+          : "BUG-TOOL-DID-NOT-FAIL",
       );
     }
-    return buildAssistantEvents(toolProgressReplyDirective);
+  }
+  if (QA_TOOL_PROGRESS_PROMPT_RE.test(toolProgressPrompt)) {
+    if (!toolProgressToolOutput) {
+      return buildToolProgressExecEvents() ?? buildToolProgressReadEvents();
+    }
+    if (toolProgressReplyDirective) {
+      return buildAssistantEvents(toolProgressReplyDirective);
+    }
   }
   if (QA_BLOCK_STREAMING_PROMPT_RE.test(allInputText) && blockStreamingMarkers) {
     if (!toolOutput) {


### PR DESCRIPTION
## Summary

- scope deterministic tool-progress planning and completion to the latest active scenario turn
- derive hidden final markers from that turn's successful read result instead of older transcript directives
- prevent unrelated later turns from reviving stale Matrix progress scenarios

## Why

The 2026.7.33 Matrix live suite reuses one mock-provider transcript. The frozen mock searched the entire transcript for tool-progress prompts and exact markers, so the read-success and opt-out scenarios could complete with a prior scenario's marker and time out at the transport assertion.

This is a test-harness-only compatibility backport of the current-turn ownership established by #116438, adapted to retain 7.33's runtime-context and continuation behavior.

## Validation

- mock-provider test file: 121 passed
- test typecheck
- repository lint
- changed-file format check
- git diff check

Worked on by Dallin Romney.
