### PR TITLE
refactor(discord): retire obsolete SDK expiry fallback

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.expiry.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.expiry.test.ts
@@ -1,29 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolvePreparedThreadBindingLifecycle } from "./thread-bindings.state.js";
 import type { ThreadBindingRecord } from "./thread-bindings.types.js";
 
-const sdk = vi.hoisted(() => ({ helperAvailable: true, calls: 0 }));
-vi.mock("openclaw/plugin-sdk/thread-bindings-session-runtime", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("openclaw/plugin-sdk/thread-bindings-session-runtime")>();
-  const resolve = (params: Parameters<typeof actual.resolveThreadBindingExpiry>[0]) => {
-    sdk.calls += 1;
-    return actual.resolveThreadBindingExpiry(params);
-  };
-  return {
-    ...actual,
-    get resolveThreadBindingExpiry() {
-      return sdk.helperAvailable ? resolve : undefined;
-    },
-  };
-});
-
-describe.each([true, false])("prepared Discord expiry (SDK helper available=%s)", (available) => {
-  beforeEach(() => {
-    sdk.helperAvailable = available;
-    sdk.calls = 0;
-  });
-
+describe("prepared Discord expiry", () => {
   it.each([
     {
       boundAt: 100,
@@ -77,6 +56,5 @@ describe.each([true, false])("prepared Discord expiry (SDK helper available=%s)"
     expect(
       resolvePreparedThreadBindingLifecycle({ record, idleTimeoutMs: idle, maxAgeMs: max }),
     ).toEqual({ idleTimeoutMs: idle, maxAgeMs: max, ...expiry });
-    expect(sdk.calls).toBe(available ? 1 : 0);
   });
 });

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -6,7 +6,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import * as threadBindingRuntime from "openclaw/plugin-sdk/thread-bindings-session-runtime";
+import { resolveThreadBindingExpiry } from "openclaw/plugin-sdk/thread-bindings-session-runtime";
 import { getDiscordRuntime } from "../runtime.js";
 import type {
   PersistedThreadBindingRecord,
@@ -250,31 +250,6 @@ function resolveTimestampExpiry(timestamp: number, durationMs: number): number |
   return Number.isFinite(at) && at > 0 ? at + durationMs : undefined;
 }
 
-// Published 2026.9.2 has lifecycle normalization but not prepared expiry selection.
-// Remove this fallback when the declared plugin API floor excludes that host.
-const threadBindingExpirySdk: Partial<
-  Pick<typeof threadBindingRuntime, "resolveThreadBindingExpiry">
-> = threadBindingRuntime;
-
-function resolveThreadBindingExpiryForHost(
-  params: Parameters<typeof threadBindingRuntime.resolveThreadBindingExpiry>[0],
-): ReturnType<typeof threadBindingRuntime.resolveThreadBindingExpiry> {
-  if (threadBindingExpirySdk.resolveThreadBindingExpiry) {
-    return threadBindingExpirySdk.resolveThreadBindingExpiry(params);
-  }
-  const { inactivityExpiresAt, maxAgeExpiresAt } = params;
-  if (
-    inactivityExpiresAt != null &&
-    (maxAgeExpiresAt == null || inactivityExpiresAt <= maxAgeExpiresAt)
-  ) {
-    return { expiresAt: inactivityExpiresAt, reason: "idle-expired" };
-  }
-  if (maxAgeExpiresAt != null) {
-    return { expiresAt: maxAgeExpiresAt, reason: "max-age-expired" };
-  }
-  return {};
-}
-
 export function resolvePreparedThreadBindingLifecycle(params: {
   record: ThreadBindingRecord;
   idleTimeoutMs: number;
@@ -291,7 +266,7 @@ export function resolvePreparedThreadBindingLifecycle(params: {
   return {
     idleTimeoutMs,
     maxAgeMs,
-    ...resolveThreadBindingExpiryForHost({
+    ...resolveThreadBindingExpiry({
       inactivityExpiresAt: resolveTimestampExpiry(params.record.lastActivityAt, idleTimeoutMs),
       maxAgeExpiresAt: resolveTimestampExpiry(params.record.boundAt, maxAgeMs),
     }),


### PR DESCRIPTION
## What Problem This Solves

Discord retains an expiry fallback for hosts older than its declared plugin API floor. Its package already requires OpenClaw 2026.9.3, whose published SDK exports the shared expiry selector. This is part of the maintainer-requested code-reduction work.

## Why This Change Was Made

Import the existing SDK selector directly and remove the obsolete availability wrapper. Discord's timestamp and duration normalization stays unchanged. The tests retain all seven semantic expiry cases against the real SDK and remove only the unsupported old-host dimension and private call counter.

## User Impact

No behavior change on supported hosts. Expiry precedence, tied deadlines, disabled limits, and invalid timestamps keep their existing results. No package version, dependency, configuration or storage change is introduced.

## Evidence

The actual published `openclaw@2026.9.3` tarball exports the helper through `plugin-sdk/thread-bindings-session-runtime`; its integrity and referenced implementation were verified. Supported package installation, update and directory discovery enforce the declared API floor.

All 44 retained Discord tests and eight shared lifecycle tests pass. The original 51-test baseline included seven additional executions of the now-unsupported availability branch. The complete changed-file gate and independent review through P2 pass.

The complete change removes 21 production and 20 test code lines, or 47 physical lines, with no new helper or test-support code.
