### PR TITLE
fix(workers): skip unused bootstrap files during startup

### DIFF
--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -6,6 +6,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as boundaryFileRead from "../infra/boundary-file-read.js";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import * as workspaceBootstrapRead from "./workspace-bootstrap-read.js";
@@ -14,7 +15,11 @@ import {
   retireWorkspaceFileCache,
   writeWorkspaceFileCache,
 } from "./workspace-file-cache.js";
-import { loadWorkspaceBootstrapFiles, DEFAULT_AGENTS_FILENAME } from "./workspace.js";
+import {
+  loadWorkspaceBootstrapFiles,
+  DEFAULT_AGENTS_FILENAME,
+  WORKSPACE_BOOTSTRAP_FILENAMES,
+} from "./workspace.js";
 
 describe("workspace bootstrap file caching", () => {
   let workspaceDir: string;
@@ -40,6 +45,45 @@ describe("workspace bootstrap file caching", () => {
     expect(agentsFile?.content).toBe(content);
     expect(agentsFile?.missing).toBe(false);
   };
+
+  it("selects before guarded reads without narrowing later default cache loads", async () => {
+    for (const name of WORKSPACE_BOOTSTRAP_FILENAMES) {
+      await writeWorkspaceFile({ dir: workspaceDir, name, content: `contents of ${name}` });
+    }
+    const openedFiles = vi.spyOn(boundaryFileRead, "openRootFileFollowingParents");
+    const readFile = vi.spyOn(workspaceBootstrapRead, "readWorkspaceBootstrapFile");
+    try {
+      const selected = await loadWorkspaceBootstrapFiles(workspaceDir, [DEFAULT_AGENTS_FILENAME]);
+      expect(selected.map((file) => [file.name, file.content])).toEqual([
+        ["AGENTS.md", "contents of AGENTS.md"],
+      ]);
+      expect(openedFiles.mock.calls.map(([params]) => params.absolutePath)).toEqual([
+        path.join(workspaceDir, "AGENTS.md"),
+      ]);
+      expect(readFile).toHaveBeenCalledTimes(1);
+      openedFiles.mockClear();
+
+      const defaults = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const expectedNames = [
+        "AGENTS.md",
+        "SOUL.md",
+        "IDENTITY.md",
+        "USER.md",
+        "BOOTSTRAP.md",
+        "MEMORY.md",
+      ];
+      expect(defaults.map((file) => [file.name, file.content])).toEqual(
+        expectedNames.map((name) => [name, `contents of ${name}`]),
+      );
+      expect(openedFiles.mock.calls.map(([params]) => params.absolutePath)).toEqual(
+        expectedNames.map((name) => path.join(workspaceDir, name)),
+      );
+      expect(readFile).toHaveBeenCalledTimes(6);
+    } finally {
+      openedFiles.mockRestore();
+      readFile.mockRestore();
+    }
+  });
 
   it("evicts the oldest cached file after 64 empty entries", async () => {
     const readFile = vi.spyOn(workspaceBootstrapRead, "readWorkspaceBootstrapFile");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1223,38 +1223,15 @@ export async function ensureAgentWorkspace(params?: {
   };
 }
 
-export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
+export async function loadWorkspaceBootstrapFiles(
+  dir: string,
+  names?: readonly WorkspaceBootstrapFileName[],
+): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
-
-  const entries: Array<{
-    name: WorkspaceBootstrapFileName;
-    filePath: string;
-  }> = [
-    {
-      name: DEFAULT_AGENTS_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_AGENTS_FILENAME),
-    },
-    {
-      name: DEFAULT_SOUL_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_SOUL_FILENAME),
-    },
-    {
-      name: DEFAULT_IDENTITY_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_IDENTITY_FILENAME),
-    },
-    {
-      name: DEFAULT_USER_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_USER_FILENAME),
-    },
-    {
-      name: DEFAULT_BOOTSTRAP_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
-    },
-    {
-      name: DEFAULT_MEMORY_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
-    },
-  ];
+  // Cache hits still open files to validate identity, so select names before I/O.
+  const entries = WORKSPACE_BOOTSTRAP_FILENAMES.filter(
+    (name) => names === undefined || names.includes(name),
+  ).map((name) => ({ name, filePath: path.join(resolvedDir, name) }));
 
   const result: WorkspaceBootstrapFile[] = [];
   for (const entry of entries) {

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -164,9 +164,7 @@ async function runWorkerEmbeddedTurnWithResources(
     compaction: { enabled: false },
     retry: { enabled: false },
   });
-  const bootstrapFiles = (await loadWorkspaceBootstrapFiles(params.cwd)).filter(
-    (file) => file.name === DEFAULT_AGENTS_FILENAME,
-  );
+  const bootstrapFiles = await loadWorkspaceBootstrapFiles(params.cwd, [DEFAULT_AGENTS_FILENAME]);
   const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, {});
   const resourceLoader = createEmbeddedAgentResourceLoader({
     cwd: params.cwd,

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -58,6 +58,7 @@ import {
   waitForExecScope,
 } from "../agents/bash-process-registry.js";
 import { runExecProcess } from "../agents/bash-tools.exec-runtime.js";
+import * as boundaryFileRead from "../infra/boundary-file-read.js";
 import { saveExecApprovals, type ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { runExec } from "../process/exec.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
@@ -1074,6 +1075,9 @@ describe("worker runtime", () => {
     const literalPrompt = path.join(workspaceDir, "not-a-prompt-file.md");
     await mkdir(promptDir);
     await writeFile(path.join(workspaceDir, "AGENTS.md"), "prepared-worker-context");
+    for (const name of ["SOUL.md", "IDENTITY.md", "USER.md", "BOOTSTRAP.md", "MEMORY.md"]) {
+      await writeFile(path.join(workspaceDir, name), "unselected-workspace-bootstrap-marker");
+    }
     await writeFile(path.join(promptDir, "SYSTEM.md"), "ambient-system-marker");
     await writeFile(path.join(promptDir, "APPEND_SYSTEM.md"), "ambient-append-marker");
     await writeFile(literalPrompt, "unrequested-file-contents");
@@ -1081,7 +1085,17 @@ describe("worker runtime", () => {
       launch.assignment.systemPrompt = literalPrompt;
     }
 
-    await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+    const openedFiles = vi.spyOn(boundaryFileRead, "openRootFileFollowingParents");
+    try {
+      await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+      expect(
+        openedFiles.mock.calls
+          .map(([params]) => params.absolutePath)
+          .filter((filePath) => path.dirname(filePath) === workspaceDir),
+      ).toEqual([path.join(workspaceDir, "AGENTS.md")]);
+    } finally {
+      openedFiles.mockRestore();
+    }
 
     const prompt = gateway.inferenceRequests[0]?.context.systemPrompt;
     expect(prompt).toContain("prepared-worker-context");
@@ -1089,6 +1103,7 @@ describe("worker runtime", () => {
     expect.soft(prompt).not.toContain("ambient-system-marker");
     expect.soft(prompt).not.toContain("ambient-append-marker");
     expect.soft(prompt).not.toContain("unrequested-file-contents");
+    expect.soft(prompt).not.toContain("unselected-workspace-bootstrap-marker");
     if (extra) {
       expect.soft(prompt).toContain(literalPrompt);
     }


### PR DESCRIPTION
Related: #134931.

## What Problem This Solves

Embedded worker turns use local `AGENTS.md` plus the prepared context supplied by the Gateway, but startup opened all six workspace bootstrap files before selecting `AGENTS.md`. This caused unnecessary filesystem reads and could report unreadable files that the worker would never use.

## Why This Change Was Made

The bootstrap loader accepts a typed optional filename selection and filters the existing canonical list before any per-file lookup or guarded read. The embedded worker requests only `AGENTS.md`. The default call retains the same six filenames and order, guarded reads, source-identity checks, and cache behavior.

## User Impact

Worker startup reads only the local bootstrap file it uses. Existing default bootstrap loading and prepared prompt content retain their behavior.

## Evidence

Both worker prompt variants reproduced all six guarded opens on unchanged code. The repaired cases observe only `AGENTS.md` while retaining the existing prompt assertions. A real-filesystem selected-then-default read verifies that a narrow call does not poison later default loading.

All 85 unique tests passed: 83 bootstrap/cache cases and both worker prompt variants. The full changed-file gate passed, and fresh independent review through P2 found no actionable issue. The deterministic improvement is six guarded opens to one; single-run timings are not a performance guarantee. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34440573991). No native provider timing claim is made for this filesystem change.
