### PR TITLE
fix: keep model probe state until cleanup finishes

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -113,7 +113,7 @@ Options:
 
 Probe rows can come from auth profiles, env credentials, or `models.json`. Probe status buckets: `ok`, `auth`, `rate_limit`, `billing`, `timeout`, `format`, `unknown`, `no_model`.
 
-Direct `models status --probe` runs create temporary internal sessions in the selected agent's canonical database, so the command requires exclusive ownership of the configured state directory. Stop a running Gateway with `openclaw gateway stop` before probing; the command removes its internal sessions and releases the state lock when it finishes or is interrupted.
+Direct `models status --probe` runs create temporary internal sessions in the selected agent's canonical database, so the command requires exclusive ownership of the configured state directory. Stop a running Gateway with `openclaw gateway stop` before probing. Probe results can be reported before slow cleanup finishes. Temporary auth directories, internal sessions, and the state lock remain held until accepted work and cleanup settle, including after interruption. Cleanup failures are reported; a timeout does not certify that resources have closed.
 
 Probe detail/reason codes to expect when a probe never reaches a model call:
 

--- a/src/commands/models/list.probe.cleanup.test.ts
+++ b/src/commands/models/list.probe.cleanup.test.ts
@@ -1,0 +1,257 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createAgentCleanupScope } from "../../agents/run-cleanup-timeout.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { validateConfigObject } from "../../config/validation.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import * as agentDatabase from "../../state/openclaw-agent-db.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { runAuthProbes, withAuthProbeStateOwnership } from "./list.probe.js";
+
+const runner = vi.hoisted(() =>
+  vi.fn<
+    (params: {
+      agentDir: string;
+      abortSignal?: AbortSignal;
+    }) => Promise<{ payloads: Array<{ text: string }> }>
+  >(),
+);
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent: runner }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  runner.mockReset();
+});
+
+function createProbeConfig(workspaceDir: string): OpenClawConfig {
+  return {
+    agents: {
+      entries: { main: { workspace: workspaceDir } },
+      defaults: { workspace: workspaceDir },
+    },
+    models: {
+      providers: {
+        "probe-control": {
+          api: "openai-completions",
+          apiKey: "synthetic-config-credential",
+          baseUrl: "https://fixture.invalid/v1",
+          models: [
+            {
+              id: "probe-model",
+              name: "Probe model",
+              contextWindow: 8192,
+              maxTokens: 64,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+it("holds state ownership for an in-flight sibling after progress rejects the probe batch", async () => {
+  const state = await createOpenClawTestState({
+    label: "probe-sibling-cleanup",
+    env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+  });
+  const cfg = createProbeConfig(state.workspaceDir);
+  expect(validateConfigObject(cfg)).toMatchObject({ ok: true });
+  await state.writeConfig(cfg);
+  await state.writeAuthProfiles({
+    version: 1,
+    profiles: {
+      "probe-control:stored": {
+        type: "api_key",
+        provider: "probe-control",
+        key: "synthetic-stored-credential",
+      },
+    },
+  });
+  const signals = new EventEmitter();
+  const lockDir = state.path("locks");
+  const lockPath = path.join(lockDir, "gateway.state.lock");
+  const firstStarted = createDeferredCore();
+  const finishFirst = createDeferredCore();
+  const firstFinished = createDeferredCore();
+  let firstSignal: AbortSignal | undefined;
+  let firstRan = false;
+  runner.mockImplementation(async (params) => {
+    firstRan = true;
+    firstSignal = params.abortSignal;
+    firstStarted.resolve();
+    await finishFirst.promise;
+    firstFinished.resolve();
+    return { payloads: [{ text: "OK" }] };
+  });
+  const parent = new AsyncWorkScope();
+  const original = new Error("synthetic progress failure");
+  let starts = 0;
+  let operation: Promise<unknown> | undefined;
+  try {
+    operation = parent.track(() =>
+      runAuthProbes({
+        cfg,
+        agentId: "main",
+        agentDir: state.agentDir(),
+        workspaceDir: state.workspaceDir,
+        providers: ["probe-control"],
+        modelCandidates: ["probe-control/probe-model"],
+        options: {
+          provider: "probe-control",
+          includeDirectKeys: true,
+          timeoutMs: 10_000,
+          concurrency: 2,
+          maxTokens: 8,
+        },
+        stateOwnership: {
+          mode: "exclusive",
+          process: signals,
+          gatewayLockOptions: {
+            allowInTests: true,
+            env: state.env,
+            lockDir,
+            readProcessStartTime: () => 123456,
+            timeoutMs: 100,
+          },
+        },
+        onProgress(update) {
+          expect(update.total).toBe(2);
+          if (update.label && ++starts === 2) {
+            throw original;
+          }
+        },
+      }),
+    );
+    await expect(operation).rejects.toBe(original);
+    await firstStarted.promise;
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(signals.listenerCount("SIGTERM")).toBe(1);
+    signals.emit("SIGTERM");
+    expect(firstSignal?.aborted).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    finishFirst.resolve();
+    await firstFinished.promise;
+    await parent.drain();
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  } finally {
+    finishFirst.resolve();
+    await operation?.catch(() => {});
+    if (firstRan) {
+      await firstFinished.promise;
+    }
+    await parent.drain();
+    await state.cleanup();
+  }
+});
+
+it("removes the staged directory and releases state ownership when database disposal reports failure", async () => {
+  const state = await createOpenClawTestState({
+    label: "probe-disposal-failure",
+    env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+  });
+  const cfg = createProbeConfig(state.workspaceDir);
+  expect(validateConfigObject(cfg)).toMatchObject({ ok: true });
+  await state.writeConfig(cfg);
+  const signals = new EventEmitter();
+  const lockDir = state.path("locks");
+  const original = new Error("synthetic database disposal failure");
+  let stagedDir: string | undefined;
+  runner.mockImplementation(async (params) => {
+    stagedDir = params.agentDir;
+    return { payloads: [{ text: "OK" }] };
+  });
+  const dispose = agentDatabase.disposeOpenClawAgentDatabaseByPath;
+  const close = vi
+    .spyOn(agentDatabase, "disposeOpenClawAgentDatabaseByPath")
+    .mockImplementation((pathname, options) => {
+      const closed = dispose(pathname, options);
+      if (stagedDir && pathname.startsWith(stagedDir + path.sep)) {
+        throw original;
+      }
+      return closed;
+    });
+  const cleanup = createAgentCleanupScope();
+  try {
+    await expect(
+      cleanup.run(() =>
+        runAuthProbes({
+          cfg,
+          agentId: "main",
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          providers: ["probe-control"],
+          modelCandidates: ["probe-control/probe-model"],
+          options: {
+            provider: "probe-control",
+            includeDirectKeys: true,
+            timeoutMs: 10_000,
+            concurrency: 1,
+            maxTokens: 8,
+          },
+          stateOwnership: {
+            mode: "exclusive",
+            process: signals,
+            gatewayLockOptions: {
+              allowInTests: true,
+              env: state.env,
+              lockDir,
+              readProcessStartTime: () => 123456,
+              timeoutMs: 100,
+            },
+          },
+        }),
+      ),
+    ).rejects.toBe(original);
+    expect(stagedDir).toContain("openclaw-auth-probe-");
+    expect(fs.existsSync(stagedDir!)).toBe(false);
+    expect(fs.existsSync(path.join(lockDir, "gateway.state.lock"))).toBe(false);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+    expect(cleanup.outcome).toBe("uncertain");
+  } finally {
+    close.mockRestore();
+    await state.cleanup();
+  }
+});
+
+it("does not acquire probe state from a closed caller scope", async () => {
+  const state = await createOpenClawTestState({ label: "probe-closed-caller" });
+  const parent = new AsyncWorkScope();
+  const inParent = parent.run(() => AsyncLocalStorage.snapshot());
+  await parent.drain();
+  const signals = new EventEmitter();
+  const lockDir = state.path("locks");
+  const run = vi.fn(async () => undefined);
+  try {
+    await expect(
+      inParent(() =>
+        withAuthProbeStateOwnership(
+          {
+            mode: "exclusive",
+            process: signals,
+            gatewayLockOptions: {
+              allowInTests: true,
+              env: state.env,
+              lockDir,
+              readProcessStartTime: () => 123456,
+              timeoutMs: 100,
+            },
+          },
+          run,
+        ),
+      ),
+    ).rejects.toThrow("Async work scope is closed");
+    expect(run).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(lockDir, "gateway.state.lock"))).toBe(false);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  } finally {
+    await state.cleanup();
+  }
+});

--- a/src/commands/models/list.probe.cleanup.ts
+++ b/src/commands/models/list.probe.cleanup.ts
@@ -1,0 +1,74 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { recordAgentCleanupFailure } from "../../agents/run-cleanup-timeout.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { redactStatusSecrets } from "../status-all/format.js";
+
+const log = createSubsystemLogger("models/probe");
+
+/** Probe-owned files and locks follow actual work without extending run admission. */
+export async function createAuthProbeWork(signal?: AbortSignal) {
+  const parent = captureAsyncWorkTracker();
+  const parentSignal = getAsyncWorkSignal();
+  const ready = createDeferredCore();
+  const completion = createDeferredCore();
+  // Register before target setup: a sibling failure can end pMap while this probe still runs.
+  void parent(() => {
+    ready.resolve();
+    return completion.promise;
+  }).catch(ready.reject);
+  await ready.promise;
+  const work = new AsyncWorkScope();
+  const context = work.run(() => AsyncLocalStorage.snapshot());
+  const abortListeners = new Map<AbortSignal, () => void>();
+  for (const source of [signal, parentSignal]) {
+    if (!source || abortListeners.has(source)) {
+      continue;
+    }
+    const abort = () => context(() => work.beginClose(source.reason));
+    abortListeners.set(source, abort);
+    source.addEventListener("abort", abort, { once: true });
+    if (source.aborted) {
+      abort();
+    }
+  }
+  return {
+    run<T>(operation: () => T | Promise<T>): Promise<T> {
+      return work.track(operation);
+    },
+    async settle(cleanup: () => Promise<void>): Promise<void> {
+      const finish = async () => {
+        try {
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [work],
+            () => context(() => work.drain()),
+          );
+          await cleanup();
+        } catch (error) {
+          recordAgentCleanupFailure();
+          completion.reject(error);
+          throw error;
+        } finally {
+          for (const [source, abort] of abortListeners) {
+            source.removeEventListener("abort", abort);
+          }
+          completion.resolve();
+        }
+      };
+      if (!work.hasPendingWork) {
+        await finish();
+        return;
+      }
+      // The reported probe can return while its caller still owns this physical cleanup.
+      void finish().catch((error: unknown) => {
+        log.warn(`Auth probe cleanup failed: ${redactStatusSecrets(formatErrorMessage(error))}`);
+      });
+    },
+  };
+}

--- a/src/commands/models/list.probe.resources.test.ts
+++ b/src/commands/models/list.probe.resources.test.ts
@@ -1,0 +1,376 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { resolveAdmittedRunActiveAssertion } from "../../agents/admitted-run-context.js";
+import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persisted.js";
+import { resolveAuthProfileDatabasePath } from "../../agents/auth-profiles/sqlite.js";
+import { makeAttemptResult } from "../../agents/embedded-agent-runner/run.overflow-compaction.fixture.js";
+import type { EmbeddedRunAttemptParams } from "../../agents/embedded-agent-runner/run/types.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared-model-runtime.test-support.js";
+import { createAgentCleanupScope } from "../../agents/run-cleanup-timeout.js";
+import { loadExactSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { validateConfigObject } from "../../config/validation.js";
+import { setLoggerOverride } from "../../logging/logger.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { PluginRegistryInspectionResources } from "../../plugins/registry-inspection-resources.js";
+import { createPluginRegistry } from "../../plugins/registry.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createPluginRuntime } from "../../plugins/runtime/index.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import * as agentDatabase from "../../state/openclaw-agent-db.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { runAuthProbes, withAuthProbeStateOwnership } from "./list.probe.js";
+
+const attempt = vi.hoisted(() => vi.fn<(params: EmbeddedRunAttemptParams) => unknown>());
+vi.mock("../../agents/embedded-agent-runner/run/attempt.js", () => ({
+  runEmbeddedAttempt: attempt,
+}));
+
+it.each([
+  "late-success",
+  "exclusive",
+  "sigterm",
+  "late-failure",
+  "db-close-failure",
+  "discovery",
+] as const)("keeps probe-owned state through bounded engine cleanup (%s)", async (mode) => {
+  const state = await createOpenClawTestState({
+    label: "probe-cleanup-resources",
+    env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "25" },
+  });
+  const pluginId = "probe-resource-fixture";
+  const provider = "probe-resource-provider";
+  const pluginRoot = state.path("plugin");
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.mkdirSync(state.agentDir(), { recursive: true });
+  const entry = path.join(pluginRoot, "index.cjs");
+  fs.writeFileSync(
+    path.join(pluginRoot, "package.json"),
+    JSON.stringify({
+      name: pluginId,
+      version: "1.0.0",
+      openclaw: { extensions: ["./index.cjs"] },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    JSON.stringify({ id: pluginId, providers: [provider], configSchema: { type: "object" } }),
+  );
+  fs.writeFileSync(
+    entry,
+    `module.exports = { id: '${pluginId}', register(api) { api.registerProvider({ id: '${provider}', label: 'Probe resource fixture', auth: [] }); } };`,
+  );
+  const cfg: OpenClawConfig = {
+    agents: {
+      entries: { main: { workspace: state.workspaceDir } },
+      defaults: { workspace: state.workspaceDir, model: { primary: `${provider}/probe-model` } },
+    },
+    models: {
+      providers: {
+        [provider]: {
+          api: "openai-completions",
+          apiKey: "synthetic-probe-credential",
+          baseUrl: "https://fixture.invalid/v1",
+          models: [
+            {
+              id: "probe-model",
+              name: "Probe model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 8192,
+              maxTokens: 64,
+            },
+          ],
+        },
+      },
+    },
+    plugins: {
+      allow: [pluginId],
+      load: { paths: [pluginRoot] },
+      slots: { memory: "none", contextEngine: pluginId },
+      entries: { [pluginId]: { enabled: true } },
+    },
+  };
+  expect(validateConfigObject(cfg)).toMatchObject({ ok: true });
+  await state.writeConfig(cfg);
+  const source = new PluginRegistryInspectionResources();
+  const builder = createPluginRegistry({
+    runtime: createPluginRuntime(),
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    activateGlobalSideEffects: false,
+  });
+  source.attach(builder.registry);
+  const record = createPluginRecord({ id: pluginId, source: entry });
+  builder.registry.plugins.push(record);
+  const api = builder.createApi(record, {
+    config: cfg,
+    registrationMode: mode === "discovery" ? "discovery" : "full",
+  });
+  const disposalStarted = createDeferredCore();
+  const finishDisposal = createDeferredCore();
+  const childStarted = createDeferredCore();
+  const finishChild = createDeferredCore();
+  const childFinished = createDeferredCore();
+  const signals = new EventEmitter();
+  const lockDir = state.path("locks");
+  const lockPath = path.join(lockDir, "gateway.state.lock");
+  const exclusive = mode !== "late-success";
+  let factoryCalls = 0;
+  let probeTarget: EmbeddedRunAttemptParams["sessionTarget"];
+  let attemptAgentDir: string | undefined;
+  const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+  let cleanupSignal: AbortSignal | undefined;
+  let stagedAgentDir: string | undefined;
+  let profileId: string | undefined;
+  let assertAdmitted: (() => void) | undefined;
+  const reads: boolean[] = [];
+  const readProbeState = () => {
+    if (!stagedAgentDir || !profileId) {
+      throw new Error("Probe factory did not capture its owned state");
+    }
+    reads.push(fs.readFileSync(path.join(stagedAgentDir, "probe-marker"), "utf8") === "owned");
+    reads.push(Boolean(loadPersistedAuthProfileStore(stagedAgentDir)?.profiles[profileId]));
+  };
+  source.runRegistration(pluginId, () => {
+    api.registerContextEngine(pluginId, (ctx) => {
+      factoryCalls++;
+      stagedAgentDir = ctx.agentDir;
+      if (!stagedAgentDir) {
+        throw new Error("Probe factory needs its staged agent directory");
+      }
+      profileId = Object.keys(loadPersistedAuthProfileStore(stagedAgentDir)?.profiles ?? {}).find(
+        (id) => id.includes(":probe-"),
+      );
+      fs.writeFileSync(path.join(stagedAgentDir, "probe-marker"), "owned");
+      return {
+        info: { id: pluginId, name: "Probe cleanup fixture" },
+        ingest: async () => ({ ingested: false }),
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+        compact: async () => ({ ok: true, compacted: false }),
+        async dispose() {
+          cleanupSignal = getAsyncWorkSignal();
+          disposalStarted.resolve();
+          await finishDisposal.promise;
+          readProbeState();
+          if (mode === "late-failure") {
+            throw new Error("synthetic engine disposal failure");
+          }
+          void trackAsyncWork(async () => {
+            childStarted.resolve();
+            await finishChild.promise;
+            try {
+              readProbeState();
+            } finally {
+              childFinished.resolve();
+            }
+          }).catch(() => {});
+        },
+      };
+    });
+  });
+  setActivePluginRegistry(builder.registry);
+  attempt.mockImplementation((params) => {
+    expect(params.disableTools).toBe(true);
+    expect(params.modelRun).toBe(true);
+    attemptAgentDir = params.agentDir;
+    probeTarget = params.sessionTarget;
+    if (mode !== "discovery") {
+      expect(params.agentDir).toBe(stagedAgentDir);
+    }
+    assertAdmitted = resolveAdmittedRunActiveAssertion(params.admittedRunContext);
+    assertAdmitted?.();
+    return makeAttemptResult({ sessionIdUsed: params.sessionId, assistantTexts: ["OK"] });
+  });
+  if (mode === "db-close-failure") {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "compact" });
+    const dispose = agentDatabase.disposeOpenClawAgentDatabaseByPath;
+    vi.spyOn(agentDatabase, "disposeOpenClawAgentDatabaseByPath").mockImplementation(
+      (pathname, options) => {
+        const closed = dispose(pathname, options);
+        if (stagedAgentDir && pathname.startsWith(stagedAgentDir + path.sep)) {
+          throw new Error("synthetic late database disposal failure");
+        }
+        return closed;
+      },
+    );
+  }
+  const readProbeSession = () => {
+    if (!probeTarget?.sessionKey || !probeTarget.storePath) {
+      throw new Error("Probe did not provide its hidden session target");
+    }
+    return loadExactSessionEntry({
+      storePath: probeTarget.storePath,
+      sessionKey: probeTarget.sessionKey,
+      agentId: probeTarget.agentId,
+    });
+  };
+  const parent = new AsyncWorkScope();
+  const cleanup = createAgentCleanupScope();
+  let operation: ReturnType<typeof runAuthProbes> | undefined;
+  let drain: Promise<void> | undefined;
+  try {
+    operation = parent.track(() =>
+      cleanup.run(() =>
+        runAuthProbes({
+          cfg,
+          agentId: "main",
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          providers: [provider],
+          modelCandidates: [`${provider}/probe-model`],
+          ...(exclusive
+            ? {
+                stateOwnership: {
+                  mode: "exclusive" as const,
+                  process: signals,
+                  gatewayLockOptions: {
+                    allowInTests: true,
+                    env: state.env,
+                    lockDir,
+                    readProcessStartTime: () => 123456,
+                    timeoutMs: 100,
+                  },
+                },
+              }
+            : {}),
+          options: {
+            provider,
+            includeDirectKeys: true,
+            timeoutMs: 10_000,
+            concurrency: 1,
+            maxTokens: 8,
+          },
+        }),
+      ),
+    );
+    if (mode === "discovery") {
+      expect((await operation).results).toMatchObject([{ status: "ok" }]);
+      await parent.drain();
+      expect(factoryCalls).toBe(0);
+      expect(attempt).toHaveBeenCalledOnce();
+      expect(attemptAgentDir).toContain("openclaw-auth-probe-");
+      expect(fs.existsSync(attemptAgentDir!)).toBe(false);
+      expect(fs.existsSync(lockPath)).toBe(false);
+      expect(signals.listenerCount("SIGTERM")).toBe(0);
+      return;
+    }
+    await Promise.race([
+      disposalStarted.promise,
+      operation.then((result) => {
+        throw new Error(
+          `Probe returned without engine disposal: ${JSON.stringify(result.results.map((probe) => ({ status: probe.status, error: probe.error })))}`,
+        );
+      }),
+    ]);
+    const reported = await operation;
+    expect(reported.results).toMatchObject([{ status: "ok" }]);
+    expect(attempt).toHaveBeenCalledOnce();
+    expect(stagedAgentDir).toContain("openclaw-auth-probe-");
+    expect(stagedAgentDir).not.toBe(state.agentDir());
+    expect(assertAdmitted).toBeTypeOf("function");
+    expect(() => assertAdmitted?.()).toThrow();
+    expect(fs.existsSync(stagedAgentDir!)).toBe(true);
+    expect(readProbeSession()?.entry).toBeDefined();
+    expect(
+      agentDatabase.isOpenClawAgentDatabaseOpen(resolveAuthProfileDatabasePath(stagedAgentDir!)),
+    ).toBe(true);
+    if (exclusive) {
+      expect(fs.existsSync(lockPath)).toBe(true);
+      expect(signals.listenerCount("SIGTERM")).toBe(1);
+    }
+    expect(cleanupSignal?.aborted).toBe(false);
+    if (mode === "sigterm") {
+      signals.emit("SIGTERM");
+      expect(cleanupSignal?.aborted).toBe(true);
+      expect(fs.existsSync(lockPath)).toBe(true);
+    }
+    finishDisposal.resolve();
+    if (mode !== "late-failure") {
+      await childStarted.promise;
+      expect(fs.existsSync(stagedAgentDir!)).toBe(true);
+      finishChild.resolve();
+      await childFinished.promise;
+    }
+    drain = parent.drain();
+    await drain;
+    expect(reads).toEqual(mode === "late-failure" ? [true, true] : [true, true, true, true]);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+    expect(fs.existsSync(stagedAgentDir!)).toBe(false);
+    expect(readProbeSession()?.entry).toBeUndefined();
+    if (mode === "db-close-failure") {
+      expect(warnings).toHaveBeenCalledWith(
+        expect.stringContaining("synthetic late database disposal failure"),
+      );
+    }
+    expect(
+      agentDatabase.isOpenClawAgentDatabaseOpen(resolveAuthProfileDatabasePath(stagedAgentDir!)),
+    ).toBe(false);
+    expect(fs.existsSync(state.agentDir())).toBe(true);
+    expect(cleanup.outcome).toBe("uncertain");
+  } finally {
+    finishDisposal.resolve();
+    finishChild.resolve();
+    await operation;
+    await drain;
+    await parent.drain();
+    await source.release();
+    await resetPreparedModelRuntimeSnapshotsForTest();
+    clearPluginMetadataLifecycleCaches();
+    resetPluginRuntimeStateForTest();
+    attempt.mockReset();
+    vi.restoreAllMocks();
+    setLoggerOverride(null);
+    await state.cleanup();
+  }
+});
+
+it.each([false, true])(
+  "releases direct state ownership before propagating no-tail failure (async: %s)",
+  async (asynchronous) => {
+    const state = await createOpenClawTestState({ label: "probe-no-tail-failure" });
+    const signals = new EventEmitter();
+    const lockDir = state.path("locks");
+    const original = new Error("synthetic direct probe failure");
+    const run = asynchronous
+      ? async () => {
+          await Promise.resolve();
+          throw original;
+        }
+      : () => {
+          throw original;
+        };
+    try {
+      await expect(
+        withAuthProbeStateOwnership(
+          {
+            mode: "exclusive",
+            process: signals,
+            gatewayLockOptions: {
+              allowInTests: true,
+              env: state.env,
+              lockDir,
+              readProcessStartTime: () => 123456,
+              timeoutMs: 100,
+            },
+          },
+          run,
+        ),
+      ).rejects.toBe(original);
+      expect(fs.existsSync(path.join(lockDir, "gateway.state.lock"))).toBe(false);
+      expect(signals.listenerCount("SIGINT")).toBe(0);
+      expect(signals.listenerCount("SIGTERM")).toBe(0);
+    } finally {
+      await state.cleanup();
+    }
+  },
+);

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -71,6 +71,7 @@ import { type SecretRefResolveCache, resolveSecretRefString } from "../../secret
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
 import { redactStatusSecrets } from "../status-all/format.js";
+import { createAuthProbeWork } from "./list.probe.cleanup.js";
 import { buildProbeCandidateMap, selectProbeModel } from "./list.probe.models.js";
 import { formatMs } from "./shared.js";
 
@@ -817,6 +818,7 @@ async function probeTarget(params: {
   let sessionTarget: Awaited<ReturnType<typeof prepareInternalSessionEffectsSession>> | undefined;
   let preparedRunAdmission: ReturnType<typeof prepareSystemAgentRunAdmission> | undefined;
 
+  const work = await createAuthProbeWork(params.abortSignal);
   const start = Date.now();
   const buildResult = (status: AuthProbeResult["status"], error?: string): AuthProbeResult => ({
     provider: target.provider,
@@ -877,44 +879,47 @@ async function probeTarget(params: {
       }
     }
     const { runEmbeddedAgent } = await loadEmbeddedRunnerModule();
+    const probeSessionTarget = sessionTarget;
     preparedRunAdmission = prepareSystemAgentRunAdmission(
       probeConfig,
       runId,
       agentId,
       "models.auth-probe",
     );
-    const runResult = (await runEmbeddedAgent({
-      preparedRunAdmission,
-      sessionId: sessionTarget.sessionId,
-      sessionKey: sessionTarget.sessionKey,
-      sessionTarget,
-      agentId,
-      workspaceDir,
-      agentDir: isolatedAgentDir ?? agentDir,
-      config: probeConfig,
-      prompt: PROBE_PROMPT,
-      provider: target.model.provider,
-      model: target.model.model,
-      modelFallbacksOverride: [],
-      authProfileId: isolatedProfileId ?? target.profileId,
-      authProfileIdSource: isolatedProfileId || target.profileId ? "user" : undefined,
-      timeoutMs,
-      runId,
-      lane: `auth-probe:${target.provider}:${target.profileId ?? target.source}`,
-      thinkLevel: "off",
-      reasoningLevel: "off",
-      verboseLevel: "off",
-      streamParams: { maxTokens },
-      agentHarnessRuntimeOverride: "openclaw",
-      disableTools: true,
-      modelRun: true,
-      cleanupBundleMcpOnRunEnd: true,
-      // Keep the isolated generation outside configured Gateway ownership: a
-      // run-provenance lease rebinds the pinned agentDir to the committed
-      // configured owner, losing the synthetic probe profile below.
-      ...(isolatedAgentDir ? { preparedModelRuntimeMode: "isolated-read-only" as const } : {}),
-      abortSignal: params.abortSignal,
-    })) as AgentRunResultView;
+    const runResult = (await work.run(() =>
+      runEmbeddedAgent({
+        preparedRunAdmission,
+        sessionId: probeSessionTarget.sessionId,
+        sessionKey: probeSessionTarget.sessionKey,
+        sessionTarget: probeSessionTarget,
+        agentId,
+        workspaceDir,
+        agentDir: isolatedAgentDir ?? agentDir,
+        config: probeConfig,
+        prompt: PROBE_PROMPT,
+        provider: model.provider,
+        model: model.model,
+        modelFallbacksOverride: [],
+        authProfileId: isolatedProfileId ?? target.profileId,
+        authProfileIdSource: isolatedProfileId || target.profileId ? "user" : undefined,
+        timeoutMs,
+        runId,
+        lane: `auth-probe:${target.provider}:${target.profileId ?? target.source}`,
+        thinkLevel: "off",
+        reasoningLevel: "off",
+        verboseLevel: "off",
+        streamParams: { maxTokens },
+        agentHarnessRuntimeOverride: "openclaw",
+        disableTools: true,
+        modelRun: true,
+        cleanupBundleMcpOnRunEnd: true,
+        // Keep the isolated generation outside configured Gateway ownership: a
+        // run-provenance lease rebinds the pinned agentDir to the committed
+        // configured owner, losing the synthetic probe profile below.
+        ...(isolatedAgentDir ? { preparedModelRuntimeMode: "isolated-read-only" as const } : {}),
+        abortSignal: params.abortSignal,
+      }),
+    )) as AgentRunResultView;
     const terminalError = extractAgentRunTerminalError(runResult);
     if (terminalError) {
       const described = describeFailoverError(new Error(terminalError));
@@ -935,12 +940,39 @@ async function probeTarget(params: {
     );
   } finally {
     preparedRunAdmission?.close();
-    await removeInternalSessionEffectsSession(sessionTarget);
-    if (isolatedAgentDir) {
-      clearRuntimeAuthProfileStoreSnapshot(isolatedAgentDir);
-      disposeOpenClawAgentDatabaseByPath(resolveAuthProfileDatabasePath(isolatedAgentDir));
-      await fs.rm(isolatedAgentDir, { recursive: true, force: true });
-    }
+    await work.settle(async () => {
+      const cleanups: Array<() => void | Promise<void>> = [
+        () => removeInternalSessionEffectsSession(sessionTarget),
+      ];
+      if (isolatedAgentDir) {
+        const ownedDir = isolatedAgentDir;
+        cleanups.push(
+          () => {
+            clearRuntimeAuthProfileStoreSnapshot(ownedDir);
+          },
+          () => {
+            disposeOpenClawAgentDatabaseByPath(resolveAuthProfileDatabasePath(ownedDir));
+          },
+          () => fs.rm(ownedDir, { recursive: true, force: true }),
+        );
+      }
+      const errors: unknown[] = [];
+      for (const cleanup of cleanups) {
+        try {
+          await cleanup();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "Auth probe resources could not all be released", {
+          cause: errors[0],
+        });
+      }
+    });
   }
 }
 
@@ -1023,16 +1055,28 @@ export async function withAuthProbeStateOwnership<T>(
     await import("../../infra/embedded-state-lock.js");
   const signalBridge = createEmbeddedStateSignalBridge(ownership.process ?? process);
   let stateLock: EmbeddedStateLockHandle | null | undefined;
+  let work: Awaited<ReturnType<typeof createAuthProbeWork>> | undefined;
   try {
+    work = await createAuthProbeWork(signalBridge.signal);
     stateLock = await acquireEmbeddedStateLock({
       options: ownership.gatewayLockOptions,
       signal: signalBridge.signal,
       formatActiveGatewayRefusal: formatActiveGatewayModelsProbeRefusal,
     });
-    return await run(signalBridge.signal);
+    return await work.run(() => run(signalBridge.signal));
   } finally {
-    await stateLock?.release();
-    signalBridge.dispose();
+    const release = async () => {
+      try {
+        await stateLock?.release();
+      } finally {
+        signalBridge.dispose();
+      }
+    };
+    if (work) {
+      await work.settle(release);
+    } else {
+      await release();
+    }
   }
 }
 

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -18,6 +18,10 @@ export class AsyncWorkScope {
     return this.controller.signal;
   }
 
+  get hasPendingWork(): boolean {
+    return this.pending.size > 0;
+  }
+
   get isClosing(): boolean {
     return this.phase !== "open";
   }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where model probes could lose temporary authentication state or release exclusive state ownership while accepted engine cleanup was still running after the reported result.

## Why This Change Was Made

Probe targets now retain their files, database, internal session, and state ownership through actual work and cleanup. Each target registers with its parent before setup, so an early concurrent-batch failure cannot release state underneath a live sibling. Independent cleanup steps continue after a failure, and the signal bridge is released even if lock release fails.

## User Impact

Probe results and admission closure remain prompt. Slow cleanup keeps the resources it still needs, including after interruption. Calls without pending work retain their existing cleanup and error timing. Late cleanup failures are recorded and reported; isolated read-only authentication behavior is unchanged.

## Evidence

The original source fails a native public-runner regression when the staged directory disappears under a blocked engine disposer. The repair passed 78 focused/sibling tests, an 11-case final fixture replay, required changed checks, documentation validation, and independent Codex review. Coverage includes exclusive locking, signal handling, hidden-session lifetime, concurrent sibling failure, discovery-only exclusion, and independent cleanup after database-disposal errors.

The normal build passed in 245.75 seconds on the rebased head; all six files remain identical to the reviewed source. A compiled proof then used a synthetic plugin loaded by the normal full composition-root loader, the public probe and embedded runner, and three real loopback SSE requests. It verified staged auth-store and directory access during late work, exclusive lock lifetime, and actual OS SIGTERM delivery to the isolated child's process bridge. Each engine instance disposed once; the full root retained its existing raw lifetime.

The strict process tree joined in 6.436 seconds, with all 11,402 captured runtime artifacts unchanged and no application-source fallback among 3,933 resolved modules. The fixture sets the existing cleanup-timeout override to 25 ms; the production default is unchanged. This is synthetic programmatic-host proof, not a packaged CLI or Gateway RPC carrier test. Earlier programmatic-registry/emitter fixtures are retained separately and are superseded for the full-loader and OS-signal observations.
