### PR TITLE
test(gateway): assert published Discord provider identity

### DIFF
--- a/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
+++ b/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
@@ -559,7 +559,10 @@ describe("Gateway admitted Discord transcript capture", () => {
       phase("model-publication:published");
       for (const agentId of ["main", "agent-b"]) {
         const published = await loadPublishedGatewayReplyDispatchRuntime({ agentId });
-        expect(published?.inboundPluginRegistry).toBe(registration.registry);
+        const inboundProvider = published?.inboundPluginRegistry.transcriptSourceProviders.find(
+          (entry) => entry.provider.id === "discord-voice",
+        )?.provider;
+        expect(inboundProvider).toBe(registration.registry.transcriptSourceProviders[0]?.provider);
         const selectedRegistry = published?.pluginGeneration.pluginRegistry;
         const selectedProvider = selectedRegistry?.transcriptSourceProviders.find(
           (entry) => entry.provider.id === "discord-voice",


### PR DESCRIPTION
## Summary
- verify the prepared inbound registry retains the fixture Discord transcript provider
- avoid invalid object-identity comparison against the unprepared fixture registry
- preserve the separate generation-registry provider assertion

## Validation
- `pnpm exec oxfmt --check test/e2e/gateway-transcripts-discord-capture.e2e.test.ts`
- `pnpm exec oxlint test/e2e/gateway-transcripts-discord-capture.e2e.test.ts`
- focused Gateway E2E test passes (1/1)