### PR TITLE
fix: release heartbeat test databases before removing fixtures

### DIFF
--- a/src/auto-reply/reply/session.heartbeat-no-reset.test.ts
+++ b/src/auto-reply/reply/session.heartbeat-no-reset.test.ts
@@ -1,10 +1,11 @@
 // Tests heartbeat messages do not reset active session routing.
-import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { cleanupSessionStateForTest } from "../../test-utils/session-state-cleanup.js";
 import type { MsgContext } from "../templating.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { initSessionState as initSessionStateRaw } from "./session.js";
@@ -21,16 +22,18 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
 
 describe("initSessionState - heartbeat should not trigger session reset", () => {
   const sessionKey = "agent:main:main:user123";
+  const tempDirs = createTempDirTracker();
   let tempDir: string;
   let storePath: string;
 
-  beforeEach(async () => {
-    tempDir = await fs.mkdtemp("/tmp/openclaw-test-");
+  beforeEach(() => {
+    tempDir = tempDirs.make("openclaw-test-");
     storePath = path.join(tempDir, "sessions.json");
   });
 
   afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true });
+    await cleanupSessionStateForTest({ stateDir: tempDir });
+    tempDirs.cleanup();
   });
 
   const createBaseConfig = (): OpenClawConfig => ({


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>
This branch is hosted in the repository and remains editable by repository maintainers.
</details>

## What Problem This Solves

Resolves a problem where heartbeat session tests ignore the selected temporary filesystem and remove fixture files while their cached SQLite handles are still open.

## Why This Change Was Made

Use the existing temporary-directory tracker and scoped session cleanup owner. Cleanup drains session work and closes fixture-owned database handles before removing the directory. The existing flat workspace and session-store layout stays intact.

## User Impact

No product behavior changes. Tests honor the selected temporary parent and release their database resources safely. All six heartbeat/reset cases and assertions remain unchanged.

## Evidence

- Original and candidate lifetime observations passed all six cases with identical names and order. Each original fixture had one actual cached database handle open immediately before its unlink boundary; diagnostic safety cleanup closed it afterward.
- In each candidate case, the real scoped cleanup closed the same captured handle while the directory still existed, before the tracker removed it. Candidate roots were under the selected temporary parent; original roots remained under literal `/tmp`.
- The uninstrumented candidate passed all six cases. Mapped checks, diff checks, and fresh independent review passed.
- Diagnostic copies were removed. This adds three net test lines and changes no production code. It does not establish the cause of historical quota or WAL failures, or an overall runtime percentage.
