### PR TITLE
refactor(android): reuse swarm controller test setup

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSwarmProgressTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSwarmProgressTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -15,18 +14,13 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ChatControllerSwarmProgressTest {
-  private val json = Json { ignoreUnknownKeys = true }
-
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun disabledSwarmDoesNotFetchChildSessions() =
     runTest {
       val methods = mutableListOf<String>()
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             methods += method
             when (method) {
@@ -50,10 +44,7 @@ class ChatControllerSwarmProgressTest {
       val target = "agent:main:wear-b"
       val requests = mutableListOf<Pair<String, String?>>()
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, params ->
             requests += method to params
             when (method) {
@@ -130,10 +121,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       val target = "agent:main:wear-b"
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> {
@@ -178,10 +166,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       val target = "agent:main:wear-b"
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> {
@@ -219,10 +204,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       val target = "agent:main:wear-b"
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> {
@@ -258,10 +240,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       val target = "main"
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, params ->
             when (method) {
               "chat.metadata" -> {
@@ -297,10 +276,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       val methods = mutableListOf<String>()
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             methods += method
             error("foreign session must fail before Gateway read")
@@ -320,10 +296,7 @@ class ChatControllerSwarmProgressTest {
       val target = "agent:main:wear-large"
       var sessionsListCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, params ->
             when (method) {
               "chat.metadata" -> {
@@ -363,10 +336,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       var sessionsListCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> {
@@ -397,10 +367,7 @@ class ChatControllerSwarmProgressTest {
     runTest {
       var currentScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1)
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> {
@@ -443,10 +410,7 @@ class ChatControllerSwarmProgressTest {
         }
         """.trimIndent()
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ ->
             when (method) {
               "chat.metadata" -> """{"commands":[],"models":[],"swarmEnabled":true}"""
@@ -499,10 +463,7 @@ class ChatControllerSwarmProgressTest {
       val listGateways = mutableListOf<String>()
       var currentScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1)
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ -> emptyChatGatewayResponse(method) },
           requestGatewayForGateway = { gatewayId, method, _ ->
             when (method) {
@@ -557,10 +518,7 @@ class ChatControllerSwarmProgressTest {
       val listGate = CompletableDeferred<Unit>()
       var currentScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1)
       val controller =
-        ChatController(
-          scope = this,
-          commandOutbox = this.createChatCommandOutbox(),
-          json = json,
+        createChatController(
           requestGateway = { method, _ -> emptyChatGatewayResponse(method) },
           requestGatewayForGateway = { gatewayId, method, _ ->
             when (method) {


### PR DESCRIPTION
## What Problem This Solves

The Android swarm tests repeat the same controller, JSON, and outbox setup in 13 scenarios even though the shared chat test factory already owns that setup. This is part of the maintainer-requested code-reduction work.

## Why This Change Was Made

Use the existing `createChatController` factory while preserving every scenario's explicit gateway scope, request responder, assertions, and coroutine scheduling. The factory still creates a fresh Room-backed outbox tied to each test scope; no new helper or production seam is added.

## User Impact

No user-visible behavior changes. This removes 41 test/support code lines (42 physical lines), with zero production changes.

## Evidence

The same 13 swarm tests passed before and after the change, with no skipped cases. Targeted Kotlin formatting and the required changed checks passed, including Android lint and the native schema guard.

Focused command: `node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.chat.ChatControllerSwarmProgressTest'`.

Independent review raised a default-cache-scope concern. Source verification rejected it: all 13 call sites retain their explicit original `cacheScope`, so the factory default is unused. Apart from the constructor substitutions and the unused JSON declaration/import, the entire test file is unchanged.
