### PR TITLE
fix(codex): isolate auth refresh integration providers

### DIFF
--- a/extensions/codex/src/app-server/auth-refresh-authority.integration.test.ts
+++ b/extensions/codex/src/app-server/auth-refresh-authority.integration.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -12,11 +13,12 @@ import {
   createPluginRecord,
   createPluginRuntimeMock,
   getActivePluginRegistry,
+  loadPluginManifestRegistryCore,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
-import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { withEnvAsync, withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { fingerprintTokenAuthProfileCacheKey } from "./auth-cache-key.js";
 import {
@@ -60,87 +62,118 @@ async function withAuthRefreshHarness(
   }) => Promise<void>,
 ): Promise<void> {
   await withStateDirEnv("openclaw-codex-auth-refresh-authority-", async ({ stateDir }) => {
-    const previousRegistry = getActivePluginRegistry();
-    const pluginRoot = path.join(process.cwd(), "extensions", "openai");
-    const registration = createPluginRegistry({
-      runtime: createPluginRuntimeMock(),
-      logger: { info() {}, warn() {}, error() {}, debug() {} },
-      activateGlobalSideEffects: false,
-    });
-    const record = createPluginRecord({
-      id: "openai",
-      source: path.join(pluginRoot, "index.ts"),
-      rootDir: pluginRoot,
-      origin: "bundled",
-      format: "bundle",
-      enabled: true,
-      providerIds: ["openai"],
-      configSchema: true,
-    });
-    const otherProviderRecord = createPluginRecord({
-      id: "anthropic",
-      source: path.join(pluginRoot, "anthropic.ts"),
-      rootDir: pluginRoot,
-      origin: "bundled",
-      format: "bundle",
-      enabled: true,
-      providerIds: ["anthropic"],
-      configSchema: true,
-    });
-    registration.registry.plugins.push(record, otherProviderRecord);
-    const api = registration.createApi(record, { config: {} });
-    const otherProviderRefresh = vi.fn(async (credential: OAuthCredential) => credential);
-    api.registerProvider({
-      id: "openai",
-      label: "OpenAI",
-      auth: [],
-      refreshOAuth,
-    });
-    registration.createApi(otherProviderRecord, { config: {} }).registerProvider({
-      id: "anthropic",
-      label: "Anthropic",
-      auth: [],
-      refreshOAuth: otherProviderRefresh,
-    });
-    setActivePluginRegistry(registration.registry, undefined, "default", process.cwd());
-
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
-    upsertAuthProfile({
-      agentDir,
-      profileId: PROFILE_ID,
-      credential: {
-        type: "oauth",
-        provider: "openai",
-        access: INITIAL_ACCESS,
-        refresh: "initial-refresh",
-        expires: Date.now() + 60_000,
-        accountId: ACCOUNT_ID,
-      },
-    });
-    const retainedStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
-    const harness = createClientHarness();
-    ensureCodexAppServerClientRuntime(harness.client, {
-      agentDir,
-      authProfileId: PROFILE_ID,
-      authProfileStore: retainedStore,
-    });
-    recordCodexAppServerAuthHandoff(harness.client, {
-      accessFingerprint: fingerprintTokenAuthProfileCacheKey(INITIAL_ACCESS),
-      chatgptAccountId: ACCOUNT_ID,
-    });
-
-    try {
-      await run({ agentDir, harness, otherProviderRefresh, retainedStore });
-    } finally {
-      harness.client.close();
-      clearRuntimeAuthProfileStoreSnapshots();
-      closeOpenClawStateDatabaseForTest();
-      if (previousRegistry) {
-        setActivePluginRegistry(previousRegistry);
-      } else {
-        resetPluginRuntimeStateForTest();
-      }
+    const bundledRoot = path.join(stateDir, "bundled");
+    for (const id of ["openai", "anthropic"]) {
+      const rootDir = path.join(bundledRoot, id);
+      fs.mkdirSync(rootDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(rootDir, "package.json"),
+        JSON.stringify({
+          name: `auth-refresh-fixture-${id}`,
+          openclaw: { extensions: ["./index.js"] },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rootDir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id,
+          providers: [id],
+          enabledByDefault: true,
+          configSchema: { type: "object", properties: {} },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rootDir, "index.js"),
+        'throw new Error("Unexpected fixture cold load");\n',
+      );
     }
+    await withEnvAsync(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      },
+      async () => {
+        const previousRegistry = getActivePluginRegistry();
+        const manifests = loadPluginManifestRegistryCore({ workspaceDir: stateDir });
+        const createProviderRecord = (id: string) => {
+          const manifest = manifests.plugins.find((plugin) => plugin.id === id);
+          if (!manifest || manifest.rootDir !== path.join(bundledRoot, id)) {
+            throw new Error(`Unexpected fixture manifest owner: ${id}`);
+          }
+          return createPluginRecord({
+            id,
+            source: manifest.source,
+            rootDir: manifest.rootDir,
+            origin: "bundled",
+            format: "bundle",
+            enabled: true,
+            providerIds: [id],
+            configSchema: true,
+          });
+        };
+        const registration = createPluginRegistry({
+          runtime: createPluginRuntimeMock(),
+          logger: { info() {}, warn() {}, error() {}, debug() {} },
+          activateGlobalSideEffects: false,
+        });
+        const record = createProviderRecord("openai");
+        const otherProviderRecord = createProviderRecord("anthropic");
+        registration.registry.plugins.push(record, otherProviderRecord);
+        const api = registration.createApi(record, { config: {} });
+        const otherProviderRefresh = vi.fn(async (credential: OAuthCredential) => credential);
+        api.registerProvider({
+          id: "openai",
+          label: "OpenAI",
+          auth: [],
+          refreshOAuth,
+        });
+        registration.createApi(otherProviderRecord, { config: {} }).registerProvider({
+          id: "anthropic",
+          label: "Anthropic",
+          auth: [],
+          refreshOAuth: otherProviderRefresh,
+        });
+        const harness = createClientHarness();
+        try {
+          setActivePluginRegistry(registration.registry, undefined, "default", stateDir);
+
+          const agentDir = path.join(stateDir, "agents", "main", "agent");
+          upsertAuthProfile({
+            agentDir,
+            profileId: PROFILE_ID,
+            credential: {
+              type: "oauth",
+              provider: "openai",
+              access: INITIAL_ACCESS,
+              refresh: "initial-refresh",
+              expires: Date.now() + 60_000,
+              accountId: ACCOUNT_ID,
+            },
+          });
+          const retainedStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+          ensureCodexAppServerClientRuntime(harness.client, {
+            agentDir,
+            authProfileId: PROFILE_ID,
+            authProfileStore: retainedStore,
+          });
+          recordCodexAppServerAuthHandoff(harness.client, {
+            accessFingerprint: fingerprintTokenAuthProfileCacheKey(INITIAL_ACCESS),
+            chatgptAccountId: ACCOUNT_ID,
+          });
+
+          await run({ agentDir, harness, otherProviderRefresh, retainedStore });
+        } finally {
+          harness.client.close();
+          clearRuntimeAuthProfileStoreSnapshots();
+          closeOpenClawStateDatabaseForTest();
+          if (previousRegistry) {
+            setActivePluginRegistry(previousRegistry);
+          } else {
+            resetPluginRuntimeStateForTest();
+          }
+        }
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the Codex auth-refresh integration fixture could select the real OpenAI provider instead of its synthetic refresh callback. The account-rotation cases then failed with an OAuth refresh error rather than exercising their intended account-fencing and persistence contracts. This is a maintainer-requested repair from the test audit.

## Why This Change Was Made

Give each synthetic provider a real, isolated package/manifest/entry root and derive its registered source identity from native manifest discovery. Bind the active registry to that same temporary workspace. Unexpected cold loading fails at an inert fixture entry, and the existing state-directory owner removes the fixture after registry/environment cleanup.

All six existing case bodies remain unchanged. The real selected-profile, account-fencing, retained-store and persisted-store paths remain under test. The patch adds 33 net test lines and changes no production code or SDK surface.

## User Impact

No runtime behavior changes. Developers get an isolated refresh fixture whose synthetic provider registration agrees with the runtime's physical ownership checks.

## Evidence

A temporary diagnostic compared the selected refresh callback by identity and rejected non-fixture callbacks before invocation, with legacy refresh fallback also denied. The original fixture produced four passes and the two expected callback-selection failures; both refresh attempts selected a non-fixture callback. With this fixture repair, all six cases passed and both refresh attempts selected the exact synthetic callback. Those diagnostic guards were removed and production source restored before final validation.

Normal Node 26.8.1 / Vitest 5 validation: 182 cases passed across the complete auth-refresh-authority integration, auth-bridge, client-runtime and auth-profile-runtime-contract files. The changed-file gate passed, including extension-test typechecking, lint, formatting and plugin boundaries. Fresh independent P2 review found no actionable issues. This is focused correctness proof, not a whole-suite performance claim.
