### PR TITLE
feat(control-ui): show plugin icons on tool calls

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3836,7 +3836,7 @@ ui/src/pages/chat/components/chat-composer.ts	5
 ui/src/pages/chat/components/chat-effort-picker.ts	6
 ui/src/pages/chat/components/chat-header-session-menu.ts	1
 ui/src/pages/chat/components/chat-message-attachment-availability.ts	1
-ui/src/pages/chat/components/chat-message-bubble.ts	2
+ui/src/pages/chat/components/chat-message-bubble.ts	1
 ui/src/pages/chat/components/chat-message-confirmation.ts	2
 ui/src/pages/chat/components/chat-message-markdown.ts	1
 ui/src/pages/chat/components/chat-message-media.ts	3

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -19,6 +19,7 @@ import { resolveChatPaneDesktopTarget } from "./chat-pane-placement.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import { renderSidebarRegion, sidebarRegionCallbacks } from "./chat-pane-sidebar-layout.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { ChatToolIconController } from "./chat-tool-icon-controller.ts";
 import { renderChat, type ChatProps } from "./chat-view.ts";
 import { publishChatWorkContext } from "./chat-work-context.ts";
 import { renderBackgroundTasksRail } from "./components/chat-background-tasks-render.ts";
@@ -55,6 +56,11 @@ type ChatPaneLayoutRenderParams = {
 };
 
 export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRender {
+  private readonly toolIcons = new ChatToolIconController(
+    this,
+    () => this.context,
+    () => (this.state && !this.catalogHost ? this.resolveChatReadTarget() : undefined),
+  );
   private desktopFocus: {
     key: string;
     client: ChatPageHost["client"];
@@ -119,6 +125,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
     ></openclaw-chat-outbox-recovery>`;
     const chat = renderChat({
       ...chatProps,
+      pluginToolIcons: this.toolIcons.icons,
       presented: this.active && this.presented,
       transcriptVisible:
         this.presented &&

--- a/ui/src/pages/chat/chat-pane-tool-icons.test.ts
+++ b/ui/src/pages/chat/chat-pane-tool-icons.test.ts
@@ -1,0 +1,52 @@
+/* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-tool-icons.test/"} */
+import { afterEach, expect, it, vi } from "vitest";
+import { GatewayBrowserClient } from "../../api/gateway.ts";
+import { setChatHistoryLoad } from "./chat-history-state.ts";
+import { ChatPane } from "./chat-pane-render.ts";
+import { createSessionCapabilityFixture, createTestChatPane } from "./chat-pane.test-support.ts";
+import { ChatToolIconController } from "./chat-tool-icon-controller.ts";
+
+afterEach(() => vi.restoreAllMocks());
+
+it("loads tool ownership for accepted history absent from the capped session list", async () => {
+  const controllers = vi.spyOn(ChatPane.prototype, "addController");
+  const client = new GatewayBrowserClient({ url: "ws://chat-pane-tool-icons.test" });
+  const request = vi.spyOn(client, "request").mockRejectedValue(new Error("optional metadata"));
+  const { pane } = createTestChatPane({ client, sessions: createSessionCapabilityFixture() });
+  const state = pane.state;
+  state.connected = true;
+  state.sessionKey = "agent:main:older-chat";
+  state.currentSessionId = "older-session";
+  state.sessionsResult = null;
+  state.chatRunId = null;
+  pane.context.gateway.snapshot.client = client;
+  pane.context.gateway.snapshot.phase = "connected";
+  setChatHistoryLoad(state, {
+    phase: "committed",
+    sessions: state.sessions,
+    client,
+    connectionEpoch: state.connectionEpoch,
+    sessionKey: state.sessionKey,
+    requestAgentId: undefined,
+    sessionInfo: {
+      key: state.sessionKey,
+      sessionId: state.currentSessionId,
+      agentId: "main",
+      kind: "direct",
+    },
+  });
+  const controller = controllers.mock.calls
+    .map(([value]) => value)
+    .find((value) => value instanceof ChatToolIconController);
+  expect(controller).toBeDefined();
+  controller?.hostUpdate();
+  controller?.icons.get("example_tool");
+  await Promise.resolve();
+  expect(request).toHaveBeenCalledWith(
+    "tools.effective",
+    { sessionKey: state.sessionKey, agentId: "main" },
+    expect.anything(),
+  );
+  controller?.hostDisconnected();
+});

--- a/ui/src/pages/chat/chat-tool-icon-controller.test.ts
+++ b/ui/src/pages/chat/chat-tool-icon-controller.test.ts
@@ -1,0 +1,334 @@
+import type { ReactiveControllerHost } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
+import { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ToolsEffectiveResult } from "../../api/types.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
+import type { PluginListResult } from "../../lib/plugins/index.ts";
+import { ChatToolIconController } from "./chat-tool-icon-controller.ts";
+
+const plugins: PluginListResult = {
+  plugins: ["meetings", "iconless", "unused"].map((id) => ({
+    id,
+    name: id,
+    installed: true,
+    enabled: true,
+    state: "enabled",
+    hasIcon: id !== "iconless",
+  })),
+  diagnostics: [],
+  mutationAllowed: false,
+};
+const catalog: ToolsEffectiveResult = {
+  agentId: "main",
+  profile: "full",
+  groups: [
+    {
+      id: "plugin",
+      label: "Tools",
+      source: "plugin",
+      tools: [
+        { id: "meeting_status", pluginId: "meetings", source: "plugin" },
+        { id: "meeting_list", pluginId: "meetings", source: "plugin" },
+        { id: "other", pluginId: "iconless", source: "plugin" },
+        { id: "unseen_status", pluginId: "unused", source: "plugin" },
+        { id: "read", source: "core" },
+      ].map((tool) =>
+        Object.assign({}, tool, {
+          source: tool.source as "plugin" | "core",
+          label: tool.id,
+          description: "",
+          rawDescription: "",
+        }),
+      ),
+    },
+  ],
+};
+
+function setup() {
+  const client = new GatewayBrowserClient({ url: window.location.origin.replace(/^http/u, "ws") });
+  const request = vi.spyOn(client, "request").mockImplementation(async (method) => {
+    if (method === "plugins.list") {
+      return plugins;
+    }
+    if (method === "tools.effective") {
+      return catalog;
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const snapshot: ApplicationGatewaySnapshot = {
+    client,
+    phase: "connected",
+    offlineStable: false,
+    hello: null,
+    canvasPluginSurfaceUrl: null,
+    assistantAgentId: "main",
+    sessionKey: "agent:main:main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const context = {
+    resourceBasePath: "",
+    gateway: {
+      snapshot,
+      connectionRevision: 1,
+      connection: {
+        gatewayUrl: window.location.origin.replace(/^http/u, "ws"),
+        token: "",
+        password: "",
+        bootstrapToken: "",
+      },
+    },
+  };
+  const host: ReactiveControllerHost = {
+    addController: vi.fn(),
+    removeController: vi.fn(),
+    requestUpdate: vi.fn(),
+    updateComplete: Promise.resolve(true),
+  };
+  const fetch = vi
+    .fn()
+    .mockImplementation(
+      async () => new Response(new Blob(["png"]), { headers: { "content-type": "image/png" } }),
+    );
+  vi.stubGlobal("fetch", fetch);
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:plugin-icon");
+  const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+  let session: { sessionKey: string; agentId: string } | undefined = {
+    sessionKey: "agent:main:main",
+    agentId: "main",
+  };
+  const controller = new ChatToolIconController(
+    host,
+    () => context,
+    () => session,
+  );
+  return {
+    controller,
+    context,
+    request,
+    fetch,
+    revoke,
+    setSession: (sessionKey: string | undefined, agentId = "main") => {
+      session = sessionKey ? { sessionKey, agentId } : undefined;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("chat tool icon ownership", () => {
+  it("invalidates rendered fallbacks when the session identity first becomes available", async () => {
+    const { controller, setSession } = setup();
+    setSession(undefined);
+    controller.hostUpdate();
+    const unavailable = controller.icons;
+    expect(unavailable.get("meeting_status")).toBeUndefined();
+    setSession("agent:main:main");
+    controller.hostUpdate();
+    expect(controller.icons).not.toBe(unavailable);
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    controller.hostDisconnected();
+  });
+
+  it("recovers a failed plugin-list read when another tool needs ownership", async () => {
+    const { controller, request, fetch } = setup();
+    let pluginRequests = 0;
+    request.mockImplementation(async (method) => {
+      if (method !== "plugins.list") {
+        return catalog;
+      }
+      if (++pluginRequests === 1) {
+        throw new Error("temporary metadata failure");
+      }
+      return plugins;
+    });
+    controller.hostUpdate();
+    controller.icons.get("meeting_status");
+    await vi.waitFor(() => expect(pluginRequests).toBe(1));
+    expect(controller.icons.get("meeting_status")).toBeUndefined();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_list")).toBeDefined());
+    expect(controller.icons.get("meeting_status")).toBeDefined();
+    expect(pluginRequests).toBe(2);
+    expect(fetch).toHaveBeenCalledOnce();
+    controller.hostDisconnected();
+  });
+
+  it("discovers newly visible tools in the same session without downloading their cached icon again", async () => {
+    const { controller, request, fetch } = setup();
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    request.mockImplementation(async (method) =>
+      method === "plugins.list"
+        ? plugins
+        : {
+            ...catalog,
+            groups: catalog.groups.map((group) =>
+              Object.assign({}, group, {
+                tools: [
+                  ...group.tools,
+                  ...["meeting_join", "meeting_leave"].map((id) => ({
+                    id,
+                    label: id,
+                    description: "",
+                    rawDescription: "",
+                    source: "plugin",
+                    pluginId: "meetings",
+                  })),
+                ],
+              }),
+            ),
+          },
+    );
+    const previous = controller.icons;
+    expect(controller.icons.get("meeting_join")).toBeUndefined();
+    expect(controller.icons.get("meeting_leave")).toBeUndefined();
+    expect(controller.icons.get("unavailable")).toBeUndefined();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_join")).toBeDefined());
+    expect(controller.icons.get("meeting_leave")?.url).toBe(
+      controller.icons.get("meeting_status")?.url,
+    );
+    expect(controller.icons).not.toBe(previous);
+    expect(controller.icons.get("unavailable")).toBeUndefined();
+    await Promise.resolve();
+    expect(request.mock.calls.filter(([method]) => method === "tools.effective")).toHaveLength(2);
+    expect(request.mock.calls.filter(([method]) => method === "plugins.list")).toHaveLength(1);
+    expect(fetch).toHaveBeenCalledOnce();
+    controller.hostDisconnected();
+  });
+
+  it("shares an icon only across tools owned by its plugin and keeps failed images on the fallback", async () => {
+    const { controller, request, fetch, revoke } = setup();
+    controller.hostUpdate();
+    expect(request).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    expect(controller.icons.get("meeting_list")?.url).toBe(
+      controller.icons.get("meeting_status")?.url,
+    );
+    expect(controller.icons.get("read")).toBeUndefined();
+    expect(controller.icons.get("other")).toBeUndefined();
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch.mock.calls[0]?.[0]).toContain("meetings");
+    controller.hostUpdate();
+    await Promise.resolve();
+    expect(request).toHaveBeenCalledTimes(2);
+    const previous = controller.icons;
+    controller.icons.get("meeting_status")?.onError();
+    expect(controller.icons.get("meeting_status")).toBeUndefined();
+    expect(controller.icons).not.toBe(previous);
+    expect(revoke).toHaveBeenCalledWith("blob:plugin-icon");
+    controller.hostDisconnected();
+  });
+
+  it.each(["session", "agent"])(
+    "ignores retired %s ownership and releases images when the connection leaves",
+    async (change) => {
+      const { controller, request, context, setSession, fetch, revoke } = setup();
+      if (change === "agent") {
+        setSession("global", "first");
+      }
+      const pending = createDeferred<ToolsEffectiveResult>();
+      request.mockImplementationOnce(() => pending.promise);
+      controller.hostUpdate();
+      controller.icons.get("meeting_status");
+      await Promise.resolve();
+      setSession(change === "agent" ? "global" : "second", "second");
+      controller.hostUpdate();
+      await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+      pending.resolve({
+        ...catalog,
+        groups: [
+          {
+            ...catalog.groups[0]!,
+            tools: [{ ...catalog.groups[0]!.tools[0]!, id: "retired_tool" }],
+          },
+        ],
+      });
+      await pending.promise;
+      await Promise.resolve();
+      expect(controller.icons.get("retired_tool")).toBeUndefined();
+      expect(fetch).toHaveBeenCalledOnce();
+      context.gateway.snapshot.phase = "offline";
+      controller.hostUpdate();
+      expect(controller.icons.get("meeting_status")).toBeUndefined();
+      expect(revoke).toHaveBeenCalledWith("blob:plugin-icon");
+    },
+  );
+
+  it("retires icons and pending ownership when the same client changes credentials", async () => {
+    const { controller, context, request, revoke } = setup();
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    const pending = createDeferred<ToolsEffectiveResult>();
+    request.mockImplementationOnce(() => pending.promise);
+    context.gateway.connectionRevision++;
+    controller.hostUpdate();
+    expect(controller.icons.get("meeting_status")).toBeUndefined();
+    expect(revoke).toHaveBeenCalledWith("blob:plugin-icon");
+    await Promise.resolve();
+    context.gateway.connectionRevision++;
+    pending.resolve(catalog);
+    await pending.promise;
+    await Promise.resolve();
+    expect(controller.icons.get("meeting_status")).toBeUndefined();
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    controller.hostDisconnected();
+  });
+
+  it.each(["plugin", "mcp"] as const)(
+    "uses effective %s ownership even for a tool in the static core catalog",
+    async (source) => {
+      const { controller, request } = setup();
+      request.mockImplementationOnce(async () => ({
+        ...catalog,
+        groups: [
+          {
+            ...catalog.groups[0]!,
+            tools: [{ ...catalog.groups[0]!.tools[0]!, id: "browser", source }],
+          },
+        ],
+      }));
+      controller.hostUpdate();
+      await vi.waitFor(() => expect(controller.icons.get("browser")).toBeDefined());
+      expect(request).toHaveBeenCalledWith(
+        "tools.effective",
+        { sessionKey: "agent:main:main", agentId: "main" },
+        expect.anything(),
+      );
+      controller.hostDisconnected();
+    },
+  );
+
+  it("discards an icon response that finishes after the pane disconnects", async () => {
+    const { controller, fetch, revoke } = setup();
+    const response = createDeferred<Response>();
+    fetch.mockReturnValueOnce(response.promise);
+    controller.hostUpdate();
+    controller.icons.get("meeting_status");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    controller.hostDisconnected();
+    response.resolve(new Response(new Blob(["png"]), { headers: { "content-type": "image/png" } }));
+    await vi.waitFor(() => expect(revoke).toHaveBeenCalledWith("blob:plugin-icon"));
+    expect(controller.icons.get("meeting_status")).toBeUndefined();
+  });
+  it("ignores a removed image's late error after its owner has been replaced", async () => {
+    const { controller, context, revoke, fetch } = setup();
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    const oldIcon = controller.icons.get("meeting_status");
+    context.gateway.connectionRevision++;
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(controller.icons.get("meeting_status")).toBeDefined());
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(revoke).toHaveBeenCalledOnce();
+    oldIcon?.onError();
+    expect(controller.icons.get("meeting_status")).toBeDefined();
+    expect(revoke).toHaveBeenCalledOnce();
+    controller.hostDisconnected();
+  });
+});

--- a/ui/src/pages/chat/chat-tool-icon-controller.ts
+++ b/ui/src/pages/chat/chat-tool-icon-controller.ts
@@ -1,0 +1,195 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ToolsEffectiveResult } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import type { PluginListResult } from "../../lib/plugins/index.ts";
+import { PluginIconController } from "../plugins/plugin-icon-controller.ts";
+
+export type PluginToolIcon = { url: string; onError: () => void };
+export type PluginToolIcons = Pick<ReadonlyMap<string, PluginToolIcon>, "get">;
+
+type ToolIconSession = { sessionKey: string; agentId?: string };
+
+export class ChatToolIconController implements ReactiveController {
+  icons: PluginToolIcons = { get: (name) => this.getIcon(name) };
+  private owner: {
+    client: NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+    session: ToolIconSession;
+    revision: number;
+    controller: AbortController;
+    plugins?: Promise<PluginListResult>;
+    loading?: boolean;
+  } | null = null;
+  private readonly toolOwners = new Map<string, string | undefined>();
+  private readonly requested = new Set<string>();
+  private readonly pending = new Set<string>();
+  private urls: Record<string, string> = {};
+  private readonly loader: PluginIconController;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly getContext: () => Pick<ApplicationContext, "resourceBasePath"> & {
+      gateway: Pick<
+        ApplicationContext["gateway"],
+        "snapshot" | "connection" | "connectionRevision"
+      >;
+    },
+    private readonly getSession: () => ToolIconSession | undefined,
+  ) {
+    host.addController(this);
+    this.loader = new PluginIconController({
+      getFetchContext: () => {
+        const { gateway, resourceBasePath } = getContext();
+        return {
+          resourceBasePath,
+          gatewayUrl: gateway.connection.gatewayUrl,
+          auth: {
+            hello: gateway.snapshot.hello,
+            settings: { token: gateway.connection.token },
+            password: gateway.connection.password,
+          },
+        };
+      },
+      isConnected: () => this.isCurrent(),
+      onUrlsChange: (urls) => this.publish(urls),
+    });
+  }
+
+  private publish(urls = this.urls) {
+    this.urls = urls;
+    this.icons = { get: (name) => this.getIcon(name) };
+    this.host.requestUpdate();
+  }
+
+  private getIcon(name: string): PluginToolIcon | undefined {
+    const owner = this.owner;
+    if (!owner || !this.isCurrent()) {
+      return undefined;
+    }
+    this.requested.add(name);
+    if (!this.toolOwners.has(name)) {
+      const scheduled = this.pending.size > 0;
+      this.pending.add(name);
+      if (!scheduled) {
+        queueMicrotask(() => this.refresh());
+      }
+    }
+    const pluginId = this.toolOwners.get(name);
+    if (!pluginId) {
+      return undefined;
+    }
+    this.loader.load(pluginId);
+    const url = this.urls[pluginId];
+    return url
+      ? {
+          url,
+          onError: () => {
+            // Removed images can fail after reconnect; only the current owner
+            // and URL may retire the replacement plugin's image.
+            if (this.owner === owner && this.isCurrent() && this.urls[pluginId] === url) {
+              this.loader.handleError(pluginId);
+            }
+          },
+        }
+      : undefined;
+  }
+
+  private isCurrent() {
+    const { snapshot, connectionRevision } = this.getContext().gateway;
+    const session = this.getSession();
+    return Boolean(
+      this.owner &&
+      snapshot.phase === "connected" &&
+      snapshot.client === this.owner.client &&
+      connectionRevision === this.owner.revision &&
+      session?.sessionKey === this.owner.session.sessionKey &&
+      session?.agentId === this.owner.session.agentId,
+    );
+  }
+
+  hostUpdate() {
+    if (this.isCurrent()) {
+      return;
+    }
+    const { snapshot, connectionRevision: revision } = this.getContext().gateway;
+    const { client, phase } = snapshot;
+    const session = this.getSession();
+    this.hostDisconnected();
+    if (phase === "connected" && client && session) {
+      this.owner = { client, session, revision, controller: new AbortController() };
+      this.publish();
+    }
+  }
+
+  private refresh() {
+    const owner = this.owner;
+    if (!owner || !this.isCurrent() || owner.loading || this.pending.size === 0) {
+      return;
+    }
+    // Remember misses as well as core/iconless tools. Only newly rendered names
+    // refresh the inventory, including names arriving while a request is active.
+    for (const name of this.pending) {
+      this.toolOwners.set(name, undefined);
+    }
+    this.pending.clear();
+    owner.loading = true;
+    const options = { signal: owner.controller.signal };
+    void Promise.all([
+      owner.client.request<ToolsEffectiveResult>("tools.effective", owner.session, options),
+      (owner.plugins ??= owner.client
+        .request<PluginListResult>("plugins.list", {}, options)
+        .catch((error: unknown) => {
+          // A later newly displayed tool can recover metadata after a failed read.
+          owner.plugins = undefined;
+          throw error;
+        })),
+    ])
+      .then(([tools, plugins]) => {
+        if (this.owner !== owner || !this.isCurrent()) {
+          return;
+        }
+        const iconIds = new Set(
+          plugins.plugins.filter((plugin) => plugin.hasIcon).map((plugin) => plugin.id),
+        );
+        // Effective inventory retains plugin ownership for built-ins such as
+        // Browser and Canvas that the static catalog groups with core tools.
+        for (const group of tools.groups) {
+          for (const tool of group.tools) {
+            this.toolOwners.set(
+              tool.id,
+              tool.pluginId && iconIds.has(tool.pluginId) ? tool.pluginId : undefined,
+            );
+            this.pending.delete(tool.id);
+          }
+        }
+        for (const name of this.requested) {
+          const pluginId = this.toolOwners.get(name);
+          if (pluginId) {
+            this.loader.load(pluginId);
+          }
+        }
+        this.publish();
+      })
+      .catch(() => {
+        // Optional presentation keeps the existing symbol after a failed lookup.
+      })
+      .finally(() => {
+        if (this.owner !== owner) {
+          return;
+        }
+        owner.loading = false;
+        this.refresh();
+      });
+  }
+
+  hostDisconnected() {
+    if (!this.owner) {
+      return;
+    }
+    this.owner.controller.abort();
+    this.owner = null;
+    this.toolOwners.clear();
+    this.requested.clear();
+    this.pending.clear();
+    this.loader.reset();
+  }
+}

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -4,7 +4,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
-import { icons, type IconName } from "../../../components/icons.ts";
+import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
@@ -28,9 +28,10 @@ import {
   isToolCardError,
 } from "../../../lib/chat/tool-cards.ts";
 import { type EmbedSandboxMode, resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
+import { isPendingSendMessage } from "../chat-thread-items.ts";
 import "../../../styles/chat/reply-preview.css";
 import "./chat-clawhub-card.ts";
-import { isPendingSendMessage } from "../chat-thread-items.ts";
+import type { PluginToolIcons } from "../chat-tool-icon-controller.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import { workspaceResultConflictFromTranscript } from "../workspace-conflict.ts";
 import {
@@ -58,6 +59,7 @@ import type { SidebarContent } from "./chat-sidebar.ts";
 import {
   renderToolApprovalReviews,
   renderToolCard,
+  renderToolIcon,
   renderPluginToolResult,
   renderToolPreview,
   resolveCollapsedToolDetail,
@@ -70,10 +72,6 @@ import {
   renderToolOutcome,
 } from "./chat-tool-content.ts";
 import { renderWorkspaceConflictTranscriptMessage } from "./chat-workspace-conflict.ts";
-
-function renderChatIcon(name: string) {
-  return icons[name as IconName] ?? icons.zap;
-}
 
 function imageMessageIdentity(message: unknown, sessionKey: string | undefined) {
   const identity = readSessionMessageIdentity(message);
@@ -248,6 +246,7 @@ export function renderGroupedMessage(
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
     fetchLinkFavicon?: LinkFaviconFetcher;
+    pluginToolIcons?: PluginToolIcons;
     githubRepo?: MarkdownRenderOptions["githubRepo"];
     onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
     avatar?: TemplateResult | typeof nothing;
@@ -409,7 +408,9 @@ export function renderGroupedMessage(
     toolSummaryLabelRaw,
     toolMessageLabel,
   );
-  const toolMessageIcon = singleToolDisplay ? renderChatIcon(singleToolDisplay.icon) : icons.zap;
+  const toolMessageIcon = singleToolDisplay
+    ? renderToolIcon(singleToolDisplay.icon, opts.pluginToolIcons?.get(singleToolDisplay.name))
+    : icons.zap;
   const assistantViewContent =
     sourceRole === "assistant" && assistantViewBlocks.length > 0
       ? html`${assistantViewBlocks.map(

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -44,6 +44,7 @@ type StreamMessageOptions = Pick<
   | "embedSandboxMode"
   | "allowExternalEmbedUrls"
   | "fetchLinkFavicon"
+  | "pluginToolIcons"
   | "githubRepo"
   | "onOpenWorkspaceFile"
 >;

--- a/ui/src/pages/chat/components/chat-read-only-transcript.ts
+++ b/ui/src/pages/chat/components/chat-read-only-transcript.ts
@@ -48,6 +48,7 @@ export function renderReadOnlyTranscript(params: {
       embedSandboxMode: chat.embedSandboxMode,
       allowExternalEmbedUrls: chat.allowExternalEmbedUrls,
       fetchLinkFavicon: chat.fetchLinkFavicon,
+      pluginToolIcons: chat.pluginToolIcons,
       autoExpandToolCalls: chat.autoExpandToolCalls,
       onRequestUpdate: chat.onRequestUpdate ?? (() => {}),
       onDraftChange: () => undefined,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -29,6 +29,7 @@ import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import type { UiSessionDefaultsHost } from "../../../lib/sessions/session-key.ts";
 import type { TurnRecapWatch } from "../chat-progress.ts";
 import { resetChatThreadState } from "../chat-thread.ts";
+import type { PluginToolIcons } from "../chat-tool-icon-controller.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
@@ -132,6 +133,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   embedSandboxMode?: EmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   fetchLinkFavicon?: LinkFaviconFetcher;
+  pluginToolIcons?: PluginToolIcons;
   githubRepo?: MarkdownRenderOptions["githubRepo"];
   autoExpandToolCalls?: boolean;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../lib/chat/tool-cards.ts";
 import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
 import { renderPluginSurface } from "../../../plugins/control-ui-view.ts";
+import type { PluginToolIcon } from "../chat-tool-icon-controller.ts";
 import { renderHighlightedCommand } from "./chat-command-highlight.ts";
 import { renderDiffStatChips } from "./chat-diff-render.ts";
 import {
@@ -85,7 +86,16 @@ export function shouldToggleSelectableDisclosure(event: MouseEvent): boolean {
   );
 }
 
-function renderToolIcon(name: string) {
+export function renderToolIcon(name: string, pluginIcon?: PluginToolIcon) {
+  if (pluginIcon) {
+    return html`<img
+      src=${pluginIcon.url}
+      alt=""
+      width="16"
+      height="16"
+      @error=${pluginIcon.onError}
+    />`;
+  }
   // SAFETY: Unknown display icon names produce undefined and use the fallback.
   return icons[name as IconName] ?? icons.puzzle;
 }
@@ -445,7 +455,9 @@ export function renderToolCard(
   const workspaceFilePath = toolWorkspacePath(card, view);
   const isFileRow = Boolean(workspaceFilePath);
   const rowContent = html`
-    <span class="chat-tool-msg-summary__icon">${renderToolIcon(icon)}</span>
+    <span class="chat-tool-msg-summary__icon"
+      >${renderToolIcon(icon, opts.pluginToolIcons?.get(card.name))}</span
+    >
     <span class="chat-tool-disclosure__content"
       >${renderToolRowContent(
         card,

--- a/ui/src/pages/chat/components/chat-tool-content.ts
+++ b/ui/src/pages/chat/components/chat-tool-content.ts
@@ -17,6 +17,7 @@ import {
   type ToolPreview,
 } from "../../../lib/chat/tool-cards.ts";
 import { formatToolDetail, resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
+import type { PluginToolIcons } from "../chat-tool-icon-controller.ts";
 import { renderHighlightedCommand } from "./chat-command-highlight.ts";
 import { renderDiffBlock } from "./chat-diff-render.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -390,6 +391,7 @@ function serializeDiff(lines: readonly { kind: string; text: string }[]): string
 }
 
 export type ToolRenderOptions = {
+  pluginToolIcons?: PluginToolIcons;
   messageKey: string;
   sessionKey?: string;
   agentId?: string;

--- a/ui/src/pages/chat/components/chat-tool-icons.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-icons.test.ts
@@ -1,0 +1,45 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderGroupedMessage } from "./chat-message-bubble.ts";
+import { prepareChatMessageRender } from "./chat-message-markdown.ts";
+
+describe("plugin tool icons", () => {
+  it.each(["assistant", "toolResult"])("uses the plugin icon for %s tool rows", (role) => {
+    const container = document.createElement("div");
+    const message =
+      role === "assistant"
+        ? {
+            role,
+            content: [{ type: "toolCall", id: "call", name: "meeting_status", arguments: {} }],
+          }
+        : {
+            role,
+            toolCallId: "call",
+            toolName: "meeting_status",
+            content: [{ type: "text", text: "No active meetings." }],
+          };
+    const onError = vi.fn();
+    const options = {
+      isStreaming: false,
+      showReasoning: false,
+      showToolCalls: true,
+      pluginToolIcons: new Map([["meeting_status", { url: "blob:meeting-icon", onError }]]),
+    };
+    render(renderGroupedMessage(prepareChatMessageRender(message), "message", options), container);
+    const icon = container.querySelector<HTMLImageElement>(".chat-tool-msg-summary__icon img");
+    expect(icon?.getAttribute("src")).toBe("blob:meeting-icon");
+    expect(icon?.alt).toBe("");
+    icon?.dispatchEvent(new Event("error"));
+    expect(onError).toHaveBeenCalledOnce();
+
+    render(
+      renderGroupedMessage(prepareChatMessageRender(message), "message", {
+        ...options,
+        pluginToolIcons: new Map(),
+      }),
+      container,
+    );
+    expect(container.querySelector(".chat-tool-msg-summary__icon img")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-summary__icon svg")).not.toBeNull();
+  });
+});

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -305,6 +305,7 @@ export function projectChatTranscript(
     embedSandboxMode: props.embedSandboxMode ?? "scripts",
     allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
     fetchLinkFavicon: props.fetchLinkFavicon,
+    pluginToolIcons: props.pluginToolIcons,
     githubRepo: props.githubRepo,
     showAssistantAvatar: avatarPlacement === "gutter" && Boolean(assistantIdentity.avatar),
   } satisfies StreamGroupOptions;
@@ -687,6 +688,7 @@ export function projectChatTranscript(
     props.embedSandboxMode ?? "scripts",
     props.allowExternalEmbedUrls ?? false,
     Boolean(props.fetchLinkFavicon),
+    props.pluginToolIcons,
     props.githubRepo?.owner,
     props.githubRepo?.repo,
     threadContextWindow,

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -222,6 +222,12 @@
   flex-shrink: 0;
 }
 
+.chat-tool-msg-summary__icon img {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
 .chat-tool-msg-summary__icon svg {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
Closes #143683.

## What Problem This Solves

Control UI chat shows generic tool symbols even when the owning plugin supplies an icon. For example, a Google Meet status call displays a puzzle piece instead of the bundled plugin’s logo.

## Why This Change Was Made

Resolve tool ownership from the runtime inventory and reuse the existing authenticated plugin icon loader. Load icons for displayed tool calls, refresh ownership when a newly encountered tool appears, and keep connection/session ownership and object-URL cleanup together. Tools without an available icon retain their existing symbol.

## User Impact

Plugin icons appear in live tool calls and restored conversations, including plugin calls made through the tool-call bridge. No plugin configuration, gateway protocol, or persistence changes are required.

## Evidence

A fresh agent call to the bundled Google Meet plugin (14.6 seconds; waiting segment at 6× speed):

https://github.com/user-attachments/assets/dba64ded-b998-4b0c-9ca7-10abc36271bb

| Desktop before | Desktop after |
| --- | --- |
| ![Generic tool icon](https://github.com/user-attachments/assets/8c74aad8-eb7b-4f39-bef2-1f29c5b3cd97) | ![Google Meet plugin icon](https://github.com/user-attachments/assets/abcfc7c3-85b1-4c2a-96a9-ba66be009685) |

<details>
<summary>Mobile before and after</summary>

| Before | After |
| --- | --- |
| ![Mobile generic tool icon](https://github.com/user-attachments/assets/3476f48c-b39f-4516-bae0-d2456ef802a5) | ![Mobile Google Meet icon](https://github.com/user-attachments/assets/7a1fc118-0c6d-48a3-984c-57705bc4ae11) |

</details>

Validation:

- Focused UI tests: 66 passing, covering rendering, fallback, late responses, reconnects, session/agent changes, older chats outside the session list, and newly discovered tools.
- `pnpm ui:build` — passed, including startup bundle budgets.
- `pnpm check:changed` — passed.
- Independent autoreview through P2 — scoped-clean; all actionable findings resolved and covered by regression tests.

Recorded comparison: baseline `41aec3ca92bc9934b43976db3b38dadd56211806`, candidate `29cc29174bae0f7b099044ffae74281223616ab2`. Landing refresh: `099058b8df6fbd382dd96c8c8a47c416b07bc2bf` on main `a0a3bd0b630`; the icon behavior is unchanged. Main already contains the transcript type relocation, so the refresh removes that duplicate mechanical change.

Direct Codex contract check: [dynamic tool parameters](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1637) and [started/completed tool events](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/core/src/tools/handlers/dynamic.rs#L204) retain the tool name. Plugin ownership comes from OpenClaw’s existing effective-tool inventory.

The proof uses a real isolated OCM gateway, local Qwen agent, and the bundled Google Meet `google_meet` status tool. The recorded result was `{"found":true,"sessions":[]}`. The proof environment was stopped after capture and all previously running gateways remained healthy. No meeting was joined or created. The baseline screenshots serve the exact baseline build through Playwright asset routing against the same live gateway; no gateway responses are mocked. Candidate screenshots and video use the gateway-served production UI.

Compared the same restored conversation at 1440×900 and 390×844; also checked 768×1024 and 1366×768. The recording covers a fresh agent call and tool disclosure. Optional metadata/image failures are covered by regression tests.

Production LOC after refresh: +229 net (+238/−9); tests +431; assertion-baseline maintenance net zero. Growth implements the new ownership/loading boundary; the existing icon fetcher, auth, sanitization, and URL lifecycle are reused. The duplicate static-icon renderer was removed.

Landing CI recovery: refreshed onto the already merged [plugin restart fix](https://github.com/openclaw/openclaw/pull/143671) and [retired handoff record fix](https://github.com/openclaw/openclaw/pull/144208), which address the two failed jobs from the original run.

Known presentation follow-up: chat currently shows the generic `tool_call` dispatcher separately from its child plugin call. The child receives the plugin icon; simplifying that duplicate presentation remains separate work.
