### PR TITLE
fix: retain summary models through completion cleanup

### DIFF
--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -522,6 +522,31 @@ async function withPreparedSimpleCompletionRuntime<T>(
   }
 }
 
+type AcquiredSimpleCompletionModel =
+  | (Extract<PreparedSimpleCompletionModel, { model: Model }> & { release: () => void })
+  | Extract<PreparedSimpleCompletionModel, { error: string }>;
+
+/** Acquire the exact provider/model already selected by a finite internal caller. */
+export async function acquireSimpleCompletionModel(
+  params: Omit<Parameters<typeof prepareSimpleCompletionModel>[0], "preparedModelRuntime">,
+): Promise<AcquiredSimpleCompletionModel> {
+  return await acquirePreparedSimpleCompletionModel(
+    params,
+    [
+      {
+        provider: params.provider,
+        modelId: params.modelId,
+        ...(params.agentRuntimeId ? { runtime: params.agentRuntimeId } : {}),
+      },
+    ],
+    (context) =>
+      prepareSimpleCompletionModelCore(
+        { ...params, agentDir: context.preparedModelRuntime.agentDir },
+        context,
+      ),
+  );
+}
+
 type AcquiredSimpleCompletionModelForAgent =
   | (Extract<PreparedSimpleCompletionModelForAgent, { model: Model }> & { release: () => void })
   | Extract<PreparedSimpleCompletionModelForAgent, { error: string }>;
@@ -602,7 +627,40 @@ export async function acquireSimpleCompletionModelForAgent(
       return { error: `No model configured for agent ${params.agentId}.` };
     }
   }
-  const result = createDeferredCore<AcquiredSimpleCompletionModelForAgent>();
+  const acquired = await acquirePreparedSimpleCompletionModel(
+    { ...params, agentDir: selection.agentDir, pluginMetadataSnapshot: metadataSnapshot },
+    [{ provider: selection.provider, modelId: selection.modelId }],
+    (context) =>
+      prepareSimpleCompletionModelCore(
+        {
+          cfg: params.cfg,
+          agentId: params.agentId,
+          provider: selection.provider,
+          modelId: selection.modelId,
+          agentDir: selection.agentDir,
+          profileId: selection.profileId,
+          preferredProfile: params.preferredProfile,
+          allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+          ...(params.allowBundledStaticCatalogFallback !== undefined
+            ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
+            : {}),
+          skipAgentDiscovery: params.skipAgentDiscovery,
+          bindAuthOwner: params.bindAuthOwner,
+        },
+        context,
+      ),
+  );
+  return { ...acquired, selection };
+}
+
+async function acquirePreparedSimpleCompletionModel(
+  params: Parameters<typeof acquirePreparedSimpleCompletionRuntime>[0],
+  runtimePluginSelections: readonly AgentHarnessPluginSelection[],
+  prepareModel: (
+    context: PreparedSimpleCompletionResolverContext,
+  ) => Promise<PreparedSimpleCompletionModel>,
+): Promise<AcquiredSimpleCompletionModel> {
+  const result = createDeferredCore<AcquiredSimpleCompletionModel>();
   const trackOwner = captureAsyncWorkTracker();
   const parentSignal = getAsyncWorkSignal();
   const work = new AsyncWorkScope();
@@ -619,12 +677,8 @@ export async function acquireSimpleCompletionModelForAgent(
   };
   const prepare = async () => {
     const runtime = await acquirePreparedSimpleCompletionRuntime(
-      {
-        ...params,
-        agentDir: selection.agentDir,
-        pluginMetadataSnapshot: metadataSnapshot,
-      },
-      [{ provider: selection.provider, modelId: selection.modelId }],
+      params,
+      runtimePluginSelections,
       (release) => {
         releaseRuntime = release;
       },
@@ -633,33 +687,15 @@ export async function acquireSimpleCompletionModelForAgent(
       runtime.context.preparedModelRuntime,
       () => {
         runInContext = AsyncLocalStorage.snapshot();
-        return prepareSimpleCompletionModelCore(
-          {
-            cfg: params.cfg,
-            agentId: params.agentId,
-            provider: selection.provider,
-            modelId: selection.modelId,
-            agentDir: selection.agentDir,
-            profileId: selection.profileId,
-            preferredProfile: params.preferredProfile,
-            allowMissingApiKeyModes: params.allowMissingApiKeyModes,
-            ...(params.allowBundledStaticCatalogFallback !== undefined
-              ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
-              : {}),
-            skipAgentDiscovery: params.skipAgentDiscovery,
-            bindAuthOwner: params.bindAuthOwner,
-          },
-          runtime.context,
-        );
+        return prepareModel(runtime.context);
       },
     );
     if ("error" in prepared) {
-      return { ...prepared, selection };
+      return prepared;
     }
     callerReleased = false;
     return {
       ...prepared,
-      selection,
       release: () => {
         callerReleased = true;
         releaseWhenUnused();

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 // TTS core coordinates text preparation, provider selection, and speech output.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -8,6 +9,8 @@ import {
   type ModelRef,
 } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
@@ -25,9 +28,13 @@ type SummarizeTextDeps = {
   requireApiKey: typeof import("../agents/model-auth.js").requireApiKey;
 };
 
-let defaultSummarizeTextDepsPromise: Promise<SummarizeTextDeps> | undefined;
+type DefaultSummarizeTextDeps = Omit<SummarizeTextDeps, "prepareSimpleCompletionModel"> & {
+  acquireSimpleCompletionModel: typeof import("../agents/simple-completion-runtime.js").acquireSimpleCompletionModel;
+};
 
-function loadDefaultSummarizeTextDeps(): Promise<SummarizeTextDeps> {
+let defaultSummarizeTextDepsPromise: Promise<DefaultSummarizeTextDeps> | undefined;
+
+function loadDefaultSummarizeTextDeps(): Promise<DefaultSummarizeTextDeps> {
   // Speech provider imports should not initialize the LLM stack. Load it only
   // when synthesis actually needs summarization, then reuse the module bindings.
   return (defaultSummarizeTextDepsPromise ??= Promise.all([
@@ -36,7 +43,7 @@ function loadDefaultSummarizeTextDeps(): Promise<SummarizeTextDeps> {
   ]).then(([completionRuntime, { requireApiKey }]) => ({
     completeWithPreparedSimpleCompletionModel:
       completionRuntime.completeWithPreparedSimpleCompletionModel,
-    prepareSimpleCompletionModel: completionRuntime.prepareSimpleCompletionModel,
+    acquireSimpleCompletionModel: completionRuntime.acquireSimpleCompletionModel,
     requireApiKey,
   })));
 }
@@ -92,80 +99,130 @@ export async function summarizeText(
   }
 
   const startTime = Date.now();
-  const resolvedDeps = deps ?? (await loadDefaultSummarizeTextDeps());
-  const { ref } = resolveSummaryModelRef(cfg, config);
-  // Dynamic model discovery precedes the request timeout, matching the established
-  // summarization contract. The timeout below bounds only the completion request.
-  const prepared = await resolvedDeps.prepareSimpleCompletionModel({
-    cfg,
-    provider: ref.provider,
-    modelId: ref.model,
-  });
-  if ("error" in prepared) {
-    throw new Error(prepared.error);
-  }
-  const completionModel = prepared.model;
-  const providerKey = resolvedDeps.requireApiKey(prepared.auth, ref.provider);
-
-  try {
-    const controller = new AbortController();
-    const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
-    const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
+  const completeSummary = async (
+    prepared: Awaited<ReturnType<SummarizeTextDeps["prepareSimpleCompletionModel"]>>,
+    provider: string,
+    completionDeps: Pick<
+      SummarizeTextDeps,
+      "completeWithPreparedSimpleCompletionModel" | "requireApiKey"
+    >,
+  ): Promise<SummarizeResult> => {
+    if ("error" in prepared) {
+      throw new Error(prepared.error);
+    }
+    const completionModel = prepared.model;
+    const providerKey = completionDeps.requireApiKey(prepared.auth, provider);
 
     try {
-      // Keep summarization on the simple-completion path so provider auth,
-      // aliases, and timeout behavior match other lightweight model calls.
-      const res = await resolvedDeps.completeWithPreparedSimpleCompletionModel({
-        model: completionModel,
-        auth: { ...prepared.auth, apiKey: providerKey },
-        context: {
-          messages: [
-            {
-              role: "user",
-              content:
-                `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
-                `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
-                `Reply only with the summary, without additional explanations.\n\n` +
-                `<text_to_summarize>\n${text}\n</text_to_summarize>`,
-              timestamp: Date.now(),
-            },
-          ],
-        },
-        cfg,
-        options: {
-          maxTokens: Math.ceil(targetLength / 2),
-          temperature: 0.3,
-          // Summary text is spoken; never recover incomplete reasoning as visible prose.
-          strictReasoningTags: true,
-          signal: controller.signal,
-        },
-      });
-      const summary = sanitizeAssistantVisibleText(
-        res.content
-          .filter((block) => block.type === "text")
-          .map((block) => block.text.trim())
-          .filter(Boolean)
-          .join(" "),
-      );
+      const controller = new AbortController();
+      const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
+      const timeout = setTimeout(() => controller.abort(), resolvedTimeoutMs);
 
-      if (!summary) {
-        throw new Error("No summary returned");
+      try {
+        // Keep summarization on the simple-completion path so provider auth,
+        // aliases, and timeout behavior match other lightweight model calls.
+        const res = await completionDeps.completeWithPreparedSimpleCompletionModel({
+          model: completionModel,
+          auth: { ...prepared.auth, apiKey: providerKey },
+          context: {
+            messages: [
+              {
+                role: "user",
+                content:
+                  `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
+                  `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
+                  `Reply only with the summary, without additional explanations.\n\n` +
+                  `<text_to_summarize>\n${text}\n</text_to_summarize>`,
+                timestamp: Date.now(),
+              },
+            ],
+          },
+          cfg,
+          options: {
+            maxTokens: Math.ceil(targetLength / 2),
+            temperature: 0.3,
+            // Summary text is spoken; never recover incomplete reasoning as visible prose.
+            strictReasoningTags: true,
+            signal: controller.signal,
+          },
+        });
+        const summary = sanitizeAssistantVisibleText(
+          res.content
+            .filter((block) => block.type === "text")
+            .map((block) => block.text.trim())
+            .filter(Boolean)
+            .join(" "),
+        );
+
+        if (!summary) {
+          throw new Error("No summary returned");
+        }
+
+        return {
+          summary,
+          latencyMs: Date.now() - startTime,
+          inputLength: text.length,
+          outputLength: summary.length,
+        };
+      } finally {
+        clearTimeout(timeout);
       }
+    } catch (err) {
+      const error = err as Error;
+      if (error.name === "AbortError") {
+        throw new Error("Summarization timed out", { cause: err });
+      }
+      throw err;
+    }
+  };
 
-      return {
-        summary,
-        latencyMs: Date.now() - startTime,
-        inputLength: text.length,
-        outputLength: summary.length,
-      };
-    } finally {
-      clearTimeout(timeout);
-    }
-  } catch (err) {
-    const error = err as Error;
-    if (error.name === "AbortError") {
-      throw new Error("Summarization timed out", { cause: err });
-    }
-    throw err;
+  // The shipped dependency-injection argument keeps its caller-owned prepared model contract.
+  if (deps) {
+    const { ref } = resolveSummaryModelRef(cfg, config);
+    const prepared = await deps.prepareSimpleCompletionModel({
+      cfg,
+      provider: ref.provider,
+      modelId: ref.model,
+    });
+    return await completeSummary(prepared, ref.provider, deps);
   }
+
+  const resolvedDeps = await loadDefaultSummarizeTextDeps();
+  const { ref } = resolveSummaryModelRef(cfg, config);
+  const reported = createDeferredCore<SummarizeResult>();
+  const parentSignal = getAsyncWorkSignal();
+  void trackAsyncWork(async () => {
+    const work = new AsyncWorkScope();
+    const runInContext = work.run(() => AsyncLocalStorage.snapshot());
+    const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
+    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
+    if (parentSignal?.aborted) {
+      closeFromParent();
+    }
+    let releaseModel: (() => void) | undefined;
+    try {
+      reported.resolve(
+        await work.track(async () => {
+          // Preparation precedes the request timer; the completion and its cleanup own the model.
+          const prepared = await resolvedDeps.acquireSimpleCompletionModel({
+            cfg,
+            provider: ref.provider,
+            modelId: ref.model,
+          });
+          if (!("error" in prepared)) {
+            releaseModel = prepared.release;
+          }
+          return await completeSummary(prepared, ref.provider, resolvedDeps);
+        }),
+      );
+    } catch (error) {
+      reported.reject(error);
+    } finally {
+      await work.runWhenIdle(() => undefined);
+      await runInContext(() => work.drain());
+      parentSignal?.removeEventListener("abort", closeFromParent);
+      releaseModel?.();
+    }
+  }).catch(reported.reject);
+  return await reported.promise;
 }

--- a/src/tts/tts-summary.resources.test.ts
+++ b/src/tts/tts-summary.resources.test.ts
@@ -1,0 +1,512 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate } from "node:timers/promises";
+import { afterAll, afterEach, expect, it, vi, type MockInstance } from "vitest";
+import { getSessionMcpRequestSignal } from "../agents/agent-bundle-mcp-request-context.js";
+import { requireApiKey } from "../agents/model-auth.js";
+import * as preparedRuntime from "../agents/prepared-model-runtime.js";
+import { closePreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.lifecycle.js";
+import {
+  completeWithPreparedSimpleCompletionModel,
+  prepareSimpleCompletionModel,
+} from "../agents/simple-completion-runtime.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { Context, Model, ProviderStreamOptions } from "../llm/types.js";
+import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import { summarizeText } from "../plugin-sdk/speech-core.js";
+import { loadPluginRegistryHandle } from "../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import {
+  getPluginRuntimeGenerationRegistry,
+  withPluginRuntimeGenerationScope,
+} from "../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope, trackAsyncWork } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { resolveTtsConfig } from "./tts-settings.js";
+
+type SummaryConnection = {
+  database: DatabaseSync;
+  dbPath: string;
+  disposals: number;
+  completionReads: number;
+  openAtCompletion?: boolean;
+  cleanupReads: number;
+  setupReads: number;
+};
+
+function nativeSummaryFixture() {
+  const dir = makePluginLoaderTempDir();
+  const id = "summary-resource-fixture";
+  const key = `__summary_resources_${path.basename(dir)}`;
+  const connections: SummaryConnection[] = [];
+  const cancellation: {
+    signal?: AbortSignal;
+    requestSignal?: AbortSignal;
+    cleanupSignal?: AbortSignal;
+    registry?: PluginRegistry;
+    afterRegistry?: PluginRegistry;
+    failure?: unknown;
+  } = {};
+  const calls: Array<{ model: string; context: Context }> = [];
+  const state = {
+    connections,
+    setupStarted: createDeferredCore(),
+    finishSetup: createDeferredCore(),
+    finishSetupTail: createDeferredCore(),
+    started: createDeferredCore(),
+    finish: createDeferredCore(),
+    finishTail: createDeferredCore(),
+    cleanupStarted: createDeferredCore(),
+    finishCleanup: createDeferredCore(),
+    holdSetup: false,
+    rejectSetup: false,
+    setupTail: false,
+    completionTail: false,
+    watchCleanup: false,
+    calls,
+    cancellation,
+    async prepare(connection: SummaryConnection, read: () => number) {
+      if (state.holdSetup) {
+        state.setupStarted.resolve();
+        await state.finishSetup.promise;
+        read();
+      }
+      if (state.setupTail) {
+        void trackAsyncWork(async () => {
+          await state.finishSetupTail.promise;
+          read();
+          connection.setupReads++;
+        }).catch((error: unknown) => {
+          cancellation.failure = error;
+        });
+      }
+      if (state.rejectSetup) {
+        throw new Error("synthetic summary setup failure");
+      }
+    },
+    async stream(
+      model: Model,
+      context: Context,
+      options: ProviderStreamOptions,
+      connection: SummaryConnection,
+      read: () => number,
+    ) {
+      connection.openAtCompletion = connection.database.isOpen;
+      read();
+      state.calls.push({ model: model.id, context });
+      cancellation.requestSignal = options.signal;
+      if (state.completionTail) {
+        void trackAsyncWork(async () => {
+          await state.finishTail.promise;
+          read();
+          connection.cleanupReads++;
+        }).catch((error: unknown) => {
+          cancellation.failure = error;
+        });
+      }
+      if (state.watchCleanup) {
+        const signal = (cancellation.signal = getSessionMcpRequestSignal());
+        const cleanup = () => {
+          cancellation.cleanupSignal = getSessionMcpRequestSignal();
+          cancellation.registry = getPluginRuntimeGenerationRegistry();
+          void trackAsyncWork(async () => {
+            state.cleanupStarted.resolve();
+            await state.finishCleanup.promise;
+            read();
+            connection.cleanupReads++;
+            cancellation.afterRegistry = getPluginRuntimeGenerationRegistry();
+          }).catch((error: unknown) => {
+            cancellation.failure = error;
+          });
+        };
+        signal?.addEventListener("abort", cleanup, { once: true });
+        if (signal?.aborted) {
+          cleanup();
+        }
+      }
+      state.started.resolve();
+      await state.finish.promise;
+      const value = read();
+      connection.completionReads++;
+      const stream = createAssistantMessageEventStream();
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: `<think>Private reasoning</think>Spoken summary ${value}.` },
+          ],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          stopReason: "stop",
+          timestamp: 0,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+        },
+      });
+      stream.end();
+      return stream;
+    },
+    dbPath: () => path.join(dir, `source-${connections.length}.sqlite`),
+  };
+  Object.defineProperty(globalThis, key, { configurable: true, value: state });
+  const plugin = writePlugin({
+    dir,
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const dbPath = state.dbPath();
+  const database = new DatabaseSync(dbPath);
+  database.exec("CREATE TABLE proof (value INTEGER); INSERT INTO proof VALUES (42)");
+  const connection = { database, dbPath, disposals: 0, completionReads: 0, cleanupReads: 0, setupReads: 0 };
+  state.connections.push(connection);
+  const read = () => database.prepare("SELECT value FROM proof").get().value;
+  api.lifecycle.registerRuntimeLifecycle({ id: "summary-db", dispose() { connection.disposals++; database.close(); } });
+  api.registerProvider({ id: ${JSON.stringify(id)}, label: "Summary fixture", auth: [],
+    prepareRuntimeAuth() { return state.prepare(connection, read); },
+    createStreamFn() { return (model, context, options) => state.stream(model, context, options, connection, read); }
+  });
+}};`,
+  });
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      providers: [id],
+      configSchema: { type: "object", properties: {}, additionalProperties: false },
+    }),
+  );
+  const config: OpenClawConfig = {
+    agents: {
+      entries: { main: {} },
+      defaults: { workspace: dir, model: { primary: `${id}/default-model` } },
+    },
+    tts: { summaryModel: `${id}/summary-model` },
+    models: {
+      providers: {
+        [id]: {
+          api: "openai-completions",
+          baseUrl: "https://summary-fixture.invalid/v1",
+          apiKey: "synthetic-fixture",
+          models: ["default-model", "summary-model"].map((model) => ({
+            id: model,
+            name: model,
+            reasoning: false,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            input: ["text"],
+            contextWindow: 8192,
+            maxTokens: 1024,
+          })),
+        },
+      },
+    },
+    plugins: { allow: [id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+  };
+  const agentDir = path.join(dir, "agent");
+  const parent = new AsyncWorkScope();
+  const outcomes: Promise<unknown>[] = [];
+  let lease: Awaited<ReturnType<typeof preparedRuntime.acquireReadOnlyPreparedModelRuntime>>;
+  let acquire: MockInstance<typeof preparedRuntime.acquireAgentRunPreparedModelRuntime>;
+  return {
+    config,
+    state,
+    parent,
+    get lease() {
+      return lease;
+    },
+    get acquire() {
+      return acquire;
+    },
+    async run(test: () => Promise<void>) {
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_HOME: dir,
+            OPENCLAW_STATE_DIR: path.join(dir, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(dir, "config.json"),
+          },
+          async () => {
+            useNoBundledPlugins();
+            lease = await preparedRuntime.acquireReadOnlyPreparedModelRuntime(
+              {
+                config,
+                agentId: "main",
+                agentDir,
+                workspaceDir: dir,
+                loadRuntimePlugins: true,
+                skipCredentials: true,
+                runtimePluginSelections: [{ provider: id, modelId: "summary-model" }],
+              },
+              undefined,
+              "static",
+            );
+            acquire = vi
+              .spyOn(preparedRuntime, "acquireAgentRunPreparedModelRuntime")
+              .mockResolvedValue(lease);
+            try {
+              await test();
+            } finally {
+              state.finishSetup.resolve();
+              state.finishSetupTail.resolve();
+              state.finish.resolve();
+              state.finishTail.resolve();
+              state.finishCleanup.resolve();
+              await Promise.all(outcomes);
+              await parent.drain();
+              lease.release();
+              await closePreparedModelRuntimeSnapshots();
+            }
+          },
+        );
+      } finally {
+        for (const connection of connections) {
+          if (connection.database.isOpen) {
+            connection.database.close();
+          }
+        }
+        Reflect.deleteProperty(globalThis, key);
+      }
+    },
+    summarize(timeoutMs = 1000, deps?: Parameters<typeof summarizeText>[1]) {
+      const outcome = parent
+        .track(() =>
+          withPluginRuntimeGenerationScope(lease.snapshot, () =>
+            summarizeText(
+              {
+                text: "The original visible reply remains intact. ".repeat(30),
+                targetLength: 120,
+                cfg: config,
+                config: resolveTtsConfig(config),
+                timeoutMs,
+              },
+              deps,
+            ),
+          ),
+        )
+        .then(
+          (result) => ({ result }),
+          (error: unknown) => ({ error }),
+        );
+      outcomes.push(outcome);
+      return outcome;
+    },
+    async assertClosed() {
+      await parent.drain();
+      await closePreparedModelRuntimeSnapshots();
+      for (const source of connections) {
+        expect(source.disposals).toBe(1);
+        expect(source.database.isOpen).toBe(false);
+        const reopened = new DatabaseSync(source.dbPath, { readOnly: true });
+        try {
+          expect(reopened.prepare("SELECT value FROM proof").get()?.value).toBe(42);
+        } finally {
+          reopened.close();
+        }
+      }
+    },
+  };
+}
+
+async function entered(phase: Promise<void>, outcome: Promise<unknown>) {
+  await Promise.race([
+    phase,
+    outcome.then((value) => {
+      throw new Error(`Summary settled before its held phase: ${JSON.stringify(value)}`);
+    }),
+  ]);
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  await closePreparedModelRuntimeSnapshots();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it.each([false, true])(
+  "owns the selected summary model through completion and cleanup (tail=%s)",
+  async (tail) => {
+    const fixture = nativeSummaryFixture();
+    await fixture.run(async () => {
+      fixture.state.completionTail = tail;
+      fixture.state.finish.resolve();
+      const outcome = await fixture.summarize();
+      expect(fixture.state.connections[0]?.openAtCompletion).toBe(true);
+      expect(outcome).toMatchObject({
+        result: { summary: "Spoken summary 42." },
+      });
+      expect(fixture.state.calls.map((call) => call.model)).toEqual(["summary-model"]);
+      if (tail) {
+        await setImmediate();
+        expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+        fixture.state.finishTail.resolve();
+      }
+      await fixture.assertClosed();
+      expect(fixture.state.connections[0]?.completionReads).toBe(1);
+      expect(fixture.state.connections[0]?.cleanupReads).toBe(tail ? 1 : 0);
+      expect(fixture.state.cancellation.failure).toBeUndefined();
+    });
+  },
+);
+
+it("starts the summary deadline after preparation and keeps an uncooperative provider owned", async () => {
+  const fixture = nativeSummaryFixture();
+  await fixture.run(async () => {
+    vi.useFakeTimers();
+    fixture.state.holdSetup = true;
+    const outcome = fixture.summarize(25);
+    let settled = false;
+    void outcome.then(() => {
+      settled = true;
+    });
+    await entered(fixture.state.setupStarted.promise, outcome);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fixture.state.calls).toHaveLength(0);
+    expect(settled).toBe(false);
+    fixture.state.finishSetup.resolve();
+    await entered(fixture.state.started.promise, outcome);
+    expect(fixture.state.cancellation.requestSignal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(fixture.state.cancellation.requestSignal?.aborted).toBe(true);
+    expect(settled).toBe(false);
+    expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+    fixture.state.finish.resolve();
+    expect(await outcome).toMatchObject({ result: { summary: "Spoken summary 42." } });
+    await fixture.assertClosed();
+  });
+});
+
+it.each(["normal", "parent"] as const)(
+  "drains summary cancellation work in the captured %s context",
+  async (mode) => {
+    const fixture = nativeSummaryFixture();
+    await fixture.run(async () => {
+      fixture.state.watchCleanup = true;
+      const outcome = fixture.summarize();
+      await entered(fixture.state.started.promise, outcome);
+      if (mode === "parent") {
+        const reason = new Error("synthetic parent shutdown");
+        withPluginRuntimeGenerationScope(
+          {
+            metadataSnapshot: fixture.lease.snapshot.metadataSnapshot,
+            pluginRegistry: createEmptyPluginRegistry(),
+          },
+          () => fixture.parent.beginClose(reason),
+        );
+        expect(fixture.state.cancellation.signal?.reason).toBe(reason);
+      }
+      fixture.state.finish.resolve();
+      expect(await outcome).toMatchObject({ result: { summary: "Spoken summary 42." } });
+      await setImmediate();
+      expect(fixture.state.cancellation.signal?.aborted).toBe(true);
+      await fixture.state.cleanupStarted.promise;
+      expect(fixture.state.cancellation.cleanupSignal?.aborted).toBe(true);
+      expect(fixture.state.cancellation.registry).toBe(fixture.lease.snapshot.pluginRegistry);
+      expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+      fixture.state.finishCleanup.resolve();
+      await fixture.assertClosed();
+      expect(fixture.state.cancellation.afterRegistry).toBe(fixture.lease.snapshot.pluginRegistry);
+      expect(fixture.state.cancellation.failure).toBeUndefined();
+      expect(fixture.state.connections[0]?.cleanupReads).toBe(1);
+    });
+  },
+);
+
+it("owns a failed summary preparation until its auth descendant settles", async () => {
+  const fixture = nativeSummaryFixture();
+  await fixture.run(async () => {
+    fixture.state.setupTail = true;
+    fixture.state.rejectSetup = true;
+    expect(await fixture.summarize()).toMatchObject({
+      error: expect.objectContaining({ message: "synthetic summary setup failure" }),
+    });
+    await setImmediate();
+    expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+    expect(fixture.state.calls).toHaveLength(0);
+    fixture.state.finishSetupTail.resolve();
+    await fixture.assertClosed();
+    expect(fixture.state.connections[0]?.setupReads).toBe(1);
+    expect(fixture.state.cancellation.failure).toBeUndefined();
+  });
+});
+
+it.each(["success", "auth-abort", "completion-abort"] as const)(
+  "keeps injected model ownership and error classification for %s",
+  async (mode) => {
+    const fixture = nativeSummaryFixture();
+    await fixture.run(async () => {
+      fixture.state.finish.resolve();
+      const abort = new Error("synthetic injected abort");
+      abort.name = "AbortError";
+      const outcome = await fixture.summarize(1000, {
+        prepareSimpleCompletionModel: (params) =>
+          prepareSimpleCompletionModel({
+            ...params,
+            preparedModelRuntime: fixture.lease.snapshot,
+          }),
+        completeWithPreparedSimpleCompletionModel: async (params) => {
+          if (mode === "completion-abort") {
+            throw abort;
+          }
+          return await completeWithPreparedSimpleCompletionModel(params);
+        },
+        requireApiKey: (auth, provider) => {
+          if (mode === "auth-abort") {
+            throw abort;
+          }
+          return requireApiKey(auth, provider);
+        },
+      });
+      if (mode === "success") {
+        expect(outcome).toMatchObject({ result: { summary: "Spoken summary 42." } });
+      } else if (mode === "auth-abort") {
+        expect(outcome).toEqual({ error: abort });
+      } else {
+        expect(outcome).toMatchObject({
+          error: { message: "Summarization timed out", cause: abort },
+        });
+      }
+      expect(fixture.acquire).not.toHaveBeenCalled();
+      expect(fixture.state.connections[0]?.database.isOpen).toBe(true);
+      expect(fixture.state.connections[0]?.disposals).toBe(0);
+      fixture.lease.release();
+      await fixture.assertClosed();
+    });
+  },
+);
+
+it("leaves a raw provider registration with its owner", async () => {
+  const fixture = nativeSummaryFixture();
+  await fixture.run(async () => {
+    const raw = loadPluginRegistryHandle({ config: fixture.config });
+    const snapshot = { ...fixture.lease.snapshot, pluginRegistry: raw };
+    fixture.acquire.mockResolvedValue({ ...fixture.lease, snapshot });
+    fixture.state.finish.resolve();
+    expect(await fixture.summarize()).toMatchObject({ result: { summary: "Spoken summary 42." } });
+    await fixture.parent.drain();
+    const rawSource = fixture.state.connections.at(-1);
+    expect(rawSource?.completionReads).toBe(1);
+    expect(rawSource?.disposals).toBe(0);
+    expect(rawSource?.database.isOpen).toBe(true);
+  });
+});

--- a/src/tts/tts-summary.test.ts
+++ b/src/tts/tts-summary.test.ts
@@ -26,7 +26,7 @@ const completion = vi.hoisted(() => ({
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
   completeWithPreparedSimpleCompletionModel: completion.complete,
-  prepareSimpleCompletionModel: completion.prepare,
+  acquireSimpleCompletionModel: completion.prepare,
 }));
 
 const model = {
@@ -77,6 +77,7 @@ beforeEach(() => {
   completion.prepare.mockReturnValue({
     model,
     auth: { apiKey: "synthetic-test-key", source: "test", mode: "api-key" },
+    release: () => {},
   });
   synthesizeMock.mockClear();
   prepareSynthesisMock.mockClear();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where TTS summarization could use a model after its plugin resources had been released, causing completion or late cleanup to fail when the source has a managed lifetime. Ordinary configured sources remain raw today; this closes the summary ownership gap before enabling their physical disposal.

## Why This Change Was Made

The default summary path now acquires the already-selected provider/model and retains it through preparation, actual completion, and cooperating cleanup, reusing the shared prepared-model acquisition lifecycle. The shipped optional injected-dependencies contract remains caller-owned, and model selection, discovery-before-timeout, deadline/result behavior, auth-error classification, and truncate fallback remain unchanged.

## User Impact

TTS summaries can safely finish and clean up when their model source has managed resources, including work that finishes after cancellation. This is lifecycle preparation: it does not enable automatic disposal for ordinary configured sources or change TTS configuration and provider routing.

## Evidence

- With the original production files restored byte-for-byte, six managed-source regressions failed while four raw/injected controls passed. The real SQLite connection was already closed at provider entry. All ten passed with the fix; 130 affected sibling cases also passed, for 140 distinct tests covering selection, setup failures, cancellation, cleanup, and the public injected contract.
- The native tests pass a real acquired read-only SQLite source through the existing acquisition input adapter into the actual public default summary path. They prove late reads, automatic exactly-once closure, and reopening. This adapter supplies managed ownership; it does not prove that ordinary configured producers already acquire managed sources.
- The full changed-file gate passed, including types, Knip, lint, formatting, database guards, and import-cycle checks. Additional static Madge found zero cycles. Fresh isolated Codex review found no actionable P0–P2 findings. Ordinary `pnpm build` passed in 261.66 seconds, including all 152 public SDK subpaths.
- A compiled synthetic probe passed in 1.99 seconds through public speech-core, TTS config resolution, and prepared-completion SDK entry points. It verified explicit summary-model selection on all four provider calls, cleanup before parent shutdown, late completion after the request signal expired, and repeated injected calls using one SDK-prepared model. All 11,694 built artifacts remained unchanged; a guard rejected TypeScript source fallback. No external inference was used.
- The compiled fixture passed the actual built config schema before execution. A final audit verified canonical config fields, matching provider registration, sealed probe/schema/log hashes, and no invalid-config or fallback diagnostics. No checkpoint or session-store behavior is claimed.
- Compiled default sources remained raw under current production policy: SQLite stayed open after summary/SDK shutdown, and the fixture owner then closed and reopened it. Automatic default-source disposal still needs compiled integration proof when that producer is activated. Observed cold-summary and warm deadline-signaled completion times were 200.47 ms and 32.26 ms respectively; these are individual synthetic observations with different work, not a benchmark or speedup claim.
