### PR TITLE
fix(backup): full backups omit required config includes

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -46,7 +46,10 @@ Archive `create`, `verify`, and `restore`, plus SQLite `create`, `list`, `verify
 - Default output is a timestamped `.tar.gz` archive in the current working directory. Timestamped filenames use your machine's local timezone and include the UTC offset. If the current working directory is inside a backed-up source tree, OpenClaw falls back to your home directory for the default archive location.
 - Existing archive files are never overwritten. Output paths inside the source state/workspace trees are rejected to avoid self-inclusion.
 - `openclaw backup verify <archive>` checks that the archive contains exactly one root manifest, rejects traversal-style archive paths, unsafe symbolic links, and SQLite sidecars, confirms every manifest-declared payload exists, validates every SQLite snapshot's file shape, and runs full integrity and role checks on canonical OpenClaw databases. Dedicated plugin schemas remain opaque because they may require owner-defined SQLite capabilities. `openclaw backup create --verify` runs that validation immediately after writing the archive.
-- `openclaw backup create --only-config` backs up just the active JSON config file.
+- Full archives include the active config and its required `$include` files, including dependencies outside the state directory. They preserve authored bytes, comments, and environment placeholders; resolved secrets are not written into the config copy. These additional files may contain sensitive data, so protect the archive accordingly.
+- Full archives refuse unresolved include graphs, files that change during config capture, and include aliases that cannot be represented safely. Fix missing or unreadable files, use regular-file include paths, or pause concurrent edits and retry. `--no-include-workspace` still includes required config dependencies, even within an excluded workspace.
+- `openclaw backup create --only-config` backs up just the active JSON config file, **not** its `$include` dependencies. It is a root-file export, not a complete modular-config recovery point.
+- Config files are pinned before database capture. SQLite snapshots retain their existing per-database consistency and sanitization; the archive is not one atomic snapshot across config and all databases. Later writes remain live and may not appear in the archive.
 
 ## Restore a full archive
 

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -599,18 +599,18 @@ export async function resolveBackupPlanFromDisk(
       `Config invalid at ${shortenHomePath(discoverySnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
     );
   }
-  const cleanupPlan = buildCleanupPlan({
-    // Discovery uses the validated compatibility view; the archive still reads configPath bytes.
-    cfg: discoverySnapshot.config,
-    stateDir,
-    configPath,
-    oauthDir,
-  });
   const unresolvedOwnership = discoverySnapshot.exists && !discoverySnapshot.valid;
+  const discoveredWorkspaceDirs = unresolvedOwnership
+    ? []
+    : buildCleanupPlan({
+        cfg: discoverySnapshot.config,
+        stateDir,
+        configPath,
+        oauthDir,
+      }).workspaceDirs;
   const agentRoots = unresolvedOwnership
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
-  const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
   // Effective agent workspaces can omit their shared base. Exclude it only here
   // so full backups and destructive cleanup retain their existing selection.
   if (!includeWorkspace && discoverySnapshot.valid) {

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -3,12 +3,16 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
 import {
-  readConfigFileSnapshot,
+  createConfigIO,
   resolveConfigPath,
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  resolveBackupConfigCapture,
+  type BackupConfigCapture,
+} from "../infra/backup-config-capture.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   resolveActivatedPluginBackupInventory,
@@ -82,6 +86,7 @@ type SkippedBackupAsset = {
 };
 
 type BackupPlan = {
+  configCapture?: BackupConfigCapture;
   stateDir: string;
   configPath: string;
   oauthDir: string;
@@ -175,6 +180,7 @@ async function resolveBackupPlanFromPaths(params: {
   workspaceDirs?: string[];
   agentRoots?: readonly BackupAgentRoot[];
   pluginInventory?: ActivatedPluginBackupInventory;
+  configCapture?: BackupConfigCapture;
   unresolvedOwnership?: boolean;
   includeWorkspace?: boolean;
   onlyConfig?: boolean;
@@ -196,7 +202,11 @@ async function resolveBackupPlanFromPaths(params: {
   const oauthSourcePath = await canonicalizePathForContainment(oauthDir);
   const inventory = await createBackupResourceInventory({
     stateDir: canonicalStateDir,
-    configPaths: [configPath, configSourcePath],
+    configPaths: [
+      configPath,
+      configSourcePath,
+      ...(params.configCapture?.files ?? []).map((file) => file.canonicalPath),
+    ],
     oauthDirs: [oauthDir, oauthSourcePath],
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
@@ -282,6 +292,12 @@ async function resolveBackupPlanFromPaths(params: {
     ...(isOwnedPathCoveredBy(oauthSourcePath, canonicalStateDir)
       ? []
       : [{ kind: "credentials" as const, sourcePath: path.resolve(oauthDir) }]),
+    ...(params.configCapture?.files ?? [])
+      .filter((file) => file.canonicalPath !== configSourcePath)
+      .map((file) => ({
+        kind: "config" as const,
+        sourcePath: file.canonicalPath,
+      })),
     ...workspaceDirs.map((workspaceDir) => ({
       kind: "workspace" as const,
       sourcePath: path.resolve(workspaceDir),
@@ -418,6 +434,7 @@ async function resolveBackupPlanFromPaths(params: {
     configPath,
     oauthDir,
     workspaceDirs: workspaceDirs.map((entry) => path.resolve(entry)),
+    configCapture: params.configCapture,
     inventory,
     included,
     skipped,
@@ -573,8 +590,10 @@ export async function resolveBackupPlanFromDisk(
   }
 
   // Backup discovery must not initialize or migrate the state DB before snapshot validation.
-  const configSnapshot = await readConfigFileSnapshot({ observe: false });
+  const configRead = await createConfigIO({ observe: false }).readConfigFileSnapshotForWrite();
+  const configSnapshot = configRead.snapshot;
   const discoverySnapshot = resolveStartupConfigSnapshot(configSnapshot) ?? configSnapshot;
+  const configCapture = await resolveBackupConfigCapture(configRead);
   if (includeWorkspace && discoverySnapshot.exists && !discoverySnapshot.valid) {
     throw new Error(
       `Config invalid at ${shortenHomePath(discoverySnapshot.path)}. OpenClaw cannot reliably discover custom workspaces for backup. Fix the config or rerun with --no-include-workspace for a partial backup.`,
@@ -615,6 +634,7 @@ export async function resolveBackupPlanFromDisk(
     workspaceDirs: discoveredWorkspaceDirs,
     agentRoots,
     pluginInventory,
+    configCapture,
     unresolvedOwnership,
     includeWorkspace,
     onlyConfig,

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -293,7 +293,9 @@ describe("backup commands", () => {
       if (!stateAsset || !workspaceAsset) {
         throw new Error("Expected backup assets to include state and workspace entries.");
       }
-      expect(capturedEntryPaths).toHaveLength(result.assets.length + 1);
+      expect(capturedEntryPaths).toEqual(
+        expect.arrayContaining(result.assets.map((asset) => asset.sourcePath)),
+      );
 
       const manifestPath = expectDefined(capturedEntryPaths[0], "manifest archive path");
       const remappedManifestEntry = { path: manifestPath };
@@ -336,7 +338,7 @@ describe("backup commands", () => {
           createMockTarStream({
             beforeRead: () => {
               const manifestPath = entryPaths[0];
-              const stateRoot = entryPaths[1];
+              const stateRoot = stateDir;
               if (!manifestPath || !stateRoot) {
                 throw new Error("backup test expected manifest and state entries");
               }

--- a/src/infra/backup-config-capture.test.ts
+++ b/src/infra/backup-config-capture.test.ts
@@ -64,22 +64,34 @@ async function restore(state: OpenClawTestState, output: string, includeWorkspac
 
 describe("full backup config include capture", () => {
   it.each([
-    { name: "external config", layout: "split", rootLink: false },
-    { name: "in-state config", layout: "state-only", rootLink: false },
-    { name: "root link", layout: "state-only", rootLink: true },
+    { name: "external config", layout: "split", rootLink: false, invalid: false },
+    { name: "in-state config", layout: "state-only", rootLink: false, invalid: false },
+    { name: "root link", layout: "state-only", rootLink: true, invalid: false },
+    { name: "schema-invalid config", layout: "split", rootLink: false, invalid: true },
   ] as const)(
     "restores a raw nested graph through $name without the original includes",
-    async ({ layout, rootLink }) => {
+    async ({ layout, rootLink, invalid }) => {
       await withOpenClawTestState({ layout }, async (state) => {
         vi.stubEnv("BACKUP_INCLUDE_PLACEHOLDER", "must-not-be-expanded");
         const graph = await configGraph(state);
+        if (invalid) {
+          const raw = graph.files
+            .get(state.configPath)!
+            .replace('ownership: "explicit"', "defaults: { workspace: 42 }");
+          graph.files.set(state.configPath, raw);
+          await fs.writeFile(state.configPath, raw);
+        }
         if (rootLink) {
           const authoredRoot = state.path("authored-config.json5");
           await fs.rename(state.configPath, authoredRoot);
           await fs.symlink(authoredRoot, state.configPath);
         }
         await fs.writeFile(state.statePath("ordinary.txt"), "ordinary");
-        const { archive, restoredPath } = await restore(state, state.path("backup.tar.gz"));
+        const { archive, restoredPath } = await restore(
+          state,
+          state.path("backup.tar.gz"),
+          !invalid,
+        );
         const entries: string[] = [];
         await tar.t({
           file: archive.archivePath,
@@ -104,7 +116,12 @@ describe("full backup config include capture", () => {
           configPath: restoredPath(state.configPath),
           observe: false,
         }).readConfigFileSnapshot();
-        expect(snapshot.valid).toBe(true);
+        expect(snapshot.valid).toBe(!invalid);
+        expect(snapshot.includeProvenance).toBeDefined();
+        expect(snapshot.issues.map((issue) => issue.path)).toEqual(
+          invalid ? ["agents.defaults.workspace"] : [],
+        );
+        expect(archive.skipped.some(({ reason }) => reason === "unresolved")).toBe(invalid);
         expect(snapshot.config.gateway?.mode).toBe("local");
       });
     },

--- a/src/infra/backup-config-capture.test.ts
+++ b/src/infra/backup-config-capture.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import { createBackupArchive } from "./backup-create.js";
 import * as sqliteCapture from "./backup-sqlite-snapshot.js";
-import { requireNodeSqlite } from "./node-sqlite.js";
+import { requireNodeSqlite, resolveSqliteFilesystemPath } from "./node-sqlite.js";
 
 const runtime: RuntimeEnv = { log: () => {}, error: () => {}, exit: () => {} };
 afterEach(() => {
@@ -277,7 +277,9 @@ describe("full backup config include capture", () => {
           { value: "captured" },
           { value: "later" },
         ]);
-        const copy = new DatabaseSync(restoredPath(dbPath), { readOnly: true });
+        const copy = new DatabaseSync(resolveSqliteFilesystemPath(restoredPath(dbPath)), {
+          readOnly: true,
+        });
         try {
           expect(copy.prepare("SELECT value FROM proof").all()).toEqual([{ value: "captured" }]);
         } finally {

--- a/src/infra/backup-config-capture.test.ts
+++ b/src/infra/backup-config-capture.test.ts
@@ -1,0 +1,376 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { backupRestoreCommand } from "../commands/backup-restore.js";
+import * as backupShared from "../commands/backup-shared.js";
+import { verifyBackupArchive } from "../commands/backup-verify.js";
+import { createConfigIO } from "../config/config.js";
+import { MAX_INCLUDE_DEPTH } from "../config/includes.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { createBackupArchive } from "./backup-create.js";
+import * as sqliteCapture from "./backup-sqlite-snapshot.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+const runtime: RuntimeEnv = { log: () => {}, error: () => {}, exit: () => {} };
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+async function configGraph(state: OpenClawTestState) {
+  vi.stubEnv("BACKUP_INCLUDE_PLACEHOLDER", "synthetic-placeholder-value");
+  const configDir = path.dirname(state.configPath);
+  const includePath = path.join(configDir, "parts", "settings.json5");
+  const leafPath = path.join(configDir, "parts", "leaf.json5");
+  const root = `// authored root\n{ "$include": "./parts/settings.json5", agents: { ownership: "explicit", entries: { main: {} } } }\n`;
+  const include = `{ "$include": "./leaf.json5" }\n`;
+  const leaf = `// keep comments and placeholders\n{ gateway: { mode: "local", auth: { mode: "token", token: "\${BACKUP_INCLUDE_PLACEHOLDER}" } } }\n`;
+  await fs.mkdir(path.dirname(includePath), { recursive: true });
+  await fs.writeFile(state.configPath, root);
+  await fs.writeFile(includePath, include);
+  await fs.writeFile(leafPath, leaf);
+  const snapshot = await createConfigIO({ observe: false }).readConfigFileSnapshot();
+  expect(snapshot.issues).toEqual([]);
+  return {
+    includePath,
+    leafPath,
+    files: new Map([
+      [state.configPath, root],
+      [includePath, include],
+      [leafPath, leaf],
+    ]),
+  };
+}
+
+async function restore(state: OpenClawTestState, output: string, includeWorkspace = true) {
+  const archive = await createBackupArchive({ output, includeWorkspace });
+  await verifyBackupArchive(output);
+  const restored = await backupRestoreCommand(runtime, {
+    archive: output,
+    target: state.path("restored"),
+  });
+  const restoredPath = (source: string) =>
+    path.join(
+      restored.targetPath,
+      backupShared.buildBackupArchivePath(archive.archiveRoot, source),
+    );
+  return { archive, restoredPath };
+}
+
+describe("full backup config include capture", () => {
+  it.each([
+    { name: "external config", layout: "split", rootLink: false },
+    { name: "in-state config", layout: "state-only", rootLink: false },
+    { name: "root link", layout: "state-only", rootLink: true },
+  ] as const)(
+    "restores a raw nested graph through $name without the original includes",
+    async ({ layout, rootLink }) => {
+      await withOpenClawTestState({ layout }, async (state) => {
+        vi.stubEnv("BACKUP_INCLUDE_PLACEHOLDER", "must-not-be-expanded");
+        const graph = await configGraph(state);
+        if (rootLink) {
+          const authoredRoot = state.path("authored-config.json5");
+          await fs.rename(state.configPath, authoredRoot);
+          await fs.symlink(authoredRoot, state.configPath);
+        }
+        await fs.writeFile(state.statePath("ordinary.txt"), "ordinary");
+        const { archive, restoredPath } = await restore(state, state.path("backup.tar.gz"));
+        const entries: string[] = [];
+        await tar.t({
+          file: archive.archivePath,
+          onReadEntry: (entry) => {
+            entries.push(entry.path);
+          },
+        });
+        expect(new Set(entries).size).toBe(entries.length);
+        for (const [source, raw] of graph.files) {
+          expect(await fs.readFile(restoredPath(source), "utf8")).toBe(raw);
+        }
+        expect(await fs.readFile(restoredPath(state.statePath("ordinary.txt")), "utf8")).toBe(
+          "ordinary",
+        );
+        // Remove only this fixture's source lookup, so parsing cannot succeed by
+        // accidentally reading the originals instead of the restored graph.
+        await fs.rename(
+          path.join(path.dirname(state.configPath), "parts"),
+          state.path("original-parts"),
+        );
+        const snapshot = await createConfigIO({
+          configPath: restoredPath(state.configPath),
+          observe: false,
+        }).readConfigFileSnapshot();
+        expect(snapshot.valid).toBe(true);
+        expect(snapshot.config.gateway?.mode).toBe("local");
+      });
+    },
+  );
+
+  it("keeps required workspace includes but leaves only-config root-only", async () => {
+    await withOpenClawTestState({ layout: "state-only" }, async (state) => {
+      const workspace = state.statePath("workspace");
+      await fs.mkdir(workspace);
+      const leaf = path.join(workspace, "required.json5");
+      await fs.writeFile(leaf, '{ gateway: { mode: "local" } }');
+      await fs.writeFile(path.join(workspace, "workspace-only.txt"), "omit");
+      await state.writeConfig({
+        $include: "./workspace/required.json5",
+        agents: { defaults: { workspace }, entries: { main: {} } },
+      });
+      const { restoredPath } = await restore(state, state.path("full.tar.gz"), false);
+      expect(await fs.readFile(restoredPath(leaf), "utf8")).toContain('mode: "local"');
+      await expect(
+        fs.stat(restoredPath(path.join(workspace, "workspace-only.txt"))),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      const rootOnly = await createBackupArchive({
+        output: state.path("root.tar.gz"),
+        onlyConfig: true,
+      });
+      await verifyBackupArchive(rootOnly.archivePath);
+      const entries: string[] = [];
+      await tar.t({
+        file: rootOnly.archivePath,
+        onReadEntry: (entry) => {
+          entries.push(entry.path);
+        },
+      });
+      expect(entries).toEqual(
+        expect.arrayContaining([
+          backupShared.buildBackupArchivePath(rootOnly.archiveRoot, state.configPath),
+        ]),
+      );
+      expect(entries.some((entry) => entry.endsWith("required.json5"))).toBe(false);
+    });
+  });
+
+  it.each(["missing", "cycle", "depth", "alias", "invalid-directive"])(
+    "refuses an indeterminate %s graph before publication",
+    async (kind) => {
+      await withOpenClawTestState({ layout: "split" }, async (state) => {
+        const graph = await configGraph(state);
+        if (kind === "missing") {
+          await fs.unlink(graph.leafPath);
+        }
+        if (kind === "cycle") {
+          await fs.writeFile(graph.leafPath, '{ "$include": "./settings.json5" }');
+        }
+        if (kind === "depth") {
+          await fs.writeFile(graph.leafPath, '{ "$include": "./depth-0.json5" }');
+          for (let i = 0; i <= MAX_INCLUDE_DEPTH; i++) {
+            await fs.writeFile(
+              path.join(path.dirname(graph.leafPath), `depth-${i}.json5`),
+              i === MAX_INCLUDE_DEPTH
+                ? "{}"
+                : JSON.stringify({ $include: `./depth-${i + 1}.json5` }),
+            );
+          }
+        }
+        if (kind === "alias") {
+          const moved = path.join(path.dirname(state.configPath), "real-parts");
+          await fs.rename(path.dirname(graph.leafPath), moved);
+          await fs.symlink(
+            moved,
+            path.dirname(graph.leafPath),
+            process.platform === "win32" ? "junction" : "dir",
+          );
+        }
+        if (kind === "invalid-directive") {
+          await fs.writeFile(state.configPath, '{ "$include": 123 }');
+        }
+        const output = state.path("refused.tar.gz");
+        await expect(createBackupArchive({ output, includeWorkspace: false })).rejects.toThrow(
+          /required config file .*retry backup/s,
+        );
+        await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+        // Even an unresolved graph can still be exported explicitly as root-only.
+        const rootOnly = await createBackupArchive({
+          output: state.path("root-only.tar.gz"),
+          onlyConfig: true,
+        });
+        await verifyBackupArchive(rootOnly.archivePath);
+      });
+    },
+  );
+
+  it.each(["leaf", "root-edge", "replacement", "unreadable"])(
+    "refuses %s changes after discovery without overwriting sources",
+    async (kind) => {
+      await withOpenClawTestState({ layout: "split" }, async (state) => {
+        const graph = await configGraph(state);
+        const resolve = backupShared.resolveBackupPlanFromDisk;
+        vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockImplementationOnce(
+          async (options) => {
+            const plan = await resolve(options);
+            if (kind === "leaf") {
+              const stat = await fs.stat(graph.leafPath);
+              await fs.writeFile(
+                graph.leafPath,
+                graph.files.get(graph.leafPath)!.replace("local", "other"),
+              );
+              await fs.utimes(graph.leafPath, stat.atime, stat.mtime);
+            } else if (kind === "root-edge") {
+              await fs.writeFile(
+                state.configPath,
+                graph.files.get(state.configPath)!.replace("settings", "replaced"),
+              );
+            } else if (kind === "replacement") {
+              await fs.rename(graph.leafPath, `${graph.leafPath}.original`);
+              await fs.writeFile(graph.leafPath, graph.files.get(graph.leafPath)!);
+            } else {
+              const open = fs.open;
+              vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+                if (args[0] === graph.leafPath) {
+                  throw Object.assign(new Error("denied"), { code: "EACCES" });
+                }
+                return open(...args);
+              });
+            }
+            return plan;
+          },
+        );
+        const output = state.path("refused.tar.gz");
+        await expect(createBackupArchive({ output, includeWorkspace: false })).rejects.toThrow(
+          /required config file .*retry backup/s,
+        );
+        await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+        if (kind === "leaf") {
+          expect(await fs.readFile(graph.leafPath, "utf8")).toContain('mode: "other"');
+        }
+        if (kind === "root-edge") {
+          expect(await fs.readFile(state.configPath, "utf8")).toContain("replaced.json5");
+        }
+        if (kind === "replacement") {
+          expect(await fs.readFile(`${graph.leafPath}.original`, "utf8")).toBe(
+            graph.files.get(graph.leafPath),
+          );
+        }
+      });
+    },
+  );
+
+  it("uses sealed config even if sources change before database capture and tar traversal", async () => {
+    await withOpenClawTestState({ layout: "state-only" }, async (state) => {
+      const graph = await configGraph(state);
+      const { DatabaseSync } = requireNodeSqlite();
+      const dbPath = state.statePath("proof.sqlite");
+      const db = new DatabaseSync(dbPath);
+      db.exec(
+        "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE proof(value TEXT); INSERT INTO proof VALUES ('captured');",
+      );
+      expect((await fs.stat(`${dbPath}-wal`)).size).toBeGreaterThan(0);
+      const snapshotSqlite = sqliteCapture.createBackupSqliteSnapshotPlan;
+      vi.spyOn(sqliteCapture, "createBackupSqliteSnapshotPlan").mockImplementationOnce(
+        async (params) => {
+          const snapshot = await snapshotSqlite(params);
+          await fs.writeFile(graph.leafPath, '{ gateway: { mode: "remote" } }');
+          db.exec("INSERT INTO proof VALUES ('later')");
+          return snapshot;
+        },
+      );
+      try {
+        const { restoredPath } = await restore(state, state.path("backup.tar.gz"));
+        expect(db.prepare("SELECT value FROM proof").all()).toEqual([
+          { value: "captured" },
+          { value: "later" },
+        ]);
+        const copy = new DatabaseSync(restoredPath(dbPath), { readOnly: true });
+        try {
+          expect(copy.prepare("SELECT value FROM proof").all()).toEqual([{ value: "captured" }]);
+        } finally {
+          copy.close();
+        }
+        expect(await fs.readFile(graph.leafPath, "utf8")).toContain('mode: "remote"');
+        expect(await fs.readFile(restoredPath(graph.leafPath), "utf8")).toBe(
+          graph.files.get(graph.leafPath),
+        );
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it.each(["present", "missing"])(
+    "does not archive a later include-bearing root that was %s without includes at capture",
+    async (initial) => {
+      await withOpenClawTestState(
+        { layout: initial === "present" ? "split" : "state-only" },
+        async (state) => {
+          const graph = await configGraph(state);
+          const plain = "{ agents: { entries: { main: {} } } }\n";
+          if (initial === "present") {
+            await fs.writeFile(state.configPath, plain);
+          } else {
+            await fs.unlink(state.configPath);
+          }
+          const snapshotSqlite = sqliteCapture.createBackupSqliteSnapshotPlan;
+          vi.spyOn(sqliteCapture, "createBackupSqliteSnapshotPlan").mockImplementationOnce(
+            async (params) => {
+              await fs.writeFile(state.configPath, graph.files.get(state.configPath)!);
+              return snapshotSqlite(params);
+            },
+          );
+          const { restoredPath } = await restore(state, state.path("plain.tar.gz"));
+          expect(await fs.readFile(state.configPath, "utf8")).toBe(
+            graph.files.get(state.configPath),
+          );
+          if (initial === "present") {
+            expect(await fs.readFile(restoredPath(state.configPath), "utf8")).toBe(plain);
+          } else {
+            await expect(fs.stat(restoredPath(state.configPath))).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+          }
+        },
+      );
+    },
+  );
+
+  it("refuses a root alias retargeted after sealing and cleans the unpublished archive", async () => {
+    await withOpenClawTestState({ layout: "state-only" }, async (state) => {
+      const first = state.statePath("first.json");
+      const second = state.statePath("second.json");
+      await fs.writeFile(first, "{}");
+      await fs.writeFile(second, "{}");
+      await fs.symlink(first, state.configPath);
+      const snapshotSqlite = sqliteCapture.createBackupSqliteSnapshotPlan;
+      vi.spyOn(sqliteCapture, "createBackupSqliteSnapshotPlan").mockImplementationOnce(
+        async (params) => {
+          await fs.unlink(state.configPath);
+          await fs.symlink(second, state.configPath);
+          return snapshotSqlite(params);
+        },
+      );
+      const output = state.path("retargeted.tar.gz");
+      await expect(createBackupArchive({ output })).rejects.toThrow(/config alias changed/);
+      await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await fs.realpath(state.configPath)).toBe(second);
+      expect(
+        (await fs.readdir(state.root)).filter((name) => name.startsWith(".openclaw-backup-")),
+      ).toEqual([]);
+    });
+  });
+
+  it("preserves staging ENOSPC and leaves no published archive", async () => {
+    await withOpenClawTestState({ layout: "split" }, async (state) => {
+      const graph = await configGraph(state);
+      const write = fs.writeFile;
+      const diskFull = Object.assign(new Error("synthetic staging disk full"), { code: "ENOSPC" });
+      vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+        if (typeof args[0] === "string" && /config-\d+$/.test(args[0])) {
+          throw diskFull;
+        }
+        return write(...args);
+      });
+      const output = state.path("refused.tar.gz");
+      await expect(createBackupArchive({ output, includeWorkspace: false })).rejects.toBe(diskFull);
+      await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+      for (const [source, raw] of graph.files) {
+        expect(await fs.readFile(source, "utf8")).toBe(raw);
+      }
+    });
+  });
+});

--- a/src/infra/backup-config-capture.ts
+++ b/src/infra/backup-config-capture.ts
@@ -34,7 +34,12 @@ export async function resolveBackupConfigCapture({
 }: ReadConfigFileSnapshotForWriteResult): Promise<BackupConfigCapture> {
   const hasIncludes =
     containsConfigIncludeDirective(snapshot.parsed) || Boolean(snapshot.includedPaths?.length);
-  if ((hasIncludes && !snapshot.valid) || (snapshot.exists && snapshot.raw === null)) {
+  // The reader attaches provenance only after resolving the whole include graph,
+  // even when later schema validation fails. Keep that recovery path available.
+  if (
+    (hasIncludes && snapshot.includeProvenance === undefined) ||
+    (snapshot.exists && snapshot.raw === null)
+  ) {
     throw captureError(snapshot.path, "include graph could not be resolved");
   }
   const hashes = writeOptions.includeFileHashesForWrite ?? {};
@@ -124,6 +129,7 @@ export async function resolveBackupConfigCapture({
         current.snapshot.valid !== snapshot.valid ||
         !isDeepStrictEqual(current.snapshot.sourceConfig, snapshot.sourceConfig) ||
         !isDeepStrictEqual(current.snapshot.includedPaths, snapshot.includedPaths) ||
+        !isDeepStrictEqual(current.snapshot.includeProvenance, snapshot.includeProvenance) ||
         !isDeepStrictEqual(current.writeOptions.includeFileHashesForWrite ?? {}, hashes) ||
         !isDeepStrictEqual(current.writeOptions.includeFileTargetsForWrite ?? {}, targets)
       ) {

--- a/src/infra/backup-config-capture.ts
+++ b/src/infra/backup-config-capture.ts
@@ -1,0 +1,191 @@
+// Pins authored config dependencies before archive traversal, without writing live config.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { hashConfigIncludeRaw } from "../config/includes.js";
+import { createConfigIO } from "../config/io.factory.js";
+import { containsConfigIncludeDirective } from "../config/io.read-helpers.js";
+import type { ReadConfigFileSnapshotForWriteResult } from "../config/io.types.js";
+
+type CapturedConfigFile = {
+  sourcePath: string;
+  canonicalPath: string;
+  hash: string;
+  dev: number;
+  ino: number;
+};
+
+export type BackupConfigCapture = {
+  files: readonly CapturedConfigFile[];
+  revalidate: () => Promise<void>;
+  assertRootAlias?: () => Promise<void>;
+};
+
+function captureError(sourcePath: string, detail: string, cause?: unknown): Error {
+  return new Error(
+    `Cannot capture required config file ${sourcePath}: ${detail}. Fix the include graph or stop concurrent edits, then retry backup.`,
+    { cause },
+  );
+}
+
+export async function resolveBackupConfigCapture({
+  snapshot,
+  writeOptions,
+}: ReadConfigFileSnapshotForWriteResult): Promise<BackupConfigCapture> {
+  const hasIncludes =
+    containsConfigIncludeDirective(snapshot.parsed) || Boolean(snapshot.includedPaths?.length);
+  if ((hasIncludes && !snapshot.valid) || (snapshot.exists && snapshot.raw === null)) {
+    throw captureError(snapshot.path, "include graph could not be resolved");
+  }
+  const hashes = writeOptions.includeFileHashesForWrite ?? {};
+  const targets = writeOptions.includeFileTargetsForWrite ?? {};
+  const files = new Map<string, string>(
+    snapshot.exists
+      ? [[snapshot.path, hashConfigIncludeRaw(snapshot.raw)], ...Object.entries(hashes)]
+      : [],
+  );
+  const capture: CapturedConfigFile[] = [];
+  let assertRootAlias: (() => Promise<void>) | undefined;
+  const canonicalConfigDir = files.size
+    ? await fs.realpath(path.dirname(snapshot.path)).catch((error: unknown) => {
+        throw captureError(snapshot.path, "config directory became unavailable", error);
+      })
+    : path.dirname(snapshot.path);
+  for (const [sourcePath, hash] of files) {
+    try {
+      const canonicalPath = await fs.realpath(sourcePath);
+      const linkStat = await fs.lstat(sourcePath);
+      const rootAlias = sourcePath === snapshot.path && linkStat.isSymbolicLink();
+      const stat = rootAlias ? await fs.stat(sourcePath) : linkStat;
+      if (rootAlias) {
+        // Existing root links keep the archive's ordinary link
+        // handling. Pin their payload and refuse a changed alias at publication.
+        assertRootAlias = async () => {
+          const current = await fs.lstat(sourcePath);
+          if (
+            current.dev !== linkStat.dev ||
+            current.ino !== linkStat.ino ||
+            current.ctimeMs !== linkStat.ctimeMs ||
+            (await fs.realpath(sourcePath)) !== canonicalPath
+          ) {
+            throw captureError(sourcePath, "config alias changed during capture");
+          }
+        };
+      }
+      // A common canonical parent (e.g. macOS /var -> /private/var) is portable.
+      // Nested aliases need link projection; do not silently archive only their targets.
+      const projectedPath = path.resolve(
+        canonicalConfigDir,
+        path.relative(path.dirname(snapshot.path), sourcePath),
+      );
+      if (
+        !stat.isFile() ||
+        (!rootAlias && canonicalPath !== sourcePath && canonicalPath !== projectedPath)
+      ) {
+        throw captureError(sourcePath, "include alias cannot be represented in this archive");
+      }
+      if (sourcePath !== snapshot.path && targets[sourcePath] !== canonicalPath) {
+        throw captureError(sourcePath, "include target changed or is unavailable");
+      }
+      capture.push({
+        sourcePath: rootAlias ? canonicalPath : sourcePath,
+        canonicalPath,
+        hash,
+        dev: stat.dev,
+        ino: stat.ino,
+      });
+    } catch (error) {
+      throw captureError(sourcePath, "file identity could not be pinned", error);
+    }
+  }
+  // Watch paths include both lexical and canonical names. Every one must belong
+  // to a successfully resolved, hash-pinned file, not a partially visited graph.
+  for (const includePath of snapshot.includedPaths ?? []) {
+    if (
+      !capture.some((file) => file.sourcePath === includePath || file.canonicalPath === includePath)
+    ) {
+      throw captureError(includePath, "include inventory is incomplete");
+    }
+  }
+  return {
+    files: capture,
+    assertRootAlias,
+    revalidate: async () => {
+      await assertRootAlias?.();
+      const current = await createConfigIO({
+        configPath: snapshot.path,
+        observe: false,
+      }).readConfigFileSnapshotForWrite();
+      // A file can be reached repeatedly during discovery. Comparing the resolved
+      // source as well as the last hashes prevents accepting mixed observations.
+      if (
+        current.snapshot.exists !== snapshot.exists ||
+        current.snapshot.raw !== snapshot.raw ||
+        current.snapshot.valid !== snapshot.valid ||
+        !isDeepStrictEqual(current.snapshot.sourceConfig, snapshot.sourceConfig) ||
+        !isDeepStrictEqual(current.snapshot.includedPaths, snapshot.includedPaths) ||
+        !isDeepStrictEqual(current.writeOptions.includeFileHashesForWrite ?? {}, hashes) ||
+        !isDeepStrictEqual(current.writeOptions.includeFileTargetsForWrite ?? {}, targets)
+      ) {
+        throw captureError(snapshot.path, "include graph changed during capture");
+      }
+    },
+  };
+}
+
+async function readCapturedConfig(file: CapturedConfigFile): Promise<Buffer> {
+  try {
+    const handle = await fs.open(file.sourcePath, "r");
+    try {
+      const stat = await handle.stat();
+      if (
+        !stat.isFile() ||
+        stat.dev !== file.dev ||
+        stat.ino !== file.ino ||
+        (await fs.realpath(file.sourcePath)) !== file.canonicalPath ||
+        !(await fs.lstat(file.sourcePath)).isFile()
+      ) {
+        throw new Error("file identity changed");
+      }
+      const bytes = await handle.readFile();
+      const raw = bytes.toString("utf8");
+      if (!bytes.equals(Buffer.from(raw)) || hashConfigIncludeRaw(raw) !== file.hash) {
+        throw new Error("file contents changed");
+      }
+      const current = await fs.lstat(file.sourcePath);
+      if (
+        !current.isFile() ||
+        current.dev !== file.dev ||
+        current.ino !== file.ino ||
+        (await fs.realpath(file.sourcePath)) !== file.canonicalPath
+      ) {
+        throw new Error("file identity changed during read");
+      }
+      return bytes;
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    throw captureError(file.sourcePath, "source changed or became unreadable", error);
+  }
+}
+
+export async function stageBackupConfigCapture(
+  capture: BackupConfigCapture | undefined,
+  tempDir: string,
+): Promise<Map<string, string>> {
+  const remaps = new Map<string, string>();
+  for (const [index, file] of (capture?.files ?? []).entries()) {
+    const bytes = await readCapturedConfig(file);
+    const stagedPath = path.join(tempDir, `config-${index}`);
+    await fs.writeFile(stagedPath, bytes, { flag: "wx", mode: 0o600 });
+    remaps.set(stagedPath, file.canonicalPath);
+  }
+  await capture?.revalidate();
+  // Seal only after every dependency has been copied. Matching all authored
+  // bytes also pins the include edges; no second resolver or mixed retry.
+  for (const file of capture?.files ?? []) {
+    await readCapturedConfig(file);
+  }
+  return remaps;
+}

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -29,6 +29,7 @@ import {
   publishPreparedBackupArchive,
   type BackupArchivePublication,
 } from "./backup-archive-publication.js";
+import { stageBackupConfigCapture } from "./backup-config-capture.js";
 import {
   observeBackupTarEntryProgress,
   removePreparedBackupArchive,
@@ -531,14 +532,20 @@ export async function createBackupArchive(
   }
   const tempArchivePath = publication.tempArchivePath;
   try {
+    const configRemaps = await stageBackupConfigCapture(plan.configCapture, tempDir);
     const { legacyAuditSnapshots, stateSqliteBackup } = await createConsistentStateSnapshotPlan({
       inventory: plan.inventory,
       stateDir: stateAsset?.sourcePath,
       tempDir,
       onlyConfig,
     });
-    const sourcePathRemaps = new Map<string, string>();
-    const skippedStateSourcePaths = new Set<string>();
+    const sourcePathRemaps = new Map(configRemaps);
+    const skippedStateSourcePaths = new Set(configRemaps.values());
+    if (plan.configCapture?.files.length === 0) {
+      // A config created after sealing must not introduce an uncaptured graph.
+      skippedStateSourcePaths.add(path.resolve(plan.configPath));
+      skippedStateSourcePaths.add(await canonicalizePathForContainment(plan.configPath));
+    }
     for (const snapshot of stateSqliteBackup.snapshots) {
       sourcePathRemaps.set(path.resolve(snapshot.sourcePath), snapshot.archiveSourcePath);
       for (const skippedSourcePath of snapshot.skippedSourcePaths) {
@@ -694,6 +701,7 @@ export async function createBackupArchive(
               },
               [
                 manifestPath,
+                ...configRemaps.keys(),
                 ...stateSqliteBackup.snapshots.map((snapshot) => snapshot.sourcePath),
                 ...legacyAuditSnapshots.map((snapshot) => snapshot.sourcePath),
                 ...result.assets.map((asset) => asset.sourcePath),
@@ -704,11 +712,18 @@ export async function createBackupArchive(
           },
         });
         const unexpectedSqliteSourcePath = unexpectedSqliteSourcePaths[0];
-        const archiveValidationError = unexpectedSqliteSourcePath
+        let archiveValidationError = unexpectedSqliteSourcePath
           ? new Error(
               `SQLite state appeared after snapshot discovery: ${unexpectedSqliteSourcePath}. Retry backup so it can be snapshotted.`,
             )
           : archiveSymlinkViolation;
+        if (!archiveValidationError) {
+          try {
+            await plan.configCapture?.assertRootAlias?.();
+          } catch (error) {
+            archiveValidationError = error instanceof Error ? error : new Error(String(error));
+          }
+        }
         if (archiveValidationError) {
           if (!removePreparedBackupArchive(prepared)) {
             publication.pendingCleanupArchives.push(prepared);


### PR DESCRIPTION
Closes #143678

## What Problem This Solves

Fixes an issue where a full backup could create, verify, and restore an archive that omitted required `$include` files when config lived outside the state directory. Verification cannot detect inputs missing from the producer's inventory.

## Why This Change Was Made

Full backups discover dependencies through the existing config snapshot, pin authored bytes in private capture files, and reuse archive inventory/remapping and publication. Incomplete, changing, or unrepresentable graphs refuse capture.

Include completeness uses the reader's existing completed provenance, not schema validity. Readable modular configs with unrelated schema errors still support `--no-include-workspace`, with existing unresolved-ownership diagnostics and no invalid workspace discovery. This corrects the reproduced P1 from PR review.

The export/refusal decision was explicitly accepted and [recorded before implementation](https://github.com/openclaw/openclaw/issues/143678). No manifest schema, config option, store, retention policy, sanitizer, or live recovery behavior changes. This is not migration rollback and is independent of #143657.

## User Impact

Full archives preserve required config dependencies, including files outside state or inside an excluded workspace. Those files can contain sensitive data. Comments and environment placeholders remain authored; resolved secrets are not serialized. `--only-config` stays root-file-only.

Config capture is not one atomic snapshot with the databases. Later writes stay live; nothing is automatically restored or replayed. The already-approved refusal tradeoff is retained, not reopened for approval.

## Evidence

Verified head: `fa01d8a0c1b2488e3a7259dd98060f4c276f6221`.

- Unmodified main `41aec3ca92bc9934b43976db3b38dadd56211806` reproduced missing external nested dependencies; the in-state control passed. Original red receipts are retained.
- Real create → verify → fresh restore covers raw nested dependencies with originals unavailable, overlapping inventory, workspace/root-only options, incomplete/alias refusal, content/identity/authority changes, later config/WAL writes, and staging ENOSPC. The schema-invalid recovery case retains authored files and ordinary state, preserves the validation error, and reports unresolved ownership.
- **251 focused tests passed** on corrected source: 19 capture, 19 backup-command, 213 config-reader/writer cases. The earlier 208-test backup-owner run also covers unchanged publication/no-clobber, corruption/cleanup, WAL and external-agent paths. Full corrected-source `check:changed` and commit-hook formatting passed.
- **[Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34442356374):** 112 successful jobs, 16 skipped. Retained Linux logs show all 19 capture cases passing.
- **Native Windows/Node 24.19.0:** 42 passed, 6 existing platform skips across capture, Windows stream and archive-publication suites; all 19 capture cases passed. Local execution was macOS/Node 24.20.0. An earlier broader Windows run failed on old raw SQLite-path and Unix-mode fixture assertions; both failure classes reproduced on unchanged main and remain outside this fix. Those failures are not reported as green.
- Exact-head synthetic source-runtime proof preserved committed WAL rows in shared state and two agent databases, including an external root. Preflight returned `exact` for all three. Integrity-valid blocking schema drift returned `incompatible`; a sibling WAL returned `indeterminate`; a truncated archive was refused. No live state, Gateway, old VM, or installed-package recovery was used. Archive integrity is not migration-recovery proof.
- Independent findings were reproduced and corrected. ClawSweeper revision 3 on this exact head confirms the recovery blocker is resolved and reports no actionable patch or security findings. Its remaining merge-risk banner names the refusal behavior already accepted in #143678; this is not merge approval.

Six files, **+649/-17 = 666 changed lines** (260 production, 401 tests/support, 5 docs). The verified recovery correction accounts for the small excess over the initial 400–650-line estimate. No merge requested.
