### PR TITLE
fix(plugins): report supported bundle hook layouts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2920,7 +2920,6 @@ src/hooks/loader.ts	1
 src/hooks/message-hook-mappers.ts	2
 src/hooks/module-loader.ts	3
 src/hooks/policy.ts	1
-src/hooks/workspace.ts	1
 src/infra/advertised-lan-host.ts	1
 src/infra/agent-event-lifecycle.ts	1
 src/infra/agent-events.ts	2

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -78,7 +78,7 @@ is detected but not yet wired.
 | ------------- | ------------------------------------------------------------------------------------------------- | -------------- |
 | Skill content | Bundle skill roots load as normal OpenClaw skills                                                 | All formats    |
 | Commands      | `commands/` and `.cursor/commands/` treated as skill roots                                        | Claude, Cursor |
-| Hook packs    | OpenClaw-style `HOOK.md` + `handler.ts` layouts                                                   | Codex          |
+| Hook packs    | OpenClaw-style `HOOK.md` + `handler.ts` layouts                                                   | Claude, Codex  |
 | MCP tools     | Bundle MCP config merged into embedded OpenClaw settings; supported stdio and HTTP servers loaded | All formats    |
 | Env contract  | `PLUGIN_ROOT` and `PLUGIN_DATA` env vars plus placeholder expansion for stdio MCP servers         | Agent Plugins  |
 | LSP servers   | Claude `.lsp.json` and manifest-declared `lspServers` merged into embedded OpenClaw LSP defaults  | Claude         |
@@ -95,9 +95,15 @@ normal OpenClaw skill loader.
 
 #### Hook packs
 
-Bundle hook roots work **only** when they use the normal OpenClaw hook-pack
-layout: `HOOK.md` plus `handler.ts` or `handler.js`. Today this is primarily
-the Codex-compatible case.
+Bundle hook roots are collection directories. Put each hook's `HOOK.md` and
+`handler.ts` or `handler.js` in its own child directory, such as `hooks/my-hook/`,
+and declare `hooks/` as the root. Declaring the hook's leaf directory directly does
+not load it.
+
+Plugin inspection lists these hook packs separately from detected JSON automation.
+Claude `hooks/hooks.json` remains in the declared capabilities, but does not appear
+as a supported hook. A bundle containing both layouts keeps its OpenClaw hook packs.
+Inspection does not execute handlers or prove that the running Gateway loaded them.
 
 #### MCP for embedded OpenClaw
 

--- a/src/hooks/discovery.ts
+++ b/src/hooks/discovery.ts
@@ -1,0 +1,248 @@
+// Hook metadata discovery shared by runtime loading and plugin inspection.
+import fs from "node:fs";
+import path from "node:path";
+import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { parseFrontmatterBlockResult } from "../../packages/markdown-core/src/frontmatter.js";
+import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { openRootFileSync, readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
+import { isPathInsideWithRealpath } from "../security/scan-paths.js";
+import { resolveHookInvocationPolicy, resolveHookManifestMetadata } from "./frontmatter.js";
+import type { Hook, HookEntry, HookSource } from "./types.js";
+
+// Hook descriptors are small metadata. Bounding the pinned descriptor read also
+// covers files that grow after the boundary open validates their identity.
+const HOOK_METADATA_MAX_BYTES = 1024 * 1024;
+
+type HookDiscoveryWarning = (message: string) => void;
+
+export type DiscoveredHookEntry = Omit<HookEntry, "hook"> & {
+  hook: Omit<Hook, "handlerPath"> & { handlerPath?: string };
+  invalidMetadata?: boolean;
+};
+
+export type HookDiscoveryRoot = {
+  dir: string;
+  source: HookSource;
+  pluginId?: string;
+  rootDir?: string;
+  includeRoot?: boolean;
+};
+
+function readHookPackagePaths(dir: string, warn?: HookDiscoveryWarning): string[] {
+  const manifestPath = path.join(dir, "package.json");
+  const raw = readRootFileUtf8(
+    {
+      absolutePath: manifestPath,
+      rootPath: dir,
+      boundaryLabel: "hook package directory",
+      maxBytes: HOOK_METADATA_MAX_BYTES,
+    },
+    warn,
+  );
+  const manifest = raw === null ? undefined : asOptionalObjectRecord(safeParseJson(raw));
+  return normalizeTrimmedStringList(asOptionalObjectRecord(manifest?.[MANIFEST_KEY])?.hooks);
+}
+
+function resolveContainedDir(baseDir: string, targetDir: string): string | null {
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(baseDir, targetDir);
+  if (
+    !isPathInsideWithRealpath(base, resolved, {
+      requireRealpath: true,
+    })
+  ) {
+    return null;
+  }
+  return resolved;
+}
+
+function loadHookFromDir(
+  params: { hookDir: string; source: HookSource; pluginId?: string },
+  warn?: HookDiscoveryWarning,
+): DiscoveredHookEntry | null {
+  const hookMdPath = path.join(params.hookDir, "HOOK.md");
+  const content = readRootFileUtf8(
+    {
+      absolutePath: hookMdPath,
+      rootPath: params.hookDir,
+      boundaryLabel: "hook directory",
+      maxBytes: HOOK_METADATA_MAX_BYTES,
+    },
+    warn,
+  );
+  if (content === null) {
+    return null;
+  }
+  try {
+    const { frontmatter, issues } = parseFrontmatterBlockResult(content);
+
+    const name = frontmatter.name || path.basename(params.hookDir);
+    const description = frontmatter.description || "";
+
+    const handlerCandidates = ["handler.ts", "handler.js", "index.ts", "index.js"];
+    let handlerPath: string | undefined;
+    for (const candidate of handlerCandidates) {
+      const candidatePath = path.join(params.hookDir, candidate);
+      const safeCandidatePath = resolveRootFilePath({
+        absolutePath: candidatePath,
+        rootPath: params.hookDir,
+        boundaryLabel: "hook directory",
+      });
+      if (safeCandidatePath) {
+        handlerPath = safeCandidatePath;
+        break;
+      }
+    }
+
+    if (!handlerPath) {
+      warn?.(`Hook "${name}" has HOOK.md but no readable handler in ${params.hookDir}`);
+    }
+
+    let baseDir = params.hookDir;
+    try {
+      baseDir = fs.realpathSync.native(params.hookDir);
+    } catch {
+      // keep the discovered path when realpath is unavailable
+    }
+
+    return {
+      hook: {
+        name,
+        description,
+        source: params.source,
+        pluginId: params.pluginId,
+        filePath: hookMdPath,
+        baseDir,
+        handlerPath,
+      },
+      frontmatter,
+      invalidMetadata: issues.length > 0,
+      metadata: resolveHookManifestMetadata(frontmatter),
+      invocation: resolveHookInvocationPolicy(frontmatter),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    warn?.(`Failed to load hook from ${params.hookDir}: ${message}`);
+    return null;
+  }
+}
+
+function loadHooksFromCandidate(
+  params: { hookDir: string; source: HookSource; pluginId?: string },
+  warn?: HookDiscoveryWarning,
+): DiscoveredHookEntry[] | null {
+  const { hookDir, source, pluginId } = params;
+  const packageHooks = readHookPackagePaths(hookDir, warn);
+  if (packageHooks.length === 0) {
+    if (!fs.existsSync(path.join(hookDir, "HOOK.md"))) {
+      return null;
+    }
+    const hook = loadHookFromDir(params, warn);
+    return hook ? [hook] : [];
+  }
+
+  const hooks: DiscoveredHookEntry[] = [];
+  for (const hookPath of packageHooks) {
+    const resolvedHookDir = resolveContainedDir(hookDir, hookPath);
+    if (!resolvedHookDir) {
+      warn?.(
+        `Ignoring out-of-package hook path "${hookPath}" in ${hookDir} (must be within package directory)`,
+      );
+      continue;
+    }
+    // Pack entries are hook leaves, never another pack or a collection to scan.
+    const hook = loadHookFromDir({ hookDir: resolvedHookDir, source, pluginId }, warn);
+    if (hook) {
+      hooks.push(hook);
+    }
+  }
+
+  return hooks;
+}
+
+export function loadHookEntriesFromDir(
+  params: HookDiscoveryRoot,
+  warn?: HookDiscoveryWarning,
+): DiscoveredHookEntry[] {
+  const { dir, source, pluginId } = params;
+  // Plugin policy selects roots even when their files disappear. Boundary checks
+  // belong to discovery, so atomic reload can retain the selected source fact.
+  if (params.rootDir && !isPathInsideWithRealpath(params.rootDir, dir, { requireRealpath: true })) {
+    warn?.(`Plugin hook path is missing or escapes plugin root (${pluginId}): ${dir}`);
+    return [];
+  }
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    return [];
+  }
+  const rootHooks = params.includeRoot
+    ? loadHooksFromCandidate({ hookDir: dir, source, pluginId }, warn)
+    : null;
+  // null means a collection. A recognized root with rejected hooks stays empty;
+  // falling back to children would execute code its manifest did not select.
+  return (
+    rootHooks ??
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      if (!entry.isDirectory()) {
+        return [];
+      }
+      return (
+        loadHooksFromCandidate({ hookDir: path.join(dir, entry.name), source, pluginId }, warn) ??
+        []
+      );
+    })
+  );
+}
+
+function readRootFileUtf8(
+  params: { absolutePath: string; rootPath: string; boundaryLabel: string; maxBytes: number },
+  warn?: HookDiscoveryWarning,
+): string | null {
+  return withOpenedRootFileSync(params, (opened) => {
+    try {
+      return readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf-8");
+    } catch (err) {
+      if (err instanceof RangeError) {
+        warn?.(
+          `Ignoring oversized hook metadata ${params.absolutePath}: file exceeds the ${params.maxBytes}-byte limit`,
+        );
+      }
+      return null;
+    }
+  });
+}
+
+function withOpenedRootFileSync<T>(
+  params: {
+    absolutePath: string;
+    rootPath: string;
+    boundaryLabel: string;
+  },
+  read: (opened: { fd: number; path: string }) => T,
+): T | null {
+  const opened = openRootFileSync({
+    absolutePath: params.absolutePath,
+    rootPath: params.rootPath,
+    boundaryLabel: params.boundaryLabel,
+    // Operator hook dirs are commonly symlinked; fs-safe still rejects hops
+    // whose canonical target escapes the hook root.
+    rejectSymlinks: false,
+  });
+  if (!opened.ok) {
+    return null;
+  }
+  try {
+    return read({ fd: opened.fd, path: opened.path });
+  } finally {
+    fs.closeSync(opened.fd);
+  }
+}
+
+function resolveRootFilePath(params: {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+}): string | null {
+  return withOpenedRootFileSync(params, (opened) => opened.path);
+}

--- a/src/hooks/plugin-hooks.test.ts
+++ b/src/hooks/plugin-hooks.test.ts
@@ -5,8 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { buildPluginCapabilitySummary } from "../plugins/capability-summary.js";
 import { setGatewayPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
+import { projectInstalledPluginComponents } from "../plugins/installed-plugin-components.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
   clearInternalHooks,
@@ -53,16 +55,20 @@ describe("bundle plugin hooks", () => {
     await fsp.rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  async function writeBundleHookFixture(): Promise<string> {
+  async function writeBundleHookFixture(
+    format = "codex",
+    withJsonHooks = false,
+    declaredRoot = "hooks",
+  ): Promise<string> {
     const bundleRoot = path.join(workspaceDir, ".openclaw", "extensions", "sample-bundle");
     const hookDir = path.join(bundleRoot, "hooks", "bundle-hook");
-    await fsp.mkdir(path.join(bundleRoot, ".codex-plugin"), { recursive: true });
+    await fsp.mkdir(path.join(bundleRoot, `.${format}-plugin`), { recursive: true });
     await fsp.mkdir(hookDir, { recursive: true });
     await fsp.writeFile(
-      path.join(bundleRoot, ".codex-plugin", "plugin.json"),
+      path.join(bundleRoot, `.${format}-plugin`, "plugin.json"),
       JSON.stringify({
         name: "Sample Bundle",
-        hooks: "hooks",
+        hooks: declaredRoot,
       }),
       "utf-8",
     );
@@ -85,6 +91,9 @@ describe("bundle plugin hooks", () => {
       'export default async function(event) { event.messages.push("bundle-hook-ok"); }\n',
       "utf-8",
     );
+    if (withJsonHooks) {
+      await fsp.writeFile(path.join(bundleRoot, "hooks", "hooks.json"), '{"hooks":[]}', "utf-8");
+    }
     return bundleRoot;
   }
 
@@ -114,22 +123,50 @@ describe("bundle plugin hooks", () => {
     return entry;
   }
 
-  it("exposes enabled bundle hook dirs as plugin-managed hook entries", async () => {
-    const bundleRoot = await writeBundleHookFixture();
+  function projectBundleComponents(pluginId: string, config: OpenClawConfig) {
+    const metadata = loadPluginMetadataSnapshot({ config, workspaceDir, env: process.env });
+    const manifest = metadata.manifestRegistry.plugins.find(({ id }) => id === pluginId);
+    if (!manifest) {
+      throw new Error(`Expected bundle manifest for ${pluginId}`);
+    }
+    const { declared } = buildPluginCapabilitySummary({ manifest, origin: manifest.origin });
+    return { declared, components: projectInstalledPluginComponents({ manifest, declared }) };
+  }
 
-    const entries = loadWorkspaceHookEntries(workspaceDir, {
-      config: createConfig(true),
-    });
+  it.each([
+    { format: "codex", withJsonHooks: false, root: "hooks", supported: ["hooks"] },
+    { format: "claude", withJsonHooks: false, root: "hooks", supported: ["hooks"] },
+    { format: "claude", withJsonHooks: true, root: "hooks", supported: ["hooks"] },
+    { format: "claude", withJsonHooks: false, root: "hooks/bundle-hook", supported: [] },
+  ])(
+    "matches $format hook components to discovery for $root with JSON hooks $withJsonHooks",
+    async ({ format, withJsonHooks, root, supported }) => {
+      const bundleRoot = await writeBundleHookFixture(format, withJsonHooks, root);
+      const config = createConfig(true);
+      const entries = loadWorkspaceHookEntries(workspaceDir, { config });
 
-    const entry = requireOnlyHookEntry(entries);
-    expect(entry.hook.name).toBe("bundle-hook");
-    expect(entry.hook.source).toBe("openclaw-plugin");
-    expect(entry.hook.pluginId).toBe("sample-bundle");
-    expect(entry.hook.baseDir).toBe(
-      fs.realpathSync.native(path.join(bundleRoot, "hooks", "bundle-hook")),
-    );
-    expect(entry.metadata?.events).toEqual(["command:new"]);
-  });
+      if (supported.length > 0) {
+        const entry = requireOnlyHookEntry(entries);
+        expect(entry.hook.name).toBe("bundle-hook");
+        expect(entry.hook.source).toBe("openclaw-plugin");
+        expect(entry.hook.pluginId).toBe("sample-bundle");
+        expect(entry.hook.baseDir).toBe(
+          fs.realpathSync.native(path.join(bundleRoot, "hooks", "bundle-hook")),
+        );
+        expect(entry.metadata?.events).toEqual(["command:new"]);
+      } else {
+        expect(entries).toHaveLength(0);
+      }
+
+      const { declared, components } = projectBundleComponents("sample-bundle", config);
+      expect(declared.hooks).toEqual(withJsonHooks ? [root, "hooks/hooks.json"] : [root]);
+      expect(components).toMatchObject({
+        mapped: supported.length > 0 ? ["hooks"] : [],
+        hooks: supported,
+        unavailable: { capabilities: supported.length > 0 ? [] : ["hooks"] },
+      });
+    },
+  );
 
   it("reuses published plugin metadata without rescanning manifests", async () => {
     const bundleRoot = await writeBundleHookFixture();
@@ -222,13 +259,19 @@ describe("bundle plugin hooks", () => {
     );
     await fsp.writeFile(path.join(bundleRoot, "hooks", "hooks.json"), '{"hooks":[]}', "utf-8");
 
-    const entries = loadWorkspaceHookEntries(workspaceDir, {
-      config: {
-        hooks: { internal: { enabled: true } },
-        plugins: { entries: { "claude-bundle": { enabled: true } } },
-      },
-    });
-
+    const config: OpenClawConfig = {
+      hooks: { internal: { enabled: true } },
+      plugins: { entries: { "claude-bundle": { enabled: true } } },
+    };
+    const entries = loadWorkspaceHookEntries(workspaceDir, { config });
     expect(entries).toHaveLength(0);
+
+    const { declared, components } = projectBundleComponents("claude-bundle", config);
+    expect(declared.hooks).toEqual(["hooks/hooks.json"]);
+    expect(components).toMatchObject({
+      mapped: [],
+      hooks: [],
+      unavailable: { capabilities: ["hooks"] },
+    });
   });
 });

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -1,42 +1,20 @@
 // Hook workspace helpers resolve hook roots and workspace-local hook files.
-import fs from "node:fs";
 import path from "node:path";
-import { safeParseJson } from "@openclaw/normalization-core";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
-import { parseFrontmatterBlockResult } from "../../packages/markdown-core/src/frontmatter.js";
-import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { openRootFileSync, readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { resolveBundledHooksDir } from "./bundled-dir.js";
-import { resolveHookInvocationPolicy, resolveHookManifestMetadata } from "./frontmatter.js";
+import {
+  loadHookEntriesFromDir,
+  type DiscoveredHookEntry,
+  type HookDiscoveryRoot,
+} from "./discovery.js";
 import { resolvePluginHookDirs } from "./plugin-hooks.js";
 import { resolveHookEntries } from "./policy.js";
-import type { Hook, HookEntry, HookPolicyEntry, HookSource } from "./types.js";
+import type { HookEntry, HookPolicyEntry } from "./types.js";
 
-// Hook descriptors are small metadata. Bounding the pinned descriptor read also
-// covers files that grow after the boundary open validates their identity.
-const HOOK_METADATA_MAX_BYTES = 1024 * 1024;
-
-type HookPackageManifest = {
-  name?: string;
-} & Partial<Record<typeof MANIFEST_KEY, { hooks?: string[] }>>;
 const log = createSubsystemLogger("hooks/workspace");
-
-type DiscoveredHookEntry = Omit<HookEntry, "hook"> & {
-  hook: Omit<Hook, "handlerPath"> & { handlerPath?: string };
-  invalidMetadata?: boolean;
-};
-
-type HookDiscoveryRoot = {
-  dir: string;
-  source: HookSource;
-  pluginId?: string;
-  rootDir?: string;
-  includeRoot?: boolean;
-};
 
 export type HookSourceFact = HookPolicyEntry & { rootId: string; filePath: string };
 type HookCandidate = HookSourceFact & { entry?: DiscoveredHookEntry };
@@ -45,174 +23,6 @@ type HookDiscoveryOptions = {
   managedHooksDir?: string;
   bundledHooksDir?: string;
 };
-
-function readHookPackageManifest(dir: string): HookPackageManifest | null {
-  const manifestPath = path.join(dir, "package.json");
-  const raw = readRootFileUtf8({
-    absolutePath: manifestPath,
-    rootPath: dir,
-    boundaryLabel: "hook package directory",
-    maxBytes: HOOK_METADATA_MAX_BYTES,
-  });
-  if (raw === null) {
-    return null;
-  }
-  return (safeParseJson(raw) as HookPackageManifest | undefined) ?? null;
-}
-
-function resolvePackageHooks(manifest: HookPackageManifest): string[] {
-  return normalizeTrimmedStringList(manifest[MANIFEST_KEY]?.hooks);
-}
-
-function resolveContainedDir(baseDir: string, targetDir: string): string | null {
-  const base = path.resolve(baseDir);
-  const resolved = path.resolve(baseDir, targetDir);
-  if (
-    !isPathInsideWithRealpath(base, resolved, {
-      requireRealpath: true,
-    })
-  ) {
-    return null;
-  }
-  return resolved;
-}
-
-function loadHookFromDir(params: {
-  hookDir: string;
-  source: HookSource;
-  pluginId?: string;
-}): DiscoveredHookEntry | null {
-  const hookMdPath = path.join(params.hookDir, "HOOK.md");
-  const content = readRootFileUtf8({
-    absolutePath: hookMdPath,
-    rootPath: params.hookDir,
-    boundaryLabel: "hook directory",
-    maxBytes: HOOK_METADATA_MAX_BYTES,
-  });
-  if (content === null) {
-    return null;
-  }
-  try {
-    const { frontmatter, issues } = parseFrontmatterBlockResult(content);
-
-    const name = frontmatter.name || path.basename(params.hookDir);
-    const description = frontmatter.description || "";
-
-    const handlerCandidates = ["handler.ts", "handler.js", "index.ts", "index.js"];
-    let handlerPath: string | undefined;
-    for (const candidate of handlerCandidates) {
-      const candidatePath = path.join(params.hookDir, candidate);
-      const safeCandidatePath = resolveRootFilePath({
-        absolutePath: candidatePath,
-        rootPath: params.hookDir,
-        boundaryLabel: "hook directory",
-      });
-      if (safeCandidatePath) {
-        handlerPath = safeCandidatePath;
-        break;
-      }
-    }
-
-    if (!handlerPath) {
-      log.warn(`Hook "${name}" has HOOK.md but no readable handler in ${params.hookDir}`);
-    }
-
-    let baseDir = params.hookDir;
-    try {
-      baseDir = fs.realpathSync.native(params.hookDir);
-    } catch {
-      // keep the discovered path when realpath is unavailable
-    }
-
-    return {
-      hook: {
-        name,
-        description,
-        source: params.source,
-        pluginId: params.pluginId,
-        filePath: hookMdPath,
-        baseDir,
-        handlerPath,
-      },
-      frontmatter,
-      invalidMetadata: issues.length > 0,
-      metadata: resolveHookManifestMetadata(frontmatter),
-      invocation: resolveHookInvocationPolicy(frontmatter),
-    };
-  } catch (err) {
-    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-    log.warn(`Failed to load hook from ${params.hookDir}: ${message}`);
-    return null;
-  }
-}
-
-function loadHooksFromCandidate(params: {
-  hookDir: string;
-  source: HookSource;
-  pluginId?: string;
-}): DiscoveredHookEntry[] | null {
-  const { hookDir, source, pluginId } = params;
-  const manifest = readHookPackageManifest(hookDir);
-  const packageHooks = manifest ? resolvePackageHooks(manifest) : [];
-  if (packageHooks.length === 0) {
-    if (!fs.existsSync(path.join(hookDir, "HOOK.md"))) {
-      return null;
-    }
-    const hook = loadHookFromDir(params);
-    return hook ? [hook] : [];
-  }
-
-  const hooks: DiscoveredHookEntry[] = [];
-  for (const hookPath of packageHooks) {
-    const resolvedHookDir = resolveContainedDir(hookDir, hookPath);
-    if (!resolvedHookDir) {
-      log.warn(
-        `Ignoring out-of-package hook path "${hookPath}" in ${hookDir} (must be within package directory)`,
-      );
-      continue;
-    }
-    // Pack entries are hook leaves, never another pack or a collection to scan.
-    const hook = loadHookFromDir({
-      hookDir: resolvedHookDir,
-      source,
-      pluginId,
-    });
-    if (hook) {
-      hooks.push(hook);
-    }
-  }
-
-  return hooks;
-}
-
-function loadHookEntriesFromDir(params: HookDiscoveryRoot): DiscoveredHookEntry[] {
-  const { dir, source, pluginId } = params;
-  // Plugin policy selects roots even when their files disappear. Boundary checks
-  // belong to discovery, so atomic reload can retain the selected source fact.
-  if (params.rootDir && !isPathInsideWithRealpath(params.rootDir, dir, { requireRealpath: true })) {
-    log.warn(`Plugin hook path is missing or escapes plugin root (${pluginId}): ${dir}`);
-    return [];
-  }
-  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
-    return [];
-  }
-  const rootHooks = params.includeRoot
-    ? loadHooksFromCandidate({ hookDir: dir, source, pluginId })
-    : null;
-  // null means a collection. A recognized root with rejected hooks stays empty;
-  // falling back to children would execute code its manifest did not select.
-  return (
-    rootHooks ??
-    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-      if (!entry.isDirectory()) {
-        return [];
-      }
-      return (
-        loadHooksFromCandidate({ hookDir: path.join(dir, entry.name), source, pluginId }) ?? []
-      );
-    })
-  );
-}
 
 function resolveHookDiscoveryRoots(
   workspaceDir: string,
@@ -255,7 +65,7 @@ export function prepareWorkspaceHookEntries(
       Boolean(root.includeRoot),
       root.rootDir,
     ]);
-    const entries: HookCandidate[] = loadHookEntriesFromDir(root).map((entry) => ({
+    const entries: HookCandidate[] = loadHookEntriesFromDir(root, log.warn).map((entry) => ({
       rootId,
       filePath: entry.hook.filePath,
       hook: { name: entry.hook.name, source: entry.hook.source },
@@ -328,58 +138,4 @@ export function loadWorkspaceHookEntries(
   opts?: HookDiscoveryOptions,
 ): HookEntry[] {
   return prepareWorkspaceHookEntries(workspaceDir, opts).entries;
-}
-
-function readRootFileUtf8(params: {
-  absolutePath: string;
-  rootPath: string;
-  boundaryLabel: string;
-  maxBytes: number;
-}): string | null {
-  return withOpenedRootFileSync(params, (opened) => {
-    try {
-      return readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf-8");
-    } catch (err) {
-      if (err instanceof RangeError) {
-        log.warn(
-          `Ignoring oversized hook metadata ${params.absolutePath}: file exceeds the ${params.maxBytes}-byte limit`,
-        );
-      }
-      return null;
-    }
-  });
-}
-
-function withOpenedRootFileSync<T>(
-  params: {
-    absolutePath: string;
-    rootPath: string;
-    boundaryLabel: string;
-  },
-  read: (opened: { fd: number; path: string }) => T,
-): T | null {
-  const opened = openRootFileSync({
-    absolutePath: params.absolutePath,
-    rootPath: params.rootPath,
-    boundaryLabel: params.boundaryLabel,
-    // Operator hook dirs are commonly symlinked; fs-safe still rejects hops
-    // whose canonical target escapes the hook root.
-    rejectSymlinks: false,
-  });
-  if (!opened.ok) {
-    return null;
-  }
-  try {
-    return read({ fd: opened.fd, path: opened.path });
-  } finally {
-    fs.closeSync(opened.fd);
-  }
-}
-
-function resolveRootFilePath(params: {
-  absolutePath: string;
-  rootPath: string;
-  boundaryLabel: string;
-}): string | null {
-  return withOpenedRootFileSync(params, (opened) => opened.path);
 }

--- a/src/plugins/installed-plugin-components.ts
+++ b/src/plugins/installed-plugin-components.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
 import type {
   PluginDeclaredSurface,
   PluginInstalledComponents,
 } from "../../packages/gateway-protocol/src/schema/plugins.js";
+import { loadHookEntriesFromDir } from "../hooks/discovery.js";
 import { inspectBundleLspRuntimeSupport } from "./bundle-lsp.js";
 import {
   inspectBundleMcpRuntimeSupport,
@@ -68,6 +70,23 @@ export function projectInstalledPluginComponents(params: {
     capabilities: manifest.bundleCapabilities ?? [],
   });
   const mapped = new Set(support.mapped);
+  const hooks =
+    mapped.has("hooks") && manifest.rootDir
+      ? sorted(
+          (manifest.hooks ?? []).filter((dir) =>
+            loadHookEntriesFromDir({
+              dir: path.resolve(manifest.rootDir, dir),
+              rootDir: manifest.rootDir,
+              pluginId: manifest.id,
+              source: "openclaw-plugin",
+            }).some(({ hook }) => Boolean(hook.handlerPath)),
+          ),
+        )
+      : [];
+  if (mapped.has("hooks") && hooks.length === 0) {
+    mapped.delete("hooks");
+    support.unavailable.push("hooks");
+  }
   const mcp = manifest.rootDir
     ? inspectBundleMcpRuntimeSupport({
         pluginId: manifest.id,
@@ -87,7 +106,7 @@ export function projectInstalledPluginComponents(params: {
     skills: mapped.has("skills") ? sorted(declared.skills) : [],
     mcpServers: mapped.has("mcpServers") ? sorted(mcp?.supportedServerNames ?? []) : [],
     commands: [],
-    hooks: mapped.has("hooks") ? sorted(declared.hooks) : [],
+    hooks,
     lspServers: mapped.has("lspServers") ? sorted(lsp?.supportedServerNames ?? []) : [],
     unavailable: {
       capabilities: sorted(support.unavailable),


### PR DESCRIPTION
## What Problem This Solves

Fixes plugin inspection reporting detected Claude JSON automation as a supported hook. A JSON-only bundle has no OpenClaw hook pack to load, while a mixed bundle should keep its valid hook collection without advertising the JSON file as a hook.

## Why This Change Was Made

Share the existing metadata reader between workspace hook discovery and installed-component inspection. The projector now inspects manifest-owned roots with the runtime's collection semantics. Raw declarations, native plugin projection, workspace selection, reload retention, and handler execution remain unchanged.

The reader accepts the existing runtime warning callback so cold inspection avoids importing logging/config machinery. Real object narrowing replaces an old unchecked manifest cast, and its one obsolete assertion-baseline entry is removed. The change adds 23 production lines; the bulk of the diff moves the existing reader.

## User Impact

Supported hook lists match the layouts OpenClaw can discover. JSON-only automation remains declared but is classified unavailable. Mixed bundles retain their OpenClaw hook packs. Documentation now explains collection roots and the difference between inspection and runtime loading.

## Evidence

- The final 10-case hook file has three intended projection failures and seven passing controls against original production; all 10 pass after the repair. Cases cover JSON-only, mixed, ordinary collections, directly declared leaves, and existing reload behavior.
- The direct-leaf control verifies that the original runtime loads zero entries from that shape. Inspection preserves those runtime semantics instead of enabling another layout.
- 95 additional owner/sibling cases passed on identical production code, covering metadata parsing, loading, component projection, and management inspection. Counts are not summed across repeated runs.
- On the private dependency checkout, all 10 final cases, all 30 canonical changed-file checks, and the full 16-phase build pass. The build verifies all 152 public SDK subpaths.
- Fresh independent Codex review found no actionable findings through P2. The newer base retains all independent baseline edits and removes only this patch's obsolete assertion entry.

Earlier compiler containment failures came from a borrowed dependency installation; the completed proof uses an owned graph. Nonfatal build warnings are retained. No live Gateway or provider was used, and component inspection does not execute hook handlers.
