### PR TITLE
refactor: reuse provider prompt stream test fixture

### DIFF
--- a/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
@@ -115,26 +115,7 @@ describe("provider prompt state", () => {
       const rawPayload = { input: "raw", model: model.id };
       const replacement = await options?.onPayload?.(rawPayload, model);
       sentPayloads.push(replacement === undefined ? rawPayload : replacement);
-      const stream = createAssistantMessageEventStream();
-      stream.end({
-        role: "assistant",
-        content: [],
-        api: model.api,
-        provider: model.provider,
-        model: model.id,
-        usage: {
-          input: 1,
-          output: 1,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 2,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "error",
-        errorMessage: "context length exceeded",
-        timestamp: 1,
-      });
-      return stream;
+      return createResultStream("error");
     });
     const finalPayload = { input: "final", model: model.id };
     const wrapped = wrapStreamFnWithProviderPromptState({


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

The provider prompt replay test duplicates an error-result stream fixture already defined and used elsewhere in the same suite. Maintaining both copies adds unnecessary test code.

## Why This Change Was Made

Reuse the existing `createResultStream("error")` at the same construction point, after the awaited payload hook and sent-payload recording. Preserve the exact result fields, nonzero usage, error text, fresh stream/result objects and every assertion. The distinct custom-error and delayed-completion fixtures remain unchanged.

## User Impact

No production behavior changes. Removes 19 net test lines without removing cases, adding helpers or changing imports. No runtime savings claim.

## Evidence

- Complete provider-prompt-state suite passes all eight cases before and after, with identical ordered names and statuses.
- Specializing the existing helper produces the same result-object AST; expanding the replacement restores the entire original file byte-for-byte.
- The helper keeps fresh returned values; its existing conditional spread allocates a nonescaping temporary object.
- Full changed gate and fresh independent review pass.
