### PR TITLE
refactor: consolidate config test environment ownership

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { withEnvOverride } from "../config/test-helpers.js";
 import type { CostUsageSummary } from "../infra/session-cost-usage.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { ExpectedCliError } from "./failure-output.js";
 import { registerGatewayCli } from "./gateway-cli.js";
 
@@ -626,7 +626,7 @@ describe("gateway-cli coverage", () => {
       fs.mkdirSync(bundleDir, { recursive: true });
       fs.writeFileSync(bundlePath, `${JSON.stringify(bundle, null, 2)}\n`, "utf8");
 
-      await withEnvOverride({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
         await runGatewayCommand([
           "gateway",
           "--port",
@@ -670,7 +670,7 @@ describe("gateway-cli coverage", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-cli-support-"));
     try {
       const outputPath = path.join(tempDir, "diagnostics.zip");
-      await withEnvOverride(
+      await withEnvAsync(
         { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
         async () => {
           await runGatewayCommand([...args, "--output", outputPath, "--json"]);
@@ -718,7 +718,7 @@ describe("gateway-cli coverage", () => {
       callGateway.mockClear();
       const tempDir = tempDirs.make("openclaw-gateway-cli-empty-");
       const outputPath = path.join(tempDir, "diagnostics.zip");
-      await withEnvOverride(
+      await withEnvAsync(
         { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
         async () => {
           await expectGatewayExit([

--- a/src/cli/update-cli/schema-preflight.test.ts
+++ b/src/cli/update-cli/schema-preflight.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { planLegacyConfigForUpdateChannel } from "../../commands/doctor/legacy-config-repair.js";
 import { createConfigIO } from "../../config/io.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../../config/test-helpers.js";
+import { withTempHome, writeOpenClawConfig } from "../../config/test-helpers.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../../state/openclaw-agent-db-contract.js";
@@ -19,6 +19,7 @@ import {
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import {
   captureTargetDatabaseSchemaContext,
   checkTargetDatabaseSchemasForContexts,
@@ -248,7 +249,7 @@ describe("planned legacy configuration admission", () => {
     "preserves original config and fences %s",
     async (scenario) => {
       await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const configPath = await writeOpenClawConfig(home, {
             gateway: { $include: "gateway.json" },
           });
@@ -270,7 +271,7 @@ describe("planned legacy configuration admission", () => {
             reason: "database-schema-preflight",
           });
           // Exercise the real caller admission forwarding, without inspecting a live service.
-          const { contexts } = await withEnvOverride({ OPENCLAW_CONFIG_PATH: configPath }, () =>
+          const { contexts } = await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, () =>
             inspectUpdateDatabaseContexts({
               roots: [],
               updateInstallKind: "package",
@@ -345,7 +346,7 @@ describe("planned migration managed profile isolation", () => {
     "other invalid source",
   ] as const)("admits only the owned service's config: %s", async (scenario) => {
     await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const callerPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local", bind: "localhost" },
         });
@@ -415,7 +416,7 @@ describe("planned migration managed profile isolation", () => {
 
   it("does not admit unrelated invalid settings alongside a migratable field", async () => {
     await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local", bind: "localhost", port: "invalid" },
         });

--- a/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
+++ b/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
@@ -7,10 +7,12 @@ import {
   readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
 } from "../config/config.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 import {
   planLegacyConfigForUpdateChannel,
   repairLegacyConfigForUpdateChannel,
@@ -25,8 +27,8 @@ describe("Doctor gateway bind persistence", () => {
     ["localhost", "loopback"],
     ["0.0.0.0", "lan"],
   ] as const)("persists gateway bind %s as %s", async (legacyBind, canonicalBind) => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         // This core writer regression needs the authoritative empty bundled-plugin inventory.
         const configPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local", bind: legacyBind },
@@ -49,7 +51,7 @@ describe("Doctor gateway bind persistence", () => {
   it.each(["ordinary", "include", "invalid", "doctor"] as const)(
     "preserves authored plugin scope during %s config repair",
     async (scenario) => {
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         const diagnostics = {
           otel: { enabled: true, endpoint: "http://collector.test:4317", protocol: "grpc" },
         };
@@ -130,7 +132,7 @@ describe("Doctor gateway bind persistence", () => {
     "persists a prepared legacy plan only for its original source: %s",
     async (scenario) => {
       await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const configPath = await writeOpenClawConfig(home, {
             gateway: { $include: "gateway.json" },
           });
@@ -161,7 +163,7 @@ describe("Doctor gateway bind persistence", () => {
           } else if (scenario === "different profile") {
             const otherPath = path.join(path.dirname(configPath), "other.json");
             await fs.writeFile(otherPath, original);
-            await withEnvOverride({ OPENCLAW_CONFIG_PATH: otherPath }, async () => {
+            await withEnvAsync({ OPENCLAW_CONFIG_PATH: otherPath }, async () => {
               await expect(persist()).rejects.toThrow(/config path changed/);
             });
             expect(await fs.readFile(otherPath, "utf8")).toBe(original);

--- a/src/commands/doctor-config-flow.include-refusal.test.ts
+++ b/src/commands/doctor-config-flow.include-refusal.test.ts
@@ -5,10 +5,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { runWriteConfigHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 
 const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
 
@@ -23,8 +25,8 @@ describe("doctor --fix include write ownership", () => {
   });
 
   it("writes a nested agent repair to its fragment and preserves both ancestor files", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           agents: { entries: { main: { $include: "./config/main-parent.json5" } } },
           gateway: { mode: "local" },
@@ -55,8 +57,8 @@ describe("doctor --fix include write ownership", () => {
   });
 
   it("records the refusal and leaves the root and the included file untouched", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           agents: { list: [{ id: "ops" }] },
           browser: { $include: "./browser.json" },

--- a/src/commands/doctor-config-flow.legacy-composition.test.ts
+++ b/src/commands/doctor-config-flow.legacy-composition.test.ts
@@ -3,10 +3,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 
 async function repairConfig(configPath: string) {
   const ctx = await prepareDoctorContext(configPath);
@@ -27,8 +29,8 @@ describe("Doctor legacy config composition", () => {
     "list with config env",
     "list with included identity",
   ])("preserves memory search settings from %s", async (shape) => {
-    await withTempHome(async (home) => {
-      await withEnvOverride(
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync(
         {
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
           DOCTOR_AGENT_ID: "research",
@@ -192,9 +194,9 @@ describe("Doctor legacy config composition", () => {
   it.each(["unnamed", "duplicate", "malformed"])(
     "repairs %s local agents beside an unrelated include",
     async (shape) => {
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         const workspace = path.join(home, "shared-agent-workspace");
-        await withEnvOverride(
+        await withEnvAsync(
           {
             OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
             DOCTOR_TRUSTED_PROXY: "127.0.0.2",
@@ -276,8 +278,8 @@ describe("Doctor legacy config composition", () => {
   it.each(["duplicate ids", "whole-entry include"])(
     "refuses ambiguous legacy roster persistence for %s",
     async (shape) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const identity = { name: "Second agent" };
           const includeRaw = `${JSON.stringify(
             shape === "duplicate ids" ? identity : { identity, memorySearch: { enabled: false } },
@@ -325,8 +327,8 @@ describe("Doctor legacy config composition", () => {
   );
 
   it.each(["root", "list", "entries"])("preserves message policy from %s", async (scope) => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const message = { allowCrossContextSend: true, broadcast: { enabled: false } };
         const agent = scope === "root" ? {} : { tools: { message } };
         const configPath = await writeOpenClawConfig(home, {
@@ -350,8 +352,8 @@ describe("Doctor legacy config composition", () => {
     });
   });
   it("preserves inherited message policy when an agent opts out of the legacy bypass", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           tools: { message: { allowCrossContextSend: true } },
           agents: {
@@ -380,8 +382,8 @@ describe("Doctor legacy config composition", () => {
   it.each(["${DOCTOR_MEMORY_KEY}", "$${DOCTOR_MEMORY_KEY}"])(
     "preserves migrated default memory references %s and explicit canonical values",
     async (apiKey) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride(
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync(
           { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", DOCTOR_MEMORY_KEY: "memory-secret-canary" },
           async () => {
             const configPath = await writeOpenClawConfig(home, {
@@ -434,8 +436,8 @@ describe("Doctor legacy config composition", () => {
   it.each([true, false])(
     "preserves the shipped message bypass precedence for root %s",
     async (globalBypass) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const denied = { allowWithinProvider: false, allowAcrossProviders: false };
           const configPath = await writeOpenClawConfig(home, {
             tools: { message: { allowCrossContextSend: globalBypass, crossContext: denied } },

--- a/src/commands/doctor-config-flow.validation-refusal.test.ts
+++ b/src/commands/doctor-config-flow.validation-refusal.test.ts
@@ -4,10 +4,12 @@
 // telling the operator exactly what to fix by hand.
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { runWriteConfigHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 
 const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
 
@@ -22,8 +24,8 @@ describe("doctor --fix with a validation-blocked candidate", () => {
   });
 
   it("never reports unpersisted fixes and leaves the config untouched", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           gatway: { port: 12345 },
           agents: { defaults: { heartbeat: { every: 5 } } },

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { makeCronJob } from "../cron/delivery.test-helpers.js";
 import { cronStoreKey } from "../cron/store/key.js";
 import { loadCronRows } from "../cron/store/row-codec.js";
@@ -15,7 +15,9 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 
 describe("Doctor workspace persistence", () => {
@@ -24,8 +26,8 @@ describe("Doctor workspace persistence", () => {
   });
 
   it("persists legacy channel command owners once and reports each rewritten entry", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const preserved = [
           "discord:100000000000000002",
           "matrix:@owner:example.org",
@@ -79,8 +81,8 @@ describe("Doctor workspace persistence", () => {
   ] as const)(
     "persists per-agent migrations with explicit ownership (%s, update in progress: %s)",
     async (shape, updateInProgress) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride(
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync(
           {
             OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
             OPENCLAW_UPDATE_IN_PROGRESS: updateInProgress ? "1" : undefined,
@@ -137,8 +139,8 @@ describe("Doctor workspace persistence", () => {
   it.each(["entries", "list"])(
     "persists explicit ownership for a markerless multi-agent %s roster",
     async (shape) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const entries = {
             ops: { workspace: path.join(home, "ops") },
             research: { workspace: path.join(home, "research") },
@@ -180,8 +182,8 @@ describe("Doctor workspace persistence", () => {
   ])(
     "preserves the markerless $legacyId agent's $kind workspace through Doctor persistence",
     async ({ kind, legacyId }) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride(
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync(
           { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_WORKSPACE_DIR: undefined },
           async () => {
             const workspace = path.join(
@@ -241,8 +243,8 @@ describe("Doctor workspace persistence", () => {
   it.each(["entries", "list", "noncanonical list"])(
     "repairs workspace and heartbeat values from %s through snapshot, doctor, and write",
     async (shape) => {
-      await withTempHome(async (home) => {
-        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+      await withDoctorConfigPreflightHome(async (home) => {
+        await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
           const agent = {
             workspace: null,
             heartbeat: { every: "30m", activeHours: { start: "99:99", end: "17:00" } },
@@ -282,8 +284,8 @@ describe("Doctor workspace persistence", () => {
   );
 
   it("refuses a legacy candidate that mixes an include-owned repair with root changes", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const configPath = await writeOpenClawConfig(home, {
           agents: {
             list: [
@@ -317,8 +319,8 @@ describe("Doctor workspace persistence", () => {
   });
 
   it("keeps the legacy owner on the shared workspace across later health writes", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
         const workspace = path.join(home, "shared-workspace");
         const configPath = await writeOpenClawConfig(home, {
           agents: {
@@ -353,9 +355,9 @@ describe("Doctor workspace persistence", () => {
   });
 
   it("persists cron runtime policy on the retained owner before rewriting its model", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const stateDir = path.join(home, ".openclaw");
-      await withEnvOverride(
+      await withEnvAsync(
         { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_STATE_DIR: stateDir },
         async () => {
           const configPath = await writeOpenClawConfig(home, {

--- a/src/commands/doctor-config-preflight.recovery.test.ts
+++ b/src/commands/doctor-config-preflight.recovery.test.ts
@@ -5,13 +5,13 @@ import {
   prepareGatewayRunBootstrap,
   recheckGatewayRunBootstrap,
 } from "../cli/gateway-cli/pre-bootstrap.js";
-import { withEnvOverride } from "../config/test-helpers.js";
 import * as checkpoint from "../infra/startup-migration-checkpoint.js";
 import { ExitError } from "../runtime.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 
@@ -57,7 +57,7 @@ it.each(["backup", "active config"] as const)(
           throw new ExitError(code);
         },
       };
-      await withEnvOverride(
+      await withEnvAsync(
         { OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined },
         async () => {
           expect(await prepareGatewayRunBootstrap({ opts: {}, runtime })).toBe(true);

--- a/src/commands/doctor-config-preflight.test-support.ts
+++ b/src/commands/doctor-config-preflight.test-support.ts
@@ -1,5 +1,6 @@
-import { withEnvOverride, withTempHome } from "../config/test-helpers.js";
+import { withTempHome } from "../config/test-helpers.js";
 import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+import { withEnvAsync } from "../test-utils/env.js";
 
 /** Keep real preflight fixtures from provisioning plugins for the developer's credentials. */
 export async function withDoctorConfigPreflightHome<T>(
@@ -12,6 +13,6 @@ export async function withDoctorConfigPreflightHome<T>(
         undefined,
       ]),
     );
-    return withEnvOverride(providerEnv, () => run(home));
+    return withEnvAsync(providerEnv, () => run(home));
   });
 }

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -6,7 +6,7 @@ import { applyCliProfileEnv } from "../cli/profile.js";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
 import { writeConfigHealthStateToStore } from "../config/io.health-state.js";
 import { createConfigHealthFingerprint } from "../config/io.observe-state.js";
-import { withEnvOverride, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   hasActiveStartupMigrationLease,
@@ -22,6 +22,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { resolveMigrationCheckpointIdentity } from "./doctor-config-preflight-checkpoint.js";
 import {
   runDoctorConfigPreflight,
@@ -233,7 +234,7 @@ describe("runDoctorConfigPreflight", () => {
     await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, config);
       const original = await fs.readFile(configPath, "utf-8");
-      await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: updating }, async () => {
+      await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: updating }, async () => {
         await expect(
           runDoctorConfigPreflight({
             ...startupCheckpointOptions,
@@ -322,7 +323,7 @@ describe("runDoctorConfigPreflight", () => {
       const configPath = path.join(stateDir, "openclaw.json");
       const defaultConfigPath = path.join(home, ".openclaw", "openclaw.json");
 
-      await withEnvOverride(
+      await withEnvAsync(
         {
           OPENCLAW_CONFIG_PATH: undefined,
           OPENCLAW_PROFILE: undefined,
@@ -348,7 +349,7 @@ describe("runDoctorConfigPreflight", () => {
       const configRoot = await fs.realpath(await fs.mkdtemp(path.join(home, "custom-config-")));
       const configPath = path.join(configRoot, "nested", "custom-openclaw.json");
 
-      await withEnvOverride(
+      await withEnvAsync(
         {
           OPENCLAW_CONFIG_PATH: configPath,
           OPENCLAW_PROFILE: undefined,
@@ -373,7 +374,7 @@ describe("runDoctorConfigPreflight", () => {
       const profileStateDir = path.join(home, ".openclaw-work");
       const configPath = path.join(profileStateDir, "openclaw.json");
 
-      await withEnvOverride(
+      await withEnvAsync(
         {
           OPENCLAW_CONFIG_PATH: undefined,
           OPENCLAW_PROFILE: undefined,
@@ -459,7 +460,7 @@ describe("runDoctorConfigPreflight", () => {
         '{ diagnostics: { otel: { enabled: false, protocol: "${OTEL_PROTOCOL}" } } }\n',
         "utf-8",
       );
-      await withEnvOverride({ OTEL_PROTOCOL: "grpc" }, async () => {
+      await withEnvAsync({ OTEL_PROTOCOL: "grpc" }, async () => {
         const interpolated = await runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -478,7 +479,7 @@ describe("runDoctorConfigPreflight", () => {
         diagnostics: { otel: { enabled: false } },
       });
 
-      await withEnvOverride({ OTEL_EXPORTER_OTLP_PROTOCOL: "grpc" }, async () => {
+      await withEnvAsync({ OTEL_EXPORTER_OTLP_PROTOCOL: "grpc" }, async () => {
         const preflight = await runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -507,7 +508,7 @@ describe("runDoctorConfigPreflight", () => {
       });
       expect(inspectOnly.snapshot.valid).toBe(false);
 
-      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const repaired = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -572,7 +573,7 @@ describe("runDoctorConfigPreflight", () => {
       );
 
       const before = await readConfigFileSnapshot();
-      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const repaired = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -628,7 +629,7 @@ describe("runDoctorConfigPreflight", () => {
         "utf-8",
       );
 
-      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const repaired = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: true,
           migrateLegacyConfig: false,
@@ -649,7 +650,7 @@ describe("runDoctorConfigPreflight", () => {
       const entries = await fs.readdir(path.dirname(configPath));
       expect(entries.filter((entry) => entry.startsWith("openclaw.json.clobbered."))).toEqual([]);
 
-      const converged = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const converged = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -696,7 +697,7 @@ describe("runDoctorConfigPreflight", () => {
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(configPath, brokenRaw, "utf-8");
 
-      await withEnvOverride({ OPENCLAW_CONTAINER_HINT: "repair-test" }, async () => {
+      await withEnvAsync({ OPENCLAW_CONTAINER_HINT: "repair-test" }, async () => {
         const failures: unknown[] = [];
         for (let attempt = 0; attempt < 3; attempt += 1) {
           failures.push(
@@ -773,7 +774,7 @@ describe("runDoctorConfigPreflight", () => {
         "utf-8",
       );
 
-      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const repaired = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,
@@ -792,7 +793,7 @@ describe("runDoctorConfigPreflight", () => {
         fs.readFile(path.join(path.dirname(configPath), clobbered[0]!), "utf-8"),
       ).resolves.toContain('"port": 19092');
 
-      const converged = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+      const converged = await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
           migrateState: false,
           migrateLegacyConfig: false,

--- a/src/commands/doctor-model-metadata-corruption.persistence.test.ts
+++ b/src/commands/doctor-model-metadata-corruption.persistence.test.ts
@@ -7,10 +7,12 @@ import {
   createConfigWriteAuditRecordBase,
   finalizeConfigWriteAuditRecord,
 } from "../config/io.audit.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 
 describe("Doctor model metadata corruption persistence", () => {
   afterEach(() => {
@@ -18,8 +20,8 @@ describe("Doctor model metadata corruption persistence", () => {
   });
 
   it("strips an audit-proven generated fallback row and rematerializes catalog capabilities", async () => {
-    await withTempHome(async (home) => {
-      await withEnvOverride(
+    await withDoctorConfigPreflightHome(async (home) => {
+      await withEnvAsync(
         {
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,

--- a/src/commands/doctor-plugin-registry.provenance.test.ts
+++ b/src/commands/doctor-plugin-registry.provenance.test.ts
@@ -3,11 +3,11 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { readConfigFileSnapshot } from "../config/config.js";
-import { withEnvOverride } from "../config/test-helpers.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import { isTrustedOfficialPluginInstallRecord } from "../plugins/official-external-install-records.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { maybeRepairPluginRegistryState } from "./doctor-plugin-registry.js";
 import {
   createCurrentIndex,
@@ -46,7 +46,7 @@ describe("doctor official plugin provenance", () => {
       } else {
         const configPath = path.join(stateDir, "openclaw.json");
         fs.writeFileSync(configPath, JSON.stringify(config));
-        await withEnvOverride(
+        await withEnvAsync(
           {
             ...hermeticEnv(),
             OPENCLAW_CONFIG_PATH: configPath,

--- a/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { withEnvOverride } from "../../../config/test-helpers.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
 import { validateConfigObjectWithPlugins } from "../../../config/validation.js";
+import { withEnvAsync } from "../../../test-utils/env.js";
 import { VERSION } from "../../../version.js";
 import {
   isStartupConfigRepairResult,
@@ -150,7 +150,7 @@ describe("automatic startup config repair", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-startup-repair-preview-"));
     try {
       await fs.mkdir(path.join(root, "state", "openclaw.sqlite"), { recursive: true });
-      await withEnvOverride({ OPENCLAW_STATE_DIR: root }, async () => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
         const snapshot = invalidSnapshot({
           config: { session: { idleMinutes: 45 } } as OpenClawConfig,
           issuePaths: ["session.idleMinutes"],

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { loadDotEnv } from "../infra/dotenv.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   applyConfigEnvVars,
   collectConfigRuntimeEnvOwnership,
@@ -18,12 +19,12 @@ import {
 import { resolveConfigEnvVars } from "./env-substitution.js";
 import { assertGatewayConfigEnvSelectionUnchanged } from "./gateway-env-selection.js";
 import { collectDurableServiceEnvVars } from "./state-dir-dotenv.js";
-import { withEnvOverride, withTempHome, writeStateDirDotEnv } from "./test-helpers.js";
+import { withTempHome, writeStateDirDotEnv } from "./test-helpers.js";
 import type { OpenClawConfig } from "./types.js";
 
 describe("config env vars", () => {
   it("applies env vars from env block when missing", async () => {
-    await withEnvOverride({ OPENROUTER_API_KEY: undefined }, async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {
       applyConfigEnvVars({ env: { vars: { OPENROUTER_API_KEY: "config-key" } } } as OpenClawConfig);
       expect(process.env.OPENROUTER_API_KEY).toBe("config-key");
     });
@@ -65,7 +66,7 @@ describe("config env vars", () => {
   );
 
   it("does not override existing env vars", async () => {
-    await withEnvOverride({ OPENROUTER_API_KEY: "existing-key" }, async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: "existing-key" }, async () => {
       applyConfigEnvVars({ env: { vars: { OPENROUTER_API_KEY: "config-key" } } } as OpenClawConfig);
       expect(process.env.OPENROUTER_API_KEY).toBe("existing-key");
     });
@@ -141,14 +142,14 @@ describe("config env vars", () => {
   });
 
   it("applies env vars from env.vars when missing", async () => {
-    await withEnvOverride({ GROQ_API_KEY: undefined }, async () => {
+    await withEnvAsync({ GROQ_API_KEY: undefined }, async () => {
       applyConfigEnvVars({ env: { vars: { GROQ_API_KEY: "gsk-config" } } } as OpenClawConfig);
       expect(process.env.GROQ_API_KEY).toBe("gsk-config");
     });
   });
 
   it("skips non-string env.vars values from runtime JSON configs", async () => {
-    await withEnvOverride({ API_TOKEN: undefined, PORT: undefined, DEBUG: undefined }, async () => {
+    await withEnvAsync({ API_TOKEN: undefined, PORT: undefined, DEBUG: undefined }, async () => {
       const cfg = JSON.parse(`{
         "env": {
           "vars": {
@@ -167,7 +168,7 @@ describe("config env vars", () => {
   });
 
   it("can build a merged runtime env without mutating process.env", async () => {
-    await withEnvOverride({ OPENROUTER_API_KEY: undefined }, async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {
       const merged = createConfigRuntimeEnv({
         env: { vars: { OPENROUTER_API_KEY: "config-key" } },
       } as OpenClawConfig);
@@ -234,7 +235,7 @@ describe("config env vars", () => {
 
   it("does not infer an equal-valued ambient env entry as config-owned", async () => {
     const key = "OPENCLAW_TEST_EQUAL_AMBIENT_ENV";
-    await withEnvOverride({ [key]: "shared" }, async () => {
+    await withEnvAsync({ [key]: "shared" }, async () => {
       try {
         const previousConfig = { env: { vars: { [key]: "shared" } } };
         initializePublishedConfigRuntimeEnv(previousConfig, { ownedEnv: {} });
@@ -257,7 +258,7 @@ describe("config env vars", () => {
 
   it("unwinds overlapping same-value publications after both roll back", async () => {
     const key = "OPENCLAW_TEST_OVERLAPPING_ENV";
-    await withEnvOverride({ [key]: "old" }, async () => {
+    await withEnvAsync({ [key]: "old" }, async () => {
       try {
         const previousConfig = { env: { vars: { [key]: "old" } } };
         const nextConfig = { env: { vars: { [key]: "new" } } };
@@ -289,7 +290,7 @@ describe("config env vars", () => {
     "unwinds different-value publications in %s rollback order",
     async (rollbackOrder) => {
       const key = "OPENCLAW_TEST_OVERLAPPING_DIFFERENT_ENV";
-      await withEnvOverride({ [key]: "old" }, async () => {
+      await withEnvAsync({ [key]: "old" }, async () => {
         try {
           const previousConfig = { env: { vars: { [key]: "old" } } };
           const olderConfig = { env: { vars: { [key]: "older" } } };
@@ -334,7 +335,7 @@ describe("config env vars", () => {
 
   it("lets a newer committed publication supersede an older late rollback", async () => {
     const key = "OPENCLAW_TEST_COMMITTED_OVERLAPPING_ENV";
-    await withEnvOverride({ [key]: "old" }, async () => {
+    await withEnvAsync({ [key]: "old" }, async () => {
       try {
         const previousConfig = { env: { vars: { [key]: "old" } } };
         const olderConfig = { env: { vars: { [key]: "older" } } };
@@ -363,7 +364,7 @@ describe("config env vars", () => {
 
   it("lets a newer publication remove a key added by an overlapping predecessor", async () => {
     const key = "OPENCLAW_TEST_OVERLAPPING_REMOVED_ENV";
-    await withEnvOverride({ [key]: undefined }, async () => {
+    await withEnvAsync({ [key]: undefined }, async () => {
       try {
         const previousConfig = {};
         const addedConfig = { env: { vars: { [key]: "added" } } };
@@ -485,7 +486,7 @@ describe("config env vars", () => {
   });
 
   it("blocks dangerous startup env vars from config env", async () => {
-    await withEnvOverride(
+    await withEnvAsync(
       {
         BASH_ENV: undefined,
         SHELL: undefined,
@@ -535,7 +536,7 @@ describe("config env vars", () => {
   });
 
   it("drops non-portable env keys from config env", async () => {
-    await withEnvOverride({ OPENROUTER_API_KEY: undefined }, async () => {
+    await withEnvAsync({ OPENROUTER_API_KEY: undefined }, async () => {
       const config = {
         env: {
           vars: {
@@ -599,7 +600,7 @@ describe("config env vars", () => {
 
   it("loads ${VAR} substitutions from ~/.openclaw/.env on repeated runtime loads", async () => {
     await withTempHome(async (_home) => {
-      await withEnvOverride({ BRAVE_API_KEY: undefined }, async () => {
+      await withEnvAsync({ BRAVE_API_KEY: undefined }, async () => {
         const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
         if (!stateDir) {
           throw new Error("Expected OPENCLAW_STATE_DIR to be set by withTempHome");

--- a/src/config/test-helpers.ts
+++ b/src/config/test-helpers.ts
@@ -73,35 +73,6 @@ export async function withTempHomeConfig<T>(
   });
 }
 
-/**
- * Helper to test env var overrides. Saves/restores env vars for a callback.
- */
-export async function withEnvOverride<T>(
-  overrides: Record<string, string | undefined>,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const saved: Record<string, string | undefined> = {};
-  for (const key of Object.keys(overrides)) {
-    saved[key] = process.env[key];
-    if (overrides[key] === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = overrides[key];
-    }
-  }
-  try {
-    return await fn();
-  } finally {
-    for (const key of Object.keys(saved)) {
-      if (saved[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = saved[key];
-      }
-    }
-  }
-}
-
 export function buildWebSearchProviderConfig(params: {
   provider: NonNullable<
     NonNullable<NonNullable<NonNullable<OpenClawConfig["tools"]>["web"]>["search"]>["provider"]


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The config test environment helper captured and changed each key in sequence. On the Windows main thread, deleting differently cased aliases could lose the value that later restoration needed. Several Doctor fixtures also inherited host provider state and could activate unrelated official providers.

## Why This Change Was Made

Use the canonical environment helper, which captures every requested value before making changes, at the same 59 call sites. Use the existing Doctor isolation helper for 21 fixture homes. Remove the duplicate helper while preserving callbacks, assertion ordering, refusal cases and real persistence checks across all 247 cases.

## User Impact

No production behavior or public API change. The 15 test and test-support files add 110 lines and remove 123, for a net reduction of 13 lines; shared runtime code and database schemas are unchanged.

## Evidence

The original full run passed 245 cases and failed two fixture-isolation cases. Changing only Doctor fixture isolation then passed all 247 cases with the original environment helper still in place. The final candidate also passed all 247 cases, retaining the same test identities. Independent source review is clean through P2.

All 30 normal local changed checks passed, including core and test typechecks, type-aware lint, dead-export checks, import-cycle checks and the required guards. Source remained unchanged through the tests and checks.

A separate native Windows main-thread probe compared eight helper/scenario combinations. The original helper failed restoration in two case-alias scenarios, while the canonical helper passed all four scenarios. This is a narrow native helper contract result, not a Windows Vitest or full-suite result.
