### PR TITLE
fix(update): avoid pointing to unavailable report files

### DIFF
--- a/src/cli/update-cli/update-command-report.test.ts
+++ b/src/cli/update-cli/update-command-report.test.ts
@@ -106,6 +106,59 @@ describe("interactive update failure action", () => {
     );
   });
 
+  it.each([
+    [
+      "duplicate issue",
+      { status: "duplicate", url: "https://github.com/openclaw/openclaw/issues/123" },
+      "Existing issue: https://github.com/openclaw/openclaw/issues/123",
+    ],
+    [
+      "duplicate fallback with a retired locator",
+      { status: "duplicate", fallbackUrl: "https://github.com/openclaw/openclaw/issues/new" },
+      "Existing prefilled issue: https://github.com/openclaw/openclaw/issues/new",
+    ],
+    ["pending", { status: "pending" }, undefined],
+    ["unsaved stale", { status: "stale" }, undefined],
+  ] as const)(
+    "keeps %s guidance without claiming a saved artifact",
+    async (_name, result, link) => {
+      const fixture = setup("report", true);
+      const message = "Report outcome details";
+      fixture.submit.mockResolvedValue({
+        ...result,
+        message,
+        savedReportPath: fixture.prepared.savedReportPath,
+      });
+
+      await expect(fixture.run()).resolves.toBe("handled");
+
+      expect(fixture.runtime.log).toHaveBeenCalledWith(message);
+      if (link) {
+        expect(fixture.runtime.log).toHaveBeenCalledWith(link);
+      }
+      expect(fixture.runtime.log).not.toHaveBeenCalledWith(
+        expect.stringContaining("Saved sanitized report:"),
+      );
+    },
+  );
+
+  it("keeps the saved report path beside an ordinary browser fallback", async () => {
+    const fixture = setup("report", true);
+    fixture.submit.mockResolvedValue({
+      status: "fallback",
+      message: "GitHub submission is unavailable.",
+      fallbackUrl: fixture.prepared.url,
+      savedReportPath: fixture.prepared.savedReportPath,
+    });
+
+    await expect(fixture.run()).resolves.toBe("handled");
+
+    expect(fixture.runtime.log).toHaveBeenCalledWith(`Prefilled issue: ${fixture.prepared.url}`);
+    expect(fixture.runtime.log).toHaveBeenCalledWith(
+      `Saved sanitized report: ${fixture.prepared.savedReportPath}`,
+    );
+  });
+
   it("returns a retryable no-start result to explicit action and confirmation", async () => {
     const fixture = setup(["report", "report"], true);
     fixture.submit

--- a/src/cli/update-cli/update-command-report.ts
+++ b/src/cli/update-cli/update-command-report.ts
@@ -31,7 +31,6 @@ function renderSubmissionResult(result: UpdateFailureReportSubmitResult): string
     result.message,
     ...(result.url ? [`Existing issue: ${result.url}`] : []),
     ...(result.fallbackUrl ? [`Existing prefilled issue: ${result.fallbackUrl}`] : []),
-    `Saved sanitized report: ${result.savedReportPath}`,
   ];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the failed-update CLI reporting a saved diagnostic file when a duplicate, pending, or stale report result carries only a possible artifact location. A completed duplicate can point to a file already cleaned up, and a stale attempt may never have saved it.

## Why This Change Was Made

Remove the unsupported saved-file claim from generic report outcomes while preserving their message and existing issue or browser-handoff link. The ordinary browser fallback still prints its saved report path. A matching fallback link alone cannot establish that a duplicate result's local locator is current.

The repair deletes one production line. It changes no report submission, receipt, artifact retention, or persistent-store behavior.

## User Impact

Operators receive useful report status and links without being directed to a file whose availability the result does not establish.

## Evidence

- Four new generic-result cases fail on original production and pass after the one-line repair, using the same final test source. Existing behavior and the ordinary saved-file fallback stay covered.
- All 32 focused report and rollback-report cases pass on the current private dependency graph.
- All 29 canonical changed-file checks pass, including types, formatting, lint, and dependency checks.
- Fresh independent Codex review found no actionable findings through P2.

The producer's existing artifact-absence tests were inspected to establish the result contract; this patch does not change or rerun its persistence implementation.
