### PR TITLE
fix(workers): retain bundles during prepared provisioning

### DIFF
--- a/docs/gateway/cloud-workers/setup-and-bundle-installation.md
+++ b/docs/gateway/cloud-workers/setup-and-bundle-installation.md
@@ -26,6 +26,8 @@ Bootstrap emits `CRABBOX_PHASE:openclaw-bootstrap-*` markers into the Crabbox co
 
 The Gateway reuses its prepared archive for subsequent enrollments with the same execution mode. Nodes keep successful installs under `~/.openclaw-worker/node-runtimes/<sha256>`, so a warm image can reuse the exact artifact. A different digest selects a different installation even when the version is unchanged. The runtime archive omits worker deploy artifacts and the Gateway's Control UI assets, reducing transfer and installation work. The Gateway continues to serve the dashboard. After enrollment, OpenClaw `worker-turn` installs the content-addressed worker bundle from a matching archive retained in a prepared project image, or downloads it through the authenticated node channel when that archive is absent. Prepared archives still undergo validation; see [Warm images](/gateway/cloud-workers/warm-images). Codex `remote-exec` starts the managed exec-server directly. Existing placement checks, node-command allowlists, and invocation approval still govern execution.
 
+While a prepared worker is provisioning, cache cleanup retains the exact worker bundle recorded at admission, including before readiness produces a bootstrap receipt. After the environment reaches a terminal state, normal bundle cleanup can reclaim those bytes when no other environment or placement needs them.
+
 ## Build a complete custom node package
 
 Automatic cloud bootstrap does not require a manually published package. For a separate deployment or package-validation workflow, the canonical package builder can still produce a complete custom distribution and explicitly include source-owned plugins that the ordinary core package excludes:

--- a/src/gateway/worker-environments/bundle.test.ts
+++ b/src/gateway/worker-environments/bundle.test.ts
@@ -2,12 +2,19 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
 import { describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
   createWorkerBundleProducer,
   resolveWorkerNpmInstallationArtifact,
   type WorkerInstallationArtifact,
 } from "./bundle.js";
+import { createWorkerProjectPreparationIdentity } from "./preparation-identity.js";
+import { createWorkerEnvironmentStore } from "./store.js";
+import { listRetainedWorkerBundleHashes } from "./worker-bundle-retention.js";
 import { workerWorkspaceRsyncReceiverEntryPath } from "./workspace-sync-helpers.js";
 
 type WorkerBundleArtifact = Extract<WorkerInstallationArtifact, { install: "bundle" }>;
@@ -202,6 +209,76 @@ describe("worker bundle producer", () => {
       await expect(fs.stat(retained.tarballPath)).resolves.toBeDefined();
       await expect(fs.stat(current.tarballPath)).resolves.toBeDefined();
       await expect(fs.stat(removedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("retains a persisted provisioning bundle until its environment terminates", async () => {
+    await withTestDir({ prefix: "openclaw-worker-bundle-provisioning-" }, async (root) => {
+      const packageRoot = path.join(root, "package");
+      const cacheDir = path.join(root, "cache");
+      const databasePath = path.join(root, "state", "openclaw.sqlite");
+      await writeFixture(packageRoot, "export const value = 1;\n");
+      const admitted = await createWorkerBundleProducer({ packageRoot, cacheDir }).prepare();
+      const admittedBytes = await fs.readFile(admitted.tarballPath);
+      const project = { key: "project", root, baseCommit: "a".repeat(40) };
+      const preparation = createWorkerProjectPreparationIdentity({
+        namespace: "bundle-retention-test",
+        providerId: "fixture",
+        profileId: "test",
+        profileSnapshot: { settings: {} },
+        project,
+        target: { machineClass: "small", platform: "linux" },
+        artifacts: {
+          nodeBootstrapSha256: "b".repeat(64),
+          enabledPluginIds: [],
+          workerBundleHash: admitted.bundleHash,
+          workerArchiveSha256: admitted.tarballSha256,
+          openclawVersion: admitted.openclawVersion,
+          protocolFeatures: [...admitted.protocolFeatures],
+        },
+      });
+      try {
+        const store = createWorkerEnvironmentStore({
+          database: openOpenClawStateDatabase({ path: databasePath }),
+        });
+        store.createIntent({
+          environmentId: "preparing",
+          providerId: "fixture",
+          profileId: "test",
+          provisionOperationId: "prepare-project",
+          profileSnapshot: { settings: {}, project: { ...project, preparation } },
+        });
+        store.transition({ environmentId: "preparing", from: "requested", to: "provisioning" });
+        closeOpenClawStateDatabaseForTest();
+
+        await writeFixture(packageRoot, "export const value = 2;\n");
+        const successor = createWorkerBundleProducer({
+          packageRoot,
+          cacheDir,
+          cacheOwnership: "exclusive",
+        });
+        const current = await successor.prepare();
+        expect(current.bundleHash).not.toBe(admitted.bundleHash);
+        const reopened = createWorkerEnvironmentStore({
+          database: openOpenClawStateDatabase({ path: databasePath }),
+        });
+        expect(reopened.get("preparing")).toMatchObject({
+          state: "provisioning",
+          bootstrapReceipt: null,
+        });
+        const retained = () =>
+          listRetainedWorkerBundleHashes({ environments: reopened.list(), placements: [] });
+
+        await successor.prune(retained());
+        await expect(fs.readFile(admitted.tarballPath)).resolves.toEqual(admittedBytes);
+
+        reopened.transition({ environmentId: "preparing", from: "provisioning", to: "failed" });
+        await successor.prune(retained());
+        await expect(fs.stat(admitted.tarballPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(current.tarballPath)).resolves.toBeDefined();
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
     });
   });
 

--- a/src/gateway/worker-environments/worker-bundle-retention.test.ts
+++ b/src/gateway/worker-environments/worker-bundle-retention.test.ts
@@ -8,12 +8,13 @@ const hash = (value: string) => value.repeat(64);
 function environment(state: WorkerEnvironmentRecord["state"], bundleHash: string) {
   return {
     state,
+    profileSnapshot: { settings: {} },
     bootstrapReceipt: {
       bundleHash,
       openclawVersion: "1.2.3",
       protocolFeatures: [],
     },
-  } as Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "state">;
+  } satisfies Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "profileSnapshot" | "state">;
 }
 
 function placement(state: WorkerSessionPlacementRecord["state"], bundleHash: string | null) {

--- a/src/gateway/worker-environments/worker-bundle-retention.ts
+++ b/src/gateway/worker-environments/worker-bundle-retention.ts
@@ -1,5 +1,6 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { WorkerSessionPlacementRecord } from "./placement-store.js";
+import { readWorkerProjectPreparation } from "./preparation-identity.js";
 import type { WorkerEnvironmentRecord } from "./store.js";
 
 const TERMINAL_ENVIRONMENT_STATES = new Set(["destroyed", "failed", "orphaned"]);
@@ -12,15 +13,22 @@ const RECOVERY_BUNDLE_PLACEMENT_STATES = new Set([
 ]);
 
 export function listRetainedWorkerBundleHashes(params: {
-  environments: Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "state">[];
+  environments: Pick<WorkerEnvironmentRecord, "bootstrapReceipt" | "profileSnapshot" | "state">[];
   placements: WorkerSessionPlacementRecord[];
 }): string[] {
   return uniqueStrings([
-    ...params.environments.flatMap((record) =>
-      record.bootstrapReceipt && !TERMINAL_ENVIRONMENT_STATES.has(record.state)
-        ? [record.bootstrapReceipt.bundleHash]
-        : [],
-    ),
+    ...params.environments.flatMap((record) => {
+      if (TERMINAL_ENVIRONMENT_STATES.has(record.state)) {
+        return [];
+      }
+      // Provisioning owns the admitted archive before readiness publishes its receipt.
+      const bundleHash =
+        record.bootstrapReceipt?.bundleHash ??
+        (record.state === "provisioning"
+          ? readWorkerProjectPreparation(record.profileSnapshot.project)?.artifacts.workerBundleHash
+          : undefined);
+      return bundleHash ? [bundleHash] : [];
+    }),
     ...params.placements.flatMap((placement) =>
       placement.workerBundleHash && RECOVERY_BUNDLE_PLACEMENT_STATES.has(placement.state)
         ? [placement.workerBundleHash]


### PR DESCRIPTION
Related: #134931.

## What Problem This Solves

A prepared worker can lose the bundle it still needs while provisioning. When a successor producer prepares another bundle, cache cleanup previously retained only bootstrap receipts and active placements, overlooking the admitted archive recorded before readiness.

## Why This Change Was Made

The shared retention selector now keeps the preparation's bundle hash while the environment is provisioning and has no bootstrap receipt. Both Gateway cache pruning and node retention use that selector. Existing receipt priority, terminal-state cleanup and placement retention remain unchanged.

## User Impact

Interrupted prepared-worker provisioning keeps its admitted archive across store reopen and successor bundle creation. Cleanup can reclaim the archive after the environment becomes terminal, provided no other owner still needs it.

## Evidence

- Reproduced on current main with real bundle archives, a persisted SQLite environment, store close/reopen and the actual exclusive cache pruner: the old code deleted bundle A while its request remained provisioning, producing `ENOENT`.
- The regression now verifies byte-for-byte preservation before terminalization and removal after terminal failure, while retaining the current producer's bundle.
- All 37 focused tests across the bundle, retention-selector and node-retention suites passed. The full changed-file gate passed, including types, lint, dead exports and runtime cycles. Final documentation formatting and whitespace checks passed.
- Fresh independent review through P2 completed with no findings.

This is a four-file extraction of the retention repair from #134931. The original combined PR remains draft and unmerged. Exact-head CI is required before landing.
