### PR TITLE
fix(logging): identify threads in SQLite transaction warnings

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -324,6 +324,21 @@ quiet while this whole-operation warning exposes slow preparation between them.
 The record inherits an existing parent trace when available; it contains no
 database path, session identifier, plan content, or raw error.
 
+### SQLite transaction timing
+
+The `sqlite/transaction` warnings `slow SQLite transaction hold`,
+`slow SQLite transaction lock wait`, and `SQLite transaction lock wait failed`
+include `pid`, Node's `threadId`, and `isMainThread` for the thread executing the
+transaction. Inspect the original `raw` record in `openclaw logs --json` to
+distinguish the main thread from Workers sharing the same process. `async: false`
+describes the synchronous transaction helper; it does not identify the thread.
+
+Hold time covers the synchronous callback and its result checks after `BEGIN`
+and before `COMMIT`, including any JavaScript consumer work inside that callback.
+It excludes database opening and the separately timed begin and commit steps.
+These elapsed durations do not measure SQL CPU time or establish a causal link
+to a nearby request.
+
 ### SQLite session writes
 
 The `session-sqlite` subsystem emits `slow SQLite session write` when total

--- a/src/infra/sqlite-transaction.test.ts
+++ b/src/infra/sqlite-transaction.test.ts
@@ -2,6 +2,7 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getNodeSqliteKysely } from "./kysely-sync.js";
@@ -380,11 +381,13 @@ describe("runSqliteImmediateTransactionSync", () => {
         code: "ERR_SQLITE_ERROR",
         database: "agent.sqlite",
         failureKind: "lock-contention",
+        isMainThread,
         operation: "session.patch",
         pid: process.pid,
         sqliteErrcode: 5,
         sqlitePrimaryCode: 5,
         step: "begin",
+        threadId,
       }),
     );
   });
@@ -468,8 +471,10 @@ describe("runSqliteImmediateTransactionSync", () => {
         async: false,
         database: "agent.sqlite",
         elapsedMs: 1_500,
+        isMainThread,
         pid: process.pid,
         step: "begin",
+        threadId,
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
@@ -478,8 +483,10 @@ describe("runSqliteImmediateTransactionSync", () => {
         async: false,
         database: "agent.sqlite",
         elapsedMs: 1_500,
+        isMainThread,
         pid: process.pid,
         step: "commit",
+        threadId,
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
@@ -487,7 +494,9 @@ describe("runSqliteImmediateTransactionSync", () => {
       expect.objectContaining({
         async: false,
         database: "agent.sqlite",
+        isMainThread,
         pid: process.pid,
+        threadId,
       }),
     );
   });
@@ -564,10 +573,13 @@ describe("runSqliteImmediateTransactionSync", () => {
         busyTimeoutMs: 20,
         code: "ERR_SQLITE_ERROR",
         failureKind: "lock-contention",
+        isMainThread,
         operation: "contention-proof",
+        pid: process.pid,
         sqliteErrcode: 5,
         sqlitePrimaryCode: 5,
         step: "begin",
+        threadId,
       }),
     );
 

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -1,6 +1,7 @@
 // Provides SQLite transaction helpers with nested savepoints.
 import type { DatabaseSync } from "node:sqlite";
 import { setTimeout as sleep } from "node:timers/promises";
+import { isMainThread, threadId } from "node:worker_threads";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
@@ -181,8 +182,10 @@ function logSlowTransactionHold(params: {
     async: false,
     ...(params.options?.databaseLabel ? { database: params.options.databaseLabel } : {}),
     elapsedMs: params.elapsedMs,
+    isMainThread,
     ...(params.options?.operationLabel ? { operation: params.options.operationLabel } : {}),
     pid: process.pid,
+    threadId,
     thresholdMs: slowTransactionHoldThresholdMs(params.options),
   });
 }
@@ -202,9 +205,11 @@ function logSlowTransactionStep(params: {
       : {}),
     ...(params.options?.databaseLabel ? { database: params.options.databaseLabel } : {}),
     elapsedMs: params.elapsedMs,
+    isMainThread,
     ...(params.options?.operationLabel ? { operation: params.options.operationLabel } : {}),
     pid: process.pid,
     step: params.step,
+    threadId,
   });
 }
 
@@ -242,11 +247,13 @@ function execTimedTransactionStep(params: {
         code: sqliteErrorCode(error),
         elapsedMs,
         failureKind: "lock-contention",
+        isMainThread,
         ...(params.options?.operationLabel ? { operation: params.options.operationLabel } : {}),
         pid: process.pid,
         ...(sqliteErrcode !== undefined ? { sqliteErrcode } : {}),
         ...(sqlitePrimaryCode !== undefined ? { sqlitePrimaryCode } : {}),
         step: params.step,
+        threadId,
       });
     }
     throw error;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators could not tell whether a SQLite transaction warning came from the main thread or a Worker. Both share a process PID, and the existing `async: false` field describes the synchronous helper rather than its executing thread.

## Why This Change Was Made

Record Node's native `threadId` and `isMainThread` alongside `pid` in the canonical transaction hold, lock-wait, and lock-failure warnings. The logging guide explains the emitter identity and the callback-inclusive wall-time boundary. Transaction behavior, warning labels, levels, thresholds, and duration calculations are unchanged.

## User Impact

Operators can distinguish main-thread and Worker SQLite warnings in structured logs. This improves attribution; it does not fix transaction latency, measure SQL CPU time, or connect a warning causally to a nearby request.

## Evidence

- Three existing warning-boundary tests failed against the original source because the native thread fields were missing, including real separate-process SQLite lock contention.
- The full focused transaction suite passes locally: 23/23 on Node 24.20.0.
- The same suite passes with a real Worker-thread pool on Linux: 23/23 on Node 24.19.0 via Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/34429634717)); the wrapper verified the candidate tree, exited successfully, and stopped its lease. The backing Testbox job can show cancelled during delegated cleanup.
- Independent autoreview found no actionable issues through P2. The updated logging page passes MDX validation and the diff passes whitespace checks.
- Full changed-scope checks pass, including core/test typechecks, changed-file lint, formatting, and repository guards.
