### PR TITLE
fix(doctor): recover legacy node tokens with invalid scopes

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -137,9 +137,18 @@ openclaw devices rotate --device <deviceId> --role operator --scope operator.rea
 
 - The target role must already exist in that device's approved pairing contract; rotation cannot mint a new unapproved role.
 - Omitting `--scope` retains the target token's current scopes. Passing explicit `--scope` values replaces that scope set, within the device's approved baseline, for future cached-token reconnects.
+- Pass `--no-scopes` to request an empty scope set. It cannot be combined with `--scope`.
 - A non-admin paired-device caller can rotate only its **own** device token, and the target scope set must stay within the caller's own operator scopes; rotation cannot mint or preserve a broader token than the caller already has.
 
 Returns rotation metadata as JSON. If the caller rotates its own token while authenticated with that device token, the response includes the replacement token so the client can persist it before reconnecting. Shared-secret callers and callers rotating another device never receive the bearer token.
+
+When Doctor reports a legacy node token carrying operator scopes, use its explicit recovery command:
+
+```bash
+openclaw devices rotate --device <deviceId> --role node --no-scopes
+```
+
+This recovery requires `operator.admin` and preserves the device's operator pairing and approved scopes. The Gateway removes only a local cached node token that matches the retired legacy token, in the same commit as rotation. For a node host using a separate state directory, provide valid shared Gateway authentication and restart the node to refresh its cache. A retired device token alone cannot authenticate the reconnect.
 
 ### `openclaw devices revoke --device <id> --role <role>`
 

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -58,6 +58,7 @@ type DevicesRpcOpts = {
   device?: string;
   role?: string;
   scope?: string[];
+  scopes?: boolean;
   name?: string;
 };
 
@@ -1114,7 +1115,7 @@ export async function runDevicesRotateCommand(opts: DevicesRpcOpts): Promise<voi
   if (!required) {
     return;
   }
-  const params = { ...required, scopes: Array.isArray(opts.scope) ? opts.scope : undefined };
+  const params = { ...required, scopes: opts.scopes === false ? [] : opts.scope };
   const scopes = await resolveTokenManagementScopes(opts, required, params.scopes);
   const result = await callGatewayCli("device.token.rotate", opts, params, { scopes });
   defaultRuntime.writeJson(result);

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -71,7 +71,7 @@ async function runDevicesApprove(argv: string[]) {
 }
 
 async function runDevicesCommand(argv: string[]) {
-  const program = new Command();
+  const program = new Command().exitOverride();
   registerDevicesCli(program);
   await program.parseAsync(["devices", ...argv], { from: "user" });
 }
@@ -759,6 +759,38 @@ describe("devices cli clear", () => {
 });
 
 describe("devices cli tokens", () => {
+  it.each([
+    { name: "omitted", flags: [], requestedScopes: undefined },
+    { name: "explicitly empty", flags: ["--no-scopes"], requestedScopes: [] },
+  ])("preserves $name rotation scope intent", async ({ flags, requestedScopes }) => {
+    callGateway.mockResolvedValueOnce({ ok: true });
+
+    await runDevicesCommand(["rotate", "--device", "device-1", "--role", "node", ...flags]);
+
+    expectGatewayCall(0, {
+      method: "device.token.rotate",
+      params: { deviceId: "device-1", role: "node", scopes: requestedScopes },
+      scopes: ["operator.admin"],
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
+  it("rejects conflicting scope options before rotating a token", async () => {
+    await expect(
+      runDevicesCommand([
+        "rotate",
+        "--device",
+        "device-1",
+        "--role",
+        "node",
+        "--scope",
+        "node.read",
+        "--no-scopes",
+      ]),
+    ).rejects.toThrow("cannot be used with option");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
   describe.each(["rotate", "revoke"])("%s", (command) => {
     it.each([
       { role: "node", scopes: ["operator.admin"] },

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -1,5 +1,5 @@
 // Commander registration for device pairing and auth-token commands.
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { runDevicesListCommand } from "./devices-cli.runtime.js";
 import { isDevicesMachineOutput } from "./devices-output-mode.js";
@@ -119,6 +119,7 @@ export function registerDevicesCli(program: Command) {
       .requiredOption("--device <id>", "Device id")
       .requiredOption("--role <role>", "Role name")
       .option("--scope <scope...>", "Scopes to attach to the token (repeatable)")
+      .addOption(new Option("--no-scopes", "Rotate with an empty scope set").conflicts("scope"))
       .action(async (opts: DevicesRpcOpts) => {
         const { runDevicesRotateCommand } = await loadDevicesRuntime();
         await runDevicesRotateCommand(opts);

--- a/src/commands/doctor-device-pairing.test.ts
+++ b/src/commands/doctor-device-pairing.test.ts
@@ -358,6 +358,41 @@ describe("noteDevicePairingHealth", () => {
     });
   });
 
+  it.each([
+    { role: "node", tokenScopes: ["operator.read"], recoveryOption: " --no-scopes" },
+    { role: "operator", tokenScopes: ["operator.admin"], recoveryOption: "" },
+  ])(
+    "recommends explicit scope recovery only for legacy node tokens: $role",
+    async ({ role, tokenScopes, recoveryOption }) => {
+      callGatewayMock.mockResolvedValue({
+        pending: [],
+        paired: [
+          {
+            deviceId: "paired-device",
+            publicKey: "paired-public-key",
+            roles: [role],
+            scopes: ["operator.read"],
+            tokens: [{ role, scopes: tokenScopes, createdAtMs: 1 }],
+            createdAtMs: 1,
+            approvedAtMs: 1,
+          },
+        ],
+      });
+
+      const findings = await collectDevicePairingHealthFindings({
+        cfg: { gateway: { mode: "remote" } },
+        healthOk: true,
+      });
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          requirement: "token-outside-approved-scope",
+          fixHint: `Rotate it with openclaw devices rotate --device paired-device --role ${role}${recoveryOption}.`,
+        }),
+      );
+    },
+  );
+
   it("does not suggest rotating local auth for a role that is no longer approved", async () => {
     await withApprovedOperatorPairing(async ({ identity }) => {
       storeDeviceAuthToken({

--- a/src/commands/doctor-device-pairing.ts
+++ b/src/commands/doctor-device-pairing.ts
@@ -361,13 +361,14 @@ function collectPairedRecordIssues(snapshot: DoctorPairingSnapshot): PairedRecor
           allowedScopes: approvedScopes,
         })
       ) {
+        const recoveryCommand = role === "node" ? `${rotateCommand} --no-scopes` : rotateCommand;
         issues.push({
           kind: "token-outside-approved-scope",
           deviceId: device.deviceId,
           deviceLabel,
           role,
-          message: `Paired device ${deviceLabel} has a ${role} token outside the approved scope baseline [${formatScopes(approvedScopes)}]. Rotate it with ${rotateCommand}.`,
-          fixHint: `Rotate it with ${rotateCommand}.`,
+          message: `Paired device ${deviceLabel} has a ${role} token outside the approved scope baseline [${formatScopes(approvedScopes)}]. Rotate it with ${recoveryCommand}.`,
+          fixHint: `Rotate it with ${recoveryCommand}.`,
         });
       }
     }

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -232,19 +232,27 @@ export function clearDeviceAuthToken(params: {
   let cleared = false;
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      const baseQuery = getNodeSqliteKysely<DeviceAuthDatabase>(db)
-        .deleteFrom("device_auth_tokens")
-        .where("device_id", "=", params.deviceId)
-        .where("role", "=", normalizeDeviceAuthRole(params.role));
-      const query =
-        params.expectedToken === undefined
-          ? baseQuery
-          : baseQuery.where("token", "=", params.expectedToken);
-      cleared = executeSqliteQuerySync(db, query).numAffectedRows === 1n;
+      cleared = clearDeviceAuthTokenFromDatabase(db, params);
     },
     { env: params.env },
   );
   return cleared;
+}
+
+/** Join token-owner recovery without opening a different profile or transaction. */
+export function clearDeviceAuthTokenFromDatabase(
+  db: DatabaseSync,
+  params: { deviceId: string; role: string; expectedToken?: string },
+): boolean {
+  const baseQuery = getNodeSqliteKysely<DeviceAuthDatabase>(db)
+    .deleteFrom("device_auth_tokens")
+    .where("device_id", "=", params.deviceId)
+    .where("role", "=", normalizeDeviceAuthRole(params.role));
+  const query =
+    params.expectedToken === undefined
+      ? baseQuery
+      : baseQuery.where("token", "=", params.expectedToken);
+  return executeSqliteQuerySync(db, query).numAffectedRows === 1n;
 }
 
 /** Load one device token bound to an exact normalized gateway origin. */

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -23,6 +23,7 @@ import {
   type OpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { clearDeviceAuthTokenFromDatabase } from "./device-auth-store.js";
 import { bindCloudWorkerSetupCompletion } from "./device-pairing-cloud-worker.js";
 import type {
   DeviceAuthToken,
@@ -59,8 +60,6 @@ const DEVICE_BOOTSTRAP_TOKEN_COLUMNS_WITHOUT_SETUP = [
   "token_key",
   "ts",
 ] as const satisfies readonly (keyof DeviceBootstrapTokens)[];
-
-type DevicePairingStoreTarget = "pending" | "paired" | "both";
 
 type DevicePairingStoreValidityToken = {
   dataVersion: number;
@@ -491,8 +490,11 @@ export function updatePairedDevicePresenceInTransaction<T>(
 export function persistDevicePairingStoreState(
   state: DevicePairingStoreState,
   baseDir: string | undefined,
-  target: DevicePairingStoreTarget,
-  options?: { clearApnsNodeIds?: readonly string[] },
+  target: "pending" | "paired" | "both",
+  options?: {
+    clearApnsNodeIds?: readonly string[];
+    retiredNodeToken?: { deviceId: string; expectedToken: string };
+  },
 ): void {
   runDevicePairingStoreMutation(baseDir, ({ db }) => {
     const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
@@ -512,6 +514,9 @@ export function persistDevicePairingStoreState(
     }
     for (const nodeId of new Set(options?.clearApnsNodeIds ?? [])) {
       clearApnsRegistrationFromDatabase(db, nodeId);
+    }
+    if (options?.retiredNodeToken) {
+      clearDeviceAuthTokenFromDatabase(db, { ...options.retiredNodeToken, role: "node" });
     }
     return { mutated: true, value: undefined };
   });

--- a/src/infra/device-pairing-tokens.ts
+++ b/src/infra/device-pairing-tokens.ts
@@ -379,7 +379,20 @@ export async function rotateDeviceToken(params: {
     device.tokens = tokens;
     clearNodePairingGenerationState(device, previousNodeGeneration);
     state.pairedByDeviceId[device.deviceId] = device;
-    persistState(state, params.baseDir, "paired");
+    const retiredNodeToken =
+      role === "node" &&
+      params.scopes !== undefined &&
+      requestedScopes.length === 0 &&
+      existing &&
+      !scopesWithinApprovedDeviceBaseline({
+        role,
+        scopes: existing.scopes,
+        approvedScopes,
+      })
+        ? { deviceId: device.deviceId, expectedToken: existing.token }
+        : undefined;
+    // Retire the matching legacy cache with the token, even if the CLI loses its response.
+    persistState(state, params.baseDir, "paired", { retiredNodeToken });
     return { ok: true, entry: next };
   });
 }

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -5,8 +5,17 @@ import {
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
 } from "../shared/device-bootstrap-profile.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import {
+  loadDeviceAuthToken,
+  loadOriginDeviceToken,
+  storeDeviceAuthToken,
+  storeOriginDeviceToken,
+} from "./device-auth-store.js";
 import { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } from "./device-bootstrap.js";
 import { approveBootstrapDevicePairing, approveDevicePairing } from "./device-pairing-approval.js";
 import { updatePairedNodeBins, updatePairedNodeSessionHost } from "./device-pairing-node-facts.js";
@@ -197,6 +206,41 @@ async function makeDevicePairingDir(): Promise<string> {
     throw new Error("device pairing test root is not initialized");
   }
   return suiteBaseDir;
+}
+
+async function setupLegacyNodeTokenRecovery() {
+  const baseDir = await suiteRootTracker.make("legacy-node-recovery");
+  const env = { ...process.env, OPENCLAW_STATE_DIR: baseDir };
+  const request = await requestDevicePairing(
+    {
+      deviceId: "device-1",
+      publicKey: "public-key-1",
+      displayName: "Workshop device",
+      roles: ["operator", "node", "observer"],
+      scopes: ["operator.read"],
+    },
+    baseDir,
+  );
+  await approveDevicePairing(
+    request.request.requestId,
+    { callerScopes: ["operator.admin"] },
+    baseDir,
+  );
+  // Unit fixture only: released upgrade production is covered by the public CLI proof.
+  await mutatePairedDevice(baseDir, "device-1", (device) => {
+    device.operatorLabel = "Workshop";
+    requireValue(device.tokens?.node, "expected node token").scopes = ["operator.read"];
+  });
+  const before = requireValue(await getPairedDevice("device-1", baseDir), "expected paired device");
+  const token = requireToken(before.tokens?.node?.token);
+  const cached = storeDeviceAuthToken({
+    deviceId: "device-1",
+    role: "node",
+    token,
+    scopes: ["operator.read"],
+    env,
+  });
+  return { baseDir, env, before, token, cached };
 }
 
 describe("device pairing tokens", () => {
@@ -1206,6 +1250,142 @@ describe("device pairing tokens", () => {
     paired = await getPairedDevice("device-1", baseDir);
     expect(paired?.tokens?.operator?.scopes).toEqual(["operator.read"]);
   });
+
+  test("recovers legacy node scopes and retires only its matching cached bearer", async () => {
+    const { baseDir, env, before, token, cached } = await setupLegacyNodeTokenRecovery();
+
+    await expect(
+      rotateDeviceToken({ deviceId: "device-1", role: "node", baseDir }),
+    ).resolves.toEqual({ ok: false, reason: "scope-outside-approved-baseline" });
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env })).toEqual(cached);
+
+    const entry = requireRotatedEntry(
+      await rotateDeviceToken({ deviceId: "device-1", role: "node", scopes: [], baseDir }),
+    );
+
+    expect(entry.scopes).toEqual([]);
+    expect(entry.token).not.toBe(token);
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env })).toBeNull();
+    expect(await getPairedDevice("device-1", baseDir)).toEqual({
+      ...before,
+      tokens: { ...before.tokens, node: entry },
+    });
+    await expect(
+      verifyDeviceToken({ deviceId: "device-1", role: "node", token, scopes: [], baseDir }),
+    ).resolves.toEqual({ ok: false, reason: "token-mismatch" });
+    await expect(
+      verifyDeviceToken({
+        deviceId: "device-1",
+        role: "node",
+        token: entry.token,
+        scopes: [],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  test("legacy node recovery preserves refreshed and unrelated cached credentials", async () => {
+    const { baseDir, env, token } = await setupLegacyNodeTokenRecovery();
+    const refreshed = storeDeviceAuthToken({
+      deviceId: "device-1",
+      role: "node",
+      token: "refreshed-node-bearer",
+      scopes: [],
+      env,
+      expectedToken: token,
+    });
+    const operator = storeDeviceAuthToken({ deviceId: "device-1", role: "operator", token, env });
+    const otherDevice = storeDeviceAuthToken({ deviceId: "device-2", role: "node", token, env });
+    const gatewayScope = "wss://other-gateway.example/rpc";
+    const origin = storeOriginDeviceToken({
+      gatewayScope,
+      deviceId: "device-1",
+      role: "node",
+      token,
+      env,
+    });
+    const otherEnv = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: await suiteRootTracker.make("other-profile"),
+    };
+    const otherProfile = storeDeviceAuthToken({
+      deviceId: "device-1",
+      role: "node",
+      token,
+      env: otherEnv,
+    });
+
+    requireRotatedEntry(
+      await rotateDeviceToken({ deviceId: "device-1", role: "node", scopes: [], baseDir }),
+    );
+
+    expect(refreshed).not.toBeNull();
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env })).toEqual(refreshed);
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator", env })).toEqual(operator);
+    expect(loadDeviceAuthToken({ deviceId: "device-2", role: "node", env })).toEqual(otherDevice);
+    expect(
+      loadOriginDeviceToken({ gatewayScope, deviceId: "device-1", role: "node", env }),
+    ).toEqual(origin);
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env: otherEnv })).toEqual(
+      otherProfile,
+    );
+  });
+
+  test("rolls back legacy node rotation when matching cache cleanup fails", async () => {
+    const { baseDir, env, before, cached } = await setupLegacyNodeTokenRecovery();
+    const { db } = openOpenClawStateDatabase({ env });
+    db.exec(`
+      CREATE TEMP TRIGGER reject_node_cache_cleanup BEFORE DELETE ON device_auth_tokens
+      WHEN OLD.device_id = 'device-1' AND OLD.role = 'node'
+      BEGIN SELECT RAISE(ABORT, 'node cache cleanup refused'); END;
+    `);
+    try {
+      await expect(
+        rotateDeviceToken({ deviceId: "device-1", role: "node", scopes: [], baseDir }),
+      ).rejects.toThrow("node cache cleanup refused");
+      expect(await getPairedDevice("device-1", baseDir)).toEqual(before);
+      expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env })).toEqual(cached);
+    } finally {
+      db.exec("DROP TRIGGER reject_node_cache_cleanup");
+    }
+
+    requireRotatedEntry(
+      await rotateDeviceToken({ deviceId: "device-1", role: "node", scopes: [], baseDir }),
+    );
+    expect(loadDeviceAuthToken({ deviceId: "device-1", role: "node", env })).toBeNull();
+  });
+
+  test.each([
+    { name: "omitted scopes", scopes: undefined, expectedScopes: ["node.exec"] },
+    { name: "explicit empty scopes", scopes: [], expectedScopes: [] },
+  ])(
+    "valid node rotation with $name does not apply legacy cache cleanup",
+    async ({ scopes, expectedScopes }) => {
+      const baseDir = await suiteRootTracker.make("valid-node-rotation");
+      const env = { ...process.env, OPENCLAW_STATE_DIR: baseDir };
+      const request = await requestDevicePairing(
+        { deviceId: "node-1", publicKey: "node-key", role: "node", scopes: ["node.exec"] },
+        baseDir,
+      );
+      await approveDevicePairing(request.request.requestId, baseDir);
+      const before = requireValue(await getPairedDevice("node-1", baseDir), "expected paired node");
+      const cached = storeDeviceAuthToken({
+        deviceId: "node-1",
+        role: "node",
+        token: requireToken(before.tokens?.node?.token),
+        scopes: ["node.exec"],
+        env,
+      });
+
+      const entry = requireRotatedEntry(
+        await rotateDeviceToken({ deviceId: "node-1", role: "node", scopes, baseDir }),
+      );
+
+      expect(entry.scopes).toEqual(expectedScopes);
+      expect(loadDeviceAuthToken({ deviceId: "node-1", role: "node", env })).toEqual(cached);
+      expect((await getPairedDevice("node-1", baseDir))?.approvedScopes).toEqual(["node.exec"]);
+    },
+  );
 
   test("preserves existing token scopes when approving a repair without requested scopes", async () => {
     const baseDir = await makeDevicePairingDir();


### PR DESCRIPTION
Fixes #143263. Thanks @matthewmoroz for the report.

## What Problem This Solves

Doctor identified legacy node tokens with inherited operator scopes, but its suggested rotation kept those scopes and was denied.

## Why This Change Was Made

The devices rotate command adds --no-scopes, and Doctor uses it in node recovery guidance. Rotation removes only the matching stale local node credential in the same transaction while preserving operator pairing, approved scopes, authorization, and token-delivery rules.

## User Impact

Operators can rotate a legacy node token without retaining invalid scopes. Omitted scopes keep their existing meaning; --scope and --no-scopes conflict. Operator access survives node recovery.

Consumers: node recovery guidance and token rotation now support explicitly empty scopes.

## Evidence

Public pairing on release 2026.3.11 followed by an upgrade reproduced the failure. The corrected command succeeded, removed the matching cached credential, and preserved operator access through restart and reconnect. All 203 focused command-line, Doctor, pairing, credential-store, and Gateway authorization tests passed. Public command and signed-protocol checks covered recovery, rejected changes, token delivery, revocation, interrupted responses, and restart. The real node fixture used Linux; native macOS executable discovery was not run.
