### PR TITLE
fix(plugins): avoid installed matches across ClawHub registries

### DIFF
--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -32,6 +32,10 @@ the full inventory or choose **Show all** to browse every installed plugin. Each
 card shows the plugin description. Choose a card to open its settings, where
 administrators can enable or disable it and read-only operators can inspect it.
 
+A package installed from another ClawHub registry stays manageable under
+**Installed plugins**. It does not mark a same-name package in the current
+catalog as installed.
+
 Choose a card to open `/settings/plugins/<plugin-id>`.
 That routed page uses the plugin's declared schema for configuration, explains
 effective access in plain language, and keeps raw capability declarations and

--- a/src/gateway/server-methods/plugins.test.ts
+++ b/src/gateway/server-methods/plugins.test.ts
@@ -566,6 +566,47 @@ describe("plugin management Gateway handlers", () => {
     });
   });
 
+  it.each([
+    {
+      label: "package-name alias",
+      plugin: { ...workboard, packageName: "memory-plus" },
+      matches: false,
+    },
+    { label: "runtime-id alias", plugin: { ...workboard, id: "memory-plus" }, matches: false },
+    {
+      label: "proven counterpart",
+      plugin: { ...workboard, clawhubPackage: "memory-plus" },
+      matches: true,
+    },
+  ])(
+    "uses only proven ClawHub identity for offline detail: $label",
+    async ({ plugin, matches }) => {
+      managementMocks.list.mockResolvedValue({
+        plugins: [plugin],
+        diagnostics: [],
+        mutationAllowed: true,
+      });
+      managementMocks.inspect.mockResolvedValue({
+        declared: { mcpServers: [], skills: ["Local planning"] },
+      });
+      catalogMocks.detail.mockRejectedValue(new Error("ClawHub offline"));
+
+      const result = await callHandler("plugins.catalog.get", { id: "ch_bWVtb3J5LXBsdXM" });
+
+      expect(result.ok).toBe(matches);
+      if (matches) {
+        expect(result.response).toMatchObject({
+          plugin: { local: { pluginId: "workboard", installed: true, action: "manage" } },
+          detail: { origin: "local", skills: [{ name: "Local planning" }] },
+        });
+      } else {
+        expect(result.response).toBeUndefined();
+        expect(result.error).toMatchObject({ code: "UNAVAILABLE" });
+        expect(managementMocks.inspect).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("does not misclassify local catalog entries when ordinary ClawHub browse fails", async () => {
     catalogMocks.browse.mockRejectedValue(new Error("service unavailable"));
     managementMocks.list.mockResolvedValue({

--- a/src/plugins/catalog-discovery.ts
+++ b/src/plugins/catalog-discovery.ts
@@ -21,29 +21,6 @@ function normalizedAlias(value: string | null | undefined): string | undefined {
   return normalized || undefined;
 }
 
-function localIdentityAliases(plugin: PluginCatalogEntry): string[] {
-  const aliases = [plugin.id, plugin.packageName, plugin.clawhubPackage];
-  if (plugin.install?.source === "clawhub") {
-    aliases.push(plugin.install.packageName);
-  }
-  return aliases.flatMap((value) => {
-    const normalized = normalizedAlias(value);
-    return normalized ? [normalized] : [];
-  });
-}
-
-function indexLocalPlugins(
-  plugins: readonly PluginCatalogEntry[],
-): Map<string, PluginCatalogEntry> {
-  const index = new Map<string, PluginCatalogEntry>();
-  for (const plugin of plugins) {
-    for (const alias of localIdentityAliases(plugin)) {
-      index.set(alias, plugin);
-    }
-  }
-  return index;
-}
-
 function indexClawHubPlugins(
   plugins: readonly PluginCatalogEntry[],
 ): Map<string, PluginCatalogEntry> {
@@ -263,7 +240,7 @@ export function findLocalPluginByIdentity(
 ): PluginCatalogEntry | undefined {
   return origin === "local"
     ? local.plugins.find((plugin) => plugin.id === identity)
-    : indexLocalPlugins(local.plugins).get(normalizedAlias(identity) ?? "");
+    : indexClawHubPlugins(local.plugins).get(normalizedAlias(identity) ?? "");
 }
 
 export function joinLocalPluginDetail(params: {

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertConfigWriteAllowedInCurrentMode } from "../config/config-write-guard.js";
+import { joinClawHubPluginCatalog } from "./catalog-discovery.js";
 import {
   configSnapshot,
   emptyMetadataSnapshot,
@@ -130,6 +131,8 @@ function mockHostedOfficialCatalog(entries: unknown[]) {
 }
 
 describe("plugin management service", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   beforeEach(() => {
     clearManagedPluginCatalogCache();
     for (const mock of Object.values(mocks)) {
@@ -307,6 +310,77 @@ describe("plugin management service", () => {
     expect(catalog.mutationAllowed).toBe(true);
   });
 
+  const privateRegistry = "https://private.example/clawhub";
+  it.each([
+    ["foreign registry", "clawhub", `${privateRegistry}/`, undefined, false],
+    ["public registry", "clawhub", "https://clawhub.ai/", undefined, true],
+    ["custom primary override", "clawhub", `${privateRegistry}/`, privateRegistry, true],
+    [
+      "custom secondary override",
+      "clawhub",
+      `${privateRegistry}/`,
+      privateRegistry,
+      true,
+      "CLAWHUB_URL",
+    ],
+    ["different custom registry", "clawhub", "https://other.example/", privateRegistry, false],
+    ["public npm counterpart", "npm", undefined, undefined, true],
+    ["public npm counterpart on custom registry", "npm", undefined, privateRegistry, false],
+    ["unproven registry", "clawhub", undefined, undefined, false],
+  ] as const)(
+    "binds remote discovery to the effective registry: %s",
+    async (
+      _label,
+      source,
+      clawhubUrl,
+      activeRegistry,
+      matches,
+      registryEnv: "OPENCLAW_CLAWHUB_URL" | "CLAWHUB_URL" = "OPENCLAW_CLAWHUB_URL",
+    ) => {
+      vi.stubEnv("OPENCLAW_CLAWHUB_URL", undefined);
+      vi.stubEnv("CLAWHUB_URL", undefined);
+      vi.stubEnv(registryEnv, activeRegistry);
+      const packageName = "@openclaw/diffs";
+      mocks.metadata.mockReturnValue(
+        metadataSnapshot({
+          enabled: false,
+          id: "diffs",
+          origin: "global",
+          categories: ["tools"],
+          installRecord:
+            source === "clawhub"
+              ? { source, clawhubUrl, clawhubPackage: packageName, version: "1.0.0" }
+              : { source, spec: packageName, resolvedName: packageName },
+        }),
+      );
+
+      const local = await listManagedPlugins({
+        config: {},
+        env: {},
+        officialCatalog: { entries: [] },
+      });
+      const [entry] = joinClawHubPluginCatalog({
+        local,
+        remote: [
+          {
+            packageName,
+            displayName: "Remote Diffs",
+            family: "code-plugin",
+            isOfficial: true,
+            categories: ["tools"],
+          },
+        ],
+      });
+
+      expect(local.plugins[0]).toMatchObject({ id: "diffs", installed: true });
+      expect(entry?.local).toMatchObject({
+        installed: matches,
+        action: matches ? "manage" : "install",
+      });
+      expect(entry?.local.pluginId).toBe(matches ? "diffs" : undefined);
+    },
+  );
+
   it("projects package-declared categories without consulting ClawHub", async () => {
     mocks.metadata.mockReturnValue(
       metadataSnapshot({
@@ -318,6 +392,7 @@ describe("plugin management service", () => {
         packageVersion: "1.2.3",
         installRecord: {
           source: "clawhub",
+          clawhubUrl: "https://clawhub.ai",
           clawhubPackage: "@openclaw/memory-tools",
           version: "1.2.3",
         },
@@ -348,6 +423,7 @@ describe("plugin management service", () => {
         packageVersion: "4.5.6",
         installRecord: {
           source: "clawhub",
+          clawhubUrl: "https://clawhub.ai",
           clawhubPackage: "community/memory",
           version: "4.5.6",
         },

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -8,7 +8,7 @@ import type {
 import { resolveConfigWidePluginMetadataSnapshot } from "../config/io.plugin-metadata.js";
 import { resolveIsConfigReadOnly } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveClawHubBaseUrl } from "../infra/clawhub-client.js";
+import { isDefaultClawHubBaseUrl, resolveClawHubBaseUrl } from "../infra/clawhub-client.js";
 import { fetchClawHubPluginVersionCategories } from "../infra/clawhub-plugin-catalog.js";
 import { resolvePendingPluginCapabilityReview } from "./capability-consent.js";
 import {
@@ -262,6 +262,8 @@ export const listManagedPlugins = withManagedPluginCache(
     );
     const installedIconsById = new Map<string, ManagedPluginIconSource | undefined>();
     const installedClawHubPackages = new Set<string>();
+    const discoveryRegistry = resolveClawHubBaseUrl();
+    const publicDiscoveryRegistry = isDefaultClawHubBaseUrl(discoveryRegistry);
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
     const categoryTargetsByRegistry = new Map<
       string,
@@ -370,10 +372,14 @@ export const listManagedPlugins = withManagedPluginCache(
         plugin.packageName = record.packageName;
       }
       const recordedClawHubPackage =
-        installRecord?.source === "clawhub"
+        installRecord?.source === "clawhub" &&
+        normalizeOptionalString(installRecord.clawhubUrl) &&
+        resolveClawHubBaseUrl(installRecord.clawhubUrl) === discoveryRegistry
           ? normalizeOptionalString(installRecord.clawhubPackage)
           : undefined;
-      const discoveryClawHubPackage = clawhubPackage ?? recordedClawHubPackage;
+      // Discovery names are registry-scoped; trusted official/npm counterparts belong to the public catalog.
+      const discoveryClawHubPackage =
+        (publicDiscoveryRegistry ? clawhubPackage : undefined) ?? recordedClawHubPackage;
       if (discoveryClawHubPackage) {
         plugin.clawhubPackage = discoveryClawHubPackage;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing plugins would see a package marked installed when only a same-name package from another ClawHub registry was installed. When ClawHub detail lookup failed, an unrelated npm package name or runtime plugin ID could also select the wrong local details.

## Why This Change Was Made

Installed discovery identities now require a recorded registry matching the effective ClawHub registry. Verified official/npm counterparts retain their public-registry mapping. Browse and offline detail fallback share the same ClawHub identity index, removing the broader alias lookup that made their decisions diverge.

## User Impact

Plugins from other registries remain locally manageable without claiming the current catalog's installed status. Custom registry selection through either supported environment variable, exact local plugin routes, public official counterparts, and valid same-source offline fallback retain their behavior. Records without a known registry remain local rather than acquiring an origin from the current environment.

## Evidence

Six regression cases fail against unchanged production code for the intended reasons: four incorrect registry matches and two unrelated-alias detail fallbacks. The repaired candidate passes all 123 focused tests across discovery, management, Gateway handlers, and Featured/source-linkage coverage, including positive custom-registry and legitimate offline-fallback cases.

Proof uses the real management projection, discovery join and RPC handlers with synthetic metadata and stubbed network boundaries. All five-file changed checks, docs checks and the isolated P0–P2 managed review passed. The change keeps existing external request shapes and UI layout; no live ClawHub request was used for proof.
