### PR TITLE
feat(ui): complete chat rail keyboard navigation

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -311,6 +311,13 @@ change to stored history. Live turns, search results, and turns without an answe
 stay expanded. User messages,
 forwarded inputs, and structural markers remain boundaries for grouping.
 
+On wide desktop panes, the conversation position rail provides keyboard shortcuts
+to messages. Tab enters at the current message, or the first marker if no message
+is current. ArrowUp and ArrowDown move focus; Home and End go to the first and last
+markers. Enter or Space jumps to the focused message. Tab or Shift+Tab leaves the
+rail in one step, and Escape closes the preview and returns focus to the transcript.
+Focusing a marker also shows its preview without jumping to the message.
+
 The chat transcript uses a centered readable frame aligned with the composer. Assistant and tool output stay left-aligned while your own messages stay right-aligned inside that frame. In multi-user sessions (for example a group chat relayed from a channel plugin), messages from other attributed participants render left-aligned with the author's avatar, name, and a stable per-identity color, so only the signed-in viewer's messages read as "mine". When two or more attributed participants are present, assistant replies carry a small "Replying to name" marker naming the participant whose message triggered the turn. System entries such as local slash-command output render as centered notice rows without an avatar.
 
 Images and video previews in your own messages appear above any accompanying text, without a surrounding bubble background. Videos use a still frame with a play icon; select the preview to open the video in the Files panel. If a preview cannot load, the attachment card remains available. Hovering media leaves that layout unchanged, and the text keeps its normal bubble color, including any per-identity tint. Assistant videos retain their inline player.

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -977,6 +977,8 @@ describe("OpenClawTerminalPanel", () => {
     });
     panel.client = newClient;
     await panel.updateComplete;
+    // Reconnect restoration waits for the lazy service-worker refresh module.
+    await vi.dynamicImportSettled();
 
     await waitForFast(() => {
       expect(panel.renderRoot.querySelector(".tabstrip-tab__status")?.textContent).toBe("exited");

--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -111,6 +111,48 @@ suite.define(() => {
           expect(await rail.locator('[role="status"]').count()).toBe(0);
           await captureUiProof(suite, page, "chat-position-rail", "idle.png");
 
+          // Exercise the composite through real Tab navigation, including reentry.
+          const focusedMarkerId = () =>
+            page.evaluate(() => document.activeElement?.getAttribute("data-position-marker-id"));
+          const currentMarkerId = () =>
+            rail.locator('[aria-current="true"]').getAttribute("data-position-marker-id");
+          await expect.poll(() => rail.locator('[aria-current="true"]').count()).toBe(1);
+          await transcript.focus();
+          const entryId = await currentMarkerId();
+          await page.keyboard.press("Tab");
+          await expect.poll(focusedMarkerId).toBe(entryId);
+          await page.keyboard.press("Home");
+          await page.keyboard.press("ArrowDown");
+          await expect.poll(focusedMarkerId).toBe("position-rail-1");
+          await expect.poll(() => preview.count()).toBe(1);
+          await page.keyboard.press("ArrowUp");
+          await expect.poll(focusedMarkerId).toBe("position-rail-0");
+          await expect.poll(() => rail.locator('[tabindex="0"]').count()).toBe(1);
+          await page.keyboard.press("Tab");
+          expect(await focusedMarkerId()).toBeNull();
+          await transcript.focus();
+          const reentryId = await currentMarkerId();
+          await page.keyboard.press("Tab");
+          await expect.poll(focusedMarkerId).toBe(reentryId);
+          await page.keyboard.press("Shift+Tab");
+          expect(await transcript.evaluate((element) => element === document.activeElement)).toBe(
+            true,
+          );
+          await page.keyboard.press("Tab");
+          await page.keyboard.press("Home");
+          await page.keyboard.press("Enter");
+          await expect.poll(() => transcript.evaluate((element) => element.scrollTop)).toBe(0);
+          await page.keyboard.press("Escape");
+          expect(await transcript.evaluate((element) => element === document.activeElement)).toBe(
+            true,
+          );
+          await expect.poll(() => preview.count()).toBe(0);
+          await page.keyboard.press("Tab");
+          await page.keyboard.press("End");
+          await page.keyboard.press(" ");
+          await expect.poll(currentMarkerId).toBe("position-rail-239");
+          await page.keyboard.press("Escape");
+
           const currentMarkerIndex = () =>
             markers.evaluateAll((items) =>
               items.findIndex((item) => item.getAttribute("aria-current") === "true"),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5621,7 +5621,7 @@ export const en: TranslationMap & {
       positionUserMessage: "User message",
       positionAssistantMessage: "Assistant message",
       positionMarkerHint:
-        "Use arrow keys to choose a marker, Enter or Space to jump, and Escape to dismiss the preview.",
+        "Use arrow keys or Home and End to choose a marker, Enter or Space to jump, and Escape to return to the conversation. Tab leaves the rail.",
     },
     pendingInputs: {
       waitingForWorkspaceSync: "Received · waiting for workspace sync",

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -19,12 +19,11 @@ const PREVIEW_LENGTH = 140;
 type RailInteraction = {
   hoveredId: string | null;
   focusedId: string | null;
-  rovingId: string | null;
   dismissed: boolean;
 };
 
 function initialInteraction(): RailInteraction {
-  return { hoveredId: null, focusedId: null, rovingId: null, dismissed: false };
+  return { hoveredId: null, focusedId: null, dismissed: false };
 }
 
 // The directive owns transient DOM interaction; the session owns reader position.
@@ -222,15 +221,7 @@ class ChatPositionRailDirective extends AsyncDirective {
     this.syncVisibilityTargets();
     // Reader offsets can move the anchor without changing any intersections.
     this.syncVisibleMarks();
-    const rovingId = this.interaction.rovingId ?? this.activeId ?? this.markerIds[0];
-    const previousTabStop = scroller.querySelector<HTMLElement>('[tabindex="0"]');
-    const tabStop = this.markerElements.get(rovingId ?? "");
-    if (tabStop && tabStop !== previousTabStop) {
-      if (previousTabStop) {
-        previousTabStop.tabIndex = -1;
-      }
-      tabStop.tabIndex = 0;
-    }
+    this.syncTabStop();
     if (this.followActive) {
       this.followActive = false;
       const current = this.markerElements.get(this.activeId ?? "");
@@ -265,6 +256,19 @@ class ChatPositionRailDirective extends AsyncDirective {
     }
   }
 
+  private syncTabStop() {
+    // Reenter at the reader position; arrow navigation owns focus only while inside the rail.
+    const rovingId = this.interaction.focusedId ?? this.activeId ?? this.markerIds[0];
+    const previousTabStop = this.scrollElement?.querySelector<HTMLElement>('[tabindex="0"]');
+    const tabStop = this.markerElements.get(rovingId ?? "");
+    if (tabStop && tabStop !== previousTabStop) {
+      if (previousTabStop) {
+        previousTabStop.tabIndex = -1;
+      }
+      tabStop.tabIndex = 0;
+    }
+  }
+
   private readonly bindScroller = (element?: Element) => {
     this.resizeObserver?.disconnect();
     this.disconnectVisibility();
@@ -286,7 +290,7 @@ class ChatPositionRailDirective extends AsyncDirective {
   };
 
   private readonly dismissPreview = (event: KeyboardEvent) => {
-    const rail = this.previewElement?.closest(".chat-position-rail");
+    const rail = this.scrollElement?.closest(".chat-position-rail");
     if (
       event.key !== "Escape" ||
       event.defaultPrevented ||
@@ -300,6 +304,10 @@ class ChatPositionRailDirective extends AsyncDirective {
     event.stopImmediatePropagation();
     this.interaction.hoveredId = null;
     this.interaction.dismissed = true;
+    if (rail.contains(rail.ownerDocument.activeElement)) {
+      // Every marker reveals a message in this transcript. Hover-only dismissal keeps focus.
+      rail.closest<HTMLElement>(".chat-thread")?.focus({ preventScroll: true });
+    }
     this.requestUpdate?.();
   };
 
@@ -358,9 +366,6 @@ class ChatPositionRailDirective extends AsyncDirective {
     if (!candidates.some((candidate) => candidate.id === interaction.hoveredId)) {
       interaction.hoveredId = null;
     }
-    if (!candidates.some((candidate) => candidate.id === interaction.rovingId)) {
-      interaction.rovingId = null;
-    }
     const markers = candidates.map(({ id, message }) => ({
       id,
       message,
@@ -394,7 +399,7 @@ class ChatPositionRailDirective extends AsyncDirective {
             PREVIEW_LENGTH,
           )
         : "";
-    const rovingId = interaction.rovingId ?? this.activeId ?? markers[0]!.id;
+    const rovingId = interaction.focusedId ?? this.activeId ?? markers[0]!.id;
     const moveFocus = (event: KeyboardEvent, index: number) => {
       const nextIndex =
         event.key === "Home"
@@ -433,6 +438,8 @@ class ChatPositionRailDirective extends AsyncDirective {
           <div
             ${ref(this.bindScroller)}
             class="chat-position-rail__marks"
+            role="list"
+            aria-label=${t("chat.thread.positionRail")}
             @scroll=${this.scheduleLayout}
             @wheel=${this.stopScrollInput}
             @touchstart=${this.stopScrollInput}
@@ -444,51 +451,61 @@ class ChatPositionRailDirective extends AsyncDirective {
                 markers,
                 (marker) => marker.id,
                 (marker, index) => html`
-                  <button
-                    class="chat-position-rail__marker"
-                    type="button"
-                    data-position-marker-id=${marker.id}
-                    tabindex=${marker.id === rovingId ? "0" : "-1"}
-                    aria-label=${t("chat.thread.positionMarker", { position: String(index + 1), count: String(count), label: marker.label })}
-                    aria-description=${t("chat.thread.positionMarkerHint")}
-                    aria-current="false"
-                    @pointerenter=${() => {
-                      interaction.hoveredId = marker.id;
-                      interaction.dismissed = false;
-                      this.requestUpdate?.();
-                    }}
-                    @focus=${(event: FocusEvent) => {
-                      // Pointer focus must not move the target before pointer-up.
-                      if (
-                        event.currentTarget instanceof HTMLElement &&
-                        event.currentTarget.matches(":focus-visible")
-                      ) {
-                        this.revealMarker(event.currentTarget);
-                      }
-                      interaction.focusedId = marker.id;
-                      interaction.rovingId = marker.id;
-                      interaction.dismissed = false;
-                      this.requestUpdate?.();
-                    }}
-                    @blur=${() => {
-                      interaction.focusedId = null;
-                      this.requestUpdate?.();
-                    }}
-                    @keydown=${(event: KeyboardEvent) => {
-                      if (
-                        ["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp", "End", "Home"].includes(
-                          event.key,
-                        )
-                      ) {
-                        moveFocus(event, index);
-                      } else if (event.key === "PageUp" || event.key === "PageDown") {
-                        event.stopPropagation();
-                      }
-                    }}
-                    @click=${() => transcript.revealMessage(marker.id)}
-                  >
-                    <span class="chat-position-rail__tick" aria-hidden="true"></span>
-                  </button>
+                  <div class="chat-position-rail__item" role="listitem">
+                    <button
+                      class="chat-position-rail__marker"
+                      type="button"
+                      data-position-marker-id=${marker.id}
+                      tabindex=${marker.id === rovingId ? "0" : "-1"}
+                      aria-label=${t("chat.thread.positionMarker", { position: String(index + 1), count: String(count), label: marker.label })}
+                      aria-description=${t("chat.thread.positionMarkerHint")}
+                      aria-current="false"
+                      @pointerenter=${() => {
+                        interaction.hoveredId = marker.id;
+                        interaction.dismissed = false;
+                        this.requestUpdate?.();
+                      }}
+                      @focus=${(event: FocusEvent) => {
+                        // Pointer focus must not move the target before pointer-up.
+                        if (
+                          event.currentTarget instanceof HTMLElement &&
+                          event.currentTarget.matches(":focus-visible")
+                        ) {
+                          this.revealMarker(event.currentTarget);
+                        }
+                        interaction.focusedId = marker.id;
+                        interaction.dismissed = false;
+                        this.syncTabStop();
+                        this.requestUpdate?.();
+                      }}
+                      @blur=${() => {
+                        interaction.focusedId = null;
+                        this.syncTabStop();
+                        this.requestUpdate?.();
+                      }}
+                      @keydown=${(event: KeyboardEvent) => {
+                        if (
+                          [
+                            "ArrowDown",
+                            "ArrowLeft",
+                            "ArrowRight",
+                            "ArrowUp",
+                            "End",
+                            "Home",
+                          ].includes(event.key)
+                        ) {
+                          moveFocus(event, index);
+                        } else if (event.key === "Escape") {
+                          this.dismissPreview(event);
+                        } else if (event.key === "PageUp" || event.key === "PageDown") {
+                          event.stopPropagation();
+                        }
+                      }}
+                      @click=${() => transcript.revealMessage(marker.id)}
+                    >
+                      <span class="chat-position-rail__tick" aria-hidden="true"></span>
+                    </button>
+                  </div>
                 `,
               ),
             )}

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -122,6 +122,10 @@
   display: none;
 }
 
+.chat-position-rail__item {
+  display: contents;
+}
+
 .chat-position-rail__marker {
   position: relative;
   z-index: 1;
@@ -162,29 +166,29 @@
 }
 
 /* The wave is pointer-only; resting and keyboard-focused marks stay uniform. */
-.chat-position-rail__marker:has(
-    + .chat-position-rail__marker + .chat-position-rail__marker + .chat-position-rail__marker:hover
+.chat-position-rail__item:has(
+    + .chat-position-rail__item + .chat-position-rail__item + .chat-position-rail__item:hover
   )
   .chat-position-rail__tick,
-.chat-position-rail__marker:hover
-  + .chat-position-rail__marker
-  + .chat-position-rail__marker
-  + .chat-position-rail__marker
+.chat-position-rail__item:hover
+  + .chat-position-rail__item
+  + .chat-position-rail__item
+  + .chat-position-rail__item
   .chat-position-rail__tick {
   width: 12px;
 }
 
-.chat-position-rail__marker:has(+ .chat-position-rail__marker + .chat-position-rail__marker:hover)
+.chat-position-rail__item:has(+ .chat-position-rail__item + .chat-position-rail__item:hover)
   .chat-position-rail__tick,
-.chat-position-rail__marker:hover
-  + .chat-position-rail__marker
-  + .chat-position-rail__marker
+.chat-position-rail__item:hover
+  + .chat-position-rail__item
+  + .chat-position-rail__item
   .chat-position-rail__tick {
   width: 16px;
 }
 
-.chat-position-rail__marker:has(+ .chat-position-rail__marker:hover) .chat-position-rail__tick,
-.chat-position-rail__marker:hover + .chat-position-rail__marker .chat-position-rail__tick {
+.chat-position-rail__item:has(+ .chat-position-rail__item:hover) .chat-position-rail__tick,
+.chat-position-rail__item:hover + .chat-position-rail__item .chat-position-rail__tick {
   width: 24px;
 }
 


### PR DESCRIPTION
Closes #143604

## What Problem This Solves

Keyboard users returning to the chat position rail land on the last focused marker instead of the current reading position, and Escape leaves focus in the rail after dismissing its preview. Current main already has a single roving Tab stop; this completes that navigation contract rather than claiming every marker currently requires a separate Tab press.

## Why This Change Was Made

Reuse the existing rail interaction owner so focus determines the Tab stop only while inside the rail. On exit, the current message (or first marker) becomes the entry point. Escape returns focus to the transcript that rail activation navigates. A labeled list retains native buttons, and the existing hover selectors follow the list wrappers without changing geometry or pointer behavior.

Based on main, including the sender previews from #143486. Related: #143296 changes which messages appear in the rail and remains separate from this improvement. Both PRs touch the rail component and E2E file, so review those hunks when reconciling whichever change lands later.

## User Impact

Tab enters once and Tab/Shift+Tab leaves once. Arrow keys and Home/End move focus and show previews; Enter/Space activate the chosen message. Escape returns to the transcript. Mouse/touch behavior and mobile visibility remain unchanged.

## Evidence

- The original browser regression failed on current-message reentry, then passed on the previous head in light and dark. Those production-UI E2E runs covered one Tab entry/exit, arrows, Home/End, Enter/Space, Escape focus return, previews, nested scrolling and mobile hiding. The attached captures and recordings come from that head and remain useful keyboard-flow evidence.
- Rebased onto current main, preserving both adjacent documentation paragraphs and the existing roving-focus implementation. The maintainer confirmed the single-Tab-stop direction.
- Investigated the original [checks-ui failure](https://github.com/openclaw/openclaw/actions/runs/34427299983/job/102715515796). The terminal replacement-client test began checking the exited tab before awaiting the lazy module that releases reconnect restoration. With a temporary 1500 ms delay in the real module import, its original assertion failed with the same undefined status; waiting for dynamic imports made it pass. The delay was removed. Assertions, mocks and timeouts are unchanged. This demonstrates the preparation race; the historical CI log does not measure import duration.
- All 51 terminal, reconnect and restore tests pass locally with the final repair. Formatting and git diff --check pass. Local rail validation could not load main's newly added markdown-it-cjk-friendly dependency, and broad local test typechecking encountered installed proxyline 0.3.11 where main requires 0.3.12. No dependencies were installed. Targeted TypeScript/style lint, i18n and the initial changed-check guards passed; the full local check:changed command did not pass.
- Fresh independent autoreview through P2 completed scoped-clean, with no findings. The [complete CI run](https://github.com/openclaw/openclaw/actions/runs/34569206182) for head afb835d2f39900249ddac0b7ef1c0d71708ceb99 passed: all three checks-ui shards, all seven UI E2E shards, real-Gateway E2E, typechecks and the required CI gate. Existing browser proof uses synthetic data and a mock Gateway; screen-reader-specific behavior and live-Gateway rail behavior were not exercised.

![Before - light theme focused preview](https://github.com/user-attachments/assets/7997deff-0330-4f72-bbe6-e5b072974c15)

![After - light theme ArrowDown focus and preview](https://github.com/user-attachments/assets/36ee41bc-f787-41f1-9f04-ea5461c3a4aa)

![Before - dark theme focused preview](https://github.com/user-attachments/assets/5a48b5da-c9ae-4aa2-8897-548e5a3546f2)

![After - dark theme ArrowDown focus and preview](https://github.com/user-attachments/assets/7b16d6b4-e929-42e5-b811-d21ac7a9af43)

https://github.com/user-attachments/assets/acc3014b-58a7-4374-bb8f-076f2b6fc27e

https://github.com/user-attachments/assets/ba341241-f095-4e0e-a8e9-05a0e8c74a94

