### PR TITLE
fix(agents): preserve flat arguments beside empty Tool Search wrappers

### DIFF
--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -141,6 +141,31 @@ describe("Tool Search flattened call arguments", () => {
       expected: { command: "flattened" },
     },
     {
+      label: "empty args wrapper with flattened top-level params",
+      arguments: {
+        id: "inspect_resource",
+        args: {},
+        command: "list",
+        timeout_ms: 5_000,
+      },
+      expected: { command: "list", timeout_ms: 5_000 },
+    },
+    {
+      label: "empty args wrapper with dotted params",
+      arguments: {
+        id: "inspect_resource",
+        args: {},
+        "args.path": "projects/example.md",
+        "args.limit": 20,
+      },
+      expected: { path: "projects/example.md", limit: 20 },
+    },
+    {
+      label: "empty args wrapper without other params",
+      arguments: { id: "inspect_resource", args: {} },
+      expected: {},
+    },
+    {
       label: "bare selector",
       arguments: { id: "inspect_resource" },
       expected: {},
@@ -177,6 +202,20 @@ describe("Tool Search flattened call arguments", () => {
       arguments: { name: "inspect_resource", id: "record-7" },
       parameters: Type.Object({ id: Type.String() }, { additionalProperties: false }),
       expected: { id: "record-7" },
+    },
+    {
+      label: "empty args wrapper with flattened target arguments",
+      arguments: {
+        id: "inspect_resource",
+        args: {},
+        command: "list",
+        timeout_ms: 5_000,
+      },
+      parameters: Type.Object(
+        { command: Type.String(), timeout_ms: Type.Number() },
+        { additionalProperties: false },
+      ),
+      expected: { command: "list", timeout_ms: 5_000 },
     },
     {
       label: "redundant selectors for a strict no-argument tool",

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -147,7 +147,11 @@ export function readToolSearchCallArgs(
       .map(([key, value]) => [key.slice(5), value]),
   );
   const nestedInput = params.args ?? params.input;
-  if (nestedInput != null) {
+  // Some local models emit an empty args/input wrapper while flattening the real
+  // arguments to the top level. Treat an empty wrapper as absent so the fallback
+  // below preserves those parameters instead of returning {}.
+  const nestedInputIsEmpty = isRecord(nestedInput) && Object.keys(nestedInput).length === 0;
+  if (nestedInput != null && !nestedInputIsEmpty) {
     return {
       id: readToolSearchId(params),
       input: isRecord(nestedInput) ? { ...dottedInput, ...nestedInput } : nestedInput,


### PR DESCRIPTION
Related: #143180. That issue's reported dotted-argument Ollama failure remains unresolved. This PR addresses the separate loss of ordinary top-level arguments beside an empty wrapper.

## What Problem This Solves

Tool Search already accepts flattened target arguments. However, an empty `args: {}` or `input: {}` wrapper returned early and discarded those ordinary fields. A call containing a valid top-level `path` therefore reached the real read tool with `{}` and failed required-input validation.

Treat an empty record wrapper like a missing wrapper and reuse the existing selector-aware fallback. Non-empty nested arguments keep their precedence. Target validation, tool policy, result handling, retry limits, and explicit `tools.toolSearch: false` remain unchanged.

## Evidence

Public proof uses the built `openclaw agent --local` command, a scripted loopback Ollama-compatible `/api/chat` provider, and a task-owned marker file. The primary turns discover the real core read tool, describe it, and emit the captured `tool_call`. Harmless plugin tools supply the selector-named and argument-less controls. The provider's final response echoes the actual returned tool result. This is transport and agent-path proof; it does not claim natural model inference or reproduction of the linked issue.

| Raw call shape | Baseline `874b2ce292f4` | Candidate `fdfdddba6fe0` |
| --- | --- | --- |
| `{id, args: {}, path}` | Real read target received `{}`; required-path error | Real read target received `path`; exact file marker returned |
| `{id, input: {}, path}` | Real read target received `{}`; required-path error | Real read target received `path`; exact file marker returned |

Twenty-one public candidate cases cover both wrappers, ordinary and dotted arguments, non-empty nested precedence, matching and conflicting selectors, selector-named target arguments, argument-less calls, implicit local defaults, explicit disable, denied tools, invalid target input, unknown targets, and earlier outer-schema rejection of alias-only calls. All providers, agent commands, and listening ports were closed after capture. Raw wire data and public trajectory exports are retained, including existing diagnostic redactions.

Both decoder/dispatcher regressions fail on baseline for the intended reasons. All 272 focused tests, formatting, syntax lint, and native commit-hook checks pass. Full type-aware checks and the final landing gates run through hosted CI and the required review.

Independent source and public-call validation passed within the stated scope.

Preserves @xydigitLybnnnn's contributor commit and repair intent. AI-assisted.
