### PR TITLE
refactor(workers): consolidate protocol and workspace ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3667,7 +3667,7 @@ src/wizard/setup.post-install-migration.ts	1
 src/wizard/setup.shared.ts	1
 src/wizard/setup.ts	2
 src/worker/inference-stream.runtime.ts	5
-src/worker/launch-descriptor.ts	6
+src/worker/launch-descriptor.ts	5
 src/worker/node-workspace-protocol.ts	1
 src/worker/worker-command.runtime.ts	1
 src/worker/worker-connection-admission.ts	2

--- a/src/gateway/worker-environments/node-carrier-binding.ts
+++ b/src/gateway/worker-environments/node-carrier-binding.ts
@@ -1,0 +1,54 @@
+import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
+import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
+import type { WorkerEnvironmentRecord } from "./store.js";
+
+export type WorkerNodeCarrierBinding = {
+  environmentId: string;
+  leaseId: string;
+  nodeDeviceId: string;
+  ownerEpoch: number;
+};
+
+export type WorkerNodeCarrierRuntime = {
+  transport: NodeWorkerSupervisorTransport;
+  streamBroker: NodeDesktopStreamBroker;
+};
+
+export function snapshotWorkerNodeCarrierBinding(
+  record: WorkerEnvironmentRecord | undefined,
+  message: string,
+  ownerEpoch = record?.ownerEpoch,
+): WorkerNodeCarrierBinding {
+  if (
+    !record ||
+    (record.state !== "ready" && record.state !== "idle" && record.state !== "attached") ||
+    record.destroyRequestedAtMs !== null ||
+    !record.leaseId ||
+    !record.nodeDeviceId ||
+    record.sshEndpoint !== null ||
+    record.ownerEpoch !== ownerEpoch
+  ) {
+    throw new Error(message);
+  }
+  return {
+    environmentId: record.environmentId,
+    leaseId: record.leaseId,
+    nodeDeviceId: record.nodeDeviceId,
+    ownerEpoch: record.ownerEpoch,
+  };
+}
+
+export function isWorkerNodeCarrierBindingCurrent(
+  current: WorkerEnvironmentRecord | undefined,
+  binding: WorkerNodeCarrierBinding,
+): boolean {
+  return Boolean(
+    current &&
+    (current.state === "ready" || current.state === "idle" || current.state === "attached") &&
+    current.destroyRequestedAtMs === null &&
+    current.leaseId === binding.leaseId &&
+    current.nodeDeviceId === binding.nodeDeviceId &&
+    current.sshEndpoint === null &&
+    current.ownerEpoch === binding.ownerEpoch,
+  );
+}

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -14,22 +14,20 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
+import {
+  isWorkerNodeCarrierBindingCurrent,
+  snapshotWorkerNodeCarrierBinding,
+  type WorkerNodeCarrierBinding,
+  type WorkerNodeCarrierRuntime,
+} from "./node-carrier-binding.js";
+import { raceNodeWorkerOperation } from "./node-worker-abort.js";
 import type { WorkerDesktopObserveResult } from "./service-contract.js";
 import type { WorkerEnvironmentRecord, WorkerEnvironmentStore } from "./store.js";
 
 const APP_LAUNCH_TIMEOUT_MS = 30_000;
 
-type NodeDesktopBinding = {
-  environmentId: string;
-  leaseId: string;
-  nodeDeviceId: string;
-  ownerEpoch: number;
+type NodeDesktopBinding = WorkerNodeCarrierBinding & {
   desktop: WorkerDesktopEndpoint;
-};
-
-type NodeDesktopRuntime = {
-  transport: NodeWorkerSupervisorTransport;
-  streamBroker: NodeDesktopStreamBroker;
 };
 
 type ActiveNodeDesktopStream = {
@@ -57,23 +55,12 @@ type WorkerNodeDesktopCarrierOptions = {
 };
 
 function snapshotNodeDesktopBinding(record: WorkerEnvironmentRecord): NodeDesktopBinding {
-  if (
-    (record.state !== "ready" && record.state !== "idle" && record.state !== "attached") ||
-    record.destroyRequestedAtMs !== null ||
-    !record.leaseId ||
-    !record.nodeDeviceId ||
-    record.sshEndpoint !== null ||
-    !record.desktop
-  ) {
-    throw new Error("Worker environment node desktop owner is not active");
+  const message = "Worker environment node desktop owner is not active";
+  const binding = snapshotWorkerNodeCarrierBinding(record, message);
+  if (!record.desktop) {
+    throw new Error(message);
   }
-  return {
-    environmentId: record.environmentId,
-    leaseId: record.leaseId,
-    nodeDeviceId: record.nodeDeviceId,
-    ownerEpoch: record.ownerEpoch,
-    desktop: structuredClone(record.desktop),
-  };
+  return { ...binding, desktop: structuredClone(record.desktop) };
 }
 
 function isBindingCurrent(
@@ -83,12 +70,7 @@ function isBindingCurrent(
   const current = store.get(binding.environmentId);
   return Boolean(
     current &&
-    (current.state === "ready" || current.state === "idle" || current.state === "attached") &&
-    current.destroyRequestedAtMs === null &&
-    current.leaseId === binding.leaseId &&
-    current.nodeDeviceId === binding.nodeDeviceId &&
-    current.sshEndpoint === null &&
-    current.ownerEpoch === binding.ownerEpoch &&
+    isWorkerNodeCarrierBindingCurrent(current, binding) &&
     current.desktop !== null &&
     isDeepStrictEqual(current.desktop, binding.desktop),
   );
@@ -129,45 +111,16 @@ function launchKey(binding: NodeDesktopBinding, app: WorkerDesktopApp): string {
   return `${binding.environmentId}\0${app.id}`;
 }
 
-function signalError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Worker environment node desktop operation aborted");
-}
-
-function raceWithSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(signalError(signal));
-  }
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => {
-      signal.removeEventListener("abort", onAbort);
-      reject(signalError(signal));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-    void operation.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error("Node desktop operation failed"));
-      },
-    );
-  });
-}
-
 /** Carries one durable worker environment's desktop over its private node connection. */
 export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrierOptions) {
-  let runtime: NodeDesktopRuntime | undefined;
+  let runtime: WorkerNodeCarrierRuntime | undefined;
   const claimedEpochs = new Map<string, number>();
   const activeStreams = new Set<ActiveNodeDesktopStream>();
   const activeLaunches = new Map<string, ActiveNodeDesktopLaunch>();
 
   const bindingIsCurrent = (
     binding: NodeDesktopBinding,
-    capturedRuntime: NodeDesktopRuntime,
+    capturedRuntime: WorkerNodeCarrierRuntime,
     node: NodeWorkerSupervisorNodeProof,
   ): boolean =>
     // A broker ticket proves the node connection only. The durable environment row remains
@@ -178,11 +131,18 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
 
   const findCurrentNode = async (
     binding: NodeDesktopBinding,
-    capturedRuntime: NodeDesktopRuntime,
+    capturedRuntime: WorkerNodeCarrierRuntime,
     signal: AbortSignal,
   ): Promise<NodeWorkerSupervisorNodeProof> => {
     signal.throwIfAborted();
-    const nodes = await raceWithSignal(capturedRuntime.transport.listCurrentNodes(), signal);
+    const nodes = await raceNodeWorkerOperation(
+      capturedRuntime.transport.listCurrentNodes(),
+      signal,
+      {
+        aborted: "Worker environment node desktop operation aborted",
+        failed: "Node desktop operation failed",
+      },
+    );
     signal.throwIfAborted();
     const node = nodes.find((candidate) => candidate.nodeId === binding.nodeDeviceId);
     if (!node || !bindingIsCurrent(binding, capturedRuntime, node)) {
@@ -465,7 +425,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
   };
 
   return {
-    bindRuntime(next: NodeDesktopRuntime): void {
+    bindRuntime(next: WorkerNodeCarrierRuntime): void {
       runtime = next;
     },
     launchApp,

--- a/src/gateway/worker-environments/node-worker-abort.ts
+++ b/src/gateway/worker-environments/node-worker-abort.ts
@@ -1,11 +1,21 @@
-export function raceNodeWorkerOperation<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+export function raceNodeWorkerOperation<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+  messages: { aborted: string; failed?: string } = {
+    aborted: "node worker operation aborted",
+    failed: "node worker operation failed",
+  },
+): Promise<T> {
   const abortError = () =>
-    signal.reason instanceof Error ? signal.reason : new Error("node worker operation aborted");
+    signal.reason instanceof Error ? signal.reason : new Error(messages.aborted);
   if (signal.aborted) {
     return Promise.reject(abortError());
   }
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(abortError());
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(abortError());
+    };
     signal.addEventListener("abort", onAbort, { once: true });
     void operation.then(
       (value) => {
@@ -14,7 +24,7 @@ export function raceNodeWorkerOperation<T>(operation: Promise<T>, signal: AbortS
       },
       (error: unknown) => {
         signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error("node worker operation failed"));
+        reject(error instanceof Error ? error : new Error(messages.failed ?? String(error)));
       },
     );
   });

--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -2,7 +2,10 @@ import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { NodeWorkerWorkspaceExecResult } from "../../worker/node-workspace-protocol.js";
-import { NODE_WORKSPACE_EMPTY_MANIFEST_REF } from "../../worker/node-workspace-transfer-protocol.js";
+import {
+  NODE_WORKSPACE_EMPTY_MANIFEST_REF,
+  type NodeWorkerWorkspaceTransferInput,
+} from "../../worker/node-workspace-transfer-protocol.js";
 import { prepareRepositoryPublicationRestore } from "../github-repository-publication-restore.js";
 import { createNodeWorkerRepositoryPreparation } from "./node-worker-repository-preparation.js";
 import {
@@ -20,28 +23,14 @@ import type {
 import { boundedWorkerError } from "./worker-error.js";
 import { runInstrumentedWorkspaceReconcile } from "./workspace-finalize.js";
 import { workerProjectSeedKey } from "./workspace-git-base.js";
-import {
-  measureLocalWorkspaceReconciliation,
-  pruneWorkspaceHashMemo,
-  withWorkspaceHashMemo,
-  type WorkspaceHashMemo,
-  type WorkspaceReconcileMetrics,
-} from "./workspace-hash-memo.js";
+import type { WorkspaceHashMemo, WorkspaceReconcileMetrics } from "./workspace-hash-memo.js";
+import { prepareLocalWorkspaceReconciliation } from "./workspace-local-reconciliation.js";
 import {
   parseWorkerWorkspaceManifest,
   serializeWorkerWorkspaceManifest,
 } from "./workspace-manifest.js";
 import { createWorkerWorkspaceQuiescence } from "./workspace-quiescence.js";
-import {
-  applyStagedWorkerWorkspace,
-  assertWorkspaceResultStable,
-  recoverWorkerWorkspaceReconciliation,
-  type WorkerWorkspaceApplyResult,
-} from "./workspace-reconcile.js";
-import {
-  workerWorkspaceResultStaging,
-  workerWorkspaceTransferPaths,
-} from "./workspace-result-staging.js";
+import { workerWorkspaceTransferPaths } from "./workspace-result-staging.js";
 
 const workspaceLog = createSubsystemLogger("gateway/worker-workspace");
 
@@ -86,6 +75,28 @@ export function createNodeWorkerWorkspaceActions(params: {
       ...command,
       ...(sessionKey === undefined ? {} : { sessionKey }),
     });
+  };
+  const transfer = async (
+    input: NodeWorkerWorkspaceTransferInput,
+    failure: string,
+    command: Pick<WorkerWorkspaceCommand, "timeoutMs" | "assertCurrent" | "signal"> = {
+      timeoutMs: 10 * 60_000,
+    },
+  ) => {
+    const result = await exec({
+      ...command,
+      argv: ["openclaw-internal-workspace-transfer"],
+      transfer: input,
+      transportRetry: "never",
+    });
+    if (
+      result.termination !== "exit" ||
+      result.code !== 0 ||
+      (input.direction === "download" && result.stdout.trim() !== input.manifestRef)
+    ) {
+      throw new Error(failure);
+    }
+    return result;
   };
   const workspace = createNodeWorkerWorkspaceFallback(exec);
   const quiesceWorkspace = createWorkerWorkspaceQuiescence({
@@ -153,20 +164,15 @@ export function createNodeWorkerWorkspaceActions(params: {
       request.baseManifestRef,
     );
     try {
-      const result = await exec({
-        argv: ["openclaw-internal-workspace-transfer"],
-        transfer: {
+      await transfer(
+        {
           direction: "upload",
           token,
           baseManifestRef: request.baseManifestRef,
           referenceManifestRef: request.source.referenceManifestRef,
         },
-        timeoutMs: 10 * 60_000,
-        transportRetry: "never",
-      });
-      if (result.code !== 0 || result.termination !== "exit") {
-        throw new Error("Node repository checkpoint upload failed");
-      }
+        "Node repository checkpoint upload failed",
+      );
       const uploaded = params.workspaceTransfer.takeUpload(
         params.environmentId,
         request.baseManifestRef,
@@ -195,21 +201,16 @@ export function createNodeWorkerWorkspaceActions(params: {
               params.environmentId,
               NODE_WORKSPACE_EMPTY_MANIFEST_REF,
             );
-            const captured = await exec({
-              argv: ["openclaw-internal-workspace-transfer"],
-              transfer: {
+            await transfer(
+              {
                 direction: "upload",
                 token: publicationToken,
                 baseManifestRef: NODE_WORKSPACE_EMPTY_MANIFEST_REF,
                 referenceManifestRef: NODE_WORKSPACE_EMPTY_MANIFEST_REF,
                 publicationBaseCommit: uploaded.base.baseCommit,
               },
-              timeoutMs: 10 * 60_000,
-              transportRetry: "never",
-            });
-            if (captured.code !== 0 || captured.termination !== "exit") {
-              throw new Error("Repository publication capture failed");
-            }
+              "Repository publication capture failed",
+            );
             publication = params.workspaceTransfer.takeUpload(
               params.environmentId,
               NODE_WORKSPACE_EMPTY_MANIFEST_REF,
@@ -272,45 +273,33 @@ export function createNodeWorkerWorkspaceActions(params: {
     request: WorkerLocalWorkspaceReconcileRequest,
     metrics: WorkspaceReconcileMetrics,
   ) => {
-    pruneWorkspaceHashMemo(placementHashMemo);
-    const runLocalReconciliation = <T>(operation: () => Promise<T>): Promise<T> =>
-      measureLocalWorkspaceReconciliation(metrics, () =>
-        withWorkspaceHashMemo(placementHashMemo, operation, metrics.gateway),
-      );
-    const pending = request.journal.load();
-    if (pending) {
-      await recoverWorkerWorkspaceReconciliation({ root: request.localPath, journal: pending });
-      request.journal.abort();
-    }
+    const acceptLocal = await prepareLocalWorkspaceReconciliation({
+      request,
+      hashMemo: placementHashMemo,
+      metrics,
+    });
     const uploadToken = params.workspaceTransfer.prepareUpload(
       params.environmentId,
       request.baseManifestRef,
     );
-    let uploadedResult: Awaited<ReturnType<typeof exec>>;
     try {
-      uploadedResult = await exec({
-        argv: ["openclaw-internal-workspace-transfer"],
-        transfer: {
+      await transfer(
+        {
           direction: "upload",
           token: uploadToken,
           baseManifestRef: request.baseManifestRef,
           referenceManifestRef: request.baseManifestRef,
         },
-        timeoutMs: 10 * 60_000,
-        transportRetry: "never",
-      });
+        "Node workspace reconcile upload failed",
+      );
     } finally {
       params.workspaceTransfer.revoke(params.environmentId, uploadToken);
-    }
-    if (uploadedResult.termination !== "exit" || uploadedResult.code !== 0) {
-      throw new Error("Node workspace reconcile upload failed");
     }
     const uploaded = params.workspaceTransfer.takeUpload(
       params.environmentId,
       request.baseManifestRef,
     );
     try {
-      const changed = uploaded.currentManifestRef !== request.baseManifestRef;
       let expectedRemoteRef = uploaded.currentManifestRef;
       const verifyStable = async () => {
         const observed = await workspace.captureManifest(
@@ -322,7 +311,6 @@ export function createNodeWorkerWorkspaceActions(params: {
           throw new Error("Cloud workspace changed during final reconciliation");
         }
       };
-      await verifyStable();
       const publishAcceptedManifest = async (accepted: {
         manifestRef: string;
         manifest: typeof uploaded.current;
@@ -338,82 +326,21 @@ export function createNodeWorkerWorkspaceActions(params: {
           root: await fsp.realpath(request.localPath),
         });
         try {
-          const published = await exec({
-            argv: ["openclaw-internal-workspace-transfer"],
-            transfer: { direction: "download", token, manifestRef: accepted.manifestRef },
-            timeoutMs: 10 * 60_000,
-            transportRetry: "never",
-          });
-          if (
-            published.termination !== "exit" ||
-            published.code !== 0 ||
-            published.stdout.trim() !== accepted.manifestRef
-          ) {
-            throw new Error("Node workspace accepted manifest publication failed");
-          }
+          await transfer(
+            { direction: "download", token, manifestRef: accepted.manifestRef },
+            "Node workspace accepted manifest publication failed",
+          );
           expectedRemoteRef = accepted.manifestRef;
         } finally {
           params.workspaceTransfer.revoke(params.environmentId, token);
         }
       };
-      const preparedStagedResult = request.stagedResult
-        ? await runLocalReconciliation(
-            async () =>
-              await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
-                request,
-                stagingRoot: uploaded.stagingRoot,
-                currentManifestRef: uploaded.currentManifestRef,
-                baseManifestRaw: uploaded.baseRaw,
-                currentManifestRaw: uploaded.currentRaw,
-                publishAcceptedManifest,
-              }),
-          )
-        : undefined;
-      let appliedWorkspaceResult: WorkerWorkspaceApplyResult | undefined;
-      if (!preparedStagedResult) {
-        appliedWorkspaceResult = await runLocalReconciliation(
-          async () =>
-            await applyStagedWorkerWorkspace({
-              root: request.localPath,
-              stagingRoot: uploaded.stagingRoot,
-              baseManifestRef: request.baseManifestRef,
-              currentManifestRef: uploaded.currentManifestRef,
-              base: uploaded.base,
-              current: uploaded.current,
-              journal: request.journal,
-              acceptance: { kind: "reconcile", publish: publishAcceptedManifest },
-            }),
-        );
-      }
-      return {
-        get manifestRef() {
-          return expectedRemoteRef;
-        },
-        changed,
+      return await acceptLocal({
+        ...uploaded,
+        publishAcceptedManifest,
+        manifestRef: () => expectedRemoteRef,
         verifyStable,
-        verifyLocalStable: async () =>
-          await runLocalReconciliation(
-            async () =>
-              await (appliedWorkspaceResult?.verifyLocalStable() ??
-                assertWorkspaceResultStable({
-                  root: request.localPath,
-                  base: uploaded.base,
-                  current: uploaded.current,
-                })),
-          ),
-        getAppliedWorkspaceResult: () => appliedWorkspaceResult,
-        ...(preparedStagedResult
-          ? {
-              ...preparedStagedResult,
-              applyPreparedStagedResult: async () => {
-                await runLocalReconciliation(
-                  async () => await preparedStagedResult.applyPreparedStagedResult(),
-                );
-                appliedWorkspaceResult = preparedStagedResult.getAppliedWorkspaceResult();
-              },
-            }
-          : {}),
-      };
+      });
     } finally {
       await fsp.rm(uploaded.stagingRoot, { recursive: true, force: true });
     }
@@ -470,24 +397,15 @@ export function createNodeWorkerWorkspaceActions(params: {
         blobPaths: new Set(workerWorkspaceTransferPaths(manifest, base)),
       });
       try {
-        const applied = await exec({
-          argv: ["openclaw-internal-workspace-transfer"],
-          transfer: {
+        await transfer(
+          {
             direction: "download",
             token,
             manifestRef,
             checkpointBaseManifestRef: baseManifestRef,
           },
-          timeoutMs: 10 * 60_000,
-          transportRetry: "never",
-        });
-        if (
-          applied.code !== 0 ||
-          applied.termination !== "exit" ||
-          applied.stdout.trim() !== manifestRef
-        ) {
-          throw new Error("Repository checkpoint restore failed");
-        }
+          "Repository checkpoint restore failed",
+        );
         for (const command of await prepareRepositoryPublicationRestore({
           ...checkpoint,
           current: manifest,
@@ -552,29 +470,23 @@ if (stat?.isFile() && (stat.mode & 0o111)) {
         environmentId: params.environmentId,
       });
       try {
-        const result = await exec({
-          argv: ["openclaw-internal-workspace-transfer"],
-          transfer: {
+        await transfer(
+          {
             direction: "download",
             token: prepared.token,
             manifestRef: prepared.snapshot.manifestRef,
             attachments: true,
           },
-          transportRetry: "never",
-          assertCurrent: () => {
-            if (!request.isAuthorized()) {
-              throw new Error("Worker attachment transfer authority closed");
-            }
+          "Worker attachment transfer failed",
+          {
+            assertCurrent: () => {
+              if (!request.isAuthorized()) {
+                throw new Error("Worker attachment transfer authority closed");
+              }
+            },
+            signal: request.signal,
           },
-          signal: request.signal,
-        });
-        if (
-          result.termination !== "exit" ||
-          result.code !== 0 ||
-          result.stdout.trim() !== prepared.snapshot.manifestRef
-        ) {
-          throw new Error("Worker attachment transfer failed");
-        }
+        );
       } finally {
         params.workspaceTransfer.revoke(params.environmentId, prepared.token);
       }
@@ -621,9 +533,8 @@ if (stat?.isFile() && (stat.mode & 0o111)) {
               return await workspace.finalizeSync(localRequest, origin.result);
             }
           }
-          const transferred = await exec({
-            argv: ["openclaw-internal-workspace-transfer"],
-            transfer: {
+          const transferred = await transfer(
+            {
               direction: "download",
               token: prepared.token,
               manifestRef: prepared.snapshot.manifestRef,
@@ -636,16 +547,8 @@ if (stat?.isFile() && (stat.mode & 0o111)) {
                   }
                 : {}),
             },
-            timeoutMs: 10 * 60_000,
-            transportRetry: "never",
-          });
-          if (
-            transferred.termination !== "exit" ||
-            transferred.code !== 0 ||
-            transferred.stdout.trim() !== prepared.snapshot.manifestRef
-          ) {
-            throw new Error("Node workspace transfer failed");
-          }
+            "Node workspace transfer failed",
+          );
           return await workspace.finalizeSync(localRequest, {
             mode: prepared.snapshot.manifest.baseCommit ? ("git" as const) : ("plain" as const),
             remoteWorkspaceDir: transferred.workspaceDir,

--- a/src/gateway/worker-environments/portal-node-carrier.ts
+++ b/src/gateway/worker-environments/portal-node-carrier.ts
@@ -6,22 +6,17 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
-import type { WorkerEnvironmentRecord, WorkerEnvironmentStore } from "./store.js";
-
-type NodePortalBinding = {
-  environmentId: string;
-  leaseId: string;
-  nodeDeviceId: string;
-  ownerEpoch: number;
-};
-
-type NodePortalRuntime = {
-  transport: NodeWorkerSupervisorTransport;
-  streamBroker: NodeDesktopStreamBroker;
-};
+import {
+  isWorkerNodeCarrierBindingCurrent,
+  snapshotWorkerNodeCarrierBinding,
+  type WorkerNodeCarrierBinding,
+  type WorkerNodeCarrierRuntime,
+} from "./node-carrier-binding.js";
+import { raceNodeWorkerOperation } from "./node-worker-abort.js";
+import type { WorkerEnvironmentStore } from "./store.js";
 
 type ActiveNodePortal = {
-  binding: NodePortalBinding;
+  binding: WorkerNodeCarrierBinding;
   controller: AbortController;
   streams: Set<ActiveNodePortalStream>;
   closed: boolean;
@@ -39,95 +34,34 @@ type ActiveNodePortalStream = {
 const UNSUPPORTED_NODE_PORTAL_MESSAGE =
   "Portals require a current cloud-worker node with portal stream support; move the session back to the gateway with sessions.move";
 
-function snapshotNodePortalBinding(
-  record: WorkerEnvironmentRecord | undefined,
-  ownerEpoch: number,
-): NodePortalBinding {
-  if (
-    !record ||
-    (record.state !== "ready" && record.state !== "idle" && record.state !== "attached") ||
-    record.destroyRequestedAtMs !== null ||
-    !record.leaseId ||
-    !record.nodeDeviceId ||
-    record.sshEndpoint !== null ||
-    record.ownerEpoch !== ownerEpoch
-  ) {
-    throw new Error(UNSUPPORTED_NODE_PORTAL_MESSAGE);
-  }
-  return {
-    environmentId: record.environmentId,
-    leaseId: record.leaseId,
-    nodeDeviceId: record.nodeDeviceId,
-    ownerEpoch: record.ownerEpoch,
-  };
-}
-
-function isNodePortalBindingCurrent(
-  store: Pick<WorkerEnvironmentStore, "get">,
-  binding: NodePortalBinding,
-): boolean {
-  const current = store.get(binding.environmentId);
-  return Boolean(
-    current &&
-    (current.state === "ready" || current.state === "idle" || current.state === "attached") &&
-    current.destroyRequestedAtMs === null &&
-    current.leaseId === binding.leaseId &&
-    current.nodeDeviceId === binding.nodeDeviceId &&
-    current.sshEndpoint === null &&
-    current.ownerEpoch === binding.ownerEpoch,
-  );
-}
-
-function nodePortalAbortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Worker environment node portal owner stopped");
-}
-
-function raceNodePortalAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(nodePortalAbortError(signal));
-  }
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(nodePortalAbortError(signal));
-    signal.addEventListener("abort", onAbort, { once: true });
-    void operation.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      },
-    );
-  });
-}
-
 /** Opens one ticketed node connection per request while its durable portal owner remains current. */
 export function createWorkerNodePortalCarrier(options: {
   store: Pick<WorkerEnvironmentStore, "get">;
 }) {
-  let runtime: NodePortalRuntime | undefined;
+  let runtime: WorkerNodeCarrierRuntime | undefined;
   const activePortals = new Set<ActiveNodePortal>();
 
   const bindingIsCurrent = (
-    binding: NodePortalBinding,
-    capturedRuntime: NodePortalRuntime,
+    binding: WorkerNodeCarrierBinding,
+    capturedRuntime: WorkerNodeCarrierRuntime,
     node: NodeWorkerSupervisorNodeProof,
   ): boolean =>
     runtime === capturedRuntime &&
-    isNodePortalBindingCurrent(options.store, binding) &&
+    isWorkerNodeCarrierBindingCurrent(options.store.get(binding.environmentId), binding) &&
     node.workerHost.portalStream === NODE_WORKER_PORTAL_STREAM_VERSION &&
     capturedRuntime.transport.isCurrent(node, false);
 
   const findCurrentNode = async (
-    binding: NodePortalBinding,
-    capturedRuntime: NodePortalRuntime,
+    binding: WorkerNodeCarrierBinding,
+    capturedRuntime: WorkerNodeCarrierRuntime,
     signal?: AbortSignal,
   ): Promise<NodeWorkerSupervisorNodeProof> => {
     const discovery = capturedRuntime.transport.listCurrentNodes();
-    const nodes = signal ? await raceNodePortalAbort(discovery, signal) : await discovery;
+    const nodes = signal
+      ? await raceNodeWorkerOperation(discovery, signal, {
+          aborted: "Worker environment node portal owner stopped",
+        })
+      : await discovery;
     signal?.throwIfAborted();
     const node = nodes.find((candidate) => candidate.nodeId === binding.nodeDeviceId);
     if (!node || !bindingIsCurrent(binding, capturedRuntime, node)) {
@@ -217,7 +151,7 @@ export function createWorkerNodePortalCarrier(options: {
   };
 
   return {
-    bindRuntime(next: NodePortalRuntime): void {
+    bindRuntime(next: WorkerNodeCarrierRuntime): void {
       if (runtime && runtime !== next) {
         for (const portal of activePortals) {
           for (const stream of portal.streams) {
@@ -233,7 +167,11 @@ export function createWorkerNodePortalCarrier(options: {
         return false;
       }
       try {
-        const binding = snapshotNodePortalBinding(options.store.get(environmentId), ownerEpoch);
+        const binding = snapshotWorkerNodeCarrierBinding(
+          options.store.get(environmentId),
+          UNSUPPORTED_NODE_PORTAL_MESSAGE,
+          ownerEpoch,
+        );
         await findCurrentNode(binding, capturedRuntime);
         return true;
       } catch {
@@ -245,8 +183,9 @@ export function createWorkerNodePortalCarrier(options: {
       ownerEpoch: number;
       remotePort: number;
     }): Promise<{ connect: () => Promise<Duplex>; close: () => Promise<void> }> {
-      const binding = snapshotNodePortalBinding(
+      const binding = snapshotWorkerNodeCarrierBinding(
         options.store.get(request.environmentId),
+        UNSUPPORTED_NODE_PORTAL_MESSAGE,
         request.ownerEpoch,
       );
       const capturedRuntime = runtime;

--- a/src/gateway/worker-environments/workspace-local-reconciliation.ts
+++ b/src/gateway/worker-environments/workspace-local-reconciliation.ts
@@ -1,0 +1,99 @@
+import type {
+  WorkerLocalWorkspaceReconcileRequest,
+  WorkerWorkspaceReconcileResult,
+} from "./tunnel-contract.js";
+import {
+  measureLocalWorkspaceReconciliation,
+  pruneWorkspaceHashMemo,
+  withWorkspaceHashMemo,
+  type WorkspaceHashMemo,
+  type WorkspaceReconcileMetrics,
+} from "./workspace-hash-memo.js";
+import type { WorkerWorkspaceManifest } from "./workspace-manifest.js";
+import {
+  applyStagedWorkerWorkspace,
+  recoverWorkerWorkspaceReconciliation,
+} from "./workspace-reconcile.js";
+import { workerWorkspaceResultStaging } from "./workspace-result-staging.js";
+
+/** Accepts authenticated transport snapshots through one local journal and result owner. */
+export async function prepareLocalWorkspaceReconciliation(params: {
+  request: WorkerLocalWorkspaceReconcileRequest;
+  hashMemo: WorkspaceHashMemo;
+  metrics: WorkspaceReconcileMetrics;
+}) {
+  const { request, hashMemo, metrics } = params;
+  const pending = request.journal.load();
+  if (pending) {
+    await recoverWorkerWorkspaceReconciliation({ root: request.localPath, journal: pending });
+    request.journal.abort();
+  }
+  pruneWorkspaceHashMemo(hashMemo);
+  const runLocal = <T>(operation: () => Promise<T>): Promise<T> =>
+    measureLocalWorkspaceReconciliation(metrics, () =>
+      withWorkspaceHashMemo(hashMemo, operation, metrics.gateway),
+    );
+
+  return async (snapshot: {
+    stagingRoot: string;
+    base: WorkerWorkspaceManifest;
+    current: WorkerWorkspaceManifest;
+    baseRaw: string;
+    currentRaw: string;
+    currentManifestRef: string;
+    publishAcceptedManifest: (accepted: {
+      manifestRef: string;
+      manifest: WorkerWorkspaceManifest;
+      conflictPaths: string[];
+    }) => Promise<void>;
+    manifestRef: () => string;
+    verifyStable: () => Promise<void>;
+  }): Promise<WorkerWorkspaceReconcileResult> => {
+    // Catch writes that raced the inbound transfer before either staging or local acceptance.
+    // Finalization repeats the remote fence after apply, before releasing its owner.
+    await snapshot.verifyStable();
+    if (request.stagedResult) {
+      const staged = await runLocal(() =>
+        workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
+          request,
+          stagingRoot: snapshot.stagingRoot,
+          currentManifestRef: snapshot.currentManifestRef,
+          baseManifestRaw: snapshot.baseRaw,
+          currentManifestRaw: snapshot.currentRaw,
+          publishAcceptedManifest: snapshot.publishAcceptedManifest,
+        }),
+      );
+      return {
+        get manifestRef() {
+          return snapshot.manifestRef();
+        },
+        changed: snapshot.currentManifestRef !== request.baseManifestRef,
+        verifyStable: snapshot.verifyStable,
+        ...staged,
+        applyPreparedStagedResult: () => runLocal(() => staged.applyPreparedStagedResult()),
+        verifyLocalStable: () => runLocal(() => staged.verifyLocalStable()),
+      };
+    }
+    const applied = await runLocal(() =>
+      applyStagedWorkerWorkspace({
+        root: request.localPath,
+        stagingRoot: snapshot.stagingRoot,
+        baseManifestRef: request.baseManifestRef,
+        currentManifestRef: snapshot.currentManifestRef,
+        base: snapshot.base,
+        current: snapshot.current,
+        journal: request.journal,
+        acceptance: { kind: "reconcile", publish: snapshot.publishAcceptedManifest },
+      }),
+    );
+    return {
+      get manifestRef() {
+        return snapshot.manifestRef();
+      },
+      changed: snapshot.currentManifestRef !== request.baseManifestRef,
+      verifyStable: snapshot.verifyStable,
+      getAppliedWorkspaceResult: () => applied,
+      verifyLocalStable: () => runLocal(() => applied.verifyLocalStable()),
+    };
+  };
+}

--- a/src/gateway/worker-environments/workspace-reconcile-core.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-core.ts
@@ -536,18 +536,3 @@ export function retainedConflictPaths(
     .filter((entryPath) => !hasPathAncestor(blockingConflicts, entryPath))
     .toSorted();
 }
-
-export async function assertWorkspaceResultStable(params: {
-  root: string;
-  base: WorkerWorkspaceManifest;
-  current: WorkerWorkspaceManifest;
-}): Promise<void> {
-  await assertWorkspaceMatchesManifest({ root: params.root, manifest: params.current });
-  const preflight = await preflightWorkspaceApply(params);
-  const unstablePath = preflight.conflictPaths[0] ?? preflight.applyPaths.values().next().value;
-  if (unstablePath) {
-    throw new ConcurrentWorkspacePathError(
-      `Gateway workspace changed after cloud dispatch: ${unstablePath}`,
-    );
-  }
-}

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -24,30 +24,21 @@ import { runInstrumentedWorkspaceReconcile } from "./workspace-finalize.js";
 import { prepareWorkerWorkspaceGitPack } from "./workspace-git-base.js";
 import {
   MAX_WORKSPACE_HASH_MEMO_BYTES,
-  measureLocalWorkspaceReconciliation,
-  pruneWorkspaceHashMemo,
-  withWorkspaceHashMemo,
   type WorkspaceHashMemo,
   type WorkspaceReconcileMetrics,
 } from "./workspace-hash-memo.js";
 import { MAX_WORKSPACE_MANIFEST_BYTES } from "./workspace-inventory-limits.js";
+import { prepareLocalWorkspaceReconciliation } from "./workspace-local-reconciliation.js";
 import { DERIVED_WORKSPACE_RSYNC_EXCLUDES } from "./workspace-path-exclusions.js";
 import { createWorkerWorkspaceQuiescence } from "./workspace-quiescence.js";
 import {
-  applyStagedWorkerWorkspace,
   assertWorkspaceMatchesManifest,
-  assertWorkspaceResultStable,
   MAX_RECONCILIATION_ENTRIES,
   MAX_RECONCILIATION_FILE_BYTES,
   MAX_RECONCILIATION_TOTAL_BYTES,
   parseWorkerWorkspaceManifest,
-  recoverWorkerWorkspaceReconciliation,
-  type WorkerWorkspaceApplyResult,
 } from "./workspace-reconcile.js";
-import {
-  workerWorkspaceResultStaging,
-  workerWorkspaceTransferPaths,
-} from "./workspace-result-staging.js";
+import { workerWorkspaceTransferPaths } from "./workspace-result-staging.js";
 import {
   captureRemoteWorkspaceManifest,
   createWorkerWorkspaceRsyncReceiverPathFactory,
@@ -444,17 +435,8 @@ export function createWorkerWorkspaceActions(
     if (!path.isAbsolute(request.localPath) || !path.posix.isAbsolute(request.remoteWorkspaceDir)) {
       throw new Error("Worker workspace reconcile paths must be absolute");
     }
-    const pending = request.journal.load();
-    if (pending) {
-      await recoverWorkerWorkspaceReconciliation({ root: request.localPath, journal: pending });
-      request.journal.abort();
-    }
-    pruneWorkspaceHashMemo(placementHashMemo);
     const hashMemo = placementHashMemo;
-    const runLocalReconciliation = <T>(operation: () => Promise<T>): Promise<T> =>
-      measureLocalWorkspaceReconciliation(metrics, () =>
-        withWorkspaceHashMemo(hashMemo, operation, metrics.gateway),
-      );
+    const acceptLocal = await prepareLocalWorkspaceReconciliation({ request, hashMemo, metrics });
     const baseDigest = await resolveRemoteWorkspaceManifest(
       runWorkspaceCommand,
       request.remoteWorkspaceDir,
@@ -610,67 +592,17 @@ export function createWorkerWorkspaceActions(
           entries: current.entries.filter((entry) => transferPathSet.has(entry.path)),
         });
       }
-      // Catch additions, deletions, and writes that raced the inbound transfer.
-      // Stop performs this check once more after local acceptance, directly
-      // before destroying the remote owner.
-      await verifyStable(currentRef);
-      const preparedStagedResult = request.stagedResult
-        ? await runLocalReconciliation(
-            async () =>
-              await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
-                request,
-                stagingRoot,
-                currentManifestRef: currentRef,
-                baseManifestRaw: baseRaw,
-                currentManifestRaw: currentRaw,
-                publishAcceptedManifest,
-              }),
-          )
-        : undefined;
-      const stagedResult = preparedStagedResult
-        ? {
-            ...preparedStagedResult,
-            applyPreparedStagedResult: async () =>
-              await runLocalReconciliation(
-                async () => await preparedStagedResult.applyPreparedStagedResult(),
-              ),
-            verifyLocalStable: async () =>
-              await runLocalReconciliation(
-                async () => await preparedStagedResult.verifyLocalStable(),
-              ),
-          }
-        : undefined;
-      let appliedWorkspaceResult: WorkerWorkspaceApplyResult | undefined;
-      if (!stagedResult) {
-        appliedWorkspaceResult = await runLocalReconciliation(
-          async () =>
-            await applyStagedWorkerWorkspace({
-              root: request.localPath,
-              stagingRoot,
-              baseManifestRef: request.baseManifestRef,
-              currentManifestRef: currentRef,
-              base,
-              current,
-              journal: request.journal,
-              acceptance: { kind: "reconcile", publish: publishAcceptedManifest },
-            }),
-        );
-      }
-      return {
-        get manifestRef() {
-          return expectedRemoteRef();
-        },
-        changed,
+      return await acceptLocal({
+        stagingRoot,
+        base,
+        current,
+        baseRaw,
+        currentRaw,
+        currentManifestRef: currentRef,
+        publishAcceptedManifest,
+        manifestRef: expectedRemoteRef,
         verifyStable: async () => await verifyStable(expectedRemoteRef()),
-        verifyLocalStable: async () =>
-          await runLocalReconciliation(
-            async () =>
-              await (appliedWorkspaceResult?.verifyLocalStable() ??
-                assertWorkspaceResultStable({ root: request.localPath, base, current })),
-          ),
-        getAppliedWorkspaceResult: () => appliedWorkspaceResult,
-        ...stagedResult,
-      };
+      });
     } finally {
       await fs.rm(temporaryDirectory, { recursive: true, force: true }).catch(() => undefined);
     }

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -31,6 +31,7 @@ import {
   isStagedInputPath,
   stagedInputDirectoriesFromEntries,
 } from "../media/staged-inputs.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import {
   boundedWorkspaceTransferChunks,
   readWorkspaceTransferBody as readResponseBody,
@@ -190,29 +191,13 @@ function workspacePath(root: string, relative: string): string {
   return candidate;
 }
 
-const workspaceTransferQueues = new Map<string, Promise<void>>();
+const workspaceTransferQueue = new KeyedAsyncQueue();
 
-export async function serializeNodeWorkerWorkspace<T>(
+export function serializeNodeWorkerWorkspace<T>(
   workspaceDir: string,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const key = path.resolve(workspaceDir);
-  const previous = workspaceTransferQueues.get(key) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.then(() => current);
-  workspaceTransferQueues.set(key, queued);
-  await previous;
-  try {
-    return await operation();
-  } finally {
-    release();
-    if (workspaceTransferQueues.get(key) === queued) {
-      workspaceTransferQueues.delete(key);
-    }
-  }
+  return workspaceTransferQueue.enqueue(path.resolve(workspaceDir), operation);
 }
 
 async function downloadWorkspace(params: {

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -203,6 +203,10 @@ describe("worker launch descriptor", () => {
         "https://github.com/openclaw/openclaw.git\n",
       ].map((remoteUrl) => withBinding({ remoteUrl })),
       withBinding({ gitAuthor: { unexpected: true } }),
+      withBinding({ remoteUrl: undefined }),
+      withBinding({ gitAuthor: undefined }),
+      withBinding({ gitAuthor: { name: undefined } }),
+      withBinding({ gitAuthor: { email: undefined } }),
       ...["name", "email"].flatMap((key) =>
         ["", " ", "author\nvalue", "author\rvalue", "author\u0000value", "x".repeat(257)].map(
           (value) => withBinding({ gitAuthor: { [key]: value } }),

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { Value } from "typebox/value";
+import { z } from "zod";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -20,7 +21,6 @@ import {
   type WorkerTranscriptMessage,
   WorkerTranscriptMessageSchema,
   WorkerTranscriptUserMessageSchema,
-  type WorkerTranscriptCommitParams,
   WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
@@ -37,13 +37,12 @@ import {
   type WorkerSkillWorkshopBinding,
 } from "../../packages/gateway-protocol/src/schema/worker-skill-workshop.js";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/version.js";
-import type { OperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import {
   ComputerUseCapabilityDescriptorSchema,
   type ComputerUseCapabilityDescriptor,
 } from "../plugins/computer-use-contract.js";
-import { hasExactOwnKeys } from "./protocol-record.js";
-import { isWorkerToolName, type WorkerToolAuthority } from "./tool-authority.js";
+import { hasExactOwnKeys, workerProtocolObject } from "./protocol-record.js";
+import { isWorkerToolName, type WorkerToolName } from "./tool-authority.js";
 import { isWorkerTranscriptMessageFrameSafe } from "./transcript-message.js";
 import {
   parseWorkerConnectionEndpoint,
@@ -52,58 +51,18 @@ import {
 
 const LAUNCH_VERSION = 4;
 
-export type WorkerBrowserLaunchDescriptor = {
-  cdpUrl: string;
-  launcherPath: string;
-};
-
-export type WorkerComputerLaunchDescriptor = {
-  nodeId: string;
-  computerUse: ComputerUseCapabilityDescriptor;
-};
-
-export type WorkerGitHubLaunchBinding = {
-  token: string;
-  login: string;
-  branch: string;
-  remoteUrl?: string;
-  gitAuthor?: { name?: string; email?: string };
-};
-
 type WorkerLaunchPermissionContext =
   | { permissionMode: SessionPermissionMode; workerContainmentRoot: string }
   | { permissionMode?: never; workerContainmentRoot?: never };
 
-type WorkerLaunchAssignment = WorkerLaunchPermissionContext & {
-  skillAuthoring?: WorkerSkillWorkshopBinding;
-  skillResources?: SkillResourceDelivery;
-  /** Host placement namespace used for worker-local policy, hooks, and audit attribution. */
-  agentId: string;
-  operationalRunInstance: OperationalRunInstanceRef;
-  /** Opaque host-signed runtime envelope; worker code never parses private identity. */
-  agentRuntimeIdentityToken: string;
-  runId: string;
-  turnId: string;
-  prompt: string | Extract<WorkerTranscriptMessage, { role: "user" }>["content"];
-  suppressPromptTranscript: boolean;
-  workspaceDir: string;
-  modelRef: WorkerInferenceModelRef;
-  inferenceOptions: WorkerInferenceOptions;
-  systemPrompt?: string;
-  initialMessages: WorkerTranscriptMessage[];
-  transcript: {
-    baseLeafId: WorkerTranscriptCommitParams["baseLeafId"];
-    nextSeq: number;
-  };
-  liveEvents: {
-    ackedSeq: number;
-    nextSeq: number;
-  };
-  toolAuthority: WorkerToolAuthority;
-  browser?: WorkerBrowserLaunchDescriptor;
-  computer?: WorkerComputerLaunchDescriptor;
-  github?: WorkerGitHubLaunchBinding;
-};
+export type WorkerBrowserLaunchDescriptor = z.infer<typeof BrowserLaunchSchema>;
+export type WorkerComputerLaunchDescriptor = z.infer<typeof ComputerLaunchSchema>;
+export type WorkerGitHubLaunchBinding = z.infer<typeof GitHubLaunchSchema>;
+type WorkerLaunchAssignment = Omit<
+  z.infer<typeof AssignmentSchema>,
+  "permissionMode" | "workerContainmentRoot"
+> &
+  WorkerLaunchPermissionContext;
 
 type WorkerLaunchAdmission = Omit<WorkerConnectParams["admission"], "runId"> & {
   sessionId: string;
@@ -119,286 +78,170 @@ export type WorkerLaunchDescriptor = WorkerLaunchPlan & {
   connectionEndpoint: WorkerConnectionEndpoint;
 };
 
-function isIdentifier(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    value.trim() === value &&
-    value.length > 0 &&
-    value.length <= WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH
-  );
-}
-
-function isSafeSequence(value: unknown, minimum: number): value is number {
-  return Number.isSafeInteger(value) && typeof value === "number" && value >= minimum;
-}
-
-function isAbsoluteHostPath(value: string): boolean {
-  return path.posix.isAbsolute(value) || path.win32.isAbsolute(value);
-}
-
-function isWorkspacePath(value: unknown): value is string {
-  // Project preparation admits paths longer than the worker identifier limit.
-  return (
-    typeof value === "string" &&
-    value.trim() === value &&
-    value.length <= 4_096 &&
-    !value.includes("\0") &&
-    isAbsoluteHostPath(value)
-  );
-}
-
-function isInferenceOptions(value: unknown): value is WorkerInferenceOptions {
-  return Value.Check(WorkerInferenceOptionsSchema, value);
-}
-
-function parseToolAuthority(value: unknown): WorkerToolAuthority | undefined {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, ["allowedToolNames"]) ||
-    !Array.isArray(value.allowedToolNames) ||
-    !value.allowedToolNames.every(isWorkerToolName) ||
-    new Set(value.allowedToolNames).size !== value.allowedToolNames.length
-  ) {
-    return undefined;
-  }
-  return { allowedToolNames: [...value.allowedToolNames] };
-}
-
-function parseBrowserLaunchDescriptor(value: unknown): WorkerBrowserLaunchDescriptor | undefined {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, ["cdpUrl", "launcherPath"]) ||
-    typeof value.cdpUrl !== "string" ||
-    typeof value.launcherPath !== "string" ||
-    !isAbsoluteHostPath(value.launcherPath)
-  ) {
-    return undefined;
-  }
-  let cdpUrl: URL;
-  try {
-    cdpUrl = new URL(value.cdpUrl);
-  } catch {
-    return undefined;
-  }
-  const port = Number(cdpUrl.port);
-  if (
-    cdpUrl.protocol !== "http:" ||
-    cdpUrl.hostname !== "127.0.0.1" ||
-    cdpUrl.username !== "" ||
-    cdpUrl.password !== "" ||
-    cdpUrl.port === "" ||
-    !Number.isInteger(port) ||
-    port < 1 ||
-    port > 65_535 ||
-    cdpUrl.pathname !== "/" ||
-    cdpUrl.search !== "" ||
-    cdpUrl.hash !== ""
-  ) {
-    return undefined;
-  }
-  return {
-    cdpUrl: value.cdpUrl,
-    launcherPath: value.launcherPath,
-  };
-}
+const Identifier = z
+  .string()
+  .min(1)
+  .max(WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH)
+  .refine((value) => value.trim() === value);
+const Sequence = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
+const AbsoluteHostPath = z
+  .string()
+  .refine((value) => path.posix.isAbsolute(value) || path.win32.isAbsolute(value));
+// Project preparation admits paths longer than the worker identifier limit.
+const WorkspacePath = AbsoluteHostPath.refine(
+  (value) => value.trim() === value && value.length <= 4_096 && !value.includes("\0"),
+);
+const ToolAuthoritySchema = workerProtocolObject({
+  allowedToolNames: z
+    .custom<WorkerToolName[]>(
+      (value) =>
+        Array.isArray(value) &&
+        value.every(isWorkerToolName) &&
+        new Set(value).size === value.length,
+    )
+    .transform((names) => [...names]),
+});
+const BrowserLaunchSchema = workerProtocolObject({
+  cdpUrl: z.string().refine((value) => {
+    const url = URL.parse(value);
+    return (
+      url !== null &&
+      url.protocol === "http:" &&
+      url.hostname === "127.0.0.1" &&
+      url.username === "" &&
+      url.password === "" &&
+      url.port !== "" &&
+      Number(url.port) >= 1 &&
+      Number(url.port) <= 65_535 &&
+      url.pathname === "/" &&
+      url.search === "" &&
+      url.hash === ""
+    );
+  }),
+  launcherPath: AbsoluteHostPath,
+});
+const ComputerLaunchSchema = workerProtocolObject({
+  nodeId: Identifier,
+  computerUse: z.custom<ComputerUseCapabilityDescriptor>((value) =>
+    Value.Check(ComputerUseCapabilityDescriptorSchema, value),
+  ),
+});
+const GitAuthorField = z
+  .string()
+  .max(256)
+  .refine((value) => Boolean(value.trim()) && !/[\0\r\n]/u.test(value));
+const GitAuthorSchema = workerProtocolObject({
+  name: GitAuthorField.optional(),
+  email: GitAuthorField.optional(),
+}).refine((value) => Object.values(value).every((entry) => entry !== undefined));
+const GitHubLaunchSchema = workerProtocolObject({
+  token: z
+    .string()
+    .min(1)
+    .max(2048)
+    .refine((value) => !/[\s\p{Cc}]/u.test(value)),
+  login: z
+    .string()
+    .regex(/^[A-Za-z0-9-]{1,39}$/u)
+    .refine((value) => value.trim() === value),
+  branch: z
+    .string()
+    .min(1)
+    .max(256)
+    .refine(
+      (value) =>
+        !/[\s~^:?*[\\]/u.test(value) &&
+        !value.includes("\0") &&
+        !value.startsWith("-") &&
+        !value.includes("..") &&
+        !value.includes("@{"),
+    ),
+  remoteUrl: z
+    .string()
+    .regex(/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/u)
+    .refine((value) => value.trim() === value)
+    .optional(),
+  gitAuthor: GitAuthorSchema.optional(),
+}).refine((value) => Object.values(value).every((entry) => entry !== undefined));
 
 export function parseWorkerGitHubLaunchBinding(
   value: unknown,
 ): WorkerGitHubLaunchBinding | undefined {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, ["token", "login", "branch"], ["remoteUrl", "gitAuthor"]) ||
-    typeof value.token !== "string" ||
-    value.token.length < 1 ||
-    value.token.length > 2048 ||
-    /[\s\p{Cc}]/u.test(value.token) ||
-    typeof value.login !== "string" ||
-    value.login.trim() !== value.login ||
-    !/^[A-Za-z0-9-]{1,39}$/u.test(value.login) ||
-    typeof value.branch !== "string" ||
-    value.branch.length < 1 ||
-    value.branch.length > 256 ||
-    /[\s~^:?*[\\]/u.test(value.branch) ||
-    value.branch.includes("\u0000") ||
-    value.branch.startsWith("-") ||
-    value.branch.includes("..") ||
-    value.branch.includes("@{") ||
-    (Object.hasOwn(value, "remoteUrl") &&
-      (typeof value.remoteUrl !== "string" ||
-        value.remoteUrl.trim() !== value.remoteUrl ||
-        !/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/u.test(value.remoteUrl)))
-  ) {
-    return undefined;
-  }
-  let gitAuthor: WorkerGitHubLaunchBinding["gitAuthor"];
-  if (Object.hasOwn(value, "gitAuthor")) {
-    if (!isRecord(value.gitAuthor) || !hasExactOwnKeys(value.gitAuthor, [], ["name", "email"])) {
-      return undefined;
-    }
-    for (const entry of Object.values(value.gitAuthor)) {
-      if (
-        typeof entry !== "string" ||
-        !entry.trim() ||
-        entry.length > 256 ||
-        entry.includes("\u0000") ||
-        /[\r\n]/u.test(entry)
-      ) {
-        return undefined;
-      }
-    }
-    gitAuthor = value.gitAuthor;
-  }
-  return {
-    token: value.token,
-    login: value.login,
-    branch: value.branch,
-    ...(typeof value.remoteUrl === "string" ? { remoteUrl: value.remoteUrl } : {}),
-    ...(gitAuthor ? { gitAuthor } : {}),
-  };
+  const parsed = GitHubLaunchSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
-function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(
-      value,
-      [
-        "agentId",
-        "runId",
-        "operationalRunInstance",
-        "agentRuntimeIdentityToken",
-        "turnId",
-        "prompt",
-        "suppressPromptTranscript",
-        "workspaceDir",
-        "modelRef",
-        "inferenceOptions",
-        "initialMessages",
-        "transcript",
-        "liveEvents",
-        "toolAuthority",
-      ],
-      [
-        "systemPrompt",
-        "browser",
-        "computer",
-        "github",
-        "permissionMode",
-        "workerContainmentRoot",
-        "skillResources",
-        "skillAuthoring",
-      ],
+const AssignmentSchema = workerProtocolObject({
+  skillAuthoring: z
+    .custom<WorkerSkillWorkshopBinding>((value) =>
+      Value.Check(WorkerSkillWorkshopBindingSchema, value),
     )
-  ) {
-    return undefined;
-  }
-  const hasPermissionMode = Object.hasOwn(value, "permissionMode");
-  if (
-    value.skillAuthoring !== undefined &&
-    !Value.Check(WorkerSkillWorkshopBindingSchema, value.skillAuthoring)
-  ) {
-    return undefined;
-  }
-  if (
-    value.skillResources !== undefined &&
-    !Value.Check(SkillResourceDeliverySchema, value.skillResources)
-  ) {
-    return undefined;
-  }
-  const hasContainmentRoot = Object.hasOwn(value, "workerContainmentRoot");
-  if (
-    hasPermissionMode !== hasContainmentRoot ||
-    (hasPermissionMode &&
-      (!Value.Check(SessionPermissionModeSchema, value.permissionMode) ||
-        !isWorkspacePath(value.workerContainmentRoot)))
-  ) {
-    return undefined;
-  }
-  if (
-    !isIdentifier(value.agentId) ||
-    !isIdentifier(value.runId) ||
-    !isRecord(value.operationalRunInstance) ||
-    !isIdentifier(value.operationalRunInstance.instanceId) ||
-    value.operationalRunInstance.runId !== value.runId ||
-    typeof value.agentRuntimeIdentityToken !== "string" ||
-    value.agentRuntimeIdentityToken.length < 1 ||
-    value.agentRuntimeIdentityToken.length > 16_384 ||
-    !isIdentifier(value.turnId) ||
-    !(
-      typeof value.prompt === "string" ||
+    .optional(),
+  skillResources: z
+    .custom<SkillResourceDelivery>((value) => Value.Check(SkillResourceDeliverySchema, value))
+    .optional(),
+  agentId: Identifier,
+  operationalRunInstance: z.object({ instanceId: Identifier, runId: Identifier }).readonly(),
+  // The worker carries this opaque host-signed envelope without parsing private identity.
+  agentRuntimeIdentityToken: z.string().min(1).max(16_384),
+  runId: Identifier,
+  turnId: Identifier,
+  prompt: z.custom<string | Extract<WorkerTranscriptMessage, { role: "user" }>["content"]>(
+    (value) =>
+      typeof value === "string" ||
       Value.Check(WorkerTranscriptUserMessageSchema, {
         role: "user",
-        content: value.prompt,
+        content: value,
         timestamp: 0,
-      })
-    ) ||
-    typeof value.suppressPromptTranscript !== "boolean" ||
-    !isWorkspacePath(value.workspaceDir) ||
-    (value.systemPrompt !== undefined && typeof value.systemPrompt !== "string") ||
-    !Array.isArray(value.initialMessages) ||
-    value.initialMessages.length > WORKER_INFERENCE_MAX_CONTEXT_MESSAGES ||
-    !value.initialMessages.every((message) => Value.Check(WorkerTranscriptMessageSchema, message))
-  ) {
+      }),
+  ),
+  suppressPromptTranscript: z.boolean(),
+  workspaceDir: WorkspacePath,
+  modelRef: z.custom<WorkerInferenceModelRef>((value) =>
+    Value.Check(WorkerInferenceModelRefSchema, value),
+  ),
+  inferenceOptions: z.custom<WorkerInferenceOptions>((value) =>
+    Value.Check(WorkerInferenceOptionsSchema, value),
+  ),
+  systemPrompt: z.string().optional(),
+  initialMessages: z.custom<WorkerTranscriptMessage[]>(
+    (value) =>
+      Array.isArray(value) &&
+      value.length <= WORKER_INFERENCE_MAX_CONTEXT_MESSAGES &&
+      value.every((message) => Value.Check(WorkerTranscriptMessageSchema, message)),
+  ),
+  transcript: workerProtocolObject({ baseLeafId: Identifier.nullable(), nextSeq: Sequence.min(1) }),
+  liveEvents: workerProtocolObject({ ackedSeq: Sequence, nextSeq: Sequence.min(1) }).refine(
+    (value) => value.nextSeq === value.ackedSeq + 1,
+  ),
+  toolAuthority: ToolAuthoritySchema,
+  browser: BrowserLaunchSchema.optional(),
+  computer: ComputerLaunchSchema.optional(),
+  github: GitHubLaunchSchema.optional(),
+  permissionMode: z
+    .custom<SessionPermissionMode>((value) => Value.Check(SessionPermissionModeSchema, value))
+    .optional(),
+  workerContainmentRoot: WorkspacePath.optional(),
+}).refine(
+  (value) =>
+    value.operationalRunInstance.runId === value.runId &&
+    value.toolAuthority.allowedToolNames.includes("computer") === (value.computer !== undefined) &&
+    (!Object.hasOwn(value, "github") || value.github !== undefined) &&
+    (Object.hasOwn(value, "permissionMode")
+      ? value.permissionMode !== undefined && value.workerContainmentRoot !== undefined
+      : !Object.hasOwn(value, "workerContainmentRoot")),
+);
+
+function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
+  const parsed = AssignmentSchema.safeParse(value);
+  if (!parsed.success) {
     return undefined;
   }
-  const toolAuthority = parseToolAuthority(value.toolAuthority);
-  if (!toolAuthority) {
-    return undefined;
+  const { permissionMode, workerContainmentRoot, ...assignment } = parsed.data;
+  if (permissionMode !== undefined && workerContainmentRoot !== undefined) {
+    return { ...assignment, permissionMode, workerContainmentRoot };
   }
-  const browser =
-    value.browser === undefined ? undefined : parseBrowserLaunchDescriptor(value.browser);
-  if (value.browser !== undefined && !browser) {
-    return undefined;
-  }
-  const github = Object.hasOwn(value, "github")
-    ? parseWorkerGitHubLaunchBinding(value.github)
-    : undefined;
-  if (Object.hasOwn(value, "github") && !github) {
-    return undefined;
-  }
-  if (
-    toolAuthority.allowedToolNames.includes("computer") !== (value.computer !== undefined) ||
-    (value.computer !== undefined &&
-      (!isRecord(value.computer) ||
-        !hasExactOwnKeys(value.computer, ["nodeId", "computerUse"]) ||
-        !isIdentifier(value.computer.nodeId) ||
-        !Value.Check(ComputerUseCapabilityDescriptorSchema, value.computer.computerUse)))
-  ) {
-    return undefined;
-  }
-  if (
-    !Value.Check(WorkerInferenceModelRefSchema, value.modelRef) ||
-    !isInferenceOptions(value.inferenceOptions)
-  ) {
-    return undefined;
-  }
-  if (
-    !isRecord(value.transcript) ||
-    !hasExactOwnKeys(value.transcript, ["baseLeafId", "nextSeq"]) ||
-    (value.transcript.baseLeafId !== null && !isIdentifier(value.transcript.baseLeafId)) ||
-    !isSafeSequence(value.transcript.nextSeq, 1)
-  ) {
-    return undefined;
-  }
-  if (
-    !isRecord(value.liveEvents) ||
-    !hasExactOwnKeys(value.liveEvents, ["ackedSeq", "nextSeq"]) ||
-    !isSafeSequence(value.liveEvents.ackedSeq, 0) ||
-    !isSafeSequence(value.liveEvents.nextSeq, 1) ||
-    value.liveEvents.nextSeq !== value.liveEvents.ackedSeq + 1
-  ) {
-    return undefined;
-  }
-  return {
-    ...value,
-    operationalRunInstance: Object.freeze({
-      instanceId: value.operationalRunInstance.instanceId,
-      runId: value.runId,
-    }),
-    toolAuthority,
-    ...(browser ? { browser } : {}),
-    ...(github ? { github } : {}),
-  } as WorkerLaunchAssignment;
+  return assignment;
 }
 
 export function buildWorkerConnectParams(

--- a/src/worker/node-supervisor-protocol.ts
+++ b/src/worker/node-supervisor-protocol.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
 import { parseWorkerLaunchPlan, type WorkerLaunchPlan } from "./launch-descriptor.js";
-import { hasExactOwnKeys } from "./protocol-record.js";
+import { workerProtocolObject } from "./protocol-record.js";
 
 const IDENTIFIER_MAX_CHARS = 256;
 const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
@@ -12,87 +13,115 @@ const NODE_WORKER_ERROR_TEXT_MAX_BYTES = 4 * 1024;
 const NODE_WORKER_CONNECTION_FAILURE_CAUSE_MAX_BYTES = 64 * 1024;
 export const NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE = "openclaw-worker-connection-failure-v1";
 
-export type NodeWorkerLaunchInput = {
-  environmentSession: 1;
-  launchId: string;
-  gatewayNamespace: string;
-  expectedBundleHash: string;
-  placementGeneration: number;
-  sessionKey?: string;
-  descriptor: WorkerLaunchPlan;
-};
-
-export type NodeWorkerEnvironmentStopInput = {
-  gatewayNamespace: string;
-  environmentId: string;
-  sessionId: string;
-  ownerEpoch: number;
-};
-
-export type NodeWorkerSupervisorIdentity = {
-  launchId: string;
-  planHash: string;
-  environmentId: string;
-  sessionId: string;
-  ownerEpoch: number;
-  placementGeneration: number;
-  runId: string;
-};
-
-type NodeWorkerSupervisorActiveReceipt = NodeWorkerSupervisorIdentity & {
-  state: "pending" | "running";
-};
-
-type NodeWorkerSupervisorCompletedReceipt = NodeWorkerSupervisorIdentity & {
-  state: "completed";
-  resultJson: string;
-};
-
-type NodeWorkerSupervisorErrorReceipt = NodeWorkerSupervisorIdentity & {
-  state: "failed" | "interrupted" | "cancelled";
-  errorText: string;
-};
-
-export type NodeWorkerSupervisorReceipt =
-  | NodeWorkerSupervisorActiveReceipt
-  | NodeWorkerSupervisorCompletedReceipt
-  | NodeWorkerSupervisorErrorReceipt;
-
-export type NodeWorkerConnectionFailureMessage = {
-  type: typeof NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE;
-  cause: string | null;
-};
-
-function isIdentifier(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    value.length > 0 &&
-    value.length <= IDENTIFIER_MAX_CHARS &&
-    value.trim() === value &&
-    !value.includes("\0")
-  );
-}
-
-function requireIdentifier(value: unknown, label: string): string {
-  if (!isIdentifier(value)) {
-    throw new Error(`INVALID_REQUEST: ${label} must be a bounded non-empty identifier`);
-  }
-  return value;
-}
-
 function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function requireNonNegativeInteger(value: unknown, label: string): number {
-  if (!isNonNegativeInteger(value)) {
-    throw new Error(`INVALID_REQUEST: ${label} must be a non-negative safe integer`);
-  }
-  return value;
-}
-
 function isPlanHash(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+const identifier = (label: string, maxChars = IDENTIFIER_MAX_CHARS) =>
+  z.custom<string>(
+    (value) =>
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= maxChars &&
+      value.trim() === value &&
+      !value.includes("\0"),
+    { error: `INVALID_REQUEST: ${label} must be a bounded non-empty identifier` },
+  );
+const nonNegativeInteger = (label: string) =>
+  z.custom<number>(isNonNegativeInteger, {
+    error: `INVALID_REQUEST: ${label} must be a non-negative safe integer`,
+  });
+const GatewayNamespace = identifier("gatewayNamespace").refine(
+  (value) => typeof value === "string" && GATEWAY_NAMESPACE_PATTERN.test(value),
+  { error: "INVALID_REQUEST: gatewayNamespace must be a safe bounded path component" },
+);
+const IdentityShape = {
+  launchId: identifier("launchId"),
+  planHash: z.custom<string>(isPlanHash, {
+    error: "INVALID_REQUEST: planHash must be 64 lowercase hexadecimal characters",
+  }),
+  environmentId: identifier("environmentId"),
+  sessionId: identifier("sessionId"),
+  ownerEpoch: nonNegativeInteger("ownerEpoch"),
+  placementGeneration: nonNegativeInteger("placementGeneration"),
+  runId: identifier("runId"),
+};
+const Identity = workerProtocolObject(IdentityShape);
+const EnvironmentStop = workerProtocolObject({
+  gatewayNamespace: GatewayNamespace,
+  environmentId: IdentityShape.environmentId,
+  sessionId: IdentityShape.sessionId,
+  ownerEpoch: IdentityShape.ownerEpoch,
+});
+const LaunchInput = workerProtocolObject({
+  environmentSession: z.literal(1, {
+    error: "INVALID_REQUEST: node worker environment lifetime support required",
+  }),
+  sessionKey: identifier("sessionKey", 1_024).optional(),
+  launchId: IdentityShape.launchId,
+  gatewayNamespace: GatewayNamespace,
+  expectedBundleHash: z.custom<string>(isPlanHash, {
+    error: "INVALID_REQUEST: expectedBundleHash must be 64 lowercase hexadecimal characters",
+  }),
+  descriptor: z.transform((value, context) => {
+    try {
+      return parseWorkerLaunchPlan(value);
+    } catch {
+      context.addIssue({
+        code: "custom",
+        message: "INVALID_REQUEST: invalid worker launch descriptor",
+      });
+      return z.NEVER;
+    }
+  }),
+  placementGeneration: IdentityShape.placementGeneration,
+});
+const Lookup = workerProtocolObject({ launchId: IdentityShape.launchId });
+const Receipt = z.union([
+  workerProtocolObject({ ...IdentityShape, state: z.enum(["pending", "running"]) }),
+  workerProtocolObject({
+    ...IdentityShape,
+    state: z.literal("completed"),
+    resultJson: z.custom<string>(isBoundedResultJson),
+  }),
+  workerProtocolObject({
+    ...IdentityShape,
+    state: z.enum(["failed", "interrupted", "cancelled"]),
+    errorText: z.custom<string>(isBoundedErrorText),
+  }),
+]);
+const ConnectionFailure = workerProtocolObject({
+  type: z.literal(NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE),
+  cause: z
+    .string()
+    .min(1)
+    .refine(
+      (value) => Buffer.byteLength(value, "utf8") <= NODE_WORKER_CONNECTION_FAILURE_CAUSE_MAX_BYTES,
+    )
+    .nullable(),
+});
+
+export type NodeWorkerLaunchInput = z.infer<typeof LaunchInput>;
+export type NodeWorkerSupervisorIdentity = z.infer<typeof Identity>;
+export type NodeWorkerEnvironmentStopInput = z.infer<typeof EnvironmentStop>;
+export type NodeWorkerSupervisorReceipt = z.infer<typeof Receipt>;
+export type NodeWorkerConnectionFailureMessage = z.infer<typeof ConnectionFailure>;
+
+function parseRequest<T>(schema: z.ZodType<T>, value: unknown, operation: string): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new Error(
+      issue?.path.length
+        ? issue.message
+        : `INVALID_REQUEST: invalid node worker ${operation} request`,
+    );
+  }
+  return parsed.data;
 }
 
 function decodeRequest(raw?: string | null): unknown {
@@ -123,112 +152,23 @@ export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunc
 }
 
 export function validateNodeWorkerLaunchInput(value: unknown): NodeWorkerLaunchInput {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(
-      value,
-      [
-        "environmentSession",
-        "launchId",
-        "gatewayNamespace",
-        "expectedBundleHash",
-        "placementGeneration",
-        "descriptor",
-      ],
-      ["sessionKey"],
-    )
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker launch request");
+  const input = parseRequest(LaunchInput, value, "launch");
+  assertNodeWorkerLaunchIdentity(input, input.descriptor);
+  if (input.sessionKey === undefined) {
+    delete input.sessionKey;
   }
-  if (value.environmentSession !== 1) {
-    throw new Error("INVALID_REQUEST: node worker environment lifetime support required");
-  }
-  if (
-    value.sessionKey !== undefined &&
-    (typeof value.sessionKey !== "string" ||
-      value.sessionKey.length === 0 ||
-      value.sessionKey.length > 1_024 ||
-      value.sessionKey.trim() !== value.sessionKey ||
-      value.sessionKey.includes("\0"))
-  ) {
-    throw new Error("INVALID_REQUEST: sessionKey must be a bounded non-empty identifier");
-  }
-  const launchId = requireIdentifier(value.launchId, "launchId");
-  const gatewayNamespace = requireIdentifier(value.gatewayNamespace, "gatewayNamespace");
-  if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
-    throw new Error("INVALID_REQUEST: gatewayNamespace must be a safe bounded path component");
-  }
-  if (!isPlanHash(value.expectedBundleHash)) {
-    throw new Error(
-      "INVALID_REQUEST: expectedBundleHash must be 64 lowercase hexadecimal characters",
-    );
-  }
-  let descriptor: WorkerLaunchPlan;
-  try {
-    descriptor = parseWorkerLaunchPlan(value.descriptor);
-  } catch {
-    throw new Error("INVALID_REQUEST: invalid worker launch descriptor");
-  }
-  assertNodeWorkerLaunchIdentity(
-    { launchId, expectedBundleHash: value.expectedBundleHash },
-    descriptor,
-  );
-  return {
-    environmentSession: 1,
-    launchId,
-    gatewayNamespace,
-    ...(value.sessionKey === undefined ? {} : { sessionKey: value.sessionKey }),
-    expectedBundleHash: value.expectedBundleHash,
-    placementGeneration: requireNonNegativeInteger(
-      value.placementGeneration,
-      "placementGeneration",
-    ),
-    descriptor,
-  };
+  return input;
 }
 
 export function parseNodeWorkerLookupInput(raw?: string | null): { launchId: string } {
-  const value = decodeRequest(raw);
-  if (!isRecord(value) || !hasExactOwnKeys(value, ["launchId"])) {
-    throw new Error("INVALID_REQUEST: invalid node worker lookup request");
-  }
-  return { launchId: requireIdentifier(value.launchId, "launchId") };
+  return parseRequest(Lookup, decodeRequest(raw), "lookup");
 }
 
 export function parseNodeWorkerCancelInput(raw?: string | null): NodeWorkerSupervisorIdentity {
   if (!raw || Buffer.byteLength(raw, "utf8") > NODE_WORKER_SUPERVISOR_CONTROL_REQUEST_MAX_BYTES) {
     throw new Error("INVALID_REQUEST: invalid node worker cancel request");
   }
-  const value = decodeRequest(raw);
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, [
-      "launchId",
-      "planHash",
-      "environmentId",
-      "sessionId",
-      "ownerEpoch",
-      "placementGeneration",
-      "runId",
-    ])
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker cancel request");
-  }
-  if (!isPlanHash(value.planHash)) {
-    throw new Error("INVALID_REQUEST: planHash must be 64 lowercase hexadecimal characters");
-  }
-  return {
-    launchId: requireIdentifier(value.launchId, "launchId"),
-    planHash: value.planHash,
-    environmentId: requireIdentifier(value.environmentId, "environmentId"),
-    sessionId: requireIdentifier(value.sessionId, "sessionId"),
-    ownerEpoch: requireNonNegativeInteger(value.ownerEpoch, "ownerEpoch"),
-    placementGeneration: requireNonNegativeInteger(
-      value.placementGeneration,
-      "placementGeneration",
-    ),
-    runId: requireIdentifier(value.runId, "runId"),
-  };
+  return parseRequest(Identity, decodeRequest(raw), "cancel");
 }
 
 export function parseNodeWorkerEnvironmentStopInput(
@@ -237,23 +177,7 @@ export function parseNodeWorkerEnvironmentStopInput(
   if (!raw || Buffer.byteLength(raw, "utf8") > NODE_WORKER_SUPERVISOR_CONTROL_REQUEST_MAX_BYTES) {
     throw new Error("INVALID_REQUEST: invalid node worker environment stop request");
   }
-  const value = decodeRequest(raw);
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, ["gatewayNamespace", "environmentId", "sessionId", "ownerEpoch"])
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker environment stop request");
-  }
-  const gatewayNamespace = requireIdentifier(value.gatewayNamespace, "gatewayNamespace");
-  if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
-    throw new Error("INVALID_REQUEST: gatewayNamespace must be a safe bounded path component");
-  }
-  return {
-    gatewayNamespace,
-    environmentId: requireIdentifier(value.environmentId, "environmentId"),
-    sessionId: requireIdentifier(value.sessionId, "sessionId"),
-    ownerEpoch: requireNonNegativeInteger(value.ownerEpoch, "ownerEpoch"),
-  };
+  return parseRequest(EnvironmentStop, decodeRequest(raw), "environment stop");
 }
 
 export function nodeWorkerPlanHash(
@@ -273,39 +197,6 @@ export function nodeWorkerPlanHash(
       }),
     )
     .digest("hex");
-}
-
-const RECEIPT_IDENTITY_KEYS = [
-  "launchId",
-  "planHash",
-  "environmentId",
-  "sessionId",
-  "ownerEpoch",
-  "placementGeneration",
-  "runId",
-] as const;
-
-function parseReceiptIdentity(value: Record<string, unknown>): NodeWorkerSupervisorIdentity | null {
-  if (
-    !isIdentifier(value.launchId) ||
-    !isPlanHash(value.planHash) ||
-    !isIdentifier(value.environmentId) ||
-    !isIdentifier(value.sessionId) ||
-    !isNonNegativeInteger(value.ownerEpoch) ||
-    !isNonNegativeInteger(value.placementGeneration) ||
-    !isIdentifier(value.runId)
-  ) {
-    return null;
-  }
-  return {
-    launchId: value.launchId,
-    planHash: value.planHash,
-    environmentId: value.environmentId,
-    sessionId: value.sessionId,
-    ownerEpoch: value.ownerEpoch,
-    placementGeneration: value.placementGeneration,
-    runId: value.runId,
-  };
 }
 
 function isBoundedResultJson(value: unknown): value is string {
@@ -335,49 +226,11 @@ function isBoundedErrorText(value: unknown): value is string {
 export function parseNodeWorkerConnectionFailureMessage(
   value: unknown,
 ): NodeWorkerConnectionFailureMessage | null {
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(value, ["type", "cause"]) ||
-    value.type !== NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE ||
-    (value.cause !== null &&
-      (typeof value.cause !== "string" ||
-        value.cause.length === 0 ||
-        Buffer.byteLength(value.cause, "utf8") > NODE_WORKER_CONNECTION_FAILURE_CAUSE_MAX_BYTES))
-  ) {
-    return null;
-  }
-  return {
-    type: NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
-    cause: value.cause,
-  };
+  return ConnectionFailure.safeParse(value).data ?? null;
 }
 
 export function parseNodeWorkerSupervisorReceipt(
   value: unknown,
 ): NodeWorkerSupervisorReceipt | null {
-  if (!isRecord(value) || typeof value.state !== "string") {
-    return null;
-  }
-  const identity = parseReceiptIdentity(value);
-  if (!identity) {
-    return null;
-  }
-  if (value.state === "pending" || value.state === "running") {
-    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state"])
-      ? { ...identity, state: value.state }
-      : null;
-  }
-  if (value.state === "completed") {
-    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "resultJson"]) &&
-      isBoundedResultJson(value.resultJson)
-      ? { ...identity, state: value.state, resultJson: value.resultJson }
-      : null;
-  }
-  if (value.state === "failed" || value.state === "interrupted" || value.state === "cancelled") {
-    return hasExactOwnKeys(value, [...RECEIPT_IDENTITY_KEYS, "state", "errorText"]) &&
-      isBoundedErrorText(value.errorText)
-      ? { ...identity, state: value.state, errorText: value.errorText }
-      : null;
-  }
-  return null;
+  return Receipt.safeParse(value).data ?? null;
 }

--- a/src/worker/node-workspace-protocol.ts
+++ b/src/worker/node-workspace-protocol.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
 import type { SpawnResult } from "../process/exec.js";
-import type { NodeWorkerWorkspaceTransferInput } from "./node-workspace-transfer-protocol.js";
-import { hasExactOwnKeys } from "./protocol-record.js";
+import { NodeWorkerWorkspaceTransferInputSchema } from "./node-workspace-transfer-protocol.js";
+import { hasExactOwnKeys, workerProtocolObject } from "./protocol-record.js";
 import {
   isWorkspaceInspectionCommand,
   WORKSPACE_INSPECTION_COMMAND,
@@ -22,24 +23,79 @@ const ARG_MAX_BYTES = 128 * 1024;
 const TIMEOUT_MAX_MS = 10 * 60 * 1000;
 export const NODE_WORKSPACE_DRAIN_COMMAND = "openclaw-internal-workspace-drain";
 
-export type NodeWorkerWorkspaceSeedInput =
-  | { action: "apply"; key: string }
-  | { action: "store"; key: string; maxAgeMs: number };
-
-export type NodeWorkerWorkspaceExecInput = {
-  gatewayNamespace: string;
-  environmentId: string;
-  sessionId: string;
-  sessionKey?: string;
-  preparationKey?: string;
-  generation: number;
-  argv: string[];
-  input?: string;
-  timeoutMs?: number;
-  resetWorkspace?: boolean;
-  transfer?: NodeWorkerWorkspaceTransferInput;
-  seed?: NodeWorkerWorkspaceSeedInput;
-};
+const SeedKey = z.string().regex(/^[a-f0-9]{64}$/u);
+const SeedInput = z.union([
+  workerProtocolObject({ action: z.literal("apply"), key: SeedKey }),
+  workerProtocolObject({
+    action: z.literal("store"),
+    key: SeedKey,
+    maxAgeMs: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  }),
+]);
+const identifier = (label: string, maxChars = IDENTIFIER_MAX_CHARS) =>
+  z.custom<string>(
+    (value) =>
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= maxChars &&
+      value.trim() === value &&
+      !value.includes("\0"),
+    { error: `INVALID_REQUEST: ${label} must be a bounded non-empty identifier` },
+  );
+const WorkspaceInput = workerProtocolObject({
+  gatewayNamespace: identifier("gatewayNamespace").refine(
+    (value) => typeof value === "string" && GATEWAY_NAMESPACE_PATTERN.test(value),
+    { error: "INVALID_REQUEST: gatewayNamespace must be a safe bounded path component" },
+  ),
+  environmentId: identifier("environmentId"),
+  sessionId: identifier("sessionId"),
+  sessionKey: identifier("sessionKey", 1_024).optional(),
+  preparationKey: z
+    .custom<string>((value) => typeof value === "string" && /^[a-f0-9]{64}$/u.test(value), {
+      error: "INVALID_REQUEST: preparationKey must be a SHA-256 hex digest",
+    })
+    .optional(),
+  generation: z.custom<number>(
+    (value) => typeof value === "number" && Number.isSafeInteger(value) && value >= 0,
+    { error: "INVALID_REQUEST: generation must be a non-negative safe integer" },
+  ),
+  argv: z
+    .custom<string[]>(
+      (value) =>
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.length <= ARGV_MAX_ITEMS &&
+        value.every(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.length > 0 &&
+            !arg.includes("\0") &&
+            Buffer.byteLength(arg, "utf8") <= ARG_MAX_BYTES,
+        ),
+      { error: "INVALID_REQUEST: argv must be a bounded non-empty string array" },
+    )
+    .transform((argv) => [...argv]),
+  input: z
+    .string({ error: "INVALID_REQUEST: workspace command input exceeds its bound" })
+    .optional(),
+  timeoutMs: z
+    .custom<number>(
+      (value) =>
+        typeof value === "number" &&
+        Number.isSafeInteger(value) &&
+        value >= 1 &&
+        value <= TIMEOUT_MAX_MS,
+      { error: "INVALID_REQUEST: workspace command timeout is invalid" },
+    )
+    .optional(),
+  resetWorkspace: z
+    .boolean({ error: "INVALID_REQUEST: resetWorkspace must be a boolean" })
+    .optional(),
+  transfer: NodeWorkerWorkspaceTransferInputSchema.optional(),
+  seed: SeedInput.optional(),
+});
+export type NodeWorkerWorkspaceSeedInput = z.infer<typeof SeedInput>;
+export type NodeWorkerWorkspaceExecInput = z.infer<typeof WorkspaceInput>;
 
 export type NodeWorkerWorkspaceExecResult = SpawnResult & { workspaceDir: string };
 
@@ -54,91 +110,47 @@ function parseJson(raw?: string | null): unknown {
   }
 }
 
-function requireIdentifier(value: unknown, label: string): string {
-  if (
-    typeof value !== "string" ||
-    value.length === 0 ||
-    value.length > IDENTIFIER_MAX_CHARS ||
-    value.trim() !== value ||
-    value.includes("\0")
-  ) {
-    throw new Error(`INVALID_REQUEST: ${label} must be a bounded non-empty identifier`);
-  }
-  return value;
-}
-
 export function parseNodeWorkerWorkspaceExecInput(
   raw?: string | null,
 ): NodeWorkerWorkspaceExecInput {
   const value = parseJson(raw);
-  if (
-    !isRecord(value) ||
-    !hasExactOwnKeys(
-      value,
-      ["gatewayNamespace", "environmentId", "sessionId", "generation", "argv"],
-      ["input", "timeoutMs", "resetWorkspace", "transfer", "seed", "sessionKey", "preparationKey"],
-    )
-  ) {
-    throw new Error("INVALID_REQUEST: invalid node worker workspace request");
+  const parsed = WorkspaceInput.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    if (issue?.path[0] === "transfer") {
+      throw new Error("INVALID_REQUEST: workspace transfer is invalid");
+    }
+    if (issue?.path[0] === "seed") {
+      const validKey =
+        isRecord(value) && isRecord(value.seed) && SeedKey.safeParse(value.seed.key).success;
+      throw new Error(
+        validKey
+          ? "INVALID_REQUEST: workspace seed action or maxAgeMs is invalid"
+          : "INVALID_REQUEST: workspace seed key must be a SHA-256 hex digest",
+      );
+    }
+    throw new Error(
+      issue?.path.length ? issue.message : "INVALID_REQUEST: invalid node worker workspace request",
+    );
   }
-  const gatewayNamespace = requireIdentifier(value.gatewayNamespace, "gatewayNamespace");
+  const input = parsed.data;
+  const inspection = isWorkspaceInspectionCommand(input.argv);
   if (
-    value.preparationKey !== undefined &&
-    (typeof value.preparationKey !== "string" || !/^[a-f0-9]{64}$/u.test(value.preparationKey))
-  ) {
-    throw new Error("INVALID_REQUEST: preparationKey must be a SHA-256 hex digest");
-  }
-  if (
-    value.sessionKey !== undefined &&
-    (typeof value.sessionKey !== "string" ||
-      value.sessionKey.length === 0 ||
-      value.sessionKey.length > 1_024 ||
-      value.sessionKey.trim() !== value.sessionKey ||
-      value.sessionKey.includes("\0"))
-  ) {
-    throw new Error("INVALID_REQUEST: sessionKey must be a bounded non-empty identifier");
-  }
-  if (!GATEWAY_NAMESPACE_PATTERN.test(gatewayNamespace)) {
-    throw new Error("INVALID_REQUEST: gatewayNamespace must be a safe bounded path component");
-  }
-  if (
-    !Number.isSafeInteger(value.generation) ||
-    typeof value.generation !== "number" ||
-    value.generation < 0
-  ) {
-    throw new Error("INVALID_REQUEST: generation must be a non-negative safe integer");
-  }
-  if (
-    !Array.isArray(value.argv) ||
-    value.argv.length === 0 ||
-    value.argv.length > ARGV_MAX_ITEMS ||
-    !value.argv.every(
-      (arg) =>
-        typeof arg === "string" &&
-        arg.length > 0 &&
-        !arg.includes("\0") &&
-        Buffer.byteLength(arg, "utf8") <= ARG_MAX_BYTES,
-    )
-  ) {
-    throw new Error("INVALID_REQUEST: argv must be a bounded non-empty string array");
-  }
-  const inspection = isWorkspaceInspectionCommand(value.argv);
-  if (
-    value.argv[0] === NODE_WORKSPACE_DRAIN_COMMAND &&
-    (value.argv.length !== 1 ||
-      value.input !== undefined ||
-      value.transfer !== undefined ||
-      value.seed !== undefined ||
-      value.resetWorkspace !== undefined)
+    input.argv[0] === NODE_WORKSPACE_DRAIN_COMMAND &&
+    (input.argv.length !== 1 ||
+      input.input !== undefined ||
+      input.transfer !== undefined ||
+      input.seed !== undefined ||
+      input.resetWorkspace !== undefined)
   ) {
     throw new Error("INVALID_REQUEST: workspace drain owns its operation");
   }
   if (
-    value.argv[0] === WORKSPACE_INSPECTION_COMMAND &&
+    input.argv[0] === WORKSPACE_INSPECTION_COMMAND &&
     (!inspection ||
-      value.transfer !== undefined ||
-      value.seed !== undefined ||
-      value.resetWorkspace !== undefined)
+      input.transfer !== undefined ||
+      input.seed !== undefined ||
+      input.resetWorkspace !== undefined)
   ) {
     throw new Error("INVALID_REQUEST: workspace inspection owns its operation");
   }
@@ -146,142 +158,21 @@ export function parseNodeWorkerWorkspaceExecInput(
     throw new Error("INVALID_REQUEST: workspace command request exceeds its bound");
   }
   if (
-    value.input !== undefined &&
-    (typeof value.input !== "string" ||
-      Buffer.byteLength(value.input, "utf8") >
-        (inspection ? WORKSPACE_INSPECTION_MAX_BYTES : NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES))
+    input.input !== undefined &&
+    Buffer.byteLength(input.input, "utf8") >
+      (inspection ? WORKSPACE_INSPECTION_MAX_BYTES : NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES)
   ) {
     throw new Error("INVALID_REQUEST: workspace command input exceeds its bound");
   }
   if (
-    value.timeoutMs !== undefined &&
-    (typeof value.timeoutMs !== "number" ||
-      !Number.isSafeInteger(value.timeoutMs) ||
-      value.timeoutMs < 1 ||
-      value.timeoutMs > TIMEOUT_MAX_MS)
+    input.seed !== undefined &&
+    (input.transfer !== undefined || input.resetWorkspace !== undefined)
   ) {
-    throw new Error("INVALID_REQUEST: workspace command timeout is invalid");
+    throw new Error(
+      "INVALID_REQUEST: workspace seed cannot combine with transfer or resetWorkspace",
+    );
   }
-  if (value.resetWorkspace !== undefined && typeof value.resetWorkspace !== "boolean") {
-    throw new Error("INVALID_REQUEST: resetWorkspace must be a boolean");
-  }
-  let seed: NodeWorkerWorkspaceSeedInput | undefined;
-  if (value.seed !== undefined) {
-    if (value.transfer !== undefined || value.resetWorkspace !== undefined) {
-      throw new Error(
-        "INVALID_REQUEST: workspace seed cannot combine with transfer or resetWorkspace",
-      );
-    }
-    if (
-      !isRecord(value.seed) ||
-      typeof value.seed.key !== "string" ||
-      !/^[a-f0-9]{64}$/u.test(value.seed.key)
-    ) {
-      throw new Error("INVALID_REQUEST: workspace seed key must be a SHA-256 hex digest");
-    }
-    const { action, key, maxAgeMs } = value.seed;
-    if (action === "apply" && hasExactOwnKeys(value.seed, ["action", "key"])) {
-      seed = { action, key };
-    } else if (
-      action === "store" &&
-      hasExactOwnKeys(value.seed, ["action", "key", "maxAgeMs"]) &&
-      typeof maxAgeMs === "number" &&
-      Number.isSafeInteger(maxAgeMs) &&
-      maxAgeMs >= 0
-    ) {
-      seed = { action, key, maxAgeMs };
-    } else {
-      throw new Error("INVALID_REQUEST: workspace seed action or maxAgeMs is invalid");
-    }
-  }
-  let transfer: NodeWorkerWorkspaceTransferInput | undefined;
-  if (value.transfer !== undefined) {
-    if (!isRecord(value.transfer)) {
-      throw new Error("INVALID_REQUEST: workspace transfer is invalid");
-    }
-    const direction = value.transfer.direction;
-    const token = value.transfer.token;
-    const manifestRef = value.transfer.manifestRef;
-    const baseManifestRef = value.transfer.baseManifestRef;
-    const referenceManifestRef = value.transfer.referenceManifestRef;
-    const validRef = (candidate: unknown): candidate is string =>
-      typeof candidate === "string" && /^sha256:[a-f0-9]{64}$/u.test(candidate);
-    if (
-      typeof token !== "string" ||
-      token.length === 0 ||
-      token.length > 1_024 ||
-      token.includes("\0") ||
-      (direction === "download"
-        ? !hasExactOwnKeys(
-            value.transfer,
-            ["direction", "token", "manifestRef"],
-            ["attachments", "seedKey", "checkpointBaseManifestRef"],
-          ) ||
-          (value.transfer.attachments !== undefined && value.transfer.attachments !== true) ||
-          (value.transfer.checkpointBaseManifestRef !== undefined &&
-            (!validRef(value.transfer.checkpointBaseManifestRef) ||
-              value.transfer.attachments !== undefined ||
-              value.transfer.seedKey !== undefined)) ||
-          (value.transfer.seedKey !== undefined &&
-            (typeof value.transfer.seedKey !== "string" ||
-              !/^[a-f0-9]{64}$/u.test(value.transfer.seedKey) ||
-              value.transfer.attachments !== undefined))
-        : direction === "upload"
-          ? !hasExactOwnKeys(
-              value.transfer,
-              ["direction", "token", "baseManifestRef", "referenceManifestRef"],
-              ["publicationBaseCommit"],
-            ) ||
-            (value.transfer.publicationBaseCommit !== undefined &&
-              (typeof value.transfer.publicationBaseCommit !== "string" ||
-                !/^[a-f0-9]{40}$/u.test(value.transfer.publicationBaseCommit)))
-          : true)
-    ) {
-      throw new Error("INVALID_REQUEST: workspace transfer is invalid");
-    }
-    if (direction === "download") {
-      if (!validRef(manifestRef)) {
-        throw new Error("INVALID_REQUEST: workspace transfer is invalid");
-      }
-      transfer = {
-        direction,
-        token,
-        manifestRef,
-        ...(typeof value.transfer.seedKey === "string" ? { seedKey: value.transfer.seedKey } : {}),
-        ...(value.transfer.attachments === true ? { attachments: true } : {}),
-        ...(typeof value.transfer.checkpointBaseManifestRef === "string"
-          ? { checkpointBaseManifestRef: value.transfer.checkpointBaseManifestRef }
-          : {}),
-      };
-    } else {
-      if (!validRef(baseManifestRef) || !validRef(referenceManifestRef)) {
-        throw new Error("INVALID_REQUEST: workspace transfer is invalid");
-      }
-      transfer = {
-        direction: "upload",
-        token,
-        baseManifestRef,
-        referenceManifestRef,
-        ...(typeof value.transfer.publicationBaseCommit === "string"
-          ? { publicationBaseCommit: value.transfer.publicationBaseCommit }
-          : {}),
-      };
-    }
-  }
-  return {
-    gatewayNamespace,
-    environmentId: requireIdentifier(value.environmentId, "environmentId"),
-    sessionId: requireIdentifier(value.sessionId, "sessionId"),
-    ...(value.sessionKey === undefined ? {} : { sessionKey: value.sessionKey }),
-    ...(value.preparationKey === undefined ? {} : { preparationKey: value.preparationKey }),
-    generation: value.generation,
-    argv: [...value.argv],
-    ...(value.input === undefined ? {} : { input: value.input }),
-    ...(value.timeoutMs === undefined ? {} : { timeoutMs: value.timeoutMs }),
-    ...(value.resetWorkspace === undefined ? {} : { resetWorkspace: value.resetWorkspace }),
-    ...(transfer ? { transfer } : {}),
-    ...(seed ? { seed } : {}),
-  };
+  return input;
 }
 
 function isBoundedText(value: unknown, maxBytes: number): value is string {

--- a/src/worker/node-workspace-transfer-protocol.ts
+++ b/src/worker/node-workspace-transfer-protocol.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import { z } from "zod";
+import { workerProtocolObject } from "./protocol-record.js";
 
 export const NODE_WORKSPACE_EMPTY_MANIFEST = JSON.stringify({
   version: 1,
@@ -42,27 +44,48 @@ export class NodeWorkerWorkspaceTransferError extends Error {
   }
 }
 
-export type NodeWorkerWorkspaceTransferInput =
-  | {
-      direction: "download";
-      token: string;
-      manifestRef: string;
-      /** Reuse this prepared project's immutable Git objects before downloading a pack. */
-      seedKey?: string;
-      /** Install attachment files only; never replace or delete workspace entries. */
-      attachments?: true;
-      /** Restore only the checkpoint delta onto its independently cloned Git base. */
-      checkpointBaseManifestRef?: string;
-    }
-  | {
-      direction: "upload";
-      token: string;
-      baseManifestRef: string;
-      /** Last accepted raw manifest; independent of the cumulative repository base. */
-      referenceManifestRef: string;
-      /** Capture normalized publication artifacts under this pinned repository base. */
-      publicationBaseCommit?: string;
-    };
+const ManifestRef = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+const TransferToken = z
+  .string()
+  .min(1)
+  .max(1_024)
+  .refine((value) => !value.includes("\0"));
+export const NodeWorkerWorkspaceTransferInputSchema = z.union([
+  workerProtocolObject({
+    direction: z.literal("download"),
+    token: TransferToken,
+    manifestRef: ManifestRef,
+    /** Reuse this prepared project's immutable Git objects before downloading a pack. */
+    seedKey: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/u)
+      .optional(),
+    /** Install attachment files only; never replace or delete workspace entries. */
+    attachments: z.literal(true).optional(),
+    /** Restore only the checkpoint delta onto its independently cloned Git base. */
+    checkpointBaseManifestRef: ManifestRef.optional(),
+  }).refine(
+    (value) =>
+      (value.seedKey === undefined || value.attachments === undefined) &&
+      (value.checkpointBaseManifestRef === undefined ||
+        (value.attachments === undefined && value.seedKey === undefined)),
+  ),
+  workerProtocolObject({
+    direction: z.literal("upload"),
+    token: TransferToken,
+    baseManifestRef: ManifestRef,
+    /** Last accepted raw manifest; independent of the cumulative repository base. */
+    referenceManifestRef: ManifestRef,
+    /** Capture normalized publication artifacts under this pinned repository base. */
+    publicationBaseCommit: z
+      .string()
+      .regex(/^[a-f0-9]{40}$/u)
+      .optional(),
+  }),
+]);
+export type NodeWorkerWorkspaceTransferInput = z.infer<
+  typeof NodeWorkerWorkspaceTransferInputSchema
+>;
 
 function nodeWorkspaceTransferEnvironmentPath(environmentId: string): string {
   return `${NODE_WORKSPACE_TRANSFER_PATH}/environments/${encodeURIComponent(environmentId)}`;

--- a/src/worker/protocol-record.ts
+++ b/src/worker/protocol-record.ts
@@ -1,3 +1,6 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
+
 export function hasExactOwnKeys(
   value: object,
   required: readonly string[],
@@ -9,4 +12,18 @@ export function hasExactOwnKeys(
     optional.every((key) => Object.hasOwn(value, key) || !Reflect.has(value, key)) &&
     Object.keys(value).every((key) => allowed.has(key))
   );
+}
+
+/** Validate the received object's own keys before schema parsing copies its properties. */
+export function workerProtocolObject<Shape extends Record<string, z.ZodType>>(shape: Shape) {
+  const required: string[] = [];
+  const optional: string[] = [];
+  for (const [key, schema] of Object.entries(shape)) {
+    (schema.isOptional() ? optional : required).push(key);
+  }
+  return z
+    .custom<Record<string, unknown>>(
+      (value) => isRecord(value) && hasExactOwnKeys(value, required, optional),
+    )
+    .pipe(z.object(shape));
 }


### PR DESCRIPTION
Closes #143654
Related: #143345, #143349, #143378

## What Problem This Solves

Maintainer-requested cleanup of cloud-worker execution after the recent recovery fixes. Worker launch and control messages repeated their fields across types, key allowlists, validators, and result builders. Node and SSH reconciliation also independently owned the same local journal and staged-result acceptance flow, making changes harder to keep consistent.

## Why This Change Was Made

Schemas now own launch, supervisor, and workspace request shapes while the existing launch parser retains assignment semantics. A shared local reconciliation owner handles journal recovery, hashing metrics, staged acceptance, and final local verification; transports retain transfer and publication ownership. Desktop and portal carriers share durable node binding checks and abort handling, and workspace transfers reuse the existing keyed queue.

The cleanup removes 1,271 production lines and adds 765 shared replacements: **506 fewer production lines overall**. The assertion baseline shrinks by one. Existing protocol versions, supported node/SSH paths, strict own-property checks, transfer bounds, and authority/cleanup contracts are preserved.

## User Impact

Existing worker behavior is preserved. Future changes have one owner for protocol field validation and local workspace acceptance. Staged node verification now contributes to local reconciliation timing consistently with SSH.

## Evidence

- Original-versus-candidate parser comparison: 4,996 variants passed, including malformed fields, missing/inherited properties, byte limits, and frozen run identity.
- Protocol/payload run: 102 tests passed.
- Node, SSH, supervisor, transfer, desktop/portal, and workspace recovery integration run: 319 tests passed; two Windows-only tests skipped on macOS.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Fresh runtime build and real-wire Gateway/node/worker E2E passed on committed head `d31183cb9b7e970ddd6abc30422a42acc667b39c`, with source tree `90274162c9b8c0484bfe9ebd591714c43fc4f4cb` verified against the local commit. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34435973870), lease `tbx_01m24r0g9mhn9qvdcdc0arm7jw`: wrapper exit 0; one real-wire E2E passed in 65.983 seconds after build. It covers dirty workspace upload/reconciliation, filesystem tools, reconnect, concurrent finalization, and restart. The model endpoint is deterministic; this is real worker execution, not external model inference. The task-owned lease was stopped after proof.

- [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/34435804325) passed, including Windows node and macOS Swift tests.
- Local changed-file validation passed its formatting, typing, lint, and dead-code stages. The macOS batch initially hit five 20-second timeouts in unchanged artifact fixtures; the complete owning suite passed all 174 tests on an unchanged rerun. All eight remaining schema, storage, media, import-cycle, and authentication guards passed. No test assertions or timeouts were weakened.
