### PR TITLE
fix: standalone OpenCode completions lack required routing identity

### DIFF
--- a/docs/plugins/sdk-runtime/models.md
+++ b/docs/plugins/sdk-runtime/models.md
@@ -146,6 +146,19 @@ Prefer `api.runtime.llm.complete` for new plugin code. Existing callers of
 with `prepareSimpleCompletionModelForAgent` and execute it with
 `completeWithPreparedSimpleCompletionModel`.
 
+The executor accepts optional `options.headers` and `options.sessionId` fields.
+Calls that omit them keep the same call shape. For HTTPS OpenCode endpoints,
+a standalone completion gets a fresh opaque `x-opencode-session` routing header
+for each invocation. An explicit model or caller routing header suppresses
+generation, regardless of header name casing. Caller headers take precedence
+over model headers.
+
+A supplied `sessionId` retains its existing provider session and cache behavior.
+It also supplies the OpenCode routing header unless an explicit header overrides
+it. A generated routing value stays in the header only: it does not create
+conversation, transcript, prompt-cache, or WebSocket session ownership. Existing
+transport retries reuse the invocation's header; the executor adds no retry policy.
+
 These prepared results have no release method. Their original Gateway or CLI
 host retains the model resources until shutdown; standalone callers retain them
 for the process lifetime. A closed host rejects new preparation and execution.

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -21,7 +21,15 @@ provider ids split so upstream per-model routing stays correct.
 OpenClaw sends a stable `x-opencode-session` conversation header on requests to
 `https://opencode.ai` across the Anthropic, Gemini, OpenAI Chat Completions, and
 OpenAI Responses transports. This header remains enabled when prompt caching is
-disabled. Direct SDK callers should supply `sessionId` in their stream options.
+disabled. Low-level SDK stream callers should supply `sessionId` in their stream
+options.
+
+Standalone `openclaw infer model run --local` calls and the
+[prepared completion helper](/plugins/sdk-runtime/models#prepared-completion-sdk-compatibility)
+generate a fresh routing header per invocation when no explicit routing header
+or session identifier is supplied. This generated value stays in the header and
+does not create a conversation or enable session-based caching. Explicit model
+or caller routing headers are preserved regardless of header name casing.
 
 ## Getting started
 

--- a/packages/ai/src/transports/simple-completion-transport.ts
+++ b/packages/ai/src/transports/simple-completion-transport.ts
@@ -3,7 +3,8 @@
  *
  * Registers provider-specific stream functions and rewrites models that need OpenClaw-managed transport semantics.
  */
-import type { Api, Model, StreamFn } from "@openclaw/llm-core";
+import { randomUUID } from "node:crypto";
+import type { Api, Model, StreamFn, StreamOptions } from "@openclaw/llm-core";
 import type { ApiRegistry } from "../api-registry.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import {
@@ -13,6 +14,20 @@ import {
   prepareTransportAwareSimpleModel,
   resolveTransportAwareSimpleApi,
 } from "./provider-transport-stream.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
+
+/** Standalone completions have no durable session, but may require routing identity. */
+export function prepareHeadersForSimpleCompletion(
+  model: Pick<Model, "baseUrl" | "headers">,
+  options?: Pick<StreamOptions, "sessionId" | "headers">,
+): Record<string, string> | undefined {
+  // Keep the synthetic identity in the required header only: a stream sessionId
+  // would also enable unrelated cache and WebSocket session ownership.
+  return resolveOpencodeSessionHeaders(model, {
+    ...options,
+    sessionId: options?.sessionId || randomUUID(),
+  });
+}
 
 const PROVIDER_SIMPLE_COMPLETION_API_PREFIX = "openclaw-provider-simple:";
 const PROVIDER_STREAM_API_PREFIX = "openclaw-provider-stream:";

--- a/packages/ai/src/transports/simple-completion-transport.ts
+++ b/packages/ai/src/transports/simple-completion-transport.ts
@@ -1,9 +1,10 @@
+import { randomUUID } from "node:crypto";
 /**
  * Simple completion transport preparation.
  *
  * Registers provider-specific stream functions and rewrites models that need OpenClaw-managed transport semantics.
  */
-import type { Api, Model, StreamFn } from "@openclaw/llm-core";
+import type { Api, Model, StreamFn, StreamOptions } from "@openclaw/llm-core";
 import type { ApiRegistry } from "../api-registry.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import {
@@ -13,6 +14,20 @@ import {
   prepareTransportAwareSimpleModel,
   resolveTransportAwareSimpleApi,
 } from "./provider-transport-stream.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
+
+/** Standalone completions have no durable session, but may require routing identity. */
+export function prepareHeadersForSimpleCompletion(
+  model: Pick<Model, "baseUrl" | "headers">,
+  options?: Pick<StreamOptions, "sessionId" | "headers">,
+): Record<string, string> | undefined {
+  // Keep the synthetic identity in the required header only: a stream sessionId
+  // would also enable unrelated cache and WebSocket session ownership.
+  return resolveOpencodeSessionHeaders(model, {
+    ...options,
+    sessionId: options?.sessionId || randomUUID(),
+  });
+}
 
 const PROVIDER_SIMPLE_COMPLETION_API_PREFIX = "openclaw-provider-simple:";
 const PROVIDER_STREAM_API_PREFIX = "openclaw-provider-stream:";

--- a/src/agents/simple-completion-execution.test.ts
+++ b/src/agents/simple-completion-execution.test.ts
@@ -58,6 +58,95 @@ describe("prepared completion import boundary", () => {
 });
 
 describe("completeWithPreparedSimpleCompletionModel", () => {
+  it.each([
+    "openai-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "google-generative-ai",
+  ] as const)(
+    "gives standalone OpenCode %s completions distinct routing identities",
+    async (api) => {
+      for (let index = 0; index < 2; index++) {
+        await completeWithPreparedSimpleCompletionModel({
+          model: {
+            ...baseModel,
+            api,
+            provider: "opencode-go",
+            baseUrl: "https://opencode.ai/zen/go/v1",
+          },
+          auth: { apiKey: "test-key", source: "test", mode: "api-key" },
+          context,
+        });
+      }
+      const [first, second] = completionRequests();
+      const firstId = first?.options.headers?.["x-opencode-session"];
+      const secondId = second?.options.headers?.["x-opencode-session"];
+      expect(firstId).toEqual(expect.any(String));
+      expect(firstId.length).toBeGreaterThan(0);
+      expect(secondId).toEqual(expect.any(String));
+      expect(secondId).not.toBe(firstId);
+      expect(first?.options.sessionId).toBeUndefined();
+    },
+  );
+
+  it.each<{
+    options: { headers: Record<string, string>; sessionId?: string };
+    expected: Record<string, string>;
+  }>([
+    {
+      options: { headers: { "X-OpenCode-Session": "caller-owned", "X-Custom": "keep" } },
+      expected: { "X-OpenCode-Session": "caller-owned", "X-Custom": "keep" },
+    },
+    {
+      options: { sessionId: "conversation-a", headers: { "X-Custom": "keep" } },
+      expected: { "x-opencode-session": "conversation-a", "X-Custom": "keep" },
+    },
+  ])("preserves caller routing options $options", async ({ options, expected }) => {
+    const original = structuredClone(options);
+    for (let index = 0; index < 2; index++) {
+      await completeWithPreparedSimpleCompletionModel({
+        model: { ...baseModel, provider: "opencode-go", baseUrl: "https://opencode.ai/zen/go/v1" },
+        auth: { apiKey: "test-key", source: "test", mode: "api-key" },
+        context,
+        options,
+      });
+    }
+    expect(completionRequests().map((request) => request.options.headers)).toEqual([
+      expected,
+      expected,
+    ]);
+    expect(options).toEqual(original);
+  });
+
+  it("preserves an explicit model routing header", async () => {
+    const model = {
+      ...baseModel,
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      headers: { "X-OpenCode-Session": "caller-owned" },
+    };
+    await completeWithPreparedSimpleCompletionModel({
+      model,
+      auth: { apiKey: "test-key", source: "test", mode: "api-key" },
+      context,
+    });
+    const [request] = completionRequests();
+    expect(request?.model.headers).toEqual({ "X-OpenCode-Session": "caller-owned" });
+    expect(request?.options.headers).toBeUndefined();
+  });
+
+  it.each(["https://proxy.example/v1", "http://opencode.ai/zen/go/v1"])(
+    "does not add routing identity to %s",
+    async (baseUrl) => {
+      await completeWithPreparedSimpleCompletionModel({
+        model: { ...baseModel, provider: "opencode-go", baseUrl },
+        auth: { apiKey: "test-key", source: "test", mode: "api-key" },
+        context,
+      });
+      expect(completionRequests()[0]?.options).toEqual({ apiKey: "test-key" });
+    },
+  );
+
   it("prepares provider-owned stream APIs before running a completion", async () => {
     const model = {
       ...baseModel,

--- a/src/agents/simple-completion-execution.ts
+++ b/src/agents/simple-completion-execution.ts
@@ -4,7 +4,10 @@ import {
   supportsOpenAIReasoningEffort,
 } from "@openclaw/ai/internal/openai";
 import { defaultApiRegistry } from "@openclaw/ai/internal/runtime";
-import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
+import {
+  prepareHeadersForSimpleCompletion,
+  prepareModelForSimpleCompletion,
+} from "@openclaw/ai/transports";
 import {
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
@@ -28,6 +31,8 @@ import type { ResolvedProviderAuth } from "./model-auth.js";
 import { isOpenAIProvider } from "./openai-routing.js";
 
 type SimpleCompletionModelOptions = {
+  headers?: Record<string, string>;
+  sessionId?: string;
   maxTokens?: number;
   temperature?: number;
   reasoning?: ThinkLevel | SimpleCompletionThinkingLevel;
@@ -78,10 +83,12 @@ async function completePreparedModel(params: PreparedCompletionParams): Promise<
   }
   const { reasoning: rawReasoning, strictReasoningTags, ...options } = params.options ?? {};
   const reasoning = normalizeSimpleCompletionReasoning(rawReasoning, completionModel);
+  const headers = prepareHeadersForSimpleCompletion(completionModel, options);
   const completionOptions = {
     ...options,
     ...(reasoning ? { reasoning } : {}),
     apiKey: params.auth.apiKey,
+    ...(headers ? { headers } : {}),
   };
   if (strictReasoningTags) {
     reasoningTagTextPolicy.markStrict(completionOptions);

--- a/src/agents/simple-completion-execution.ts
+++ b/src/agents/simple-completion-execution.ts
@@ -4,7 +4,10 @@ import {
   supportsOpenAIReasoningEffort,
 } from "@openclaw/ai/internal/openai";
 import { defaultApiRegistry } from "@openclaw/ai/internal/runtime";
-import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
+import {
+  prepareHeadersForSimpleCompletion,
+  prepareModelForSimpleCompletion,
+} from "@openclaw/ai/transports";
 import {
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
@@ -27,6 +30,8 @@ import type { ResolvedProviderAuth } from "./model-auth.js";
 import { isOpenAIProvider } from "./openai-routing.js";
 
 type SimpleCompletionModelOptions = {
+  headers?: Record<string, string>;
+  sessionId?: string;
   maxTokens?: number;
   temperature?: number;
   reasoning?: ThinkLevel | SimpleCompletionThinkingLevel;
@@ -57,10 +62,12 @@ export async function completeWithPreparedSimpleCompletionModel(params: {
   }
   const { reasoning: rawReasoning, strictReasoningTags, ...options } = params.options ?? {};
   const reasoning = normalizeSimpleCompletionReasoning(rawReasoning, completionModel);
+  const headers = prepareHeadersForSimpleCompletion(completionModel, options);
   const completionOptions = {
     ...options,
     ...(reasoning ? { reasoning } : {}),
     apiKey: params.auth.apiKey,
+    ...(headers ? { headers } : {}),
   };
   if (strictReasoningTags) {
     reasoningTagTextPolicy.markStrict(completionOptions);


### PR DESCRIPTION
Standalone OpenCode calls such as `openclaw infer model run --local` can fail with `MissingSessionID` because they have no conversation identity. This change prepares a fresh routing header once per completion invocation using the existing HTTPS OpenCode endpoint policy. The generated value stays in the header; explicit headers and session ownership retain their existing behavior.

The prepared-completion SDK now documents the optional `headers` and `sessionId` fields, case-insensitive header precedence, and the difference between routing identity and session/cache ownership. The newer prepared-completion lifecycle checks remain intact. Related: #137165; follow-up to #137464.

Validation:
- Built public CLI on the pinned main baseline: `400 MissingSessionID`. Rebuilt candidate: Go and Zen return the expected completion through an isolated TLS stand-in at the exact HTTPS endpoint, with synthetic credentials and no external provider access.
- Independent Go and Zen invocations use distinct routing headers. A real Responses encrypted-content recovery through the public prepared SDK keeps one header across the rejected request and retry.
- Explicit model, provider, caller, and session-backed controls pass, including mixed-case caller-over-model precedence. HTTP, custom, lookalike, and unrelated-host controls preserve exclusion behavior.
- 275 focused tests pass across executor, canonical header policy, direct and managed transports, and prepared-completion lifecycle. The new regression fails on baseline for missing routing headers.
- Candidate `qaRuntime` build, changed-file format and ordinary lint, MDX syntax, line and assertion ratchets pass. The full docs anchor audit finds three existing `windows-app-node` links in unchanged generated maturity pages; the new documentation link resolves.

The isolated proof verifies request routing and visible output, not OpenCode account entitlement or live service availability. Raw synthetic credentials and routing identities remain private.
