### PR TITLE
fix(sessions): keep maintenance responsive after handle eviction

### DIFF
--- a/docs/reference/database-schemas/integrity-and-recovery.md
+++ b/docs/reference/database-schemas/integrity-and-recovery.md
@@ -36,6 +36,8 @@ Agent database maintenance fences other writers with a 60-second lease in the sh
 
 Asynchronous agent-database admission and maintenance run their initial full-file integrity check in a read-only child process when that check is outside a write transaction. The connection and owning scope remain held until the child closes, including on cancellation or timeout. Schema changes, index repairs, and compaction retain their synchronous phases.
 
+Explicit session-maintenance finalization uses this asynchronous admission if its writable handle was evicted during archive or deletion preparation. It keeps its place in the session writer queue and rechecks maintenance and deletion authority before committing. Automatic maintenance retires when its original handle closes instead of reopening it.
+
 The integrity child and both asynchronous and synchronous read-only snapshot workers share a lifetime budget: 30 seconds for startup and shutdown plus one second per 32 MiB of source database file size, rounded up, capped at 30 minutes. A full copy or full scan reads the whole file at least once; the budget allows for a conservative cold-cache read rate of 32 MiB/s. A 9.4 GiB database gets 331 seconds. Budgets above 30 seconds are logged once per call at debug level with the operation, path, size, and applied budget, keeping ordinary CLI output quiet. If the snapshot worker cannot stat the source, it uses the 30-second base budget and lets the child report the underlying error.
 
 The synchronous byte-neutral snapshot strategy is for small or quiescent databases. Inspections of a live agent database, including memory-core readiness, use the asynchronous online-backup worker.

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -51,6 +51,7 @@ import {
   getSessionKysely,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  withSqliteSessionDatabase,
   type ResolvedSqliteReadScope,
 } from "./session-accessor.sqlite-scope.js";
 import { planSessionEntryMaintenance } from "./store-maintenance-plan.js";
@@ -583,34 +584,44 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
         batch.entryRemovals.flatMap(({ expectedEntry: entry, sessionKey }) =>
           entry ? [{ entry, sessionKey }] : [],
         ),
-        async () =>
+        async (assertCurrent) =>
           await runExclusiveSqliteSessionWrite(
             scope,
             async () => {
               if (!isCurrent()) {
                 return [];
               }
-              let committed: SessionLifecycleArchivedTranscript[] = [];
-              runOpenClawAgentWriteTransaction((database) => {
-                const partition = partitionUnchangedPlannedLifecycleArtifactEntries(
-                  database,
-                  batch.entryRemovals,
-                );
-                changedEntryRemovals = partition.changed;
-                committedEntryRemovals = partition.unchanged;
-                committed = deleteMaterializedSessionStatePlans(
-                  database,
-                  materializedPlans,
-                  undefined,
-                  new Set(committedEntryRemovals.map((removal) => removal.sessionKey)),
-                );
-                deletePlannedLifecycleArtifactEntries(database, committedEntryRemovals);
-                deferOpenClawAgentPostCommitPublication(
-                  database,
-                  prepareCommittedSessionEntryRemovals(scope.agentId, committedEntryRemovals),
-                );
-              }, toDatabaseOptions(scope));
-              return committed;
+              return await withSqliteSessionDatabase(
+                toDatabaseOptions(scope),
+                () => {
+                  // Cold admission can yield while this maintenance owner retires.
+                  if (!isCurrent()) {
+                    return [];
+                  }
+                  let committed: SessionLifecycleArchivedTranscript[] = [];
+                  runOpenClawAgentWriteTransaction((database) => {
+                    const partition = partitionUnchangedPlannedLifecycleArtifactEntries(
+                      database,
+                      batch.entryRemovals,
+                    );
+                    changedEntryRemovals = partition.changed;
+                    committedEntryRemovals = partition.unchanged;
+                    committed = deleteMaterializedSessionStatePlans(
+                      database,
+                      materializedPlans,
+                      undefined,
+                      new Set(committedEntryRemovals.map((removal) => removal.sessionKey)),
+                    );
+                    deletePlannedLifecycleArtifactEntries(database, committedEntryRemovals);
+                    deferOpenClawAgentPostCommitPublication(
+                      database,
+                      prepareCommittedSessionEntryRemovals(scope.agentId, committedEntryRemovals),
+                    );
+                  }, toDatabaseOptions(scope));
+                  return committed;
+                },
+                assertCurrent,
+              );
             },
             "session.maintenance.finalize",
           ),

--- a/src/config/sessions/session-accessor.sqlite-prepared-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-prepared-admission.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -20,9 +21,11 @@ import {
   closeOpenClawAgentDatabasesForTest,
   getOpenClawAgentDatabaseIfOpen,
   openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config.js";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
 import {
   loadSessionEntryReadOnly,
   loadTranscriptEventsSync,
@@ -31,12 +34,17 @@ import {
 } from "./session-accessor.js";
 import type { SessionEntryLifecycleMutationResult } from "./session-accessor.sqlite-contract.js";
 import {
+  applySessionEntryMaintenance,
+  finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
+} from "./session-accessor.sqlite-maintenance.js";
+import {
   applySessionEntryLifecycleMutation,
   applySessionEntryReplacements,
   applySessionStoreProjection,
 } from "./session-accessor.sqlite-projection.js";
 import {
   resolveSqliteScope,
+  resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
@@ -56,6 +64,7 @@ vi.mock("node:child_process", async (importOriginal) => {
     },
   };
 });
+
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
   return {
@@ -649,5 +658,207 @@ it.each([false, true])(
     expect(rollback).not.toHaveBeenCalled();
     probe.expectHealthy(1);
     expect(loadSessionEntryReadOnly(f.input)?.sessionId).toBe(revoked ? "original" : undefined);
+  },
+);
+
+function maintenanceFixture(native = false) {
+  const f = fixture();
+  const stale = { ...f.input, sessionKey: "agent:main:subagent:maintenance-old", sessionId: "old" };
+  replaceSessionEntrySync(stale, {
+    sessionId: stale.sessionId,
+    updatedAt: 1,
+    ...(native ? { agentHarnessId: "maintenance-native", lifecycleRevision: "generation-1" } : {}),
+  });
+  const events = [{ type: "session", id: "old", content: "retained maintenance history" }];
+  replaceTranscriptEventsSync(stale, events);
+  const config = {
+    session: { maintenance: { mode: "enforce" as const, maxEntries: 1, pruneAfter: "1000000d" } },
+  };
+  setRuntimeConfigSnapshot(config, config);
+  const archiveDirectory = resolveSqliteTranscriptArchiveDirectory(f.scope);
+  return { ...f, stale, events, archiveDirectory };
+}
+
+function expectMaintenanceArchived(f: ReturnType<typeof maintenanceFixture>) {
+  expect(loadSessionEntryReadOnly(f.stale)).toBeUndefined();
+  expect(loadSessionEntryReadOnly(f.input)?.sessionId).toBe("original");
+  expect(loadTranscriptEventsSync(f.stale)).toEqual([]);
+  const archives = fs
+    .readdirSync(f.archiveDirectory)
+    .filter((name) => name.startsWith("old.jsonl.deleted."));
+  expect(archives).toHaveLength(1);
+  expect(
+    readSessionArchiveContentSync(path.join(f.archiveDirectory, archives[0]!))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+  ).toEqual(f.events);
+}
+
+it.each(
+  (["whole-store", "lifecycle", "replacement"] as const).flatMap((owner) =>
+    ([false, true] as const).map((cold) => ({ owner, cold })),
+  ),
+)(
+  "keeps $owner maintenance finalization in the writer FIFO (cold: $cold)",
+  async ({ owner, cold }) => {
+    const f = maintenanceFixture();
+    const probe = observeAdmission(f.databasePath, cold);
+    let preparationWriterRan = false;
+    hooks.afterMaterialize = async () => {
+      await runExclusiveSqliteSessionWrite(
+        f.scope,
+        async () => {
+          preparationWriterRan = true;
+        },
+        "session.transcript.batch",
+      );
+      if (cold) {
+        expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+      }
+    };
+    const work = own<void | SessionEntryLifecycleMutationResult>(
+      owner === "whole-store"
+        ? applySessionStoreProjection({
+            storePath: f.databasePath,
+            update: (store) => {
+              store[f.input.sessionKey]!.label = "kept";
+              return { persist: true, result: undefined };
+            },
+          })
+        : owner === "replacement"
+          ? applySessionEntryReplacements({
+              storePath: f.databasePath,
+              sessionKeys: [f.input.sessionKey],
+              skipMaintenance: false,
+              update: (entries) => ({
+                result: undefined,
+                replacements: entries.map(({ entry, sessionKey }) => ({
+                  sessionKey,
+                  entry: { ...entry, label: "kept" },
+                })),
+              }),
+            })
+          : applySessionEntryLifecycleMutation({
+              storePath: f.databasePath,
+              upserts: [
+                {
+                  sessionKey: f.input.sessionKey,
+                  buildEntry: ({ currentEntry }) => ({ ...currentEntry!, label: "kept" }),
+                },
+              ],
+            }),
+    );
+    if (cold) {
+      await probe.expectPending(work);
+      let laterRan = false;
+      const later = own(
+        runExclusiveSqliteSessionWrite(
+          f.scope,
+          async () => {
+            laterRan = true;
+            expect(loadSessionEntryReadOnly(f.stale)).toBeUndefined();
+          },
+          "session.transcript.batch",
+        ),
+      );
+      await yieldToEventLoop();
+      expect(preparationWriterRan).toBe(true);
+      expect(laterRan).toBe(false);
+      expect(loadSessionEntryReadOnly(f.stale)?.sessionId).toBe("old");
+      probe.release.resolve();
+      await work;
+      await later;
+    } else {
+      await work;
+    }
+    expect(preparationWriterRan).toBe(true);
+    expect(loadSessionEntryReadOnly(f.input)?.label).toBe("kept");
+    expectMaintenanceArchived(f);
+    probe.expectHealthy(cold ? 1 : 0);
+  },
+);
+
+function maintenancePlan(f: ReturnType<typeof maintenanceFixture>) {
+  return runOpenClawAgentWriteTransaction(
+    (database) =>
+      applySessionEntryMaintenance(database, {
+        activeSessionKey: f.input.sessionKey,
+        archiveDirectory: f.archiveDirectory,
+        storePath: f.databasePath,
+      }),
+    f.options,
+  );
+}
+
+it("rechecks maintenance lifetime after cold finalizer admission", async () => {
+  const f = maintenanceFixture();
+  const plan = maintenancePlan(f);
+  const probe = observeAdmission(f.databasePath, true);
+  hooks.afterMaterialize = async () => {
+    expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+  };
+  let current = true;
+  const work = own(
+    finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(f.scope, [plan], {
+      isCurrent: () => current,
+    }),
+  );
+  await probe.expectPending(work);
+  current = false;
+  probe.release.resolve();
+  await expect(work).resolves.toMatchObject({ capped: 0, archivedTranscripts: [] });
+  expect(loadSessionEntryReadOnly(f.stale)?.sessionId).toBe("old");
+  expect(loadTranscriptEventsSync(f.stale)).toEqual(f.events);
+  probe.expectHealthy(1);
+});
+
+it.each([false, true])(
+  "rechecks native deletion ownership after cold maintenance admission (revoked: %s)",
+  async (revoked) => {
+    const f = maintenanceFixture(true);
+    const plan = maintenancePlan(f);
+    const registry = createEmptyPluginRegistry();
+    const commit = vi.fn();
+    const rollback = vi.fn();
+    const harness: AgentHarness = {
+      id: "maintenance-native",
+      label: "Maintenance native test",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => {
+        throw new Error("unused test harness");
+      },
+      withSessionDeletion: async (params, run) => {
+        expect(closeOpenClawAgentDatabaseByPath(f.databasePath)).toBe(true);
+        params.assertCurrent();
+        return await run({ commit, rollback });
+      },
+    };
+    const record = createPluginRecord({ id: "maintenance-native-owner" });
+    registry.plugins.push(record);
+    registry.agentHarnesses.push({ harness, pluginId: record.id, source: "runtime" });
+    markPluginRegistryActive(registry);
+    const probe = observeAdmission(f.databasePath, true);
+    const work = own(
+      withPluginRuntimeRegistryScope(registry, () =>
+        finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(f.scope, [plan]),
+      ),
+    );
+    await probe.expectPending(work);
+    expect(commit).not.toHaveBeenCalled();
+    if (revoked) {
+      markPluginRegistryRetired(registry);
+    }
+    probe.release.resolve();
+    await expect(work).resolves.toMatchObject({ capped: revoked ? 0 : 1 });
+    expect(commit).toHaveBeenCalledTimes(revoked ? 0 : 1);
+    expect(rollback).not.toHaveBeenCalled();
+    probe.expectHealthy(1);
+    if (revoked) {
+      expect(loadSessionEntryReadOnly(f.stale)?.sessionId).toBe("old");
+      expect(loadTranscriptEventsSync(f.stale)).toEqual(f.events);
+    } else {
+      expectMaintenanceArchived(f);
+    }
   },
 );


### PR DESCRIPTION
Related: #143434, #143451

## What Problem This Solves

Resolves a problem where explicit session cleanup could run a full SQLite integrity scan on the main thread when its cached database handle was evicted during archive or native deletion preparation.

## Why This Change Was Made

Reacquire the finalizer's database through the existing asynchronous owner while keeping its writer-queue position. Revalidate deletion authority and maintenance lifetime after admission, then run the unchanged synchronous transaction and canonical entry checks. Automatic maintenance still retires when its original handle closes.

This changes no schema, retention rule, queue model, checkpoint mode, warning threshold, or audit policy. The adjacent planner-statistics acquisition is outside this repair.

## User Impact

Cold explicit maintenance can complete its integrity admission without blocking the main thread. Warm finalization, deletion outcomes, archive contents, and writer ordering remain intact.

## Evidence

- Original-source probe: warm finalization performed no main-thread integrity scan; explicit handle closure and actual 64-handle LRU eviction each produced one real main-thread `PRAGMA integrity_check` at the finalizer. All cases retained the same archive/deletion result. The repaired replay produces zero such scans in all three cases.
- Six maintained cold-path regressions fail on the original code because finalization finishes without entering asynchronous child admission. Three warm cases and the existing automatic-owner refusal control pass.
- All 63 cases in the five complete admission, handle lifecycle, maintenance writer, lifecycle authority, and writer-label suites pass with the repair. They verify real integrity-child completion, archive decoding, FIFO ordering, maintenance retirement, and native authority revocation.
- Independent P0–P2 review is clean. Full changed-file validation passed.
- Fresh [Linux proof](https://github.com/openclaw/openclaw/actions/runs/34427513795) at `e1f4645d5c4a` on Node 24.19.0 passed all 63 tests across the same five suites. Native artifacts verify process-tree settlement, both output pipes closed, and unchanged source; the owned Testbox is stopped. The [first attempt](https://github.com/openclaw/openclaw/actions/runs/34426030815) failed in SSH transport with an unverified remote outcome and is not counted as proof.

The tiny-fixture measurements establish the execution boundary; they do not attribute a historical production latency spike or establish sustained-load performance.
