### PR TITLE
fix(sdk): preserve authored requests when model catalogs overlap

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -392,6 +392,12 @@ values. A self-hosted mirror can be selected with an HTTPS
 
 Custom providers configured under `models.providers` are written into `models.json` under the agent directory (default `~/.openclaw/agents/<agentId>/agent/models.json`). Provider-plugin catalogs are stored separately as generated plugin-owned catalog shards and load automatically. This file is merged with config by default; set `models.mode: "replace"` to use only your configured providers.
 
+Generated plugin catalogs supply model inventory, not request credentials. Their
+cached API keys, authentication modes, and request headers do not authorize model
+requests. Use a current auth profile or authored request configuration instead.
+The session SDK preserves authored `models.json` keys and headers while merging
+generated model metadata below authored rows.
+
 <AccordionGroup>
   <Accordion title="Merge mode precedence">
     For matching provider IDs:

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -125,10 +125,12 @@ describe("models-config merge helpers", () => {
         explicit: { example: explicit },
       });
       const provider = merged.example;
-      const selected = provider.models.find((model) => model.id === implicit.models[0].id);
+      const selected = provider?.models.find(
+        (model) => model.id === (overlap ? "config-model" : "catalog-only"),
+      );
       expect(selected).toBeDefined();
-      expect(selected?.api ?? provider.api).toBe(explicit.api);
-      expect(selected?.baseUrl ?? provider.baseUrl).toBe(explicit.baseUrl);
+      expect(selected?.api ?? provider?.api).toBe(explicit.api);
+      expect(selected?.baseUrl ?? provider?.baseUrl).toBe(explicit.baseUrl);
     },
   );
 

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -104,6 +104,34 @@ describe("models-config merge helpers", () => {
     ]);
   });
 
+  it.each([false, true])(
+    "preserves configured provider routing for catalog rows (overlap: %s)",
+    (overlap) => {
+      const implicit = createConfigProvider({
+        api: "anthropic-messages",
+        baseUrl: "https://catalog.example/v1",
+        models: [
+          createModel({
+            id: overlap ? "config-model" : "catalog-only",
+            ...(overlap
+              ? { api: "anthropic-messages", baseUrl: "https://catalog-model.example/v1" }
+              : {}),
+          }),
+        ],
+      });
+      const explicit = createConfigProvider();
+      const merged = mergeProviders({
+        implicit: { example: implicit },
+        explicit: { example: explicit },
+      });
+      const provider = merged.example;
+      const selected = provider.models.find((model) => model.id === implicit.models[0].id);
+      expect(selected).toBeDefined();
+      expect(selected?.api ?? provider.api).toBe(explicit.api);
+      expect(selected?.baseUrl ?? provider.baseUrl).toBe(explicit.baseUrl);
+    },
+  );
+
   it("uses source input presence when merging matching model metadata", () => {
     const implicit = {
       api: "ollama",

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -7,6 +7,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asPositiveFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { mergeModelCost } from "../config/model-cost.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import {
@@ -55,6 +56,28 @@ export type SourceModelFields = ReadonlyMap<
   { inputOmitted: boolean; cost: ProviderConfig["models"][number]["cost"] | undefined }
 >;
 
+type ProviderModelCatalog = {
+  api?: string;
+  baseUrl?: string;
+  headers?: ProviderConfig["headers"];
+  compat?: ModelDefinitionConfig["compat"];
+  models?: Array<
+    Omit<Partial<ModelDefinitionConfig>, "id" | "api"> & {
+      id: string;
+      api?: string;
+      maxTokensSource?: "configured" | "discovered";
+    }
+  >;
+};
+
+type ProviderModelMergeOptions = {
+  providerId: string;
+  modelIdMatching?: "exact";
+  sourceModelFields?: SourceModelFields;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
+  preserveConfiguredModelMembership?: boolean;
+};
+
 function getProviderModelId(model: unknown): string {
   if (!model || typeof model !== "object") {
     return "";
@@ -64,16 +87,16 @@ function getProviderModelId(model: unknown): string {
 }
 
 /** Merges implicit provider models with explicit config while preserving explicit fields. */
+export function mergeProviderModels<TProvider extends ProviderModelCatalog>(
+  implicit: TProvider,
+  explicit: TProvider,
+  options?: ProviderModelMergeOptions,
+): TProvider;
 export function mergeProviderModels(
-  implicit: ProviderConfig,
-  explicit: ProviderConfig,
-  options?: {
-    providerId: string;
-    sourceModelFields?: SourceModelFields;
-    manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
-    preserveConfiguredModelMembership?: boolean;
-  },
-): ProviderConfig {
+  implicit: ProviderModelCatalog,
+  explicit: ProviderModelCatalog,
+  options?: ProviderModelMergeOptions,
+): ProviderModelCatalog {
   const implicitModels = Array.isArray(implicit.models) ? implicit.models : [];
   const explicitModels = Array.isArray(explicit.models) ? explicit.models : [];
   const implicitHeaders =
@@ -99,16 +122,18 @@ export function mergeProviderModels(
     };
   }
 
+  const getModelId = (model: { id: string }) =>
+    options?.modelIdMatching === "exact" ? model.id : getProviderModelId(model);
   const implicitById = new Map(
     implicitModels
-      .map((model) => [getProviderModelId(model), model] as const)
+      .map((model) => [getModelId(model), model] as const)
       .filter(([id]) => Boolean(id)),
   );
   const seen = new Set<string>();
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
 
   const mergedModels = explicitModels.map((explicitModel) => {
-    const id = getProviderModelId(explicitModel);
+    const id = getModelId(explicitModel);
     if (!id) {
       return explicitModel;
     }
@@ -147,9 +172,14 @@ export function mergeProviderModels(
     const contextTokens =
       asPositiveFiniteNumber(explicitModel.contextTokens) ??
       asPositiveFiniteNumber(implicitModel.contextTokens);
-    const maxTokens =
-      asPositiveFiniteNumber(explicitModel.maxTokens) ??
-      asPositiveFiniteNumber(implicitModel.maxTokens);
+    const explicitMaxTokens = asPositiveFiniteNumber(explicitModel.maxTokens);
+    const maxTokens = explicitMaxTokens ?? asPositiveFiniteNumber(implicitModel.maxTokens);
+    const maxTokensSource =
+      explicitMaxTokens === undefined
+        ? implicitModel.maxTokensSource
+        : explicitModel.maxTokensSource;
+    const api = explicitModel.api ?? implicitModel.api;
+    const baseUrl = explicitModel.baseUrl ?? implicitModel.baseUrl;
     const compat = resolveCatalogOwnedModelCompat({
       catalogRoute: {
         api: implicitModel.api ?? implicit.api,
@@ -157,36 +187,48 @@ export function mergeProviderModels(
       },
       catalogCompat: implicitModel.compat,
       configuredRoute: {
-        api: explicitModel.api ?? explicit.api ?? implicitModel.api ?? implicit.api,
-        baseUrl:
-          explicitModel.baseUrl ?? explicit.baseUrl ?? implicitModel.baseUrl ?? implicit.baseUrl,
+        api: api ?? explicit.api ?? implicit.api,
+        baseUrl: baseUrl ?? explicit.baseUrl ?? implicit.baseUrl,
       },
       configuredCompat: explicitModel.compat,
     });
 
+    const {
+      headers: _headers,
+      maxTokensSource: _maxTokensSource,
+      ...implicitMetadata
+    } = implicitModel;
     return Object.assign(
       {},
+      implicitMetadata,
       explicitModel,
       {
         input,
         cost,
         reasoning: `reasoning` in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       },
+      api === undefined ? {} : { api },
+      baseUrl === undefined ? {} : { baseUrl },
       contextWindow === undefined ? {} : { contextWindow },
       contextTokens === undefined ? {} : { contextTokens },
       maxTokens === undefined ? {} : { maxTokens },
+      maxTokensSource === undefined ? {} : { maxTokensSource },
       { compat },
     );
   });
 
   if (!options?.preserveConfiguredModelMembership) {
     for (const implicitModel of implicitModels) {
-      const id = getProviderModelId(implicitModel);
+      const id = getModelId(implicitModel);
       if (!id || seen.has(id)) {
         continue;
       }
       seen.add(id);
-      mergedModels.push(implicitModel);
+      mergedModels.push({
+        ...implicitModel,
+        api: implicitModel.api ?? implicit.api,
+        baseUrl: implicitModel.baseUrl ?? implicit.baseUrl,
+      });
     }
   }
 

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -180,8 +180,6 @@ export function mergeProviderModels(
       explicitMaxTokens === undefined
         ? implicitModel.maxTokensSource
         : explicitModel.maxTokensSource;
-    const api = explicitModel.api ?? implicitModel.api;
-    const baseUrl = explicitModel.baseUrl ?? implicitModel.baseUrl;
     const compat = resolveCatalogOwnedModelCompat({
       catalogRoute: {
         api: implicitModel.api ?? implicit.api,
@@ -189,13 +187,16 @@ export function mergeProviderModels(
       },
       catalogCompat: implicitModel.compat,
       configuredRoute: {
-        api: api ?? explicit.api ?? implicit.api,
-        baseUrl: baseUrl ?? explicit.baseUrl ?? implicit.baseUrl,
+        api: explicitModel.api ?? explicit.api ?? implicitModel.api ?? implicit.api,
+        baseUrl:
+          explicitModel.baseUrl ?? explicit.baseUrl ?? implicitModel.baseUrl ?? implicit.baseUrl,
       },
       configuredCompat: explicitModel.compat,
     });
 
     const {
+      api: _api,
+      baseUrl: _baseUrl,
       headers: _headers,
       maxTokensSource: _maxTokensSource,
       ...implicitMetadata
@@ -209,8 +210,6 @@ export function mergeProviderModels(
         cost,
         reasoning: `reasoning` in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       },
-      api === undefined ? {} : { api },
-      baseUrl === undefined ? {} : { baseUrl },
       contextWindow === undefined ? {} : { contextWindow },
       contextTokens === undefined ? {} : { contextTokens },
       maxTokens === undefined ? {} : { maxTokens },
@@ -226,11 +225,7 @@ export function mergeProviderModels(
         continue;
       }
       seen.add(id);
-      mergedModels.push({
-        ...implicitModel,
-        api: implicitModel.api ?? implicit.api,
-        baseUrl: implicitModel.baseUrl ?? implicit.baseUrl,
-      });
+      mergedModels.push(implicitModel);
     }
   }
 

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -7,7 +7,10 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asPositiveFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { mergeModelCost } from "../config/model-cost.js";
-import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig as ProviderConfig,
+} from "../config/types.models.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import {
@@ -15,7 +18,6 @@ import {
   createConfiguredProviderCatalogModelIdNormalizer,
   type ModelManifestNormalizationContext,
 } from "./model-ref-shared.js";
-import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
 export function normalizeProviderMapKeys<T>(
   providers: Record<string, T> | null | undefined,

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { PLUGIN_MODEL_CATALOG_GENERATED_BY } from "../plugin-model-catalog.js";
+import { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+
+const provider = "registry-source-example";
+const pluginId = "registry-source-owner";
+const rootUrl = "https://authored.example.test/v1";
+const catalogUrl = "https://catalog.example.test/v1";
+const authored = {
+  api: "openai-completions",
+  baseUrl: rootUrl,
+  apiKey: "authored-fixture-key",
+  headers: { "X-Authored-Provider": "root" },
+  models: [
+    { id: "shared", name: "Authored", maxTokens: 2048, headers: { "X-Authored-Model": "root" } },
+    { id: "Shared", name: "Case-distinct authored model" },
+  ],
+};
+const generated = {
+  api: "openai-completions",
+  baseUrl: catalogUrl,
+  apiKey: "cached-fixture-key",
+  authHeader: true,
+  headers: { "X-Cached-Provider": "cache" },
+  models: [
+    {
+      id: "shared",
+      name: "Generated",
+      input: ["text", "image"],
+      maxTokens: 8192,
+      headers: { "X-Cached-Model": "cache" },
+    },
+    { id: "generated-only", maxTokens: 4096 },
+  ],
+};
+
+function createRegistry(
+  options: {
+    authored?: Record<string, unknown> | null;
+    generated?: Record<string, unknown>;
+    credentials?: Parameters<typeof AuthStorage.inMemory>[0];
+  } = {},
+) {
+  const root = options.authored === undefined ? authored : options.authored;
+  return ModelRegistry.create(
+    AuthStorage.inMemory(options.credentials ?? {}),
+    "captured:models.json",
+    {
+      modelsJsonContents:
+        root === null ? null : JSON.stringify({ providers: { [provider]: root } }),
+      pluginCatalogs: [
+        {
+          pluginId,
+          contents: JSON.stringify({
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: { [provider]: options.generated ?? generated },
+          }),
+        },
+      ],
+      pluginMetadataSnapshot: {
+        index: { plugins: [{ pluginId, enabled: true }] },
+        owners: {
+          channels: new Map(),
+          channelConfigs: new Map(),
+          providers: new Map([[provider, [pluginId]]]),
+          modelCatalogProviders: new Map([[provider, [pluginId]]]),
+          cliBackends: new Map(),
+          setupProviders: new Map(),
+          commandAliases: new Map(),
+          contracts: new Map(),
+          modelIdNormalizationPolicies: new Map(),
+        },
+      },
+    },
+  );
+}
+
+describe("ModelRegistry source composition", () => {
+  it("composes exact root and generated identities before filling runtime defaults", () => {
+    const registry = createRegistry();
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.getAll().map((model) => model.id)).toEqual([
+      "shared",
+      "Shared",
+      "generated-only",
+    ]);
+    expect(registry.find(provider, "shared")).toMatchObject({
+      name: "Authored",
+      input: ["text", "image"],
+      maxTokens: 2048,
+      maxTokensSource: "configured",
+    });
+    expect(registry.find(provider, "generated-only")).toMatchObject({
+      baseUrl: catalogUrl,
+      maxTokens: 4096,
+      maxTokensSource: "discovered",
+    });
+  });
+
+  it("retains discovered output-limit provenance when the authored definition omits the limit", () => {
+    const registry = createRegistry({
+      authored: { ...authored, models: [{ id: "shared", name: "Sparse" }] },
+    });
+    expect(registry.find(provider, "shared")).toMatchObject({
+      name: "Sparse",
+      input: ["text", "image"],
+      maxTokens: 8192,
+      maxTokensSource: "discovered",
+    });
+  });
+
+  it("preserves generated optional metadata omitted by an authored row", () => {
+    const registry = createRegistry({
+      authored: { ...authored, models: [{ id: "shared" }] },
+      generated: {
+        ...generated,
+        models: [
+          {
+            id: "shared",
+            name: "Discovered name",
+            params: { canonicalModelId: "canonical-example" },
+            thinkingLevelMap: { high: "provider-high" },
+          },
+        ],
+      },
+    });
+    expect(registry.find(provider, "shared")).toMatchObject({
+      name: "Discovered name",
+      params: { canonicalModelId: "canonical-example" },
+      thinkingLevelMap: { high: "provider-high" },
+    });
+  });
+
+  it("keeps distinct literal SDK model IDs when their trimmed spelling matches", () => {
+    const registry = createRegistry({
+      authored: { ...authored, models: [{ id: "shared", name: "Authored" }] },
+      generated: { ...generated, models: [{ id: " shared ", name: "Distinct generated model" }] },
+    });
+    expect(registry.getAll().map((model) => model.id)).toEqual(["shared", " shared "]);
+    expect(registry.find(provider, "shared")?.name).toBe("Authored");
+    expect(registry.find(provider, " shared ")?.name).toBe("Distinct generated model");
+  });
+
+  it.each([undefined, { "X-Cached-Model": "cache" }])(
+    "does not let generated model headers replace or erase authored request headers: %j",
+    async (headers) => {
+      const registry = createRegistry({
+        generated: { ...generated, models: [{ id: "shared", headers }] },
+      });
+      const model = registry.find(provider, "shared");
+      expect(model).toBeDefined();
+      await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+        ok: true,
+        apiKey: "authored-fixture-key",
+        headers: { "X-Authored-Provider": "root", "X-Authored-Model": "root" },
+      });
+    },
+  );
+
+  it("keeps generated-only inventory without adopting its credential or bearer headers", async () => {
+    const registry = createRegistry({ authored: null });
+    const model = registry.find(provider, "shared");
+    expect(model).toBeDefined();
+    expect(registry.hasConfiguredAuth(model!)).toBe(false);
+    expect(registry.getAvailable()).toEqual([]);
+    expect(registry.getProviderAuthStatus(provider).configured).toBe(false);
+    await expect(registry.getApiKeyForProvider(provider)).resolves.toBeUndefined();
+    await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+      ok: true,
+      apiKey: undefined,
+      headers: undefined,
+    });
+  });
+
+  it("uses current request-store credentials without restoring generated request headers", async () => {
+    const registry = createRegistry({
+      authored: null,
+      credentials: {
+        [provider]: { type: "api_key", key: "current-store-fixture-key" },
+      },
+    });
+    const model = registry.find(provider, "shared");
+    expect(model).toBeDefined();
+    expect(registry.hasConfiguredAuth(model!)).toBe(true);
+    await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+      ok: true,
+      apiKey: "current-store-fixture-key",
+      headers: undefined,
+    });
+  });
+
+  it("does not adopt the generated provider's AWS SDK auth mode", () => {
+    const registry = createRegistry({
+      authored: null,
+      generated: {
+        api: "bedrock-converse-stream",
+        baseUrl: catalogUrl,
+        auth: "aws-sdk",
+        models: [{ id: "shared" }],
+      },
+    });
+    expect(registry.find(provider, "shared")).toBeDefined();
+    expect(registry.getProviderAuthStatus(provider).configured).toBe(false);
+  });
+
+  it.each(["openai-completions", "operator-custom-api"])(
+    "preserves raw SDK authored request authority for %s",
+    async (api) => {
+      const registry = createRegistry({
+        authored: { ...authored, api, authHeader: true },
+        generated: {
+          api: "openai-completions",
+          baseUrl: catalogUrl,
+          models: [{ id: "generated-only" }],
+        },
+      });
+      const model = registry.find(provider, "shared");
+      expect(model?.api).toBe(api);
+      await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+        ok: true,
+        apiKey: "authored-fixture-key",
+        headers: {
+          "X-Authored-Provider": "root",
+          "X-Authored-Model": "root",
+          Authorization: "Bearer authored-fixture-key",
+        },
+      });
+    },
+  );
+
+  it("forks the composed inventory and request headers while isolating current credentials", async () => {
+    const registry = createRegistry();
+    const first = registry.fork(
+      AuthStorage.inMemory({
+        [provider]: { type: "api_key", key: "first-request-key" },
+      }),
+    );
+    const second = registry.fork(
+      AuthStorage.inMemory({
+        [provider]: { type: "api_key", key: "second-request-key" },
+      }),
+    );
+    first.refresh();
+    expect(first.getAll().map((model) => model.id)).toEqual(["shared", "Shared", "generated-only"]);
+    await expect(first.getApiKeyAndHeaders(first.find(provider, "shared")!)).resolves.toEqual({
+      ok: true,
+      apiKey: "first-request-key",
+      headers: { "X-Authored-Provider": "root", "X-Authored-Model": "root" },
+    });
+    await expect(second.getApiKeyAndHeaders(second.find(provider, "shared")!)).resolves.toEqual({
+      ok: true,
+      apiKey: "second-request-key",
+      headers: { "X-Authored-Provider": "root", "X-Authored-Model": "root" },
+    });
+  });
+});

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -77,6 +77,39 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it.each([rootUrl, catalogUrl])(
+    "limits authored request settings to authored endpoints for generated-only rows at %s",
+    async (baseUrl) => {
+      const registry = createRegistry({
+        generated: { ...generated, baseUrl, models: [{ id: "generated-only" }] },
+      });
+      const model = registry.find(provider, "generated-only");
+      expect(model).toBeDefined();
+      expect(registry.hasConfiguredAuth(model!)).toBe(baseUrl === rootUrl);
+      expect(registry.getAvailable().some((entry) => entry.id === "generated-only")).toBe(
+        baseUrl === rootUrl,
+      );
+      await expect(registry.getApiKeyAndHeaders(model!)).resolves.toEqual({
+        ok: true,
+        apiKey: baseUrl === rootUrl ? "authored-fixture-key" : undefined,
+        headers: baseUrl === rootUrl ? { "X-Authored-Provider": "root" } : undefined,
+      });
+    },
+  );
+
+  it("keeps authored model endpoint pins eligible for provider request settings", async () => {
+    const registry = createRegistry({
+      authored: { ...authored, models: [{ id: "shared", baseUrl: catalogUrl }] },
+    });
+    const model = registry.find(provider, "shared");
+    expect(model?.baseUrl).toBe(catalogUrl);
+    await expect(registry.getApiKeyAndHeaders(model!)).resolves.toMatchObject({
+      ok: true,
+      apiKey: "authored-fixture-key",
+      headers: { "X-Authored-Provider": "root" },
+    });
+  });
+
   it.each([false, true])(
     "keeps the authored request route when generated model routing conflicts (model pin: %s)",
     (modelPin) => {

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -37,6 +37,7 @@ const generated = {
 
 function createRegistry(
   options: {
+    authoredProvider?: string;
     authored?: Record<string, unknown> | null;
     generated?: Record<string, unknown>;
     credentials?: Parameters<typeof AuthStorage.inMemory>[0];
@@ -48,7 +49,9 @@ function createRegistry(
     "captured:models.json",
     {
       modelsJsonContents:
-        root === null ? null : JSON.stringify({ providers: { [provider]: root } }),
+        root === null
+          ? null
+          : JSON.stringify({ providers: { [options.authoredProvider ?? provider]: root } }),
       pluginCatalogs: [
         {
           pluginId,
@@ -77,6 +80,25 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it("keeps model headers separate for literal provider/model pairs with delimiters", async () => {
+    const authoredProvider = `${provider}:variant`;
+    const registry = createRegistry({
+      authoredProvider,
+      authored: {
+        ...authored,
+        models: [{ id: "shared", headers: { "X-Authored-Model": "private" } }],
+      },
+      generated: { ...generated, models: [{ id: "variant:shared" }] },
+      credentials: { [provider]: { type: "api_key", key: "current-store-key" } },
+    });
+    await expect(
+      registry.getApiKeyAndHeaders(registry.find(provider, "variant:shared")!),
+    ).resolves.toEqual({ ok: true, apiKey: "current-store-key", headers: undefined });
+    await expect(
+      registry.getApiKeyAndHeaders(registry.find(authoredProvider, "shared")!),
+    ).resolves.toMatchObject({ headers: { "X-Authored-Model": "private" } });
+  });
+
   it.each([rootUrl, catalogUrl])(
     "limits authored request settings to authored endpoints for generated-only rows at %s",
     async (baseUrl) => {

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -77,6 +77,36 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it.each([false, true])(
+    "keeps the authored request route when generated model routing conflicts (model pin: %s)",
+    (modelPin) => {
+      const expectedApi = modelPin ? "openai-responses" : "openai-completions";
+      const expectedUrl = modelPin ? "https://model-pin.example.test/v1" : rootUrl;
+      const registry = createRegistry({
+        authored: {
+          ...authored,
+          models: [
+            { id: "shared", ...(modelPin ? { api: expectedApi, baseUrl: expectedUrl } : {}) },
+          ],
+        },
+        generated: {
+          ...generated,
+          models: [
+            {
+              id: "shared",
+              api: "anthropic-messages",
+              baseUrl: "https://conflicting.example.test/v1",
+            },
+          ],
+        },
+      });
+      expect(registry.find(provider, "shared")).toMatchObject({
+        api: expectedApi,
+        baseUrl: expectedUrl,
+      });
+    },
+  );
+
   it("composes exact root and generated identities before filling runtime defaults", () => {
     const registry = createRegistry();
     expect(registry.getError()).toBeUndefined();

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -80,6 +80,44 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it.each([rootUrl, catalogUrl])(
+    "preserves source compatibility without mixing provider defaults at %s",
+    (baseUrl) => {
+      const registry = createRegistry({
+        authored: {
+          ...authored,
+          compat: { maxTokensField: "max_tokens", supportsDeveloperRole: false },
+          models: [{ id: "shared" }, { id: "authored-only" }],
+        },
+        generated: {
+          ...generated,
+          baseUrl,
+          compat: { maxTokensField: "max_completion_tokens" },
+          models: [
+            { id: "shared" },
+            { id: "generated-only" },
+            { id: "model-override", compat: { maxTokensField: "max_tokens" } },
+          ],
+        },
+      });
+      expect(registry.find(provider, "generated-only")?.compat).toEqual({
+        maxTokensField: "max_completion_tokens",
+      });
+      expect(registry.find(provider, "model-override")?.compat).toEqual({
+        maxTokensField: "max_tokens",
+      });
+      expect(registry.find(provider, "authored-only")?.compat).toEqual({
+        maxTokensField: "max_tokens",
+        supportsDeveloperRole: false,
+      });
+      expect(registry.find(provider, "shared")?.compat).toEqual(
+        baseUrl === rootUrl
+          ? { maxTokensField: "max_completion_tokens" }
+          : { maxTokensField: "max_tokens", supportsDeveloperRole: false },
+      );
+    },
+  );
+
   it("keeps model headers separate for literal provider/model pairs with delimiters", async () => {
     const authoredProvider = `${provider}:variant`;
     const registry = createRegistry({

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -326,7 +326,7 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.getAvailable().map((model) => model.id)).toEqual(["example-model"]);
   });
 
-  it("automatically migrates released provider models before the first registry load", async () => {
+  it("migrates released provider inventory without adopting cached credentials", async () => {
     // A synthetic provider keeps host credentials out of this migration-only fixture.
     const providerId = "migrated-catalog-provider";
     const modelsPath = writeModelsJson({ providers: {} });
@@ -352,9 +352,8 @@ describe("ModelRegistry models.json auth", () => {
 
     expect(registry.getError()).toBeUndefined();
     expect(registry.find(providerId, "glm-5.1")?.name).toBe("GLM 5.1");
-    await expect(registry.getApiKeyForProvider(providerId)).resolves.toBe(
-      "released-zai-provider-test-key",
-    );
+    await expect(registry.getApiKeyForProvider(providerId)).resolves.toBeUndefined();
+    expect(registry.getProviderAuthStatus(providerId).configured).toBe(false);
     expect(listPersistedPluginModelCatalogs(agentDir)).toEqual([{ pluginId: "zai", contents }]);
     expect(existsSync(catalogPath)).toBe(false);
   });

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -621,7 +621,15 @@ export class ModelRegistry {
             : providerConfig),
           models: providerConfig.models?.map((model) => {
             const { headers: _headers, ...inventory } = model;
-            return Object.assign(generated ? inventory : model, { maxTokensSource });
+            if (generated) {
+              return Object.assign(inventory, { maxTokensSource });
+            }
+            // Capture the authored request route before lower-trust model fields merge.
+            return Object.assign(model, {
+              maxTokensSource,
+              api: model.api ?? providerConfig.api,
+              baseUrl: model.baseUrl ?? providerConfig.baseUrl,
+            });
           }),
         };
       }

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -813,7 +813,7 @@ export class ModelRegistry {
   }
 
   private getModelRequestKey(provider: string, modelId: string): string {
-    return `${provider}:${modelId}`;
+    return JSON.stringify([provider, modelId]);
   }
 
   private storeProviderRequestConfig(

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -24,6 +24,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentDir } from "../config.js";
 import { hasUsableCustomProviderApiKey } from "../model-auth-provider-config.js";
 import { parseModelCatalogJson } from "../model-catalog-json.js";
+import { modelTransportRoutesMatch } from "../model-compat-catalog.js";
 import { resolveModelPluginMetadataSnapshot } from "../model-discovery-context.js";
 import { mergeProviderModels } from "../models-config.merge.js";
 import {
@@ -241,6 +242,7 @@ function formatValidationPath(error: TLocalizedValidationError): string {
 }
 
 interface ProviderRequestConfig {
+  baseUrls?: readonly string[];
   apiKey?: string;
   auth?: ProviderAuthMode;
   headers?: Record<string, string>;
@@ -789,11 +791,25 @@ export class ModelRegistry {
    * Get API key for a model.
    */
   hasConfiguredAuth(model: Model): boolean {
+    const providerConfig = this.getModelProviderRequestConfig(model);
     return (
       this.authStorage.hasAuth(model.provider) ||
-      this.providerRequestConfigs.get(model.provider)?.auth === "aws-sdk" ||
-      this.providerRequestConfigs.get(model.provider)?.apiKey !== undefined
+      providerConfig?.auth === "aws-sdk" ||
+      providerConfig?.apiKey !== undefined
     );
+  }
+
+  private getModelProviderRequestConfig(model: Model): ProviderRequestConfig | undefined {
+    const config = this.providerRequestConfigs.get(model.provider);
+    if (
+      config?.baseUrls &&
+      !config.baseUrls.some((baseUrl) =>
+        modelTransportRoutesMatch({ baseUrl }, { baseUrl: model.baseUrl }),
+      )
+    ) {
+      return undefined;
+    }
+    return config;
   }
 
   private getModelRequestKey(provider: string, modelId: string): string {
@@ -803,6 +819,8 @@ export class ModelRegistry {
   private storeProviderRequestConfig(
     providerName: string,
     config: {
+      baseUrl?: string;
+      models?: readonly { baseUrl?: string }[];
       apiKey?: string;
       auth?: ProviderAuthMode;
       headers?: Record<string, string>;
@@ -814,6 +832,11 @@ export class ModelRegistry {
     }
 
     this.providerRequestConfigs.set(providerName, {
+      // File-authored endpoints authorize these settings; generated destinations do not.
+      // Route-less runtime registrations retain their explicit caller-owned scope.
+      baseUrls: config.baseUrl
+        ? [config.baseUrl, ...(config.models ?? []).flatMap((model) => model.baseUrl ?? [])]
+        : undefined,
       apiKey: config.apiKey,
       auth: config.auth,
       headers: config.headers,
@@ -839,7 +862,7 @@ export class ModelRegistry {
    */
   async getApiKeyAndHeaders(model: Model): Promise<ResolvedRequestAuth> {
     try {
-      const providerConfig = this.providerRequestConfigs.get(model.provider);
+      const providerConfig = this.getModelProviderRequestConfig(model);
       const usesAwsSdkAuth = providerConfig?.auth === "aws-sdk";
       const apiKeyFromAuthStorage = usesAwsSdkAuth
         ? undefined

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -621,11 +621,8 @@ export class ModelRegistry {
             : providerConfig),
           models: providerConfig.models?.map((model) => {
             const { headers: _headers, ...inventory } = model;
-            if (generated) {
-              return Object.assign(inventory, { maxTokensSource });
-            }
-            // Capture the authored request route before lower-trust model fields merge.
-            return Object.assign(model, {
+            // Capture each source's route before its provider defaults are merged.
+            return Object.assign(generated ? inventory : model, {
               maxTokensSource,
               api: model.api ?? providerConfig.api,
               baseUrl: model.baseUrl ?? providerConfig.baseUrl,

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -25,6 +25,7 @@ import { getAgentDir } from "../config.js";
 import { hasUsableCustomProviderApiKey } from "../model-auth-provider-config.js";
 import { parseModelCatalogJson } from "../model-catalog-json.js";
 import { resolveModelPluginMetadataSnapshot } from "../model-discovery-context.js";
+import { mergeProviderModels } from "../models-config.merge.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
   isGeneratedPluginModelCatalog,
@@ -218,6 +219,12 @@ const validateModelsConfig = Compile(ModelsConfigSchema);
 
 type ModelsConfig = Static<typeof ModelsConfigSchema>;
 type MaxTokensSource = "configured" | "discovered";
+type RegistryProviderSources = Record<
+  string,
+  Omit<ModelsConfig["providers"][string], "models"> & {
+    models?: Array<Static<typeof ModelDefinitionSchema> & { maxTokensSource?: MaxTokensSource }>;
+  }
+>;
 
 function formatValidationPath(error: TLocalizedValidationError): string {
   if (error.keyword === "required") {
@@ -253,12 +260,12 @@ export type ResolvedRequestAuth =
 
 /** Result of loading custom models from models.json */
 interface CustomModelsResult {
-  models: Model[];
+  providers: RegistryProviderSources;
   error: string | undefined;
 }
 
 function emptyCustomModelsResult(error?: string): CustomModelsResult {
-  return { models: [], error };
+  return { providers: {}, error };
 }
 
 type ModelRegistryOptions = {
@@ -483,7 +490,9 @@ export class ModelRegistry {
       // Plugin catalog failures can return salvaged models; root failures return empty.
     }
 
-    let combined = [...customResult.models, ...capturedPluginResult.models];
+    let combined = this.parseModels(
+      this.mergeProviderSources(capturedPluginResult.providers, customResult.providers),
+    );
 
     // Let OAuth providers modify their models (e.g., update baseUrl)
     for (const oauthProvider of this.authStorage.getOAuthProviders()) {
@@ -496,10 +505,29 @@ export class ModelRegistry {
     this.models = combined;
   }
 
+  private mergeProviderSources(
+    ...sources: readonly RegistryProviderSources[]
+  ): RegistryProviderSources {
+    const providers: RegistryProviderSources = {};
+    for (const source of sources) {
+      for (const [providerId, provider] of Object.entries(source)) {
+        const existing = providers[providerId];
+        providers[providerId] = existing
+          ? mergeProviderModels(existing, provider, {
+              providerId,
+              modelIdMatching: "exact",
+              manifestPlugins: this.pluginMetadataSnapshot,
+            })
+          : provider;
+      }
+    }
+    return providers;
+  }
+
   private loadCapturedPluginCatalogs(
     pluginCatalogs: readonly PersistedPluginModelCatalog[],
   ): CustomModelsResult {
-    const models: Model[] = [];
+    let providers: RegistryProviderSources = {};
     const errors: string[] = [];
     for (const pluginCatalog of pluginCatalogs) {
       const result = this.loadCustomModels(
@@ -511,12 +539,12 @@ export class ModelRegistry {
           requireGeneratedCatalog: true,
         },
       );
-      models.push(...result.models);
+      providers = this.mergeProviderSources(providers, result.providers);
       if (result.error) {
         errors.push(result.error);
       }
     }
-    return { models, error: errors.join("\n\n") || undefined };
+    return { providers, error: errors.join("\n\n") || undefined };
   }
 
   private loadCustomModels(
@@ -574,18 +602,30 @@ export class ModelRegistry {
       // Additional validation
       this.validateConfig(configForUse);
 
+      const generated = options.requireGeneratedCatalog === true;
+      const maxTokensSource: MaxTokensSource = generated ? "discovered" : "configured";
+      let sourceProviders: RegistryProviderSources = {};
       for (const [providerName, providerConfig] of Object.entries(configForUse.providers)) {
-        if ((providerConfig.models ?? []).length > 0) {
+        if (!generated && (providerConfig.models ?? []).length > 0) {
           this.storeProviderRequestConfig(providerName, providerConfig);
         }
+        // Generated catalogs supply inventory, never request authority. Record the
+        // source before merging so their headers cannot replace an authored row's.
+        sourceProviders[providerName] = {
+          ...(generated
+            ? {
+                api: providerConfig.api,
+                baseUrl: providerConfig.baseUrl,
+                compat: providerConfig.compat,
+              }
+            : providerConfig),
+          models: providerConfig.models?.map((model) => {
+            const { headers: _headers, ...inventory } = model;
+            return Object.assign(generated ? inventory : model, { maxTokensSource });
+          }),
+        };
       }
 
-      // Root models.json rows are author-owned; generated plugin shards are
-      // catalog-owned. Preserve that distinction before runtime resolution.
-      const models = this.parseModels(
-        configForUse,
-        options.requireGeneratedCatalog === true ? "discovered" : "configured",
-      );
       const pluginCatalogErrors: string[] = [];
       if (options.includePluginCatalogs !== false) {
         let pluginCatalogs: readonly PersistedPluginModelCatalog[] = [];
@@ -601,13 +641,13 @@ export class ModelRegistry {
           );
         }
         const pluginResult = this.loadCapturedPluginCatalogs(pluginCatalogs);
-        models.push(...pluginResult.models);
+        sourceProviders = this.mergeProviderSources(pluginResult.providers, sourceProviders);
         if (pluginResult.error) {
           pluginCatalogErrors.push(pluginResult.error);
         }
       }
 
-      return { models, error: pluginCatalogErrors.join("\n\n") || undefined };
+      return { providers: sourceProviders, error: pluginCatalogErrors.join("\n\n") || undefined };
     } catch (error) {
       if (error instanceof SyntaxError) {
         if (options.requireGeneratedCatalog === true) {
@@ -661,10 +701,10 @@ export class ModelRegistry {
     }
   }
 
-  private parseModels(config: ModelsConfig, maxTokensSource: MaxTokensSource): Model[] {
+  private parseModels(providers: RegistryProviderSources): Model[] {
     const models: Model[] = [];
 
-    for (const [providerName, providerConfig] of Object.entries(config.providers)) {
+    for (const [providerName, providerConfig] of Object.entries(providers)) {
       const modelDefs = providerConfig.models ?? [];
       if (modelDefs.length === 0) {
         continue;
@@ -705,7 +745,9 @@ export class ModelRegistry {
           cost: modelDef.cost ?? defaultCost,
           contextWindow: modelDef.contextWindow ?? 128000,
           maxTokens: modelDef.maxTokens ?? 16384,
-          ...(modelDef.maxTokens !== undefined ? { maxTokensSource } : {}),
+          ...(modelDef.maxTokens !== undefined
+            ? { maxTokensSource: modelDef.maxTokensSource }
+            : {}),
           params: modelDef.params,
           headers: undefined,
           compat,

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -623,11 +623,12 @@ export class ModelRegistry {
             : providerConfig),
           models: providerConfig.models?.map((model) => {
             const { headers: _headers, ...inventory } = model;
-            // Capture each source's route before its provider defaults are merged.
+            // Capture route and effective compatibility before provider defaults merge.
             return Object.assign(generated ? inventory : model, {
               maxTokensSource,
               api: model.api ?? providerConfig.api,
               baseUrl: model.baseUrl ?? providerConfig.baseUrl,
+              compat: mergeCompat(providerConfig.compat, model.compat),
             });
           }),
         };
@@ -737,7 +738,6 @@ export class ModelRegistry {
           continue;
         }
 
-        const compat = mergeCompat(providerConfig.compat, modelDef.compat);
         this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
         const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
         models.push({
@@ -757,7 +757,7 @@ export class ModelRegistry {
             : {}),
           params: modelDef.params,
           headers: undefined,
-          compat,
+          compat: modelDef.compat,
         } as Model);
       }
     }


### PR DESCRIPTION
Related: #136257. AI-assisted.

## What Problem This Solves

Session API callers could select an authored model but receive credentials, headers, or request defaults from a generated catalog. Cached inventory could also revive removed authentication.

## Why This Change Was Made

The registry captures each source's routes and compatibility settings before composition. Authored request settings apply only to their authored endpoints; generated rows supply model metadata without credential authority. Encoded provider/model identity pairs prevent header collisions. Shared configuration callers retain their existing route precedence.

## User Impact

Authored keys, headers, routes, sparse metadata, and custom APIs remain usable. Generated-only inventory requires current credentials or authored configuration. No operator field or persistent schema is added.

Consumers: session model lookup, availability, and compaction preserve each source's routing, authentication, headers, and token settings.

## Evidence

Public API compaction requests reproduced the original crossover. Compiled transport checks verified endpoint isolation, removed-auth rejection, literal-identity header isolation, and source-specific token fields. The final correction passed 66 focused checks and continuous integration. Fresh checks repeated compatibility requests and targeted API controls on the compiled build. Responses and credentials were synthetic; persistent credential writing, live activation, and provider success were not tested.
