### PR TITLE
fix(gateway): restore real-Gateway worker setup coverage

### DIFF
--- a/src/gateway/worker-environments/worker-turn-launcher-initial-setup.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-initial-setup.test.ts
@@ -16,7 +16,6 @@ import { runCommandWithTimeout } from "../../process/exec.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
 import { createCoordinatorTestService } from "./placement-dispatch-coordinator.test-support.js";
-import { seedAttachedPlacementEnvironment } from "./placement-test-fixtures.js";
 import type { WorkerTunnelHandle } from "./tunnel-contract.js";
 import {
   ENVIRONMENT_ID,
@@ -26,6 +25,7 @@ import {
   attachedEnvironment,
   cleanupWorkerTurnLauncherTest,
   database,
+  dispatchInitialWorkerPlacement,
   createWorkerSessionTurnPlacementProvider,
   placements,
   root,
@@ -42,49 +42,23 @@ async function setup(executionMode: "worker-turn" | "remote-exec", pauseAt = "sy
   let failure: Error | undefined;
   const dispatch = coordinateWorkerPlacementDispatch(
     createCoordinatorTestService({
-      dispatch: async (_request, report) => {
-        let placement = placements.startDispatch({ ...sessionTarget, executionMode });
-        const publish = async () => {
-          report?.(placement);
-          if (placement.state === pauseAt) {
-            paused.resolve();
-            await finish.promise;
-            if (failure) {
-              throw failure;
+      dispatch: async (_request, report) =>
+        await dispatchInitialWorkerPlacement({
+          database,
+          placements,
+          identity: { ...sessionTarget, executionMode },
+          workspace: root,
+          onTransition: async (placement) => {
+            report?.(placement);
+            if (placement.state === pauseAt) {
+              paused.resolve();
+              await finish.promise;
+              if (failure) {
+                throw failure;
+              }
             }
-          }
-        };
-        await publish();
-        seedAttachedPlacementEnvironment(database, {
-          environmentId: ENVIRONMENT_ID,
-          sessionId: SESSION_ID,
-          ownerEpoch: OWNER_EPOCH,
-        });
-        for (const step of [
-          { to: "provisioning", patch: { environmentId: ENVIRONMENT_ID } },
-          { to: "syncing", patch: { workerBundleHash: "a".repeat(64) } },
-          {
-            to: "starting",
-            patch: {
-              remoteWorkspaceDir: root,
-              workspaceBaseManifestRef: MANIFEST_REF,
-            },
           },
-          { to: "active", patch: { activeOwnerEpoch: OWNER_EPOCH } },
-        ] as const) {
-          placement = placements.transition({
-            sessionId: SESSION_ID,
-            from: placement.state,
-            expectedGeneration: placement.generation,
-            ...step,
-          });
-          await publish();
-        }
-        if (placement.state !== "active") {
-          throw new Error("fixture did not activate");
-        }
-        return placement;
-      },
+        }),
     }),
     (_request, run) => run(),
   );

--- a/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
@@ -22,6 +22,10 @@ import {
 import type { WorkerComputerLaunchDescriptor } from "../../worker/launch-descriptor.js";
 import type { MintedWorkerCredential } from "./credential.js";
 import { measureNodeWorkerLaunchBytes } from "./node-launch-adapter.js";
+import type {
+  WorkerSessionPlacementDispatchIdentity,
+  WorkerSessionPlacementRecord,
+} from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
@@ -135,6 +139,46 @@ export function createWorkerSessionTurnPlacementProvider(
 
 export function openSessionManager(): SessionManager {
   return SessionManager.open(sessionTarget);
+}
+
+export async function dispatchInitialWorkerPlacement(params: {
+  database: OpenClawStateDatabase;
+  placements: WorkerSessionPlacementStore;
+  identity: WorkerSessionPlacementDispatchIdentity;
+  workspace: string;
+  onTransition: (placement: WorkerSessionPlacementRecord) => Promise<void>;
+}) {
+  let placement = params.placements.startDispatch(params.identity);
+  await params.onTransition(placement);
+  seedAttachedPlacementEnvironment(params.database, {
+    environmentId: ENVIRONMENT_ID,
+    sessionId: params.identity.sessionId,
+    ownerEpoch: OWNER_EPOCH,
+  });
+  for (const step of [
+    { to: "provisioning", patch: { environmentId: ENVIRONMENT_ID } },
+    { to: "syncing", patch: { workerBundleHash: BUNDLE_HASH } },
+    {
+      to: "starting",
+      patch: {
+        remoteWorkspaceDir: params.workspace,
+        workspaceBaseManifestRef: MANIFEST_REF,
+      },
+    },
+    { to: "active", patch: { activeOwnerEpoch: OWNER_EPOCH } },
+  ] as const) {
+    placement = params.placements.transition({
+      sessionId: params.identity.sessionId,
+      from: placement.state,
+      expectedGeneration: placement.generation,
+      ...step,
+    });
+    await params.onTransition(placement);
+  }
+  if (placement.state !== "active") {
+    throw new Error("setup fixture did not activate");
+  }
+  return placement;
 }
 
 export function seedActivePlacement(

--- a/ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts
@@ -22,6 +22,7 @@ import { createWorkerSessionTurnPlacementProvider } from "../../../src/gateway/w
 import {
   attachedEnvironment,
   credential,
+  dispatchInitialWorkerPlacement,
   ENVIRONMENT_ID,
   MANIFEST_REF,
   measureLaunchTurn,
@@ -31,6 +32,7 @@ import {
 import { createWorkerWorkspaceOperationCoordinator } from "../../../src/gateway/worker-environments/workspace-operation-coordinator.js";
 import { runCommandWithTimeout } from "../../../src/process/exec.js";
 import { createDeferredCore } from "../../../src/shared/deferred.js";
+import { openOpenClawStateDatabase } from "../../../src/state/openclaw-state-db.js";
 import { createOpenClawTestState } from "../../../src/test-utils/openclaw-test-state.js";
 import { getFreePort } from "../../../src/test-utils/ports.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
@@ -125,38 +127,25 @@ suite.define(() => {
         sidecarStartup: "start",
       });
       await gateway.startupSettled;
-      const placements = createWorkerSessionPlacementStore();
+      const database = openOpenClawStateDatabase();
+      const placements = createWorkerSessionPlacementStore({ database });
       const syncing = createDeferredCore();
       const dispatch = coordinateWorkerPlacementDispatch(
         createCoordinatorTestService({
-          dispatch: async (_request, report) => {
-            let placement = placements.startDispatch({ ...scope, executionMode: "worker-turn" });
-            for (const step of [
-              { to: "provisioning", patch: { environmentId: ENVIRONMENT_ID } },
-              { to: "syncing", patch: { workerBundleHash: "a".repeat(64) } },
-              {
-                to: "starting",
-                patch: { remoteWorkspaceDir: workspace, workspaceBaseManifestRef: MANIFEST_REF },
+          dispatch: async (_request, report) =>
+            await dispatchInitialWorkerPlacement({
+              database,
+              placements,
+              identity: { ...scope, executionMode: "worker-turn" },
+              workspace,
+              onTransition: async (placement) => {
+                report?.(placement);
+                if (placement.state === "syncing") {
+                  syncing.resolve();
+                  await release.promise;
+                }
               },
-              { to: "active", patch: { activeOwnerEpoch: OWNER_EPOCH } },
-            ] as const) {
-              placement = placements.transition({
-                sessionId,
-                from: placement.state,
-                expectedGeneration: placement.generation,
-                ...step,
-              });
-              report?.(placement);
-              if (placement.state === "syncing") {
-                syncing.resolve();
-                await release.promise;
-              }
-            }
-            if (placement.state !== "active") {
-              throw new Error("setup fixture did not activate");
-            }
-            return placement;
-          },
+            }),
         }),
         (_request, run) => run(),
       );


### PR DESCRIPTION
Refs #143372

## What Problem This Solves

Resolves a problem where unrelated pull requests fail the real-Gateway Control UI job after #143372. The initial-setup browser fixture advances a real placement to active but never publishes its synthetic environment in SQLite, so the atomic activation guard correctly rejects it.

The cited failures are [run 34431819459](https://github.com/openclaw/openclaw/actions/runs/34431819459/job/102733144936) and [run 34432664162](https://github.com/openclaw/openclaw/actions/runs/34432664162/job/102731425647). Both report one failed file and 21 passed files; repeated diagnostics are from the initial-setup case.

## Why This Change Was Made

Share the initial-placement fixture between the existing admission unit tests and the real-Gateway browser test, including the existing durable attachment helper. This removes the duplicate fixture that missed the attachment update and lets the focused unit suite protect the browser fixture's placement-store boundary.

The failure precedes Gateway cleanup. Normal socket closure emits “service restart” in server-close.ts; this test never restarts the Gateway. Production placement assertions, restart behavior, and bounded-ready-capacity semantics stay unchanged.

## User Impact

Restores CI coverage of browser and sessions_send inputs held during worker setup, then executed exactly once. There is no runtime behavior change.

## Evidence

Before the attachment repair:

- Original browser test: one failed test, “Worker session placement setup-proof-session lost its attached environment”, at placement-store.ts:131.
- Shared fixture, before adding its attachment seed: the existing “executes once after syncing becomes authoritative and active” unit case fails with the same error for session-worker-turn. No assertions or budgets were weakened.

Commands and final results:

- `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-launcher-initial-setup.test.ts -t 'executes once after syncing becomes authoritative and active'` — failing-before proof.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-launcher-initial-setup.test.ts src/gateway/worker-environments/placement-store.activation.test.ts` — 28 passed, including missing/stale attachment rollback and database-reopen/adoption coverage.

- `pnpm build` — passed (runtime and UI).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts` — three cases passed: initial setup, avatar rendering, and agent-file read/save. Two neighboring cases failed as described below.
- `node scripts/check-changed.mjs` — passed, including typechecking, lint, ratchets, and dead-export scans.
- `git diff --check` — passed.

Known local proof gaps: the unchanged chat-loading case fails in `agents.update`; an isolated diagnostic rerun exposes `UNAVAILABLE: existing managed handoff lease is incompatible` from `src/infra/update-managed-service-handoff-lease.ts:186`. The unchanged catalog-publication case reads back null instead of the selected model configuration. These are outside the placement fixture and remain recorded rather than changing their assertions. Temporary diagnostic edits were removed.

Autoreview and landing remain with the campaign lead. This PR does not claim a production restart defect.

Exact-head CI: `node scripts/watch-pr-ci.mjs 143666 e5764ebeab55bf5972a18112ccca71d91585ba74` completed with `GREEN`, `github_rollup=SUCCESS`, and zero pending checks. [Run 34435757929](https://github.com/openclaw/openclaw/actions/runs/34435757929) includes a successful [checks-ui-e2e-real-gateway job](https://github.com/openclaw/openclaw/actions/runs/34435757929/job/102740482212).
