### PR TITLE
fix(agents): avoid repeated subagent tree refreshes

### DIFF
--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -383,7 +383,6 @@ async function killSubagentRunTree(
         result.descendants = true;
       }
       if (result.descendants && tree.canTraverse()) {
-        params.scope.refresh();
         await Promise.all(tree.children.map(visit));
       }
     } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #143389. Resetting a session with many retained subagent runs repeatedly refreshed the entire selected tree once per traversable node, stalling the gateway during `/new`.

## Why This Change Was Made

The cancellation owner already refreshes before each convergence pass and when a successor is rebound. The per-node refresh duplicated that whole-tree discovery without changing the traversal contract, so it was removed at the producer of the redundant work.

## User Impact

Session resets avoid repeated registry/session traversal while retaining late-child discovery, ownership checks, and convergence behavior.

## Evidence

- Current head: `52a038620381c5f8b46e07d9f4818fe809615817`.
- Production diff: one deletion in `src/agents/subagents/registry/subagent-control-kill.ts` (`0 additions, 1 deletion`); `git diff --check` passes.
- GitHub CI for this exact head is green, including `openclaw/ci-gate`, `check-prod-types`, lint, test types, dependency guards, security-fast, and PR context/evidence checks: [CI run](https://github.com/openclaw/openclaw/actions/runs/34428923937).
- The change preserves the existing refresh boundaries: initial selection refresh, successor-retarget refresh, and the before/after convergence refresh loop remain unchanged. The per-node refresh was the only removed operation.
- The linked production report recorded 184 retained terminal roots and an 82.020 s reset, with 81.231 s in session initialization; after deploying this identical deletion and restarting, the operator reported a reset completing in seconds. The report also records eight extracted-function paired cases covering terminal roots, nested active/yielded runs, late descendants, ownership revocation, retargeting, exceptions, and invalid traversal ownership.

## Validation

- GitHub CI passed on the exact PR head.
- Source-level lifecycle boundaries and the linked real-operator after-fix observation were reviewed by ClawSweeper.
- Local focused Vitest could not be executed because this environment has Node 24.13.1 while the checkout requires Node >=24.16 or >=26.1; a retry with shared dependencies hit a Vitest `defineCacheKeyGenerator` version mismatch.

## Validation limits

A fresh WhatsApp reset transcript and before/after RSS capture are not available from this environment. The linked issue contains the real operator result and retained-run conditions; no private runtime data is included here.
