### PR TITLE
fix(daemon): persist Bun SQLite library selection into managed services

### DIFF
--- a/docs/install/bun-compatibility.md
+++ b/docs/install/bun-compatibility.md
@@ -46,6 +46,8 @@ Set `OPENCLAW_SQLITE_LIBRARY` in the process environment before starting OpenCla
 OPENCLAW_SQLITE_LIBRARY=/path/to/libsqlite3.dylib bun openclaw.mjs gateway
 ```
 
+On macOS, `openclaw gateway install --runtime bun`, `openclaw node install --runtime bun`, and wrapper-based installs persist `OPENCLAW_SQLITE_LIBRARY` and `HOMEBREW_PREFIX` from the installing shell into the managed service definition, so the service selects the same library. To change these values for an already-installed service, reinstall with `openclaw gateway install --runtime bun --force` (or `openclaw node install --runtime bun --force` for a managed node host) from a shell with the desired values; a bare reinstall of an already-loaded service is a no-op. Direct Node-runtime services never persist them.
+
 An invalid override fails with:
 
 ```text
@@ -75,6 +77,7 @@ See [Bun](/install/bun) for the workflow and lifecycle trust commands.
 
 | Release                            | Change                                                                                                                                                                                               |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unreleased (main)                  | Managed Bun services on macOS persist OPENCLAW_SQLITE_LIBRARY and HOMEBREW_PREFIX from the installing shell.                                                                                         |
 | Unreleased (main)                  | Daemon install, repair, doctor, and service audits probe Bun executables through the same SQLite library selection as Gateway startup, with a minimal probe environment. #142186                     |
 | Unreleased (main)                  | Automatically selects a WAL-safe, extension-capable macOS SQLite library and propagates it to the memory KNN child. Adds `OPENCLAW_SQLITE_LIBRARY`. #141854                                          |
 | Unreleased (main)                  | Documents Bun 1.4.2 retaining native statements and WAL/shared-memory files after close or disposal, with Node advised when prompt file release matters. #141846                                     |

--- a/src/cli/daemon-cli/install-environment.test.ts
+++ b/src/cli/daemon-cli/install-environment.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import { mergeInstallInvocationEnv } from "./install.js";
 
 describe("mergeInstallInvocationEnv", () => {
+  it("uses only the current shell's HOMEBREW_PREFIX", () => {
+    const existingServiceEnv = { HOMEBREW_PREFIX: "/opt/homebrew" };
+    const env = mergeInstallInvocationEnv({ env: {}, existingServiceEnv, platform: "darwin" });
+    expect(env.HOMEBREW_PREFIX).toBeUndefined();
+    const current = mergeInstallInvocationEnv({
+      env: { HOMEBREW_PREFIX: "/usr/local" },
+      existingServiceEnv,
+      platform: "darwin",
+    });
+    expect(current.HOMEBREW_PREFIX).toBe("/usr/local");
+  });
+
   it("canonicalizes Windows install env keys while filtering dangerous loader env", () => {
     const env = mergeInstallInvocationEnv({
       env: {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -130,6 +130,7 @@ export function mergeInstallInvocationEnv(params: {
       upper === "HOME" ||
       upper === "PATH" ||
       upper === "TMPDIR" ||
+      upper === "HOMEBREW_PREFIX" ||
       upper.startsWith("OPENCLAW_")
     ) {
       continue;

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -2479,6 +2479,7 @@ describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist",
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
+        ...(env.HOMEBREW_PREFIX !== undefined ? { HOMEBREW_PREFIX: env.HOMEBREW_PREFIX } : {}),
         ...(env.OPENCLAW_CONFIG_READONLY !== undefined
           ? { OPENCLAW_CONFIG_READONLY: env.OPENCLAW_CONFIG_READONLY }
           : {}),
@@ -2497,6 +2498,17 @@ describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist",
   it("continues to drop stale OPENCLAW_ALLOW_ROOT", async () => {
     const result = await buildEnvironment({ OPENCLAW_ALLOW_ROOT: "1" });
     expect(result.OPENCLAW_ALLOW_ROOT).toBeUndefined();
+  });
+
+  it("uses only the current install's HOMEBREW_PREFIX", async () => {
+    const existingEnvironment = { HOMEBREW_PREFIX: "/opt/homebrew" };
+    const result = await buildEnvironment(existingEnvironment);
+    expect(result.HOMEBREW_PREFIX).toBeUndefined();
+    const current = await buildEnvironment(existingEnvironment, {
+      HOME: "/tmp",
+      HOMEBREW_PREFIX: "/usr/local",
+    });
+    expect(current.HOMEBREW_PREFIX).toBe("/usr/local");
   });
 
   it("preserves OPENCLAW_CLI_CONTAINER_BYPASS and OPENCLAW_CONTAINER_HINT", async () => {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -575,10 +575,12 @@ function collectPreservedExistingServiceEnvVars(
       continue;
     }
     const upper = key.toUpperCase();
+    // Like OPENCLAW_SQLITE_LIBRARY, HOMEBREW_PREFIX must regenerate from each install/repair invocation.
     if (
       upper === "HOME" ||
       upper === "PATH" ||
       upper === "TMPDIR" ||
+      upper === "HOMEBREW_PREFIX" ||
       (upper.startsWith("OPENCLAW_") && !PRESERVED_OPENCLAW_OPERATOR_OPT_IN_ENV_KEYS.has(upper))
     ) {
       continue;

--- a/src/commands/node-daemon-install-helpers.test.ts
+++ b/src/commands/node-daemon-install-helpers.test.ts
@@ -68,6 +68,7 @@ describe("buildNodeInstallPlan", () => {
     expect(mocks.resolvePreferredNodePath).not.toHaveBeenCalled();
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
       env: {},
+      runtime: "node",
       extraPathDirs: ["/custom/node/bin"],
     });
   });
@@ -97,6 +98,7 @@ describe("buildNodeInstallPlan", () => {
     expect(mocks.resolveSystemNodeInfo).not.toHaveBeenCalled();
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
       env: { HOME: "/home/test" },
+      runtime: "bun",
       extraPathDirs: ["/home/test/.bun/bin"],
     });
   });
@@ -126,6 +128,7 @@ describe("buildNodeInstallPlan", () => {
 
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
       env: {},
+      runtime: "node",
       extraPathDirs: undefined,
     });
   });

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -80,6 +80,7 @@ export async function buildNodeInstallPlan(params: {
 
   const environment = buildNodeServiceEnvironment({
     env: params.env,
+    runtime: params.runtime,
     // Match the Gateway install path so supervised services keep the chosen
     // runtime toolchain on PATH for sibling binaries when needed.
     extraPathDirs: resolveDaemonRuntimeBinDir(runtimePath),

--- a/src/daemon/service-env.sqlite-library.test.ts
+++ b/src/daemon/service-env.sqlite-library.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildNodeServiceEnvironment, buildServiceEnvironment } from "./service-env.js";
+
+describe("managed service SQLite library environment", () => {
+  const sqliteEnv = {
+    HOME: "/Users/testuser",
+    OPENCLAW_SQLITE_LIBRARY: " /opt/homebrew/opt/sqlite/lib/libsqlite3.dylib ",
+    HOMEBREW_PREFIX: " /opt/homebrew ",
+  };
+  const expectedSqliteEnv = {
+    OPENCLAW_SQLITE_LIBRARY: "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib",
+    HOMEBREW_PREFIX: "/opt/homebrew",
+  };
+
+  it.each([
+    ["darwin", "bun", undefined, true],
+    ["darwin", "node", undefined, false],
+    ["linux", "bun", undefined, false],
+    ["win32", "bun", undefined, false],
+    ["darwin", "node", " /usr/local/bin/openclaw-wrapper ", true],
+    ["darwin", "node", "   ", false],
+  ] as const)(
+    "forwards gateway SQLite inputs on %s with runtime %s and wrapper %s: %s",
+    (platform, runtime, wrapper, forwards) => {
+      const env = buildServiceEnvironment({
+        env: { ...sqliteEnv, OPENCLAW_WRAPPER: wrapper },
+        port: 18789,
+        platform,
+        runtime,
+      });
+
+      if (forwards) {
+        expect(env).toMatchObject(expectedSqliteEnv);
+      } else {
+        expect(env).not.toHaveProperty("OPENCLAW_SQLITE_LIBRARY");
+        expect(env).not.toHaveProperty("HOMEBREW_PREFIX");
+      }
+    },
+  );
+
+  it("omits blank overrides and relative Homebrew prefixes for macOS Bun services", () => {
+    const env = buildServiceEnvironment({
+      env: { ...sqliteEnv, OPENCLAW_SQLITE_LIBRARY: "   ", HOMEBREW_PREFIX: " opt/homebrew " },
+      port: 18789,
+      platform: "darwin",
+      runtime: "bun",
+    });
+
+    expect(env).not.toHaveProperty("OPENCLAW_SQLITE_LIBRARY");
+    expect(env).not.toHaveProperty("HOMEBREW_PREFIX");
+  });
+
+  it.each(["bun", undefined] as const)(
+    "forwards macOS node-host SQLite inputs only with Bun selected (runtime: %s)",
+    (runtime) => {
+      const env = buildNodeServiceEnvironment({ env: sqliteEnv, platform: "darwin", runtime });
+
+      if (runtime === "bun") {
+        expect(env).toMatchObject(expectedSqliteEnv);
+      } else {
+        expect(env).not.toHaveProperty("OPENCLAW_SQLITE_LIBRARY");
+        expect(env).not.toHaveProperty("HOMEBREW_PREFIX");
+      }
+    },
+  );
+});

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -49,6 +49,27 @@ export const SERVICE_PROXY_ENV_KEYS = [
   "all_proxy",
 ] as const;
 
+function readServiceSqliteEnvironment(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+  runtime: GatewayDaemonRuntime | undefined,
+): { OPENCLAW_SQLITE_LIBRARY?: string; HOMEBREW_PREFIX?: string } {
+  // Match the library selected by the installing shell and judged by the daemon
+  // probe (src/daemon/runtime-paths.ts RUNTIME_PROBE_ENV_KEYS); wrappers hide the runtime.
+  if (
+    platform !== "darwin" ||
+    (runtime !== "bun" && !normalizeOptionalString(env.OPENCLAW_WRAPPER))
+  ) {
+    return {};
+  }
+  const library = normalizeOptionalString(env.OPENCLAW_SQLITE_LIBRARY);
+  const prefix = normalizeOptionalString(env.HOMEBREW_PREFIX);
+  return {
+    ...(library ? { OPENCLAW_SQLITE_LIBRARY: library } : {}),
+    ...(prefix && path.posix.isAbsolute(prefix) ? { HOMEBREW_PREFIX: prefix } : {}),
+  };
+}
+
 function readServiceProxyEnvironment(
   env: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
@@ -355,6 +376,7 @@ export function buildServiceEnvironment(params: {
   const systemdUnit = resolveGatewaySystemdUnitEnv(env);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
+    ...readServiceSqliteEnvironment(env, platform, params.runtime),
     // An empty assignment clears supervisor ambient options; omission would
     // allow preloads/debug flags to bypass the heap-only service boundary.
     NODE_OPTIONS: resolveGatewayHeapNodeOptions(
@@ -378,6 +400,7 @@ export function buildServiceEnvironment(params: {
 
 export function buildNodeServiceEnvironment(params: {
   env: Record<string, string | undefined>;
+  runtime?: GatewayDaemonRuntime;
   platform?: NodeJS.Platform;
   extraPathDirs?: string[];
   execPath?: string;
@@ -397,6 +420,7 @@ export function buildNodeServiceEnvironment(params: {
   const allowInsecurePrivateWs = normalizeOptionalString(env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
+    ...readServiceSqliteEnvironment(env, platform, params.runtime),
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,
     OPENCLAW_GATEWAY_PASSWORD: gatewayPassword,
     CF_ACCESS_CLIENT_ID: cloudflareAccessClientId,


### PR DESCRIPTION
Related: #142186

## What Problem This Solves

Fixes an issue where a managed Gateway or node-host service installed with `--runtime bun` on macOS could select a different SQLite library than the shell that installed it, because the service's generated environment never carried `OPENCLAW_SQLITE_LIBRARY` or `HOMEBREW_PREFIX`. An operator setting `OPENCLAW_SQLITE_LIBRARY` before install saw it work in that shell and then silently vanish once the service ran under launchd or systemd.

## Why This Change Was Made

`src/daemon/service-env.ts` now forwards both inputs into the generated environment for the Gateway and node-host services, gated to macOS and to a Bun runtime (or an `OPENCLAW_WRAPPER`, which hides the runtime the same way the heap `NODE_OPTIONS` logic already treats it) so Node-runtime services never carry them and never log Gateway startup's "override ignored" warning. `OPENCLAW_SQLITE_LIBRARY` is trimmed; `HOMEBREW_PREFIX` must be an absolute POSIX path or it is omitted. Both values are inline and non-secret, and regenerate from the invoking shell on every install or repair exactly like every other `OPENCLAW_*` service key, so `mergeInstallInvocationEnv` needed no change. This closes the loop with #142186: the daemon probe, the installing shell, and the running service now all judge the same two inputs.

## User Impact

`openclaw gateway install --runtime bun` and `openclaw node install --runtime bun` on macOS now install a service that opens the same SQLite library the operator configured, instead of silently falling back to discovery or Apple's system library. Re-running install or `openclaw gateway start` repair from a shell with the desired values changes them.

## Evidence

New test file `src/daemon/service-env.sqlite-library.test.ts` covers: macOS+Bun forwards both keys (trimmed); macOS+Node forwards neither; Linux/Windows+Bun forwards neither; a wrapper on macOS+Node forwards both; blank overrides and a relative `HOMEBREW_PREFIX` are omitted; node-host service environment forwards only when Bun is selected.

135 tests green across `src/daemon/service-env.sqlite-library.test.ts`, `src/daemon/service-env.test.ts`, `src/commands/node-daemon-install-helpers.test.ts`, `src/daemon/launchd-plist.test.ts`, `src/daemon/systemd-unit.test.ts`. `oxfmt`/`oxlint` clean on all touched files. `check:changed` green (typecheck core + core tests, both Knip dead-export scans, import cycles). Codex autoreview at P1 scoped-clean (0.94).
