### PR TITLE
fix: wait for updater process-group cleanup in tests

### DIFF
--- a/src/cli/update-cli/update-command-executor.test.ts
+++ b/src/cli/update-cli/update-command-executor.test.ts
@@ -544,7 +544,10 @@ describe("candidate executor delegation", () => {
       );
     } finally {
       process.kill(pid, "SIGTERM");
-      await waitForPidToExit(pid);
+      await vi.waitFor(() => expect(isChildProcessTreeAlive({ pid })).toBe(false), {
+        timeout: 2_000,
+        interval: 25,
+      });
     }
     const store = createManagedHandoffLeaseStore();
     const acquired = store.acquire(root, "new", { kind: "update" });

--- a/src/cli/update-cli/update-command-executor.test.ts
+++ b/src/cli/update-cli/update-command-executor.test.ts
@@ -4,7 +4,7 @@ import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { resolveServiceManagerEnv } from "../../daemon/service-process-env.js";
@@ -14,6 +14,7 @@ import { createManagedHandoffLeaseStore } from "../../infra/update-managed-servi
 import { MANAGED_HANDOFF_RUNTIME_ENTRY } from "../../infra/update-managed-service-handoff-runtime-assets.js";
 import { stageManagedHandoffRuntime } from "../../infra/update-managed-service-handoff-runtime.js";
 import type { UpdateRecoveryFence } from "../../infra/update-run-recovery.js";
+import { isChildProcessTreeAlive } from "../../process/child-process-tree.js";
 import { runUtf8CommandWithTimeout } from "../../process/exec.js";
 import { waitForPidToExit } from "../../test-utils/process-tree.js";
 import {
@@ -492,7 +493,13 @@ describe("candidate executor delegation", () => {
         expect(store.acquire(root, "new", { kind: "update" }).kind).toBe("busy");
       } finally {
         process.kill(descendant, "SIGTERM");
-        await waitForPidToExit(descendant);
+        const candidate = store.read(root + "/.openclaw-update-child-group");
+        assert(candidate.kind === "current", "Candidate group lease is missing");
+        // A Linux zombie has exited but retains its process group until reaped.
+        await vi.waitFor(
+          () => expect(isChildProcessTreeAlive(candidate.lease.executor)).toBe(false),
+          { timeout: 2_000, interval: 25 },
+        );
       }
       const next = store.acquire(root, "new", { kind: "update" });
       expect(next.kind).toBe("acquired");


### PR DESCRIPTION
Related: #143658, #140339

## What Problem This Solves

Fixes an intermittent updater test failure where lease acquisition still returned busy immediately after the test terminated its orphaned descendant.

## Why This Change Was Made

Both affected tests now wait for the candidate process group to disappear before their existing acquisition assertions. A single-thread Linux zombie has exited, but still retains its process group until reaped. The cleanup budget remains two seconds with the same polling interval.

## User Impact

No production behavior changes. The test observes the same process-group boundary that the installation lease already enforces.

## Evidence

A controlled Linux parent delayed reaping its own orphan zombie for 250 ms. The original test failed with a busy lease; the corrected group wait passed after reaping, within the existing deadline. Owned descendants were joined and the Testbox was stopped.

All 28 updater/reaper tests passed on Blacksmith Testbox and locally. Final assertion spelling and the adjacent group-leader case passed the same 28 tests locally. The Linux delayed-reap proof establishes the shared whole-group lifetime invariant. Required test types, lint, dead-export checks, and independent Codex review passed. The change is one test file, with no product code or timeout changes.
