### PR TITLE
fix(ui): let embedded reports fill the content area

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6072,16 +6072,16 @@ td.data-table-key-col {
 
 .plugin-tab-embed {
   display: flex;
+  flex: 1;
+  min-width: 0;
   min-height: 0;
-  height: 100%;
 }
 
 .plugin-tab-embed__frame {
   flex: 1;
-  min-height: 480px;
+  min-height: 0;
   width: 100%;
   border: none;
-  border-radius: 10px;
   background: var(--card);
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4355,6 +4355,26 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-height: 0;
 }
 
+/* Embedded pages own their spacing and scrolling inside the frame. */
+.content:has(.plugin-tab-embed) {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+  gap: 0;
+}
+
+.content:has(.plugin-tab-embed) > * + * {
+  margin-top: 0;
+}
+
+.content:has(.plugin-tab-embed) > openclaw-router-outlet {
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+}
+
 :root[data-theme-mode="light"] .content {
   background: var(--bg-content);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Reports or another iframe-backed plugin page see the page inset inside a padded, rounded container instead of filling the content area beside the sidebar.

## Why This Change Was Made

Let embedded pages own their spacing and scrolling. The shared shell now fills its available area only when an iframe-backed plugin page is mounted; the iframe no longer has rounded corners or a 480px minimum height. Other plugin views retain their existing layout.

## User Impact

Reports fills the available content area on desktop and mobile, including short windows, while keeping the report's internal spacing intact.

## Evidence

- `node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/styles/components.css` passed, including core/UI typechecks, formatting, and style lint.
- Independent autoreview through P2: no accepted/actionable findings.
- Live browser measurements confirmed the original 20px side, 16px top, and 32px bottom inset, plus 10px iframe corner radius.
- Synthetic Chrome layout proof using the actual CSS from both commits: desktop inset goes from 16/20/32/20px to zero, with square frame corners. At a 390×360 mobile viewport, the iframe fits the 390×302 content area instead of overflowing it by 182px. Scrolling remains inside the iframe.
- These captures verify the CSS layout boundary, not full application boot, authentication, or live report contents.

### Desktop

| Before | After |
| --- | --- |
| ![Synthetic desktop before](https://github.com/user-attachments/assets/af38f21d-58e5-42cf-867a-23c637693112) | ![Synthetic desktop after](https://github.com/user-attachments/assets/ef1bd1c1-8446-454e-b199-851936ccbfbf) |

### Short mobile viewport

| Before | After |
| --- | --- |
| ![Synthetic mobile before](https://github.com/user-attachments/assets/ad1c308d-b135-4b29-a094-10e6587cf373) | ![Synthetic mobile after](https://github.com/user-attachments/assets/924e6abe-9779-4584-a4b8-e513b9d3a4e6) |
