### PR TITLE
fix: retain copied engine registries through cleanup

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -91,6 +91,13 @@ runtime alive through maintenance, coalesced reruns, and engine disposal. Accept
 does not mean cleanup has finished. Return asynchronous work from engine methods
 and `dispose()` so the host can join it before releasing their resources.
 
+A logical turn also retains its managed supplying registry through engine disposal.
+When that registry copied a runtime engine from another inspection, its recorded
+donor dependency can keep the engine usable after the donor inspection retires.
+Retiring the supplying registry still refuses new logical turns; existing engine
+work keeps its physical resources until cleanup finishes. Raw registrations keep
+their caller-owned lifetime.
+
 For the bundled non-ACP Codex harness, OpenClaw applies the same lifecycle by projecting assembled context into Codex developer instructions and the current turn prompt. Codex still owns its native thread history and native compactor.
 
 ### Subagent lifecycle (optional)

--- a/src/context-engine/registry.copied-view-resources.test.ts
+++ b/src/context-engine/registry.copied-view-resources.test.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, expect, it } from "vitest";
+import { createContextEngineLogicalTurnLease } from "../agents/harness/context-engine-logical-turn.js";
+import { acquireAgentRuntimePluginRegistry } from "../agents/runtime-plugins.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { getSpeechProvider } from "../plugin-sdk/speech.js";
+import { LegacyPluginSdkResourceHost } from "../plugins/legacy-sdk-resource-host.js";
+import {
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
+import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { LegacyContextEngine } from "./legacy.js";
+import {
+  adoptRuntimeContextEngineRegistrations,
+  registerContextEngineInRegistry,
+} from "./registry.js";
+
+const require = createRequire(import.meta.url);
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+});
+
+it.each(["retired-donor", "live-donor", "raw-donor"] as const)(
+  "keeps a real copied view through factory and engine disposal (%s)",
+  async (mode) => {
+    await withOpenClawTestState(
+      { prefix: "copied-engine-source-", layout: "split" },
+      async (state) => {
+        useNoBundledPlugins();
+        const id = "copied-native-engine";
+        const providerId = `${id}-reader`;
+        const pluginRoot = state.path("plugin");
+        fs.mkdirSync(pluginRoot, { recursive: true });
+        const entry = path.join(pluginRoot, "index.cjs");
+        const key = `__copied_engine_${path.basename(state.root)}`;
+        const connections: Array<{
+          database: DatabaseSync;
+          file: string;
+          mode: string;
+          disposals: number;
+        }> = [];
+        const reads: number[] = [];
+        const disposalStarted = createDeferredCore();
+        const disposalResume = createDeferredCore();
+        const bridge = {
+          connections,
+          reads,
+          getSpeechProvider,
+          disposalStarted,
+          disposalResume,
+          factoryCalls: 0,
+          engineDisposals: 0,
+        };
+        Object.defineProperty(globalThis, key, { configurable: true, value: bridge });
+        fs.writeFileSync(
+          path.join(pluginRoot, "package.json"),
+          JSON.stringify({
+            name: id,
+            version: "1.0.0",
+            type: "commonjs",
+            openclaw: { extensions: ["./index.cjs"] },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(pluginRoot, "openclaw.plugin.json"),
+          JSON.stringify({
+            id,
+            kind: "context-engine",
+            contracts: { speechProviders: [providerId] },
+            configSchema: { type: "object" },
+          }),
+        );
+        fs.writeFileSync(
+          entry,
+          `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const file = ${JSON.stringify(state.path("source-"))} + state.connections.length + ".sqlite";
+  const database = new DatabaseSync(file);
+  database.exec("CREATE TABLE fixture(value INTEGER)");
+  database.prepare("INSERT INTO fixture VALUES (?)").run(api.registrationMode === "full" ? 42 : 84);
+  const connection = { database, file, mode: api.registrationMode, disposals: 0 };
+  state.connections.push(connection);
+  const read = () => {
+    const value = Number(database.prepare("SELECT value FROM fixture").get().value);
+    state.reads.push(value); return value;
+  };
+  api.lifecycle.registerRuntimeLifecycle({ id: "native-source", dispose() {
+    read(); connection.disposals++; database.close();
+  }, cleanup() { if (database.isOpen) database.close(); } });
+  if (api.registrationMode !== "full") {
+    api.registerSpeechProvider({ id: ${JSON.stringify(providerId)}, label: "Primary reader",
+      isConfigured: () => true,
+      async synthesize() { throw new Error("Unused native speech synthesis"); },
+      async listVoices() { return [{ id: String(read()), name: "Native primary" }]; }
+    });
+    return;
+  }
+  api.registerContextEngine(${JSON.stringify(id)}, async (context) => {
+    state.factoryCalls++; read();
+    const provider = state.getSpeechProvider(${JSON.stringify(providerId)}, context.config);
+    if (!provider?.listVoices) throw new Error("Missing public speech provider from supplying view");
+    const readPrimary = async () => {
+      const voices = await provider.listVoices({ cfg: context.config });
+      if (voices[0]?.id !== "84") throw new Error("Factory selected another registry's provider");
+    };
+    await readPrimary();
+    return {
+      info: { id: ${JSON.stringify(id)}, name: "Copied native engine" },
+      async ingest() { return { ingested: false }; },
+      async assemble({ messages }) { read(); await readPrimary(); return { messages, estimatedTokens: 0 }; },
+      async compact() { return { ok: true, compacted: false }; },
+      async dispose() {
+        state.disposalStarted.resolve(); await state.disposalResume.promise;
+        read(); await readPrimary(); state.engineDisposals++;
+      }
+    };
+  });
+} };
+`,
+        );
+        const config: OpenClawConfig = {
+          plugins: {
+            allow: [id],
+            load: { paths: [pluginRoot] },
+            slots: { memory: "none", contextEngine: id },
+          },
+        };
+        await state.writeConfig(config);
+        const donor = createPluginRegistry({
+          runtime: createPluginRuntime(),
+          logger: { info() {}, warn() {}, error() {}, debug() {} },
+          activateGlobalSideEffects: false,
+        });
+        const donorSource =
+          mode === "raw-donor" ? undefined : new PluginRegistryInspectionResources();
+        donorSource?.attach(donor.registry);
+        const record = createPluginRecord({ id, source: entry });
+        donor.registry.plugins.push(record);
+        const api = donor.createApi(record, { config, registrationMode: "full" });
+        const plugin: unknown = require(entry);
+        if (!isRecord(plugin) || typeof plugin.register !== "function") {
+          throw new Error("Invalid native plugin fixture");
+        }
+        const register = plugin.register;
+        if (donorSource) {
+          donorSource.runRegistration(id, () => register(api));
+        } else {
+          register(api);
+        }
+        setActivePluginRegistry(donor.registry);
+        const donorCurrent = capturePluginLifecycleAuthority(donor.registry);
+        const sdkHost = new LegacyPluginSdkResourceHost();
+        let acquired: Awaited<ReturnType<typeof acquireAgentRuntimePluginRegistry>> | undefined;
+        let lease: Awaited<ReturnType<typeof createContextEngineLogicalTurnLease>> | undefined;
+        let disposal: Promise<void> | undefined;
+        try {
+          await sdkHost.run(async () => {
+            acquired = await acquireAgentRuntimePluginRegistry({
+              config,
+              workspaceDir: state.workspaceDir,
+              basePluginIds: [id],
+            });
+            if (!("resources" in acquired)) {
+              throw new Error("Fixture did not acquire a primary inspection");
+            }
+            const copied = acquired.registry;
+            expect(copied === acquired.primaryRegistry).toBe(false);
+            expect(copied.contextEngines.get(id) === donor.registry.contextEngines.get(id)).toBe(
+              true,
+            );
+            expect(connections.length).toBe(2);
+            expect(connections[0]?.mode).toBe("full");
+            expect(connections[1]?.mode).toBe("discovery");
+            expect(donor.registry.contextEngines.get(id)?.lifecycle).toBe("runtime");
+            if (mode === "retired-donor") {
+              await donorSource?.release();
+              expect(donorCurrent?.()).toBe(false);
+            }
+            expect(connections.every((connection) => connection.database.isOpen)).toBe(true);
+            const createLease = () =>
+              createContextEngineLogicalTurnLease({
+                identity: { runId: "copied-source-run", sessionId: "copied-source-session" },
+                config,
+                workspaceDir: state.workspaceDir,
+                warn: () => {},
+              });
+            lease = await withPluginRuntimeRegistryScope(copied, createLease);
+            expect(lease.effectiveEngineId).toBe(id);
+            expect(lease.degraded).toBe(false);
+            expect(bridge.factoryCalls).toBe(1);
+            expect(connections.length).toBe(2);
+            const engine = lease.begin().engine;
+            await engine.assemble({ messages: [], sessionId: "copied-source-session" });
+            await acquired.releaseRegistry();
+            await expect(
+              withPluginRuntimeRegistryScope(copied, createLease).then(() => undefined),
+            ).rejects.toThrow(/released/);
+            expect(bridge.factoryCalls).toBe(1);
+            disposal = lease.dispose();
+            await disposalStarted.promise;
+            // The fast fallback has time to release its own primary claim independently.
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(connections.every((connection) => connection.database.isOpen)).toBe(true);
+            disposalResume.resolve();
+            await disposal;
+            expect(bridge.engineDisposals).toBe(1);
+            const primary = connections.find((connection) => connection.mode !== "full");
+            expect(primary?.database.isOpen).toBe(false);
+            expect(primary?.disposals).toBe(1);
+            expect(reads.includes(42)).toBe(true);
+            expect(reads.includes(84)).toBe(true);
+            if (mode === "retired-donor") {
+              expect(donorCurrent?.()).toBe(false);
+              expect(connections[0]?.database.isOpen).toBe(false);
+              expect(connections[0]?.disposals).toBe(1);
+            } else {
+              expect(connections[0]?.database.isOpen).toBe(true);
+            }
+          });
+          await donorSource?.release();
+          await sdkHost.close();
+          for (const connection of connections) {
+            const database = new DatabaseSync(connection.file, { readOnly: true });
+            try {
+              expect(database.prepare("SELECT value FROM fixture").get()?.value).toBe(
+                connection.mode === "full" ? 42 : 84,
+              );
+            } finally {
+              database.close();
+            }
+          }
+        } finally {
+          disposalResume.resolve();
+          await (disposal ?? lease?.dispose());
+          if (acquired && "releaseRegistry" in acquired) {
+            await acquired.releaseRegistry();
+          }
+          await donorSource?.release();
+          await sdkHost.close();
+          for (const connection of connections) {
+            if (connection.database.isOpen) {
+              connection.database.close();
+            }
+          }
+          delete require.cache[entry];
+          Reflect.deleteProperty(globalThis, key);
+        }
+      },
+    );
+  },
+);
+
+it.each([false, true])(
+  "does not treat an uncovered view as a retired donor's owner (failed dependency=%s)",
+  async (failedDependency) => {
+    const donor = createEmptyPluginRegistry();
+    const target = createEmptyPluginRegistry();
+    const donorSource = new PluginRegistryInspectionResources();
+    const primarySource = new PluginRegistryInspectionResources();
+    donorSource.attach(donor);
+    primarySource.attach(target);
+    const record = { id: "uncovered-engine", source: "/synthetic/uncovered-engine.cjs" };
+    donor.plugins.push(createPluginRecord(record));
+    target.plugins.push(createPluginRecord(record));
+    let calls = 0;
+    let primaryDisposals = 0;
+    primarySource.register(record.id, {
+      id: "primary",
+      dispose() {
+        primaryDisposals++;
+      },
+    });
+    registerContextEngineInRegistry(
+      donor,
+      record.id,
+      () => {
+        calls++;
+        return new LegacyContextEngine();
+      },
+      `plugin:${record.id}`,
+    );
+    const copied = adoptRuntimeContextEngineRegistrations(target, donor);
+    primarySource.attach(copied);
+    await donorSource.release();
+    if (failedDependency) {
+      expect(() => primarySource.retainDependency(donorSource)).toThrow(/released/);
+    }
+    let lease: Awaited<ReturnType<typeof createContextEngineLogicalTurnLease>> | undefined;
+    try {
+      lease = await withPluginRuntimeRegistryScope(copied, () =>
+        createContextEngineLogicalTurnLease({
+          identity: { runId: "uncovered-run", sessionId: "uncovered-session" },
+          config: { plugins: { slots: { contextEngine: record.id } } },
+          warn: () => {},
+        }),
+      );
+      expect(lease.degraded).toBe(true);
+      expect(calls).toBe(0);
+      await primarySource.release();
+      await lease.dispose();
+      expect(primaryDisposals).toBe(1);
+    } finally {
+      await lease?.dispose();
+      await primarySource.release();
+    }
+  },
+);

--- a/src/context-engine/registry.logical-turn-resources.test.ts
+++ b/src/context-engine/registry.logical-turn-resources.test.ts
@@ -76,6 +76,7 @@ it.each([
   "closing-factory",
   "last-user",
   "raw",
+  "raw-view",
 ] as const)("retains the adopted engine's native source through %s", async (mode) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "context-engine-source-"));
   const databasePath = path.join(directory, "source.sqlite");
@@ -90,7 +91,9 @@ it.each([
   if (mode !== "raw") {
     source.attach(donor);
   }
-  viewSource.attach(supplyingView);
+  if (mode !== "raw-view") {
+    viewSource.attach(supplyingView);
+  }
   let sourceDisposals = 0;
   const sourceDisposed = createDeferred();
   source.register(plugin.id, {
@@ -225,7 +228,9 @@ it.each([
     registerContextEngineInRegistry(donor, "selected", factory, `plugin:${plugin.id}`);
   });
   const copiedView = adoptRuntimeContextEngineRegistrations(supplyingView, donor);
-  viewSource.attach(copiedView);
+  if (mode !== "raw-view") {
+    viewSource.attach(copiedView);
+  }
   const config = { plugins: { slots: { contextEngine: "selected" } } };
   const cleanupScope = createAgentCleanupScope();
   const parent = new AsyncWorkScope();

--- a/src/context-engine/registry.resources.ts
+++ b/src/context-engine/registry.resources.ts
@@ -15,7 +15,7 @@ import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { ContextEngine } from "./types.js";
 
-// Adoption copies entries by identity; the copied view's primary source is not their owner.
+// Adoption preserves entry identity and the original registration source.
 const registrationSources = resolveGlobalSingleton(
   Symbol.for("openclaw.contextEngineRegistrationSources"),
   () => new WeakMap<ContextEngineRegistration, PluginRegistryInspectionResources>(),
@@ -42,7 +42,7 @@ export class ContextEngineFactoryResources {
     this.cleanupContext(() => this.cleanupWork.beginClose(this.parentSignal?.reason));
   };
 
-  constructor(private readonly claim: { release: () => Promise<void> }) {
+  constructor(private readonly claims: readonly { release: () => Promise<void> }[]) {
     this.parentSignal?.addEventListener("abort", this.abort, { once: true });
     if (this.parentSignal?.aborted) {
       this.abort();
@@ -61,17 +61,44 @@ export class ContextEngineFactoryResources {
     }
   }
 
-  release(): Promise<void> {
+  async release(): Promise<void> {
     this.parentSignal?.removeEventListener("abort", this.abort);
-    return this.claim.release();
+    let failure: { error: unknown } | undefined;
+    // An uncovered donor stays held while primary cleanup finishes, even if that cleanup fails.
+    for (const claim of this.claims) {
+      try {
+        await claim.release();
+      } catch (error) {
+        failure ??= { error };
+      }
+    }
+    if (failure) {
+      throw failure.error;
+    }
   }
 }
 
 function retainContextEngineFactorySource(
   registration: ContextEngineRegistration | undefined,
+  primary: PluginRegistryInspectionResources | undefined,
+  abandon: ContextEngineFactoryFailureCleanup,
 ): ContextEngineFactoryResources | undefined {
-  const claim = registration && registrationSources.get(registration)?.retain();
-  return claim ? new ContextEngineFactoryResources(claim) : undefined;
+  const claims: Array<{ release: () => Promise<void> }> = [];
+  try {
+    if (primary) {
+      claims.push(primary.retain());
+    }
+    const source = registration && registrationSources.get(registration);
+    if (source && !primary?.coversSource(source)) {
+      claims.push(source.retain());
+    }
+    return claims.length > 0 ? new ContextEngineFactoryResources(claims) : undefined;
+  } catch (error) {
+    if (claims.length > 0) {
+      abandon(new ContextEngineFactoryResources(claims));
+    }
+    throw error;
+  }
 }
 
 /** One instance may come from both factories; every source stays held through shared cleanup. */
@@ -160,18 +187,21 @@ export async function runContextEngineFactoryResolution<T>(
 }
 
 export function retainLogicalTurnContextEngineSources(
+  registry: PluginRegistry,
   fallback: ContextEngineRegistration | undefined,
   configured: ContextEngineRegistration | undefined,
+  abandon: ContextEngineFactoryFailureCleanup,
 ): {
   fallback: ContextEngineFactoryResources | undefined;
   configured?: ContextEngineFactoryResources;
   configuredFailure?: { error: unknown };
 } {
-  const fallbackSource = retainContextEngineFactorySource(fallback);
+  const primary = getPluginRegistryInspectionResources(registry);
+  const fallbackSource = retainContextEngineFactorySource(fallback, primary, abandon);
   try {
     const configuredSource =
       configured?.lifecycle === "runtime"
-        ? retainContextEngineFactorySource(configured)
+        ? retainContextEngineFactorySource(configured, primary, abandon)
         : undefined;
     return { fallback: fallbackSource, configured: configuredSource };
   } catch (error) {

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -648,12 +648,15 @@ export async function resolveLogicalTurnContextEngines(
       agentDir: options?.agentDir,
       workspaceDir: options?.workspaceDir,
     };
-    const entries = getContextEngines();
+    const registry = requireActivePluginRegistry();
+    const entries = registry.contextEngines;
     const fallbackEntry = entries.get(defaultEngineId);
     const configuredEntry = entries.get(configuredEngineId);
     const sources = retainLogicalTurnContextEngineSources(
+      registry,
       fallbackEntry,
       configuredEngineId === defaultEngineId ? undefined : configuredEntry,
+      abandon,
     );
     const sourceResources = new Map<ContextEngine, ContextEngineFactoryResources[]>();
     let fallback: ResolvedContextEngineRef;

--- a/src/plugins/registry-inspection-resources.ts
+++ b/src/plugins/registry-inspection-resources.ts
@@ -27,6 +27,7 @@ export class PluginRegistryInspectionResources {
   readonly #source = new PluginRegistrationResourceSource();
   readonly #claim = this.#source.acquireClaim("inspection");
   readonly #registries = new Set<PluginRegistry>();
+  readonly #dependencies = new WeakSet<PluginRegistryInspectionResources>();
   #release?: Promise<void>;
 
   /** Attach views of this source; independently borrowed donors keep their own owner. */
@@ -61,7 +62,13 @@ export class PluginRegistryInspectionResources {
     }
     if (dependency !== this) {
       this.#source.retainDependency(() => dependency.retain());
+      this.#dependencies.add(dependency);
     }
+  }
+
+  /** Recorded coverage survives retirement; retain() still checks this inspection's lifetime. */
+  coversSource(source: PluginRegistryInspectionResources): boolean {
+    return source === this || this.#dependencies.has(source);
   }
 
   /** Retains physical resources without extending this inspection's authority. */


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an agent using a copied plugin context engine could fall back unexpectedly after the original registry retired, even though its prepared registry still kept the engine's resources alive. Cleanup could also close the prepared registry while a copied engine's asynchronous disposer still needed one of its provider callbacks.

## Why This Change Was Made

Logical engine construction now captures the supplying registry once and retains its managed resource source for each factory and engine lifetime. Successful donor acquisition records weak one-hop source coverage, so a copied engine can use its live covering source without reopening the retired donor's authority. An uncovered donor still receives its own claim, and partial acquisition failures use the existing cleanup path.

The supplying registry is retained independently for each factory: finishing fallback cleanup cannot release resources that the selected engine still needs. Cleanup releases the primary before an uncovered donor, including when primary disposal fails. Raw supplying registries preserve their existing direct-donor ownership behavior. This adds no SDK contract, cache, schema change, or transitive dependency graph.

## User Impact

Prepared agent runs keep their selected copied context engine and can finish asynchronous cleanup safely. Retiring the supplying registry still prevents new logical turns; this change extends physical cleanup custody without reviving execution authority. Raw registrations retain their documented caller-owned lifetime.

## Evidence

Native SQLite regressions use the real prepared-registry acquisition path and a full-registration donor. Original source fails three cases: retired-donor selection and supplying-registry lifetime with live and raw donors. The candidate passes all three, plus uncovered and failed-dependency controls. A raw supplying-registry control also passes on the original source.

The final candidate passes 62 distinct tests across context-engine ownership, prepared-registry integration, donor resources, and inspection resources. The full changed gate passed in 371.80 seconds, followed by focused checks for the final test-only control. After the one-line weak-membership refinement, all 48 affected lifecycle controls and core type, targeted lint, and formatting checks passed again.

Independent Codex review found no actionable P0–P2 issues. The normal build passed in 235.76 seconds. Three compiled probes then passed against the same 11,400 sealed build artifacts, using the actual prepared-registry acquisition path and public speech-provider callback. All six SQLite files reopened with the expected values; all managed child processes exited, and 3,948 resolved modules contained no TypeScript source fallback. Engine resolution took 1.12–1.24 ms and disposal 0.97–1.54 ms in these one-shot synthetic probes; these are smoke timings, not a throughput comparison.
