### PR TITLE
test(clawrouter): refresh catalog before asserting models

### DIFF
--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -133,7 +133,7 @@ describe("ClawRouter managed gateway contract", () => {
     expect(gatewayReadiness).toMatchObject({ ready: true, failing: [] });
 
     const catalog = await instance.cli(
-      ["models", "list", "--all", "--provider", "clawrouter", "--json"],
+      ["models", "list", "--all", "--provider", "clawrouter", "--refresh", "--json"],
       { timeoutMs: 120_000 },
     );
     expect(catalog.code, catalog.stderr).toBe(0);


### PR DESCRIPTION
## Summary
- request an explicit Gateway catalog refresh before asserting dynamic ClawRouter models
- turn the catalog read into the synchronization barrier required by the managed-provider contract

## Validation
- focused ClawRouter managed gateway E2E passes (1/1)
- oxfmt and oxlint pass