### PR TITLE
fix: distinguish interrupted dev runners from completed shutdowns

### DIFF
--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -159,7 +159,20 @@ Benchmark mode suppresses sync-I/O trace spam by default. Set `OPENCLAW_TRACE_SY
 
 The tmux wrapper carries common non-secret runtime selectors into the pane, including `OPENCLAW_PROFILE`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `OPENCLAW_GATEWAY_PORT`, and `OPENCLAW_SKIP_CHANNELS`. Put provider credentials in your normal profile/config, or use raw foreground mode for one-off ephemeral secrets.
 
-If the watched Gateway exits during startup, the watcher runs `openclaw doctor --fix --non-interactive` once and restarts the Gateway child. Set `OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0` to see the original startup failure without the dev-only repair pass.
+If the watched Gateway returns a startup error, the watcher runs `openclaw doctor --fix --non-interactive` once and restarts the Gateway child. Set `OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0` to see the original startup failure without the dev-only repair pass.
+
+On Unix, if a native runner is terminated by a signal, the foreground command
+preserves that signal and stops instead of running doctor or restarting. This also applies
+when a requested restart or shutdown has to kill an unresponsive runner. Its
+detached workers may still need cleanup; signal termination does not certify
+that they stopped. Ordinary returned errors, acknowledged stops, and source
+changes keep their existing recovery and rebuild behavior. Windows retains its
+existing termination and restart behavior because its signal emulation does not
+make the same distinction.
+
+The UI dev wrapper acknowledges a requested stop only after its child returns
+normally and the captured child tree has stopped. A signaled child or forced
+cleanup retains a signal outcome instead of reporting an acknowledged stop.
 
 The managed tmux pane defaults to colored Gateway logs; set `FORCE_COLOR=0` when starting `pnpm gateway:watch` to disable ANSI output.
 

--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -123,6 +123,7 @@ type SpawnedProcessResult = {
   exitSignal: NodeJS.Signals | null;
   forwardedSignal: NodeJS.Signals | null;
 };
+type RunNodeExit = number | NodeJS.Signals;
 
 function asRunNodeChild(value: unknown): RunNodeChild {
   if (!value || typeof value !== "object" || !("on" in value) || typeof value.on !== "function") {
@@ -1174,7 +1175,7 @@ const waitForSpawnedProcess = async (childProcess: RunNodeChild, deps: RunNodeDe
         settle({ exitCode: 1, exitSignal: null, forwardedSignal });
       };
       const handleExit = (exitCode: number | null, exitSignal: NodeJS.Signals | null) => {
-        if (forwardedSignal && !cleanedForwardedSignalGroup) {
+        if ((forwardedSignal || exitSignal) && !cleanedForwardedSignalGroup) {
           cleanedForwardedSignalGroup = true;
           signalSpawnedProcess(childProcess, "SIGKILL", useProcessGroup, deps);
         }
@@ -1193,9 +1194,14 @@ const waitForSpawnedProcess = async (childProcess: RunNodeChild, deps: RunNodeDe
   }
 };
 
-const getInterruptedSpawnExitCode = (res: SpawnedProcessResult) => {
+const getInterruptedSpawnOutcome = (
+  res: SpawnedProcessResult,
+  platform: NodeJS.Platform,
+): RunNodeExit | null => {
   if (res.exitSignal) {
-    return getSignalExitCode(res.exitSignal);
+    // The child did not acknowledge completion. A numeric exit could let the
+    // watch parent retry after the owner of detached workers has disappeared.
+    return platform === "win32" ? getSignalExitCode(res.exitSignal) : res.exitSignal;
   }
   if (res.forwardedSignal) {
     return getSignalExitCode(res.forwardedSignal);
@@ -1215,9 +1221,9 @@ const runNodeChild = async (deps: RunNodeDeps, args: string[]) => {
   );
   pipeSpawnedOutput(nodeProcess, deps);
   const res = await waitForSpawnedProcess(nodeProcess, deps);
-  const interruptedExitCode = getInterruptedSpawnExitCode(res);
-  if (interruptedExitCode !== null) {
-    return interruptedExitCode;
+  const interrupted = getInterruptedSpawnOutcome(res, deps.platform);
+  if (interrupted !== null) {
+    return interrupted;
   }
   return res.exitCode ?? 1;
 };
@@ -1313,7 +1319,7 @@ const createSyncIoTraceStderrFilter = (deps: RunNodeDeps) => {
   };
 };
 
-const closeRunNodeOutputTee = async (deps: RunNodeDeps, exitCode: number) => {
+const closeRunNodeOutputTee = async (deps: RunNodeDeps, exitCode: RunNodeExit) => {
   if (!deps.outputTee) {
     return exitCode;
   }
@@ -1599,7 +1605,7 @@ function createRunNodeDeps(params: RunNodeMainParams) {
 }
 
 /** Runs the dev build/watch loop and keeps the child CLI in sync with changes. */
-export async function runNodeMain(params: RunNodeMainParams = {}): Promise<number> {
+export async function runNodeMain(params: RunNodeMainParams = {}): Promise<RunNodeExit> {
   const deps = createRunNodeDeps(params);
   if (deps.args[0] === "qa") {
     deps.env.OPENCLAW_BUILD_PRIVATE_QA = "1";
@@ -1609,7 +1615,7 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
   deps.outputTee = createRunNodeOutputTee(deps);
 
   try {
-    let exitCode = 1;
+    let exitCode: RunNodeExit = 1;
     if (shouldFastPathExistingDistForGatewayClient(deps)) {
       exitCode = await runOpenClaw(deps);
       return await closeRunNodeOutputTee(deps, exitCode);
@@ -1700,7 +1706,7 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
         );
         pipeSpawnedOutput(build, deps, { stdoutTarget: "stderr" });
         const result = await waitForSpawnedProcess(build, deps);
-        return getInterruptedSpawnExitCode(result) ?? result.exitCode ?? 1;
+        return getInterruptedSpawnOutcome(result, deps.platform) ?? result.exitCode ?? 1;
       });
     });
     if (buildExitCode !== 0) {
@@ -1716,7 +1722,13 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   void runNodeMain()
-    .then((code) => process.exit(code))
+    .then((outcome) => {
+      if (typeof outcome === "string") {
+        process.kill(process.pid, outcome);
+        return;
+      }
+      process.exit(outcome);
+    })
     .catch((err: unknown) => {
       console.error(err);
       process.exit(1);

--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -217,6 +217,9 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
   const forwardedSignals = ["SIGTERM", "SIGHUP"] as const;
   let forwardedSignal: (typeof forwardedSignals)[number] | null = null;
   let forwardedSignalPids: number[] = [];
+  let forwardedSignalTreeComplete = false;
+  let childExit: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  let forcedSignalCleanup = false;
   let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
   let forwardedSignalDrainTimer: ReturnType<typeof setInterval> | null = null;
   const clearForwardedSignalTimers = () => {
@@ -230,13 +233,23 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
     }
   };
   const finishForwardedSignal = () => {
-    cleanupSignalHandlers();
-    if (forwardedSignal) {
-      process.kill(process.pid, forwardedSignal);
+    if (!forwardedSignal || !childExit) {
+      return;
     }
+    cleanupSignalHandlers();
+    const interrupted =
+      childExit.signal ??
+      (forcedSignalCleanup ? "SIGKILL" : !forwardedSignalTreeComplete ? forwardedSignal : null);
+    if (interrupted) {
+      process.kill(process.pid, interrupted);
+      return;
+    }
+    // A returned child and quiescent captured tree acknowledge this stop.
+    // Raw signal death and forced cleanup cannot make that same promise.
+    process.exit(forwardedSignal === "SIGTERM" ? 143 : 129);
   };
   const waitForForwardedSignalChildren = () => {
-    if (!forwardedSignal || processTreeIsAlive(forwardedSignalPids)) {
+    if (!forwardedSignal || !childExit || processTreeIsAlive(forwardedSignalPids)) {
       return;
     }
     finishForwardedSignal();
@@ -250,11 +263,16 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
       () => {
         if (!forwardedSignal) {
           forwardedSignal = signal;
-          forwardedSignalPids = collectChildProcessTreePids(child);
+          const tree = collectChildProcessTreePids(child);
+          forwardedSignalPids = tree.pids;
+          forwardedSignalTreeComplete = tree.complete;
           signalProcessTree(child, signal, forwardedSignalPids);
           forwardedSignalDrainTimer = setInterval(waitForForwardedSignalChildren, 25);
           forceKillTimer = setTimeout(() => {
-            signalProcessTree(child, "SIGKILL", forwardedSignalPids);
+            if (processTreeIsAlive(forwardedSignalPids)) {
+              forcedSignalCleanup = true;
+              signalProcessTree(child, "SIGKILL", forwardedSignalPids);
+            }
           }, FORWARDED_SIGNAL_KILL_GRACE_MS);
           forceKillTimer.unref?.();
         }
@@ -277,6 +295,7 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
     process.exit(1);
   });
   child.on("exit", (code, signal) => {
+    childExit = { code, signal };
     if (forwardedSignal) {
       waitForForwardedSignalChildren();
       return;
@@ -292,22 +311,28 @@ function runSpawnCall(spawnCall: UiSpawnCall, label: string): void {
   });
 }
 
-function collectChildProcessTreePids(child: ChildProcess): number[] {
+function collectChildProcessTreePids(child: ChildProcess): { pids: number[]; complete: boolean } {
   if (process.platform === "win32" || typeof child.pid !== "number") {
-    return typeof child.pid === "number" ? [child.pid] : [];
+    return { pids: typeof child.pid === "number" ? [child.pid] : [], complete: false };
   }
   const ps = spawnSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf8" });
   if (ps.status !== 0) {
-    return [child.pid];
+    return { pids: [child.pid], complete: false };
   }
   const childrenByParent = new Map<number, number[]>();
+  let complete = true;
+  let childFound = false;
   for (const line of ps.stdout.split("\n")) {
     const match = line.trim().match(/^(\d+)\s+(\d+)$/u);
     if (!match) {
+      if (line.trim()) {
+        complete = false;
+      }
       continue;
     }
     const pid = Number(match[1]);
     const ppid = Number(match[2]);
+    childFound ||= pid === child.pid;
     const siblings = childrenByParent.get(ppid) ?? [];
     siblings.push(pid);
     childrenByParent.set(ppid, siblings);
@@ -318,7 +343,7 @@ function collectChildProcessTreePids(child: ChildProcess): number[] {
       pids.push(pid);
     }
   }
-  return [...new Set(pids)];
+  return { pids: [...new Set(pids)], complete: complete && childFound };
 }
 
 function processTreeIsAlive(pids: number[]): boolean {

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
 
-await runTsxCliShim(import.meta.url, { implementation: "./watch-node.mts" });
+await runTsxCliShim(import.meta.url, {
+  implementation: "./watch-node.mts",
+  terminationOwner: "implementation",
+});

--- a/scripts/watch-node.mts
+++ b/scripts/watch-node.mts
@@ -17,7 +17,6 @@ import {
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
 const WATCH_RESTART_SIGNAL = "SIGTERM";
 const WATCH_RESTARTABLE_CHILD_EXIT_CODES = new Set([143]);
-const WATCH_RESTARTABLE_CHILD_SIGNALS = new Set(["SIGTERM"]);
 const WATCH_IGNORED_PATH_SEGMENTS = new Set([".git", "dist", "node_modules"]);
 const WATCH_LOCK_WAIT_MS = 5_000;
 const WATCH_LOCK_POLL_MS = 100;
@@ -27,6 +26,7 @@ const WATCH_DIST_ENTRY_POLL_MS = 1_000;
 const WATCH_DIST_ENTRY_TIMEOUT_MS = 5 * 60 * 1_000;
 const AUTO_DOCTOR_DISABLE_VALUES = new Set(["0", "false", "no", "off"]);
 type ProcessSignal = `SIG${string}`;
+type WatchExit = number | ProcessSignal;
 type TimerHandle = ReturnType<typeof setTimeout>;
 
 type WatchChild = {
@@ -156,9 +156,13 @@ const isIgnoredWatchPath = (
   return !pathClassifier.isRestartRelevantRunNodePath(repoPath);
 };
 
-const shouldRestartAfterChildExit = (exitCode: number | null, exitSignal: ProcessSignal | null) =>
+const shouldRestartAfterChildExit = (
+  exitCode: number | null,
+  exitSignal: ProcessSignal | null,
+  platform: NodeJS.Platform,
+) =>
   (typeof exitCode === "number" && WATCH_RESTARTABLE_CHILD_EXIT_CODES.has(exitCode)) ||
-  (typeof exitSignal === "string" && WATCH_RESTARTABLE_CHILD_SIGNALS.has(exitSignal));
+  (platform === "win32" && exitSignal === "SIGTERM");
 
 const isGatewayWatchCommand = (args: string[]) => args[0] === "gateway";
 
@@ -329,7 +333,7 @@ const releaseWatchLock = (lockHandle: { lockPath: string; pid: number } | null) 
 /**
  * Runs the watch loop and restarts the child process on relevant changes.
  */
-export async function runWatchMain(params: WatchMainParams = {}): Promise<number> {
+export async function runWatchMain(params: WatchMainParams = {}): Promise<WatchExit> {
   const cwd = params.cwd ?? process.cwd();
   const deps = {
     spawn: params.spawn ?? spawn,
@@ -353,7 +357,8 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
 
   const childEnv = { ...deps.env };
   const watchSession = `${deps.now()}-${deps.process.pid}`;
-  const useChildProcessGroup = process.platform !== "win32" && !deps.process.stdin?.isTTY;
+  const platform = deps.process.platform ?? process.platform;
+  const useChildProcessGroup = platform !== "win32" && !deps.process.stdin?.isTTY;
   childEnv.OPENCLAW_WATCH_MODE = "1";
   childEnv.OPENCLAW_WATCH_SESSION = watchSession;
   // The watcher owns process restarts; keep SIGUSR1/config reloads in-process
@@ -363,7 +368,7 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
     childEnv.OPENCLAW_WATCH_COMMAND = deps.args.join(" ");
   }
 
-  return await new Promise<number>((resolve, reject) => {
+  return await new Promise<WatchExit>((resolve, reject) => {
     let settled = false;
     let shuttingDown = false;
     let restartRequested = false;
@@ -375,6 +380,7 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
     let autoDoctorAttempted = false;
     let shutdownExitCode: number | null = null;
     let shutdownKillTimer: TimerHandle | null = null;
+    let watcherStartupError: Error | null = null;
 
     const signalWatchProcess = (child: WatchChild, signal: ProcessSignal) => {
       if (!child || typeof child.kill !== "function") {
@@ -406,7 +412,7 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
       }
     };
 
-    const settle = (code: number) => {
+    const settle = (outcome: WatchExit) => {
       if (settled) {
         return;
       }
@@ -422,7 +428,32 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
       }
       releaseWatchLock(lockHandle);
       watcher?.close?.()?.catch?.(() => {});
-      resolve(code);
+      if (watcherStartupError && typeof outcome !== "string") {
+        reject(watcherStartupError);
+      } else {
+        resolve(outcome);
+      }
+    };
+
+    const settleIfSignaled = (child: WatchChild | null, signal: ProcessSignal | null) => {
+      // Windows emulates SIGTERM with unconditional termination, including
+      // ordinary requested restarts. It has no Unix completion distinction.
+      if (!signal || platform === "win32") {
+        return false;
+      }
+      // The native implementation normally acknowledges stop with an exit
+      // code. Its signal death cannot prove its detached workers have stopped,
+      // even when we requested a restart or were already shutting down.
+      try {
+        forceKillWatchProcessGroup(child);
+      } catch (error) {
+        logWatcher(
+          `Failed to stop the exited runner's process group: ${errorMessage(error)}`,
+          deps,
+        );
+      }
+      settle(signal);
+      return true;
     };
 
     const requestShutdown = (code: number) => {
@@ -480,10 +511,10 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
         if (settled) {
           return;
         }
-        if (settleIfShuttingDown(exitedProcess)) {
+        if (settleIfSignaled(exitedProcess, exitSignal) || settleIfShuttingDown(exitedProcess)) {
           return;
         }
-        if (restartRequested || shouldRestartAfterChildExit(exitCode, exitSignal)) {
+        if (restartRequested || shouldRestartAfterChildExit(exitCode, exitSignal, platform)) {
           forceKillWatchProcessGroup(exitedProcess);
           restartRequested = false;
           deferredRestartGeneration += 1;
@@ -528,20 +559,10 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
       if (settled) {
         return;
       }
-      settled = true;
-      shuttingDown = true;
-      if (watchProcess && typeof watchProcess.kill === "function") {
-        signalWatchProcess(watchProcess, WATCH_RESTART_SIGNAL);
-      }
-      releaseWatchLock(lockHandle);
-      watcher?.close?.()?.catch?.(() => {});
-      if (onSigInt) {
-        deps.process.off("SIGINT", onSigInt);
-      }
-      if (onSigTerm) {
-        deps.process.off("SIGTERM", onSigTerm);
-      }
-      reject(toErrorObject(err, "Non-Error rejection"));
+      // Source already started before the asynchronous watcher was loaded.
+      // Keep its exit observable until cleanup acknowledges this startup error.
+      watcherStartupError = toErrorObject(err, "Non-Error rejection");
+      requestShutdown(1);
     };
 
     const resolveCreateWatcher = async () => {
@@ -585,7 +606,7 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
         if (settled) {
           return;
         }
-        if (settleIfShuttingDown(exitedProcess)) {
+        if (settleIfSignaled(exitedProcess, exitSignal) || settleIfShuttingDown(exitedProcess)) {
           return;
         }
         if (exitCode === 0 && !exitSignal) {
@@ -755,7 +776,13 @@ export async function runWatchMain(params: WatchMainParams = {}): Promise<number
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   void runWatchMain()
-    .then((code) => process.exit(code))
+    .then((outcome) => {
+      if (typeof outcome === "string") {
+        process.kill(process.pid, outcome);
+        return;
+      }
+      process.exit(outcome);
+    })
     .catch((err: unknown) => {
       if (!isInvalidPackageConfigError(err)) {
         console.error(err);

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -423,8 +423,9 @@ async function trackProjectWithGit(tmp: string) {
 type RunNodeTestOptions = NonNullable<Parameters<typeof runNodeMain>[0]> & {
   stdout?: NodeJS.WriteStream;
 };
+type RunNodeResult = Awaited<ReturnType<typeof runNodeMain>>;
 
-async function runNodeCommand(tmp: string, options: RunNodeTestOptions): Promise<number> {
+async function runNodeCommand(tmp: string, options: RunNodeTestOptions): Promise<RunNodeResult> {
   const { env, ...overrides } = options;
   return await runNodeMain({
     cwd: tmp,
@@ -449,11 +450,11 @@ type RunCommandParams = {
   }) => void | Promise<void>;
 };
 
-async function runStatusCommand({ tmp, ...options }: RunCommandParams): Promise<number> {
+async function runStatusCommand({ tmp, ...options }: RunCommandParams): Promise<RunNodeResult> {
   return await runNodeCommand(tmp, options);
 }
 
-async function runQaCommand(params: RunCommandParams): Promise<number> {
+async function runQaCommand(params: RunCommandParams): Promise<RunNodeResult> {
   return await runStatusCommand({
     ...params,
     args: ["qa", "suite", "--transport", "qa-channel", "--provider-mode", "mock-openai"],
@@ -1329,6 +1330,29 @@ describe("run-node script", () => {
     expect(spawn).toHaveBeenCalledOnce();
     expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
   });
+
+  it.for([
+    { platform: "linux", signal: "SIGKILL", expected: "SIGKILL" },
+    { platform: "linux", signal: "SIGTERM", expected: "SIGTERM" },
+    { platform: "win32", signal: "SIGKILL", expected: 1 },
+    { platform: "win32", signal: "SIGTERM", expected: 143 },
+  ] as const)(
+    "preserves child signal outcomes without changing Windows exits: %j",
+    async ({ platform, signal, expected }, { tmp }) => {
+      await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
+      for (const rebuild of [false, true]) {
+        const spawn = vi.fn(() => createExitedProcess(null, signal));
+        const outcome = await runNodeCommand(tmp, {
+          env: { OPENCLAW_FORCE_BUILD: rebuild ? "1" : "0" },
+          platform,
+          spawn,
+          runRuntimePostBuild: skipRuntimePostBuild,
+        });
+        expect(outcome).toBe(expected);
+        expect(spawn).toHaveBeenCalledOnce();
+      }
+    },
+  );
 
   it.for([false, true])(
     "forwards SIGTERM to the active child and returns 143 (rebuild: %s)",

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -37,7 +37,11 @@ const createKillableChild = () => {
     kill: vi.fn(),
   });
   child.kill.mockImplementation((signal: NodeJS.Signals = "SIGTERM") => {
-    queueMicrotask(() => child.emit("exit", null, signal));
+    // A native run-node owner that completes requested cleanup acknowledges
+    // SIGTERM with a code. Raw signal death is covered independently below.
+    queueMicrotask(() =>
+      signal === "SIGTERM" ? child.emit("exit", 143, null) : child.emit("exit", null, signal),
+    );
     return true;
   });
   return child;
@@ -109,6 +113,92 @@ function requireSpawnEnv(spawn: ReturnType<typeof vi.fn>, callIndex: number) {
 }
 
 describe("watch-node script", () => {
+  it.each(["SIGTERM", "SIGKILL", "SIGHUP"] as const)(
+    "preserves raw Unix runner %s without doctor or restart",
+    async (signal) => {
+      const child = Object.assign(new EventEmitter(), { kill: vi.fn() });
+      const spawn = vi.fn(() => child);
+      const fakeProcess = Object.assign(createFakeProcess(), { platform: "linux" });
+      const run = runWatch({
+        args: ["gateway"],
+        env: {},
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+        createWatcher: () => ({ on: () => {}, close: async () => {} }),
+      });
+      child.emit("exit", null, signal);
+      await expect(run).resolves.toBe(signal);
+      expect(spawn).toHaveBeenCalledOnce();
+      expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+    },
+  );
+
+  it.each(["restart", "shutdown", "doctor", "startup-error"] as const)(
+    "does not hide raw Unix signal loss during %s",
+    async (phase) => {
+      const child = Object.assign(new EventEmitter(), { kill: vi.fn() });
+      const doctor = Object.assign(new EventEmitter(), { kill: vi.fn() });
+      const spawn = vi.fn().mockReturnValueOnce(child).mockReturnValueOnce(doctor);
+      const watcher = Object.assign(new EventEmitter(), { close: vi.fn(async () => {}) });
+      const fakeProcess = Object.assign(createFakeProcess(), { platform: "linux" });
+      const startupError = new Error("watcher dependency failed");
+      const run = runWatch({
+        args: ["gateway"],
+        env: {},
+        fs: { existsSync: () => true },
+        lockDisabled: true,
+        process: fakeProcess,
+        spawn,
+        ...(phase === "startup-error"
+          ? {
+              loadChokidar: async () => {
+                throw startupError;
+              },
+            }
+          : { createWatcher: () => watcher }),
+      });
+      if (phase === "restart") {
+        watcher.emit("change", "src/index.ts");
+      } else if (phase === "shutdown") {
+        fakeProcess.emit("SIGTERM");
+      } else if (phase === "doctor") {
+        child.emit("exit", 1, null);
+      } else {
+        await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith("SIGTERM"));
+      }
+      (phase === "doctor" ? doctor : child).emit("exit", null, "SIGKILL");
+      await expect(run).resolves.toBe("SIGKILL");
+      expect(spawn).toHaveBeenCalledTimes(phase === "doctor" ? 2 : 1);
+      expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+    },
+  );
+
+  it("preserves requested Windows SIGTERM rebuilds and shutdown", async () => {
+    const first = Object.assign(new EventEmitter(), { kill: vi.fn() });
+    const second = Object.assign(new EventEmitter(), { kill: vi.fn() });
+    const spawn = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+    const watcher = Object.assign(new EventEmitter(), { close: vi.fn(async () => {}) });
+    const fakeProcess = Object.assign(createFakeProcess(), { platform: "win32" });
+    const run = runWatch({
+      args: ["gateway"],
+      env: {},
+      fs: { existsSync: () => true },
+      lockDisabled: true,
+      process: fakeProcess,
+      spawn,
+      createWatcher: () => watcher,
+    });
+    watcher.emit("change", "src/index.ts");
+    expect(first.kill).toHaveBeenCalledWith("SIGTERM");
+    first.emit("exit", null, "SIGTERM");
+    expect(spawn).toHaveBeenCalledTimes(2);
+    fakeProcess.emit("SIGTERM");
+    second.emit("exit", null, "SIGTERM");
+    await expect(run).resolves.toBe(143);
+    expect(second.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("wires chokidar watch to run-node with watched source/config paths", async () => {
     const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
     await withTestDir({ prefix: "openclaw-watch-node-" }, async (cwd) => {

--- a/test/scripts/fixtures/native-runner-signals.mjs
+++ b/test/scripts/fixtures/native-runner-signals.mjs
@@ -1,0 +1,72 @@
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = process.env.OPENCLAW_TEST_NATIVE_RUNNER_ROOT;
+const sourceRoot = process.env.OPENCLAW_TEST_NATIVE_RUNNER_SOURCE;
+const mode = process.env.OPENCLAW_TEST_NATIVE_RUNNER_MODE;
+if (!root || !sourceRoot || (mode !== "runner" && mode !== "watch")) {
+  throw new Error("Native runner signal fixture is missing its private scope");
+}
+const fixture = fileURLToPath(import.meta.url);
+const release = path.join(root, "release");
+const terminate = path.join(root, "terminate");
+const released = () => fs.existsSync(release);
+const writePid = (role) => {
+  const destination = path.join(root, `${role}.pid`);
+  fs.writeFileSync(destination + ".tmp", String(process.pid));
+  fs.renameSync(destination + ".tmp", destination);
+};
+const waitForRelease = (mayTerminate) => {
+  setInterval(() => {
+    if (released()) {
+      process.exit(0);
+    }
+    if (mayTerminate && fs.existsSync(terminate)) {
+      process.kill(process.pid, "SIGKILL");
+    }
+  }, 20);
+};
+
+if (process.argv.includes("--fixture-worker")) {
+  writePid("worker");
+  waitForRelease(false);
+} else if (process.argv.includes("--fixture-build")) {
+  if (released()) {
+    process.exit(0);
+  }
+  writePid("build");
+  const worker = childProcess.spawn(process.execPath, [fixture, "--fixture-worker"], {
+    detached: true,
+    env: process.env,
+    // This writer is behind run-node's private build-output pipe, not the
+    // native entrypoint's inherited stdout/stderr or its process group.
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  worker.unref();
+  waitForRelease(mode === "runner");
+} else if (process.argv[1] === path.join(sourceRoot, "scripts/run-node.mts")) {
+  if (process.argv[2] === "doctor") {
+    fs.writeFileSync(path.join(root, "doctor-started"), "ready");
+    process.exit(0);
+  }
+  // An unsafe old watcher can run doctor and restart after losing its first
+  // owner. Let that replacement acknowledge zero without spawning more work.
+  if (fs.existsSync(path.join(root, "implementation.pid"))) {
+    process.exit(0);
+  }
+  writePid("implementation");
+  const spawn = childProcess.spawn;
+  childProcess.spawn = (_command, _args, options) =>
+    spawn(process.execPath, [fixture, "--fixture-build"], options);
+  syncBuiltinESMExports();
+  waitForRelease(mode === "watch");
+} else if (process.argv[1] === path.join(sourceRoot, "scripts/watch-node.mts")) {
+  const spawn = childProcess.spawn;
+  childProcess.spawn = (command, args, options) =>
+    spawn(command, [path.join(sourceRoot, "scripts/run-node.mjs"), ...args.slice(1)], options);
+  syncBuiltinESMExports();
+  waitForRelease(false);
+}

--- a/test/scripts/run-node-lifecycle.test.ts
+++ b/test/scripts/run-node-lifecycle.test.ts
@@ -1,10 +1,99 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { expect, it } from "vitest";
 import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
 import { formatShimResult, withShimFixture } from "./direct-run-entrypoints.test-support.js";
+
+it.runIf(process.platform !== "win32").each(["runner", "watch"] as const)(
+  "preserves native %s signal loss while a private-pipe worker survives",
+  async (mode) => {
+    const root = mkdtempSync(path.join(path.dirname(tmpdir()), "openclaw-native-signal-"));
+    const checkout = path.join(root, "checkout");
+    const sourceRoot = process.cwd();
+    const hook = fileURLToPath(new URL("./fixtures/native-runner-signals.mjs", import.meta.url));
+    mkdirSync(path.join(checkout, "src"), { recursive: true });
+    mkdirSync(path.join(root, "home"));
+    writeFileSync(path.join(checkout, "package.json"), '{"name":"openclaw-signal-fixture"}');
+    writeFileSync(path.join(checkout, "src/index.ts"), "export {};\n");
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: path.join(root, "home"),
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      OPENCLAW_CONFIG_PATH: path.join(root, "state/openclaw.json"),
+      OPENCLAW_FORCE_BUILD: "1",
+      OPENCLAW_RUNNER_LOG: "0",
+      OPENCLAW_TEST_NATIVE_RUNNER_ROOT: root,
+      OPENCLAW_TEST_NATIVE_RUNNER_SOURCE: sourceRoot,
+      OPENCLAW_TEST_NATIVE_RUNNER_MODE: mode,
+      NODE_OPTIONS: `--import=${pathToFileURL(hook).href}`,
+      PNPM_CONFIG_MODULES_DIR: path.dirname(
+        path.dirname(createRequire(import.meta.url).resolve("tsx/package.json")),
+      ),
+    };
+    const entrypoint = path.join(
+      sourceRoot,
+      "scripts",
+      mode === "watch" ? "watch-node.mjs" : "run-node.mjs",
+    );
+    let observedExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+    const command = runNodeScript([entrypoint, "gateway"], env, 10_000, {
+      cwd: checkout,
+      onReady(child) {
+        child.once("exit", (code, signal) => {
+          observedExit = { code, signal };
+        });
+      },
+    });
+    const pidPaths = ["implementation", "build", "worker"].map((role) =>
+      path.join(root, `${role}.pid`),
+    );
+    await runQaGatewayFixture(
+      async () => {
+        const worker = await waitForPidFile(path.join(root, "worker.pid"), 5_000);
+        expect(isProcessAlive(worker)).toBe(true);
+        writeFileSync(path.join(root, "terminate"), "terminate");
+        const result = await command;
+        expect(result.error, formatShimResult(result)).toBeUndefined();
+        // The managed test command converts the actual OS signal to its shell
+        // status. The old runner returns1; the old watch/doctor path returns0.
+        expect(result.status, formatShimResult(result)).toBe(137);
+        expect(observedExit).toEqual({ code: null, signal: "SIGKILL" });
+        expect(existsSync(path.join(root, "doctor-started"))).toBe(false);
+        expect(
+          isProcessAlive(worker),
+          "the fixture must retain the escaped worker until rescue",
+        ).toBe(true);
+      },
+      async () => {
+        // This private release is independent of the native cleanup under test.
+        // It also stops fixtures created while an early failure is unwinding.
+        writeFileSync(path.join(root, "release"), "release");
+        await command;
+      },
+      ...pidPaths.map((pidPath) => async () => {
+        if (existsSync(pidPath)) {
+          await waitForDead(Number(readFileSync(pidPath, "utf8")), 5_000);
+        }
+      }),
+      () => {
+        if (
+          pidPaths.some(
+            (pidPath) =>
+              existsSync(pidPath) && isProcessAlive(Number(readFileSync(pidPath, "utf8"))),
+          )
+        ) {
+          throw new Error(`Native signal fixture still owns processes; retained ${root}`);
+        }
+        rmSync(root, { recursive: true, force: true });
+      },
+    );
+  },
+);
 
 it.runIf(process.platform !== "win32").each(["SIGTERM", "SIGHUP"] as const)(
   "joins the dev runner's resistant child before returning from %s",
@@ -30,13 +119,15 @@ setInterval(() => {}, 1000);
 import { spawn } from "node:child_process";
 import { runNodeMain } from ${JSON.stringify(implementationUrl)};
 fs.writeFileSync(${JSON.stringify(wrapperPidPath)}, String(process.ppid));
-process.exit(await runNodeMain({
+const outcome = await runNodeMain({
   cwd: ${JSON.stringify(checkoutRoot)},
   env: { ...process.env, OPENCLAW_FORCE_BUILD: "1", OPENCLAW_RUNNER_LOG: "0" },
   spawn: (_command, _args, options) => spawn(process.execPath, [${JSON.stringify(childPath)}], {
     ...options, stdio: "ignore",
   }),
-}));
+});
+if (typeof outcome === "string") process.kill(process.pid, outcome);
+else process.exit(outcome);
 `,
       );
       const env: NodeJS.ProcessEnv = {

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/ui.mts";
 import { mergeProcessEnv } from "../../src/infra/process-env.js";
 import { normalizeControlUiBuildInfo } from "../../ui/src/build-info-normalizers.ts";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
 // writeFileSync creates the file before its content lands, so an existence
 // poll can observe an empty file on loaded runners; wait for bytes instead.
 function readNonEmpty(file: string): string | null {
@@ -55,6 +56,52 @@ async function waitForExit(
       reject(error);
     });
   });
+}
+
+async function withUiProcessCleanup(
+  wrapper: ChildProcess,
+  root: string,
+  pidFiles: string[],
+  run: () => Promise<void>,
+): Promise<void> {
+  const readPid = (file: string): number | null => {
+    const value = readNonEmpty(file);
+    if (value === null) {
+      return null;
+    }
+    const pid = Number(value);
+    if (!Number.isInteger(pid) || pid <= 0) {
+      throw new Error(`Invalid fixture PID in ${file}`);
+    }
+    return pid;
+  };
+  await runQaGatewayFixture(
+    run,
+    () => fs.writeFileSync(path.join(root, "release"), "release"),
+    async () => {
+      if (wrapper.exitCode === null && wrapper.signalCode === null) {
+        await waitForExit(wrapper);
+      }
+    },
+    ...pidFiles.map((file) => async () => {
+      const pid = readPid(file);
+      if (pid !== null) {
+        await waitFor(() => !pidAlive(pid), "UI fixture process exit", 5_000);
+      }
+    }),
+    () => {
+      if (
+        (wrapper.exitCode === null && wrapper.signalCode === null) ||
+        pidFiles.some((file) => {
+          const pid = readPid(file);
+          return pid !== null && pidAlive(pid);
+        })
+      ) {
+        throw new Error(`UI fixture cleanup is unverified; retained ${root}`);
+      }
+      fs.rmSync(root, { force: true, recursive: true });
+    },
+  );
 }
 
 describe("scripts/ui windows spawn behavior", () => {
@@ -571,115 +618,162 @@ require("node:module").syncBuiltinESMExports();
     expect(packageJson.scripts["ui:build"]).toBe("node scripts/ui.js build");
   });
 
-  it.runIf(process.platform !== "win32").each(["SIGTERM", "SIGHUP"] as const)(
-    "terminates the pnpm child on wrapper %s",
-    async (signal) => {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ui-wrapper-signals-"));
+  it.runIf(process.platform !== "win32").each([
+    {
+      label: "acknowledged SIGTERM",
+      requested: "SIGTERM",
+      childSignal: null,
+      code: 143,
+      signal: null,
+    },
+    {
+      label: "acknowledged SIGHUP",
+      requested: "SIGHUP",
+      childSignal: null,
+      code: 129,
+      signal: null,
+    },
+    {
+      label: "raw SIGTERM",
+      requested: "SIGTERM",
+      childSignal: "SIGTERM",
+      code: null,
+      signal: "SIGTERM",
+    },
+    {
+      label: "raw SIGKILL",
+      requested: "SIGTERM",
+      childSignal: "SIGKILL",
+      code: null,
+      signal: "SIGKILL",
+    },
+  ] as const)(
+    "preserves $label after UI wrapper shutdown",
+    async ({ requested, childSignal, code, signal }) => {
+      // Keep the release outside the disposable Vitest namespace until every
+      // fixture process is confirmed stopped, including on an assertion failure.
+      const tempDir = fs.mkdtempSync(
+        path.join(path.dirname(os.tmpdir()), "openclaw-ui-wrapper-signals-"),
+      );
       const runnerPath = path.join(tempDir, "pnpm.mjs");
       const readyFile = path.join(tempDir, "ready");
+      const runnerPidFile = path.join(tempDir, "runner.pid");
       const signaledFile = path.join(tempDir, "signaled");
+      const releaseFile = path.join(tempDir, "release");
+      const childOutcome = childSignal
+        ? `process.kill(process.pid, '${childSignal}');`
+        : "setTimeout(() => process.exit(0), 25);";
       const handlerLines = ["SIGTERM", "SIGHUP"].flatMap((handledSignal) => [
-        `process.on('${handledSignal}', () => {`,
+        `process.once('${handledSignal}', () => {`,
         `  fs.writeFileSync(process.env.SIGNALED_FILE, '${handledSignal}');`,
-        "  setTimeout(() => process.exit(0), 25);",
+        childOutcome,
         "});",
       ]);
-
       fs.writeFileSync(
         runnerPath,
         [
           "import fs from 'node:fs';",
           ...handlerLines,
+          "fs.writeFileSync(process.env.RUNNER_PID_FILE, String(process.pid));",
           "fs.writeFileSync(process.env.READY_FILE, process.argv.slice(2).join(' '));",
-          "setInterval(() => {}, 1000);",
+          "setInterval(() => { if (fs.existsSync(process.env.RELEASE_FILE)) process.exit(0); }, 20);",
         ].join("\n"),
       );
-
       const wrapper = spawn(process.execPath, ["scripts/ui.js", "install"], {
         cwd: path.resolve("."),
         env: {
           ...process.env,
           npm_execpath: runnerPath,
           READY_FILE: readyFile,
+          RUNNER_PID_FILE: runnerPidFile,
+          RELEASE_FILE: releaseFile,
           SIGNALED_FILE: signaledFile,
         },
         stdio: "ignore",
       });
-
-      try {
+      await withUiProcessCleanup(wrapper, tempDir, [runnerPidFile], async () => {
         await waitFor(() => readNonEmpty(readyFile) !== null, "UI runner readiness");
         expect(fs.readFileSync(readyFile, "utf8")).toBe("install");
-        wrapper.kill(signal);
-
+        const runnerPid = Number(fs.readFileSync(runnerPidFile, "utf8"));
+        wrapper.kill(requested);
         const exit = await waitForExit(wrapper);
-        expect(exit).toEqual({ code: null, signal });
-        expect(fs.readFileSync(signaledFile, "utf8")).toBe(signal);
-      } finally {
-        wrapper.kill("SIGKILL");
-        fs.rmSync(tempDir, { force: true, recursive: true });
-      }
+        expect(exit).toEqual({ code, signal });
+        expect(fs.readFileSync(signaledFile, "utf8")).toBe(requested);
+        expect(pidAlive(runnerPid), "UI wrapper returned before its child stopped").toBe(false);
+      });
     },
   );
 
-  it.runIf(process.platform !== "win32")(
-    "cleans pnpm descendants before forwarding wrapper SIGTERM",
-    async () => {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ui-wrapper-tree-"));
+  it.runIf(process.platform !== "win32").each([false, true])(
+    "keeps resistant-descendant cleanup raw with failed capture=%s",
+    async (failedCapture) => {
+      const tempDir = fs.mkdtempSync(
+        path.join(path.dirname(os.tmpdir()), "openclaw-ui-wrapper-tree-"),
+      );
       const runnerPath = path.join(tempDir, "pnpm.mjs");
       const readyFile = path.join(tempDir, "ready");
+      const runnerPidFile = path.join(tempDir, "runner.pid");
       const descendantPidFile = path.join(tempDir, "descendant.pid");
-      let descendantPid: number | undefined;
-
+      const releaseFile = path.join(tempDir, "release");
+      const failedCaptureFile = path.join(tempDir, "capture-failed");
+      const descendantSource = [
+        "import fs from 'node:fs';",
+        "process.on('SIGTERM', () => {});",
+        "fs.writeFileSync(process.env.DESCENDANT_PID_FILE, String(process.pid));",
+        "setInterval(() => { if (fs.existsSync(process.env.RELEASE_FILE)) process.exit(0); }, 20);",
+      ].join("\n");
       fs.writeFileSync(
         runnerPath,
         [
           "import { spawn } from 'node:child_process';",
           "import fs from 'node:fs';",
-          "fs.writeFileSync(process.env.READY_FILE, 'ready');",
-          "const child = spawn(process.execPath, ['-e', \"process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);\"], { stdio: 'ignore' });",
-          "child.unref();",
-          "fs.writeFileSync(process.env.DESCENDANT_PID_FILE, String(child.pid));",
           "process.on('SIGTERM', () => process.exit(0));",
-          "setInterval(() => {}, 1000);",
+          "fs.writeFileSync(process.env.RUNNER_PID_FILE, String(process.pid));",
+          "fs.writeFileSync(process.env.READY_FILE, 'ready');",
+          `const child = spawn(process.execPath, ['--input-type=module', '--eval', ${JSON.stringify(descendantSource)}], { stdio: 'ignore' });`,
+          "child.unref();",
+          "setInterval(() => { if (fs.existsSync(process.env.RELEASE_FILE)) process.exit(0); }, 20);",
         ].join("\n"),
       );
-
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        DESCENDANT_PID_FILE: descendantPidFile,
+        RUNNER_PID_FILE: runnerPidFile,
+        RELEASE_FILE: releaseFile,
+        npm_execpath: runnerPath,
+        READY_FILE: readyFile,
+      };
+      if (failedCapture) {
+        const bin = path.join(tempDir, "bin");
+        fs.mkdirSync(bin);
+        fs.writeFileSync(
+          path.join(bin, "ps"),
+          '#!/bin/sh\nprintf failed > "$PS_FAILURE_FILE"\nexit 1\n',
+          { mode: 0o755 },
+        );
+        env.PATH = `${bin}${path.delimiter}${env.PATH ?? ""}`;
+        env.PS_FAILURE_FILE = failedCaptureFile;
+      }
       const wrapper = spawn(process.execPath, ["scripts/ui.js", "install"], {
         cwd: path.resolve("."),
-        env: {
-          ...process.env,
-          DESCENDANT_PID_FILE: descendantPidFile,
-          npm_execpath: runnerPath,
-          READY_FILE: readyFile,
-        },
+        env,
         stdio: "ignore",
       });
-
-      try {
+      await withUiProcessCleanup(wrapper, tempDir, [runnerPidFile, descendantPidFile], async () => {
+        // The descendant publishes only after its resistant handler is installed.
         await waitFor(
           () => readNonEmpty(descendantPidFile) !== null,
           "UI runner descendant readiness",
         );
-        descendantPid = Number(fs.readFileSync(descendantPidFile, "utf8"));
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 25);
-        });
-
+        const descendantPid = Number(fs.readFileSync(descendantPidFile, "utf8"));
         wrapper.kill("SIGTERM");
         const exit = await waitForExit(wrapper, 8_000);
-
-        expect(exit).toEqual({ code: null, signal: "SIGTERM" });
-        await waitFor(
-          () => !descendantPid || !pidAlive(descendantPid),
-          "UI runner descendant exit",
-        );
-      } finally {
-        wrapper.kill("SIGKILL");
-        if (descendantPid && pidAlive(descendantPid)) {
-          process.kill(descendantPid, "SIGKILL");
+        expect(exit).toEqual({ code: null, signal: failedCapture ? "SIGTERM" : "SIGKILL" });
+        expect(pidAlive(descendantPid)).toBe(failedCapture);
+        if (failedCapture) {
+          expect(fs.readFileSync(failedCaptureFile, "utf8")).toBe("failed");
         }
-        fs.rmSync(tempDir, { force: true, recursive: true });
-      }
+      });
     },
   );
 });

--- a/test/scripts/watch-node.test.ts
+++ b/test/scripts/watch-node.test.ts
@@ -41,7 +41,7 @@ describe("watch-node shutdown cleanup", () => {
     vi.useFakeTimers();
     const fakeProcess = new FakeProcess();
     const child = new FakeChild();
-    let resolvedCode: number | undefined;
+    let resolvedCode: Awaited<ReturnType<typeof runWatchMain>> | undefined;
 
     const run = runWatchMain({
       args: ["gateway"],
@@ -60,7 +60,7 @@ describe("watch-node shutdown cleanup", () => {
     expect(child.signals).toEqual(["SIGTERM"]);
 
     await vi.advanceTimersByTimeAsync(1);
-    await expect(run).resolves.toBe(143);
+    await expect(run).resolves.toBe(process.platform === "win32" ? 143 : "SIGKILL");
     expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
   });
 
@@ -98,7 +98,7 @@ describe("watch-node shutdown cleanup", () => {
     const runner = new FakeChild();
     const doctor = new FakeChild();
     const children = [runner, doctor];
-    let resolvedCode: number | undefined;
+    let resolvedCode: Awaited<ReturnType<typeof runWatchMain>> | undefined;
 
     const run = runWatchMain({
       args: ["gateway"],
@@ -121,7 +121,7 @@ describe("watch-node shutdown cleanup", () => {
     expect(doctor.signals).toEqual(["SIGTERM"]);
 
     await vi.advanceTimersByTimeAsync(1);
-    await expect(run).resolves.toBe(143);
+    await expect(run).resolves.toBe(process.platform === "win32" ? 143 : "SIGKILL");
     expect(doctor.signals).toEqual(["SIGTERM", "SIGKILL"]);
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where developers running from source could see an ordinary error or an automatic doctor/restart after a native runner was killed, even while detached workers survived. The UI wrapper also reported cooperative shutdown as a signal, making completed and interrupted stops indistinguishable to callers.

## Why This Change Was Made

On Unix, preserve raw signal termination through the runner, watcher, doctor, and startup-error paths. The UI wrapper acknowledges a stop only after its child returns normally and a complete captured process tree is quiescent; child signal loss, forced cleanup, and failed enumeration retain a signal outcome. Ordinary returned errors, acknowledged rebuilds, and Windows restart behavior retain their existing handling.

## User Impact

Callers can distinguish acknowledged shutdown from losing a native runner and avoid treating interrupted cleanup as a successful restart or stop.

## Evidence

- 178 affected runner, watcher, native lifecycle, and UI wrapper tests passed remotely, with changed-file formatting/lint, line and assertion ratchets, and the relevant scripts/root/infra type graphs.
- Actual native entrypoints reproduce the old runner exit 1 and watch exit 0 after SIGKILL, then preserve `{code: null, signal: "SIGKILL"}` with this change.
- Native UI controls distinguish acknowledged TERM/HUP, raw child termination, forced descendant cleanup, and a failed process scan with a surviving worker. Each fixture independently releases and verifies its owned processes.
