### PR TITLE
improve: reduce SQLite snapshot test comparison time

### DIFF
--- a/src/infra/sqlite-snapshot.test.ts
+++ b/src/infra/sqlite-snapshot.test.ts
@@ -316,8 +316,13 @@ describe("createVerifiedSqliteSnapshot", () => {
 
       await expectSnapshotSuccess({ sourcePath, targetPath });
 
-      await expect(fs.readFile(sourcePath)).resolves.toEqual(sourceBefore);
-      await expect(fs.readFile(`${sourcePath}-journal`)).resolves.toEqual(journalBefore);
+      expect((await fs.readFile(sourcePath)).equals(sourceBefore), "source bytes unchanged").toBe(
+        true,
+      );
+      expect(
+        (await fs.readFile(`${sourcePath}-journal`)).equals(journalBefore),
+        "journal bytes unchanged",
+      ).toBe(true);
       withReadOnlySnapshot(sqlite, targetPath, (snapshot) => {
         expect(
           snapshot.prepare("SELECT COUNT(*) AS count FROM records WHERE value = 'committed'").get(),
@@ -377,8 +382,13 @@ describe("createVerifiedSqliteSnapshot", () => {
         /super-journal.*cannot be recovered privately/iu,
       );
 
-      await expect(fs.readFile(sourcePath)).resolves.toEqual(sourceBefore);
-      await expect(fs.readFile(`${sourcePath}-journal`)).resolves.toEqual(journalBefore);
+      expect((await fs.readFile(sourcePath)).equals(sourceBefore), "source bytes unchanged").toBe(
+        true,
+      );
+      expect(
+        (await fs.readFile(`${sourcePath}-journal`)).equals(journalBefore),
+        "journal bytes unchanged",
+      ).toBe(true);
       await expect(fs.readFile(superJournalPath)).resolves.toEqual(superJournalBefore);
       await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
     },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where SQLite snapshot CI tests spend roughly 10 seconds comparing unchanged database and rollback-journal bytes. Profiling attributed 10.22 seconds to four generic Buffer equality assertions.

## Why This Change Was Made

Use native `Buffer.equals` for the four large byte comparisons, with source/journal assertion labels. This preserves exact content and length checks while avoiding generic deep-equality traversal. Real crash-created journals, private recovery, integrity checks, super-journal refusal, and cleanup assertions remain intact.

## User Impact

Developers spend less time waiting on snapshot test assertions. No production code, storage semantics, test selection, worker counts, or timeouts change.

## Evidence

Measured locally on macOS arm64, Node 24.16.0, against baseline `c9b30878a696a24dabb9ac0320c38f8cf4a4e98a`:

- Same three focused hot-journal cases: **11.615s → 2.165s** combined test-body time, saving **9.45s (81%)**.
- Individual cases: 5541/438/5636ms → 997/316/852ms.
- A temporary one-byte mutation of the expected source buffer failed the intended assertion; the mutation was restored.
- Final complete file: **35 passed, 2 platform skips**.
- `node scripts/check-changed.mjs`: passed, including typecheck, lint, repository guards, and dead-export scans.
- Independent P2 autoreview: no actionable findings. `git diff --check`: passed.

Focused reproduction: `node scripts/run-vitest.mjs src/infra/sqlite-snapshot.test.ts -t 'hot rollback journal|hot journal depends'`. Full-file validation: `node scripts/run-vitest.mjs src/infra/sqlite-snapshot.test.ts`.

These are test-body measurements, not a measured whole-job saving. The focused command wall time was noisier and increased from 28.37s to 31.97s under concurrent host work and transform preparation. Linux CI savings and workflow critical-path impact remain unmeasured.
