### PR TITLE
fix(firecrawl): unresolvable baseUrl reported as private-endpoint policy

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -1,5 +1,6 @@
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 // Focused parser contracts; public Firecrawl execution lives in firecrawl-tools.test.ts.
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 let firecrawlClient: typeof import("./firecrawl-client.js").testing;
 const hostileControlToken = ["<|im_", "start|>system"].join("");
@@ -212,5 +213,44 @@ describe("Firecrawl scrape payloads", () => {
         maxChars: 1_000,
       }),
     ).toThrow("Firecrawl scrape returned no content.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEndpoint — baseUrl SSRF + DNS failure classification (#135333)
+// ---------------------------------------------------------------------------
+describe("resolveEndpoint baseUrl resolution", () => {
+  it("surfaces a DNS resolution failure instead of a privateness policy violation", async () => {
+    // Unresolvable hosts fail inside the SSRF resolver. Previously the catch
+    // swallowed that and reported a privateness policy violation (#135333).
+    const lookupFn: LookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND unresolvable.invalid");
+    });
+    await expect(
+      firecrawlClient.resolveEndpoint("http://unresolvable.invalid", "/v2/search", lookupFn),
+    ).rejects.toThrow(/Unable to resolve Firecrawl baseUrl host: unresolvable\.invalid/i);
+  });
+
+  it("surfaces a DNS resolution failure when lookup returns no addresses", async () => {
+    const lookupFn: LookupFn = vi.fn(async () => []);
+    await expect(
+      firecrawlClient.resolveEndpoint("http://empty.invalid", "/v2/search", lookupFn),
+    ).rejects.toThrow(/Unable to resolve Firecrawl baseUrl host: empty\.invalid/i);
+  });
+
+  it("surfaces a DNS resolution failure for https unresolvable hosts", async () => {
+    const lookupFn: LookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND unresolvable.invalid");
+    });
+    await expect(
+      firecrawlClient.resolveEndpoint("https://unresolvable.invalid", "/v2/search", lookupFn),
+    ).rejects.toThrow(/Unable to resolve Firecrawl baseUrl host: unresolvable\.invalid/i);
+  });
+
+  it("still rejects a host resolving to a public address as a privateness policy violation", async () => {
+    const lookupFn: LookupFn = vi.fn(async () => [{ address: "8.8.8.8", family: 4 }]);
+    await expect(
+      firecrawlClient.resolveEndpoint("http://public.example", "/v2/search", lookupFn),
+    ).rejects.toThrow(/must target a private or internal self-hosted endpoint/i);
   });
 });

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -57,6 +57,13 @@ const FIRECRAWL_SELF_HOSTED_PRIVATE_ERROR =
 const FIRECRAWL_HTTP_PRIVATE_ERROR =
   "Firecrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.";
 
+function firecrawlUnresolvableHostError(hostname: string, cause: unknown): Error {
+  return new Error(
+    `Unable to resolve Firecrawl baseUrl host: ${hostname}. Verify the hostname or DNS configuration.`,
+    { cause },
+  );
+}
+
 type FirecrawlEndpointMode = "selfHosted" | "strict";
 type FirecrawlResolvedEndpoint = {
   url: string;
@@ -139,8 +146,17 @@ async function firecrawlEndpointTargetsPrivateNetwork(
       policy: { allowPrivateNetwork: true },
     });
     return pinned.addresses.every((address) => isPrivateIpAddress(address));
-  } catch {
-    return false;
+  } catch (error) {
+    // Distinguish a host that cannot be resolved (empty DNS answer or lookup
+    // rejection such as ENOTFOUND) from one that resolves to a blocked or
+    // non-private address. Swallowing resolution failures previously reported
+    // unresolvable hosts as privateness policy violations (#135333).
+    // SsrFBlockedError is an SSRF result and still falls through to the
+    // caller's policy error for non-private targets.
+    if (error instanceof SsrFBlockedError) {
+      return false;
+    }
+    throw firecrawlUnresolvableHostError(url.hostname, error);
   }
 }
 


### PR DESCRIPTION
Closes #135333.
Related: #137783.

## What Problem This Solves

Fixes an issue where operators configuring a self-hosted Firecrawl `baseUrl` would see a private-endpoint / SSRF policy error when the hostname simply failed DNS (for example `http://raspberrypi:3002` or `http://firecrawl.lan:3002`). The message pointed them at HTTPS or privateness policy when the real cause was resolution failure.

## Why This Change Was Made

`firecrawlEndpointTargetsPrivateNetwork` was swallowing every resolver failure with `catch { return false }`, so DNS misses took the same path as “resolved to a public host.” Resolution failures (empty answers and lookup rejects such as `ENOTFOUND`) now throw a host-specific DNS error; `SsrFBlockedError` still falls through to the existing private-endpoint policy messages. Successful public resolves keep those policy errors. The same classification was previously attempted in #137783 and self-closed over live channel proof this error-path change does not need. The searxng client still has the same swallow-all catch and is left as a follow-up.

## User Impact

Operators and plugin authors who mistype or cannot resolve a Firecrawl `baseUrl` host now see:

`Unable to resolve Firecrawl baseUrl host: <host>. Verify the hostname or DNS configuration.`

instead of the HTTP/HTTPS “must target a private or internal self-hosted endpoint” messages. Hosted `api.firecrawl.dev` and correctly resolving private self-hosted endpoints behave as before.

## Evidence

### Real behavior (system DNS, no mocked lookupFn)

Same plugin invocation path on current `main` vs this branch. `baseUrl=http://unresolvable.invalid:3002`, keyless `runFirecrawlSearch`, plus `testing.resolveEndpoint`. Host deliberately uses the reserved `.invalid` TLD so resolution fails via real DNS (`ENOTFOUND`).

**Before (origin/main @ cdda5825f8bb):**

```text
=== Before-fix real-DNS Firecrawl proof (current main) ===
ref: origin/main
sha: cdda5825f8bb50e4112f13a9405856cad87bfa79
baseUrl: http://unresolvable.invalid:3002
lookupFn: (none — system DNS)

--- 1) testing.resolveEndpoint ---
error.message: Firecrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.

--- 2) runFirecrawlSearch (keyless) ---
error.message: Firecrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.
```

**After (fix/firecrawl-unresolvable-baseurl @ c01c38b263a0):**

```text
=== After-fix real-DNS Firecrawl proof ===
branch: fix/firecrawl-unresolvable-baseurl
head: c01c38b263a071d15542606060c6017cac21cdec
baseUrl: http://unresolvable.invalid:3002
lookupFn: (none — system DNS)

--- 1) testing.resolveEndpoint (plugin validation path) ---
error.message: Unable to resolve Firecrawl baseUrl host: unresolvable.invalid. Verify the hostname or DNS configuration.

--- 2) runFirecrawlSearch (plugin invocation; fails at endpoint validation before HTTP) ---
error.message: Unable to resolve Firecrawl baseUrl host: unresolvable.invalid. Verify the hostname or DNS configuration.

--- 3) https sibling ---
error.message: Unable to resolve Firecrawl baseUrl host: unresolvable.invalid. Verify the hostname or DNS configuration.

--- 4) DNS sanity (system resolver) ---
getaddrinfo ENOTFOUND: getaddrinfo ENOTFOUND unresolvable.invalid
```

### Regression tests (mocked DNS)

```text
pnpm exec vitest run extensions/firecrawl/src/firecrawl-client.test.ts
# 34 passed — including DNS vs privateness classification cases

pnpm test:extension firecrawl
# Test Files  3 passed (3)
# Tests       103 passed (103)
```
