### PR TITLE
test: reuse transforms across native Gateway fixtures

### DIFF
--- a/src/gateway/server.fixture-lifetime.test-support.ts
+++ b/src/gateway/server.fixture-lifetime.test-support.ts
@@ -5,34 +5,28 @@ import os from "node:os";
 import path from "node:path";
 import { expect, type TestContext } from "vitest";
 import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
+import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
 import { runVitestShutdownCommand } from "../../test/helpers/vitest-shutdown-command.js";
 import { hasErrnoCode } from "../infra/errno.js";
 
-export function runGatewayFixtureFork(
-  context: Pick<TestContext, "signal" | "onTestFinished">,
-  source: (repoRoot: string, root: string) => string,
-  assertJournal: (journal: unknown, text: string) => void,
-): Promise<void> {
-  const run = Promise.resolve().then(async () => {
-    context.signal.throwIfAborted();
-    const repoRoot = path.resolve(import.meta.dirname, "../..");
-    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "gateway-close-fork-")));
-    let joined = false;
-    try {
-      // Failed child claims belong here, never to the outer worker's resource namespace.
-      createVitestResourceOwner(root);
-      const require = createRequire(import.meta.url);
-      const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
+export function createGatewayFixtureFork(
+  registerCleanup: (cleanup: () => Promise<void>) => unknown,
+) {
+  const lifetime = createFixtureLifetime();
+  registerCleanup(() => lifetime.cleanup());
+  const repoRoot = path.resolve(import.meta.dirname, "../..");
+  let project: Promise<{ root: string; config: string }> | undefined;
+  const prepareProject = () =>
+    (project ??= (async () => {
+      const root = lifetime.createTempDir("gateway-fixture-code-");
       await fs.symlink(
         path.join(repoRoot, "node_modules"),
         path.join(root, "node_modules"),
         "junction",
       );
-      await fs.mkdir(path.join(root, "home"));
-      await fs.mkdir(path.join(root, "tmp"));
-      await fs.writeFile(path.join(root, "fixture.test.ts"), source(repoRoot, root));
+      const config = path.join(root, "vitest.config.ts");
       await fs.writeFile(
-        path.join(root, "vitest.config.ts"),
+        config,
         `
 import { defineConfig } from "vitest/config";
 import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.shared.config.ts"))};
@@ -48,81 +42,120 @@ export default defineConfig({
     hookTimeout: sharedVitestConfig.test.hookTimeout,
     deps: sharedVitestConfig.test.deps,
     server: sharedVitestConfig.test.server,
+    fsModuleCache: sharedVitestConfig.test.fsModuleCache,
+    fsModuleCachePath: ${JSON.stringify(path.join(root, "modules"))},
   },
 });
 `,
       );
-      const reportFile = path.join(root, "report.json");
-      let child: ChildProcess | undefined;
-      const output = await runVitestShutdownCommand({
-        args: [
-          path.join(vitestPackageDir, "vitest.mjs"),
-          "run",
-          "--root",
-          root,
-          "--config",
-          path.join(root, "vitest.config.ts"),
-          "--configLoader",
-          "runner",
-          "--reporter=verbose",
-          "--reporter=json",
-          `--outputFile=${reportFile}`,
-        ],
-        cwd: repoRoot,
-        signal: context.signal,
-        timeoutMs: 90_000,
-        maxBytes: 4 * 1024 * 1024,
-        env: {
-          PATH: process.env.PATH,
-          HOME: path.join(root, "home"),
-          USERPROFILE: path.join(root, "home"),
-          OPENCLAW_HOME: path.join(root, "home"),
-          OPENCLAW_STATE_DIR: path.join(root, "home/.openclaw"),
-          OPENCLAW_CONFIG_PATH: path.join(root, "home/.openclaw/openclaw.json"),
-          TMPDIR: path.join(root, "tmp"),
-          TMP: path.join(root, "tmp"),
-          TEMP: path.join(root, "tmp"),
-          CI: "1",
-          NO_COLOR: "1",
-        },
-        onReady(owned) {
-          child = owned;
-        },
-      });
-      const diagnostics = `${output.stdout}\n${output.stderr}`;
-      expect(child?.signalCode, diagnostics).toBeNull();
-      expect(child?.killed, diagnostics).toBe(false);
-      const pid = Number(await fs.readFile(path.join(root, "worker.pid"), "utf8"));
-      expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
-      let workerStopped = false;
+      return { root, config };
+    })());
+
+  return function runGatewayFixtureFork(
+    context: Pick<TestContext, "signal" | "onTestFinished">,
+    source: (repoRoot: string, root: string) => string,
+    assertJournal: (journal: unknown, text: string) => void,
+  ): Promise<void> {
+    const run = lifetime.run(async () => {
+      context.signal.throwIfAborted();
+      const root = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "gateway-close-fork-")),
+      );
+      let joined = false;
       try {
-        process.kill(pid, 0);
-      } catch (error) {
-        if (!hasErrnoCode(error, "ESRCH")) {
-          throw error;
+        // Failed child claims stay private; only transformed code is shared across fresh forks.
+        createVitestResourceOwner(root);
+        const prepared = await prepareProject();
+        const require = createRequire(import.meta.url);
+        const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
+        await fs.symlink(
+          path.join(repoRoot, "node_modules"),
+          path.join(root, "node_modules"),
+          "junction",
+        );
+        await fs.mkdir(path.join(root, "home"));
+        await fs.mkdir(path.join(root, "tmp"));
+        await fs.writeFile(path.join(root, "fixture.test.ts"), source(repoRoot, root));
+        const reportFile = path.join(root, "report.json");
+        let child: ChildProcess | undefined;
+        const output = await runVitestShutdownCommand({
+          args: [
+            path.join(vitestPackageDir, "vitest.mjs"),
+            "run",
+            "--root",
+            prepared.root,
+            "--dir",
+            root,
+            "--config",
+            prepared.config,
+            "--configLoader",
+            "runner",
+            "--reporter=verbose",
+            "--reporter=json",
+            `--outputFile=${reportFile}`,
+          ],
+          cwd: repoRoot,
+          signal: context.signal,
+          timeoutMs: 90_000,
+          maxBytes: 4 * 1024 * 1024,
+          env: {
+            PATH: process.env.PATH,
+            OPENCLAW_VITEST_FS_MODULE_CACHE: process.env.OPENCLAW_VITEST_FS_MODULE_CACHE,
+            HOME: path.join(root, "home"),
+            USERPROFILE: path.join(root, "home"),
+            OPENCLAW_HOME: path.join(root, "home"),
+            OPENCLAW_STATE_DIR: path.join(root, "home/.openclaw"),
+            OPENCLAW_CONFIG_PATH: path.join(root, "home/.openclaw/openclaw.json"),
+            TMPDIR: path.join(root, "tmp"),
+            TMP: path.join(root, "tmp"),
+            TEMP: path.join(root, "tmp"),
+            CI: "1",
+            NO_COLOR: "1",
+          },
+          onReady(owned) {
+            child = owned;
+          },
+        });
+        const diagnostics = `${output.stdout}\n${output.stderr}`;
+        expect(child?.signalCode, diagnostics).toBeNull();
+        expect(child?.killed, diagnostics).toBe(false);
+        const pid = Number(await fs.readFile(path.join(root, "worker.pid"), "utf8"));
+        expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+        let workerStopped = false;
+        try {
+          process.kill(pid, 0);
+        } catch (error) {
+          if (!hasErrnoCode(error, "ESRCH")) {
+            throw error;
+          }
+          workerStopped = true;
         }
-        workerStopped = true;
+        expect(workerStopped, "native fixture worker must exit before root release").toBe(true);
+        joined = true;
+        expect(output.code, diagnostics).toBe(0);
+        expect(JSON.parse(await fs.readFile(reportFile, "utf8")), diagnostics).toMatchObject({
+          numPassedTests: 1,
+          numFailedTests: 0,
+          success: true,
+        });
+        const journal = await fs.readFile(path.join(root, "journal.json"), "utf8");
+        assertJournal(JSON.parse(journal), journal);
+      } finally {
+        if (joined) {
+          await fs.rm(root, { recursive: true, force: true });
+        } else {
+          // A missing PID receipt can be a plain assertion/IO error. Keep shared code
+          // alive too; ordinary rejected bodies alone do not retain fixture inputs.
+          void lifetime.verifyCleanup(async () => {
+            throw new Error(`Unjoined native Gateway fixture still owns shared code: ${root}`);
+          });
+          console.warn(`Retained unjoined native Gateway fixture: ${root}`);
+        }
       }
-      expect(workerStopped, "native fixture worker must exit before root release").toBe(true);
-      joined = true;
-      expect(output.code, diagnostics).toBe(0);
-      expect(JSON.parse(await fs.readFile(reportFile, "utf8")), diagnostics).toMatchObject({
-        numPassedTests: 1,
-        numFailedTests: 0,
-        success: true,
-      });
-      const journal = await fs.readFile(path.join(root, "journal.json"), "utf8");
-      assertJournal(JSON.parse(journal), journal);
-    } finally {
-      if (joined) {
-        await fs.rm(root, { recursive: true, force: true });
-      } else {
-        console.warn(`Retained unjoined native Gateway fixture: ${root}`);
-      }
-    }
-  });
-  context.onTestFinished(() => run);
-  return run;
+    });
+    context.onTestFinished(() => run);
+    return run;
+  };
 }
 
 export type GatewayStartupFixtureCase = {

--- a/src/gateway/server.sessions.fixture-lifecycle.test.ts
+++ b/src/gateway/server.sessions.fixture-lifecycle.test.ts
@@ -9,7 +9,7 @@ import {
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import { captureEnv } from "../test-utils/env.js";
-import { runGatewayFixtureFork } from "./server.fixture-lifetime.test-support.js";
+import { createGatewayFixtureFork } from "./server.fixture-lifetime.test-support.js";
 
 // Run the actual fixture hooks with controlled setup/teardown overlap instead
 // of waiting for the runner's 180s timeout. Consumer test bodies stay uncalled.
@@ -54,8 +54,9 @@ vi.mock("./server.js", async (importOriginal) => ({
   },
 }));
 
-const { afterEach, beforeEach, expect, test } =
+const { afterAll, afterEach, beforeEach, expect, test } =
   await vi.importActual<typeof import("vitest")>("vitest");
+const runGatewayFixtureFork = createGatewayFixtureFork(afterAll);
 await import("./server.sessions.create.test.js");
 const consumerHooks = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
 const sessions = await import("./test/server-sessions.test-helpers.js");

--- a/src/gateway/server.startup-fixture-lifetime.test.ts
+++ b/src/gateway/server.startup-fixture-lifetime.test.ts
@@ -1,8 +1,16 @@
-import { expect, test } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, expect, test, type TestContext } from "vitest";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
+import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
+import { hasErrnoCode } from "../infra/errno.js";
+import { captureEnv } from "../test-utils/env.js";
 import {
   gatewayStartupFixtureSource,
-  runGatewayFixtureFork,
+  createGatewayFixtureFork,
 } from "./server.fixture-lifetime.test-support.js";
+
+const runGatewayFixtureFork = createGatewayFixtureFork(afterAll);
 
 // Each retained failure needs its own fork: a later case must not reset the failed owner.
 for (const scenario of [
@@ -72,3 +80,75 @@ for (const scenario of [
       },
     ));
 }
+
+test("retains shared code when a native fixture has no worker join receipt", async (context) => {
+  const probe = createFixtureLifetime();
+  const root = probe.createTempDir("gateway-fixture-receipt-probe-");
+  const owner = createVitestResourceOwner(root);
+  const env = captureEnv(["TMPDIR", "TMP", "TEMP"]);
+  const cleanups: Array<() => Promise<void>> = [];
+  const finishers: Array<Parameters<TestContext["onTestFinished"]>[0]> = [];
+  const run = createGatewayFixtureFork((cleanup) => cleanups.push(cleanup));
+  let caseRoot: string | undefined;
+  let completion: Promise<void> | undefined;
+  let probeWorkerExited = false;
+  try {
+    for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+      process.env[key] = root;
+    }
+    completion = run(
+      { signal: context.signal, onTestFinished: (callback) => finishers.push(callback) },
+      (_repoRoot, ownedRoot) => {
+        caseRoot = ownedRoot;
+        return `
+import fs from "node:fs";
+import { test } from "vitest";
+test("finishes without publishing the required join receipt", () => {
+  fs.writeFileSync(${JSON.stringify(path.join(ownedRoot, "probe-worker.pid"))}, String(process.pid));
+});
+`;
+      },
+      () => {
+        throw new Error("Journal validation must not run without a worker join receipt");
+      },
+    );
+    const failure = await completion.catch((error: unknown) => error);
+    expect(failure).toMatchObject({ code: "ENOENT" });
+    for (const finish of finishers) {
+      await expect(finish(context)).rejects.toBe(failure);
+    }
+    expect(caseRoot).toBeDefined();
+    const pid = Number(await fs.readFile(path.join(caseRoot!, "probe-worker.pid"), "utf8"));
+    expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (!hasErrnoCode(error, "ESRCH")) {
+        throw error;
+      }
+      probeWorkerExited = true;
+    }
+    expect(probeWorkerExited).toBe(true);
+    const sharedRoots = (await fs.readdir(root)).filter((name) =>
+      name.startsWith("gateway-fixture-code-"),
+    );
+    expect(sharedRoots).toHaveLength(1);
+    const config = path.join(root, sharedRoots[0]!, "vitest.config.ts");
+    expect(cleanups).toHaveLength(1);
+    await expect(cleanups[0]!()).rejects.toThrow("Fixture cleanup unverified");
+    await expect(fs.access(config)).resolves.toBeUndefined();
+    await expect(fs.access(caseRoot!)).resolves.toBeUndefined();
+    expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+  } finally {
+    await Promise.allSettled(completion ? [completion] : []);
+    env.restore();
+    if (!probeWorkerExited) {
+      void probe.verifyCleanup(async () => {
+        throw new Error(`Native receipt probe exit is unverified: ${root}`);
+      });
+    }
+    // This independent PID observation permits probe disposal only; the fixture's
+    // missing join receipt and retained code claim are never repaired or released.
+    await probe.cleanup();
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Gateway lifecycle tests launch four fresh native Vitest processes. Each received a new project root/configuration and no filesystem module cache, so startup scenarios repeatedly transformed the same Gateway source graph. Those imports took roughly nine seconds per fork in a phase trace.

## Why This Change Was Made

Give each test file a disposable code/config/cache owner through the existing fixture-lifetime helper. Keep that project identity stable, and use Vitest's supported `--dir` option to select each unchanged private case root. This permits transformed-code reuse while preserving four separate native processes, fresh evaluation, state/configuration, resource owners, journals and PID checks.

The shared owner joins complete borrowers before cleanup. If a child has no verified join receipt, shared code is retained along with its case root. A lightweight native regression verifies that boundary. The session test registers cleanup through its actual afterAll hook, outside the fixture hooks it intentionally intercepts.

All 11 original cases and assertions remain; one ownership regression is appended within an existing file. The existing cache toggle and Windows default-off policy are honored; the outer cache path is never inherited. No production, dependency, timeout, worker, shard, root-limit or cache-key-policy change.

## User Impact

Faster native Gateway startup/failure coverage without combining processes or resetting intentionally retained failed owners. Warm startup forks two and three fall from roughly 15–18 seconds each to 4–5 seconds.

## Evidence

| Same 11-case whole invocation | Time |
| --- | ---: |
| Original | 97.29s |
| Candidate | 71.60s |
| Restored original | 77.54s |

All cases passed in the same order. These include wrapper preparation, the first cold transforms, native execution and cleanup. Local load varied: the conservative candidate improvement over the faster original control is 7.7%. The first cache population adds work; no speedup is promised for the session file's single native fork.

Final validation passed all **12 cases** in **68.88s**, including the added ownership regression. Its file ordering differed from the comparison above, so it is correctness evidence rather than another matched timing sample. Peak command RSS remained around 2.27 GB. The startup cache held about 107 MB of temporary transformed artifacts.

- An early-start observer captured separate original native CLI/worker pairs. After the first startup row, 4,436 cache artifacts retained identical sizes/mtimes across the next row; one new fixture entry appeared, and configuration bytes stayed identical. All original process/journal/liveness assertions passed, and code/cache/case roots were removed after verified completion.
- The ownership regression uses a real lightweight child that omits only its required join receipt. Shared code and case state must remain. Removing only the new failed-cleanup obligation made the test fail because cleanup incorrectly resolved; restoring it passed. A separate probe PID permits test cleanup without repairing the helper's missing receipt.
- A native probe caught an initially lost cache-disable toggle. Forwarding the existing toggle made the same probe pass with no module-cache directory; the temporary diagnostic assertion was removed.
- All 13 existing cache-policy tests passed, including source/config/alias/lock invalidation and fresh evaluation. Required changed-file guards, typechecks, dead-export checks and lint passed. Independent P2 review is clean.

Proof used pinned Node 24.19.0/pnpm 12.3.4, unchanged physical dependencies/build stamps and freshly emptied private benchmark paths. Diagnostic traces and observers are not committed. No Windows performance or full-main CI saving is claimed.
