### PR TITLE
fix(webchat): expose inline uploads to file tools

### DIFF
--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -393,6 +393,34 @@ describe("resolveCurrentTurnImages", () => {
     expect(resolveAgentTurnAttachments).not.toHaveBeenCalled();
   });
 
+  it("does not rehydrate a managed copy of an already-provided inline image", async () => {
+    vi.mocked(resolveAgentTurnAttachments).mockClear();
+    const inlineImage = {
+      type: "image" as const,
+      data: Buffer.from("inline").toString("base64"),
+      mimeType: "image/png",
+    };
+
+    const result = await resolveCurrentTurnImages({
+      ctx: {
+        Body: "inspect",
+        media: [
+          {
+            path: "/state/media/inbound/photo.png",
+            contentType: "image/png",
+            hydrationSuppressed: true,
+          },
+        ],
+      } satisfies MsgContext,
+      cfg: {} as OpenClawConfig,
+      images: [inlineImage],
+      imageOrder: ["inline"],
+    });
+
+    expect(result).toEqual({ images: [inlineImage], imageOrder: ["inline"] });
+    expect(resolveAgentTurnAttachments).not.toHaveBeenCalled();
+  });
+
   it("hydrates only current image facts missing prompt descriptions", async () => {
     const imageData = Buffer.from("second image").toString("base64");
     vi.mocked(resolveAgentTurnAttachments).mockResolvedValueOnce({

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -14,6 +14,7 @@ import {
   type ExtractedFileImage,
 } from "../../media-understanding/extracted-file-images.js";
 import type { MediaAttachment } from "../../media-understanding/types.js";
+import { normalizeMediaFacts } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
 import {
@@ -40,7 +41,15 @@ export type CurrentTurnImages = {
 };
 
 function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment[] {
+  const hydrationSuppressedIndexes = new Set(
+    normalizeMediaFacts(ctx.media).flatMap((fact, index) =>
+      fact.hydrationSuppressed === true ? [index] : [],
+    ),
+  );
   return normalizeAttachments(ctx).flatMap((attachment) => {
+    if (hydrationSuppressedIndexes.has(attachment.index)) {
+      return [];
+    }
     const mediaPath = normalizeOptionalString(attachment.path);
     return mediaPath && isImageAttachment(attachment) ? [{ ...attachment, path: mediaPath }] : [];
   });

--- a/src/auto-reply/reply/get-reply.media-staging.test.ts
+++ b/src/auto-reply/reply/get-reply.media-staging.test.ts
@@ -1,9 +1,12 @@
+import fs from "node:fs/promises";
 import { beforeAll, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { waitForAbortSignal } from "../../infra/abort-signal.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { withFastReplyConfig } from "./get-reply-fast-path.test-support.js";
 import {
+  buildGetReplyCtx,
   buildGetReplyGroupCtx,
   createGetReplyContinueDirectivesResult,
   createGetReplySessionState,
@@ -160,3 +163,100 @@ it.each(["remote preprocessing", "local staging"] as const)(
     );
   },
 );
+
+it.each([
+  { name: "ordinary session cwd", kind: "session", destination: "session-workspace" },
+  { name: "configured workspace", kind: "default", destination: "configured-workspace" },
+  { name: "inherited subagent workspace", kind: "spawned", destination: "inherited-workspace" },
+] as const)("stages inbound media in the $name", async ({ kind, destination }) => {
+  await withOpenClawTestState(
+    { label: "reply-media-workspace", env: { OPENCLAW_TEST_FAST: undefined } },
+    async (state) => {
+      const configuredWorkspace = state.path("configured-workspace");
+      const sessionCwd = state.path("session-workspace");
+      const inheritedWorkspace = state.path("inherited-workspace");
+      const sessionKey =
+        kind === "spawned" ? "agent:main:subagent:upload-workspace" : "agent:main:upload-workspace";
+      await Promise.all(
+        [configuredWorkspace, sessionCwd, inheritedWorkspace].map((directory) =>
+          fs.mkdir(directory, { recursive: true }),
+        ),
+      );
+      const sessionEntry: SessionEntry = {
+        sessionId: "session-media-workspace",
+        updatedAt: 1,
+        ...(kind !== "default" ? { spawnedCwd: sessionCwd } : {}),
+        ...(kind === "spawned"
+          ? {
+              spawnedBy: "agent:main:main",
+              spawnedWorkspaceDir: inheritedWorkspace,
+            }
+          : {}),
+      };
+      const ctx = buildGetReplyCtx({
+        Provider: "webchat",
+        Surface: "webchat",
+        SessionKey: sessionKey,
+        From: "webchat:owner",
+        To: "webchat:workspace",
+        media: [{ path: state.path("media/inbound/photo.png"), contentType: "image/png" }],
+      });
+      vi.mocked(stageSandboxMedia).mockReset().mockResolvedValue({ staged: new Map() });
+      vi.mocked(applyMediaUnderstanding).mockReset().mockResolvedValue({
+        outputs: [],
+        decisions: [],
+        extractedFileImages: [],
+        appliedImage: false,
+        appliedAudio: false,
+        appliedVideo: false,
+        appliedFile: false,
+      });
+      vi.mocked(runPreparedReply).mockReset().mockResolvedValue({ text: "ready" });
+      mocks.createInternalHookEvent.mockClear();
+      mocks.triggerInternalHook.mockClear();
+      mocks.initSessionState.mockReset().mockResolvedValue(
+        createGetReplySessionState({
+          sessionCtx: ctx,
+          sessionEntry,
+          sessionEntryHandle: createReplySessionEntryHandle({ sessionEntry, sessionKey }),
+          sessionKey,
+          sessionId: sessionEntry.sessionId,
+          storePath: state.path("sessions.json"),
+        }),
+      );
+      mocks.resolveReplySessionPreprocessingState.mockReset().mockReturnValue({
+        sessionEntry: undefined,
+        sessionKey,
+        storePath: state.path("sessions.json"),
+      });
+      mocks.resolveReplyDirectives.mockReset().mockResolvedValue(
+        createGetReplyContinueDirectivesResult({
+          body: "inspect this attachment",
+          abortKey: sessionKey,
+          from: "webchat:owner",
+          to: "webchat:workspace",
+          senderId: "owner",
+          commandSource: "message",
+          senderIsOwner: true,
+          resetHookTriggered: false,
+        }),
+      );
+      mocks.handleInlineActions.mockReset().mockResolvedValue({
+        kind: "continue",
+        directives: {},
+        cleanedBody: "inspect this attachment",
+      });
+
+      await getReplyFromConfig(
+        ctx,
+        undefined,
+        withFastReplyConfig({ agents: { defaults: { workspace: configuredWorkspace } } }),
+      );
+
+      expect(stageSandboxMedia).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ workspaceDir: state.path(destination) }),
+      );
+      expect(runPreparedReply).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -17,6 +17,7 @@ import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-model-catalog-owner.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
+import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { resolveEffectiveToolFsRootExpansionAllowed } from "../../agents/tool-fs-policy.js";
 import {
@@ -1196,6 +1197,12 @@ export async function getReplyFromConfig(
     hasInboundMedia(ctx)
   ) {
     const { stageSandboxMedia } = await stageSandboxMediaRuntimeLoader.load();
+    const stagingWorkspaceDir =
+      resolveIngressWorkspaceOverrideForSessionRun({
+        spawnedBy: sessionEntry.spawnedBy,
+        workspaceDir: sessionEntry.spawnedWorkspaceDir,
+        cwd: sessionEntry.spawnedCwd,
+      }) ?? workspaceDir;
     const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
       stageSandboxMedia({
         ctx,
@@ -1203,7 +1210,7 @@ export async function getReplyFromConfig(
         cfg,
         agentId,
         sessionKey,
-        workspaceDir,
+        workspaceDir: stagingWorkspaceDir,
         abortSignal: internalOptsWithSkillFilter?.abortSignal,
       }),
     );

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -156,6 +156,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     accountId,
     ctx,
     isInternalTextSlashCommandTurn,
+    managedMediaApplyMode,
     pluginBoundMediaPromise,
     queuedFollowupOwnerKey,
     replyOptionImages,
@@ -324,7 +325,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
           }
           const pluginBoundMedia = await pluginBoundMediaPromise;
           assertWorkspaceRunOwnership?.();
-          applyChatSendManagedMedia(ctx, pluginBoundMedia);
+          applyChatSendManagedMedia(ctx, pluginBoundMedia, managedMediaApplyMode);
           const dispatchInbound = () => {
             assertWorkspaceRunOwnership?.();
             return dispatchInboundMessageWithProjectedDispatcher({

--- a/src/gateway/server-methods/chat-send-message-injection.test.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.test.ts
@@ -218,6 +218,7 @@ describe("createChatSendMessageInjectionStarter", () => {
         accountId: undefined,
         ctx: { Provider: "dashboard", Body: params?.body, media: params?.media },
         isInternalTextSlashCommandTurn: params?.isInternalTextSlashCommandTurn ?? false,
+        managedMediaApplyMode: "replace-empty",
         queuedFollowupOwnerKey: undefined,
         pluginBoundMediaPromise: Promise.resolve([]),
         replyOptionImages: params?.replyOptionImages ?? [],

--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -621,6 +621,85 @@ describe("prepareChatSendUserTurn", () => {
     }
   });
 
+  it("exposes an ordinary WebChat inline image as managed media for downstream staging", async () => {
+    const persistedPath = "/state/media/inbound/photo.png";
+    const persist = vi
+      .spyOn(chatAttachments, "persistInboundImagesForTranscript")
+      .mockResolvedValueOnce({
+        entries: [
+          {
+            id: "photo.png",
+            path: persistedPath,
+            sourceIndex: 0,
+            imageKind: "inline",
+            fact: {
+              url: "media://inbound/photo.png",
+              contentType: "image/png",
+              kind: "image",
+              sizeBytes: 10,
+            },
+          },
+        ],
+        omission: "none",
+      });
+    try {
+      const { controller } = createUserTurnInputController();
+      const prepared = prepareChatSendUserTurn({
+        request: {
+          inboundMessage: "inspect",
+          clientInfo: createClientInfo({
+            id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+          }),
+          suppressCommandInterpretation: false,
+          systemInputProvenance: undefined,
+          systemProvenanceReceipt: undefined,
+        },
+        session: {
+          agentId: "main",
+          clientRunId: "run-inline",
+          sessionKey: "agent:main:main",
+        },
+        admission: {
+          originatingRoute: { originatingChannel: "webchat", explicitDeliverRoute: false },
+        },
+        attachments: createAttachments({
+          imageOrder: ["inline"],
+          parsedImages: [
+            { type: "image", data: "aGVsbG8=", mimeType: "image/png", sourceIndex: 0 },
+          ],
+        }),
+        client: null,
+        logGateway: { warn: vi.fn() } as never,
+        userTurn: controller,
+      });
+
+      const managedMedia = await prepared.pluginBoundMediaPromise;
+      expect(managedMedia).toEqual([
+        {
+          path: persistedPath,
+          contentType: "image/png",
+          hydrationSuppressed: true,
+        },
+      ]);
+      const ctx = {
+        media: [{ path: "uploads/report.pdf", workspaceDir: "/workspace" }],
+      } as MsgContext;
+      applyChatSendManagedMedia(ctx, managedMedia, prepared.managedMediaApplyMode);
+      applyChatSendManagedMedia(ctx, managedMedia, prepared.managedMediaApplyMode);
+      expect(ctx.media).toEqual([
+        { path: "uploads/report.pdf", workspaceDir: "/workspace" },
+        {
+          path: persistedPath,
+          contentType: "image/png",
+          hydrationSuppressed: true,
+        },
+      ]);
+    } finally {
+      persist.mockRestore();
+    }
+  });
+
   it.each([
     { kind: "audio" as const, mimeType: "audio/mpeg", fileName: "voice.mp3" },
     { kind: "video" as const, mimeType: "video/mp4", fileName: "clip.mp4" },

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -59,16 +59,40 @@ async function persistChatSendImages(params: {
   });
 }
 
-function resolveChatSendManagedMedia(entries: PersistedChatSendMedia): MediaFact[] {
+function resolveChatSendManagedMedia(
+  entries: PersistedChatSendMedia,
+  suppressInlineHydration = false,
+): MediaFact[] {
   return entries.map((entry) => ({
     path: entry.path,
     contentType: entry.fact.contentType ?? "application/octet-stream",
+    ...(suppressInlineHydration && entry.imageKind === "inline"
+      ? { hydrationSuppressed: true }
+      : {}),
   }));
 }
 
-export function applyChatSendManagedMedia(ctx: MsgContext, media: MediaFact[]): void {
-  if ((!ctx.media || ctx.media.length === 0) && media.length > 0) {
-    ctx.media = media;
+type ChatSendManagedMediaApplyMode = "replace-empty" | "append-missing";
+
+export function applyChatSendManagedMedia(
+  ctx: MsgContext,
+  media: MediaFact[],
+  mode: ChatSendManagedMediaApplyMode = "replace-empty",
+): void {
+  if (media.length === 0) {
+    return;
+  }
+  if (mode === "replace-empty") {
+    if (!ctx.media || ctx.media.length === 0) {
+      ctx.media = media;
+    }
+    return;
+  }
+  const existing = ctx.media ?? [];
+  const existingPaths = new Set(existing.flatMap((fact) => (fact.path ? [fact.path] : [])));
+  const missing = media.filter((fact) => !fact.path || !existingPaths.has(fact.path));
+  if (missing.length > 0) {
+    ctx.media = [...existing, ...missing];
   }
 }
 
@@ -132,10 +156,13 @@ export function prepareChatSendUserTurn(params: {
     }),
   );
   const pluginBoundMediaPromise =
-    attachments.explicitOriginTargetsPlugin && attachments.parsedImages.length > 0
-      ? persistedMediaForTranscriptPromise.then((result) =>
-          resolveChatSendManagedMedia(result.entries),
-        )
+    attachments.parsedImages.length > 0
+      ? persistedMediaForTranscriptPromise.then((result) => {
+          const entries = attachments.explicitOriginTargetsPlugin
+            ? result.entries
+            : result.entries.filter((entry) => entry.imageKind === "inline");
+          return resolveChatSendManagedMedia(entries, !attachments.explicitOriginTargetsPlugin);
+        })
       : Promise.resolve([]);
   void pluginBoundMediaPromise.catch(() => undefined);
   // Generated media hints belong to the prompt and reset payload, not command arguments.
@@ -239,6 +266,9 @@ export function prepareChatSendUserTurn(params: {
     isInternalTextSlashCommandTurn: commandSource === "text",
     queuedFollowupOwnerKey,
     pluginBoundMediaPromise,
+    managedMediaApplyMode: attachments.explicitOriginTargetsPlugin
+      ? ("replace-empty" as const)
+      : ("append-missing" as const),
     replyOptionImages: mediaPathOffloadsIncludeImages
       ? undefined
       : attachments.parsedImages.length > 0

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -6294,7 +6294,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         ],
         ["/tmp/chat-send-image-a.png", "/tmp/chat-send-image-b.jpg"],
       );
-      expect(mockState.lastDispatchCtx?.media).toBeUndefined();
+      expect(mockState.lastDispatchCtx?.media).toEqual([
+        {
+          path: "/tmp/chat-send-image-a.png",
+          contentType: "image/png",
+          hydrationSuppressed: true,
+        },
+        {
+          path: "/tmp/chat-send-image-b.jpg",
+          contentType: "image/jpeg",
+          hydrationSuppressed: true,
+        },
+      ]);
       expect(mockState.lastDispatchImages).toHaveLength(2);
     });
   });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -3646,6 +3646,78 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.send exposes inline image uploads as managed media without duplicating vision input", async () => {
+    openDirectChatSession();
+    try {
+      testState.agentConfig = { model: { primary: "test-provider/vision-model" } };
+      await writeStoredMainSession({
+        modelProvider: "test-provider",
+        model: "vision-model",
+      });
+
+      const context = createDirectChatContext({
+        getRuntimeConfig,
+        loadGatewayModelCatalogSnapshot: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalogSnapshot"]>()
+          .mockResolvedValue(createChatVisionModelCatalogSnapshot()),
+      });
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      let captured: { ctx?: Record<string, unknown>; replyOptions?: GetReplyOptions } | undefined;
+      dispatchInboundMessageMock.mockImplementation(async (...args: unknown[]) => {
+        const [params] = args as [
+          {
+            ctx: Record<string, unknown>;
+            replyOptions?: GetReplyOptions;
+          },
+        ];
+        if (params.replyOptions?.runId === "idem-inline-image-managed-media") {
+          captured = {
+            ctx: params.ctx,
+            replyOptions: params.replyOptions,
+          };
+        }
+      });
+
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      await callDirectChat("chat.send", {
+        id: "inline-image-managed-media",
+        params: makeChatSendParams({
+          message: "inspect the uploaded file",
+          idempotencyKey: "idem-inline-image-managed-media",
+          attachments: [
+            {
+              type: "image",
+              mimeType: "image/png",
+              fileName: "dot.png",
+              content: pngB64,
+            },
+          ],
+        }),
+        respond: captureChatResponse(responses),
+        context,
+      });
+
+      expect(responses[0]?.ok).toBe(true);
+      await waitForFast(() => expect(captured).toBeDefined(), FAST_WAIT_OPTS);
+      expect(captured?.replyOptions?.images).toEqual([
+        { type: "image", data: pngB64, mimeType: "image/png", sourceIndex: 0 },
+      ]);
+      expect(captured?.ctx?.media).toEqual([
+        expect.objectContaining({
+          path: expect.any(String),
+          contentType: "image/png",
+          hydrationSuppressed: true,
+        }),
+      ]);
+      await waitForFast(() => expect(context.removeChatRun).toHaveBeenCalledTimes(1));
+    } finally {
+      dispatchInboundMessageMock.mockReset();
+      testState.agentConfig = undefined;
+      testState.sessionStorePath = undefined;
+    }
+  });
+
   test.each(configuredImageModelCases)(
     "chat.send preserves text-only image uploads as MediaPaths even with configured imageModel: $id",
     async ({ id, imageModel }) => {


### PR DESCRIPTION
Refs #103198

## What Problem This Solves

Small images uploaded through WebChat reach vision, but the agent cannot use the same upload with file tools because the active turn omits its persisted media entry.

This change passes that entry to the existing validated staging owner and selects the session's execution workspace. It suppresses image hydration from the managed copy, so the model keeps one original user-image input. Configured workspaces for skills and model preparation remain separate from session and subagent execution workspaces.

## Evidence

The built Gateway and bundled Control UI reproduced the missing-path failure on pinned main `94a2d79bf934`. Real browser validation also found that the initial fix staged a selected-workspace upload in the default workspace, where the file guard correctly rejected it. The completed repair stages the upload in its selected workspace before the actual file read and digest command.

Verified runtime outcomes:

- Ordinary small-image upload, actual file read, and actual SHA-256 command agree on the uploaded bytes.
- Mixed image/document uploads remain readable with one image on the current user message.
- A second workspace receives its own files; its file guard rejects the first workspace.
- Larger offloaded images retain their original bytes and single vision input.

The small-image digest was `860f57b09f6d8d3e4264ec14ea3ca2157878804e0cd7ae0cd375ea3da62c502e`. The distinct mixed/selected-workspace image digest was `86c4823ac6fb1fc20bb1e0cad44a384c1bbbf60e580761caf82baa8c40abd296`.

Validation: 125 distinct focused attachment, Gateway, staging, lifecycle, and workspace cases passed across the retained proof; affected staging and skills/cwd cases were rerun after the workspace correction. Durable image claims remain path-free while active media provides the files for staging. New regressions fail on baseline production for the intended reasons. Runtime builds, changed-file formatting, syntax lint, and line/assertion checks pass. Independent runtime validation uses synthetic uploads and fresh judgments for each local provider request.

Scope: this fixes ordinary inline upload access. The existing vision-capable all-offloaded route still supplies no file-tool path, so the broader issue remains linked. File-policy proof is not an OS-container test. AI-assisted.
