### PR TITLE
fix: retain compaction services through issued work

### DIFF
--- a/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
@@ -1,0 +1,607 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { getAiTransportHost, type AssistantMessage, type Model } from "@openclaw/ai";
+import { createAssistantMessageEventStream } from "@openclaw/ai/event-stream";
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { validateConfigObjectRaw } from "../../config/validation-core.js";
+import { delegateCompactionToRuntime } from "../../context-engine/delegate.js";
+import { initializeGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "../../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { createColdPluginFixture } from "../../plugins/test-helpers/cold-plugin-fixtures.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../prepared-model-runtime.test-support.js";
+import type { StreamFn } from "../runtime/index.js";
+import type { AgentSession } from "../sessions/agent-session.js";
+import { createEventBus } from "../sessions/event-bus.js";
+import { loadExtensionFromFactory } from "../sessions/extensions/loader.js";
+import type { ExtensionContext } from "../sessions/extensions/types.js";
+import { SessionManager } from "../sessions/session-manager.js";
+import { recordSessionModelUsage } from "../sessions/session-model-usage.js";
+import { attachCompactionAccountingRecorder } from "./run/compaction-accounting-bridge.js";
+
+type Mode =
+  | "success"
+  | "abort-before-commit"
+  | "abort-after-commit"
+  | "automatic-after-commit"
+  | "timeout-after-commit"
+  | "session-hook-tail"
+  | "provider-tail"
+  | "cleanup-tail"
+  | "preparation-failure"
+  | "before_compaction"
+  | "after_compaction"
+  | "raw";
+type Connection = { file: string; database: DatabaseSync; disposals: number };
+type Fixture = {
+  mode: Mode;
+  root: string;
+  source?: Connection;
+  registrations: Connection[];
+  tools: Connection[];
+  entered: ReturnType<typeof createDeferredCore<void>>;
+  finish: ReturnType<typeof createDeferredCore<void>>;
+  pending: Promise<unknown>[];
+  eventBus: ReturnType<typeof createEventBus>;
+  session?: AgentSession;
+  context?: ExtensionContext;
+  disposals: number;
+  envRestored: boolean;
+  lateReads: number;
+};
+const active = vi.hoisted(() => ({ fixture: undefined as Fixture | undefined }));
+const providerId = "delegate-resource-provider";
+const summary = "The deployment checklist was reviewed. Compare the remaining rollout options.";
+
+function fixture(): Fixture {
+  return expectDefined(active.fixture, "active delegate fixture");
+}
+
+// RUN ownership is not activated here. Supply the existing managed read-only
+// producer to the real delegate, leaving selection, sessions, and disposal intact.
+vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../prepared-model-runtime.js")>();
+  return {
+    ...actual,
+    acquireAgentRunPreparedModelRuntime: async (
+      input: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[0],
+      options: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[1],
+    ) => {
+      const current = fixture();
+      const lease =
+        current.mode === "raw"
+          ? await actual.acquireAgentRunPreparedModelRuntime(input, options)
+          : await actual.acquireReadOnlyPreparedModelRuntime(
+              {
+                ...input,
+                readOnly: true,
+                loadRuntimePlugins: true,
+                runtimePluginSelections: [
+                  { provider: providerId, modelId: "model", agentId: "main" },
+                ],
+              },
+              options?.abortSignal,
+              "static",
+            );
+      expect(current.registrations.length).toBe(1);
+      if (current.mode === "before_compaction" || current.mode === "after_compaction") {
+        expect(
+          lease.snapshot.pluginRegistry?.typedHooks.filter((hook) => hook.hookName === current.mode)
+            .length,
+        ).toBe(1);
+      }
+      current.source = expectDefined(current.registrations[0], "selected registration");
+      return lease;
+    },
+  };
+});
+
+function remember(current: Fixture, pending: Promise<unknown>) {
+  current.pending.push(pending);
+  void pending.catch(() => {});
+  return pending;
+}
+
+async function hold(current: Fixture, readTools = true) {
+  current.entered.resolve();
+  await current.finish.promise;
+  const source = expectDefined(current.source, "acquired registration");
+  expect(source.database.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+  for (const tool of readTools ? current.tools : []) {
+    expect(tool.database.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+  }
+  current.lateReads++;
+}
+
+vi.mock("../sessions/sdk.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../sessions/sdk.js")>();
+  return {
+    ...actual,
+    createAgentSessionForEmbeddedRunner: async (
+      options: Parameters<typeof actual.createAgentSessionForEmbeddedRunner>[0],
+      internalOptions: Parameters<typeof actual.createAgentSessionForEmbeddedRunner>[1],
+    ) => {
+      const current = fixture();
+      const extensions = expectDefined(
+        options.resourceLoader,
+        "real resource loader",
+      ).getExtensions();
+      extensions.extensions.push(
+        await loadExtensionFromFactory(
+          (api) => {
+            api.on("session_before_compact", async (event, context) => {
+              current.context = context;
+              if (current.mode === "abort-before-commit") {
+                await remember(current, hold(current));
+                return {
+                  compaction: {
+                    summary,
+                    firstKeptEntryId: event.preparation.firstKeptEntryId,
+                    tokensBefore: event.preparation.tokensBefore,
+                  },
+                };
+              }
+              return undefined;
+            });
+            api.on("session_compact", async () => {
+              if (
+                current.mode === "abort-after-commit" ||
+                current.mode === "automatic-after-commit" ||
+                current.mode === "timeout-after-commit"
+              ) {
+                await remember(current, hold(current));
+              } else if (current.mode === "session-hook-tail") {
+                void remember(
+                  current,
+                  trackAsyncWork(() => hold(current)),
+                );
+              }
+            });
+          },
+          options.cwd ?? current.root,
+          current.eventBus,
+          extensions.runtime,
+        ),
+      );
+      const created = await actual.createAgentSessionForEmbeddedRunner(options, internalOptions);
+      current.session = created.session;
+      const dispose = created.session.dispose.bind(created.session);
+      vi.spyOn(created.session, "dispose").mockImplementation(() => {
+        current.disposals++;
+        dispose();
+      });
+      return created;
+    },
+  };
+});
+
+function assistant(model: Model, text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    stopReason: "stop",
+    timestamp: 1,
+    usage: {
+      input: 100,
+      output: 20,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 120,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+}
+
+vi.mock("./stream-resolution.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./stream-resolution.js")>();
+  return {
+    ...actual,
+    resolveEmbeddedAgentStream: (
+      params: Parameters<typeof actual.resolveEmbeddedAgentStream>[0],
+    ) => {
+      const resolved = actual.resolveEmbeddedAgentStream(params);
+      const streamFn: StreamFn = (model) => {
+        const current = fixture();
+        if (current.mode === "provider-tail") {
+          const pending = remember(current, hold(current));
+          expectDefined(
+            getAiTransportHost().observePendingProviderWork,
+            "provider work observer",
+          )(pending);
+        }
+        const result = createAssistantMessageEventStream();
+        result.push({ type: "done", reason: "stop", message: assistant(model, summary) });
+        result.end();
+        return result;
+      };
+      return { ...resolved, streamFn };
+    },
+  };
+});
+
+function openTool(current: Fixture, name: string): Connection {
+  const file = path.join(current.root, `${name}.sqlite`);
+  const database = new DatabaseSync(file);
+  database.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+  const connection = { file, database, disposals: 0 };
+  current.tools.push(connection);
+  return connection;
+}
+
+// These real SQLite handles stand at the existing MCP/LSP factory boundary;
+// this fixture tests runtime custody, not either wire protocol.
+vi.mock("../agent-bundle-mcp-tools.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agent-bundle-mcp-tools.js")>()),
+  createBundleMcpToolRuntime: async () => {
+    const current = fixture();
+    const connection = openTool(current, "mcp");
+    const track = captureAsyncWorkTracker();
+    if (current.mode === "preparation-failure") {
+      void remember(
+        current,
+        track(() => hold(current)),
+      );
+    }
+    return {
+      tools: [],
+      dispose: async () => {
+        if (current.mode === "cleanup-tail") {
+          void remember(
+            current,
+            track(() => hold(current, false)),
+          );
+        }
+        connection.disposals++;
+        connection.database.close();
+      },
+    };
+  },
+}));
+
+vi.mock("../agent-bundle-lsp-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agent-bundle-lsp-runtime.js")>()),
+  createBundleLspToolRuntime: async () => {
+    const current = fixture();
+    if (current.mode === "preparation-failure") {
+      throw new Error("fixture LSP setup failed");
+    }
+    const connection = openTool(current, "lsp");
+    return {
+      tools: [],
+      sessions: [],
+      dispose: async () => {
+        connection.disposals++;
+        connection.database.close();
+      },
+    };
+  },
+}));
+
+vi.mock("./skill-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./skill-runtime.js")>();
+  return {
+    ...actual,
+    prepareEmbeddedSkills: (params: Parameters<typeof actual.prepareEmbeddedSkills>[0]) => {
+      const prepared = actual.prepareEmbeddedSkills(params);
+      const current = fixture();
+      return {
+        ...prepared,
+        restoreSkillEnv: () => {
+          prepared.restoreSkillEnv();
+          current.envRestored = true;
+        },
+      };
+    },
+  };
+});
+
+describe("delegate compaction resource retirement", () => {
+  it.each<Mode>([
+    "success",
+    "abort-before-commit",
+    "abort-after-commit",
+    "automatic-after-commit",
+    "timeout-after-commit",
+    "session-hook-tail",
+    "provider-tail",
+    "cleanup-tail",
+    "preparation-failure",
+    "before_compaction",
+    "after_compaction",
+    "raw",
+  ])(
+    "keeps actual work owned through %s",
+    async (mode) => {
+      await withOpenClawTestState(
+        { label: "delegate-resources", layout: "split" },
+        async (state) => {
+          const current: Fixture = {
+            mode,
+            root: state.root,
+            registrations: [],
+            tools: [],
+            entered: createDeferredCore(),
+            finish: createDeferredCore(),
+            pending: [],
+            eventBus: createEventBus(),
+            disposals: 0,
+            envRestored: false,
+            lateReads: 0,
+          };
+          active.fixture = current;
+          const pluginRoot = state.path("plugin");
+          const emptyBundled = state.path("empty-bundled");
+          fs.mkdirSync(pluginRoot);
+          fs.mkdirSync(emptyBundled);
+          const plugin = createColdPluginFixture({
+            rootDir: pluginRoot,
+            pluginId: providerId,
+            providerId,
+            manifest: { channels: [], channelConfigs: {}, providerAuthChoices: [] },
+          });
+          const key = `__delegate_resources_${path.basename(state.root)}`;
+          const bridge = {
+            connections: current.registrations,
+            hold: () => remember(current, hold(current)),
+          };
+          Object.defineProperty(globalThis, key, { configurable: true, value: bridge });
+          fs.writeFileSync(
+            plugin.runtimeSource,
+            `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(providerId)}, register(api) {
+  const bridge = globalThis[${JSON.stringify(key)}];
+  const file = ${JSON.stringify(state.root)} + "/registration-" + bridge.connections.length + ".sqlite";
+  const database = new DatabaseSync(file);
+  database.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+  const connection = { file, database, disposals: 0 };
+  bridge.connections.push(connection);
+  api.lifecycle.registerRuntimeLifecycle({ id: "database", dispose() {
+    connection.disposals++;
+    database.close();
+  } });
+  api.registerProvider({ id: ${JSON.stringify(providerId)}, label: "Fixture provider", auth: [] });
+  ${
+    mode === "before_compaction" || mode === "after_compaction"
+      ? `api.on(${JSON.stringify(mode)}, async () => {
+    await bridge.hold();
+    database.prepare("SELECT value FROM answer").get();
+  }, { timeoutMs: 25 });`
+      : ""
+  }
+} };
+`,
+          );
+          const configuredModel = {
+            id: "model",
+            name: "Fixture model",
+            api: "openai-completions",
+            baseUrl: "https://fixture.invalid/v1",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128_000,
+            maxTokens: 1_024,
+          } satisfies ModelDefinitionConfig;
+          const model = { ...configuredModel, provider: providerId };
+          const config: OpenClawConfig = {
+            session: { store: state.path("transcripts", "openclaw-agent.sqlite") },
+            agents: {
+              ownership: "explicit",
+              entries: { main: {} },
+              defaults: {
+                workspace: state.workspaceDir,
+                model: { primary: `${providerId}/model` },
+                compaction: {
+                  mode: "default",
+                  keepRecentTokens: 1,
+                  postIndexSync: "off",
+                  timeoutSeconds: mode === "timeout-after-commit" ? 1 : 180,
+                },
+              },
+            },
+            models: {
+              providers: {
+                [providerId]: {
+                  api: "openai-completions",
+                  apiKey: "fixture-key",
+                  baseUrl: model.baseUrl,
+                  agentRuntime: { id: "openclaw" },
+                  models: [configuredModel],
+                },
+              },
+            },
+            plugins: {
+              allow: [providerId],
+              load: { paths: [pluginRoot] },
+              slots: { memory: "none" },
+              entries: {
+                [providerId]: { enabled: true, hooks: { allowConversationAccess: true } },
+              },
+            },
+          };
+          const validation = validateConfigObjectRaw(config);
+          expect(
+            validation.ok,
+            validation.ok ? "" : validation.issues.map((issue) => issue.path).join(", "),
+          ).toBe(true);
+          const target = {
+            agentId: "main",
+            sessionId: "delegate-session",
+            sessionKey: "agent:main:delegate-session",
+            storePath: state.path("transcripts", "openclaw-agent.sqlite"),
+          };
+          await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+          const manager = SessionManager.open(target, state.workspaceDir);
+          manager.appendModelChange(model.provider, model.id);
+          manager.appendThinkingLevelChange("off");
+          for (const text of [
+            "Review the deployment checklist.",
+            "Compare the remaining options.",
+            "Keep the rollout notes.",
+          ]) {
+            manager.appendMessage({ role: "user", content: text, timestamp: 1 });
+            manager.appendMessage(assistant(model, `Recorded: ${text}`));
+          }
+          manager.flushPendingPersistence();
+          const runtimeContext = {
+            workspaceDir: state.workspaceDir,
+            provider: providerId,
+            model: "model",
+            trigger: mode === "automatic-after-commit" ? "overflow" : "manual",
+            thinkLevel: "off",
+            config,
+          };
+          const recordUsage = vi.fn();
+          const recordCompaction = vi.fn();
+          attachCompactionAccountingRecorder(runtimeContext, { recordUsage, recordCompaction });
+          const parent = new AsyncWorkScope();
+          const controller = new AbortController();
+          let operation: ReturnType<typeof delegateCompactionToRuntime> | undefined;
+          let drained: Promise<void> | undefined;
+          await withEnvAsync(
+            { OPENCLAW_BUNDLED_PLUGINS_DIR: emptyBundled, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+            async () => {
+              await resetPreparedModelRuntimeSnapshotsForTest();
+              clearPluginMetadataLifecycleCaches();
+              initializeGlobalHookRunner(createEmptyPluginRegistry());
+              try {
+                operation = parent.track(() =>
+                  delegateCompactionToRuntime({
+                    sessionId: target.sessionId,
+                    sessionKey: target.sessionKey,
+                    sessionTarget: target,
+                    runtimeContext,
+                    abortSignal: controller.signal,
+                  }),
+                );
+                const held = mode !== "success" && mode !== "raw";
+                if (held) {
+                  await Promise.race([
+                    current.entered.promise,
+                    operation.then(() => {
+                      if (mode !== "cleanup-tail") {
+                        throw new Error("Delegate returned before the fixture work started");
+                      }
+                      return current.entered.promise;
+                    }),
+                  ]);
+                  if (current.session) {
+                    await current.session.agent.waitForIdle();
+                  }
+                  if (
+                    mode === "abort-before-commit" ||
+                    mode === "abort-after-commit" ||
+                    mode === "automatic-after-commit"
+                  ) {
+                    controller.abort(new Error("fixture caller cancelled compaction"));
+                  }
+                }
+                const result = await operation;
+                const cancelled =
+                  mode === "abort-before-commit" ||
+                  mode === "abort-after-commit" ||
+                  mode === "automatic-after-commit" ||
+                  mode === "timeout-after-commit";
+                expect(result.ok).toBe(!cancelled && mode !== "preparation-failure");
+                expect(current.envRestored).toBe(true);
+                expect(current.disposals).toBe(mode === "preparation-failure" ? 0 : 1);
+                if (current.context) {
+                  expect(() => current.context?.isIdle()).toThrow();
+                }
+                const usageCount = recordUsage.mock.calls.length;
+                recordSessionModelUsage(
+                  current.session?.sessionManager,
+                  assistant(model, summary).usage,
+                );
+                expect(recordUsage.mock.calls.length).toBe(usageCount);
+                const committed = mode !== "abort-before-commit" && mode !== "preparation-failure";
+                expect(
+                  SessionManager.open(target, state.workspaceDir)
+                    .getBranch()
+                    .filter((entry) => entry.type === "compaction").length,
+                ).toBe(committed ? 1 : 0);
+                expect(recordCompaction.mock.calls.length).toBe(committed ? 1 : 0);
+                const source = expectDefined(current.source, "selected managed source");
+                if (held) {
+                  expect(source.database.isOpen).toBe(true);
+                  expect(current.tools.length).toBe(mode === "preparation-failure" ? 1 : 2);
+                  if (mode !== "cleanup-tail") {
+                    expect(current.tools.every((tool) => tool.database.isOpen)).toBe(true);
+                  }
+                  let finished = false;
+                  drained = parent.drain().then(() => {
+                    finished = true;
+                  });
+                  await new Promise<void>((resolve) => {
+                    setImmediate(resolve);
+                  });
+                  expect(finished).toBe(false);
+                  current.finish.resolve();
+                  await Promise.all(current.pending);
+                  await drained;
+                  expect(current.lateReads).toBeGreaterThan(0);
+                } else {
+                  await parent.drain();
+                }
+                expect(source.disposals).toBe(mode === "raw" ? 0 : 1);
+                expect(source.database.isOpen).toBe(mode === "raw");
+                for (const tool of current.tools) {
+                  expect(tool.disposals).toBe(1);
+                  expect(tool.database.isOpen).toBe(false);
+                }
+                expect(recordCompaction.mock.calls.length).toBe(committed ? 1 : 0);
+                if (mode !== "raw") {
+                  const reopened = new DatabaseSync(source.file);
+                  try {
+                    expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+                  } finally {
+                    reopened.close();
+                  }
+                }
+              } finally {
+                current.finish.resolve();
+                await Promise.allSettled([operation, ...current.pending]);
+                await (drained ?? parent.drain());
+                await resetPreparedModelRuntimeSnapshotsForTest();
+                current.eventBus.clear();
+                vi.restoreAllMocks();
+                for (const connection of [...current.registrations, ...current.tools]) {
+                  if (connection.database.isOpen) {
+                    connection.database.close();
+                  }
+                }
+                delete (globalThis as Record<string, unknown>)[key];
+                active.fixture = undefined;
+                cleanupPluginLoaderFixturesForTest();
+                resetPluginLoaderTestStateForTest();
+                clearPluginMetadataLifecycleCaches();
+              }
+            },
+          );
+        },
+      );
+    },
+    30_000,
+  );
+});

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1,6 +1,7 @@
 /**
  * Public facade and fallback coordinator for embedded-agent compaction.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { projectPublicSessionEntry } from "../../config/sessions/session-entry-projection.js";
@@ -8,6 +9,12 @@ import { isAbortError } from "../../infra/abort-signal.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { resolveSessionPinnedHarnessId } from "../../sessions/agent-harness-session-key.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { resolveUserPath } from "../../utils.js";
 import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
@@ -329,216 +336,260 @@ export async function compactEmbeddedAgentSessionDirect(
   ) {
     return lockedHarnessCompactionFailure(lockedHarnessRuntime);
   }
-  const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
-    {
-      config: requestedParams.config ?? {},
-      agentId: requestedAgentIds.sessionAgentId,
-      agentDir: requestedAgentDir,
-      workspaceDir: requestedWorkspaceDir,
-      preserveWorkspaceDirOnRefresh: requestedWorkspaceDir !== canonicalWorkspaceDir,
-      ...(requestedParams.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-    },
-    {
-      abortSignal: requestedParams.abortSignal,
-      deriveRuntimePluginSelections: ({ config: admittedConfig, metadataSnapshot }) => {
-        const config = projectCodexHostTranscriptBytePreflightConfig(
-          admittedConfig,
-          Boolean(transcriptBytePreflightAuthority),
-        );
-        const selected = resolveCompactionRuntimeSelection({
-          ...requestedParams,
-          config,
-          modelId: requestedParams.model,
-          boundHarnessRuntime: requestedParams.agentHarnessId,
-          preparedRuntimePlan: requestedParams.runtimePlan,
-          manifestPlugins: metadataSnapshot,
-          allowPluginNormalization: false,
-        });
-        const pluginPlanCandidates = resolveModelCandidateChain({
-          cfg: config,
-          agentId: requestedAgentIds.sessionAgentId,
-          manifestPlugins: metadataSnapshot,
-          allowPluginNormalization: false,
-          provider: selected.provider,
-          model: selected.modelId,
-          requestedRouteResolution: "resolved",
-          fallbacksOverride: transcriptBytePreflightAuthority
-            ? []
-            : resolveCompactionFallbacksOverride({ ...requestedParams, config }),
-        });
-        return [
-          {
-            provider: selected.provider,
-            modelId: selected.modelId,
-            ...(selected.selectedHarnessRuntime
-              ? { runtime: selected.selectedHarnessRuntime }
-              : {}),
-            agentId: requestedAgentIds.sessionAgentId,
-          },
-          ...pluginPlanCandidates
-            .filter(
-              (candidate) =>
-                candidate.provider !== selected.provider || candidate.model !== selected.modelId,
-            )
-            .map((candidate) => ({
-              provider: candidate.provider,
-              modelId: candidate.model,
-              runtime: selected.boundHarnessRuntime,
-              agentId: requestedAgentIds.sessionAgentId,
-            })),
-        ];
+  const callerResult = createDeferredCore<EmbeddedAgentCompactResult>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  const cancellationSignal =
+    requestedParams.abortSignal && parentSignal
+      ? AbortSignal.any([requestedParams.abortSignal, parentSignal])
+      : (requestedParams.abortSignal ?? parentSignal);
+  const work = new AsyncWorkScope();
+  let context = work.run(() => AsyncLocalStorage.snapshot());
+  let releasePreparedRuntime: (() => void) | undefined;
+  const runPreparedCompaction = async () => {
+    const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
+      {
+        config: requestedParams.config ?? {},
+        agentId: requestedAgentIds.sessionAgentId,
+        agentDir: requestedAgentDir,
+        workspaceDir: requestedWorkspaceDir,
+        preserveWorkspaceDirOnRefresh: requestedWorkspaceDir !== canonicalWorkspaceDir,
+        ...(requestedParams.allowGatewaySubagentBinding
+          ? { allowGatewaySubagentBinding: true }
+          : {}),
       },
-    },
-  );
-  try {
-    const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
-    const preparedConfig =
-      projectCodexHostTranscriptBytePreflightConfig(
-        preparedModelRuntimeOwnerSnapshot.config,
-        Boolean(transcriptBytePreflightAuthority),
-      ) ?? preparedModelRuntimeOwnerSnapshot.config;
-    const preparedWorkspaceDir =
-      preparedModelRuntimeOwnerSnapshot.workspaceDir ?? requestedWorkspaceDir;
-    const repoRoot =
-      resolveSystemPromptRepoRoot({
-        config: preparedConfig,
-        workspaceDir: preparedWorkspaceDir,
-        cwd: requestedParams.cwd,
-      }) ?? null;
-    const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
-    const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
-      requestedParams.sessionId,
-      projectKey,
+      {
+        abortSignal: requestedParams.abortSignal,
+        deriveRuntimePluginSelections: ({ config: admittedConfig, metadataSnapshot }) => {
+          const config = projectCodexHostTranscriptBytePreflightConfig(
+            admittedConfig,
+            Boolean(transcriptBytePreflightAuthority),
+          );
+          const selected = resolveCompactionRuntimeSelection({
+            ...requestedParams,
+            config,
+            modelId: requestedParams.model,
+            boundHarnessRuntime: requestedParams.agentHarnessId,
+            preparedRuntimePlan: requestedParams.runtimePlan,
+            manifestPlugins: metadataSnapshot,
+            allowPluginNormalization: false,
+          });
+          const pluginPlanCandidates = resolveModelCandidateChain({
+            cfg: config,
+            agentId: requestedAgentIds.sessionAgentId,
+            manifestPlugins: metadataSnapshot,
+            allowPluginNormalization: false,
+            provider: selected.provider,
+            model: selected.modelId,
+            requestedRouteResolution: "resolved",
+            fallbacksOverride: transcriptBytePreflightAuthority
+              ? []
+              : resolveCompactionFallbacksOverride({ ...requestedParams, config }),
+          });
+          return [
+            {
+              provider: selected.provider,
+              modelId: selected.modelId,
+              ...(selected.selectedHarnessRuntime
+                ? { runtime: selected.selectedHarnessRuntime }
+                : {}),
+              agentId: requestedAgentIds.sessionAgentId,
+            },
+            ...pluginPlanCandidates
+              .filter(
+                (candidate) =>
+                  candidate.provider !== selected.provider || candidate.model !== selected.modelId,
+              )
+              .map((candidate) => ({
+                provider: candidate.provider,
+                modelId: candidate.model,
+                runtime: selected.boundHarnessRuntime,
+                agentId: requestedAgentIds.sessionAgentId,
+              })),
+          ];
+        },
+      },
     );
-    const preparedModelRuntime = Object.freeze({
-      ...preparedModelRuntimeOwnerSnapshot,
-      config: preparedConfig,
-      repoRoot,
-      projectKey,
-      activeProjectKeys,
-    });
-    // Fallback policy and every attempt consume the same generation as model/auth discovery.
-    // A reload may have committed while session targeting was resolved above.
-    const params: PreparedCompactEmbeddedAgentSessionParams = {
-      ...requestedParams,
-      config: preparedConfig,
-      agentId: preparedModelRuntime.agentId ?? requestedAgentIds.sessionAgentId,
-      agentDir: preparedModelRuntime.agentDir,
-      workspaceDir: preparedWorkspaceDir,
-      preparedModelRuntime,
-      ...(transcriptBytePreflightClaim
-        ? {
-            transcriptBytePreflightAuthority: true as const,
-            ...(transcriptBytePreflightClaim.withCompactionPersistence
-              ? {
-                  transcriptByteCompactionPersistence:
-                    transcriptBytePreflightClaim.withCompactionPersistence,
-                }
-              : {}),
-          }
-        : {}),
-    };
-    const compactPrepared = async () => {
-      if (
-        transcriptBytePreflightAuthority ||
-        hasExplicitCompactionModel(params) ||
-        !hasCompactionModelFallbackCandidates(params)
-      ) {
-        return await compactEmbeddedAgentSessionDirectOnce(params);
-      }
-      const resolvedCompactionTarget = resolveEmbeddedCompactionTarget({
-        config: params.config,
-        provider: params.provider,
-        modelId: params.model,
-        authProfileId: params.authProfileId,
-        modelSelectionLocked: params.modelSelectionLocked,
-        defaultProvider: DEFAULT_PROVIDER,
-        defaultModel: DEFAULT_MODEL,
-      });
-      const primaryProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
-      const primaryModel = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
-      const requestedPrimaryProvider = params.provider?.trim() || DEFAULT_PROVIDER;
-      const resolveAuthProvider = (provider: string) =>
-        resolveProviderIdForAuth(provider, {
-          config: params.config,
-          metadataSnapshot: preparedModelRuntime.metadataSnapshot,
-        });
-      const primaryAuthProviders = new Set(
-        [primaryProvider, requestedPrimaryProvider].map(resolveAuthProvider),
+    releasePreparedRuntime = () => preparedModelRuntimeLease.release();
+    try {
+      const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
+      const preparedConfig =
+        projectCodexHostTranscriptBytePreflightConfig(
+          preparedModelRuntimeOwnerSnapshot.config,
+          Boolean(transcriptBytePreflightAuthority),
+        ) ?? preparedModelRuntimeOwnerSnapshot.config;
+      const preparedWorkspaceDir =
+        preparedModelRuntimeOwnerSnapshot.workspaceDir ?? requestedWorkspaceDir;
+      const repoRoot =
+        resolveSystemPromptRepoRoot({
+          config: preparedConfig,
+          workspaceDir: preparedWorkspaceDir,
+          cwd: requestedParams.cwd,
+        }) ?? null;
+      const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
+      const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
+        requestedParams.sessionId,
+        projectKey,
       );
-      const fallbacksOverride = resolveCompactionFallbacksOverride(params);
-      const fallbackAgentId = resolveSessionAgentIds({
-        sessionKey: params.sandboxSessionKey ?? params.sessionKey,
-        config: params.config,
-        agentId: params.sandboxAgentId ?? params.agentId,
-      }).sessionAgentId;
-      const resolvedPrimaryCandidate = resolveModelCandidateChain({
-        cfg: params.config,
-        agentId: fallbackAgentId,
-        manifestPlugins: preparedModelRuntime.metadataSnapshot,
-        provider: primaryProvider,
-        model: primaryModel,
-        requestedRouteResolution: "resolved",
-        fallbacksOverride,
-      })[0];
-      const fallbackSessionKey = params.sandboxSessionKey ?? params.sessionKey ?? params.sessionId;
-      const fallbackResult = await runWithModelFallback<EmbeddedAgentCompactResult>({
-        cfg: params.config,
-        manifestPlugins: preparedModelRuntime.metadataSnapshot,
-        provider: primaryProvider,
-        model: primaryModel,
-        requestedRouteResolution: "resolved",
-        runId: params.runId ?? params.sessionId,
-        agentDir: params.agentDir,
-        agentId: fallbackAgentId,
-        sessionId: params.sessionId,
-        sessionKey: fallbackSessionKey,
-        userLockedAuthProfileId:
-          params.authProfileIdSource === "user" ? params.authProfileId : undefined,
-        abortSignal: params.abortSignal,
-        prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
-          await ensureSelectedAgentHarnessPlugin({
-            config: params.config,
-            provider,
-            modelId: model,
-            agentId: fallbackAgentId,
-            sessionKey: fallbackSessionKey,
-            agentHarnessRuntimeOverride,
-            workspaceDir: params.workspaceDir,
-            pluginRegistry: preparedModelRuntime.pluginRegistry!,
-          });
-        },
-        fallbacksOverride,
-        classifyResult: ({ result, provider, model }) =>
-          classifyCompactionFallbackResult(result, provider, model),
-        run: async (provider, model) => {
-          const isPrimaryCandidate =
-            provider === resolvedPrimaryCandidate?.provider &&
-            model === resolvedPrimaryCandidate.model;
-          const preservesPrimaryAuth =
-            isPrimaryCandidate || primaryAuthProviders.has(resolveAuthProvider(provider));
-          const authProfileId = preservesPrimaryAuth ? params.authProfileId : undefined;
-          return await compactEmbeddedAgentSessionDirectOnce({
-            ...params,
-            provider,
-            model,
-            authProfileId,
-            authProfileIdSource: preservesPrimaryAuth ? params.authProfileIdSource : undefined,
-            // The primary attempt retains its already prepared atomic plan. An
-            // actual fallback may change route/auth class and must rebuild it.
-            runtimeAuthPlan: isPrimaryCandidate ? params.runtimeAuthPlan : undefined,
-            runtimePlan: isPrimaryCandidate ? params.runtimePlan : undefined,
-          });
-        },
+      const preparedModelRuntime = Object.freeze({
+        ...preparedModelRuntimeOwnerSnapshot,
+        config: preparedConfig,
+        repoRoot,
+        projectKey,
+        activeProjectKeys,
       });
-      return fallbackResult.result;
-    };
-    return await withPluginRuntimeGenerationScope(preparedModelRuntime, compactPrepared);
-  } catch (err) {
-    return fallbackFailureToCompactionResult(err);
-  } finally {
-    preparedModelRuntimeLease.release();
-  }
+      // Fallback policy and every attempt consume the same generation as model/auth discovery.
+      // A reload may have committed while session targeting was resolved above.
+      const params: PreparedCompactEmbeddedAgentSessionParams = {
+        ...requestedParams,
+        config: preparedConfig,
+        agentId: preparedModelRuntime.agentId ?? requestedAgentIds.sessionAgentId,
+        agentDir: preparedModelRuntime.agentDir,
+        workspaceDir: preparedWorkspaceDir,
+        preparedModelRuntime,
+        ...(transcriptBytePreflightClaim
+          ? {
+              transcriptBytePreflightAuthority: true as const,
+              ...(transcriptBytePreflightClaim.withCompactionPersistence
+                ? {
+                    transcriptByteCompactionPersistence:
+                      transcriptBytePreflightClaim.withCompactionPersistence,
+                  }
+                : {}),
+            }
+          : {}),
+      };
+      const compactPrepared = async () => {
+        if (
+          transcriptBytePreflightAuthority ||
+          hasExplicitCompactionModel(params) ||
+          !hasCompactionModelFallbackCandidates(params)
+        ) {
+          return await compactEmbeddedAgentSessionDirectOnce(params);
+        }
+        const resolvedCompactionTarget = resolveEmbeddedCompactionTarget({
+          config: params.config,
+          provider: params.provider,
+          modelId: params.model,
+          authProfileId: params.authProfileId,
+          modelSelectionLocked: params.modelSelectionLocked,
+          defaultProvider: DEFAULT_PROVIDER,
+          defaultModel: DEFAULT_MODEL,
+        });
+        const primaryProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
+        const primaryModel = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
+        const requestedPrimaryProvider = params.provider?.trim() || DEFAULT_PROVIDER;
+        const resolveAuthProvider = (provider: string) =>
+          resolveProviderIdForAuth(provider, {
+            config: params.config,
+            metadataSnapshot: preparedModelRuntime.metadataSnapshot,
+          });
+        const primaryAuthProviders = new Set(
+          [primaryProvider, requestedPrimaryProvider].map(resolveAuthProvider),
+        );
+        const fallbacksOverride = resolveCompactionFallbacksOverride(params);
+        const fallbackAgentId = resolveSessionAgentIds({
+          sessionKey: params.sandboxSessionKey ?? params.sessionKey,
+          config: params.config,
+          agentId: params.sandboxAgentId ?? params.agentId,
+        }).sessionAgentId;
+        const resolvedPrimaryCandidate = resolveModelCandidateChain({
+          cfg: params.config,
+          agentId: fallbackAgentId,
+          manifestPlugins: preparedModelRuntime.metadataSnapshot,
+          provider: primaryProvider,
+          model: primaryModel,
+          requestedRouteResolution: "resolved",
+          fallbacksOverride,
+        })[0];
+        const fallbackSessionKey =
+          params.sandboxSessionKey ?? params.sessionKey ?? params.sessionId;
+        const fallbackResult = await runWithModelFallback<EmbeddedAgentCompactResult>({
+          cfg: params.config,
+          manifestPlugins: preparedModelRuntime.metadataSnapshot,
+          provider: primaryProvider,
+          model: primaryModel,
+          requestedRouteResolution: "resolved",
+          runId: params.runId ?? params.sessionId,
+          agentDir: params.agentDir,
+          agentId: fallbackAgentId,
+          sessionId: params.sessionId,
+          sessionKey: fallbackSessionKey,
+          userLockedAuthProfileId:
+            params.authProfileIdSource === "user" ? params.authProfileId : undefined,
+          abortSignal: params.abortSignal,
+          prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
+            await ensureSelectedAgentHarnessPlugin({
+              config: params.config,
+              provider,
+              modelId: model,
+              agentId: fallbackAgentId,
+              sessionKey: fallbackSessionKey,
+              agentHarnessRuntimeOverride,
+              workspaceDir: params.workspaceDir,
+              pluginRegistry: preparedModelRuntime.pluginRegistry!,
+            });
+          },
+          fallbacksOverride,
+          classifyResult: ({ result, provider, model }) =>
+            classifyCompactionFallbackResult(result, provider, model),
+          run: async (provider, model) => {
+            const isPrimaryCandidate =
+              provider === resolvedPrimaryCandidate?.provider &&
+              model === resolvedPrimaryCandidate.model;
+            const preservesPrimaryAuth =
+              isPrimaryCandidate || primaryAuthProviders.has(resolveAuthProvider(provider));
+            const authProfileId = preservesPrimaryAuth ? params.authProfileId : undefined;
+            return await compactEmbeddedAgentSessionDirectOnce({
+              ...params,
+              provider,
+              model,
+              authProfileId,
+              authProfileIdSource: preservesPrimaryAuth ? params.authProfileIdSource : undefined,
+              // The primary attempt retains its already prepared atomic plan. An
+              // actual fallback may change route/auth class and must rebuild it.
+              runtimeAuthPlan: isPrimaryCandidate ? params.runtimeAuthPlan : undefined,
+              runtimePlan: isPrimaryCandidate ? params.runtimePlan : undefined,
+            });
+          },
+        });
+        return fallbackResult.result;
+      };
+      return await withPluginRuntimeGenerationScope(preparedModelRuntime, () => {
+        context = AsyncLocalStorage.snapshot();
+        return compactPrepared();
+      });
+    } catch (err) {
+      return fallbackFailureToCompactionResult(err);
+    }
+  };
+  // Logical completion reports promptly; actual attempt work retains this generation.
+  void trackOwner(async () => {
+    const closeWork = () => context(() => work.beginClose(cancellationSignal?.reason));
+    cancellationSignal?.addEventListener("abort", closeWork, { once: true });
+    if (cancellationSignal?.aborted) {
+      closeWork();
+    }
+    try {
+      callerResult.resolve(await work.track(runPreparedCompaction));
+    } catch (error) {
+      callerResult.reject(error);
+    } finally {
+      try {
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => context(() => work.drain()),
+        );
+      } finally {
+        try {
+          releasePreparedRuntime?.();
+        } finally {
+          cancellationSignal?.removeEventListener("abort", closeWork);
+        }
+      }
+    }
+  }).catch(callerResult.reject);
+  return await callerResult.promise;
 }
 
 export const testing = {

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -140,588 +140,575 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
       }));
     const assertActive =
       memoryTranscript?.assertActive ?? captureOwnedTranscriptWriteAssertion(sessionTarget);
-    try {
-      assertActive();
-      const transcriptPolicy = runtimePlan.transcript.resolvePolicy(runtimePlanModelContext);
-      const sessionManager = guardSessionManager(
-        memoryTranscript?.sessionManager ?? SessionManager.open(sessionTarget),
-        {
-          agentId: sessionAgentId,
-          runId: params.runId,
-          sessionKey: params.sessionKey,
-          config: params.config,
-          contextWindowTokens: contextTokenBudget,
-          allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
-          missingToolResultText:
-            effectiveModel.api === "openai-responses" ||
-            effectiveModel.api === "azure-openai-responses" ||
-            effectiveModel.api === "openai-chatgpt-responses"
-              ? "aborted"
-              : undefined,
-          allowedToolNames,
-          withCompactionPersistence: params.transcriptByteCompactionPersistence,
-        },
-      );
-      checkpointSnapshot = memoryTranscript
-        ? null
-        : await compactionCheckpointStore.captureSnapshot({
-            sessionManager,
-            sessionFile: params.sessionFile,
-            sessionTarget,
-          });
-      compactionSessionManager = sessionManager;
-      const recordUsage = accountingRecorder?.recordUsage
-        ? (usage: UsageLike) => {
-            const normalized = normalizeUsage(usage);
-            if (normalized) {
-              accountingRecorder.recordUsage?.(normalized);
-            }
+    assertActive();
+    const transcriptPolicy = runtimePlan.transcript.resolvePolicy(runtimePlanModelContext);
+    const sessionManager = guardSessionManager(
+      memoryTranscript?.sessionManager ?? SessionManager.open(sessionTarget),
+      {
+        agentId: sessionAgentId,
+        runId: params.runId,
+        sessionKey: params.sessionKey,
+        config: params.config,
+        contextWindowTokens: contextTokenBudget,
+        allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+        missingToolResultText:
+          effectiveModel.api === "openai-responses" ||
+          effectiveModel.api === "azure-openai-responses" ||
+          effectiveModel.api === "openai-chatgpt-responses"
+            ? "aborted"
+            : undefined,
+        allowedToolNames,
+        withCompactionPersistence: params.transcriptByteCompactionPersistence,
+      },
+    );
+    checkpointSnapshot = memoryTranscript
+      ? null
+      : await compactionCheckpointStore.captureSnapshot({
+          sessionManager,
+          sessionFile: params.sessionFile,
+          sessionTarget,
+        });
+    compactionSessionManager = sessionManager;
+    const recordUsage = accountingRecorder?.recordUsage
+      ? (usage: UsageLike) => {
+          const normalized = normalizeUsage(usage);
+          if (normalized) {
+            accountingRecorder.recordUsage?.(normalized);
           }
-        : undefined;
-      if (recordUsage) {
-        setSessionModelUsageSink(sessionManager, recordUsage);
-      }
-      const settingsManager = createPreparedEmbeddedAgentSettingsManager({
-        cwd: effectiveCwd,
-        agentDir,
-        cfg: params.config,
-        pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({
-          config: params.config,
-          env: process.env,
-          workspaceDir: effectiveWorkspace,
-        }),
-        contextTokenBudget,
-      });
-      // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
-      const extensionFactories = buildEmbeddedExtensionFactories({
-        cfg: params.config,
-        sessionManager,
+        }
+      : undefined;
+    if (recordUsage) {
+      setSessionModelUsageSink(sessionManager, recordUsage);
+    }
+    const settingsManager = createPreparedEmbeddedAgentSettingsManager({
+      cwd: effectiveCwd,
+      agentDir,
+      cfg: params.config,
+      pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({
+        config: params.config,
+        env: process.env,
+        workspaceDir: effectiveWorkspace,
+      }),
+      contextTokenBudget,
+    });
+    // Sets compaction/pruning runtime state and returns extension factories
+    // that must be passed to the resource loader for the safeguard to be active.
+    const extensionFactories = buildEmbeddedExtensionFactories({
+      cfg: params.config,
+      sessionManager,
+      provider,
+      modelId,
+      model: effectiveModel,
+      contextTokenBudget,
+      agentId: sessionAgentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey ?? sandboxSessionKey,
+      runId,
+    });
+    const resourceLoader = createEmbeddedAgentResourceLoader({
+      cwd: effectiveCwd,
+      agentDir,
+      settingsManager,
+      extensionFactories,
+    });
+    await resourceLoader.reload();
+    // Reloading settings discards prepared compaction overrides and restores
+    // runtime auto-compaction, so reapply both guards after reload.
+    applyAgentCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: params.config,
+      contextTokenBudget,
+    });
+    // contextEngineInfo is intentionally omitted: this guard runs inside the
+    // compaction LLM session, which is not the user-facing agent session and
+    // has no associated context engine.
+    applyAgentAutoCompactionGuard({
+      settingsManager,
+      silentOverflowProneProvider: isSilentOverflowProneModel({
         provider,
         modelId,
-        model: effectiveModel,
-        contextTokenBudget,
+        baseUrl: effectiveModel.baseUrl ?? undefined,
+      }),
+    });
+
+    const { customTools } = splitSdkTools({
+      tools: effectiveTools,
+      sandboxEnabled: Boolean(sandbox?.enabled),
+      toolHookContext: {
         agentId: sessionAgentId,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey ?? sandboxSessionKey,
-        runId,
-      });
-      const resourceLoader = createEmbeddedAgentResourceLoader({
+        config: params.config,
         cwd: effectiveCwd,
-        agentDir,
-        settingsManager,
-        extensionFactories,
-      });
-      await resourceLoader.reload();
-      // Reloading settings discards prepared compaction overrides and restores
-      // runtime auto-compaction, so reapply both guards after reload.
-      applyAgentCompactionSettingsFromConfig({
-        settingsManager,
-        cfg: params.config,
-        contextTokenBudget,
-      });
-      // contextEngineInfo is intentionally omitted: this guard runs inside the
-      // compaction LLM session, which is not the user-facing agent session and
-      // has no associated context engine.
-      applyAgentAutoCompactionGuard({
-        settingsManager,
-        silentOverflowProneProvider: isSilentOverflowProneModel({
+        sessionKey: sandboxSessionKey,
+        sessionId: params.sessionId,
+        runId: params.runId,
+        channelId: params.currentChannelId,
+      },
+    });
+    // The session runtime treats `tools` as a name allowlist during session creation. Pass the
+    // exact OpenClaw-managed registrations so custom tools survive startup.
+    const sessionToolAllowlist = toSessionToolAllowlist(collectRegisteredToolNames(customTools));
+
+    const providerStreamFn = resolveCompactionProviderStream({
+      effectiveModel,
+      config: params.config,
+      agentDir,
+      effectiveWorkspace,
+      apiRegistry: getModelRegistryRuntime(modelRegistry).apiRegistry,
+    });
+    while (true) {
+      // A thinking retry starts a new attempt; setup/endpoint failures must not reuse its predecessor's cause.
+      setCompactionSafeguardCancellation(sessionManager, undefined);
+      // Rebuild on retry so provider wrappers and payload shaping use the fallback effort.
+      attemptedThinking.add(thinkLevel);
+      const systemPromptText = buildSystemPromptText();
+      let session: AgentSession | undefined;
+      let diagnosticOwner: DiagnosticEmbeddedRunOwner | undefined;
+      let resetCompactionTimeout: (() => void) | undefined;
+      try {
+        const createdSession = await createAgentSessionForEmbeddedRunner(
+          {
+            cwd: effectiveCwd,
+            agentDir,
+            authStorage,
+            modelRegistry,
+            model: effectiveModel,
+            thinkingLevel: mapThinkingLevel(thinkLevel),
+            tools: sessionToolAllowlist,
+            customTools,
+            sessionManager,
+            settingsManager,
+            resourceLoader,
+          },
+          {},
+        );
+        session = createdSession.session;
+        session[agentSessionSetContextReplacementHook](
+          accountingRecorder?.recordCompaction,
+          assertActive,
+        );
+        session.setActiveToolsByName(sessionToolAllowlist);
+        applySystemPromptToSession(session, systemPromptText);
+        // Compaction builds the same embedded system prompt, so it must flow
+        // through the same transport/payload shaping stack as normal turns.
+        const { effectiveExtraParams, transportApiKey } = await prepareCompactionSessionAgent({
+          session,
+          llmRuntime: getModelRegistryRuntime(modelRegistry).llmRuntime,
+          providerStreamFn,
+          sessionId: params.sessionId,
+          signal: runAbortController.signal,
+          effectiveModel,
+          resolvedApiKey: hasRuntimeAuthExchange ? undefined : apiKeyInfo?.apiKey,
+          authStorage,
+          config: params.config,
           provider,
           modelId,
-          baseUrl: effectiveModel.baseUrl ?? undefined,
-        }),
-      });
-
-      const { customTools } = splitSdkTools({
-        tools: effectiveTools,
-        sandboxEnabled: Boolean(sandbox?.enabled),
-        toolHookContext: {
-          agentId: sessionAgentId,
-          config: params.config,
-          cwd: effectiveCwd,
+          thinkLevel,
+          sessionAgentId,
+          effectiveWorkspace,
+          agentDir,
+          runtimePlan,
           sessionKey: sandboxSessionKey,
+          sandboxToolPolicy: sandbox?.tools,
+          messageProvider: resolvedMessageProvider,
+          agentAccountId: params.agentAccountId,
+          groupId: params.groupId,
+          groupChannel: params.groupChannel,
+          groupSpace: params.groupSpace,
+          spawnedBy: params.spawnedBy,
+          senderId: params.senderId,
+          senderName: params.senderName,
+          senderUsername: params.senderUsername,
+          senderE164: params.senderE164,
+        });
+        const compactionReplayEnabled = resolveCompactionReplayEligibility(effectiveModel, {
+          extraParams: effectiveExtraParams,
+          apiKey: transportApiKey,
+        });
+        diagnosticOwner = createDiagnosticEmbeddedRunOwner({
           sessionId: params.sessionId,
-          runId: params.runId,
-          channelId: params.currentChannelId,
-        },
-      });
-      // The session runtime treats `tools` as a name allowlist during session creation. Pass the
-      // exact OpenClaw-managed registrations so custom tools survive startup.
-      const sessionToolAllowlist = toSessionToolAllowlist(collectRegisteredToolNames(customTools));
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          runId: diagnosticCompactionRunId,
+          workKey: diagnosticCompactionRunId,
+        });
+        markDiagnosticEmbeddedRunStarted({
+          sessionId: params.sessionId,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          runId: diagnosticCompactionRunId,
+          workKey: diagnosticCompactionRunId,
+          owner: diagnosticOwner,
+        });
+        session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(session.agent.streamFn, {
+          runId: diagnosticCompactionRunId,
+          ...(params.sessionKey && { sessionKey: params.sessionKey }),
+          sessionId: params.sessionId,
+          provider,
+          model: modelId,
+          api: effectiveModel.api,
+          transport: session.agent.transport,
+          requestTimeoutMs: compactionTimeoutMs,
+          contextTokenBudget,
+          trace: compactionModelCallTrace,
+          contentCapture: resolveDiagnosticModelContentCapturePolicy(params.config),
+          nextCallId: nextDiagnosticModelCallId,
+          ownerGeneration: diagnosticOwner.generation,
+          // Multi-stage compaction intentionally serializes provider calls. Each new
+          // request is progress, so both native and delegated watchdogs get a fresh window.
+          onStarted: () => {
+            resetCompactionTimeout?.();
+            params.compactionTimeoutReset?.();
+          },
+        });
 
-      const providerStreamFn = resolveCompactionProviderStream({
-        effectiveModel,
-        config: params.config,
-        agentDir,
-        effectiveWorkspace,
-        apiRegistry: getModelRegistryRuntime(modelRegistry).apiRegistry,
-      });
-      while (true) {
-        // A thinking retry starts a new attempt; setup/endpoint failures must not reuse its predecessor's cause.
-        setCompactionSafeguardCancellation(sessionManager, undefined);
-        // Rebuild on retry so provider wrappers and payload shaping use the fallback effort.
-        attemptedThinking.add(thinkLevel);
-        const systemPromptText = buildSystemPromptText();
-        let session: AgentSession | undefined;
-        let diagnosticOwner: DiagnosticEmbeddedRunOwner | undefined;
-        let resetCompactionTimeout: (() => void) | undefined;
-        try {
-          const createdSession = await createAgentSessionForEmbeddedRunner(
-            {
-              cwd: effectiveCwd,
-              agentDir,
-              authStorage,
-              modelRegistry,
+        const prior = await sanitizeSessionHistory({
+          messages: session.messages,
+          modelApi: effectiveModel.api,
+          modelId,
+          provider,
+          allowedToolNames,
+          config: params.config,
+          workspaceDir: effectiveWorkspace,
+          env: process.env,
+          model: effectiveModel,
+          sessionManager,
+          sessionId: params.sessionId,
+          policy: transcriptPolicy,
+          preserveLatestAssistantThinking: false,
+        });
+        const validated = await validateReplayTurns({
+          messages: prior,
+          modelApi: effectiveModel.api,
+          modelId,
+          provider,
+          config: params.config,
+          workspaceDir: effectiveWorkspace,
+          env: process.env,
+          model: effectiveModel,
+          sessionId: params.sessionId,
+          policy: transcriptPolicy,
+        });
+        const dedupedValidated = dedupeDuplicateUserMessagesForCompaction(validated);
+        // Apply validated transcript to the live session even when no history limit is configured,
+        // so compaction and hook metrics are based on the same message set.
+        session.agent.state.messages = dedupedValidated;
+        // "Original" compaction metrics should describe the validated transcript that enters
+        // limiting/compaction, not the raw on-disk session snapshot.
+        const originalMessages = session.messages.slice();
+        const truncated = preserveCompactionReplayWindow(
+          originalMessages,
+          limitHistoryTurns(
+            session.messages,
+            getHistoryLimitFromSessionKey(params.sessionKey, params.config, {
+              accountId: params.agentAccountId,
+              peerId: params.conversationRoutePeerId,
+              chatType: params.chatType,
+            }),
+          ),
+          effectiveModel,
+          {
+            sessionId: params.sessionId,
+            authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+            enabled: compactionReplayEnabled,
+          },
+        );
+        // Re-run tool_use/tool_result pairing repair after truncation, since
+        // limitHistoryTurns can orphan tool_result blocks by removing the
+        // assistant message that contained the matching tool_use.
+        const limited = transcriptPolicy.repairToolUseResultPairing
+          ? sanitizeToolUseResultPairingForModel(
+              truncated,
+              effectiveModel.api === "openai-responses" ||
+                effectiveModel.api === "azure-openai-responses" ||
+                effectiveModel.api === "openai-chatgpt-responses",
+            )
+          : truncated;
+        if (limited.length > 0) {
+          session.agent.state.messages = limited;
+        }
+        const hookRunner = asCompactionHookRunner(getGlobalHookRunner());
+        const observedTokenCount = normalizeObservedTokenCount(params.currentTokenCount);
+        const beforeHookMetrics = buildBeforeCompactionHookMetrics({
+          originalMessages,
+          currentMessages: session.messages,
+          observedTokenCount,
+          estimateTokensFn: estimateTokens,
+        });
+        const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
+          hookRunner,
+          sessionId: params.sessionId,
+          sessionKey: sessionTarget.sessionKey,
+          sessionAgentId,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: resolvedMessageProvider,
+          metrics: beforeHookMetrics,
+          assertActive,
+          onHookMessages: params.onCompactionHookMessages,
+        });
+        const { messageCountOriginal, tokenCountBefore: limitedTranscriptTokensBefore } =
+          beforeHookMetrics;
+        const diagEnabled = log.isEnabled("debug");
+        const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
+        if (preMetrics) {
+          log.debug(
+            `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
+              `attempt=${attempt} maxAttempts=${maxAttempts} ` +
+              `pre.messages=${preMetrics.messages} pre.historyTextChars=${preMetrics.historyTextChars} ` +
+              `pre.toolResultChars=${preMetrics.toolResultChars} pre.estTokens=${preMetrics.estTokens ?? "unknown"}`,
+          );
+          log.debug(
+            `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
+          );
+        }
+
+        if (!containsRealConversationMessages(session.messages)) {
+          log.info(
+            `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
+          );
+          return {
+            ok: true,
+            compacted: false,
+            reason: "no real conversation messages",
+          };
+        }
+
+        const compactStartedAt = Date.now();
+        // Setup completed: give the first provider request a full safety window.
+        params.compactionTimeoutReset?.();
+        let serverTokensAfter: number | undefined;
+        const recordServerCompaction = () => {
+          // Endpoint output_tokens omits retained inputs; observe the actual
+          // replacement window synchronously with its accepted rewrite.
+          serverTokensAfter = estimateLlmBoundaryTokenPressure({
+            messages: sessionManager.buildSessionContext().messages,
+            systemPrompt: systemPromptText,
+            prompt: "",
+            replay: {
               model: effectiveModel,
-              thinkingLevel: mapThinkingLevel(thinkLevel),
-              tools: sessionToolAllowlist,
-              customTools,
-              sessionManager,
-              settingsManager,
-              resourceLoader,
-            },
-            {},
-          );
-          session = createdSession.session;
-          session[agentSessionSetContextReplacementHook](
-            accountingRecorder?.recordCompaction,
-            assertActive,
-          );
-          session.setActiveToolsByName(sessionToolAllowlist);
-          applySystemPromptToSession(session, systemPromptText);
-          // Compaction builds the same embedded system prompt, so it must flow
-          // through the same transport/payload shaping stack as normal turns.
-          const { effectiveExtraParams, transportApiKey } = await prepareCompactionSessionAgent({
-            session,
-            llmRuntime: getModelRegistryRuntime(modelRegistry).llmRuntime,
-            providerStreamFn,
-            sessionId: params.sessionId,
-            signal: runAbortController.signal,
-            effectiveModel,
-            resolvedApiKey: hasRuntimeAuthExchange ? undefined : apiKeyInfo?.apiKey,
-            authStorage,
-            config: params.config,
-            provider,
-            modelId,
-            thinkLevel,
-            sessionAgentId,
-            effectiveWorkspace,
-            agentDir,
-            runtimePlan,
-            sessionKey: sandboxSessionKey,
-            sandboxToolPolicy: sandbox?.tools,
-            messageProvider: resolvedMessageProvider,
-            agentAccountId: params.agentAccountId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            spawnedBy: params.spawnedBy,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-          });
-          const compactionReplayEnabled = resolveCompactionReplayEligibility(effectiveModel, {
-            extraParams: effectiveExtraParams,
-            apiKey: transportApiKey,
-          });
-          diagnosticOwner = createDiagnosticEmbeddedRunOwner({
-            sessionId: params.sessionId,
-            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-            runId: diagnosticCompactionRunId,
-            workKey: diagnosticCompactionRunId,
-          });
-          markDiagnosticEmbeddedRunStarted({
-            sessionId: params.sessionId,
-            ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-            runId: diagnosticCompactionRunId,
-            workKey: diagnosticCompactionRunId,
-            owner: diagnosticOwner,
-          });
-          session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(
-            session.agent.streamFn,
-            {
-              runId: diagnosticCompactionRunId,
-              ...(params.sessionKey && { sessionKey: params.sessionKey }),
-              sessionId: params.sessionId,
-              provider,
-              model: modelId,
-              api: effectiveModel.api,
-              transport: session.agent.transport,
-              requestTimeoutMs: compactionTimeoutMs,
-              contextTokenBudget,
-              trace: compactionModelCallTrace,
-              contentCapture: resolveDiagnosticModelContentCapturePolicy(params.config),
-              nextCallId: nextDiagnosticModelCallId,
-              ownerGeneration: diagnosticOwner.generation,
-              // Multi-stage compaction intentionally serializes provider calls. Each new
-              // request is progress, so both native and delegated watchdogs get a fresh window.
-              onStarted: () => {
-                resetCompactionTimeout?.();
-                params.compactionTimeoutReset?.();
-              },
-            },
-          );
-
-          const prior = await sanitizeSessionHistory({
-            messages: session.messages,
-            modelApi: effectiveModel.api,
-            modelId,
-            provider,
-            allowedToolNames,
-            config: params.config,
-            workspaceDir: effectiveWorkspace,
-            env: process.env,
-            model: effectiveModel,
-            sessionManager,
-            sessionId: params.sessionId,
-            policy: transcriptPolicy,
-            preserveLatestAssistantThinking: false,
-          });
-          const validated = await validateReplayTurns({
-            messages: prior,
-            modelApi: effectiveModel.api,
-            modelId,
-            provider,
-            config: params.config,
-            workspaceDir: effectiveWorkspace,
-            env: process.env,
-            model: effectiveModel,
-            sessionId: params.sessionId,
-            policy: transcriptPolicy,
-          });
-          const dedupedValidated = dedupeDuplicateUserMessagesForCompaction(validated);
-          // Apply validated transcript to the live session even when no history limit is configured,
-          // so compaction and hook metrics are based on the same message set.
-          session.agent.state.messages = dedupedValidated;
-          // "Original" compaction metrics should describe the validated transcript that enters
-          // limiting/compaction, not the raw on-disk session snapshot.
-          const originalMessages = session.messages.slice();
-          const truncated = preserveCompactionReplayWindow(
-            originalMessages,
-            limitHistoryTurns(
-              session.messages,
-              getHistoryLimitFromSessionKey(params.sessionKey, params.config, {
-                accountId: params.agentAccountId,
-                peerId: params.conversationRoutePeerId,
-                chatType: params.chatType,
-              }),
-            ),
-            effectiveModel,
-            {
               sessionId: params.sessionId,
               authProfileId: runtimePlan.auth.forwardedAuthProfileId,
               enabled: compactionReplayEnabled,
             },
-          );
-          // Re-run tool_use/tool_result pairing repair after truncation, since
-          // limitHistoryTurns can orphan tool_result blocks by removing the
-          // assistant message that contained the matching tool_use.
-          const limited = transcriptPolicy.repairToolUseResultPairing
-            ? sanitizeToolUseResultPairingForModel(
-                truncated,
-                effectiveModel.api === "openai-responses" ||
-                  effectiveModel.api === "azure-openai-responses" ||
-                  effectiveModel.api === "openai-chatgpt-responses",
-              )
-            : truncated;
-          if (limited.length > 0) {
-            session.agent.state.messages = limited;
-          }
-          const hookRunner = asCompactionHookRunner(getGlobalHookRunner());
-          const observedTokenCount = normalizeObservedTokenCount(params.currentTokenCount);
-          const beforeHookMetrics = buildBeforeCompactionHookMetrics({
-            originalMessages,
-            currentMessages: session.messages,
-            observedTokenCount,
-            estimateTokensFn: estimateTokens,
           });
-          const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
-            hookRunner,
-            sessionId: params.sessionId,
-            sessionKey: sessionTarget.sessionKey,
-            sessionAgentId,
-            workspaceDir: effectiveWorkspace,
-            messageProvider: resolvedMessageProvider,
-            metrics: beforeHookMetrics,
-            assertActive,
-            onHookMessages: params.onCompactionHookMessages,
-          });
-          const { messageCountOriginal, tokenCountBefore: limitedTranscriptTokensBefore } =
-            beforeHookMetrics;
-          const diagEnabled = log.isEnabled("debug");
-          const preMetrics = diagEnabled
-            ? summarizeCompactionMessages(session.messages)
-            : undefined;
-          if (preMetrics) {
-            log.debug(
-              `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-                `attempt=${attempt} maxAttempts=${maxAttempts} ` +
-                `pre.messages=${preMetrics.messages} pre.historyTextChars=${preMetrics.historyTextChars} ` +
-                `pre.toolResultChars=${preMetrics.toolResultChars} pre.estTokens=${preMetrics.estTokens ?? "unknown"}`,
-            );
-            log.debug(
-              `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
-            );
-          }
-
-          if (!containsRealConversationMessages(session.messages)) {
-            log.info(
-              `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
-            );
-            return {
-              ok: true,
-              compacted: false,
-              reason: "no real conversation messages",
-            };
-          }
-
-          const compactStartedAt = Date.now();
-          // Setup completed: give the first provider request a full safety window.
-          params.compactionTimeoutReset?.();
-          let serverTokensAfter: number | undefined;
-          const recordServerCompaction = () => {
-            // Endpoint output_tokens omits retained inputs; observe the actual
-            // replacement window synchronously with its accepted rewrite.
-            serverTokensAfter = estimateLlmBoundaryTokenPressure({
-              messages: sessionManager.buildSessionContext().messages,
-              systemPrompt: systemPromptText,
-              prompt: "",
-              replay: {
-                model: effectiveModel,
+          accountingRecorder?.recordCompaction?.(serverTokensAfter);
+        };
+        const serverResult = params.transcriptBytePreflightAuthority
+          ? undefined
+          : await attemptServerEndpointCompaction({
+              trigger,
+              streamFn: session.agent.streamFn,
+              model: effectiveModel,
+              context: { systemPrompt: systemPromptText, messages: session.messages },
+              sessionManager,
+              extraParams: effectiveExtraParams,
+              customInstructions: params.customInstructions,
+              config: params.config,
+              onUsage: recordUsage,
+              onCompactionCommitted: recordServerCompaction,
+              assertActive,
+              requestOptions: {
+                apiKey: transportApiKey,
                 sessionId: params.sessionId,
                 authProfileId: runtimePlan.auth.forwardedAuthProfileId,
-                enabled: compactionReplayEnabled,
+                timeoutMs: compactionTimeoutMs,
+                signal: params.abortSignal,
               },
             });
-            accountingRecorder?.recordCompaction?.(serverTokensAfter);
-          };
-          const serverResult = params.transcriptBytePreflightAuthority
-            ? undefined
-            : await attemptServerEndpointCompaction({
-                trigger,
-                streamFn: session.agent.streamFn,
-                model: effectiveModel,
-                context: { systemPrompt: systemPromptText, messages: session.messages },
-                sessionManager,
-                extraParams: effectiveExtraParams,
-                customInstructions: params.customInstructions,
-                config: params.config,
-                onUsage: recordUsage,
-                onCompactionCommitted: recordServerCompaction,
-                assertActive,
-                requestOptions: {
-                  apiKey: transportApiKey,
-                  sessionId: params.sessionId,
-                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
-                  timeoutMs: compactionTimeoutMs,
-                  signal: params.abortSignal,
-                },
-              });
-          const activeSession = session;
-          let clientResult: Awaited<ReturnType<typeof activeSession.compact>> | undefined;
-          if (!serverResult) {
-            try {
-              // The client watchdog starts here; refresh the delegated host watchdog with it.
-              params.compactionTimeoutReset?.();
-              const outcome = await compactWithSafetyTimeout(
-                async (_signal, resetTimeout) => {
-                  resetCompactionTimeout = resetTimeout;
-                  setCompactionSafeguardCancellation(compactionSessionManager, undefined);
-                  const requestState = trigger === "overflow" ? ("unresolved" as const) : undefined;
-                  if (trigger === "manual") {
-                    return {
-                      status: "completed" as const,
-                      result: await activeSession.compact(params.customInstructions),
-                    };
-                  }
-                  return activeSession[agentSessionAutomaticCompaction](
-                    params.customInstructions,
-                    requestState,
-                    resolveEffectiveCompactionMode(params.config) === "default"
-                      ? undefined
-                      : "none",
-                    {
-                      requestBudget: accountingRecorder?.requestBudget,
-                      pendingUserEntryId: accountingRecorder?.pendingUserEntryId,
-                    },
-                  );
-                },
-                compactionTimeoutMs,
-                {
-                  abortSignal: params.abortSignal,
-                  onCancel: () => activeSession.abortCompaction(),
-                },
-              );
-              if (outcome.status === "skipped") {
-                assertActive();
-                return { ok: true, compacted: false, reason: outcome.reason };
-              }
-              clientResult = outcome.result;
-            } finally {
-              resetCompactionTimeout = undefined;
-            }
-          }
-          // Compaction succeeded: post-processing gets its own full watchdog window.
-          params.compactionTimeoutReset?.();
-          const effectiveFirstKeptEntryId = clientResult?.firstKeptEntryId;
-          const tokensBefore = serverResult?.usage.input_tokens ?? clientResult!.tokensBefore;
-          const tokensAfter = serverResult
-            ? serverTokensAfter
-            : estimateTokensAfterCompaction({
-                messagesAfter: session.messages,
-                observedTokenCount,
-                fullSessionTokensBefore: limitedTranscriptTokensBefore ?? 0,
-                estimateTokensFn: estimateTokens,
-                requestBudget: accountingRecorder?.requestBudget,
-              });
-          const messageCountAfter = session.messages.length;
-          const compactedCount = Math.max(0, messageCountOriginal - messageCountAfter);
-          const activeSessionFile = memoryTranscript
-            ? params.sessionFile
-            : formatSqliteSessionFileMarker({
-                ...sessionTarget,
-                sessionId: params.sessionId,
-              });
-          if (!memoryTranscript) {
-            await runPostCompactionSideEffects({
-              config: params.config,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              agentId: sessionAgentId,
-              sessionFile: activeSessionFile,
-              assertActive,
-            });
-          }
-          if (clientResult) {
-            checkpointSnapshotRetained = await persistCompactionCheckpoint({
-              config: params.config,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              trigger: params.trigger,
-              snapshot: checkpointSnapshot,
-              summary: clientResult.summary,
-              firstKeptEntryId: effectiveFirstKeptEntryId,
-              tokensBefore: observedTokenCount ?? clientResult.tokensBefore,
-              tokensAfter,
-              sessionFile: activeSessionFile,
-              leafId: sessionManager.getLeafId?.() ?? undefined,
-              createdAt: compactStartedAt,
-            });
-          }
-          const postMetrics = diagEnabled
-            ? summarizeCompactionMessages(session.messages)
-            : undefined;
-          if (preMetrics && postMetrics) {
-            log.debug(
-              `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-                `attempt=${attempt} maxAttempts=${maxAttempts} outcome=compacted reason=none ` +
-                `durationMs=${Date.now() - compactStartedAt} retrying=false ` +
-                `post.messages=${postMetrics.messages} post.historyTextChars=${postMetrics.historyTextChars} ` +
-                `post.toolResultChars=${postMetrics.toolResultChars} post.estTokens=${postMetrics.estTokens ?? "unknown"} ` +
-                `delta.messages=${postMetrics.messages - preMetrics.messages} ` +
-                `delta.historyTextChars=${postMetrics.historyTextChars - preMetrics.historyTextChars} ` +
-                `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
-                `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
-            );
-          }
-          await runAfterCompactionHooks({
-            hookRunner,
-            sessionId: params.sessionId,
-            sessionAgentId,
-            hookSessionKey,
-            missingSessionKey,
-            workspaceDir: effectiveWorkspace,
-            messageProvider: resolvedMessageProvider,
-            messageCountAfter,
-            tokensAfter,
-            compactedCount,
-            sessionFile: activeSessionFile,
-            summaryLength: clientResult?.summary.length,
-            tokensBefore,
-            firstKeptEntryId: effectiveFirstKeptEntryId,
-            assertActive,
-            onHookMessages: params.onCompactionHookMessages,
-          });
-          const resultSessionTarget: ContextEngineSessionTarget = {
-            agentId: sessionTarget.agentId,
-            sessionId: sessionTarget.sessionId,
-            sessionKey: sessionTarget.sessionKey,
-            storePath: sessionTarget.storePath,
-          };
-          if (params.sessionTarget?.threadId !== undefined) {
-            resultSessionTarget.threadId = params.sessionTarget.threadId;
-          }
-          return {
-            ok: true,
-            compacted: true,
-            ...(serverResult ? { compactionKind: "server-endpoint" as const } : {}),
-            result: {
-              sessionTarget: resultSessionTarget,
-              ...(clientResult
-                ? {
-                    summary: clientResult.summary,
-                    firstKeptEntryId: clientResult.firstKeptEntryId,
-                  }
-                : { kind: "server-endpoint" as const }),
-              tokensBefore: serverResult
-                ? tokensBefore
-                : (observedTokenCount ?? clientResult!.tokensBefore),
-              tokensAfter,
-              details: serverResult
-                ? {
-                    compactionKind: "server-endpoint" as const,
-                    droppedMessageCount: serverResult.usage.dropped_message_count,
-                  }
-                : clientResult!.details,
-            },
-          };
-        } catch (err) {
-          assertActive();
-          const failure = resolveCompactionFailure({
-            error: err,
-            safeguardCancellation: getCompactionSafeguardRuntime(sessionManager)?.cancellation,
-            abortSignal: params.abortSignal,
-          });
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: formatErrorMessage(failure.error),
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking) {
-            log.warn(
-              `[compaction] request rejected for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-            );
-            thinkLevel = fallbackThinking;
-            // The rejected request may have consumed nearly its full window. Rearm the
-            // delegated watchdog before rebuilding the session for the fallback attempt.
+        const activeSession = session;
+        let clientResult: Awaited<ReturnType<typeof activeSession.compact>> | undefined;
+        if (!serverResult) {
+          try {
+            // The client watchdog starts here; refresh the delegated host watchdog with it.
             params.compactionTimeoutReset?.();
-            continue;
-          }
-          throw err;
-        } finally {
-          // Retire diagnostic ownership before asynchronous session cleanup can yield.
-          if (diagnosticOwner) {
-            closeDiagnosticEmbeddedRunOwner(diagnosticOwner);
-          }
-          try {
-            await flushPendingToolResultsAfterIdle({
-              agent: session?.agent,
-              sessionManager,
-            });
-          } catch {
-            /* best-effort */
-          }
-          try {
-            session?.dispose();
-          } catch {
-            /* best-effort */
+            const outcome = await compactWithSafetyTimeout(
+              async (_signal, resetTimeout) => {
+                resetCompactionTimeout = resetTimeout;
+                setCompactionSafeguardCancellation(compactionSessionManager, undefined);
+                const requestState = trigger === "overflow" ? ("unresolved" as const) : undefined;
+                if (trigger === "manual") {
+                  return {
+                    status: "completed" as const,
+                    result: await activeSession.compact(params.customInstructions),
+                  };
+                }
+                return activeSession[agentSessionAutomaticCompaction](
+                  params.customInstructions,
+                  requestState,
+                  resolveEffectiveCompactionMode(params.config) === "default" ? undefined : "none",
+                  {
+                    requestBudget: accountingRecorder?.requestBudget,
+                    pendingUserEntryId: accountingRecorder?.pendingUserEntryId,
+                  },
+                );
+              },
+              compactionTimeoutMs,
+              {
+                abortSignal: params.abortSignal,
+                onCancel: () => activeSession.abortCompaction(),
+              },
+            );
+            if (outcome.status === "skipped") {
+              assertActive();
+              return { ok: true, compacted: false, reason: outcome.reason };
+            }
+            clientResult = outcome.result;
+          } finally {
+            resetCompactionTimeout = undefined;
           }
         }
+        // Compaction succeeded: post-processing gets its own full watchdog window.
+        params.compactionTimeoutReset?.();
+        const effectiveFirstKeptEntryId = clientResult?.firstKeptEntryId;
+        const tokensBefore = serverResult?.usage.input_tokens ?? clientResult!.tokensBefore;
+        const tokensAfter = serverResult
+          ? serverTokensAfter
+          : estimateTokensAfterCompaction({
+              messagesAfter: session.messages,
+              observedTokenCount,
+              fullSessionTokensBefore: limitedTranscriptTokensBefore ?? 0,
+              estimateTokensFn: estimateTokens,
+              requestBudget: accountingRecorder?.requestBudget,
+            });
+        const messageCountAfter = session.messages.length;
+        const compactedCount = Math.max(0, messageCountOriginal - messageCountAfter);
+        const activeSessionFile = memoryTranscript
+          ? params.sessionFile
+          : formatSqliteSessionFileMarker({
+              ...sessionTarget,
+              sessionId: params.sessionId,
+            });
+        if (!memoryTranscript) {
+          await runPostCompactionSideEffects({
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            agentId: sessionAgentId,
+            sessionFile: activeSessionFile,
+            assertActive,
+          });
+        }
+        if (clientResult) {
+          checkpointSnapshotRetained = await persistCompactionCheckpoint({
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            trigger: params.trigger,
+            snapshot: checkpointSnapshot,
+            summary: clientResult.summary,
+            firstKeptEntryId: effectiveFirstKeptEntryId,
+            tokensBefore: observedTokenCount ?? clientResult.tokensBefore,
+            tokensAfter,
+            sessionFile: activeSessionFile,
+            leafId: sessionManager.getLeafId?.() ?? undefined,
+            createdAt: compactStartedAt,
+          });
+        }
+        const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
+        if (preMetrics && postMetrics) {
+          log.debug(
+            `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
+              `attempt=${attempt} maxAttempts=${maxAttempts} outcome=compacted reason=none ` +
+              `durationMs=${Date.now() - compactStartedAt} retrying=false ` +
+              `post.messages=${postMetrics.messages} post.historyTextChars=${postMetrics.historyTextChars} ` +
+              `post.toolResultChars=${postMetrics.toolResultChars} post.estTokens=${postMetrics.estTokens ?? "unknown"} ` +
+              `delta.messages=${postMetrics.messages - preMetrics.messages} ` +
+              `delta.historyTextChars=${postMetrics.historyTextChars - preMetrics.historyTextChars} ` +
+              `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
+              `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
+          );
+        }
+        await runAfterCompactionHooks({
+          hookRunner,
+          sessionId: params.sessionId,
+          sessionAgentId,
+          hookSessionKey,
+          missingSessionKey,
+          workspaceDir: effectiveWorkspace,
+          messageProvider: resolvedMessageProvider,
+          messageCountAfter,
+          tokensAfter,
+          compactedCount,
+          sessionFile: activeSessionFile,
+          summaryLength: clientResult?.summary.length,
+          tokensBefore,
+          firstKeptEntryId: effectiveFirstKeptEntryId,
+          assertActive,
+          onHookMessages: params.onCompactionHookMessages,
+        });
+        const resultSessionTarget: ContextEngineSessionTarget = {
+          agentId: sessionTarget.agentId,
+          sessionId: sessionTarget.sessionId,
+          sessionKey: sessionTarget.sessionKey,
+          storePath: sessionTarget.storePath,
+        };
+        if (params.sessionTarget?.threadId !== undefined) {
+          resultSessionTarget.threadId = params.sessionTarget.threadId;
+        }
+        return {
+          ok: true,
+          compacted: true,
+          ...(serverResult ? { compactionKind: "server-endpoint" as const } : {}),
+          result: {
+            sessionTarget: resultSessionTarget,
+            ...(clientResult
+              ? {
+                  summary: clientResult.summary,
+                  firstKeptEntryId: clientResult.firstKeptEntryId,
+                }
+              : { kind: "server-endpoint" as const }),
+            tokensBefore: serverResult
+              ? tokensBefore
+              : (observedTokenCount ?? clientResult!.tokensBefore),
+            tokensAfter,
+            details: serverResult
+              ? {
+                  compactionKind: "server-endpoint" as const,
+                  droppedMessageCount: serverResult.usage.dropped_message_count,
+                }
+              : clientResult!.details,
+          },
+        };
+      } catch (err) {
+        assertActive();
+        const failure = resolveCompactionFailure({
+          error: err,
+          safeguardCancellation: getCompactionSafeguardRuntime(sessionManager)?.cancellation,
+          abortSignal: params.abortSignal,
+        });
+        const fallbackThinking = pickFallbackThinkingLevel({
+          message: formatErrorMessage(failure.error),
+          attempted: attemptedThinking,
+        });
+        if (fallbackThinking) {
+          log.warn(
+            `[compaction] request rejected for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+          );
+          thinkLevel = fallbackThinking;
+          // The rejected request may have consumed nearly its full window. Rearm the
+          // delegated watchdog before rebuilding the session for the fallback attempt.
+          params.compactionTimeoutReset?.();
+          continue;
+        }
+        throw err;
+      } finally {
+        // Retire diagnostic ownership before asynchronous session cleanup can yield.
+        if (diagnosticOwner) {
+          closeDiagnosticEmbeddedRunOwner(diagnosticOwner);
+        }
+        try {
+          await flushPendingToolResultsAfterIdle({
+            agent: session?.agent,
+            sessionManager,
+          });
+        } catch {
+          /* best-effort */
+        }
+        try {
+          session?.dispose();
+        } catch {
+          /* best-effort */
+        }
       }
-    } finally {
-      await runtime.disposeToolRuntimes();
     }
   } catch (err) {
     const failure = resolveCompactionFailure({

--- a/src/agents/embedded-agent-runner/direct-compaction.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction.ts
@@ -1,5 +1,12 @@
 /** Coordinates one direct compaction attempt through explicit lifecycle phases. */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { executePreparedCompactionSession } from "./compaction-session-execution.js";
 import {
   prepareDirectCompactionAttempt,
@@ -7,24 +14,81 @@ import {
 } from "./direct-compaction-preparation.js";
 import {
   buildPreparedCompactionRuntime,
-  type PreparedCompactionRuntime,
+  type PreparedCompactionCleanup,
 } from "./prepared-compaction-runtime.js";
+import type { EmbeddedAgentCompactResult } from "./types.js";
 
 export async function compactEmbeddedAgentSessionDirectOnce(
   params: PreparedCompactEmbeddedAgentSessionParams,
-) {
-  const preparation = await prepareDirectCompactionAttempt(params);
-  if (!preparation.ok) {
-    return preparation.result;
-  }
-
-  let runtime: PreparedCompactionRuntime | undefined;
-  try {
-    runtime = await buildPreparedCompactionRuntime(preparation.value);
-    return await executePreparedCompactionSession(runtime);
-  } catch (err) {
-    return preparation.value.fail(formatErrorMessage(err), err);
-  } finally {
-    await runtime?.dispose();
-  }
+): Promise<EmbeddedAgentCompactResult> {
+  const callerResult = createDeferredCore<EmbeddedAgentCompactResult>();
+  const trackOwner = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  const cancellationSignal =
+    params.abortSignal && parentSignal
+      ? AbortSignal.any([params.abortSignal, parentSignal])
+      : (params.abortSignal ?? parentSignal);
+  const work = new AsyncWorkScope();
+  const context = work.run(() => AsyncLocalStorage.snapshot());
+  const cleanupWork = new AsyncWorkScope();
+  const cleanupContext = cleanupWork.run(() => AsyncLocalStorage.snapshot());
+  let cleanup: PreparedCompactionCleanup | undefined;
+  const runAttempt = async () => {
+    const preparation = await prepareDirectCompactionAttempt(params);
+    if (!preparation.ok) {
+      return preparation.result;
+    }
+    try {
+      const runtime = await buildPreparedCompactionRuntime(preparation.value, (preparedCleanup) => {
+        cleanup = preparedCleanup;
+      });
+      return await executePreparedCompactionSession(runtime);
+    } catch (err) {
+      return preparation.value.fail(formatErrorMessage(err), err);
+    } finally {
+      cleanup?.restoreSkillEnvironment();
+    }
+  };
+  void trackOwner(async () => {
+    const closeWork = () => {
+      context(() => work.beginClose(cancellationSignal?.reason));
+      cleanupContext(() => cleanupWork.beginClose(cancellationSignal?.reason));
+    };
+    cancellationSignal?.addEventListener("abort", closeWork, { once: true });
+    if (cancellationSignal?.aborted) {
+      closeWork();
+    }
+    try {
+      callerResult.resolve(await work.track(runAttempt));
+    } catch (error) {
+      callerResult.reject(error);
+    } finally {
+      try {
+        // Session retirement has already revoked authority. Its accepted work still needs tools.
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => context(() => work.beginClose()),
+        );
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => cleanupWork.track(() => cleanupContext(() => cleanup?.disposeToolRuntimes())),
+        );
+      } finally {
+        try {
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [work, cleanupWork],
+            () => cleanupContext(() => cleanupWork.beginClose()),
+          );
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [work, cleanupWork],
+            () =>
+              Promise.all([context(() => work.drain()), cleanupContext(() => cleanupWork.drain())]),
+          );
+        } finally {
+          cancellationSignal?.removeEventListener("abort", closeWork);
+        }
+      }
+    }
+  }).catch(callerResult.reject);
+  return await callerResult.promise;
 }

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -77,7 +77,15 @@ import { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 import { collectAllowedToolNames } from "./tool-name-allowlist.js";
 import { mapThinkingLevelForProvider } from "./utils.js";
 
-export async function buildPreparedCompactionRuntime(prepared: DirectCompactionPreparation) {
+export type PreparedCompactionCleanup = {
+  disposeToolRuntimes: () => Promise<void>;
+  restoreSkillEnvironment: () => void;
+};
+
+export async function buildPreparedCompactionRuntime(
+  prepared: DirectCompactionPreparation,
+  onCleanupReady: (cleanup: PreparedCompactionCleanup) => void,
+) {
   const {
     params,
     runId,
@@ -137,10 +145,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     skillEnvironmentRestored = true;
     restoreSkillEnv?.();
   };
-  const dispose = async () => {
-    await disposeToolRuntimes();
-    restoreSkillEnvironment();
-  };
+  onCleanupReady({ disposeToolRuntimes, restoreSkillEnvironment });
 
   try {
     const preparedSkills = prepareEmbeddedSkills({
@@ -577,12 +582,9 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       buildSystemPromptText,
       resolvedMessageProvider,
       sessionAgentId,
-      disposeToolRuntimes,
-      restoreSkillEnvironment,
-      dispose,
     };
   } catch (err) {
-    await dispose();
+    restoreSkillEnvironment();
     throw err;
   }
 }

--- a/src/plugins/hooks.timed-work.test.ts
+++ b/src/plugins/hooks.timed-work.test.ts
@@ -1,0 +1,117 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, expect, it, vi } from "vitest";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { createHookRunner } from "./hooks.js";
+import { createMockPluginRegistry, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-fixtures.js";
+
+describe("timed hook work", () => {
+  it.each(["open", "closing"] as const)(
+    "joins a raw handler after its timeout with an %s owner",
+    async (phase) => {
+      const owner = new AsyncWorkScope();
+      const finish = createDeferredCore();
+      let settled = false;
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const runner = createHookRunner(
+        createMockPluginRegistry([
+          {
+            pluginId: "held-hook",
+            hookName: "before_compaction",
+            timeoutMs: 5,
+            handler: async () => {
+              await finish.promise;
+              settled = true;
+            },
+          },
+        ]),
+        { logger },
+      );
+      let drain: Promise<void> | undefined;
+      try {
+        if (phase === "closing") {
+          owner.beginClose();
+        }
+        await owner.run(() =>
+          runner.runBeforeCompaction({ messageCount: 3 }, TEST_PLUGIN_AGENT_CTX),
+        );
+        expect(settled).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+          "[hooks] before_compaction handler from held-hook failed: timed out after 5ms",
+        );
+        let drained = false;
+        drain = owner.drain().then(() => {
+          drained = true;
+        });
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(drained).toBe(false);
+        finish.resolve();
+        await drain;
+        expect(settled).toBe(true);
+      } finally {
+        finish.resolve();
+        await (drain ?? owner.drain());
+      }
+    },
+  );
+
+  it.each([
+    { phase: "raw", outcome: "success" },
+    { phase: "closed", outcome: "success" },
+    { phase: "raw", outcome: "late rejection" },
+    { phase: "closed", outcome: "late rejection" },
+  ] as const)("preserves $phase hook reporting through $outcome", async ({ phase, outcome }) => {
+    const owner = new AsyncWorkScope();
+    const context = owner.run(() => AsyncLocalStorage.snapshot());
+    await owner.drain();
+    const finish = createDeferredCore();
+    const settled = createDeferredCore();
+    const failure = new Error("fixture late hook failure");
+    let calls = 0;
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          pluginId: "held-hook",
+          hookName: "before_compaction",
+          timeoutMs: 5,
+          handler: async () => {
+            calls++;
+            try {
+              await finish.promise;
+              if (outcome === "late rejection") {
+                throw failure;
+              }
+            } finally {
+              settled.resolve();
+            }
+          },
+        },
+      ]),
+      { logger },
+    );
+    const run = () => runner.runBeforeCompaction({ messageCount: 3 }, TEST_PLUGIN_AGENT_CTX);
+    const result = phase === "closed" ? context(run) : run();
+    try {
+      expect(calls).toBe(1);
+      if (outcome === "success") {
+        finish.resolve();
+      }
+      await expect(result).resolves.toBeUndefined();
+      if (outcome === "success") {
+        expect(logger.error).not.toHaveBeenCalled();
+      } else {
+        expect(logger.error).toHaveBeenCalledOnce();
+        expect(logger.error).toHaveBeenCalledWith(
+          "[hooks] before_compaction handler from held-hook failed: timed out after 5ms",
+        );
+      }
+    } finally {
+      finish.resolve();
+      await settled.promise;
+      await result;
+    }
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -22,6 +22,7 @@ import { recordRuntimeActionDecision } from "../audit/runtime-action-decision.js
 import { copyReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { projectModelContextMessages } from "../shared/model-context-message.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import {
@@ -684,6 +685,9 @@ export function createHookRunner(
     timeoutMs: number,
     optionsResult: { unref?: boolean } = {},
   ): Promise<T> => {
+    // The handler has started. Retain its work without replacing the raced promise
+    // if its caller's scope has already closed; hook policy still owns its errors.
+    void trackAsyncWork(() => promise).catch(() => {});
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelling or timing out compaction could close MCP/LSP resources while issued compaction work or plugin hooks were still using them. A timed-out hook could also escape the work owner that retained its prepared database resources.

## Why This Change Was Made

Compaction now separates the caller's result from physical cleanup. Its owner waits for actual preparation, compaction, provider, and hook work before disposing tool runtimes, then joins cleanup tails before releasing the prepared generation. Partial setup failures transfer cleanup ownership before allocating resources.

Timed hook dispatch observes the already-started handler promise while preserving the original timeout race and error policy. Session disposal still retires authority at the original boundary; diagnostics, transcript fences, accounting, checkpoints, and skill-environment restoration keep their existing ordering.

## User Impact

Compaction can report cancellation or timeout promptly while allowing already-issued work to finish safely. Normal compaction, native CLI routing, fallbacks, and the default 180-second watchdog remain unchanged. Hook deadlines and fail-open behavior are preserved.

Normal-run registry disposal is not enabled by this change. The database disposal regression uses the existing managed read-only producer at the native delegate input boundary. The compiled smoke uses the public delegate with the current normal-run producer; managed default-flow integration remains required before activating its disposal.

## Evidence

- Validated fixture configuration reproduces ten premature-close failures on the original code; success and raw-source controls pass. All twelve cases pass with the repair. Separate hook tests reproduce early drainage while preserving raw/closed-scope reporting controls.
- 321 focused and sibling tests passed. The twelve delegate cases were rerun after correcting fixture configuration. Required changed checks and the affected fixture checks passed.
- Final independent Codex review found no actionable P0–P2 issues.
- Full build passed in 241 seconds. Compiled public-delegate proof used four loopback model completions, real MCP HTTP sessions, real LSP processes, and both timed compaction hooks. Each service stayed live through the reported result, then closed once; the LSP SQLite files reopened successfully.
- With a declared 25 ms hook timeout, reports arrived 27–57 ms after hook entry and physical cleanup took 48–50 ms after releasing the held work. These are synthetic smoke timings, not throughput benchmarks.
