### PR TITLE
fix(qa): bundle rich Telegram evidence helpers

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -809,7 +809,7 @@ describe("scenario-flow-runner", () => {
     });
   });
 
-  it("loads bundled QA fixture modules through qaImport", async () => {
+  it("loads bundled QA runtime modules through qaImport", async () => {
     const result = await runScenarioFlow({
       api: {
         state: createQaBusState(),
@@ -853,8 +853,19 @@ describe("scenario-flow-runner", () => {
                 },
               },
               {
+                set: "artifacts",
+                value: { expr: 'await qaImport("./suite-artifacts.js")' },
+              },
+              {
+                set: "redaction",
+                value: { expr: 'await qaImport("./gateway-log-redaction.js")' },
+              },
+              {
                 assert: {
-                  expr: 'typeof plugin.evaluateCodexPluginLifecycle === "function"',
+                  expr:
+                    'typeof plugin.evaluateCodexPluginLifecycle === "function" && ' +
+                    'typeof artifacts.publishQaSuiteArtifactFiles === "function" && ' +
+                    'typeof redaction.redactQaGatewayDebugText === "function"',
                 },
               },
             ],

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -24,6 +24,7 @@ const qaFlowImportLoaders: Record<string, QaFlowImportLoader> = {
   "./auth-profile.fixture.js": () => import("./auth-profile.fixture.js"),
   "./codex-plugin.fixture.js": () => import("./codex-plugin.fixture.js"),
   "./errors.js": () => import("./errors.js"),
+  "./gateway-log-redaction.js": () => import("./gateway-log-redaction.js"),
   "./live-transports/matrix/scenarios/scenario-runtime-allowbots.js": () =>
     import("./live-transports/matrix/scenarios/scenario-runtime-allowbots.js"),
   "./live-transports/matrix/scenarios/scenario-runtime-approval.js": () =>
@@ -67,6 +68,7 @@ const qaFlowImportLoaders: Record<string, QaFlowImportLoader> = {
     import("./live-transports/slack/scenario-runtime.js"),
   "./live-transports/whatsapp/scenario-runtime.js": () =>
     import("./live-transports/whatsapp/scenario-runtime.js"),
+  "./suite-artifacts.js": () => import("./suite-artifacts.js"),
   "./tool-search-gateway.fixture.js": () => import("./tool-search-gateway.fixture.js"),
 };
 


### PR DESCRIPTION
## Summary

- register the QA suite artifact and gateway-log redaction modules in the explicit scenario-flow import map
- keep rich Telegram evidence capture inside the bundled candidate instead of falling back to runtime-relative imports
- cover both helpers in the bundled `qaImport` regression test

## Failure

Full Validation trusted Telegram QA failed `telegram-rich-inline-composition` with:

```
ENOENT: no such file or directory, open /opt/openclaw-telegram-sut-candidate-34418955409-1/dist/suite-artifacts.js
```

## Validation

- `pnpm exec vitest run extensions/qa-lab/src/scenario-flow-runner.test.ts` (48/48)
- `pnpm build`
- `pnpm exec oxfmt --check extensions/qa-lab/src/scenario-flow-runner.ts extensions/qa-lab/src/scenario-flow-runner.test.ts`
- `pnpm exec oxlint extensions/qa-lab/src/scenario-flow-runner.ts extensions/qa-lab/src/scenario-flow-runner.test.ts`