### PR TITLE
fix(models): prefer exact-case provider inference

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -305,7 +305,8 @@ Without a scope flag, selections change only the current session. `agents.defaul
 - A user-selected `/model` ref is strict for that session: if it becomes unreachable, the reply fails visibly instead of silently falling back through `agents.defaults.model.fallbacks`. Configured defaults and cron job primaries still use fallback chains.
 - `/model status` is the detailed view: auth candidates per provider, and (when configured) the provider endpoint `baseUrl` plus `api` mode.
 - Model refs are parsed by splitting on the first `/`; type `provider/model`. If the model ID itself contains `/` (OpenRouter-style), include the provider prefix, e.g. `/model openrouter/moonshotai/kimi-k2`. If you omit the provider, OpenClaw tries: (1) alias match, (2) unique configured-provider match for that exact unprefixed model id, (3) the configured default provider (deprecated fallback) — and if that provider no longer exposes the configured default model, the first configured provider/model instead, to avoid surfacing a stale removed-provider default.
-- Model refs are normalized to lowercase; provider IDs are otherwise exact, so use the ID advertised by the plugin.
+- When inferring a provider, exact model ID case takes precedence over case-insensitive matches within the same configuration scope. A case-insensitive match is used only when it identifies one provider. Per-agent model entries take precedence over global entries and configured provider catalogs.
+- Provider IDs are normalized to lowercase; model IDs follow the provider's normalization rules. Use the spelling advertised by the plugin.
 
 Full command behavior and config: [Slash commands](/tools/slash-commands).
 

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -273,6 +273,30 @@ function mergeModelCatalogEntries(params: {
   return merged;
 }
 
+/** One scope ranks exact IDs ahead of folded matches; ambiguity remains a match. */
+function createModelProviderMatcher(raw: string) {
+  const model = raw.trim();
+  const foldedModel = normalizeLowercaseStringOrEmpty(model);
+  const exact = new Set<string>();
+  const folded = new Set<string>();
+  return {
+    add(provider: string, ...ids: string[]) {
+      const providerId = normalizeProviderId(provider);
+      if (!model || !providerId) {
+        return;
+      }
+      if (ids.some((id) => id.trim() === model)) {
+        exact.add(providerId);
+      } else if (ids.some((id) => normalizeLowercaseStringOrEmpty(id) === foldedModel)) {
+        folded.add(providerId);
+      }
+    },
+    get matches() {
+      return exact.size > 0 ? exact : folded;
+    },
+  };
+}
+
 /** Infer a unique provider for a bare model from configured model rows. */
 export function inferUniqueProviderFromConfiguredModels(
   params: {
@@ -282,16 +306,14 @@ export function inferUniqueProviderFromConfiguredModels(
     allowManifestNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): string | undefined {
-  const model = params.model.trim();
-  if (!model) {
+  if (!params.model.trim()) {
     return undefined;
   }
-  const normalized = normalizeLowercaseStringOrEmpty(model);
   const collectModelMapProviders = (models: Record<string, unknown> | undefined) => {
-    const providers = new Set<string>();
+    const matcher = createModelProviderMatcher(params.model);
     for (const key of Object.keys(models ?? {})) {
       const ref = key.trim();
-      if (!ref || !ref.includes("/") || ref.endsWith("/*")) {
+      if (!ref.includes("/") || ref.endsWith("/*")) {
         continue;
       }
       const parsed = parseModelRef(ref, DEFAULT_PROVIDER, {
@@ -299,65 +321,38 @@ export function inferUniqueProviderFromConfiguredModels(
         allowPluginNormalization: false,
         manifestPlugins: params.manifestPlugins,
       });
-      if (
-        parsed &&
-        (parsed.model === model || normalizeLowercaseStringOrEmpty(parsed.model) === normalized)
-      ) {
-        providers.add(normalizeProviderId(parsed.provider));
+      if (parsed) {
+        matcher.add(parsed.provider, parsed.model);
       }
     }
-    return providers;
+    return matcher;
   };
-  const agentProviders = params.agentId
-    ? collectModelMapProviders(resolveAgentConfig(params.cfg, params.agentId)?.models)
-    : new Set<string>();
-  if (agentProviders.size > 0) {
-    return agentProviders.size === 1 ? agentProviders.values().next().value : undefined;
-  }
-
-  const providers = collectModelMapProviders(params.cfg.agents?.defaults?.models);
-  const addProvider = (provider: string) => {
-    const normalizedProvider = normalizeProviderId(provider);
-    if (!normalizedProvider) {
-      return;
+  if (params.agentId) {
+    const { matches } = collectModelMapProviders(
+      resolveAgentConfig(params.cfg, params.agentId)?.models,
+    );
+    if (matches.size > 0) {
+      return matches.size === 1 ? matches.values().next().value : undefined;
     }
-    providers.add(normalizedProvider);
-  };
-  const configuredProviders = params.cfg.models?.providers;
-  if (configuredProviders) {
-    const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({
-      allowManifestNormalization: params.allowManifestNormalization,
-      manifestPlugins: params.manifestPlugins,
-    });
-    for (const [providerId, providerConfig] of Object.entries(configuredProviders)) {
-      const models = providerConfig?.models;
-      if (!Array.isArray(models)) {
-        continue;
-      }
-      for (const entry of models) {
-        const modelId = entry?.id?.trim();
-        if (!modelId) {
-          continue;
-        }
-        const normalizedModelId = normalizeModelId(providerId, modelId);
-        if (
-          modelId === model ||
-          normalizeLowercaseStringOrEmpty(modelId) === normalized ||
-          normalizedModelId === model ||
-          normalizeLowercaseStringOrEmpty(normalizedModelId) === normalized
-        ) {
-          addProvider(providerId);
-        }
-      }
-      if (providers.size > 1) {
-        return undefined;
+  }
+  const matcher = collectModelMapProviders(params.cfg.agents?.defaults?.models);
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({
+    allowManifestNormalization: params.allowManifestNormalization,
+    manifestPlugins: params.manifestPlugins,
+  });
+  for (const [providerId, providerConfig] of Object.entries(params.cfg.models?.providers ?? {})) {
+    if (!Array.isArray(providerConfig?.models)) {
+      continue;
+    }
+    for (const entry of providerConfig.models) {
+      const modelId = entry?.id?.trim();
+      if (modelId) {
+        matcher.add(providerId, modelId, normalizeModelId(providerId, modelId));
       }
     }
   }
-  if (providers.size !== 1) {
-    return undefined;
-  }
-  return providers.values().next().value;
+  const { matches } = matcher;
+  return matches.size === 1 ? matches.values().next().value : undefined;
 }
 
 /** Infer a unique provider for a bare model from a provider catalog. */
@@ -365,29 +360,12 @@ function inferUniqueProviderFromCatalog(params: {
   catalog: readonly ModelCatalogEntry[];
   model: string;
 }): string | undefined {
-  const model = params.model.trim();
-  if (!model) {
-    return undefined;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(model);
-  const providers = new Set<string>();
+  const matcher = createModelProviderMatcher(params.model);
   for (const entry of params.catalog) {
-    const entryId = entry.id.trim();
-    if (!entryId) {
-      continue;
-    }
-    if (entryId !== model && normalizeLowercaseStringOrEmpty(entryId) !== normalized) {
-      continue;
-    }
-    const provider = normalizeProviderId(entry.provider);
-    if (provider) {
-      providers.add(provider);
-    }
-    if (providers.size > 1) {
-      return undefined;
-    }
+    matcher.add(entry.provider, entry.id);
   }
-  return providers.size === 1 ? providers.values().next().value : undefined;
+  const { matches } = matcher;
+  return matches.size === 1 ? matches.values().next().value : undefined;
 }
 
 /** Resolve the provider used when a model string omits provider/id syntax. */

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -14,6 +14,7 @@ import {
   buildAllowedModelSet,
   buildConfiguredModelCatalog,
   inferUniqueProviderFromConfiguredModels,
+  resolveBareModelDefaultProvider,
   getModelRefStatus,
   parseModelRef,
   buildModelAliasIndex,
@@ -688,6 +689,12 @@ describe("model-selection", () => {
         expected: "anthropic",
       },
       {
+        name: "retains a unique case-insensitive configured match",
+        cfg: createProviderInferenceAllowlistConfig("custom/Model"),
+        model: "MODEL",
+        expected: "custom",
+      },
+      {
         name: "infers provider for slash-containing model id when allowlist match is unique",
         cfg: createProviderInferenceAllowlistConfig(
           "vercel-ai-gateway/anthropic/claude-sonnet-4-6",
@@ -751,23 +758,30 @@ describe("model-selection", () => {
       expect(inferUniqueProviderFromConfiguredModels({ cfg, model })).toBeUndefined();
     });
 
-    it("prefers a unique agent match over global and provider-config collisions", () => {
-      const cfg = {
-        agents: {
-          defaults: { models: { "openai/shared-model": {} } },
-          entries: {
-            worker: { models: { "anthropic/shared-model": {} } },
+    it.each(["shared-model", "SHARED-MODEL"])(
+      "prefers a unique agent match over global and provider-config collisions (%s)",
+      (agentModel) => {
+        const cfg = {
+          agents: {
+            defaults: { models: { "openai/shared-model": {} } },
+            entries: {
+              worker: { models: { [`anthropic/${agentModel}`]: {} } },
+            },
           },
-        },
-        models: {
-          providers: { minimax: { models: [{ id: "shared-model" }] } },
-        },
-      } as unknown as OpenClawConfig;
+          models: {
+            providers: { minimax: { models: [{ id: "shared-model" }] } },
+          },
+        } as unknown as OpenClawConfig;
 
-      expect(
-        inferUniqueProviderFromConfiguredModels({ cfg, agentId: "worker", model: "shared-model" }),
-      ).toBe("anthropic");
-    });
+        expect(
+          inferUniqueProviderFromConfiguredModels({
+            cfg,
+            agentId: "worker",
+            model: "shared-model",
+          }),
+        ).toBe("anthropic");
+      },
+    );
 
     it("keeps ambiguous agent matches unresolved without falling back globally", () => {
       const cfg = {
@@ -789,6 +803,48 @@ describe("model-selection", () => {
       ).toBeUndefined();
     });
   });
+
+  describe.each(["defaults", "agent", "configured catalog", "catalog"] as const)(
+    "bare provider inference from %s",
+    (scope) => {
+      it.each([false, true])(
+        "prefers exact case regardless of row order (reverse=%s)",
+        (reverse) => {
+          const rows = [
+            { provider: "first", id: "model", name: "model" },
+            { provider: "second", id: "MODEL", name: "MODEL" },
+            { provider: "third", id: "Model", name: "Model" },
+          ];
+          if (reverse) {
+            rows.reverse();
+          }
+          const models = Object.fromEntries(rows.map((row) => [`${row.provider}/${row.id}`, {}]));
+          const cfg: OpenClawConfig =
+            scope === "defaults"
+              ? { agents: { defaults: { models } } }
+              : scope === "agent"
+                ? { agents: { entries: { worker: { models } } } }
+                : scope === "configured catalog"
+                  ? createProviderInferenceCatalogConfig(
+                      Object.fromEntries(rows.map((row) => [row.provider, [row.id]])),
+                    )
+                  : {};
+          const resolve = (model: string) =>
+            resolveBareModelDefaultProvider({
+              cfg,
+              catalog: scope === "catalog" ? rows : [],
+              agentId: "worker",
+              model,
+              defaultProvider: "fallback",
+            });
+
+          expect(resolve(" Model ")).toBe("third");
+          expect(resolve("MODEL")).toBe("second");
+          expect(resolve("mOdEl")).toBe("fallback");
+        },
+      );
+    },
+  );
 
   describe("buildConfiguredModelCatalog", () => {
     it.each([


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where choosing a bare model ID is treated as ambiguous even when one provider has an exact match. A differently cased model on another provider could force a fallback, and an early ambiguity result could miss an exact row later in the catalog.

## Why This Change Was Made

Share an exact-first matcher between configured and discovered catalog inference. Within each existing precedence scope, use exact matches before case-insensitive matches and require a unique provider. Preserve the agent-specific scope and the existing unique case-insensitive fallback. The refactor removes 22 production lines.

## User Impact

A bare model selection consistently resolves to its exact matching provider regardless of row order. Ambiguous selections remain ambiguous.

## Evidence

Eight regression cases failed on main and pass with the repair. All 159 focused model-selection and session-model cases pass, including agent precedence and unique case-insensitive fallback controls. Independent P2 review and the complete changed-file gate passed. The model-selection documentation describes the precedence.

A fresh full build passed at `ae7a5347c7d1b35b381ee8408b2d428b1ece0cac`; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34439134317) is green. Six isolated compiled CLI `models status --json` cases covered defaults, per-agent settings, and configured provider catalogs in both row orders. All resolved `third/Model`, exited successfully, and left no process groups.

The strict import guard observed no source imports or rejections. All 1,034 loaded files projected into the distribution fixture matched the completed build byte-for-byte; remaining imports were built modules or ready dependencies. This is compiled distribution-layout proof, not npm installation proof. Two earlier development-checkout attempts rejected optional source probes and remain recorded; the final fixture retained the guard and assertions.
