### PR TITLE
fix: render scalar unions with literal branches

### DIFF
--- a/ui/src/components/config-form-composition-integrity.browser.test.ts
+++ b/ui/src/components/config-form-composition-integrity.browser.test.ts
@@ -124,7 +124,6 @@ describe("config form composition integrity", () => {
     });
 
     expect(analysis.unsupportedPaths).toEqual([
-      "retention",
       "guarded",
       "nullableBoolean",
       "ambiguousBooleanLabel",

--- a/ui/src/components/config-form-map-integrity.browser.test.ts
+++ b/ui/src/components/config-form-map-integrity.browser.test.ts
@@ -337,7 +337,7 @@ describe("config form map integrity", () => {
         type: "object",
         properties: {
           name: { type: "string" },
-          retained: { anyOf: [{ type: "string" }, { const: false }] },
+          retained: { anyOf: [{ type: "boolean", not: { const: true } }, { const: "auto" }] },
         },
       } satisfies JsonSchema;
       const collection = (name: string) =>

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -77,6 +77,8 @@ const RENDERABLE_UNION_TYPES = new Set([
   "object",
   "array",
 ]);
+const MIXED_LITERAL_RENDERABLE_UNION_TYPES = new Set(["string", "number", "integer"]);
+const MIXED_LITERAL_BRANCH_KEYS = new Set([...SUPPORTED_CONSTRAINT_ONLY_KEYS, "type"]);
 
 function isAnySchema(schema: JsonSchema): boolean {
   const keys = Object.keys(schema ?? {}).filter((key) => !META_KEYS.has(key));
@@ -625,9 +627,14 @@ function normalizeUnion(
       literals.unshift(true, false);
     } else if (
       schema.anyOf === undefined ||
+      nullable ||
       !remaining.every((entry) => {
         const type = schemaType(entry);
-        return Boolean(type) && RENDERABLE_UNION_TYPES.has(String(type));
+        return (
+          Boolean(type) &&
+          MIXED_LITERAL_RENDERABLE_UNION_TYPES.has(String(type)) &&
+          hasOnlySupportedKeywords(entry, MIXED_LITERAL_BRANCH_KEYS)
+        );
       })
     ) {
       return null;
@@ -653,7 +660,10 @@ function normalizeUnion(
     return {
       schema: {
         ...schema,
-        anyOf: [...remaining, ...literals.map((literal) => ({ const: literal }))],
+        anyOf: [
+          ...remaining,
+          ...union.filter((entry) => "const" in entry || Array.isArray(entry.enum)),
+        ],
         oneOf: undefined,
         nullable,
       },

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -613,16 +613,25 @@ function normalizeUnion(
     const booleanBranch = remaining.length === 1 ? remaining[0] : undefined;
     const plainBooleanBranch =
       booleanBranch?.type === "boolean" && Object.keys(booleanBranch).length === 1;
-    if (
-      !plainBooleanBranch ||
-      literals.includes("true") ||
-      literals.includes("false") ||
-      (schema.anyOf === undefined && literals.some((literal) => typeof literal === "boolean"))
+    if (plainBooleanBranch) {
+      if (
+        literals.includes("true") ||
+        literals.includes("false") ||
+        (schema.anyOf === undefined && literals.some((literal) => typeof literal === "boolean"))
+      ) {
+        return null;
+      }
+      remaining.pop();
+      literals.unshift(true, false);
+    } else if (
+      schema.anyOf === undefined ||
+      !remaining.every((entry) => {
+        const type = schemaType(entry);
+        return Boolean(type) && RENDERABLE_UNION_TYPES.has(String(type));
+      })
     ) {
       return null;
     }
-    remaining.pop();
-    literals.unshift(true, false);
   }
 
   if (literals.length > 0 && remaining.length === 0) {
@@ -635,6 +644,18 @@ function normalizeUnion(
         anyOf: undefined,
         oneOf: undefined,
         allOf: undefined,
+      },
+      unsupportedPaths: [],
+    };
+  }
+
+  if (literals.length > 0 && remaining.length > 0) {
+    return {
+      schema: {
+        ...schema,
+        anyOf: [...remaining, ...literals.map((literal) => ({ const: literal }))],
+        oneOf: undefined,
+        nullable,
       },
       unsupportedPaths: [],
     };

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -463,6 +463,64 @@ describe("config form renderer", () => {
     expect(selectedLabels).toEqual(["tailnet", "openai"]);
   });
 
+  it("renders mixed scalar unions with literal branches", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const schema = {
+      type: "object",
+      properties: {
+        cron: {
+          type: "object",
+          properties: {
+            sessionRetention: {
+              anyOf: [{ type: "string" }, { type: "boolean", const: false }],
+              title: "Automations Session Retention",
+            },
+          },
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).toEqual([]);
+
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: { cron: { sessionRetention: "7d" } },
+        onPatch,
+      }),
+      container,
+    );
+
+    const input = expectElement(
+      container.querySelector<HTMLInputElement>("input.settings-input"),
+      "session retention input",
+    );
+    expect(input.value).toBe("7d");
+    input.value = "false";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["cron", "sessionRetention"], false);
+
+    input.value = "retain";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["cron", "sessionRetention"], "retain");
+  });
+
+  it("keeps oneOf scalar unions with literal overlap in Raw mode", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        retention: {
+          oneOf: [{ type: "string" }, { type: "boolean", const: false }],
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).toEqual(["retention"]);
+  });
+
   it("renders map fields from additionalProperties", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");


### PR DESCRIPTION
## What Problem This Solves

`cron.sessionRetention` and similar settings schemas can be expressed as a scalar branch plus a literal branch, for example `anyOf: [{ type: "string" }, { const: false }]`. The Control UI analyzer treated that shape as unsupported, so otherwise editable Settings rows fell back to Raw mode even though the scalar editor can represent the valid string value and the explicit `false` literal.

Fixes #143646.

## Summary

- allow config-form analysis to keep safe renderable `anyOf` unions that mix scalar branches with literal branches
- narrow that support to non-nullable string/number/integer scalar branches with supported constraint-only keywords
- preserve original literal branch schemas instead of rebuilding them as const-only entries
- keep unsafe guarded, nullable, boolean, overlapping, and `oneOf` cases in Raw mode
- update integrity fixtures so Raw-only coverage still uses genuinely unsupported schemas

## Evidence

- `git diff --check`
- `pnpm exec oxfmt --write ui/src/components/config-form.analyze.ts ui/src/components/config-form-composition-integrity.browser.test.ts ui/src/components/config-form-map-integrity.browser.test.ts`
- `node --import ./scripts/tsx.mjs /tmp/check-config-analyze.mts`
  - confirmed `anyOf: [{ type: "string" }, { const: false }]` is no longer listed in `unsupportedPaths`
  - confirmed guarded boolean, nullable boolean, ambiguous boolean-label, and overlapping `oneOf` fixtures remain unsupported
  - confirmed the map integrity fixture still reports `values.*.retained` as unsupported for the guarded boolean union
- Earlier temporary jsdom/unit copy of the two new regression cases: `2 passed`

## Local Validation Notes

I attempted the repository's targeted browser Vitest command, but local validation is partially blocked by this host environment:

- `pnpm --dir ui vitest run src/components/config-form.browser.test.ts src/components/config-form-composition-integrity.browser.test.ts src/components/config-form-map-integrity.browser.test.ts` fails when Playwright Chromium launches because `libatk-1.0.so.0` is missing on the host.
- `pnpm --dir ui vitest run src/components/config-form.browser.test.ts --project unit` finds no matching files because `.browser.test.ts` files are excluded from the unit project.
- Earlier `pnpm install --frozen-lockfile` linked packages, then failed the preinstall Node gate because this host has Node `24.15.0` while current OpenClaw requires `>=24.16.0 <25 || >=26.1.0`.

I have not yet produced Gateway-served screenshot/recording proof; CI and reviewer feedback may still require that before merge.
