### PR TITLE
fix: retain foreground compaction resources through disposal

### DIFF
--- a/src/agents/embedded-agent-runner/compact.foreground-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.foreground-resources.test.ts
@@ -1,0 +1,439 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import {
+  loadSessionEntryReadOnly,
+  loadTranscriptEventsSync,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { PluginRegistryInspectionResources } from "../../plugins/registry-inspection-resources.js";
+import { createPluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry, resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { createPluginRuntime } from "../../plugins/runtime/index.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { closePreparedModelRuntimeSnapshots } from "../prepared-model-runtime.lifecycle.js";
+import { SessionManager } from "../sessions/session-manager.js";
+import { compactEmbeddedAgentSession } from "./compact.queued.js";
+import { waitForDeferredTurnMaintenanceForSession } from "./context-engine-maintenance.js";
+
+// Exercise the existing managed producer without enabling RUN resource disposal.
+vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../prepared-model-runtime.js")>();
+  return {
+    ...actual,
+    acquireAgentRunPreparedModelRuntime: (
+      input: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[0],
+      options: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[1],
+    ) => {
+      const provider = input.config.plugins?.allow?.[0];
+      if (!provider) {
+        throw new Error("Foreground fixture provider is missing");
+      }
+      return actual.acquireReadOnlyPreparedModelRuntime(
+        {
+          ...input,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [{ provider, modelId: "model", agentId: "main" }],
+        },
+        options?.abortSignal,
+        "static",
+      );
+    },
+  };
+});
+
+it.each([
+  { mode: "timeout", factory: "none", deferred: false },
+  { mode: "caller-abort", factory: "none", deferred: false },
+  { mode: "success-tail", factory: "none", deferred: false },
+  { mode: "factory-service", factory: "service", deferred: false },
+  { mode: "factory-signal", factory: "signal", deferred: false },
+  { mode: "operation-signal", factory: "service", deferred: false },
+  { mode: "deferred-factory-service", factory: "service", deferred: true },
+  { mode: "deferred-factory-signal", factory: "signal", deferred: true },
+] as const)(
+  "retains $mode resources through disposal without retaining write authority",
+  async ({ mode, factory, deferred }) => {
+    const state = await createOpenClawTestState({
+      prefix: "openclaw-foreground-compaction-",
+      layout: "split",
+    });
+    try {
+      const pluginId = `foreground-${mode}-fixture`;
+      const pluginRoot = state.path("plugin");
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.mkdirSync(state.workspaceDir, { recursive: true });
+      fs.mkdirSync(state.agentDir(), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: pluginId,
+          version: "1.0.0",
+          openclaw: { extensions: ["./index.cjs"] },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: pluginId,
+          providers: [pluginId],
+          configSchema: { type: "object" },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "index.cjs"),
+        `module.exports = {
+          id: '${pluginId}', register(api) {
+            api.registerProvider({ id: '${pluginId}', label: 'Foreground fixture', auth: [] });
+          }
+        };`,
+      );
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: state.workspaceDir,
+            model: { primary: `${pluginId}/model` },
+            compaction: { timeoutSeconds: 1 },
+          },
+        },
+        models: {
+          providers: {
+            [pluginId]: {
+              api: "openai-completions",
+              apiKey: "synthetic-fixture",
+              baseUrl: "https://fixture.invalid/v1",
+              models: [
+                {
+                  id: "model",
+                  name: "Model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          allow: [pluginId],
+          load: { paths: [pluginRoot] },
+          slots: { memory: "none", contextEngine: pluginId },
+          entries: { [pluginId]: { enabled: true } },
+        },
+      };
+      await state.writeConfig(config);
+      const target = {
+        agentId: "main",
+        sessionId: "foreground-registration",
+        sessionKey: "agent:main:foreground-registration",
+        storePath: state.path("sessions.sqlite"),
+      };
+      await replaceSessionEntry(target, {
+        sessionId: target.sessionId,
+        updatedAt: 1,
+        lifecycleRevision: "foreground-lifecycle",
+        activeWriterRunId: "foreground-writer",
+      });
+      const firstEntryId = SessionManager.open(target, state.workspaceDir).appendMessage({
+        role: "user",
+        content: "Preserve this conversation.",
+        timestamp: 1,
+      });
+      const entryBefore = structuredClone(loadSessionEntryReadOnly(target));
+      const transcriptBefore = loadTranscriptEventsSync(target);
+      const entered = createDeferredCore();
+      const resume = createDeferredCore();
+      const disposalEntered = createDeferredCore();
+      const cleanupTailEntered = createDeferredCore();
+      const finishDisposal = createDeferredCore();
+      const closed = createDeferredCore();
+      const stopFactory = createDeferredCore();
+      const forceDisposal = createDeferredCore();
+      const factoryAborted = createDeferredCore();
+      const operationAborted = createDeferredCore();
+      const parent = deferred ? new AsyncWorkScope() : undefined;
+      let factorySignal: AbortSignal | undefined;
+      let factoryCloseContextMatches = false;
+      let factoryClosedAfterDisposalStarted = false;
+      const work: Promise<unknown>[] = [];
+      const values: unknown[] = [];
+      let lateWriteBlocked = false;
+      let disposalCalls = 0;
+      let physicalDisposals = 0;
+      let workSignal: AbortSignal | undefined;
+      let backendSignal: AbortSignal | undefined;
+      let disposalContextMatches = false;
+      let selectedRegistry: ReturnType<typeof getPluginRuntimeGatewayRequestScope>;
+      const file = state.path("registration.sqlite");
+      const db = new DatabaseSync(file);
+      db.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+      const donor = createPluginRegistry({
+        runtime: createPluginRuntime(),
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+        activateGlobalSideEffects: false,
+      });
+      const source = new PluginRegistryInspectionResources();
+      source.attach(donor.registry);
+      const record = createPluginRecord({
+        id: pluginId,
+        source: path.join(pluginRoot, "index.cjs"),
+      });
+      donor.registry.plugins.push(record);
+      const api = donor.createApi(record, { config, registrationMode: "full" });
+      source.runRegistration(pluginId, () => {
+        api.lifecycle.registerRuntimeLifecycle({
+          id: "database",
+          dispose() {
+            physicalDisposals++;
+            db.close();
+            closed.resolve();
+          },
+        });
+        api.registerContextEngine(pluginId, () => {
+          if (factory !== "none") {
+            factorySignal = getAsyncWorkSignal();
+            const registry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+            factorySignal?.addEventListener(
+              "abort",
+              () => {
+                factoryCloseContextMatches =
+                  getPluginRuntimeGatewayRequestScope()?.pluginRegistry === registry;
+                factoryClosedAfterDisposalStarted = disposalCalls > 0;
+                factoryAborted.resolve();
+              },
+              { once: true },
+            );
+            const service = trackAsyncWork(async () => {
+              await stopFactory.promise;
+              values.push(db.prepare("SELECT value FROM answer").get()?.value);
+            });
+            work.push(service);
+            void service.catch(() => {});
+          }
+          return {
+            info: {
+              id: pluginId,
+              name: "Foreground fixture",
+              ownsCompaction: true,
+              ...(deferred ? { turnMaintenanceMode: "background" as const } : {}),
+            },
+            ingest: async () => ({ ingested: false }),
+            assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+            async maintain() {
+              selectedRegistry = getPluginRuntimeGatewayRequestScope();
+              entered.resolve();
+              await resume.promise;
+              return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+            },
+            compact(params) {
+              if (deferred) {
+                throw new Error("Expected deferred maintenance");
+              }
+              workSignal = getAsyncWorkSignal();
+              workSignal?.addEventListener("abort", () => operationAborted.resolve(), {
+                once: true,
+              });
+              backendSignal = params.abortSignal;
+              selectedRegistry = getPluginRuntimeGatewayRequestScope();
+              if (factory !== "none") {
+                entered.resolve();
+                return Promise.resolve({ ok: true, compacted: false });
+              }
+              const manager = SessionManager.open(target, state.workspaceDir);
+              const compact = async () => {
+                entered.resolve();
+                await resume.promise;
+                if (mode === "success-tail") {
+                  workSignal?.throwIfAborted();
+                }
+                try {
+                  manager.appendCompaction("Late summary", firstEntryId, 100);
+                } catch {
+                  lateWriteBlocked = true;
+                }
+                values.push(db.prepare("SELECT value FROM answer").get()?.value);
+                return { ok: true, compacted: false };
+              };
+              const pending = mode === "success-tail" ? trackAsyncWork(compact) : compact();
+              work.push(pending);
+              void pending.catch(() => {});
+              return mode === "success-tail"
+                ? Promise.resolve({ ok: true, compacted: false })
+                : pending;
+            },
+            async dispose() {
+              disposalCalls++;
+              disposalEntered.resolve();
+              const capturedSignal =
+                mode === "operation-signal"
+                  ? workSignal
+                  : factory === "signal"
+                    ? factorySignal
+                    : undefined;
+              if (capturedSignal && !capturedSignal.aborted) {
+                await Promise.race([
+                  mode === "operation-signal" ? operationAborted.promise : factoryAborted.promise,
+                  forceDisposal.promise,
+                ]);
+              }
+              stopFactory.resolve();
+              disposalContextMatches =
+                getPluginRuntimeGatewayRequestScope()?.pluginRegistry ===
+                selectedRegistry?.pluginRegistry;
+              const pending = trackAsyncWork(async () => {
+                cleanupTailEntered.resolve();
+                await finishDisposal.promise;
+                values.push(db.prepare("SELECT value FROM answer").get()?.value);
+              });
+              work.push(pending);
+              void pending.catch(() => {});
+            },
+          };
+        });
+      });
+      setActivePluginRegistry(donor.registry);
+      const caller = new AbortController();
+      const callerReason = new Error("foreground compaction caller cancelled");
+      let pending: Promise<unknown> | undefined;
+      try {
+        expect(getAsyncWorkSignal()).toBeUndefined();
+        const start = () =>
+          compactEmbeddedAgentSession({
+            ...target,
+            sessionTarget: target,
+            sessionFile: target.sessionKey,
+            workspaceDir: state.workspaceDir,
+            agentDir: state.agentDir(),
+            config,
+            provider: pluginId,
+            model: "model",
+            trigger: deferred ? "budget" : "manual",
+            ...(deferred ? { deferOwningContextEngineCompaction: true } : {}),
+            abortSignal: caller.signal,
+            enqueue: async (task) => await task(),
+          });
+        const completion = parent ? parent.run(start) : start();
+        pending = completion;
+        if (deferred) {
+          await completion;
+          await withTestTimeout(
+            entered.promise,
+            5_000,
+            "Deferred factory never entered maintenance",
+          );
+        } else {
+          await Promise.race([
+            entered.promise,
+            completion.then(() => {
+              throw new Error("Compaction ended before the backend entered");
+            }),
+          ]);
+        }
+        if (mode === "caller-abort") {
+          caller.abort(callerReason);
+        }
+        const result = await completion;
+        expect(result).toMatchObject({
+          ok: mode === "success-tail" || factory !== "none",
+          compacted: false,
+        });
+        if (parent) {
+          parent.beginClose(new Error("Foreground caller retired"));
+          await withTestTimeout(
+            parent.drain(),
+            1_000,
+            "Foreground parent retained transferred factory work",
+          );
+          expect(factorySignal?.aborted ?? false).toBe(false);
+        }
+        if (mode === "timeout") {
+          expect(result.reason).toContain("timed out");
+          expect(caller.signal.aborted).toBe(false);
+          expect(backendSignal?.aborted).toBe(true);
+        }
+        if (mode === "caller-abort") {
+          expect(backendSignal?.reason === callerReason).toBe(true);
+        }
+        await source.release();
+        expect.soft(db.isOpen).toBe(true);
+        if (factory === "none" || deferred) {
+          expect.soft(disposalCalls).toBe(0);
+        }
+        if (factory === "none") {
+          expect.soft(workSignal?.aborted ?? false).toBe(false);
+        }
+        resume.resolve();
+        if (factory === "none") {
+          await Promise.allSettled(work.slice(0, 1));
+        }
+        await withTestTimeout(
+          disposalEntered.promise,
+          1_000,
+          "Factory service prevented disposal from starting",
+        );
+        await withTestTimeout(
+          cleanupTailEntered.promise,
+          1_000,
+          "Disposer remained blocked on a captured work signal",
+        );
+        expect.soft(db.isOpen).toBe(true);
+        expect.soft(disposalContextMatches).toBe(true);
+        expect.soft(physicalDisposals).toBe(0);
+        finishDisposal.resolve();
+        const outcomes = await Promise.allSettled(work);
+        expect.soft(outcomes.map((outcome) => outcome.status)).toEqual(["fulfilled", "fulfilled"]);
+        await closed.promise;
+        expect(values).toEqual([42, 42]);
+        if (factory === "none") {
+          expect(lateWriteBlocked).toBe(true);
+        } else if (factorySignal) {
+          expect(factorySignal.aborted).toBe(true);
+          expect(factoryCloseContextMatches).toBe(true);
+          expect(factoryClosedAfterDisposalStarted).toBe(true);
+        }
+        expect(loadTranscriptEventsSync(target)).toEqual(transcriptBefore);
+        expect(loadSessionEntryReadOnly(target)).toEqual(entryBefore);
+        expect(disposalCalls).toBe(1);
+        expect(physicalDisposals).toBe(1);
+        expect(db.isOpen).toBe(false);
+        const reopened = new DatabaseSync(file, { readOnly: true });
+        try {
+          expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        resume.resolve();
+        finishDisposal.resolve();
+        stopFactory.resolve();
+        forceDisposal.resolve();
+        await Promise.allSettled([...(pending ? [pending] : []), ...work]);
+        await waitForDeferredTurnMaintenanceForSession(target.sessionKey);
+        await parent?.drain();
+        await closePreparedModelRuntimeSnapshots();
+        await source.release();
+        resetPluginRuntimeStateForTest();
+        clearPluginMetadataLifecycleCaches();
+        if (db.isOpen) {
+          db.close();
+        }
+      }
+    } finally {
+      await state.cleanup();
+    }
+  },
+);

--- a/src/agents/embedded-agent-runner/compact.foreground-work.ts
+++ b/src/agents/embedded-agent-runner/compact.foreground-work.ts
@@ -1,0 +1,121 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ContextEngine } from "../../context-engine/types.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { PreparedModelRuntimeLease } from "../prepared-model-runtime.js";
+import { log } from "./logger.js";
+import type { EmbeddedAgentCompactResult } from "./types.js";
+
+export type ForegroundCompactionOwner = {
+  adoptLease: (lease: PreparedModelRuntimeLease) => void;
+  resolveEngine: (factory: () => Promise<ContextEngine>) => Promise<ContextEngine>;
+  closeFactoryWork: () => Promise<void>;
+  captureContext: () => void;
+  transferEngine: (completion: Promise<void>) => void;
+};
+
+/** Keeps physical cleanup separate from the compaction result and transcript fences. */
+export async function runForegroundCompactionWork(
+  run: (owner: ForegroundCompactionOwner) => Promise<EmbeddedAgentCompactResult>,
+): Promise<EmbeddedAgentCompactResult> {
+  const result = createDeferredCore<EmbeddedAgentCompactResult>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  void trackOwner(async () => {
+    const work = new AsyncWorkScope();
+    const factoryWork = new AsyncWorkScope();
+    const cleanupWork = new AsyncWorkScope();
+    let runInContext = work.run(() => AsyncLocalStorage.snapshot());
+    let factoryContext = factoryWork.run(() => AsyncLocalStorage.snapshot());
+    let cleanupContext = cleanupWork.run(() => AsyncLocalStorage.snapshot());
+    let factoryClosed: Promise<void> | undefined;
+    const closeFactoryWork = () => (factoryClosed ??= factoryContext(() => factoryWork.drain()));
+    let lease: PreparedModelRuntimeLease | undefined;
+    let engine: ContextEngine | undefined;
+    let deferredCompletion: Promise<void> | undefined;
+    const closeFromParent = () => {
+      runInContext(() => work.beginClose(parentSignal?.reason));
+      if (!deferredCompletion) {
+        factoryContext(() => factoryWork.beginClose(parentSignal?.reason));
+      }
+      cleanupContext(() => cleanupWork.beginClose(parentSignal?.reason));
+    };
+    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
+    if (parentSignal?.aborted) {
+      closeFromParent();
+    }
+    try {
+      result.resolve(
+        await work.track(() =>
+          run({
+            adoptLease: (acquired) => {
+              lease = acquired;
+            },
+            resolveEngine: (factory) =>
+              factoryWork.track(async () => {
+                factoryContext = AsyncLocalStorage.snapshot();
+                engine = await factory();
+                return engine;
+              }),
+            closeFactoryWork,
+            captureContext: () => {
+              runInContext = AsyncLocalStorage.snapshot();
+            },
+            transferEngine: (completion) => {
+              engine = undefined;
+              deferredCompletion = completion;
+            },
+          }),
+        ),
+      );
+    } catch (error) {
+      result.reject(error);
+    } finally {
+      try {
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => runInContext(() => work.drain()),
+        );
+        if (!deferredCompletion) {
+          cleanupContext = factoryContext(() =>
+            cleanupWork.run(() => AsyncLocalStorage.snapshot()),
+          );
+          // Factory services can need their disposer to start before their signal closes.
+          const disposal = cleanupContext(() =>
+            cleanupWork.track(async () => {
+              try {
+                await engine?.dispose?.();
+              } catch (error) {
+                log.warn("context engine dispose failed", {
+                  errorMessage: formatErrorMessage(error),
+                });
+              }
+            }),
+          );
+          await Promise.all([disposal, closeFactoryWork()]);
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [cleanupWork],
+            () => cleanupContext(() => cleanupWork.drain()),
+          );
+        }
+      } finally {
+        parentSignal?.removeEventListener("abort", closeFromParent);
+        const retained = lease;
+        if (retained && deferredCompletion) {
+          // Background maintenance retains its independent shutdown owner.
+          void deferredCompletion
+            .then(closeFactoryWork, closeFactoryWork)
+            .then(retained.release, retained.release);
+        } else {
+          retained?.release();
+        }
+      }
+    }
+  }).catch(result.reject);
+  return await result.promise;
+}

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3730,6 +3730,8 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("releases the prepared runtime lease when host authority expires after admission", async () => {
+    const { AsyncWorkScope } = await import("../../shared/async-work-scope.js");
+    const parent = new AsyncWorkScope();
     const admissionStarted = createDeferred();
     const releaseAdmission = createDeferred();
     const releaseLease = vi.fn();
@@ -3747,18 +3749,27 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       return { ...lease, release: releaseLease };
     }) as never);
 
-    const pending = compactEmbeddedAgentSession(wrappedCompactionArgs(), {
-      assertActive: () => {
-        if (!hostActive) {
-          throw new Error("queued compaction host authority expired");
-        }
-      },
-    });
+    const pending = parent.run(() =>
+      compactEmbeddedAgentSession(wrappedCompactionArgs(), {
+        assertActive: () => {
+          if (!hostActive) {
+            throw new Error("queued compaction host authority expired");
+          }
+        },
+      }),
+    );
     await admissionStarted.promise;
     hostActive = false;
     releaseAdmission.resolve(undefined);
 
-    await expect(pending).rejects.toThrow("queued compaction host authority expired");
+    try {
+      await expect(pending).rejects.toThrow("queued compaction host authority expired");
+    } finally {
+      await AsyncWorkScope.runWhenAllIdle(
+        () => [parent],
+        () => parent.drain(),
+      );
+    }
     expect(releaseLease).toHaveBeenCalledTimes(1);
     expect(resolveContextEngineMock).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -39,6 +39,10 @@ import type { SandboxContext } from "../sandbox/types.js";
 import { beginForegroundSessionMaintenance } from "../session-maintenance/coordinator.js";
 import { resolveSessionPlacementSandbox } from "../session-placement-admission.js";
 import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
+import {
+  runForegroundCompactionWork,
+  type ForegroundCompactionOwner,
+} from "./compact.foreground-work.js";
 import { compactNativeCliSession } from "./compact.js";
 import {
   createQueuedCompactionAbortedResult,
@@ -116,16 +120,6 @@ function resolveManualCompactionActiveRunSessionId(
   );
 }
 
-async function disposeContextEngine(contextEngine: ContextEngine): Promise<void> {
-  try {
-    await contextEngine.dispose?.();
-  } catch (err) {
-    log.warn("context engine dispose failed", {
-      errorMessage: formatErrorMessage(err),
-    });
-  }
-}
-
 async function deferOwningContextEngineBudgetCompaction(params: {
   compactParams: CompactEmbeddedAgentSessionParams;
   contextEngineSessionKey?: string;
@@ -133,6 +127,7 @@ async function deferOwningContextEngineBudgetCompaction(params: {
   contextEngineRuntimeContext: ContextEngineRuntimeContext;
   contextEngineRuntimeSettings: ContextEngineRuntimeSettings;
   onDeferredMaintenance: (completion: Promise<void>) => void;
+  closeFactoryWork: () => Promise<void>;
 }): Promise<EmbeddedAgentCompactResult> {
   let deferredScheduled = false;
   let deferredScheduleFailure: unknown;
@@ -149,6 +144,7 @@ async function deferOwningContextEngineBudgetCompaction(params: {
       config: params.compactParams.config,
       contextEngineAgentId: params.compactParams.contextEngineAgentId,
       disposeDeferredContextEngineAfterMaintenance: true,
+      closeFactoryWork: params.closeFactoryWork,
       onDeferredMaintenance: (completion) => {
         deferredScheduled = true;
         params.onDeferredMaintenance(completion);
@@ -301,6 +297,24 @@ async function compactEmbeddedAgentSessionImpl(
   host: QueuedCompactionHostOptions,
   contextEngineSessionKey?: string,
 ): Promise<EmbeddedAgentCompactResult> {
+  return await runForegroundCompactionWork((owner) =>
+    compactEmbeddedAgentSessionPrepared(
+      params,
+      expectedEntry,
+      host,
+      contextEngineSessionKey,
+      owner,
+    ),
+  );
+}
+
+async function compactEmbeddedAgentSessionPrepared(
+  params: QueuedCompactionParams,
+  expectedEntry: Parameters<typeof acceptCompactionSuccessor>[0]["expectedEntry"],
+  host: QueuedCompactionHostOptions,
+  contextEngineSessionKey: string | undefined,
+  owner: ForegroundCompactionOwner,
+): Promise<EmbeddedAgentCompactResult> {
   if (params.abortSignal?.aborted) {
     return createQueuedCompactionAbortedResult();
   }
@@ -380,6 +394,7 @@ async function compactEmbeddedAgentSessionImpl(
       },
     },
   );
+  owner.adoptLease(lease);
   // Admission can replace config and agent storage while preserving the requested workspace.
   const preparedParams = {
     ...params,
@@ -390,48 +405,31 @@ async function compactEmbeddedAgentSessionImpl(
     ),
     agentDir: lease.snapshot.agentDir,
   };
-  let deferredCompletion: Promise<void> | undefined;
   const run = async () => {
+    owner.captureContext();
     ensureContextEnginesInitialized();
-    const contextEngine = await resolveContextEngine(preparedParams.config, {
-      agentDir: preparedParams.agentDir,
-      workspaceDir: resolvedWorkspaceDir,
-    });
-    let disposeContextEngineOnExit = true;
-    try {
-      assertQueuedCompactionPreparationActive(params, host);
-      // Foreground disposal belongs to this finally. Only accepted background
-      // maintenance transfers engine ownership away from this call.
-      return await compactResolvedContextEngine(
-        preparedParams,
-        expectedEntry,
-        host,
-        contextEngine,
-        preparedParams.agentDir,
-        resolvedWorkspaceDir,
-        lease.snapshot,
-        contextEngineSessionKey,
-        (completion) => {
-          disposeContextEngineOnExit = false;
-          deferredCompletion = completion;
-        },
-      );
-    } finally {
-      if (disposeContextEngineOnExit) {
-        await disposeContextEngine(contextEngine);
-      }
-    }
-  };
-  try {
+    const contextEngine = await owner.resolveEngine(() =>
+      resolveContextEngine(preparedParams.config, {
+        agentDir: preparedParams.agentDir,
+        workspaceDir: resolvedWorkspaceDir,
+      }),
+    );
     assertQueuedCompactionPreparationActive(params, host);
-    return await withPluginRuntimeGenerationScope(lease.snapshot, run);
-  } finally {
-    if (deferredCompletion) {
-      void deferredCompletion.then(lease.release, lease.release);
-    } else {
-      lease.release();
-    }
-  }
+    return await compactResolvedContextEngine(
+      preparedParams,
+      expectedEntry,
+      host,
+      contextEngine,
+      preparedParams.agentDir,
+      resolvedWorkspaceDir,
+      lease.snapshot,
+      contextEngineSessionKey,
+      owner.transferEngine,
+      owner.closeFactoryWork,
+    );
+  };
+  assertQueuedCompactionPreparationActive(params, host);
+  return await withPluginRuntimeGenerationScope(lease.snapshot, run);
 }
 
 async function compactResolvedContextEngine(
@@ -444,6 +442,7 @@ async function compactResolvedContextEngine(
   preparedModelRuntime: PreparedModelRuntimeSnapshot,
   contextEngineSessionKey: string | undefined,
   transferContextEngineOwnership: (completion: Promise<void>) => void,
+  closeFactoryWork: () => Promise<void>,
 ): Promise<EmbeddedAgentCompactResult> {
   const runtimeTarget = params.sessionTarget;
   const lockedHarnessRuntime = resolveSessionPinnedHarnessId(params.sessionEntry);
@@ -677,6 +676,7 @@ async function compactResolvedContextEngine(
       contextEngineRuntimeContext,
       contextEngineRuntimeSettings,
       onDeferredMaintenance: transferContextEngineOwnership,
+      closeFactoryWork,
     });
   }
   return await executeQueuedContextEngineCompaction({

--- a/src/agents/embedded-agent-runner/compact.runtime-generation.test.ts
+++ b/src/agents/embedded-agent-runner/compact.runtime-generation.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./compact.hooks.harness.js";
 
 const { compactEmbeddedAgentSession } = await loadCompactHooksHarness();
+const { AsyncWorkScope } = await import("../../shared/async-work-scope.js");
 const [{ upsertSessionEntryCore }, { closeOpenClawAgentDatabasesForTest }] = await Promise.all([
   import("../../config/sessions/session-accessor.js"),
   import("../../state/openclaw-agent-db.js"),
@@ -49,17 +50,28 @@ it("uses the admitted config and agent storage throughout queued compaction", as
     acquire({ ...input, config: admittedConfig, agentDir: admittedAgentDir }),
   );
 
-  const result = await compactEmbeddedAgentSession({
-    ...sessionTarget,
-    sessionTarget,
-    sessionFile: sessionTarget.sessionKey,
-    workspaceDir,
-    allowGatewaySubagentBinding: true,
-    provider: "openai",
-    model: "gpt-5.6-luna",
-    config: requestedConfig,
-    enqueue: async (task) => await task(),
-  });
+  const parent = new AsyncWorkScope();
+  let result: Awaited<ReturnType<typeof compactEmbeddedAgentSession>>;
+  try {
+    result = await parent.run(() =>
+      compactEmbeddedAgentSession({
+        ...sessionTarget,
+        sessionTarget,
+        sessionFile: sessionTarget.sessionKey,
+        workspaceDir,
+        allowGatewaySubagentBinding: true,
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        config: requestedConfig,
+        enqueue: async (task) => await task(),
+      }),
+    );
+  } finally {
+    await AsyncWorkScope.runWhenAllIdle(
+      () => [parent],
+      () => parent.drain(),
+    );
+  }
 
   expect(result).toMatchObject({ ok: true, compacted: true });
   const { snapshot, release } = await expectDefined(

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -7,6 +7,7 @@ import { isRuntimeCompactionDelegate } from "../../context-engine/delegate.js";
 import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
 import { createAbortError } from "../../infra/abort-signal.js";
 import { runAbortableTimeout } from "../../node-host/with-timeout.js";
+import { trackAsyncWork } from "../../shared/async-work-scope.js";
 
 const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
 
@@ -93,7 +94,7 @@ export async function compactWithSafetyTimeout<T>(
 
       try {
         return await raceCompactionWithAbortSignal(
-          () => compact(composedAbortSignal, resetTimeout),
+          () => trackAsyncWork(() => compact(composedAbortSignal, resetTimeout)),
           abortSignal,
           cancel,
         );

--- a/src/agents/embedded-agent-runner/context-engine-factory-disposal.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-factory-disposal.test.ts
@@ -1,0 +1,178 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import type { ContextEngine } from "../../context-engine/types.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "../../tasks/task-runtime.test-helpers.js";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import {
+  runContextEngineMaintenance,
+  waitForDeferredTurnMaintenanceForSession,
+} from "./context-engine-maintenance.js";
+
+it.each([
+  { name: "one shared instance", ids: ["active", "active", "active"] },
+  { name: "a superseded instance", ids: ["active", "superseded", "latest"] },
+  { name: "a shared queued instance", ids: ["active", "latest", "latest"] },
+  { name: "a return to the active instance", ids: ["active", "superseded", "active"] },
+] as const)("joins every factory lifetime for $name", async ({ ids }) => {
+  await withStateDirEnv("openclaw-factory-disposal-", async ({ stateDir }) => {
+    resetCommandQueueStateForTest();
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+    const db = new DatabaseSync(path.join(stateDir, "factory.sqlite"));
+    db.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+    const context = new AsyncLocalStorage<string>();
+    const activeEntered = createDeferredCore();
+    const finishActive = createDeferredCore();
+    const sessionKey = "agent:main:factory-disposal";
+    const disposals: string[] = [];
+    const factoryValues: unknown[] = [];
+    const cleanupValues: unknown[] = [];
+    const callbacks: Array<{ closed: Promise<void>; force: () => Promise<void> }> = [];
+    const services: Promise<unknown>[] = [];
+    const cleanupTails: Promise<unknown>[] = [];
+    const closingContext: boolean[] = [];
+    const closingOrder: boolean[] = [];
+    const engines = new Map<
+      string,
+      { engine: ContextEngine; stop: () => void; signals: AbortSignal[]; wait: Promise<void> }
+    >();
+    const pending: Promise<void>[] = [];
+    const getEngine = (id: string) => {
+      const existing = engines.get(id);
+      if (existing) {
+        return existing;
+      }
+      const stop = createDeferredCore();
+      const signals: AbortSignal[] = [];
+      const item = {
+        signals,
+        stop: () => stop.resolve(),
+        engine: {
+          info: { id, name: id, turnMaintenanceMode: "background" },
+          ingest: async () => ({ ingested: false }),
+          assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+          compact: async () => ({ ok: true, compacted: false }),
+          async maintain() {
+            if (id === "active") {
+              activeEntered.resolve();
+              await finishActive.promise;
+            }
+            return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+          },
+          async dispose() {
+            disposals.push(id);
+            // The actual disposer starts before any of its captured factories close.
+            await Promise.all(
+              signals.map((signal) =>
+                signal.aborted
+                  ? Promise.resolve()
+                  : new Promise<void>((resolve) => {
+                      signal.addEventListener("abort", () => resolve(), { once: true });
+                    }),
+              ),
+            );
+            stop.resolve();
+            const signal = getAsyncWorkSignal();
+            if (!signal) {
+              throw new Error("Disposal did not inherit its cleanup owner");
+            }
+            const tail = trackAsyncWork(async () => {
+              await stop.promise;
+              signal.throwIfAborted();
+              cleanupValues.push(db.prepare("SELECT value FROM answer").get()?.value);
+            });
+            cleanupTails.push(tail);
+            void tail.catch(() => {});
+          },
+        } satisfies ContextEngine,
+        wait: stop.promise,
+      };
+      engines.set(id, item);
+      return item;
+    };
+    const schedule = async (id: string, index: number) => {
+      const item = getEngine(id);
+      const work = new AsyncWorkScope();
+      const label = `${id}:${index}`;
+      const captured = context.run(label, () => work.run(() => AsyncLocalStorage.snapshot()));
+      const closed = createDeferredCore();
+      work.signal.addEventListener(
+        "abort",
+        () => {
+          closingContext.push(context.getStore() === label && getAsyncWorkSignal() === work.signal);
+          closingOrder.push(disposals.includes(id));
+          closed.resolve();
+        },
+        { once: true },
+      );
+      item.signals.push(work.signal);
+      const service = captured(() =>
+        trackAsyncWork(async () => {
+          await item.wait;
+          factoryValues.push(db.prepare("SELECT value FROM answer").get()?.value);
+        }),
+      );
+      services.push(service);
+      void service.catch(() => {});
+      const closeFactoryWork = () => captured(() => work.drain());
+      callbacks.push({ closed: closed.promise, force: closeFactoryWork });
+      await runContextEngineMaintenance({
+        contextEngine: item.engine,
+        sessionId: "factory-disposal",
+        sessionKey,
+        sessionFile: path.join(stateDir, "session.jsonl"),
+        reason: "turn",
+        disposeDeferredContextEngineAfterMaintenance: true,
+        closeFactoryWork,
+        onDeferredMaintenance: (completion) => {
+          pending.push(completion);
+        },
+      });
+    };
+    try {
+      await schedule(ids[0], 0);
+      await withTestTimeout(activeEntered.promise, 1_000, "Initial maintenance did not start");
+      await schedule(ids[1], 1);
+      await schedule(ids[2], 2);
+      finishActive.resolve();
+      await withTestTimeout(
+        Promise.all(callbacks.map(({ closed }) => closed)),
+        1_000,
+        "Disposal did not close all factories of its coalesced engine",
+      );
+      expect(closingContext).toEqual([true, true, true]);
+      expect(closingOrder).toEqual([true, true, true]);
+      await waitForDeferredTurnMaintenanceForSession(sessionKey);
+      await Promise.all(pending);
+      expect(factoryValues).toEqual([42, 42, 42]);
+      expect(cleanupValues).toHaveLength(new Set(ids).size);
+      expect(cleanupValues.every((value) => value === 42)).toBe(true);
+      expect(disposals.toSorted()).toEqual([...new Set(ids)].toSorted());
+    } finally {
+      finishActive.resolve();
+      for (const engine of engines.values()) {
+        engine.stop();
+      }
+      await Promise.all(callbacks.map(({ force }) => force()));
+      await Promise.allSettled([...services, ...cleanupTails, ...pending]);
+      await waitForDeferredTurnMaintenanceForSession(sessionKey);
+      db.close();
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/context-engine-maintenance-work.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance-work.ts
@@ -1,7 +1,8 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { hasSameContextEngineInstance } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import { AsyncWorkScope, trackAsyncWork } from "../../shared/async-work-scope.js";
 import type { createSessionMaintenanceOwner } from "../session-maintenance/coordinator.js";
 import { log } from "./logger.js";
 
@@ -37,6 +38,7 @@ export async function disposeDeferredMaintenanceContextEngine(
   params: {
     contextEngine: ContextEngine;
     runInContext: ReturnType<typeof AsyncLocalStorage.snapshot>;
+    factoryWorkClosers?: ReadonlySet<() => Promise<void>>;
   },
   maintenance: Pick<ReturnType<typeof createSessionMaintenanceOwner>, "run" | "signal">,
 ): Promise<void> {
@@ -44,7 +46,13 @@ export async function disposeDeferredMaintenanceContextEngine(
     await params.runInContext(() =>
       maintenance.run(() =>
         runContextEngineMaintenanceWork(async () => {
-          await params.contextEngine.dispose?.();
+          const disposal = (async () => {
+            await params.contextEngine.dispose?.();
+          })();
+          const factoryWork = [...(params.factoryWorkClosers ?? [])].map((close) =>
+            trackAsyncWork(close),
+          );
+          await Promise.all([disposal, ...factoryWork]);
         }, maintenance.signal),
       ),
     );
@@ -53,4 +61,30 @@ export async function disposeDeferredMaintenanceContextEngine(
       errorMessage: formatErrorMessage(err),
     });
   }
+}
+
+type ContextEngineFactoryWork = {
+  contextEngine: ContextEngine;
+  factoryWorkClosers: Set<() => Promise<void>>;
+};
+
+/** Shared engine instances retain every factory lifetime until their final disposer starts. */
+export function mergeContextEngineFactoryWork(
+  params: ContextEngineFactoryWork,
+  activeEngine: ContextEngine,
+  activeClosers: Set<() => Promise<void>>,
+  superseded?: ContextEngineFactoryWork,
+): Set<() => Promise<void>> {
+  if (superseded && hasSameContextEngineInstance(superseded.contextEngine, params.contextEngine)) {
+    for (const close of superseded.factoryWorkClosers) {
+      params.factoryWorkClosers.add(close);
+    }
+  }
+  if (hasSameContextEngineInstance(params.contextEngine, activeEngine)) {
+    for (const close of params.factoryWorkClosers) {
+      activeClosers.add(close);
+    }
+    return activeClosers;
+  }
+  return params.factoryWorkClosers;
 }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -51,6 +51,7 @@ import { SessionManager } from "../sessions/index.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import {
   disposeDeferredMaintenanceContextEngine,
+  mergeContextEngineFactoryWork,
   runContextEngineMaintenanceWork,
 } from "./context-engine-maintenance-work.js";
 import { log } from "./logger.js";
@@ -84,6 +85,7 @@ type ContextEngineMaintenanceParams = {
   onDeferredMaintenanceFailure?: (error: unknown) => void;
   config?: OpenClawConfig;
   disposeDeferredContextEngineAfterMaintenance?: boolean;
+  closeFactoryWork?: () => Promise<void>;
 };
 
 type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
@@ -92,6 +94,7 @@ type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
   runInContext: ReturnType<typeof AsyncLocalStorage.snapshot>;
   disposeContextEngineAfterMaintenance?: boolean;
   onScheduleFailure?: (error: unknown) => void;
+  factoryWorkClosers: Set<() => Promise<void>>;
 };
 
 type DeferredTurnMaintenanceRunState = {
@@ -100,6 +103,7 @@ type DeferredTurnMaintenanceRunState = {
   promise: Promise<void>;
   rerunRequested: boolean;
   activeContextEngine: ContextEngine;
+  activeFactoryWorkClosers: Set<() => Promise<void>>;
   disposeActiveContextEngineAfterMaintenance: boolean;
   latestParams: DeferredTurnMaintenanceScheduleParams;
 };
@@ -456,6 +460,12 @@ function scheduleDeferredTurnMaintenance(
   if (activeRun) {
     const supersededParams = activeRun.rerunRequested ? activeRun.latestParams : undefined;
     const latestParams = { ...params, sessionKey };
+    latestParams.factoryWorkClosers = mergeContextEngineFactoryWork(
+      latestParams,
+      activeRun.activeContextEngine,
+      activeRun.activeFactoryWorkClosers,
+      supersededParams,
+    );
     // Coalesced resolutions may wrap one shared factory instance. Carry disposal
     // ownership forward without closing an engine still used by active or newer work.
     if (
@@ -664,6 +674,7 @@ function scheduleDeferredTurnMaintenance(
     promise: trackedPromise,
     rerunRequested: false,
     activeContextEngine: params.contextEngine,
+    activeFactoryWorkClosers: params.factoryWorkClosers,
     disposeActiveContextEngineAfterMaintenance:
       params.disposeContextEngineAfterMaintenance === true,
     latestParams: { ...params, sessionKey },
@@ -711,6 +722,7 @@ export async function runContextEngineMaintenance(
         contextEngine,
         sessionKey,
         runInContext: AsyncLocalStorage.snapshot(),
+        factoryWorkClosers: new Set(params.closeFactoryWork ? [params.closeFactoryWork] : []),
         disposeContextEngineAfterMaintenance: params.disposeDeferredContextEngineAfterMaintenance,
         onScheduleFailure: params.onDeferredMaintenanceFailure,
       });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users compacting a session could encounter closed-database errors when a context engine continued working after a timeout, cancellation, or early result. Engine cleanup could also lose access to its SQLite resources before its asynchronous work finished.

## Why This Change Was Made

Keep the prepared runtime alive until the actual compaction and cleanup work settles, while preserving the existing timing of results, cancellation, transcript closure, and successor protection. The canonical compaction watchdog observes the original invocation, so returning from its timeout race no longer ends physical resource ownership.

Factory services need a separate lifetime because disposal may be their stopper. Finite compaction work drains first; disposal starts before factory work closes; cleanup descendants retain their resources until they finish. A private factory-lifetime handoff follows the existing deferred-maintenance, coalescing, same-instance, and superseded-engine ownership decisions. This accounts for the additional maintenance changes without replacing engine objects or changing which engine maintenance selects.

## User Impact

Context engines can finish accepted work and cleanup with their database available, then release it exactly once. A timed-out operation still cannot write to the closed transcript. Deferred maintenance retains its resources independently of the completed foreground operation. Public configuration, database schemas, timeout policy, and built-in delegate cleanup are unchanged.

## Evidence

- Against original production code, seven focused regressions failed: five exposed closed SQLite during actual compaction/disposal, and two exposed deferred factory work retaining the foreground parent. Tests also caught and eliminated two intermediate shutdown-order defects: waiting for factory services before starting their disposer, and awaiting a disposer before closing the finite operation signal it needed.
- Final ownership coverage passed 20 tests across five files. Six subsequent targeted controls passed after the final maintenance extraction and test cleanup. Broader sibling coverage passed 283 tests initially; its two remaining release assertions passed after joining actual owner drainage, with the original assertions retained.
- The complete nine-file changed gate passed in 383.87 seconds, including type checks, fresh Knip scans, lint, runtime-cycle checks, and selected database/schema guards. Fresh independent Codex review found no actionable P0–P2 findings; the full build passed in 263.77 seconds.
- Plain Node running emitted artifacts passed three real-SQLite scenarios in 4.04 seconds: watchdog timeout (1306.74 ms), factory-signal disposal (81.52 ms), and deferred factory-signal disposal (65.10 ms). Each completed both late SQL reads and closed once; the probe also checked refused late transcript writes, retained catalog ownership, reopening persisted data, and deferred independence. Source and built artifacts remained unchanged, and all managed process trees joined.

The compiled probe proves compaction/SQLite ownership with a bounded harness lifetime. Its referenced 30-second deadline fails the probe if exceeded and is cleared in `finally`; the probe exercises the production watchdog with a one-second configured timeout and unchanged unref behavior. An earlier probe exited with unsettled top-level await because synthetic gates supplied no referenced I/O; that receipt is retained. This is not proof of standalone CLI liveness without referenced I/O. The successful probe used synthetic plugin state and no real Gateway, external service, or credentials.
