### PR TITLE
refactor: remove redundant terminal media trust evidence

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -4,11 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { createHookRunner } from "../plugins/hooks.js";
 import { createMockPluginRegistry, TEST_PLUGIN_AGENT_CTX } from "../plugins/hooks.test-fixtures.js";
-import {
-  __testing,
-  handleAgentEnd,
-  handleAgentStart,
-} from "./embedded-agent-subscribe.handlers.lifecycle.js";
+import { handleAgentEnd, handleAgentStart } from "./embedded-agent-subscribe.handlers.lifecycle.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import { createReplyDelivery } from "./embedded-agent-subscribe.reply-delivery.js";
 
@@ -28,7 +24,6 @@ const BEFORE_AGENT_FINALIZE_EVENT = {
   stopHookActive: false,
   lastAssistantMessage: "done",
 };
-const { resolveTerminalToolMediaTrust } = __testing;
 
 vi.mock("../infra/agent-events.js", () => ({
   emitAgentEvent: emitAgentEventMock,
@@ -127,53 +122,6 @@ function firstMockCall(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknow
 function firstWarnMeta(ctx: EmbeddedAgentSubscribeContext): Record<string, unknown> {
   return readRecord(firstMockCall(vi.mocked(ctx.log.warn))[1]);
 }
-
-describe("resolveTerminalToolMediaTrust", () => {
-  it.each([
-    {
-      name: "mixed pending batch",
-      pendingMediaUrls: ["/tmp/trusted.mp3", "/tmp/untrusted.mp3"],
-      pendingTrustByUrl: new Map([
-        ["/tmp/trusted.mp3", true],
-        ["/tmp/untrusted.mp3", false],
-      ]),
-      deferredReplies: [],
-      expected: false,
-    },
-    {
-      name: "all-trusted pending batch",
-      pendingMediaUrls: ["/tmp/first.mp3", "/tmp/second.mp3"],
-      pendingTrustByUrl: new Map([
-        ["/tmp/first.mp3", true],
-        ["/tmp/second.mp3", true],
-      ]),
-      deferredReplies: [],
-      expected: true,
-    },
-    {
-      name: "mixed deferred batch",
-      pendingMediaUrls: [],
-      pendingTrustByUrl: new Map<string, boolean>(),
-      deferredReplies: [
-        { mediaUrls: ["/tmp/trusted.mp3"], trustedLocalMedia: true },
-        { mediaUrls: ["/tmp/untrusted.mp3"] },
-      ],
-      expected: false,
-    },
-    {
-      name: "all-trusted deferred batch",
-      pendingMediaUrls: [],
-      pendingTrustByUrl: new Map<string, boolean>(),
-      deferredReplies: [
-        { mediaUrls: ["/tmp/first.mp3"], trustedLocalMedia: true },
-        { mediaUrls: ["/tmp/second.mp3"], trustedLocalMedia: true },
-      ],
-      expected: true,
-    },
-  ])("returns $expected for $name", ({ expected, ...params }) => {
-    expect(resolveTerminalToolMediaTrust(params)).toBe(expected);
-  });
-});
 
 describe("handleAgentEnd", () => {
   it("contains rejected lifecycle start event callbacks", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -108,11 +108,6 @@ export function handleAgentEnd(
     toolAudioAsVoice:
       ctx.state.pendingToolAudioAsVoice ||
       ctx.state.deferredBlockReplies.some((payload) => payload.audioAsVoice),
-    toolTrustedLocalMedia: resolveTerminalToolMediaTrust({
-      pendingMediaUrls: ctx.state.pendingToolMediaUrls,
-      pendingTrustByUrl: ctx.state.pendingToolMediaTrustByUrl,
-      deferredReplies: ctx.state.deferredBlockReplies,
-    }),
     hasToolMediaBlockReply: ctx.state.hasToolMediaBlockReply,
     didDeliverSourceReplyViaMessageTool:
       ctx.state.messageToolOnlySourceReplyDelivered ||
@@ -416,19 +411,3 @@ export function handleAgentEnd(
   }
   return deliverTerminalWithLifecycleErrorFallback();
 }
-function resolveTerminalToolMediaTrust(params: {
-  pendingMediaUrls: readonly string[];
-  pendingTrustByUrl: ReadonlyMap<string, boolean>;
-  deferredReplies: readonly { mediaUrls?: string[]; trustedLocalMedia?: boolean }[];
-}): boolean {
-  const trust = [
-    ...params.pendingMediaUrls.map((url) => params.pendingTrustByUrl.get(url.trim()) === true),
-    ...params.deferredReplies.flatMap((payload) =>
-      (payload.mediaUrls ?? []).map(() => payload.trustedLocalMedia === true),
-    ),
-  ];
-  return trust.length > 0 && trust.every(Boolean);
-}
-
-const testing = { resolveTerminalToolMediaTrust };
-export { testing as __testing };


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers can push updates.

</details>

## What Problem This Solves

The embedded-agent terminal path maintains a second media-evidence calculation whose result cannot change the outcome for media produced by the runtime. Four private-helper tests keep that redundant path and a test-only export in place.

## Why This Change Was Made

Remove the subscriber-specific all-trusted-media predicate and its direct tests. The same call already supplies every pending and deferred media URL, and the real producers normalize or derive nonblank URLs: a true result from the removed predicate therefore already implies terminal URL evidence. The general terminal-evidence helper and outbound media trust classification remain unchanged.

## User Impact

No user-visible behavior change. This removes 21 production lines and 52 net test lines while retaining the real lifecycle, subscription, delivery, and media-producer coverage.

## Evidence

- Five complete owner/producer suites: 236 passing cases before, 232 after; exactly the four deleted private-predicate cases disappear, with every retained case and status in the same order.
- Repeated the final five suites under the corrected frozen dependency install: 232 passed, zero pending, identical ordered cases. The initial changed gate exposed an installed proxyline version older than the manifest; normal installation resolved it without source or lockfile changes.
- Eight temporary real-subscription controls pass on both original and candidate. Removing only the retained URL-evidence argument from the candidate makes the two nonempty pending-media controls fail with abandoned instead of working terminal state.
- Deferred MEDIA-only controls preserve queue consumption, withheld callbacks, ordered delivery, and trust. They do not isolate deferred liveness: raw MEDIA directives also count as visible text. The source producer/aliasing proof establishes the deferred implication separately.
- Full changed gate and independent P2 review passed. No runtime-savings claim.
