### PR TITLE
fix(update): make verified rollback failure actions opt-in

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -41,8 +41,12 @@ launcher scripts).
 
 Failed update and repair attempts enter [recovery triage](/cli/update#recover-a-failed-update)
 after service recovery and cleanup finish.
-A verified rollback does not start triage: the previous generation is running
-again, and the report keeps the failing check as the reason.
+A verified rollback does not automatically start triage: the previous generation
+is running again, and the report keeps the failing check as the reason.
+An interactive update offers the diagnose/report menu with **Exit** selected by
+default. Declining or cancelling preserves the failed update's nonzero exit
+status. JSON, non-interactive, `--yes`, and managed-service handoff invocations do
+not prompt after rollback.
 
 After a final interactive update failure, **Diagnose update failure** and
 **Report update failure** are separate choices. Reporting first shows the exact

--- a/docs/install/updating/rollback-and-recovery.md
+++ b/docs/install/updating/rollback-and-recovery.md
@@ -156,7 +156,12 @@ or stopped from the latest service observation, even when a running candidate di
 not pass verification. A restored Gateway must pass its own verification checks
 before the run can finish as `rolled-back`.
 Automatic triage never follows a verified rollback; it runs only when the update
-ends failed.
+ends failed. In an interactive terminal, you can choose **Diagnose update failure**,
+**Report update failure**, or **Exit**, which is selected by default. Reporting
+shows the sanitized preview and requires separate confirmation before issue
+creation. Skipping or cancelling does not start diagnosis or submit a report.
+JSON, `--yes`, non-interactive, and managed-service handoff invocations do not
+show this menu after rollback.
 
 If the config file changed after the activation Doctor pass or the databases are
 not schema-neutral, rollback is refused with

--- a/src/cli/update-cli/update-command-report.ts
+++ b/src/cli/update-cli/update-command-report.ts
@@ -41,11 +41,15 @@ export async function runInteractiveUpdateFailureAction(params: {
   env: NodeJS.ProcessEnv;
   error?: string;
   result?: UpdateRunResult;
+  rollbackCompleted?: boolean;
   runtime: Pick<RuntimeEnv, "error" | "log">;
 }): Promise<"triage" | "handled"> {
   while (true) {
     const action = await select<UpdateFailureAction>({
-      message: "Choose the next action for this failed update",
+      message: params.rollbackCompleted
+        ? "Update failed, but rollback completed successfully. Choose the next action"
+        : "Choose the next action for this failed update",
+      ...(params.rollbackCompleted ? { initialValue: "dismiss" as const } : {}),
       options: [
         { value: "triage", label: "Diagnose update failure" },
         { value: "report", label: "Report update failure" },

--- a/src/cli/update-cli/update-command-result.ts
+++ b/src/cli/update-cli/update-command-result.ts
@@ -160,6 +160,15 @@ export function mergeWindowsTaskRecoveryFailure(
   };
 }
 
+/** The restored package and its running service have both passed verification. */
+export function isVerifiedUpdateRollback(result: UpdateRunResult): boolean {
+  return (
+    result.recovery?.serviceRestartSafe === true &&
+    result.recovery.packageRollbackVerified === true &&
+    result.recovery.service === "healthy"
+  );
+}
+
 export function resolveAutomaticUpdateTriage(
   result: UpdateRunResult,
   detail: string | undefined,
@@ -174,12 +183,8 @@ export function resolveAutomaticUpdateTriage(
 ): TriageFailureContext | undefined {
   // Triage follows a failed update, never a verified rollback: the restored
   // generation is serving, and an autonomous repair turn there is unwanted.
-  const verifiedRollback =
-    result.recovery?.serviceRestartSafe === true &&
-    result.recovery.packageRollbackVerified === true &&
-    result.recovery.service === "healthy";
   const eligible =
-    !verifiedRollback &&
+    !isVerifiedUpdateRollback(result) &&
     (params.mutationStarted || result.reason === "restart-unhealthy") &&
     result.reason !== "service-revalidation-failed" &&
     !(

--- a/src/cli/update-cli/update-command-rollback-report.test.ts
+++ b/src/cli/update-cli/update-command-rollback-report.test.ts
@@ -1,0 +1,278 @@
+import { confirm as clackConfirm, isCancel } from "@clack/prompts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withTriageTerminal } from "../../commands/triage.test-support.js";
+import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import {
+  UpdateCommandFailure,
+  UpdateCommandFinalizedRecoveryFailure,
+  UpdateCommandPendingRecoveryFailure,
+} from "./update-command-result.js";
+import { withUpdateFailureTriage } from "./update-command-triage.js";
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn<(options: unknown) => Promise<string | symbol>>(),
+  confirm: vi.fn<() => Promise<boolean | symbol>>(),
+  prepare:
+    vi.fn<typeof import("../../infra/update-failure-report.js").prepareUpdateFailureReport>(),
+  submit: vi.fn<typeof import("../../infra/update-failure-report.js").submitUpdateFailureReport>(),
+  triage: vi.fn(),
+}));
+
+vi.mock("../../commands/configure.shared.js", () => ({
+  select: mocks.select,
+  confirm: mocks.confirm,
+}));
+vi.mock("../../infra/update-failure-report.js", () => ({
+  prepareUpdateFailureReport: mocks.prepare,
+  submitUpdateFailureReport: mocks.submit,
+}));
+vi.mock("../../infra/update-triage.js", () => ({
+  prepareUpdateFailureTriage: async () => mocks.triage,
+}));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const runId = "b89e301f-2df4-4dd8-a7ea-4f4b4e10b6f3";
+
+async function cancelPrompt(): Promise<symbol> {
+  const cancelled = await clackConfirm({
+    message: "Cancelled fixture",
+    signal: AbortSignal.abort(),
+  });
+  if (!isCancel(cancelled)) {
+    throw new Error("Expected Clack cancellation");
+  }
+  return cancelled;
+}
+
+function setup() {
+  const stateDir = tempDirs.make("openclaw-rollback-report-");
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const result: UpdateRunResult = {
+    runId,
+    status: "error",
+    mode: "npm",
+    reason: "restart-unhealthy",
+    before: { version: "2026.9.1" },
+    after: { version: "2026.9.1" },
+    steps: [],
+    durationMs: 1,
+    recovery: {
+      serviceRestartSafe: true,
+      packageRollbackVerified: true,
+      service: "healthy",
+      version: "2026.9.1",
+    },
+  };
+  const prepared = {
+    attemptId: runId,
+    body: "Sanitized failure and rollback details",
+    previewDigest: "a".repeat(64),
+    marker: `openclaw-report:${"b".repeat(64)}`,
+    browserFallback: {
+      status: "available" as const,
+      url: "https://github.com/openclaw/openclaw/issues/new",
+    },
+    savedReportPath: `${stateDir}/report.md`,
+    title: "Update failed: restart-unhealthy",
+    url: "https://github.com/openclaw/openclaw/issues/new",
+  };
+  mocks.prepare.mockResolvedValue(prepared);
+  mocks.submit.mockResolvedValue({
+    savedReportPath: prepared.savedReportPath,
+    status: "created",
+    url: "https://github.com/openclaw/openclaw/issues/123",
+  });
+  const opts = { run: { runId, env } };
+  const target = { env };
+  const fail = async () => {
+    throw new UpdateCommandFailure(result);
+  };
+  const run = () =>
+    withTriageTerminal(true, async () => {
+      await expect(withUpdateFailureTriage(opts, target, fail)).rejects.toMatchObject({ code: 1 });
+    });
+  return { env, fail, opts, prepared, result, run, target };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.select.mockResolvedValue("dismiss");
+  vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+  vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+  vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("verified rollback failure actions", () => {
+  it("offers an optional report, previews it, and submits once only after confirmation", async () => {
+    const f = setup();
+    mocks.select.mockImplementation(async () => {
+      expect(mocks.prepare).not.toHaveBeenCalled();
+      expect(mocks.submit).not.toHaveBeenCalled();
+      return "report";
+    });
+    mocks.confirm.mockImplementation(async () => {
+      expect(defaultRuntime.log).toHaveBeenCalledWith(f.prepared.body);
+      expect(mocks.submit).not.toHaveBeenCalled();
+      return true;
+    });
+
+    await f.run();
+
+    expect(mocks.select).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message: expect.stringContaining("rollback completed"),
+        initialValue: "dismiss",
+        options: [
+          { value: "triage", label: "Diagnose update failure" },
+          { value: "report", label: "Report update failure" },
+          { value: "dismiss", label: "Exit" },
+        ],
+      }),
+    );
+    expect(mocks.prepare).toHaveBeenCalledExactlyOnceWith(
+      { attemptId: runId, result: f.result },
+      { env: f.env, stateDir: f.env.OPENCLAW_STATE_DIR },
+    );
+    expect(mocks.confirm).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ initialValue: false }),
+    );
+    expect(mocks.submit).toHaveBeenCalledExactlyOnceWith(f.prepared, f.prepared.previewDigest, {
+      env: f.env,
+      stateDir: f.env.OPENCLAW_STATE_DIR,
+    });
+    expect(mocks.triage).not.toHaveBeenCalled();
+    expect(f.result.status).toBe("error");
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it.each(["declined", "cancelled"])("does not submit when confirmation is %s", async (answer) => {
+    const f = setup();
+    mocks.select.mockResolvedValue("report");
+    mocks.confirm.mockResolvedValue(answer === "declined" ? false : await cancelPrompt());
+
+    await f.run();
+
+    expect(defaultRuntime.log).toHaveBeenCalledWith(f.prepared.body);
+    expect(defaultRuntime.log).toHaveBeenCalledWith("Update failure report cancelled.");
+    expect(mocks.submit).not.toHaveBeenCalled();
+    expect(mocks.triage).not.toHaveBeenCalled();
+  });
+
+  it.each(["dismiss", "cancel"])("does nothing after the menu returns %s", async (action) => {
+    const f = setup();
+    mocks.select.mockResolvedValue(action === "dismiss" ? action : await cancelPrompt());
+
+    await f.run();
+
+    expect(mocks.select).toHaveBeenCalledOnce();
+    expect(mocks.prepare).not.toHaveBeenCalled();
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(mocks.submit).not.toHaveBeenCalled();
+    expect(mocks.triage).not.toHaveBeenCalled();
+  });
+
+  it("diagnoses the original failure only when selected", async () => {
+    const f = setup();
+    mocks.select.mockResolvedValue("triage");
+
+    await f.run();
+
+    expect(mocks.triage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ failure: { result: f.result }, target: f.target }),
+    );
+    expect(mocks.prepare).not.toHaveBeenCalled();
+    expect(mocks.submit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "JSON", opts: { json: true } },
+    { name: "--yes", opts: { yes: true } },
+    { name: "noninteractive", interactive: false },
+    { name: "dry run", opts: { dryRun: true } },
+    { name: "post-core child", env: { [POST_CORE_UPDATE_ENV]: "1" } },
+    { name: "managed handoff", env: { OPENCLAW_UPDATE_RUN_HANDOFF: "1" } },
+    { name: "signal cancellation", signal: true },
+  ])("keeps $name rollback quiet", async (testCase) => {
+    const f = setup();
+    Object.assign(f.env, testCase.env);
+    if (testCase.signal) {
+      f.result.steps.push({
+        name: "update",
+        command: "synthetic-update",
+        cwd: "/synthetic",
+        durationMs: 1,
+        exitCode: 130,
+        termination: "signal",
+      });
+    }
+    await withTriageTerminal(testCase.interactive ?? true, async () => {
+      await expect(
+        withUpdateFailureTriage({ ...f.opts, ...testCase.opts }, f.target, f.fail),
+      ).rejects.toMatchObject({ code: 1 });
+    });
+
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(mocks.prepare).not.toHaveBeenCalled();
+    expect(mocks.submit).not.toHaveBeenCalled();
+    expect(mocks.triage).not.toHaveBeenCalled();
+  });
+
+  it.each<{ name: string; recovery: UpdateRunResult["recovery"] }>([
+    {
+      name: "unverified service",
+      recovery: { serviceRestartSafe: true, packageRollbackVerified: true, version: "2026.9.1" },
+    },
+    {
+      name: "unsafe restart",
+      recovery: {
+        serviceRestartSafe: false,
+        packageRollbackVerified: true,
+        reason: "runtime-verification-failed",
+      },
+    },
+    {
+      name: "unverified package",
+      recovery: { serviceRestartSafe: true, service: "healthy", version: "2026.9.1" },
+    },
+  ])("keeps ordinary failure actions for $name", async ({ recovery }) => {
+    const f = setup();
+    f.result.recovery = recovery;
+    await f.run();
+    expect(mocks.select).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: "Choose the next action for this failed update" }),
+    );
+    expect(mocks.select.mock.calls[0]?.[0]).not.toHaveProperty("initialValue", "dismiss");
+  });
+
+  it.each([UpdateCommandPendingRecoveryFailure, UpdateCommandFinalizedRecoveryFailure])(
+    "preserves the legacy recovery marker exit without a menu (%s)",
+    async (Failure) => {
+      const f = setup();
+      await withTriageTerminal(true, async () => {
+        await expect(
+          withUpdateFailureTriage(f.opts, f.target, async () => {
+            throw new Failure(f.result);
+          }),
+        ).rejects.toMatchObject({ code: 1 });
+      });
+
+      expect(mocks.select).not.toHaveBeenCalled();
+      expect(mocks.triage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not prompt after a successful update", async () => {
+    const f = setup();
+    await withTriageTerminal(true, async () => {
+      await withUpdateFailureTriage(f.opts, f.target, async () => {});
+    });
+
+    expect(mocks.select).not.toHaveBeenCalled();
+    expect(mocks.triage).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/update-cli/update-command-triage.ts
+++ b/src/cli/update-cli/update-command-triage.ts
@@ -18,6 +18,7 @@ import { resolveNodeRunner, resolveUpdateRoot, type UpdateCommandOptions } from 
 import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { runInteractiveUpdateFailureAction } from "./update-command-report.js";
 import {
+  isVerifiedUpdateRollback,
   UpdateCommandFailure,
   UpdateCommandFinalizedRecoveryFailure,
   UpdateCommandPendingRecoveryFailure,
@@ -64,6 +65,17 @@ export async function withUpdateFailureTriage(
       return exitCliAfterOutput(defaultRuntime, error.exitCode);
     }
     const reportedFailure = error instanceof UpdateCommandFailure;
+    const rollbackCompleted = reportedFailure && isVerifiedUpdateRollback(error.result);
+    // A healthy restored installation needs only an explicit terminal choice,
+    // never automatic diagnostics or a second managed-helper report.
+    if (
+      rollbackCompleted &&
+      (mode !== "interactive" ||
+        target.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1" ||
+        error.result.steps.some((step) => step.termination === "signal"))
+    ) {
+      return exitCliAfterOutput(defaultRuntime, error.exitCode);
+    }
     // Post-core children return phase data; only their outer updater owns the final failure.
     if (
       (!reportedFailure || classifyUpdateOutcome(error.result) === "failed") &&
@@ -114,6 +126,7 @@ export async function withUpdateFailureTriage(
               env: opts.run?.env ?? target.env,
               ...(failure.error ? { error: failure.error } : {}),
               ...(failure.result ? { result: failure.result } : {}),
+              ...(rollbackCompleted ? { rollbackCompleted: true } : {}),
               runtime: defaultRuntime,
             });
           } catch (reportError) {


### PR DESCRIPTION
Related: #140339

<details>
<summary>Additional instructions</summary>

Maintainers can update this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users whose failed update safely rolled back received the generic failure menu without a clear rollback outcome or a default Exit choice. Quiet invocations could also enter diagnostic collection after the previous Gateway was already healthy.

## Why This Change Was Made

Offer the existing Diagnose / Report / Exit choices after a verified rollback, explain that the update failed but rollback succeeded, and default to Exit. Reuse the existing rollback-verification predicate, sanitized report preview, explicit submission confirmation, and report deduplication. Automatic triage, recovery ownership, and rollback mechanics are unchanged.

This is a separate prompt-only follow-up to merged #140339, based on actual main. It does not restore checkpoint or migration-crossing rollback behavior. The former checkpoint marker remains on its existing no-prompt path.

## User Impact

Interactive users can investigate or report the original failed update without mistaking successful rollback for a successful update. Declining, cancelling, diagnosing, or reporting preserves the failure exit code. JSON, --yes, noninteractive, dry-run, post-core, managed-handoff, and signal-cancelled rollback paths do not prompt or start diagnosis. Incomplete or unsafe rollback retains ordinary failure handling.

## Evidence

- Before the fix on main `5b6a23012177b2ea2d5658d873d8e078b4df269c`: five expected failures and 14 passing controls. Failures covered the rollback-specific menu/default, quiet diagnostic collection, and signal cancellation.
- After the fix: 235 tests passed across nine focused files, including 19 rollback boundary cases, existing reporting consent/deduplication/transport tests, and finalization/recovery regressions. Submission and agent launch are mocked or inert; no real issue was created as a test.
- Required changed checks passed against the pinned main base, including core/test typechecks, formatting, type-aware lint, unused-export scans, and repository guards.
- Fresh independent review found no actionable P0–P2 findings. Both changed docs passed the MDX check.
- The selected finalization tests prepared their declared runtime through the repository runner. No live installed rollback or VM matrix was run.
- The original pre-merge patch's 148-test result is historical, not evidence for this head.
- Exact-head [CI run 34434759611, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34434759611/attempts/2) completed successfully on `09bc1abb14b6864d687662c17d198e7e0a108ea1`; the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34434759611/job/102743715970) passed. Attempt 1 hit an unrelated concurrent-request ordering assertion in `clawhub-plugin-catalog.test.ts`. One job-scoped retry passed without code changes; the other completed checks were retained.
- [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/143657#issuecomment-5612681595) found no actionable or security findings and marked the PR ready for maintainer review. No unresolved review threads remain.

Production changes are 28 additions and six deletions across three files. The 278-line boundary test file covers the prompt, preview-before-confirmation, decline/cancel, failure exit status, quiet modes, and incomplete verification. Two existing docs receive short behavior updates. No service, reporting protocol, storage, or scheduler changes.

