### PR TITLE
fix(agents): land forced block-chunk breaks on real boundaries

### DIFF
--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -447,4 +447,90 @@ describe("EmbeddedBlockChunker", () => {
       expect(chunks.every((chunk) => chunk.trimEnd() !== `${marker}\n${marker}`)).toBe(true);
     },
   );
+
+  it.each([1, 3, 10])(
+    "waits for maxChars before a forced paragraph break so the cut lands on a line boundary (delta %i)",
+    (delta) => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 800,
+        maxChars: 1200,
+        breakPreference: "paragraph",
+        flushOnParagraph: false,
+      });
+      const bullets =
+        "Here is a summary of the proposed changes to the schema.\n\n" +
+        Array.from(
+          { length: 40 },
+          (_, i) => `- Item ${i}: the field must be set to a verified value\n`,
+        ).join("");
+
+      const chunks: string[] = [];
+      for (let i = 0; i < bullets.length; i += delta) {
+        chunker.append(bullets.slice(i, i + delta));
+        chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+      }
+      chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+      expect(chunks.length).toBeGreaterThan(1);
+      // The drain that crosses minChars holds only a few characters past it,
+      // so the cut must wait for real boundaries instead of scanning the
+      // whitespace inside the current sentence.
+      expect(chunks[0].length).toBeGreaterThanOrEqual(800);
+      expect(bullets.charAt(chunks[0].length)).toBe("\n");
+    },
+  );
+
+  it.each([1, 50])(
+    "closes and reopens a still-streaming fence cut exactly at the buffer boundary (delta %i)",
+    (delta) => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 800,
+        maxChars: 1200,
+        breakPreference: "paragraph",
+        flushOnParagraph: false,
+      });
+      const code =
+        "Intro paragraph before the block.\n\n```ts\n" +
+        "const x = compute(1);\n".repeat(120) +
+        "```\n\nTrailing text.\n";
+
+      const chunks: string[] = [];
+      for (let i = 0; i < code.length; i += delta) {
+        chunker.append(code.slice(i, i + delta));
+        chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+      }
+      chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+      expect(chunks.length).toBeGreaterThan(1);
+      // An unterminated fence's span ends at the buffer boundary, so the cut
+      // at that boundary must carry the synthetic close/reopen pair instead of
+      // emitting an odd number of fence markers.
+      for (const chunk of chunks) {
+        expect((chunk.match(/```/g) ?? []).length % 2).toBe(0);
+      }
+    },
+  );
+
+  it("cuts cleanly after a balanced fence that ends exactly at the source boundary", () => {
+    // The closing marker is the buffer's final bytes, so the fence span ends
+    // exactly at the cut; probing inside that span must still recognize the
+    // balanced fence and emit it without a synthetic close/reopen pair.
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 100,
+      maxChars: 200,
+      breakPreference: "paragraph",
+    });
+    const body = "const x = 1;\n".repeat(14);
+    const text = `Intro.\n\n\`\`\`ts\n${body}\n\`\`\``;
+    expect(text.length).toBe(200);
+
+    const chunks: string[] = [];
+    for (let i = 0; i < text.length; i += 1) {
+      chunker.append(text.slice(i, i + 1));
+      chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+    }
+    chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+    expect(chunks).toEqual([text]);
+  });
 });

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -486,7 +486,11 @@ export class EmbeddedBlockChunker {
       }
     }
 
-    if (preference === "newline" && buffer.length < maxChars) {
+    // Only reachable once paragraph, newline, and sentence boundaries have all
+    // failed. More buffered text can only add candidates, so every preference
+    // benefits from waiting until maxChars instead of falling through to the
+    // whitespace scan and cutting mid-sentence.
+    if (buffer.length < maxChars) {
       return { index: -1 };
     }
 
@@ -503,36 +507,43 @@ export class EmbeddedBlockChunker {
         0,
         Math.max(maxChars, firstCodePointWidth),
       ).length;
-      if (isSafeFenceBreak(fenceSpans, offset + forcedBreakIndex)) {
+      // A cut at the end of the source lands exactly on a still-streaming
+      // fence's span.end, which the exclusive fence lookup treats as outside
+      // the fence; probe the last included character there instead. A span
+      // whose final line is a genuine closing marker is already balanced, so
+      // cutting after it needs no synthetic close/reopen pair.
+      const atSourceEnd = forcedBreakIndex >= buffer.length;
+      const fenceProbe = atSourceEnd ? forcedBreakIndex - 1 : forcedBreakIndex;
+      const fence = findFenceSpanAt(fenceSpans, offset + fenceProbe);
+      if (!fence) {
         return { index: forcedBreakIndex };
       }
-      const fence = findFenceSpanAt(fenceSpans, offset + forcedBreakIndex);
-      if (fence) {
-        const reopenFenceLine = resolveFenceReopenLine(fence, chunking.maxChars);
-        if (!reopenFenceLine) {
-          return { index: forcedBreakIndex };
-        }
-        // Synthetic fence wrappers consume the same transport budget as source
-        // text; reserving them here keeps every emitted payload deliverable.
-        const closeFenceLine = `${fence.indent}${fence.marker}`;
-        const fenceBreakIndex = sliceUtf16Safe(
-          buffer,
-          0,
-          Math.max(1, maxChars - closeFenceLine.length - 1),
-        ).length;
-        if (fenceBreakIndex <= 0) {
-          return { index: forcedBreakIndex };
-        }
-        const closeFenceStart = findFenceCloseLineStart(buffer, fence, offset);
-        return {
-          index:
-            closeFenceStart >= minChars && closeFenceStart <= fenceBreakIndex
-              ? closeFenceStart
-              : fenceBreakIndex,
-          fenceSplit: { closeFenceLine, reopenFenceLine, fence },
-        };
+      if (atSourceEnd && findFenceCloseLineStart(buffer, fence, offset) !== -1) {
+        return { index: forcedBreakIndex };
       }
-      return { index: forcedBreakIndex };
+      const reopenFenceLine = resolveFenceReopenLine(fence, chunking.maxChars);
+      if (!reopenFenceLine) {
+        return { index: forcedBreakIndex };
+      }
+      // Synthetic fence wrappers consume the same transport budget as source
+      // text; reserving them here keeps every emitted payload deliverable.
+      const closeFenceLine = `${fence.indent}${fence.marker}`;
+      const fenceBreakIndex = sliceUtf16Safe(
+        buffer,
+        0,
+        Math.max(1, maxChars - closeFenceLine.length - 1),
+      ).length;
+      if (fenceBreakIndex <= 0) {
+        return { index: forcedBreakIndex };
+      }
+      const closeFenceStart = findFenceCloseLineStart(buffer, fence, offset);
+      return {
+        index:
+          closeFenceStart >= minChars && closeFenceStart <= fenceBreakIndex
+            ? closeFenceStart
+            : fenceBreakIndex,
+        fenceSplit: { closeFenceLine, reopenFenceLine, fence },
+      };
     }
 
     return { index: -1 };


### PR DESCRIPTION
Fixes #143641.

## What Problem This Solves

`EmbeddedBlockChunker` corrupted streamed block replies in two independent ways, both reproduced on `main` (`15a781e3df2`'s parent `92888bf9fdc`):

1. **Mid-sentence forced cuts.** The drain that crosses `minChars` holds only a few characters past it, so paragraph/newline/sentence boundary searches at index ≥ `minChars` cannot succeed yet. The defer guard that waits for real boundaries was scoped to `breakPreference: "newline"` only; every other preference fell through to the whitespace scan and cut at whatever whitespace was already buffered. The cut was delta-dependent, which made the bug look intermittent.
2. **Unbalanced fences at the buffer boundary.** A still-streaming fence has no closing marker, so its span ends at the buffer end. The forced-break path probed the cut directly, and the exclusive fence lookup (`span.start < index < span.end`) reported a cut at `span.end` as outside the fence. `isSafeFenceBreak` returned true, the close/reopen path was skipped, and the chunk was emitted with an odd number of ``` markers.

## Solution

`#pickBreakIndex`, two changes:

1. The defer guard now applies to **every** preference. It is only reachable once paragraph, newline, and sentence searches have all failed; more buffered text can only add candidates, and the whitespace fallback plus `maxChars` clamp still run once the buffer reaches `maxChars`. Force drains are unaffected (they reach this helper only when `remainingLength > maxChars`).
2. When the forced cut lands at the end of the source, the fence lookup probes the **last included character** instead of the exclusive boundary. A span whose final line is a genuine closing marker (checked with the existing `findFenceCloseLineStart`) is still recognized as balanced, so a fence that ends exactly at the cut is emitted as-is without a synthetic close/reopen pair.

## Why not the issue's suggested diff verbatim

The issue proposes probing `maxChars - 1` whenever `maxChars === buffer.length`. That variant also treats a **balanced fence whose closing marker is the buffer's final bytes** as still-streaming and wraps it in a synthetic close/reopen pair, so the balanced fence is emitted twice-closed and the content after it is pulled into the reopened code block. The added test `cuts cleanly after a balanced fence that ends exactly at the source boundary` is red under that variant and green under this patch.

## Evidence

All runs against this head (`15a781e3df2`), pre-fix runs against the same source before the two `#pickBreakIndex` hunks:

- **Pre-fix red (defect 1):** `waits for maxChars before a forced paragraph break so the cut lands on a line boundary (delta 1/3/10)` — failed with the first chunk ending mid-line (`bullets.charAt(firstChunk.length)` was `" "`, not `"\n"`).
- **Pre-fix red (defect 2):** `closes and reopens a still-streaming fence cut exactly at the buffer boundary (delta 1/50)` — failed with chunks carrying an odd ``` count.
- **Boundary guard red under the issue's variant:** `cuts cleanly after a balanced fence that ends exactly at the source boundary` — passes on `main` (43-test baseline), stays green with this patch, fails with the `maxChars - 1` probe alone.
- **Post-fix:** `embedded-agent-block-chunker.test.ts` 49/49 (43 pre-existing unchanged), `packages/markdown-core` 27 files / 382 tests, chunking-adjacent `embedded-agent-subscribe.code-span-awareness` + `block-reply-rejections` suites.
- `tsgo -p tsconfig.core.json --noEmit` exit 0; `oxlint --type-aware` and `oxfmt --check` clean on both changed files.

## Impact

Streamed embedded-agent replies (block reply chunking is user-configurable per channel via `blockReplyChunking`, default `breakPreference: "paragraph"`) no longer split mid-sentence and no longer publish broken markdown when a forced chunk boundary lands on a streaming code fence. Non-streaming and force-flush output is unchanged apart from the two repaired cut positions.
