### PR TITLE
fix(cron): keep legacy jobs on maintenance timer

### DIFF
--- a/src/cron/service.armtimer-tight-loop.test.ts
+++ b/src/cron/service.armtimer-tight-loop.test.ts
@@ -6,7 +6,7 @@ import { createCronServiceState } from "./service/state.js";
 import { ensureLoaded } from "./service/store.js";
 import { armTimer } from "./service/timer.js";
 import { onTimer } from "./service/timer.test-support.js";
-import { saveCronStore } from "./store.js";
+import { loadCronStore, saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
 const noopLogger = createNoopLogger();
@@ -341,6 +341,15 @@ describe("CronService - armTimer tight loop prevention", () => {
       expect(noopLogger.debug).toHaveBeenLastCalledWith(
         { jobCount: 1, enabledCount: 1, withNextRun: 0, delayMs: 60_000 },
         "cron: timer armed for maintenance recheck",
+      );
+
+      await onTimer(state);
+      const recovered = (await loadCronStore(store.storePath)).jobs[0];
+      expect(recovered?.enabled).toBe(true);
+      expect(recovered?.state.nextRunAtMs).toBeGreaterThan(now);
+      expect(noopLogger.debug).toHaveBeenLastCalledWith(
+        expect.objectContaining({ nextAt: recovered?.state.nextRunAtMs }),
+        "cron: timer armed",
       );
     } finally {
       timeoutSpy.mockRestore();

--- a/src/cron/service.armtimer-tight-loop.test.ts
+++ b/src/cron/service.armtimer-tight-loop.test.ts
@@ -263,4 +263,33 @@ describe("CronService - armTimer tight loop prevention", () => {
     timeoutSpy.mockRestore();
     await store.cleanup();
   });
+
+  it("keeps a maintenance wake armed for legacy jobs without enabled", () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const now = Date.parse("2026-02-28T12:32:00.000Z");
+    const job = {
+      id: "legacy-missing-enabled",
+      name: "legacy-missing-enabled",
+      enabled: undefined as unknown as boolean,
+      deleteAfterRun: false,
+      createdAtMs: now - 60_000,
+      updatedAtMs: now - 60_000,
+      schedule: { kind: "cron" as const, expr: "*/15 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "test" },
+      delivery: { mode: "none" as const },
+      state: {},
+    } satisfies CronJob;
+    const state = createTimerState({ storePath: "/tmp/test-cron/jobs.json", now });
+    state.store = { version: 1, jobs: [job] };
+
+    try {
+      armTimer(state);
+      expect(state.timer).toBe(latestTimeoutHandle(timeoutSpy));
+      expect(extractTimeoutDelays(timeoutSpy)).toContain(60_000);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
 });

--- a/src/cron/service.armtimer-tight-loop.test.ts
+++ b/src/cron/service.armtimer-tight-loop.test.ts
@@ -1,7 +1,9 @@
 // Timer tight-loop tests cover cron service guards against immediate rearm loops.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { createNoopLogger, createCronStoreHarness } from "./service.test-harness.js";
 import { createCronServiceState } from "./service/state.js";
+import { ensureLoaded } from "./service/store.js";
 import { armTimer } from "./service/timer.js";
 import { onTimer } from "./service/timer.test-support.js";
 import { saveCronStore } from "./store.js";
@@ -290,6 +292,59 @@ describe("CronService - armTimer tight loop prevention", () => {
       expect(extractTimeoutDelays(timeoutSpy)).toContain(60_000);
     } finally {
       timeoutSpy.mockRestore();
+    }
+  });
+
+  it("keeps a maintenance wake armed after loading a persisted legacy row", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const store = await makeStorePath();
+    const now = Date.parse("2026-02-28T12:32:00.000Z");
+    const job = {
+      id: "persisted-legacy-missing-enabled",
+      name: "persisted-legacy-missing-enabled",
+      enabled: true,
+      deleteAfterRun: false,
+      createdAtMs: now - 60_000,
+      updatedAtMs: now - 60_000,
+      schedule: { kind: "cron" as const, expr: "*/15 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "test" },
+      delivery: { mode: "none" as const },
+      state: {},
+    } satisfies CronJob;
+
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+    runOpenClawStateWriteTransaction(({ db }) => {
+      const row = db
+        .prepare("SELECT job_json FROM cron_jobs WHERE store_key = ? AND job_id = ?")
+        .get(store.storePath, job.id) as { job_json: string };
+      const persisted = JSON.parse(row.job_json) as Record<string, unknown>;
+      delete persisted.enabled;
+      db.prepare("UPDATE cron_jobs SET job_json = ? WHERE store_key = ? AND job_id = ?").run(
+        JSON.stringify(persisted),
+        store.storePath,
+        job.id,
+      );
+    });
+
+    try {
+      const state = createTimerState({ storePath: store.storePath, now });
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+      expect(state.store?.jobs).toHaveLength(1);
+      expect(state.store?.jobs[0]?.enabled).toBeUndefined();
+      armTimer(state);
+
+      expect(state.timer).toBe(latestTimeoutHandle(timeoutSpy));
+      expect(extractTimeoutDelays(timeoutSpy)).toContain(60_000);
+      expect(noopLogger.debug).toHaveBeenLastCalledWith(
+        { jobCount: 1, enabledCount: 1, withNextRun: 0, delayMs: 60_000 },
+        "cron: timer armed for maintenance recheck",
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      await store.cleanup();
     }
   });
 });

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -747,13 +747,11 @@ export function summarizeCronJobSchedule(state: CronServiceState) {
     jobCount += 1;
     const nextRun = job.state.nextRunAtMs;
     const hasNextRun = hasScheduledNextRunAtMs(nextRun);
-    const rawEnabled = job.enabled;
-    // Timer diagnostics historically count only explicit enablement, while
-    // wake selection keeps older jobs without `enabled` runnable.
-    if (rawEnabled) {
+    const enabled = isJobEnabled(job);
+    if (enabled) {
       enabledCount += 1;
     }
-    if ((rawEnabled ?? true) && hasNextRun) {
+    if (enabled && hasNextRun) {
       nextWake = nextWake === undefined ? nextRun : Math.min(nextWake, nextRun);
     }
   }


### PR DESCRIPTION
<!-- Source-first cron code bug; no public issue is linked. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where legacy persisted cron jobs that omit the optional `enabled` field could stop receiving scheduler maintenance wakes when their next-run timestamp was missing.

## Why This Change Was Made

Cron scheduling already treats a missing `enabled` value as enabled through `isJobEnabled`, and next-wake selection follows that rule. The maintenance-timer summary used a different explicit-true check, so it could report no enabled jobs and leave the scheduler without a recovery timer. The summary now uses the canonical enabled predicate, with a focused regression covering the legacy shape.

## User Impact

Older cron records continue receiving the 60-second maintenance wake that repairs a missing 
extRunAtMs`, instead of remaining silent until another mutation or restart.

## Evidence

- **Persisted production path:** The focused regression first writes a cron job to the real SQLite-backed cron store, removes only `job_json.enabled` from the stored row (leaving the supported current-schema record with the legacy omission), then calls production `ensureLoaded(..., forceReload)` before `armTimer`. This is distinct from the merged schema-v13 migration repair, which reconstructs `job_json.enabled` during an upgrade from an older wide row.
- **Inspectable result on exact head:**
  ```text
  persisted job after production load: enabled=undefined
  timer diagnostic: jobCount=1 enabledCount=1 withNextRun=0 delayMs=60000
  maintenance wake: armed (60000 ms)
  maintenance callback: nextRunAtMs restored and persisted (> now)
  ```
- **Focused proof:** 
ode scripts/run-vitest.mjs src/cron/service.armtimer-tight-loop.test.ts --reporter=verbose` — 1 file, 6 tests passed, including the persisted-row case.
- **Real service timer proof on exact head:** A real `CronService.start()` loaded the persisted SQLite row with `enabled=undefined`; after `resumeScheduling()`, the actual 60-second maintenance callback ran and persisted 
extRunAtMs=1789066128525` (> proof start `1789062593261`).
- **Checks:** Targeted `oxfmt --check` and `git diff --check` passed.
- **Proof boundary:** No external channel, provider, or user account was used; the proof covers the local production SQLite loader and scheduler timer path only.
- **Exact candidate head:** `5f5d662a101c86c2615c6eb677e26c51ccbed040`.
