### PR TITLE
fix(sessions): keep old metadata from breaking reset history

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -20,6 +20,7 @@ import {
   readSessionTranscriptHistoryAnchorPage,
   readSessionTranscriptHistoryEvents,
   readSessionTranscriptHistoryEventById,
+  readSessionTranscriptHistoryEventCount,
   readSessionTranscriptHistoryEventPage,
 } from "./session-accessor.sqlite-history-events.js";
 
@@ -300,6 +301,100 @@ describe("SQLite transcript history events", () => {
       });
     },
   );
+
+  it("excludes pre-reset custom metadata while retaining the reset prefix and later markers", async () => {
+    // Valid transcript JSON can exceed SQLite's 1,000-level JSON nesting limit.
+    const details: unknown = JSON.parse(`${"[".repeat(1_001)}0${"]".repeat(1_001)}`);
+    const oldNotice = {
+      type: "custom_message",
+      id: "old-notice",
+      parentId: null,
+      customType: "display-report",
+      content: "old report",
+      display: true,
+      details,
+      timestamp: "2026-09-07T00:00:00.000Z",
+    };
+    const events = [
+      { type: "session", version: 3, id: scope.sessionId },
+      oldNotice,
+      {
+        type: "message",
+        id: "kept-user",
+        parentId: "old-notice",
+        message: { role: "user", content: "retained prompt" },
+      },
+      { ...oldNotice, id: "shallow-notice", parentId: "kept-user", details: {} },
+      {
+        type: "message",
+        id: "kept-assistant",
+        parentId: "shallow-notice",
+        message: { role: "assistant", content: "retained reply" },
+      },
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "kept-assistant",
+        firstKeptEntryId: "kept-user",
+        reason: "new",
+        timestamp: "2026-09-07T01:00:00.000Z",
+      },
+      {
+        type: "compaction",
+        id: "compaction",
+        parentId: "reset",
+        summary: "current summary",
+        timestamp: "2026-09-07T02:00:00.000Z",
+      },
+    ];
+    await replaceTranscriptEvents(scope, events);
+
+    const history = readSessionTranscriptHistoryEvents(scope);
+    expect(history.map(historyEventId)).toEqual([
+      "kept-user",
+      "kept-assistant",
+      "reset",
+      "compaction",
+    ]);
+    expect(history.map(({ seq }) => seq)).toEqual([1, 2, 3, 4]);
+    expect(readSessionTranscriptHistoryEventCount(scope)).toBe(4);
+
+    const recent = readRecentSessionTranscriptHistoryEvents(scope, {
+      maxBytes: 65_536,
+      maxLines: 2,
+      maxMessages: 2,
+    });
+    expect(recent.totalMessages).toBe(4);
+    expect(recent.events.map(historyEventId)).toEqual(["reset", "compaction"]);
+    expect(recent.events.map(({ seq }) => seq)).toEqual([3, 4]);
+
+    const page = readSessionTranscriptHistoryEventPage(scope, { offset: 2, maxMessages: 2 });
+    expect(page.totalMessages).toBe(4);
+    expect(page.events.map(historyEventId)).toEqual(["kept-user", "kept-assistant"]);
+    expect(page.events.map(({ seq }) => seq)).toEqual([1, 2]);
+
+    const anchored = readSessionTranscriptHistoryAnchorPage(scope, {
+      messageId: "reset",
+      maxMessages: 4,
+    });
+    expect(anchored).toMatchObject({ found: true, totalMessages: 4 });
+    expect(anchored.events.map(historyEventId)).toEqual([
+      "kept-user",
+      "kept-assistant",
+      "reset",
+      "compaction",
+    ]);
+
+    expect(() =>
+      readSessionTranscriptHistoryAnchorPage(scope, { messageId: "old-notice", maxMessages: 3 }),
+    ).toThrow(/malformed JSON/i);
+
+    await replaceTranscriptEvents(scope, [
+      ...events,
+      { ...oldNotice, id: "current-notice", parentId: "compaction" },
+    ]);
+    expect(() => readSessionTranscriptHistoryEvents(scope)).toThrow(/malformed JSON/i);
+  });
 
   it("does not read an inactive boundary between active sequence bounds", async () => {
     await persistSessionTranscriptTurn(scope, {

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -85,7 +85,6 @@ function resolveVisibleHistoryProjection(
       )
       .select([
         "identity.event_id",
-        "identity.event_type",
         "identity.seq",
         /* kysely-allow-raw: history byte caps include each event's JSONL newline. */
         sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
@@ -102,17 +101,25 @@ function resolveVisibleHistoryProjection(
           .as("next_message_position"),
       )
       .where("active.session_id", "=", projection.resolved.sessionId)
-      .where((eb) =>
-        isVisibleHistoryNonMessageEventSql(
-          eb.ref("identity.event_type"),
-          eb.ref("event.event_json"),
-        ),
-      )
+      .where((eb) => {
+        const type = eb.ref("identity.event_type");
+        const event = eb.ref("event.event_json");
+        if (visibleMessages.boundaryActivePosition === undefined) {
+          return isVisibleHistoryNonMessageEventSql(type, event);
+        }
+        const inWindow = eb("active.active_position", ">=", visibleMessages.boundaryActivePosition);
+        // Fence the JSON argument while leaving type/range predicates visible to the planner.
+        return eb.and([
+          inWindow,
+          isVisibleHistoryNonMessageEventSql(
+            type,
+            eb.case().when(inWindow).then(event).else(null).end(),
+          ),
+        ]);
+      })
       .orderBy("active.active_position", "asc"),
   ).rows;
-  const resetIndex = rows.findLastIndex((row) => row.event_type === "reset");
-  const visibleRows = rows.slice(Math.max(0, resetIndex));
-  const boundaries = visibleRows.map((row, index): VisibleHistoryBoundary => {
+  const boundaries = rows.map((row, index): VisibleHistoryBoundary => {
     // Kept messages precede the latest reset; later markers share its logical window.
     // Rebase raw positions so discarded messages cannot shift those markers.
     const nextMessagePosition = row.next_message_position ?? projection.state.activeMessageCount;

--- a/src/config/sessions/session-accessor.sqlite-history-interval.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-interval.ts
@@ -20,7 +20,7 @@ import {
 /** Select display slots without loading custom content or details into history metadata. */
 export function isVisibleHistoryNonMessageEventSql(
   type: Expression<string | null>,
-  event: Expression<string>,
+  event: Expression<string | null>,
 ): RawBuilder<SqlBool> {
   // Match isVisibleTranscriptRecord; CASE avoids parsing unrelated marker payloads.
   return /* kysely-allow-raw: query-time display selection leaves canonical events and message indexes unchanged. */ sql<SqlBool>`CASE

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -18,6 +18,7 @@ import {
 import { projectModelContextNavigationSql } from "./session-model-context-projection.js";
 
 type VisibleMessagePositions = {
+  boundaryActivePosition?: number;
   kept: number[];
   postStart: number;
   total: number;
@@ -336,6 +337,7 @@ export function resolveVisibleMessagePositions(
     return { kept: [], postStart: 0, total: projection.state.activeMessageCount };
   }
   return {
+    boundaryActivePosition: window.boundaryActivePosition,
     kept: window.keptMessagePositions,
     postStart: window.postBoundaryMessagePosition,
     total:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could not load the current conversation history after resetting a session that contained an older plugin message with deeply nested metadata. That older message was outside the current history window, but reads could still fail with `malformed JSON`.

## Why This Change Was Made

Reuse the existing reset boundary to limit non-message markers before their JSON is evaluated. Keep the active-position predicate available to the query planner and guard only excluded JSON arguments, while retaining the existing message-prefix selection, snapshot, and cache ownership.

## User Impact

Current history remains readable when excluded older marker metadata exceeds SQLite's JSON nesting limit. Retained user and assistant messages, the reset marker, later compactions, pagination, and selected historical/current errors keep their existing behavior. No stored data, schema, index, or retention policy changes.

## Evidence

- The new regression fails on original `989abf687037` at the first current-history read with `malformed JSON`, after canonical transcript replacement succeeds.
- All 12 tests in the complete history-events suite pass with the repair, including retained messages separated by an old custom marker, inclusive reset with no later message, later compaction, paging/anchor ordinals, and preserved selected-row errors.
- Full changed-file validation passed with all gates enabled; independent P0–P2 review found no actionable issues. The first check run hit its outer supervision limit during typechecking; the unchanged checks passed with a longer outer budget. Test and assertion timeouts were unchanged.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34440214812) tested the same tree as `f3b7476c90f1` and exercised the real Gateway `readSessionMessagesWithSourceAsync` entrypoint on isolated synthetic SQLite state. Full and recent reads returned the expected retained messages, markers, and sequence numbers, and a selected deep marker still raised an error. Native artifacts confirm source and child/pipe closure; the lease is stopped.

The Linux workload and artifact transfer succeeded. Its local controller retained a nonzero result because a final local Git verification read timed out; a separate exact source, index, tool, bundle, and program verification passed afterward. This is a correctness proof for the history boundary, not an attribution of earlier production latency observations.
