### PR TITLE
fix(update): preserve restart intent across schema upgrades

### DIFF
--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -28,6 +28,11 @@ openclaw gateway restart --wait 30s
 
 `--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
 
+During an upgrade, restart records its reason and drain options in the existing
+Gateway state without starting a schema migration while the old Gateway is still
+running. If no state database exists, it logs that intent recording was skipped
+and continues the restart.
+
 On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
 
 On macOS, when `openclaw gateway restart`, `stop`, `install`, or `uninstall` runs inside the managed LaunchAgent's process tree, including an agent's shell command, OpenClaw detects that from launchd's service environment or, when a hand-written plist omits those variables, from process ancestry against the PID launchd reports for the job. Restart hands off to a detached helper so `kickstart -k` cannot kill the caller. Stop, install, and uninstall refuse and ask you to run the command from an external shell.

--- a/src/infra/restart-intent.test.ts
+++ b/src/infra/restart-intent.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -14,21 +15,28 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import {
+  clearGatewayRestartIntentSync,
   consumeGatewayRestartIntentPayloadSync,
   consumeGatewayRestartIntentSync,
   writeGatewayRestartIntentSync,
 } from "./restart-intent.js";
+import { tryAcquireExclusiveSqliteCoordinator } from "./sqlite-coordinator.js";
+import { acquireGatewayLifecycleCoordinator } from "./state-database-coordinator.js";
 
 const tempDirs: string[] = [];
 type GatewayRestartIntentDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_intent">;
 
-function createIntentEnv(): NodeJS.ProcessEnv {
+function createIntentEnv(initialize = true): NodeJS.ProcessEnv {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-intent-"));
   tempDirs.push(dir);
-  return {
+  const env = {
     ...process.env,
     OPENCLAW_STATE_DIR: dir,
   };
+  if (initialize) {
+    openOpenClawStateDatabase({ env });
+  }
+  return env;
 }
 
 function legacyIntentPath(env: NodeJS.ProcessEnv): string {
@@ -92,6 +100,59 @@ describe("gateway restart intent", () => {
     expect(consumeGatewayRestartIntentSync(env)).toBe(true);
     expect(readIntentRow(env)).toBeUndefined();
     expect(fs.existsSync(legacyIntentPath(env))).toBe(false);
+  });
+
+  it("records restart options while an older Gateway owns a pending-migration database", () => {
+    const env = createIntentEnv();
+    const database = openOpenClawStateDatabase({ env });
+    const filename = database.path;
+    closeOpenClawStateDatabaseForTest();
+    const db = new DatabaseSync(filename);
+    // The restart table is unchanged across this schema boundary.
+    db.exec("PRAGMA user_version=15; UPDATE schema_meta SET schema_version=15");
+    const before = db.prepare("SELECT * FROM sqlite_schema ORDER BY name").all();
+    const anchor = acquireGatewayLifecycleCoordinator({ databasePath: filename });
+    anchor.release();
+    // An independent connection models the running Gateway's non-reentrant lease.
+    const owner = tryAcquireExclusiveSqliteCoordinator(anchor.path);
+    if (!owner) {
+      db.close();
+      throw new Error("Fixture Gateway lifecycle lease unavailable");
+    }
+    try {
+      expect(
+        writeGatewayRestartIntentSync({
+          env,
+          targetPid: process.pid,
+          intent: { reason: "gateway.restart", force: true, waitMs: 12_345 },
+        }),
+      ).toBe(true);
+      expect(
+        db.prepare("SELECT pid, reason, force, wait_ms FROM gateway_restart_intent").get(),
+      ).toEqual({
+        pid: process.pid,
+        reason: "gateway.restart",
+        force: 1,
+        wait_ms: 12_345,
+      });
+      expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 15 });
+      expect(db.prepare("SELECT schema_version FROM schema_meta").get()).toEqual({
+        schema_version: 15,
+      });
+      expect(db.prepare("SELECT * FROM sqlite_schema ORDER BY name").all()).toEqual(before);
+      clearGatewayRestartIntentSync(env);
+      expect(db.prepare("SELECT * FROM gateway_restart_intent").all()).toEqual([]);
+      expect(db.prepare("SELECT * FROM sqlite_schema ORDER BY name").all()).toEqual(before);
+    } finally {
+      owner.release();
+      db.close();
+    }
+  });
+
+  it("skips intent recording instead of bootstrapping missing Gateway state", () => {
+    const env = createIntentEnv(false);
+    expect(writeGatewayRestartIntentSync({ env, targetPid: process.pid })).toBe(false);
+    expect(fs.readdirSync(env.OPENCLAW_STATE_DIR ?? "")).toEqual([]);
   });
 
   it("rejects an intent for a different process", () => {

--- a/src/infra/restart-intent.ts
+++ b/src/infra/restart-intent.ts
@@ -1,12 +1,13 @@
+import { existsSync } from "node:fs";
 // Persists short-lived gateway restart intent for supervisor SIGTERM handoff.
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { runExistingOpenClawStateWriteTransaction } from "../state/openclaw-state-db-existing-write.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import {
-  openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
-} from "../state/openclaw-state-db.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -15,6 +16,15 @@ import {
 
 const GATEWAY_RESTART_INTENT_KEY = "gateway-restart";
 const GATEWAY_RESTART_INTENT_TTL_MS = 60_000;
+const schemaStart = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+  "CREATE TABLE IF NOT EXISTS gateway_restart_intent (",
+);
+const schemaEndMarker = ") STRICT;";
+const schemaEnd = OPENCLAW_STATE_SCHEMA_SQL.indexOf(schemaEndMarker, schemaStart);
+if (schemaStart < 0 || schemaEnd < 0) {
+  throw new Error("Gateway restart intent schema markers are missing");
+}
+const schema = OPENCLAW_STATE_SCHEMA_SQL.slice(schemaStart, schemaEnd + schemaEndMarker.length);
 
 const restartLog = createSubsystemLogger("restart");
 type GatewayRestartIntentDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_intent">;
@@ -57,6 +67,10 @@ export function writeGatewayRestartIntentSync(opts: {
   }
   const env = opts.env ?? process.env;
   try {
+    if (!existsSync(resolveOpenClawStateSqlitePath(env))) {
+      restartLog.info("skipped gateway restart intent: no existing state database");
+      return false;
+    }
     const reason = normalizeRestartIntentReason(opts.reason ?? opts.intent?.reason);
     const waitMs =
       typeof opts.intent?.waitMs === "number" &&
@@ -65,7 +79,8 @@ export function writeGatewayRestartIntentSync(opts: {
         ? Math.floor(opts.intent.waitMs)
         : null;
     const createdAt = Date.now();
-    runOpenClawStateWriteTransaction(
+    // The old Gateway still owns the schema until the restart hands off.
+    runExistingOpenClawStateWriteTransaction(
       ({ db }) => {
         const stateDb = getNodeSqliteKysely<GatewayRestartIntentDatabase>(db);
         executeSqliteQuerySync(
@@ -96,6 +111,7 @@ export function writeGatewayRestartIntentSync(opts: {
         );
       },
       { env },
+      { schemaSql: schema, operationLabel: "gateway.restart-intent.write" },
     );
     return true;
   } catch (err) {
@@ -106,7 +122,7 @@ export function writeGatewayRestartIntentSync(opts: {
 
 export function clearGatewayRestartIntentSync(env: NodeJS.ProcessEnv = process.env): void {
   try {
-    runOpenClawStateWriteTransaction(
+    runExistingOpenClawStateWriteTransaction(
       ({ db }) => {
         const stateDb = getNodeSqliteKysely<GatewayRestartIntentDatabase>(db);
         executeSqliteQuerySync(
@@ -117,6 +133,7 @@ export function clearGatewayRestartIntentSync(env: NodeJS.ProcessEnv = process.e
         );
       },
       { env },
+      { schemaSql: schema, operationLabel: "gateway.restart-intent.clear" },
     );
   } catch {}
 }

--- a/test/scripts/bench-gateway-restart.test.ts
+++ b/test/scripts/bench-gateway-restart.test.ts
@@ -820,7 +820,8 @@ node    1234 user   12u  IPv4    0t0      TCP localhost:1234
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-bench-test-"));
     try {
       const env = { OPENCLAW_STATE_DIR: path.join(root, "state") };
-
+      // The benchmark records intent only after Gateway startup creates state.
+      openOpenClawStateDatabase({ env });
       expect(testing.writeRestartIntent(env, 12345, "gateway-restart-bench")).toBe(true);
       const row = readRestartIntentRow(env);
 


### PR DESCRIPTION
Fixes #143543

## What Problem This Solves

Fixes an issue where users restarting after an upgrade would see a shared-state schema-mutation conflict and lose their restart reason and drain options while the older Gateway still owned the state directory.

## Why This Change Was Made

Record and clear restart intent through the existing-schema transaction owner, validating only the canonical restart table. That owner retains write authority, file-generation, integrity, and transaction checks without admitting schema migration. Missing state produces one explicit skipped-recording message instead of bootstrapping a database. Doctor's stop → migrate → restart sequence is unchanged.

## User Impact

Managed restarts preserve their reason, force flag, and wait budget across supported schema changes without the misleading migration warning. Thanks @RomneyDa for the diagnosis and report.

## Evidence

- Before: `node scripts/run-vitest.mjs src/infra/restart-intent.test.ts` — new regression failed with `expected false to be true`; 1 failed, 7 passed.
- After: `node scripts/run-vitest.mjs src/infra/restart-intent.test.ts src/cli/daemon-cli/lifecycle-core.test.ts` — 9 restart-intent and 49 service lifecycle tests passed.
- The regression uses real SQLite with older version metadata and an independent connection holding the same lifecycle lease as a running Gateway. It verifies the persisted PID/reason/force/wait values, unchanged schema metadata and definitions, and cleanup while ownership remains held.
- `node scripts/check-changed.mjs` and `git diff --check` run before publication; CI attaches to this branch head.
- Limitation: this is storage/lifecycle boundary proof, not an installed cross-version Gateway restart. Campaign lead owns independent review and landing.

Initial exact-head CI found one additional fixture that assumed restart recording bootstrapped state: `test/scripts/bench-gateway-restart.test.ts`, in [checks-node-compact-small-33](https://github.com/openclaw/openclaw/actions/runs/34442321896/job/102759963796). Its existing `expected false to be true` failure retained all row assertions. The follow-up initializes the fixture database, matching the benchmark's startup-before-restart ordering; it does not relax an assertion or change production behavior.

Follow-up proof: `node scripts/run-vitest.mjs test/scripts/bench-gateway-restart.test.ts --reporter=dot` passed all 33 tests, including the original CI failure. The fixture retains the target PID/reason/row assertions.

The follow-up also passed `node scripts/check-changed.mjs -- test/scripts/bench-gateway-restart.test.ts` (test-root types, export scans, script/test lint, and guards) and `git diff --check`. CI is watching the new branch head; no merge has been requested.

Final exact-head CI: [run 34444724012](https://github.com/openclaw/openclaw/actions/runs/34444724012) completed successfully for `d61552e350ddb76c71bfb57118b9a90536ec6334`. The bounded watcher finished `GREEN`, with zero pending checks and six superseded checks. GitHub's aggregate remains `FAILURE` because of this unrelated [canceled label job](https://github.com/openclaw/openclaw/actions/runs/34444722451/job/102766932576); no current test failure remains. The PR is ready, mergeable, and unmerged.


## Review notes

No SQLite schema, persisted record format, install-record, or configuration-schema change is introduced. The existing `gateway_restart_intent` fields, PID matching, 60-second TTL, and restart/drain payload remain unchanged. The writer and cleanup now use the existing-schema transaction owner, with additive initialization disabled; ownership, generation, integrity, and schema-shape checks remain enforced. No bundled-plugin alias projection or external-path install behavior is changed by this PR.

Compatibility proof is the failing-before/passing-after real-SQLite test with older schema metadata and an independently held Gateway lifecycle lease. It verifies recorded options, unchanged schema metadata/definitions, and cleanup while the lease remains held. The nine intent cases cover fresh consumption, older-Gateway recording, missing-state skip, PID mismatch, expiry, malformed rows, restart-option round-trip without successor identity, Unicode reason bounds, and overwrite. Service lifecycle and benchmark coverage is reported above. The lead reviewed the exact head and accepts this boundary proof; an installed cross-version Gateway restart remains unproven. The generic data-model checklist does not represent an outstanding code finding or a schema migration requirement.
