### PR TITLE
fix(skills): use HTTP liveness for auth-none release smoke

### DIFF
--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -125,7 +125,13 @@ After the track-specific publication checks pass:
 2. Dev Gateway live model smoke:
    - Use temp HOME/workspace, not the user's normal state:
      `HOME=/tmp/openclaw-release-smoke/home OPENCLAW_WORKSPACE=/tmp/openclaw-release-smoke/work pnpm openclaw --dev gateway run --auth none --force --verbose`.
-   - Health check via CLI: `openclaw --dev gateway health --json`.
+   - Resolve the launched Gateway's bound port from its startup output or log.
+   - For `--auth none`, require unauthenticated
+     `GET http://127.0.0.1:<PORT>/healthz` to return HTTP 200 with the exact JSON
+     object `{"ok":true,"status":"live"}`.
+   - Reserve `gateway health --json` for intentionally credentialed or
+     device-paired smoke, passing the explicit credential required by that
+     Gateway.
    - Run one Gateway-backed agent turn with inherited `OPENAI_API_KEY`, short
      prompt, explicit session key, JSON output, and a known-available model.
    - If the configured default model fails as unavailable, record that caveat
@@ -143,5 +149,5 @@ After the track-specific publication checks pass:
 - Divergent checkout caveat: say when local source SHA differs from release tag
   or origin and which live sources were used instead.
 - Smoke caveat: distinguish Gateway-backed agent success from local embedded
-  fallback. A valid Gateway smoke has health OK plus gateway log/run id for the
-  agent call.
+  fallback. A valid auth-none live smoke has the exact `/healthz` result plus a
+  successful Gateway-backed agent turn and the Gateway log/run id for that call.


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-verification failure where an auth-none Gateway was probed through the credentialed/device-paired RPC health path, causing a live Gateway to be reported unhealthy with `device identity required`.

## Why This Change Was Made

Auth-none smoke now resolves the launched port and verifies the public HTTP liveness contract: unauthenticated `GET /healthz`, HTTP 200, and the exact JSON object `{"ok":true,"status":"live"}`. RPC `gateway health --json` remains available only for intentionally credentialed or device-paired smoke with an explicit credential.

A valid auth-none live verification still requires a successful Gateway-backed agent turn and the corresponding Gateway log/run ID; HTTP liveness alone is not promoted to inference proof.

## User Impact

Release verification no longer produces a false failure by applying an authenticated RPC probe to an auth-none Gateway. Credentialed smoke keeps its stronger RPC check.

## Evidence

- Published `openclaw@2026.9.3` Testbox payload: https://github.com/openclaw/openclaw/actions/runs/34438069837
  - exact package install and CLI version passed
  - `GET /healthz` returned HTTP 200 with exact `{"ok":true,"status":"live"}`
  - Gateway exited cleanly on SIGTERM and the closed port returned `ECONNREFUSED`
  - the payload succeeded, but the GitHub wrapper concluded `cancelled` due delegated Testbox teardown fallout; this cancelled wrapper is not claimed as a passing check
- Stable published-core inference evidence: https://github.com/openclaw/openclaw/releases/download/v2026.9.3/openclaw-2026.9.3-published-core-verification.json
  - published SHA-256 metadata matched the downloaded asset
  - records Gateway-backed health and agent inference success with a Gateway run ID
- Current source contract: `src/gateway/server-http.probe.test.ts` requires `/healthz` HTTP 200 with the exact liveness object.
- `git diff --check`
- `pnpm exec oxfmt --check .agents/skills/verify-release/SKILL.md`
- `node scripts/check-changed.mjs` (`docs-only` lane)

No release, publish, tag, registry, FRV, source, lockfile, test, or changelog action was performed.
