### PR TITLE
fix: preserve attachments with prototype-named content types

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -570,6 +570,28 @@ describe("normalizeMimeType", () => {
   });
 });
 
+describe("prototype-named mime keys", () => {
+  // Remote senders control Content-Type headers; object-literal lookups must
+  // not resolve inherited Object.prototype members or downstream string ops throw.
+  it.each([
+    { input: "__proto__", expected: "__proto__" },
+    { input: "constructor", expected: "constructor" },
+  ] as const)("normalizeMimeType($input) stays a plain string", ({ input, expected }) => {
+    expect(normalizeMimeType(input)).toBe(expected);
+  });
+
+  it.each(["__proto__", "constructor"])(
+    "kindFromMime(%s) returns undefined, not a throw",
+    (input) => {
+      expect(kindFromMime(input)).toBeUndefined();
+    },
+  );
+
+  it.each(["__proto__", "constructor"])("extensionForMime(%s) returns undefined", (input) => {
+    expect(extensionForMime(input)).toBeUndefined();
+  });
+});
+
 describe("mediaKindFromMime", () => {
   it.each([
     { mime: "text/plain", expected: "document" },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -175,7 +175,9 @@ export function normalizeMimeType(mime?: string | null): string | undefined {
   if (!cleaned) {
     return undefined;
   }
-  return MIME_SYNONYMS[cleaned] ?? cleaned;
+  // Object.hasOwn: a remote "__proto__"/"constructor" header would otherwise
+  // resolve to inherited Object.prototype members and break the string contract.
+  return Object.hasOwn(MIME_SYNONYMS, cleaned) ? MIME_SYNONYMS[cleaned] : cleaned;
 }
 
 /** Returns the bounded buffer prefix used for dependency MIME sniffing. */
@@ -290,7 +292,9 @@ export function extensionForMime(mime?: string | null): string | undefined {
   if (!normalized) {
     return undefined;
   }
-  return EXT_BY_MIME[normalized];
+  // Same prototype-key hazard as normalizeMimeType: a "__proto__" lookup would
+  // return Object.prototype where callers expect string | undefined.
+  return Object.hasOwn(EXT_BY_MIME, normalized) ? EXT_BY_MIME[normalized] : undefined;
 }
 
 /** Returns true when content type or filename identifies GIF media. */


### PR DESCRIPTION
## What Problem This Solves
Remote attachments with `Content-Type: __proto__` or `constructor` crash media handling before upload.

## Why This Change Was Made
Both MIME lookups now accept only their own entries. Unknown types remain strings, with no preferred extension. No shared state is written. The MIME module changes by +6/-2 to enforce these contracts.
Growth accepted under the owner's standing acceptance (2026-09-15).
Alternative: #144458 applies the same guards.

## User Impact
Malformed headers no longer prevent attachment delivery. Ordinary types keep their behavior.

## Evidence
`openclaw message send --channel discord --target channel:<qa-channel> --media <fixture-url>`
Before: both headers fail with `mime.split is not a function`, before upload.
After: recipient downloads contain the exact 31 fixture bytes for both headers and a normal unknown type. An ordinary PNG also arrives byte-for-byte.

## Compatibility
No configuration, schema, protocol, dependency or public signature changes.

## Consumers
Shared remote readers and channel attachment sends use the repaired MIME results.

## Invalidation
No cache or persistent state changes.

## Tests
290 tests passed on a fresh merge: `packages/media-core/src/mime.test.ts`, `src/media/fetch.test.ts`, and `src/media/fetch.prototype-headers.test.ts`. The hosted runner selects the new HTTP test once; all three cases pass.
