### PR TITLE
refactor(models): share catalog metadata overlays

### DIFF
--- a/src/agents/model-catalog-metadata.ts
+++ b/src/agents/model-catalog-metadata.ts
@@ -1,0 +1,128 @@
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
+
+function mergeCatalogFields<T extends object>(
+  base: T | undefined,
+  override: T | undefined,
+): T | undefined {
+  return base && override ? { ...base, ...override } : (override ?? base);
+}
+
+export function normalizeCatalogRouteBaseUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const url = new URL(value);
+    url.pathname = url.pathname.replace(/\/+$/u, "") || "/";
+    return url.toString();
+  } catch {
+    return value.replace(/\/+$/u, "");
+  }
+}
+
+function catalogRouteChanges(base: ModelCatalogEntry, overlay: ModelCatalogEntry): boolean {
+  if (overlay.api === undefined && overlay.baseUrl === undefined) {
+    return false;
+  }
+  return (
+    (overlay.api !== undefined && base.api !== undefined && overlay.api !== base.api) ||
+    (overlay.baseUrl !== undefined &&
+      base.baseUrl !== undefined &&
+      normalizeCatalogRouteBaseUrl(overlay.baseUrl) !== normalizeCatalogRouteBaseUrl(base.baseUrl))
+  );
+}
+
+function clearRouteBoundCatalogMetadata(entry: ModelCatalogEntry): ModelCatalogEntry {
+  const {
+    contextWindow: _contextWindow,
+    contextWindows: _contextWindows,
+    contextWindowDefault: _contextWindowDefault,
+    contextTokens: _contextTokens,
+    reasoning: _reasoning,
+    configuredReasoning: _configuredReasoning,
+    thinkingLevelMap: _thinkingLevelMap,
+    input: _input,
+    params: _params,
+    compat: _compat,
+    mediaInput: _mediaInput,
+    ...routeNeutral
+  } = entry;
+  return routeNeutral;
+}
+
+export function overlayCatalogMetadata(
+  base: ModelCatalogEntry,
+  overlay: ModelCatalogEntry,
+  options?: {
+    preserveBaseCompat?: boolean;
+  },
+): ModelCatalogEntry {
+  // Catalog rows with one logical provider/id may describe different physical
+  // routes. Capabilities are atomic with their route; never carry them across
+  // an API/endpoint change when the new source omits those facts.
+  const routeChanged = catalogRouteChanges(base, overlay);
+  const routeBase = routeChanged ? clearRouteBoundCatalogMetadata(base) : base;
+  const params = mergeCatalogFields(routeBase.params, overlay.params);
+  const thinkingLevelMap = overlay.thinkingLevelMap ?? routeBase.thinkingLevelMap;
+  // Options + default are one normalized unit (default ∈ options): an overlay
+  // that replaces the options list must also own the default, or a base default
+  // absent from the new list would leak through the field-by-field merge.
+  const {
+    contextWindows: _baseContextWindows,
+    contextWindowDefault: _baseContextWindowDefault,
+    ...selectionNeutralBase
+  } = routeBase;
+  const contextWindowSelection =
+    overlay.contextWindows !== undefined
+      ? {
+          contextWindows: overlay.contextWindows,
+          ...(overlay.contextWindowDefault !== undefined
+            ? { contextWindowDefault: overlay.contextWindowDefault }
+            : {}),
+        }
+      : {
+          ...(routeBase.contextWindows !== undefined
+            ? { contextWindows: routeBase.contextWindows }
+            : {}),
+          ...((overlay.contextWindowDefault ?? routeBase.contextWindowDefault)
+            ? {
+                contextWindowDefault:
+                  overlay.contextWindowDefault ?? routeBase.contextWindowDefault,
+              }
+            : {}),
+        };
+  return {
+    ...selectionNeutralBase,
+    ...contextWindowSelection,
+    ...(routeChanged ? { name: overlay.name } : {}),
+    ...(overlay.api !== undefined ? { api: overlay.api } : {}),
+    ...(overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
+    ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
+    ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
+    ...(overlay.reasoning !== undefined ? { reasoning: overlay.reasoning } : {}),
+    ...(overlay.configuredReasoning !== undefined
+      ? { configuredReasoning: overlay.configuredReasoning }
+      : {}),
+    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+    ...(overlay.input !== undefined ? { input: overlay.input } : {}),
+    ...(params ? { params } : {}),
+    ...(overlay.mediaInput !== undefined ? { mediaInput: overlay.mediaInput } : {}),
+    ...(overlay.providerOrder !== undefined ? { providerOrder: overlay.providerOrder } : {}),
+    ...(overlay.status !== undefined ? { status: overlay.status } : {}),
+    ...(overlay.statusReason !== undefined ? { statusReason: overlay.statusReason } : {}),
+    ...(overlay.replaces !== undefined ? { replaces: overlay.replaces } : {}),
+    ...(overlay.replacedBy !== undefined ? { replacedBy: overlay.replacedBy } : {}),
+    compat: options?.preserveBaseCompat
+      ? resolveCatalogOwnedModelCompat({
+          catalogRoute: base,
+          catalogCompat: base.compat,
+          configuredRoute: {
+            api: overlay.api ?? base.api,
+            baseUrl: overlay.baseUrl ?? base.baseUrl,
+          },
+          configuredCompat: overlay.compat,
+        })
+      : mergeCatalogFields(routeBase.compat, overlay.compat),
+  };
+}

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -17,10 +17,10 @@ import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runt
 import { createLazyPromise } from "../shared/lazy-promise.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
+import { normalizeCatalogRouteBaseUrl, overlayCatalogMetadata } from "./model-catalog-metadata.js";
 import { assignProviderModelOrder, compareModelCatalogEntries } from "./model-catalog-order.js";
 import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
-import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
@@ -66,151 +66,6 @@ const loadProviderApiKeyResolver = createLazyPromise(
 export function resetModelCatalogBuilderCacheForTest() {
   manifestModelCatalogCache = new WeakMap();
   hasLoggedModelCatalogError = false;
-}
-
-function mergeCatalogCompat(
-  base: ModelCatalogEntry["compat"] | undefined,
-  override: ModelCatalogEntry["compat"] | undefined,
-): ModelCatalogEntry["compat"] | undefined {
-  if (!base) {
-    return override;
-  }
-  if (!override) {
-    return base;
-  }
-  return { ...base, ...override };
-}
-
-function mergeCatalogParams(
-  base: ModelCatalogEntry["params"] | undefined,
-  override: ModelCatalogEntry["params"] | undefined,
-): ModelCatalogEntry["params"] | undefined {
-  if (!base) {
-    return override;
-  }
-  if (!override) {
-    return base;
-  }
-  return { ...base, ...override };
-}
-
-function normalizeCatalogRouteBaseUrl(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  try {
-    const url = new URL(value);
-    url.pathname = url.pathname.replace(/\/+$/u, "") || "/";
-    return url.toString();
-  } catch {
-    return value.replace(/\/+$/u, "");
-  }
-}
-
-function catalogRouteChanges(base: ModelCatalogEntry, overlay: ModelCatalogEntry): boolean {
-  if (overlay.api === undefined && overlay.baseUrl === undefined) {
-    return false;
-  }
-  return (
-    (overlay.api !== undefined && base.api !== undefined && overlay.api !== base.api) ||
-    (overlay.baseUrl !== undefined &&
-      base.baseUrl !== undefined &&
-      normalizeCatalogRouteBaseUrl(overlay.baseUrl) !== normalizeCatalogRouteBaseUrl(base.baseUrl))
-  );
-}
-
-function clearRouteBoundCatalogMetadata(entry: ModelCatalogEntry): ModelCatalogEntry {
-  const {
-    contextWindow: _contextWindow,
-    contextWindows: _contextWindows,
-    contextWindowDefault: _contextWindowDefault,
-    contextTokens: _contextTokens,
-    reasoning: _reasoning,
-    configuredReasoning: _configuredReasoning,
-    thinkingLevelMap: _thinkingLevelMap,
-    input: _input,
-    params: _params,
-    compat: _compat,
-    mediaInput: _mediaInput,
-    ...routeNeutral
-  } = entry;
-  return routeNeutral;
-}
-
-function overlayCatalogMetadata(
-  base: ModelCatalogEntry,
-  overlay: ModelCatalogEntry,
-  options?: {
-    preserveBaseCompat?: boolean;
-  },
-): ModelCatalogEntry {
-  // Catalog rows with one logical provider/id may describe different physical
-  // routes. Capabilities are atomic with their route; never carry them across
-  // an API/endpoint change when the new source omits those facts.
-  const routeChanged = catalogRouteChanges(base, overlay);
-  const routeBase = routeChanged ? clearRouteBoundCatalogMetadata(base) : base;
-  const params = mergeCatalogParams(routeBase.params, overlay.params);
-  const thinkingLevelMap = overlay.thinkingLevelMap ?? routeBase.thinkingLevelMap;
-  // Options + default are one normalized unit (default ∈ options): an overlay
-  // that replaces the options list must also own the default, or a base default
-  // absent from the new list would leak through the field-by-field merge.
-  const {
-    contextWindows: _baseContextWindows,
-    contextWindowDefault: _baseContextWindowDefault,
-    ...selectionNeutralBase
-  } = routeBase;
-  const contextWindowSelection =
-    overlay.contextWindows !== undefined
-      ? {
-          contextWindows: overlay.contextWindows,
-          ...(overlay.contextWindowDefault !== undefined
-            ? { contextWindowDefault: overlay.contextWindowDefault }
-            : {}),
-        }
-      : {
-          ...(routeBase.contextWindows !== undefined
-            ? { contextWindows: routeBase.contextWindows }
-            : {}),
-          ...((overlay.contextWindowDefault ?? routeBase.contextWindowDefault)
-            ? {
-                contextWindowDefault:
-                  overlay.contextWindowDefault ?? routeBase.contextWindowDefault,
-              }
-            : {}),
-        };
-  return {
-    ...selectionNeutralBase,
-    ...contextWindowSelection,
-    ...(routeChanged ? { name: overlay.name } : {}),
-    ...(overlay.api !== undefined ? { api: overlay.api } : {}),
-    ...(overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
-    ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
-    ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
-    ...(overlay.reasoning !== undefined ? { reasoning: overlay.reasoning } : {}),
-    ...(overlay.configuredReasoning !== undefined
-      ? { configuredReasoning: overlay.configuredReasoning }
-      : {}),
-    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
-    ...(overlay.input !== undefined ? { input: overlay.input } : {}),
-    ...(params ? { params } : {}),
-    ...(overlay.mediaInput !== undefined ? { mediaInput: overlay.mediaInput } : {}),
-    ...(overlay.providerOrder !== undefined ? { providerOrder: overlay.providerOrder } : {}),
-    ...(overlay.status !== undefined ? { status: overlay.status } : {}),
-    ...(overlay.statusReason !== undefined ? { statusReason: overlay.statusReason } : {}),
-    ...(overlay.replaces !== undefined ? { replaces: overlay.replaces } : {}),
-    ...(overlay.replacedBy !== undefined ? { replacedBy: overlay.replacedBy } : {}),
-    compat: options?.preserveBaseCompat
-      ? resolveCatalogOwnedModelCompat({
-          catalogRoute: base,
-          catalogCompat: base.compat,
-          configuredRoute: {
-            api: overlay.api ?? base.api,
-            baseUrl: overlay.baseUrl ?? base.baseUrl,
-          },
-          configuredCompat: overlay.compat,
-        })
-      : mergeCatalogCompat(routeBase.compat, overlay.compat),
-  };
 }
 
 function normalizeCatalogEntryContract(entry: ModelCatalogEntry): ModelCatalogEntry {


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Catalog construction duplicates the same parameter and compatibility-field merge and keeps route-aware metadata overlay logic inside a large builder. The remaining model-runtime repairs need that existing overlay owner without copying it again.

## Why This Change Was Made

Extract the existing catalog overlay into its own module and share the identical field merge. Preserve route-bound capabilities, coupled context-window options/defaults, and catalog-owned compatibility. This maintainer-requested cleanup changes two production files and removes 17 lines.

## User Impact

Catalog behavior is unchanged. The same metadata owner can be reused by subsequent focused repairs.

## Evidence

All 51 existing catalog and route tests pass with no test changes. The complete changed-file gate passed, and independent P2 review found no actionable findings. The change excludes registry identity and catalog-membership behavior.

A fresh full build at `a0b7a9d8003f144ab1a88b2471bc4a225957aeec` passed. Compiled catalog checks passed same-route field merging, context options/default ownership, catalog-owned compatibility, and capability clearing after a route change. An isolated compiled CLI inventory kept separate Reader/reader rows with their own context and input metadata. Both processes exited with zero checkout-source imports. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34439728911) passed.

This proof uses synthetic local catalog data and the real CLI; it does not make an external provider request.
