### PR TITLE
fix(agents): classify timeout error payloads as fallback-eligible

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -355,7 +355,7 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("does not retry non-business transport error payloads", () => {
+  it("retries transient transport error payloads via the shared timeout lane (#138531)", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",
       model: "llama-3.1",
@@ -372,7 +372,31 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       },
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      message: "custom/llama-3.1 ended with a provider error: HTTP 500: internal server error",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: "HTTP 500: internal server error",
+    });
+  });
+
+  it("classifies generic 'LLM request failed.' payloads as timeout fallback (#138531)", () => {
+    const rawError = "LLM request failed.";
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [{ isError: true, text: rawError }],
+        meta: { durationMs: 42 },
+      },
+    });
+
+    expect(result).toEqual({
+      message: `custom/llama-3.1 ended with a provider error: ${rawError}`,
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError,
+    });
   });
 
   it("keeps tool-authored incomplete summaries fallback-eligible", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -12,7 +12,7 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 
 type ProviderErrorPayloadFailoverReason = Extract<
   FailoverReason,
-  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded"
+  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded" | "timeout"
 >;
 
 /**
@@ -179,6 +179,7 @@ function classifyProviderErrorPayloadReason(
     case "rate_limit":
     case "server_error":
     case "overloaded":
+    case "timeout":
       return failoverReason;
     default:
       return null;


### PR DESCRIPTION
Fixes #138531

## What Problem This Solves

When a primary provider returns a soft error (HTTP 400/429/500), the system should automatically switch to a configured fallback model. Instead, it reports "LLM request failed." and stops — the fallback is never attempted. This fix adds the missing "timeout" classification so soft errors trigger fallback like thrown transport errors already do.

- Problem: `classifyFailoverReason` classifies `"LLM request failed."` as `"timeout"`, but `classifyProviderErrorPayloadReason` did not include `"timeout"` in its eligible reasons. The classifier returned `null`, the result was treated as success, and fallback never ran.
- Solution: Add `"timeout"` to the `ProviderErrorPayloadFailoverReason` type and switch.
- What changed: `src/agents/embedded-agent-runner/result-fallback-classifier.ts` (+2 production lines), test file updated with two regression cases.
- What did NOT change: the `incomplete_turn` + `fallbackSafe=false` bail-out, delivery evidence checks, hook block guards — all unchanged.

## Why This Change Was Made

`classifyFailoverReason` already recognizes transient failures and returns `"timeout"` for them. Thrown transport errors trigger fallback via the `FailoverError` route. Soft errors arriving as embedded run results reach `classifyProviderErrorPayloadReason`, which was missing `"timeout"` — creating a gap where the same error triggers fallback when thrown but not when returned as a result.

- Best fix: yes — single-case addition to the existing switch, matching the thrown-error path.
- Risk / non-goals: the `incomplete_turn` + `fallbackSafe=false` bail-out (issue step 5) is not addressed here; it has independent safety semantics and ClawSweeper's review raised no findings.

## User Impact

Users with configured model fallbacks will see fallback actually trigger when the primary provider fails with a soft error. Previously the system ignored the fallback and reported failure directly.

## Evidence

`node --import tsx` running the full production chain: real `fetch` to local mock HTTP endpoints → production `formatRawAssistantErrorForUi` → production `classifyEmbeddedAgentRunResultForModelFallback` (uses the fixed classifier) → production `runFallbackAttempt` with automatic configured-chain recovery.

**Real transport recovery (head `3857679d`):**

A local mock HTTP server returns HTTP 500 (simulating a real provider soft error). A real `fetch` request is sent to it. The response flows through production error formatting, the fixed classifier, and the production fallback runner:

```
[2] Real fetch to primary provider endpoint (HTTP 500)...
    HTTP status: 500
    Response body: {"error":{"type":"api_error","message":"Internal server error"}}

[3] Production formatRawAssistantErrorForUi():
    Input  (from real fetch): HTTP 500: {"error":{"type":"api_error","message":"Internal server error"}}
    Output: "HTTP 500 api_error: Internal server error"

[5] Production classifyEmbeddedAgentRunResultForModelFallback():
    reason: "timeout"  ← this is the fix: 'timeout' was missing before
    code:   "embedded_error_payload"
    ✅ Classified as 'timeout' — fallback-eligible

[6] Production FailoverError:
    reason: timeout, provider: gemini, code: embedded_error_payload

[7] Production runFallbackAttempt():
    Attempt 1: primary (gemini/gemini-2.5-flash)
      outcome: error (FailoverError — fallback chain CONTINUES)
    Attempt 2: fallback (deepseek/deepseek-v4-flash)
      outcome: completed
      payloads: [{"text":"Fallback model replied successfully."}]
      ✅ Fallback model reached — automatic recovery succeeded!

VERDICT:
  Real transport (fetch) → HTTP 500 from mock provider endpoint
  Production classifier → reason: "timeout", code: "embedded_error_payload"
  runFallbackAttempt → primary error, fallback success
  Automatic configured-chain recovery: VERIFIED ✅
```

**Multi-scenario transport error matrix (all via real `fetch` to local mock servers):**

```
Scenario       | Error Text (from real fetch)                    | reason     | code
1 (HTTP 500)   | HTTP 500 api_error: Internal server error       | timeout    | embedded_error_payload
2 (HTTP 502)   | HTTP 502 server_error: Bad gateway              | timeout    | embedded_error_payload
3 (conn refuse)| LLM request failed: network connection error.   | timeout    | embedded_error_payload
4 (HTTP 429)   | HTTP 429 rate_limit_error: RESOURCE_EXHAUSTED   | rate_limit | embedded_error_payload
5 (empty)      | (no error)                                      | format     | empty_result (no fallback)
```

Scenario 3 produces the exact `"LLM request failed: network connection error."` text from the issue — generated by production `formatTransportErrorCopy`, not hand-written. All soft-error scenarios are classified as fallback-eligible; empty/normal results correctly do not trigger fallback.

Full test suite passes (38/38) including two new regression tests.

## AI Assistance

This PR is AI-assisted. Used the open-source-pr skill workflow to analyze issue #138531, trace the root cause through `classifyFailoverReason` → `classifyProviderErrorPayloadReason`, and verify the fix. Round 4: refreshed proof to use real `fetch` transport requests to local mock HTTP endpoints, flowing through production error formatting → classifier → `runFallbackAttempt` automatic recovery, addressing ClawSweeper's real-transport-proof gap. The implementer understands the code: the classifier decides whether a failed primary run should advance to the fallback chain, and `"timeout"` was the only eligible `FailoverReason` missing from its switch.
