### PR TITLE
docs(update): clarify failure recovery choices

### DIFF
--- a/docs/cli/update/repair-and-recovery.md
+++ b/docs/cli/update/repair-and-recovery.md
@@ -12,11 +12,14 @@ What happens when an update fails, and the subcommands that finish the job. Part
 
 ## Recover a failed update
 
-After a failed interactive update or repair, OpenClaw finishes cleanup and
-opens [Triage](/cli/triage). Triage immediately starts the first directly
-launchable coding agent on `PATH`, in this order: Claude Code, Codex, OpenCode,
-then Pi. It passes the captured update failure directly and leaves fresh Doctor
-checks and diagnostics collection to the agent, so a broken installation does
+After a failed interactive update or repair, OpenClaw finishes cleanup and offers
+**Diagnose update failure**, **Report update failure**, or **Exit**. Reporting
+previews the sanitized issue body and requires separate confirmation.
+
+Choosing **Diagnose update failure** opens [Triage](/cli/triage), which starts the
+first directly launchable coding agent on `PATH`, in this order: Claude Code,
+Codex, OpenCode, then Pi. It passes the captured update failure directly and leaves
+fresh Doctor checks and diagnostics collection to the agent, so a broken installation does
 not delay the handoff. The agent keeps its existing authentication, sandbox, and
 approval settings.
 
@@ -24,9 +27,15 @@ The agent starts in the operator's original working directory, or their OS home
 if that directory is no longer accessible. The failed installation's resolved
 state, config, and default workspace paths remain pinned for the repair.
 
-Updates using `--yes`, `--json`, or a non-interactive session (including piped
-input or output) collect diagnostics and print handoff commands without starting
-an external coding agent. The updater's earlier
+A verified rollback leaves the previous generation running. The interactive menu
+selects **Exit** by default; declining or cancelling keeps the failed update's
+nonzero exit status. After a verified rollback, `--json`, `--yes`, non-interactive,
+and managed-service handoff runs do not prompt or collect automatic diagnostics.
+
+For failures without a verified rollback, updates using `--yes`, `--json`, or a
+non-interactive session (including piped input or output) collect diagnostics
+and print handoff commands without starting an external coding agent. The updater's
+earlier
 [unattended repair slot](/install/updating#unattended-repair-on-your-own-inference)
 can still run on configured inference. With `--json`, triage output goes to stderr so stdout retains
 the original update result. Diagnostic collection failures never hide the update
@@ -58,10 +67,10 @@ succeeds.
 Dry runs and commands rejected by the initial argument, external-supervisor,
 state-store ownership, handoff identity, or immutable-config checks do not
 collect diagnostics or start an agent. Once those checks pass, failed metadata,
-schema, runtime, and managed-service checks enter triage even when installation
-is blocked. This includes an update that cannot safely stop its parent Gateway
-process. Diagnosis preserves that refusal: it does not stop the Gateway, retry
-the update, or bypass safety checks. See
+schema, runtime, and managed-service checks use the failure actions above even
+when installation is blocked. This includes an update that cannot safely stop
+its parent Gateway process. Diagnosis preserves that refusal: it does not stop the
+Gateway, retry the update, or bypass safety checks. See
 [Update troubleshooting](/install/update-troubleshooting).
 
 ## `update repair`


### PR DESCRIPTION
Related: #143657

## What Problem This Solves

The update-recovery reference says a failed interactive update immediately launches diagnosis and that unattended failures always collect diagnostics. Those claims no longer match the CLI.

## Why This Change Was Made

Document the existing Diagnose, Report, and Exit choices, separate report confirmation, and the quiet path after a verified rollback. Preserve the manual commands, agent selection order, JSON output rules, and failed-update exit status.

## User Impact

Operators can predict the next prompt and understand why a healthy restored installation does not start another automatic repair or diagnostic run.

## Evidence

Audited the current failure wrapper, action menu, rollback predicate, and their existing tests. All 10 changed-file checks and git diff --check pass. Independent Codex review found no actionable findings through P2. Documentation only; runtime behavior and report retention are unchanged.
