### PR TITLE
fix(gateway): stop pipelined MCP calls after rejected uploads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2717,7 +2717,6 @@ src/gateway/mcp-app-operations.ts	3
 src/gateway/mcp-app-reconstruction.ts	3
 src/gateway/mcp-grant-store.ts	2
 src/gateway/mcp-http.handlers.ts	4
-src/gateway/mcp-http.request.ts	2
 src/gateway/mcp-http.schema.ts	3
 src/gateway/method-scopes.ts	10
 src/gateway/node-browser-proxy-policy.ts	1

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -12,7 +12,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
-import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { getHeader } from "./http-utils.js";
 import {
   resolveAttachGrant,
@@ -22,11 +21,7 @@ import {
 import { isLoopbackAddress } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
 
-const MAX_MCP_BODY_BYTES = 1_048_576;
 const DEFAULT_MCP_BODY_TIMEOUT_MS = 30_000;
-const MCP_HTTP_BODY_TOO_LARGE_CODE = "ETOOBIG";
-const MCP_HTTP_BODY_TIMEOUT_CODE = "ETIMEDOUT";
-const MCP_HTTP_BODY_CLOSED_CODE = "ECONNRESET";
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -280,105 +275,6 @@ export function validateMcpLoopbackRequest(params: {
   }
 
   return sender;
-}
-
-export async function readMcpHttpBody(
-  req: IncomingMessage,
-  options: { maxBytes?: number; timeoutMs?: number } = {},
-): Promise<string> {
-  return await new Promise((resolve, reject) => {
-    const maxBytes = Math.max(1, Math.floor(options.maxBytes ?? MAX_MCP_BODY_BYTES));
-    const timeoutMs = resolveSafeTimeoutDelayMs(options.timeoutMs ?? DEFAULT_MCP_BODY_TIMEOUT_MS);
-    const chunks: Buffer[] = [];
-    let received = 0;
-    let settled = false;
-    // Remove listeners on every terminal path; oversized bodies keep the error
-    // listener briefly so Node can deliver the pause/error safely.
-    const cleanup = (cleanupOptions?: { keepErrorListener?: boolean }) => {
-      req.off("data", onData);
-      req.off("end", onEnd);
-      req.off("close", onClose);
-      if (cleanupOptions?.keepErrorListener !== true) {
-        req.off("error", onError);
-      }
-      clearTimeout(timeout);
-    };
-    const rejectOnce = (error: Error, rejectOptions?: { keepErrorListener?: boolean }) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup(rejectOptions);
-      reject(error);
-    };
-    const onData = (chunk: Buffer) => {
-      received += chunk.length;
-      if (received > maxBytes) {
-        req.pause();
-        rejectOnce(createMcpHttpBodyTooLargeError(maxBytes), { keepErrorListener: true });
-        return;
-      }
-      chunks.push(chunk);
-    };
-    const onEnd = () => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      resolve(Buffer.concat(chunks).toString("utf-8"));
-    };
-    const onError = (error: Error) => {
-      rejectOnce(error);
-    };
-    const onClose = () => {
-      rejectOnce(createMcpHttpBodyClosedError());
-    };
-    const timeout = setTimeout(() => {
-      req.pause();
-      rejectOnce(createMcpHttpBodyTimeoutError(), { keepErrorListener: true });
-    }, timeoutMs);
-    timeout.unref?.();
-
-    req.on("data", onData);
-    req.on("end", onEnd);
-    req.on("close", onClose);
-    req.on("error", onError);
-  });
-}
-
-function createMcpHttpBodyTooLargeError(maxBytes: number): Error & { code: string } {
-  return Object.assign(new Error(`Request body exceeds ${maxBytes} bytes`), {
-    code: MCP_HTTP_BODY_TOO_LARGE_CODE,
-  });
-}
-
-function createMcpHttpBodyTimeoutError(): Error & { code: string } {
-  return Object.assign(new Error("Request body timed out"), {
-    code: MCP_HTTP_BODY_TIMEOUT_CODE,
-  });
-}
-
-function createMcpHttpBodyClosedError(): Error & { code: string } {
-  return Object.assign(new Error("Request body connection closed"), {
-    code: MCP_HTTP_BODY_CLOSED_CODE,
-  });
-}
-
-export function isMcpHttpBodyTooLargeError(error: unknown): error is Error & { code: string } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === MCP_HTTP_BODY_TOO_LARGE_CODE
-  );
-}
-
-export function isMcpHttpBodyTimeoutError(error: unknown): error is Error & { code: string } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === MCP_HTTP_BODY_TIMEOUT_CODE
-  );
 }
 
 export function resolveMcpHttpBodyTimeoutMs(): number {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2,6 +2,7 @@
 // JSON-RPC surface, including hook filtering and context propagation.
 import { EventEmitter } from "node:events";
 import { request, ServerResponse } from "node:http";
+import { connect } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import {
@@ -3907,6 +3908,125 @@ describe("mcp loopback server", () => {
       }
     }
   });
+
+  it.each(["exact-size", "declared-size", "timeout", "disconnect", "pipeline"] as const)(
+    "preserves body admission and capture cleanup over real HTTP: %s",
+    async (mode) => {
+      vi.stubEnv(
+        "OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS",
+        mode === "timeout" || mode === "declared-size" ? "30" : "30000",
+      );
+      const captureKey = `body-lifecycle-${mode}`;
+      const events: string[] = [];
+      const admitted = createDeferred();
+      const finished = createDeferred();
+      const execute = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+      mockScopedTools([makeMessageTool({ execute })]);
+      beginMcpLoopbackToolCallCapture({
+        captureKey,
+        onRequestStart: () => {
+          events.push("start");
+          admitted.resolve();
+        },
+        onRequestClassified: () => events.push("classified"),
+        onRequestFinish: () => {
+          events.push("finish");
+          finished.resolve();
+        },
+        onToolCallResult: () => events.push("result"),
+      });
+      const { runtime, port } = await startLoopbackServerForTest();
+      const socket = connect({ host: "127.0.0.1", port, allowHalfOpen: true });
+      const received: Buffer[] = [];
+      let captureFinishedAtPeerEnd = false;
+      const socketErrors: string[] = [];
+      socket.on("error", (error) => socketErrors.push(error.message));
+      socket.on("data", (chunk: Buffer) => received.push(chunk));
+      socket.on("end", () => {
+        captureFinishedAtPeerEnd = events.includes("finish");
+        socket.end();
+      });
+      const closed = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      const headers = (framing: string) =>
+        `POST /mcp HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer ${runtime.ownerToken}\r\nContent-Type: application/json\r\nX-OpenClaw-Cli-Capture-Key: ${captureKey}\r\n${framing}\r\n\r\n`;
+      const call = Buffer.from(mcpToolCallBody("message", { text: "🦞" }));
+      try {
+        if (mode === "exact-size") {
+          const body = Buffer.concat([call, Buffer.alloc(1_048_576 - call.length, 0x20)]);
+          const split = call.indexOf(Buffer.from("🦞")) + 2;
+          socket.write(headers(`Content-Length: ${body.length}\r\nConnection: close`));
+          socket.write(body.subarray(0, split));
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          socket.write(body.subarray(split));
+        } else if (mode === "declared-size") {
+          socket.write(headers("Content-Length: 1048577"));
+        } else if (mode === "timeout") {
+          socket.write(headers("Transfer-Encoding: chunked") + "1\r\n{\r\n");
+        } else if (mode === "disconnect") {
+          socket.write(headers("Content-Length: 100"));
+          await admitted.promise;
+          socket.destroy();
+        } else {
+          const oversized = "x".repeat(1_048_577);
+          socket.write(
+            headers("Transfer-Encoding: chunked") +
+              `${oversized.length.toString(16)}\r\n${oversized}\r\n0\r\n\r\n` +
+              headers(`Content-Length: ${call.length}\r\nConnection: close`) +
+              call.toString(),
+          );
+        }
+        await expectPromiseResolvesWithin(closed, 2_000, "body probe socket close");
+        await expectPromiseResolvesWithin(finished.promise, 500, "body probe capture finish");
+        const wire = Buffer.concat(received).toString();
+        const statuses = [...wire.matchAll(/HTTP\/1\.1 (\d{3}) /g)].map((match) =>
+          Number(match[1]),
+        );
+        expect(socketErrors).toEqual([]);
+        expect(events.filter((event) => event === "start").length).toBeGreaterThan(0);
+        expect(events.filter((event) => event === "finish")).toHaveLength(
+          events.filter((event) => event === "start").length,
+        );
+        expect(events.filter((event) => event === "classified")).toHaveLength(
+          events.filter((event) => event === "start").length,
+        );
+        expect(
+          await waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+            timeoutMs: 100,
+            admissionGraceMs: 0,
+          }),
+        ).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(mode === "exact-size" ? 1 : 0);
+        if (mode === "exact-size") {
+          expect(execute).toHaveBeenCalledWith(
+            expect.any(String),
+            { text: "🦞" },
+            expect.any(AbortSignal),
+          );
+        }
+        if (mode !== "disconnect") {
+          expect(captureFinishedAtPeerEnd).toBe(true);
+          const status = mode === "exact-size" ? 200 : mode === "timeout" ? 408 : 413;
+          expect(statuses).toEqual([status]);
+          if (status !== 200) {
+            expect(wire).toContain(
+              JSON.stringify({
+                error: status === 413 ? "payload_too_large" : "request_body_timeout",
+              }),
+            );
+          }
+        }
+      } finally {
+        socket.destroy();
+        await closed;
+        clearMcpLoopbackToolCallCapture(captureKey);
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it("rejects cross-origin browser requests before auth", async () => {
     await expectBrowserToolsListStatus({

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -19,6 +19,8 @@ import { getRuntimeConfig } from "../config/io.js";
 import { resolveSessionEntryAccessTarget } from "../config/sessions/session-accessor.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { isRequestBodyLimitError, readRequestBodyWithLimit } from "../infra/http-body.js";
+import { sendHttpRequestRejection } from "../infra/http-request-lifecycle.js";
 import { logDebug, logWarn } from "../logger.js";
 import {
   AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
@@ -44,9 +46,6 @@ import {
 } from "./mcp-http.loopback-runtime.js";
 import { jsonRpcError, type JsonRpcRequest } from "./mcp-http.protocol.js";
 import {
-  isMcpHttpBodyTooLargeError,
-  isMcpHttpBodyTimeoutError,
-  readMcpHttpBody,
   resolveMcpCliCaptureKey,
   resolveMcpHttpBodyTimeoutMs,
   resolveMcpRequestContext,
@@ -57,6 +56,8 @@ import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 // Loopback MCP server exposes gateway-scoped tools to local MCP clients over a
 // bearer-token HTTP endpoint bound to 127.0.0.1. Only one active server/runtime
 // is registered per process.
+
+const MAX_MCP_BODY_BYTES = 1_048_576;
 
 let closeActiveMcpLoopbackServer: (() => Promise<void>) | undefined;
 let activeMcpLoopbackServerPromise: Promise<void> | null = null;
@@ -213,7 +214,11 @@ async function startMcpLoopbackServer(port = 0): Promise<() => Promise<void>> {
       let parsed: unknown;
       let cliCaptureHandles: Array<ReturnType<typeof markMcpLoopbackToolCallStarted>> = [];
       try {
-        const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
+        const body = await readRequestBodyWithLimit(req, {
+          maxBytes: MAX_MCP_BODY_BYTES,
+          timeoutMs: resolveMcpHttpBodyTimeoutMs(),
+          destroyOnLimit: false,
+        });
         parsed = parseMcpJsonBody(body);
         if (Array.isArray(parsed) && parsed.length === 0) {
           markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
@@ -447,21 +452,33 @@ async function startMcpLoopbackServer(port = 0): Promise<() => Promise<void>> {
           }
         });
       } catch (error) {
-        logWarn(`mcp-loopback: request handling failed: ${formatErrorMessage(error)}`);
-        logMcpLoopbackTraffic("request-failed", {
-          message: formatErrorMessage(error),
-        });
+        const message = isRequestBodyLimitError(error)
+          ? {
+              PAYLOAD_TOO_LARGE: `Request body exceeds ${MAX_MCP_BODY_BYTES} bytes`,
+              REQUEST_BODY_TIMEOUT: "Request body timed out",
+              CONNECTION_CLOSED: "Request body connection closed",
+            }[error.code]
+          : formatErrorMessage(error);
+        logWarn(`mcp-loopback: request handling failed: ${message}`);
+        logMcpLoopbackTraffic("request-failed", { message });
         if (!res.headersSent) {
-          if (isMcpHttpBodyTooLargeError(error)) {
-            res.writeHead(413, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "payload_too_large" }), () => {
-              req.destroy();
-            });
-          } else if (isMcpHttpBodyTimeoutError(error)) {
-            res.writeHead(408, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "request_body_timeout" }), () => {
-              req.destroy();
-            });
+          // Capture settles when rejection is queued; the transport owner joins socket cleanup.
+          if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
+            void sendHttpRequestRejection(
+              req,
+              res,
+              413,
+              JSON.stringify({ error: "payload_too_large" }),
+              "application/json",
+            );
+          } else if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
+            void sendHttpRequestRejection(
+              req,
+              res,
+              408,
+              JSON.stringify({ error: "request_body_timeout" }),
+              "application/json",
+            );
           } else if (isMcpJsonParseError(error)) {
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(JSON.stringify(jsonRpcError(null, -32700, "Parse error")));


### PR DESCRIPTION
## What Problem This Solves

An oversized request to the loopback MCP server could return HTTP 413 while a valid tool call pipelined behind it still executed. The private MCP body reader did not mark the connection as closing when it rejected the body.

## Why This Change Was Made

Use the existing bounded HTTP body reader and rejection transport. They mark the connection as closing synchronously, prevent later body reads from reaching tool execution, and flush the caller's error response before retiring the socket. MCP capture finalization remains independent of the transport's close grace period. The duplicate reader and its error predicates are removed.

## User Impact

Rejected oversized uploads cannot execute a following pipelined tool call. The 1 MiB limit, default 30-second deadline, HTTP 413/408 JSON responses, and MCP diagnostics remain. An excessive declared Content-Length is now rejected immediately with 413, rather than potentially waiting for 408. The shared timer caps extreme overrides at 2,147,000,000 ms, up to 483,647 ms earlier than the old cap for deadlines of roughly 25 days.

## Evidence

The original implementation passed 162 existing tests. Real loopback TCP probes reproduced the pipelined tool execution and the declared-size error difference. The candidate passed all 167 tests across MCP, shared body ingestion, and shared rejection, including all five new probe cases. Final probe validation also asserts the exact UTF-8 tool argument after splitting its bytes across writes.

The probes cover exact-size input, declared oversize, stalled upload, disconnect, capture completion before peer half-close, and suppression of the pipelined tool call. Capture may still register and finalize the following request; the verified guarantee is zero tool execution. This uses synthetic local HTTP and mocked tool discovery, not an external service or operator Gateway.

The complete change removes 80 production code lines and adds 119 test code lines: net +39 maintained code lines (+33 physical). The obsolete type-assertion baseline row is removed separately.

All required commands selected by `check:changed` completed successfully. The initial run caught two Promise-executor lint issues in the new test; after the mechanical block-body repair, lint and every remaining required command passed. The 167-test suite and final five-case probe preceded that repair; no production code or runtime assertion changed. Independent review found no P0–P2 issues, and the final block-body repair was reviewed separately.
