### PR TITLE
refactor(fleet): define command target boundary

### DIFF
--- a/src/cli/fleet-cli/commands.runtime.ts
+++ b/src/cli/fleet-cli/commands.runtime.ts
@@ -8,13 +8,14 @@ import {
   type FleetLogsOptions,
 } from "../../fleet/service.runtime.js";
 import { defaultRuntime } from "../../runtime.js";
+import type { FleetCommandTarget } from "./target.js";
 
-const fleetService = createFleetService();
+const fleetTarget: FleetCommandTarget = createFleetService();
 
 export async function runFleetCreateCommand(
   options: FleetCreateOptions & { json: boolean },
 ): Promise<void> {
-  const result = await fleetService.create(options);
+  const result = await fleetTarget.create(options);
   if (options.json) {
     defaultRuntime.writeJson(result);
     return;
@@ -33,7 +34,7 @@ export async function runFleetBackupCommand(options: {
   maxBytes?: number;
   json: boolean;
 }): Promise<void> {
-  const result = await fleetService.backup(options);
+  const result = await fleetTarget.backup(options);
   if (options.json) {
     defaultRuntime.writeJson(result);
     return;
@@ -54,7 +55,7 @@ export async function runFleetRestoreCommand(options: {
   maxBytes?: number;
   json: boolean;
 }): Promise<void> {
-  const result = await fleetService.restore(options);
+  const result = await fleetTarget.restore(options);
   if (options.json) {
     defaultRuntime.writeJson(result);
     return;
@@ -68,7 +69,7 @@ export async function runFleetDoctorCommand(options: {
   tenant?: string;
   json: boolean;
 }): Promise<void> {
-  const reports = await fleetService.doctor(options.tenant);
+  const reports = await fleetTarget.doctor(options.tenant);
   if (options.json) {
     defaultRuntime.writeJson(reports);
   } else {
@@ -99,7 +100,7 @@ export async function runFleetDoctorCommand(options: {
 }
 
 export async function runFleetListCommand(options: { json: boolean }): Promise<void> {
-  const cells = await fleetService.list();
+  const cells = await fleetTarget.list();
   if (options.json) {
     defaultRuntime.writeJson({ cells });
     return;
@@ -143,7 +144,7 @@ export async function runFleetStatusCommand(options: {
   tenant: string;
   json: boolean;
 }): Promise<void> {
-  const result = await fleetService.status(options.tenant);
+  const result = await fleetTarget.status(options.tenant);
   if (options.json) {
     defaultRuntime.writeJson(result);
     return;
@@ -159,14 +160,14 @@ export async function runFleetStatusCommand(options: {
 }
 
 export async function runFleetLogsCommand(options: FleetLogsOptions): Promise<void> {
-  await fleetService.logs(options);
+  await fleetTarget.logs(options);
 }
 
 export async function runFleetLifecycleCommand(options: {
   tenant: string;
   action: FleetLifecycleAction;
 }): Promise<void> {
-  const result = await fleetService.lifecycle(options.tenant, options.action);
+  const result = await fleetTarget.lifecycle(options.tenant, options.action);
   defaultRuntime.log(`${result.action} complete for fleet cell ${result.tenant}.`);
 }
 
@@ -174,7 +175,7 @@ export async function runFleetUpgradeCommand(options: {
   tenant: string;
   image?: string;
 }): Promise<void> {
-  const result = await fleetService.upgrade(options.tenant, options.image);
+  const result = await fleetTarget.upgrade(options.tenant, options.image);
   defaultRuntime.log(`Upgraded fleet cell ${result.tenant} to ${result.image}.`);
 }
 
@@ -183,7 +184,7 @@ export async function runFleetRemoveCommand(options: {
   purgeData: boolean;
   force: boolean;
 }): Promise<void> {
-  const result = await fleetService.remove(options);
+  const result = await fleetTarget.remove(options);
   defaultRuntime.log(
     result.dataPurged
       ? `Removed fleet cell ${result.tenant} and purged its data.`

--- a/src/cli/fleet-cli/target.ts
+++ b/src/cli/fleet-cli/target.ts
@@ -1,0 +1,23 @@
+import type { createFleetService } from "../../fleet/service.runtime.js";
+
+type LocalFleetService = ReturnType<typeof createFleetService>;
+
+/**
+ * Lifecycle surface consumed by Fleet commands for one selected execution target.
+ *
+ * This is an in-process adapter contract, not a transport schema. A remote target
+ * must translate these command inputs into a separately validated, bounded wire
+ * protocol rather than forwarding secrets, environment entries, or host paths.
+ */
+export interface FleetCommandTarget {
+  create: LocalFleetService["create"];
+  list: LocalFleetService["list"];
+  status: LocalFleetService["status"];
+  logs: LocalFleetService["logs"];
+  lifecycle: LocalFleetService["lifecycle"];
+  upgrade: LocalFleetService["upgrade"];
+  backup: LocalFleetService["backup"];
+  restore: LocalFleetService["restore"];
+  doctor: LocalFleetService["doctor"];
+  remove: LocalFleetService["remove"];
+}


### PR DESCRIPTION
Related: #143471

## What Problem This Solves

Fleet CLI commands currently bind directly to the concrete single-host lifecycle service. That leaves no explicit command-side boundary where a future target resolver can choose the existing local executor or a paired-node executor without pushing remote concerns into the container runtime.

This draft makes that boundary reviewable while the product and security contracts in #143471 are decided.

## Why This Change Was Made

Define a narrow CLI-owned `FleetCommandTarget` structural contract and have the current local `createFleetService()` implementation conform directly. The contract is explicitly in-process and is not a transport or wire schema, so secret-bearing create inputs, host paths, backup paths, and log streams are not accidentally blessed as remote protocol fields.

This draft does **not** add a target flag, target persistence, paired-node dispatch, remote Docker/SSH access, Swarm scheduling, or any user-visible behavior. Persistent-state and private-protocol work remains pending the product/security decision in #143471 and the lifecycle prerequisite in #143098.

## User Impact

No user-visible behavior changes in this draft. Existing local Fleet commands keep the same inputs, outputs, lifecycle ownership, and lazy CLI loading.

If the design is accepted, this boundary is intended to let a later PR resolve an explicitly selected local or paired-node target above the existing host-local Fleet service.

## Evidence

- `node scripts/run-vitest.mjs src/cli/fleet-cli/commands.runtime.test.ts src/cli/fleet-cli/register.test.ts` — 23 tests passed.
- `node scripts/check-changed.mjs --base upstream/main` — core/coreTests changed gate passed.
- `pnpm exec oxfmt --check src/cli/fleet-cli/commands.runtime.ts src/cli/fleet-cli/target.ts` — passed.
- `git diff --check` — passed.
- Independent test audit found no new test was justified: compile-time conformance plus the existing CLI suites protect this behavior-neutral boundary without adding an implementation-mirroring forwarding test.

### Known design gates

- #143471 is labeled for a product decision and security review.
- #143098 must land before remote lifecycle work proceeds.
- Future paired-node operations require separately validated, bounded, versioned DTOs. This in-process interface must not be reused as that wire contract.

<!-- morrow-fleet-real-proof-20260910:start -->
## Real Behavior Proof

**HEAD:** `591c93dab2e6ae2583ac4946cd932c3d5925909e`

**Claim:** The registered `fleet list` command still reaches the real local Fleet service after this behavior-preserving command-target refactor. JSON and human output reflect the explicitly selected canonical SQLite registry; the synthetic ambient-decoy registry is not returned by the selected-state invocation.

**Exercised surface:** A source launcher creates a real Commander `Command`, calls production `registerFleetCli`, and parses `fleet list --json` / `fleet list`. Registration lazily loads the production command handler, which calls the production `createFleetService().list()`, the canonical SQLite `listFleetCells`, and the default Docker adapter. No handlers, services, registry methods, command executors, output writers, or dependencies are mocked or injected. Only the stored input records are synthetic, seeded through canonical `reserveFleetCell`.

This is **source-registered CLI evidence**, not a packaged/built `openclaw` executable or full-app bootstrap run. The installed `tsx` runner was used without installing dependencies or building OpenClaw.

**Environment:** Kali GNU/Linux 2026.3, Linux x86_64; Node `v24.19.0`; installed pnpm `12.3.4`; Docker client/server `28.5.2+dfsg4`. Runtime selection was pinned to the local Unix Docker socket and a task-only empty Docker config. The source child received an allowlisted, nonsecret environment, an explicitly selected task-only `OPENCLAW_STATE_DIR`, and a nonexistent task-only config path. `HOME` was not changed. No operator Fleet state, real cell data, Gateway, or container lifecycle operation was used.

**Scenario:**

1. Confirm local Docker and independently confirm two UUID-named synthetic containers do not exist.
2. Use `reserveFleetCell` to seed `proof-selected` (port 43101) in one real canonical SQLite store and `proof-decoy` (port 43102) in a different synthetic store. Both fixture image strings are `ghcr.io/openclaw/openclaw:2026.9.3`; no image is pulled or started.
3. Keep the proof controller's ambient state set to the decoy. Run the registered CLI once against that decoy, then explicitly override `OPENCLAW_STATE_DIR` for selected-state JSON and human runs, then run against a fresh empty state.
4. Observe distinct selected/decoy output, `missing` from the real Docker inspection, and the selected run's actual child-process command trace.
5. Compare SQLite records, schema, and main-database hashes before/after; confirm the empty run created no database and the source worktree remains clean at the tested HEAD. Task-only fixtures are retained with the evidence; no services were created or changed.

**Executed command:**

```console
python3 /tmp/openclaw-143589-proof-20260910/run-proof.py
```

The exact selected-state child invocation (cwd `/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910`) was:

```console
env -i DOCKER_CONFIG=/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910/docker-config DOCKER_HOST=unix:///var/run/docker.sock FLEET_DECOY_CONTAINER_NAME=fleet-proof-143589-decoy-ec18d4e16fe8494ba0ed09fe4843db1c FLEET_PROOF_ARTIFACT_DIR=/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910 FLEET_PROOF_WORKTREE=/home/rev/projects/openclaw-prs/fleet-paired-targets FLEET_SELECTED_CONTAINER_NAME=fleet-proof-143589-selected-ec18d4e16fe8494ba0ed09fe4843db1c HOME=/home/rev LANG=C.UTF-8 NODE_DEBUG=child_process NO_COLOR=1 OPENCLAW_CONFIG_PATH=/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910/nonexistent-openclaw.json OPENCLAW_STATE_DIR=/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910/selected PATH=/usr/bin:/bin TMPDIR=/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910/runtime-tmp TSX_DISABLE_CACHE=1 /usr/bin/node /home/rev/projects/openclaw-prs/fleet-paired-targets/node_modules/tsx/dist/cli.mjs --tsconfig /home/rev/projects/openclaw-prs/fleet-paired-targets/tsconfig.json /home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910/source-fleet-cli.mts fleet list --json
```

**Relevant raw output:**

```text
HEAD=591c93dab2e6ae2583ac4946cd932c3d5925909e
PLATFORM=Linux x86_64
v24.19.0
client=28.5.2+dfsg4 server=28.5.2+dfsg4
```

Selected-state `fleet list --json` (exit 0):

```json
{
  "cells": [
    {
      "tenant": "proof-selected",
      "state": "missing",
      "port": 43101,
      "image": "ghcr.io/openclaw/openclaw:2026.9.3",
      "created": "2026-09-10T12:00:00.000Z"
    }
  ]
}
```

Competing decoy `fleet list --json` (exit 0):

```json
{
  "cells": [
    {
      "tenant": "proof-decoy",
      "state": "missing",
      "port": 43102,
      "image": "ghcr.io/openclaw/openclaw:2026.9.3",
      "created": "2026-09-10T12:00:00.000Z"
    }
  ]
}
```

Fresh empty state `fleet list --json` (exit 0):

```json
{
  "cells": []
}
```

The selected run's raw Node child-process diagnostics show the production adapter commands (excerpts only; full trace retained):

```text
  args: [ 'docker', 'context', 'inspect' ],
  args: [
    'docker',
    'container',
    'inspect',
    'fleet-proof-143589-selected-ec18d4e16fe8494ba0ed09fe4843db1c'
  ],
```

The independent precondition check returned `Error response from daemon: No such container` for that same selected synthetic name. Human output also showed `proof-selected`, `missing`, and `43101` without the decoy. Final assertions reported:

```text
PASS: selected registry returns proof-selected/missing; competing decoy returns proof-decoy/missing; selected output excludes decoy.
PASS: empty state returns {"cells": []} without creating a database.
PASS: selected and decoy SQLite rows/schema/main-file hashes unchanged; source worktree remains clean at tested HEAD.
```

**Artifacts:** Local retained evidence directory `/tmp/openclaw-143589-proof-20260910` is a symlink to root-backed `/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910`. It contains the complete launcher/setup/controller (`source-fleet-cli.mts`, `seed-registry.mts`, `run-proof.py`), exact per-process environment/commands (`commands.json`), stdout/stderr, full selected-run child-process trace, before/after SQLite observations, `transcript.txt`, and `result.json`. These are local artifacts, not public download links; decisive observed output is included above.

**Observed result:** PASS for this real source-registered local list path, including selected-state routing, nonempty JSON/human output, missing-container inspection, and empty state.

**Not tested:** Built/package executable and full CLI bootstrap; create/start/stop/restart/upgrade/remove/backup/restore/status/logs/doctor; running-container health or lifecycle; Podman; paired/remote targets; non-Linux systems; version upgrade or migration; concurrency. This PR is a behavior-preserving refactor, not a defect repair, so no failing-before/passing-after defect reproduction is claimed. Proof does not establish maintainer sponsorship or design acceptance.

## Separate Review Blockers

- **Maintainer sponsorship remains unresolved.** The review requires an explicit maintainer request tied to a concrete accepted fix/deliverable. This evidence does not supply that decision; retain draft/deferred status until it is established.
- **Stored-data-model classification:** The pinned patch changes only `commands.runtime.ts` and the type-only `target.ts`. Reversing the local-variable rename and removing the type-only import/annotation yields byte-identical pre-refactor command source; all ten service calls and arguments are preserved. No registry/schema/migration source changes. The synthetic current-schema read proof above is not an upgrade test. Please reassess the migration/backfill/repair classification against that actual diff rather than treating this as migration evidence.
- **Review status is not self-assigned.** This records executed proof for review; it does not claim Platinum/Ready or waive the maintainer decision. Any subsequent code change requires affected proof rerun at the new full HEAD.

**Maintainer decision request:** Do you explicitly sponsor this standalone behavior-preserving Fleet command-target refactor for a concrete accepted deliverable under #143471? If so, please identify that deliverable and its scope. Otherwise this draft remains deferred; the new local CLI proof does not imply acceptance of the paired-node design.

## Sources

- Current review: https://github.com/openclaw/openclaw/pull/143589#issuecomment-5611555641
- Pinned published proof contract: https://github.com/openclaw/clawsweeper/blob/3d77465b6b6efa3bc111b069b06b3bfdf05630cf/CONTRIBUTING.md#L71-L98
- Actual proof/readiness rubric at the same revision: https://github.com/openclaw/clawsweeper/blob/3d77465b6b6efa3bc111b069b06b3bfdf05630cf/prompts/review-item.md#L550-L568 and https://github.com/openclaw/clawsweeper/blob/3d77465b6b6efa3bc111b069b06b3bfdf05630cf/prompts/review-item.md#L1138-L1161
- Production registration: https://github.com/openclaw/openclaw/blob/591c93dab2e6ae2583ac4946cd932c3d5925909e/src/cli/fleet-cli/register.ts#L164-L173
- Production handler: https://github.com/openclaw/openclaw/blob/591c93dab2e6ae2583ac4946cd932c3d5925909e/src/cli/fleet-cli/commands.runtime.ts#L102-L110
- Existing real service/registry: https://github.com/openclaw/openclaw/blob/591c93dab2e6ae2583ac4946cd932c3d5925909e/src/fleet/service.runtime.ts#L422-L458 and https://github.com/openclaw/openclaw/blob/591c93dab2e6ae2583ac4946cd932c3d5925909e/src/fleet/registry.ts#L87-L107
- Sponsorship policy: https://github.com/openclaw/openclaw/blob/591c93dab2e6ae2583ac4946cd932c3d5925909e/CONTRIBUTING.md#L21

<details>
<summary>Standalone source launcher and canonical fixture setup</summary>

`source-fleet-cli.mts`:

```typescript
import assert from "node:assert/strict";
import path from "node:path";
import { pathToFileURL } from "node:url";

// An explicit source-registered CLI launcher, not the built/package entrypoint.
// No service, registry, runtime, output writer, or child-process mocks/injections.
const worktree = process.env.FLEET_PROOF_WORKTREE;
assert.equal(worktree, "/home/rev/projects/openclaw-prs/fleet-paired-targets");
const args = process.argv.slice(2);
assert.equal(args[0], "fleet");
assert.ok(args[1] === "list" || args[1] === "ls");
assert.ok(args.length === 2 || (args.length === 3 && args[2] === "--json"));
const { Command } = await import(pathToFileURL(path.join(worktree, "node_modules/commander/index.js")).href);
const { registerFleetCli } = await import(pathToFileURL(path.join(worktree, "src/cli/fleet-cli/register.ts")).href);
const program = new Command().name("openclaw");
registerFleetCli(program);
await program.parseAsync(args, { from: "user" });
```

`seed-registry.mts`:

```typescript
import assert from "node:assert/strict";
import path from "node:path";
import { pathToFileURL } from "node:url";

const worktree = process.env.FLEET_PROOF_WORKTREE;
const artifactDir = process.env.FLEET_PROOF_ARTIFACT_DIR;
assert.equal(worktree, "/home/rev/projects/openclaw-prs/fleet-paired-targets");
assert.equal(artifactDir, "/home/rev/projects/openclaw-prs/openclaw-143589-proof-20260910");
const { reserveFleetCell, listFleetCells } = await import(pathToFileURL(path.join(worktree, "src/fleet/registry.ts")).href);
const { closeOpenClawStateDatabaseByPath } = await import(pathToFileURL(path.join(worktree, "src/state/openclaw-state-db.ts")).href);
const { resolveOpenClawStateSqlitePath } = await import(pathToFileURL(path.join(worktree, "src/state/openclaw-state-db.paths.ts")).href);
for (const [stateName, tenantId, requestedPort, containerName] of [
  ["selected", "proof-selected", 43101, process.env.FLEET_SELECTED_CONTAINER_NAME],
  ["ambient-decoy", "proof-decoy", 43102, process.env.FLEET_DECOY_CONTAINER_NAME],
] as const) {
  assert.ok(containerName?.startsWith("fleet-proof-143589-"));
  const stateDir = path.join(artifactDir, stateName);
  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
  const record = reserveFleetCell(env, {
    tenantId,
    createdAtMs: Date.parse("2026-09-10T12:00:00.000Z"),
    image: "ghcr.io/openclaw/openclaw:2026.9.3",
    runtime: "docker",
    requestedPort,
    containerName,
    dataDir: path.join(stateDir, "fleet", "cells", tenantId),
  });
  assert.deepEqual(listFleetCells(env), [record]);
  const databasePath = resolveOpenClawStateSqlitePath(env);
  assert.equal(closeOpenClawStateDatabaseByPath(databasePath), true);
  console.log(JSON.stringify({ stateName, databasePath, record }));
}
```

</details>

<!-- morrow-fleet-real-proof-20260910:end -->
