### PR TITLE
refactor(tooling): narrow cache transport dependency types

### DIFF
--- a/scripts/e2e/lib/anthropic-cache/transport-loader.mts
+++ b/scripts/e2e/lib/anthropic-cache/transport-loader.mts
@@ -1,7 +1,8 @@
 import type { StreamFn } from "@openclaw/ai";
 
-type AnthropicTransportModule = typeof import("@openclaw/ai/transports");
-type AnthropicTransportImporter = () => Promise<AnthropicTransportModule>;
+type AnthropicTransportImporter = () => Promise<
+  Pick<typeof import("@openclaw/ai/transports"), "createAnthropicMessagesTransportStreamFn">
+>;
 
 function isMissingTransportExport(error: unknown): boolean {
   return (

--- a/test/scripts/anthropic-cache-transport-loader.test.ts
+++ b/test/scripts/anthropic-cache-transport-loader.test.ts
@@ -1,18 +1,16 @@
+import type { StreamFn } from "@openclaw/ai";
 import { describe, expect, it, vi } from "vitest";
 import { loadAnthropicTransportStream } from "../../scripts/e2e/lib/anthropic-cache/transport-loader.mts";
 
 describe("loadAnthropicTransportStream", () => {
   it("loads the managed transport when the candidate exports it", async () => {
-    const stream = vi.fn();
+    const stream = vi.fn<StreamFn>();
     const factory = vi.fn(() => stream);
 
     await expect(
-      loadAnthropicTransportStream(
-        async () =>
-          ({
-            createAnthropicMessagesTransportStreamFn: factory,
-          }) as never,
-      ),
+      loadAnthropicTransportStream(async () => ({
+        createAnthropicMessagesTransportStreamFn: factory,
+      })),
     ).resolves.toBe(stream);
     expect(factory).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/143508

## What Problem This Solves

The optional cache-transport loader requires one factory, but its importer type required the entire transport module. The test hid that mismatch with `as never`.

## Why This Change Was Made

Require only the existing factory's exact type, use a typed stream mock, and remove the redundant module alias. Unrelated transport exports no longer affect this fixture's contract.

## User Impact

Runtime loading and error handling are unchanged. The fixture is now checked against the dependency it actually supplies.

## Evidence

- Six existing loader and mock-provider cases pass. Final alias inlining changes only erased types; test and runtime statement bodies remain identical.
- All 20 canonical checks pass on the final source, including script and root-test typechecks, formatting, lint, and dead-export checks.
- Independent Codex review found no actionable findings through P2.
