### PR TITLE
fix(agents): failed sandbox setup leaves containers running

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -18,6 +18,9 @@ const resolveProviderRuntimePluginHandle = vi.hoisted(() => vi.fn());
 const resolveSandboxContext = vi.hoisted(() =>
   vi.fn<typeof resolveRealSandboxContext>(async () => null),
 );
+const removeCreatedSandboxRuntime = vi.hoisted(() =>
+  vi.fn<(containerName: string) => Promise<void>>(async () => {}),
+);
 
 vi.mock("../../../plugins/provider-hook-runtime.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../plugins/provider-hook-runtime.js")>()),
@@ -25,6 +28,8 @@ vi.mock("../../../plugins/provider-hook-runtime.js", async (importOriginal) => (
 }));
 
 vi.mock("../../sandbox.js", () => ({ resolveSandboxContext }));
+
+vi.mock("../../sandbox/created-runtime.js", () => ({ removeCreatedSandboxRuntime }));
 
 import {
   installEmbeddedAttemptContextGuards,
@@ -65,6 +70,7 @@ describe("prepareEmbeddedAttemptSetup", () => {
   beforeEach(() => {
     resolveProviderRuntimePluginHandle.mockReset();
     resolveSandboxContext.mockClear();
+    removeCreatedSandboxRuntime.mockClear();
   });
 
   it("prepares the identity that owns the current agent session", async () => {
@@ -271,6 +277,45 @@ describe("prepareEmbeddedAttemptSetup", () => {
         workspaceDir,
       }),
     ).rejects.toThrow("sandbox workspace is not read-write; collection review skipped");
+  });
+
+  it("releases a runtime it created when workspace setup fails before dispatch", async () => {
+    const workspaceDir = tempDirs.make("openclaw-attempt-setup-created-runtime-release-");
+    resolveSandboxContext.mockResolvedValueOnce({
+      ...sandboxContext("ro"),
+      createdRuntime: true,
+    });
+
+    await expect(
+      resolveAttemptWorkspaceSandbox({
+        agentId: "main",
+        config: { agents: { defaults: { sandbox: { mode: "all", workspaceAccess: "ro" } } } },
+        sessionId: "session-created-runtime-release",
+        sessionKey: "agent:main:skill-collection-review",
+        requireWritableSandbox: true,
+        workspaceDir,
+      }),
+    ).rejects.toThrow("sandbox workspace is not read-write; collection review skipped");
+
+    expect(removeCreatedSandboxRuntime).toHaveBeenCalledWith("openclaw-sandbox");
+  });
+
+  it("keeps a reused runtime when workspace setup fails before dispatch", async () => {
+    const workspaceDir = tempDirs.make("openclaw-attempt-setup-reused-runtime-kept-");
+    resolveSandboxContext.mockResolvedValueOnce(sandboxContext("ro"));
+
+    await expect(
+      resolveAttemptWorkspaceSandbox({
+        agentId: "main",
+        config: { agents: { defaults: { sandbox: { mode: "all", workspaceAccess: "ro" } } } },
+        sessionId: "session-reused-runtime-kept",
+        sessionKey: "agent:main:skill-collection-review",
+        requireWritableSandbox: true,
+        workspaceDir,
+      }),
+    ).rejects.toThrow("sandbox workspace is not read-write; collection review skipped");
+
+    expect(removeCreatedSandboxRuntime).not.toHaveBeenCalled();
   });
 
   it("reuses lifecycle metadata and the provider handle from the runtime plan", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -13,6 +13,7 @@ import {
 import { resolveAgentDir } from "../../agent-scope.js";
 import { buildExecAutoReviewTranscript } from "../../exec-auto-review-transcript.js";
 import { recordAgentCleanupFailure, runOwnedAgentCleanup } from "../../run-cleanup-timeout.js";
+import { removeCreatedSandboxRuntime } from "../../sandbox/created-runtime.js";
 import {
   clearToolSearchCatalog,
   type ToolSearchCatalogRef,
@@ -88,6 +89,10 @@ export async function runEmbeddedAttempt(
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
   let toolSearchCatalogApplied = false;
+  // This attempt owns a runtime it created until dispatch takes over. Ownership
+  // is released at the dispatch boundary so successful runs and post-dispatch
+  // failures keep their session-scoped sandbox available for reuse.
+  let sandboxRuntimeOwned = sandbox?.createdRuntime === true;
   let runCleanups: Array<(reason: string) => Promise<void>> = [];
   const resources: EmbeddedAttemptSessionResources = {
     trajectoryRecorder: null,
@@ -119,6 +124,17 @@ export async function runEmbeddedAttempt(
       recordAgentCleanupFailure();
     } finally {
       bundleLspRuntime = undefined;
+    }
+    if (sandboxRuntimeOwned && sandbox) {
+      sandboxRuntimeOwned = false;
+      try {
+        await removeCreatedSandboxRuntime(sandbox.containerName);
+      } catch (error) {
+        recordAgentCleanupFailure();
+        log.warn(
+          `failed to remove sandbox runtime created for this attempt: runId=${params.runId} ${String(error)}`,
+        );
+      }
     }
   };
   const externalAbortController = createEmbeddedAttemptExternalAbortController({
@@ -429,6 +445,9 @@ export async function runEmbeddedAttempt(
       bundleMcpRuntime = undefined;
       bundleLspRuntime = undefined;
       toolSearchCatalogApplied = false;
+      // Dispatch owns the sandbox from here on; a session-scoped runtime must
+      // survive both success and post-dispatch failure for reuse.
+      sandboxRuntimeOwned = false;
       await cleanupStep("embedded-session", () =>
         cleanupEmbeddedAttemptSessionPhase({
           attempt: params,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -252,9 +252,13 @@ function assertSandboxSessionSecretOwnerAvailable(
   });
 }
 
+/** Tracks a runtime this resolution created so a failure releases only that runtime. */
+type SandboxRuntimeOwnership = { createdRuntimeId?: string };
+
 async function resolveProvisionedSandboxContext(
   params: ResolveSandboxContextParams,
   resolved: ResolvedSandboxSession,
+  ownership: SandboxRuntimeOwnership = {},
 ): Promise<SandboxContext> {
   const { rawSessionKey, cfg, runtime } = resolved;
 
@@ -304,6 +308,15 @@ async function resolveProvisionedSandboxContext(
       ? { requireCurrentConfig: params.requireCurrentConfig }
       : {}),
   });
+  // The factory can only reuse a runtime whose ID was already registered for
+  // this scope, so an ID absent from that list was created by this call. Taking
+  // ownership here keeps it inside the provisioning lifecycle instead of
+  // inferring it later from registry timestamps, which cannot tell a runtime
+  // this attempt created from one another attempt is still using.
+  const createdRuntime = !registeredRuntimeIds.includes(backend.runtimeId);
+  if (createdRuntime) {
+    ownership.createdRuntimeId = backend.runtimeId;
+  }
   await updateRegistry({
     containerName: backend.runtimeId,
     backendId: backend.id,
@@ -369,6 +382,7 @@ async function resolveProvisionedSandboxContext(
     runtimeId: backend.runtimeId,
     runtimeLabel: backend.runtimeLabel,
     containerName: backend.runtimeId,
+    ...(createdRuntime ? { createdRuntime: true as const } : {}),
     containerWorkdir: backend.workdir,
     docker: resolvedCfg.docker,
     tools: resolvedCfg.tools,
@@ -400,10 +414,21 @@ export async function resolveSandboxContext(params: {
   // Once a sandbox session is selected, every remaining step is local
   // provisioning. Preserve that owner boundary across backend, browser,
   // registry, and filesystem-bridge setup so model fallback never retries it.
+  const ownership: SandboxRuntimeOwnership = {};
   try {
     assertSandboxSessionSecretOwnerAvailable(params.config, resolved);
-    return await resolveProvisionedSandboxContext(params, resolved);
+    return await resolveProvisionedSandboxContext(params, resolved, ownership);
   } catch (error) {
+    // Browser and fs-bridge setup run after the runtime exists, so a failure
+    // here would otherwise leave a container running with no handle to it.
+    if (ownership.createdRuntimeId) {
+      try {
+        const { removeCreatedSandboxRuntime } = await import("./created-runtime.js");
+        await removeCreatedSandboxRuntime(ownership.createdRuntimeId);
+      } catch {
+        // Teardown failure must not replace the provisioning error.
+      }
+    }
     throw toSandboxProvisioningError(error, resolved.cfg.backend);
   }
 }

--- a/src/agents/sandbox/created-runtime.ts
+++ b/src/agents/sandbox/created-runtime.ts
@@ -1,0 +1,31 @@
+import { getSandboxBackendManager } from "./backend.js";
+import { readRegistry, removeRegistryEntry } from "./registry.js";
+
+/**
+ * Removes a sandbox runtime that one attempt created for itself.
+ *
+ * Mirrors the prune teardown order: stop the backing runtime through its
+ * backend manager first, then drop the registry entry, so the registry never
+ * advertises a runtime that is already gone.
+ *
+ * Throws when the owning backend is unavailable or rejects removal. Callers
+ * unwinding from an earlier failure must catch and log; a teardown error must
+ * never replace the error that caused the failure.
+ */
+export async function removeCreatedSandboxRuntime(containerName: string): Promise<void> {
+  const registry = await readRegistry();
+  const entry = registry.entries.find((candidate) => candidate.containerName === containerName);
+  if (!entry) {
+    return;
+  }
+  const backendId = entry.backendId ?? "docker";
+  const manager = getSandboxBackendManager(backendId);
+  if (!manager) {
+    throw new Error(
+      `Sandbox backend "${backendId}" is unavailable; cannot remove runtime ${containerName}.`,
+    );
+  }
+  const { getRuntimeConfig } = await import("../../config/config.js");
+  await manager.removeRuntime({ entry, config: getRuntimeConfig() });
+  await removeRegistryEntry(containerName);
+}

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -115,6 +115,8 @@ export type SandboxContext = {
   runtimeId: string;
   runtimeLabel: string;
   containerName: string;
+  /** Set when this resolution created the runtime instead of reusing a registered one. */
+  createdRuntime?: true;
   containerWorkdir: string;
   docker: SandboxDockerConfig;
   tools: SandboxToolPolicy;

--- a/src/agents/workspace-sandbox.ts
+++ b/src/agents/workspace-sandbox.ts
@@ -3,6 +3,7 @@ import { resolveUserPath } from "../utils.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
 import { resolveSandboxContext } from "./sandbox.js";
+import { removeCreatedSandboxRuntime } from "./sandbox/created-runtime.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "./tool-fs-policy.js";
 
 export type WorkspaceSandboxParams = Pick<
@@ -44,41 +45,57 @@ export async function resolveAttemptWorkspaceSandbox(params: WorkspaceSandboxPar
     skillsSnapshot: params.skillsSnapshot,
     workspaceDir: resolvedWorkspace,
   });
-  const effectiveWorkspace =
-    sandbox?.enabled && sandbox.workspaceAccess !== "rw" ? sandbox.workspaceDir : resolvedWorkspace;
-  if (params.requireWritableSandbox && sandbox?.enabled && sandbox.workspaceAccess !== "rw") {
-    throw new Error("sandbox workspace is not read-write; collection review skipped");
-  }
-  const requestedCwd = params.cwd ? resolveUserPath(params.cwd) : undefined;
-  // Recorded roots pin worktree/explicit-cwd boundaries; rootless sessions use
-  // the agent's canonical workspace as their permission boundary.
-  const sessionPermissionRoot = params.sessionRoot ?? (await fs.realpath(resolvedWorkspace));
-  const sessionPermissionPolicy = params.permissionMode
-    ? {
-        root: sessionPermissionRoot,
-        mode: params.permissionMode,
+  // Every failure below returns an error while the runtime resolved above keeps
+  // running, so own it here: release only a runtime this call created, then
+  // rethrow the original error untouched.
+  try {
+    const effectiveWorkspace =
+      sandbox?.enabled && sandbox.workspaceAccess !== "rw"
+        ? sandbox.workspaceDir
+        : resolvedWorkspace;
+    if (params.requireWritableSandbox && sandbox?.enabled && sandbox.workspaceAccess !== "rw") {
+      throw new Error("sandbox workspace is not read-write; collection review skipped");
+    }
+    const requestedCwd = params.cwd ? resolveUserPath(params.cwd) : undefined;
+    // Recorded roots pin worktree/explicit-cwd boundaries; rootless sessions use
+    // the agent's canonical workspace as their permission boundary.
+    const sessionPermissionRoot = params.sessionRoot ?? (await fs.realpath(resolvedWorkspace));
+    const sessionPermissionPolicy = params.permissionMode
+      ? {
+          root: sessionPermissionRoot,
+          mode: params.permissionMode,
+        }
+      : undefined;
+    if (sandbox?.enabled && requestedCwd && requestedCwd !== resolvedWorkspace) {
+      throw new Error(
+        "cwd override is not supported for sandboxed embedded agent runs; omit cwd or use the agent workspace as cwd",
+      );
+    }
+    await fs.mkdir(effectiveWorkspace, { recursive: true });
+    return {
+      effectiveCwd: sandbox?.enabled ? effectiveWorkspace : (requestedCwd ?? effectiveWorkspace),
+      effectiveFsWorkspaceOnly:
+        params.requireWorkspaceOnly === true ||
+        resolveEffectiveToolFsWorkspaceOnly({
+          cfg: params.config,
+          agentId: sessionAgentId,
+        }),
+      effectiveWorkspace,
+      resolvedWorkspace,
+      sessionPermissionRoot,
+      sessionPermissionPolicy,
+      sandbox,
+      sandboxSessionKey,
+      sessionAgentId,
+    };
+  } catch (error) {
+    if (sandbox?.createdRuntime) {
+      try {
+        await removeCreatedSandboxRuntime(sandbox.containerName);
+      } catch {
+        // Teardown failure must not replace the original setup error.
       }
-    : undefined;
-  if (sandbox?.enabled && requestedCwd && requestedCwd !== resolvedWorkspace) {
-    throw new Error(
-      "cwd override is not supported for sandboxed embedded agent runs; omit cwd or use the agent workspace as cwd",
-    );
+    }
+    throw error;
   }
-  await fs.mkdir(effectiveWorkspace, { recursive: true });
-  return {
-    effectiveCwd: sandbox?.enabled ? effectiveWorkspace : (requestedCwd ?? effectiveWorkspace),
-    effectiveFsWorkspaceOnly:
-      params.requireWorkspaceOnly === true ||
-      resolveEffectiveToolFsWorkspaceOnly({
-        cfg: params.config,
-        agentId: sessionAgentId,
-      }),
-    effectiveWorkspace,
-    resolvedWorkspace,
-    sessionPermissionRoot,
-    sessionPermissionPolicy,
-    sandbox,
-    sandboxSessionKey,
-    sessionAgentId,
-  };
 }


### PR DESCRIPTION
Closes #143685

## What Problem This Solves

Fixes an issue where operators running sandboxed isolated sessions accumulate idle sandbox containers when a run fails during setup, before the model is ever dispatched. Each failed run leaves one container running and registered. With the default prune limits of 24 idle hours and 7 days max age, those containers persist for hours, consuming host memory and process capacity. The reporter observed 15 residual containers after a sequence of failed runs.

## Why This Change Was Made

A sandbox runtime is provisioned during attempt setup, but no caller could tell whether a runtime was newly created for that attempt or reused from an earlier one, so no failure path could safely remove it. Ownership is now derived inside the provisioning lifecycle: the backend factory can only reuse a runtime whose ID was already registered for the scope, so an ID absent from that list before the factory ran was created by that call. `SandboxContext` carries this as an optional `createdRuntime` flag.

Three failure windows previously leaked and are now closed: provisioning failures after the runtime exists (browser and filesystem-bridge setup), the read-write and cwd guards in `resolveAttemptWorkspaceSandbox`, and pre-dispatch preparation failures in `runEmbeddedAttempt`.

Boundaries and non-goals. Reused runtimes are never removed. Ownership is released at the dispatch boundary, so successful runs and post-dispatch failures keep their session-scoped sandbox available for reuse. Teardown routes through the backend manager's `removeRuntime` and mirrors the prune order, so Docker, SSH, and Podman backends are covered rather than Docker alone. Cleanup failures are recorded through the existing `recordAgentCleanupFailure` path and never replace the original error. Ownership is deliberately not inferred from registry timestamps, which cannot distinguish a runtime this attempt created from one another attempt is still using.

## User Impact

Operators running sandboxed isolated or short-lived sessions no longer accumulate idle containers when runs fail during setup. A container created for a failed run is released immediately instead of lingering until the prune cycle. Sessions that reuse an existing sandbox, and sessions that reach model dispatch, are unaffected.

## Evidence

Focused tests added to `src/agents/embedded-agent-runner/run/attempt-setup.test.ts`, both driven through the existing read-only-sandbox failure path:

- `releases a runtime it created when workspace setup fails before dispatch`
- `keeps a reused runtime when workspace setup fails before dispatch`

With the fix applied, the whole file passes:

