### PR TITLE
fix: preserve streamed reply boundaries without replaying code

### DIFF
--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -28,6 +28,82 @@ function expectChunksWithinLength(chunks: string[], maxLength: number) {
 
 describe("EmbeddedBlockChunker", () => {
   it.each([
+    { breakPreference: "paragraph", suffix: "ready\n\nTail", expected: "First line is ready" },
+    { breakPreference: "newline", suffix: "ready\nTail", expected: "First line is ready" },
+    { breakPreference: "sentence", suffix: "ready. Tail", expected: "First line is ready." },
+  ] as const)(
+    "waits for a $breakPreference boundary before falling back to whitespace",
+    ({ breakPreference, suffix, expected }) => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 8,
+        maxChars: 30,
+        breakPreference,
+        flushOnParagraph: false,
+      });
+
+      for (const character of "First line is ") {
+        chunker.append(character);
+        expect(drainChunks(chunker)).toEqual([]);
+      }
+      chunker.append(suffix);
+
+      expect(drainChunks(chunker)).toEqual([expected]);
+      expect(drainChunks(chunker, true)).toEqual(["Tail"]);
+      expect(chunker.bufferedText).toBe("");
+    },
+  );
+
+  it("balances an unfinished fence at the exact cap and retains its later continuation", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 8,
+      maxChars: 20,
+      breakPreference: "paragraph",
+    });
+    chunker.append("```ts\nabcdefghijklm");
+    expect(drainChunks(chunker)).toEqual([]);
+
+    chunker.append("n");
+    expect(drainChunks(chunker)).toEqual(["```ts\nabcdefghij\n```"]);
+    expect(chunker.bufferedText).toBe("```ts\nklmn");
+
+    chunker.append("op\n```");
+    expect(drainChunks(chunker)).toEqual([]);
+    expect(drainChunks(chunker, true)).toEqual(["```ts\nklmnop\n```"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it.each([
+    { text: "```ts\nabcdefg.", expected: [] },
+    { text: "```ts\nabcdefghijklm.", expected: ["```ts\nabcdefghij\n```"] },
+  ])("keeps terminal code punctuation inside its unfinished fence: $text", ({ text, expected }) => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 8,
+      maxChars: 20,
+      breakPreference: "paragraph",
+    });
+    chunker.append(text);
+
+    expect(drainChunks(chunker)).toEqual(expected);
+  });
+
+  it("keeps a genuinely closed fence at the exact cap without reopening it", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 8,
+      maxChars: 20,
+      breakPreference: "paragraph",
+    });
+    chunker.append("```ts\nabcdefghij\n");
+    expect(drainChunks(chunker)).toEqual([]);
+
+    chunker.append("```");
+    expect(drainChunks(chunker)).toEqual(["```ts\nabcdefghij\n```"]);
+    expect(drainChunks(chunker, true)).toEqual([]);
+
+    chunker.append("Tail");
+    expect(drainChunks(chunker, true)).toEqual(["Tail"]);
+  });
+
+  it.each([
     { tail: "Tail", changed: false, expected: ["Tail"] },
     { tail: "", changed: true, expected: [] },
     { tail: "Fixed tail", changed: true, expected: ["Fixed tail"] },
@@ -282,9 +358,9 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("After fence");
   });
 
-  it("parses fence spans once per drain call for long fenced buffers", () => {
+  it("scans fence spans once per drain call for long fenced buffers", () => {
     // Long streaming buffers should not rescan fences for every emitted chunk.
-    const parseSpy = vi.spyOn(fences, "parseFenceSpans");
+    const scanSpy = vi.spyOn(fences, "scanFenceSpans");
     const chunker = new EmbeddedBlockChunker({
       minChars: 20,
       maxChars: 80,
@@ -295,8 +371,8 @@ describe("EmbeddedBlockChunker", () => {
     const chunks = drainChunks(chunker);
 
     expect(chunks.length).toBeGreaterThan(2);
-    expect(parseSpy).toHaveBeenCalledTimes(1);
-    parseSpy.mockRestore();
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+    scanSpy.mockRestore();
   });
 
   it("does not split inside the closing fence marker when clamping at maxChars", () => {

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -103,6 +103,22 @@ describe("EmbeddedBlockChunker", () => {
     expect(drainChunks(chunker, true)).toEqual(["Tail"]);
   });
 
+  it("reports original source across synthetic wrappers and a consumed closing fence", () => {
+    const chunker = new EmbeddedBlockChunker({ minChars: 1, maxChars: 20 });
+    const delivered: Array<{ text: string; sourceText?: string }> = [];
+    chunker.append("```txt\nabcdefghijklmnopqr\n```\n\nTail");
+    chunker.drain({
+      force: true,
+      emit: (text, options) => delivered.push({ text, sourceText: options?.sourceText }),
+    });
+
+    expect(delivered).toEqual([
+      { text: "```txt\nabcdefghi\n```", sourceText: "```txt\nabcdefghi" },
+      { text: "```txt\njklmnopqr\n```", sourceText: "jklmnopqr\n```\n\n" },
+      { text: "Tail", sourceText: "Tail" },
+    ]);
+  });
+
   it.each([
     { tail: "Tail", changed: false, expected: ["Tail"] },
     { tail: "", changed: true, expected: [] },

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -7,7 +7,7 @@ import type { FenceSpan } from "../../packages/markdown-core/src/fences.js";
 import {
   findFenceSpanAt,
   isSafeFenceBreak,
-  parseFenceSpans,
+  scanFenceSpans,
 } from "../../packages/markdown-core/src/fences.js";
 
 export type BlockReplyChunking = {
@@ -39,6 +39,7 @@ function findSafeSentenceBreakIndex(
   fenceSpans: FenceSpan[],
   minChars: number,
   offset = 0,
+  openFence?: FenceSpan,
 ): number {
   const matches = text.matchAll(/[.!?](?=\s|$)/g);
   let sentenceIdx = -1;
@@ -48,7 +49,7 @@ function findSafeSentenceBreakIndex(
       continue;
     }
     const candidate = at + 1;
-    if (isSafeFenceBreak(fenceSpans, offset + candidate)) {
+    if (offset + candidate !== openFence?.end && isSafeFenceBreak(fenceSpans, offset + candidate)) {
       sentenceIdx = candidate;
     }
   }
@@ -217,7 +218,8 @@ export class EmbeddedBlockChunker {
 
     // Keep original source text so shortened language hints and synthetic
     // fences cannot move the source cursor during checkpoint reconciliation.
-    const fenceSpans = parseFenceSpans(source);
+    const { spans: fenceSpans, state: fenceState } = scanFenceSpans(source);
+    const openFence = fenceState.open ? fenceSpans.at(-1) : undefined;
     const removedFenceInfo: Array<{ at: number; length: number }> = [];
     let removedFenceInfoLength = 0;
     for (const fence of fenceSpans) {
@@ -286,7 +288,7 @@ export class EmbeddedBlockChunker {
       const view = source.slice(start);
       const breakResult =
         force && remainingLength <= maxChars
-          ? this.#pickSoftBreakIndex(view, fenceSpans, chunking, 1, start)
+          ? this.#pickSoftBreakIndex(view, fenceSpans, chunking, 1, start, openFence)
           : this.#pickBreakIndex(
               view,
               fenceSpans,
@@ -294,6 +296,7 @@ export class EmbeddedBlockChunker {
               force ? 1 : undefined,
               start,
               maxChars - reopenPrefix.length,
+              openFence,
             );
       if (breakResult.index <= 0) {
         if (force) {
@@ -394,6 +397,7 @@ export class EmbeddedBlockChunker {
     chunking: BlockReplyChunking,
     minCharsOverride?: number,
     offset = 0,
+    openFence?: FenceSpan,
   ): BreakResult {
     const minChars = Math.max(1, Math.floor(minCharsOverride ?? chunking.minChars));
     if (buffer.length < minChars) {
@@ -428,7 +432,13 @@ export class EmbeddedBlockChunker {
     }
 
     if (preference !== "newline") {
-      const sentenceIdx = findSafeSentenceBreakIndex(buffer, fenceSpans, minChars, offset);
+      const sentenceIdx = findSafeSentenceBreakIndex(
+        buffer,
+        fenceSpans,
+        minChars,
+        offset,
+        openFence,
+      );
       if (sentenceIdx !== -1) {
         return { index: sentenceIdx };
       }
@@ -444,6 +454,7 @@ export class EmbeddedBlockChunker {
     minCharsOverride?: number,
     offset = 0,
     maxCharsOverride?: number,
+    openFence?: FenceSpan,
   ): BreakResult {
     const minChars = Math.max(1, Math.floor(minCharsOverride ?? chunking.minChars));
     const maxChars = Math.max(1, Math.floor(maxCharsOverride ?? chunking.maxChars));
@@ -480,13 +491,19 @@ export class EmbeddedBlockChunker {
     }
 
     if (preference !== "newline") {
-      const sentenceIdx = findSafeSentenceBreakIndex(window, fenceSpans, minChars, offset);
+      const sentenceIdx = findSafeSentenceBreakIndex(
+        window,
+        fenceSpans,
+        minChars,
+        offset,
+        openFence,
+      );
       if (sentenceIdx !== -1) {
         return { index: sentenceIdx };
       }
     }
 
-    if (preference === "newline" && buffer.length < maxChars) {
+    if (buffer.length < maxChars) {
       return { index: -1 };
     }
 
@@ -503,10 +520,11 @@ export class EmbeddedBlockChunker {
         0,
         Math.max(maxChars, firstCodePointWidth),
       ).length;
-      if (isSafeFenceBreak(fenceSpans, offset + forcedBreakIndex)) {
-        return { index: forcedBreakIndex };
-      }
-      const fence = findFenceSpanAt(fenceSpans, offset + forcedBreakIndex);
+      // An unfinished span ends at the buffer boundary without a source closer.
+      const absoluteBreakIndex = offset + forcedBreakIndex;
+      const fence =
+        findFenceSpanAt(fenceSpans, absoluteBreakIndex) ??
+        (openFence?.end === absoluteBreakIndex ? openFence : undefined);
       if (fence) {
         const reopenFenceLine = resolveFenceReopenLine(fence, chunking.maxChars);
         if (!reopenFenceLine) {

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -190,7 +190,10 @@ export class EmbeddedBlockChunker {
   }
 
   /** Emit safe chunks according to size and Markdown fence constraints. */
-  drain(params: { force: boolean; emit: (chunk: string) => void }) {
+  drain(params: {
+    force: boolean;
+    emit: (chunk: string, options?: { sourceText: string }) => void;
+  }) {
     // KNOWN: We cannot split inside fenced code blocks (Markdown breaks + UI glitches).
     // When forced (maxChars), we close + reopen the fence to keep Markdown valid.
     const { force, emit } = params;
@@ -208,7 +211,7 @@ export class EmbeddedBlockChunker {
 
     if (!chunking || (force && source.length <= maxChars && !this.#reopenPrefix)) {
       if (!chunking || source.trim().length > 0) {
-        emit(source);
+        emit(source, { sourceText: this.#buffer });
       }
       this.#consumedLength += this.#buffer.length;
       this.#buffer = "";
@@ -245,6 +248,16 @@ export class EmbeddedBlockChunker {
       fence.end -= removedLength;
       removedFenceInfoLength += removedLength;
     }
+    const sourceOffset = (index: number) =>
+      Math.max(
+        0,
+        removedFenceInfo.reduce(
+          (offset, removed) => offset + (removed.at <= index ? removed.length : 0),
+          index,
+        ) - this.#reopenPrefix.length,
+      );
+    const emitSourceChunk = (chunk: string, from: number, to: number) =>
+      emit(chunk, { sourceText: this.#buffer.slice(sourceOffset(from), sourceOffset(to)) });
     let start = 0;
     let reopenFence: FenceSplit | undefined;
     const resumedFence = this.#reopenPrefix ? fenceSpans[0] : undefined;
@@ -273,10 +286,14 @@ export class EmbeddedBlockChunker {
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
         if (paragraphBreak && paragraphBreak.index - start <= paragraphLimit) {
           const chunk = `${reopenPrefix}${source.slice(start, paragraphBreak.index)}`;
+          const nextStart = skipLeadingNewlines(
+            source,
+            paragraphBreak.index + paragraphBreak.length,
+          );
           if (chunk.trim().length > 0) {
-            emit(chunk);
+            emitSourceChunk(chunk, start, nextStart);
           }
-          start = skipLeadingNewlines(source, paragraphBreak.index + paragraphBreak.length);
+          start = nextStart;
           reopenFence = undefined;
           continue;
         }
@@ -300,22 +317,24 @@ export class EmbeddedBlockChunker {
             );
       if (breakResult.index <= 0) {
         if (force) {
-          emit(`${reopenPrefix}${source.slice(start)}`);
+          emitSourceChunk(`${reopenPrefix}${source.slice(start)}`, start, source.length);
           start = source.length;
           reopenFence = undefined;
         }
         break;
       }
 
-      const consumed = this.#emitBreakResult({
+      const consumed = this.#resolveBreakResult({
         breakResult,
-        emit,
         reopenPrefix,
         source,
         start,
       });
       if (consumed === null) {
         continue;
+      }
+      if (consumed.chunk) {
+        emitSourceChunk(consumed.chunk, start, consumed.start);
       }
       start = consumed.start;
       reopenFence = consumed.reopenFence;
@@ -335,24 +354,19 @@ export class EmbeddedBlockChunker {
     if (start === 0) {
       return;
     }
-    const sourceStart = removedFenceInfo.reduce(
-      (offset, removed) => offset + (removed.at <= start ? removed.length : 0),
-      start,
-    );
-    const consumed = Math.max(0, sourceStart - this.#reopenPrefix.length);
+    const consumed = sourceOffset(start);
     this.#consumedLength += consumed;
     this.#buffer = this.#buffer.slice(consumed);
     this.#reopenPrefix = reopenFence ? `${reopenFence.reopenFenceLine}\n` : "";
   }
 
-  #emitBreakResult(params: {
+  #resolveBreakResult(params: {
     breakResult: BreakResult;
-    emit: (chunk: string) => void;
     reopenPrefix: string;
     source: string;
     start: number;
-  }): { start: number; reopenFence?: FenceSplit } | null {
-    const { breakResult, emit, reopenPrefix, source, start } = params;
+  }): { chunk?: string; start: number; reopenFence?: FenceSplit } | null {
+    const { breakResult, reopenPrefix, source, start } = params;
     const breakIdx = breakResult.index;
     if (breakIdx <= 0) {
       return null;
@@ -372,23 +386,25 @@ export class EmbeddedBlockChunker {
       rawChunk = `${rawChunk}${closeFence}`;
     }
 
-    emit(rawChunk);
-
     if (fenceSplit) {
       const closeFenceStart = findFenceCloseLineStart(source, fenceSplit.fence);
       if (absoluteBreakIdx === closeFenceStart) {
         // The synthetic closer already owns this boundary; replaying the source
         // closer after reopening would publish an empty fenced-code message.
-        return { start: skipLeadingNewlines(source, fenceSplit.fence.end) };
+        return { chunk: rawChunk, start: skipLeadingNewlines(source, fenceSplit.fence.end) };
       }
-      return { start: absoluteBreakIdx, reopenFence: fenceSplit };
+      return { chunk: rawChunk, start: absoluteBreakIdx, reopenFence: fenceSplit };
     }
 
     const nextStart =
       absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
         ? absoluteBreakIdx + 1
         : absoluteBreakIdx;
-    return { start: skipLeadingNewlines(source, nextStart), reopenFence: undefined };
+    return {
+      chunk: rawChunk,
+      start: skipLeadingNewlines(source, nextStart),
+      reopenFence: undefined,
+    };
   }
 
   #pickSoftBreakIndex(

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -256,6 +256,7 @@ export type EmbeddedAgentSubscribeContext = {
   emitBlockChunk: (
     text: string,
     options?: {
+      sourceText?: string;
       assistantMessageIndex?: number;
       final?: boolean;
       finalReply?: ReplyDirectiveParseResult;
@@ -299,7 +300,11 @@ export type EmbeddedAgentSubscribeContext = {
   ) => void;
   emitBlockReply: (
     payload: BlockReplyPayload,
-    options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
+    options?: {
+      assistantMessageIndex?: number;
+      consumePendingToolMedia?: boolean;
+      blockSourceText?: string;
+    },
   ) => void;
   flushAssistantStream: () => void;
   releaseDeferredReplies: () => void;

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -356,7 +356,7 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
         pendingToolMedia?.attachments?.[index] ?? {},
       ]),
     );
-    const blockPayload =
+    const blockPayload: BlockReplyPayload =
       autoDeliveryMediaUrls.length === 0
         ? withToolMedia
         : markReplyPayloadForSourceSuppressionDelivery({

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -326,7 +326,11 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
   };
   const emitBlockReply = (
     payload: BlockReplyPayload,
-    options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
+    options?: {
+      assistantMessageIndex?: number;
+      consumePendingToolMedia?: boolean;
+      blockSourceText?: string;
+    },
   ) => {
     flushAssistantStream();
     const withAssistantDirectives = consumePendingAssistantReplyDirectivesIntoReply(state, payload);
@@ -372,6 +376,9 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
             ...(assistantTranscriptMediaUrls.length > 0 ? { assistantTranscriptMediaUrls } : {}),
           })
         : blockPayload;
+    if (blockPayload.text && options?.blockSourceText !== undefined) {
+      setReplyPayloadMetadata(taggedPayload, { blockSourceText: options.blockSourceText });
+    }
     if (state.deferBlockReplyDelivery) {
       if (pendingToolMedia) {
         deferredToolMediaReplies.set(taggedPayload, {
@@ -409,6 +416,7 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
       const index = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
       if (!payload.isReasoning && isSuperseded(index)) {
         payload.text = undefined;
+        setReplyPayloadMetadata(payload, { blockSourceText: undefined });
       }
     }
     provisionalAssistantBlocks.clear();

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -359,6 +359,7 @@ export function createStreamRendering({
   const emitBlockChunk = (
     text: string,
     options?: {
+      sourceText?: string;
       assistantMessageIndex?: number;
       final?: boolean;
       completeMarkdownChunk?: boolean;
@@ -520,6 +521,8 @@ export function createStreamRendering({
       },
       {
         assistantMessageIndex: options?.assistantMessageIndex ?? state.assistantMessageIndex,
+        blockSourceText:
+          chunk === text.trimEnd() && cleanedText === chunk ? options?.sourceText : undefined,
         consumePendingToolMedia:
           options?.finalReply !== undefined || Boolean(mediaUrls?.length || audioAsVoice),
       },
@@ -541,26 +544,28 @@ export function createStreamRendering({
     if (!params.onBlockReply) {
       return undefined;
     }
-    let pendingChunk: string | undefined;
+    let pendingChunk: { text: string; sourceText?: string } | undefined;
     if (blockChunker.hasBuffered()) {
       blockChunker.drain({
         force: true,
-        emit: (text) => {
+        emit: (text, metadata) => {
           if (pendingChunk !== undefined) {
-            emitBlockChunk(pendingChunk, {
+            emitBlockChunk(pendingChunk.text, {
+              sourceText: pendingChunk.sourceText,
               assistantMessageIndex: options?.assistantMessageIndex,
               completeMarkdownChunk: true,
             });
           }
-          pendingChunk = text;
+          pendingChunk = { text, sourceText: metadata?.sourceText };
         },
       });
     }
     if (pendingChunk !== undefined || options?.final) {
       // Only the final chunk can select attachments or consume fallback tool
       // media. Intermediate chunks remain text-only until that selection exists.
-      emitBlockChunk(pendingChunk ?? "", {
+      emitBlockChunk(pendingChunk?.text ?? "", {
         ...options,
+        sourceText: pendingChunk?.sourceText,
         completeMarkdownChunk: options?.final === true,
       });
     }

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts
@@ -1,5 +1,6 @@
 // Markdown block-reply chunking and fence preservation.
 import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyPipeline } from "../auto-reply/reply/block-reply-pipeline.js";
 import {
   createParagraphChunkedBlockReplyHarness,
   emitAssistantTextDeltaAndEnd,
@@ -59,6 +60,27 @@ describe("paragraph and whole-fence chunking", () => {
 });
 
 describe("oversized fenced block chunking", () => {
+  it("acknowledges the original fenced answer after delivering its wrapped chunks", async () => {
+    const delivered: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      timeoutMs: 5000,
+    });
+    const { emit } = createParagraphChunkedBlockReplyHarness({
+      chunking: { minChars: 8, maxChars: 20 },
+      onBlockReply: (payload) => pipeline.enqueue(payload),
+    });
+    const text = "```ts\nabcdefghijklmnop\n```";
+    emitAssistantTextDeltaAndEnd({ emit, text });
+    await pipeline.flush({ force: true });
+
+    expect(delivered).toEqual(["```ts\nabcdefghij\n```", "```ts\nklmnop\n```"]);
+    expect(pipeline.hasSentPayload({ text })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "```ts\nabcdefghijklmnopq\n```" })).toBe(false);
+  });
+
   const cases = [
     {
       name: "reopens fenced blocks when splitting inside them",

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts
@@ -495,10 +495,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     emit({ type: "message_end", message: assistantMessage });
     await Promise.resolve();
 
-    expect(onBlockReply.mock.calls.map((call) => call[0]?.text)).toEqual([
-      "Answer ends with",
-      "<fi",
-    ]);
+    expect(onBlockReply.mock.calls.map((call) => call[0]?.text)).toEqual(["Answer ends with <fi"]);
   });
 
   it("preserves literal trailing tag-prefix text from message end fallback", () => {

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -196,6 +196,8 @@ export type ReplyPayloadMetadata = {
   /** The model failed after a committed recovery compaction in the same turn. */
   postCompactionModelFailure?: true;
   assistantMessageIndex?: number;
+  /** Visible source represented by this block, excluding synthetic chunk wrappers. */
+  blockSourceText?: string;
   /** Persisted assistant speech facts; never serialized into channel payloads. */
   tts?: AssistantDeliveryTtsFacts;
   /** Structured message-tool speech is an explicit request, independent of auto-TTS mode. */

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -1,6 +1,11 @@
 // Coalesces buffered block-streaming payloads into sendable reply parts.
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { copyReplyPayloadMetadata, isReplyPayloadStatusNotice } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
+  setReplyPayloadMetadata,
+} from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
 
@@ -26,6 +31,7 @@ export function createBlockReplyCoalescer(params: {
   const flushOnEnqueue = config.flushOnEnqueue === true;
 
   let bufferText = "";
+  let bufferSourceText: string | undefined;
   let bufferedPayload: ReplyPayload | undefined;
   let idleTimer: NodeJS.Timeout | undefined;
 
@@ -39,6 +45,7 @@ export function createBlockReplyCoalescer(params: {
 
   const resetBuffer = () => {
     bufferText = "";
+    bufferSourceText = undefined;
     bufferedPayload = undefined;
   };
 
@@ -65,10 +72,13 @@ export function createBlockReplyCoalescer(params: {
       scheduleIdleFlush();
       return;
     }
-    const payload = copyReplyPayloadMetadata(bufferedPayload, {
-      ...bufferedPayload,
-      text: bufferText,
-    });
+    const payload = setReplyPayloadMetadata(
+      copyReplyPayloadMetadata(bufferedPayload, {
+        ...bufferedPayload,
+        text: bufferText,
+      }),
+      { blockSourceText: bufferSourceText },
+    );
     resetBuffer();
     await onFlush(payload);
   };
@@ -90,6 +100,11 @@ export function createBlockReplyCoalescer(params: {
   /** Merges buffered text into a media payload without changing media metadata. */
   const mergeBufferedTextWithMedia = (payload: ReplyPayload, text: string): ReplyPayload => {
     const mergedText = text ? `${bufferText}${joiner}${text}` : bufferText;
+    const sourceText = text ? getReplyPayloadMetadata(payload)?.blockSourceText : undefined;
+    const mergedSourceText =
+      bufferSourceText !== undefined || sourceText !== undefined
+        ? (bufferSourceText ?? bufferText) + (sourceText ?? text)
+        : undefined;
     const mergedPayload: ReplyPayload = {
       ...bufferedPayload,
       ...payload,
@@ -103,7 +118,9 @@ export function createBlockReplyCoalescer(params: {
       mergedPayload,
     );
     resetBuffer();
-    return copyReplyPayloadMetadata(payload, metadataMergedPayload);
+    return setReplyPayloadMetadata(copyReplyPayloadMetadata(payload, metadataMergedPayload), {
+      blockSourceText: mergedSourceText,
+    });
   };
 
   const enqueue = (payload: ReplyPayload) => {
@@ -113,6 +130,7 @@ export function createBlockReplyCoalescer(params: {
     const reply = resolveSendableOutboundReplyParts(payload);
     const hasMedia = reply.hasMedia;
     const text = reply.text;
+    const sourceText = getReplyPayloadMetadata(payload)?.blockSourceText;
     const hasText = reply.hasText;
     if (hasMedia) {
       if (canMergeBufferedTextWithMedia(payload)) {
@@ -135,6 +153,7 @@ export function createBlockReplyCoalescer(params: {
       }
       bufferedPayload = payload;
       bufferText = text;
+      bufferSourceText = sourceText;
       void flush({ force: true });
       return;
     }
@@ -176,6 +195,7 @@ export function createBlockReplyCoalescer(params: {
           return;
         }
         bufferText = text;
+        bufferSourceText = sourceText;
         scheduleIdleFlush();
         return;
       }
@@ -183,6 +203,11 @@ export function createBlockReplyCoalescer(params: {
       return;
     }
 
+    // Keep source coverage separate from inserted transport joiners.
+    bufferSourceText =
+      bufferSourceText !== undefined || sourceText !== undefined
+        ? (bufferSourceText ?? bufferText) + (sourceText ?? text)
+        : undefined;
     bufferText = nextText;
     if (bufferText.length >= maxChars) {
       void flush({ force: true });

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -505,6 +505,163 @@ describe("createBlockReplyPipeline dedup with threading", () => {
 });
 
 describe("createBlockReplyPipeline content coverage dedup", () => {
+  it.each([false, true])(
+    "recognizes delivered source through synthetic fence wrappers (coalescing=%s)",
+    async (coalescing) => {
+      const sent: ReplyPayload[] = [];
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async (payload) => {
+          sent.push(payload);
+        },
+        timeoutMs: 5000,
+        ...(coalescing
+          ? { coalescing: { minChars: 100, maxChars: 200, idleMs: 0, joiner: "\n\n" } }
+          : {}),
+      });
+      const first = "```ts\nconst x = \n```";
+      const second = "```ts\n1;\n```";
+      const final = setReplyPayloadMetadata(
+        { text: "```ts\nconst x = 1;\n```" },
+        { assistantMessageIndex: 7 },
+      );
+      pipeline.enqueue(
+        setReplyPayloadMetadata(
+          { text: first },
+          { assistantMessageIndex: 7, blockSourceText: "```ts\nconst x = " },
+        ),
+      );
+      pipeline.enqueue(
+        setReplyPayloadMetadata(
+          { text: second },
+          { assistantMessageIndex: 7, blockSourceText: "1;\n```" },
+        ),
+      );
+      expect(pipeline.hasSentPayload(final)).toBe(false);
+
+      await pipeline.flush({ force: true });
+
+      expect(sent.map((payload) => payload.text)).toEqual(
+        coalescing ? [`${first}\n\n${second}`] : [first, second],
+      );
+      expect(pipeline.hasSentPayload(final)).toBe(true);
+      expect(pipeline.hasSentExactPayload?.(final)).toBe(false);
+      expect(
+        pipeline.hasSentPayload(
+          setReplyPayloadMetadata({ ...final }, { assistantMessageIndex: 8 }),
+        ),
+      ).toBe(false);
+      expect(pipeline.hasSentPayload({ text: "```ts\nconst x = 2;\n```" })).toBe(false);
+    },
+  );
+
+  it("does not acknowledge source from a rejected fenced block", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        if (payload.text === "```ts\n1;\n```") {
+          throw new Error("channel rejected the continuation");
+        }
+      },
+      timeoutMs: 5000,
+    });
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { text: "```ts\nconst x = \n```" },
+        { blockSourceText: "```ts\nconst x = " },
+      ),
+    );
+    pipeline.enqueue(
+      setReplyPayloadMetadata({ text: "```ts\n1;\n```" }, { blockSourceText: "1;\n```" }),
+    );
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = 1;\n```" })).toBe(false);
+    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = " })).toBe(true);
+  });
+
+  it("merges source coverage through ordinary text and a media continuation", async () => {
+    const sent: ReplyPayload[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push(payload);
+      },
+      timeoutMs: 5000,
+      coalescing: { minChars: 100, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+    });
+    pipeline.enqueue({ text: "Example:" });
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { text: "```ts\nconst x = \n```" },
+        { blockSourceText: "```ts\nconst x = " },
+      ),
+    );
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { text: "```ts\n1;\n```", mediaUrl: "file:///example.png" },
+        { blockSourceText: "1;\n```" },
+      ),
+    );
+    await pipeline.flush({ force: true });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      text: "Example:\n\n```ts\nconst x = \n```\n\n```ts\n1;\n```",
+      mediaUrl: "file:///example.png",
+    });
+    expect(pipeline.hasSentPayload({ text: "Example:\n```ts\nconst x = 1;\n```" })).toBe(true);
+    expect(pipeline.getSentMediaUrls()).toEqual(["file:///example.png"]);
+  });
+
+  it("does not credit removed source text when merging a media-only reply", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+      coalescing: { minChars: 100, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+    });
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { text: "```ts\nconst x = 1;\n```" },
+        { blockSourceText: "```ts\nconst x = 1;\n```" },
+      ),
+    );
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { mediaUrl: "file:///example.png" },
+        { blockSourceText: "withdrawn source" },
+      ),
+    );
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = 1;\n```" })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = 1;\n```withdrawn source" })).toBe(
+      false,
+    );
+  });
+
+  it("retains source coverage when buffered audio gains voice presentation", async () => {
+    const sent: ReplyPayload[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push(payload);
+      },
+      timeoutMs: 5000,
+      buffer: createAudioAsVoiceBuffer({ isAudioPayload: (payload) => Boolean(payload.mediaUrl) }),
+    });
+    pipeline.enqueue(
+      setReplyPayloadMetadata(
+        { text: "```ts\n1;\n```", mediaUrl: "file:///example.ogg", audioAsVoice: true },
+        { blockSourceText: "1;\n```", assistantMessageIndex: 7 },
+      ),
+    );
+    await pipeline.flush({ force: true });
+
+    expect(sent[0]).toMatchObject({ audioAsVoice: true, mediaUrl: "file:///example.ogg" });
+    expect(
+      pipeline.hasSentPayload(
+        setReplyPayloadMetadata({ text: "1;\n```" }, { assistantMessageIndex: 7 }),
+      ),
+    ).toBe(true);
+  });
+
   it("matches final assembled text to successfully streamed text chunks after abort", async () => {
     vi.useFakeTimers();
 

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -7,6 +7,7 @@ import {
 import { logVerbose } from "../../globals.js";
 import { runAbortableTimeout } from "../../node-host/with-timeout.js";
 import {
+  copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
   isReplyPayloadTerminalContent,
@@ -49,7 +50,10 @@ export function createAudioAsVoiceBuffer(params: {
       }
     },
     shouldBuffer: (payload) => params.isAudioPayload(payload),
-    finalize: (payload) => (seenAudioAsVoice ? { ...payload, audioAsVoice: true } : payload),
+    finalize: (payload) =>
+      seenAudioAsVoice
+        ? copyReplyPayloadMetadata(payload, { ...payload, audioAsVoice: true })
+        : payload,
   };
 }
 
@@ -139,6 +143,7 @@ export function createBlockReplyPipeline(params: {
     }
     const payloadKey = createBlockReplyPayloadKey(payload);
     const contentKey = createBlockReplyContentKey(payload);
+    const blockSourceText = getReplyPayloadMetadata(payload)?.blockSourceText;
     if (!bypassSeenCheck) {
       if (seenKeys.has(payloadKey)) {
         return;
@@ -189,7 +194,7 @@ export function createBlockReplyPipeline(params: {
         if (isTerminalContent && reply.trimmedText) {
           const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
           const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
-          fragments.push(reply.trimmedText);
+          fragments.push(blockSourceText ?? reply.trimmedText);
           streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
         }
         if (!isStatusNotice) {

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -1,7 +1,11 @@
 /** Normalizes reply directives and delivers block replies through streaming or direct paths. */
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
-import { copyReplyPayloadMetadata, isReplyPayloadTerminalContent } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  isReplyPayloadTerminalContent,
+  setReplyPayloadMetadata,
+} from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -156,6 +160,9 @@ export function createBlockReplyDeliveryHandler(params: {
       payload,
       params.applyReplyToMode(mediaNormalizedPayload),
     );
+    if (blockPayload.text?.trim() !== payload.text?.trim()) {
+      setReplyPayloadMetadata(blockPayload, { blockSourceText: undefined });
+    }
     const blockHasNonTextContent = hasOutboundReplyContent({ ...blockPayload, text: undefined });
 
     // Skip empty payloads unless they have audioAsVoice flag (need to track it).


### PR DESCRIPTION
Closes #143641. Related: #143702. Thanks @rgregg for the report.

## What Problem This Solves

Small streamed updates could split a bullet line too early or display code outside its fence. The final answer could then repeat code already delivered in continuation blocks.

## Why This Change Was Made

The chunker waits for a natural boundary before splitting at whitespace and preserves open-fence state across forced breaks. Private reply metadata carries each block's original source through coalescing; final accounting credits it after successful delivery. Rejected or rewritten text retains final-answer recovery.

## User Impact

Prose keeps complete lines when they fit. Code continuations stay fenced within message limits, and delivered code is not repeated in the final answer.

Consumers: streamed chunks, coalesced blocks, and final-reply accounting now preserve source coverage across continuation wrappers.

## Evidence

Real guild messages reproduced premature prose splitting and an unclosed fence. Corrected messages reconstructed the full code exactly once for six update sizes. All 263 focused tests and 24 final-tag streaming tests passed. Draft edits, handoff, deletion, cancellation, and replacement checks passed. Existing platform normalization of line endings and trailing spaces remains; general byte preservation is not claimed. A misleading cancellation timeout notice also reproduced before the change.
