### PR TITLE
test(agent): follow direct CLI transport cleanup

### DIFF
--- a/src/commands/agent-exec-plugin.e2e.test.ts
+++ b/src/commands/agent-exec-plugin.e2e.test.ts
@@ -170,7 +170,7 @@ function buildCliSource(args: string[]): string {
 
 describe("agent exec built runtime", () => {
   it.skipIf(process.platform === "win32")(
-    "reclaims authentication-probe descendants when the CLI run times out",
+    "reclaims CLI transport descendants when the run times out",
     async () => {
       const root = tempDirs.make("openclaw-agent-exec-auth-timeout-");
       const binDir = path.join(root, "bin");
@@ -254,7 +254,7 @@ if (process.argv[2] === "--version") {
         expect(result.status, result.stderr).toBe(2);
         expect(JSON.parse(result.stdout)).toMatchObject({ ok: false, status: "timeout" });
         const receipts = await readProcesses();
-        expect(receipts.map(({ phase }) => phase)).toContain("auth");
+        expect(receipts.map(({ phase }) => phase)).toContain("agent");
         await Promise.all(
           receipts.flatMap(({ pids }) => pids.map((pid) => waitForDead(pid, 5_000))),
         );


### PR DESCRIPTION
## Summary
- align the cleanup E2E with the direct Claude CLI transport introduced after the test
- continue proving timeout cleanup kills the transport and its descendant process

## Validation
- focused agent exec E2E passes (1/1 selected)
- oxfmt and oxlint pass