### PR TITLE
refactor(msteams): remove duplicate threading helper tests

### DIFF
--- a/extensions/msteams/src/action-threading.test.ts
+++ b/extensions/msteams/src/action-threading.test.ts
@@ -82,15 +82,6 @@ describe("resolveMSTeamsAutoThreadId", () => {
     replyToMode: "all" as const,
   };
 
-  it("returns ambient thread root for same conversation", () => {
-    expect(
-      resolveMSTeamsAutoThreadId({
-        to: "conversation:19:channel@thread.tacv2",
-        toolContext: sameChannel,
-      }),
-    ).toBe("thread-root");
-  });
-
   it("returns ambient thread root for bare conversation id target", () => {
     expect(
       resolveMSTeamsAutoThreadId({
@@ -137,15 +128,6 @@ describe("resolveMSTeamsAutoThreadId", () => {
         toolContext: sameChannel,
       }),
     ).toBe("explicit-root");
-  });
-
-  it("returns undefined for a different conversation", () => {
-    expect(
-      resolveMSTeamsAutoThreadId({
-        to: "conversation:19:other@thread.tacv2",
-        toolContext: sameChannel,
-      }),
-    ).toBeUndefined();
   });
 
   it("returns undefined when replyToMode is off", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Two Teams threading tests repeat behavior already covered through the real plugin threading hook.

## Why This Change Was Made

Remove the direct helper replays for the same-conversation thread root and different-conversation rejection. The retained plugin tests call the same implementation and check the same results while also verifying the plugin wiring. Distinct explicit-target, missing-thread, Graph-target, case-sensitive, policy and single-use cases remain.

## User Impact

No user-visible behavior change. This removes 18 test lines without changing production code or reducing the covered threading behaviors.

## Evidence

The complete helper and plugin action suites passed before and after: 95 cases became 93, with exactly the two reviewed duplicate cases removed and all retained identities, order and results unchanged. Both plugin-boundary equivalents passed. All other source bytes and production owners remain unchanged.

Changed checks and independent review passed. No runtime improvement is claimed.
