### PR TITLE
refactor: reuse shared sidebar storage test fixtures

### DIFF
--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   loadStoredCollapsedSessionSections,
   loadStoredHiddenSessionCatalogIds,
@@ -18,20 +19,6 @@ import {
 // getSafeLocalStorage only accepts an own value property under Vitest, so the
 // jsdom getter-backed localStorage must be replaced with a plain mock.
 let originalLocalStorage: PropertyDescriptor | undefined;
-
-function createStorageMock(): Storage {
-  const values = new Map<string, string>();
-  return {
-    get length() {
-      return values.size;
-    },
-    clear: () => values.clear(),
-    getItem: (key: string) => values.get(key) ?? null,
-    key: (index: number) => [...values.keys()][index] ?? null,
-    removeItem: (key: string) => void values.delete(key),
-    setItem: (key: string, value: string) => void values.set(key, value),
-  };
-}
 
 beforeEach(() => {
   originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");

--- a/ui/src/components/session-owner-filter-controller.test.ts
+++ b/ui/src/components/session-owner-filter-controller.test.ts
@@ -2,6 +2,7 @@
 
 import type { ReactiveController } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   loadStoredSidebarSessionOwnerFilter,
   storeSidebarSessionOwnerFilter,
@@ -11,15 +12,10 @@ import { SessionOwnerFilterController } from "./session-owner-filter-controller.
 let originalLocalStorage: PropertyDescriptor | undefined;
 
 beforeEach(() => {
-  const values = new Map<string, string>();
   originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
-    value: {
-      getItem: (key: string) => values.get(key) ?? null,
-      removeItem: (key: string) => void values.delete(key),
-      setItem: (key: string, value: string) => void values.set(key, value),
-    },
+    value: createStorageMock(),
   });
 });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Two sidebar test suites duplicated map-backed local-storage fixtures that already exist in the shared UI test helpers. Maintaining separate copies added scaffolding without distinct behavior coverage.

## Why This Change Was Made

Use the existing `createStorageMock` factory in both suites. Each test still receives fresh storage, and the original global property descriptor is still restored afterward. Preference defaults, gateway/user isolation, unavailable-storage handling and pending owner-filter refresh assertions remain unchanged.

## User Impact

No user-visible behavior change. Production code and storage behavior are unchanged; the two test files lose 17 lines net.

## Evidence

Original and candidate runs both passed all 14 cases with identical case/status inventories, retaining all 35 assertions. All 18 normal local changed checks passed. Independent Codex review was clean through P2.

Proof uses the existing memory-backed storage fixtures and test runner; it does not claim live-browser or native Storage validation.
