### PR TITLE
fix: keep exact model metadata when aliases coexist

### DIFF
--- a/src/agents/model-catalog-lookup.test.ts
+++ b/src/agents/model-catalog-lookup.test.ts
@@ -23,6 +23,25 @@ describe("catalog model identity", () => {
     expect(findModelCatalogEntry(catalog, { modelId: "READER" })).toBeUndefined();
   });
 
+  it.each([false, true])(
+    "prefers a literal catalog row over provider equivalence (reversed=%s)",
+    (reverse) => {
+      const rows = [
+        {
+          provider: "arcee",
+          id: "arcee-ai/trinity-large-thinking",
+          name: "Wire",
+          contextWindow: 32_000,
+        },
+        { provider: "arcee", id: "trinity-large-thinking", name: "Logical", contextWindow: 64_000 },
+      ];
+      const catalog = reverse ? rows.toReversed() : rows;
+      for (const row of rows) {
+        expect(findModelInCatalog(catalog, row.provider, row.id)).toBe(row);
+      }
+    },
+  );
+
   it("keeps unique case-insensitive SDK matches and providerless ambiguity", () => {
     const other = { ...lower, provider: "other" };
     expect(findModelInCatalog([upper], "CUSTOM", " reader ")).toBe(upper);

--- a/src/agents/model-catalog-lookup.ts
+++ b/src/agents/model-catalog-lookup.ts
@@ -156,6 +156,10 @@ export function findModelInCatalog<T extends Pick<ModelCatalogEntry, "provider" 
   const providerCatalog = catalog.filter(
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider,
   );
+  const literal = providerCatalog.find((entry) => entry.id === modelId.trim());
+  if (literal) {
+    return literal;
+  }
   // One synchronous lookup uses one policy owner instead of reloading it for every row.
   const surface = resolveProviderModelPolicySurface(normalizedProvider);
   const identityOf = (id: string) =>


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where catalog lookup returns another model row's capabilities when a provider has both a literal model ID and an equivalent ID in its catalog. For Arcee, changing row order could swap the 32K and 64K context metadata.

## Why This Change Was Made

Prefer the exact provider-scoped literal ID before applying provider equivalence. Keep provider-owned aliases and the unique case-insensitive SDK fallback on a literal miss. The production change is four lines.

## User Impact

Model capability lookup returns the requested row consistently regardless of catalog ordering.

## Evidence

Both catalog orders failed on the baseline; all 15 focused tests pass with the repair. Existing alias, case, ambiguity, and thinking-capability cases remain intact. Independent P2 review and the complete changed-file gate passed. One fresh full build passed at `bb00b5c147906e709c3e2802dac651d3caebb3e9`; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34437863073) is green.

The compiled public SDK passed both missing-literal alias-fallback controls and all four literal-row selections across both catalog orders. Each result retained exact object identity, context limits, and input capabilities. The supplemental isolated CLI inventory reported the expected 64K logical model; it canonicalizes equivalent rows upstream, so the SDK matrix is the decisive two-row proof. Both processes exited and their isolated state was removed. No provider request was needed for this catalog lookup boundary.
