### PR TITLE
refactor: re-export shared provider ID helpers

### DIFF
--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -4,11 +4,7 @@
  * isolate built-in normalization behavior.
  */
 import type { ProviderModelRef as ModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import {
-  findNormalizedProviderKey as findNormalizedProviderKeyCore,
-  normalizeProviderId as normalizeProviderIdCore,
-  normalizeProviderIdForAuth as normalizeProviderIdForAuthCore,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeBuiltInProviderModelId,
   normalizeConfiguredProviderCatalogModelRef,
@@ -22,6 +18,11 @@ import {
 } from "../plugins/manifest-model-id-normalization.js";
 import { modelKey } from "../shared/model-key.js";
 import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
+export {
+  findNormalizedProviderKey,
+  normalizeProviderId,
+  normalizeProviderIdForAuth,
+} from "@openclaw/model-catalog-core/provider-id";
 export { modelKey } from "../shared/model-key.js";
 
 export type { ProviderModelRef as ModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
@@ -33,24 +34,6 @@ export type ModelManifestNormalizationContext = {
 export type ProviderModelIdNormalizationOptions = ModelManifestNormalizationContext & {
   allowManifestNormalization?: boolean;
 };
-
-/** Normalize a provider ID using the shared catalog rules. */
-export function normalizeProviderId(provider: string): string {
-  return normalizeProviderIdCore(provider);
-}
-
-/** Normalize a provider ID for auth lookup. */
-export function normalizeProviderIdForAuth(provider: string): string {
-  return normalizeProviderIdForAuthCore(provider);
-}
-
-/** Find the original provider key matching a normalized provider ID. */
-export function findNormalizedProviderKey(
-  entries: Record<string, unknown> | undefined,
-  provider: string,
-): string | undefined {
-  return findNormalizedProviderKeyCore(entries, provider);
-}
 
 /** Normalize a static provider model ID with built-in and optional manifest policy. */
 export function normalizeStaticProviderModelId(


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Model-reference code wraps three provider-ID helpers that already have a shared owner. Those passthrough functions add another place to maintain the same public names and signatures during the model-runtime repairs.

## Why This Change Was Made

Re-export the catalog-core functions directly and retain the local provider-normalization binding used by this module. This maintainer-requested cleanup changes one production file and removes 17 lines. Model parsing and normalization policy are unchanged.

## User Impact

No behavior change. Existing provider-ID helper imports and signatures stay available.

## Evidence

All 177 existing catalog-reference and agent/model-reference tests pass. The complete changed-file gate passed, and independent P2 review found no actionable findings. No new tests or production test seams were added.

A fresh full build at `94a2d29df57e7b5ff7751a3adbb23ee69a74f72c` passed. Both compiled public SDK barrels passed 102 assertions for provider aliases, model-reference parsing, and invalid references under plain Node, with no source loader or credentials. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34439537480) passed.
