### PR TITLE
refactor(qa): share mock provider decisions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1015,7 +1015,7 @@ extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts	4
 extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts	4
 extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts	6
 extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts	2
-extensions/qa-lab/src/providers/mock-openai/server.ts	16
+extensions/qa-lab/src/providers/mock-openai/server.ts	15
 extensions/qa-lab/src/providers/shared/auth-store.ts	1
 extensions/qa-lab/src/qa-bus-protocol.ts	1
 extensions/qa-lab/src/qa-transport.ts	1

--- a/extensions/qa-lab/src/providers/aimock/server.ts
+++ b/extensions/qa-lab/src/providers/aimock/server.ts
@@ -9,7 +9,7 @@ import {
   type JournalEntry,
   type Mountable,
 } from "@copilotkit/aimock";
-import { parseQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
+import { resolveQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
 import { writeJson } from "../shared/http-json.js";
 
 type AimockRequestSnapshot = {
@@ -325,28 +325,13 @@ function createDebugMount(): Mountable {
         const url = new URL(req.url ?? "/", "http://127.0.0.1");
         const afterText = url.searchParams.get("after");
         if (afterText !== null) {
-          const after = parseQaDebugRequestCursor(afterText);
-          if (after === null) {
-            writeJson(res, 400, { error: "after must be a non-negative safe integer" });
-            return true;
-          }
-          const latestCursor = nextRequestCursor - 1;
-          const oldestCursor = selected[0]?.cursor ?? nextRequestCursor;
-          if (after > latestCursor) {
-            writeJson(res, 409, {
-              error: "request cursor is ahead of the latest recorded request",
-              after,
-              latestCursor,
-            });
-            return true;
-          }
-          if (after < oldestCursor - 1) {
-            writeJson(res, 409, {
-              error: "request cursor expired",
-              after,
-              oldestCursor,
-              latestCursor,
-            });
+          const after = resolveQaDebugRequestCursor(
+            afterText,
+            selected[0]?.cursor ?? nextRequestCursor,
+            nextRequestCursor - 1,
+          );
+          if (typeof after !== "number") {
+            writeJson(res, after.status, after.body);
             return true;
           }
           selected = selected.filter((request) => request.cursor > after);

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -11,9 +11,6 @@ import {
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
   QA_IMAGE_GENERATION_PROMPT_RE,
   QA_SKILL_WORKSHOP_GIF_PROMPT_RE,
-  QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE,
-  QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE,
-  buildSlackMpimHistoryBotReply,
   QA_TOOL_SEARCH_PROMPT_RE,
   QA_TOOL_SEARCH_FAILURE_PROMPT_RE,
 } from "./mock-openai-contracts.js";
@@ -37,7 +34,7 @@ import {
   splitMockConversationContext,
   extractToolOutput,
   extractLatestToolOutput,
-  extractSlackMpimRetainedBotNonce,
+  buildSlackMpimHistoryReply,
   extractAllUserTexts,
   extractUserTurnTexts,
   extractAllRequestTexts,
@@ -219,17 +216,9 @@ export function buildAssistantText(input: ResponsesInputItem[], body: Record<str
     toolJson,
   });
 
-  const slackMpimHistoryRecall = QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE.exec(prompt);
-  if (slackMpimHistoryRecall) {
-    const [, botReplyPrefix, recalledMarker, missingMarker] = slackMpimHistoryRecall;
-    const nonce = botReplyPrefix
-      ? extractSlackMpimRetainedBotNonce(prompt, botReplyPrefix)
-      : undefined;
-    return nonce && recalledMarker ? `${recalledMarker}_${nonce}` : (missingMarker ?? "");
-  }
-  const slackMpimHistorySeed = QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE.exec(prompt)?.[1];
-  if (slackMpimHistorySeed) {
-    return buildSlackMpimHistoryBotReply(slackMpimHistorySeed);
+  const slackMpimHistoryReply = buildSlackMpimHistoryReply(prompt);
+  if (slackMpimHistoryReply !== undefined) {
+    return slackMpimHistoryReply;
   }
   if (/what was the qa canary code/i.test(prompt) && rememberedFact) {
     return `Protocol note: the QA canary code was ${rememberedFact}.`;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
@@ -217,23 +217,37 @@ export function hasDeclaredTool(body: Record<string, unknown>, name: string) {
 export function hasToolDefinition(body: Record<string, unknown>, name: string) {
   const tools = Array.isArray(body.tools) ? body.tools : [];
   const dynamicTools = Array.isArray(body.dynamicTools) ? body.dynamicTools : [];
-  return [...tools, ...dynamicTools].some((tool) => toolDefinitionMentionsName(tool, name));
+  return [...tools, ...dynamicTools].some((tool) => findNamedToolDefinition(tool, name) !== null);
 }
 
-function toolDefinitionMentionsName(value: unknown, name: string, depth = 0): boolean {
+export function findNamedToolDefinition(
+  value: unknown,
+  name: string,
+  depth = 0,
+): Record<string, unknown> | null {
   if (depth > 6 || !value || typeof value !== "object") {
-    return false;
+    return null;
   }
   if (Array.isArray(value)) {
-    return value.some((item) => toolDefinitionMentionsName(item, name, depth + 1));
+    for (const item of value) {
+      const match = findNamedToolDefinition(item, name, depth + 1);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
   }
   const record = value as Record<string, unknown>;
-  for (const key of ["name", "tool", "functionName"]) {
-    if (record[key] === name) {
-      return true;
+  if (record.name === name || record.tool === name || record.functionName === name) {
+    return record;
+  }
+  for (const item of Object.values(record)) {
+    const match = findNamedToolDefinition(item, name, depth + 1);
+    if (match) {
+      return match;
     }
   }
-  return Object.values(record).some((item) => toolDefinitionMentionsName(item, name, depth + 1));
+  return null;
 }
 
 function instructionTextMentionsToolName(text: string, name: string) {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
@@ -3,6 +3,9 @@ import {
   type ResponsesInputItem,
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
+  QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE,
+  QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE,
+  buildSlackMpimHistoryBotReply,
   QA_WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER_RE,
   QA_WHATSAPP_BROADCAST_PROMPT_RE,
   QA_WHATSAPP_RUNTIME_AGENT_RE,
@@ -263,7 +266,20 @@ export function extractUserTurnTexts(input: ResponsesInputItem[]) {
   return input.filter(isUserTurn).map((item) => extractInputText(item.content));
 }
 
-export function extractSlackMpimRetainedBotNonce(
+export function buildSlackMpimHistoryReply(prompt: string): string | undefined {
+  const recall = QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE.exec(prompt);
+  if (recall) {
+    const [, botReplyPrefix, recalledMarker, missingMarker] = recall;
+    const nonce = botReplyPrefix
+      ? extractSlackMpimRetainedBotNonce(prompt, botReplyPrefix)
+      : undefined;
+    return nonce && recalledMarker ? `${recalledMarker}_${nonce}` : (missingMarker ?? "");
+  }
+  const seed = QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE.exec(prompt)?.[1];
+  return seed ? buildSlackMpimHistoryBotReply(seed) : undefined;
+}
+
+function extractSlackMpimRetainedBotNonce(
   prompt: string,
   botReplyPrefix: string,
 ): string | undefined {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1829,6 +1829,20 @@ describe("qa mock openai server", () => {
       ],
     });
     expect(outputText(withHumanAttributedSeed)).toBe(missingMarker);
+
+    for (const prefix of [
+      "Please remember this fact for later: ORBIT-22. ",
+      "Reply exactly `SHADOWED-EXACT-REPLY`. ",
+    ]) {
+      const overlappingSeed = await expectOpenAiNonStreamingResponsesJson<unknown>(server, {
+        input: [makeUserInput(prefix + seedPrompt)],
+      });
+      expect(outputText(overlappingSeed)).toMatch(new RegExp(`^${seedMarker}_BOT_[A-Z0-9]+$`, "u"));
+      const overlappingRecall = await expectOpenAiNonStreamingResponsesJson<unknown>(server, {
+        input: [makeUserInput(prefix + recallPrompt)],
+      });
+      expect(outputText(overlappingRecall)).toBe(missingMarker);
+    }
   });
 
   it("drives repo-contract followthrough as read-read-read-write-then-report", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -9,7 +9,7 @@ import {
   dispatchQaHttpRequest,
   writeQaRequestBodyLimitError,
 } from "../../bus-server.js";
-import { parseQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
+import { resolveQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
 import { writeJson } from "../shared/http-json.js";
 import {
   listMockCodexModelInfos,
@@ -72,9 +72,6 @@ import {
   QA_SLACK_CHART_PRESENTATION_PROMPT_RE,
   QA_MESSAGE_DECISION_SUPPRESSION_PROMPT_RE,
   QA_MESSAGE_DECISION_SEND_PROMPT_RE,
-  QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE,
-  QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE,
-  buildSlackMpimHistoryBotReply,
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_REACT_PROMPT_RE,
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE,
@@ -138,6 +135,7 @@ import {
   QA_SLACK_PROGRESS_COMMENTARY_MARKER_RE,
   hasDeclaredTool,
   hasToolDefinition,
+  findNamedToolDefinition,
   isQaToolSearchFixture,
   buildExplicitSessionsSpawnArgs,
   buildQaA2aMessageToolMirrorSessionsSendArgs,
@@ -175,7 +173,7 @@ import {
   extractLatestToolOutput,
   extractAllToolOutputText,
   extractUserTextAfterLatestToolOutput,
-  extractSlackMpimRetainedBotNonce,
+  buildSlackMpimHistoryReply,
   extractUserTurnTexts,
   extractInstructionsText,
   extractAllRequestTexts,
@@ -404,36 +402,6 @@ function decodeCodeModeTarget(code: string | undefined) {
   } catch {
     return null;
   }
-}
-
-function findNamedToolDefinition(
-  value: unknown,
-  name: string,
-  depth = 0,
-): Record<string, unknown> | null {
-  if (depth > 6 || !value || typeof value !== "object") {
-    return null;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const match = findNamedToolDefinition(item, name, depth + 1);
-      if (match) {
-        return match;
-      }
-    }
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  if (record.name === name || record.tool === name || record.functionName === name) {
-    return record;
-  }
-  for (const item of Object.values(record)) {
-    const match = findNamedToolDefinition(item, name, depth + 1);
-    if (match) {
-      return match;
-    }
-  }
-  return null;
 }
 
 type CodeModeExecSurface = "native" | "guest";
@@ -1962,19 +1930,9 @@ async function buildResponsesPayload(
   if (whatsAppStickerMarker) {
     return buildAssistantEvents(whatsAppStickerMarker);
   }
-  const slackMpimHistoryRecall = QA_SLACK_MPIM_HISTORY_RECALL_PROMPT_RE.exec(prompt);
-  if (slackMpimHistoryRecall) {
-    const [, botReplyPrefix, recalledMarker, missingMarker] = slackMpimHistoryRecall;
-    const nonce = botReplyPrefix
-      ? extractSlackMpimRetainedBotNonce(prompt, botReplyPrefix)
-      : undefined;
-    return buildAssistantEvents(
-      nonce && recalledMarker ? `${recalledMarker}_${nonce}` : (missingMarker ?? ""),
-    );
-  }
-  const slackMpimHistorySeed = QA_SLACK_MPIM_HISTORY_SEED_PROMPT_RE.exec(prompt)?.[1];
-  if (slackMpimHistorySeed) {
-    return buildAssistantEvents(buildSlackMpimHistoryBotReply(slackMpimHistorySeed));
+  const slackMpimHistoryReply = buildSlackMpimHistoryReply(prompt);
+  if (slackMpimHistoryReply !== undefined) {
+    return buildAssistantEvents(slackMpimHistoryReply);
   }
   if (/\bmarker\b/i.test(prompt) && promptExactMarkerDirective) {
     return buildAssistantEvents(promptExactMarkerDirective);
@@ -2980,28 +2938,13 @@ export async function startQaMockOpenAiServer(params?: {
           writeJson(res, 200, requests);
           return;
         }
-        const after = parseQaDebugRequestCursor(afterText);
-        if (after === null) {
-          writeJson(res, 400, { error: "after must be a non-negative safe integer" });
-          return;
-        }
-        const latestCursor = nextRequestCursor - 1;
-        const oldestCursor = requests[0]?.cursor ?? nextRequestCursor;
-        if (after > latestCursor) {
-          writeJson(res, 409, {
-            error: "request cursor is ahead of the latest recorded request",
-            after,
-            latestCursor,
-          });
-          return;
-        }
-        if (after < oldestCursor - 1) {
-          writeJson(res, 409, {
-            error: "request cursor expired",
-            after,
-            oldestCursor,
-            latestCursor,
-          });
+        const after = resolveQaDebugRequestCursor(
+          afterText,
+          requests[0]?.cursor ?? nextRequestCursor,
+          nextRequestCursor - 1,
+        );
+        if (typeof after !== "number") {
+          writeJson(res, after.status, after.body);
           return;
         }
         writeJson(

--- a/extensions/qa-lab/src/providers/shared/debug-request-cursor.ts
+++ b/extensions/qa-lab/src/providers/shared/debug-request-cursor.ts
@@ -1,10 +1,38 @@
 // Shared by the QA mock providers and the fixtures that consume their debug logs.
-export function parseQaDebugRequestCursor(value: string): number | null {
+function parseQaDebugRequestCursor(value: string): number | null {
   if (!/^(?:0|[1-9]\d*)$/u.test(value)) {
     return null;
   }
   const cursor = Number(value);
   return Number.isSafeInteger(cursor) ? cursor : null;
+}
+
+export function resolveQaDebugRequestCursor(
+  value: string,
+  oldestCursor: number,
+  latestCursor: number,
+) {
+  const after = parseQaDebugRequestCursor(value);
+  if (after === null) {
+    return { status: 400, body: { error: "after must be a non-negative safe integer" } };
+  }
+  if (after > latestCursor) {
+    return {
+      status: 409,
+      body: {
+        error: "request cursor is ahead of the latest recorded request",
+        after,
+        latestCursor,
+      },
+    };
+  }
+  if (after < oldestCursor - 1) {
+    return {
+      status: 409,
+      body: { error: "request cursor expired", after, oldestCursor, latestCursor },
+    };
+  }
+  return after;
 }
 
 export function readQaMockRequestCursor(value: unknown): number {


### PR DESCRIPTION
## What Problem This Solves

Private QA mock providers repeat Slack MPIM history decisions, recursive tool-definition matching, and debug-cursor validation, leaving multiple implementations of the same behavior to maintain.

## Why This Change Was Made

Give each decision one shared owner while preserving the original dispatch positions, lookup depth and ordering, and cursor error responses. Keep AIMock tool-result pairing before window selection and shrink the assertion baseline from 16 to 15.

## User Impact

No product behavior change. This reduces maintained private QA source, which is normally excluded from packaged builds. Default cloc 2.10 counts: **−26 production / +13 tests = −13 code lines total**; physical lines decrease by 11 overall.

## Evidence

- Expanded existing Slack MPIM HTTP proof passes on both original and candidate source, including overlapping remember and exact-reply prompts.
- All 336 tests pass across the mock OpenAI server, AIMock server, and forked-context helper test files.
- Changed-file gate passes for all eight files against the pinned base, including type checks, lint, boundaries, ratchets, and import-cycle checks.
- Managed P0–P2 review is clean; the only later change is the exact numeric assertion-baseline shrink.

Validation uses disposable local mock HTTP/WebSocket servers and helper tests; it does not claim live Gateway proof.
