### PR TITLE
refactor(tasks): share audit summary counting

### DIFF
--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -9,6 +9,7 @@ import type {
 } from "./task-flow-registry.audit.types.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { summarizeAuditFindings } from "./task-registry.audit.shared.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 export type {
@@ -257,15 +258,5 @@ export function listTaskFlowAuditFindings(
 export function summarizeTaskFlowAuditFindings(
   findings: Iterable<TaskFlowAuditFinding>,
 ): TaskFlowAuditSummary {
-  const summary = createEmptyTaskFlowAuditSummary();
-  for (const finding of findings) {
-    summary.total += 1;
-    summary.byCode[finding.code] += 1;
-    if (finding.severity === "error") {
-      summary.errors += 1;
-    } else {
-      summary.warnings += 1;
-    }
-  }
-  return summary;
+  return summarizeAuditFindings(findings, createEmptyTaskFlowAuditSummary());
 }

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -51,6 +51,22 @@ export function createEmptyTaskAuditSummary(): TaskAuditSummary {
   };
 }
 
+export function summarizeAuditFindings<Code extends string>(
+  findings: Iterable<{ code: Code; severity: TaskAuditSeverity }>,
+  summary: Omit<TaskAuditSummary, "byCode"> & { byCode: Record<Code, number> },
+) {
+  for (const finding of findings) {
+    summary.total += 1;
+    summary.byCode[finding.code] += 1;
+    if (finding.severity === "error") {
+      summary.errors += 1;
+    } else {
+      summary.warnings += 1;
+    }
+  }
+  return summary;
+}
+
 export function compareTaskAuditFindingSortKeys(
   left: TaskAuditComparableFinding,
   right: TaskAuditComparableFinding,

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -2,6 +2,7 @@
 import {
   compareTaskAuditFindingSortKeys,
   createEmptyTaskAuditSummary,
+  summarizeAuditFindings,
   type TaskAuditCode,
   type TaskAuditFinding,
   type TaskAuditSeverity,
@@ -198,17 +199,7 @@ function isRetainedLostTaskAuditFinding(finding: TaskAuditFinding, now = Date.no
 }
 
 export function summarizeTaskAuditFindings(findings: Iterable<TaskAuditFinding>): TaskAuditSummary {
-  const summary = createEmptyTaskAuditSummary();
-  for (const finding of findings) {
-    summary.total += 1;
-    summary.byCode[finding.code] += 1;
-    if (finding.severity === "error") {
-      summary.errors += 1;
-    } else {
-      summary.warnings += 1;
-    }
-  }
-  return summary;
+  return summarizeAuditFindings(findings, createEmptyTaskAuditSummary());
 }
 
 export function summarizeActionableTaskAuditFindings(


### PR DESCRIPTION
Closes #143656

## What Problem This Solves

Maintainer-requested maintenance refactor: task and task-flow audit summaries duplicate the same counting loop, creating two places to maintain identical behavior. This is not a reproduced user-facing bug.

## Why This Change Was Made

Extract the unchanged loop into the existing shared audit module. Both public summary functions retain their signatures and use their unchanged, fresh summary factories.

Single-pass counting, duplicate handling, update order, severity handling, and separate task/flow code vocabularies are preserved. Finding generation, retained-loss handling, storage, configuration, and audit provenance are unchanged.

## User Impact

No user-visible behavior change. Audit JSON retains its legacy task-only top-level summary plus separate task-flow and combined summaries. Filtering still affects displayed findings, not totals. No release-note entry is needed for this mechanical refactor.

## Evidence

- Cached-base development proof on `f2a629ea05ce3f46c3d89a6d45866c50ad2c04cf`: the three focused audit/command suites passed, 42 tests total (7 task audit, 8 task-flow audit, 27 task commands).
- The scoped `check:changed` gate passed, including formatting, core and test typechecks, targeted lint, and static guards; `git diff --check` passed.
- Diff-scoped cleanup and independent P2 implementation review passed with no findings.
- Candidate `205c9307c61646368096cfbd3ca18d45c6a4526a` passed real CLI proof on Linux/Node 24 through the configured Testbox wrapper, with source/tree and file-byte verification: https://github.com/openclaw/openclaw/actions/runs/34437581537.
- `openclaw tasks audit --json` reported 5 task findings (2 errors, 3 warnings), 4 task-flow findings (2 errors, 2 warnings), and 9 combined findings. The six task-code and eight flow-code counters remained separate.
- Filtering to one displayed `stale_running` error preserved the full summaries. `openclaw tasks maintenance --json` remained preview-only and left the isolated synthetic task/flow records unchanged.
- Delegated proof exited 0; the owned Testbox lease is confirmed completed. Its backing Actions step may show cancellation during normal lease cleanup.
- Exact-head required CI passed: https://github.com/openclaw/openclaw/actions/runs/34437681530/job/102748975264.
- Native current-main review and hosted Testbox gates passed. All eight relevant source/type/test/CLI boundary files matched the approved cached base at native main checkpoint `15548547d0785013c96a87246b06ed89e64d4861`.
- Native squash landing completed as https://github.com/openclaw/openclaw/commit/05b20287fc039d1b8525ea7714b1e7124d883b91. The landed delta contains exactly the three approved files, whose bytes match the verified candidate.
