### PR TITLE
fix(models): preserve captured routes in configured catalog views

### DIFF
--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -17,10 +17,7 @@ import {
   resolveConfiguredModelCatalogOverrides,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
-import {
-  buildConfiguredModelCatalog,
-  dedupeModelCatalogEntries,
-} from "./model-selection-shared.js";
+import { dedupeModelCatalogEntries } from "./model-selection-shared.js";
 import {
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
   createModelVisibilityPolicy,
@@ -142,9 +139,7 @@ export async function prepareLogicalVisibleModelCatalog(
   const { configuredKeys, retainedKeys } = policy;
   const retained = params.catalog.filter((entry) => retainedKeys.has(keyOf(entry)));
   const wildcard = policy.allowAny || policy.hasProviderWildcards;
-  const configuredCatalog = wildcard
-    ? sortModelCatalogEntries(buildConfiguredModelCatalog({ cfg: params.cfg }))
-    : [];
+  const configuredCatalog = wildcard ? sortModelCatalogEntries([...policy.configuredCatalog]) : [];
   const candidates =
     params.view === "all"
       ? params.catalog

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -15,6 +15,7 @@ import {
   modelSupportsVision,
 } from "./model-catalog.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 import type { ModelRegistry } from "./sessions/index.js";
 
 type AugmentModelCatalogWithProviderPlugins =
@@ -657,6 +658,66 @@ describe("prepared model catalog builder", () => {
         );
       }
       expect(snapshot.routeVariants).toHaveLength(discovered ? 4 : 2);
+    },
+  );
+
+  it.each([
+    { accepted: false, pinned: false },
+    { accepted: true, pinned: false },
+    { accepted: true, pinned: true },
+  ])(
+    "preserves captured routes unless the model pins them (accepted=$accepted, pinned=$pinned)",
+    async ({ accepted, pinned }) => {
+      const defaults = {
+        api: "openai-completions",
+        baseUrl: "https://provider.example.test/v1",
+      } as const;
+      const captured = {
+        api: "openai-responses",
+        baseUrl: "https://account.example.test/v1",
+      } as const;
+      const configured: ModelDefinitionConfig = {
+        id: "demo",
+        name: "Configured Demo",
+        contextWindow: 32_000,
+        maxTokens: 4096,
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        ...(pinned ? defaults : {}),
+      };
+      const config: OpenClawConfig = {
+        plugins: { enabled: false },
+        models: { providers: { custom: { ...defaults, models: [configured] } } },
+      };
+      const snapshot = await build({
+        config,
+        entries: accepted
+          ? [{ provider: "custom", id: "demo", name: "Captured Demo", ...captured }]
+          : [],
+      });
+      const expectedRoute = accepted && !pinned ? captured : defaults;
+      const policy = createModelVisibilityPolicy({
+        cfg: config,
+        catalog: snapshot.entries,
+        defaultProvider: "custom",
+        manifestPlugins: metadataSnapshot,
+      });
+
+      for (const catalog of [snapshot.entries, policy.configuredCatalog]) {
+        expect(catalog).toEqual([
+          expect.objectContaining({
+            provider: "custom",
+            id: "demo",
+            ...expectedRoute,
+            contextWindow: 32_000,
+            reasoning: true,
+            input: ["text", "image"],
+          }),
+        ]);
+      }
+      expect(snapshot.routeVariants).toContainEqual(expect.objectContaining(expectedRoute));
+      expect(snapshot.routeVariants).toHaveLength(accepted && pinned ? 2 : 1);
     },
   );
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -488,10 +488,12 @@ export async function buildPreparedModelCatalogSnapshot(
     mergeCatalogRouteVariants(routeVariants, manifestModels);
     mergeCatalogEntries(models, manifestModels);
     logStage("manifest-models-merged", `entries=${models.length}`);
-    const configuredModels = buildConfiguredModelCatalog({
+    const configuredCatalogParams = {
       cfg,
+      catalog: orderedRegistryModels,
       manifestPlugins: manifestMetadataSnapshot,
-    });
+    };
+    const configuredModels = buildConfiguredModelCatalog(configuredCatalogParams);
     logStage("configured-models-prepared", `entries=${models.length}`);
 
     if (!params.readOnly && params.includeProviderPluginAugmentation !== false) {
@@ -579,6 +581,7 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("plugin-models-merged", `entries=${models.length}`);
 
     if (configuredModels.length > 0) {
+      const configuredOverrides = buildConfiguredModelCatalog(configuredCatalogParams);
       // Augmentation may mutate borrowed rows. Reindex before configured overlays so
       // route lookup keeps the first current donor, including duplicate keys.
       routeVariants.indexByKey.clear();
@@ -588,11 +591,11 @@ export async function buildPreparedModelCatalogSnapshot(
           routeVariants.indexByKey.set(key, index);
         }
       });
-      mergeCatalogEntries(models, configuredModels, {
+      mergeCatalogEntries(models, configuredOverrides, {
         catalogRoutes: routeVariants,
         preserveBaseCompat: true,
       });
-      mergeCatalogRouteVariants(routeVariants, configuredModels, { preserveBaseCompat: true });
+      mergeCatalogRouteVariants(routeVariants, configuredOverrides, { preserveBaseCompat: true });
     }
     logStage("configured-models-finalized", `entries=${models.length}`);
 

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -17,6 +17,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "./configured-provider-fallback.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
@@ -1386,6 +1387,14 @@ export function buildConfiguredModelCatalog(params: {
 
   const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
+  const capturedByIdentity = params.catalog?.length
+    ? new Map(
+        dedupeByKey(params.catalog, resolveModelCatalogIdentityKey).map((entry) => [
+          resolveModelCatalogIdentityKey(entry),
+          entry,
+        ]),
+      )
+    : undefined;
   const catalog: ModelCatalogEntry[] = [];
   for (const [providerRaw, provider] of Object.entries(providers)) {
     const providerId = normalizeProviderId(providerRaw);
@@ -1399,9 +1408,8 @@ export function buildConfiguredModelCatalog(params: {
         continue;
       }
       // Provider defaults are fallbacks; only a model-level pin overrides its captured route.
-      const identity = resolveModelCatalogIdentityKey({ provider: providerId, id });
-      const accepted = params.catalog?.find(
-        (entry) => resolveModelCatalogIdentityKey(entry) === identity,
+      const accepted = capturedByIdentity?.get(
+        resolveModelCatalogIdentityKey({ provider: providerId, id }),
       );
       const api = model.api ?? accepted?.api ?? provider.api;
       const baseUrl = model.baseUrl ?? accepted?.baseUrl ?? provider.baseUrl;

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -20,7 +20,7 @@ import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "./configured-provider-fallback.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
-import { findModelCatalogEntry } from "./model-catalog-lookup.js";
+import { findModelCatalogEntry, findModelInCatalog } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -1032,6 +1032,7 @@ function prepareModelPolicy(params: ModelPolicyPreparationParams) {
       : policyAliasIndex;
   const configuredCatalog = buildConfiguredModelCatalog({
     cfg: params.cfg,
+    catalog: params.catalog,
     manifestPlugins: params.manifestPlugins,
   });
   const metadata = buildModelCatalogMetadata({
@@ -1374,6 +1375,7 @@ function resolveConfiguredModelManifestPlugins(params: {
 /** Build catalog entries from configured provider model rows. */
 export function buildConfiguredModelCatalog(params: {
   cfg: OpenClawConfig;
+  catalog?: readonly ModelCatalogEntry[];
   workspaceDir?: string;
   manifestPlugins?: ModelManifestPlugins;
 }): ModelCatalogEntry[] {
@@ -1396,6 +1398,10 @@ export function buildConfiguredModelCatalog(params: {
       if (!id) {
         continue;
       }
+      // Provider defaults are fallbacks; only a model-level pin overrides its captured route.
+      const accepted = findModelInCatalog(params.catalog ?? [], providerId, id);
+      const api = model.api ?? accepted?.api ?? provider.api;
+      const baseUrl = model.baseUrl ?? accepted?.baseUrl ?? provider.baseUrl;
       const name = normalizeOptionalString(model?.name) || id;
       const contextWindow =
         typeof model?.contextWindow === "number" && model.contextWindow > 0
@@ -1419,10 +1425,8 @@ export function buildConfiguredModelCatalog(params: {
         provider: providerId,
         id,
         name,
-        api: model.api ?? provider.api,
-        ...((model.baseUrl ?? provider.baseUrl)
-          ? { baseUrl: model.baseUrl ?? provider.baseUrl }
-          : {}),
+        api,
+        ...(baseUrl ? { baseUrl } : {}),
         contextWindow,
         contextTokens,
         reasoning,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -20,7 +20,7 @@ import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "./configured-provider-fallback.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
-import { findModelCatalogEntry, findModelInCatalog } from "./model-catalog-lookup.js";
+import { findModelCatalogEntry } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -1399,7 +1399,10 @@ export function buildConfiguredModelCatalog(params: {
         continue;
       }
       // Provider defaults are fallbacks; only a model-level pin overrides its captured route.
-      const accepted = findModelInCatalog(params.catalog ?? [], providerId, id);
+      const identity = resolveModelCatalogIdentityKey({ provider: providerId, id });
+      const accepted = params.catalog?.find(
+        (entry) => resolveModelCatalogIdentityKey(entry) === identity,
+      );
       const api = model.api ?? accepted?.api ?? provider.api;
       const baseUrl = model.baseUrl ?? accepted?.baseUrl ?? provider.baseUrl;
       const name = normalizeOptionalString(model?.name) || id;

--- a/src/agents/prepared-model-runtime.configured-catalog.test.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.test.ts
@@ -10,6 +10,7 @@ describe("configured catalog registry composition", () => {
     {
       mode: "merge",
       capturedBaseUrl: "https://fixture.invalid/v1",
+      capturedId: "selected",
       pin: false,
       expectedBaseUrl: "https://fixture.invalid/v1",
       expectedIds: ["selected", "retained-only"],
@@ -17,6 +18,7 @@ describe("configured catalog registry composition", () => {
     {
       mode: "replace",
       capturedBaseUrl: "https://fixture.invalid/v1",
+      capturedId: "selected",
       pin: false,
       expectedBaseUrl: "https://fixture.invalid/v1",
       expectedIds: ["selected"],
@@ -24,6 +26,7 @@ describe("configured catalog registry composition", () => {
     {
       mode: "merge",
       capturedBaseUrl: "http://127.0.0.1:9/v1",
+      capturedId: "selected",
       pin: false,
       expectedBaseUrl: "http://127.0.0.1:9/v1",
       expectedIds: ["selected", "retained-only"],
@@ -31,6 +34,7 @@ describe("configured catalog registry composition", () => {
     {
       mode: "replace",
       capturedBaseUrl: "http://127.0.0.1:9/v1",
+      capturedId: "selected",
       pin: false,
       expectedBaseUrl: "https://fixture.invalid/v1",
       expectedIds: ["selected"],
@@ -38,13 +42,22 @@ describe("configured catalog registry composition", () => {
     {
       mode: "merge",
       capturedBaseUrl: "http://127.0.0.1:9/v1",
+      capturedId: "selected",
       pin: true,
       expectedBaseUrl: "https://fixture.invalid/v1",
       expectedIds: ["selected", "retained-only"],
     },
+    {
+      mode: "merge",
+      capturedBaseUrl: "http://127.0.0.1:9/v1",
+      capturedId: "Selected",
+      pin: false,
+      expectedBaseUrl: "https://fixture.invalid/v1",
+      expectedIds: ["selected", "Selected", "retained-only"],
+    },
   ] as const)(
-    "keeps $mode rows and routes (captured=$capturedBaseUrl, pin=$pin)",
-    ({ mode, capturedBaseUrl, pin, expectedBaseUrl, expectedIds }) => {
+    "keeps $mode rows and routes (captured=$capturedId at $capturedBaseUrl, pin=$pin)",
+    ({ mode, capturedBaseUrl, capturedId, pin, expectedBaseUrl, expectedIds }) => {
       const configured: ModelCatalogEntry = {
         provider: "donor-fixture",
         id: "selected",
@@ -91,7 +104,7 @@ describe("configured catalog registry composition", () => {
               baseUrl: capturedBaseUrl,
               models: [
                 {
-                  id: "selected",
+                  id: capturedId,
                   name: "Earlier selected",
                   contextWindow: 64_000,
                   maxTokens: 4096,

--- a/src/agents/prepared-model-runtime.configured-catalog.test.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.test.ts
@@ -7,67 +7,129 @@ import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 
 describe("configured catalog registry composition", () => {
   it.each([
-    { mode: "merge", expectedIds: ["selected", "retained-only"] },
-    { mode: "replace", expectedIds: ["selected"] },
-  ] as const)("keeps the $mode row set and configured fields", ({ mode, expectedIds }) => {
-    const config: OpenClawConfig = {
-      models: { mode },
-    };
-    const configured: ModelCatalogEntry = {
-      provider: "donor-fixture",
-      id: "selected",
-      name: "Configured selected",
-      api: "openai-completions",
-      baseUrl: "https://fixture.invalid/v1",
-      contextWindow: 32_000,
-      reasoning: true,
-      configuredReasoning: true,
-      input: ["text"],
-    };
-    const registry = ModelRegistry.create(AuthStorage.inMemory({}), "captured:models.json", {
-      config,
-      includePluginCatalogs: false,
-      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
-      modelsJsonContents: JSON.stringify({
-        providers: {
-          "donor-fixture": {
-            api: "openai-completions",
-            baseUrl: "https://fixture.invalid/v1",
-            models: [
-              {
-                id: "selected",
-                name: "Earlier selected",
-                contextWindow: 64_000,
-                maxTokens: 4096,
-                reasoning: false,
-                input: ["text", "image"],
-              },
-              {
-                id: "retained-only",
-                name: "Retained authored row",
-                contextWindow: 48_000,
-                maxTokens: 4096,
-                reasoning: false,
-                input: ["text", "image"],
-              },
-            ],
+    {
+      mode: "merge",
+      capturedBaseUrl: "https://fixture.invalid/v1",
+      pin: false,
+      expectedBaseUrl: "https://fixture.invalid/v1",
+      expectedIds: ["selected", "retained-only"],
+    },
+    {
+      mode: "replace",
+      capturedBaseUrl: "https://fixture.invalid/v1",
+      pin: false,
+      expectedBaseUrl: "https://fixture.invalid/v1",
+      expectedIds: ["selected"],
+    },
+    {
+      mode: "merge",
+      capturedBaseUrl: "http://127.0.0.1:9/v1",
+      pin: false,
+      expectedBaseUrl: "http://127.0.0.1:9/v1",
+      expectedIds: ["selected", "retained-only"],
+    },
+    {
+      mode: "replace",
+      capturedBaseUrl: "http://127.0.0.1:9/v1",
+      pin: false,
+      expectedBaseUrl: "https://fixture.invalid/v1",
+      expectedIds: ["selected"],
+    },
+    {
+      mode: "merge",
+      capturedBaseUrl: "http://127.0.0.1:9/v1",
+      pin: true,
+      expectedBaseUrl: "https://fixture.invalid/v1",
+      expectedIds: ["selected", "retained-only"],
+    },
+  ] as const)(
+    "keeps $mode rows and routes (captured=$capturedBaseUrl, pin=$pin)",
+    ({ mode, capturedBaseUrl, pin, expectedBaseUrl, expectedIds }) => {
+      const configured: ModelCatalogEntry = {
+        provider: "donor-fixture",
+        id: "selected",
+        name: "Configured selected",
+        api: "openai-completions",
+        baseUrl: "https://fixture.invalid/v1",
+        contextWindow: 32_000,
+        reasoning: true,
+        configuredReasoning: true,
+        input: ["text"],
+      };
+      const metadataSnapshot = createPluginMetadataSnapshotFixture();
+      const config: OpenClawConfig = {
+        models: {
+          mode,
+          providers: {
+            "donor-fixture": {
+              api: "openai-completions",
+              baseUrl: "https://fixture.invalid/v1",
+              models: [
+                {
+                  id: "selected",
+                  name: "Configured selected",
+                  contextWindow: 32_000,
+                  maxTokens: 4096,
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  ...(pin ? { baseUrl: configured.baseUrl } : {}),
+                },
+              ],
+            },
           },
         },
-      }),
-    });
-    const agentFacts = {
-      input: { config },
-      configuredModelRefs: [{ provider: "donor-fixture", modelId: "selected" }],
-    };
-    const { modelCatalog } = prepareCapturedRuntimeFacts({
-      agentFacts,
-      workspaceFacts: { configuredCatalogEntries: [configured], inlineProviderModels: [] },
-      templateModelRegistry: registry,
-      configuredRuntimeModels: [],
-    });
+      };
+      const registry = ModelRegistry.create(AuthStorage.inMemory({}), "captured:models.json", {
+        config,
+        includePluginCatalogs: false,
+        pluginMetadataSnapshot: metadataSnapshot,
+        modelsJsonContents: JSON.stringify({
+          providers: {
+            "donor-fixture": {
+              api: "openai-completions",
+              baseUrl: capturedBaseUrl,
+              models: [
+                {
+                  id: "selected",
+                  name: "Earlier selected",
+                  contextWindow: 64_000,
+                  maxTokens: 4096,
+                  reasoning: false,
+                  input: ["text", "image"],
+                },
+                {
+                  id: "retained-only",
+                  name: "Retained authored row",
+                  contextWindow: 48_000,
+                  maxTokens: 4096,
+                  reasoning: false,
+                  input: ["text", "image"],
+                },
+              ],
+            },
+          },
+        }),
+      });
+      const agentFacts = {
+        input: { config },
+        configuredModelRefs: [{ provider: "donor-fixture", modelId: "selected" }],
+      };
+      const workspaceFacts = {
+        configuredCatalogEntries: [configured],
+        pluginMetadataSnapshot: metadataSnapshot,
+        inlineProviderModels: [],
+      };
+      const { modelCatalog } = prepareCapturedRuntimeFacts({
+        agentFacts,
+        workspaceFacts,
+        templateModelRegistry: registry,
+        configuredRuntimeModels: [],
+      });
 
-    expect(modelCatalog.entries.map((entry) => entry.id)).toEqual(expectedIds);
-    expect(modelCatalog.entries[0]).toEqual(configured);
-    expect(modelCatalog.routeVariants).toEqual(modelCatalog.entries);
-  });
+      expect(modelCatalog.entries.map((entry) => entry.id)).toEqual(expectedIds);
+      expect(modelCatalog.entries[0]).toEqual({ ...configured, baseUrl: expectedBaseUrl });
+      expect(modelCatalog.routeVariants).toEqual(modelCatalog.entries);
+    },
+  );
 });

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -1,10 +1,11 @@
 import type { ModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
-import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import type { PreparedModelRuntimeCatalogFacts } from "./prepared-model-runtime.catalog-contract.js";
 import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
@@ -16,7 +17,7 @@ type ConfiguredCatalogAgentFacts = {
 };
 
 type ConfiguredCatalogWorkspaceFacts = {
-  configuredCatalogEntries: readonly ModelCatalogEntry[];
+  pluginMetadataSnapshot: PluginMetadataSnapshot;
   inlineProviderModels: readonly InlineModelEntry[];
 };
 
@@ -26,26 +27,24 @@ function createConfiguredModelCatalogSnapshot(params: {
   templateModelRegistry: ModelRegistry;
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
 }): ModelCatalogSnapshot {
-  const entries = new Map<string, ModelCatalogEntry>();
-  const addEntry = (entry: ModelCatalogEntry) => {
-    const key = resolveModelCatalogIdentityKey(entry);
-    if (!entries.has(key)) {
-      entries.set(key, entry);
-    }
-  };
-  for (const entry of params.workspaceFacts.configuredCatalogEntries) {
-    addEntry(entry);
-  }
-  for (const configured of params.configuredRuntimeModels) {
-    addEntry(modelCatalogRowToEntry(configured.model));
-  }
-  for (const { provider, modelId } of params.agentFacts.configuredModelRefs) {
-    const model = params.templateModelRegistry.find(provider, modelId);
-    if (model) {
-      addEntry(modelCatalogRowToEntry(model));
-    }
-  }
-  const configuredEntries = [...entries.values()];
+  const configuredEntries = dedupeByKey(
+    [
+      ...buildConfiguredModelCatalog({
+        cfg: params.agentFacts.input.config,
+        catalog:
+          params.agentFacts.input.config.models?.mode === "replace"
+            ? []
+            : params.templateModelRegistry.getAll().map(modelCatalogRowToEntry),
+        manifestPlugins: params.workspaceFacts.pluginMetadataSnapshot,
+      }),
+      ...params.configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
+      ...params.agentFacts.configuredModelRefs.flatMap(({ provider, modelId }) => {
+        const model = params.templateModelRegistry.find(provider, modelId);
+        return model ? [modelCatalogRowToEntry(model)] : [];
+      }),
+    ],
+    resolveModelCatalogIdentityKey,
+  );
   const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
     modelCatalogRowToEntry(model),
   );


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Configured model listings could show provider-default routing even when the captured catalog retained a different route, such as reporting a local endpoint as remote.

## Why This Change Was Made

Configured composition now prefers an explicit model route, then the captured route for the exact model identity, then provider defaults. Startup and visibility use that same decision. A per-call identity index removes repeated scans without introducing a persistent cache.

## User Impact

Listings retain captured routes while respecting explicit settings and case-distinct identities. Configuration-only callers retain provider defaults when no captured catalog is supplied. No credential, schema, protocol, or operator-option change is introduced.

Consumers: configured catalog composition, startup publication, and visibility now share captured-route selection.

## Evidence

The original Gateway returned incorrect locality in all three catalog views. Twelve authenticated candidate responses across four route scenarios retained the expected locality and metadata. Source regressions passed, including the case-distinct identity control. A producer benchmark improved from 1,963 to 35 ms at 400 rows; this is not end-to-end latency. Continuous integration passed its 400-model, 11-agent case with no upstream requests. Passive-read checks preserved saved configuration and catalog bytes. Inference and live account sign-in were not tested.
