### PR TITLE
fix(media): preserve native image hooks in provider registry

### DIFF
--- a/packages/media-understanding-common/src/provider-supports.ts
+++ b/packages/media-understanding-common/src/provider-supports.ts
@@ -1,6 +1,7 @@
 import type { MediaUnderstandingCapability } from "./types.js";
 
 type MediaCapabilityProvider = {
+  capabilities?: readonly MediaUnderstandingCapability[];
   transcribeAudio?: unknown;
   transcribeAudioWithContext?: unknown;
   describeImage?: unknown;
@@ -9,7 +10,7 @@ type MediaCapabilityProvider = {
 
 // Capability checks for media-understanding provider objects.
 
-/** Return true when a provider exposes the method for a media capability. */
+/** Image providers can use shared model dispatch; audio/video require registered methods. */
 export function providerSupportsCapability(
   provider: MediaCapabilityProvider | undefined,
   capability: MediaUnderstandingCapability,
@@ -21,7 +22,7 @@ export function providerSupportsCapability(
     return Boolean(provider.transcribeAudioWithContext || provider.transcribeAudio);
   }
   if (capability === "image") {
-    return Boolean(provider.describeImage);
+    return Boolean(provider.describeImage || provider.capabilities?.includes("image"));
   }
   return Boolean(provider.describeVideo);
 }

--- a/src/agents/tools/image-tool.provider-loading.test.ts
+++ b/src/agents/tools/image-tool.provider-loading.test.ts
@@ -34,6 +34,7 @@ async function executeImage(params: {
   fallbacks?: string[];
   preparedProviders?: MediaUnderstandingProvider[];
   configuredProvider?: string;
+  paths?: string[];
 }) {
   const config: OpenClawConfig = {
     agents: {
@@ -81,7 +82,10 @@ async function executeImage(params: {
   if (!tool) {
     throw new Error("expected configured image tool");
   }
-  return await tool.execute("image-loading", { path: image });
+  return await tool.execute(
+    "image-loading",
+    params.paths ? { paths: params.paths } : { path: image },
+  );
 }
 
 describe("image tool provider loading", () => {
@@ -91,7 +95,7 @@ describe("image tool provider loading", () => {
     testing.setProviderDepsForTest({
       buildProviderRegistry: (overrides, cfg, preparedProviders) => {
         // An unrelated plugin may fail or block during broad discovery. Keep the
-        // real registry hydration but make that unwanted cold path observable.
+        // real registry merge but make that unwanted cold path observable.
         if (preparedProviders === undefined) {
           throw new Error("unrelated media plugin failed to initialize");
         }
@@ -121,6 +125,35 @@ describe("image tool provider loading", () => {
     expect(resolveProvider.mock.calls.map(([params]) => params.providerId)).toEqual(["selected"]);
     expect(genericDescribe).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])(
+    "uses a single-image provider for each image with prepared=%s",
+    async (prepared) => {
+      const describeImage = vi.fn<NonNullable<MediaUnderstandingProvider["describeImage"]>>(
+        async ({ buffer }) => ({ text: buffer.toString("utf8") }),
+      );
+      const owner: MediaUnderstandingProvider = {
+        id: "selected",
+        capabilities: ["image"],
+        describeImage,
+      };
+      resolveProvider.mockReturnValue(owner);
+      const result = await executeImage({
+        paths: [image, "data:image/png;base64,aW1hZ2UtdHdv"],
+        ...(prepared ? { preparedProviders: [owner] } : {}),
+      });
+
+      expect(describeImage).toHaveBeenCalledTimes(2);
+      expect(describeImage.mock.calls.map(([request]) => request.buffer.toString("utf8"))).toEqual([
+        "image",
+        "image-two",
+      ]);
+      expect(result.content).toEqual([
+        { type: "text", text: "Image 1:\nimage\n\nImage 2:\nimage-two" },
+      ]);
+      expect(genericDescribe).not.toHaveBeenCalled();
+    },
+  );
 
   it("loads the next fallback owner only after the primary fails", async () => {
     const primary = provider("selected");

--- a/src/media-understanding/provider-registry.test.ts
+++ b/src/media-understanding/provider-registry.test.ts
@@ -1,7 +1,6 @@
 // Provider registry tests cover runtime provider loading, normalization aliases,
-// manifest-only hook hydration, and config-derived image providers.
+// manifest-only image capability, and config-derived image providers.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { describeImageWithModel, describeImagesWithModel } from "./image-runtime.js";
 import {
   buildMediaUnderstandingRegistry,
   getMediaUnderstandingProvider,
@@ -47,8 +46,7 @@ describe("media-understanding provider registry", () => {
     const registry = buildMediaUnderstandingRegistry();
 
     expect(requireMediaProvider(registry, "groq").id).toBe("groq");
-    expect(typeof requireMediaProvider(registry, "groq").describeImage).toBe("function");
-    expect(typeof requireMediaProvider(registry, "groq").describeImages).toBe("function");
+    expect(requireMediaProvider(registry, "groq").capabilities).toContain("image");
     expect(requireMediaProvider(registry, "deepgram").id).toBe("deepgram");
     expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
       key: "mediaUnderstandingProviders",
@@ -56,7 +54,7 @@ describe("media-understanding provider registry", () => {
     });
   });
 
-  it("hydrates manifest-only image providers with model-backed image hooks", () => {
+  it("keeps manifest-only image providers available for model-backed dispatch", () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createMediaProvider({
         id: "zai",
@@ -69,11 +67,11 @@ describe("media-understanding provider registry", () => {
     const provider = requireMediaProvider(registry, "zai");
 
     expect(provider.defaultModels?.image).toBe("glm-4.6v");
-    expect(provider.describeImage).toBe(describeImageWithModel);
-    expect(provider.describeImages).toBe(describeImagesWithModel);
+    expect(provider.describeImage).toBeUndefined();
+    expect(provider.describeImages).toBeUndefined();
   });
 
-  it("resets earlier custom hooks when a prepared owner explicitly requests generic hooks", () => {
+  it("resets earlier custom hooks when a prepared owner requests model-backed dispatch", () => {
     const customImage = vi.fn(async () => ({ text: "custom image" }));
     const customImages = vi.fn(async () => ({ text: "custom images" }));
     const registry = buildMediaUnderstandingRegistry(undefined, undefined, [
@@ -94,11 +92,11 @@ describe("media-understanding provider registry", () => {
 
     const provider = requireMediaProvider(registry, "zai");
     expect(provider.defaultModels?.image).toBe("glm-4.6v");
-    expect(provider.describeImage).toBe(describeImageWithModel);
-    expect(provider.describeImages).toBe(describeImagesWithModel);
+    expect(provider.describeImage).toBeUndefined();
+    expect(provider.describeImages).toBeUndefined();
   });
 
-  it("keeps partial explicit overrides ahead of hydrated prepared hooks", () => {
+  it("preserves partial native overrides for dispatch", () => {
     const overrideImage = vi.fn(async () => ({ text: "override image" }));
     const registry = buildMediaUnderstandingRegistry(
       {
@@ -114,7 +112,7 @@ describe("media-understanding provider registry", () => {
 
     const provider = requireMediaProvider(registry, "zai");
     expect(provider.describeImage).toBe(overrideImage);
-    expect(provider.describeImages).toBe(describeImagesWithModel);
+    expect(provider.describeImages).toBeUndefined();
   });
 
   it("keeps provider id normalization behavior for capability providers", () => {
@@ -146,8 +144,8 @@ describe("media-understanding provider registry", () => {
 
     expect(glmProvider.id).toBe("glm");
     expect(glmProvider.capabilities).toEqual(["image"]);
-    expect(typeof glmProvider.describeImage).toBe("function");
-    expect(typeof glmProvider.describeImages).toBe("function");
+    expect(glmProvider.describeImage).toBeUndefined();
+    expect(glmProvider.describeImages).toBeUndefined();
     expect(textOnlyProvider).toBeUndefined();
   });
 

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -2,7 +2,6 @@ import { normalizeMediaProviderId } from "../../packages/media-understanding-com
 import type { OpenClawConfig } from "../config/types.js";
 import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { resolveImageCapableConfigProviderIds } from "./config-provider-models.js";
-import { describeImageWithModel, describeImagesWithModel } from "./image-runtime.js";
 import type { MediaUnderstandingProvider } from "./types.js";
 
 function mergeProviderIntoRegistry(
@@ -23,27 +22,9 @@ function mergeProviderIntoRegistry(
         documentModels: provider.documentModels ?? existing.documentModels,
       }
     : provider;
-  // Own undefined hooks reset earlier owners; absent hooks inherit. Hydrate after
-  // merging so providers sharing a normalized id retain that distinction.
-  registry.set(normalizedKey, hydrateModelBackedMediaProvider(merged));
-}
-
-function hydrateModelBackedMediaProvider(
-  provider: MediaUnderstandingProvider,
-): MediaUnderstandingProvider {
-  // Manifest-only image providers can still route through the generic model
-  // runtime when they declare image capability but no plugin hook.
-  if (!provider.capabilities?.includes("image")) {
-    return provider;
-  }
-  if (provider.describeImage && provider.describeImages) {
-    return provider;
-  }
-  return {
-    ...provider,
-    describeImage: provider.describeImage ?? describeImageWithModel,
-    describeImages: provider.describeImages ?? describeImagesWithModel,
-  };
+  // Own undefined hooks reset earlier owners; absent hooks inherit. Dispatch
+  // supplies model-backed fallbacks without hiding the provider's native hooks.
+  registry.set(normalizedKey, merged);
 }
 
 export { normalizeMediaProviderId } from "../../packages/media-understanding-common/src/provider-id.js";

--- a/src/media-understanding/runner.auto-selection.test.ts
+++ b/src/media-understanding/runner.auto-selection.test.ts
@@ -45,6 +45,47 @@ afterEach(() => {
 });
 
 describe("automatic media selection", () => {
+  it.each(["manifest", "config"] as const)(
+    "auto-selects hookless image providers from %s",
+    async (source) => {
+      const provider = "selection-image";
+      const cfg: OpenClawConfig =
+        source === "config"
+          ? {
+              models: {
+                providers: {
+                  [provider]: {
+                    baseUrl: "https://image.example/v1",
+                    models: [
+                      {
+                        id: "vision",
+                        name: "Vision",
+                        reasoning: false,
+                        input: ["text", "image"],
+                        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                        contextWindow: 8192,
+                        maxTokens: 128,
+                      },
+                    ],
+                  },
+                },
+              },
+            }
+          : {};
+      if (source === "manifest") {
+        selection.providers.push({
+          id: provider,
+          capabilities: ["image"],
+          defaultModels: { image: "vision" },
+          autoPriority: { image: 1 },
+        });
+      }
+
+      expect(await resolveAutoImageModel({ cfg })).toEqual({ provider, model: "vision" });
+      expect(selection.auth).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ provider }));
+    },
+  );
+
   it.each([
     { capability: "image", route: "active", model: "after-auth", provider: "google" },
     { capability: "image", route: "key", model: "before-auth", provider: "GEMINI" },

--- a/src/plugins/registry.diagnostics.test.ts
+++ b/src/plugins/registry.diagnostics.test.ts
@@ -1,9 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
-import {
-  describeImageWithModel,
-  describeImagesWithModel,
-} from "../media-understanding/image-runtime.js";
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
 import type { MediaUnderstandingProvider } from "../media-understanding/types.js";
 import { runPluginRegisterSyncInRegistry } from "./loader-module-runtime.js";
@@ -206,18 +202,10 @@ describe("plugin registration diagnostics", () => {
         "merged media provider",
       );
       expect(provider.describeImage).toBe(
-        single === "absent"
-          ? inheritedImage
-          : single === "custom"
-            ? customImage
-            : describeImageWithModel,
+        single === "absent" ? inheritedImage : single === "custom" ? customImage : undefined,
       );
       expect(provider.describeImages).toBe(
-        multiple === "absent"
-          ? inheritedImages
-          : multiple === "custom"
-            ? customImages
-            : describeImagesWithModel,
+        multiple === "absent" ? inheritedImages : multiple === "custom" ? customImages : undefined,
       );
     },
   );


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where sending multiple images to a plugin with a native single-image hook silently bypasses that hook and uses generic model dispatch instead.

## Why This Change Was Made

Keep absent native hooks absent in the provider registry. The existing image dispatch boundary can then call a native batch hook, call the native single-image hook for each image in order, or supply model-backed dispatch when no native hook exists. Preserve capability-only image providers in automatic selection. Audio and video requirements are unchanged. The repair removes 18 production lines across two owners.

## User Impact

Image plugins receive the image requests their native hooks support. Manifest-only and configured image-capable providers remain available through generic dispatch.

## Evidence

The two native two-image regressions fail on the original main code. Removing registry hydration alone also exposed a generic auto-selection regression; the same cases pass on original main and with the complete repair. All 172 focused tests now pass, including native dispatch, manifest/config automatic selection, overrides, and resets. The complete changed-file gate and independent P2 review passed.

A full build and six compiled image-tool cases passed at `5678943431a41b2bb07d1ac3fc59638eebec9878`. Native single-image hooks received both images in order; the batch hook ran once; both avoided generic HTTP dispatch. Generic automatic selection made one loopback POST containing two distinct images. Prepared and unprepared paths, overrides and reset controls passed with no checkout-source imports and complete cleanup.

CI exposed 15 stale registry diagnostic expectations for synthesized hooks. The failure reproduced locally; the test-only follow-up preserves all 27 ownership combinations and passes all 31 diagnostics tests, fresh P2 review and the complete six-file changed gate. Final head `2dd4f2a0366ff29fa297539f4f5739fb4566a162` changes only that test file from the built revision. Source, runtime/dependency inputs and executed-module hashes were reverified unchanged; build metadata retains its original revision. [Updated-head CI](https://github.com/openclaw/openclaw/actions/runs/34444646481) passed.
