### PR TITLE
ci(release): fail verification when the npm beta tag lags latest

### DIFF
--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -1182,7 +1182,9 @@ When cutting a regular orchestrated stable release:
 7. If the release landed on `beta`, use the `openclaw/releases/.github/workflows/openclaw-npm-dist-tags.yml` workflow to promote that stable version from `beta` to `latest`.
 8. Immediately after publishing or promoting to `latest`, manually dispatch that same release-ledger workflow to repair the beta floor. Every package's `beta` must be at least its own `latest`; preserve a newer beta. The daily scheduled repair is only a backstop, not a substitute for this release step.
 
-The release ledger owns npm dist-tag promotion and repair because those operations require `NPM_TOKEN`, while the source repo keeps OIDC-only publish. Post-publication verification reads npm dist-tags and fails when core or an official plugin in the release selection has a missing beta or a beta older than latest, listing the affected packages and observed tags. Repair the registry state and rerun verification before completing the release.
+The release ledger owns npm dist-tag promotion and repair because those operations require `NPM_TOKEN`, while the source repo keeps OIDC-only publish. Post-publication verification reads npm dist-tags through the exact release version and fails when core or an official plugin in the release selection has a missing beta or a beta older than latest, listing the affected packages and observed tags.
+
+Until the release-ledger workflow covers official plugin packages, stale plugin beta tags intentionally block verification and require manual operator repair. For each listed stale package, run `npm dist-tag add <pkg>@<latest> beta`, substituting that package's name and current `latest` version. Preserve any newer beta tag. This manual recovery is required even if the core-only ledger repair succeeds; rerun verification before completing the release.
 
 If a maintainer must fall back to local npm authentication, run any 1Password CLI (`op`) commands only inside a dedicated tmux session. Do not call `op` directly from the main agent shell; keeping it inside tmux makes prompts, alerts, and OTP handling observable and prevents repeated host alerts.
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -32,7 +32,7 @@ Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `al
 - `PATCH` is a sequential monthly release-train number, not a calendar day. Regular final and beta releases advance the current train; alpha-only tags never consume or advance the beta/regular patch number, so ignore legacy alpha-only tags with higher patch numbers when selecting a beta or regular train.
 - Alpha/nightly builds use the next unreleased patch train and increment only `alpha.N` for repeated builds. Once that patch has a beta, new alpha builds move to the following patch.
 - npm versions are immutable: never delete, republish, or reuse a published tag. Cut the next prerelease number or the next monthly patch instead.
-- `latest` continues to follow the current regular/daily npm line; `beta` is the current beta install target
+- `latest` continues to follow the current regular/daily npm line. For core and every published official plugin, `beta` must always resolve to a version greater than or equal to `latest` under semver ordering; a same-train prerelease is older than its final release.
 - `extended-stable` means the supported trailing-month Gateway distribution, beginning at patch `33`; patch `34` and later are maintenance releases on that monthly line
 - Regular final and regular correction releases publish to npm `beta` by default; release operators can target `latest` explicitly, or promote a vetted beta build later
 - Gateway extended-stable publishes core, every npm-publishable official plugin,
@@ -41,7 +41,7 @@ Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `al
 
 ## Release cadence
 
-- Releases move beta-first; stable follows only after the latest beta is validated
+- Releases move beta-first; stable follows only after the latest beta is validated. Publishing or promoting to `latest` requires immediate beta-floor repair through the release ledger; a newer beta remains unchanged.
 - Maintainers normally cut releases from a `release/YYYY.M.PATCH` branch created from current `main`, so release validation and fixes do not block new development on `main`
 - If a beta tag has been pushed or published and needs a fix, maintainers cut the next `-beta.N` tag instead of deleting or recreating the old one
 - Detailed release procedure, approvals, credentials, and recovery notes are maintainer-only
@@ -1180,9 +1180,9 @@ When cutting a regular orchestrated stable release:
 5. Save the successful `preflight_run_id`, `full_release_validation_run_id`, and exact `full_release_validation_run_attempt`.
 6. Run `OpenClaw Release Publish` from the protected `release-publish/<sha12>-<epoch>` tooling tag with the same `tag`, the same `npm_dist_tag`, the optional Windows input pair, the saved `preflight_run_id`, `full_release_validation_run_id`, and `full_release_validation_run_attempt`. It starts plugin npm and ClawHub in parallel, then promotes the prepared OpenClaw npm package once plugin npm succeeds. GitHub finalization waits for npm and Docker evidence; apps attach independently afterward.
 7. If the release landed on `beta`, use the `openclaw/releases/.github/workflows/openclaw-npm-dist-tags.yml` workflow to promote that stable version from `beta` to `latest`.
-8. If the release intentionally published directly to `latest` and `beta` should follow the same stable build immediately, use that same release workflow to point both dist-tags at the stable version, or let its scheduled self-healing sync move `beta` later.
+8. Immediately after publishing or promoting to `latest`, manually dispatch that same release-ledger workflow to repair the beta floor. Every package's `beta` must be at least its own `latest`; preserve a newer beta. The daily scheduled repair is only a backstop, not a substitute for this release step.
 
-The dist-tag mutation lives in the release ledger repo because it still requires `NPM_TOKEN`, while the source repo keeps OIDC-only publish. That keeps the direct publish path and the beta-first promotion path both documented and operator-visible.
+The release ledger owns npm dist-tag promotion and repair because those operations require `NPM_TOKEN`, while the source repo keeps OIDC-only publish. Post-publication verification reads npm dist-tags and fails when core or an official plugin in the release selection has a missing beta or a beta older than latest, listing the affected packages and observed tags. Repair the registry state and rerun verification before completing the release.
 
 If a maintainer must fall back to local npm authentication, run any 1Password CLI (`op`) commands only inside a dedicated tmux session. Do not call `op` directly from the main agent shell; keeping it inside tmux makes prompts, alerts, and OTP handling observable and prevents repeated host alerts.
 

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -173,9 +173,7 @@ const diagnosticChildNames = [
   "npmTelegram",
 ] as const;
 type DiagnosticStageName = (typeof diagnosticStageNames)[number];
-type NpmDiagnosticScope =
-  | { stage: "coreNpm" }
-  | { stage: "pluginNpm"; packageName: string };
+type NpmDiagnosticScope = { stage: "coreNpm" } | { stage: "pluginNpm"; packageName: string };
 type DiagnosticChildName = (typeof diagnosticChildNames)[number];
 const diagnosticId = z.string().max(20).regex(POSITIVE_INTEGER_PATTERN).nullable();
 const diagnosticSha = z.string().regex(COMMIT_SHA_PATTERN).nullable();
@@ -530,7 +528,11 @@ class PostpublishDiagnostics {
     this.packageName = undefined;
     this.data.currentStage = stage;
     this.data.stages[stage].state = "started";
-    if (!["evidence", "binding", "assets"].includes(stage)) {
+    // Collecting later observations must not erase an already observed failure.
+    if (
+      !["evidence", "binding", "assets"].includes(stage) &&
+      this.data.verification !== "failure"
+    ) {
       this.data.verification = "started";
     }
     this.save();
@@ -1084,11 +1086,14 @@ export async function fetchStatusWithRetry(url: string, method: "GET" | "HEAD"):
   }
 }
 
-async function readNpmBetaFloorError(packageName: string): Promise<string | undefined> {
+async function readNpmBetaFloorError(
+  packageName: string,
+  version: string,
+): Promise<string | undefined> {
   const entries = resolveNpmJsonEntries(
     parseJson(
-      await runNpmViewWithRetry(["view", packageName, "dist-tags", "--json"]),
-      `npm view ${packageName} dist-tags`,
+      await runNpmViewWithRetry(["view", `${packageName}@${version}`, "dist-tags", "--json"]),
+      `npm view ${packageName}@${version} dist-tags`,
     ),
   );
   const tags = entries.length === 1 ? entries[0] : undefined;
@@ -1114,7 +1119,7 @@ async function readNpmBetaFloorError(packageName: string): Promise<string | unde
 
 function createNpmBetaFloorError(errors: readonly string[]): Error {
   return new Error(
-    `npm beta must be at or above latest; release verification failed:\n${errors.join("\n")}\nRun the release ledger's npm dist-tag repair, then verify again.`,
+    `npm beta must be at or above latest; release verification failed:\n${errors.join("\n")}\nFor each listed stale package, run:\nnpm dist-tag add <pkg>@<latest> beta\nUse that package's current latest version, preserve newer beta tags, then verify again.`,
   );
 }
 
@@ -1962,7 +1967,7 @@ export async function verifyBetaRelease(
     diagnostic.start("coreNpm");
     const openclawNpm = await verifyNpmPackage("openclaw", args.version, args.distTag);
     diagnostic.observeNpmPublication({ stage: "coreNpm" });
-    const coreBetaFloorError = await readNpmBetaFloorError("openclaw");
+    const coreBetaFloorError = await readNpmBetaFloorError("openclaw", args.version);
     if (coreBetaFloorError !== undefined) {
       betaFloorErrors.push({ scope: { stage: "coreNpm" }, message: coreBetaFloorError });
       diagnostic.fail(createNpmBetaFloorError([coreBetaFloorError]));
@@ -1999,7 +2004,7 @@ export async function verifyBetaRelease(
       await verifyNpmPackage(plugin.packageName, args.version, args.distTag);
       const scope: NpmDiagnosticScope = { stage: "pluginNpm", packageName: plugin.packageName };
       diagnostic.observeNpmPublication(scope);
-      const betaFloorError = await readNpmBetaFloorError(plugin.packageName);
+      const betaFloorError = await readNpmBetaFloorError(plugin.packageName, args.version);
       if (betaFloorError !== undefined) {
         betaFloorErrors.push({ scope, message: betaFloorError });
         diagnostic.fail(createNpmBetaFloorError([betaFloorError]));

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -12,11 +12,13 @@ import {
 } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { lt as semverLt, valid as validSemver } from "semver";
 import { z } from "zod";
 import { isRecord as isJsonRecord } from "../../packages/normalization-core/src/record-coerce.ts";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.ts";
 import { readPublicationArtifactArchive, sha256Digest } from "./actions-artifact-archive.mjs";
 import { readBoundedResponseText } from "./bounded-response.mjs";
+import { resolveNpmJsonEntries } from "./npm-json-output.mts";
 import { collectClawHubPublishablePluginPackages } from "./plugin-clawhub-release.ts";
 import {
   collectPublishablePluginPackages,
@@ -171,6 +173,9 @@ const diagnosticChildNames = [
   "npmTelegram",
 ] as const;
 type DiagnosticStageName = (typeof diagnosticStageNames)[number];
+type NpmDiagnosticScope =
+  | { stage: "coreNpm" }
+  | { stage: "pluginNpm"; packageName: string };
 type DiagnosticChildName = (typeof diagnosticChildNames)[number];
 const diagnosticId = z.string().max(20).regex(POSITIVE_INTEGER_PATTERN).nullable();
 const diagnosticSha = z.string().regex(COMMIT_SHA_PATTERN).nullable();
@@ -540,6 +545,18 @@ class PostpublishDiagnostics {
     this.save();
   }
 
+  observeNpmPublication(scope: NpmDiagnosticScope) {
+    const stage = this.data.stages[scope.stage];
+    const entry =
+      scope.stage === "coreNpm"
+        ? stage
+        : stage.packages.find((item) => item.name === scope.packageName);
+    if (entry) {
+      entry.publication = "observed";
+      this.save();
+    }
+  }
+
   packages(stage: "pluginNpm" | "clawHub", packages: readonly { packageName: string }[]) {
     this.data.stages[stage].packages = packages
       .slice(0, DIAGNOSTIC_MAX_PACKAGES)
@@ -567,7 +584,11 @@ class PostpublishDiagnostics {
     this.save();
   }
 
-  fail(error: unknown) {
+  fail(error: unknown, scope?: NpmDiagnosticScope) {
+    if (scope) {
+      this.data.currentStage = scope.stage;
+      this.packageName = scope.stage === "pluginNpm" ? scope.packageName : undefined;
+    }
     const stage = this.data.currentStage;
     if (!stage) {
       return;
@@ -770,7 +791,9 @@ function parseJson(raw: string, label: string): unknown {
 }
 
 export function parseNpmViewFields(raw: string, distTag: string): NpmViewFields {
-  const parsed = parseJson(raw, "npm view");
+  const value = parseJson(raw, "npm view");
+  const entries = resolveNpmJsonEntries(value);
+  const parsed = entries.length === 1 && isJsonRecord(entries[0]) ? entries[0] : value;
   if (Array.isArray(parsed)) {
     return {
       version: normalizeOptionalString(parsed[0]),
@@ -1059,6 +1082,40 @@ export async function fetchStatusWithRetry(url: string, method: "GET" | "HEAD"):
   } finally {
     await cancelResponseBody(response);
   }
+}
+
+async function readNpmBetaFloorError(packageName: string): Promise<string | undefined> {
+  const entries = resolveNpmJsonEntries(
+    parseJson(
+      await runNpmViewWithRetry(["view", packageName, "dist-tags", "--json"]),
+      `npm view ${packageName} dist-tags`,
+    ),
+  );
+  const tags = entries.length === 1 ? entries[0] : undefined;
+  if (!isJsonRecord(tags)) {
+    throw new Error(`${packageName}: npm dist-tags returned an unsupported JSON shape.`);
+  }
+  // A package published only to beta has no stable floor yet.
+  if (tags.latest === undefined) {
+    return undefined;
+  }
+  const latest = normalizeOptionalString(tags.latest);
+  const beta = normalizeOptionalString(tags.beta);
+  const observed = `${packageName}: beta=${beta ?? JSON.stringify(tags.beta) ?? "<missing>"}, latest=${latest ?? JSON.stringify(tags.latest)}`;
+  if (
+    latest === undefined ||
+    !validSemver(latest) ||
+    (tags.beta !== undefined && (beta === undefined || !validSemver(beta)))
+  ) {
+    return `${observed} (invalid semver dist-tag)`;
+  }
+  return beta === undefined || semverLt(beta, latest) ? observed : undefined;
+}
+
+function createNpmBetaFloorError(errors: readonly string[]): Error {
+  return new Error(
+    `npm beta must be at or above latest; release verification failed:\n${errors.join("\n")}\nRun the release ledger's npm dist-tag repair, then verify again.`,
+  );
 }
 
 async function verifyNpmPackage(
@@ -1870,6 +1927,8 @@ export async function verifyBetaRelease(
 ): Promise<string[]> {
   const rootDir = options.rootDir ?? resolve(".");
   const diagnostic = new PostpublishDiagnostics(args, rootDir, "verify");
+  const betaFloorErrors: { scope: NpmDiagnosticScope; message: string }[] = [];
+  let betaFloorFailureScope: NpmDiagnosticScope | undefined;
   try {
     diagnostic.start("checkout");
     const rootVersion = readRootPackageVersion(rootDir);
@@ -1902,10 +1961,17 @@ export async function verifyBetaRelease(
 
     diagnostic.start("coreNpm");
     const openclawNpm = await verifyNpmPackage("openclaw", args.version, args.distTag);
-    diagnostic.success("coreNpm", true);
-    lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
+    diagnostic.observeNpmPublication({ stage: "coreNpm" });
+    const coreBetaFloorError = await readNpmBetaFloorError("openclaw");
+    if (coreBetaFloorError !== undefined) {
+      betaFloorErrors.push({ scope: { stage: "coreNpm" }, message: coreBetaFloorError });
+      diagnostic.fail(createNpmBetaFloorError([coreBetaFloorError]));
+    } else {
+      diagnostic.success("coreNpm");
+      lines.push(`openclaw npm OK: ${args.version} (${args.distTag})`);
+    }
 
-    if (!args.skipPostpublish) {
+    if (!args.skipPostpublish && coreBetaFloorError === undefined) {
       diagnostic.start("postpublish");
       const postpublishVerifier = resolveOpenClawNpmPostpublishVerifier(
         rootDir,
@@ -1931,9 +1997,25 @@ export async function verifyBetaRelease(
     for (const plugin of npmPlugins) {
       diagnostic.package("pluginNpm", plugin.packageName, "started");
       await verifyNpmPackage(plugin.packageName, args.version, args.distTag);
-      diagnostic.package("pluginNpm", plugin.packageName, "success");
+      const scope: NpmDiagnosticScope = { stage: "pluginNpm", packageName: plugin.packageName };
+      diagnostic.observeNpmPublication(scope);
+      const betaFloorError = await readNpmBetaFloorError(plugin.packageName);
+      if (betaFloorError !== undefined) {
+        betaFloorErrors.push({ scope, message: betaFloorError });
+        diagnostic.fail(createNpmBetaFloorError([betaFloorError]));
+      } else {
+        diagnostic.package("pluginNpm", plugin.packageName, "success");
+      }
     }
-    diagnostic.success("pluginNpm");
+    if (!betaFloorErrors.some(({ scope }) => scope.stage === "pluginNpm")) {
+      diagnostic.success("pluginNpm");
+    }
+    const firstBetaFloorError = betaFloorErrors[0];
+    if (firstBetaFloorError) {
+      // The final catch must not overwrite the last healthy package or stage.
+      betaFloorFailureScope = firstBetaFloorError.scope;
+      throw createNpmBetaFloorError(betaFloorErrors.map(({ message }) => message));
+    }
     lines.push(`plugin npm OK: ${npmPlugins.length}`);
 
     if (!args.skipClawHub) {
@@ -2129,7 +2211,7 @@ export async function verifyBetaRelease(
 
     return lines;
   } catch (error) {
-    diagnostic.fail(error);
+    diagnostic.fail(error, betaFloorFailureScope);
     throw error;
   }
 }

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -102,12 +102,32 @@ describe("verifyBetaRelease workflow outcomes", () => {
     overrides: Record<string, unknown> = {},
     telegram = true,
     npmError?: string,
+    npm: {
+      version: string;
+      distTag: string;
+      tags: Record<string, Record<string, string>>;
+      transientlyMissing?: string;
+      npm12?: boolean;
+    } = {
+      version,
+      distTag: "beta",
+      tags: { openclaw: { beta: version, latest: "2026.5.9" } },
+    },
   ) {
     const rootDir = tempDirs.make("release-workflow-outcome-");
     const binDir = join(rootDir, "bin");
     mkdirSync(binDir);
     mkdirSync(join(rootDir, "extensions"));
-    writeFileSync(join(rootDir, "package.json"), JSON.stringify({ version }));
+    writeFileSync(join(rootDir, "package.json"), JSON.stringify({ version: npm.version }));
+    writeFileSync(join(binDir, "npm.json"), JSON.stringify(npm));
+    for (const name of Object.keys(npm.tags).filter((packageName) => packageName !== "openclaw")) {
+      writePublishablePluginFixture(rootDir, {
+        extensionId: name.slice("@openclaw/".length),
+        packageName: name,
+        version: npm.version,
+        publishTo: "npm",
+      });
+    }
     const run = {
       workflowName: telegram ? "NPM Telegram Beta E2E" : "OpenClaw NPM Release",
       headBranch: "main",
@@ -126,7 +146,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
 fs.appendFileSync(path.join(path.dirname(process.argv[1]), "commands.jsonl"), JSON.stringify([path.basename(process.argv[1]), ...args]) + "\\n");
-if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].endsWith("@${version}")) {
+if (path.basename(process.argv[1]) === "npm" && args[0] === "view") {
   if (${JSON.stringify(npmError ?? "")}) {
     process.stderr.write(${JSON.stringify(npmError ?? "")});
     process.exit(7);
@@ -136,7 +156,21 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].en
     const failure = JSON.parse(fs.readFileSync(failures, "utf8"))[args[1]];
     if (failure) { process.stderr.write(failure); process.exit(9); }
   }
-  console.log(JSON.stringify({version: "${version}", "dist-tags.beta": "${version}", "dist.integrity": "sha512-test", "dist.tarball": "https://example.invalid/openclaw.tgz"}));
+  const npm = JSON.parse(fs.readFileSync(path.join(path.dirname(process.argv[1]), "npm.json")));
+  const print = (value) => console.log(JSON.stringify(npm.npm12 ? [value] : value));
+  if (args[2] === "dist-tags" && npm.tags[args[1]]) {
+    const visible = path.join(path.dirname(process.argv[1]), "npm-visible");
+    if (npm.transientlyMissing === args[1] && !fs.existsSync(visible)) {
+      fs.writeFileSync(visible, "ready");
+      console.error("npm ERR! code E404");
+      process.exit(1);
+    }
+    print(npm.tags[args[1]]);
+  } else {
+    const name = Object.keys(npm.tags).find((name) => args[1] === name + "@" + npm.version);
+    if (!name) throw new Error("Unexpected npm package: " + args[1]);
+    print({version: npm.version, "dist-tags": npm.tags[name], "dist.integrity": "sha512-test", "dist.tarball": "https://example.invalid/package.tgz"});
+  }
 } else if (args[0] === "run" && args[1] === "view" && args[2] === "44") {
   process.stdout.write(fs.readFileSync(path.join(path.dirname(process.argv[1]), "run.json")));
 } else if (args[0] === "api" && args[1].endsWith("/actions/runs/34")) {
@@ -154,7 +188,9 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].en
     }
     vi.stubEnv("PATH", `${binDir}:${process.env.PATH}`);
     const args = parseReleaseVerifyBetaArgs([
-      version,
+      npm.version,
+      "--dist-tag",
+      npm.distTag,
       "--skip-postpublish",
       "--skip-github-release",
       "--skip-clawhub",
@@ -165,7 +201,7 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].en
       "--evidence-out",
       "evidence.json",
     ]);
-    return { args, rootDir, binDir };
+    return { args, rootDir, binDir, npm };
   }
 
   function runCli(fixture: ReturnType<typeof workflowFixture>, extra: string[] = [], preload = "") {
@@ -337,7 +373,9 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1].en
           extensionId,
           publishTo: "both",
         });
+        fixture.npm.tags[`@openclaw/${extensionId}`] = { beta: version };
       }
+      writeFileSync(join(fixture.binDir, "npm.json"), JSON.stringify(fixture.npm));
       // The collector's order is alphabetical: first, last, middle.
       if (surface === "npm") {
         writeFileSync(
@@ -459,6 +497,80 @@ syncBuiltinESMExports();
     expect(Buffer.byteLength(text)).toBeLessThanOrEqual(128 * 1024);
     expect(text).not.toMatch(/password|token=|synthetic-secret/u);
   });
+
+  it.each(
+    [
+      { label: "missing", beta: undefined, fails: true },
+      { label: "older same-train prerelease", beta: "2026.9.3-beta.1", fails: true },
+      { label: "older final", beta: "2026.9.1", fails: true },
+      { label: "equal", beta: "2026.9.3", fails: false },
+      { label: "newer next-train prerelease", beta: "2026.9.4-beta.1", fails: false },
+    ].flatMap(({ label, beta, fails }) =>
+      [false, true].map((npm12) => ({ label, beta, fails, npm12 })),
+    ),
+  )(
+    "enforces the beta floor for a plugin with $label beta (npm 12: $npm12)",
+    async ({ beta, fails, npm12 }) => {
+      const latest = "2026.9.3";
+      const fixture = workflowFixture({}, true, undefined, {
+        version: latest,
+        distTag: "latest",
+        npm12,
+        tags: {
+          openclaw: { latest, beta: latest },
+          "@openclaw/demo": { latest, ...(beta === undefined ? {} : { beta }) },
+        },
+      });
+
+      const verification = verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir });
+      if (fails) {
+        await expect(verification).rejects.toThrow(
+          `@openclaw/demo: beta=${beta ?? "<missing>"}, latest=${latest}`,
+        );
+      } else {
+        await expect(verification).resolves.toContain("plugin npm OK: 1");
+      }
+    },
+  );
+
+  it("lists every core and plugin beta floor violation together", async () => {
+    const latest = "2026.9.3";
+    const fixture = workflowFixture({}, true, undefined, {
+      version: latest,
+      distTag: "latest",
+      tags: {
+        openclaw: { latest, beta: "2026.9.1" },
+        "@openclaw/demo": { latest, beta: "2026.9.3-beta.1" },
+        "@openclaw/other": { latest },
+      },
+    });
+
+    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+      "openclaw: beta=2026.9.1, latest=2026.9.3\n" +
+        "@openclaw/demo: beta=2026.9.3-beta.1, latest=2026.9.3\n" +
+        "@openclaw/other: beta=<missing>, latest=2026.9.3",
+    );
+  });
+
+  it.each([false, true])(
+    "allows a beta-only plugin before its first stable publication (initial E404: %s)",
+    async (transientlyMissing) => {
+      const beta = "2026.9.4-beta.1";
+      const fixture = workflowFixture({}, true, undefined, {
+        version: beta,
+        distTag: "beta",
+        tags: {
+          openclaw: { latest: "2026.9.3", beta },
+          "@openclaw/demo": { beta },
+        },
+        transientlyMissing: transientlyMissing ? "@openclaw/demo" : undefined,
+      });
+
+      await expect(
+        verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir }),
+      ).resolves.toContain("plugin npm OK: 1");
+    },
+  );
 
   it.each([
     { status: "completed", conclusion: "failure" },

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -8,6 +8,10 @@ import { crc32 } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  parsePublicationDiagnostic,
+  parsePublicationRun,
+} from "../../scripts/frv-publication-status.mts";
+import {
   downloadClawHubBootstrapReadback,
   fetchJsonWithRetry,
   fetchStatusWithRetry,
@@ -158,17 +162,19 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view") {
   }
   const npm = JSON.parse(fs.readFileSync(path.join(path.dirname(process.argv[1]), "npm.json")));
   const print = (value) => console.log(JSON.stringify(npm.npm12 ? [value] : value));
-  if (args[2] === "dist-tags" && npm.tags[args[1]]) {
+  const name = Object.keys(npm.tags).find((name) => args[1] === name || args[1] === name + "@" + npm.version);
+  if (!name) throw new Error("Unexpected npm package: " + args[1]);
+  if (args[2] === "dist-tags") {
     const visible = path.join(path.dirname(process.argv[1]), "npm-visible");
-    if (npm.transientlyMissing === args[1] && !fs.existsSync(visible)) {
+    if (npm.transientlyMissing === name && !fs.existsSync(visible)) {
       fs.writeFileSync(visible, "ready");
       console.error("npm ERR! code E404");
       process.exit(1);
     }
-    print(npm.tags[args[1]]);
+    if (args[1] === name && !npm.tags[name].latest) process.exit(0);
+    print(npm.tags[name]);
   } else {
-    const name = Object.keys(npm.tags).find((name) => args[1] === name + "@" + npm.version);
-    if (!name) throw new Error("Unexpected npm package: " + args[1]);
+    if (args[1] !== name + "@" + npm.version) throw new Error("Expected an exact npm version");
     print({version: npm.version, "dist-tags": npm.tags[name], "dist.integrity": "sha512-test", "dist.tarball": "https://example.invalid/package.tgz"});
   }
 } else if (args[0] === "run" && args[1] === "view" && args[2] === "44") {
@@ -545,20 +551,23 @@ syncBuiltinESMExports();
       },
     });
 
-    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+    const verification = verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir });
+    await expect(verification).rejects.toThrow(
       "openclaw: beta=2026.9.1, latest=2026.9.3\n" +
         "@openclaw/demo: beta=2026.9.3-beta.1, latest=2026.9.3\n" +
         "@openclaw/other: beta=<missing>, latest=2026.9.3",
     );
+    await expect(verification).rejects.toThrow("npm dist-tag add <pkg>@<latest> beta");
   });
 
   it.each([false, true])(
-    "allows a beta-only plugin before its first stable publication (initial E404: %s)",
+    "queries a beta-only plugin without latest (npm 12 and initial E404: %s)",
     async (transientlyMissing) => {
       const beta = "2026.9.4-beta.1";
       const fixture = workflowFixture({}, true, undefined, {
         version: beta,
         distTag: "beta",
+        npm12: transientlyMissing,
         tags: {
           openclaw: { latest: "2026.9.3", beta },
           "@openclaw/demo": { beta },
@@ -571,6 +580,114 @@ syncBuiltinESMExports();
       ).resolves.toContain("plugin npm OK: 1");
     },
   );
+
+  it("retains a core beta failure if later plugin verification is interrupted", () => {
+    const fixture = workflowFixture({}, true, undefined, {
+      version,
+      distTag: "beta",
+      tags: {
+        openclaw: { beta: version, latest: "2026.5.10" },
+        "@openclaw/demo": { beta: version },
+      },
+    });
+    const result = runCli(
+      fixture,
+      [],
+      `import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+const exec = childProcess.execFileSync;
+childProcess.execFileSync = (command, args, options) => {
+  if (command === "npm" && args?.[1]?.startsWith("@openclaw/demo@")) process.exit(23);
+  return exec(command, args, options);
+};
+syncBuiltinESMExports();`,
+    );
+    expect(result.status, result.stderr).toBe(23);
+    const diagnostic: unknown = JSON.parse(
+      readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+    );
+    expect(diagnostic).toMatchObject({
+      verification: "failure",
+      stages: {
+        coreNpm: { state: "failure", publication: "observed" },
+        pluginNpm: { state: "started" },
+      },
+    });
+    expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+  });
+
+  it.each([
+    { coreStale: true, pluginStale: false },
+    { coreStale: false, pluginStale: true },
+    { coreStale: true, pluginStale: true },
+  ])("retains publication facts when beta floors fail: %j", async ({ coreStale, pluginStale }) => {
+    vi.stubEnv("GITHUB_RUN_ID", "");
+    const latest = "2026.9.3";
+    const fixture = workflowFixture({}, true, undefined, {
+      version: latest,
+      distTag: "latest",
+      npm12: true,
+      tags: {
+        openclaw: { latest, beta: coreStale ? "2026.9.1" : latest },
+        "@openclaw/a-plugin": { latest, beta: pluginStale ? "2026.9.3-beta.1" : latest },
+        "@openclaw/z-healthy": { latest, beta: latest },
+      },
+    });
+
+    await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
+      "npm beta must be at or above latest",
+    );
+    const diagnostic: unknown = JSON.parse(
+      readFileSync(join(fixture.rootDir, "release-postpublish-diagnostics.json"), "utf8"),
+    );
+    expect(diagnostic).toMatchObject({
+      verification: "failure",
+      currentStage: coreStale ? "coreNpm" : "pluginNpm",
+      stages: {
+        coreNpm: {
+          state: coreStale ? "failure" : "success",
+          publication: "observed",
+        },
+        pluginNpm: {
+          state: pluginStale ? "failure" : "success",
+          packages: [
+            {
+              name: "@openclaw/a-plugin",
+              state: pluginStale ? "failure" : "success",
+              publication: "observed",
+              error: pluginStale ? { class: "selector-mismatch" } : null,
+            },
+            {
+              name: "@openclaw/z-healthy",
+              state: "success",
+              publication: "observed",
+              error: null,
+            },
+          ],
+        },
+        evidence: { state: "unattempted" },
+      },
+    });
+    expect(existsSync(join(fixture.rootDir, "evidence.json"))).toBe(false);
+    const run = parsePublicationRun(
+      {
+        id: 44,
+        run_attempt: 1,
+        workflow_id: 2,
+        repository: { full_name: "openclaw/openclaw" },
+        head_sha: "a".repeat(40),
+        head_branch: "main",
+        path: ".github/workflows/openclaw-release-publish.yml",
+        event: "workflow_dispatch",
+        status: "completed",
+        conclusion: "failure",
+      },
+      "openclaw/openclaw",
+      "44",
+    );
+    // The existing v1 reader validates the shape before rejecting this unbound fixture.
+    expect(parsePublicationDiagnostic(diagnostic, run)).toBeNull();
+  });
 
   it.each([
     { status: "completed", conclusion: "failure" },

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1217,6 +1217,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/frv.test.ts",
         "test/scripts/openclaw-release-ready.test.ts",
         "test/scripts/plugin-npm-extended-stable-workflow.test.ts",
+        "test/scripts/release-beta-verifier.test.ts",
         "test/scripts/release-candidate-checklist.test.ts",
         "test/scripts/release-no-push-workflow.test.ts",
         "test/scripts/release-plan-producer.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with beta-pinned plugins could receive older packages after a core update because release verification checked the requested npm tag without checking that beta was at least latest. The update-repair campaign reported 93 stale beta tags on 2026-09-10: core plus 92 official plugin/provider packages, with latest at 2026.9.3.

The release-ledger [scheduled run 34314815043](https://github.com/openclaw/releases/actions/runs/34314815043) observed core latest=2026.9.3 and beta=2026.9.1, selected repair, then failed with npm E401. That workflow also lacked plugin coverage.

## Why This Change Was Made

Post-publication verification now reads npm dist-tags for core and every official plugin in the release selection, aggregates missing/older beta values into a blocking error, and lists package names with observed tags. It uses the existing semver dependency and npm visibility helper. Equal beta and a newer next-train prerelease pass; packages published only to beta have no stable floor yet.

The release policy now requires beta >= latest and immediate manual release-ledger repair after latest publication or promotion. The daily schedule is a backstop. Registry mutation and the cross-repository handoff remain owned by the separate ledger repair; this PR changes no publisher workflow or credentials.

## User Impact

Release verification can no longer report success while the checked beta channel points behind stable. The error tells operators which packages need repair before completing the release, protecting beta-pinned plugin updates from stale channel selectors.

Release-note context: fail post-publication verification when npm beta lags latest for core or official plugins, preserving newer beta versions and beta-first publication.

## Evidence

Before the production fix:

```text
node scripts/run-vitest.mjs test/scripts/release-beta-verifier.test.ts -t 'beta floor'
Tests 4 failed | 2 passed | 35 skipped (41)
Failure: promise resolved instead of rejecting
```

After the final fix:

```text
node scripts/run-vitest.mjs test/scripts/release-beta-verifier.test.ts
Test Files 1 passed (1)
Tests 48 passed (48)
```

Coverage includes missing beta, older same-train prerelease, older final, equal beta, newer next-train prerelease, aggregate core/plugin diagnostics, beta-only plugins, and existing first-publication visibility handling. The five decision cases run through both npm 11 object output and npm 12 singleton-array output using the existing npm JSON normalizer. The visibility regression also failed with E404 before reusing the existing helper and passed afterward.

Read-only live npm 12.0.2 queries confirmed singleton-array dist-tag output for core and @openclaw/diffs-language-pack. No registry tags were changed. Formal autoreview and landing remain with the campaign lead.

Final validation: `node scripts/check-changed.mjs` passed, including script/root-test typechecks, lint, formatting, and repository guards. `git diff --check` passed. Two fixture lint findings in the first check run were fixed before the successful rerun.

## Review notes

The release owner accepts landing the corrected detector before the ledger's plugin-repair patch. Until that patch is deployed, stale plugin beta tags fail verification by design and require an operator to run `npm dist-tag add <pkg>@<latest> beta` for each listed stale package, using that package's current latest version and preserving newer betas. The campaign lead confirmed this manual recovery for 94 packages on 2026-09-10. The verifier error and release policy now give this recovery command explicitly.

The accepted P2 is fixed by reading `npm view <name>@<release-version> dist-tags --json`, using the exact version already being verified. The fixture now reproduces npm's successful empty output when an unversioned beta-only package has no latest selector. Both affected cases failed before this follow-up with `Unexpected end of JSON input`; all 48 focused tests pass after the repair.

There is no persisted-state, install-record, config-schema, SQLite, or data-model change, so no migration is required. The change performs npm metadata reads and validation; plugin candidate projections, path-install ownership, and trust behavior are unchanged.

The 13 relevant regression cases are: missing beta on npm 11 and npm 12; older same-train prerelease on npm 11 and npm 12; older final on npm 11 and npm 12; equal beta on npm 11 and npm 12; newer next-train prerelease on npm 11 and npm 12; aggregate core/plugin diagnostics; beta-only metadata on npm 11; and beta-only npm 12 metadata after an initial E404. Aggregate diagnostics also assert the exact manual recovery command.

Follow-up validation on `328e709682f5c462b2c7722287ac8e81d3dd3720`: 48 focused tests passed; `node scripts/check-changed.mjs` and `git diff --check` passed; independent autoreview of the follow-up was scoped-clean at P0–P2. The beta-only regression run before the fix reported `2 failed | 46 skipped (48)` with `Unexpected end of JSON input`.

## Rebase validation

Rebased onto main `54ede4571c83cf7d0a50d1a63cc9d9b0ae0a970b` as `7d80bc16deeed08e18c8d1faffddcf9e804ffc2e`. Main introduced post-publication diagnostics in the same verifier while this PR was under review. The resolution preserves its existing v1 schema and stage names: exact npm readback records publication as observed, floor failures stay with the existing core/plugin owner, healthy packages keep their observations, and an observed failure remains sticky if later verification is interrupted. No persisted-state, install-record, config, or diagnostic schema migration is introduced.

Validation after the resolution: 65 verifier tests passed; the FRV suite passed; the unchanged FRV v1 reader accepts the resulting diagnostic shape; changed-file checks and `git diff --check` passed; full-candidate autoreview was scoped-clean at P0–P2. The new interruption regression failed before the sticky-failure repair (`verification` was `started` instead of `failure`) and passed afterward. The original 13 beta-floor cases remain, with additional core-only/plugin-only/combined diagnostic failure and interruption coverage.


## CI follow-up

The first rebased CI run (34443230469) caught one stale test-routing expectation: the verifier's new FRV-reader compatibility coverage correctly adds `release-beta-verifier.test.ts` to the release-publish workflow's dependency-derived targets. The expectation now includes that test; routing behavior and exact assertions are unchanged. The focused reproduction failed with 16 actual versus 15 expected targets before the correction. Afterward, all 480 routing tests passed. Independent autoreview of this correction was scoped-clean at P0–P2.
