### PR TITLE
test: reuse transforms for Gateway acquisition fixtures

### DIFF
--- a/src/gateway/server.fixture-lifetime.test-support.ts
+++ b/src/gateway/server.fixture-lifetime.test-support.ts
@@ -11,6 +11,7 @@ import { hasErrnoCode } from "../infra/errno.js";
 
 export function createGatewayFixtureFork(
   registerCleanup: (cleanup: () => Promise<void>) => unknown,
+  maxBytes = 4 * 1024 * 1024,
 ) {
   const lifetime = createFixtureLifetime();
   registerCleanup(() => lifetime.cleanup());
@@ -54,7 +55,7 @@ export default defineConfig({
   return function runGatewayFixtureFork(
     context: Pick<TestContext, "signal" | "onTestFinished">,
     source: (repoRoot: string, root: string) => string,
-    assertJournal: (journal: unknown, text: string) => void,
+    assertJournal?: (journal: unknown, text: string) => void,
   ): Promise<void> {
     const run = lifetime.run(async () => {
       context.signal.throwIfAborted();
@@ -97,7 +98,7 @@ export default defineConfig({
           cwd: repoRoot,
           signal: context.signal,
           timeoutMs: 90_000,
-          maxBytes: 4 * 1024 * 1024,
+          maxBytes,
           env: {
             PATH: process.env.PATH,
             OPENCLAW_VITEST_FS_MODULE_CACHE: process.env.OPENCLAW_VITEST_FS_MODULE_CACHE,
@@ -138,8 +139,10 @@ export default defineConfig({
           numFailedTests: 0,
           success: true,
         });
-        const journal = await fs.readFile(path.join(root, "journal.json"), "utf8");
-        assertJournal(JSON.parse(journal), journal);
+        if (assertJournal) {
+          const journal = await fs.readFile(path.join(root, "journal.json"), "utf8");
+          assertJournal(JSON.parse(journal), journal);
+        }
       } finally {
         if (joined) {
           await fs.rm(root, { recursive: true, force: true });

--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -1,23 +1,19 @@
 import { once } from "node:events";
-import fs from "node:fs/promises";
 import { createServer } from "node:http";
-import { createRequire } from "node:module";
 import type { Socket } from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { setImmediate } from "node:timers/promises";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { WebSocketServer } from "../../packages/gateway-client/src/websocket.test-support.js";
-import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { runVitestShutdownCommand } from "../../test/helpers/vitest-shutdown-command.js";
 import {
   buildMinimalGatewayHelloOkPayload,
   closeMinimalGatewayServer,
   parseMinimalGatewayRequestFrame,
   sendMinimalGatewayConnectChallenge,
 } from "./minimal-gateway.test-helpers.js";
+import { createGatewayFixtureFork } from "./server.fixture-lifetime.test-support.js";
 
 afterEach(() => {
   vi.doUnmock("ws");
@@ -358,113 +354,9 @@ export async function verifyCompositeAcquisition({
   );
 }
 
-async function runRetainedAcquisitionFork(
-  scenario: CompositeAcquisitionCase,
-  signal: AbortSignal,
-): Promise<void> {
-  signal.throwIfAborted();
-  const repoRoot = path.resolve(import.meta.dirname, "../..");
-  const root = await fs.realpath(
-    await fs.mkdtemp(path.join(os.tmpdir(), "gateway-acquisition-fork-")),
-  );
-  let joined = false;
-  try {
-    // Rejected native close permanently retains its owner; each case needs its own worker.
-    createVitestResourceOwner(root);
-    const require = createRequire(import.meta.url);
-    const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
-    await fs.symlink(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    await fs.mkdir(path.join(root, "home"));
-    await fs.mkdir(path.join(root, "tmp"));
-    await fs.writeFile(
-      path.join(root, "fixture.test.ts"),
-      `
-import { it, vi } from "vitest";
-vi.mock("vitest", async (importOriginal) => ({
-  ...(await importOriginal()),
-  describe: () => {},
-}));
-const { verifyCompositeAcquisition } = await import(${JSON.stringify(import.meta.filename)});
-it("retains a failed acquisition owner", async () => {
-  await verifyCompositeAcquisition(${JSON.stringify(scenario)});
-});
-`,
-    );
-    await fs.writeFile(
-      path.join(root, "vitest.config.ts"),
-      `
-import { defineConfig } from "vitest/config";
-import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.shared.config.ts"))};
-export default defineConfig({
-  envDir: false,
-  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},
-  plugins: sharedVitestConfig.plugins,
-  resolve: sharedVitestConfig.resolve,
-  test: {
-    pool: "forks", isolate: true, maxWorkers: 1, fileParallelism: false,
-    include: ["fixture.test.ts"],
-    testTimeout: sharedVitestConfig.test.testTimeout,
-    hookTimeout: sharedVitestConfig.test.hookTimeout,
-    deps: sharedVitestConfig.test.deps,
-    server: sharedVitestConfig.test.server,
-  },
-});
-`,
-    );
-    const reportFile = path.join(root, "report.json");
-    const output = await runVitestShutdownCommand({
-      args: [
-        path.join(vitestPackageDir, "vitest.mjs"),
-        "run",
-        "--root",
-        root,
-        "--config",
-        path.join(root, "vitest.config.ts"),
-        "--configLoader",
-        "runner",
-        "--reporter=json",
-        `--outputFile=${reportFile}`,
-      ],
-      cwd: repoRoot,
-      signal,
-      timeoutMs: 90_000,
-      env: {
-        PATH: process.env.PATH,
-        HOME: path.join(root, "home"),
-        USERPROFILE: path.join(root, "home"),
-        OPENCLAW_HOME: path.join(root, "home"),
-        OPENCLAW_STATE_DIR: path.join(root, "home/.openclaw"),
-        OPENCLAW_CONFIG_PATH: path.join(root, "home/.openclaw/openclaw.json"),
-        TMPDIR: path.join(root, "tmp"),
-        TMP: path.join(root, "tmp"),
-        TEMP: path.join(root, "tmp"),
-        CI: "1",
-        NO_COLOR: "1",
-      },
-    });
-    // The managed command verifies process-tree exit before this root can be released.
-    joined = true;
-    const diagnostics = `${output.stdout}\n${output.stderr}`;
-    expect(output.code, diagnostics).toBe(0);
-    expect(JSON.parse(await fs.readFile(reportFile, "utf8")), diagnostics).toMatchObject({
-      numPassedTests: 1,
-      numFailedTests: 0,
-      success: true,
-    });
-  } finally {
-    if (joined) {
-      await fs.rm(root, { recursive: true, force: true });
-    } else {
-      console.warn(`Retained unjoined Gateway acquisition fixture: ${root}`);
-    }
-  }
-}
-
 describe("raw Gateway helper acquisition ownership", () => {
+  const runRetainedAcquisitionFork = createGatewayFixtureFork(afterAll, 2 * 1024 * 1024);
+
   it.each([
     { helper: "tracked", behavior: "hold upgrade", error: "timeout waiting for ws open" },
     { helper: "tracked", behavior: "reject upgrade", error: "Unexpected server response: 503" },
@@ -632,9 +524,23 @@ describe("raw Gateway helper acquisition ownership", () => {
     "$helper retains server ownership after $failure failure and $shutdown shutdown",
     async (scenario, context) => {
       if (scenario.helper === "raw" && scenario.shutdown === "rejected") {
-        const run = runRetainedAcquisitionFork(scenario, context.signal);
-        context.onTestFinished(() => run);
-        await run;
+        // Rejected close retains its owner; each case still needs a fresh native worker.
+        await runRetainedAcquisitionFork(
+          context,
+          (_repoRoot, root) => `
+import fs from "node:fs";
+import { it, vi } from "vitest";
+vi.mock("vitest", async (importOriginal) => ({
+  ...(await importOriginal()),
+  describe: () => {},
+}));
+fs.writeFileSync(${JSON.stringify(path.join(root, "worker.pid"))}, String(process.pid));
+const { verifyCompositeAcquisition } = await import(${JSON.stringify(import.meta.filename)});
+it("retains a failed acquisition owner", async () => {
+  await verifyCompositeAcquisition(${JSON.stringify(scenario)});
+});
+`,
+        );
       } else {
         await verifyCompositeAcquisition(scenario);
       }


### PR DESCRIPTION
Related: #143628

## What Problem This Solves

The Gateway acquisition ownership suite rebuilt the same TypeScript dependency graph in each of three isolated failed-shutdown workers, adding repeated startup work to CI.

## Why This Change Was Made

Reuse the file-owned native Gateway fixture runner introduced in #143628 and remove the duplicate runner. Each failed acquisition still gets a fresh Vitest process, private home/state/temporary directories, and its own resource owner. Only transformed code is reused. The shared runner now accepts the acquisition suite's existing 2 MiB output limit and permits callers whose assertions live entirely inside the native test to omit a journal callback. Worker death, launcher exit, the one-test JSON report and cleanup remain mandatory.

All 31 acquisition cases, socket/lifecycle assertions, dynamic database-cleanup imports after module resets, original deadlines and three rejected-owner forks remain. The runner is created inside the parent describe block, which the native child already suppresses. The child writes a real worker PID receipt before loading its assertions.

## User Impact

CI-only improvement; no production behavior change. Production delta is zero, and test/support code is reduced by 91 lines. Runner counts, sharding and runtime state isolation are unchanged.

## Evidence

The complete 31-case file passed on both versions using the repository wrapper and empty task-owned transform/temp roots: 86.37 seconds before and 77.87 seconds after. The three native cases changed from 7.98/8.03/8.07 seconds to 8.96/2.75/3.28 seconds. The first case pays cache population; later workers reuse it. Whole-command timing includes worker preparation, cache writes, process joins and cleanup. This is one matched local A/B sample, not a CI speed guarantee.

The observer saw three distinct launchers and three workers, all absent after completion. The initial 2,381 cache files (55.1 MB) remained unchanged across the later forks, which added only their distinct fixture entries. Config bytes stayed identical; all private roots were removed. Maximum command RSS was 2.19 GB before and 2.14 GB after.

A repeat run of the unchanged baseline encountered a host-load spike: worker preparation rose from about five seconds to 72 seconds and the first original case timed out at its unchanged 120-second deadline (30 other cases passed). That failed run is retained as a limitation and is excluded from the successful timing comparison. Cold-import sensitivity under contention remains a follow-up; no timeout was raised.

A later combined run passed 42 of 43 cases, with the existing session fixture reaching its unchanged 90-second deadline. The checkout dependency directory was subsequently removed by a background cache cleanup. The removal occurred after the timed-out run and is not evidence of its direct cause. After restoring the frozen install, all 12 startup/session lifecycle cases passed, the full changed-file gate passed, and the source remained identical to the independently reviewed patch (no actionable P2 findings). These later runs are correctness evidence, not matched timing samples. No Windows speedup is claimed; existing platform cache defaults remain.
