### PR TITLE
fix(qa): use the canonical OpenAI live default

### DIFF
--- a/extensions/qa-lab/src/model-selection.runtime.test.ts
+++ b/extensions/qa-lab/src/model-selection.runtime.test.ts
@@ -36,9 +36,9 @@ describe("qa model selection runtime", () => {
   it("keeps the OpenAI live default when an API key is configured", () => {
     resolveEnvApiKey.mockReturnValue({ apiKey: "sk-test" });
 
-    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6");
+    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6-sol");
     expect(resolveQaRuntimeModelPair({ providerMode: "live-frontier" })).toEqual({
-      primaryModel: "openai/gpt-5.6",
+      primaryModel: "openai/gpt-5.6-sol",
       alternateModel: "openai/gpt-5.6-luna",
     });
     expect(loadAuthProfileStoreForRuntime).not.toHaveBeenCalled();
@@ -78,7 +78,7 @@ describe("qa model selection runtime", () => {
       },
     });
 
-    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6");
+    expect(defaultQaRuntimeModelForMode("live-frontier")).toBe("openai/gpt-5.6-sol");
   });
 
   it.each(["openai/gpt-5.6", "openai/gpt-5.6-sol"])(
@@ -111,7 +111,7 @@ describe("qa model selection runtime", () => {
       }),
     ).toEqual({
       primaryModel: "anthropic/claude-sonnet-4-6",
-      alternateModel: "openai/gpt-5.6",
+      alternateModel: "openai/gpt-5.6-sol",
     });
   });
 

--- a/extensions/qa-lab/src/providers/live-frontier/index.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/index.ts
@@ -31,7 +31,7 @@ function isClaudeOpusModel(modelRef: string) {
 export const liveFrontierProviderDefinition: QaProviderDefinition = {
   mode: "live-frontier",
   kind: "live",
-  defaultModel: (options) => options?.preferredLiveModel ?? "openai/gpt-5.6",
+  defaultModel: (options) => options?.preferredLiveModel ?? "openai/gpt-5.6-sol",
   defaultImageGenerationProviderIds: ["openai"],
   defaultImageGenerationModel: ({ modelProviderIds }) =>
     modelProviderIds.includes("openai") ? "openai/gpt-image-1" : null,

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -171,7 +171,7 @@ describe("qa suite provider selection", () => {
       };
       expect(summary.run).toMatchObject({
         providerMode: "live-frontier",
-        primaryModel: "openai/gpt-5.6",
+        primaryModel: "openai/gpt-5.6-sol",
         alternateModel: "openai/gpt-5.6-luna",
       });
       expect(summary.run.primaryModel).not.toBe(summary.run.alternateModel);


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Resolves a problem where QA live-frontier runs without an explicit model select the old OpenAI model alias, while the packaged runtime resolves it to the canonical model. Model-switch evidence then disagrees with the default the suite requested.

## Why This Change Was Made

Use `openai/gpt-5.6-sol` as the live-frontier default. Keep explicit selections and the `openai/gpt-5.6-luna` alternate unchanged. This is a separate three-file cut from the larger model-runtime work, with no production LOC growth.

## User Impact

QA operators can omit model options and exercise the same canonical OpenAI model that the runtime reports.

## Evidence

- 50 focused tests passed across model selection, suite provider selection, and Gateway configuration. Complete changed-file checks and independent P2 review passed.
- A fresh full private-QA build passed at `5ddc2137f1ec5fd913eefc270efcbcc902176de7`; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34436466164) is green.
- The packaged `model-switch-follow-up` scenario passed on Blacksmith Testbox with model, alternate, and fast options omitted. Requested, effective, and response identities were exactly `openai/gpt-5.6-sol` then `openai/gpt-5.6-luna`, in one session with distinct runs, no reroute, visible terminal replies, and one successful delivery. Existing exact assertions were unchanged.
- The remote wrapper verified the PR's exact source tree `d14a4d71e048ef3995dd0b8bf42432c53c59edeb`; its natural execution/build commit is recorded separately. The [live command](https://github.com/openclaw/openclaw/actions/runs/34436607655) exited successfully, all child jobs joined, isolated state was removed, and the owned lease was stopped. Four result files passed secret scanning and hash verification.

The initial harness attempt stopped before building or calling a provider because its HEAD check did not account for the wrapper's transport commit. The corrected verifier retains exact source-tree checks and records both identities without restamping metadata. Only one live scenario execution was performed.
