### PR TITLE
refactor(scripts): share concurrent Knip scan orchestration

### DIFF
--- a/scripts/check-deadcode-exports.mts
+++ b/scripts/check-deadcode-exports.mts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 // Enforces a hard-zero policy for Knip's unused exports.
 import { fileURLToPath } from "node:url";
-import { isLikelyRepoFilePath, runKnip, uniqueSorted } from "./deadcode-knip-runner.mts";
-
-type KnipResult = Awaited<ReturnType<typeof runKnip>>;
+import {
+  isLikelyRepoFilePath,
+  runKnipScans,
+  type KnipRunResult,
+  uniqueSorted,
+} from "./deadcode-knip-runner.mts";
 
 const KNIP_ISSUES = "exports,nsExports,types,nsTypes,enumMembers,namespaceMembers";
 
@@ -121,21 +124,7 @@ export function checkExportScan(scanName: string, output: string) {
   };
 }
 
-async function main() {
-  // The scans are independent Knip child processes over separate configs;
-  // running them concurrently cuts the lane's serial wall clock roughly 2x.
-  const results = await Promise.all(
-    KNIP_SCANS.map(async (scan) => {
-      const result = await runKnip([...scan.args, ...KNIP_COMMON_ARGS], { scanName: scan.name });
-      return reportUnusedExportScan(scan, result);
-    }),
-  );
-  if (results.includes(false)) {
-    process.exitCode = 1;
-  }
-}
-
-function reportUnusedExportScan(scan: (typeof KNIP_SCANS)[number], result: KnipResult) {
+function reportUnusedExportScan(scan: (typeof KNIP_SCANS)[number], result: KnipRunResult) {
   if (result.errorCode || result.status === null) {
     console.error(
       `deadcode ${scan.name} failed: ${result.errorCode ?? result.signal ?? "unknown"}${
@@ -178,5 +167,5 @@ function reportUnusedExportScan(scan: (typeof KNIP_SCANS)[number], result: KnipR
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  await main();
+  await runKnipScans(KNIP_SCANS, KNIP_COMMON_ARGS, reportUnusedExportScan);
 }

--- a/scripts/check-deadcode-unused-files.mts
+++ b/scripts/check-deadcode-unused-files.mts
@@ -3,7 +3,7 @@
 import { fileURLToPath } from "node:url";
 import {
   isLikelyRepoFilePath,
-  runKnip,
+  runKnipScans,
   type KnipRunResult,
   uniqueSorted,
 } from "./deadcode-knip-runner.mts";
@@ -80,20 +80,6 @@ export function checkKnipUnusedFileScanResult(result: KnipRunResult) {
   return { ok: check.ok, failureReason: "", message: check.message };
 }
 
-async function main() {
-  // The scans are independent Knip child processes over separate configs;
-  // running them concurrently halves the lane's serial wall clock.
-  const results = await Promise.all(
-    KNIP_SCANS.map(async (scan) => {
-      const result = await runKnip([...scan.args, ...KNIP_COMMON_ARGS], { scanName: scan.name });
-      return reportUnusedFileScan(scan, result);
-    }),
-  );
-  if (results.includes(false)) {
-    process.exitCode = 1;
-  }
-}
-
 function reportUnusedFileScan(scan: (typeof KNIP_SCANS)[number], result: KnipRunResult) {
   const validation = checkKnipUnusedFileScanResult(result);
   if (validation.failureReason) {
@@ -118,5 +104,5 @@ function reportUnusedFileScan(scan: (typeof KNIP_SCANS)[number], result: KnipRun
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  await main();
+  await runKnipScans(KNIP_SCANS, KNIP_COMMON_ARGS, reportUnusedFileScan);
 }

--- a/scripts/deadcode-knip-runner.mts
+++ b/scripts/deadcode-knip-runner.mts
@@ -298,3 +298,19 @@ export async function runKnip(knipArgs: string[], params: KnipRunParams = {}) {
     });
   });
 }
+
+export async function runKnipScans<T extends { name: string; args: readonly string[] }>(
+  scans: readonly T[],
+  commonArgs: readonly string[],
+  report: (scan: T, result: KnipRunResult) => boolean,
+): Promise<void> {
+  const results = await Promise.all(
+    scans.map(async (scan) => {
+      const result = await runKnip([...scan.args, ...commonArgs], { scanName: scan.name });
+      return report(scan, result);
+    }),
+  );
+  if (results.includes(false)) {
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Closes #143743

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; maintainer edits are available.

</details>

## What Problem This Solves

The unused-export and unused-file commands maintain duplicate concurrent scan
orchestration. This maintainer-requested refactor removes that maintenance drift
risk without changing dead-code policy or reporting.

Context: https://github.com/openclaw/openclaw/issues/143743

## Why This Change Was Made

Both commands now call a shared `runKnipScans` helper in the existing Knip runner.
The shared body preserves concurrent dispatch, immediate per-completion reporting,
and the existing false-result aggregate. Scan definitions, arguments, parsers,
reporters, entrypoint guards, and the complete `runKnip` lifecycle remain unchanged.

## User Impact

No user-visible behavior change. No new configuration, dependency, timeout,
baseline, ignore, or test change.

## Evidence

- Development-base proof at `f2a629ea05ce3f46c3d89a6d45866c50ad2c04cf`: all three
  `test/scripts/check-deadcode-{reporting,exports,unused-files}.test.ts` suites
  passed together, 50 tests.
- Explicit-base/path lane selection and the full selected `check-changed` gate
  passed, including formatting, script types, erasability, lint, and guards.
- `git diff --check` passed; the change is limited to three scripts.
- Independent review completed through P2. Its one finding proposed retaining a
  prior nonzero exit code when any reporter returns false. Rejected against both
  original wrappers and the requested behavior-preserving scope: false still
  assigns 1; all-success leaves an existing exit code untouched. No review-driven
  behavior change was made.
- Immediate per-completion reporting and existing-exit-code behavior were reviewed
  as source invariants; the existing tests are not claimed as direct coverage of
  those two edge cases.
- Fresh-main-integrated proof passed on Blacksmith Testbox, Linux Node `v24.19.0`
  / pnpm `12.3.4`: a fresh physical frozen install, all three suites (50 tests),
  `pnpm deadcode:exports` (three scans, zero findings), and
  `pnpm deadcode:unused-files` (two scans, zero findings).
  Exact candidate `a71e98938e4a3f9393c4d0f04eadf3dbfb2dfd3b` was applied to captured
  main `0b92bfeda7ea00e01cc09efb4bd21181a784a0c3`, producing integrated tree
  `1220600d9a55ab892da1024567ea9dba79de14e9`. The full three-file delta,
  original/candidate blobs, current main configs/guidance, and final tree were verified.
  Run: https://github.com/openclaw/openclaw/actions/runs/34442905574
- All remote proof commands exited 0. The provider wrapper subsequently exited 1
  during lease cleanup; an explicit stop recovered that cleanup, and direct provider
  status confirmed the lease completed. The proof was not rerun.
- Exact-head hosted CI passed for `a71e98938e4a3f9393c4d0f04eadf3dbfb2dfd3b`:
  https://github.com/openclaw/openclaw/actions/runs/34442902912
