### PR TITLE
fix(docs): restore anchor ids dropped by heading renames

### DIFF
--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -48,6 +48,8 @@ flowchart TD
 | Execute code on every tool call           | Plugin hooks                               | Typed `api.on(...)` handlers can intercept tool calls  |
 | Always check compliance before replying   | Standing Orders                            | Injected into every session automatically              |
 
+<a id="scheduled-tasks-cron-vs-heartbeat" />
+
 ### Automations vs Heartbeat
 
 | Dimension       | User-authored automations                   | Heartbeat monitor automation            |

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -159,6 +159,8 @@ The button is disabled when the current Control UI session does not have
 administrator access. Use the CLI approval flow below from the Gateway host in
 that case.
 
+<a id="pair-via-telegram-recommended-for-ios" />
+
 ### Pair via Telegram
 
 If you use the `device-pair` plugin, you can do first-time device pairing entirely from Telegram:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -17,6 +17,8 @@ Setup commands by intent:
 - `openclaw configure` changes targeted parts of an existing setup: model auth, gateway, channels, plugins, or skills.
 - `openclaw channels add` configures channel accounts after the baseline exists; a channel selection alone uses guided setup, while account, credential, or channel-config flags use the direct path for scripts.
 
+<a id="status" />
+
 ## Command pages
 
 | Area                         | Commands                                                                                                                                                                                                                              |

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -68,6 +68,8 @@ Full key reference, defaults, and JSON5 examples: [Configuration reference](/gat
 
 Explicit `modelPolicy.allow` restrictions were introduced in v2026.8.1. For directly authored legacy model maps, `openclaw doctor --fix` copies the complete restriction into `modelPolicy.allow` when every ref is valid. If any ref needs provider qualification, Doctor preserves the entire legacy restriction and reports how to set an explicit policy. Until then, model-map edits still change the legacy restriction; no keys are silently dropped and no empty policy is substituted. Include-owned migrations retain the existing edit-owning-file requirement.
 
+<a id="selection-source-and-fallback-behavior" />
+
 ## Selection source and fallback strictness
 
 The same `provider/model` behaves differently depending on where it came from:

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -52,7 +52,7 @@ still resolves. Each entry points at the page that now holds the content.
 - <a id="discord-mantis-scenarios" />[Discord Mantis scenarios](/concepts/qa-e2e-automation/operator-flow#discord-mantis-scenarios)
 - <a id="mantis-slack-desktop-and-visual-task-runners" />[Mantis Slack desktop and visual-task runners](/concepts/qa-e2e-automation/operator-flow#mantis-slack-desktop-and-visual-task-runners)
 - <a id="credential-pool-health-check" />[Credential pool health check](/concepts/qa-e2e-automation/operator-flow#credential-pool-health-check)
-- <a id="canonical-scenario-coverage" />[Canonical scenario coverage](/concepts/qa-e2e-automation/scenario-coverage#canonical-scenario-coverage)
+- <a id="live-transport-coverage" /><a id="canonical-scenario-coverage" />[Canonical scenario coverage](/concepts/qa-e2e-automation/scenario-coverage#canonical-scenario-coverage)
 - <a id="buzz%2C-discord%2C-slack%2C-telegram%2C-and-whatsapp-qa-reference" /><a id="buzz-discord-slack-telegram-and-whatsapp-qa-reference" />[Buzz, Discord, Slack, Telegram, and WhatsApp QA reference](/concepts/qa-e2e-automation/channel-qa-reference#buzz-discord-slack-telegram-and-whatsapp-qa-reference)
 - <a id="shared-cli-flags" />[Shared CLI flags](/concepts/qa-e2e-automation/channel-qa-reference#shared-cli-flags)
 - <a id="buzz-qa" />[Buzz QA](/concepts/qa-e2e-automation/channel-qa-reference#buzz-qa)

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -66,6 +66,8 @@ Node and SSH workspace access and reconciliation outlive worker RPC credential e
 - GitHub CLI (`gh`) on the worker's `PATH` for GitHub commands and HTTPS pushes. The sealed worker bundle includes the credential-binding launcher, not GitHub CLI. Crabbox developer images include `gh`; install it in `settings.setup` for other images.
 - A repository session created with `repository: { url, ref? }`, or a live, registry-owned session managed worktree created with `worktree: true`. Repository sources require a managed node and access to the upstream Git repository. Cloud dispatch does not accept arbitrary plain directories. Manifest mirroring after Git metadata becomes unavailable does not make plain directories dispatchable.
 
+<a id="coordinator-backed-crabbox" />
+
 ### Crabbox provider support
 
 Select a Crabbox backend with `settings.provider`. Use the [Crabbox provider reference](https://crabbox.sh/providers/index.html) for supported providers, authentication, sizing, snapshots, networking, and provider-specific limitations. OpenClaw does not maintain a separate backend catalog; accepting a profile does not establish that the backend can host a cloud session.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -113,6 +113,7 @@ Moved to [Configuration — browser, UI, and desktop](/gateway/config-browser-ui
 
 Moved to [Configuration — gateway](/gateway/config-gateway). Sections: OpenAI-compatible endpoints, Multi-instance isolation, `gateway.tls`, `gateway.reload`.
 
+<a id="gateway-field-details"></a>
 <a id="openai-compatible-endpoints"></a>
 <a id="multi-instance-isolation"></a>
 <a id="gatewaytls"></a>

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -54,6 +54,8 @@ legacy encrypted OAuth sidecar credentials. It must persist for that recovery
 path and remain separate from `OPENCLAW_CONFIG_DIR`, but it does not encrypt
 current SQLite rows or protect a state-only backup or copy.
 
+<a id="build-and-launch" />
+
 ## Run the maintained Docker setup
 
 ```bash
@@ -196,6 +198,8 @@ to the same file in place does not cause this divergence.
 
 Fix: keep the directory mount from Compose. Edit `openclaw.json` on the host
 inside that directory.
+
+<a id="updates" />
 
 ## Update OpenClaw
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -497,6 +497,8 @@ Related Anthropic docs:
 
 </Note>
 
+<a id="safety-refusal-fallback-claude-fable-5" />
+
 ## Safety refusal fallback (Claude Opus 5 and Fable 5)
 
 <Warning>

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -53,6 +53,8 @@ Pick a provider, authenticate, then set the default model as `provider/model`.
 For the full provider catalog and advanced configuration, see
 [Provider directory](/providers/index) and [Model providers](/concepts/model-providers).
 
+<a id="additional-bundled-provider-variants" />
+
 ## Additional provider variants
 
 - `anthropic-vertex` - install `@openclaw/anthropic-vertex-provider` for implicit Anthropic on Google Vertex support when Vertex credentials are available; no separate onboarding auth choice

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -515,6 +515,8 @@ Batch enablement is the only remote batching setting. Concurrency, polling, and 
 
 ---
 
+<a id="session-memory-search-experimental" />
+
 ## Session memory search
 
 Index session transcripts and surface them via `memory_search`:

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -201,6 +201,8 @@ Do not edit those managed directories directly. Use the editor, the
 authorized authoring tool. Runtime copies are separate from project files and
 must not be committed with a project.
 
+<a id="agent-skill-allowlists" />
+
 ## Agent allowlists
 
 Skill **location** (precedence) and skill **visibility** (which agent can use

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -61,6 +61,8 @@ command handling is enabled for the surface.
   </Accordion>
 </AccordionGroup>
 
+<a id="config" />
+
 ## Configuration
 
 ```json5

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -477,6 +477,8 @@ Agent selection and its `overview|files|tools|skills|channels|cron|memory`
 panels use paths. Older links with `?agent=<agentId>` are replaced once with
 the agent path while keeping other query parameters and the fragment.
 
+<a id="special-documents-and-startup-modes" />
+
 ## Other special documents and startup modes
 
 These Gateway-served documents sit outside the application route table:


### PR DESCRIPTION
## What Problem This Solves

Renaming a documentation heading changes its minted id. `docs/AGENTS.md` requires
the old named anchor to survive a reorganization, but fourteen ids were dropped
without an `<a id>` stub, so published links — bookmarks, search results, and
URLs written in source — landed on a page that scrolled nowhere.

Nothing caught it. `docs-link-audit` walks the docs tree only, so a URL living
in source or in a bookmark is invisible to it; and once the in-repo links are
repointed, an id that simply stops being minted breaks no in-repo link at all.

## Why This Change Was Made

PR #143497 repaired nine dead anchors emitted from source code. Three of the
nine were this class — the docs page renamed a heading and the code kept
pointing at the id that no longer existed, so the source was repointed and the
published id stayed dead:

| route | old id | dropped by | successor heading |
|---|---|---|---|
| `/tools/slash-commands` | `config` | `5976f148326` (2026-05-31) | `## Configuration` |
| `/concepts/models` | `selection-source-and-fallback-behavior` | `f7d7148cf04` (2026-07-05) | `## Selection source and fallback strictness` |
| `/cli` | `status` | `bd4cfe0e7e2` (2026-04-23) | content now at `/cli/status`, listed under `## Command pages` |

Each id was established by parsing **every historical revision** of the page
with the repo's own `parseDocsDocument` and diffing the id sets across each
commit — not by re-deriving a slug by hand. `git log -S` on the id itself finds
nothing, because a minted id is never written down anywhere except in links to it.

### The wider sweep

To find the rest of the class rather than only the three that source code
happened to link, every `docs/**/*.md(x)` page was parsed at four snapshots
(2026-05-01, 06-15, 07-15, 08-15) and at the merge base: **3,467 ids** have been
dropped from still-existing pages since May. Intersecting those with every
`route#fragment` reference that has ever appeared **anywhere in the repo** at
those same revisions leaves **29 dropped ids with inbound-link evidence**.
Eleven more are restored here, each with the reference that pointed at it:

| restored | successor heading | one inbound reference |
|---|---|---|
| `/automation#scheduled-tasks-cron-vs-heartbeat` | `### Automations vs Heartbeat` | `docs/reference/templates/AGENTS.md:102` |
| `/channels/pairing#pair-via-telegram-recommended-for-ios` | `### Pair via Telegram` | `docs/channels/telegram.md:390` |
| `/gateway/cloud-workers#coordinator-backed-crabbox` | `### Crabbox provider support` | `docs/gateway/configuration-reference.md:972` |
| `/install/docker-vm-runtime#build-and-launch` | `## Run the maintained Docker setup` | `docs/install/gcp.md:293` |
| `/install/docker-vm-runtime#updates` | `## Update OpenClaw` | `docs/install/gcp.md:295` |
| `/providers/anthropic#safety-refusal-fallback-claude-fable-5` | `## Safety refusal fallback (Claude Opus 5 and Fable 5)` | `docs/concepts/model-failover.md:300` |
| `/providers/models#additional-bundled-provider-variants` | `## Additional provider variants` | `docs/providers/index.md:84` |
| `/reference/memory-config#session-memory-search-experimental` | `## Session memory search` | `docs/concepts/experimental-features.md:27` |
| `/tools/skills#agent-skill-allowlists` | `## Agent allowlists` | `docs/concepts/multi-agent.md:40` |
| `/web/urls#special-documents-and-startup-modes` | `## Other special documents and startup modes` | `docs/web/control-ui.md:285` |
| `/concepts/qa-e2e-automation#live-transport-coverage` | moved-list entry for `canonical-scenario-coverage` | `docs/concepts/qa-matrix.md:132` |
| `/gateway/configuration-reference#gateway-field-details` | moved-list entry for `/gateway/config-gateway` | `docs/nodes/index.md:252` |

The last two use each file's own "Where each section moved" convention: those
ids were renamed *before* the page was split, so the split preserved only the
post-rename spelling.

### Deliberately not stubbed

Thirteen of the 29 are **not** heading renames — the documented thing was
removed, so a stub would land a reader on a page that no longer covers it.
Listed rather than fixed, with the commit that removed each:

- `/gateway/configuration-reference` `#commitments` (`edecdbd05ef`), `#worktrees` (`783a5d21cfc`) — config-surface reduction
- `/gateway/config-tools` `#toolsexperimental` (`d7ef7fc5a6c`) — `tools.experimental` promoted to `tools.updatePlan`; that commit deliberately replaced the authored stub
- `/install/docker` `#shell-helpers-optional` (`ee0d376e0fe`) — ClawDock shell helpers retired
- `/plugins/sdk-migration` `#active-deprecations` (`c7e7ac27289`) — expired compatibility surfaces removed
- `/plugins/community` `#wecom`, `#yuanbao` (`079bf996716`) — the listed-plugins section is gone
- `/concepts/dreaming` `#dreaming-never-runs-status-shows-blocked` (`f7d7148cf04`) — no successor heading
- `/gateway/openai-http-api` `#model-list-and-agent-routing` (`f7d7148cf04`) — section removed in the rewrite
- `/gateway/security` `#security-audit-checklist` (`f7d7148cf04`) — restructured, no single successor
- `/gateway/troubleshooting` `#gateway-restored-last-known-good-config` (`0ee52e94054`) — became `## Gateway rejected invalid config`, a different symptom
- `/plugins/codex-harness` `#inspect-a-codex-thread-from-the-cli`, `#v1-support-contract` (`ce0584af89b`) — the page moved to `/plugins/codex-harness-runtime`; redirect territory, not a stub
- `/providers/zai` `#thinking-and-preserved-thinking` (`f7d7148cf04`) — an `<Accordion title>` id, not a heading; component ids carry a document-wide verbatim-marker index and were never stable anchors

## User Impact

Fourteen previously published documentation URLs resolve again. No heading, link,
route, or rendered wording changes; every diff hunk is an added `<a id>` stub.

## Evidence

Every changed page's id set was enumerated with `parseDocsDocument` before and
after. All 14 pages: strict superset, exactly one (two for
`docker-vm-runtime.md`) id gained, **zero lost**, `collisions: []`, no duplicate
authored/canonical id.

```
PASS docs/automation/index.md                before=12 after=13 gained=[scheduled-tasks-cron-vs-heartbeat]
PASS docs/channels/pairing.md                before=16 after=17 gained=[pair-via-telegram-recommended-for-ios]
PASS docs/cli/index.md                       before=10 after=11 gained=[status]
PASS docs/concepts/models.md                 before=21 after=22 gained=[selection-source-and-fallback-behavior]
PASS docs/concepts/qa-e2e-automation.md      before=27 after=28 gained=[live-transport-coverage]
PASS docs/gateway/cloud-workers.md           before=27 after=28 gained=[coordinator-backed-crabbox]
PASS docs/gateway/configuration-reference.md before=60 after=61 gained=[gateway-field-details]
PASS docs/install/docker-vm-runtime.md       before=10 after=12 gained=[build-and-launch,updates]
PASS docs/providers/anthropic.md             before=45 after=46 gained=[safety-refusal-fallback-claude-fable-5]
PASS docs/providers/models.md                before= 6 after= 7 gained=[additional-bundled-provider-variants]
PASS docs/reference/memory-config.md         before=33 after=34 gained=[session-memory-search-experimental]
PASS docs/tools/skills.md                    before=59 after=60 gained=[agent-skill-allowlists]
PASS docs/tools/slash-commands.md            before=55 after=56 gained=[config]
PASS docs/web/urls.md                        before=13 after=14 gained=[special-documents-and-startup-modes]

14 changed docs pages, 0 failing
```

Baseline measured in a detached worktree at the merge base `f98cd2d29b5`, not
at `origin/main` (which moves several times an hour).

- `pnpm check:docs` — **pass**, exit 0. Formatting clean (1280 files), markdownlint 1279 files / 0 issues, templates, mdx, i18n glossary, links, config examples.
- `node scripts/docs-link-audit.mjs --anchors` — output **byte-identical** to the merge-base baseline: `checked_internal_links=13320`, `broken_links=3`, `omitted_compatibility_aliases=0`. All three are the pre-existing `#windows-app-node` errors in `docs/maturity/`.
- `python3 .audit/stranded-stubs.py docs` — **0 suspect stubs** (each stub travels with the heading below it).
- `vitest --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files, 16 tests, pass**.
- `vitest --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — 1 file, **1 failed | 32 passed**. Pre-existing and unrelated: the identical failure (`expected [ 'ass-guide', 'param-ass-guide' ] to deeply equal [ 'as-s-guide', 'param-as-s-guide' ]`, `src/scripts/docs-link-audit.test.ts:155`) reproduces at the merge base in a clean detached worktree.

No new files, so `.github/labeler.yml` needs no new glob. No route changed, so no
redirect and no `docs.json` edit. No new page titles or list-item link labels, so
`docs/.i18n/glossary.zh-CN.json` needs no entries (`docs:check-i18n-glossary` passes).

## Review findings addressed

Both blocking items from the previous revision are resolved by descoping, not by
argument:

- **[P3] Leave the historical changelog correction to the release workflow.** Correct, and the policy citation is right: `CONTRIBUTING.md:82` says not to edit `CHANGELOG.md` in normal PRs. The hunk is **removed**. Context retained here for release-owned maintenance: `CHANGELOG.md:25601` still links `https://docs.openclaw.ai/tools/thinking#fast-mode-fast`, an id that has **never existed** — the heading has always been `## Fast mode (/fast)`, which mints `fast-mode-(%2Ffast)` and `fast-mode-/fast`. `e45a9460ce3` repaired the same link in `docs/releases/2026.6.11.md`, `docs/providers/openai/advanced.md` and `docs/concepts/model-providers/official-provider-plugins.md` and missed the CHANGELOG copy; the correct destination is `#fast-mode-%2Ffast`.
- **[P1] Security-owner involvement for the sandboxing documentation change.** `.github/CODEOWNERS` (last-match-wins, simulated with working positive and negative controls) puts `/docs/gateway/sandboxing.md` under `@openclaw/openclaw-secops`, and that review cannot be obtained from inside this PR. Rather than merge around the requirement, the hunk is **removed**; no changed path in this revision has a CODEOWNERS entry. The dropped change was one line, and is ready to re-send to secops on its own:

  ```diff
  -- <a id="multiple-folders-for-one-agent" />[Multiple folders for one agent](…)
  ++ <a id="custom-bind-mounts" /><a id="multiple-folders-for-one-agent" />[Multiple folders for one agent](…)
  ```

  `/gateway/sandboxing#custom-bind-mounts` was renamed to `#multiple-folders-for-one-agent` by `b44bab171d0` (2026-07-16), before the page was split, so the split's "Where each section moved" list preserved only the post-rename spelling. It was linked from `docs/channels/groups.md:194`.
