### PR TITLE
fix(models): reuse prepared stores when discovery is skipped

### DIFF
--- a/src/agents/embedded-agent-runner/model.generation-scope.test.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test.ts
@@ -241,45 +241,85 @@ describe("model runtime generation scope", () => {
     { auth: true, registry: false },
     { auth: false, registry: true },
     { auth: false, registry: false },
-  ])("fills only missing discovery stores (auth=$auth, registry=$registry)", async (supplied) => {
-    const generation = createModelGenerationFixture({
-      agentDir: state.agentDir(),
-      workspaceDir: state.workspaceDir,
-      config: {},
-      label: "stores",
-    });
-    const { preparedModelRuntime } = generation;
-    const stores = preparedModelRuntime.createStores();
-    stores.authStorage.setRuntimeApiKey(generation.provider, "fixture-runtime-key");
-    const preparedStores = vi.spyOn(preparedModelRuntime, "createStores");
-    const emptyAuth = vi.spyOn(AuthStorage, "inMemory");
-    const emptyRegistry = vi.spyOn(ModelRegistry, "inMemory");
+  ])(
+    "fills missing stores from the prepared runtime (auth=$auth, registry=$registry)",
+    async (supplied) => {
+      const provider = "generation-stores";
+      const modelId = "literal-store-model";
+      const createStores = (label: string) => {
+        const authStorage = AuthStorage.inMemory({});
+        authStorage.setRuntimeApiKey(provider, `fixture-${label}-key`);
+        const modelRegistry = ModelRegistry.inMemory(authStorage);
+        modelRegistry.registerProvider(provider, {
+          api: "openai-completions",
+          baseUrl: "https://stores.example.test/v1",
+          models: [
+            {
+              id: modelId,
+              name: label,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 32_768,
+              maxTokens: 4_096,
+            },
+          ],
+        });
+        return { authStorage, modelRegistry };
+      };
+      const preparedStores = createStores("prepared");
+      const callerStores = createStores("caller");
+      const generation = createModelGenerationFixture({
+        agentDir: state.agentDir(),
+        workspaceDir: state.workspaceDir,
+        config: {},
+        label: "stores",
+        provider,
+        requestProvider: provider,
+        modelId,
+        createStores: () => preparedStores,
+      });
+      const { preparedModelRuntime } = generation;
 
-    const result = await resolveModelAsync(
-      generation.provider,
-      generation.modelId,
-      preparedModelRuntime.agentDir,
-      preparedModelRuntime.config,
-      {
-        ...(supplied.auth ? { authStorage: stores.authStorage } : {}),
-        ...(supplied.registry ? { modelRegistry: stores.modelRegistry } : {}),
-        preparedModelRuntime,
-        skipAgentDiscovery: true,
-        workspaceDir: preparedModelRuntime.workspaceDir,
-      },
-    );
+      const result = await resolveModelAsync(
+        provider,
+        modelId,
+        preparedModelRuntime.agentDir,
+        preparedModelRuntime.config,
+        {
+          ...(supplied.auth ? { authStorage: callerStores.authStorage } : {}),
+          ...(supplied.registry ? { modelRegistry: callerStores.modelRegistry } : {}),
+          preparedModelRuntime,
+          skipAgentDiscovery: true,
+          workspaceDir: preparedModelRuntime.workspaceDir,
+        },
+      );
 
-    expect(preparedStores).not.toHaveBeenCalled();
-    const allocations = supplied.auth && supplied.registry ? 0 : 1;
-    expect(emptyAuth).toHaveBeenCalledTimes(allocations);
-    expect(emptyRegistry).toHaveBeenCalledTimes(allocations);
-    expect(result.authStorage === stores.authStorage).toBe(supplied.auth);
-    expect(result.modelRegistry === stores.modelRegistry).toBe(supplied.registry);
-    const model = expectDefined(result.model, "resolved fixture model");
-    expect(await result.modelRegistry.getApiKeyAndHeaders(model)).toMatchObject({
-      apiKey: supplied.auth || supplied.registry ? "fixture-runtime-key" : undefined,
-    });
-  });
+      if (supplied.auth) {
+        expect(result.authStorage).toBe(callerStores.authStorage);
+      }
+      if (supplied.registry) {
+        expect(result.modelRegistry).toBe(callerStores.modelRegistry);
+      }
+      const model = expectDefined(result.model, "resolved fixture model");
+      expect(model).toMatchObject({
+        provider,
+        id: modelId,
+        name: supplied.registry ? "caller" : "prepared",
+        contextWindow: 32_768,
+        maxTokens: 4_096,
+      });
+      expect(await result.authStorage.getApiKey(provider)).toBe(
+        supplied.auth ? "fixture-caller-key" : "fixture-prepared-key",
+      );
+      expect(await result.modelRegistry.getApiKeyAndHeaders(model)).toMatchObject({
+        apiKey: supplied.auth || supplied.registry ? "fixture-caller-key" : "fixture-prepared-key",
+      });
+      expect(await preparedStores.modelRegistry.getApiKeyAndHeaders(model)).toMatchObject({
+        apiKey: "fixture-prepared-key",
+      });
+    },
+  );
 
   it("keeps alias, suppression, static metadata, and runtime hooks on the prepared generation", async () => {
     const config = {} satisfies OpenClawConfig;

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -289,7 +289,11 @@ import { getModelProviderRequestTransport } from "../provider-request-config.js"
 import { applyConfiguredProviderOverrides } from "./model.configured-overrides.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
-import { resolveModelAsync, resolveModelWithRegistry } from "./model.js";
+import {
+  createEmptyAgentDiscoveryStores,
+  resolveModelAsync,
+  resolveModelWithRegistry,
+} from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
   makeOpenClawConfigFixture,
@@ -1262,7 +1266,7 @@ describe("resolveModel", () => {
       modelCatalog: { entries: [], routeVariants: [] },
       configuredRuntimeModels: [],
       inlineProviderModels: [],
-      createStores: () => ({ authStorage: {} as never, modelRegistry: {} as never }),
+      createStores: createEmptyAgentDiscoveryStores,
     } satisfies PreparedModelRuntimeSnapshot;
     resolveBundledProviderStaticCatalogModelMock.mockResolvedValueOnce({
       provider: "google",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -117,13 +117,9 @@ export async function resolveModelAsync(
     options?.agentId,
   );
   const explicitPreparedRuntime = options?.preparedModelRuntime;
-  const emptyDiscoveryStores =
-    options?.skipAgentDiscovery && (!options.authStorage || !options.modelRegistry)
-      ? createEmptyAgentDiscoveryStores()
-      : undefined;
   const needsPreparedSnapshot =
     !explicitPreparedRuntime &&
-    !emptyDiscoveryStores &&
+    !options?.skipAgentDiscovery &&
     (!options?.authStorage || !options?.modelRegistry);
   const publishedSnapshot = needsPreparedSnapshot
     ? resolvePreparedAgentSnapshot(
@@ -153,10 +149,7 @@ export async function resolveModelAsync(
     const normalizedRef = normalizeProviderModelRef({ provider, modelId, cfg, workspaceDir });
     let { authStorage, modelRegistry } = options ?? {};
     if (!authStorage || !modelRegistry) {
-      const stores =
-        emptyDiscoveryStores ??
-        preparedModelRuntime?.createStores() ??
-        createEmptyAgentDiscoveryStores();
+      const stores = preparedModelRuntime?.createStores() ?? createEmptyAgentDiscoveryStores();
       authStorage ??= stores.authStorage;
       modelRegistry ??= options?.authStorage
         ? stores.modelRegistry.fork(authStorage)


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where a model operation that already has a prepared runtime loses its captured model limits and credentials when it skips agent discovery.

## Why This Change Was Made

Use the supplied runtime to fill missing model/auth stores before creating empty stores. Explicit caller stores still take precedence; skipping discovery still avoids discovering another agent. The repair removes the early empty-store allocation and seven production lines.

## User Impact

Prepared model operations retain the model capabilities and authentication they were given, including when only one store is supplied explicitly.

## Evidence

The baseline failed three intended regression cases: captured context/output limits became defaults, and a captured auth key was missing. All 177 focused cases now pass, including the supplied-store combinations and relevant runtime-hook/compaction paths. The tests also verify the caller overrides do not mutate the prepared registry's auth.

Independent P2 review and the complete changed-file gate passed. One fresh full build passed at `d0342de5a4ae888f103561716594f160a3a4cd07`; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34438264753) is green.

The compiled runtime completed a loopback HTTP request using the prepared synthetic credential and retained the captured model name and 32K context limit; source regressions also verify the 4K output limit. Caller-auth/prepared-registry, caller-registry/prepared-auth, and no-snapshot/no-discovery controls passed. The import guard recorded 2,866 compiled imports and no checkout-source imports. All jobs joined, the server closed, and isolated state was removed. This is runtime boundary proof using synthetic HTTP, not an external-provider claim.

An initial external harness lookup missed the build's emitted `.mjs` chunks and stopped before any request. The harness was corrected, with source and build unchanged; that attempt remains recorded.
