### PR TITLE
fix(workers): stop workspace scans after cancellation

### DIFF
--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -269,7 +269,11 @@ export function createNodeWorkspaceTransferService(options: {
       }
       const root = await fsp.realpath(params.localPath);
       params.signal.throwIfAborted();
-      const actual = await readActualWorkspaceManifest({ root, baseCommit: null });
+      const actual = await readActualWorkspaceManifest({
+        root,
+        baseCommit: null,
+        signal: params.signal,
+      });
       params.signal.throwIfAborted();
       if (!isCurrentContext(context) || !params.isAuthorized()) {
         throw new Error("Worker attachment transfer authority closed");

--- a/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
@@ -68,7 +68,12 @@ export async function prepareNodeWorkspaceTransferSnapshot(params: {
     }
     includePaths = manifestPaths;
   }
-  const actual = await readActualWorkspaceManifest({ root, baseCommit, includePaths });
+  const actual = await readActualWorkspaceManifest({
+    root,
+    baseCommit,
+    includePaths,
+    signal: params.signal,
+  });
   return {
     ...actual,
     rawManifest: serializeWorkerWorkspaceManifest(actual.manifest),

--- a/src/gateway/worker-environments/workspace-actual-manifest.test.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.test.ts
@@ -4,15 +4,76 @@ import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import { prepareNodeWorkspaceTransferSnapshot } from "./node-workspace-transfer-snapshot.js";
 import {
   readActualWorkspaceManifestImpl,
   readWorkspaceFileSnapshotWithLimit,
 } from "./workspace-actual-manifest.js";
 import { withWorkspaceHashMemo, workspaceStatIdentity } from "./workspace-hash-memo.js";
 import { MAX_WORKSPACE_INVENTORY_TOTAL_BYTES } from "./workspace-inventory-limits.js";
+import { readActualWorkspaceManifest } from "./workspace-reconcile-core.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
+
+it.each(["before traversal", "during traversal", "root resolution", "safe-root setup"] as const)(
+  "rejects an empty inventory aborted %s",
+  async (phase) => {
+    const root = await fs.realpath(tempDirs.make("workspace-inventory-empty-abort-"));
+    const controller = new AbortController();
+    const reason = new Error("empty inventory aborted");
+    const entered = createDeferred();
+    const gate = createDeferred();
+    const setupFailure = phase === "root resolution" || phase === "safe-root setup";
+    if (setupFailure) {
+      const realpath = fs.realpath.bind(fs);
+      vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        if (String(args[0]) !== root) {
+          return await realpath(...args);
+        }
+        const resolved = phase === "safe-root setup" ? await realpath(...args) : undefined;
+        entered.resolve();
+        await gate.promise;
+        return resolved ?? (await realpath(...args));
+      });
+    }
+    const opendir = fs.opendir.bind(fs);
+    const opened = vi.spyOn(fs, "opendir").mockImplementation(async (...args) => {
+      const directory = await opendir(...args);
+      entered.resolve();
+      await gate.promise;
+      return directory;
+    });
+    if (phase === "before traversal") {
+      controller.abort(reason);
+      gate.resolve();
+    }
+    const params = {
+      root,
+      baseCommit: null,
+      signal: controller.signal,
+      ...(phase === "before traversal" ? { includePaths: new Set<string>() } : {}),
+    };
+    const scan = readActualWorkspaceManifest(params);
+    const rejected = expect(scan).rejects.toBe(reason);
+    try {
+      if (phase !== "before traversal") {
+        await entered.promise;
+        controller.abort(reason);
+        if (setupFailure) {
+          await fs.rmdir(root);
+        }
+        gate.resolve();
+      }
+      await rejected;
+      expect(opened).toHaveBeenCalledTimes(phase === "during traversal" ? 1 : 0);
+    } finally {
+      gate.resolve();
+      await Promise.allSettled([scan, rejected]);
+    }
+  },
+);
 
 it.each(["metadata", "files"] as const)(
   "bounds pending promise resources while %s operations are blocked",
@@ -71,12 +132,40 @@ it.each(["metadata", "files"] as const)(
   },
 );
 
-it("joins bounded file readers after a workspace file moves outside its root", async () => {
+const fileFailures = ["symlink replacement", "snapshot abort", "attachment abort"] as const;
+it.each(fileFailures)("drains admitted file reads after %s", async (failure) => {
   const root = await fs.realpath(tempDirs.make("workspace-inventory-readers-"));
   const outside = await fs.realpath(tempDirs.make("workspace-inventory-outside-"));
   const files = Array.from({ length: 9 }, (_, index) => `file-${index}.txt`);
   await Promise.all(files.map((file) => fs.writeFile(path.join(root, file), "inside")));
   await fs.writeFile(path.join(outside, "target.txt"), "outside");
+  const controller = new AbortController();
+  const reason = new Error("manifest scan aborted");
+  const service =
+    failure === "attachment abort"
+      ? createNodeWorkspaceTransferService({
+          temporaryRoot: tempDirs.make("workspace-inventory-transfers-"),
+          getOwner: () => ({
+            credential: { ownerEpoch: 1, sessionId: "session" },
+            environment: {
+              ownerEpoch: 1,
+              attachedSessionIds: ["session"],
+              destroyRequestedAtMs: null,
+              state: "attached",
+            },
+          }),
+        })
+      : undefined;
+  if (service) {
+    await service.prepareSync({
+      environmentId: "environment",
+      ownerEpoch: 1,
+      sessionId: "session",
+      generation: 1,
+      localPath: tempDirs.make("workspace-inventory-empty-source-"),
+      isAuthorized: () => true,
+    });
+  }
   const open = fs.open.bind(fs);
   const gates: Array<ReturnType<typeof createDeferred<void>>> = [];
   const gatedPaths: string[] = [];
@@ -102,11 +191,20 @@ it("joins bounded file readers after a workspace file moves outside its root", a
     }
     return handle;
   });
-  const scan = readActualWorkspaceManifestImpl({
-    root,
-    baseCommit: null,
-    includePaths: new Set(files),
-  });
+  const scan = service
+    ? service.prepareAttachments({
+        environmentId: "environment",
+        localPath: root,
+        isAuthorized: () => true,
+        signal: controller.signal,
+      })
+    : failure === "snapshot abort"
+      ? prepareNodeWorkspaceTransferSnapshot({
+          localPath: root,
+          temporaryRoot: tempDirs.make("workspace-inventory-snapshot-"),
+          signal: controller.signal,
+        })
+      : readActualWorkspaceManifest({ root, baseCommit: null, includePaths: new Set(files) });
   let settled = false;
   void scan.then(
     () => {
@@ -118,8 +216,12 @@ it("joins bounded file readers after a workspace file moves outside its root", a
   );
   try {
     await vi.waitFor(() => expect(gates).toHaveLength(4));
-    await fs.rename(gatedPaths[0]!, path.join(outside, "moved.txt"));
-    await fs.symlink(path.join(outside, "target.txt"), gatedPaths[0]!);
+    if (failure === "symlink replacement") {
+      await fs.rename(gatedPaths[0]!, path.join(outside, "moved.txt"));
+      await fs.symlink(path.join(outside, "target.txt"), gatedPaths[0]!);
+    } else {
+      controller.abort(reason);
+    }
     gates[0]!.resolve();
     await firstClosed.promise;
     expect(settled).toBe(false);
@@ -130,13 +232,26 @@ it("joins bounded file readers after a workspace file moves outside its root", a
       gate.resolve();
     }
     await Promise.allSettled([scan]);
+    await service?.closeAll();
   }
-  await expect(scan).rejects.toThrow();
+  if (failure === "symlink replacement") {
+    await expect(scan).rejects.toThrow();
+  } else {
+    await expect(scan).rejects.toBe(reason);
+  }
   expect(opened).toHaveBeenCalledTimes(4);
   expect(closed).toBe(4);
 });
 
-it("joins the admitted metadata batch and preserves its first error", async () => {
+const metadataFailures = [
+  "metadata error",
+  "caller abort",
+  "abort before metadata error",
+  "walk abort before metadata error",
+] as const;
+it.each(metadataFailures)("settles metadata after %s", async (failure) => {
+  const walk = failure === "walk abort before metadata error";
+  const admitted = walk ? 1 : 4;
   const root = await fs.realpath(tempDirs.make("workspace-inventory-metadata-"));
   const files = Array.from({ length: 9 }, (_, index) => `file-${index}.txt`);
   await Promise.all(files.map((file) => fs.writeFile(path.join(root, file), "inside")));
@@ -144,6 +259,8 @@ it("joins the admitted metadata batch and preserves its first error", async () =
   const gates: Array<ReturnType<typeof createDeferred<void>>> = [];
   const failed = createDeferred();
   const error = new Error("inventory metadata unavailable");
+  const controller = new AbortController();
+  const abortError = new Error("manifest scan aborted");
   let releasing = false;
   let started = 0;
   vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
@@ -156,16 +273,21 @@ it("joins the admitted metadata batch and preserves its first error", async () =
       }
       if (first) {
         failed.resolve();
-        throw error;
+        if (failure !== "caller abort") {
+          throw error;
+        }
       }
     }
     return await lstat(...args);
   });
-  const scan = readActualWorkspaceManifestImpl({
+  const opened = vi.spyOn(fs, "open");
+  const params = {
     root,
     baseCommit: null,
-    includePaths: new Set(files),
-  });
+    ...(walk ? {} : { includePaths: new Set(files) }),
+    signal: controller.signal,
+  };
+  const scan = readActualWorkspaceManifest(params);
   let settled = false;
   void scan.then(
     () => {
@@ -176,11 +298,21 @@ it("joins the admitted metadata batch and preserves its first error", async () =
     },
   );
   try {
-    await vi.waitFor(() => expect(gates).toHaveLength(4));
+    await vi.waitFor(() => expect(gates).toHaveLength(admitted));
+    if (failure !== "metadata error") {
+      controller.abort(abortError);
+    }
     gates[0]!.resolve();
     await failed.promise;
     expect(settled).toBe(false);
-    expect(started).toBe(4);
+    expect(started).toBe(admitted);
+    if (failure === "metadata error") {
+      // Let the rejected operation reach the scan owner before the later cancellation.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      controller.abort(abortError);
+    }
   } finally {
     releasing = true;
     for (const gate of gates) {
@@ -188,8 +320,64 @@ it("joins the admitted metadata batch and preserves its first error", async () =
     }
     await Promise.allSettled([scan]);
   }
-  await expect(scan).rejects.toBe(error);
-  expect(started).toBe(4);
+  await expect(scan).rejects.toBe(failure === "metadata error" ? error : abortError);
+  expect(started).toBe(admitted);
+  expect(opened).not.toHaveBeenCalled();
+});
+
+it("stops an admitted directory enumeration on caller cancellation", async () => {
+  const root = await fs.realpath(tempDirs.make("workspace-inventory-directory-abort-"));
+  const target = path.join(root, "directory");
+  await fs.mkdir(target);
+  await Promise.all(
+    ["a.txt", "b.txt"].map((file) => fs.writeFile(path.join(target, file), "inside")),
+  );
+  const controller = new AbortController();
+  const reason = new Error("directory scan aborted");
+  const entered = createDeferred();
+  const gate = createDeferred();
+  const opendir = fs.opendir.bind(fs);
+  let visited = 0;
+  let closed = false;
+  vi.spyOn(fs, "opendir").mockImplementation(async (...args) => {
+    const directory = await opendir(...args);
+    if (String(args[0]) === target) {
+      const iterate = directory[Symbol.asyncIterator].bind(directory);
+      vi.spyOn(directory, Symbol.asyncIterator).mockImplementation(async function* () {
+        try {
+          for await (const entry of iterate()) {
+            visited++;
+            entered.resolve();
+            await gate.promise;
+            yield entry;
+          }
+        } finally {
+          closed = true;
+        }
+        return undefined;
+      });
+    }
+    return directory;
+  });
+  const params = {
+    root,
+    baseCommit: null,
+    includePaths: new Set(["directory"]),
+    signal: controller.signal,
+  };
+  const scan = readActualWorkspaceManifest(params);
+  const rejected = expect(scan).rejects.toBe(reason);
+  try {
+    await entered.promise;
+    controller.abort(reason);
+    gate.resolve();
+    await rejected;
+    expect(visited).toBe(1);
+    expect(closed).toBe(true);
+  } finally {
+    gate.resolve();
+    await Promise.allSettled([scan, rejected]);
+  }
 });
 
 it("preserves bottom-up directory membership and canonical output across input orders", async () => {

--- a/src/gateway/worker-environments/workspace-actual-manifest.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.ts
@@ -129,9 +129,18 @@ export async function readActualWorkspaceManifestImpl(params: {
   baseCommit: string | null;
   preserveDirectories?: ReadonlySet<string>;
   includePaths?: ReadonlySet<string>;
+  signal?: AbortSignal;
 }): Promise<{ manifest: WorkerWorkspaceManifest; manifestRef: string }> {
-  const root = await fs.realpath(params.root);
-  const isStagedInput = createStagedInputPathMatcher(await fsRoot(root));
+  params.signal?.throwIfAborted();
+  let root: string;
+  let isStagedInput: ReturnType<typeof createStagedInputPathMatcher>;
+  try {
+    root = await fs.realpath(params.root);
+    isStagedInput = createStagedInputPathMatcher(await fsRoot(root));
+  } catch (error) {
+    params.signal?.throwIfAborted();
+    throw error;
+  }
   const rawEntries: Array<
     WorkerWorkspaceManifestEntry | { path: string; type: "directory"; mode: number }
   > = [];
@@ -157,8 +166,11 @@ export async function readActualWorkspaceManifestImpl(params: {
     }
   };
   const scanController = new AbortController();
+  const scanSignal = params.signal
+    ? AbortSignal.any([params.signal, scanController.signal])
+    : scanController.signal;
   const checkTraversal = (relative: string): void => {
-    scanController.signal.throwIfAborted();
+    scanSignal.throwIfAborted();
     traversedEntries += 1;
     traversedPathBytes += Buffer.byteLength(relative);
     if (traversedEntries > MAX_WORKSPACE_INVENTORY_ENTRIES) {
@@ -175,21 +187,32 @@ export async function readActualWorkspaceManifestImpl(params: {
     scan: (index: number) => Promise<void>,
   ): Promise<void> => {
     let next = start;
+    let taskFailureWasFirst = false;
     const result = await runTasksWithConcurrency({
       // Keep the queued graph bounded too: each worker claims an index before
       // awaiting I/O, rather than retaining one task per inventory entry.
       tasks: Array.from({ length: Math.min(4, end - start) }, () => async () => {
-        while (next < end && !scanController.signal.aborted) {
+        while (next < end && !scanSignal.aborted) {
           await scan(next++);
         }
       }),
       limit: 4,
       errorMode: "stop",
-      onTaskError: (error) => scanController.abort(error),
+      onTaskError: (error) => {
+        // Composite signals can resolve reasons lazily; record ordering at the owner.
+        if (!scanController.signal.aborted) {
+          taskFailureWasFirst = !params.signal?.aborted;
+        }
+        scanController.abort(error);
+      },
     });
     if (result.hasError) {
+      if (!taskFailureWasFirst) {
+        params.signal?.throwIfAborted();
+      }
       throw result.firstError;
     }
+    scanSignal.throwIfAborted();
   };
   const addFile = async (relative: string): Promise<void> => {
     const snapshot = await readWorkspaceFileSnapshotWithLimit(
@@ -199,7 +222,7 @@ export async function readActualWorkspaceManifestImpl(params: {
         return size;
       },
       root,
-      scanController.signal,
+      scanSignal,
     );
     if (snapshot.type === "file") {
       addEntry({
@@ -240,6 +263,7 @@ export async function readActualWorkspaceManifestImpl(params: {
       let hasDerivedEntry = false;
       let hasIncludedEntry = false;
       for await (const entry of await fs.opendir(absolute)) {
+        scanSignal.throwIfAborted();
         const child = `${relative}/${entry.name}`;
         if (
           isDerivedWorkspacePath(child, await isStagedInput(child)) ||
@@ -362,11 +386,14 @@ export async function readActualWorkspaceManifestImpl(params: {
       start = end;
     }
   } else {
-    await walk("");
+    await runScans(0, 1, async () => {
+      await walk("");
+    });
   }
   // No file readers overlap metadata selection; failures stop new admission
   // and join all opened handles before any manifest can be returned.
   await runScans(0, filePaths.length, (index) => addFile(filePaths[index]!));
+  scanSignal.throwIfAborted();
   const directories = rawEntries
     .filter((entry) => entry.type === "directory")
     .toSorted((left, right) => left.path.localeCompare(right.path));

--- a/src/gateway/worker-environments/workspace-reconcile-core.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-core.ts
@@ -185,6 +185,7 @@ export async function readActualWorkspaceManifest(params: {
   baseCommit: string | null;
   preserveDirectories?: ReadonlySet<string>;
   includePaths?: ReadonlySet<string>;
+  signal?: AbortSignal;
 }): Promise<{ manifest: WorkerWorkspaceManifest; manifestRef: string }> {
   return await readActualWorkspaceManifestImpl(params);
 }


### PR DESCRIPTION
Related: #134931.

## What Problem This Solves

Canceling worker preparation or attachment transfer could leave the Gateway scanning and hashing the workspace. The caller's cancellation signal reached Git discovery but was dropped before the filesystem inventory scan.

## Why This Change Was Made

Snapshot and attachment preparation forward the caller's signal to the inventory owner, which combines it with the existing internal failure signal. Cancellation stops new file and metadata work, joins already-admitted operations, and closes their handles before returning. The owner records the first observed cause explicitly, preserving an earlier I/O failure or caller cancellation through later failures. This avoids relying on lazy composite-signal reason evaluation.

## User Impact

Canceled preparation stops reading additional workspace files, and the operation returns only after its admitted file and directory work has settled.

## Evidence

Real-filesystem regressions reproduce continued reads after cancellation through the public snapshot and attachment APIs, metadata and directory traversal, and empty inventories. Additional regressions reproduce both cancellation/error orderings and real directory removal during initial root setup. The final 27-case focused run passes, including exact handle closure and preservation of already-observed failures.

Fresh full-slice independent review through P2 passed. The full changed-file gate passed. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34442915964). The existing inventory limits, canonical manifests, and storage formats remain unchanged. This is local filesystem and API-boundary proof, without a cloud-provider timing claim.
