### PR TITLE
fix: prevent clipping in agent identity fields

### DIFF
--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -2,7 +2,11 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { pathForRoute, type RouteId } from "../app-route-paths.ts";
-import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
 import {
   createControlUiE2eContextOptions,
   createControlUiE2eSuite,
@@ -187,6 +191,41 @@ function createCronLayoutMethodResponses() {
 }
 
 suite.define(() => {
+  it("keeps agent identity inputs inside their fields at desktop and mobile widths", async () => {
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "agents.update"],
+      });
+      await page.goto(`${suite.server.baseUrl}settings/agents`);
+      const editor = page.locator(".agent-identity-editor");
+      await editor.waitFor();
+
+      for (const viewport of responsiveViewports) {
+        await page.setViewportSize(viewport);
+        for (const name of ["Display name", "Emoji"]) {
+          const input = editor.getByRole("textbox", { name, exact: true });
+          await input.focus();
+          await expect
+            .poll(
+              () =>
+                input.evaluate((element) => {
+                  const inputBox = element.getBoundingClientRect();
+                  const fieldBox = element.closest("label")!.getBoundingClientRect();
+                  const cardBox = element.closest(".settings-row")!.getBoundingClientRect();
+                  return (
+                    inputBox.width > 0 &&
+                    inputBox.left >= Math.max(fieldBox.left, cardBox.left) - 1 &&
+                    inputBox.right <= Math.min(fieldBox.right, cardBox.right) + 1
+                  );
+                }),
+              { message: `${name} input is contained at ${viewport.width}px` },
+            )
+            .toBe(true);
+        }
+      }
+    });
+  });
+
   it("loads provider-settings copy after New Session and Chat without startup errors", async () => {
     const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     await suite.withPage(

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4070,6 +4070,11 @@ td.data-table-key-col {
   flex: 0 1 96px;
 }
 
+.agent-identity-editor__fields input {
+  min-width: 0;
+  width: 100%;
+}
+
 .agent-identity-editor__hint {
   font-size: 12px;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing an agent's identity see the emoji input extend beyond its column and get clipped at the right edge of the identity card.

## Why This Change Was Made

The field has a compact 96px column, but the native input retained its intrinsic minimum width inside the grid label (186.5px in the desktop reproduction). Let identity inputs shrink and fill their assigned field width. Existing wrapping continues to handle narrow screens.

## User Impact

Display name and emoji fields remain fully visible within the identity card on desktop and mobile.

## Evidence

- Reproduced in Chrome against the local mocked Control UI with synthetic data. The emoji input exceeded its 96px field before the fix and measured 96px afterward.
- Added a browser geometry regression covering both inputs at 390, 768, 1366, and 1440px. It failed before the CSS repair and passed after it.
- Focused bundled Control UI E2E regression passed; its production UI build also passed.
- Independent autoreview: no actionable findings through P2.
- Changed-file checks passed: core/UI typechecks, formatting, lint, stylelint, i18n, and repository guards.

### Desktop before

![Identity emoji input clipped before the fix](https://github.com/user-attachments/assets/34c49e3c-8d3e-4f26-8260-f46790ccab6e)

### Desktop after

![Identity emoji input fits its column after the fix](https://github.com/user-attachments/assets/7b6e7229-9a16-42bf-9afa-7bb0e0b12c7e)

<details>
<summary>Mobile before and after</summary>

| Before | After |
| --- | --- |
| ![Mobile identity before](https://github.com/user-attachments/assets/d2c8c725-c14c-46dd-88e7-4cec3db01273) | ![Mobile identity after](https://github.com/user-attachments/assets/4fe92426-e84d-4295-a353-dfec060b4247) |

</details>
