### PR TITLE
fix(system-agent): read quoted configuration keys

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -102,6 +102,10 @@ quit
 
 OpenClaw uses typed operations instead of editing config ad hoc.
 
+For `config get`, quote record keys that contain dots or brackets, such as
+`config get channels.modelByChannel.telegram["team.ops[west]"]`.
+Config reads redact sensitive values before selecting the requested path.
+
 Read-only operations run immediately: show overview, list agents, list installed plugins, search ClawHub plugins, show model/backend status, run status/health checks, check Gateway reachability, run doctor without interactive fixes, validate config, show the audit-log path.
 
 Starting a guided setup flow also runs immediately: channel setup (`connect telegram`), workspace skills setup (`configure skills`), web-search provider setup (`configure web search`), and local Gateway setup (`configure gateway`). Each config-backed hosted wizard collects explicit answers and owns the resulting writes; completions append audit entries and re-validate config. A web-search provider that needs a plugin install writes config only after the install succeeds — a failed or timed-out install stops setup and reports it instead of claiming the provider is configured.

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -1,5 +1,6 @@
 // Shared execution helpers keep the public dispatcher small and reviewable.
 import { tryResolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
+import { parseConfigSetPath } from "../cli/config-cli-path.js";
 import type { ConfigSetOptions } from "../cli/config-set-input.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -40,22 +41,19 @@ export function readConfigValueAtPath(
   path: string,
 ): { found: boolean; value?: unknown } {
   let current: unknown = config;
-  for (const rawSegment of path.split(".")) {
-    // Support foo[0] style array segments alongside dotted keys.
-    const parts = rawSegment.split(/[[\]]/).filter(Boolean);
-    for (const part of parts) {
-      if (current === null || typeof current !== "object") {
-        return { found: false };
-      }
-      const index = /^\d+$/.test(part) ? Number(part) : undefined;
-      if (index !== undefined && Array.isArray(current)) {
-        current = current[index];
-      } else {
-        current = (current as Record<string, unknown>)[part];
-      }
-      if (current === undefined) {
-        return { found: false };
-      }
+  for (const part of parseConfigSetPath(path)) {
+    if (current === null || typeof current !== "object") {
+      return { found: false };
+    }
+    // Reads allow array properties and indices beyond the CLI writer's sparse-write limit.
+    const index = /^\d+$/.test(part) ? Number(part) : undefined;
+    if (index !== undefined && Array.isArray(current)) {
+      current = current[index];
+    } else {
+      current = (current as Record<string, unknown>)[part];
+    }
+    if (current === undefined) {
+      return { found: false };
     }
   }
   return { found: true, value: current };
@@ -358,7 +356,6 @@ async function isDefaultAgentListPath(segments: readonly string[]): Promise<bool
 export async function assertConfigWriteDoesNotBypassInferenceVerification(
   operation: Extract<SystemAgentOperation, { kind: "config-set" | "config-set-ref" }>,
 ): Promise<void> {
-  const { parseConfigSetPath } = await import("../cli/config-cli.js");
   const segments = parseConfigSetPath(operation.path);
   const verdict: InferenceRoutePathVerdict = classifyInferenceRouteConfigPath(segments);
   if (verdict === "allowed") {

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -18,6 +18,7 @@ import {
   describeSystemAgentPersistentOperation,
   executeSystemAgentOperation,
   isPersistentSystemAgentOperation,
+  parseSystemAgentOperation,
 } from "./operations.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 import { createSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
@@ -57,6 +58,14 @@ function requireFirstMockCall(mock: unknown, label: string): unknown[] {
 function expectRuntimeArg(value: unknown) {
   const runtime = requireRecord(value, "runtime argument");
   expect(typeof runtime.log).toBe("function");
+}
+
+async function readConfigOutput(...paths: string[]): Promise<string> {
+  const { runtime, lines } = createSystemAgentTestRuntime();
+  for (const configPath of paths) {
+    await executeSystemAgentOperation({ kind: "config-get", path: configPath }, runtime);
+  }
+  return lines.join("\n");
 }
 
 const mockConfig = vi.hoisted(() => {
@@ -266,15 +275,10 @@ describe("system agent operations", () => {
         },
       },
     });
-    const { runtime, lines } = createSystemAgentTestRuntime();
+    const output = await readConfigOutput("models.providers.local.localService");
 
-    await executeSystemAgentOperation(
-      { kind: "config-get", path: "models.providers.local.localService" },
-      runtime,
-    );
-
-    expect(lines.join("\n")).toContain('"HF_HOME": "<redacted>"');
-    expect(lines.join("\n")).not.toContain("/private/model-cache");
+    expect(output).toContain('"HF_HOME": "<redacted>"');
+    expect(output).not.toContain("/private/model-cache");
     expect(
       describeSystemAgentPersistentOperation({
         kind: "config-set",
@@ -282,6 +286,27 @@ describe("system agent operations", () => {
         value: "/private/model-cache",
       }),
     ).toBe("set config models.providers.local.localService.env.HF_HOME to <redacted>");
+  });
+
+  it.each([
+    ['channels.modelByChannel.telegram["team.ops[west]"]', '"openai/gpt-5.5"'],
+    ["channels.modelByChannel.telegram['team.ops[west]']", '"openai/gpt-5.5"'],
+    [String.raw`channels.modelByChannel.telegram.team\.ops\[west\]`, '"openai/gpt-5.5"'],
+    ['models.providers["local.service"].apiKey', '"<redacted>"'],
+    ["agents.list[0].id", '"main"'],
+    ["agents.list[00].id", '"main"'],
+    ["agents.list.length", "1"],
+  ])("reads canonical config path %s after redaction", async (configPath, expected) => {
+    mockConfig.setConfig({
+      channels: { modelByChannel: { telegram: { "team.ops[west]": "openai/gpt-5.5" } } },
+      models: { providers: { "local.service": { apiKey: "synthetic-key" } } },
+      agents: { list: [{ id: "main" }] },
+    });
+    const { runtime, lines } = createSystemAgentTestRuntime();
+    const operation = parseSystemAgentOperation(`config get ${configPath}`);
+    expect(operation).toEqual({ kind: "config-get", path: configPath });
+    expect(await executeSystemAgentOperation(operation, runtime)).toEqual({ applied: false });
+    expect(lines).toEqual([`${configPath} = ${expected}`]);
   });
 
   it("keeps invalid config reads available without exposing recovery secrets", async () => {
@@ -294,13 +319,7 @@ describe("system agent operations", () => {
       },
       {},
     );
-    const { runtime, lines } = createSystemAgentTestRuntime();
-    await executeSystemAgentOperation({ kind: "config-get", path: "gateway" }, runtime);
-    await executeSystemAgentOperation(
-      { kind: "config-get", path: "plugins.entries.missing" },
-      runtime,
-    );
-    const output = lines.join("\n");
+    const output = await readConfigOutput("gateway", "plugins.entries.missing");
     expect(output).toContain('"port": 19001');
     expect(output).toContain('"token": "<redacted>"');
     expect(output).toContain('"config": "<redacted>"');
@@ -317,15 +336,7 @@ describe("system agent operations", () => {
       },
       channels: { missing: { enabled: true, opaque: "missing-channel-secret" } },
     });
-    const { runtime, lines } = createSystemAgentTestRuntime();
-
-    await executeSystemAgentOperation(
-      { kind: "config-get", path: "plugins.entries.missing" },
-      runtime,
-    );
-    await executeSystemAgentOperation({ kind: "config-get", path: "channels.missing" }, runtime);
-
-    const output = lines.join("\n");
+    const output = await readConfigOutput("plugins.entries.missing", "channels.missing");
     expect(output).toContain('"enabled": true');
     expect(output).toContain('"config": "<redacted>"');
     expect(output).toContain('channels.missing = "<redacted>"');
@@ -340,15 +351,7 @@ describe("system agent operations", () => {
         modelByChannel: { telegram: { chat: "openai/gpt-5.5" } },
       },
     });
-    const { runtime, lines } = createSystemAgentTestRuntime();
-
-    await executeSystemAgentOperation({ kind: "config-get", path: "channels.defaults" }, runtime);
-    await executeSystemAgentOperation(
-      { kind: "config-get", path: "channels.modelByChannel" },
-      runtime,
-    );
-
-    const output = lines.join("\n");
+    const output = await readConfigOutput("channels.defaults", "channels.modelByChannel");
     expect(output).toContain('"groupPolicy": "open"');
     expect(output).toContain('"chat": "openai/gpt-5.5"');
     expect(output).not.toContain("<redacted>");
@@ -365,17 +368,12 @@ describe("system agent operations", () => {
     };
     mockConfig.setConfig(config);
     const pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
-    const { runtime, lines } = createSystemAgentTestRuntime();
+    const output = await pluginMetadata.run(() =>
+      readConfigOutput("plugins.entries.codex.config.appServer"),
+    );
 
-    await pluginMetadata.run(async () => {
-      await executeSystemAgentOperation(
-        { kind: "config-get", path: "plugins.entries.codex.config.appServer" },
-        runtime,
-      );
-    });
-
-    expect(lines.join("\n")).toContain('"headers": "<redacted>"');
-    expect(lines.join("\n")).not.toContain(authorization);
+    expect(output).toContain('"headers": "<redacted>"');
+    expect(output).not.toContain(authorization);
   });
 
   it("keeps sensitive channel callback URLs out of model-visible config reads", async () => {
@@ -395,19 +393,14 @@ describe("system agent operations", () => {
     mockConfig.setConfig(config);
     setRuntimeConfigSnapshot(config, config);
     const pluginMetadata = createSystemAgentPluginMetadataTestSnapshot(config);
-    const { runtime, lines } = createSystemAgentTestRuntime();
-
     try {
       await pluginMetadata.run(async () => {
-        await executeSystemAgentOperation(
-          { kind: "config-get", path: "channels.synology-chat" },
-          runtime,
-        );
+        const output = await readConfigOutput("channels.synology-chat");
 
-        expect(lines.join("\n")).toContain('"webhookUrl": "<redacted>"');
-        expect(lines.join("\n")).toContain('"incomingUrl": "<redacted>"');
-        expect(lines.join("\n")).not.toContain("callback-secret");
-        expect(lines.join("\n")).not.toContain("incoming-secret");
+        expect(output).toContain('"webhookUrl": "<redacted>"');
+        expect(output).toContain('"incomingUrl": "<redacted>"');
+        expect(output).not.toContain("callback-secret");
+        expect(output).not.toContain("incoming-secret");
         expect(
           describeSystemAgentPersistentOperation({
             kind: "config-set",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading configuration through the OpenClaw setup agent or its tool would receive “not set” for existing record keys containing dots or brackets. For example, `config get channels.modelByChannel.telegram["team.ops[west]"]` was accepted as a command but could not read the matching value.

## Why This Change Was Made

Use the existing configuration-path parser for reads as well as command validation, removing the reader's independent dot/bracket splitting. Keep whole-config redaction before selection and retain existing array lookup behavior, including length, zero-padded indices, and indices above the CLI writer's sparse-write limit. Malformed paths supplied directly through the tool now receive the canonical path error through its existing error handler.

## User Impact

Quoted and escaped record keys can be read correctly, and sensitive values remain redacted. The setup-agent documentation includes a quoted-key example. No configuration writes, schema, or inference behavior changes.

## Evidence

- Before the fix, four new operation-boundary cases failed with “not set”; the ordinary indexed-array control passed. The cases cover double quotes, single quotes, escaped punctuation, and a redacted credential field.
- Final operation, parser, and redaction suites: 129 tests passed, including preserved zero-padded indices and array length.
- A comparison of the original and final reader functions with the real shared parser preserves 523 existing results, including missing/null/undefined values and indices above 100,000, and verifies four corrected quoted-key results. This is bounded function proof; no live Gateway or real configuration was used.
- Fresh managed review: scoped clean through P2. The full changed-file gate and `pnpm build` pass. The build reports a non-enforcing UI startup gzip budget overrun of 8 bytes (352,243 versus 352,235 bytes); no UI source is changed.

This is a correctness repair found during the reduction audit. Sharing the existing config-read test setup keeps every assertion and makes room for the new regressions without raising the file limit. Complete local cost is −3 production / −2 test = −5 maintained code lines (−10 physical); documentation adds 3 code / 4 physical lines separately.
