### PR TITLE
fix(gateway): keep update history reads responsive

### DIFF
--- a/docs/cli/update/status-and-history.md
+++ b/docs/cli/update/status-and-history.md
@@ -87,6 +87,10 @@ fields and adds optional `activeRun` and `lastRun` records. While a run is activ
 the Gateway broadcasts `update.run.changed` with `runId`, `phase`, `status`, and
 `updatedAtMs`. Reconnect and read the row to recover changes missed during restart.
 
+When a history request needs a read-only snapshot, the Gateway prepares it
+asynchronously so other requests can continue. The snapshot preserves the source
+database and its sidecar files.
+
 Native service-stop observations do not advance the update's recorded phase.
 If the Control UI cannot read fresh progress, it shows the read error alongside
 the last recorded run; use **Check status** to retry without starting another update.

--- a/src/gateway/server-methods/update-status.ts
+++ b/src/gateway/server-methods/update-status.ts
@@ -12,8 +12,9 @@ import { gatewayUpdateCampaign } from "../../infra/update-campaign.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import {
   findActiveUpdateRun,
-  getUpdateRun,
+  getUpdateRunAsync,
   listUpdateRuns,
+  listUpdateRunsAsync,
 } from "../../infra/update-run-ledger.js";
 import {
   getUpdateAvailable,
@@ -120,16 +121,16 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
     }
     respond(true, result);
   },
-  "update.runs.get": ({ params, respond }) => {
+  "update.runs.get": async ({ params, respond }) => {
     if (!assertValidParams(params, validateUpdateRunsGetParams, "update.runs.get", respond)) {
       return;
     }
-    respond(true, { run: getUpdateRun(params.runId) ?? null });
+    respond(true, { run: (await getUpdateRunAsync(params.runId)) ?? null });
   },
-  "update.runs.list": ({ params, respond }) => {
+  "update.runs.list": async ({ params, respond }) => {
     if (!assertValidParams(params, validateUpdateRunsListParams, "update.runs.list", respond)) {
       return;
     }
-    respond(true, { runs: listUpdateRuns(params) });
+    respond(true, { runs: await listUpdateRunsAsync(params) });
   },
 };

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -1,5 +1,6 @@
 // Role allowlist update tests cover operator-driven gateway updates, node lists,
 // device/node pairing state, restart sentinels, and runtime plugin visibility.
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +14,13 @@ import { approveNodePairing, requestNodePairing } from "../infra/device-pairing-
 import { listDevicePairing } from "../infra/device-pairing.js";
 import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../infra/supervisor-markers.js";
+import { createUpdateRun } from "../infra/update-run-ledger.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  isOpenClawStateDatabaseOpen,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { captureEnv, deleteTestEnvValue } from "../test-utils/env.js";
 import {
   GATEWAY_CLIENT_MODES,
@@ -23,6 +30,57 @@ import {
 import type { GatewayClient } from "./client.js";
 import type { HealthSummary } from "./health/types.js";
 import type { ManagedGatewayConfigReloaderParams } from "./server-reload-contracts.js";
+
+const readonlyPreparation = vi.hoisted(() => ({
+  prepared: [] as Array<{ pathname: string; location?: string; progressed: boolean }>,
+  turns: [] as Promise<void>[],
+}));
+
+vi.mock("../infra/sqlite-readonly-location.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/sqlite-readonly-location.js")>();
+  const observe = (pathname: string) => {
+    let progressed = false;
+    readonlyPreparation.turns.push(
+      new Promise<void>((resolve) => {
+        setImmediate(() => {
+          progressed = true;
+          resolve();
+        });
+      }),
+    );
+    return (prepared?: { location: string }) =>
+      readonlyPreparation.prepared.push({
+        pathname,
+        location: prepared?.location,
+        progressed,
+      });
+  };
+  return {
+    ...actual,
+    prepareSqliteReadOnlyLocationSync(pathname: string) {
+      const finish = observe(pathname);
+      let prepared: ReturnType<typeof actual.prepareSqliteReadOnlyLocationSync> | undefined;
+      try {
+        prepared = actual.prepareSqliteReadOnlyLocationSync(pathname);
+        return prepared;
+      } finally {
+        finish(prepared);
+      }
+    },
+    async prepareSqliteReadOnlyLocation(
+      ...args: Parameters<typeof actual.prepareSqliteReadOnlyLocation>
+    ) {
+      const finish = observe(args[0]);
+      let prepared: Awaited<ReturnType<typeof actual.prepareSqliteReadOnlyLocation>> | undefined;
+      try {
+        prepared = await actual.prepareSqliteReadOnlyLocation(...args);
+        return prepared;
+      } finally {
+        finish(prepared);
+      }
+    },
+  };
+});
 
 const reloadFixture = vi.hoisted<{
   reconcileRuntimePolicy?: ManagedGatewayConfigReloaderParams["reconcileRuntimePolicy"];
@@ -411,6 +469,55 @@ describe("gateway role enforcement", () => {
       expect(healthPayload.ok).toBe(true);
     } finally {
       nodeClient?.stop();
+    }
+  });
+});
+
+describe("gateway update history", () => {
+  test("keeps authenticated update history reads responsive after closing shared state", async () => {
+    const client = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token: "secret",
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      clientVersion: "1.0.0",
+      scopes: ["operator.admin"],
+    });
+    try {
+      const run = createUpdateRun({ trigger: "api" });
+      const databasePath = openOpenClawStateDatabase().path;
+      for (const method of ["update.runs.get", "update.runs.list"] as const) {
+        for (const cache of ["warm", "closed"] as const) {
+          openOpenClawStateDatabase();
+          if (cache === "closed") {
+            expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
+          }
+          expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(cache === "warm");
+          const before = readonlyPreparation.prepared.length;
+          const result = await client.request(
+            method,
+            method === "update.runs.get" ? { runId: run.runId } : { limit: 1 },
+          );
+          await Promise.all(readonlyPreparation.turns);
+          expect(result).toEqual(method === "update.runs.get" ? { run } : { runs: [run] });
+          const prepared = readonlyPreparation.prepared
+            .slice(before)
+            .filter((entry) => entry.pathname === databasePath);
+          if (cache === "warm") {
+            expect(prepared).toEqual([]);
+          } else {
+            expect(prepared).toHaveLength(1);
+            expect(
+              prepared[0]?.progressed,
+              "the Gateway isolate must progress while its snapshot child runs",
+            ).toBe(true);
+            expect(prepared[0]?.location).toBeDefined();
+            expect(existsSync(prepared[0]!.location!)).toBe(false);
+          }
+        }
+      }
+    } finally {
+      await client.stopAndWait();
     }
   });
 });

--- a/src/infra/update-run-ledger.test.ts
+++ b/src/infra/update-run-ledger.test.ts
@@ -17,7 +17,9 @@ import {
   findActiveUpdateRun,
   finishUpdateRun,
   getUpdateRun,
+  getUpdateRunAsync,
   listUpdateRuns,
+  listUpdateRunsAsync,
   recordUpdateRunPhase,
   recordUpdateRunRepairAttempt,
   recordUpdateRunStep,
@@ -116,12 +118,12 @@ describe("update run ledger", () => {
   });
 
   it.each(
-    (["get", "list", "active"] as const).flatMap((reader) =>
+    (["get", "list", "active", "get-async", "list-async"] as const).flatMap((reader) =>
       [false, true].map((retainedWal) => ({ reader, retainedWal })),
     ),
   )(
     "keeps cold $reader reads artifact-preserving with retained WAL=$retainedWal",
-    ({ reader, retainedWal }) => {
+    async ({ reader, retainedWal }) => {
       const sourceOptions = isolatedOptions();
       const created = createUpdateRun({ trigger: "cli" }, sourceOptions);
       const sourcePath = resolveOpenClawStateSqlitePath(sourceOptions.env);
@@ -159,8 +161,12 @@ describe("update run ledger", () => {
           ? getUpdateRun(created.runId, options)
           : reader === "list"
             ? listUpdateRuns({}, options)
-            : findActiveUpdateRun(options);
-      expect(result).toEqual(reader === "list" ? [expected] : expected);
+            : reader === "get-async"
+              ? await getUpdateRunAsync(created.runId, options)
+              : reader === "list-async"
+                ? await listUpdateRunsAsync({}, options)
+                : findActiveUpdateRun(options);
+      expect(result).toEqual(reader === "list" || reader === "list-async" ? [expected] : expected);
       expect(snapshotDatabaseFiles(filename)).toEqual(before);
     },
   );
@@ -178,7 +184,7 @@ describe("update run ledger", () => {
     expect(getUpdateRun(run.runId, options)?.verification).toEqual({ serviceRunning: true });
   });
 
-  it("leaves a cold store without the history table unchanged", () => {
+  it("leaves a cold store without the history table unchanged", async () => {
     const options = isolatedOptions();
     const { db } = openOpenClawStateDatabase(options);
     expect(
@@ -190,6 +196,8 @@ describe("update run ledger", () => {
     expect(getUpdateRun(randomUUID(), options)).toBeUndefined();
     expect(listUpdateRuns({}, options)).toEqual([]);
     expect(findActiveUpdateRun(options)).toBeUndefined();
+    expect(await getUpdateRunAsync(randomUUID(), options)).toBeUndefined();
+    expect(await listUpdateRunsAsync({}, options)).toEqual([]);
     expect(snapshotDatabaseFiles(filename)).toEqual(before);
   });
 

--- a/src/infra/update-run-ledger.ts
+++ b/src/infra/update-run-ledger.ts
@@ -5,7 +5,10 @@ import {
   UPDATE_RUN_PHASES,
 } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
-import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
+} from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
@@ -582,27 +585,56 @@ export function getUpdateRun(
   );
 }
 
+export async function getUpdateRunAsync(
+  runId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<UpdateRunRecord | undefined> {
+  return await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+    ({ db }) => (tableExists(db, "update_runs") ? readRun(db, runId) : undefined),
+    options,
+  );
+}
+
+type ListUpdateRunsInput = { limit?: number; active?: boolean };
+
+function readUpdateRuns(db: DatabaseSync, input: ListUpdateRunsInput): UpdateRunRecord[] {
+  if (!tableExists(db, "update_runs")) {
+    return [];
+  }
+  let query = getNodeSqliteKysely<LedgerDatabase>(db).selectFrom("update_runs").selectAll();
+  if (input.active) {
+    query = query.where("status", "=", "running");
+  }
+  return executeSqliteQuerySync(
+    db,
+    query
+      .orderBy("created_at_ms", "desc")
+      .orderBy("run_id", "desc")
+      .limit(Math.max(1, Math.min(100, Math.trunc(input.limit ?? 20)))),
+  ).rows.map(decodeRun);
+}
+
 export function listUpdateRuns(
-  input: { limit?: number; active?: boolean } = {},
+  input: ListUpdateRunsInput = {},
   options: OpenClawStateDatabaseOptions = {},
 ): UpdateRunRecord[] {
   return (
-    withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(({ db }) => {
-      if (!tableExists(db, "update_runs")) {
-        return [];
-      }
-      let query = getNodeSqliteKysely<LedgerDatabase>(db).selectFrom("update_runs").selectAll();
-      if (input.active) {
-        query = query.where("status", "=", "running");
-      }
-      return executeSqliteQuerySync(
-        db,
-        query
-          .orderBy("created_at_ms", "desc")
-          .orderBy("run_id", "desc")
-          .limit(Math.max(1, Math.min(100, Math.trunc(input.limit ?? 20)))),
-      ).rows.map(decodeRun);
-    }, options) ?? []
+    withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
+      ({ db }) => readUpdateRuns(db, input),
+      options,
+    ) ?? []
+  );
+}
+
+export async function listUpdateRunsAsync(
+  input: ListUpdateRunsInput = {},
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<UpdateRunRecord[]> {
+  return (
+    (await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+      ({ db }) => readUpdateRuns(db, input),
+      options,
+    )) ?? []
   );
 }
 

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -1,10 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as sqliteReadOnly from "../infra/sqlite-readonly-location.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
+  clearOpenClawDatabaseQuarantine,
+  recordOpenClawDatabaseQuarantine,
+} from "./openclaw-quarantine-store.js";
+import { recordOpenClawStateDatabaseOpenFailure } from "./openclaw-state-db-cache.js";
+import {
+  isArtifactPreservingStateRead,
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
   withExistingOpenClawStateDatabaseReadOnly,
   withArtifactPreservingStateReads,
 } from "./openclaw-state-db-readonly.js";
@@ -21,17 +29,21 @@ function createOptions(stateDir: string) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
 });
 
-describe.each(["admission", "explicit"] as const)("%s read-only state reads", (mode) => {
-  const readState: typeof withExistingOpenClawStateDatabaseReadOnly =
-    mode === "admission"
-      ? (operation, options) =>
-          withArtifactPreservingStateReads(() =>
-            withExistingOpenClawStateDatabaseReadOnly(operation, options),
-          )
-      : withExistingOpenClawStateDatabaseArtifactPreservingReadOnly;
+describe.each(["admission", "explicit", "async"] as const)("%s read-only state reads", (mode) => {
+  const admittedRead: typeof withExistingOpenClawStateDatabaseReadOnly = (operation, options) =>
+    withArtifactPreservingStateReads(() =>
+      withExistingOpenClawStateDatabaseReadOnly(operation, options),
+    );
+  const readState =
+    mode === "async"
+      ? withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync
+      : mode === "admission"
+        ? admittedRead
+        : withExistingOpenClawStateDatabaseArtifactPreservingReadOnly;
   it("reads a consolidated WAL database without creating source sidecars", async () => {
     await withTempDir("openclaw-state-readonly-sidecars-", async (stateDir) => {
       const options = createOptions(stateDir);
@@ -44,9 +56,12 @@ describe.each(["admission", "explicit"] as const)("%s read-only state reads", (m
       const before = fs.readFileSync(options.path);
       expect(fs.readdirSync(path.dirname(options.path))).toEqual(["openclaw.sqlite"]);
 
-      expect(readState(({ db }) => db.prepare("SELECT value FROM held").all(), options)).toEqual([
-        { value: "committed" },
-      ]);
+      expect(
+        await readState(({ db }) => {
+          expect(isArtifactPreservingStateRead()).toBe(true);
+          return db.prepare("SELECT value FROM held").all();
+        }, options),
+      ).toEqual([{ value: "committed" }]);
       expect(fs.readdirSync(path.dirname(options.path))).toEqual(["openclaw.sqlite"]);
       expect(fs.readFileSync(options.path)).toEqual(before);
     });
@@ -64,7 +79,7 @@ describe.each(["admission", "explicit"] as const)("%s read-only state reads", (m
         const writer = cacheState === "cached" ? opened.db : new DatabaseSync(options.path);
         writer.exec("BEGIN; UPDATE held SET value = 'uncommitted';");
         try {
-          const result = readState(({ db, path: pathname }) => {
+          const result = await readState(({ db, path: pathname }) => {
             expect(db).not.toBe(writer);
             expect(pathname).toBe(options.path);
             return db.prepare("SELECT value FROM held").all();
@@ -90,11 +105,97 @@ describe.each(["admission", "explicit"] as const)("%s read-only state reads", (m
       const opened = openOpenClawStateDatabase(options);
       opened.db.exec("CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('original');");
 
+      let called = false;
       const result = readState(({ db }) => {
+        called = true;
+        expect(isArtifactPreservingStateRead()).toBe(true);
         expect(db).toBe(opened.db);
         return db.prepare("SELECT value FROM held").all();
       }, options);
-      expect(result).toEqual([{ value: "original" }]);
+      expect(called).toBe(true);
+      expect(isArtifactPreservingStateRead()).toBe(false);
+      opened.db.exec("BEGIN; UPDATE held SET value = 'uncommitted';");
+      try {
+        expect(await result).toEqual([{ value: "original" }]);
+        expect(opened.db.isTransaction).toBe(true);
+      } finally {
+        opened.db.exec("ROLLBACK");
+      }
     });
+  });
+});
+
+it.each(["latch", "quarantine", "callback"] as const)(
+  "cleans the async snapshot after %s rejection",
+  async (failure) => {
+    await withTempDir("openclaw-state-readonly-admission-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      openOpenClawStateDatabase(options);
+      closeOpenClawStateDatabaseForTest();
+      const refused = new Error("synthetic readonly verification failure");
+      const prepare = sqliteReadOnly.prepareSqliteReadOnlyLocation;
+      let preparedLocation: string | undefined;
+      let failurePublished = false;
+      vi.spyOn(sqliteReadOnly, "prepareSqliteReadOnlyLocation").mockImplementationOnce(
+        async (...args) => {
+          const prepared = await prepare(...args);
+          preparedLocation = prepared.location;
+          if (failure === "latch") {
+            failurePublished = recordOpenClawStateDatabaseOpenFailure(options.path, refused);
+          } else if (failure === "quarantine") {
+            failurePublished = recordOpenClawDatabaseQuarantine({
+              env: options.env,
+              kind: "state",
+              path: options.path,
+              reason: "synthetic readonly quarantine",
+            });
+          }
+          return prepared;
+        },
+      );
+      const operation = vi.fn(() => {
+        throw refused;
+      });
+      try {
+        const result = withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+          operation,
+          options,
+        );
+        if (failure !== "quarantine") {
+          await expect(result).rejects.toBe(refused);
+        } else {
+          await expect(result).rejects.toThrow("synthetic readonly quarantine");
+        }
+        if (failure === "callback") {
+          expect(operation).toHaveBeenCalledOnce();
+        } else {
+          expect(failurePublished).toBe(true);
+          expect(operation).not.toHaveBeenCalled();
+        }
+        expect(preparedLocation).toBeDefined();
+        expect(fs.existsSync(path.dirname(preparedLocation!))).toBe(false);
+        expect(isArtifactPreservingStateRead()).toBe(false);
+      } finally {
+        clearOpenClawDatabaseQuarantine(options.path, { env: options.env });
+      }
+    });
+  },
+);
+
+it("keeps missing and non-missing filesystem failures distinct for async reads", async () => {
+  await withTempDir("openclaw-state-readonly-missing-", async (stateDir) => {
+    const options = createOptions(stateDir);
+    const operation = vi.fn();
+    await expect(
+      withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(operation, options),
+    ).resolves.toBeUndefined();
+    fs.writeFileSync(path.join(stateDir, "file"), "not a directory");
+    await expect(
+      withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(operation, {
+        ...options,
+        path: path.join(stateDir, "file", "state.sqlite"),
+      }),
+    ).rejects.toMatchObject({ code: "ENOTDIR" });
+    expect(operation).not.toHaveBeenCalled();
   });
 });

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import {
+  prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocationSync,
+} from "../infra/sqlite-readonly-location.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
@@ -94,17 +97,25 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
     ? prepareSqliteReadOnlyLocationSync(pathname)
     : undefined;
   try {
-    const db = openNodeSqliteDatabase(prepared?.location ?? pathname, { readOnly: true });
-    try {
-      db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-      assertSupportedStateSchemaVersion(db, pathname);
-      return operation({ db, path: pathname });
-    } finally {
-      clearNodeSqliteKyselyCacheForDatabase(db);
-      db.close();
-    }
+    return withOpenClawStateReadOnlyLocation(operation, pathname, prepared?.location ?? pathname);
   } finally {
     prepared?.cleanup();
+  }
+}
+
+function withOpenClawStateReadOnlyLocation<T>(
+  operation: (database: OpenClawStateReadOnlyDatabase) => T,
+  pathname: string,
+  location: string,
+): T {
+  const db = openNodeSqliteDatabase(location, { readOnly: true });
+  try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    assertSupportedStateSchemaVersion(db, pathname);
+    return operation({ db, path: pathname });
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
   }
 }
 
@@ -146,4 +157,33 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
   return withArtifactPreservingStateReads(() =>
     withExistingOpenClawStateDatabaseReadOnly(operation, options),
   );
+}
+
+/** Preserve source artifacts while allowing the caller to progress during snapshot preparation. */
+export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync<T>(
+  operation: (database: OpenClawStateReadOnlyDatabase) => T,
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<T | undefined> {
+  return withArtifactPreservingStateReads(async () => {
+    const pathname = resolveReadOnlyPath(options);
+    const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
+    if (reused.reused) {
+      return reused.value;
+    }
+    if (existingPathOrUndefined(pathname) === undefined) {
+      return undefined;
+    }
+    const env = options.env ?? process.env;
+    openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
+    const prepared = await prepareSqliteReadOnlyLocation(pathname, {
+      preserveSourceArtifacts: true,
+    });
+    try {
+      // Verification can quarantine the live path while the snapshot child is running.
+      openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
+      return withOpenClawStateReadOnlyLocation(operation, pathname, prepared.location);
+    } finally {
+      prepared.cleanup();
+    }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where requesting update-run history could pause other Gateway work when the shared-state database was not already open.

## Why This Change Was Made

`update.runs.get` and `update.runs.list` now await an artifact-preserving history snapshot. The existing raw-copy worker and readonly query logic remain authoritative; warm callbacks still run directly, and fresh admission is rechecked after snapshot preparation. Existing synchronous ledger consumers and `update.status` keep their behavior.

## User Impact

Opening update history or a run's details can wait for a cold snapshot without blocking the Gateway event loop on that preparation. Database contents, sidecars, committed-view isolation, and error behavior are preserved.

## Evidence

- The authenticated CLI regression fails on the original code because the Gateway isolate cannot progress before snapshot preparation returns, and passes with the repair. It lives in the existing update integration suite.
- 64 focused local tests passed, covering Gateway requests, warm callback timing, missing stores/history tables, committed rows with retained WAL, admission changes during preparation, callback failures, and snapshot cleanup.
- Required changed-file checks passed, including core/test types, lint, import/dead-export checks, and native state-schema guards. The existing Gateway test-root cap remains unchanged.
- Independent P0–P2 review found no actionable findings.
- The configured [Blacksmith Linux proof](https://github.com/openclaw/openclaw/actions/runs/34426184910) also passed all 64 tests through the repository wrapper (exit 0); the one-shot lease completed after cleanup.
