### PR TITLE
refactor: replace obsolete plugin loader test expectations

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -373,10 +373,6 @@ function createAutoEnabledOptionalContext() {
   return { rawContext, autoEnabledConfig };
 }
 
-function expectAutoEnabledOptionalLoad(autoEnabledConfig: unknown) {
-  expectLoaderCall({ config: autoEnabledConfig });
-}
-
 function resolveAutoEnabledOptionalDemoTools() {
   setOptionalDemoRegistry();
   const { rawContext, autoEnabledConfig } = createAutoEnabledOptionalContext();
@@ -545,11 +541,6 @@ function expectResolvedToolNames(
   expectedToolNames: readonly string[],
 ) {
   expect(tools.map((tool) => tool.name)).toEqual(expectedToolNames);
-}
-
-function expectLoaderCall(overrides: Record<string, unknown>) {
-  void overrides;
-  expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
 }
 
 function mockCallParams(
@@ -2340,51 +2331,27 @@ describe("resolvePluginTools optional tools", () => {
     expect(factory).toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      name: "uses loaded plugin tools with an explicit env",
-      params: {
-        env: { OPENCLAW_HOME: "/srv/openclaw-home" } as NodeJS.ProcessEnv,
-        toolAllowlist: ["optional_tool"],
-      },
-      expectedLoaderCall: {
-        env: { OPENCLAW_HOME: "/srv/openclaw-home" },
-      },
-    },
-    {
-      name: "uses loaded plugin tools with gateway subagent binding",
-      params: {
-        allowGatewaySubagentBinding: true,
-        toolAllowlist: ["optional_tool"],
-      },
-      expectedLoaderCall: {
-        runtimeOptions: {
-          allowGatewaySubagentBinding: true,
-        },
-      },
-    },
-  ])("$name", ({ params, expectedLoaderCall }) => {
+  it("uses loaded plugin tools with an explicit env", () => {
+    const env = { OPENCLAW_HOME: "/srv/openclaw-home" };
     setOptionalDemoRegistry();
-    if (params.env) {
-      installToolManifestSnapshot({
-        config: createContext().config,
-        env: params.env,
-        plugin: {
-          id: "optional-demo",
-          origin: "bundled",
-          enabledByDefault: true,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["optional_tool"],
-          },
-        },
-      });
-    }
+    installToolManifestSnapshot({
+      config: createContext().config,
+      env,
+      plugin: createToolManifest("optional-demo", ["optional_tool"]),
+    });
 
-    resolvePluginTools(createResolveToolsParams(params));
+    const tools = resolvePluginTools(
+      createResolveToolsParams({ env, toolAllowlist: ["optional_tool"] }),
+    );
 
-    expectLoaderCall(expectedLoaderCall);
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    const actualEnv = mockCallParams(applyPluginAutoEnableMock).env;
+    const actualHome =
+      typeof actualEnv === "object" && actualEnv !== null
+        ? Reflect.get(actualEnv, "OPENCLAW_HOME")
+        : undefined;
+    expect(actualHome).toBe("/srv/openclaw-home");
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("skips malformed plugin tools while keeping valid sibling tools", () => {
@@ -3552,7 +3519,7 @@ describe("resolvePluginTools optional tools", () => {
       expectedToolNames: ["optional_tool"],
     },
   ] as const)("$name", ({ expectedToolNames }) => {
-    const { rawContext, autoEnabledConfig, tools } = resolveAutoEnabledOptionalDemoTools();
+    const { rawContext, tools } = resolveAutoEnabledOptionalDemoTools();
 
     const autoEnableParams = mockCallParams(applyPluginAutoEnableMock) as {
       config?: { plugins?: { allow?: unknown; load?: unknown } };
@@ -3564,7 +3531,7 @@ describe("resolvePluginTools optional tools", () => {
     if (expectedToolNames) {
       expectResolvedToolNames(tools, expectedToolNames);
     }
-    expectAutoEnabledOptionalLoad(autoEnabledConfig);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("reuses a compatible active registry instead of loading again", () => {
@@ -3827,11 +3794,7 @@ describe("resolvePluginTools optional tools", () => {
     );
 
     expectResolvedToolNames(tools, ["optional_tool"]);
-    expectLoaderCall({
-      runtimeOptions: {
-        allowGatewaySubagentBinding: true,
-      },
-    });
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("reloads when gateway binding would otherwise reuse a default-mode active registry", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Optional plugin-tool tests carried expected loader arguments through a helper that discarded them and only asserted that the loader was not called. One gateway-binding row repeated a standalone case with stronger output coverage.

## Why This Change Was Made

Remove the ignored expectation data and helper wrappers, keep direct no-loader assertions, and remove the redundant gateway row. The retained explicit-environment case now checks its resolved tool and the independently expected OPENCLAW_HOME value at the existing auto-enable boundary. It accepts equivalent environment copies and limits failure output to that single field.

## User Impact

No production changes. The tests are 37 lines shorter and now detect a real environment-forwarding regression that the old assertion missed.

## Evidence

- Full owning suite: 115 cases passed before, 114 after. Exactly one redundant row was removed; the retained env case now displays its full title rather than the shortened table title.
- Replacing only the real owner’s auto-enable env argument with process.env passed the original case and failed the revised case at the scalar assertion. Production bytes were restored exactly.
- The first original mutation run selected zero cases because of the shortened title; it was invalid proof. The corrected prefix-selected run executed and passed one case.
- Changed-file gate and fresh independent review passed. The previously landed metadata helper and all other retained assertions remain unchanged.

No runtime-speedup claim.
