### PR TITLE
refactor: share isolated and TTS cleanup ownership

### DIFF
--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -13,6 +13,7 @@ import { withTempWorkspace } from "../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import type { AssistantMessage, Model } from "../llm/types.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveCliBackendConfig, resolveCliRuntimeCanonicalProvider } from "./cli-backends.js";
@@ -27,7 +28,6 @@ import type {
   AgentHarnessIsolatedCompletionParamsV2,
   AgentHarnessIsolatedCompletionResult,
 } from "./harness/types.js";
-import { runWithIsolatedCompletionResources } from "./isolated-completion-work.js";
 import { ensureAuthProfileStore } from "./model-auth.js";
 import {
   isCliRuntimeAliasForProvider,
@@ -400,7 +400,7 @@ async function prepareHostAuthorization(params: {
 export async function runIsolatedCompletion(
   params: RunIsolatedCompletionParams,
 ): Promise<IsolatedCompletionResult> {
-  return await runWithIsolatedCompletionResources((acceptLease, captureWorkContext) =>
+  return await runWithAsyncWorkResources((acceptLease, captureWorkContext) =>
     runIsolatedCompletionOwned(params, acceptLease, captureWorkContext),
   );
 }

--- a/src/shared/async-work-resources.ts
+++ b/src/shared/async-work-resources.ts
@@ -1,16 +1,13 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import {
-  AsyncWorkScope,
-  captureAsyncWorkTracker,
-  getAsyncWorkSignal,
-} from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
-import type { PreparedModelRuntimeLease } from "./prepared-model-runtime.js";
+import { AsyncWorkScope, captureAsyncWorkTracker, getAsyncWorkSignal } from "./async-work-scope.js";
+import { createDeferredCore } from "./deferred.js";
 
-/** Retains isolated completion resources through admitted setup and transport cleanup. */
-export async function runWithIsolatedCompletionResources<T>(
+type AsyncWorkResources = { release: () => void | Promise<void> };
+
+/** Returns the logical result while retaining resources through owned cleanup. */
+export async function runWithAsyncWorkResources<T>(
   run: (
-    acceptLease: (lease: PreparedModelRuntimeLease) => void,
+    onAcquired: (resources: AsyncWorkResources) => void,
     captureWorkContext: () => void,
   ) => Promise<T>,
 ): Promise<T> {
@@ -19,7 +16,7 @@ export async function runWithIsolatedCompletionResources<T>(
   const parentSignal = getAsyncWorkSignal();
   void trackOwner(async () => {
     const work = new AsyncWorkScope();
-    let lease: PreparedModelRuntimeLease | undefined;
+    let resources: AsyncWorkResources | undefined;
     let runInContext = work.run(() => AsyncLocalStorage.snapshot());
     const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
     parentSignal?.addEventListener("abort", closeFromParent, { once: true });
@@ -31,7 +28,7 @@ export async function runWithIsolatedCompletionResources<T>(
         await work.track(() =>
           run(
             (acquired) => {
-              lease = acquired;
+              resources = acquired;
             },
             () => {
               runInContext = AsyncLocalStorage.snapshot();
@@ -49,7 +46,7 @@ export async function runWithIsolatedCompletionResources<T>(
         );
       } finally {
         parentSignal?.removeEventListener("abort", closeFromParent);
-        lease?.release();
+        await resources?.release();
       }
     }
   }).catch(result.reject);

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 // TTS core coordinates text preparation, provider selection, and speech output.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -9,8 +8,7 @@ import {
   type ModelRef,
 } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
+import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
@@ -189,40 +187,16 @@ export async function summarizeText(
 
   const resolvedDeps = await loadDefaultSummarizeTextDeps();
   const { ref } = resolveSummaryModelRef(cfg, config);
-  const reported = createDeferredCore<SummarizeResult>();
-  const parentSignal = getAsyncWorkSignal();
-  void trackAsyncWork(async () => {
-    const work = new AsyncWorkScope();
-    const runInContext = work.run(() => AsyncLocalStorage.snapshot());
-    const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
-    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
-    if (parentSignal?.aborted) {
-      closeFromParent();
+  return await runWithAsyncWorkResources(async (onAcquired) => {
+    // Preparation precedes the request timer; the completion and its cleanup own the model.
+    const prepared = await resolvedDeps.acquireSimpleCompletionModel({
+      cfg,
+      provider: ref.provider,
+      modelId: ref.model,
+    });
+    if (!("error" in prepared)) {
+      onAcquired(prepared);
     }
-    let releaseModel: (() => void) | undefined;
-    try {
-      reported.resolve(
-        await work.track(async () => {
-          // Preparation precedes the request timer; the completion and its cleanup own the model.
-          const prepared = await resolvedDeps.acquireSimpleCompletionModel({
-            cfg,
-            provider: ref.provider,
-            modelId: ref.model,
-          });
-          if (!("error" in prepared)) {
-            releaseModel = prepared.release;
-          }
-          return await completeSummary(prepared, ref.provider, resolvedDeps);
-        }),
-      );
-    } catch (error) {
-      reported.reject(error);
-    } finally {
-      await work.runWhenIdle(() => undefined);
-      await runInContext(() => work.drain());
-      parentSignal?.removeEventListener("abort", closeFromParent);
-      releaseModel?.();
-    }
-  }).catch(reported.reject);
-  return await reported.promise;
+    return await completeSummary(prepared, ref.provider, resolvedDeps);
+  });
 }


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Isolated completions and TTS summaries separately implement the same resource-retention lifecycle. Keeping those copies aligned makes cleanup repairs harder, particularly when a result is available before owned transport work has drained.

## Why This Change Was Made

Move the existing isolated-completion resource owner into the shared async-work module and reuse it for TTS summaries. Preserve logical result timing, parent cancellation, context capture, and release after owned work drains. Model selection and the injected TTS path are unchanged. This maintainer-requested cleanup removes 29 production lines ahead of the remaining model-runtime repairs.

## User Impact

Completion and TTS behavior stays the same, with one owner for resource cleanup.

## Evidence

All 59 existing focused cases pass with no test edits. Independent P2 review and a fresh full build passed. Six compiled loopback cases passed: isolated completion and TTS each cover success, authentication error, and cancellation. Tracked cleanup reads the live synthetic SQLite resource before the fixture owner closes it, and the import guard observed no checkout-source imports. Actual ephemeral registry disposal remains covered by the source suite. The complete changed-file gate passed.

The build was produced from the frozen staged candidate before commit; its natural build metadata retains the base revision. Commit `eca5e03bf0aa30597b04b57b2ccfb33d54eedbb7` has the identical built source tree; build metadata was not restamped.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34439962212) passed.
