### PR TITLE
refactor(tests): share channel runtime spies

### DIFF
--- a/extensions/discord/src/gateway-logging.test.ts
+++ b/extensions/discord/src/gateway-logging.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover gateway logging plugin behavior.
 import { EventEmitter } from "node:events";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 
 // Suite runs isolate=false: a partial factory here poisons the shared module
 // cache for later files in the worker (#123025), so spread the real module.
@@ -16,12 +17,6 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
 let logVerbose: typeof import("openclaw/plugin-sdk/runtime-env").logVerbose;
 let attachDiscordGatewayLogging: typeof import("./gateway-logging.js").attachDiscordGatewayLogging;
 
-const makeRuntime = () => ({
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-});
-
 describe("attachDiscordGatewayLogging", () => {
   beforeAll(async () => {
     const { logVerbose: loadedLogVerbose } = await import("openclaw/plugin-sdk/runtime-env");
@@ -34,7 +29,7 @@ describe("attachDiscordGatewayLogging", () => {
   });
   it("logs debug events and promotes reconnect/close to info", () => {
     const emitter = new EventEmitter();
-    const runtime = makeRuntime();
+    const runtime = createRuntimeSpies();
 
     const cleanup = attachDiscordGatewayLogging({
       emitter,
@@ -67,7 +62,7 @@ describe("attachDiscordGatewayLogging", () => {
 
   it("promotes warnings while keeping metrics verbose-only", () => {
     const emitter = new EventEmitter();
-    const runtime = makeRuntime();
+    const runtime = createRuntimeSpies();
 
     const cleanup = attachDiscordGatewayLogging({
       emitter,
@@ -88,7 +83,7 @@ describe("attachDiscordGatewayLogging", () => {
 
   it("removes listeners on cleanup", () => {
     const emitter = new EventEmitter();
-    const runtime = makeRuntime();
+    const runtime = createRuntimeSpies();
 
     const cleanup = attachDiscordGatewayLogging({
       emitter,

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover gateway metadata plugin behavior.
 import { createServer, type Server } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 import {
   fetchDiscordGatewayInfoWithTimeout,
   fetchDiscordGatewayMetadataGuarded,
@@ -95,11 +96,7 @@ describe("Discord gateway metadata", () => {
         }),
       timeoutMs: 1_000,
     }).catch((err: unknown) => err);
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     const resolved = resolveGatewayInfoWithFallback({ runtime, error });
 

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover gateway plugin plugin behavior.
 import { EventEmitter } from "node:events";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 import { DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT } from "./gateway-handle.js";
 import {
   fetchDiscordGatewayInfoWithTimeout,
@@ -94,11 +95,7 @@ describe("createDiscordGatewayPlugin", () => {
   function createPlugin(
     testing?: NonNullable<Parameters<typeof createDiscordGatewayPlugin>[0]["testing"]>,
     discordConfig: Parameters<typeof createDiscordGatewayPlugin>[0]["discordConfig"] = {},
-    runtime: Parameters<typeof createDiscordGatewayPlugin>[0]["runtime"] = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    },
+    runtime: Parameters<typeof createDiscordGatewayPlugin>[0]["runtime"] = createRuntimeSpies(),
   ) {
     return createDiscordGatewayPlugin({
       discordConfig,
@@ -330,11 +327,7 @@ describe("createDiscordGatewayPlugin", () => {
 
   it("logs Discord gateway websocket error and abnormal close details", () => {
     const socket = new EventEmitter() as EventEmitter & { binaryType?: string };
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
     const plugin = createPlugin(
       {
         webSocketCtor: function WebSocketCtor() {
@@ -368,11 +361,7 @@ describe("createDiscordGatewayPlugin", () => {
 
   it("keeps gateway close reason logs UTF-16 safe", () => {
     const socket = new EventEmitter() as EventEmitter & { binaryType?: string };
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
     const plugin = createPlugin(
       {
         webSocketCtor: function WebSocketCtor() {

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -101,6 +101,7 @@ vi.mock("./presence.js", () => ({
   resolveDiscordPresenceUpdate: vi.fn(() => undefined),
 }));
 
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 import { DISCORD_REST_TIMEOUT_MS } from "../proxy-request-client.js";
 import { registerDiscordListener } from "./listeners.js";
 import {
@@ -115,14 +116,6 @@ describe("createDiscordMonitorClient", () => {
     waitForDiscordGatewayPluginRegistrationMock.mockReset().mockReturnValue(undefined);
     vi.mocked(registerDiscordListener).mockClear();
   });
-
-  function createRuntime() {
-    return {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-  }
 
   function createClientWithPlugins(
     _options: ConstructorParameters<typeof import("../internal/discord.js").Client>[0],
@@ -184,7 +177,7 @@ describe("createDiscordMonitorClient", () => {
       modals: [],
       voiceEnabled: true,
       discordConfig: {},
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       createClient: createClientWithPlugins,
       createGatewayPlugin: () => gatewayPlugin as never,
       createGatewaySupervisor: () => ({ shutdown: vi.fn(), handleError: vi.fn() }) as never,
@@ -217,7 +210,7 @@ describe("createDiscordMonitorClient", () => {
       modals: [],
       voiceEnabled: false,
       discordConfig: {},
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       createClient: createClientWithPlugins,
       createGatewayPlugin: () => gatewayPlugin as never,
       createGatewaySupervisor: createGatewaySupervisor as never,
@@ -252,7 +245,7 @@ describe("createDiscordMonitorClient", () => {
       modals: [],
       voiceEnabled: false,
       discordConfig: {},
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       commandDeployHashStore,
       createClient,
       createGatewayPlugin: () => ({ id: "gateway" }) as never,
@@ -291,7 +284,7 @@ describe("createDiscordMonitorClient", () => {
       modals: [],
       voiceEnabled: false,
       discordConfig: {},
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       createClient,
       createGatewayPlugin: () => ({ id: "gateway" }) as never,
       createGatewaySupervisor: () => ({ shutdown: vi.fn(), handleError: vi.fn() }) as never,
@@ -331,7 +324,7 @@ describe("createDiscordMonitorClient", () => {
         modals: [],
         voiceEnabled: false,
         discordConfig: {},
-        runtime: createRuntime(),
+        runtime: createRuntimeSpies(),
         createClient: createClientWithPlugins,
         createGatewayPlugin: () => gatewayPlugin as never,
         createGatewaySupervisor: createGatewaySupervisor as never,
@@ -350,14 +343,6 @@ describe("registerDiscordMonitorListeners", () => {
     vi.mocked(registerDiscordListener).mockClear();
   });
 
-  function createRuntime() {
-    return {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-  }
-
   function createListenerParams(
     overrides: Partial<Parameters<typeof registerDiscordMonitorListeners>[0]> = {},
   ): Parameters<typeof registerDiscordMonitorListeners>[0] {
@@ -366,7 +351,7 @@ describe("registerDiscordMonitorListeners", () => {
       client: { listeners: [] },
       accountId: "default",
       discordConfig: {},
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       botUserId: "bot-1",
       dmEnabled: false,
       groupDmEnabled: false,

--- a/extensions/discord/src/test-support/provider.test-support.ts
+++ b/extensions/discord/src/test-support/provider.test-support.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { Mock } from "vitest";
 import { expect, vi } from "vitest";
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 
 type NativeCommandSpecMock = {
   name: string;
@@ -261,11 +262,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
   voiceRuntimeModuleLoadedMock.mockClear();
 }
 
-export const baseRuntime = (): RuntimeEnv => ({
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-});
+export const baseRuntime = (): RuntimeEnv => createRuntimeSpies();
 
 export const baseConfig = (): OpenClawConfig =>
   ({

--- a/extensions/feishu/src/monitor.bot-identity.rejection.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.rejection.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { RuntimeEnv } from "../runtime-api.js";
 import { startBotIdentityRecovery } from "./monitor.bot-identity.js";
 
@@ -26,11 +27,7 @@ afterEach(() => {
 describe("Feishu bot identity retry failures", () => {
   it("reports a rejected background retry without leaking an unhandled rejection", async () => {
     fetchBotIdentityForMonitorMock.mockRejectedValueOnce(new Error("probe exploded"));
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } satisfies RuntimeEnv;
+    const runtime = createRuntimeSpies() satisfies RuntimeEnv;
     const unhandled: unknown[] = [];
     const onUnhandledRejection = (reason: unknown) => {
       unhandled.push(reason);
@@ -68,11 +65,7 @@ describe("Feishu bot identity retry failures", () => {
   });
 
   it("stops an aborted retry without probing or reporting an error", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } satisfies RuntimeEnv;
+    const runtime = createRuntimeSpies() satisfies RuntimeEnv;
     const controller = new AbortController();
 
     startBotIdentityRecovery({

--- a/extensions/feishu/src/monitor.bot-menu.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.test.ts
@@ -1,5 +1,6 @@
 // Feishu tests cover monitor.bot menu plugin behavior.
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { expectFirstSentCardUsesFillWidthOnly } from "./card-test-helpers.js";
 import { createFeishuBotMenuHandler } from "./monitor.bot-menu-handler.js";
@@ -42,13 +43,7 @@ function createBotMenuEvent(params: { eventKey: string; timestamp: string }) {
 }
 
 async function registerHandlers(params: { runtime?: RuntimeEnv } = {}) {
-  const runtime =
-    params.runtime ??
-    ({
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as RuntimeEnv);
+  const runtime = params.runtime ?? (createRuntimeSpies() as RuntimeEnv);
   return createFeishuBotMenuHandler({
     cfg: {} as ClawdbotConfig,
     accountId: "default",

--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -20,6 +20,7 @@ vi.mock("./client.js", () => ({
   createFeishuWSClient: createFeishuWSClientMock,
 }));
 
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { monitorWebSocket } from "./monitor.transport.js";
 
 type MockWsClient = {
@@ -27,7 +28,7 @@ type MockWsClient = {
   close: ReturnType<typeof vi.fn>;
 };
 
-type MockRuntime = ReturnType<typeof createRuntime>;
+type MockRuntime = ReturnType<typeof createRuntimeSpies>;
 
 function createAccount(accountId: string): ResolvedFeishuAccount {
   return {
@@ -51,15 +52,7 @@ function createWsClient(): MockWsClient {
   };
 }
 
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
-
-function startWebSocketMonitor(accountId: string, runtime: MockRuntime = createRuntime()) {
+function startWebSocketMonitor(accountId: string, runtime: MockRuntime = createRuntimeSpies()) {
   const abortController = new AbortController();
   return {
     abortController,

--- a/extensions/feishu/src/monitor.vc-meeting-invited-handler.test.ts
+++ b/extensions/feishu/src/monitor.vc-meeting-invited-handler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import { monitorSingleAccount } from "./monitor.account.js";
@@ -127,11 +128,7 @@ describe("createFeishuVcMeetingInvitedHandler", () => {
   });
 
   it("ignores invitations unless VC auto-join is enabled", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
     const handler = createFeishuVcMeetingInvitedHandler({
       cfg: buildConfig(),
       accountId: "default",
@@ -150,11 +147,7 @@ describe("createFeishuVcMeetingInvitedHandler", () => {
   });
 
   it("adapts the VC invite into the normal Feishu DM message ingress", async () => {
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
     const channelRuntime = {} as PluginRuntime["channel"];
     const handler = createFeishuVcMeetingInvitedHandler({
       cfg: buildConfig(),

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -39,6 +39,7 @@ vi.mock("./monitor.state.js", async (importOriginal) => {
   };
 });
 
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { RuntimeEnv } from "../runtime-api.js";
 import { buildFeishuWebhookRateLimitKey } from "./monitor-rate-limit-key.js";
 import { resolveRequestClientIp } from "./monitor-transport-runtime-api.js";
@@ -235,11 +236,7 @@ describe("Feishu webhook security hardening", () => {
       monitorWebhook({
         account,
         accountId: account.accountId,
-        runtime: {
-          log: vi.fn(),
-          error: vi.fn(),
-          exit: vi.fn(),
-        } as RuntimeEnv,
+        runtime: createRuntimeSpies() as RuntimeEnv,
         abortSignal: new AbortController().signal,
         eventDispatcher: {} as never,
       }),

--- a/extensions/test-support/runtime-spies.ts
+++ b/extensions/test-support/runtime-spies.ts
@@ -1,0 +1,9 @@
+import { vi } from "vitest";
+
+export function createRuntimeSpies() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}

--- a/extensions/whatsapp/src/auth-store.test.ts
+++ b/extensions/whatsapp/src/auth-store.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import {
   getWebAuthAgeMs,
   hasWebCredsSync,
@@ -285,11 +286,7 @@ describe("auth-store", () => {
         "utf-8",
       );
 
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
+      const runtime = createRuntimeSpies();
 
       await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(true);
       expect(fsSync.existsSync(authDir)).toBe(false);
@@ -327,11 +324,7 @@ describe("auth-store", () => {
       }
       return await originalRm.call(fs, target, options as never);
     });
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     try {
       hoisted.oauthDir = authDir;
@@ -398,11 +391,7 @@ describe("auth-store", () => {
   it("does not delete unrelated non-empty directories on logout", async () => {
     const authDir = tempDirs.make("openclaw-wa-auth-unrelated-");
     fsSync.writeFileSync(path.join(authDir, "notes.txt"), "keep me", "utf-8");
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
     expect(fsSync.existsSync(authDir)).toBe(true);

--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -13,6 +13,7 @@ import { resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeAll, beforeEach, vi, type Mock } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { WebChannelStatus } from "./auto-reply/types.js";
 import type { WebInboundCallbackMessage, WebListenerCloseReason } from "./inbound.js";
 import type { WhatsAppSendResult } from "./inbound/send-result.js";
@@ -344,14 +345,6 @@ export function createWebInboundDeliverySpies(): AnyExport {
   };
 }
 
-function createWebAutoReplyRuntime(): WebAutoReplyRuntime {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
-
 export function startWebAutoReplyMonitor(params: {
   monitorWebChannelFn: (...args: unknown[]) => Promise<unknown>;
   listenerFactory: unknown;
@@ -365,7 +358,7 @@ export function startWebAutoReplyMonitor(params: {
   accountId?: string;
   statusSink?: (status: WebChannelStatus) => void;
 }): WebAutoReplyMonitorHarness {
-  const runtime = createWebAutoReplyRuntime();
+  const runtime: WebAutoReplyRuntime = createRuntimeSpies();
   const controller = new AbortController();
   const run = params.monitorWebChannelFn(
     false,

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { getChildLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { getActiveWebListener } from "./active-listener.js";
 import { WhatsAppAuthUnstableError, resolveWebCredsPath } from "./auth-store.js";
 import { resolveOAuthDir } from "./auth-store.runtime.js";
@@ -922,11 +923,7 @@ describe("web auto-reply connection", () => {
     const logPath = `/tmp/openclaw-heartbeat-${crypto.randomUUID()}.log`;
     setLoggerOverride({ level: "trace", file: logPath });
 
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     const controller = new AbortController();
     const listenerFactory = vi.fn(async () => {

--- a/extensions/whatsapp/src/logout.test.ts
+++ b/extensions/whatsapp/src/logout.test.ts
@@ -4,12 +4,9 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 
-const runtime = {
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-};
+const runtime = createRuntimeSpies();
 const WEB_LOGOUT_TEST_TIMEOUT_MS = 15_000;
 
 describe("web logout", () => {

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -14,6 +14,7 @@ import {
   type MockInstance,
   vi,
 } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { logWebSelfId } from "./auth-store.js";
 import { enqueueCredsSave } from "./creds-persistence.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
@@ -710,11 +711,7 @@ describe("web session", () => {
       JSON.stringify({ me: { id: "12345@s.whatsapp.net" } }),
       "utf-8",
     );
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     logWebSelfId(authDir, runtime as never, true);
 
@@ -733,11 +730,7 @@ describe("web session", () => {
       }),
       "utf-8",
     );
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
+    const runtime = createRuntimeSpies();
 
     logWebSelfId(authDir, runtime as never, true);
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Discord, Feishu and WhatsApp tests repeatedly construct the same three logging and exit spies, leaving duplicated setup and several wrappers that only rename that construction.

## Why This Change Was Made

Share one fixed, nine-line fixture in the existing test-support directory. Each call still creates a fresh object with separate `log`, `error` and nonthrowing `exit` spies at the original allocation point. Remove five unnecessary private wrappers while preserving annotated test-support boundaries, default-argument timing, and the module-scoped WhatsApp fixture. This removes 88 net test/support lines without changing production code or adding a runtime API.

## User Impact

No user-visible behavior change. The same logging, retry, cleanup, ingress and connection tests retain their independent assertions and state.

## Evidence

All 219 existing cases passed before and after across 18 test files: 27 E2E cases and 192 plugin cases. The normal E2E and plugin invocations were separated to satisfy the reporter's project requirements; no routing, deadlines or assertions changed.

Parser and lexical-binding checks reconstruct the original complete source and AST for all 15 consumer files, including the removed wrappers and preserved type annotations. Two temporary actual-Vitest controls passed for fresh objects/spies, exact sparse keys and descriptors, receiver identity, nonthrowing exit, and independent histories/reset/mutation. Those temporary tests were removed afterward.

Changed checks, typechecks, lint and independent P2 review passed. No runtime improvement is claimed.
