### PR TITLE
refactor(comfy): share local and cloud workflow polling

### DIFF
--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -451,7 +451,7 @@ function extractHistoryEntry(history: unknown, promptId: string): ComfyHistoryEn
   return null;
 }
 
-async function waitForLocalHistory(params: {
+async function waitForComfyHistory(params: {
   baseUrl: string;
   promptId: string;
   headers: Headers;
@@ -459,71 +459,57 @@ async function waitForLocalHistory(params: {
   pollIntervalMs: number;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
-}): Promise<ComfyHistoryEntry> {
+  mode: ComfyMode;
+}): Promise<unknown> {
   const deadline = Date.now() + params.timeoutMs;
-  for (;;) {
-    const requestTimeoutMs = resolveComfyRemainingMs(deadline, params.timeoutMs);
-    const history = await readJsonResponse<unknown>({
-      url: `${params.baseUrl}/history/${params.promptId}`,
+  const read = <T>(path: string, kind: "history" | "status", timeoutMs: number) =>
+    readJsonResponse<T>({
+      url: `${params.baseUrl}${path}`,
       init: {
         method: "GET",
         headers: params.headers,
       },
-      timeoutMs: requestTimeoutMs,
+      timeoutMs,
       policy: params.policy,
       dispatcherPolicy: params.dispatcherPolicy,
-      auditContext: "comfy-history",
-      errorPrefix: "Comfy history lookup failed",
+      auditContext: `comfy-${kind}`,
+      errorPrefix: `Comfy ${kind} lookup failed`,
     });
 
-    const entry = extractHistoryEntry(history, params.promptId);
-    if (entry?.outputs && Object.keys(entry.outputs).length > 0) {
-      return entry;
-    }
-
-    const pollDelayMs = resolveComfyRemainingMs(deadline, params.timeoutMs, params.pollIntervalMs);
-    await new Promise((resolve) => {
-      setTimeout(resolve, pollDelayMs);
-    });
-  }
-}
-
-async function waitForCloudCompletion(params: {
-  baseUrl: string;
-  promptId: string;
-  headers: Headers;
-  timeoutMs: number;
-  pollIntervalMs: number;
-  policy?: SsrFPolicy;
-  dispatcherPolicy?: ComfyDispatcherPolicy;
-}): Promise<void> {
-  const deadline = Date.now() + params.timeoutMs;
   for (;;) {
     const requestTimeoutMs = resolveComfyRemainingMs(deadline, params.timeoutMs);
-    const status = await readJsonResponse<ComfyStatusResponse>({
-      url: `${params.baseUrl}/api/job/${params.promptId}/status`,
-      init: {
-        method: "GET",
-        headers: params.headers,
-      },
-      timeoutMs: requestTimeoutMs,
-      policy: params.policy,
-      dispatcherPolicy: params.dispatcherPolicy,
-      auditContext: "comfy-status",
-      errorPrefix: "Comfy status lookup failed",
-    });
-
-    if (status.status === "completed") {
-      return;
-    }
-    if (status.status === "failed" || status.status === "cancelled") {
-      const detail = redactProviderResponseErrorText(
-        status.error ?? status.message ?? params.promptId,
-        params.headers,
+    if (params.mode === "cloud") {
+      const status = await read<ComfyStatusResponse>(
+        `/api/job/${params.promptId}/status`,
+        "status",
+        requestTimeoutMs,
       );
-      throw new Error(`Comfy workflow ${status.status}: ${detail}`);
+      if (status.status === "completed") {
+        // Cloud history gets a fresh request budget after the job completes.
+        return await read<unknown>(
+          `/api/history_v2/${params.promptId}`,
+          "history",
+          params.timeoutMs,
+        );
+      }
+      if (status.status === "failed" || status.status === "cancelled") {
+        const detail = redactProviderResponseErrorText(
+          status.error ?? status.message ?? params.promptId,
+          params.headers,
+        );
+        throw new Error(`Comfy workflow ${status.status}: ${detail}`);
+      }
+    } else {
+      const history = await read<unknown>(
+        `/history/${params.promptId}`,
+        "history",
+        requestTimeoutMs,
+      );
+      const entry = extractHistoryEntry(history, params.promptId);
+      if (entry?.outputs && Object.keys(entry.outputs).length > 0) {
+        return entry;
+      }
     }
-
     const pollDelayMs = resolveComfyRemainingMs(deadline, params.timeoutMs, params.pollIntervalMs);
     await new Promise((resolve) => {
       setTimeout(resolve, pollDelayMs);
@@ -863,40 +849,16 @@ export async function runComfyWorkflow(params: {
     throw new Error("Comfy workflow submit response missing prompt_id");
   }
 
-  const history =
-    mode === "cloud"
-      ? await (async () => {
-          await waitForCloudCompletion({
-            baseUrl: normalizedBaseUrl,
-            promptId,
-            headers: new Headers(headers),
-            timeoutMs,
-            pollIntervalMs,
-            policy: networkPolicy.apiPolicy,
-            dispatcherPolicy,
-          });
-          return await readJsonResponse<unknown>({
-            url: `${normalizedBaseUrl}/api/history_v2/${promptId}`,
-            init: {
-              method: "GET",
-              headers: new Headers(headers),
-            },
-            timeoutMs,
-            policy: networkPolicy.apiPolicy,
-            dispatcherPolicy,
-            auditContext: "comfy-history",
-            errorPrefix: "Comfy history lookup failed",
-          });
-        })()
-      : await waitForLocalHistory({
-          baseUrl: normalizedBaseUrl,
-          promptId,
-          headers: new Headers(headers),
-          timeoutMs,
-          pollIntervalMs,
-          policy: networkPolicy.apiPolicy,
-          dispatcherPolicy,
-        });
+  const history = await waitForComfyHistory({
+    baseUrl: normalizedBaseUrl,
+    promptId,
+    headers: new Headers(headers),
+    timeoutMs,
+    pollIntervalMs,
+    policy: networkPolicy.apiPolicy,
+    dispatcherPolicy,
+    mode,
+  });
 
   const historyEntry = extractHistoryEntry(history, promptId);
   if (!historyEntry) {


### PR DESCRIPTION
## What Problem This Solves

Comfy's local and cloud workflows maintained separate polling loops with the same deadline, request setup and bounded delay. Changes to that shared behavior had to be kept consistent in both implementations and their separate callers.

## Why This Change Was Made

One private workflow wait now owns the polling lifecycle. Local history and cloud status retain their distinct completion rules. Cloud completion still performs its final history request with a fresh full timeout, and the existing guarded transport, redaction and output processing remain in place.

## User Impact

Image, video and music generation retain their existing behavior, network policy and errors. The change removes one duplicated loop and caller setup without adding an SDK surface or changing configuration.

## Evidence

All 70 existing Comfy tests pass on both original and candidate source. The full changed-file gate and isolated P0–P2 review pass.

A separate task-only real-socket harness exercised the actual workflow boundary in 20 original/candidate scenarios. Methods, paths, query strings, JSON request bodies, returned outputs and errors match; Authorization is asserted separately on every request. The scenarios cover local/cloud flows for all three capabilities, submission and polling deadlines, the fresh cloud-history budget, direct/nested history, terminal error precedence and redaction, malformed JSON, and 429/503 failures without retry. Other wire headers are not compared, and no external Comfy service was contacted.

The complete repository change removes 35 production code lines and 38 physical lines from one file. Existing tests remain unchanged. The 138-line task proof is retained separately and is not claimed as persistent repository regression coverage or deletion credit.
