### PR TITLE
test(plugins): stabilize concurrent catalog assertions

### DIFF
--- a/src/infra/clawhub-plugin-catalog.test.ts
+++ b/src/infra/clawhub-plugin-catalog.test.ts
@@ -397,13 +397,15 @@ describe("ClawHub plugin catalog client", () => {
       fetchImpl,
     });
 
-    expect(requestedUrls).toEqual([
-      "/api/v1/packages/memory-plus",
-      "/api/v1/packages/memory-plus/versions?limit=10",
-      "/api/v1/packages/memory-plus/versions/1.2.2",
-      "/api/v1/packages/memory-plus/file?path=README.md&preview=1&version=1.2.2",
-      "/api/v1/packages/memory-plus/versions/1.2.2/security",
-    ]);
+    expect(requestedUrls[0]).toBe("/api/v1/packages/memory-plus");
+    expect(requestedUrls.slice(1).toSorted()).toEqual(
+      [
+        "/api/v1/packages/memory-plus/versions?limit=10",
+        "/api/v1/packages/memory-plus/versions/1.2.2",
+        "/api/v1/packages/memory-plus/file?path=README.md&preview=1&version=1.2.2",
+        "/api/v1/packages/memory-plus/versions/1.2.2/security",
+      ].toSorted(),
+    );
     expect(detail).toMatchObject({
       packageName: "memory-plus",
       owner: {


### PR DESCRIPTION
## What Problem This Solves

The ClawHub detail test can fail when four concurrent requests reach the fetch boundary in a different order. [This CI failure](https://github.com/openclaw/openclaw/actions/runs/34436149080/job/102741649800) had all five expected URLs, with the README and version-detail requests exchanged.

## Why This Change Was Made

Keep the package metadata request first, then compare sorted copies of the four remaining exact URLs. This preserves request counts, duplicates, paths, query strings, and the selected version. The normalized detail and sequential pagination assertions remain unchanged.

## User Impact

Removes an order-sensitive CI failure. Production code and request scheduling are unchanged.

## Evidence

The observed CI failure is the before evidence; source, test, and direct helpers match the affected UI PR's base and head and this branch's main base. The complete 12-case catalog file and all 20 canonical changed-file checks pass. Fresh independent Codex review found no actionable findings through P2. No new test, delay, retry, serialization, or authentication override was added.
