### PR TITLE
fix(test): preserve expanded shard timing identities

### DIFF
--- a/scripts/lib/vitest-shard-metadata.mts
+++ b/scripts/lib/vitest-shard-metadata.mts
@@ -13,6 +13,8 @@ export type VitestShardTimingSpec = {
   config: string;
   env?: NodeJS.ProcessEnv;
   includePatterns?: readonly string[] | null;
+  /** Exact chunk files for scheduling; does not configure execution filtering. */
+  timingTargets?: readonly string[];
   watchMode?: boolean;
 };
 
@@ -95,18 +97,17 @@ export function createCompactSplitTimingGeneration(params: CompactSplitTimingGen
 }
 
 export function resolveShardTimingKey(spec: VitestShardTimingSpec): string {
-  if (!Array.isArray(spec.includePatterns) || spec.includePatterns.length === 0) {
+  const targets = spec.timingTargets ?? spec.includePatterns;
+  if (!Array.isArray(targets) || targets.length === 0) {
     return spec.config;
   }
 
   const shardName = sanitizeTimingLabel(spec.env?.[SHARD_NAME_ENV_KEY] ?? "");
-  if (shardName) {
+  if (shardName && !spec.timingTargets) {
     return `${spec.config}#${shardName}`;
   }
 
-  return `${spec.config}#include-${spec.includePatterns.length}-${hashIncludePatterns(
-    spec.includePatterns,
-  )}`;
+  return `${spec.config}#include-${targets.length}-${hashIncludePatterns(targets)}`;
 }
 
 // Advisory per-file cost hints (seconds) for stripe balancing, from file walls,

--- a/scripts/lib/vitest-shard-timings.mts
+++ b/scripts/lib/vitest-shard-timings.mts
@@ -23,7 +23,8 @@ export function createShardTimingSample(spec: VitestShardTimingSpec, durationMs:
     return null;
   }
 
-  const includePatternCount = Array.isArray(spec.includePatterns) ? spec.includePatterns.length : 0;
+  const targets = spec.timingTargets ?? spec.includePatterns;
+  const includePatternCount = Array.isArray(targets) ? targets.length : 0;
   return {
     baseConfig: spec.config,
     config: resolveShardTimingKey(spec),

--- a/scripts/test-projects-run.mts
+++ b/scripts/test-projects-run.mts
@@ -324,6 +324,7 @@ export async function runTestProjects(
     targetArgs.length === 0 && changedTargetArgs === null
       ? buildFullSuiteVitestRunPlans(args, process.cwd()).map((plan) => ({
           config: plan.config,
+          timingTargets: plan.timingTargets,
           continueOnFailure: true,
           env: baseEnv,
           includeFilePath: null,

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -111,6 +111,7 @@ import {
 type VitestRunPlan = {
   config: string;
   forwardedArgs: string[];
+  timingTargets?: string[];
   includePatterns: string[] | null;
   watchMode: boolean;
 };
@@ -369,7 +370,7 @@ function resolveSpecSortWeight(
   }
   // Exact selections use their file costs; a whole-config sample would price a
   // single worker proof like all tooling. Globs keep the whole-config fallback.
-  const includes = spec.includePatterns;
+  const includes = spec.timingTargets ?? spec.includePatterns;
   const estimateFileSeconds =
     spec.config === TOOLING_VITEST_CONFIG
       ? estimateVitestToolingFileSeconds
@@ -4146,7 +4147,7 @@ export function buildVitestRunPlans(
   return plans;
 }
 
-export function buildFullSuiteVitestRunPlans(args: string[], cwd = process.cwd()) {
+export function buildFullSuiteVitestRunPlans(args: string[], cwd = process.cwd()): VitestRunPlan[] {
   const { forwardedArgs, targetArgs, watchMode } = parseTestProjectsArgs(args, cwd);
   if (watchMode) {
     return [
@@ -4218,6 +4219,7 @@ export function buildFullSuiteVitestRunPlans(args: string[], cwd = process.cwd()
           return chunks.map((targets) => ({
             config,
             forwardedArgs: [...forwardedArgs, ...targets],
+            timingTargets: targets,
             includePatterns: null,
             watchMode: false,
           }));
@@ -4481,6 +4483,7 @@ export function createVitestRunSpecs(
       : null;
     return {
       config: plan.config,
+      timingTargets: plan.timingTargets,
       env: includeFilePath
         ? {
             ...baseEnv,

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -425,6 +425,63 @@ async function start(args: string[]) {
   await import(entryUrl);
 }
 
+describe("full-suite timing metadata", () => {
+  it("carries chunk targets into timing samples without changing launch selection", async () => {
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+    vi.stubEnv("OPENCLAW_VITEST_MAX_WORKERS", "1");
+    vi.stubEnv("OPENCLAW_VITEST_SHARD_NAME", "same-parent");
+    vi.stubEnv("OPENCLAW_VITEST_ENABLE_MAGLEV", "0");
+    const planner = await import("../../scripts/test-projects.test-support.mts");
+    const timings = await import("../../scripts/lib/vitest-shard-timings.mts");
+    const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
+    const files = ["test/scripts/run-with-env.test.ts", "test/scripts/run-node.test.ts"];
+    const config = "test/vitest/vitest.tooling.config.ts";
+    vi.spyOn(planner, "buildFullSuiteVitestRunPlans").mockReturnValue(
+      files.map((file) => ({
+        config,
+        forwardedArgs: [file],
+        timingTargets: [file],
+        includePatterns: null,
+        watchMode: false,
+      })),
+    );
+    const writeTimings = vi.spyOn(timings, "writeShardTimings");
+    commands.prepare.mockResolvedValue(0);
+    commands.reader.mockImplementation(() => ({
+      completion: Promise.resolve({ code: 0, signal: null, groupJoined: true }),
+      getForwardedSignal: () => undefined,
+    }));
+
+    await runTestProjects(async () => {}, []);
+
+    expect(commands.reader).toHaveBeenCalledTimes(2);
+    const launches = commands.reader.mock.calls.map(([input]) => input);
+    expect(launches.map((input) => input.pnpmArgs)).toEqual(
+      files.map((file) => [
+        "exec",
+        "node",
+        "--no-maglev",
+        resolveVitestCliEntry(),
+        "run",
+        "--config",
+        config,
+        file,
+      ]),
+    );
+    for (const input of launches) {
+      expect(input.env.OPENCLAW_VITEST_INCLUDE_FILE).toBeFalsy();
+      expect(input.env.OPENCLAW_VITEST_MAX_WORKERS).toBe("1");
+    }
+    expect(writeTimings).toHaveBeenCalledTimes(1);
+    const samples = writeTimings.mock.calls[0]?.[0] ?? [];
+    expect(samples).toHaveLength(2);
+    expect(new Set(samples.map((sample) => sample?.config)).size).toBe(2);
+    for (const sample of samples) {
+      expect(sample).toMatchObject({ baseConfig: config, includePatternCount: 1 });
+    }
+  });
+});
+
 describe("parallel cache lease completion", () => {
   it.each([
     { platform: "linux", phase: "preflight" },

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4239,6 +4239,17 @@ describe("scripts/test-projects full-suite sharding", () => {
     expect(orderFullSuiteSpecsForParallelRun([runtime, tooling])).toEqual([tooling, runtime]);
   });
 
+  it("prices expanded chunk files without enabling include-file filtering", () => {
+    const chunk = {
+      config: "test/vitest/vitest.tooling.config.ts",
+      includePatterns: null,
+      timingTargets: ["test/scripts/vitest-worker-artifacts.test.ts"],
+    };
+    const whole = { config: "test/vitest/vitest.runtime-config.config.ts", includePatterns: null };
+
+    expect(orderFullSuiteSpecsForParallelRun([whole, chunk])).toEqual([chunk, whole]);
+  });
+
   it("uses observed selection timings without substituting a whole-config sample", () => {
     const fastTooling = {
       config: "test/vitest/vitest.tooling.config.ts",
@@ -4548,6 +4559,10 @@ describe("scripts/test-projects full-suite sharding", () => {
         const toolingPlans = targetedPlans("test/vitest/vitest.tooling.config.ts");
         expect(toolingPlans.length).toBeGreaterThan(1);
         expect(toolingPlans.every((plan) => plan.forwardedArgs.length <= 2)).toBe(true);
+        for (const plan of plans.filter((entry) => entry.forwardedArgs.length > 0)) {
+          expect(plan.timingTargets).toEqual(plan.forwardedArgs);
+          expect(plan.includePatterns).toBeNull();
+        }
       },
     );
   });

--- a/test/scripts/vitest-shard-timings.test.ts
+++ b/test/scripts/vitest-shard-timings.test.ts
@@ -39,6 +39,35 @@ describe("scripts/lib/vitest-shard-timings.mts", () => {
     ).toBe("test/vitest/vitest.auto-reply-reply.config.ts#auto-reply-reply-agent-dispatch");
   });
 
+  it("keeps expanded chunk samples separate under one inherited shard name", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shard-timings-"));
+    tempDirs.push(tempDir);
+    const env = {
+      OPENCLAW_TEST_PROJECTS_TIMINGS_PATH: path.join(tempDir, "timings.json"),
+      OPENCLAW_VITEST_SHARD_NAME: "same-parent",
+    };
+    const config = "test/vitest/vitest.tooling.config.ts";
+    const first = { config, env, includePatterns: null, timingTargets: ["src/a.test.ts"] };
+    const second = { ...first, timingTargets: ["src/b.test.ts"] };
+    const firstKey = resolveShardTimingKey(first);
+    const secondKey = resolveShardTimingKey(second);
+    expect(firstKey).not.toBe(config);
+    expect(firstKey).not.toBe(secondKey);
+    const firstSample = createShardTimingSample(first, 1000)!;
+    const secondSample = createShardTimingSample(second, 3000)!;
+    expect(firstSample.includePatternCount).toBe(1);
+    expect(secondSample.includePatternCount).toBe(1);
+
+    writeShardTimings([firstSample, secondSample], tempDir, env);
+
+    expect(readShardTimings(tempDir, env)).toEqual(
+      new Map([
+        [firstKey, 1000],
+        [secondKey, 3000],
+      ]),
+    );
+  });
+
   it.each([
     ["src/b.test.ts", "src/a.test.ts"],
     ["src/ä.test.ts", "src/z.test.ts", "src/A.test.ts"],


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Expanded full-suite test chunks lose their selected-file information before scheduling and timing history are recorded. Different chunks are priced as whole projects and overwrite the same timing history, which can leave long projects late in the queue.

## Why This Change Was Made

Carry the planner's known file targets separately as scheduling metadata. The existing cost estimator and timing-key owner use those targets, while execution arguments, include-file filtering, worker budgets, concurrency, and build prerequisites retain their existing owners. Expanded chunks get distinct target-derived keys even under a shared parent label; existing include-file callers keep their named-key behavior.

## User Impact

Cold scheduling and learned timing histories now describe the actual chunks. The CLI weight is unchanged. No runtime speedup or reduction in total test time is claimed yet.

## Evidence

Four focused regressions failed on original code for the intended missing-target, wrong-cost-order, and colliding-key conditions. The candidate passed all 608 tests across the three complete planner, timing, and build-admission owner suites. A subsequent two-line lint correction replaced conditional metadata spreads with direct assignments; all four focused regressions passed again, followed by the complete mapped changed-file gate and fresh independent P2 review.

Read-only native metadata analysis on a coherent source compared 664 specs: execution descriptors and membership were identical, with unchanged outer concurrency 8, requested workers 1, and build prerequisite. Distinct timing keys increased from 96 to 664, and the CLI process project moved from position 581 to 143. These are planning results, not benchmark measurements. The change adds 101 test lines and six tooling lines to protect the repaired contracts.
