### PR TITLE
fix(configure): stop Moonshot China auth reinstall loops

### DIFF
--- a/docs/plugins/manifest/setup-and-auth.md
+++ b/docs/plugins/manifest/setup-and-auth.md
@@ -51,6 +51,8 @@ resource is missing.
 
 Each `providerAuthChoices` entry describes one onboarding or auth choice. OpenClaw reads this before provider runtime loads. Provider setup lists use these manifest choices, descriptor-derived setup choices, and install-catalog metadata without loading provider runtime.
 
+When a manifest choice is selected, setup resolves its `provider` and `method` in the owning installed plugin. The runtime auth method does not need to repeat `choiceId` in its wizard metadata. A different plugin or auth method cannot satisfy that declared choice. Explicit `provider-plugin:<provider>:<method>` choices retain their encoded target.
+
 | Field                  | Required | Type                                                                  | What it means                                                                                                                       |
 | ---------------------- | -------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `provider`             | Yes      | `string`                                                              | Provider id this choice belongs to.                                                                                                 |

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -5,6 +5,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayAuthConfig } from "../config/config.js";
 import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
 import { isInvalidGatewaySecret } from "../gateway/known-weak-gateway-secrets.js";
+import { resolveManifestProviderAuthChoice } from "../plugins/provider-auth-choices.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { promptAuthChoiceGrouped } from "./auth-choice-prompt.js";
@@ -51,6 +52,12 @@ async function resolveProviderChoiceModelPrompt(params: {
   const resolved = resolveProviderPluginChoice({
     providers,
     choice: params.authChoice,
+    manifestChoice: resolveManifestProviderAuthChoice(params.authChoice, {
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      includeUntrustedWorkspacePlugins: false,
+    }),
   });
   const wizard = resolved?.provider.wizard?.setup;
   if (!wizard) {

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
@@ -127,6 +127,7 @@ export async function applyNonInteractivePluginProviderChoice(params: {
       includeUntrustedWorkspacePlugins: false,
     }),
     choice: params.authChoice,
+    manifestChoice: trustedManifestMatch,
   });
   if (!providerChoice) {
     if (prefixedProviderId) {
@@ -213,6 +214,7 @@ export async function applyNonInteractivePluginProviderChoice(params: {
         includeUntrustedWorkspacePlugins: false,
       }),
       choice: params.authChoice,
+      manifestChoice: installCatalogEntry,
     });
     if (!providerChoice) {
       return reject(

--- a/src/plugins/provider-auth-choice.npm-installed.test.ts
+++ b/src/plugins/provider-auth-choice.npm-installed.test.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import type http from "node:http";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { promptAuthConfig } from "../commands/configure.gateway-auth.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createNonExitingRuntime } from "../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { WizardSelectParams } from "../wizard/prompts.js";
+import { installPluginFromArchive, installPluginFromNpmSpec } from "./install.js";
+import { writePersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
+import { buildNpmResolutionInstallFields } from "./installs.js";
+import {
+  clearPluginLoaderCache,
+  resetPluginLoaderTestStateForTest,
+} from "./loader.test-fixtures.js";
+import { prepareAuthChoiceLoadedPluginProvider } from "./provider-auth-choice.js";
+import { buildPluginRegistrySnapshotReport } from "./status-snapshot.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+import { registryPackages, startStaticRegistry } from "./test-helpers/npm-registry-fixtures.js";
+
+const install = vi.hoisted(() =>
+  vi.fn<
+    typeof import("../commands/onboarding-plugin-install.js").ensureOnboardingPluginInstalled
+  >(),
+);
+const modelPicker = vi.hoisted(() =>
+  vi.fn<typeof import("../commands/model-picker.js").promptModelAllowlist>(),
+);
+vi.mock("../commands/onboarding-plugin-install.js", () => ({
+  ensureOnboardingPluginInstalled: install,
+}));
+vi.mock("../commands/model-picker.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commands/model-picker.js")>()),
+  promptModelAllowlist: modelPicker,
+}));
+
+const tempDirs: string[] = [];
+const servers: http.Server[] = [];
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+  install.mockReset();
+  modelPicker.mockReset();
+  resetPluginLoaderTestStateForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+it.each([
+  { pluginId: "moonshot", source: "npm" },
+  { pluginId: "moonshot", source: "archive" },
+  { pluginId: "deepseek", source: "npm" },
+  { pluginId: "qwen", source: "npm" },
+] as const)(
+  "continues $pluginId auth from the $source inventory without reinstalling",
+  { timeout: 120_000 },
+  async ({ pluginId, source }) => {
+    const root = fs.realpathSync(makeTrackedTempDir("provider-npm-installed", tempDirs));
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    const npmConfig = path.join(root, "npmrc");
+    fs.writeFileSync(npmConfig, "");
+    const packageName = `@openclaw/${pluginId}-provider`;
+    const methods = pluginId === "moonshot" ? ["api-key", "api-key-cn"] : ["api-key"];
+    const choices = methods.map((method) => ({
+      provider: pluginId,
+      method,
+      choiceId: `${pluginId}-${method}`,
+      choiceLabel: `${pluginId} ${method}`,
+      groupId: pluginId,
+      groupLabel: pluginId,
+    }));
+    const registry = await startStaticRegistry(
+      await registryPackages(root, [
+        {
+          packageName,
+          pluginId,
+          manifest: { providers: [pluginId], providerAuthChoices: choices },
+          indexJs: `export default {
+        id: ${JSON.stringify(pluginId)},
+        register(api) {
+          api.registerProvider({ id: ${JSON.stringify(pluginId)}, label: "Fixture provider",
+            auth: ${JSON.stringify(choices)}.map((choice) => ({
+              id: choice.method, label: choice.choiceLabel, kind: "api_key",
+              // Moonshot 2026.9.3's secondary method omits its manifest choice ID.
+              wizard: choice.method === "api-key-cn" ? { groupLabel: "Moonshot" } : { choiceId: choice.choiceId },
+              async run(ctx) {
+                await ctx.prompter.text({ message: choice.choiceId });
+                return { profiles: [], defaultModel: choice.provider + "/fixture-model" };
+              }
+            }))
+          });
+        }
+      };`,
+        },
+      ]),
+      servers,
+    );
+    await withEnvAsync(
+      {
+        HOME: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        NPM_CONFIG_USERCONFIG: npmConfig,
+        npm_config_userconfig: npmConfig,
+        NPM_CONFIG_REGISTRY: registry,
+        npm_config_registry: registry,
+        NPM_CONFIG_CACHE: path.join(root, "npm-cache"),
+        npm_config_cache: path.join(root, "npm-cache"),
+      },
+      async () => {
+        const config: OpenClawConfig = {
+          gateway: { mode: "local" },
+          plugins: { entries: { [pluginId]: { enabled: true } } },
+        };
+        const archivePath = path.join(root, `openclaw-${pluginId}-provider-1.0.0.tgz`);
+        const installOptions = {
+          expectedPluginId: pluginId,
+          config,
+          logger: { info() {}, warn() {} },
+        };
+        const result =
+          source === "npm"
+            ? await installPluginFromNpmSpec({
+                ...installOptions,
+                spec: packageName,
+                npmDir: path.join(stateDir, "npm"),
+              })
+            : await installPluginFromArchive({
+                ...installOptions,
+                archivePath,
+                extensionsDir: path.join(stateDir, "extensions"),
+              });
+        expect(result.ok, JSON.stringify(result)).toBe(true);
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        await writePersistedInstalledPluginIndexInstallRecords(
+          {
+            [pluginId]: {
+              source,
+              spec: packageName,
+              installPath: result.targetDir,
+              ...buildNpmResolutionInstallFields(result.npmResolution),
+            },
+          },
+          { config, workspaceDir },
+        );
+        clearPluginLoaderCache();
+        const report = buildPluginRegistrySnapshotReport({ config, workspaceDir });
+        expect(report.plugins.find((plugin) => plugin.id === pluginId)).toMatchObject({
+          enabled: true,
+          version: "1.0.0",
+        });
+        install.mockImplementation(async ({ cfg }) => ({
+          cfg,
+          pluginId,
+          installed: true,
+          status: "installed",
+        }));
+        for (const { choiceId } of choices) {
+          const prompter = createWizardPrompter();
+          const prepared = await prepareAuthChoiceLoadedPluginProvider({
+            authChoice: choiceId,
+            config,
+            workspaceDir,
+            agentId: "main",
+            agentDir: path.join(stateDir, "agents", "main", "agent"),
+            prompter,
+            runtime: createNonExitingRuntime(),
+            setDefaultModel: false,
+          });
+          expect(install, choiceId).not.toHaveBeenCalled();
+          expect(prepared?.retrySelection, choiceId).not.toBe(true);
+          expect(prepared?.provider?.id, choiceId).toBe(pluginId);
+          expect(prompter.text).toHaveBeenCalledWith({ message: choiceId });
+          expect(prepared?.agentModelOverride).toBe(`${pluginId}/fixture-model`);
+        }
+        const authChoice = pluginId === "moonshot" ? "moonshot-api-key-cn" : `${pluginId}-api-key`;
+        const prompter = createWizardPrompter({
+          select: async <T>({ options }: WizardSelectParams<T>) => {
+            const selected =
+              options.find((option) => option.value === authChoice) ??
+              options.find((option) => option.value === pluginId) ??
+              options.find((option) => option.value === "__more");
+            if (!selected) {
+              throw new Error("Unexpected configure selection");
+            }
+            return selected.value;
+          },
+        });
+        modelPicker.mockResolvedValue({ models: undefined });
+        await promptAuthConfig(config, createNonExitingRuntime(), prompter, {
+          agentId: "main",
+          agentDir: path.join(stateDir, "agents", "main", "agent"),
+          workspaceDir,
+        });
+        expect(install, authChoice).not.toHaveBeenCalled();
+        expect(prompter.text).toHaveBeenCalledWith({ message: authChoice });
+        expect(modelPicker).toHaveBeenCalledOnce();
+        expect(modelPicker).toHaveBeenCalledWith(
+          expect.objectContaining({ preferredProvider: pluginId }),
+        );
+      },
+    );
+  },
+);

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -503,12 +503,14 @@ export async function prepareAuthChoiceLoadedPluginProvider(
     let resolved = resolveProviderPluginChoice({
       providers,
       choice: params.authChoice,
+      manifestChoice: manifestAuthChoice ?? installCatalogEntry,
     });
     if (!resolved && setupProvider) {
       providers = resolveScopedRuntimeProviders(enabledConfig);
       resolved = resolveProviderPluginChoice({
         providers,
         choice: params.authChoice,
+        manifestChoice: manifestAuthChoice ?? installCatalogEntry,
       });
     }
     if (!resolved && installCatalogEntry) {
@@ -546,6 +548,7 @@ export async function prepareAuthChoiceLoadedPluginProvider(
       resolved = resolveProviderPluginChoice({
         providers,
         choice: params.authChoice,
+        manifestChoice: manifestAuthChoice ?? installCatalogEntry,
       });
     }
     if (!resolved) {

--- a/src/plugins/provider-wizard.test.ts
+++ b/src/plugins/provider-wizard.test.ts
@@ -25,6 +25,78 @@ function makeProvider(overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, 
   } satisfies ProviderPlugin;
 }
 
+describe("manifest auth choice dispatch", () => {
+  const manifestChoice = {
+    pluginId: "moonshot",
+    providerId: "moonshot",
+    methodId: "api-key-cn",
+    choiceId: "moonshot-api-key-cn",
+  };
+  const provider = makeProvider({
+    id: "moonshot",
+    pluginId: "moonshot",
+    label: "Moonshot",
+    auth: [
+      { id: "api-key", label: "Global", kind: "api_key", run: vi.fn() },
+      {
+        id: "api-key-cn",
+        label: "China",
+        kind: "api_key",
+        wizard: { groupLabel: "Moonshot", modelSelection: { allowKeepCurrent: false } },
+        run: vi.fn(),
+      },
+    ],
+  });
+
+  it("resolves the declared method without a duplicate runtime choice ID", () => {
+    expect(
+      resolveProviderPluginChoiceCore({
+        providers: [{ ...provider, pluginId: "other-plugin" }, provider],
+        choice: manifestChoice.choiceId,
+        manifestChoice,
+      }),
+    ).toEqual({ provider, method: provider.auth[1], wizard: provider.auth[1]?.wizard });
+  });
+
+  it("preserves explicit provider-method targets over a conflicting manifest choice", () => {
+    const choice = buildProviderPluginMethodChoice(provider.id, "api-key");
+    expect(
+      resolveProviderPluginChoiceCore({
+        providers: [{ ...provider, id: "other-provider", pluginId: "other-plugin" }, provider],
+        choice,
+        manifestChoice: {
+          ...manifestChoice,
+          pluginId: "other-plugin",
+          providerId: "other-provider",
+          choiceId: choice,
+        },
+      }),
+    ).toEqual({ provider, method: provider.auth[0] });
+  });
+
+  it.each([
+    { pluginId: "other-plugin" },
+    { providerId: "other-provider" },
+    { methodId: "missing" },
+    { methodId: "" },
+    { choiceId: "other-choice" },
+  ])("rejects an unmatched manifest identity: %j", (override) => {
+    const conflictingRuntime = {
+      ...provider,
+      auth: provider.auth.map((method) =>
+        Object.assign({}, method, { wizard: { choiceId: manifestChoice.choiceId } }),
+      ),
+    };
+    expect(
+      resolveProviderPluginChoiceCore({
+        providers: [conflictingRuntime],
+        choice: manifestChoice.choiceId,
+        manifestChoice: { ...manifestChoice, ...override },
+      }),
+    ).toBeNull();
+  });
+});
+
 function createSglangWizardProvider(params?: {
   includeSetup?: boolean;
   includeModelPicker?: boolean;

--- a/src/plugins/provider-wizard.ts
+++ b/src/plugins/provider-wizard.ts
@@ -8,6 +8,7 @@ import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import type { ProviderAuthChoiceMetadata } from "./provider-auth-choices.js";
 import { resolvePluginProvidersCore } from "./providers.runtime.js";
 import { resolvePluginSetupProviderCore } from "./setup-registry.js";
 import type {
@@ -246,6 +247,10 @@ export function resolveProviderModelPickerEntries(params: {
 export function resolveProviderPluginChoiceCore(params: {
   providers: ProviderPlugin[];
   choice: string;
+  manifestChoice?: Pick<
+    ProviderAuthChoiceMetadata,
+    "pluginId" | "providerId" | "methodId" | "choiceId"
+  >;
 }): {
   provider: ProviderPlugin;
   method: ProviderAuthMethod;
@@ -269,6 +274,25 @@ export function resolveProviderPluginChoiceCore(params: {
     }
     const method = resolveMethodById(provider, methodId);
     return method ? { provider, method } : null;
+  }
+
+  // The manifest owns dispatch; runtime wizard metadata need not repeat its choice ID.
+  if (params.manifestChoice) {
+    const declared = params.manifestChoice;
+    if (declared.choiceId !== choice) {
+      return null;
+    }
+    const provider = params.providers.find(
+      (entry) =>
+        entry.pluginId === declared.pluginId &&
+        normalizeProviderId(entry.id) === normalizeProviderId(declared.providerId),
+    );
+    const methodId = normalizeOptionalLowercaseString(declared.methodId);
+    if (!provider || !methodId) {
+      return null;
+    }
+    const method = resolveMethodById(provider, methodId);
+    return method ? { provider, method, wizard: method.wizard } : null;
   }
 
   for (const provider of params.providers) {

--- a/src/plugins/test-helpers/npm-registry-fixtures.ts
+++ b/src/plugins/test-helpers/npm-registry-fixtures.ts
@@ -24,6 +24,7 @@ type PackPluginParams = {
   dependencies?: Record<string, string>;
   hookName?: string;
   indexJs?: string;
+  manifest?: Record<string, unknown>;
   openclaw?: Record<string, unknown>;
   optionalDependencies?: Record<string, string>;
   packageName: string;
@@ -99,6 +100,7 @@ export async function packPlugins(
             id: params.pluginId ?? params.packageName,
             name: params.pluginId ?? params.packageName,
             configSchema: { type: "object" },
+            ...params.manifest,
           },
           null,
           2,
@@ -192,7 +194,7 @@ export async function startStaticRegistry(
     }
 
     for (const pkg of packageEntries) {
-      if (url.pathname === `/${pkg.encodedPackageName}`) {
+      if (decodeURIComponent(url.pathname) === `/${pkg.packageName}`) {
         response.writeHead(200, { "content-type": "application/json" });
         response.end(
           `${JSON.stringify({
@@ -284,7 +286,7 @@ export async function startMutableRegistry(
       return;
     }
 
-    if (url.pathname === `/${encodedPackageName}`) {
+    if (decodeURIComponent(url.pathname) === `/${params.packageName}`) {
       metadataRequests += 1;
       const metadataLatest = latestVersion;
       if (metadataRequests === 1) {


### PR DESCRIPTION
Fixes #143630

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users selecting Moonshot's China API-key option in configure are asked to install an already-enabled provider again. The manifest advertises `moonshot-api-key-cn`, but the published 2026.9.3 runtime's secondary auth method omits that wizard choice ID. Inventory and npm install-record discovery are correct; runtime choice matching loses the selected method.

## Why This Change Was Made

The shared provider-choice resolver now dispatches manifest choices through their owning plugin, provider, and auth-method IDs. Interactive authentication, noninteractive onboarding, and configure's model prompt carry that metadata into the resolver. A missing owner or method fails matching instead of selecting a different runtime alias or the first auth method. Runtime wizard policy remains attached to the selected method.

This repairs selection for existing installed artifacts without changing installation records, adding directory scans, or requiring a plugin republish. The manifest reference documents the dispatch contract.

## User Impact

Users can finish Moonshot's regional authentication and continue to model selection without reinstalling the plugin. Existing primary-model preservation remains covered. Release-note context: configure/onboarding now recognize manifest-declared auth methods even when the runtime does not duplicate their choice IDs.

## Evidence

- Real npm installs against an isolated loopback fixture registry reproduce the published Moonshot manifest/runtime mismatch. The regression checks enabled inventory, both Moonshot auth methods, and the real configure flow reaching its model-picker boundary without reinstalling. It also covers an archive install under `extensions/`, plus npm-installed DeepSeek and Qwen.
- Before the repair: `moonshot-api-key-cn: expected "vi.fn()" to not be called at all, but actually been called 1 times`. The archive case also failed to resolve the declared method. DeepSeek and Qwen passed.
- After the repair: 99 focused tests passed across provider dispatch, install continuation, configure, and noninteractive onboarding. The final provider-dispatch and full-configure fixture run passed all 19 cases.
- Boundary tests reject mismatched plugin, provider, method, and choice IDs while preserving method wizard policy and the existing precedence of explicit `provider-plugin:<provider>:<method>` targets.
- History: commit `087fb56f77d` (#122337) moved Moonshot's China method from SDK-normalized `auth` into `extraAuth`, losing the automatically supplied choice ID.
- Static audit of all 38 provider plugins with differing npm specs and manifest IDs found no package/spec mismatch. Moonshot was the only `extraAuth` implementation missing an explicit choice ID; the other implementations declare theirs.
- All checks selected by `node scripts/check-changed.mjs` passed: core and test typechecks, formatting, lint, ratchets, boundaries, dead exports, import cycles, schema/storage guards, and auth/body-order guards. The initial run stopped on two test-lint findings; both were corrected and the lint plus remaining planned checks were rerun successfully. Core test typechecking was also repeated after the fixture expansion.

Reproduce the primary regression and dispatch boundaries with:

```sh
node scripts/run-vitest.mjs src/plugins/provider-auth-choice.npm-installed.test.ts src/plugins/provider-wizard.test.ts
```

The broader focused run also included `src/plugins/provider-auth-choice.install-discovery.test.ts`, `src/plugins/provider-auth-choice.test.ts`, `src/commands/configure.gateway-auth.prompt-auth-config.test.ts`, and `src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts`.

CI attached to [run 34442722859](https://github.com/openclaw/openclaw/actions/runs/34442722859) for head `707853b9211fc1392c1a505ee1a0aa1a8758cbde`.

Known gaps: the issue does not identify the selected auth method; this reproduction establishes the China (`.cn`) path. The original Arch/pacman environment was not reproduced. The published 2026.9.3 package was inspected and installed in isolated state, but its full source-runtime probe was stopped after prolonged module loading; the deterministic regression uses a small packaged fixture with the same auth metadata. No provider API calls or real credentials are required by these tests. The campaign lead owns formal autoreview and landing.
