### PR TITLE
fix: restore final answers after an earlier tool error

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
@@ -1,6 +1,7 @@
 /** Classifies terminal assistant visibility and provider retry eligibility. */
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { extractEmbeddedAssistantText } from "../../embedded-agent-utils.js";
 import {
@@ -9,6 +10,7 @@ import {
 } from "../../execution-contract.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { assessLastAssistantMessage } from "../thinking.js";
+import type { EmbeddedAgentRunResult } from "../types.js";
 import { resolveCurrentAttemptAssistant } from "./attempt-terminal-evidence.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
@@ -77,6 +79,40 @@ export function hasComposedVisibleAnswerAfterSettledTools(params: {
     const trimmed = text.trim();
     return trimmed.length > 0 && !preToolTexts.has(trimmed);
   });
+}
+
+/** Excludes only plain progress text; structured or tool-owned payloads remain delivery evidence. */
+export function countSettledTurnDeliveryPayloads(params: {
+  payloads: EmbeddedAgentRunResult["payloads"];
+  attempt: IncompleteTurnAttempt;
+}): number {
+  const hasNoAssistantText = params.attempt.assistantTexts.every((text) => !text.trim());
+  const hasComposedVisibleAnswer = hasComposedVisibleAnswerAfterSettledTools(params.attempt);
+  const canFinalizeProviderError =
+    params.attempt.settledTurnFinalizationContext && !hasComposedVisibleAnswer;
+  return (params.payloads ?? []).filter((payload) => {
+    const metadata = getReplyPayloadMetadata(payload);
+    const syntheticFallback =
+      payload.isError === true &&
+      Object.keys(payload).every((key) => key === "text" || key === "isError") &&
+      ((hasNoAssistantText && metadata?.toolErrorWarning) ||
+        (canFinalizeProviderError && metadata?.terminalProviderError));
+    if (syntheticFallback) {
+      return false;
+    }
+    if (hasComposedVisibleAnswer || metadata !== undefined) {
+      return true;
+    }
+    const text = typeof payload.text === "string" ? payload.text.trim() : "";
+    const hasNonTextDelivery = Object.entries(payload).some(
+      ([key, value]) => key !== "text" && value !== undefined && value !== false,
+    );
+    return (
+      hasNonTextDelivery ||
+      !text ||
+      !params.attempt.assistantTexts.some((candidate) => candidate.trim() === text)
+    );
+  }).length;
 }
 
 export function hasPositiveOutputTokenUsage(message: AgentMessage | null): boolean {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -276,10 +276,19 @@ export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) 
       id !== null && name !== null && settledToolResults.get(id)?.isError === true ? [name] : [],
     ),
   );
+  const hasStaleToolError = Boolean(
+    attempt.lastToolError &&
+    assistant?.stopReason === "toolUse" &&
+    allToolsProvenSettled &&
+    failedToolNames.size === 0,
+  );
   // ToolErrorSummary has no call id: its owner must match a failed result in the
   // proven terminal batch, or a stale/unrelated error could authorize continuation.
+  // A fully settled successful batch proves that a retained error belongs to an
+  // earlier tool and cannot block text-only finalization of the current batch.
   const hasUnsettledToolError = Boolean(
     attempt.lastToolError &&
+    !hasStaleToolError &&
     (assistant?.stopReason !== "toolUse" ||
       !allToolsProvenSettled ||
       !failedToolNames.has(attempt.lastToolError.toolName)),
@@ -288,7 +297,7 @@ export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) 
     allToolsProvenSettled &&
     assistant?.stopReason === "toolUse" &&
     failedToolNames.size === 0 &&
-    !attempt.lastToolError &&
+    !hasUnsettledToolError &&
     !hasAsyncActivity(attempt.toolMetas) &&
     requestedToolCalls.every(({ id, name }) => {
       const metadata = attempt.toolMetas.findLast(
@@ -302,6 +311,7 @@ export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) 
     allToolsProvenSettled,
     parkedCodeModeRun,
     failedToolNames,
+    hasStaleToolError,
     hasUnsettledToolError,
     intentionalTermination,
   };

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -5,7 +5,10 @@ import {
   makeEmbeddedRunnerAttempt,
 } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import { isIncompleteTerminalAssistantTurn } from "./incomplete-turn-classification.js";
-import { resolveSettledToolTerminalContinuationInstruction } from "./incomplete-turn-recovery.js";
+import {
+  resolveSettledToolBatchEvidence,
+  resolveSettledToolTerminalContinuationInstruction,
+} from "./incomplete-turn-recovery.js";
 import { resolveReplayInvalidFlag, resolveRunLivenessState } from "./incomplete-turn-resolution.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
@@ -508,6 +511,36 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     );
 
     expect(instruction).toBeNull();
+  });
+
+  it("keeps a successful terminating batch terminal with a stale earlier error (#132762)", () => {
+    const toolUseAssistant = makeLastAssistant({
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "tool_1", name: "ask_user", arguments: {} }],
+    });
+    const evidence = resolveSettledToolBatchEvidence(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [
+          { toolName: "ask_user", toolCallId: "tool_1", isError: false, terminate: true },
+        ],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          { role: "toolResult", toolCallId: "tool_1", toolName: "ask_user", isError: false },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: "exec", error: "earlier failure" },
+      }),
+    );
+
+    expect(evidence).toMatchObject({
+      allToolsProvenSettled: true,
+      hasStaleToolError: true,
+      hasUnsettledToolError: false,
+      intentionalTermination: true,
+    });
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -137,6 +137,44 @@ function settledSuccessfulAttempt(): EmbeddedRunAttemptWithReceiptEvidence {
   return attempt;
 }
 
+function settledSuccessfulAttemptAfterStaleError(): EmbeddedRunAttemptWithReceiptEvidence {
+  const progress = "I’ll inspect the file before answering.";
+  const failedAssistant = buildEmbeddedRunnerAssistant({
+    stopReason: "toolUse",
+    content: [{ type: "toolCall", id: "tool-failed", name: "exec", arguments: {} }],
+  });
+  const terminalAssistant = buildEmbeddedRunnerAssistant({
+    stopReason: "toolUse",
+    content: [
+      { type: "text", text: progress },
+      { type: "toolCall", id: "tool-succeeded", name: "read", arguments: {} },
+    ],
+  });
+  return makeEmbeddedRunnerAttempt({
+    terminal: { kind: "ok" },
+    sessionIdUsed: "session-settled",
+    assistantTexts: [progress],
+    messagesSnapshot: [
+      { role: "user", content: [{ type: "text", text: "Inspect the file." }] },
+      failedAssistant,
+      { role: "toolResult", toolCallId: "tool-failed", toolName: "exec", isError: true },
+      terminalAssistant,
+      { role: "toolResult", toolCallId: "tool-succeeded", toolName: "read", isError: false },
+    ] as never,
+    toolMetas: [
+      { toolName: "exec", toolCallId: "tool-failed", isError: true, replaySafe: false },
+      { toolName: "read", toolCallId: "tool-succeeded", isError: false, replaySafe: true },
+    ],
+    itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
+    lastAssistant: terminalAssistant,
+    currentAttemptAssistant: terminalAssistant,
+    currentAttemptCompletedAssistant: terminalAssistant,
+    lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+    replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+  });
+}
+
 let admittedRunContext: AdmittedRunContext;
 
 function finalizationInput(attempt: ReturnType<typeof settledFailedAttempt>) {
@@ -193,6 +231,39 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       }
     },
   );
+
+  it("uses a safe fallback when finalization fails after a stale tool error (#132762)", async () => {
+    const attempt = settledSuccessfulAttemptAfterStaleError();
+    const input = finalizationInput(attempt);
+    input.terminalBase.runParams.trigger = "user";
+    input.terminalBase.runParams.sourceReplyDeliveryMode = "automatic";
+    backendMocks.runSettledFinalization.mockRejectedValue(new Error("finalizer unavailable"));
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(result.attempt.lastToolError).toBeUndefined();
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
+    ]);
+    expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
+  });
+
+  it("clears only a proven-stale error when finalization is unavailable (#132762)", async () => {
+    const attempt = settledSuccessfulAttemptAfterStaleError();
+    const input = finalizationInput(attempt);
+    input.terminalBase.runParams.trigger = "user";
+    input.finalization.harness.finalizeSettledTurn = undefined;
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(backendMocks.runSettledFinalization).not.toHaveBeenCalled();
+    expect(result.finalizationOutcome).toBe("not-attempted");
+    expect(result.attempt.lastToolError).toBeUndefined();
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: "I’ll inspect the file before answering." }),
+    ]);
+  });
 
   it.each([
     { reported: false, outcome: "answered" },

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -87,7 +87,11 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   };
 }) {
   const initial = input.initial;
-  let attempt = initial.attempt;
+  const settledToolBatch = resolveSettledToolBatchEvidence(initial.attempt);
+  const settledAttempt = settledToolBatch.hasStaleToolError
+    ? { ...initial.attempt, lastToolError: undefined }
+    : initial.attempt;
+  let attempt = settledAttempt;
   let lastRunPromptUsage = input.lastRunPromptUsage;
   let prepared = prepareEmbeddedRunTerminal({
     ...input.terminalBase,
@@ -115,6 +119,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   if (!prompt) {
     return {
       ...initial,
+      attempt,
       prepared,
       lastRunPromptUsage,
       finalizationOutcome: "not-attempted" as const,
@@ -145,7 +150,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   // A host summary cannot replace a tool failure. Keep its original warning
   // when recovery produces no answer, including for silent helper runs.
   const terminalFallbackAllowed =
-    input.finalization.preparedAttempt.silentExpected !== true && !initial.attempt.lastToolError;
+    input.finalization.preparedAttempt.silentExpected !== true && !settledAttempt.lastToolError;
   log.warn(
     `settled post-tool turn lacked a final answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
       `provider=${errorContext.provider}/${errorContext.model} — running isolated finalization`,
@@ -166,7 +171,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
           sessionId: committedSessionTarget?.sessionId ?? initial.sessionIdUsed,
           sessionFile: initial.sessionFileUsed ?? input.finalization.preparedAttempt.sessionFile,
         },
-        settledAttempt: initial.attempt,
+        settledAttempt,
         harness: input.finalization.harness,
         prompt,
         createAttemptControls: input.finalization.createAttemptControls,
@@ -248,7 +253,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       };
     }
     attempt = buildSettledToolFallbackAttemptResult({
-      settledAttempt: initial.attempt,
+      settledAttempt,
       sourceAttempt: attempt,
       prompt,
       agentHarnessId: input.finalization.preparedAttempt.agentHarnessId,
@@ -258,7 +263,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   }
   // Only an actual recovery replaces a failed tool turn's terminal ownership.
   const completion =
-    finalizationOutcome !== "answered" && initial.attempt.lastToolError
+    finalizationOutcome !== "answered" && settledAttempt.lastToolError
       ? initial
       : {
           attempt,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.settled-request.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.settled-request.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { setReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import {
   buildEmbeddedRunnerAssistant,
@@ -180,5 +181,102 @@ describe("resolveSettledTurnFinalizationRequest", () => {
         }),
       }),
     ).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+  });
+
+  it("finalizes after successful tools despite pre-tool progress and a stale error (#132762)", () => {
+    const failedAssistant = buildEmbeddedRunnerAssistant({
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "tool-failed", name: "exec", arguments: {} }],
+    });
+    const progress = "I’ll inspect the file before answering.";
+    const terminalAssistant = buildEmbeddedRunnerAssistant({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: progress },
+        { type: "toolCall", id: "tool-succeeded", name: "read", arguments: {} },
+      ],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [progress],
+      messagesSnapshot: [
+        { role: "user", content: [{ type: "text", text: "Inspect the file." }] },
+        failedAssistant,
+        {
+          role: "toolResult",
+          toolCallId: "tool-failed",
+          toolName: "exec",
+          isError: true,
+        },
+        terminalAssistant,
+        {
+          role: "toolResult",
+          toolCallId: "tool-succeeded",
+          toolName: "read",
+          isError: false,
+        },
+      ] as never,
+      toolMetas: [
+        { toolName: "exec", toolCallId: "tool-failed", isError: true, replaySafe: false },
+        { toolName: "read", toolCallId: "tool-succeeded", isError: false, replaySafe: true },
+      ],
+      itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
+      lastAssistant: terminalAssistant,
+      currentAttemptAssistant: terminalAssistant,
+      lastToolError: { toolName: "exec", error: "Command exited with code 1" },
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+
+    const request = (
+      payloadsWithToolMedia = buildEmbeddedRunPayloads({
+        assistantTexts: attempt.assistantTexts,
+        lastAssistant: terminalAssistant,
+        currentAssistant: terminalAssistant,
+        lastToolError: attempt.lastToolError,
+        sessionKey: "session:stale-error",
+      }),
+    ) =>
+      resolveSettledTurnFinalizationRequest({
+        runParams: {
+          sessionId: "session:stale-error",
+          runId: "run:stale-error",
+          trigger: "user",
+          terminalReplyExpectation: "required",
+        } as never,
+        attempt,
+        activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
+        modelApi: "openai-responses",
+        executionContract: undefined,
+        payloadsWithToolMedia,
+        hasTerminalToolPresentation: false,
+        terminalState: resolveEmbeddedRunAttemptTerminalState({
+          attempt,
+          assistant: terminalAssistant,
+        }),
+        settledTurnFinalizationAvailable: true,
+      });
+
+    expect(request()).toBe(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+    expect(request([{ text: progress, mediaUrls: ["file:///tmp/result.png"] }])).toBeNull();
+    attempt.settledTurnFinalizationContext = {
+      source: "openclaw-transcript",
+      messages: attempt.messagesSnapshot,
+    };
+    expect(
+      request([
+        { text: progress },
+        setReplyPayloadMetadata(
+          { text: "The provider connection ended.", isError: true },
+          { terminalProviderError: true },
+        ),
+      ]),
+    ).toBe(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+
+    const finalAnswer = "The file contains the requested value.";
+    attempt.assistantTexts.push(finalAnswer);
+    attempt.messagesSnapshot.push(
+      buildEmbeddedRunnerAssistant({ content: [{ type: "text", text: finalAnswer }] }),
+    );
+    expect(request([{ text: finalAnswer }])).toBeNull();
   });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from "node:crypto";
 import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
-import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
@@ -34,7 +33,7 @@ import {
 } from "./auth-profile-success.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import { resolveFinalAssistantVisibleText } from "./helpers.js";
-import { hasComposedVisibleAnswerAfterSettledTools } from "./incomplete-turn-classification.js";
+import { countSettledTurnDeliveryPayloads } from "./incomplete-turn-classification.js";
 import {
   resolveEmptyResponseRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
@@ -126,27 +125,11 @@ export function resolveSettledTurnFinalizationRequest(input: {
   }
   const terminalAborted = isEmbeddedRunTerminalAbort(input.terminalState.outcome);
   const terminalTimedOut = isEmbeddedRunTerminalTimeout(input.terminalState.outcome);
-  // Generated errors are fallback surfaces, not authored answers. Trust their
-  // producer provenance; the recovery owner still requires exact settlement,
-  // transient-failure context, and no delivery or asynchronous work.
-  const hasNoAssistantText = input.attempt.assistantTexts.every((text) => !text.trim());
-  const canFinalizeProviderError =
-    input.attempt.settledTurnFinalizationContext &&
-    !hasComposedVisibleAnswerAfterSettledTools(input.attempt);
-  const hasOnlySyntheticErrorPayload =
-    (input.payloadsWithToolMedia?.length ?? 0) > 0 &&
-    input.payloadsWithToolMedia?.every((payload) => {
-      const metadata = getReplyPayloadMetadata(payload);
-      return (
-        payload.isError === true &&
-        Object.keys(payload).every((key) => key === "text" || key === "isError") &&
-        ((hasNoAssistantText && metadata?.toolErrorWarning) ||
-          (canFinalizeProviderError && metadata?.terminalProviderError))
-      );
-    });
-  const preparedPayloadCount = hasOnlySyntheticErrorPayload
-    ? 0
-    : (input.payloadsWithToolMedia?.length ?? 0);
+  // Generated errors and pre-tool commentary are fallback surfaces, not authored answers.
+  const preparedPayloadCount = countSettledTurnDeliveryPayloads({
+    payloads: input.payloadsWithToolMedia,
+    attempt: input.attempt,
+  });
   const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
     isCronTrigger: input.runParams.trigger === "cron",
     payloadCount: preparedPayloadCount,


### PR DESCRIPTION
Fixes #132762.

## What Problem This Solves

Fixes an issue where users received no composed answer after an early tool failed, a later different tool succeeded, and the model stopped after reporting progress.

## Why This Change Was Made

A fully settled successful final tool batch can now request a tool-free final answer despite an earlier retained error. Pre-tool progress and its transcript bookkeeping do not count as final delivery. The original error remains available to terminal handling, including existing fatal execution-denial signals used by scheduled runs.

## User Impact

Users get the missing final answer without repeating completed tools. Existing cancellation, delivery, asynchronous work, silence, and successful termination controls remain in place.

## Evidence

Used a deterministic loopback provider with the real built public CLI, Gateway, node host, tools, and isolated state.

| Scenario | Before | Corrected candidate |
| --- | --- | --- |
| Missing-file read, then successful shell check with progress, then empty model stop | Three model requests; empty final answer; generated read warning; one shell effect | Four requests, including one tool-free finalizer; one honest final answer; one shell effect |
| Independent prompt and different file/check | — | Same result; original read error stays saved and counted; no repeated tools |
| Real nested node execution denial, then successful direct read | — | One tool-free finalizer produces an honest answer; scheduled status stays `error` with `SYSTEM_RUN_DENIED` |
| Same fatal signal with finalizer rejected by the provider | — | Scheduled status stays `error`; original execution failure remains in diagnostics; no repeated tools |

The scheduled controls use the supported Tool Search code guest to retain the native nested denial. They request no channel delivery; finalizer text is verified in the saved transcript, while public run history verifies the failed status. The ordinary and independent CLI turns verify the visible final answer. Direct-tool error serialization is outside this change.

Validation: 80 focused owner/sibling tests, including indexed progress, retained fatal signals with answered/failed/empty/unavailable/cancelled finalization, termination/silence, lifecycle/replay/delivery guards, and writer fencing. Formatting, syntax and boundary lint, file-size and assertion-safety ratchets, and the combined runtime/UI build pass.

Baseline: `b158c5214f2a1eef5cd59aa8d1bd35b163e3dc4f`. Corrected source: `61034eb322419971f92970b002c9f9a9f9002eb0`, preserving contributor `9a7a29200c623d35512839f46a3f167554aa700e`. The tested build was made from the same tree before signing; its original build stamp is retained.

The original overflow report is retained as history. The later 2026.8.2 report was withdrawn and is not used as proof. This repair preserves the contributor's original commit ancestry and addresses the two review findings about progress metadata and fatal failure retention.
