### PR TITLE
fix: show full subagent transcripts in the task sidebar

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -931,6 +931,7 @@ enum class GatewayMethod(
   PluginsCatalogBrowse("plugins.catalog.browse"),
   PluginsCatalogCategories("plugins.catalog.categories"),
   PluginsCatalogGet("plugins.catalog.get"),
+  TasksHistory("tasks.history"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13011,6 +13011,7 @@ public struct TaskSummary: Codable, Sendable {
     public let agentid: String?
     public let sessionkey: String?
     public let childsessionkey: String?
+    public let hastranscript: Bool?
     public let ownerkey: String?
     public let runid: String?
     public let taskid: String?
@@ -13042,6 +13043,7 @@ public struct TaskSummary: Codable, Sendable {
         agentid: String? = nil,
         sessionkey: String? = nil,
         childsessionkey: String? = nil,
+        hastranscript: Bool? = nil,
         ownerkey: String? = nil,
         runid: String? = nil,
         taskid: String? = nil,
@@ -13072,6 +13074,7 @@ public struct TaskSummary: Codable, Sendable {
         self.agentid = agentid
         self.sessionkey = sessionkey
         self.childsessionkey = childsessionkey
+        self.hastranscript = hastranscript
         self.ownerkey = ownerkey
         self.runid = runid
         self.taskid = taskid
@@ -13104,6 +13107,7 @@ public struct TaskSummary: Codable, Sendable {
         case agentid = "agentId"
         case sessionkey = "sessionKey"
         case childsessionkey = "childSessionKey"
+        case hastranscript = "hasTranscript"
         case ownerkey = "ownerKey"
         case runid = "runId"
         case taskid = "taskId"
@@ -13201,6 +13205,46 @@ public struct TasksGetResult: Codable, Sendable {
         task: TaskSummary)
     {
         self.task = task
+    }
+}
+
+public struct TasksHistoryParams: Codable, Sendable {
+    public let taskid: String
+    public let cursor: String?
+    public let limit: Int?
+
+    public init(
+        taskid: String,
+        cursor: String? = nil,
+        limit: Int? = nil)
+    {
+        self.taskid = taskid
+        self.cursor = cursor
+        self.limit = limit
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case taskid = "taskId"
+        case cursor
+        case limit
+    }
+}
+
+public struct TasksHistoryResult: Codable, Sendable {
+    public let messages: [AnyCodable]
+    public let nextcursor: String?
+
+    public init(
+        messages: [AnyCodable],
+        nextcursor: String? = nil)
+    {
+        self.messages = messages
+        self.nextcursor = nextcursor
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case messages
+        case nextcursor = "nextCursor"
     }
 }
 

--- a/docs/plugins/sdk-agent-harness/sessions-and-results.md
+++ b/docs/plugins/sdk-agent-harness/sessions-and-results.md
@@ -64,7 +64,10 @@ hooks are notifications, not the owner of durable binding removal.
 Native subagents can expose the shared task transcript view through the optional
 `taskHistory` harness capability. Declare the owned `taskKinds` and implement
 `read({ task, cfg, cursor, limit, assertCurrent })`. Return chronological chat
-`messages` with stable message IDs and an optional `nextCursor` for older history.
+`messages` with a stable `messageId` (or canonical `__openclaw.id`) and an optional
+`nextCursor` for older history. Internal runtime-only IDs are insufficient: the
+shared viewer must recognize the identity across pages and refreshes. Rows that
+share a transcript entry ID remain one display group.
 Preserve typed thinking, tool-call, and tool-result content so the normal chat
 renderer can display it. Bound native reads and response sizes.
 

--- a/docs/plugins/sdk-agent-harness/sessions-and-results.md
+++ b/docs/plugins/sdk-agent-harness/sessions-and-results.md
@@ -59,6 +59,27 @@ mutating native state. The callback belongs to one registered harness lifetime;
 retaining it after the operation closes does not retain authority. Post-delete
 hooks are notifications, not the owner of durable binding removal.
 
+## Subagent task history
+
+Native subagents can expose the shared task transcript view through the optional
+`taskHistory` harness capability. Declare the owned `taskKinds` and implement
+`read({ task, cfg, cursor, limit, assertCurrent })`. Return chronological chat
+`messages` with stable message IDs and an optional `nextCursor` for older history.
+Preserve typed thinking, tool-call, and tool-result content so the normal chat
+renderer can display it. Bound native reads and response sizes.
+
+The Gateway's `tasks.history` method authorizes the task's requester session and
+routes history to its existing OpenClaw child session or the owning harness.
+It accepts a task ID, an optional opaque cursor, and a limit from 1 to 200
+(default 100). The harness must verify native parent/child lineage and the
+bound connection, and call `assertCurrent()` after awaited work. The Gateway
+rechecks access before returning a page and caps the response at 4 MiB.
+
+Keep `childSessionKey` absent for native children: it describes an OpenClaw
+session and also determines lifecycle ownership. Reading history must not adopt
+the child, create another transcript store, or change cancellation and recovery.
+`TaskSummary.hasTranscript` advertises readable history to the shared viewer.
+
 ## Tool and media results
 
 Core constructs the OpenClaw tool list and passes it into the prepared

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -308,6 +308,17 @@ Images and video previews in your own messages appear above any accompanying tex
 
 Messages forwarded by `sessions_send` render as left-aligned speech bubbles with a source-session chip above the message. When avatars are shown, messages from a different known agent use that agent's avatar, or initials in a stable identity color if no avatar is available. Same-agent forwards and unknown senders keep the forward icon. Select the chip to open the source session; hover it to see session progress. Each source session has a stable bubble tint. Forwarded messages without a known source session show the source agent when available, or a generic forwarded-message label. The receiving agent's own replies remain flat text.
 
+## Subagent transcripts
+
+Subagents use the same task transcript view, including subagents run by the
+Codex harness. Select a task to read its messages, thinking, and tool calls;
+select **Show earlier** to load older history. Task activity refreshes the view
+while the subagent runs. The generic fallback label is **Subagent**.
+
+The viewer reads history from the runtime that owns it. If that runtime or its
+parent binding is unavailable, the panel shows an error with a retry action.
+Tasks without readable history retain their prompt and output inspector.
+
 ## Chat message width
 
 Drag the side-panel divider to resize a task's **Review** transcript. Messages

--- a/extensions/codex/harness.task-history.test.ts
+++ b/extensions/codex/harness.task-history.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AgentHarnessV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import { resolveCodexBindingAppServerConnection } from "./src/app-server/binding-connection.js";
@@ -47,6 +48,10 @@ afterEach(async () => {
 });
 
 type ReadParams = Parameters<NonNullable<AgentHarnessV2["taskHistory"]>["read"]>[0];
+function messageIds(messages: unknown[]) {
+  return messages.map((message) => asOptionalRecord(message)?.messageId);
+}
+
 function item(id: string, overrides: Partial<CodexThreadItem>): CodexThreadItem {
   return {
     id,
@@ -210,10 +215,23 @@ describe("native subagent history through the harness", () => {
       },
       { role: "assistant", content: [{ type: "text", text: "Working on it" }] },
     ]);
+    const ids = messageIds(page.messages);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(page.messages.length);
     expect(native.acquire).toHaveBeenCalledWith(
       expect.objectContaining({ agentDir: expect.any(String) }),
     );
     expect(native.release).toHaveBeenCalledOnce();
+    f.items[2]!.aggregatedOutput = "/workspace/updated";
+    const updated = await f.read();
+    expect(messageIds(updated.messages)).toEqual(ids);
+    expect(updated.messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId: "command",
+        content: [{ type: "text", text: "/workspace/updated" }],
+      }),
+    );
   });
 
   it("paginates older messages without replay or loss after a live append", async () => {
@@ -236,9 +254,21 @@ describe("native subagent history through the harness", () => {
       ),
     );
     expect(third.nextCursor).toBeUndefined();
-    expect((await f.read()).messages).toContainEqual(
+    const full = await f.read();
+    expect(full.messages).toContainEqual(
       expect.objectContaining({
         content: [{ type: "text", text: "new live message" }],
+      }),
+    );
+    expect(messageIds([...third.messages, ...second.messages, ...first.messages])).toEqual(
+      messageIds(full.messages.slice(0, -1)),
+    );
+    f.items[5]!.text = "Updated content for the same native item";
+    const refreshed = await f.read();
+    expect(messageIds(refreshed.messages)).toEqual(messageIds(full.messages));
+    expect(refreshed.messages).toContainEqual(
+      expect.objectContaining({
+        content: [{ type: "text", text: "Updated content for the same native item" }],
       }),
     );
   });

--- a/extensions/codex/harness.task-history.test.ts
+++ b/extensions/codex/harness.task-history.test.ts
@@ -1,0 +1,391 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentHarnessV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCodexAppServerAgentHarness } from "./harness.js";
+import { resolveCodexBindingAppServerConnection } from "./src/app-server/binding-connection.js";
+import {
+  buildCodexAppServerConnectionFingerprint,
+  buildCodexAppServerRuntimeFingerprint,
+} from "./src/app-server/plugin-app-cache-key.js";
+import type { CodexThread, CodexThreadItem } from "./src/app-server/protocol.js";
+import {
+  createCodexTestBindingStore,
+  sessionBindingIdentity,
+  type CodexAppServerThreadBinding,
+} from "./src/app-server/session-binding.test-helpers.js";
+
+const native = vi.hoisted(() => ({
+  request: vi.fn<(method: string, params: Record<string, unknown>) => Promise<unknown>>(),
+  acquire: vi.fn(),
+  release: vi.fn(),
+  version: "0.153.4",
+  home: "/synthetic/codex-home",
+}));
+vi.mock("./src/app-server/shared-client.js", () => ({
+  getLeasedSharedCodexAppServerClient: native.acquire,
+  releaseLeasedSharedCodexAppServerClient: native.release,
+}));
+
+const directories: string[] = [];
+beforeEach(() => {
+  native.request.mockReset();
+  native.acquire.mockReset().mockResolvedValue({
+    request: native.request,
+    getServerVersion: () => native.version,
+    getRuntimeIdentity: () => ({ serverVersion: native.version, codexHome: native.home }),
+  });
+  native.release.mockReset();
+});
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+type ReadParams = Parameters<NonNullable<AgentHarnessV2["taskHistory"]>["read"]>[0];
+function item(id: string, overrides: Partial<CodexThreadItem>): CodexThreadItem {
+  return {
+    id,
+    type: "agentMessage",
+    title: null,
+    status: null,
+    name: null,
+    tool: null,
+    server: null,
+    command: null,
+    cwd: null,
+    query: null,
+    aggregatedOutput: null,
+    text: "",
+    changes: [],
+    ...overrides,
+  };
+}
+
+async function fixture(supervised = false) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-history-"));
+  directories.push(directory);
+  const agentDir = path.join(directory, "agent");
+  const storePath = path.join(directory, "sessions.json");
+  const cfg: OpenClawConfig = {
+    session: { store: storePath },
+    agents: { entries: { main: { agentDir } } },
+  };
+  const session = { agentId: "main", sessionId: "parent-session", sessionKey: "agent:main:parent" };
+  await upsertSessionEntry({
+    agentId: session.agentId,
+    sessionKey: session.sessionKey,
+    storePath,
+    entry: { sessionId: session.sessionId, updatedAt: 1 },
+  });
+  const bindingStore = createCodexTestBindingStore();
+  const pluginConfig = supervised ? { supervision: { enabled: true } } : undefined;
+  const connection = resolveCodexBindingAppServerConnection({ pluginConfig, agentDir });
+  let binding: CodexAppServerThreadBinding = {
+    threadId: "parent-thread",
+    cwd: directory,
+    appServerRuntimeFingerprint: buildCodexAppServerRuntimeFingerprint({
+      appServer: connection.appServer,
+      appServerVersion: native.version,
+      runtimeIdentity: { serverVersion: native.version, codexHome: native.home },
+    }),
+  };
+  if (supervised) {
+    const { resolveCodexSupervisionAppServerRuntimeOptions } =
+      await import("./src/app-server/config.js");
+    binding = {
+      ...binding,
+      connectionScope: "supervision",
+      supervisionSourceThreadId: "source",
+      preserveNativeModel: true,
+      conversationSourceTransferComplete: true,
+      model: "gpt-5.6-sol",
+      modelProvider: "openai",
+      appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
+        resolveCodexSupervisionAppServerRuntimeOptions({ pluginConfig, agentDir }),
+        agentDir,
+      ),
+    };
+  }
+  const identity = sessionBindingIdentity(session);
+  await bindingStore.mutate(identity, { kind: "set", binding });
+  const harness = createCodexAppServerAgentHarness({ bindingStore, pluginConfig });
+  const params: ReadParams = {
+    cfg,
+    task: {
+      taskId: "task-1",
+      runtime: "subagent",
+      taskKind: "codex-native",
+      requesterSessionKey: session.sessionKey,
+      agentId: "main",
+      runId: "codex-thread:child-thread",
+      ownerKey: "main",
+      scopeKind: "session",
+      task: "Inspect code",
+      status: "running",
+      deliveryStatus: "pending",
+      notifyPolicy: "done_only",
+      createdAt: 1,
+    },
+    limit: 100,
+    assertCurrent: vi.fn(),
+  };
+  const thread: CodexThread = {
+    id: "child-thread",
+    projectId: null,
+    createdAt: 123,
+    historyMode: "paginated",
+    source: { subAgent: { thread_spawn: { parent_thread_id: "parent-thread" } } },
+  };
+  const threads = new Map([[thread.id, thread]]);
+  const items: CodexThreadItem[] = [];
+  native.request.mockImplementation(async (method, request) => {
+    if (method === "thread/read") {
+      const selected = threads.get(String(request.threadId));
+      if (!selected) {
+        throw new Error("Thread is unavailable");
+      }
+      return { thread: selected };
+    }
+    if (method === "thread/items/list") {
+      const newest = items.toReversed();
+      const offset = request.cursor
+        ? newest.findIndex((entry) => entry.id === request.cursor) + 1
+        : 0;
+      const selected = newest.slice(offset, offset + Number(request.limit));
+      return {
+        data: selected.map((entry) => ({ turnId: "turn-1", item: entry })),
+        ...(offset + selected.length < newest.length ? { nextCursor: selected.at(-1)?.id } : {}),
+      };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  return {
+    params,
+    items,
+    thread,
+    threads,
+    binding,
+    bindingStore,
+    identity,
+    storePath,
+    harness,
+    read: (overrides: Partial<ReadParams> = {}) =>
+      harness.taskHistory!.read({ ...params, ...overrides }),
+  };
+}
+
+describe("native subagent history through the harness", () => {
+  it("renders user, reasoning, tool call/result, and active assistant content in chronological order", async () => {
+    const f = await fixture();
+    f.items.push(
+      item("user", { type: "userMessage", content: [{ type: "text", text: "Check this" }] }),
+      item("thinking", { type: "reasoning", summary: ["Inspecting the code"] }),
+      item("command", {
+        type: "commandExecution",
+        command: "pwd",
+        aggregatedOutput: "/workspace",
+        status: "completed",
+        exitCode: 0,
+      }),
+      item("assistant", { text: "Working on it", phase: "commentary" }),
+    );
+    const page = await f.read();
+    expect(page.messages).toMatchObject([
+      { role: "user", content: "Check this" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "Inspecting the code" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "command", name: "bash", arguments: { command: "pwd" } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "command",
+        content: [{ type: "text", text: "/workspace" }],
+        isError: false,
+      },
+      { role: "assistant", content: [{ type: "text", text: "Working on it" }] },
+    ]);
+    expect(native.acquire).toHaveBeenCalledWith(
+      expect.objectContaining({ agentDir: expect.any(String) }),
+    );
+    expect(native.release).toHaveBeenCalledOnce();
+  });
+
+  it("paginates older messages without replay or loss after a live append", async () => {
+    const f = await fixture();
+    f.items.push(
+      ...Array.from({ length: 7 }, (_, index) =>
+        item(`item-${index}`, { text: `message ${index}` }),
+      ),
+    );
+    const first = await f.read({ limit: 6 });
+    f.items.push(item("new", { text: "new live message" }));
+    const second = await f.read({ limit: 4, cursor: first.nextCursor });
+    const third = await f.read({ limit: 6, cursor: second.nextCursor });
+    expect([...third.messages, ...second.messages, ...first.messages]).toEqual(
+      Array.from({ length: 7 }, (_, index) =>
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: `message ${index}` }],
+        }),
+      ),
+    );
+    expect(third.nextCursor).toBeUndefined();
+    expect((await f.read()).messages).toContainEqual(
+      expect.objectContaining({
+        content: [{ type: "text", text: "new live message" }],
+      }),
+    );
+  });
+
+  it.each([false, true])(
+    "reconnects the binding-owned store (supervision=%s)",
+    async (supervised) => {
+      const f = await fixture(supervised);
+      f.items.push(item("answer", { text: "Stored child history" }));
+      expect((await f.read()).messages).toMatchObject([
+        { content: [{ text: "Stored child history" }] },
+      ]);
+      expect(native.acquire).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authProfileId: supervised ? null : undefined,
+          startOptions: expect.objectContaining({ homeScope: supervised ? "user" : "agent" }),
+        }),
+      );
+    },
+  );
+
+  it("reads nested subagents only after metadata verifies every ancestor back to the bound parent", async () => {
+    const f = await fixture();
+    f.thread.parentThreadId = "worker-2";
+    f.threads.set("worker-2", {
+      id: "worker-2",
+      projectId: null,
+      source: { subAgent: { thread_spawn: { parent_thread_id: "worker-1" } } },
+    });
+    f.threads.set("worker-1", { id: "worker-1", projectId: null, parentThreadId: "parent-thread" });
+    f.items.push(item("answer", { text: "Nested work" }));
+    expect((await f.read()).messages).toMatchObject([{ content: [{ text: "Nested work" }] }]);
+    expect(
+      native.request.mock.calls.map(([method, params]) => [
+        method,
+        params.threadId,
+        params.includeTurns,
+      ]),
+    ).toEqual([
+      ["thread/read", "child-thread", false],
+      ["thread/read", "worker-2", false],
+      ["thread/read", "worker-1", false],
+      ["thread/items/list", "child-thread", undefined],
+    ]);
+  });
+
+  it.each(["cycle", "foreign root", "missing ancestor", "mismatched ancestor", "excessive depth"])(
+    "rejects %s before reading any history",
+    async (failure) => {
+      const f = await fixture();
+      f.thread.parentThreadId = "worker-1";
+      if (failure !== "missing ancestor") {
+        f.threads.set("worker-1", {
+          id: failure === "mismatched ancestor" ? "different-worker" : "worker-1",
+          projectId: null,
+          ...(failure === "cycle" ? { parentThreadId: "child-thread" } : {}),
+        });
+      }
+      if (failure === "excessive depth") {
+        for (let depth = 1; depth < 40; depth++) {
+          f.threads.set(`worker-${depth}`, {
+            id: `worker-${depth}`,
+            projectId: null,
+            parentThreadId: `worker-${depth + 1}`,
+          });
+        }
+      }
+      await expect(f.read()).rejects.toThrow(
+        failure === "missing ancestor" ? "unavailable" : "does not belong",
+      );
+      expect(
+        native.request.mock.calls.every(
+          ([method, params]) => method === "thread/read" && params.includeTurns === false,
+        ),
+      ).toBe(true);
+      expect(native.request.mock.calls.length).toBeLessThanOrEqual(32);
+      expect(native.release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("rechecks the parent binding after awaiting ancestor metadata", async () => {
+    const f = await fixture();
+    f.thread.parentThreadId = "worker-1";
+    f.threads.set("worker-1", { id: "worker-1", projectId: null, parentThreadId: "parent-thread" });
+    const request = native.request.getMockImplementation()!;
+    native.request.mockImplementation(async (method, params) => {
+      const result = await request(method, params);
+      if (method === "thread/read" && params.threadId === "worker-1") {
+        await f.bindingStore.mutate(f.identity, {
+          kind: "patch",
+          threadId: "parent-thread",
+          patch: { appServerRuntimeFingerprint: "changed" },
+        });
+      }
+      return result;
+    });
+    await expect(f.read()).rejects.toThrow("parent changed");
+    expect(native.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/read",
+    ]);
+    expect(native.release).toHaveBeenCalledOnce();
+  });
+
+  it("rejects copied thread ids from a different native store", async () => {
+    const f = await fixture();
+    native.acquire.mockResolvedValueOnce({
+      request: native.request,
+      getServerVersion: () => native.version,
+      getRuntimeIdentity: () => ({ serverVersion: native.version, codexHome: "/other/home" }),
+    });
+    await expect(f.read()).rejects.toThrow("connection changed");
+    expect(native.request).not.toHaveBeenCalled();
+    expect(native.release).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an awaited page after the harness is disposed", async () => {
+    const f = await fixture();
+    f.items.push(item("answer", { text: "Pending result" }));
+    const request = native.request.getMockImplementation()!;
+    native.request.mockImplementation(async (method, params) => {
+      const result = await request(method, params);
+      if (method === "thread/items/list") {
+        await f.harness.dispose?.();
+      }
+      return result;
+    });
+    await expect(f.read()).rejects.toThrow("harness is disposed");
+    expect(native.release).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks the physical parent session after awaited history reads", async () => {
+    const f = await fixture();
+    const request = native.request.getMockImplementation()!;
+    native.request.mockImplementation(async (method, params) => {
+      const result = await request(method, params);
+      if (method === "thread/items/list") {
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey: f.params.task.requesterSessionKey,
+          storePath: f.storePath,
+          entry: { sessionId: "replacement-session", updatedAt: 2 },
+        });
+      }
+      return result;
+    });
+    await expect(f.read()).rejects.toThrow("parent changed");
+    expect(native.release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -166,6 +166,26 @@ export function createCodexAppServerAgentHarness(
           },
         }
       : {}),
+    taskHistory: {
+      taskKinds: ["codex-native"],
+      read: async (params) => {
+        const { readCodexNativeSubagentHistory } =
+          await import("./src/app-server/native-subagent-history.js");
+        const assertCurrent = () => {
+          params.assertCurrent();
+          if (disposed) {
+            throw new Error("Agent harness is disposed");
+          }
+        };
+        return readCodexNativeSubagentHistory(
+          { ...params, assertCurrent },
+          {
+            bindingStore: options.bindingStore,
+            pluginConfig: resolveAttemptPluginConfig(params.cfg),
+          },
+        );
+      },
+    },
     authBinding: {
       fingerprint: async (params) => {
         const { fingerprintCodexAppServerAuthBinding } =

--- a/extensions/codex/src/app-server/native-subagent-history.ts
+++ b/extensions/codex/src/app-server/native-subagent-history.ts
@@ -20,6 +20,7 @@ import {
 } from "./shared-client.js";
 import { readCodexThreadHistoryPage } from "./thread-history-page.js";
 import { projectCodexThreadHistoryItem } from "./transcript-history-projection.js";
+import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 
 type TaskHistoryParams = Parameters<NonNullable<AgentHarnessV2["taskHistory"]>["read"]>[0];
 const MAX_SUBAGENT_ANCESTRY_READS = 32;
@@ -177,7 +178,16 @@ export async function readCodexNativeSubagentHistory(
       {
         project: (entries) =>
           entries.map((entry) =>
-            projectCodexThreadHistoryItem(thread, entry, taskHistoryToolItems),
+            projectCodexThreadHistoryItem(thread, entry, taskHistoryToolItems).map((message) => {
+              const messageIdentity = readMirrorIdentity(message);
+              if (!messageIdentity) {
+                throw new Error("Subagent history message is missing its native identity.");
+              }
+              // The shared transcript reader uses messageId to merge live and older pages.
+              return Object.assign(message, {
+                messageId: JSON.stringify([threadId, messageIdentity]),
+              });
+            }),
           ),
         fits: (result) => Buffer.byteLength(JSON.stringify(result), "utf8") <= 512 * 1024,
       },

--- a/extensions/codex/src/app-server/native-subagent-history.ts
+++ b/extensions/codex/src/app-server/native-subagent-history.ts
@@ -1,0 +1,188 @@
+import type { AgentHarnessV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
+import {
+  CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
+  CODEX_NATIVE_SUBAGENT_TASK_KIND,
+} from "./native-subagent-task-ids.js";
+import {
+  buildCodexAppServerConnectionFingerprint,
+  buildCodexAppServerRuntimeFingerprint,
+} from "./plugin-app-cache-key.js";
+import type { CodexThread } from "./protocol.js";
+import { sessionBindingIdentity } from "./session-binding-record.js";
+import type { CodexAppServerBindingStore } from "./session-binding.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+} from "./shared-client.js";
+import { readCodexThreadHistoryPage } from "./thread-history-page.js";
+import { projectCodexThreadHistoryItem } from "./transcript-history-projection.js";
+
+type TaskHistoryParams = Parameters<NonNullable<AgentHarnessV2["taskHistory"]>["read"]>[0];
+const MAX_SUBAGENT_ANCESTRY_READS = 32;
+
+function parentThreadId(thread: CodexThread): string | undefined {
+  const source = thread.source;
+  const spawn =
+    source &&
+    typeof source === "object" &&
+    "subAgent" in source &&
+    typeof source.subAgent === "object" &&
+    "thread_spawn" in source.subAgent
+      ? source.subAgent.thread_spawn
+      : undefined;
+  return thread.parentThreadId?.trim() ?? spawn?.parent_thread_id.trim();
+}
+
+/** Resolves history from the parent binding's native store without adopting the child. */
+export async function readCodexNativeSubagentHistory(
+  params: TaskHistoryParams,
+  options: { bindingStore: CodexAppServerBindingStore; pluginConfig?: unknown },
+) {
+  params.assertCurrent();
+  const { task, cfg } = params;
+  const sessionKey = task.requesterSessionKey;
+  const agentId = task.agentId;
+  const threadId = task.runId?.startsWith(CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX)
+    ? task.runId.slice(CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX.length)
+    : undefined;
+  if (task.taskKind !== CODEX_NATIVE_SUBAGENT_TASK_KIND || !sessionKey || !agentId || !threadId) {
+    throw new Error("Subagent transcript owner is unavailable.");
+  }
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const readSession = () =>
+    getSessionEntry({
+      agentId,
+      sessionKey,
+      storePath,
+      hydrateSkillPromptRefs: false,
+      readConsistency: "latest",
+    });
+  const session = readSession();
+  if (!session?.sessionId) {
+    throw new Error("Subagent parent session is unavailable.");
+  }
+  const identity = sessionBindingIdentity({
+    agentId,
+    sessionId: session.sessionId,
+    sessionKey,
+    config: cfg,
+  });
+  const binding = options.bindingStore.read(identity);
+  if (!binding || binding.pendingSupervisionBranch) {
+    throw new Error("Subagent parent thread is unavailable.");
+  }
+  const assertCurrent = () => {
+    params.assertCurrent();
+    const current = options.bindingStore.read(identity);
+    if (
+      readSession()?.sessionId !== session.sessionId ||
+      current?.threadId !== binding.threadId ||
+      current?.appServerRuntimeFingerprint !== binding.appServerRuntimeFingerprint ||
+      current?.connectionScope !== binding.connectionScope ||
+      current?.authProfileId !== binding.authProfileId
+    ) {
+      throw new Error("Subagent parent changed; refresh its transcript.");
+    }
+  };
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const connection = resolveCodexBindingAppServerConnection({
+    binding,
+    pluginConfig: options.pluginConfig,
+    agentDir,
+    authProfileId: binding.authProfileId,
+  });
+  const client = await getLeasedSharedCodexAppServerClient({
+    startOptions: connection.appServer.start,
+    timeoutMs: connection.appServer.requestTimeoutMs,
+    authProfileId: connection.clientAuthProfileId,
+    agentDir,
+    config: cfg,
+    assertCurrent,
+  });
+  try {
+    assertCurrent();
+    const fingerprint =
+      binding.connectionScope === "supervision"
+        ? buildCodexAppServerConnectionFingerprint(connection.appServer, agentDir)
+        : buildCodexAppServerRuntimeFingerprint({
+            appServer: connection.appServer,
+            appServerVersion: client.getServerVersion(),
+            runtimeIdentity: client.getRuntimeIdentity(),
+          });
+    if (
+      !binding.appServerRuntimeFingerprint ||
+      fingerprint !== binding.appServerRuntimeFingerprint
+    ) {
+      throw new Error("Subagent connection changed; reconnect its parent session.");
+    }
+    const { thread } = await client.request(
+      "thread/read",
+      { threadId, includeTurns: false },
+      { assertCurrent },
+    );
+    assertCurrent();
+    if (thread.id !== threadId || threadId === binding.threadId) {
+      throw new Error("Subagent transcript does not belong to this parent session.");
+    }
+    // Nested children share the OpenClaw requester, but native lineage records their immediate parent.
+    const visited = new Set([threadId]);
+    let ancestor = thread;
+    for (;;) {
+      const parentId = parentThreadId(ancestor);
+      if (parentId === binding.threadId) {
+        break;
+      }
+      if (!parentId || visited.has(parentId) || visited.size >= MAX_SUBAGENT_ANCESTRY_READS) {
+        throw new Error("Subagent transcript does not belong to this parent session.");
+      }
+      visited.add(parentId);
+      const response = await client.request(
+        "thread/read",
+        { threadId: parentId, includeTurns: false },
+        { assertCurrent },
+      );
+      assertCurrent();
+      if (response.thread.id !== parentId) {
+        throw new Error("Subagent transcript does not belong to this parent session.");
+      }
+      ancestor = response.thread;
+    }
+    const page = await readCodexThreadHistoryPage(
+      {
+        listItemPage: async (request) => {
+          assertCurrent();
+          const result = await client.request("thread/items/list", request, { assertCurrent });
+          assertCurrent();
+          return result;
+        },
+        listTurnPage: async (request) => {
+          assertCurrent();
+          const result = await client.request("thread/turns/list", request, { assertCurrent });
+          assertCurrent();
+          return result;
+        },
+      },
+      thread,
+      {
+        threadId,
+        cursor: params.cursor,
+        // One tool item can yield both a call and a result; keep both on the same page.
+        limit: Math.max(1, Math.floor(Math.min(params.limit, 200) / 2)),
+      },
+      {
+        project: (entries) => entries.map((entry) => projectCodexThreadHistoryItem(thread, entry)),
+        fits: (result) => Buffer.byteLength(JSON.stringify(result), "utf8") <= 512 * 1024,
+      },
+    );
+    assertCurrent();
+    return {
+      messages: page.items.toReversed().flat(),
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+    };
+  } finally {
+    releaseLeasedSharedCodexAppServerClient(client);
+  }
+}

--- a/extensions/codex/src/app-server/native-subagent-history.ts
+++ b/extensions/codex/src/app-server/native-subagent-history.ts
@@ -2,6 +2,7 @@ import type { AgentHarnessV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
+import { itemToolArgs, itemTranscriptResultText } from "./event-projector-tool-items.js";
 import {
   CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
   CODEX_NATIVE_SUBAGENT_TASK_KIND,
@@ -22,6 +23,7 @@ import { projectCodexThreadHistoryItem } from "./transcript-history-projection.j
 
 type TaskHistoryParams = Parameters<NonNullable<AgentHarnessV2["taskHistory"]>["read"]>[0];
 const MAX_SUBAGENT_ANCESTRY_READS = 32;
+const taskHistoryToolItems = { itemToolArgs, itemTranscriptResultText };
 
 function parentThreadId(thread: CodexThread): string | undefined {
   const source = thread.source;
@@ -173,7 +175,10 @@ export async function readCodexNativeSubagentHistory(
         limit: Math.max(1, Math.floor(Math.min(params.limit, 200) / 2)),
       },
       {
-        project: (entries) => entries.map((entry) => projectCodexThreadHistoryItem(thread, entry)),
+        project: (entries) =>
+          entries.map((entry) =>
+            projectCodexThreadHistoryItem(thread, entry, taskHistoryToolItems),
+          ),
         fits: (result) => Buffer.byteLength(JSON.stringify(result), "utf8") <= 512 * 1024,
       },
     );

--- a/extensions/codex/src/app-server/native-subagent-monitor.live.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.live.test.ts
@@ -205,7 +205,7 @@ describeLive("codex native subagent monitor live", () => {
             scopeKind: "session",
             agentId: "live",
             runId: recoveryRunId,
-            label: "Codex subagent",
+            label: "Subagent",
             task: "live recovery probe",
             status: "running",
             deliveryStatus: "not_applicable",

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -893,7 +893,7 @@ describe("CodexNativeSubagentMonitor", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "codex-thread:child-thread",
-        progressSummary: "Codex native subagent is idle.",
+        progressSummary: "Subagent is idle.",
       }),
     );
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
@@ -954,7 +954,7 @@ describe("CodexNativeSubagentMonitor", () => {
     expect(runtime.createRunningTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "codex-thread:child-v2",
-        task: "Codex native subagent /root/researcher",
+        task: "Subagent /root/researcher",
       }),
     );
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
@@ -1802,7 +1802,7 @@ describe("CodexNativeSubagentMonitor", () => {
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
           statusLabel: "completed_without_final_message",
-          result: "Codex native subagent completed without a final assistant message.",
+          result: "Subagent completed without a final assistant message.",
         }),
       );
       client.close();
@@ -2101,7 +2101,7 @@ describe("CodexNativeSubagentMonitor", () => {
       expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
           status: "failed",
-          result: "Codex app-server reported a system error for the native subagent thread.",
+          result: "Subagent runtime reported a system error.",
         }),
       );
       expect(releaseClient).toHaveBeenCalledTimes(1);

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -485,7 +485,7 @@ class Monitor {
     this.clearPendingDirectSpawnEvidenceForParent(parentThreadId);
     for (const childState of Array.from(this.childStates.values())) {
       if (childState.parentThreadId === parentThreadId) {
-        this.retireChild(state, childState, "Codex native subagent parent session ended.");
+        this.retireChild(state, childState, "Subagent parent session ended.");
       }
     }
     if (this.parentStates.get(parentThreadId) === state) {
@@ -968,7 +968,7 @@ class Monitor {
         continue;
       }
       if (childState) {
-        this.retireChild(state, childState, "Codex native subagent was closed.");
+        this.retireChild(state, childState, "Subagent was closed.");
       } else {
         this.updateChildThreadOwnership("release", childThreadId, this.releaseChildThread);
       }
@@ -1276,8 +1276,8 @@ class Monitor {
         childSessionKey: codexNativeSubagentRunId(completion.childThreadId),
         childSessionId: completion.childThreadId,
         announceId: `codex-native:${state.parentThreadId}:${completion.childThreadId}:${completion.status}`,
-        announceType: "Codex native subagent",
-        taskLabel: "Codex native subagent",
+        announceType: "Subagent",
+        taskLabel: "Subagent",
         status: completion.status,
         statusLabel: completion.statusLabel,
         result: completion.result,
@@ -2127,7 +2127,7 @@ function toChildTurnCompletion(
       childThreadId: childState.childThreadId,
       status: "succeeded",
       statusLabel: result ? "turn_completed" : "completed_without_final_message",
-      result: result ?? "Codex native subagent completed without a final assistant message.",
+      result: result ?? "Subagent completed without a final assistant message.",
     };
   }
   if (status === "failed") {
@@ -2135,7 +2135,7 @@ function toChildTurnCompletion(
       childThreadId: childState.childThreadId,
       status: "failed",
       statusLabel: "turn_failed",
-      result: readTurnErrorMessage(turn) ?? "Codex native subagent failed.",
+      result: readTurnErrorMessage(turn) ?? "Subagent failed.",
     };
   }
   return undefined;
@@ -2172,7 +2172,7 @@ function systemErrorFallbackCompletion(childThreadId: string): RecoveredCompleti
     childThreadId,
     status: "failed",
     statusLabel: "system_error",
-    result: "Codex app-server reported a system error for the native subagent thread.",
+    result: "Subagent runtime reported a system error.",
   };
 }
 
@@ -2193,7 +2193,7 @@ function readTurnCompletion(
       childThreadId,
       status: "succeeded",
       statusLabel: result ? "task_complete" : "completed_without_final_message",
-      result: result ?? "Codex native subagent completed without a final assistant message.",
+      result: result ?? "Subagent completed without a final assistant message.",
       completedAt,
     };
   }
@@ -2207,7 +2207,7 @@ function readTurnCompletion(
       childThreadId,
       status: "failed",
       statusLabel: "task_failed",
-      result: readTurnErrorMessage(turn) ?? result ?? "Codex native subagent failed.",
+      result: readTurnErrorMessage(turn) ?? result ?? "Subagent failed.",
       completedAt,
     };
   }

--- a/extensions/codex/src/app-server/native-subagent-notification.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.test.ts
@@ -99,13 +99,13 @@ describe("Codex native subagent notifications", () => {
         agentPath: "null-child",
         status: "succeeded",
         statusLabel: "completed_without_final_message",
-        result: "Codex native subagent completed without a final assistant message.",
+        result: "Subagent completed without a final assistant message.",
       },
       {
         agentPath: "empty-child",
         status: "succeeded",
         statusLabel: "completed_without_final_message",
-        result: "Codex native subagent completed without a final assistant message.",
+        result: "Subagent completed without a final assistant message.",
       },
     ]);
   });

--- a/extensions/codex/src/app-server/native-subagent-notification.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.ts
@@ -224,7 +224,7 @@ function completedWithoutFinalAssistantMessage(): {
   kind: "no_final_assistant_message";
 } {
   return {
-    text: "Codex native subagent completed without a final assistant message.",
+    text: "Subagent completed without a final assistant message.",
     kind: "no_final_assistant_message",
   };
 }

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -61,7 +61,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
       preferMetadata: true,
       startedAt: 10_000,
       lastEventAt: 20_000,
-      progressSummary: "Codex native subagent started.",
+      progressSummary: "Subagent started.",
     });
     expect(vi.mocked(runtime.tryCreateRunningTaskRun).mock.calls[0]?.[0]).not.toHaveProperty(
       "childSessionKey",
@@ -69,7 +69,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       lastEventAt: 20_000,
-      progressSummary: "Codex native subagent is active.",
+      progressSummary: "Subagent is active.",
     });
   });
 
@@ -203,7 +203,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: codexNativeSubagentRunId("child-thread"),
       lastEventAt: 30_000,
-      progressSummary: "Codex native subagent is idle.",
+      progressSummary: "Subagent is idle.",
     });
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
@@ -211,9 +211,9 @@ describe("CodexNativeSubagentTaskMirror", () => {
       status: "failed",
       endedAt: 30_000,
       lastEventAt: 30_000,
-      error: "Codex app-server reported a system error for the native subagent thread.",
-      progressSummary: "Codex native subagent hit a system error.",
-      terminalSummary: "Codex native subagent failed.",
+      error: "Subagent encountered a system error.",
+      progressSummary: "Subagent hit a system error.",
+      terminalSummary: "Subagent failed.",
     });
   });
 
@@ -255,17 +255,17 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenNthCalledWith(1, {
       runId: codexNativeSubagentRunId("child-thread"),
       lastEventAt: 35_000,
-      progressSummary: "Codex native subagent is idle.",
+      progressSummary: "Subagent is idle.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenNthCalledWith(2, {
       runId: codexNativeSubagentRunId("child-thread"),
       lastEventAt: 35_000,
-      progressSummary: "Codex native subagent hit a system error; awaiting recovery.",
+      progressSummary: "Subagent hit a system error; awaiting recovery.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenNthCalledWith(3, {
       runId: codexNativeSubagentRunId("child-thread"),
       lastEventAt: 35_000,
-      progressSummary: "Codex native subagent is active.",
+      progressSummary: "Subagent is active.",
     });
   });
 
@@ -319,14 +319,14 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.tryCreateRunningTaskRun).toHaveBeenCalledWith({
       sourceId: "codex-thread:child-thread",
       runId: "codex-thread:child-thread",
-      label: "Codex subagent",
+      label: "Subagent",
       task: "write the proof file",
       notifyPolicy: "silent",
       deliveryStatus: "not_applicable",
       preferMetadata: true,
       startedAt: 40_000,
       lastEventAt: 40_000,
-      progressSummary: "Codex native subagent spawned.",
+      progressSummary: "Subagent spawned.",
     });
     expect(vi.mocked(runtime.tryCreateRunningTaskRun).mock.calls[0]?.[0]).not.toHaveProperty(
       "childSessionKey",
@@ -334,7 +334,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       lastEventAt: 40_000,
-      progressSummary: "Codex native subagent is initializing.",
+      progressSummary: "Subagent is initializing.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
@@ -392,24 +392,24 @@ describe("CodexNativeSubagentTaskMirror", () => {
       sourceId: "codex-thread:child-v2",
       agentId: "main",
       runId: "codex-thread:child-v2",
-      label: "Codex subagent",
-      task: "Codex native subagent /root/researcher",
+      label: "Subagent",
+      task: "Subagent /root/researcher",
       notifyPolicy: "silent",
       deliveryStatus: "not_applicable",
       preferMetadata: true,
       startedAt: 41_000,
       lastEventAt: 41_000,
-      progressSummary: "Codex native subagent started.",
+      progressSummary: "Subagent started.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-v2",
       lastEventAt: 41_000,
-      progressSummary: "Codex native subagent received more input.",
+      progressSummary: "Subagent received more input.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-v2",
       lastEventAt: 41_000,
-      progressSummary: "Codex native subagent was interrupted.",
+      progressSummary: "Subagent was interrupted.",
     });
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
@@ -571,7 +571,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       lastEventAt: 46_000,
-      progressSummary: "Codex native subagent is initializing.",
+      progressSummary: "Subagent is initializing.",
     });
     expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
   });
@@ -746,7 +746,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       lastEventAt: 55_000,
-      progressSummary: "Codex native subagent is idle.",
+      progressSummary: "Subagent is idle.",
     });
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
@@ -809,7 +809,7 @@ describe("CodexNativeSubagentTaskMirror", () => {
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",
       lastEventAt: 60_000,
-      progressSummary: "Codex native subagent is initializing.",
+      progressSummary: "Subagent is initializing.",
     });
     expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
       runId: "codex-thread:child-thread",

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -109,10 +109,10 @@ export class CodexNativeSubagentTaskMirror {
       normalizeOptionalString(thread.agentNickname) ??
       normalizeOptionalString(spawn.agent_role) ??
       normalizeOptionalString(thread.agentRole) ??
-      "Codex subagent";
+      "Subagent";
     const task =
       normalizeOptionalString(thread.preview) ??
-      `Codex native subagent${label === "Codex subagent" ? "" : ` ${label}`}`;
+      `Subagent${label === "Subagent" ? "" : ` ${label}`}`;
     const createdAt = secondsToMillis(thread.createdAt) ?? this.now();
     if (
       !this.createRunningTask({
@@ -120,7 +120,7 @@ export class CodexNativeSubagentTaskMirror {
         label,
         task,
         startedAt: createdAt,
-        progressSummary: "Codex native subagent started.",
+        progressSummary: "Subagent started.",
       })
     ) {
       return;
@@ -156,7 +156,7 @@ export class CodexNativeSubagentTaskMirror {
       this.runtime.recordTaskRunProgressByRunId({
         runId,
         lastEventAt: eventAt,
-        progressSummary: "Codex native subagent is active.",
+        progressSummary: "Subagent is active.",
       });
       return;
     }
@@ -164,7 +164,7 @@ export class CodexNativeSubagentTaskMirror {
       this.runtime.recordTaskRunProgressByRunId({
         runId,
         lastEventAt: eventAt,
-        progressSummary: "Codex native subagent is idle.",
+        progressSummary: "Subagent is idle.",
       });
       return;
     }
@@ -174,7 +174,7 @@ export class CodexNativeSubagentTaskMirror {
         this.runtime.recordTaskRunProgressByRunId({
           runId,
           lastEventAt: eventAt,
-          progressSummary: "Codex native subagent hit a system error; awaiting recovery.",
+          progressSummary: "Subagent hit a system error; awaiting recovery.",
         });
         return;
       }
@@ -184,9 +184,9 @@ export class CodexNativeSubagentTaskMirror {
         status: "failed",
         endedAt: eventAt,
         lastEventAt: eventAt,
-        error: "Codex app-server reported a system error for the native subagent thread.",
-        progressSummary: "Codex native subagent hit a system error.",
-        terminalSummary: "Codex native subagent failed.",
+        error: "Subagent encountered a system error.",
+        progressSummary: "Subagent hit a system error.",
+        terminalSummary: "Subagent failed.",
       });
       return;
     }
@@ -194,7 +194,7 @@ export class CodexNativeSubagentTaskMirror {
       this.runtime.recordTaskRunProgressByRunId({
         runId,
         lastEventAt: eventAt,
-        progressSummary: "Codex native subagent is not loaded.",
+        progressSummary: "Subagent is not loaded.",
       });
     }
   }
@@ -277,9 +277,7 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const message =
-      kind === "interacted"
-        ? "Codex native subagent received more input."
-        : "Codex native subagent was interrupted.";
+      kind === "interacted" ? "Subagent received more input." : "Subagent was interrupted.";
     this.applyCollabAgentStatus(
       threadId,
       kind === "interacted" ? "running" : "interrupted",
@@ -291,10 +289,10 @@ export class CodexNativeSubagentTaskMirror {
     const eventAt = this.now();
     this.createRunningTask({
       threadId,
-      label: "Codex subagent",
-      task: agentPath ? `Codex native subagent ${agentPath}` : "Codex native subagent",
+      label: "Subagent",
+      task: agentPath ? `Subagent ${agentPath}` : "Subagent",
       startedAt: eventAt,
-      progressSummary: "Codex native subagent started.",
+      progressSummary: "Subagent started.",
     });
   }
 
@@ -303,10 +301,10 @@ export class CodexNativeSubagentTaskMirror {
     const createdAt = this.now();
     this.createRunningTask({
       threadId,
-      label: "Codex subagent",
-      task: prompt ?? "Codex native subagent",
+      label: "Subagent",
+      task: prompt ?? "Subagent",
       startedAt: createdAt,
-      progressSummary: "Codex native subagent spawned.",
+      progressSummary: "Subagent spawned.",
     });
   }
 
@@ -374,16 +372,16 @@ export class CodexNativeSubagentTaskMirror {
         progressSummary:
           normalizeOptionalString(message) ??
           (normalizedStatus === "pendingInit"
-            ? "Codex native subagent is initializing."
+            ? "Subagent is initializing."
             : normalizedStatus === "interrupted"
-              ? "Codex native subagent was interrupted."
-              : "Codex native subagent is running."),
+              ? "Subagent was interrupted."
+              : "Subagent is running."),
       });
       return;
     }
     if (normalizedStatus === "completed") {
       this.terminalRunIds.add(runId);
-      const summary = normalizeOptionalString(message) ?? "Codex native subagent completed.";
+      const summary = normalizeOptionalString(message) ?? "Subagent completed.";
       if (this.expectedAuthoritativeRunIds.has(runId)) {
         this.runtime.recordTaskRunProgressByRunId({
           runId,
@@ -411,8 +409,8 @@ export class CodexNativeSubagentTaskMirror {
         status: "succeeded",
         endedAt: eventAt,
         lastEventAt: eventAt,
-        progressSummary: normalizeOptionalString(message) ?? "Codex native subagent blocked.",
-        terminalSummary: normalizeOptionalString(message) ?? "Codex native subagent blocked.",
+        progressSummary: normalizeOptionalString(message) ?? "Subagent blocked.",
+        terminalSummary: normalizeOptionalString(message) ?? "Subagent blocked.",
         terminalOutcome: "blocked",
       });
       return;
@@ -423,12 +421,9 @@ export class CodexNativeSubagentTaskMirror {
       status: normalizedStatus === "shutdown" ? "cancelled" : "failed",
       endedAt: eventAt,
       lastEventAt: eventAt,
-      error:
-        normalizeOptionalString(message) ?? `Codex native subagent status: ${normalizedStatus}`,
-      progressSummary:
-        normalizeOptionalString(message) ?? `Codex native subagent ${normalizedStatus}.`,
-      terminalSummary:
-        normalizeOptionalString(message) ?? "Codex native subagent did not complete.",
+      error: normalizeOptionalString(message) ?? `Subagent status: ${normalizedStatus}`,
+      progressSummary: normalizeOptionalString(message) ?? `Subagent ${normalizedStatus}.`,
+      terminalSummary: normalizeOptionalString(message) ?? "Subagent did not complete.",
     });
   }
 }

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -456,6 +456,7 @@ export type CodexTurn = {
 export type CodexThread = {
   id: string;
   forkedFromId?: string | null;
+  parentThreadId?: string | null;
   sessionId?: string;
   path?: string | null;
   projectId: string | null;

--- a/extensions/codex/src/app-server/thread-history-page.ts
+++ b/extensions/codex/src/app-server/thread-history-page.ts
@@ -1,0 +1,154 @@
+import {
+  CatalogParamsError,
+  parseTranscriptPage,
+  readControlCursor,
+} from "../session-catalog-parsing.js";
+import type {
+  CodexThread,
+  CodexThreadItem,
+  CodexThreadItemsListParams,
+  CodexThreadItemsListResponse,
+  CodexThreadTurnsListParams,
+  CodexThreadTurnsListResponse,
+  CodexTurn,
+} from "./protocol.js";
+
+export type CodexHistoryItemEntry = {
+  turnId: string;
+  item: CodexThreadItem;
+  turn?: Omit<CodexTurn, "items">;
+};
+export type CodexHistoryPageRequest = { threadId: string; cursor?: string; limit: number };
+export type CodexHistoryPage<T> = { items: T[]; nextCursor?: string };
+type HistoryReader = {
+  listTurnPage(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
+  listItemPage(params: CodexThreadItemsListParams): Promise<CodexThreadItemsListResponse>;
+};
+type HistoryProjection<T> = {
+  project(entries: CodexHistoryItemEntry[], limit: number): T[];
+  fits(page: CodexHistoryPage<T>): boolean;
+};
+const TURN_ITEM_CURSOR_PREFIX = "turn-item:";
+
+function encodeTurnItemCursor(turnCursor: string, itemId: string): string {
+  return (
+    TURN_ITEM_CURSOR_PREFIX +
+    Buffer.from(JSON.stringify([turnCursor, itemId])).toString("base64url")
+  );
+}
+
+function decodeTurnItemCursor(cursor?: string): { turnCursor?: string; itemId?: string } {
+  if (!cursor?.startsWith(TURN_ITEM_CURSOR_PREFIX)) {
+    return { turnCursor: cursor };
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(
+      Buffer.from(cursor.slice(TURN_ITEM_CURSOR_PREFIX.length), "base64url").toString(),
+    );
+  } catch {
+    throw new CatalogParamsError("invalid Codex transcript item cursor");
+  }
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    typeof value[0] !== "string" ||
+    !value[0] ||
+    typeof value[1] !== "string" ||
+    !value[1]
+  ) {
+    throw new CatalogParamsError("invalid Codex transcript item cursor");
+  }
+  return { turnCursor: value[0], itemId: value[1] };
+}
+
+/** Legacy stores expose only turn cursors; an item identity preserves paging across appends. */
+export async function readLegacyCodexHistoryPage<T>(
+  readTurns: (
+    params: CodexHistoryPageRequest & { sortDirection: "desc"; itemsView: "full" },
+  ) => Promise<CodexThreadTurnsListResponse>,
+  request: CodexHistoryPageRequest,
+  projection: HistoryProjection<T>,
+): Promise<CodexHistoryPage<T>> {
+  const { turnCursor, itemId } = decodeTurnItemCursor(request.cursor);
+  const page = parseTranscriptPage(
+    await readTurns({
+      threadId: request.threadId,
+      limit: 1,
+      sortDirection: "desc",
+      itemsView: "full",
+      ...(turnCursor ? { cursor: turnCursor } : {}),
+    }),
+  );
+  const source = page.data.flatMap(({ items, ...turn }) =>
+    items.toReversed().map((item) => ({ turnId: turn.id, item, turn })),
+  );
+  const anchorIndex = itemId ? source.findIndex(({ item }) => item.id === itemId) : -1;
+  if (itemId && anchorIndex < 0) {
+    throw new CatalogParamsError(
+      "Codex transcript changed; refresh the session before loading older items",
+    );
+  }
+  const remaining = source.slice(anchorIndex + 1);
+  const items = projection.project(remaining.slice(0, request.limit), request.limit);
+  const result = (): CodexHistoryPage<T> => {
+    const lastSource = remaining[items.length - 1];
+    const partial = lastSource !== undefined && items.length < remaining.length;
+    const nativeCursor = partial ? page.backwardsCursor : page.nextCursor;
+    const cursor = nativeCursor
+      ? partial
+        ? encodeTurnItemCursor(nativeCursor, lastSource.item.id)
+        : nativeCursor
+      : undefined;
+    if (partial && !cursor) {
+      throw new Error("Codex app-server did not provide a transcript continuation anchor");
+    }
+    return { items, ...(cursor ? { nextCursor: cursor } : {}) };
+  };
+  let bounded = result();
+  while (!projection.fits(bounded)) {
+    if (items.length <= 1) {
+      throw new Error("Codex transcript item exceeds the safe response size");
+    }
+    items.pop();
+    bounded = result();
+  }
+  return bounded;
+}
+
+/** Callers authorize the thread; this reader owns native cursor and response-size semantics. */
+export async function readCodexThreadHistoryPage<T>(
+  control: HistoryReader,
+  thread: Pick<CodexThread, "historyMode">,
+  request: CodexHistoryPageRequest,
+  projection: HistoryProjection<T>,
+): Promise<CodexHistoryPage<T>> {
+  if (thread.historyMode !== "paginated") {
+    return readLegacyCodexHistoryPage(
+      (params) => control.listTurnPage(params),
+      request,
+      projection,
+    );
+  }
+  let limit = request.limit;
+  for (;;) {
+    const page = await control.listItemPage({
+      threadId: request.threadId,
+      limit,
+      sortDirection: "desc",
+      ...(request.cursor ? { cursor: request.cursor } : {}),
+    });
+    const nextCursor = readControlCursor(page.nextCursor, "transcript next response");
+    const items = projection.project(page.data, limit);
+    const result = { items, ...(nextCursor ? { nextCursor } : {}) };
+    const fittingCount = items.length - (projection.fits(result) ? 0 : 1);
+    if (fittingCount === page.data.length) {
+      return result;
+    }
+    if (fittingCount < 1) {
+      throw new Error("Codex transcript item exceeds the safe response size");
+    }
+    // The native cursor must describe exactly the delivered entries. Never slice and retain it.
+    limit = fittingCount;
+  }
+}

--- a/extensions/codex/src/app-server/transcript-history-projection.ts
+++ b/extensions/codex/src/app-server/transcript-history-projection.ts
@@ -4,7 +4,10 @@ import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
-import type { CodexThread, JsonValue } from "./protocol.js";
+import { auditNativeToolName, itemName, itemStatus } from "./event-projector-items.js";
+import { itemToolArgs, itemTranscriptResultText } from "./event-projector-tool-items.js";
+import type { CodexThread, CodexTurn, JsonValue } from "./protocol.js";
+import type { CodexHistoryItemEntry } from "./thread-history-page.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 
 const CODEX_HISTORY_IMPORT_MAX_MESSAGES = 200;
@@ -114,7 +117,7 @@ function selectTurnsThroughBoundary(
 
 function projectCodexThreadHistory(params: {
   thread: CodexThread;
-  throughTurnId: string | null;
+  turns: CodexTurn[];
   importedAt: number;
   modelProvider?: string;
 }): ProjectedCodexHistoryMessage[] {
@@ -124,7 +127,7 @@ function projectCodexThreadHistory(params: {
       ? params.thread.createdAt * 1000
       : params.importedAt;
   let itemOffset = 0;
-  for (const turn of selectTurnsThroughBoundary(params.thread, params.throughTurnId)) {
+  for (const turn of params.turns) {
     for (const value of turn.items) {
       const item = value;
       const itemId = normalizeOptionalString(item.id);
@@ -236,7 +239,7 @@ export function projectBoundedCodexThreadHistory(params: {
 }): BoundedCodexThreadHistoryProjection {
   const projected = projectCodexThreadHistory({
     thread: params.thread,
-    throughTurnId: params.throughTurnId,
+    turns: selectTurnsThroughBoundary(params.thread, params.throughTurnId),
     importedAt: params.importedAt,
     ...(params.modelProvider ? { modelProvider: params.modelProvider } : {}),
   });
@@ -309,4 +312,76 @@ export function projectBoundedCodexVisibleSessionHistory(
     });
   }
   return selectBoundedCodexHistoryTail(projected).map(({ responseItem }) => responseItem);
+}
+
+/** Displays native items through the shared transcript roles, including an unfinished turn. */
+export function projectCodexThreadHistoryItem(
+  thread: CodexThread,
+  entry: CodexHistoryItemEntry,
+): AgentMessage[] {
+  const { item } = entry;
+  const timestamp = (entry.turn?.startedAt ?? thread.createdAt ?? 0) * 1000;
+  if (item.type === "userMessage" || item.type === "agentMessage") {
+    return projectCodexThreadHistory({
+      thread,
+      turns: [{ ...entry.turn, id: entry.turnId, items: [item] }],
+      importedAt: timestamp,
+    }).map(({ message }) => message);
+  }
+  const identity = `${entry.turnId}:${item.id}`;
+  const assistant = (content: AssistantMessage["content"], toolUse = false): AssistantMessage =>
+    attachCodexMirrorIdentity(
+      {
+        role: "assistant",
+        content,
+        api: CODEX_HISTORY_ASSISTANT_API,
+        provider: normalizeOptionalString(thread.modelProvider) ?? CODEX_HISTORY_ASSISTANT_PROVIDER,
+        model: CODEX_HISTORY_ASSISTANT_MODEL,
+        usage: CODEX_HISTORY_ZERO_USAGE,
+        stopReason: toolUse ? "toolUse" : "stop",
+        timestamp,
+      },
+      identity,
+    );
+  if (item.type === "reasoning") {
+    const parts =
+      Array.isArray(item.summary) && item.summary.length > 0 ? item.summary : item.content;
+    const thinking = normalizeImportedHistoryText(
+      Array.isArray(parts)
+        ? parts.filter((part) => typeof part === "string").join("\n")
+        : item.text,
+    );
+    return thinking ? [assistant([{ type: "thinking", thinking }])] : [];
+  }
+  if (item.type === "contextCompaction") {
+    return [assistant([{ type: "text", text: "Context compacted." }])];
+  }
+  const toolName = itemName(item) ?? auditNativeToolName(item);
+  if (!toolName) {
+    const text = normalizeImportedHistoryText(item.text ?? item.title);
+    return text ? [assistant([{ type: "text", text }])] : [];
+  }
+  const messages: AgentMessage[] = [
+    assistant(
+      [{ type: "toolCall", id: item.id, name: toolName, arguments: itemToolArgs(item) ?? {} }],
+      true,
+    ),
+  ];
+  const status = itemStatus(item);
+  if (status !== "running") {
+    messages.push(
+      attachCodexMirrorIdentity(
+        {
+          role: "toolResult",
+          toolCallId: item.id,
+          toolName,
+          content: [{ type: "text", text: itemTranscriptResultText(item) ?? status }],
+          isError: status === "failed" || status === "blocked",
+          timestamp,
+        },
+        `${identity}:result`,
+      ),
+    );
+  }
+  return messages;
 }

--- a/extensions/codex/src/app-server/transcript-history-projection.ts
+++ b/extensions/codex/src/app-server/transcript-history-projection.ts
@@ -5,7 +5,6 @@ import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
 import { auditNativeToolName, itemName, itemStatus } from "./event-projector-items.js";
-import { itemToolArgs, itemTranscriptResultText } from "./event-projector-tool-items.js";
 import type { CodexThread, CodexTurn, JsonValue } from "./protocol.js";
 import type { CodexHistoryItemEntry } from "./thread-history-page.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
@@ -318,6 +317,11 @@ export function projectBoundedCodexVisibleSessionHistory(
 export function projectCodexThreadHistoryItem(
   thread: CodexThread,
   entry: CodexHistoryItemEntry,
+  // Catalog registration shares this module; only the lazy history reader loads tool runtime.
+  toolItems: Pick<
+    typeof import("./event-projector-tool-items.js"),
+    "itemToolArgs" | "itemTranscriptResultText"
+  >,
 ): AgentMessage[] {
   const { item } = entry;
   const timestamp = (entry.turn?.startedAt ?? thread.createdAt ?? 0) * 1000;
@@ -363,7 +367,14 @@ export function projectCodexThreadHistoryItem(
   }
   const messages: AgentMessage[] = [
     assistant(
-      [{ type: "toolCall", id: item.id, name: toolName, arguments: itemToolArgs(item) ?? {} }],
+      [
+        {
+          type: "toolCall",
+          id: item.id,
+          name: toolName,
+          arguments: toolItems.itemToolArgs(item) ?? {},
+        },
+      ],
       true,
     ),
   ];
@@ -375,7 +386,7 @@ export function projectCodexThreadHistoryItem(
           role: "toolResult",
           toolCallId: item.id,
           toolName,
-          content: [{ type: "text", text: itemTranscriptResultText(item) ?? status }],
+          content: [{ type: "text", text: toolItems.itemTranscriptResultText(item) ?? status }],
           isError: status === "failed" || status === "blocked",
           timestamp,
         },

--- a/extensions/codex/src/session-catalog-transcript.ts
+++ b/extensions/codex/src/session-catalog-transcript.ts
@@ -1,22 +1,18 @@
 import type { SessionCatalogTranscriptItem } from "openclaw/plugin-sdk/session-catalog";
 import { sessionCatalogPaging } from "openclaw/plugin-sdk/session-catalog-paging";
 import { z } from "zod";
-import type { CodexThreadItem, CodexThreadTurnsListResponse } from "./app-server/protocol.js";
+import type { CodexThreadItem } from "./app-server/protocol.js";
 import {
-  CatalogParamsError,
-  MAX_TRANSCRIPT_PAGE_BYTES,
-  parseTranscriptPage,
-  readControlCursor,
-} from "./session-catalog-parsing.js";
+  readCodexThreadHistoryPage,
+  readLegacyCodexHistoryPage,
+} from "./app-server/thread-history-page.js";
+import { MAX_TRANSCRIPT_PAGE_BYTES } from "./session-catalog-parsing.js";
 import { toGenericTranscriptItem } from "./session-catalog-transcript-item.js";
 import type { CodexSessionCatalogControl } from "./session-catalog-types.js";
 
 type TranscriptRequest = { threadId: string; cursor?: string; limit: number };
 type TranscriptPage = { items: SessionCatalogTranscriptItem[]; nextCursor?: string };
-type ReadTurns = (
-  params: TranscriptRequest & { sortDirection: "desc"; itemsView: "full" },
-) => Promise<CodexThreadTurnsListResponse>;
-const TURN_ITEM_CURSOR_PREFIX = "turn-item:";
+type ReadTurns = Parameters<typeof readLegacyCodexHistoryPage>[0];
 const transcriptPageSchema = z.strictObject({
   items: z.array(
     z.strictObject({
@@ -32,38 +28,6 @@ const transcriptPageSchema = z.strictObject({
 
 export function parseCodexCatalogTranscriptPage(value: unknown): TranscriptPage {
   return transcriptPageSchema.parse(value);
-}
-
-function encodeTurnItemCursor(turnCursor: string, itemId: string): string {
-  return (
-    TURN_ITEM_CURSOR_PREFIX +
-    Buffer.from(JSON.stringify([turnCursor, itemId])).toString("base64url")
-  );
-}
-
-function decodeTurnItemCursor(cursor?: string): { turnCursor?: string; itemId?: string } {
-  if (!cursor?.startsWith(TURN_ITEM_CURSOR_PREFIX)) {
-    return { turnCursor: cursor };
-  }
-  let value: unknown;
-  try {
-    value = JSON.parse(
-      Buffer.from(cursor.slice(TURN_ITEM_CURSOR_PREFIX.length), "base64url").toString(),
-    );
-  } catch {
-    throw new CatalogParamsError("invalid Codex transcript item cursor");
-  }
-  if (
-    !Array.isArray(value) ||
-    value.length !== 2 ||
-    typeof value[0] !== "string" ||
-    !value[0] ||
-    typeof value[1] !== "string" ||
-    !value[1]
-  ) {
-    throw new CatalogParamsError("invalid Codex transcript item cursor");
-  }
-  return { turnCursor: value[0], itemId: value[1] };
 }
 
 function projectTranscriptPage(
@@ -94,50 +58,14 @@ export async function readLegacyCodexTranscriptPage(
   readTurns: ReadTurns,
   request: TranscriptRequest,
 ): Promise<TranscriptPage> {
-  const { turnCursor, itemId } = decodeTurnItemCursor(request.cursor);
-  const page = parseTranscriptPage(
-    await readTurns({
-      threadId: request.threadId,
-      limit: 1,
-      sortDirection: "desc",
-      itemsView: "full",
-      ...(turnCursor ? { cursor: turnCursor } : {}),
-    }),
-  );
-  const source = page.data.flatMap((turn) => turn.items.toReversed());
-  // Appends can shift a turn's newest-relative offsets. The delivered item is the
-  // stable boundary, so later pages neither replay it nor skip older items.
-  const anchorIndex = itemId ? source.findIndex((item) => item.id === itemId) : -1;
-  if (itemId && anchorIndex < 0) {
-    throw new CatalogParamsError(
-      "Codex transcript changed; refresh the session before loading older items",
-    );
-  }
-  const remaining = source.slice(anchorIndex + 1);
-  const items = projectTranscriptPage(remaining, request.limit);
-  const result = (): TranscriptPage => {
-    const lastSource = remaining[items.length - 1];
-    const partial = lastSource !== undefined && items.length < remaining.length;
-    const nativeCursor = partial ? page.backwardsCursor : page.nextCursor;
-    const cursor = nativeCursor
-      ? partial
-        ? encodeTurnItemCursor(nativeCursor, lastSource.id)
-        : nativeCursor
-      : undefined;
-    if (partial && !cursor) {
-      throw new Error("Codex app-server did not provide a transcript continuation anchor");
-    }
-    return { items, ...(cursor ? { nextCursor: cursor } : {}) };
-  };
-  let bounded = result();
-  while (!pageFitsNodeTransport(bounded)) {
-    if (items.length <= 1) {
-      throw new Error("Codex transcript item exceeds the safe response size");
-    }
-    items.pop();
-    bounded = result();
-  }
-  return bounded;
+  return readLegacyCodexHistoryPage(readTurns, request, {
+    project: (entries, limit) =>
+      projectTranscriptPage(
+        entries.map(({ item }) => item),
+        limit,
+      ),
+    fits: pageFitsNodeTransport,
+  });
 }
 
 /** Uses the native store's item cursor whenever that store supports item history. */
@@ -146,32 +74,12 @@ export async function readCodexCatalogTranscriptPage(
   request: TranscriptRequest,
 ): Promise<TranscriptPage> {
   const thread = await control.requireEligibleThread(request.threadId);
-  if (thread.historyMode !== "paginated") {
-    return readLegacyCodexTranscriptPage((params) => control.listTurnPage(params), request);
-  }
-  let limit = request.limit;
-  for (;;) {
-    const page = await control.listItemPage({
-      threadId: request.threadId,
-      limit,
-      sortDirection: "desc",
-      ...(request.cursor ? { cursor: request.cursor } : {}),
-    });
-    const nextCursor = readControlCursor(page.nextCursor, "transcript next response");
-    const items = projectTranscriptPage(
-      page.data.map(({ item }) => item),
-      limit,
-    );
-    const result = { items, ...(nextCursor ? { nextCursor } : {}) };
-    const fittingCount = items.length - (pageFitsNodeTransport(result) ? 0 : 1);
-    if (fittingCount === page.data.length) {
-      return result;
-    }
-    if (fittingCount < 1) {
-      throw new Error("Codex transcript item exceeds the safe response size");
-    }
-    // Re-read the same anchor with a strictly smaller count. The returned native cursor
-    // must describe exactly the items sent; slicing while retaining it would skip history.
-    limit = fittingCount;
-  }
+  return readCodexThreadHistoryPage(control, thread, request, {
+    project: (entries, limit) =>
+      projectTranscriptPage(
+        entries.map(({ item }) => item),
+        limit,
+      ),
+    fits: pageFitsNodeTransport,
+  });
 }

--- a/extensions/copilot/src/native-subagent-task-mirror.test.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.test.ts
@@ -108,15 +108,15 @@ describe("CopilotNativeSubagentTaskMirror", () => {
       preferMetadata: true,
       startedAt: 100,
       lastEventAt: 100,
-      progressSummary: "Copilot native subagent started.",
+      progressSummary: "Subagent started.",
     });
     expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
       runId: "copilot-agent:child-1",
       status: "succeeded",
       endedAt: 100,
       lastEventAt: 100,
-      progressSummary: "Copilot native subagent completed.",
-      terminalSummary: "Copilot native subagent completed (2 tool calls, 30 tokens).",
+      progressSummary: "Subagent completed.",
+      terminalSummary: "Subagent completed (2 tool calls, 30 tokens).",
     });
   });
 
@@ -213,9 +213,9 @@ describe("CopilotNativeSubagentTaskMirror", () => {
       status: "cancelled",
       endedAt: 300,
       lastEventAt: 300,
-      error: "Copilot native subagent ended with its parent attempt.",
-      progressSummary: "Copilot native subagent cancelled with its parent attempt.",
-      terminalSummary: "Copilot native subagent cancelled.",
+      error: "Subagent ended with its parent attempt.",
+      progressSummary: "Subagent cancelled with its parent attempt.",
+      terminalSummary: "Subagent cancelled.",
     });
   });
 });

--- a/extensions/copilot/src/native-subagent-task-mirror.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.ts
@@ -80,9 +80,9 @@ class CopilotNativeSubagentTaskMirror {
         status: "cancelled",
         endedAt: eventAt,
         lastEventAt: eventAt,
-        error: "Copilot native subagent ended with its parent attempt.",
-        progressSummary: "Copilot native subagent cancelled with its parent attempt.",
-        terminalSummary: "Copilot native subagent cancelled.",
+        error: "Subagent ended with its parent attempt.",
+        progressSummary: "Subagent cancelled with its parent attempt.",
+        terminalSummary: "Subagent cancelled.",
       });
     }
     this.activeRunIds.clear();
@@ -102,19 +102,19 @@ class CopilotNativeSubagentTaskMirror {
     }
     const eventAt = this.now();
     const label = event.data.agentDisplayName.trim() || event.data.agentName.trim();
-    const task = event.data.agentDescription.trim() || `Copilot native subagent ${label}`;
+    const task = event.data.agentDescription.trim() || `Subagent ${label}`;
     const taskRecord = this.runtime.tryCreateRunningTaskRun({
       sourceId: toolCallId,
       agentId: this.params.agentId,
       runId,
-      label: label || "Copilot subagent",
+      label: label || "Subagent",
       task,
       notifyPolicy: "silent",
       deliveryStatus: "not_applicable",
       preferMetadata: true,
       startedAt: eventAt,
       lastEventAt: eventAt,
-      progressSummary: "Copilot native subagent started.",
+      progressSummary: "Subagent started.",
     });
     if (!taskRecord) {
       return;
@@ -143,7 +143,7 @@ class CopilotNativeSubagentTaskMirror {
       status: "succeeded",
       endedAt: eventAt,
       lastEventAt: eventAt,
-      progressSummary: "Copilot native subagent completed.",
+      progressSummary: "Subagent completed.",
       terminalSummary: buildCompletionSummary(event),
     });
   }
@@ -164,8 +164,8 @@ class CopilotNativeSubagentTaskMirror {
       endedAt: eventAt,
       lastEventAt: eventAt,
       error: event.data.error,
-      progressSummary: "Copilot native subagent failed.",
-      terminalSummary: "Copilot native subagent failed.",
+      progressSummary: "Subagent failed.",
+      terminalSummary: "Subagent failed.",
     });
   }
 
@@ -193,7 +193,5 @@ function buildCompletionSummary(
     event.data.totalToolCalls !== undefined ? `${event.data.totalToolCalls} tool calls` : undefined,
     event.data.totalTokens !== undefined ? `${event.data.totalTokens} tokens` : undefined,
   ].filter((value): value is string => value !== undefined);
-  return details.length > 0
-    ? `Copilot native subagent completed (${details.join(", ")}).`
-    : "Copilot native subagent completed.";
+  return details.length > 0 ? `Subagent completed (${details.join(", ")}).` : "Subagent completed.";
 }

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -223,9 +223,9 @@
     "properties": {}
   },
   "controlUi": {
-    "entry": "dist/control-ui/045246ad28fee377c4f2114901761aa38047053350e65f7cd6b238dabb5c764e/index.js",
+    "entry": "dist/control-ui/f1138a8b8713a4bdbda0187775eb49b557a9913ee4ed3ed658eda1adaa568584/index.js",
     "styles": [
-      "dist/control-ui/045246ad28fee377c4f2114901761aa38047053350e65f7cd6b238dabb5c764e/index.css"
+      "dist/control-ui/f1138a8b8713a4bdbda0187775eb49b557a9913ee4ed3ed658eda1adaa568584/index.css"
     ]
   }
 }

--- a/packages/gateway-protocol/src/public-schema.ts
+++ b/packages/gateway-protocol/src/public-schema.ts
@@ -353,6 +353,8 @@ export {
   TasksListResultSchema,
   TasksGetParamsSchema,
   TasksGetResultSchema,
+  TasksHistoryParamsSchema,
+  TasksHistoryResultSchema,
   TasksCancelParamsSchema,
   TasksCancelResultSchema,
   TasksRecoveryParamsSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-operations.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-operations.ts
@@ -89,6 +89,8 @@ export const OperationsProtocolSchemas = {
   TasksListResult: tasks.TasksListResultSchema,
   TasksGetParams: tasks.TasksGetParamsSchema,
   TasksGetResult: tasks.TasksGetResultSchema,
+  TasksHistoryParams: tasks.TasksHistoryParamsSchema,
+  TasksHistoryResult: tasks.TasksHistoryResultSchema,
   TasksCancelParams: tasks.TasksCancelParamsSchema,
   TasksCancelResult: tasks.TasksCancelResultSchema,
   TasksRecoveryParams: tasks.TasksRecoveryParamsSchema,

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -55,6 +55,7 @@ export const TaskSummarySchema = closedObject({
   agentId: Type.Optional(Type.String()),
   sessionKey: Type.Optional(Type.String()),
   childSessionKey: Type.Optional(Type.String()),
+  hasTranscript: Type.Optional(Type.Boolean()),
   ownerKey: Type.Optional(Type.String()),
   runId: Type.Optional(Type.String()),
   taskId: Type.Optional(Type.String()),
@@ -108,6 +109,18 @@ export const TasksGetResultSchema = closedObject({
   task: TaskSummarySchema,
 });
 
+/** Runtime-independent, bounded transcript pages in chronological order. */
+export const TasksHistoryParamsSchema = closedObject({
+  taskId: NonEmptyString,
+  cursor: Type.Optional(Type.String({ minLength: 1, maxLength: 8192 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+});
+
+export const TasksHistoryResultSchema = closedObject({
+  messages: Type.Array(Type.Unknown()),
+  nextCursor: Type.Optional(Type.String({ maxLength: 8192 })),
+});
+
 /** Cancel request for one task id with optional operator reason. */
 export const TasksCancelParamsSchema = closedObject({
   taskId: NonEmptyString,
@@ -145,6 +158,8 @@ export type TasksListParams = Static<typeof TasksListParamsSchema>;
 export type TasksListResult = Static<typeof TasksListResultSchema>;
 export type TasksGetParams = Static<typeof TasksGetParamsSchema>;
 export type TasksGetResult = Static<typeof TasksGetResultSchema>;
+export type TasksHistoryParams = Static<typeof TasksHistoryParamsSchema>;
+export type TasksHistoryResult = Static<typeof TasksHistoryResultSchema>;
 export type TasksCancelParams = Static<typeof TasksCancelParamsSchema>;
 export type TasksCancelResult = Static<typeof TasksCancelResultSchema>;
 export type TasksRecoveryParams = Static<typeof TasksRecoveryParamsSchema>;

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -117,6 +117,7 @@ export const TasksHistoryParamsSchema = closedObject({
 });
 
 export const TasksHistoryResultSchema = closedObject({
+  /** Stable messageId or __openclaw.id anchors refreshes; entry IDs can have sibling rows. */
   messages: Type.Array(Type.Unknown()),
   nextCursor: Type.Optional(Type.String({ maxLength: 8192 })),
 });

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -336,6 +336,7 @@ export const validateTaskSuggestionsAcceptParams = compile(S.TaskSuggestionsAcce
 export const validateTaskSuggestionsDismissParams = compile(S.TaskSuggestionsDismissParamsSchema);
 export const validateTasksListParams = compile(S.TasksListParamsSchema);
 export const validateTasksGetParams = compile(S.TasksGetParamsSchema);
+export const validateTasksHistoryParams = compile(S.TasksHistoryParamsSchema);
 export const validateTasksCancelParams = compile(S.TasksCancelParamsSchema);
 export const validateTasksRecoveryParams = compile(S.TasksRecoveryParamsSchema);
 export const validateConfigGetParams = compile(S.ConfigGetParamsSchema);

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -559,6 +559,23 @@ type AgentHarnessModelCatalogCapability = {
   ): { accountType: string } | undefined;
 };
 
+type AgentHarnessTaskHistoryCapability = {
+  /** Reads native task history without creating an OpenClaw child session. */
+  taskHistory?: {
+    taskKinds: readonly string[];
+    read(params: {
+      task: Readonly<import("../../tasks/task-registry.types.js").TaskRecord>;
+      cfg: OpenClawConfig;
+      cursor?: string;
+      limit: number;
+      /** Revalidate the task, requester access, and registered owner after awaited work. */
+      assertCurrent: () => void;
+    }): Promise<
+      import("../../../packages/gateway-protocol/src/schema/tasks.js").TasksHistoryResult
+    >;
+  };
+};
+
 /**
  * @deprecated Implement AgentHarnessV2. This registration contract remains
  * source-compatible for existing plugins through 2026-10-12.
@@ -573,6 +590,7 @@ export type AgentHarness = AgentHarnessRunCapability &
   AgentHarnessModelCatalogCapability &
   AgentHarnessMcpCatalogCapability &
   AgentHarnessSessionForkCapability &
+  AgentHarnessTaskHistoryCapability &
   AgentHarnessSessionLifecycleCapability;
 
 /** Current harness contract for hosts that always supply versioned capabilities. */
@@ -586,6 +604,7 @@ export type AgentHarnessV2 = AgentHarnessRunCapability<AgentHarnessAttemptParams
   AgentHarnessModelCatalogCapability &
   AgentHarnessMcpCatalogCapability &
   AgentHarnessSessionForkCapability &
+  AgentHarnessTaskHistoryCapability &
   AgentHarnessSessionLifecycleCapability;
 
 export type RegisteredAgentHarness = {

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -90,6 +90,7 @@ describe("method scope resolution", () => {
     ["users.setDisplayName", ["operator.write"]],
     ["users.setAvatar", ["operator.write"]],
     ["tasks.get", ["operator.read"]],
+    ["tasks.history", ["operator.read"]],
     ["taskSuggestions.list", ["operator.read"]],
     ["taskSuggestions.create", ["operator.write"]],
     ["taskSuggestions.accept", ["operator.admin"]],

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -658,6 +658,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["plugins.catalog.browse", "plugins", "operator.read", "2026.9"],
   ["plugins.catalog.categories", "plugins", "operator.read", "2026.9"],
   ["plugins.catalog.get", "plugins", "operator.read", "2026.9"],
+  ["tasks.history", "tasks", "operator.read", "2026.9"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -183,6 +183,7 @@ describe("listGatewayMethods", () => {
       "session.publicShare.set",
       "claws.monitors",
       ...pluginDiscoveryMethods,
+      "tasks.history",
     ];
     expect(listGatewayMethods().slice(-expectedSuffix.length)).toEqual(expectedSuffix);
     const methods = listGatewayMethods();
@@ -206,6 +207,7 @@ describe("listGatewayMethods", () => {
       "session.publicShare.set",
       "claws.monitors",
       ...pluginDiscoveryMethods,
+      "tasks.history",
     ]);
   });
 
@@ -356,6 +358,7 @@ describe("listGatewayMethods", () => {
       "session.publicShare.set",
       "claws.monitors",
       ...pluginDiscoveryMethods,
+      "tasks.history",
     ];
     expect(coreMethods.slice(-expectedCoreSuffix.length)).toEqual(expectedCoreSuffix);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));

--- a/src/gateway/server-methods/task-history.test.ts
+++ b/src/gateway/server-methods/task-history.test.ts
@@ -1,0 +1,260 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import type { TasksHistoryResult } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { registerAgentHarness } from "../../agents/harness/registry.js";
+import type { AgentHarness } from "../../agents/harness/types.js";
+import {
+  appendTranscriptMessage,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import { markTaskTerminalById } from "../../tasks/runtime-internal.js";
+import {
+  createTaskFixture,
+  resetTaskRegistryForTests,
+} from "../../tasks/task-registry.test-support.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { identifiedClient, runTaskHandler } from "./tasks.test-helpers.js";
+
+type ReadTaskHistory = NonNullable<AgentHarness["taskHistory"]>["read"];
+const requesterSessionKey = "agent:main:dashboard:task-parent";
+const readerConfig = {
+  gateway: {
+    roles: {
+      default: "reader",
+      definitions: {
+        reader: { agents: "*", scopes: ["operator.read"], sessions: { others: "none" } },
+      },
+    },
+  },
+} satisfies OpenClawConfig;
+
+function registerHistoryReader(read: ReadTaskHistory) {
+  registerAgentHarness({
+    id: "synthetic-history",
+    label: "Synthetic history",
+    supports: () => ({ supported: false }),
+    runAttempt: async () => {
+      throw new Error("History reads must not start an agent");
+    },
+    taskHistory: { taskKinds: ["synthetic-child"], read },
+  });
+}
+
+function createNativeTask(runId = "synthetic-child-1") {
+  return createTaskFixture("subagent", {
+    taskKind: "synthetic-child",
+    runId,
+    agentId: "main",
+    requesterAgentId: "main",
+    requesterSessionKey,
+    ownerKey: requesterSessionKey,
+    task: "Inspect synthetic files",
+  });
+}
+
+async function withHistoryState(run: () => Promise<void>) {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const registry = captureActivePluginRegistrySnapshot();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    resetTaskRegistryForTests();
+    try {
+      await run();
+    } finally {
+      resetTaskRegistryForTests();
+      restoreActivePluginRegistrySnapshot(registry);
+    }
+  });
+}
+
+async function createRequester(actorId: string, incognito = false) {
+  await upsertSessionEntryCore(
+    { agentId: "main", sessionKey: requesterSessionKey },
+    {
+      sessionId: "task-parent",
+      updatedAt: 1,
+      createdActor: { type: "human", source: "profile", id: actorId },
+      visibility: "shared",
+      ...(incognito ? { incognito: true } : {}),
+    },
+  );
+}
+
+describe("tasks.history", () => {
+  it("reads and pages a registered harness transcript without a child session", async () => {
+    await withHistoryState(async () => {
+      const older = { role: "user", content: "Inspect the files" };
+      const latest = { role: "assistant", content: "The files are consistent" };
+      const read = vi.fn<ReadTaskHistory>(async ({ cursor }) =>
+        cursor === undefined
+          ? { messages: [latest], nextCursor: "older-page" }
+          : { messages: [older] },
+      );
+      registerHistoryReader(read);
+      const task = createNativeTask();
+      expect(task.childSessionKey).toBeUndefined();
+      const summary = await runTaskHandler("tasks.get", { taskId: task.taskId });
+      expect(summary.payload?.task).toMatchObject({ hasTranscript: true });
+      const first = await runTaskHandler("tasks.history", { taskId: task.taskId, limit: 1 });
+      expect(first.calls[0]?.[0]).toBe(true);
+      expect(first.payload?.messages).toEqual([latest]);
+      const cursor = expectDefined(first.payload?.nextCursor, "older task history cursor");
+      const second = await runTaskHandler("tasks.history", {
+        taskId: task.taskId,
+        limit: 1,
+        cursor,
+      });
+      expect(second.payload?.messages).toEqual([older]);
+      expect(second.payload?.nextCursor).toBeUndefined();
+      expect(
+        read.mock.calls.map(([params]) => [params.task.runId, params.limit, params.cursor]),
+      ).toEqual([
+        [task.runId, 1, undefined],
+        [task.runId, 1, "older-page"],
+      ]);
+      const other = createNativeTask("synthetic-child-2");
+      const crossed = await runTaskHandler("tasks.history", { taskId: other.taskId, cursor });
+      expect(crossed.calls[0]).toMatchObject([false, undefined, { code: "INVALID_REQUEST" }]);
+      expect(read).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("reads the OpenClaw child transcript through chat history and preserves pagination", async () => {
+    await withHistoryState(async () => {
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:subagent:child",
+        sessionId: "child",
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      for (const content of [
+        "First child message",
+        "Second child message",
+        "Latest child message",
+      ]) {
+        await appendTranscriptMessage(scope, { message: { role: "assistant", content } });
+      }
+      const task = createTaskFixture("subagent", {
+        requesterSessionKey,
+        ownerKey: requesterSessionKey,
+        childSessionKey: scope.sessionKey,
+        runId: "openclaw-child",
+        task: "Inspect synthetic files",
+      });
+      const context = createDirectChatContext();
+      const first = await runTaskHandler(
+        "tasks.history",
+        { taskId: task.taskId, limit: 2 },
+        {},
+        null,
+        context,
+      );
+      expect(first.calls[0]?.[0]).toBe(true);
+      expect(first.payload?.messages).toMatchObject([
+        { content: "Second child message" },
+        { content: "Latest child message" },
+      ]);
+      const cursor = expectDefined(first.payload?.nextCursor, "older child transcript cursor");
+      const second = await runTaskHandler(
+        "tasks.history",
+        { taskId: task.taskId, limit: 2, cursor },
+        {},
+        null,
+        context,
+      );
+      expect(second.payload?.messages).toMatchObject([{ content: "First child message" }]);
+      expect(second.payload?.nextCursor).toBeUndefined();
+    });
+  });
+
+  it.each(["own", "foreign", "incognito"] as const)(
+    "checks %s requester access before invoking the harness",
+    async (access) => {
+      await withHistoryState(async () => {
+        const viewer = ensureProfileForEmail("viewer@example.test");
+        await createRequester(
+          access === "own" ? viewer.id : "someone-else",
+          access === "incognito",
+        );
+        const task = createNativeTask();
+        const read = vi.fn<ReadTaskHistory>(async () => ({
+          messages: [{ role: "assistant", content: "Child output" }],
+        }));
+        registerHistoryReader(read);
+        const result = await runTaskHandler(
+          "tasks.history",
+          { taskId: task.taskId },
+          readerConfig,
+          identifiedClient(["operator.read"], viewer.id),
+        );
+        if (access === "own") {
+          expect(result.payload?.messages).toEqual([
+            { role: "assistant", content: "Child output" },
+          ]);
+          expect(read).toHaveBeenCalledTimes(1);
+        } else {
+          expect(result.calls[0]).toMatchObject([false, undefined, { message: "Task not found." }]);
+          expect(read).not.toHaveBeenCalled();
+        }
+      });
+    },
+  );
+
+  it.each(["task identity", "requester access", "harness registration"] as const)(
+    "revalidates %s after an asynchronous history read",
+    async (change) => {
+      await withHistoryState(async () => {
+        const viewer = ensureProfileForEmail("viewer@example.test");
+        await createRequester(change === "requester access" ? "someone-else" : viewer.id);
+        let config: OpenClawConfig = structuredClone(readerConfig);
+        if (change === "requester access") {
+          config.gateway!.roles!.definitions.reader!.sessions = { others: "view" };
+        }
+        const context = createDirectChatContext({ getRuntimeConfig: () => config });
+        const task = createNativeTask();
+        const entered = createDeferred();
+        const history = createDeferred<TasksHistoryResult>();
+        registerHistoryReader(async () => {
+          entered.resolve();
+          return await history.promise;
+        });
+        const pending = runTaskHandler(
+          "tasks.history",
+          { taskId: task.taskId },
+          config,
+          identifiedClient(["operator.read"], viewer.id),
+          context,
+        );
+        await entered.promise;
+        if (change === "task identity") {
+          markTaskTerminalById({
+            taskId: task.taskId,
+            status: "succeeded",
+            endedAt: Date.now(),
+            childSessionKey: "agent:main:subagent:new-child",
+          });
+        } else if (change === "requester access") {
+          config = readerConfig;
+        } else {
+          registerHistoryReader(async () => ({ messages: [] }));
+        }
+        history.resolve({
+          messages: [{ role: "assistant", content: "Output from stale authority" }],
+        });
+        const result = await pending;
+        expect(result.calls).toHaveLength(1);
+        expect(result.calls[0]).toMatchObject([false, undefined, { code: "UNAVAILABLE" }]);
+        expect(result.payload?.messages).toBeUndefined();
+      });
+    },
+  );
+});

--- a/src/gateway/server-methods/task-history.ts
+++ b/src/gateway/server-methods/task-history.ts
@@ -1,0 +1,195 @@
+import { createHash } from "node:crypto";
+import { expectDefined } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  ErrorCodes,
+  errorShape,
+  validateTasksHistoryParams,
+  type TasksHistoryResult,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { getTaskById } from "../../tasks/runtime-internal.js";
+import { resolveTaskHistoryHarness, taskTranscriptSessionKey } from "../../tasks/task-history.js";
+import type { TaskRecord } from "../../tasks/task-registry.types.js";
+import { canAccessTaskRequesterSession } from "../task-session-access.js";
+import type { GatewayRequestHandler } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+const MAX_TASK_HISTORY_BYTES = 4 * 1024 * 1024;
+
+function historyBinding(task: TaskRecord): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        task.taskId,
+        task.runId,
+        task.runtime,
+        task.taskKind,
+        task.childSessionKey,
+        task.agentId,
+        task.requesterAgentId,
+        task.requesterSessionKey,
+        task.ownerKey,
+      ]),
+    )
+    .digest("base64url");
+}
+
+function decodeCursor(cursor: string | undefined, binding: string): string | undefined {
+  if (cursor === undefined) {
+    return undefined;
+  }
+  const value: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    value[0] !== binding ||
+    typeof value[1] !== "string" ||
+    !value[1]
+  ) {
+    throw new Error("Invalid task history cursor");
+  }
+  return value[1];
+}
+
+export const taskHistoryHandler: GatewayRequestHandler = async (opts) => {
+  const { params, respond, context, client } = opts;
+  if (!assertValidParams(params, validateTasksHistoryParams, "tasks.history", respond)) {
+    return;
+  }
+  const task = getTaskById(params.taskId);
+  const allowed = (value: TaskRecord | undefined): value is TaskRecord =>
+    Boolean(
+      value &&
+      canAccessTaskRequesterSession({
+        cfg: context.getRuntimeConfig(),
+        client,
+        task: value,
+      }),
+    );
+  if (!allowed(task)) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "Task not found."));
+    return;
+  }
+  const binding = historyBinding(task);
+  let cursor: string | undefined;
+  try {
+    cursor = decodeCursor(params.cursor, binding);
+  } catch {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, "Invalid task history cursor. Refresh the task."),
+    );
+    return;
+  }
+  const sessionKey = taskTranscriptSessionKey(task);
+  const harness = resolveTaskHistoryHarness(task);
+  let active = true;
+  const assertCurrent = () => {
+    const current = getTaskById(task.taskId);
+    if (
+      !active ||
+      opts.signal?.aborted ||
+      !allowed(current) ||
+      historyBinding(current) !== binding ||
+      (!sessionKey && resolveTaskHistoryHarness(current) !== harness)
+    ) {
+      throw new Error("Task history access changed");
+    }
+  };
+  const publish = (page: TasksHistoryResult) => {
+    assertCurrent();
+    const result: TasksHistoryResult = {
+      messages: page.messages,
+      ...(page.nextCursor
+        ? {
+            nextCursor: Buffer.from(JSON.stringify([binding, page.nextCursor])).toString(
+              "base64url",
+            ),
+          }
+        : {}),
+    };
+    if (
+      Buffer.byteLength(JSON.stringify(result), "utf8") > MAX_TASK_HISTORY_BYTES ||
+      (result.nextCursor?.length ?? 0) > 8192
+    ) {
+      throw new Error("Task history page exceeds the response limit");
+    }
+    respond(true, result);
+  };
+  try {
+    const limit = params.limit ?? 100;
+    if (sessionKey) {
+      const offset = cursor === undefined ? 0 : Number(cursor);
+      if (!Number.isSafeInteger(offset) || offset < 0) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "Invalid task history cursor. Refresh the task."),
+        );
+        return;
+      }
+      const { chatHistoryHandlers } = await import("./chat-history-handler.js");
+      assertCurrent();
+      const childAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? task.agentId;
+      await expectDefined(
+        chatHistoryHandlers["chat.history"],
+        "chat history handler",
+      )({
+        ...opts,
+        params: {
+          sessionKey,
+          ...(childAgentId ? { agentId: childAgentId } : {}),
+          limit,
+          offset,
+          maxBytes: MAX_TASK_HISTORY_BYTES - 16_384,
+        },
+        respond: (ok, payload, error) => {
+          assertCurrent();
+          if (!ok) {
+            respond(false, undefined, error);
+            return;
+          }
+          const page = asOptionalRecord(payload);
+          if (!Array.isArray(page?.messages)) {
+            throw new Error("Task transcript returned no messages");
+          }
+          publish({
+            messages: page.messages,
+            ...(page.hasMore === true && typeof page.nextOffset === "number"
+              ? { nextCursor: String(page.nextOffset) }
+              : {}),
+          });
+        },
+      });
+    } else if (harness?.taskHistory) {
+      publish(
+        await harness.taskHistory.read({
+          task,
+          cfg: context.getRuntimeConfig(),
+          cursor,
+          limit,
+          assertCurrent,
+        }),
+      );
+    } else {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "This task has no readable transcript."),
+      );
+    }
+  } catch {
+    respond(
+      false,
+      undefined,
+      errorShape(
+        ErrorCodes.UNAVAILABLE,
+        "Unable to load this task's transcript. Refresh the task and try again.",
+      ),
+    );
+  } finally {
+    active = false;
+  }
+};

--- a/src/gateway/server-methods/task-summary.ts
+++ b/src/gateway/server-methods/task-summary.ts
@@ -1,6 +1,7 @@
 // Public task summaries keep task-registry internals and unbounded status text
 // out of gateway responses and events.
 import type { TaskSummary } from "../../../packages/gateway-protocol/src/index.js";
+import { hasTaskTranscript } from "../../tasks/task-history.js";
 import { getTaskActivitySnapshot } from "../../tasks/task-registry-activity.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
@@ -79,6 +80,7 @@ export function mapTaskSummary(task: TaskRecord, opts?: { includePrompt?: boolea
     ...(task.agentId ? { agentId: task.agentId } : {}),
     sessionKey: task.requesterSessionKey,
     ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+    hasTranscript: hasTaskTranscript(task),
     ownerKey: task.ownerKey,
     ...(task.runId ? { runId: task.runId } : {}),
     ...(task.parentFlowId ? { flowId: task.parentFlowId } : {}),

--- a/src/gateway/server-methods/tasks.test-helpers.ts
+++ b/src/gateway/server-methods/tasks.test-helpers.ts
@@ -4,6 +4,7 @@ import { tasksHandlers } from "./tasks.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 type TaskResponsePayload = {
+  messages?: unknown[];
   tasks?: Array<Record<string, unknown>>;
   task?: Record<string, unknown>;
   found?: boolean;
@@ -69,7 +70,13 @@ export function createSnapshotTask(overrides: Partial<TaskRecord>): TaskRecord {
 }
 
 export async function runTaskHandler(
-  method: "tasks.list" | "tasks.get" | "tasks.cancel" | "tasks.retry" | "tasks.dismiss",
+  method:
+    | "tasks.history"
+    | "tasks.list"
+    | "tasks.get"
+    | "tasks.cancel"
+    | "tasks.retry"
+    | "tasks.dismiss",
   params: Record<string, unknown>,
   config: Record<string, unknown> = {},
   client: GatewayClient | null = null,

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -26,6 +26,7 @@ import {
   canAccessTaskRequesterSession,
   prepareTaskSessionReadFilter,
 } from "../task-session-access.js";
+import { taskHistoryHandler } from "./task-history.js";
 import { mapTaskSummary } from "./task-summary.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -289,6 +290,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     // stay compact while detail views can show the operator what was requested.
     respond(true, { task: mapTaskSummary(task, { includePrompt: true }) });
   },
+  "tasks.history": taskHistoryHandler,
   "tasks.cancel": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksCancelParams, "tasks.cancel", respond)) {
       return;

--- a/src/tasks/task-history.ts
+++ b/src/tasks/task-history.ts
@@ -1,0 +1,24 @@
+import { listRegisteredAgentHarnesses } from "../agents/harness/registry.js";
+import { isHarnessOwnedSubagentTask } from "./harness-owned-subagent-task.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+/** History routing must not change which runtime owns a task's lifecycle. */
+export function resolveTaskHistoryHarness(task: TaskRecord) {
+  if (!isHarnessOwnedSubagentTask(task)) {
+    return undefined;
+  }
+  const owners = listRegisteredAgentHarnesses().filter(({ harness }) =>
+    harness.taskHistory?.taskKinds.includes(task.taskKind ?? ""),
+  );
+  return owners.length === 1 ? owners[0]?.harness : undefined;
+}
+
+export function taskTranscriptSessionKey(task: TaskRecord): string | undefined {
+  return task.runtime === "subagent"
+    ? task.childSessionKey?.trim() || undefined
+    : task.childSessionKey?.trim() || task.requesterSessionKey.trim() || undefined;
+}
+
+export function hasTaskTranscript(task: TaskRecord): boolean {
+  return Boolean(taskTranscriptSessionKey(task) || resolveTaskHistoryHarness(task));
+}

--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -98,16 +98,15 @@ describeControlUiE2e("Control UI chat file links", () => {
               browser: { path: "", entries: [] },
             },
             "tasks.list": { tasks: intent === "task" ? [task] : [] },
-            "chat.history": {
+            "tasks.history": {
               cases: [
                 {
-                  match: { sessionKey: task.childSessionKey },
+                  match: { taskId: task.id },
                   response: {
-                    sessionId: "review-intent-child",
-                    thinkingLevel: null,
                     messages: [
                       {
                         role: "assistant",
+                        messageId: "review-intent-result",
                         content: [{ type: "text", text: "Current task result." }],
                         timestamp: Date.now(),
                       },
@@ -175,8 +174,8 @@ describeControlUiE2e("Control UI chat file links", () => {
               },
               files: await gateway.getRequests("sessions.files.get"),
               lists: await gateway.getRequests("sessions.files.list"),
-              taskHistory: (await gateway.getRequests("chat.history")).filter(
-                (request) => asNullableRecord(request.params)?.sessionKey === task.childSessionKey,
+              taskHistory: (await gateway.getRequests("tasks.history")).filter(
+                (request) => asNullableRecord(request.params)?.taskId === task.id,
               ),
             },
             null,

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -35,17 +35,17 @@ function withoutElapsedLabels(text: string | null): string {
   return (text ?? "").replaceAll(/\d+(?:\.\d+)?\s*(?:ms|[smhd])\b/g, "<elapsed>");
 }
 
-function requestSessionKey(request: MockGatewayRequest): string | undefined {
+function requestTaskId(request: MockGatewayRequest): string | undefined {
   const { params } = request;
   if (
     typeof params !== "object" ||
     params === null ||
-    !("sessionKey" in params) ||
-    typeof params.sessionKey !== "string"
+    !("taskId" in params) ||
+    typeof params.taskId !== "string"
   ) {
     return undefined;
   }
-  return params.sessionKey;
+  return params.taskId;
 }
 
 const runningSubagent = {
@@ -304,6 +304,11 @@ suite.define(() => {
         // round-trip below; live relative ages ("11s") tick across second
         // boundaries on slow runners. Fix Date while keeping timers running.
         await page.clock.setFixedTime(baseTime);
+        const nativeSubagent = {
+          ...runningSubagent,
+          childSessionKey: undefined,
+          hasTranscript: true,
+        };
         const gateway = await installMockGateway(page, {
           historyMessages: [
             {
@@ -313,25 +318,62 @@ suite.define(() => {
             },
           ],
           methodResponses: {
-            "chat.history": {
+            "tasks.history": {
               cases: [
                 {
-                  match: { sessionKey: runningSubagent.childSessionKey },
+                  match: { taskId: nativeSubagent.id, cursor: "task-earlier" },
+                  response: {
+                    messages: [
+                      {
+                        role: "user",
+                        messageId: "task-prompt",
+                        content: "Inspect the model routing boundary.",
+                        timestamp: baseTime - 3_000,
+                      },
+                      {
+                        role: "assistant",
+                        messageId: "task-check",
+                        content: [
+                          {
+                            type: "toolCall",
+                            id: "routing-check",
+                            name: "exec",
+                            arguments: {
+                              command: "pnpm test routing",
+                              title: "Check model routing",
+                            },
+                          },
+                        ],
+                        timestamp: baseTime - 2_000,
+                      },
+                      {
+                        role: "toolResult",
+                        messageId: "task-check-result",
+                        toolCallId: "routing-check",
+                        toolName: "exec",
+                        content: [{ type: "text", text: "Routing boundary checks passed." }],
+                        timestamp: baseTime - 1_000,
+                      },
+                    ],
+                  },
+                },
+                {
+                  match: { taskId: runningSubagent.id },
                   response: {
                     messages: [
                       {
                         content: [{ type: "text", text: taskReviewMarkdown }],
                         role: "assistant",
+                        messageId: "task-review",
                         timestamp: Date.now(),
                       },
                     ],
-                    sessionId: "subagent-transcript",
-                    thinkingLevel: null,
+                    nextCursor: "task-earlier",
                   },
                 },
               ],
             },
-            "tasks.list": { tasks: [runningSubagent, queuedCron, finishedCli] },
+            "tasks.list": { tasks: [nativeSubagent, queuedCron, finishedCli] },
             "tasks.cancel": {
               found: true,
               cancelled: true,
@@ -406,17 +448,17 @@ suite.define(() => {
         ).toBe(true);
         await expect
           .poll(async () =>
-            (await gateway.getRequests("chat.history")).some(
-              (request) => requestSessionKey(request) === runningSubagent.childSessionKey,
+            (await gateway.getRequests("tasks.history")).some(
+              (request) => requestTaskId(request) === runningSubagent.id,
             ),
           )
           .toBe(true);
-        const transcriptRequest = (await gateway.getRequests("chat.history")).find(
-          (request) => requestSessionKey(request) === runningSubagent.childSessionKey,
+        const transcriptRequest = (await gateway.getRequests("tasks.history")).find(
+          (request) => requestTaskId(request) === runningSubagent.id,
         );
         expect(transcriptRequest?.params).toEqual({
-          sessionKey: runningSubagent.childSessionKey,
-          limit: 800,
+          taskId: runningSubagent.id,
+          limit: 100,
         });
         expect(page.url()).toBe(chatUrl);
         expect(withoutElapsedLabels(await mainTranscript.textContent())).toBe(mainTranscriptBefore);
@@ -439,6 +481,33 @@ suite.define(() => {
           path.join(railFlowDir, "02-task-detail-expanded.png"),
           await takeControlUiViewportScreenshot(page, page.locator(".shell"), [detailPanel]),
         );
+        await detailPanel.getByRole("button", { name: "Show earlier", exact: true }).click();
+        await detailPanel
+          .getByText("Inspect the model routing boundary.", { exact: true })
+          .waitFor();
+        const toolRow = detailPanel.locator(".chat-tool-row", { hasText: "Check model routing" });
+        await toolRow.waitFor();
+        await toolRow.click();
+        const toolBody = detailPanel.locator(".chat-tool-msg-body", {
+          hasText: "Routing boundary checks passed.",
+        });
+        await toolBody.waitFor();
+        expect(await toolBody.textContent()).toContain("pnpm test routing");
+        expect(
+          await detailPanel.getByRole("button", { name: "Show earlier", exact: true }).count(),
+        ).toBe(0);
+        expect((await gateway.getRequests("tasks.history")).at(-1)?.params).toEqual({
+          taskId: nativeSubagent.id,
+          limit: 100,
+          cursor: "task-earlier",
+        });
+        await writeFile(
+          path.join(railFlowDir, "02-native-transcript-with-tool-result.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            detailPanel,
+            toolBody,
+          ]),
+        );
         await page.getByRole("button", { name: "Restore split", exact: true }).click();
         await expect
           .poll(() => page.locator(".chat-panel-focus").getAttribute("aria-pressed"))
@@ -448,13 +517,16 @@ suite.define(() => {
         await gateway.emitGatewayEvent("task", {
           action: "upserted",
           task: {
-            ...runningSubagent,
+            ...nativeSubagent,
             status: "completed",
             updatedAt: baseTime + 1_000,
             terminalSummary: "Routing map complete",
           },
         });
-        await detailPanel.getByText("Completed").waitFor({ state: "visible" });
+        await detailPanel
+          .locator(".chat-tasks-rail__task-status")
+          .filter({ hasText: "Completed" })
+          .waitFor({ state: "visible" });
         await page
           .locator(".side-panel__header .tabstrip wa-tab")
           .filter({ hasText: "Tasks" })
@@ -530,10 +602,10 @@ suite.define(() => {
             },
           ],
           methodResponses: {
-            "chat.history": {
+            "tasks.history": {
               cases: [
                 {
-                  match: { sessionKey: "agent:main:subagent:parallel-one" },
+                  match: { taskId: "task-parallel-one" },
                   response: {
                     messages: [
                       {
@@ -544,8 +616,6 @@ suite.define(() => {
                         timestamp: Date.now(),
                       },
                     ],
-                    sessionId: "parallel-one-child",
-                    thinkingLevel: null,
                   },
                 },
               ],
@@ -604,17 +674,17 @@ suite.define(() => {
         expect(await detailPanel.locator(".chat-diffstat__del").textContent()).toBe("-3");
         await expect
           .poll(async () =>
-            (await gateway.getRequests("chat.history")).some(
-              (request) => requestSessionKey(request) === first.childSessionKey,
+            (await gateway.getRequests("tasks.history")).some(
+              (request) => requestTaskId(request) === first.id,
             ),
           )
           .toBe(true);
-        const childHistoryRequest = (await gateway.getRequests("chat.history")).find(
-          (request) => requestSessionKey(request) === first.childSessionKey,
+        const childHistoryRequest = (await gateway.getRequests("tasks.history")).find(
+          (request) => requestTaskId(request) === first.id,
         );
         expect(childHistoryRequest?.params).toEqual({
-          sessionKey: first.childSessionKey,
-          limit: 800,
+          taskId: first.id,
+          limit: 100,
         });
 
         await gateway.emitGatewayEvent("task", {

--- a/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
@@ -357,7 +357,6 @@ describe("chat pane retained presentation lifecycle", () => {
     const detailHost = state as unknown as TaskDetailHost;
     readTaskTranscript(detailHost, {
       taskId: "task-live",
-      sessionKey: "agent:main:subagent:task-live",
     });
     expect(detailHost.taskDetailState).toBeDefined();
     pane.presentationId = "p1:visible";

--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -9,7 +9,9 @@ import { renderChatDetailSlot } from "./chat-detail-slot.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 import * as taskDetailState from "./chat-task-detail-state.ts";
 import {
+  loadOlderTaskTranscript,
   observeTaskDetailEvent,
+  retryTaskTranscript,
   readTaskTranscript,
   type TaskDetailHost,
 } from "./chat-task-detail-state.ts";
@@ -27,9 +29,7 @@ function deferred<T>() {
 
 function history(text: string) {
   return {
-    messages: [{ role: "assistant", content: [{ type: "text", text }] }],
-    sessionId: "child-session",
-    thinkingLevel: null,
+    messages: [{ role: "assistant", messageId: "answer", content: [{ type: "text", text }] }],
   };
 }
 
@@ -152,7 +152,7 @@ describe("task detail transcript state", () => {
     expect(reset).toHaveBeenCalledOnce();
   });
 
-  it("loads the selected child transcript", async () => {
+  it("loads the selected task transcript", async () => {
     const pending = deferred<ReturnType<typeof history>>();
     const request = vi.fn().mockReturnValue(pending.promise);
     const host = hostWith(request);
@@ -160,12 +160,11 @@ describe("task detail transcript state", () => {
     expect(
       readTaskTranscript(host, {
         taskId: "task-1",
-        sessionKey: "agent:main:subagent:child",
       }),
     ).toEqual({ status: "loading" });
-    expect(request).toHaveBeenCalledWith("chat.history", {
-      sessionKey: "agent:main:subagent:child",
-      limit: 800,
+    expect(request).toHaveBeenCalledWith("tasks.history", {
+      taskId: "task-1",
+      limit: 100,
     });
 
     pending.resolve(history("Child transcript loaded."));
@@ -173,7 +172,6 @@ describe("task detail transcript state", () => {
     expect(
       readTaskTranscript(host, {
         taskId: "task-1",
-        sessionKey: "agent:main:subagent:child",
       }),
     ).toMatchObject({
       status: "loaded",
@@ -181,12 +179,15 @@ describe("task detail transcript state", () => {
     });
   });
 
-  it("surfaces a history request failure", async () => {
+  it("retries a failed history request", async () => {
     const pending = deferred<never>();
-    const host = hostWith(vi.fn().mockReturnValue(pending.promise));
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(pending.promise)
+      .mockResolvedValue(history("Recovered"));
+    const host = hostWith(request);
     readTaskTranscript(host, {
       taskId: "task-1",
-      sessionKey: "agent:main:subagent:child",
     });
 
     pending.reject(new Error("history unavailable"));
@@ -194,9 +195,182 @@ describe("task detail transcript state", () => {
     expect(
       readTaskTranscript(host, {
         taskId: "task-1",
-        sessionKey: "agent:main:subagent:child",
       }),
     ).toEqual({ status: "error" });
+    retryTaskTranscript(host);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      status: "loaded",
+      messages: history("Recovered").messages,
+    });
+  });
+
+  it("retains older history through paging failures and terminal refreshes", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(10_000);
+    const message = (id: string, text = id) => ({
+      role: "assistant",
+      messageId: id,
+      content: text,
+    });
+    const older = deferred<{ messages: unknown[]; nextCursor?: string }>();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ messages: [message("3"), message("4")], nextCursor: "older-1" })
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockReturnValueOnce(older.promise)
+      .mockResolvedValueOnce({
+        messages: [message("4", "Updated result"), message("5")],
+        nextCursor: "new-tail",
+      })
+      .mockResolvedValueOnce({ messages: [message("0"), message("1")], nextCursor: "older-1" });
+    const host = hostWith(request);
+    readTaskTranscript(host, { taskId: "task-1" });
+    await flushAsync();
+
+    loadOlderTaskTranscript(host);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      status: "loaded",
+      error: "older",
+      messages: [message("3"), message("4")],
+    });
+    retryTaskTranscript(host);
+    expect(request).toHaveBeenLastCalledWith("tasks.history", {
+      taskId: "task-1",
+      limit: 100,
+      cursor: "older-1",
+    });
+    observeTaskDetailEvent(host, { action: "upserted", task: task("completed") });
+    older.resolve({ messages: [message("1"), message("2"), message("3")], nextCursor: "older-2" });
+    await flushAsync();
+    vi.advanceTimersByTime(2_000);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      status: "loaded",
+      messages: [
+        message("1"),
+        message("2"),
+        message("3"),
+        message("4", "Updated result"),
+        message("5"),
+      ],
+      nextCursor: "older-2",
+    });
+
+    loadOlderTaskTranscript(host);
+    await flushAsync();
+    expect(request).toHaveBeenLastCalledWith("tasks.history", {
+      taskId: "task-1",
+      limit: 100,
+      cursor: "older-2",
+    });
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      messages: [
+        message("0"),
+        message("1"),
+        message("2"),
+        message("3"),
+        message("4", "Updated result"),
+        message("5"),
+      ],
+      nextCursor: undefined,
+    });
+  });
+
+  it.each([1, 3])("keeps %i refreshed projected siblings as one history group", async (count) => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(10_000);
+    const row = (seq: number, text: string) => ({
+      role: "assistant",
+      __openclaw: { id: `record-${seq}`, seq },
+      content: [{ type: "text", text }],
+    });
+    const oldSiblings = [row(2, "old first"), row(2, "old second")];
+    const siblings = Array.from({ length: count }, (_, index) => row(2, `updated ${index}`));
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: [...oldSiblings, row(3, "old tail")],
+        nextCursor: "older",
+      })
+      .mockResolvedValueOnce({ messages: [row(1, "earlier"), ...oldSiblings] })
+      .mockResolvedValueOnce({ messages: [...siblings, row(3, "final tail")] });
+    const host = hostWith(request);
+    readTaskTranscript(host, { taskId: "task-1" });
+    await flushAsync();
+    loadOlderTaskTranscript(host);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      messages: [row(1, "earlier"), ...oldSiblings, row(3, "old tail")],
+    });
+    observeTaskDetailEvent(host, { action: "upserted", task: task("completed") });
+    vi.advanceTimersByTime(2_000);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      messages: [row(1, "earlier"), ...siblings, row(3, "final tail")],
+      nextCursor: undefined,
+    });
+  });
+
+  it("restarts older paging from a disjoint refreshed tail without skipping the gap", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(10_000);
+    const message = (id: string) => ({ role: "assistant", messageId: id, content: id });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ messages: [message("1")], nextCursor: "old-boundary" })
+      .mockResolvedValueOnce({ messages: [message("4")], nextCursor: "gap" })
+      .mockResolvedValueOnce({ messages: [message("2"), message("3")], nextCursor: "before-gap" })
+      .mockResolvedValueOnce({ messages: [message("1")] });
+    const host = hostWith(request);
+    readTaskTranscript(host, { taskId: "task-1" });
+    await flushAsync();
+    observeTaskDetailEvent(host, { action: "upserted", task: task("running") });
+    vi.advanceTimersByTime(2_000);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      messages: [message("4")],
+      nextCursor: "gap",
+    });
+    loadOlderTaskTranscript(host);
+    await flushAsync();
+    expect(request).toHaveBeenLastCalledWith("tasks.history", {
+      taskId: "task-1",
+      limit: 100,
+      cursor: "gap",
+    });
+    loadOlderTaskTranscript(host);
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId: "task-1" })).toMatchObject({
+      messages: [message("1"), message("2"), message("3"), message("4")],
+      nextCursor: undefined,
+    });
+  });
+
+  it.each(["task", "connection"])("discards an older page after the %s changes", async (change) => {
+    const older = deferred<ReturnType<typeof history>>();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ ...history("Previous task"), nextCursor: "older" })
+      .mockReturnValueOnce(older.promise)
+      .mockResolvedValueOnce(history("Current task"));
+    const host = hostWith(request);
+    readTaskTranscript(host, { taskId: "task-1" });
+    await flushAsync();
+    loadOlderTaskTranscript(host);
+    const taskId = change === "task" ? "task-2" : "task-1";
+    if (change === "connection") {
+      host.connectionEpoch = 5;
+    }
+    readTaskTranscript(host, { taskId });
+    await flushAsync();
+    older.resolve(history("Stale private history"));
+    await flushAsync();
+    expect(readTaskTranscript(host, { taskId })).toMatchObject({
+      status: "loaded",
+      messages: history("Current task").messages,
+    });
   });
 
   it("coalesces in-flight events and performs the terminal refresh after the throttle", async () => {
@@ -208,7 +382,6 @@ describe("task detail transcript state", () => {
     const host = hostWith(request);
     readTaskTranscript(host, {
       taskId: "task-1",
-      sessionKey: "agent:main:subagent:child",
     });
 
     observeTaskDetailEvent(host, { action: "upserted", task: task("running") });
@@ -227,7 +400,6 @@ describe("task detail transcript state", () => {
     expect(
       readTaskTranscript(host, {
         taskId: "task-1",
-        sessionKey: "agent:main:subagent:child",
       }),
     ).toMatchObject({ status: "loaded" });
     expect(request).toHaveBeenCalledTimes(2);

--- a/ui/src/pages/chat/components/chat-task-detail-state.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.ts
@@ -1,28 +1,34 @@
+import type { TasksHistoryResult } from "../../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import { visibleChatHistoryMessages } from "../../../lib/chat/message-visibility.ts";
 import type { UiSessionDefaultsHost } from "../../../lib/sessions/session-key.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
-import type { ChatHistoryResult } from "../chat-history-snapshot.ts";
+import { readChatThreadMessageIdentity } from "../chat-thread-items.ts";
 
 const TASK_TRANSCRIPT_REFRESH_MS = 2_000;
-// The task preview has no back-scroll pagination; retain its wider transcript window.
-const TASK_TRANSCRIPT_REQUEST_LIMIT = 800;
+const TASK_TRANSCRIPT_REQUEST_LIMIT = 100;
 
-type TaskTranscriptLoad =
-  | { status: "loading" }
-  | { status: "loaded"; messages: unknown[] }
-  | { status: "error" };
+type LoadedTaskTranscript = {
+  status: "loaded";
+  messages: unknown[];
+  nextCursor?: string;
+  loading: boolean;
+  error?: "refresh" | "older";
+};
+
+type TaskTranscriptLoad = { status: "loading" } | LoadedTaskTranscript | { status: "error" };
 
 type TaskDetailState = {
   client: GatewayBrowserClient;
   connectionEpoch: number | undefined;
   eventVersion: number;
+  refreshedEventVersion: number;
   inFlight: boolean;
   lastRequestStartedAt: number;
   load: TaskTranscriptLoad;
   refreshTimer: number | null;
   requestId: number;
-  sessionKey: string;
+  olderCursors: Set<string>;
   taskId: string;
 };
 
@@ -67,6 +73,39 @@ function scheduleTranscriptLoad(host: TaskDetailHost, state: TaskDetailState) {
     return;
   }
   clearRefreshTimer(state);
+  void loadTranscriptPage(host, state);
+}
+
+function transcriptEntryKey(message: unknown): string | undefined {
+  const identity = readChatThreadMessageIdentity(message);
+  if (!identity) {
+    return undefined;
+  }
+  const key = identity.externalSource
+    ? `external:${identity.externalSource}`
+    : identity.id
+      ? `id:${identity.id}`
+      : identity.sequence == null
+        ? undefined
+        : `seq:${identity.sequence}`;
+  return key;
+}
+
+function mergeTranscriptMessages(earlier: unknown[], later: unknown[]): unknown[] {
+  const laterKeys = new Set(later.map(transcriptEntryKey).filter(Boolean));
+  const overlap = earlier.findIndex((message) => {
+    const key = transcriptEntryKey(message);
+    return key !== undefined && laterKeys.has(key);
+  });
+  // An entry can project into several rows. Replace the overlapping tail as a
+  // whole so updated, added, and removed siblings stay together.
+  return [...earlier.slice(0, overlap < 0 ? earlier.length : overlap), ...later];
+}
+
+async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, cursor?: string) {
+  if (host.taskDetailState !== state || state.inFlight) {
+    return;
+  }
   const client = host.client;
   if (
     !client ||
@@ -80,53 +119,85 @@ function scheduleTranscriptLoad(host: TaskDetailHost, state: TaskDetailState) {
   }
   const requestId = ++state.requestId;
   const eventVersion = state.eventVersion;
+  const previous = state.load.status === "loaded" ? state.load : undefined;
   state.inFlight = true;
-  state.lastRequestStartedAt = Date.now();
-  if (state.load.status !== "loaded") {
-    state.load = { status: "loading" };
+  if (!cursor) {
+    state.lastRequestStartedAt = Date.now();
+  }
+  state.load = previous ? { ...previous, loading: true, error: undefined } : { status: "loading" };
+  host.requestUpdate?.();
+  let load: TaskTranscriptLoad;
+  try {
+    const result = await client.request<TasksHistoryResult>("tasks.history", {
+      taskId: state.taskId,
+      limit: TASK_TRANSCRIPT_REQUEST_LIMIT,
+      ...(cursor ? { cursor } : {}),
+    });
+    const messages = visibleChatHistoryMessages(result.messages);
+    const previousKeys = new Set(previous?.messages.map(transcriptEntryKey).filter(Boolean));
+    const overlaps = messages.some((message) => {
+      const key = transcriptEntryKey(message);
+      return key !== undefined && previousKeys.has(key);
+    });
+    const retainPrevious = previous !== undefined && (cursor !== undefined || overlaps);
+    if (cursor) {
+      state.olderCursors.add(cursor);
+    } else if (!retainPrevious) {
+      // A disjoint tail may have skipped whole pages. Restart pagination from
+      // that tail so Show earlier can reach every intervening message.
+      state.olderCursors.clear();
+    }
+    load = {
+      status: "loaded",
+      messages: retainPrevious
+        ? cursor
+          ? mergeTranscriptMessages(messages, previous.messages)
+          : mergeTranscriptMessages(previous.messages, messages)
+        : messages,
+      // Only overlapping refreshes preserve the oldest boundary already loaded.
+      nextCursor:
+        retainPrevious && !cursor
+          ? previous.nextCursor
+          : result.nextCursor && !state.olderCursors.has(result.nextCursor)
+            ? result.nextCursor
+            : undefined,
+      loading: false,
+    };
+  } catch {
+    load = previous
+      ? { ...previous, loading: false, error: cursor ? "older" : "refresh" }
+      : { status: "error" };
+  }
+  const current = host.taskDetailState;
+  if (
+    current !== state ||
+    current.requestId !== requestId ||
+    host.client !== client ||
+    host.connectionEpoch !== state.connectionEpoch
+  ) {
+    return;
+  }
+  state.inFlight = false;
+  state.load = load;
+  if (!cursor) {
+    state.refreshedEventVersion = eventVersion;
   }
   host.requestUpdate?.();
-  void (async () => {
-    let load: TaskTranscriptLoad;
-    try {
-      const result = await client.request<ChatHistoryResult>("chat.history", {
-        sessionKey: state.sessionKey,
-        limit: TASK_TRANSCRIPT_REQUEST_LIMIT,
-      });
-      load = { status: "loaded", messages: visibleChatHistoryMessages(result.messages) };
-    } catch {
-      load = { status: "error" };
-    }
-    const current = host.taskDetailState;
-    if (
-      current !== state ||
-      current.requestId !== requestId ||
-      host.client !== client ||
-      host.connectionEpoch !== state.connectionEpoch
-    ) {
-      return;
-    }
-    state.inFlight = false;
-    state.load = load;
-    host.requestUpdate?.();
-    // Events that arrived during this request own a later snapshot. This also
-    // guarantees one final history read after a terminal transition.
-    if (state.eventVersion > eventVersion) {
-      scheduleTranscriptLoad(host, state);
-    }
-  })();
+  // Also refresh after events received during an older-page request.
+  if (state.eventVersion > state.refreshedEventVersion) {
+    scheduleTranscriptLoad(host, state);
+  }
 }
 
 export function readTaskTranscript(
   host: TaskDetailHost,
-  selection: { taskId: string; sessionKey: string },
+  selection: { taskId: string },
 ): TaskTranscriptLoad {
   const client = host.client;
   const current = host.taskDetailState;
   if (
     current &&
     current.taskId === selection.taskId &&
-    current.sessionKey === selection.sessionKey &&
     current.client === client &&
     current.connectionEpoch === host.connectionEpoch
   ) {
@@ -140,17 +211,39 @@ export function readTaskTranscript(
     client,
     connectionEpoch: host.connectionEpoch,
     eventVersion: 0,
+    refreshedEventVersion: 0,
     inFlight: false,
     lastRequestStartedAt: Number.NEGATIVE_INFINITY,
     load: { status: "loading" },
     refreshTimer: null,
     requestId: 0,
-    sessionKey: selection.sessionKey,
+    olderCursors: new Set(),
     taskId: selection.taskId,
   };
   host.taskDetailState = next;
   scheduleTranscriptLoad(host, next);
   return next.load;
+}
+
+export function loadOlderTaskTranscript(host: TaskDetailHost) {
+  const state = host.taskDetailState;
+  if (state?.load.status === "loaded" && state.load.nextCursor) {
+    void loadTranscriptPage(host, state, state.load.nextCursor);
+  }
+}
+
+export function retryTaskTranscript(host: TaskDetailHost) {
+  const state = host.taskDetailState;
+  if (!state) {
+    host.requestUpdate?.();
+    return;
+  }
+  if (state.load.status === "loaded" && state.load.error === "older") {
+    loadOlderTaskTranscript(host);
+  } else {
+    clearRefreshTimer(state);
+    void loadTranscriptPage(host, state);
+  }
 }
 
 export function observeTaskDetailEvent(

--- a/ui/src/pages/chat/components/chat-task-detail.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail.test.ts
@@ -58,6 +58,7 @@ describe("task detail panel", () => {
       runtime: "cli",
       agentId: "main",
       title: "Current-session command",
+      hasTranscript: true,
       sessionKey: "agent:main:main",
       terminalSummary: "Command complete",
       createdAt: 1_000,
@@ -140,6 +141,97 @@ describe("task detail panel", () => {
     expect(panel?.textContent).toContain("Inspect the current task.");
     expect(panel?.textContent).not.toContain("Loading task transcript");
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "native subagent", hasTranscript: true },
+    { name: "child session", childSessionKey: "agent:main:subagent:child" },
+  ])("renders and pages the $name transcript through the task API", async (source) => {
+    const task: TaskSummary = {
+      id: "task-child",
+      taskId: "task-child",
+      status: "completed",
+      runtime: "subagent",
+      agentId: "main",
+      title: "Investigate rendering",
+      sessionKey: "agent:main:main",
+      ...source,
+    };
+    const currentMessage = {
+      role: "assistant",
+      messageId: "answer",
+      content: "The rendering issue is fixed.",
+    };
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("history unavailable"))
+      .mockResolvedValueOnce({ messages: [currentMessage], nextCursor: "previous-page" })
+      .mockResolvedValueOnce({
+        messages: [
+          { role: "user", messageId: "prompt", content: "Inspect the renderer." },
+          currentMessage,
+        ],
+      });
+    const host: TaskDetailHost = {
+      sessionKey: "agent:main:main",
+      client: createGatewayBrowserClientFixture({ request }),
+      connected: true,
+      hello: null,
+    };
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = () => {
+      render(
+        html`${renderTaskDetailPanel({
+          backgroundTasks: backgroundTasks(task),
+          chat: threadProps("pane-1", host.sessionKey),
+          host,
+          task,
+          transcript,
+        })}`,
+        container,
+      );
+      transcript.hostUpdated();
+    };
+    const button = (label: string) =>
+      Array.from(container.querySelectorAll("button")).find((element) =>
+        element.textContent?.includes(label),
+      );
+    rerender();
+    await vi.waitFor(() => expect(host.taskDetailState?.load.status).toBe("error"));
+    rerender();
+    expect(button("Retry")).toBeDefined();
+    button("Retry")?.click();
+    await vi.waitFor(() => expect(host.taskDetailState?.load.status).toBe("loaded"));
+    rerender();
+    transcript.hostConnected();
+    await flushDeferredRowPrune();
+
+    expect(container.textContent).toContain("The rendering issue is fixed.");
+    expect(container.textContent).not.toContain("Inspect the current task.");
+    expect(request).toHaveBeenLastCalledWith("tasks.history", { taskId: task.id, limit: 100 });
+    expect(button("Show earlier")).toBeDefined();
+    button("Show earlier")?.click();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() =>
+      expect(host.taskDetailState?.load).toMatchObject({
+        status: "loaded",
+        loading: false,
+        nextCursor: undefined,
+      }),
+    );
+    rerender();
+    await flushDeferredRowPrune();
+
+    expect(request).toHaveBeenLastCalledWith("tasks.history", {
+      taskId: task.id,
+      limit: 100,
+      cursor: "previous-page",
+    });
+    expect(container.textContent).toContain("Inspect the renderer.");
+    expect(container.textContent?.split("The rendering issue is fixed.")).toHaveLength(2);
+    expect(button("Show earlier")).toBeUndefined();
+    transcript.hostDisconnected();
   });
 
   it.each([

--- a/ui/src/pages/chat/components/chat-task-detail.ts
+++ b/ui/src/pages/chat/components/chat-task-detail.ts
@@ -25,10 +25,13 @@ import {
 } from "./chat-background-tasks-shared.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import { renderDiffStatChips } from "./chat-diff-render.ts";
+import { renderChatHistoryBoundary } from "./chat-history-boundary.ts";
 import { renderReadOnlyTranscript } from "./chat-read-only-transcript.ts";
 import {
+  loadOlderTaskTranscript,
   readTaskTranscript,
   resetTaskDetail,
+  retryTaskTranscript,
   type TaskDetailHost,
 } from "./chat-task-detail-state.ts";
 import type { ChatThreadProps } from "./chat-thread-interactions.ts";
@@ -55,25 +58,26 @@ export function renderTaskDetailPanel(params: {
   }
   const detailedTask = backgroundTasks.taskDetails.get(task.id);
   const currentTask = newestTaskSnapshot(task, detailedTask);
-  // A subagent's sessionKey is its requester's conversation, never its own
-  // work; only the child session is that task's transcript.
+  // A subagent's sessionKey names its requester. Only a child session can supply
+  // session metadata; harness-owned transcripts are addressed by task ID.
   const transcriptSessionKey = normalizeOptionalString(
     currentTask.runtime === "subagent"
       ? currentTask.childSessionKey
       : (currentTask.childSessionKey ?? currentTask.sessionKey),
   );
-  // A task pointing at this pane's canonical session uses the inspector. Mirroring
-  // the current conversation into its own detail sidebar would duplicate the chat.
-  const content =
-    transcriptSessionKey &&
-    !uiConversationMatches(
-      params.host,
-      params.host.sessionKey,
-      transcriptSessionKey,
-      currentTask.agentId,
-    )
-      ? renderTaskTranscript({ ...params, task: currentTask, sessionKey: transcriptSessionKey })
-      : renderTaskFallback(currentTask, backgroundTasks, params.host);
+  // Preserve child-session previews while allowing the task owner to advertise
+  // transcript history without creating an OpenClaw session.
+  const hasTranscript = transcriptSessionKey
+    ? !uiConversationMatches(
+        params.host,
+        params.host.sessionKey,
+        transcriptSessionKey,
+        currentTask.agentId,
+      )
+    : currentTask.hasTranscript === true;
+  const content = hasTranscript
+    ? renderTaskTranscript({ ...params, task: currentTask, sessionKey: transcriptSessionKey })
+    : renderTaskFallback(currentTask, backgroundTasks, params.host);
   return html`
     <div class="sidebar-panel chat-task-detail" data-task-detail-panel>
       ${renderTaskHeader(taskTitle(currentTask), currentTask, backgroundTasks)} ${content}
@@ -151,13 +155,12 @@ function renderTaskHeader(
 function renderTaskTranscript(params: {
   chat: ChatThreadProps;
   host: TaskDetailHost;
-  sessionKey: string;
+  sessionKey: string | undefined;
   task: TaskSummary;
   transcript: ChatTranscriptController;
 }): TemplateResult {
   const load = readTaskTranscript(params.host, {
     taskId: params.task.id,
-    sessionKey: params.sessionKey,
   });
   if (load.status === "loading") {
     return renderPanelLoadingSkeleton("review", t("chat.backgroundTasks.transcriptLoading"));
@@ -165,22 +168,52 @@ function renderTaskTranscript(params: {
   if (load.status === "error") {
     return html`<div class="sidebar-content chat-task-detail__state chat-task-detail__state--error">
       ${t("chat.backgroundTasks.transcriptFailed")}
+      <button class="btn btn--sm" type="button" @click=${() => retryTaskTranscript(params.host)}>
+        ${t("common.retry")}
+      </button>
     </div>`;
   }
-  if (load.messages.length === 0) {
+  if (load.messages.length === 0 && !load.nextCursor && !load.error) {
     return html`<div class="sidebar-content chat-task-detail__state">
       ${t("chat.backgroundTasks.transcriptEmpty")}
     </div>`;
   }
-  const selectedSession = params.chat.sessions?.sessions.find(
-    (row) =>
-      (row.key !== "global" ||
-        (isUiGlobalScopeConfigured(params.host) &&
-          normalizeAgentId(params.host.sessionsResultAgentId ?? "") ===
-            normalizeAgentId(params.task.agentId))) &&
-      uiSessionRowMatchesSelectedChat(params.host, row.key, params.sessionKey),
-  );
+  const sessionKey = params.sessionKey;
+  const selectedSession = sessionKey
+    ? params.chat.sessions?.sessions.find(
+        (row) =>
+          (row.key !== "global" ||
+            (isUiGlobalScopeConfigured(params.host) &&
+              normalizeAgentId(params.host.sessionsResultAgentId ?? "") ===
+                normalizeAgentId(params.task.agentId))) &&
+          uiSessionRowMatchesSelectedChat(params.host, row.key, sessionKey),
+      )
+    : undefined;
   return html`<div class="sidebar-content chat-task-detail__content">
+    ${
+      load.error
+        ? html`<div class="chat-task-detail__state chat-task-detail__state--error" role="status">
+            ${t("chat.backgroundTasks.transcriptFailed")}
+            <button
+              class="btn btn--sm"
+              type="button"
+              ?disabled=${load.loading}
+              @click=${() => retryTaskTranscript(params.host)}
+            >
+              ${t("common.retry")}
+            </button>
+          </div>`
+        : nothing
+    }
+    ${
+      load.nextCursor
+        ? renderChatHistoryBoundary({
+            hasMore: true,
+            loading: load.loading,
+            onShowEarlier: () => loadOlderTaskTranscript(params.host),
+          })
+        : nothing
+    }
     <div class="chat-task-detail__transcript">
       ${renderReadOnlyTranscript({
         chat: {
@@ -190,7 +223,7 @@ function renderTaskTranscript(params: {
         },
         messages: load.messages,
         paneId: `${params.chat.paneId}:task-sidebar`,
-        sessionKey: params.sessionKey,
+        sessionKey: params.sessionKey ?? `task:${params.task.id}`,
         transcript: params.transcript,
       })}
     </div>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting a native subagent in the Control UI Tasks sidebar would see progress metadata instead of the child's transcript. OpenClaw-managed children already had transcript viewing, while native children exposed a different experience and runtime-specific fallback labels.

## Why This Change Was Made

Both paths now use one paginated `tasks.history` API and the existing read-only transcript renderer. The Gateway authorizes the requester session and routes reads to the OpenClaw child session or the native harness's verified parent/descendant store; native tasks keep their existing lifecycle ownership.

The optional harness history capability is the intended plugin contract for this unification; existing plugins are not required to implement it.

The viewer preserves complete projected message groups during refreshes, supports older history and retries, and keeps the prompt/output inspector for tasks belonging to the current conversation. Native history reads retain connection, ancestry, disposal, and response-size guards.

## User Impact

Subagents show messages, thinking, and expandable tool calls/results in the same view, including nested native subagents. Generated labels and progress text say **Subagent**. Native history remains dependent on an available parent binding; unavailable history fails visibly instead of reading another conversation.

## Evidence

- The original renderer failed the native transcript regression; the repaired renderer passes. Additional regressions cover nested ancestry, requester access, asynchronous ownership changes, pagination gaps, and shrinking/growing sibling display groups.
- Focused Gateway, Codex, Copilot, and UI tests passed; all four background-task browser E2E scenarios passed with synthetic Gateway data.
- `pnpm build`, source/test/UI/plugin typechecks, lint and architecture guards passed. Android ktlint passed with the installed Android Studio JDK; generated `OpenClawProtocol` compiled and Swift lint passed. The full macOS app suite was not run on the operator desktop.
- Independent reviews were completed and accepted findings repaired; the final follow-up found no actionable P0–P2 issue.
- Review follow-up: native projection output now includes supported, thread-scoped `messageId` values. Tests use actual production projection output to verify all row identities, full/paged identity equality, and identity stability when assistant or tool content changes. The missing-identity regression failed before the fix.
- CI follow-up: the registration import boundary is covered by its existing guard, and the dependent Workboard manifest is regenerated and committed. All 77 focused Codex tests and `pnpm plugins:assets:check` pass locally.
- All six file-link browser E2Es pass after migrating the task-result fixture to the shared history endpoint.
- Post-merge live verification found a parent-thread replacement case, repaired in #143869. Final real-provider, pagination, Gateway-restart, and actual sidebar checks passed on main `5ae901326b85b094d58339587157900093e0b48d`. The before/after images below are synthetic; #143869 also includes inspected real-Gateway captures with synthetic test data.

### Before

![Before: native subagent opens only the prompt/output inspector](https://github.com/user-attachments/assets/8b3106f6-16f0-4e7a-a129-07f959fb404b)

### After

![After: shared subagent transcript with earlier messages and an expanded tool result](https://github.com/user-attachments/assets/d7968d39-93c0-4afd-b7be-324ede8f0ab5)
