### PR TITLE
fix(heartbeat): classify prepared-model-runtime generation supersession as preemption, not agent-runner-failure

### DIFF
--- a/src/auto-reply/reply/reply-operation-abort.superseded-classification.test.ts
+++ b/src/auto-reply/reply/reply-operation-abort.superseded-classification.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { FailoverError } from "../../agents/failover/error.js";
+import {
+  PreparedModelRuntimeOwnerNotPublishedError,
+  PreparedModelRuntimePublicationSupersededError,
+} from "../../agents/prepared-model-runtime.errors.js";
+import {
+  isPreparedModelRuntimeSupersessionError,
+  resolveReplyOperationAbortReason,
+} from "./reply-operation-abort.js";
+
+/**
+ * Regression for the recurring `heartbeat-main` false `agent-runner-failure`.
+ *
+ * The TOCTOU race: `main` re-prepares its runtime and bumps the published owner
+ * generation after the heartbeat run passed its point-in-time idle guards but
+ * before the model turn acquired that owner. The turn then throws a
+ * `PreparedModelRuntimeOwnerNotPublishedError` ("plugin generation was
+ * superseded") that fast-fails every model-fallback candidate. Because it is a
+ * thrown error (not an abort-signal supersession), it must be recognised here so
+ * the heartbeat classifies it as a benign preemption skip instead of a genuine
+ * runner failure — while any other thrown error stays a real failure.
+ */
+describe("prepared-model-runtime supersession classification", () => {
+  const supersession = () =>
+    new PreparedModelRuntimeOwnerNotPublishedError(
+      "prepared model runtime plugin generation was superseded for /agents/main/agent",
+    );
+
+  // The FailoverError the model-fallback loop throws when every candidate
+  // fast-failed on the same supersession; the last real error rides as `cause`.
+  const fallbackSummaryWith = (cause: unknown) =>
+    new FailoverError("All model fallback candidates failed (4): ...", {
+      reason: "unknown",
+      attempts: [
+        { provider: "openai", model: "gpt-6-astra", reason: "unknown", error: "superseded" },
+      ] as never,
+      soonestCooldownExpiry: null,
+      cause: cause instanceof Error ? cause : undefined,
+    });
+
+  describe("isPreparedModelRuntimeSupersessionError", () => {
+    it("detects a directly thrown generation-supersession error", () => {
+      expect(isPreparedModelRuntimeSupersessionError(supersession())).toBe(true);
+    });
+
+    it("detects the publication-superseded subclass", () => {
+      expect(
+        isPreparedModelRuntimeSupersessionError(
+          new PreparedModelRuntimePublicationSupersededError(
+            "prepared model runtime publication was superseded for /agents/main/agent",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects a supersession carried as the cause of a model-fallback summary", () => {
+      expect(isPreparedModelRuntimeSupersessionError(fallbackSummaryWith(supersession()))).toBe(
+        true,
+      );
+    });
+
+    it("detects a supersession chained via error cause", () => {
+      expect(
+        isPreparedModelRuntimeSupersessionError(
+          new Error("embedded agent failed before reply", { cause: supersession() }),
+        ),
+      ).toBe(true);
+    });
+
+    it("leaves a genuine (non-supersession) failure unclassified", () => {
+      expect(isPreparedModelRuntimeSupersessionError(new Error("provider 500"))).toBe(false);
+      expect(isPreparedModelRuntimeSupersessionError(fallbackSummaryWith(new Error("boom")))).toBe(
+        false,
+      );
+      expect(isPreparedModelRuntimeSupersessionError(undefined)).toBe(false);
+    });
+  });
+
+  describe("resolveReplyOperationAbortReason maps supersession to a benign preemption", () => {
+    it("returns 'superseded' for a thrown supersession error (no abort signal)", () => {
+      expect(resolveReplyOperationAbortReason(undefined, supersession())).toBe("superseded");
+    });
+
+    it("returns 'superseded' for the model-fallback summary carrying the supersession", () => {
+      expect(resolveReplyOperationAbortReason(undefined, fallbackSummaryWith(supersession()))).toBe(
+        "superseded",
+      );
+    });
+
+    it("returns undefined for a genuine runner failure so it stays a real failure", () => {
+      expect(resolveReplyOperationAbortReason(undefined, new Error("provider 500"))).toBeUndefined();
+    });
+  });
+});

--- a/src/auto-reply/reply/reply-operation-abort.ts
+++ b/src/auto-reply/reply/reply-operation-abort.ts
@@ -1,4 +1,5 @@
 import { isFallbackSummaryError } from "../../agents/model-fallback-attempt.js";
+import { PreparedModelRuntimeOwnerNotPublishedError } from "../../agents/prepared-model-runtime.errors.js";
 import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   isAgentRunDirectAbortReason,
@@ -69,7 +70,7 @@ export function resolveReplyOperationAbortReason(
 ): "user" | "restart" | "superseded" | undefined {
   return isAgentRunRestartAbortReason(error) || isReplyOperationRestartAbort(replyOperation)
     ? "restart"
-    : isReplyOperationSuperseded(replyOperation)
+    : isReplyOperationSuperseded(replyOperation) || isPreparedModelRuntimeSupersessionError(error)
       ? "superseded"
       : isAgentRunDirectAbortReason(error) || isReplyOperationUserAbort(replyOperation)
         ? "user"
@@ -97,4 +98,38 @@ export function resolveRestartLifecycleError(
     }
   }
   return undefined;
+}
+
+/**
+ * True when a thrown reply-operation error is (or wraps) a prepared-model-runtime
+ * generation supersession — the benign TOCTOU race where `main` re-prepares its
+ * runtime and bumps the published owner generation after the heartbeat run passed
+ * its point-in-time idle guards but before the model turn acquired that owner.
+ *
+ * This surfaces as a thrown `PreparedModelRuntimeOwnerNotPublishedError` fast-failing
+ * every model-fallback candidate, not as an abort-signal supersession, so
+ * `isReplyOperationSuperseded` (abort-signal based) does not catch it. Walking the
+ * fallback-summary attempts and error causes lets callers classify it as a
+ * preemption skip instead of a genuine agent-runner failure, while any other thrown
+ * error stays a real, visible failure.
+ */
+export function isPreparedModelRuntimeSupersessionError(error: unknown): boolean {
+  const pending = [error];
+  const seen = new Set<unknown>();
+  for (const candidate of pending) {
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (candidate instanceof PreparedModelRuntimeOwnerNotPublishedError) {
+      return true;
+    }
+    if (isFallbackSummaryError(candidate)) {
+      pending.push(...candidate.attempts.map((attempt) => attempt.error));
+    }
+    if (candidate instanceof Error && "cause" in candidate) {
+      pending.push(candidate.cause);
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

Fixes the recurring `heartbeat-main` false **`agent-runner-failure`** (job `7bf06607`), observed live on 2026-09-09 (e.g. run `18:17:12` → failed `18:23:44`, and repeated hourly).

**Root cause — a TOCTOU race in the runtime, not config or network.** The heartbeat run passes its point-in-time idle guards (`resolveHeartbeatWakeStage`), then `main` re-prepares its runtime and bumps the *published owner generation*. When the heartbeat's model turn goes to acquire that owner, `prepared-model-runtime` throws `PreparedModelRuntimeOwnerNotPublishedError` ("prepared model runtime plugin generation was superseded"), which fast-fails **every** model-fallback candidate in a few ms and surfaces as `Embedded agent failed before reply`.

Because this arrives as a **thrown** error (carried on the model-fallback summary's `cause`), not an abort-signal supersession, `resolveReplyOperationAbortReason` did not recognise it, so the run was classified `failed` → a false `agent-runner-failure` alert. The **non-throwing** supersession path already maps to a benign `preempted` skip; this makes the thrown path consistent.

Live evidence (sanitized), run history, and the full write-up are attached to the ops report.

## Fix

Teach `resolveReplyOperationAbortReason(replyOperation, error)` to detect a prepared-model-runtime generation supersession carried by the **terminal error** — direct, `cause`-chained, or inside a model-fallback summary — via a new `isPreparedModelRuntimeSupersessionError` chain-walk (mirroring the existing `resolveRestartLifecycleError` walk). It then returns `"superseded"`, and the existing plumbing (`handleAgentExecutionError` → `resolveReplyOperationAbortReason(op, err)` → `{kind:"aborted", reason}` → heartbeat dispatch) maps it to a `preempted` skip.

Any other thrown error stays a real, visible failure — this **preserves error visibility** and only reclassifies the genuine race. A lower turn timeout or more retries would *not* fix this (verified in the prior diagnosis); the failure interleaves with healthy 260 ms `no-route` skips.

## Not a duplicate-delivery bug

The "duplicate log entries" are duplicate `applyJobResult` WARN emissions, not duplicate sends: the authoritative `cron runs` history has **one** finished run per failure while the raw log has two WARN lines, and all 50 runs report `deliveryStatus: not-requested`. Heartbeat sends nothing here, so there were zero duplicate chat messages.

## Tests

New `src/auto-reply/reply/reply-operation-abort.superseded-classification.test.ts` (8 cases): the classifier (direct / fallback-summary-cause / cause-chained / genuine-negative) and the abort-reason resolution. The two integration cases go **RED** when the one wiring line is reverted, and the genuine-failure case stays classified as a real failure. `tsgo -p tsconfig.core.json` and `-p tsconfig.extensions.json` both exit 0; touched existing suites (`heartbeat-wake.preemption`, `heartbeat-runner.failure-delivery`, `heartbeat-runner.tool-response`) stay green (52 + 8 = 60 passed).

## DEPLOY
- target: none (merge only)
- service: agent-runtime
- depends-on: none
- supersedes: none
- frontend-touched: no
- migrations: no
- env-vars: none
- feature-flag: none
- verify: `node scripts/run-vitest.mjs run src/auto-reply/reply/reply-operation-abort.superseded-classification.test.ts` (8 passed); revert the `|| isPreparedModelRuntimeSupersessionError(error)` clause to see the 2 integration cases go RED. Live activation is a separate, gated step (install to `/opt/homebrew/lib/node_modules/openclaw/dist` + one detached Gateway restart) — NOT performed here because a campaign worker is active.
- rollback: revert this PR / restore the unpatched installed `dist` (previous snapshot); no state or config changes.
- urgency: normal
