### PR TITLE
fix(telegram): keep suppressed sends from failing tools and jobs

### DIFF
--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -243,6 +243,14 @@ Use `payloadOutcomes` when a batch mixes sent, suppressed, and failed
 payloads. Do not infer hook cancellation from an empty legacy
 direct-delivery result.
 
+A `suppressed` result is ambiguous when its reason is
+`adapter_returned_no_identity`, or any payload outcome records a send, an
+identityless send, or a failure with `sentBeforeError`. Check the whole batch
+before treating suppression as intentional non-delivery. For a known omission,
+an action can return `{ status: "suppressed", reason: result.reason }` without
+a tool error or a fabricated receipt. Keep free-form hook diagnostics private.
+Suppression does not recover an earlier failed send.
+
 Failure is not permission to send the same payload through another path.
 Once admitted, the queue owns retry or reconciliation until its exact owner
 acknowledges or terminally retires the intent. Pending custody is not a

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
+import type { DurableMessageBatchSendResult } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
@@ -82,7 +83,7 @@ const sendDurableMessageBatch = vi.fn(
       readFile?: (filePath: string) => Promise<Buffer>;
       workspaceDir?: string;
     };
-  }) => {
+  }): Promise<DurableMessageBatchSendResult> => {
     const payload = params.payloads[0] ?? {};
     const mediaUrls = payload.mediaUrls?.length
       ? payload.mediaUrls
@@ -1137,6 +1138,168 @@ describe("handleTelegramAction", () => {
       { type: "text", text: JSON.stringify(details, null, 2) },
     ]);
   });
+
+  it.each([
+    "cancelled_by_message_sending_hook",
+    "cancelled_by_reply_payload_sending_hook",
+    "empty_after_message_sending_hook",
+    "empty_after_reply_payload_sending_hook",
+    "no_visible_payload",
+    "adapter_returned_no_send",
+    "no_visible_result",
+  ] as const)("returns intentional %s without a tool error or hook diagnostics", async (reason) => {
+    sendDurableMessageBatch.mockResolvedValueOnce({
+      status: "suppressed",
+      results: [],
+      receipt: { platformMessageIds: [], parts: [], sentAt: 1 },
+      reason,
+      payloadOutcomes: [
+        {
+          index: 0,
+          status: "suppressed",
+          reason,
+          hookEffect: { cancelReason: "dedupe" },
+        },
+      ],
+    });
+
+    const result = await handleTelegramAction(
+      { action: "sendMessage", to: "@testchannel", content: "Hello, Telegram!" },
+      telegramConfig(),
+    );
+    expect(result.details).toEqual({ status: "suppressed", reason });
+    expect(JSON.stringify(result)).not.toContain("dedupe");
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("preserves the required reason when optional payload diagnostics are absent", async () => {
+    sendDurableMessageBatch.mockResolvedValueOnce({
+      status: "suppressed",
+      results: [],
+      receipt: { platformMessageIds: [], parts: [], sentAt: 1 },
+      reason: "cancelled_by_message_sending_hook",
+    });
+    const result = await handleTelegramAction(
+      { action: "sendMessage", to: "123", content: "hello" },
+      telegramConfig(),
+    );
+    expect(result.details).toEqual({
+      status: "suppressed",
+      reason: "cancelled_by_message_sending_hook",
+    });
+  });
+
+  it.each<{
+    name: string;
+    reason: Extract<DurableMessageBatchSendResult, { status: "suppressed" }>["reason"];
+    payloadOutcomes: Extract<
+      DurableMessageBatchSendResult,
+      { status: "suppressed" }
+    >["payloadOutcomes"];
+    ambiguous: boolean;
+  }>([
+    {
+      name: "top-level identityless send",
+      reason: "adapter_returned_no_identity",
+      payloadOutcomes: undefined,
+      ambiguous: true,
+    },
+    {
+      name: "later identityless send",
+      reason: "cancelled_by_message_sending_hook",
+      payloadOutcomes: [{ index: 1, status: "suppressed", reason: "adapter_returned_no_identity" }],
+      ambiguous: true,
+    },
+    {
+      name: "later identified send",
+      reason: "cancelled_by_message_sending_hook",
+      payloadOutcomes: [
+        { index: 1, status: "sent", results: [{ channel: "telegram", messageId: "accepted-1" }] },
+      ],
+      ambiguous: true,
+    },
+    {
+      name: "later partial failure",
+      reason: "cancelled_by_message_sending_hook",
+      payloadOutcomes: [
+        {
+          index: 1,
+          status: "failed",
+          error: new Error("partial failure"),
+          stage: "platform_send",
+          sentBeforeError: true,
+        },
+      ],
+      ambiguous: true,
+    },
+    {
+      name: "failure before any send",
+      reason: "cancelled_by_message_sending_hook",
+      payloadOutcomes: [
+        {
+          index: 1,
+          status: "failed",
+          error: new Error("pre-dispatch failure"),
+          stage: "platform_send",
+          sentBeforeError: false,
+        },
+      ],
+      ambiguous: false,
+    },
+  ])(
+    "preserves the delivery evidence for $name after cancellation",
+    async ({ reason, payloadOutcomes, ambiguous }) => {
+      sendDurableMessageBatch.mockResolvedValueOnce({
+        status: "suppressed",
+        results: [],
+        receipt: { platformMessageIds: [], parts: [], sentAt: 1 },
+        reason,
+        ...(payloadOutcomes
+          ? {
+              payloadOutcomes: [
+                { index: 0, status: "suppressed", reason: "cancelled_by_message_sending_hook" },
+                ...payloadOutcomes,
+              ],
+            }
+          : {}),
+      });
+      const result = handleTelegramAction(
+        { action: "sendMessage", to: "123", content: "hello" },
+        telegramConfig(),
+      );
+      if (ambiguous) {
+        await expect(result).rejects.toThrow(
+          "Telegram sendMessage was suppressed before delivery.",
+        );
+      } else {
+        await expect(result).resolves.toMatchObject({ details: { status: "suppressed", reason } });
+      }
+    },
+  );
+
+  it.each(["failed", "partial_failed"] as const)(
+    "preserves a %s delivery error",
+    async (status) => {
+      const error = new Error("Telegram transport failed");
+      sendDurableMessageBatch.mockResolvedValueOnce(
+        status === "failed"
+          ? { status, error }
+          : {
+              status,
+              error,
+              sentBeforeError: true,
+              results: [{ channel: "telegram", messageId: "accepted-1" }],
+              receipt: { platformMessageIds: ["accepted-1"], parts: [], sentAt: 1 },
+            },
+      );
+      await expect(
+        handleTelegramAction(
+          { action: "sendMessage", to: "123", content: "hello" },
+          telegramConfig(),
+        ),
+      ).rejects.toBe(error);
+    },
+  );
 
   it("persists sendMessage action deliveries before Telegram platform send", async () => {
     const stateDir = openClawState.stateDir;

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
+import type { DurableMessageBatchSendResult } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
@@ -82,7 +83,7 @@ const sendDurableMessageBatch = vi.fn(
       readFile?: (filePath: string) => Promise<Buffer>;
       workspaceDir?: string;
     };
-  }) => {
+  }): Promise<DurableMessageBatchSendResult> => {
     const payload = params.payloads[0] ?? {};
     const mediaUrls = payload.mediaUrls?.length
       ? payload.mediaUrls
@@ -1136,6 +1137,40 @@ describe("handleTelegramAction", () => {
     expect(result.content).toStrictEqual([
       { type: "text", text: JSON.stringify(details, null, 2) },
     ]);
+  });
+
+  it("surfaces the bounded suppression reason and keeps hook diagnostics internal", async () => {
+    sendDurableMessageBatch.mockResolvedValueOnce({
+      status: "suppressed",
+      results: [],
+      receipt: { platformMessageIds: [], parts: [], sentAt: 1 },
+      reason: "cancelled_by_message_sending_hook",
+      payloadOutcomes: [
+        {
+          index: 0,
+          status: "suppressed",
+          reason: "cancelled_by_message_sending_hook",
+          hookEffect: { cancelReason: "dedupe" },
+        },
+      ],
+    });
+
+    // The caller-facing error carries the bounded enum reason; the hook's
+    // free-form cancelReason stays out of the model-facing boundary.
+    const error = await handleTelegramAction(
+      { action: "sendMessage", to: "@testchannel", content: "Hello, Telegram!" },
+      telegramConfig(),
+    ).then(
+      () => {
+        throw new Error("expected handleTelegramAction to reject");
+      },
+      (rejection: unknown) => rejection as Error,
+    );
+    expect(error.message).toBe(
+      "Telegram sendMessage was suppressed before delivery: cancelled_by_message_sending_hook",
+    );
+    expect(error.message).not.toContain("dedupe");
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
   });
 
   it("persists sendMessage action deliveries before Telegram platform send", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -760,7 +760,18 @@ export async function handleTelegramAction(
       throw durableResult.error;
     }
     if (durableResult.status === "suppressed") {
-      throw new Error("Telegram sendMessage was suppressed before delivery.");
+      const mayHaveReachedRecipient =
+        durableResult.reason === "adapter_returned_no_identity" ||
+        durableResult.payloadOutcomes?.some((outcome) =>
+          outcome.status === "failed"
+            ? outcome.sentBeforeError
+            : outcome.status === "sent" || outcome.reason === "adapter_returned_no_identity",
+        );
+      if (mayHaveReachedRecipient) {
+        throw new Error("Telegram sendMessage was suppressed before delivery.");
+      }
+      // Hook diagnostics remain private; only the durable owner's bounded reason crosses here.
+      return jsonResult({ status: "suppressed", reason: durableResult.reason });
     }
     const result = getLastDurableTelegramActionResult(durableResult);
     notifyVisibleOutboundSuccess(to, messageThreadId);

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -760,7 +760,18 @@ export async function handleTelegramAction(
       throw durableResult.error;
     }
     if (durableResult.status === "suppressed") {
-      throw new Error("Telegram sendMessage was suppressed before delivery.");
+      // Caller-facing errors may carry only the bounded suppression reason.
+      // Free-form hook diagnostics (`hookEffect.cancelReason`) stay in the
+      // durable result's internal audit trail, matching the shared delivery
+      // serializer's model-facing boundary.
+      const suppressionReason = durableResult.payloadOutcomes?.find(
+        (outcome) => outcome.status === "suppressed",
+      )?.reason;
+      throw new Error(
+        suppressionReason
+          ? `Telegram sendMessage was suppressed before delivery: ${suppressionReason}`
+          : "Telegram sendMessage was suppressed before delivery.",
+      );
     }
     const result = getLastDurableTelegramActionResult(durableResult);
     notifyVisibleOutboundSuccess(to, messageThreadId);

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -174,7 +174,9 @@ function readPluginDeliveryId(value: unknown): string | undefined {
   return found;
 }
 
-function projectPluginPayload(value: unknown): EmbeddedMessageDeliveryFact | undefined {
+export function projectPluginMessageDeliveryFact(
+  value: unknown,
+): EmbeddedMessageDeliveryFact | undefined {
   if (pluginEnvelopeHas(value, "dryRun")) {
     return { status: "dryRun", ...EMPTY_DELIVERY_FACT };
   }
@@ -209,7 +211,7 @@ export function pluginBroadcastHasDelivery(value: unknown): boolean {
           return false;
         }
         return [entry.payload, entry.toolResult].some(
-          (payload) => projectPluginPayload(payload)?.status === "settled",
+          (payload) => projectPluginMessageDeliveryFact(payload)?.status === "settled",
         );
       }),
   );
@@ -257,7 +259,7 @@ export function projectEmbeddedMessageDeliveryFact(
   if (currentSourceReply && result.handledBy === "plugin") {
     return result.dryRun
       ? { status: "dryRun", ...EMPTY_DELIVERY_FACT }
-      : projectPluginPayload(result.payload);
+      : projectPluginMessageDeliveryFact(result.payload);
   }
   if (result.kind === "send") {
     return result.handledBy === "core" && result.sendResult
@@ -287,7 +289,7 @@ export function projectEmbeddedMessageDeliveryFact(
       : entry.sentBeforeError
         ? { status: "settled" as const, partialDelivery: true, createdThreadIds: [] }
         : entry.ok
-          ? projectPluginPayload(entry.payload)
+          ? projectPluginMessageDeliveryFact(entry.payload)
           : undefined,
   }));
   const facts = entries.flatMap(({ fact }) => (fact ? [fact] : []));

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1680,6 +1680,28 @@ describe("handleToolExecutionEnd sessions_spawn terminal success tracking", () =
 });
 
 describe("handleToolExecutionEnd mutating failure recovery", () => {
+  it("keeps an earlier message error when the next delivery is intentionally suppressed", async () => {
+    const { ctx } = createTestContext();
+    await executeTool(ctx, {
+      toolName: "message",
+      toolCallId: "message-failed",
+      args: { action: "send", channel: "telegram", target: "123", message: "failed" },
+      isError: true,
+      result: { details: { status: "error", error: "Telegram transport failed" } },
+    });
+    await executeTool(ctx, {
+      toolName: "message",
+      toolCallId: "message-suppressed",
+      args: { action: "send", channel: "telegram", target: "123", message: "omitted" },
+      isError: false,
+      result: { details: { status: "suppressed", reason: "cancelled_by_message_sending_hook" } },
+    });
+    expect(ctx.state.lastToolError).toMatchObject({
+      toolName: "message",
+      error: "Telegram transport failed",
+    });
+  });
+
   it("marks middleware failures on the last tool error", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/tool-error-state.ts
+++ b/src/agents/tool-error-state.ts
@@ -6,6 +6,7 @@ type ToolTerminalState = {
 };
 
 type ToolErrorState = {
+  read: () => ToolTerminalState;
   recordFailure: (failure: ToolErrorSummary) => ToolTerminalState;
   recordSuccess: (toolName: string) => ToolTerminalState;
 };
@@ -16,6 +17,7 @@ export function createToolErrorState(): ToolErrorState {
   const terminalState = (): ToolTerminalState => (lastToolError ? { lastToolError } : {});
 
   return {
+    read: terminalState,
     recordFailure(failure) {
       lastToolError = failure;
       return terminalState();

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -14,6 +14,36 @@ import { createToolTerminalObserver } from "./tool-terminal-outcome.js";
 describe("tool terminal outcome observer", () => {
   afterEach(() => resetAdjustedParamsByToolCallIdForTests());
 
+  it("retains a genuine message failure across suppression until a real send succeeds", () => {
+    const observe = createToolTerminalObserver("run-suppression");
+    const suppression = {
+      toolName: "message",
+      arguments: { action: "send", target: "123", message: "omitted" },
+      outcome: "success" as const,
+      result: { details: { status: "suppressed", reason: "cancelled_by_message_sending_hook" } },
+    };
+    expect(observe(suppression).lastToolError).toBeUndefined();
+    observe({
+      toolName: "message",
+      arguments: { action: "send", target: "123", message: "failed" },
+      outcome: "failure",
+      failure: { error: "Telegram transport failed" },
+    });
+    const afterSuppression = observe(suppression);
+    expect(afterSuppression.lastToolError).toMatchObject({ error: "Telegram transport failed" });
+    expect(buildPayloads({ lastToolError: afterSuppression.lastToolError })).toEqual([
+      expect.objectContaining({ isError: true }),
+    ]);
+    expect(
+      observe({
+        toolName: "message",
+        arguments: { action: "send", target: "123", message: "delivered" },
+        outcome: "success",
+        result: { details: { ok: true, messageId: "sent-1" } },
+      }).lastToolError,
+    ).toBeUndefined();
+  });
+
   it("keeps the latest failure when a different tool succeeds", () => {
     const observe = createToolTerminalObserver("run-1");
     const actionA = { action: "send", to: "channel:a", message: "A" };

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -4,6 +4,7 @@ import {
   peekAdjustedParamsForToolCall,
   peekPreExecutionBlockedToolCall,
 } from "./agent-tools.before-tool-call.state.js";
+import { projectPluginMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
 import { buildToolEffectReceipt, readToolEffectReceipt } from "./tool-effect-receipt.js";
 import { createToolErrorState } from "./tool-error-state.js";
@@ -50,6 +51,12 @@ export function createToolTerminalObserver(
         mutatingAction,
       };
       lastToolError = errors.recordFailure(failure).lastToolError;
+    } else if (
+      observation.toolName === "message" &&
+      projectPluginMessageDeliveryFact(observation.result)?.status === "suppressed"
+    ) {
+      // A handled omission does not recover an earlier failed delivery.
+      lastToolError = errors.read().lastToolError;
     } else {
       lastToolError = errors.recordSuccess(observation.toolName).lastToolError;
     }

--- a/src/infra/outbound/message-action-send.mirror-order.test.ts
+++ b/src/infra/outbound/message-action-send.mirror-order.test.ts
@@ -10,6 +10,7 @@ import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadExactSessionEntry,
+  loadTranscriptEventsSync,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -138,5 +139,34 @@ describe("outbound mirror route ordering", () => {
       provider: "testchat",
       from: "testchat:12345",
     });
+  });
+
+  it("leaves the stored route untouched when a plugin intentionally suppresses delivery", async () => {
+    const transcriptScope = {
+      agentId: "main",
+      sessionKey: MAIN_SESSION_KEY,
+      sessionId: "main-session",
+      storePath,
+    };
+    const transcriptBefore = loadTranscriptEventsSync(transcriptScope);
+    handleAction.mockResolvedValue(
+      jsonResult({ status: "suppressed", reason: "cancelled_by_message_sending_hook" }),
+    );
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: { channel: "testchat", to: "user:12345", message: "omitted" },
+      agentId: "main",
+      dryRun: false,
+    });
+    expect(result.payload).toEqual({
+      status: "suppressed",
+      reason: "cancelled_by_message_sending_hook",
+    });
+    expect(mainSessionOrigin()).toMatchObject({
+      provider: "discord",
+      from: "discord:operator",
+    });
+    expect(loadTranscriptEventsSync(transcriptScope)).toEqual(transcriptBefore);
   });
 });

--- a/src/infra/outbound/message-action-send.test.ts
+++ b/src/infra/outbound/message-action-send.test.ts
@@ -18,7 +18,7 @@ import {
   runMessageAction,
   setMessageActionTestPlugin as setTestPlugin,
 } from "./message-action-runner.test-helpers.js";
-import { ensureOutboundSessionEntry } from "./outbound-session.js";
+import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 const requireLabeledRecord = createRequireRecord("record", "expected-label");
@@ -71,6 +71,43 @@ describe("runMessageAction plugin dispatch", () => {
       setActivePluginRegistry(createTestRegistry([]));
       vi.clearAllMocks();
       vi.unstubAllEnvs();
+    });
+    it("does not persist a route for Gateway-relayed suppression", async () => {
+      vi.mocked(resolveOutboundSessionRoute).mockResolvedValueOnce({
+        sessionKey: "agent:main:gatewaychat:direct:user-123",
+        baseSessionKey: "agent:main:gatewaychat:direct:user-123",
+        peer: { kind: "direct", id: "user-123" },
+        chatType: "direct",
+        from: "gatewaychat:user-123",
+        to: "user-123",
+      });
+      setTestPlugin(
+        createGatewayActionPlugin({
+          pluginId: "gatewaychat",
+          label: "Gateway Chat",
+          blurb: "Gateway Chat send test plugin.",
+          actions: ["send"],
+          messaging: { targetResolver: { looksLikeId: () => true } },
+          handleAction: vi.fn(),
+        }),
+        "gatewaychat",
+      );
+      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+        status: "suppressed",
+        reason: "cancelled_by_message_sending_hook",
+      });
+      const result = await runMessageAction({
+        cfg: { channels: { gatewaychat: { enabled: true } } } as OpenClawConfig,
+        action: "send",
+        params: { channel: "gatewaychat", target: "user-123", message: "omitted" },
+        agentId: "main",
+        gateway: { clientName: "cli", mode: "cli" },
+      });
+      expect(result.payload).toEqual({
+        status: "suppressed",
+        reason: "cancelled_by_message_sending_hook",
+      });
+      expect(ensureOutboundSessionEntry).not.toHaveBeenCalled();
     });
     it.each([
       { name: "raw base64", buffer: "SGVsbG8=" },

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { projectPluginMessageDeliveryFact } from "../../agents/embedded-agent-message-delivery.js";
 import { resolveAgentIdentity, resolveResponsePrefix } from "../../agents/identity.js";
 import { readStringArrayParam, readToolStringParam } from "../../agents/tools/common.js";
 import {
@@ -543,7 +544,9 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
         }),
       });
   if (gatewayPluginAction) {
-    await commitOutboundSessionRoute();
+    if (projectPluginMessageDeliveryFact(gatewayPluginAction.payload)?.status !== "suppressed") {
+      await commitOutboundSessionRoute();
+    }
     return annotateSourceDelivery(
       withSendNormalization(gatewayPluginAction, sendPayload.normalization),
       ctx,
@@ -615,7 +618,11 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
   // a non-failed, non-suppressed return is their success proof. Failed and
   // suppressed sends leave the durable route untouched.
   const coreDeliveryStatus = send.sendResult?.deliveryStatus;
-  if (coreDeliveryStatus !== "failed" && coreDeliveryStatus !== "suppressed") {
+  if (
+    coreDeliveryStatus !== "failed" &&
+    coreDeliveryStatus !== "suppressed" &&
+    projectPluginMessageDeliveryFact(send.payload)?.status !== "suppressed"
+  ) {
     await commitOutboundSessionRoute();
   }
 

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,5 +1,6 @@
 // Outbound send service chooses plugin-handled message actions or the core
 // message/poll path while preserving media policy and transcript mirrors.
+import { projectPluginMessageDeliveryFact } from "../../agents/embedded-agent-message-delivery.js";
 import type { AgentToolResult } from "../../agents/runtime/index.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ChatType } from "../../channels/chat-type.js";
@@ -203,7 +204,9 @@ async function tryHandleWithPluginAction(params: {
   if (!handled) {
     return null;
   }
-  await params.onHandled?.();
+  if (projectPluginMessageDeliveryFact(handled)?.status !== "suppressed") {
+    await params.onHandled?.();
+  }
   return {
     handledBy: "plugin",
     payload: extractToolPayload(handled),


### PR DESCRIPTION
Closes #143461

## What Problem This Solves

Fixes an issue where an intentional Telegram `message_sending` hook cancellation appeared as a message-tool outage. Announced scheduled jobs could also finish with “Message failed” even though the hook correctly prevented delivery.

## Why This Change Was Made

Return a structured, non-error suppression result with the durable sender's bounded reason. Keep possible delivery, partial sends, and genuine failures distinct. Suppressed sends do not save a delivery route, mirror a delivered message, or clear an earlier genuine message error. Free-form hook diagnostics remain private.

## User Impact

Plugins can intentionally omit a message without causing a false tool failure or failed scheduled job. Normal sends and hook rewrites keep their existing delivery behavior.

## Evidence

- Pinned-main reproduction used a registered hook, the real Gateway-backed agent message tool, Telegram Test Server, a deterministic model endpoint, and an announced isolated scheduled job.
- Baseline: the durable owner recorded intentional suppression with zero platform dispatch; the model still received an error, and the scheduled job saved an error status.
- Candidate `ac3e7a9`: ordinary, scheduled, reasonless, and empty-content suppression return bounded non-error results with zero platform sends. The scheduled job finishes `ok` and remains undelivered. Ordinary commands finish `ok/completed` with one message call and no replay.
- Normal sends and hook rewrites have exact Test Server receipts. Fresh independent live acceptance passes; awkward failure/recovery and unchanged lifecycle preservation are covered by separate native owner checks and source review.
- New regressions failed on pinned main at the affected owners. Focused owner and lifecycle/queue checks passed after repair; corrected Telegram suite: 144 passing tests. SDK surface limits are unchanged and pass.

Preserves @sunlit-deng's contribution and addresses the scheduled-job follow-up from @jerabinovich.
