### PR TITLE
refactor(tests): reuse remaining channel runtime spies

### DIFF
--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -4,6 +4,7 @@ import type {
   ProviderAuthMethodNonInteractiveContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../test-support/runtime-spies.js";
 
 const { probeClaudeCliAuthStatus } = vi.hoisted(() => ({
   probeClaudeCliAuthStatus: vi.fn(),
@@ -126,11 +127,7 @@ function createProviderAuthContext(
     agentDir: "/tmp/openclaw/agents/main",
     workspaceDir: "/tmp/openclaw/workspace",
     prompter: createTestWizardPrompter(),
-    runtime: {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    },
+    runtime: createRuntimeSpies(),
     allowSecretRefPrompt: false,
     isRemote: false,
     openUrl: vi.fn(),
@@ -148,11 +145,7 @@ function createProviderAuthMethodNonInteractiveContext(
     config,
     baseConfig: config,
     opts: {},
-    runtime: {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    },
+    runtime: createRuntimeSpies(),
     agentDir: "/tmp/openclaw/agents/main",
     workspaceDir: "/tmp/openclaw/workspace",
     resolveApiKey: vi.fn(async () => null),

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -2,6 +2,7 @@
 import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { createIMessageRpcClient, IMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import type { attachIMessageMonitorAbortHandler } from "./monitor/abort-handler.js";
@@ -30,14 +31,6 @@ vi.mock("./client.js", () => ({
 vi.mock("./monitor/abort-handler.js", () => ({
   attachIMessageMonitorAbortHandler: attachIMessageMonitorAbortHandlerMock,
 }));
-
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
 
 type MockIMessageRpcClient = IMessageRpcClient & {
   request: ReturnType<typeof vi.fn<(method: string) => Promise<unknown>>>;
@@ -88,7 +81,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
   });
 
   it("retries a transient watch.subscribe startup timeout without tearing down the monitor", async () => {
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const statusSink = vi.fn();
     const firstClient = createRpcClient({
       request: async () => {
@@ -150,7 +143,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
   });
 
   it("still fails after bounded startup retries are exhausted", async () => {
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const statusSink = vi.fn();
     createIMessageRpcClientMock.mockImplementation(async () =>
       createRpcClient({
@@ -199,7 +192,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     await expect(
       monitorIMessageProvider({
         config: { channels: { imessage: {} } } as never,
-        runtime: createRuntime() as never,
+        runtime: createRuntimeSpies() as never,
         statusSink,
       }),
     ).rejects.toThrow("permission denied");
@@ -220,7 +213,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     async ({ reason, groupScope }) => {
       vi.useRealTimers();
       installIMessageStateRuntimeForTest();
-      const runtime = createRuntime();
+      const runtime = createRuntimeSpies();
       let onNotification:
         | ((message: { method: string; params: unknown }) => void | Promise<void>)
         | undefined;
@@ -319,7 +312,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
   it("redacts the conversation identifier in rate-limit suppression warnings", async () => {
     vi.useRealTimers();
     installIMessageStateRuntimeForTest();
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const sender = "+15550002222";
     const chatId = 456;
     const scope = `default:chat_id:${chatId}`;

--- a/extensions/matrix/src/matrix/monitor/config.test.ts
+++ b/extensions/matrix/src/matrix/monitor/config.test.ts
@@ -1,19 +1,11 @@
 // Matrix tests cover config plugin behavior.
 import { describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../../../test-support/runtime-spies.js";
 import type { RuntimeEnv } from "../../../runtime-api.js";
 import type { CoreConfig, MatrixRoomConfig } from "../../types.js";
 import { resolveMatrixMonitorConfig, resolveMatrixMonitorLiveUserAllowlist } from "./config.js";
 
 type MatrixRoomsConfig = Record<string, MatrixRoomConfig>;
-
-function createRuntime() {
-  const runtime: RuntimeEnv = {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-  return runtime;
-}
 
 function createConfig(params?: { dangerouslyAllowNameMatching?: boolean }): CoreConfig {
   return {
@@ -49,7 +41,7 @@ function expectResolveTargetCall(
 
 describe("resolveMatrixMonitorConfig", () => {
   it("canonicalizes resolved user aliases and room keys without keeping stale aliases", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(
       async ({ inputs, kind }: { inputs: string[]; kind: "user" | "group" }) => {
         if (kind === "user") {
@@ -126,7 +118,7 @@ describe("resolveMatrixMonitorConfig", () => {
     // Room version 12 (MSC4291) dropped the trailing ":server" from room IDs — they're
     // now a hash of the create event — so this must not be sent through name/alias
     // resolution the way an unresolved query would be.
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async ({ inputs }: { inputs: string[] }) =>
       inputs.map((input) => ({ input, resolved: false })),
     );
@@ -152,7 +144,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("strips config prefixes before lookups and logs unresolved guidance once per section", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(
       async ({ kind, inputs }: { inputs: string[]; kind: "user" | "group" }) =>
         inputs.map((input) => ({
@@ -203,7 +195,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("resolves exact room aliases to canonical room ids instead of trusting alias keys directly", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(
       async ({ kind, inputs }: { inputs: string[]; kind: "user" | "group" }) => {
         if (kind === "group") {
@@ -242,7 +234,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("does not resolve mutable allowlist entries or room names by default", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(
       async ({ kind, inputs }: { inputs: string[]; kind: "user" | "group" }) => {
         if (kind === "group") {
@@ -307,7 +299,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("keeps case-distinct qualified user ids in startup allowlists", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async () => []);
     const caseDistinctIds = ["@alice:Example.org", "@alice:example.org"];
 
@@ -338,7 +330,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("does not resolve mutable live allowlist entries by default", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async () => [
       { input: "Alice", resolved: true, id: "@alice:example.org" },
     ]);
@@ -357,7 +349,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("keeps case-distinct qualified user ids in live allowlists", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async () => []);
     const caseDistinctIds = ["@alice:Example.org", "@alice:example.org"];
 
@@ -374,7 +366,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("keeps unresolved live group allowlist entries configured for fail-closed matching", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async () => [
       { input: "Alice", resolved: true, id: "@alice:example.org" },
     ]);
@@ -394,7 +386,7 @@ describe("resolveMatrixMonitorConfig", () => {
   });
 
   it("resolves mutable live allowlist entries when name matching is enabled", async () => {
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const resolveTargets = vi.fn(async () => [
       { input: "Alice", resolved: true, id: "@alice:example.org" },
     ]);

--- a/extensions/ollama/src/setup.non-interactive-auth.test.ts
+++ b/extensions/ollama/src/setup.non-interactive-auth.test.ts
@@ -1,6 +1,7 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { jsonResponse, requestBodyText, requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { configureOllamaNonInteractive } from "./setup.js";
 
 const upsertAuthProfileWithLock = vi.hoisted(() => vi.fn(async () => {}));
@@ -64,14 +65,6 @@ function createOllamaFetchMock(params: {
   });
 }
 
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv;
-}
-
 describe("Ollama non-interactive onboarding", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -88,7 +81,7 @@ describe("Ollama non-interactive onboarding", () => {
           capabilities: { "embedding-model": capabilities },
         }),
       );
-      const runtime = createRuntime();
+      const runtime: RuntimeEnv = createRuntimeSpies();
       const nextConfig = { agents: { defaults: { model: { primary: "ollama/qwen3:1.7b" } } } };
       const result = await configureOllamaNonInteractive({
         nextConfig,
@@ -121,7 +114,7 @@ describe("Ollama non-interactive onboarding", () => {
       pullResponse: new Response(body, { status: 200 }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const nextConfig = {};
 
     const result = await configureOllamaNonInteractive({
@@ -160,7 +153,7 @@ describe("Ollama non-interactive onboarding", () => {
       pullResponse: new Response('{"error":"disk full"}\n', { status: 200 }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const nextConfig = {
       agents: {
@@ -202,7 +195,7 @@ describe("Ollama non-interactive onboarding", () => {
       capabilities: { "qwen3:1.7b": ["completion", "embedding"] },
     });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const result = await configureOllamaNonInteractive({
       nextConfig: {},
@@ -227,7 +220,7 @@ describe("Ollama non-interactive onboarding", () => {
   it("keeps an installed suggested local model first in non-interactive setup", async () => {
     const fetchMock = createOllamaFetchMock({ tags: ["qwen3:1.7b", "gemma4"] });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const result = await configureOllamaNonInteractive({
       nextConfig: {},
@@ -270,7 +263,7 @@ describe("Ollama non-interactive onboarding", () => {
       },
     });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const result = await configureOllamaNonInteractive({
       nextConfig: {},
@@ -300,7 +293,7 @@ describe("Ollama non-interactive onboarding", () => {
         customBaseUrl: "http://127.0.0.1:11434",
         customModelId: modelId,
       },
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(result.agents?.defaults?.model).toEqual({ primary: `ollama/${modelId}` });
@@ -345,7 +338,7 @@ describe("Ollama non-interactive onboarding", () => {
           customBaseUrl: "http://127.0.0.1:11434",
           customModelId: modelId,
         },
-        runtime: createRuntime(),
+        runtime: createRuntimeSpies(),
       });
 
       expect(result.agents?.defaults?.model).toEqual({ primary: `ollama/${modelId}` });

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { jsonResponse, requestBodyText, requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import {
   configureOllamaNonInteractive,
   ensureOllamaModelPulled,
@@ -122,14 +123,6 @@ function createDefaultOllamaConfig(primary: string) {
     agents: { defaults: { model: { primary } } },
     models: { providers: { ollama: { baseUrl: "http://127.0.0.1:11434", models: [] } } },
   };
-}
-
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv;
 }
 
 describe("ollama setup", () => {
@@ -957,7 +950,7 @@ describe("ollama setup", () => {
       pullResponse: new Response('{"status":"success"}\n', { status: 200 }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const result = await configureOllamaNonInteractive({
       nextConfig: {},
@@ -978,7 +971,7 @@ describe("ollama setup", () => {
   it("uses the discovered latest tag as the non-interactive default without pulling", async () => {
     const fetchMock = createOllamaFetchMock({ tags: ["gemma4:latest"] });
     vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+    const runtime: RuntimeEnv = createRuntimeSpies();
 
     const result = await configureOllamaNonInteractive({
       nextConfig: {},
@@ -1005,7 +998,7 @@ describe("ollama setup", () => {
     async (modelId) => {
       const fetchMock = createOllamaFetchMock({ tags: [] });
       vi.stubGlobal("fetch", fetchMock);
-      const runtime = createRuntime();
+      const runtime: RuntimeEnv = createRuntimeSpies();
 
       const result = await configureOllamaNonInteractive({
         nextConfig: {},
@@ -1028,11 +1021,7 @@ describe("ollama setup", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    } as unknown as RuntimeEnv;
+    const runtime: RuntimeEnv = createRuntimeSpies();
     const nextConfig = {};
 
     const result = await configureOllamaNonInteractive({

--- a/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover provider reconnect loop behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 import { getSlackClient, getSlackTestState, resetSlackTestState } from "../monitor.test-helpers.js";
 
 const { monitorSlackProvider } = await import("./provider.js");
@@ -165,11 +166,7 @@ describe("slack socket reconnect loop", () => {
       appToken: "app",
       abortSignal: controller.signal,
       config: slackTestState.config,
-      runtime: {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
+      runtime: createRuntimeSpies(),
       setStatus,
     });
 

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { readCachedTelegramBotInfo, writeCachedTelegramBotInfo } from "./bot-info-cache.js";
 import type { TelegramBotInfo } from "./bot-info.js";
 import { telegramPlugin } from "./channel.js";
@@ -67,14 +68,6 @@ function installTelegramRuntime() {
   } as unknown as TelegramRuntime;
   setTelegramRuntime(telegramRuntime);
   return telegramRuntime;
-}
-
-function createRuntimeEnvMock() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
 }
 
 function createTelegramConfig(
@@ -439,7 +432,7 @@ describe("telegramPlugin gateway startup", () => {
       accountId: "ops",
       prevCfg: createTelegramConfig("ops"),
       nextCfg: createTelegramConfig("ops", { botToken: "123456:new-token" }),
-      runtime: createRuntimeEnvMock(),
+      runtime: createRuntimeSpies(),
     });
 
     await expect(
@@ -462,7 +455,7 @@ describe("telegramPlugin gateway startup", () => {
       accountId: "ops",
       prevCfg: createTelegramConfig("ops"),
       nextCfg: createTelegramConfig("ops", { timeoutSeconds: 60 }),
-      runtime: createRuntimeEnvMock(),
+      runtime: createRuntimeSpies(),
     });
 
     await expect(
@@ -484,7 +477,7 @@ describe("telegramPlugin gateway startup", () => {
     await telegramPlugin.lifecycle?.onAccountRemoved?.({
       accountId: "ops",
       prevCfg: createTelegramConfig("ops"),
-      runtime: createRuntimeEnvMock(),
+      runtime: createRuntimeSpies(),
     });
 
     await expect(
@@ -511,7 +504,7 @@ describe("telegramPlugin gateway startup", () => {
       accountId: "ops",
       account,
       cfg,
-      runtime: createRuntimeEnvMock(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(result).toEqual({ cleared: true, envToken: false, loggedOut: true });
@@ -547,7 +540,7 @@ describe("telegramPlugin gateway startup", () => {
       accountId: "ops",
       account: telegramPlugin.config.resolveAccount(cfg, "ops"),
       cfg,
-      runtime: createRuntimeEnvMock(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(result).toEqual({ cleared: true, envToken: false, loggedOut: false });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Seven plugin test files still repeat the same logging and exit spy setup despite an existing shared test fixture.

## Why This Change Was Made

Reuse the existing runtime-spy factory and remove five private constructors that only repeat its behavior. Keep every allocation at its original call site, preserve the typed runtime boundaries, and remove three unnecessary type assertions. This removes 50 net test lines without changing the helper or production code.

## User Impact

No user-visible behavior change. Auth/setup, monitoring, reconnect, allowlist and channel lifecycle assertions remain intact.

## Evidence

All 127 cases passed before and after across the complete seven suites, with identical ordered results. Parser and lexical-binding checks reconstruct the original full source and AST, including the five removed constructors, 31 bound calls and preserved runtime types. The shared helper's hash is unchanged.

Changed checks, typechecking, lint and independent P2 review passed. No new tests, runtime API or performance claim.
