### PR TITLE
fix(workers): discard abandoned publication uploads

### DIFF
--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -152,6 +152,7 @@ export function createNodeWorkerWorkspaceActions(params: {
       params.environmentId,
       request.baseManifestRef,
     );
+    let preparedCheckpoint: { discard: () => Promise<void> } | undefined;
     try {
       const result = await exec({
         argv: ["openclaw-internal-workspace-transfer"],
@@ -229,6 +230,10 @@ export function createNodeWorkerWorkspaceActions(params: {
             workspaceLog.warn(
               `Repository publication capture unavailable: ${boundedWorkerError(error)}`,
             );
+          } finally {
+            if (publicationToken) {
+              await params.workspaceTransfer.discardUpload(params.environmentId, publicationToken);
+            }
           }
           // Publication restrictions never own recovery acceptance. Its remote
           // stability, live owner and final quiescence fences still run below.
@@ -243,6 +248,7 @@ export function createNodeWorkerWorkspaceActions(params: {
             baseManifestRef: uploaded.baseManifestRef,
             currentManifestRef: uploaded.currentManifestRef,
           });
+          preparedCheckpoint = prepared;
           return {
             manifestRef: uploaded.currentManifestRef,
             changed: uploaded.currentManifestRef !== uploaded.baseManifestRef,
@@ -254,9 +260,6 @@ export function createNodeWorkerWorkspaceActions(params: {
             discardPreparedStagedResult: () => prepared.discard(),
           };
         } finally {
-          if (publicationToken) {
-            await params.workspaceTransfer.discardUpload(params.environmentId, publicationToken);
-          }
           if (publication) {
             await fsp.rm(publication.stagingRoot, { recursive: true, force: true });
           }
@@ -264,6 +267,18 @@ export function createNodeWorkerWorkspaceActions(params: {
       } finally {
         await fsp.rm(uploaded.stagingRoot, { recursive: true, force: true });
       }
+    } catch (error) {
+      // Finalizers can reject before the caller receives the checkpoint's disposer.
+      try {
+        await preparedCheckpoint?.discard();
+      } catch (discardError) {
+        throw new AggregateError(
+          [error, discardError],
+          "Repository checkpoint handoff cleanup failed",
+          { cause: discardError },
+        );
+      }
+      throw error;
     } finally {
       params.workspaceTransfer.revoke(params.environmentId, token);
     }

--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -255,7 +255,7 @@ export function createNodeWorkerWorkspaceActions(params: {
           };
         } finally {
           if (publicationToken) {
-            params.workspaceTransfer.revoke(params.environmentId, publicationToken);
+            await params.workspaceTransfer.discardUpload(params.environmentId, publicationToken);
           }
           if (publication) {
             await fsp.rm(publication.stagingRoot, { recursive: true, force: true });

--- a/src/gateway/worker-environments/node-worker-workspace-publication.test.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-publication.test.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { runNodeWorkerWorkspaceTransfer } from "../../node-host/node-worker-transfer-client.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import { createNodeWorkerWorkspaceActions } from "./node-worker-workspace-actions.js";
+import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import { prepareNodeWorkspaceTransferSnapshot } from "./node-workspace-transfer-snapshot.js";
+import { startNodeWorkspaceTransferTestServer } from "./node-workspace-transfer.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+it.each(["completed", "receiving"] as const)(
+  "disposes an abandoned %s publication upload before the next checkpoint",
+  async (boundary) => {
+    const root = tempDirs.make("node-publication-disposal-");
+    const workspaceDir = path.join(root, "worker");
+    const home = path.join(root, "home");
+    const temporaryRoot = path.join(root, "transfers");
+    await fs.mkdir(workspaceDir);
+    const exec = async (argv: string[]) => {
+      const result = await runCommandWithTimeout(argv, {
+        cwd: workspaceDir,
+        timeoutMs: 10_000,
+        baseEnv: {
+          PATH: process.env.PATH,
+          HOME: home,
+          GIT_CONFIG_GLOBAL: "/dev/null",
+          GIT_CONFIG_NOSYSTEM: "1",
+        },
+      });
+      expect(result.code, result.stderr).toBe(0);
+      return { ...result, workspaceDir };
+    };
+    await exec(["git", "init", "--quiet"]);
+    await fs.writeFile(path.join(workspaceDir, "result.txt"), "base\n");
+    await exec(["git", "add", "result.txt"]);
+    await exec([
+      "git",
+      "-c",
+      "user.name=Publication Test",
+      "-c",
+      "user.email=publication@example.invalid",
+      "commit",
+      "--quiet",
+      "-m",
+      "base",
+    ]);
+    const base = await prepareNodeWorkspaceTransferSnapshot({
+      localPath: workspaceDir,
+      temporaryRoot: root,
+    });
+    if (!base.manifest.baseCommit) {
+      throw new Error("Repository fixture has no base commit");
+    }
+    const manifests = path.join(home, ".openclaw-worker", "manifests");
+    await fs.mkdir(manifests, { recursive: true });
+    await fs.writeFile(path.join(manifests, `${base.manifestRef.slice(7)}.json`), base.rawManifest);
+    await fs.writeFile(path.join(workspaceDir, "result.txt"), "checkpoint edit\n");
+    const owner = new AbortController();
+    const service = createNodeWorkspaceTransferService({
+      temporaryRoot,
+      getOwner: () => ({
+        credential: { ownerEpoch: 1, sessionId: "session" },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: ["session"],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+    });
+    const server = await startNodeWorkspaceTransferTestServer(service);
+    const receiving = createDeferred();
+    const release = createDeferred();
+    const checkpointPrepared = createDeferred();
+    let publicationActive = false;
+    let failPublication = true;
+    let blocked = false;
+    let uploadOutcome: Promise<"completed" | "rejected"> | undefined;
+    const realpath = fs.realpath.bind(fs);
+    vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      if (
+        boundary === "receiving" &&
+        publicationActive &&
+        !blocked &&
+        typeof args[0] === "string" &&
+        path.basename(args[0]).startsWith("upload-")
+      ) {
+        blocked = true;
+        receiving.resolve();
+        await release.promise;
+      }
+      return await realpath(...args);
+    });
+    const actions = createNodeWorkerWorkspaceActions({
+      environmentId: "environment",
+      ownerEpoch: 1,
+      sessionId: "session",
+      ownerSignal: owner.signal,
+      isOwnerCurrent: () => !owner.signal.aborted,
+      restoredWorkspace: {
+        source: {
+          kind: "repository",
+          baseCommit: base.manifest.baseCommit,
+          baseManifestRef: base.manifestRef,
+        },
+        manifestRef: base.manifestRef,
+        remoteWorkspaceDir: workspaceDir,
+      },
+      workspaceTransfer: service,
+      runWorkspaceCommand: async (command) => {
+        if (!command.transfer) {
+          return await exec([...command.argv]);
+        }
+        const publication =
+          command.transfer.direction === "upload" &&
+          Boolean(command.transfer.publicationBaseCommit);
+        publicationActive = publication && failPublication;
+        const upload = runNodeWorkerWorkspaceTransfer({
+          gatewayUrl: server.gatewayUrl,
+          environmentId: "environment",
+          workspaceDir,
+          manifestHome: home,
+          transfer: command.transfer,
+        });
+        if (publicationActive) {
+          uploadOutcome = upload.then(
+            () => "completed",
+            () => "rejected",
+          );
+          if (boundary === "receiving") {
+            await withTestTimeout(receiving.promise, 5_000, "publication never reached staging");
+          } else {
+            expect(await uploadOutcome).toBe("completed");
+          }
+          // The data channel can outlive a lost control-channel command result.
+          return {
+            workspaceDir,
+            stdout: "",
+            stderr: "control channel lost its result",
+            code: 1,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        }
+        return {
+          workspaceDir,
+          stdout: await upload,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      },
+    });
+    const checkpoint = vi.fn(async (payload: { stagingRoot: string }) => {
+      expect(await fs.readFile(path.join(payload.stagingRoot, "result.txt"), "utf8")).toBe(
+        "checkpoint edit\n",
+      );
+      checkpointPrepared.resolve();
+      return { verify: async () => {}, publish: async () => {}, discard: async () => {} };
+    });
+    const reconcile = () =>
+      actions.reconcileWorkspace({
+        remoteWorkspaceDir: workspaceDir,
+        baseManifestRef: base.manifestRef,
+        source: {
+          kind: "repository",
+          referenceManifestRef: base.manifestRef,
+          prepareCheckpoint: checkpoint,
+        },
+      });
+    let first: ReturnType<typeof reconcile> | undefined;
+    try {
+      await actions.validateRestoredWorkspace();
+      first = reconcile();
+      if (boundary === "receiving") {
+        let settled = false;
+        void first.then(
+          () => {
+            settled = true;
+          },
+          () => {
+            settled = true;
+          },
+        );
+        await withTestTimeout(checkpointPrepared.promise, 5_000, "checkpoint was not prepared");
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect.soft(settled, "reconciliation must join abandoned staging work").toBe(false);
+        release.resolve();
+      }
+      expect((await first).changed).toBe(true);
+      if (boundary === "receiving") {
+        expect(await uploadOutcome).toBe("rejected");
+      }
+      expect(
+        (await fs.readdir(temporaryRoot, { recursive: true })).filter((entry) =>
+          path.basename(entry).startsWith("upload-"),
+        ),
+      ).toEqual([]);
+      failPublication = false;
+      expect((await reconcile()).changed).toBe(true);
+      expect(checkpoint).toHaveBeenCalledTimes(2);
+    } finally {
+      release.resolve();
+      await first?.catch(() => undefined);
+      await uploadOutcome;
+      await service.closeAll();
+      await server.close();
+    }
+  },
+);

--- a/src/gateway/worker-environments/node-worker-workspace-publication.test.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-publication.test.ts
@@ -5,17 +5,33 @@ import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.j
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { runNodeWorkerWorkspaceTransfer } from "../../node-host/node-worker-transfer-client.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { createSessionRepositoryWorkspaceStore } from "../../state/session-repository-workspaces.js";
 import { createNodeWorkerWorkspaceActions } from "./node-worker-workspace-actions.js";
 import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
 import { prepareNodeWorkspaceTransferSnapshot } from "./node-workspace-transfer-snapshot.js";
 import { startNodeWorkspaceTransferTestServer } from "./node-workspace-transfer.test-support.js";
+import { stageSessionRepositoryCheckpoint } from "./session-repository-checkpoints.js";
+import type { WorkerWorkspaceReconcileRequest } from "./tunnel-contract.js";
+import { requireWorkspaceResultGit } from "./workspace-result-git.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
 
-it.each(["completed", "receiving"] as const)(
-  "disposes an abandoned %s publication upload before the next checkpoint",
+it.each([
+  "completed",
+  "receiving",
+  "receiving-failure",
+  "publication-cleanup-failure",
+  "checkpoint-cleanup-failure",
+] as const)(
+  "preserves prepared checkpoint cleanup custody and successful retries after %s",
   async (boundary) => {
+    const receivingUpload = boundary.startsWith("receiving");
+    const cleanupFailure = boundary.endsWith("cleanup-failure");
     const root = tempDirs.make("node-publication-disposal-");
     const workspaceDir = path.join(root, "worker");
     const home = path.join(root, "home");
@@ -56,6 +72,30 @@ it.each(["completed", "receiving"] as const)(
     if (!base.manifest.baseCommit) {
       throw new Error("Repository fixture has no base commit");
     }
+    const database = openOpenClawStateDatabase({ path: path.join(root, "openclaw.sqlite") });
+    const store = createSessionRepositoryWorkspaceStore({ database });
+    const created = store.create({
+      agentId: "main",
+      sessionKey: "agent:main:publication",
+      url: "https://github.com/example/project.git",
+      assertCurrent: () => {},
+    });
+    const repository = store.bindBase({
+      workspaceId: created.workspaceId,
+      expectedRevision: created.revision,
+      baseCommit: base.manifest.baseCommit,
+      baseManifestHash: base.manifestRef,
+      assertCurrent: () => {},
+    });
+    const artifactRoot = store.artifactPath(repository.workspaceId);
+    await fs.mkdir(artifactRoot, { recursive: true });
+    await requireWorkspaceResultGit(artifactRoot, ["init", "--quiet", "--bare"]);
+    const candidates = () =>
+      requireWorkspaceResultGit(artifactRoot, [
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/openclaw/worker-result-candidates/",
+      ]);
     const manifests = path.join(home, ".openclaw-worker", "manifests");
     await fs.mkdir(manifests, { recursive: true });
     await fs.writeFile(path.join(manifests, `${base.manifestRef.slice(7)}.json`), base.rawManifest);
@@ -76,15 +116,31 @@ it.each(["completed", "receiving"] as const)(
     const server = await startNodeWorkspaceTransferTestServer(service);
     const receiving = createDeferred();
     const release = createDeferred();
-    const checkpointPrepared = createDeferred();
+    const discardStarted = createDeferred();
+    const discardUpload = service.discardUpload.bind(service);
+    vi.spyOn(service, "discardUpload").mockImplementation(async (...args) => {
+      discardStarted.resolve();
+      await discardUpload(...args);
+    });
     let publicationActive = false;
-    let failPublication = true;
+    let failPublication = !cleanupFailure;
     let blocked = false;
+    let cleanupRoot: string | undefined;
+    const cleanupError = new Error("Taken upload staging cleanup failed");
+    let failCleanup = cleanupFailure;
+    const remove = fs.rm.bind(fs);
+    vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+      if (cleanupRoot && args[0] === cleanupRoot && failCleanup) {
+        failCleanup = false;
+        throw cleanupError;
+      }
+      await remove(...args);
+    });
     let uploadOutcome: Promise<"completed" | "rejected"> | undefined;
     const realpath = fs.realpath.bind(fs);
     vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
       if (
-        boundary === "receiving" &&
+        receivingUpload &&
         publicationActive &&
         !blocked &&
         typeof args[0] === "string" &&
@@ -93,6 +149,9 @@ it.each(["completed", "receiving"] as const)(
         blocked = true;
         receiving.resolve();
         await release.promise;
+        if (boundary === "receiving-failure") {
+          throw new Error("Publication staging validation failed during disposal");
+        }
       }
       return await realpath(...args);
     });
@@ -132,7 +191,7 @@ it.each(["completed", "receiving"] as const)(
             () => "completed",
             () => "rejected",
           );
-          if (boundary === "receiving") {
+          if (receivingUpload) {
             await withTestTimeout(receiving.promise, 5_000, "publication never reached staging");
           } else {
             expect(await uploadOutcome).toBe("completed");
@@ -159,13 +218,29 @@ it.each(["completed", "receiving"] as const)(
         };
       },
     });
-    const checkpoint = vi.fn(async (payload: { stagingRoot: string }) => {
+    const checkpoint: Extract<
+      WorkerWorkspaceReconcileRequest["source"],
+      { kind: "repository" }
+    >["prepareCheckpoint"] = async (payload) => {
       expect(await fs.readFile(path.join(payload.stagingRoot, "result.txt"), "utf8")).toBe(
         "checkpoint edit\n",
       );
-      checkpointPrepared.resolve();
-      return { verify: async () => {}, publish: async () => {}, discard: async () => {} };
-    });
+      const prepared = await stageSessionRepositoryCheckpoint({
+        ...payload,
+        store,
+        workspaceId: repository.workspaceId,
+        expectedRevision: store.get(repository.workspaceId)!.revision,
+        assertCurrent: () => {},
+      });
+      if (cleanupFailure) {
+        cleanupRoot =
+          boundary === "publication-cleanup-failure"
+            ? payload.publicationStagingRoot
+            : payload.stagingRoot;
+        expect(cleanupRoot).toBeDefined();
+      }
+      return prepared;
+    };
     const reconcile = () =>
       actions.reconcileWorkspace({
         remoteWorkspaceDir: workspaceDir,
@@ -177,10 +252,22 @@ it.each(["completed", "receiving"] as const)(
         },
       });
     let first: ReturnType<typeof reconcile> | undefined;
+    const accept = async (pending: ReturnType<typeof reconcile>) => {
+      const result = await pending;
+      try {
+        expect(result.changed).toBe(true);
+        await result.verifyLocalStable();
+        await result.publishStagedResult?.();
+        expect(store.get(repository.workspaceId)?.manifestHash).toBe(result.manifestRef);
+      } finally {
+        await result.discardPreparedStagedResult?.();
+      }
+      expect(await candidates()).toBe("");
+    };
     try {
       await actions.validateRestoredWorkspace();
       first = reconcile();
-      if (boundary === "receiving") {
+      if (receivingUpload) {
         let settled = false;
         void first.then(
           () => {
@@ -190,31 +277,48 @@ it.each(["completed", "receiving"] as const)(
             settled = true;
           },
         );
-        await withTestTimeout(checkpointPrepared.promise, 5_000, "checkpoint was not prepared");
+        await withTestTimeout(discardStarted.promise, 5_000, "publication disposal did not start");
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
         expect.soft(settled, "reconciliation must join abandoned staging work").toBe(false);
         release.resolve();
       }
-      expect((await first).changed).toBe(true);
-      if (boundary === "receiving") {
+      if (boundary === "receiving-failure" || cleanupFailure) {
+        if (cleanupFailure) {
+          await expect(first).rejects.toBe(cleanupError);
+        } else {
+          await expect(first).rejects.toThrow("payload did not match its staged result");
+        }
+        expect(store.get(repository.workspaceId)?.checkpointRef).toBeNull();
+        expect(await candidates(), "failed handoff must not strand prepared checkpoint refs").toBe(
+          "",
+        );
+      } else {
+        await accept(first);
+      }
+      if (receivingUpload) {
         expect(await uploadOutcome).toBe("rejected");
       }
-      expect(
-        (await fs.readdir(temporaryRoot, { recursive: true })).filter((entry) =>
-          path.basename(entry).startsWith("upload-"),
-        ),
-      ).toEqual([]);
+      if (cleanupFailure) {
+        expect((await fs.stat(cleanupRoot!)).isDirectory()).toBe(true);
+      } else {
+        expect(
+          (await fs.readdir(temporaryRoot, { recursive: true })).filter((entry) =>
+            path.basename(entry).startsWith("upload-"),
+          ),
+        ).toEqual([]);
+      }
       failPublication = false;
-      expect((await reconcile()).changed).toBe(true);
-      expect(checkpoint).toHaveBeenCalledTimes(2);
+      await accept(reconcile());
     } finally {
       release.resolve();
       await first?.catch(() => undefined);
       await uploadOutcome;
       await service.closeAll();
       await server.close();
+      closeOpenClawStateDatabaseByPath(database.path);
     }
+    await expect(fs.stat(temporaryRoot)).rejects.toMatchObject({ code: "ENOENT" });
   },
 );

--- a/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts
@@ -24,11 +24,15 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("workspace upload cancellation", () => {
   it.each([
-    { boundary: "before handler", abort: false },
-    { boundary: "before handler", abort: true },
-    { boundary: "after body", abort: false },
-    { boundary: "after body", abort: true },
-  ] as const)("settles $boundary with owner abort=$abort", async ({ boundary, abort }) => {
+    { boundary: "before handler", cancellation: "none" },
+    { boundary: "before handler", cancellation: "owner" },
+    { boundary: "before handler", cancellation: "discard" },
+    { boundary: "after body", cancellation: "none" },
+    { boundary: "after body", cancellation: "owner" },
+    { boundary: "after body", cancellation: "discard" },
+    { boundary: "after body", cancellation: "discard-and-close" },
+    { boundary: "after body", cancellation: "discard-and-fail" },
+  ] as const)("settles $boundary with $cancellation", async ({ boundary, cancellation }) => {
     const root = tempDirs.make("workspace-upload-cancellation-");
     const localPath = path.join(root, "source");
     await fs.mkdir(localPath);
@@ -65,6 +69,9 @@ describe("workspace upload cancellation", () => {
           // Staged-manifest verification happens after the reader consumes EOF.
           reached.resolve();
           await release.promise;
+          if (cancellation === "discard-and-fail") {
+            throw new Error("Staging validation failed while discard was waiting");
+          }
         }
         return await realpath(...args);
       });
@@ -112,22 +119,53 @@ describe("workspace upload cancellation", () => {
       async (response) => ({ status: response.status, body: await response.json() }),
       () => "rejected" as const,
     );
+    let cleanup: Promise<unknown> | undefined;
+    let cleanupSettled = false;
+    let expectedDisposalError: unknown;
     try {
       await withTestTimeout(reached.promise, 2_000, "upload did not reach cancellation boundary");
       if (boundary === "after body") {
         expect(incoming?.readableEnded).toBe(true);
         expect(incoming?.destroyed).toBe(true);
       }
-      if (abort) {
+      if (cancellation === "owner") {
         owner.abort(new Error("Workspace transfer owner closed"));
       }
-      if (!abort || boundary === "before handler") {
+      if (cancellation.startsWith("discard")) {
+        cleanup = Promise.all([
+          service.discardUpload("environment", token),
+          service.discardUpload("environment", token),
+          ...(cancellation === "discard-and-close" ? [service.close("environment")] : []),
+        ]).then(() => {
+          cleanupSettled = true;
+        });
+        void cleanup.catch(() => undefined);
+        if (boundary === "before handler") {
+          await withTestTimeout(cleanup, 2_000, "discard waited for an unstarted handler");
+        } else {
+          expect(() => service.prepareUpload("environment", snapshot.manifestRef)).toThrow();
+        }
+      }
+      if (cancellation === "none" || boundary === "before handler") {
         release.resolve();
       }
       const result = await withTestTimeout(request, 2_000, "upload response remained open");
+      if (cleanup && boundary === "after body") {
+        expect(cleanupSettled, "cleanup must join blocked staging validation").toBe(false);
+      }
       release.resolve();
       await finished.promise;
-      if (abort) {
+      if (cancellation === "discard-and-fail") {
+        await expect(
+          cleanup?.catch((error: unknown) => {
+            expectedDisposalError = error;
+            throw error;
+          }),
+        ).rejects.toThrow("payload did not match its staged result");
+      } else {
+        await cleanup;
+      }
+      if (cancellation !== "none") {
         expect(result).toBe("rejected");
         expect(() => service.takeUpload("environment", snapshot.manifestRef)).toThrow();
       } else {
@@ -136,15 +174,28 @@ describe("workspace upload cancellation", () => {
           snapshot.manifestRef,
         );
       }
+      if (cancellation === "discard" || cancellation === "discard-and-fail") {
+        const replacement = service.prepareUpload("environment", snapshot.manifestRef);
+        await service.discardUpload("environment", token);
+        expect(() => service.prepareUpload("environment", snapshot.manifestRef)).toThrow(
+          "already active",
+        );
+        await service.discardUpload("environment", replacement);
+      }
     } finally {
       release.resolve();
       server.closeAllConnections();
       await request;
       await finished.promise;
+      await cleanup?.catch(() => undefined);
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
-      await service.closeAll();
+      await service.closeAll().catch((error: unknown) => {
+        if (error !== expectedDisposalError) {
+          throw error;
+        }
+      });
     }
   });
 });

--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -381,7 +381,9 @@ describe("node workspace transfer service", () => {
         headers: { authorization: `Bearer ${uploadToken}`, "content-length": "0" },
       });
       expect(replay.status).toBe(404);
+      service.revoke("environment-1", uploadToken);
       const uploaded = service.takeUpload("environment-1", prepared.snapshot.manifestRef);
+      await service.discardUpload("environment-1", uploadToken);
       expect(uploaded.current.entries).toContainEqual(
         expect.objectContaining({ path: "result.txt", type: "file" }),
       );

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -69,6 +69,9 @@ type UploadOperation = {
   expiresAtMs: number;
   state: "ready" | "receiving" | "completed";
   uploaded?: NodeWorkspaceTransferUpload;
+  abortController: AbortController;
+  receiving?: { result: Promise<{ manifestRef: string }>; signal: AbortSignal };
+  disposal?: Promise<void>;
 };
 
 type TransferContext = {
@@ -152,17 +155,53 @@ export function createNodeWorkspaceTransferService(options: {
     contexts.get(context.environmentId) === context &&
     contextOwnerValid(context, options.getOwner(context.environmentId));
 
+  const discardUpload = (context: TransferContext, operation: UploadOperation): Promise<void> => {
+    if (!operation.disposal) {
+      operation.abortController.abort(new Error("Node workspace upload discarded"));
+      operation.disposal = (async () => {
+        const receiving = operation.receiving;
+        try {
+          await receiving?.result.catch((error: unknown) => {
+            if (!receiving.signal.aborted || error !== receiving.signal.reason) {
+              throw error;
+            }
+          });
+        } finally {
+          try {
+            if (operation.uploaded) {
+              await fsp.rm(operation.uploaded.stagingRoot, { recursive: true, force: true });
+            }
+          } finally {
+            // Keep the slot until cleanup settles, including errors. Duplicate discard
+            // and context close join the same owner before a replacement can start.
+            if (context.upload === operation) {
+              context.upload = undefined;
+            }
+          }
+        }
+      })();
+    }
+    return operation.disposal;
+  };
+
   const closeContext = async (context: TransferContext) => {
     if (!context.abortController.signal.aborted) {
       context.abortController.abort(new Error("Node workspace transfer context closed"));
     }
     context.stopWatchingOwnerSignal?.();
+    // Readers and pack processes must release scratch before its parent is removed.
+    const settled = await Promise.allSettled([
+      context.pack?.catch(() => undefined),
+      context.upload ? discardUpload(context, context.upload) : undefined,
+    ]);
+    await fsp.rm(context.temporaryRoot, { recursive: true, force: true });
     if (contexts.get(context.environmentId) === context) {
       contexts.delete(context.environmentId);
     }
-    // Cancellation fences requests before pack processes release their scratch files.
-    await context.pack?.catch(() => undefined);
-    await fsp.rm(context.temporaryRoot, { recursive: true, force: true });
+    const failed = settled.find((result) => result.status === "rejected");
+    if (failed) {
+      throw failed.reason;
+    }
   };
 
   const closeEnvironment = (environmentId: string) =>
@@ -225,6 +264,7 @@ export function createNodeWorkspaceTransferService(options: {
           !capability.signal?.aborted &&
           capability.isAuthorized?.() !== false
       : context.upload === capability &&
+          !capability.abortController.signal.aborted &&
           (capability.state === "receiving" || capability.state === "completed");
   };
 
@@ -405,6 +445,7 @@ export function createNodeWorkspaceTransferService(options: {
         baseManifestRef,
         expiresAtMs: now() + TRANSFER_TIMEOUT_MS,
         state: "ready",
+        abortController: new AbortController(),
       };
       return token;
     },
@@ -416,6 +457,7 @@ export function createNodeWorkspaceTransferService(options: {
         !context ||
         !operation ||
         operation.state !== "completed" ||
+        operation.abortController.signal.aborted ||
         operation.baseManifestRef !== baseManifestRef ||
         !operation.uploaded ||
         !isCurrentContext(context)
@@ -424,6 +466,14 @@ export function createNodeWorkspaceTransferService(options: {
       }
       context.upload = undefined;
       return operation.uploaded;
+    },
+
+    async discardUpload(environmentId: string, token: string): Promise<void> {
+      const context = contexts.get(environmentId);
+      const operation = context?.upload;
+      if (context && operation?.token === token) {
+        await discardUpload(context, operation);
+      }
     },
 
     getSnapshot(
@@ -500,7 +550,9 @@ export function createNodeWorkspaceTransferService(options: {
       const capability = authorization.capability;
       return capability.direction === "download" && capability.signal
         ? AbortSignal.any([signal, capability.signal])
-        : signal;
+        : capability.direction === "upload"
+          ? AbortSignal.any([signal, capability.abortController.signal])
+          : signal;
     },
 
     snapshot(authorization: TransferAuthorization): NodeWorkspaceTransferSnapshot | undefined {
@@ -581,51 +633,57 @@ export function createNodeWorkspaceTransferService(options: {
       ) {
         throw new Error("Workspace transfer upload owner is unavailable");
       }
-      const assertCurrent = () => {
-        params.signal.throwIfAborted();
-        assertAuthorizationCurrent(authorization);
-      };
-      let uploaded: NodeWorkspaceTransferUpload | undefined;
-      try {
-        uploaded = await readNodeWorkspaceUpload({
-          request: params.request,
-          baseManifestRef: operation.baseManifestRef,
-          temporaryRoot: authorization.context.temporaryRoot,
-          signal: params.signal,
-          assertCurrent,
-          isAuthorized: () => authorizationCurrent(authorization),
-        });
-        assertCurrent();
-        const context = authorization.context;
-        if (context.localPath && !context.snapshots.has(uploaded.baseManifestRef)) {
-          if (context.baseCommit !== uploaded.base.baseCommit) {
-            await context.pack?.catch(() => undefined);
-            assertCurrent();
-            context.pack = undefined;
-            context.baseCommit = uploaded.base.baseCommit;
-          }
-          // Reconnect may snapshot newer local files. Retain the authenticated original
-          // base before upload-token revocation; accepted publication needs its exact pack.
-          context.snapshots.set(uploaded.baseManifestRef, {
-            manifest: uploaded.base,
-            manifestRef: uploaded.baseManifestRef,
-            rawManifest: uploaded.baseRaw,
-            root: context.localPath,
+      const signal = AbortSignal.any([params.signal, operation.abortController.signal]);
+      const result = (async () => {
+        const assertCurrent = () => {
+          signal.throwIfAborted();
+          assertAuthorizationCurrent(authorization);
+        };
+        let uploaded: NodeWorkspaceTransferUpload | undefined;
+        try {
+          signal.throwIfAborted();
+          uploaded = await readNodeWorkspaceUpload({
+            request: params.request,
+            baseManifestRef: operation.baseManifestRef,
+            temporaryRoot: authorization.context.temporaryRoot,
+            signal,
+            assertCurrent,
+            isAuthorized: () => authorizationCurrent(authorization),
           });
-          context.currentManifestRef = uploaded.baseManifestRef;
+          assertCurrent();
+          const context = authorization.context;
+          if (context.localPath && !context.snapshots.has(uploaded.baseManifestRef)) {
+            if (context.baseCommit !== uploaded.base.baseCommit) {
+              await context.pack?.catch(() => undefined);
+              assertCurrent();
+              context.pack = undefined;
+              context.baseCommit = uploaded.base.baseCommit;
+            }
+            // Reconnect may snapshot newer local files. Retain the authenticated original
+            // base before upload-token revocation; accepted publication needs its exact pack.
+            context.snapshots.set(uploaded.baseManifestRef, {
+              manifest: uploaded.base,
+              manifestRef: uploaded.baseManifestRef,
+              rawManifest: uploaded.baseRaw,
+              root: context.localPath,
+            });
+            context.currentManifestRef = uploaded.baseManifestRef;
+          }
+          operation.uploaded = uploaded;
+          operation.state = "completed";
+          return { manifestRef: uploaded.currentManifestRef };
+        } catch (error) {
+          if (uploaded) {
+            await fsp.rm(uploaded.stagingRoot, { recursive: true, force: true });
+          }
+          if (authorization.context.upload === operation && !operation.disposal) {
+            authorization.context.upload = undefined;
+          }
+          throw error;
         }
-        operation.uploaded = uploaded;
-        operation.state = "completed";
-        return { manifestRef: uploaded.currentManifestRef };
-      } catch (error) {
-        if (uploaded) {
-          await fsp.rm(uploaded.stagingRoot, { recursive: true, force: true });
-        }
-        if (authorization.context.upload === operation) {
-          authorization.context.upload = undefined;
-        }
-        throw error;
-      }
+      })();
+      operation.receiving = { result, signal };
+      return await result;
     },
 
     async verifyBlob(params: { path: string; size: number; sha256: string }): Promise<boolean> {


### PR DESCRIPTION
Related: #134931.

## What Problem This Solves

A lost worker-command result after optional publication capture could leave its separate HTTP upload running or completed. The abandoned upload retained staging files and occupied the slot needed by later repository checkpoints. Cleanup could also reject after checkpoint candidates were prepared, leaving their Git refs without a cleanup callback available to the caller.

## Why This Change Was Made

The transfer service owns upload disposal: abort the exact operation, join receiving and staging work, remove abandoned output, and release the slot after settlement. Concurrent discard and context shutdown join that same operation. Receive and cleanup errors remain visible.

Repository reconciliation settles abandoned upload disposal before preparing a checkpoint and retains responsibility for the prepared candidate through both staging finalizers. If handoff fails, it discards the candidate locally; if that discard also fails, both errors are preserved. Normal token revocation and already-taken upload ownership retain their existing behavior.

## User Impact

Failed optional publication captures release their upload slot so later checkpoints can proceed. Context shutdown waits for upload work before removing scratch files, and a failed checkpoint handoff no longer strands candidate refs.

## Evidence

- Real Node uploader, localhost Gateway HTTP handler, Git workspaces, and files reproduced abandoned completed and receiving uploads before the repair.
- The real SQLite repository store and checkpoint staging owner reproduced three candidate-ref leaks: receive validation failure during disposal, publication staging removal failure, and checkpoint staging removal failure. The repaired cases leave no candidate refs and a later checkpoint publishes successfully.
- All 66 cases across six focused and sibling files passed. They also cover cancellation before handler startup, concurrent discard/shutdown, replacement-token isolation, ordinary result ownership, and checkpoint recovery across turns and restart.

The full changed-file gate passed, including both type lanes, lint, dead exports, runtime cycles, and schema checks. Fresh independent review through P2 covered the complete PR with the actual checkpoint owner and startup caller and found no remaining issues. These results cover successor head `a215748ed82f2532bdec1ec1f3210ef66c56eceb`; [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34439868796). Its recorded merge checkout was verified against the audited integration with current main.

This is a five-file extraction with real local HTTP, stream, filesystem, SQLite and Git proof. It does not claim cloud-provider validation or change configuration, schema, dependencies, or protocol. The original combined #134931 remains draft and unmerged.
