### PR TITLE
fix: release model-selected plugin resources after agent runs

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -45,6 +45,20 @@ still does not invoke a discovery-only engine factory. `dispose()` must not dele
 durable state or disable another registration. Existing raw loader and Gateway
 lifetimes do not gain automatic disposal: keep their `cleanup(ctx)` behavior.
 
+Prepared model runtimes for agent runs also own fresh model-selected registrations.
+They use the same discovery registration mode and plugin selection, but fresh
+registrations bypass the global registry cache. Warm callers share their prepared
+generation. Registration resources remain held through admitted work and cleanup;
+`dispose()` runs after the final claim releases, including any bounded idle
+retention between runs.
+
+Creating a configured or standalone publication does not enable this ownership.
+Existing root registries and raw SDK host registrations keep their original owner;
+borrowing an already managed generation preserves that source's ownership.
+The shared database behind `api.runtime.state` keyed and blob stores remains
+process-owned. A registration's disposer must not close that database or delete
+its durable rows.
+
 Image and music generation also own fresh registrations acquired by
 `api.runtime.imageGeneration.generate(...)` and
 `api.runtime.musicGeneration.generate(...)`. They wait for the provider's complete

--- a/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate-resources.test.ts
@@ -16,6 +16,7 @@ import {
   resetPluginLoaderTestStateForTest,
 } from "../../plugins/loader.test-fixtures.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
 import { createColdPluginFixture } from "../../plugins/test-helpers/cold-plugin-fixtures.js";
 import {
@@ -74,8 +75,8 @@ function fixture(): Fixture {
   return expectDefined(active.fixture, "active delegate fixture");
 }
 
-// RUN ownership is not activated here. Supply the existing managed read-only
-// producer to the real delegate, leaving selection, sessions, and disposal intact.
+// Exercise the read-only producer alongside borrowing an actual raw standalone owner.
+// Selection, sessions, and disposal still run through the real delegate.
 vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../prepared-model-runtime.js")>();
   return {
@@ -85,6 +86,28 @@ vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
       options: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[1],
     ) => {
       const current = fixture();
+      let standalone: Awaited<ReturnType<typeof actual.activateStandalonePreparedModelRuntime>>;
+      if (current.mode === "raw") {
+        const metadataSnapshot = resolvePluginMetadataSnapshot({
+          config: input.config,
+          env: input.env,
+          workspaceDir: input.workspaceDir,
+          allowWorkspaceScopedCurrent: true,
+        });
+        standalone = await actual.activateStandalonePreparedModelRuntime(
+          {
+            ...input,
+            runtimePluginSelections: [
+              ...(input.runtimePluginSelections ?? []),
+              ...(options?.deriveRuntimePluginSelections?.({
+                config: input.config,
+                metadataSnapshot,
+              }) ?? []),
+            ],
+          },
+          { catalogMode: "static" },
+        );
+      }
       const lease =
         current.mode === "raw"
           ? await actual.acquireAgentRunPreparedModelRuntime(input, options)
@@ -100,15 +123,24 @@ vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
               options?.abortSignal,
               "static",
             );
-      expect(current.registrations.length).toBe(1);
-      if (current.mode === "before_compaction" || current.mode === "after_compaction") {
-        expect(
-          lease.snapshot.pluginRegistry?.typedHooks.filter((hook) => hook.hookName === current.mode)
-            .length,
-        ).toBe(1);
+      try {
+        expect(current.registrations.length).toBe(1);
+        if (current.mode === "raw") {
+          expect(lease.snapshot === standalone).toBe(true);
+        }
+        if (current.mode === "before_compaction" || current.mode === "after_compaction") {
+          expect(
+            lease.snapshot.pluginRegistry?.typedHooks.filter(
+              (hook) => hook.hookName === current.mode,
+            ).length,
+          ).toBe(1);
+        }
+        current.source = expectDefined(current.registrations[0], "selected registration");
+        return lease;
+      } catch (error) {
+        lease.release();
+        throw error;
       }
-      current.source = expectDefined(current.registrations[0], "selected registration");
-      return lease;
     },
   };
 });

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -82,7 +82,7 @@ export type PreparedModelRuntimeBuildCandidate = Readonly<{
   isBuildCurrent?: () => boolean;
   /** Shared publication guards run before workspace preparation; registration guards do not. */
   isPreparationCurrent?: () => boolean;
-  ownsEphemeralRegistries?: boolean;
+  ownsRegistryResources?: boolean;
 }>;
 
 export type PreparedModelRuntimeBuildResult = Readonly<{
@@ -384,8 +384,8 @@ async function buildSnapshotBatch(
     [
       ...groupBuildCandidates(generationCandidates, (candidate) => {
         const workspace = preparedModelRuntimeWorkspaceFactsKey(candidate.input);
-        if (candidate.ownsEphemeralRegistries) {
-          return `ephemeral\0${workspace}`;
+        if (candidate.ownsRegistryResources) {
+          return `owned\0${workspace}`;
         }
         const kind = candidate.prepareInboundPluginRegistry ? "configured" : "dynamic";
         return pluginGeneration ? workspace : `${kind}\0${workspace}`;
@@ -445,7 +445,7 @@ async function buildSnapshotBatch(
         includeCredentialProviders,
         getConfiguredHarnessRuntimes,
         onStage,
-        ...(groupCandidates.some((candidate) => candidate.ownsEphemeralRegistries)
+        ...(groupCandidates.some((candidate) => candidate.ownsRegistryResources)
           ? { registryResources }
           : {}),
       },

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -484,7 +484,8 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
       inventoryOwner: owner,
       pluginGeneration: owner.pendingPluginGeneration,
       prepareInboundPluginRegistry: owner.provenance === "configured",
-      ownsEphemeralRegistries: owner.provenance === "ephemeral" && input.readOnly === true,
+      ownsRegistryResources:
+        owner.provenance === "run" || (owner.provenance === "ephemeral" && input.readOnly === true),
       isGenerationCurrent,
       isBuildCurrent: params.isBuildCurrent ?? isCurrent,
       isPreparationCurrent: params.isBuildCurrent,
@@ -657,7 +658,8 @@ export async function publishModelRuntimeSnapshot(
         isGenerationCurrent,
         isBuildCurrent: isGenerationCurrent,
         prepareInboundPluginRegistry: provenance === "configured",
-        ownsEphemeralRegistries: provenance === "ephemeral" && input.readOnly === true,
+        ownsRegistryResources:
+          provenance === "run" || (provenance === "ephemeral" && input.readOnly === true),
         pluginGeneration: reusablePluginGeneration,
       },
     ],

--- a/src/agents/prepared-model-runtime.run-resources.test.ts
+++ b/src/agents/prepared-model-runtime.run-resources.test.ts
@@ -1,0 +1,507 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
+import { expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  acquirePublishedPreparedModelRuntime,
+  activateStandalonePreparedModelRuntime,
+  getPreparedModelRuntimeSnapshot,
+  publishPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+  type PreparedModelRuntimeLease,
+} from "./prepared-model-runtime.js";
+import { closePreparedModelRuntimeSnapshots } from "./prepared-model-runtime.lifecycle.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+
+const providerId = "run-owner-provider";
+const siblingId = "run-owner-sibling";
+
+type Registration = {
+  id: string;
+  mode: string;
+  database: DatabaseSync;
+  file: string;
+  disposals: number;
+  store: PluginStateKeyedStore<{ value: number }>;
+};
+
+async function withRunFixture(
+  run: (fixture: {
+    config: OpenClawConfig;
+    input: Parameters<typeof acquireAgentRunPreparedModelRuntime>[0];
+    registrations: Registration[];
+    acquire: (
+      options?: Parameters<typeof acquireAgentRunPreparedModelRuntime>[1],
+      workspace?: string,
+    ) => Promise<PreparedModelRuntimeLease>;
+    original: () => Registration;
+    finishDisposal: ReturnType<typeof createDeferredCore<void>>;
+    disposalStarted: ReturnType<typeof createDeferredCore<void>>;
+    holdDisposal: () => void;
+    catalogStarted: ReturnType<typeof createDeferredCore<void>>;
+    finishCatalog: ReturnType<typeof createDeferredCore<void>>;
+  }) => Promise<void>,
+  options: { catalog?: "hold" | "reject" } = {},
+) {
+  await withOpenClawTestState({ label: "run-registry-ownership" }, async (state) => {
+    const bundled = state.path("bundled");
+    fs.mkdirSync(bundled);
+    const registrations: Registration[] = [];
+    const leases: PreparedModelRuntimeLease[] = [];
+    const finishDisposal = createDeferredCore();
+    const disposalStarted = createDeferredCore();
+    const catalogStarted = createDeferredCore();
+    const finishCatalog = createDeferredCore();
+    const bridge = {
+      registrations,
+      hold: false,
+      finishDisposal,
+      disposalStarted,
+      catalog: options.catalog,
+      providers: {},
+      catalogStarted,
+      finishCatalog,
+    };
+    const key = `__run_registry_${path.basename(state.root)}`;
+    Object.defineProperty(globalThis, key, { configurable: true, value: bridge });
+    for (const id of [providerId, siblingId]) {
+      const pluginRoot = path.join(bundled, id);
+      fs.mkdirSync(pluginRoot);
+      const plugin = createColdPluginFixture({
+        rootDir: pluginRoot,
+        pluginId: id,
+        providerId: id,
+        manifest: {
+          channels: [],
+          channelConfigs: {},
+          providerAuthChoices: [],
+          ...(options.catalog && id === providerId
+            ? { providerCatalogEntry: "./catalog.cjs" }
+            : {}),
+          ...(!options.catalog
+            ? {
+                modelCatalog: {
+                  providers: {
+                    [id]: {
+                      discovery: "static",
+                      api: "openai-completions",
+                      baseUrl: "https://fixture.invalid/v1",
+                      models: [{ id: "model", name: "Fixture model", input: ["text"] }],
+                    },
+                  },
+                },
+              }
+            : {}),
+        },
+      });
+      fs.writeFileSync(
+        plugin.runtimeSource,
+        `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: ${JSON.stringify(id)}, register(api) {
+  const bridge = globalThis[${JSON.stringify(key)}];
+  const file = ${JSON.stringify(state.root)} + "/registration-" + bridge.registrations.length + ".sqlite";
+  const database = new DatabaseSync(file);
+  database.exec("CREATE TABLE answer(value INTEGER); INSERT INTO answer VALUES (42)");
+  const store = api.runtime.state.openKeyedStore({ namespace: "run-proof", maxEntries: 20 });
+  const record = { id: api.id, mode: api.registrationMode, database, file, disposals: 0, store };
+  bridge.registrations.push(record);
+  api.lifecycle.registerRuntimeLifecycle({ id: "database", async dispose() {
+    if (bridge.hold && record === bridge.registrations[0]) {
+      bridge.disposalStarted.resolve();
+      await bridge.finishDisposal.promise;
+    }
+    if (database.prepare("SELECT value FROM answer").get().value !== 42) throw new Error("lost registration state");
+    record.disposals++;
+    database.close();
+  } });
+  const provider = { id: api.id, label: api.id, auth: [],
+    ...(bridge.catalog && api.id === ${JSON.stringify(providerId)} ? { staticCatalog: { async run() {
+      bridge.catalogStarted.resolve();
+      await bridge.finishCatalog.promise;
+      if (database.prepare("SELECT value FROM answer").get().value !== 42) throw new Error("catalog lost registration state");
+      if (bridge.catalog === "reject") throw new Error("fixture static catalog failed");
+      return { provider: { api: "openai-completions", baseUrl: "https://fixture.invalid/v1", models: [{ id: "model", name: "Fixture model", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8192, maxTokens: 1024 }] } };
+    } } } : {})
+  };
+  bridge.providers[api.id] = provider;
+  api.registerProvider(provider);
+} };
+`,
+      );
+      if (options.catalog && id === providerId) {
+        fs.writeFileSync(
+          path.join(pluginRoot, "catalog.cjs"),
+          `module.exports = globalThis[${JSON.stringify(key)}].providers[${JSON.stringify(id)}];`,
+        );
+      }
+    }
+    const config: OpenClawConfig = {
+      agents: {
+        entries: { main: { default: true, workspace: state.workspaceDir } },
+        defaults: { workspace: state.workspaceDir, model: `${providerId}/model` },
+      },
+      models: {
+        providers: Object.fromEntries(
+          [providerId, siblingId].map((id) => [
+            id,
+            {
+              api: "openai-completions" as const,
+              apiKey: "synthetic-run-key",
+              baseUrl: "https://fixture.invalid/v1",
+              models:
+                options.catalog && id === providerId
+                  ? []
+                  : [
+                      {
+                        id: "model",
+                        name: "Fixture model",
+                        reasoning: false,
+                        input: ["text" as const],
+                        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                        contextWindow: 8192,
+                        maxTokens: 1024,
+                      },
+                    ],
+            },
+          ]),
+        ),
+      },
+      plugins: {
+        allow: [providerId, siblingId],
+        slots: { memory: "none" },
+        entries: { [providerId]: { enabled: true }, [siblingId]: { enabled: true } },
+      },
+    };
+    const input = {
+      config,
+      agentId: "main",
+      agentDir: state.agentDir("main"),
+      workspaceDir: state.workspaceDir,
+      runtimePluginSelections: [{ provider: providerId, modelId: "model", agentId: "main" }],
+    };
+    await withEnvAsync(
+      { OPENCLAW_BUNDLED_PLUGINS_DIR: bundled, OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined },
+      async () => {
+        await resetPreparedModelRuntimeSnapshotsForTest();
+        clearPluginMetadataLifecycleCaches();
+        try {
+          await run({
+            config,
+            input,
+            registrations,
+            acquire: async (leaseOptions, workspace) => {
+              const lease = await acquireAgentRunPreparedModelRuntime(
+                { ...input, ...(workspace ? { workspaceDir: workspace } : {}) },
+                leaseOptions,
+              );
+              leases.push(lease);
+              return lease;
+            },
+            original: () =>
+              expectDefined(
+                registrations.find((record) => record.id === providerId),
+                "selected provider registration",
+              ),
+            finishDisposal,
+            disposalStarted,
+            catalogStarted,
+            finishCatalog,
+            holdDisposal: () => {
+              bridge.hold = true;
+            },
+          });
+        } finally {
+          finishDisposal.resolve();
+          finishCatalog.resolve();
+          for (const lease of leases) {
+            lease.release();
+          }
+          await resetPreparedModelRuntimeSnapshotsForTest();
+          resetPluginLoaderTestStateForTest();
+          cleanupPluginLoaderFixturesForTest();
+          clearPluginMetadataLifecycleCaches();
+          closeOpenClawStateDatabase();
+          for (const record of registrations) {
+            // The original raw producer has no disposer; fixture cleanup owns those handles.
+            if (record.database.isOpen) {
+              record.database.close();
+            }
+          }
+          delete (globalThis as Record<string, unknown>)[key];
+        }
+      },
+    );
+  });
+}
+
+function readAnswer(record: Registration): unknown {
+  return record.database.prepare("SELECT value FROM answer").get()?.value;
+}
+
+function expectReopened(record: Registration) {
+  const reopened = new DatabaseSync(record.file, { readOnly: true });
+  try {
+    expect(reopened.prepare("SELECT value FROM answer").get()?.value).toBe(42);
+  } finally {
+    reopened.close();
+  }
+}
+
+it("keeps overlapping RUN callers on one registration and closes only after the last release", async () => {
+  await withRunFixture(async ({ acquire, original, registrations }) => {
+    const first = await acquire();
+    const count = registrations.length;
+    const second = await acquire();
+    expect(first.snapshot === second.snapshot).toBe(true);
+    expect(registrations.length).toBe(count);
+    expect(original().mode).toBe("discovery");
+    first.release();
+    await nextTurn();
+    expect(readAnswer(original())).toBe(42);
+    expect(original().disposals).toBe(0);
+    second.release();
+    await expect.poll(() => original().disposals).toBe(1);
+    expect(original().database.isOpen).toBe(false);
+    expectReopened(original());
+  });
+});
+
+it("retains a replaced RUN generation without letting its release retire the replacement", async () => {
+  await withRunFixture(async ({ acquire, input, original, registrations }) => {
+    const first = await acquire();
+    const old = original();
+    await publishPreparedModelRuntimeSnapshot(input, {
+      provenance: "run",
+      catalogMode: "static",
+      force: true,
+    });
+    const second = await acquire();
+    expect(first.snapshot === second.snapshot).toBe(false);
+    const replacement = expectDefined(
+      registrations.find((record) => record.id === providerId && record !== old),
+      "replacement registration",
+    );
+    expect(readAnswer(old)).toBe(42);
+    expect(old.disposals).toBe(0);
+    first.release();
+    await expect.poll(() => old.disposals).toBe(1);
+    expect(readAnswer(replacement)).toBe(42);
+    const third = await acquire();
+    expect(third.snapshot === second.snapshot).toBe(true);
+    second.release();
+    third.release();
+    await expect.poll(() => replacement.disposals).toBe(1);
+  });
+});
+
+it("preserves the direct one-entry idle retention policy across RUN eviction", async () => {
+  await withRunFixture(async ({ acquire, original, input }) => {
+    const first = await acquire({ retainIdleRunOwner: true });
+    first.release();
+    await nextTurn();
+    expect(readAnswer(original())).toBe(42);
+    const warm = await acquire({ retainIdleRunOwner: true });
+    expect(warm.snapshot === first.snapshot).toBe(true);
+    const next = await acquire({ retainIdleRunOwner: true }, `${input.workspaceDir}/next`);
+    expect(readAnswer(original())).toBe(42);
+    warm.release();
+    await expect.poll(() => original().disposals).toBe(1);
+    next.release();
+  });
+});
+
+it("keeps shared SDK KV namespaces available across RUN registration retirement", async () => {
+  await withRunFixture(async ({ acquire, original, registrations }) => {
+    const first = await acquire();
+    const old = original();
+    const sibling = expectDefined(
+      registrations.find((record) => record.id === siblingId),
+      "sibling plugin registration",
+    );
+    await old.store.register("answer", { value: 42 });
+    await sibling.store.register("answer", { value: 84 });
+    const shared = openOpenClawStateDatabase().db;
+    first.release();
+    await expect.poll(() => old.disposals).toBe(1);
+    expect(shared.isOpen).toBe(true);
+    const next = await acquire();
+    const latest = expectDefined(
+      registrations.find((record) => record.id === providerId && record !== old),
+      "next SDK state user",
+    );
+    expect((await latest.store.lookup("answer"))?.value).toBe(42);
+    expect((await sibling.store.lookup("answer"))?.value).toBe(84);
+    expect(openOpenClawStateDatabase().db === shared).toBe(true);
+    await latest.store.register("next", { value: 43 });
+    next.release();
+    await closePreparedModelRuntimeSnapshots();
+    expect(shared.isOpen).toBe(true);
+    closeOpenClawStateDatabase();
+    expect(shared.isOpen).toBe(false);
+    expect((await latest.store.lookup("next"))?.value).toBe(43);
+  });
+});
+
+it("process close waits for admitted registration disposal and rejects new RUN admission", async () => {
+  await withRunFixture(
+    async ({ acquire, original, holdDisposal, disposalStarted, finishDisposal }) => {
+      const lease = await acquire();
+      holdDisposal();
+      let closed = false;
+      const closing = closePreparedModelRuntimeSnapshots().then(() => {
+        closed = true;
+      });
+      lease.release();
+      try {
+        await expect.poll(() => original().database.isOpen && !closed).toBe(true);
+        await expect(acquire().then(() => undefined)).rejects.toThrow("process lifetime closed");
+        await Promise.race([
+          disposalStarted.promise,
+          closing.then(() => {
+            throw new Error("Process close finished before registration disposal");
+          }),
+        ]);
+        expect(readAnswer(original())).toBe(42);
+        expect(closed).toBe(false);
+      } finally {
+        finishDisposal.resolve();
+        await closing;
+      }
+      expect(original().disposals).toBe(1);
+      expectReopened(original());
+    },
+  );
+});
+
+it("keeps configured registry identity and its raw resources under the configured owner", async () => {
+  await withRunFixture(async ({ config, acquire, original }) => {
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const first = await acquire();
+    const raw = original();
+    const second = await acquire();
+    expect(first.snapshot === second.snapshot).toBe(true);
+    first.release();
+    second.release();
+    await closePreparedModelRuntimeSnapshots();
+    expect(raw.disposals).toBe(0);
+    expect(readAnswer(raw)).toBe(42);
+  });
+});
+
+it("preserves eight Gateway RUN retention entries without closing an evicted live lease", async () => {
+  await withRunFixture(async ({ config, input, acquire, registrations }) => {
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const configuredCount = registrations.length;
+    const first = await acquire({}, `${input.workspaceDir}/run-0`);
+    const oldest = expectDefined(
+      registrations.slice(configuredCount).find((record) => record.id === providerId),
+      "first dynamic registration",
+    );
+    for (let index = 1; index < 9; index++) {
+      const lease = await acquire({}, `${input.workspaceDir}/run-${index}`);
+      lease.release();
+    }
+    expect(readAnswer(oldest)).toBe(42);
+    expect(oldest.disposals).toBe(0);
+    first.release();
+    await expect.poll(() => oldest.disposals).toBe(1);
+    expect(
+      registrations
+        .slice(configuredCount)
+        .filter((record) => record.id === providerId && record.database.isOpen).length,
+    ).toBe(8);
+    await closePreparedModelRuntimeSnapshots();
+    expect(registrations.slice(configuredCount).every((record) => record.disposals === 1)).toBe(
+      true,
+    );
+    expect(registrations.slice(0, configuredCount).every((record) => record.disposals === 0)).toBe(
+      true,
+    );
+  });
+});
+
+it.each(["hold", "reject"] as const)(
+  "keeps an ordinary RUN static catalog source through %s build settlement",
+  async (catalog) => {
+    await withRunFixture(
+      async ({ acquire, input, original, catalogStarted, finishCatalog }) => {
+        const abort = new AbortController();
+        const pending = acquire({ abortSignal: abort.signal });
+        void pending.catch(() => undefined);
+        try {
+          await Promise.race([
+            catalogStarted.promise,
+            pending.then(() => {
+              throw new Error("Catalog hook was not entered");
+            }),
+          ]);
+          expect(readAnswer(original())).toBe(42);
+          if (catalog === "hold") {
+            abort.abort(new Error("fixture admission cancelled"));
+            await expect(pending.then(() => undefined)).rejects.toThrow("aborted");
+            expect(getPreparedModelRuntimeSnapshot(input) === undefined).toBe(true);
+            expect(original().disposals).toBe(0);
+          }
+          finishCatalog.resolve();
+          if (catalog === "reject") {
+            await expect(pending.then(() => undefined)).rejects.toThrow(
+              "fixture static catalog failed",
+            );
+          }
+          await closePreparedModelRuntimeSnapshots();
+          expect(original().disposals).toBe(1);
+          expectReopened(original());
+        } finally {
+          finishCatalog.resolve();
+          await Promise.allSettled([pending]);
+        }
+      },
+      { catalog },
+    );
+  },
+);
+
+it("retains a managed RUN source borrowed after matching standalone publication reuse", async () => {
+  await withRunFixture(async ({ acquire, input, original }) => {
+    const first = await acquire();
+    const activated = await activateStandalonePreparedModelRuntime(input, {
+      catalogMode: "static",
+    });
+    expect(activated === first.snapshot).toBe(true);
+    const borrowed = await acquirePublishedPreparedModelRuntime(input);
+    try {
+      first.release();
+      expect(readAnswer(original())).toBe(42);
+      expect(original().disposals).toBe(0);
+    } finally {
+      borrowed.release();
+    }
+    await expect.poll(() => original().disposals).toBe(1);
+    expectReopened(original());
+  });
+});

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, it, vi } from "vitest";
 import type { Model } from "../llm/types.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 
 const mocks = vi.hoisted(() => ({
@@ -56,6 +57,7 @@ vi.mock("./sessions/model-registry-runtime.js", () => ({
 
 import {
   prepareSimpleCompletionModel,
+  acquireSimpleCompletionModel,
   acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
@@ -78,6 +80,8 @@ function createOllamaModelResolver(): typeof resolveModelAsync {
   }));
 }
 
+let preparedModelRuntime: PreparedModelRuntimeSnapshot & { testGeneration: string };
+
 beforeEach(() => {
   mocks.publishedGeneration = "A";
   mocks.acquireRuntimeLease.mockReset();
@@ -88,26 +92,27 @@ beforeEach(() => {
     .mockReturnValue(createPluginMetadataSnapshotFixture());
   const authStorage = AuthStorage.inMemory({});
   const modelRegistry = ModelRegistry.inMemory(authStorage);
-  mocks.acquireRuntimeLease.mockResolvedValue({
-    snapshot: {
-      testGeneration: "A",
-      agentDir: "/tmp/openclaw-agent",
-      workspaceDir: "/tmp/runtime-workspace",
-      config: {},
-      authModes: {},
-      metadataSnapshot: createPluginMetadataSnapshotFixture(),
-      allowGatewaySubagentBinding: false,
-      modelCatalog: { entries: [] },
-      configuredRuntimeModels: [],
-      inlineProviderModels: [],
-      activeProjectKeys: [],
-      createStores: () => ({ authStorage, modelRegistry }),
-    },
-    release: vi.fn(),
-  });
+  preparedModelRuntime = {
+    testGeneration: "A",
+    catalogOwner: undefined,
+    observationConfig: {},
+    isCurrent: () => true,
+    agentDir: "/tmp/openclaw-agent",
+    workspaceDir: "/tmp/runtime-workspace",
+    config: {},
+    authModes: {},
+    metadataSnapshot: createPluginMetadataSnapshotFixture(),
+    allowGatewaySubagentBinding: false,
+    modelCatalog: { entries: [], routeVariants: [] },
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    activeProjectKeys: [],
+    createStores: () => ({ authStorage, modelRegistry }),
+  };
+  mocks.acquireRuntimeLease.mockResolvedValue({ snapshot: preparedModelRuntime, release: vi.fn() });
 });
 
-it("keeps route rematerialization and runtime auth on the acquired generation", async () => {
+it("keeps route rematerialization and runtime auth on the supplied generation", async () => {
   const observedModelGenerations: string[] = [];
   const observedRuntimeAuthGenerations: string[] = [];
   const modelResolver: typeof resolveModelAsync = vi.fn(
@@ -153,6 +158,7 @@ it("keeps route rematerialization and runtime auth on the acquired generation", 
   });
 
   const result = await prepareSimpleCompletionModel({
+    preparedModelRuntime,
     cfg: {},
     agentId: "main",
     provider: "openai",
@@ -178,7 +184,7 @@ it("acquires direct completion runtime for the exact selected model", async () =
     mode: "api-key",
   });
 
-  await prepareSimpleCompletionModel({
+  const acquired = await acquireSimpleCompletionModel({
     cfg: {},
     agentId: "main",
     provider: "ollama",
@@ -188,20 +194,27 @@ it("acquires direct completion runtime for the exact selected model", async () =
     modelResolver,
   });
 
-  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
-    expect.objectContaining({
-      runtimePluginSelections: [
-        {
-          provider: "ollama",
-          modelId: "qwen3:0.6b",
-          runtime: "openclaw",
-          agentId: "main",
-        },
-      ],
-    }),
-    expect.objectContaining({ catalogMode: "static" }),
-  );
-  expect(modelResolver).toHaveBeenCalledOnce();
+  if ("error" in acquired) {
+    throw new Error(acquired.error);
+  }
+  try {
+    expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimePluginSelections: [
+          {
+            provider: "ollama",
+            modelId: "qwen3:0.6b",
+            runtime: "openclaw",
+            agentId: "main",
+          },
+        ],
+      }),
+      expect.objectContaining({ catalogMode: "static" }),
+    );
+    expect(modelResolver).toHaveBeenCalledOnce();
+  } finally {
+    acquired.release();
+  }
 });
 
 it("selects an explicit agent completion model before runtime acquisition", async () => {

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -26,6 +26,7 @@ import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 import {
   completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModel,
+  acquireSimpleCompletionModel,
   acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
@@ -193,13 +194,17 @@ module.exports = {
           }
           return acquired;
         }
-        return await prepareSimpleCompletionModel({
+        const acquired = await acquireSimpleCompletionModel({
           cfg: config,
           agentId: "main",
           modelResolver,
           provider: selected.providerId,
           modelId: expectedModelId,
         });
+        if (!("error" in acquired)) {
+          release = acquired.release;
+        }
+        return acquired;
       });
       expect(result).toMatchObject({
         error: `stop after selected resolver ${selected.providerId}/${expectedModelId}`,
@@ -330,6 +335,7 @@ module.exports = {
                   },
                   { catalogMode: "static" },
                 );
+          let releasePreparedModel: (() => void) | undefined;
           try {
             if (mode === "empty") {
               expect(lease?.snapshot.pluginRegistry).toBeUndefined();
@@ -347,15 +353,27 @@ module.exports = {
             // Loading the public SDK must retain the host's registered metadata owners.
             const metadataReaders = readHostMetadataReaders();
             expect(metadataReaders.every((reader) => typeof reader === "function")).toBe(true);
-            const prepared = await prepareSimpleCompletionModel({
+            const modelParams = {
               cfg,
               agentId: "main",
               agentDir: input.agentDir,
               workspaceDir: input.workspaceDir,
               provider: selected.providerId,
               modelId: "selected-model",
-              ...(lease ? { preparedModelRuntime: lease.snapshot } : {}),
-            });
+            };
+            let prepared: Awaited<ReturnType<typeof prepareSimpleCompletionModel>>;
+            if (lease) {
+              prepared = await prepareSimpleCompletionModel({
+                ...modelParams,
+                preparedModelRuntime: lease.snapshot,
+              });
+            } else {
+              const acquired = await acquireSimpleCompletionModel(modelParams);
+              if (!("error" in acquired)) {
+                releasePreparedModel = acquired.release;
+              }
+              prepared = acquired;
+            }
             if ("error" in prepared) {
               throw new Error(prepared.error);
             }
@@ -386,6 +404,7 @@ module.exports = {
               "public SDK loading must preserve registered host metadata readers",
             ).toEqual(metadataReaders);
           } finally {
+            releasePreparedModel?.();
             lease?.release();
           }
         });
@@ -405,6 +424,7 @@ module.exports = {
     const tempRoot = fs.realpathSync(tempRoots.makeTempDir());
     const selected = createTransportOwnerFixture(path.join(tempRoot, "selected"), "A", false);
     const requestPaths: string[] = [];
+    let releasePreparedModel: (() => void) | undefined;
     const server = createServer((request, response) => {
       request.resume();
       const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -479,7 +499,7 @@ module.exports = {
         OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
       };
       await withEnvAsync(env, async () => {
-        const prepared = await prepareSimpleCompletionModel({
+        const prepared = await acquireSimpleCompletionModel({
           cfg,
           agentId: "main",
           agentDir: path.join(tempRoot, "agent"),
@@ -490,6 +510,7 @@ module.exports = {
         if ("error" in prepared) {
           throw new Error(prepared.error);
         }
+        releasePreparedModel = prepared.release;
         const completionTransport = getModelCompletionTransport(prepared.model);
         if (!completionTransport) {
           throw new Error("Managed completion transport was not prepared");
@@ -534,6 +555,7 @@ module.exports = {
         expect(modelRequestIndex).toBeGreaterThan(reloadIndex);
       }
     } finally {
+      releasePreparedModel?.();
       server.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -14,6 +14,8 @@ import {
   fingerprintAuthProfileCredential,
   fingerprintResolvedProviderAuth,
 } from "./execution-auth-binding.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 
 // Hoisted mocks keep Vitest module replacement stable while the implementation
@@ -43,6 +45,7 @@ vi.mock("../plugins/runtime/generation-scope.js", () => ({
 }));
 
 vi.mock("./sessions/model-registry-runtime.js", () => ({
+  initializeModelRegistryRuntime: vi.fn(),
   getModelRegistryRuntime: () => {
     const apiRegistry = createApiRegistry();
     return {
@@ -91,6 +94,8 @@ import {
   resolveSimpleCompletionSelectionForAgent,
 } from "./simple-completion-runtime.js";
 
+let preparedModelRuntime: PreparedModelRuntimeSnapshot;
+
 beforeEach(() => {
   hoisted.acquireRuntimeLeaseMock.mockReset();
   hoisted.resolveModelMock.mockReset();
@@ -101,23 +106,26 @@ beforeEach(() => {
   hoisted.prepareProviderRuntimeAuthMock.mockReset();
   hoisted.ensureAuthProfileStoreMock.mockReset();
   hoisted.getCurrentPluginMetadataSnapshotMock.mockReset();
+  const authStorage = AuthStorage.inMemory({});
+  const modelRegistry = ModelRegistry.inMemory(authStorage);
+  preparedModelRuntime = {
+    catalogOwner: undefined,
+    agentDir: "/tmp/openclaw-agent",
+    workspaceDir: "/tmp/runtime-workspace",
+    config: {},
+    observationConfig: {},
+    isCurrent: () => true,
+    authModes: {},
+    metadataSnapshot: createPluginMetadataSnapshotFixture(),
+    allowGatewaySubagentBinding: false,
+    modelCatalog: { entries: [], routeVariants: [] },
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    activeProjectKeys: [],
+    createStores: () => ({ authStorage, modelRegistry }),
+  };
   hoisted.acquireRuntimeLeaseMock.mockResolvedValue({
-    snapshot: {
-      agentDir: "/tmp/openclaw-agent",
-      workspaceDir: "/tmp/runtime-workspace",
-      config: {},
-      authModes: {},
-      metadataSnapshot: createPluginMetadataSnapshotFixture(),
-      allowGatewaySubagentBinding: false,
-      modelCatalog: { entries: [] },
-      configuredRuntimeModels: [],
-      inlineProviderModels: [],
-      activeProjectKeys: [],
-      createStores: () => ({
-        authStorage: { setRuntimeApiKey: hoisted.setRuntimeApiKeyMock },
-        modelRegistry: {},
-      }),
-    },
+    snapshot: preparedModelRuntime,
     release: vi.fn(),
   });
 
@@ -220,6 +228,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
@@ -255,6 +264,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: {},
       provider: "anthropic",
       modelId: "claude-opus-4-6",
@@ -316,9 +326,9 @@ describe("prepareSimpleCompletionModel", () => {
       }),
     };
 
-    const before = await prepareSimpleCompletionModel(params);
+    const before = await prepareSimpleCompletionModel({ ...params, preparedModelRuntime });
     credential = { ...credential, access: "access-after-refresh", refresh: "refresh-after" };
-    const after = await prepareSimpleCompletionModel(params);
+    const after = await prepareSimpleCompletionModel({ ...params, preparedModelRuntime });
 
     expectPreparedModelResult(before);
     expectPreparedModelResult(after);
@@ -340,6 +350,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "anthropic",
       modelId: "missing-model",
@@ -358,6 +369,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
@@ -392,6 +404,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "amazon-bedrock",
       modelId: "anthropic.claude-sonnet-4-6",
@@ -427,6 +440,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "github-copilot",
       modelId: "gpt-4.1",
@@ -469,6 +483,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "github-copilot",
       modelId: "gpt-4.1",
@@ -503,6 +518,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "github-copilot",
       modelId: "gpt-4.1",
@@ -540,6 +556,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "github-copilot",
       modelId: "gpt-4.1",
@@ -556,6 +573,7 @@ describe("prepareSimpleCompletionModel", () => {
     hoisted.getApiKeyForModelMock.mockRejectedValueOnce(new Error("Profile not found: copilot"));
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
@@ -592,6 +610,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "local-openai",
       modelId: "chat-local",
@@ -642,6 +661,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "amazon-bedrock-mantle",
       modelId: "anthropic.claude-opus-4-7",
@@ -697,6 +717,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "ollama",
       modelId: "llama3.2:latest",
@@ -739,6 +760,7 @@ describe("prepareSimpleCompletionModel", () => {
     hoisted.resolveModelMock.mockReset();
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
@@ -773,6 +795,7 @@ describe("prepareSimpleCompletionModel", () => {
     });
 
     const result = await prepareSimpleCompletionModel({
+      preparedModelRuntime,
       cfg: undefined,
       provider: "mistral",
       modelId: "mistral-medium-3-5",

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -165,7 +165,7 @@ export function resolveSimpleCompletionSelectionForAgent(
   return resolveSimpleCompletionSelectionRequest(params)?.selection ?? null;
 }
 
-export async function prepareSimpleCompletionModel(params: {
+export type PrepareSimpleCompletionModelParams = {
   cfg: OpenClawConfig | undefined;
   agentId?: string;
   provider: string;
@@ -182,26 +182,35 @@ export async function prepareSimpleCompletionModel(params: {
   preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   workspaceDir?: string;
   agentRuntimeId?: string;
-}): Promise<PreparedSimpleCompletionModel> {
-  return await withPreparedSimpleCompletionRuntime(
-    params,
-    [
-      {
-        provider: params.provider,
-        modelId: params.modelId,
-        ...(params.agentRuntimeId ? { runtime: params.agentRuntimeId } : {}),
-      },
-    ],
-    async (context) =>
-      await prepareSimpleCompletionModelCore(
-        { ...params, agentDir: context.preparedModelRuntime.agentDir },
-        context,
-      ),
+};
+
+/** Prepares a model within the exact generation already held by its caller. */
+export async function prepareSimpleCompletionModel(
+  params: PrepareSimpleCompletionModelParams & {
+    preparedModelRuntime: PreparedModelRuntimeSnapshot;
+  },
+): Promise<PreparedSimpleCompletionModel> {
+  const config = params.cfg ?? {};
+  const preparedModelRuntime = params.preparedModelRuntime;
+  const context = createPreparedSimpleCompletionResolverContext({
+    preparedModelRuntime,
+    workspaceDir:
+      params.workspaceDir ??
+      preparedModelRuntime.workspaceDir ??
+      resolveAgentWorkspaceDir(config, params.agentId ?? resolveDefaultAgentId(config)),
+    modelResolver: params.modelResolver,
+    agentRuntimeId: params.agentRuntimeId,
+  });
+  return await withPluginRuntimeGenerationScope(preparedModelRuntime, () =>
+    prepareSimpleCompletionModelCore(
+      { ...params, agentDir: preparedModelRuntime.agentDir },
+      context,
+    ),
   );
 }
 
 async function prepareSimpleCompletionModelCore(
-  params: Parameters<typeof prepareSimpleCompletionModel>[0],
+  params: PrepareSimpleCompletionModelParams,
   context: PreparedSimpleCompletionResolverContext,
 ): Promise<PreparedSimpleCompletionModel> {
   const { modelResolver, workspaceDir } = context;
@@ -450,76 +459,43 @@ async function acquirePreparedSimpleCompletionRuntime(
     agentId?: string;
     agentDir?: string;
     modelResolver?: typeof resolveModelAsync;
-    preparedModelRuntime?: PreparedModelRuntimeSnapshot;
     workspaceDir?: string;
     agentRuntimeId?: string;
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
   runtimePluginSelections: readonly AgentHarnessPluginSelection[],
-  onAcquired?: (release: () => void) => void,
-): Promise<{ context: PreparedSimpleCompletionResolverContext; release: () => void }> {
+  onAcquired: (release: () => void) => void,
+): Promise<PreparedSimpleCompletionResolverContext> {
   const config = params.cfg ?? {};
   const agentId = params.agentId ?? resolveDefaultAgentId(config);
   const agentDir = params.agentDir?.trim() || resolveAgentDir(config, agentId);
-  const requestedWorkspaceDir =
-    params.workspaceDir ??
-    params.preparedModelRuntime?.workspaceDir ??
-    resolveAgentWorkspaceDir(config, agentId);
-  const lease = params.preparedModelRuntime
-    ? undefined
-    : await acquireAgentRunPreparedModelRuntime(
-        {
-          config,
-          agentId,
-          agentDir,
-          workspaceDir: requestedWorkspaceDir,
-          loadRuntimePlugins: true,
-          runtimePluginSelections: runtimePluginSelections.map((selection) => ({
-            ...selection,
-            agentId,
-          })),
-        },
-        {
-          catalogMode: "static",
-          ...(params.pluginMetadataSnapshot
-            ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-            : {}),
-        },
-      );
-  const release = () => lease?.release();
-  onAcquired?.(release);
-  const preparedModelRuntime = params.preparedModelRuntime ?? lease!.snapshot;
-  const workspaceDir =
-    params.workspaceDir ?? preparedModelRuntime.workspaceDir ?? requestedWorkspaceDir;
-  try {
-    const context = createPreparedSimpleCompletionResolverContext({
-      preparedModelRuntime,
-      workspaceDir,
-      modelResolver: params.modelResolver,
-      agentRuntimeId: params.agentRuntimeId,
-    });
-    return { context, release };
-  } catch (error) {
-    if (!onAcquired) {
-      release();
-    }
-    throw error;
-  }
-}
-
-async function withPreparedSimpleCompletionRuntime<T>(
-  params: Parameters<typeof acquirePreparedSimpleCompletionRuntime>[0],
-  runtimePluginSelections: readonly AgentHarnessPluginSelection[],
-  run: (context: PreparedSimpleCompletionResolverContext) => Promise<T>,
-): Promise<T> {
-  const runtime = await acquirePreparedSimpleCompletionRuntime(params, runtimePluginSelections);
-  try {
-    return await withPluginRuntimeGenerationScope(runtime.context.preparedModelRuntime, () =>
-      run(runtime.context),
-    );
-  } finally {
-    runtime.release();
-  }
+  const requestedWorkspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId);
+  const lease = await acquireAgentRunPreparedModelRuntime(
+    {
+      config,
+      agentId,
+      agentDir,
+      workspaceDir: requestedWorkspaceDir,
+      loadRuntimePlugins: true,
+      runtimePluginSelections: runtimePluginSelections.map((selection) => ({
+        ...selection,
+        agentId,
+      })),
+    },
+    {
+      catalogMode: "static",
+      ...(params.pluginMetadataSnapshot
+        ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+        : {}),
+    },
+  );
+  onAcquired(() => lease.release());
+  return createPreparedSimpleCompletionResolverContext({
+    preparedModelRuntime: lease.snapshot,
+    workspaceDir: params.workspaceDir ?? lease.snapshot.workspaceDir ?? requestedWorkspaceDir,
+    modelResolver: params.modelResolver,
+    agentRuntimeId: params.agentRuntimeId,
+  });
 }
 
 type AcquiredSimpleCompletionModel =
@@ -676,20 +652,17 @@ async function acquirePreparedSimpleCompletionModel(
     }
   };
   const prepare = async () => {
-    const runtime = await acquirePreparedSimpleCompletionRuntime(
+    const context = await acquirePreparedSimpleCompletionRuntime(
       params,
       runtimePluginSelections,
       (release) => {
         releaseRuntime = release;
       },
     );
-    const prepared = await withPluginRuntimeGenerationScope(
-      runtime.context.preparedModelRuntime,
-      () => {
-        runInContext = AsyncLocalStorage.snapshot();
-        return prepareModel(runtime.context);
-      },
-    );
+    const prepared = await withPluginRuntimeGenerationScope(context.preparedModelRuntime, () => {
+      runInContext = AsyncLocalStorage.snapshot();
+      return prepareModel(context);
+    });
     if ("error" in prepared) {
       return prepared;
     }

--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -65,9 +65,18 @@ vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
   normalizeProviderModelIdWithRuntime: () => undefined,
 }));
 
-vi.mock("../agents/runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: vi.fn(),
-}));
+vi.mock("../agents/runtime-plugins.js", async () => {
+  const { createEmptyPluginRegistry } = await import("../plugins/registry-empty.js");
+  return {
+    loadAgentRuntimePluginRegistryHandle: vi.fn(),
+    acquireAgentRuntimePluginRegistry: vi.fn<
+      typeof import("../agents/runtime-plugins.js").acquireAgentRuntimePluginRegistry
+    >(async () => {
+      const registry = createEmptyPluginRegistry();
+      return { registry, primaryRegistry: registry };
+    }),
+  };
+});
 
 vi.mock("../agents/subagents/announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: vi.fn(),

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -24,7 +24,11 @@ export {
 
 type SummarizeTextDeps = {
   completeWithPreparedSimpleCompletionModel: typeof import("../agents/simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel;
-  prepareSimpleCompletionModel: typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModel;
+  prepareSimpleCompletionModel: (
+    params: import("../agents/simple-completion-runtime.js").PrepareSimpleCompletionModelParams,
+  ) => ReturnType<
+    typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModel
+  >;
   requireApiKey: typeof import("../agents/model-auth.js").requireApiKey;
 };
 


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Fixes an issue where repeated agent runs could retain model-selected plugin resources after their last user finished.

## Why This Change Was Made

Fresh RUN generations now use the existing registration-resource owner. Resources stay available through admitted work and cleanup, then dispose after the final claim releases, including existing bounded idle retention. Warm callers continue sharing their prepared generation.

The internal borrowed-model helper now requires its caller's prepared snapshot, removing an unused implicit-acquisition path. Public SDK and injected TTS request contracts remain unchanged. Production code shrinks by 21 lines.

## User Impact

Model-selected resources gain a defined cleanup lifetime across cancellation, replacement, and shutdown. Fresh registrations bypass the global raw registry cache; configured, standalone, root, and raw SDK sources retain their existing host contracts. Borrowing an already managed generation preserves its ownership. Shared SDK state remains process-owned, and its durable rows survive registration disposal.

## Evidence

Required changed checks passed, along with 42 lifecycle/helper tests and 28 Cron cases. Independent Codex reviews found no actionable P0–P2 findings. Initial CI exposed a shared Cron mock missing the acquisition export; this PR fixes that fixture without changing its assertions or production behavior.

The final normal build passed in 208 seconds. Ten compiled runtime groups passed on the final head: public SDK setup, TTS, foreground and delegated compaction, copied engines, Image, PDF, isolated completion, terminal disposal failure/shared KV, and public probe cleanup. These exercise real SQLite reads during late work, exactly-once disposal and reopening, replacement/refusal, cancellation, and process cleanup. The public probe includes actual OS SIGTERM. Setup, isolated completion and compaction use loopback model transports; delegate proof also runs MCP HTTP and LSP processes.

Each group checked the complete source and artifact inventories before and after execution. A final independent audit verified all 40,582 tracked files, index/diffs, and 14,588 built artifacts unchanged; all owned processes joined. Image/PDF/isolated cover 14 scenarios, 30 provider calls, and 24 SQLite registrations with automatic or explicitly caller-owned cleanup.

Proof uses private synthetic state. Copied-engine managed-donor controls use an explicitly constructed host; raw-root proof uses normal full loading. The terminal-failure fixture copies byte-identical production artifacts and adds three sealed synthetic plugin files. Existing timeout settings are shortened only in fixtures. These runs do not claim production-vendor or standalone CLI process-liveness coverage.

Earlier matched five-sample timings measured warm acquisition around 0.18 ms and fresh-after-release acquisition increasing from 2.79 to 5.73 ms as registrations are created anew. That is a measured fresh-owner cost, not a speedup claim or a benchmark of the final base. Final smoke runs recorded 41 ms preparation and 97 ms close/reopen for the terminal case, and 2.91 seconds for all three public probe modes.

Hosted CI is green on the final head: [run 34442074608](https://github.com/openclaw/openclaw/actions/runs/34442074608). The prompt-snapshot job initially failed during a Matrix native dependency download (HTTP 500), before tests. One unchanged retry and the dependent CI gate passed; no snapshots were changed.
