### PR TITLE
fix(ui): hide Markdown syntax in subagent previews

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -63,7 +63,7 @@ They are generated separately from the agent's work, so a title is not a complet
 status or a report of tool access. Existing titles and manual names are left
 unchanged; click a title to rename it.
 
-Collapsed tool rows keep the tool label visible and truncate long summaries with an ellipsis. Tool and subagent activity rows use the same text size and weight. Running subagents show **Subagent** beside an animated indicator; terminal rows show **Subagent finished**, **Subagent failed**, or **Subagent cancelled**.
+Collapsed tool rows keep the tool label visible and truncate long summaries with an ellipsis. Tool and subagent activity rows use the same text size and weight. Running subagents show **Subagent** beside an animated indicator; terminal rows show **Subagent finished**, **Subagent failed**, or **Subagent cancelled**. Subagent previews and their hover text flatten Markdown into a single plain-text line, including unfinished emphasis in live updates. Open the subagent details to read the full formatted transcript.
 
 A turn that fails before producing any reply leaves a durable notice in the thread. Failed and timed-out turns also show the available failure reason in the sidebar's compact summary and run-error tooltip, including while a session refresh is still catching up.
 

--- a/ui/src/pages/chat/components/chat-subagent-activity.test.ts
+++ b/ui/src/pages/chat/components/chat-subagent-activity.test.ts
@@ -93,6 +93,46 @@ afterEach(() => {
 });
 
 describe("subagent activity rows", () => {
+  it.each([
+    {
+      lastActivity: "**Evidence limits:** original regression",
+      expected: "Evidence limits: original regression",
+    },
+    { lastActivity: "**Block", expected: "Block" },
+    {
+      progressSummary: "All runs bind `abc123`, **not final** qualification",
+      expected: "All runs bind abc123, not final qualification",
+    },
+    { lastToolName: "read_file", expected: "read_file" },
+    { lastActivity: "Inspecting items[0", expected: "Inspecting items[0" },
+    {
+      status: "completed" as const,
+      terminalSummary: "## Done\n- Read [results](https://example.com/results)",
+      expected: "Done Read results",
+    },
+    {
+      lastActivity: "Checking foo_bar_baz at ~/.openclaw: 1 < 2 and ~5 files",
+      expected: "Checking foo_bar_baz at ~/.openclaw: 1 < 2 and ~5 files",
+    },
+  ])("shows readable preview text for $expected", ({ expected, ...overrides }) => {
+    const task = makeTask({ id: "markdown-subagent", ...overrides });
+    const container = renderStatusRow({
+      tasks: [task],
+      subagentActivity: deriveSubagentActivity({
+        tasks: [task],
+        sessionKey: "agent:main:current",
+        terminalObservedAtByTask: new Map(),
+        canonicalizeSessionKey: (sessionKey) => sessionKey ?? "",
+        now: 3_000,
+      }),
+    });
+
+    const snippet = container.querySelector(".chat-subagent-activity__snippet");
+    expect(snippet?.textContent).toBe(expected);
+    expect(snippet?.getAttribute("title")).toBe(expected);
+    expect(snippet?.childElementCount).toBe(0);
+  });
+
   it("opens the selected subagent from an accessible activity control", () => {
     const task = makeTask({ id: "clickable-subagent" });
     const onOpenTaskDetail = vi.fn();

--- a/ui/src/pages/chat/components/chat-subagent-activity.ts
+++ b/ui/src/pages/chat/components/chat-subagent-activity.ts
@@ -1,6 +1,8 @@
+import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import { html, nothing, type TemplateResult } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { repeat } from "lit/directives/repeat.js";
+import remend from "remend";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { isActiveTask, sortTasks, taskTimestampMs, taskTitle } from "../../../lib/tasks/data.ts";
@@ -114,7 +116,22 @@ function renderSubagentActivityRow(
   task: TaskSummary,
   onOpenTaskDetail?: (task: TaskSummary) => void,
 ): TemplateResult {
-  const snippet = subagentActivitySnippet(task);
+  const rawSnippet = subagentActivitySnippet(task);
+  // Previews can end mid-emphasis. Repair delimiters without adding escapes
+  // intended for a Markdown renderer; the row and tooltip stay plain text.
+  const snippet = rawSnippet
+    ? flattenMarkdownToPlainText(
+        remend(rawSnippet, {
+          katex: false,
+          links: false,
+          images: false,
+          comparisonOperators: false,
+          singleTilde: false,
+          setextHeadings: false,
+          htmlTags: false,
+        }),
+      )
+    : undefined;
   const label = subagentActivityLabel(task);
   const content = html`
     ${renderSubagentActivityIndicator(task)}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching subagent activity in the Control UI see raw Markdown in compact previews and hover text. Bold markers, backticks, headings, and link syntax leak into the rows, including unfinished updates such as `**Block`.

## Why This Change Was Made

Flatten previews through the existing shared Markdown-to-plain-text formatter, repairing incomplete streaming delimiters first. Keep the row and tooltip as escaped text so the whole row remains a single control that opens the subagent details; the full transcript retains its formatting.

## User Impact

Subagent activity stays readable while work is running and when its completion summary appears. Plain tool names, paths, ordinary underscore-containing identifiers, and literal unmatched brackets remain readable.

## Evidence

- The literal-bracket regression (`Inspecting items[0`) failed with automatic link repair enabled and passes with link/image repair disabled.
- Regression cases failed on the original renderer for complete emphasis, incomplete emphasis, inline code, and heading/link summaries, then passed after the fix.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-subagent-activity.test.ts packages/normalization-core/src/markdown-plain-text.test.ts`: 21 tests passed, including existing row interaction and lifecycle coverage.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-subagent-activity.ts ui/src/pages/chat/components/chat-subagent-activity.test.ts docs/web/control-ui/chat.md`: passed, including core-test and UI typechecks, lint, formatting, and guards.
- Real Chrome verification against a synthetic local fixture confirmed cleaned row text and matching tooltips, no nested markup, and successful row selection. The comparison renders the original and fixed components with identical synthetic inputs.

![Synthetic subagent preview comparison: original raw Markdown above, readable plain text below](https://github.com/user-attachments/assets/db82891c-068a-4e65-9f76-84af386d6015)
