### PR TITLE
fix(ui): preserve plugin selection and restart progress

### DIFF
--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -56,6 +56,8 @@ Installing, updating, or removing plugin code requires a Gateway restart.
 Enablement changes for plugins in the startup inventory can be applied without
 a restart when the plugin and current Gateway runtime support it; otherwise
 the UI tells you a restart is required.
+The install dialog waits through the Gateway reconnect before confirming completion
+and offers a retry if the restart does not complete.
 The Control UI does not install from arbitrary npm, git, or local-path sources,
 or update plugin packages. Use the CLI workflows below for those operations.
 

--- a/ui/src/e2e/plugins-request-ownership.e2e.test.ts
+++ b/ui/src/e2e/plugins-request-ownership.e2e.test.ts
@@ -1,0 +1,263 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import type {
+  PluginCatalogItem,
+  PluginDiscoveryDetailResult,
+  PluginsInspectResult,
+} from "../lib/plugins/index.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Plugin request ownership" });
+const capture = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const featureMethods = [
+  "config.get",
+  "config.schema",
+  "config.set",
+  "plugins.list",
+  "plugins.inspect",
+  "plugins.catalog.browse",
+  "plugins.catalog.categories",
+  "plugins.catalog.get",
+  "plugins.install",
+];
+const workboard: PluginCatalogItem = {
+  id: "workboard",
+  name: "Workboard",
+  origin: "global",
+  installed: true,
+  enabled: true,
+  state: "enabled",
+  version: "1.2.3",
+  catalogId: "ch_d29ya2JvYXJk",
+};
+
+function detail(id: string, name: string, installed = false): PluginDiscoveryDetailResult {
+  return {
+    plugin: {
+      id,
+      catalog: { name, official: true, categories: [] },
+      local: {
+        present: installed,
+        installed,
+        enabled: installed,
+        state: installed ? "enabled" : "not-installed",
+        action: installed ? "manage" : "install",
+      },
+    },
+    detail: {
+      origin: "clawhub",
+      packageName: name.toLowerCase(),
+      topics: [],
+      configuration: [],
+      mcpServers: [],
+      skills: [],
+      versions: [],
+    },
+  };
+}
+
+function inspection(skill: string): PluginsInspectResult {
+  return {
+    ok: true,
+    reviewToken: "synthetic-review",
+    plugin: {
+      id: "workboard",
+      name: "Workboard",
+      origin: "global",
+      installed: true,
+      enabled: true,
+    },
+    source: { kind: "npm", packageName: "workboard" },
+    declared: {
+      channels: [],
+      providers: [],
+      tools: [],
+      contracts: [],
+      hooks: [],
+      mcpServers: [],
+      cliCommands: [],
+      cliBackends: [],
+      skills: [],
+      dangerousConfigFlags: [],
+    },
+    components: {
+      mapped: ["skills"],
+      skills: [skill],
+      mcpServers: [],
+      commands: [],
+      hooks: [],
+      lspServers: [],
+      unavailable: { capabilities: [], mcpServers: [], lspServers: [] },
+    },
+    grants: {
+      hooks: {
+        allowPromptInjection: { effective: false },
+        allowConversationAccess: { effective: false },
+      },
+    },
+  };
+}
+
+function configResponse(greeting: string) {
+  const config = { plugins: { entries: { workboard: { config: { greeting } } } } };
+  return {
+    config,
+    hash: greeting,
+    appliedConfigHash: greeting,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+async function captureSettled(page: Page, name: string, surface: Locator = page.locator(".shell")) {
+  // Delivered RPC callbacks and Lit updates settle before sampling the visible surface.
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      }),
+  );
+  if (capture) {
+    const dir = createControlUiE2eArtifactDir(name);
+    await writeFile(
+      path.join(dir, "result.png"),
+      await takeControlUiViewportScreenshot(page, surface, [page.locator("openclaw-plugins-page")]),
+    );
+  }
+}
+
+suite.define(() => {
+  it("keeps the current rendered inspection after an old optional catalog response", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods,
+        deferredMethods: ["plugins.catalog.get"],
+        methodResponses: {
+          "plugins.list": { plugins: [workboard], diagnostics: [], mutationAllowed: true },
+          "plugins.inspect": {
+            sequence: [inspection("Original skill"), inspection("Current skill")],
+          },
+          "plugins.catalog.get": {
+            __mockError: { code: "UNAVAILABLE", message: "Optional catalog unavailable" },
+          },
+          "config.get": configResponse("Before"),
+          "config.set": { ok: true, hash: "After" },
+          "config.schema": {
+            schema: {
+              type: "object",
+              properties: {
+                plugins: {
+                  type: "object",
+                  properties: {
+                    entries: {
+                      type: "object",
+                      properties: {
+                        workboard: {
+                          type: "object",
+                          properties: {
+                            config: {
+                              type: "object",
+                              properties: { greeting: { type: "string", title: "Greeting" } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            uiHints: {},
+            version: "synthetic",
+            generatedAt: "2026-09-01T00:00:00.000Z",
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/plugins/workboard#configuration`);
+      await gateway.waitForRequest("plugins.catalog.get");
+      await gateway.setMethodResponse("config.get", configResponse("After"));
+      await page.getByRole("textbox", { name: "Greeting", exact: true }).fill("After");
+      await gateway.waitForRequest("config.set");
+      await gateway.waitForRequest("plugins.inspect", { after: 1 });
+      await gateway.waitForRequest("plugins.catalog.get", { after: 1 });
+      await page
+        .locator(".plugin-catalog-detail__tabs")
+        .getByRole("tab", { name: "Skills", exact: true })
+        .click();
+      const rows = page.locator(".plugin-catalog-detail__row h3");
+      await expect.poll(() => rows.allTextContents()).toEqual(["Current skill"]);
+
+      await gateway.resolveDeferred(
+        "plugins.catalog.get",
+        detail(workboard.catalogId!, "Workboard", true),
+      );
+      await captureSettled(page, "plugin-inspection-ownership");
+      expect(await rows.allTextContents()).toEqual(["Current skill"]);
+      expect(await gateway.getRequests("plugins.inspect")).toHaveLength(2);
+    });
+  });
+
+  it.each([false, true])(
+    "keeps the selected install wizard after an older detail response (installing=%s)",
+    async (installing) => {
+      await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+        const alpha = detail("ch_YWxwaGE", "Alpha");
+        const beta = detail("ch_YmV0YQ", "Beta");
+        const gateway = await installMockGateway(page, {
+          featureMethods,
+          deferredMethods: ["plugins.catalog.get"],
+          methodResponses: {
+            "plugins.list": { plugins: [], diagnostics: [], mutationAllowed: true },
+            "plugins.catalog.browse": {
+              cases: [
+                { match: { intent: "all" }, response: { items: [alpha.plugin, beta.plugin] } },
+                { match: { intent: "featured" }, response: { items: [] } },
+                { match: { intent: "trending" }, response: { items: [] } },
+              ],
+            },
+            "plugins.catalog.categories": { categories: [] },
+            "plugins.catalog.get": beta,
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}plugins`);
+        await page.getByRole("button", { name: "Install Alpha", exact: true }).click();
+        await gateway.waitForRequest("plugins.catalog.get", { match: { id: alpha.plugin.id } });
+        await page.getByRole("button", { name: "Install Beta", exact: true }).click();
+        const wizard = page.locator(".plugin-install-wizard");
+        await wizard.getByRole("heading", { name: "Beta", exact: true }).waitFor();
+        try {
+          if (installing) {
+            await gateway.deferNext("plugins.install");
+            await wizard.getByRole("button", { name: "Install Beta", exact: true }).click();
+            const request = await gateway.waitForRequest("plugins.install");
+            expect(request.params).toEqual({ source: "clawhub", packageName: "beta" });
+          }
+          await gateway.resolveDeferred("plugins.catalog.get", alpha);
+          await captureSettled(
+            page,
+            installing ? "plugin-installing-ownership" : "plugin-review-ownership",
+            page.locator("openclaw-modal-dialog dialog"),
+          );
+          expect(await wizard.getByRole("heading").textContent()).toBe("Beta");
+          expect(await wizard.getAttribute("data-stage")).toBe(
+            installing ? "installing" : "review",
+          );
+          expect(await gateway.getRequests("plugins.install")).toHaveLength(installing ? 1 : 0);
+        } finally {
+          if (installing) {
+            await gateway.rejectDeferred("plugins.install", {
+              code: "UNAVAILABLE",
+              message: "Synthetic install complete",
+            });
+          }
+        }
+      });
+    },
+  );
+});

--- a/ui/src/pages/plugins/install-wizard-controller.ts
+++ b/ui/src/pages/plugins/install-wizard-controller.ts
@@ -1,3 +1,4 @@
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { serializeConfigForm } from "../../lib/config-form-utils.ts";
@@ -467,6 +468,10 @@ export class InstallWizardController {
     try {
       await this.host.requestRestart(t("pluginsPage.installWizard.restartReason"));
     } catch (error) {
+      if (!this.host.isConnected() && !(error instanceof GatewayRequestError)) {
+        // The restart can close its socket before acknowledging; reconnect owns completion.
+        return;
+      }
       this.fail(
         attempt,
         catalogId,

--- a/ui/src/pages/plugins/install-wizard-controller.ts
+++ b/ui/src/pages/plugins/install-wizard-controller.ts
@@ -56,6 +56,7 @@ export class InstallWizardController {
   invalidate(): void {
     const state = this.host.getState();
     if (!state) {
+      this.retireAttempt();
       return;
     }
     if (!this.ownerIsCurrent()) {
@@ -74,23 +75,39 @@ export class InstallWizardController {
   }
 
   open(result: PluginDiscoveryDetailResult): void {
-    const request = installRequestForDiscoveryDetail(result);
-    if (!request) {
+    if (!installRequestForDiscoveryDetail(result)) {
       return;
     }
-    this.clearReconnectTimeout();
-    this.attempt += 1;
+    this.prepareOpen()?.open(result);
+  }
+
+  prepareOpen() {
+    if (this.busy) {
+      return null;
+    }
+    // Detail loading belongs to the same attempt as review and installation.
+    this.close();
     this.owner = this.host.getOwner();
-    this.restartRequirement = null;
-    this.host.setState({
-      catalogId: result.plugin.id,
-      detail: result,
-      request,
-      stage: "review",
-    });
-    // Prepare the canonical form before the intentional restart so setup can resume immediately.
-    void this.host.getRuntimeConfig().ensureLoaded();
-    void this.host.getRuntimeConfig().ensureSchemaLoaded();
+    const attempt = this.attempt;
+    const isCurrent = () => attempt === this.attempt && this.ownerIsCurrent();
+    return {
+      isCurrent,
+      open: (result: PluginDiscoveryDetailResult) => {
+        const request = installRequestForDiscoveryDetail(result);
+        if (!isCurrent() || !request) {
+          return;
+        }
+        this.host.setState({
+          catalogId: result.plugin.id,
+          detail: result,
+          request,
+          stage: "review",
+        });
+        // Prepare configuration before restart so setup can resume immediately.
+        void this.host.getRuntimeConfig().ensureLoaded();
+        void this.host.getRuntimeConfig().ensureSchemaLoaded();
+      },
+    };
   }
 
   close(): void {

--- a/ui/src/pages/plugins/plugins-page.routing.test.ts
+++ b/ui/src/pages/plugins/plugins-page.routing.test.ts
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n, t } from "../../i18n/index.ts";
+import type { PluginCatalogItem, PluginDiscoveryDetailResult } from "../../lib/plugins/index.ts";
 import {
   createClient,
   createContext,
@@ -17,6 +19,34 @@ import {
   resetPluginsPageTestState,
 } from "./plugins-page.test-support.ts";
 import type { PluginsRouteData } from "./route-data.ts";
+
+function discoveryDetail(
+  plugin: PluginCatalogItem & { catalogId: string },
+): PluginDiscoveryDetailResult {
+  return {
+    plugin: {
+      id: plugin.catalogId,
+      catalog: { name: plugin.name, official: true, categories: [] },
+      local: {
+        present: plugin.installed,
+        installed: plugin.installed,
+        enabled: plugin.enabled,
+        state: plugin.state,
+        pluginId: plugin.id,
+        action: plugin.installed ? "manage" : "install",
+      },
+    },
+    detail: {
+      origin: "clawhub",
+      packageName: plugin.id,
+      topics: [],
+      configuration: [],
+      mcpServers: [],
+      skills: [],
+      versions: [],
+    },
+  };
+}
 
 function clickHubTab(page: HTMLElement, tab: "plugins" | "skills") {
   page
@@ -351,6 +381,222 @@ describe("PluginsPage routing", () => {
     nextCatalog.resolve(result);
     await refresh;
   });
+
+  it("keeps the autosaved inspection when an older optional catalog completes", async () => {
+    const plugin = { ...createPlugin(), catalogId: "ch_d29ya2JvYXJk", version: "1.2.3" };
+    const result = createResult(plugin);
+    const catalog = deferred<PluginDiscoveryDetailResult>();
+    let inspections = 0;
+    let catalogs = 0;
+    const { client, request } = createClient(async (method) => {
+      if (method === "plugins.inspect") {
+        const inspection = createInspectResult();
+        return {
+          ...inspection,
+          components: {
+            ...inspection.components,
+            skills: [++inspections === 1 ? "Original skill" : "Current skill"],
+          },
+        };
+      }
+      if (method === "plugins.catalog.get") {
+        if (++catalogs === 1) {
+          return catalog.promise;
+        }
+        throw new Error("Optional catalog unavailable");
+      }
+      if (method === "plugins.list") {
+        return result;
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const harness = createGateway(client);
+    const configState = {
+      connected: true,
+      configFormDirty: false,
+      lastError: null,
+      configAutoSaveStatus: "idle",
+      configForm: { plugins: { entries: { workboard: { config: { greeting: "Before" } } } } },
+      configUiHints: {},
+      configSchema: {
+        type: "object",
+        properties: {
+          plugins: {
+            type: "object",
+            properties: {
+              entries: {
+                type: "object",
+                properties: {
+                  workboard: {
+                    type: "object",
+                    properties: {
+                      config: {
+                        type: "object",
+                        properties: { greeting: { type: "string", title: "Greeting" } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const runtimeConfig = createRuntimeConfigHarness(
+      vi.fn(async () => undefined),
+      configState,
+      () => client,
+    );
+    const { page } = await mountPage(
+      createContext(harness.gateway, undefined, undefined, runtimeConfig),
+      createPluginsRouteData(
+        harness.gateway,
+        result,
+        createPluginsRouteLocation("/settings/plugins/workboard#configuration"),
+      ),
+    );
+    await vi.waitFor(() => expect(catalogs).toBe(1));
+    const input = page.querySelector<HTMLInputElement>(
+      '.plugin-catalog-detail__panel input[type="text"]',
+    );
+    expect(input).not.toBeNull();
+    input!.value = "After";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(runtimeConfig.runtimeConfig.patchForm).toHaveBeenCalledWith(
+      ["plugins", "entries", "workboard", "config", "greeting"],
+      "After",
+    );
+    configState.configForm.plugins.entries.workboard.config.greeting = "After";
+    configState.configAutoSaveStatus = "saving";
+    runtimeConfig.notify();
+    configState.configAutoSaveStatus = "saved";
+    runtimeConfig.notify();
+    await vi.waitFor(() => expect(catalogs).toBe(2));
+    page
+      .querySelector("#plugin-installed-detail-tab-skills")!
+      .dispatchEvent(new MouseEvent("click", { detail: 1, bubbles: true }));
+    await page.updateComplete;
+    const rows = () =>
+      [...page.querySelectorAll(".plugin-catalog-detail__row h3")].map((row) => row.textContent);
+    expect(rows()).toEqual(["Current skill"]);
+
+    catalog.resolve(discoveryDetail(plugin));
+    await catalog.promise;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await page.updateComplete;
+
+    expect(rows()).toEqual(["Current skill"]);
+    expect(request.mock.calls.filter(([method]) => method === "plugins.inspect")).toHaveLength(2);
+  });
+
+  it.each(["review", "installing"])(
+    "keeps the latest Install selection while its wizard is %s",
+    async (stage) => {
+      const details = ["Alpha", "Beta"].map((name) =>
+        discoveryDetail({
+          ...createPlugin({
+            id: name.toLowerCase(),
+            name,
+            installed: false,
+            state: "not-installed",
+          }),
+          catalogId: name === "Alpha" ? "ch_YWxwaGE" : "ch_YmV0YQ",
+        }),
+      );
+      const [alpha, beta] = details;
+      const alphaRead = deferred<PluginDiscoveryDetailResult>();
+      const betaRead = deferred<PluginDiscoveryDetailResult>();
+      const installation = deferred<unknown>();
+      const { client, request } = createClient(async (method, params) => {
+        if (method === "plugins.catalog.browse") {
+          return {
+            items:
+              asNullableRecord(params)?.intent === "all"
+                ? details.map((detail) => detail.plugin)
+                : [],
+          };
+        }
+        if (method === "plugins.catalog.categories") {
+          return { categories: [] };
+        }
+        if (method === "plugins.catalog.get") {
+          return asNullableRecord(params)?.id === alpha!.plugin.id
+            ? alphaRead.promise
+            : betaRead.promise;
+        }
+        if (method === "plugins.install") {
+          return installation.promise;
+        }
+        if (method === "plugins.list") {
+          return createResult();
+        }
+        throw new Error(`Unexpected method: ${method}`);
+      });
+      const harness = createGateway(client);
+      const { page } = await mountPage(
+        createContext(harness.gateway),
+        createPluginsRouteData(
+          harness.gateway,
+          createResult(),
+          createPluginsRouteLocation("/plugins"),
+        ),
+      );
+      try {
+        await vi.waitFor(() =>
+          expect(page.querySelectorAll(".plugin-catalog-card__install")).toHaveLength(2),
+        );
+        page.querySelector<HTMLButtonElement>('[aria-label="Install Alpha"]')!.click();
+        page.querySelector<HTMLButtonElement>('[aria-label="Install Beta"]')!.click();
+        await vi.waitFor(() =>
+          expect(
+            request.mock.calls.filter(([method]) => method === "plugins.catalog.get"),
+          ).toHaveLength(2),
+        );
+        betaRead.resolve(beta!);
+        const wizard = () => page.querySelector(".plugin-install-wizard");
+        await vi.waitFor(() => expect(wizard()?.querySelector("h2")?.textContent).toBe("Beta"));
+        if (stage === "installing") {
+          [...wizard()!.querySelectorAll<HTMLButtonElement>("button")]
+            .find((button) => button.textContent?.trim() === "Install Beta")!
+            .click();
+          await vi.waitFor(() =>
+            expect(request).toHaveBeenCalledWith("plugins.install", {
+              source: "clawhub",
+              packageName: "beta",
+            }),
+          );
+          expect(wizard()?.getAttribute("data-stage")).toBe("installing");
+        }
+        alphaRead.resolve(alpha!);
+        await alphaRead.promise;
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        await page.updateComplete;
+
+        expect(wizard()?.querySelector("h2")?.textContent).toBe("Beta");
+        expect(wizard()?.getAttribute("data-stage")).toBe(stage);
+        expect(request.mock.calls.filter(([method]) => method === "plugins.install")).toHaveLength(
+          stage === "installing" ? 1 : 0,
+        );
+      } finally {
+        alphaRead.resolve(alpha!);
+        betaRead.resolve(beta!);
+        installation.resolve({
+          ok: true,
+          plugin: createPlugin({ id: "beta", name: "Beta", enabled: true, state: "enabled" }),
+          restartRequired: false,
+        });
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        await page.updateComplete;
+      }
+    },
+  );
 
   it("renders local settings before optional ClawHub presentation settles", async () => {
     const plugin = createPlugin({

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -2,7 +2,6 @@ import { consume } from "@lit/context";
 import { initialState, Task, TaskStatus } from "@lit/task";
 import type { PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   pathForPluginSettings,
   pathForRoute,
@@ -129,7 +128,7 @@ class PluginsPage extends OpenClawLightDomElement {
       }
     },
     applyMutationResult: (result) => this.applyMutationResult(result),
-    refreshCatalogAfterMutation: (client) => this.refreshCatalogAfterMutation(client),
+    refreshCatalogAfterMutation: (client) => this.refreshCatalog(client),
     reconnectAfterMutation: (rowKey) => {
       // The reconnect refreshes hello-owned plugin tabs. Keep only its committed
       // outcome; unrelated Gateway identity changes still clear all row messages.
@@ -212,6 +211,12 @@ class PluginsPage extends OpenClawLightDomElement {
 
   override willUpdate(changed: PropertyValues<this>) {
     if (changed.has("routeData")) {
+      if (
+        !this.installWizard &&
+        changed.get("routeData")?.location.pathname !== this.routeData?.location.pathname
+      ) {
+        this.installWizardController.close();
+      }
       this.applyRouteData();
     }
   }
@@ -398,12 +403,7 @@ class PluginsPage extends OpenClawLightDomElement {
 
   private ensureInitialData() {
     // The route owns initial loading; a warm page module can render before its data arrives.
-    if (
-      !this.routeDataConsumed ||
-      !this.gateway.connected ||
-      !this.gateway.client ||
-      (this.routeData && !this.routeDataConsumed)
-    ) {
+    if (!this.routeDataConsumed || !this.gateway.connected || !this.gateway.client) {
       return;
     }
     if (!this.loading && !this.result && !this.error) {
@@ -421,9 +421,8 @@ class PluginsPage extends OpenClawLightDomElement {
     }
   }
 
-  private async refreshCatalog(): Promise<void> {
-    const client = this.gateway.client;
-    if (!client || !this.gateway.connected) {
+  private async refreshCatalog(client = this.gateway.connected ? this.gateway.client : null) {
+    if (!client) {
       return;
     }
     this.error = null;
@@ -452,16 +451,14 @@ class PluginsPage extends OpenClawLightDomElement {
     return Boolean(this.result?.mutationAllowed) && this.mutationBlockedReason() === null;
   }
 
-  private configBlockedReason(): string | null {
-    return pluginMutationBlockedReason({
-      connected: this.context.runtimeConfig.state.connected,
-      hasAdminAccess: hasOperatorAdminAccess(this.context.gateway.snapshot.hello?.auth ?? null),
-      mutationAllowed: this.context.runtimeConfig.canSet,
-    });
-  }
-
   private canEditConfig(): boolean {
-    return this.configBlockedReason() === null;
+    return (
+      pluginMutationBlockedReason({
+        connected: this.context.runtimeConfig.state.connected,
+        hasAdminAccess: hasOperatorAdminAccess(this.context.gateway.snapshot.hello?.auth ?? null),
+        mutationAllowed: this.context.runtimeConfig.canSet,
+      }) === null
+    );
   }
 
   private setBusy(key: string, value: boolean) {
@@ -489,14 +486,10 @@ class PluginsPage extends OpenClawLightDomElement {
     this.replaceResult(mergePluginCatalogItem(this.result, result.plugin), true);
   }
 
-  /** Plugin changes can affect both catalog state and route visibility (for example Workboard). */
-  private async refreshCatalogAfterMutation(client: GatewayBrowserClient): Promise<void> {
-    this.error = null;
-    await this.catalogTask.run([client]);
-  }
-
   private async showDetails(pluginId: string | null) {
-    const detail = pluginId ? { pluginId, inspection: null, error: null } : null;
+    let detail: PluginsPageDetail | null = pluginId
+      ? { pluginId, inspection: null, error: null }
+      : null;
     this.detail = detail;
     const plugin = pluginId
       ? this.result?.plugins.find((entry) => entry.id === pluginId)
@@ -507,9 +500,11 @@ class PluginsPage extends OpenClawLightDomElement {
     }
     try {
       const inspection = await inspectPlugin(scope.client, plugin.id);
-      if (this.gateway.isCurrent(scope) && this.detail === detail) {
-        this.detail = { ...detail, inspection };
+      if (!this.gateway.isCurrent(scope) || this.detail !== detail) {
+        return;
       }
+      detail = { ...detail, inspection };
+      this.detail = detail;
       if (!plugin.catalogId) {
         return;
       }
@@ -520,8 +515,8 @@ class PluginsPage extends OpenClawLightDomElement {
           undefined,
           plugin.version,
         );
-        if (this.gateway.isCurrent(scope) && this.detail?.pluginId === plugin.id) {
-          this.detail = { ...this.detail, inspection: { ...inspection, catalog } };
+        if (this.gateway.isCurrent(scope) && this.detail === detail) {
+          this.detail = { ...detail, inspection: { ...inspection, catalog } };
         }
       } catch {
         // ClawHub presentation is optional; local capabilities and controls are already visible.
@@ -567,15 +562,19 @@ class PluginsPage extends OpenClawLightDomElement {
     if (!scope || !this.canMutate()) {
       return;
     }
+    const opening = this.installWizardController.prepareOpen();
+    if (!opening) {
+      return;
+    }
     try {
       const result = await loadPluginDiscoveryDetail(scope.client, id);
-      if (!this.gateway.isCurrent(scope)) {
+      if (!this.gateway.isCurrent(scope) || !opening.isCurrent()) {
         return;
       }
       this.syncCatalogIcons(result);
-      this.installWizardController.open(result);
+      opening.open(result);
     } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
+      if (this.gateway.isCurrent(scope) && opening.isCurrent()) {
         this.discovery.error = formatUiError(error);
         this.requestUpdate();
       }
@@ -628,7 +627,7 @@ class PluginsPage extends OpenClawLightDomElement {
             });
           }
         }
-        await this.refreshCatalogAfterMutation(client);
+        await this.refreshCatalog(client);
       },
       { confirm: () => confirmPluginUninstall(name) },
     );

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -167,101 +167,130 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
     }
   });
 
-  it("installs, configures, and enables a catalog plugin across Gateway restarts", async () => {
-    const context = await newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: [...pluginMethods, "config.schema", "config.set"],
-      methodResponses: {
-        ...pluginMethodResponses(),
-        "config.schema": matrixConfigSchema,
-        "plugins.list": {
-          sequence: [
-            initialInventory,
-            inventory([...initialInventory.plugins, matrixNeedsSetup]),
-            inventory([...initialInventory.plugins, matrixNeedsSetup]),
-            inventory([...initialInventory.plugins, matrixNeedsSetup]),
-            inventory([...initialInventory.plugins, matrixEnabled]),
-          ],
-        },
-        "plugins.install": {
-          ok: true,
-          plugin: matrixNeedsSetup,
-          restartRequired: true,
-        },
-        "plugins.setEnabled": {
-          ok: true,
-          plugin: matrixEnabled,
-          restartRequired: true,
-        },
-      },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}plugins/${matrixDiscoveryPlugin.id}`);
-      await page.getByRole("heading", { level: 1, name: "Matrix", exact: true }).waitFor();
-      await page.getByRole("button", { name: "Install", exact: true }).click();
-
-      const wizard = page.locator('openclaw-modal-dialog[label="Install Matrix"]');
-      await wizard.waitFor();
-      expect(await wizard.textContent()).toContain("ClawHub · matrix");
-      expect(await wizard.textContent()).toContain("Gateway restart");
-      expect(await wizard.textContent()).toContain("Matrix messaging");
-      await wizard.getByRole("button", { name: "Install Matrix", exact: true }).click();
-
-      const installRequest = await gateway.waitForRequest("plugins.install");
-      expect(installRequest.params).toEqual({ source: "clawhub", packageName: "matrix" });
-      expect((await gateway.waitForRequest("gateway.restart.request")).params).toEqual({
-        reason: "Apply an installed plugin change",
-      });
-      const cancel = await wizard.evaluate((element) => {
-        const event = new CustomEvent("modal-cancel", { cancelable: true });
-        element.dispatchEvent(event);
-        return event.defaultPrevented;
-      });
-      expect(cancel).toBe(true);
-      expect(await wizard.count()).toBe(1);
-      await reconnectMockGateway(page, gateway, "plugins-install-configuring");
-
-      await expect
-        .poll(() => wizard.locator(".plugin-install-wizard").getAttribute("data-stage"), {
-          timeout: 5_000,
-        })
-        .toBe("configuring");
-      await expect.poll(() => wizard.textContent(), { timeout: 5_000 }).toContain("Homeserver");
-      await wizard.getByRole("textbox", { name: "Homeserver" }).fill("https://matrix.example");
-      await wizard.getByRole("textbox", { name: "Access token" }).fill("secret-token");
-      await wizard.getByRole("combobox", { name: "Mode" }).selectOption("__null__");
-      await wizard.getByRole("button", { name: "Save and enable", exact: true }).click();
-
-      const configSet = await gateway.waitForRequest("config.set");
-      expect(JSON.parse(String((configSet.params as { raw?: unknown }).raw))).toEqual({
-        plugins: {
-          entries: {
-            workboard: { enabled: false },
-            matrix: {
-              config: {
-                homeserver: "https://matrix.example",
-                accessToken: "secret-token",
-                mode: null,
-              },
-            },
+  it.each(["acknowledged", "lost on reconnect", "rejected"] as const)(
+    "installs, configures, and handles the final restart acknowledgement (%s)",
+    async (acknowledgement) => {
+      const context = await newContext();
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        featureMethods: [...pluginMethods, "config.schema", "config.set"],
+        methodResponses: {
+          ...pluginMethodResponses(),
+          "config.schema": matrixConfigSchema,
+          "plugins.list": {
+            sequence: [
+              initialInventory,
+              inventory([...initialInventory.plugins, matrixNeedsSetup]),
+              inventory([...initialInventory.plugins, matrixNeedsSetup]),
+              inventory([...initialInventory.plugins, matrixNeedsSetup]),
+              inventory([...initialInventory.plugins, matrixEnabled]),
+            ],
+          },
+          "plugins.install": {
+            ok: true,
+            plugin: matrixNeedsSetup,
+            restartRequired: true,
+          },
+          "plugins.setEnabled": {
+            ok: true,
+            plugin: matrixEnabled,
+            restartRequired: true,
           },
         },
       });
-      await gateway.waitForRequest("plugins.setEnabled");
-      await expect
-        .poll(async () => (await gateway.getRequests("gateway.restart.request")).length)
-        .toBe(2);
-      await reconnectMockGateway(page, gateway, "plugins-install-enabled");
-      await wizard.getByText("Plugin ready", { exact: true }).waitFor();
-      expect(await gateway.getRequests("config.set")).toHaveLength(1);
-      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
-      expect(await wizard.textContent()).toContain("Matrix is installed and enabled.");
-    } finally {
-      await context.close();
-    }
-  });
+
+      try {
+        await page.goto(`${server.baseUrl}plugins/${matrixDiscoveryPlugin.id}`);
+        await page.getByRole("heading", { level: 1, name: "Matrix", exact: true }).waitFor();
+        await page.getByRole("button", { name: "Install", exact: true }).click();
+
+        const wizard = page.locator('openclaw-modal-dialog[label="Install Matrix"]');
+        await wizard.waitFor();
+        expect(await wizard.textContent()).toContain("ClawHub · matrix");
+        expect(await wizard.textContent()).toContain("Gateway restart");
+        expect(await wizard.textContent()).toContain("Matrix messaging");
+        await wizard.getByRole("button", { name: "Install Matrix", exact: true }).click();
+
+        const installRequest = await gateway.waitForRequest("plugins.install");
+        expect(installRequest.params).toEqual({ source: "clawhub", packageName: "matrix" });
+        expect((await gateway.waitForRequest("gateway.restart.request")).params).toEqual({
+          reason: "Apply an installed plugin change",
+        });
+        const cancel = await wizard.evaluate((element) => {
+          const event = new CustomEvent("modal-cancel", { cancelable: true });
+          element.dispatchEvent(event);
+          return event.defaultPrevented;
+        });
+        expect(cancel).toBe(true);
+        expect(await wizard.count()).toBe(1);
+        await reconnectMockGateway(page, gateway, "plugins-install-configuring");
+
+        await expect
+          .poll(() => wizard.locator(".plugin-install-wizard").getAttribute("data-stage"), {
+            timeout: 5_000,
+          })
+          .toBe("configuring");
+        await expect.poll(() => wizard.textContent(), { timeout: 5_000 }).toContain("Homeserver");
+        await wizard.getByRole("textbox", { name: "Homeserver" }).fill("https://matrix.example");
+        await wizard.getByRole("textbox", { name: "Access token" }).fill("secret-token");
+        await wizard.getByRole("combobox", { name: "Mode" }).selectOption("__null__");
+        await gateway.deferNext("gateway.restart.request");
+        await wizard.getByRole("button", { name: "Save and enable", exact: true }).click();
+
+        const configSet = await gateway.waitForRequest("config.set");
+        expect(JSON.parse(String((configSet.params as { raw?: unknown }).raw))).toEqual({
+          plugins: {
+            entries: {
+              workboard: { enabled: false },
+              matrix: {
+                config: {
+                  homeserver: "https://matrix.example",
+                  accessToken: "secret-token",
+                  mode: null,
+                },
+              },
+            },
+          },
+        });
+        await gateway.waitForRequest("plugins.setEnabled");
+        await expect
+          .poll(async () => (await gateway.getRequests("gateway.restart.request")).length)
+          .toBe(2);
+        if (acknowledgement === "rejected") {
+          await gateway.rejectDeferred("gateway.restart.request", {
+            code: "INVALID_REQUEST",
+            message: "Restart request rejected",
+          });
+          await wizard
+            .getByRole("alert")
+            .getByText("Restart request rejected", { exact: true })
+            .waitFor();
+        } else if (acknowledgement === "acknowledged") {
+          await gateway.resolveDeferred("gateway.restart.request");
+        }
+        await reconnectMockGateway(page, gateway, "plugins-install-enabled");
+        if (acknowledgement === "lost on reconnect") {
+          await gateway.resolveDeferred("gateway.restart.request");
+        }
+        if (acknowledgement === "rejected") {
+          await wizard
+            .getByRole("alert")
+            .getByText("Restart request rejected", { exact: true })
+            .waitFor();
+          expect(await wizard.getByRole("button", { name: "Try again", exact: true }).count()).toBe(
+            1,
+          );
+        } else {
+          await wizard.getByText("Plugin ready", { exact: true }).waitFor();
+          expect(await wizard.textContent()).toContain("Matrix is installed and enabled.");
+        }
+        expect(await gateway.getRequests("config.set")).toHaveLength(1);
+        expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      } finally {
+        await context.close();
+      }
+    },
+  );
 
   it("discards staged plugin configuration when installation is cancelled", async () => {
     const context = await newContext();


### PR DESCRIPTION
## What Problem This Solves

Fixes plugin-page requests that can overwrite a newer choice: delayed ClawHub metadata could restore an old inspection after autosave, and a slow first Install request could replace the second plugin's review or active installation dialog. Also fixes the install dialog reporting failure when the Gateway restarts before acknowledging a committed plugin change.

## Why This Change Was Made

Keep the same request identity through local inspection and optional catalog enrichment. Reserve the existing wizard attempt before loading installation details, so later selection, close, route changes, and connection retirement invalidate stale work while a busy installation keeps its owner. Reuse one catalog refresh method and remove redundant checks.

During a committed restart, transport loss leaves the wizard waiting for its existing boot and inventory confirmation. Explicit server rejections still show an error, and the existing deadline still offers a retry if the restart stalls. No mutation is retried automatically and no shared client or restart policy changes. The complete change adds 21 production lines.

## User Impact

Current settings and the latest selected plugin remain visible. An active installation retains its dialog and can finish after the expected Gateway reconnect, even when that restart interrupts its acknowledgement.

## Evidence

- 77 focused cases across 8 files pass on the final source: 20 browser cases and 57 mounted-page/model/policy cases.
- The original three request-ordering scenarios fail before their repair and pass afterward. The final browser run includes all three on the final committed test source.
- The permanent restart table first failed only the lost-acknowledgement case on original production; acknowledged and explicit-rejection controls passed. All three pass after the repair, alongside existing stalled-restart, same-boot, cancellation, consent, setup, and retry controls.
- All 20 canonical changed-file checks pass, including types, formatting, i18n, dependency and export checks, and lint.
- Fresh independent Codex review of the complete staged change found no actionable findings through P2.

An earlier CI run also exposed an unrelated catalog request-order assertion, fixed separately in #143710. Its existing restart test timed out without a diagnostic artifact; the controlled browser reproduction establishes a valid lost-acknowledgement failure, not the unknown interleaving in that CI run.

The screenshots show the selection and metadata repairs using synthetic data. Restart recovery is covered by browser assertions. No real package installation, live Gateway, or provider was used.

| Scenario | Before | After |
| --- | --- | --- |
| Old metadata after autosave | ![Before: old metadata restores Original skill](https://github.com/user-attachments/assets/cde5c316-758d-4bf9-a84f-8ce567f08049) | ![After: Current skill remains visible](https://github.com/user-attachments/assets/af7e1b03-1c04-4e98-a43e-3bcc75c33aad) |
| Late first Install response | ![Before: Alpha replaces the selected Beta review](https://github.com/user-attachments/assets/8b078d84-889c-4dcc-a802-c7069317cc54) | ![After: Beta remains selected](https://github.com/user-attachments/assets/06103253-354e-47eb-81a0-9a06d41415f9) |
| Late response during installation | ![Before: active Beta installation is replaced by Alpha review](https://github.com/user-attachments/assets/8cf367c5-65f0-4d1b-ac8d-119307046230) | ![After: Beta retains its installation progress](https://github.com/user-attachments/assets/fe5157c4-8722-4c10-b325-a54e75458e7a) |
