### PR TITLE
refactor(gateway,tui): one owner for question validation and controller state

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
@@ -397,6 +397,7 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
   }
 }
 
+// Attempt claims allow legacy steering and preserve supplied run or source-bound authority.
 export async function claimEmbeddedPendingUserInputAnswer(
   text: string,
   options: EmbeddedAgentQueueMessageOptions | undefined,

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -620,7 +620,7 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
   return queueEmbeddedAgentMessageAsync(sessionId, text, options);
 }
 
-/** Answers pending input without making ordinary messages bypass local queue policy. */
+/** TUI preflight requires V2 ownership; failure leaves ordinary input to local queue policy. */
 export async function claimPendingEmbeddedAgentQuestionAnswer(
   sessionId: string,
   text: string,

--- a/src/agents/harness/gateway-question.ts
+++ b/src/agents/harness/gateway-question.ts
@@ -288,7 +288,7 @@ export async function claimPendingAgentQuestionAnswerFromCaller(params: {
   });
 }
 
-/** Claims eligible question input; unmatched input remains owned by ordinary admission. */
+/** Owns reservation and persistence; absent questions return before checking caller authority. */
 export async function claimPendingAgentQuestionAnswer(params: {
   sessionKey?: string;
   text: string;

--- a/src/gateway/question-validation.ts
+++ b/src/gateway/question-validation.ts
@@ -1,0 +1,57 @@
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
+import type { QuestionRequestParams } from "../../packages/gateway-protocol/src/index.js";
+import { ENV_SECRET_REF_ID_RE } from "../config/types.secrets.js";
+import { SECRET_STORE_ALLOWED_HOSTS_MAX } from "../secrets/store/secret-store-validation-error.js";
+
+/** Shape rules after protocol validation; callers retain admission policy and error types. */
+export function questionShapeError(
+  questions: QuestionRequestParams["questions"],
+  options: { allowPlainSecretQuestions: boolean; validateUrls: boolean },
+): string | undefined {
+  const ids = new Set<string>();
+  for (const question of questions) {
+    if (ids.has(question.questionId)) {
+      return `duplicate question id '${question.questionId}'`;
+    }
+    ids.add(question.questionId);
+    if (options.validateUrls && question.url !== undefined) {
+      const url = URL.parse(question.url);
+      if (!url || !hasHttpUrlPrefix(question.url) || url.username || url.password) {
+        return `question '${question.questionId}' requires an absolute HTTP(S) URL without credentials`;
+      }
+    }
+    if (question.options.length === 1) {
+      return `question '${question.questionId}' must have either no options or 2 to 4 options`;
+    }
+    const binding = question.secretStore;
+    if (question.isSecret && !binding && !options.allowPlainSecretQuestions) {
+      return `question '${question.questionId}': secret questions are not supported yet`;
+    }
+    if (binding) {
+      if (!question.isSecret) {
+        return `question '${question.questionId}': secret store binding requires a secret question`;
+      }
+      if (questions.length !== 1 || question.options.length !== 0 || question.multiSelect) {
+        return `question '${question.questionId}': secret store requests require one free-text, single-select question`;
+      }
+      if (!ENV_SECRET_REF_ID_RE.test(binding.name)) {
+        return `question '${question.questionId}': invalid secret store entry name`;
+      }
+      if (binding.kind !== "secret") {
+        return `question '${question.questionId}': masked requests require kind "secret"; set environment values in Settings or the CLI`;
+      }
+      if ((binding.allowedHosts?.length ?? 0) > SECRET_STORE_ALLOWED_HOSTS_MAX) {
+        return `question '${question.questionId}': secret store allowed hosts exceed the limit`;
+      }
+    }
+    const optionLabels = new Set<string>();
+    for (const option of question.options) {
+      const normalizedLabel = option.label.trim().toLowerCase();
+      if (optionLabels.has(normalizedLabel)) {
+        return `question '${question.questionId}' has duplicate option label '${option.label}'`;
+      }
+      optionLabels.add(normalizedLabel);
+    }
+  }
+  return undefined;
+}

--- a/src/gateway/server-methods/question.ts
+++ b/src/gateway/server-methods/question.ts
@@ -1,5 +1,4 @@
 // Question gateway methods create, inspect, wait for, and resolve transient prompts.
-import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import {
   ErrorCodes,
   errorShape,
@@ -14,7 +13,6 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { registerActiveEmbeddedRunHumanInputWait } from "../../agents/embedded-agent-runner/run-state.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { ENV_SECRET_REF_ID_RE } from "../../config/types.secrets.js";
 import {
   handleQuestionChannelRequested,
   handleQuestionChannelResolved,
@@ -22,7 +20,6 @@ import {
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
 import {
   listSecretStoreEntries,
-  SECRET_STORE_ALLOWED_HOSTS_MAX,
   SecretStoreValidationError,
 } from "../../secrets/store/secret-store.js";
 import { hasOperatorBoundary } from "../operator-role-policy.js";
@@ -31,6 +28,7 @@ import {
   QuestionManagerError,
   QuestionManagerErrorCodes,
 } from "../question-manager.js";
+import { questionShapeError } from "../question-validation.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import {
   authorizeSessionSharing,
@@ -100,57 +98,16 @@ function authorizeQuestionRecord(params: {
 }
 
 function normalizeQuestions(params: QuestionRequestParams): Question[] {
-  const ids = new Set<string>();
+  const error = questionShapeError(params.questions, {
+    allowPlainSecretQuestions: false,
+    validateUrls: true,
+  });
+  if (error) {
+    throw new QuestionRequestValidationError(error);
+  }
   return params.questions.map((question) => {
-    if (ids.has(question.questionId)) {
-      throw new QuestionRequestValidationError(`duplicate question id '${question.questionId}'`);
-    }
-    ids.add(question.questionId);
-    if (question.url !== undefined) {
-      const url = URL.parse(question.url);
-      if (!url || !hasHttpUrlPrefix(question.url) || url.username || url.password) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}' requires an absolute HTTP(S) URL without credentials`,
-        );
-      }
-    }
-    if (question.options.length === 1) {
-      throw new QuestionRequestValidationError(
-        `question '${question.questionId}' must have either no options or 2 to 4 options`,
-      );
-    }
     const binding = question.secretStore;
-    if (question.isSecret && !binding) {
-      throw new QuestionRequestValidationError(
-        `question '${question.questionId}': secret questions are not supported yet`,
-      );
-    }
     if (binding) {
-      if (!question.isSecret) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}': secret store binding requires a secret question`,
-        );
-      }
-      if (params.questions.length !== 1 || question.options.length !== 0 || question.multiSelect) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}': secret store requests require one free-text, single-select question`,
-        );
-      }
-      if (!ENV_SECRET_REF_ID_RE.test(binding.name)) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}': invalid secret store entry name`,
-        );
-      }
-      if (binding.kind !== "secret") {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}': masked requests require kind "secret"; set environment values in Settings or the CLI`,
-        );
-      }
-      if ((binding.allowedHosts?.length ?? 0) > SECRET_STORE_ALLOWED_HOSTS_MAX) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}': secret store allowed hosts exceed the limit`,
-        );
-      }
       const existing = listSecretStoreEntries({ scope: { kind: "team" } }).find(
         (entry) => entry.name === binding.name,
       );
@@ -170,16 +127,6 @@ function normalizeQuestions(params: QuestionRequestParams): Question[] {
             }
           : {}),
       };
-    }
-    const optionLabels = new Set<string>();
-    for (const option of question.options) {
-      const normalizedLabel = option.label.trim().toLowerCase();
-      if (optionLabels.has(normalizedLabel)) {
-        throw new QuestionRequestValidationError(
-          `question '${question.questionId}' has duplicate option label '${option.label}'`,
-        );
-      }
-      optionLabels.add(normalizedLabel);
     }
     return question;
   });

--- a/src/infra/embedded-question-broker.ts
+++ b/src/infra/embedded-question-broker.ts
@@ -20,6 +20,7 @@ import {
   QuestionManagerError,
   QuestionManagerErrorCodes,
 } from "../gateway/question-manager.js";
+import { questionShapeError } from "../gateway/question-validation.js";
 import { notifyListeners } from "../shared/listeners.js";
 import { racePromiseWithAbortSignal } from "./abort-signal.js";
 import {
@@ -70,25 +71,12 @@ export class EmbeddedQuestionBroker {
       // A local prompt must not collect a value it cannot safely commit there.
       throw invalidRequest(EMBEDDED_SECRET_STORE_REQUEST_BLOCKER);
     }
-    const ids = new Set<string>();
-    for (const question of params.questions) {
-      if (ids.has(question.questionId)) {
-        throw invalidRequest(`duplicate question id '${question.questionId}'`);
-      }
-      ids.add(question.questionId);
-      if (question.options.length === 1) {
-        throw invalidRequest(
-          `question '${question.questionId}' must have either no options or 2 to 4 options`,
-        );
-      }
-      const labels = new Set<string>();
-      for (const option of question.options) {
-        const label = option.label.trim().toLowerCase();
-        if (labels.has(label)) {
-          throw invalidRequest(`question '${question.questionId}' has duplicate option labels`);
-        }
-        labels.add(label);
-      }
+    const error = questionShapeError(params.questions, {
+      allowPlainSecretQuestions: true,
+      validateUrls: false,
+    });
+    if (error) {
+      throw invalidRequest(error);
     }
     const caller = getGatewayToolCallerIdentity();
     const authority =

--- a/src/tui/tui-questions.ts
+++ b/src/tui/tui-questions.ts
@@ -28,6 +28,14 @@ type TuiQuestionControllerDeps = {
   requestRender: () => void;
   onPendingChange: (text: string) => void;
 };
+type QuestionState = {
+  record?: QuestionRecord;
+  collapsed?: boolean;
+  prompt?: QuestionPrompt;
+  resolving?: boolean;
+  unconfirmed?: QuestionRecord;
+  recovery?: Promise<"pending" | "terminal" | "unknown">;
+};
 type QuestionMutation = { version: number; question: QuestionRecord | null };
 
 function isSecretStoreRefreshFailure(record: QuestionRecord, error: unknown): boolean {
@@ -40,12 +48,7 @@ function isSecretStoreRefreshFailure(record: QuestionRecord, error: unknown): bo
 }
 
 export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
-  const pending = new Map<string, QuestionRecord>();
-  const collapsed = new Set<string>();
-  const drafts = new Map<string, QuestionPrompt>();
-  const resolving = new Set<string>();
-  const unconfirmed = new Map<string, QuestionRecord>();
-  const checking = new Map<string, Promise<"pending" | "terminal" | "unknown">>();
+  const questions = new Map<string, QuestionState>();
   const mutations = new Map<string, QuestionMutation>();
   let mutationVersion = 0;
   let active: { id: string; handle: OverlayHandle } | null = null;
@@ -71,28 +74,43 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
     }
   }
 
+  const questionRecords = (field: "record" | "unconfirmed" = "record") =>
+    [...questions.values()].flatMap((state) => {
+      const record = state[field];
+      return record ? [record] : [];
+    });
+
+  function update(id: string, patch: QuestionState) {
+    const state = { ...questions.get(id), ...patch };
+    // Resolved events can precede RPC completion; keep its admission/recovery locks.
+    if (!disposed && (state.record || state.resolving || state.recovery)) {
+      questions.set(id, state);
+    } else {
+      questions.delete(id);
+    }
+  }
+
   function remove(id: string) {
-    pending.delete(id);
-    unconfirmed.delete(id);
-    collapsed.delete(id);
-    drafts.get(id)?.dispose();
-    drafts.delete(id);
+    const state = questions.get(id);
+    state?.prompt?.dispose();
+    questions.delete(id);
+    update(id, { resolving: state?.resolving, recovery: state?.recovery });
     remember(id, null);
     if (active?.id === id) {
       closeActive();
     }
+    return state?.record;
   }
 
   function finish(id: string, status: Exclude<QuestionStatus, "pending">) {
-    const record = pending.get(id);
-    remove(id);
+    const record = remove(id);
     if (record && matchesSession(record)) {
       deps.chatLog.addSystem(`Question: ${status === "cancelled" ? "skipped" : status}.`);
     }
   }
 
   function abandon(record: QuestionRecord) {
-    if (!pending.has(record.id)) {
+    if (!questions.get(record.id)?.record) {
       return;
     }
     remove(record.id);
@@ -104,7 +122,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
   }
 
   async function recoverOnce(record: QuestionRecord): Promise<"pending" | "terminal" | "unknown"> {
-    if (disposed || !unconfirmed.has(record.id)) {
+    if (disposed || !questions.get(record.id)?.unconfirmed) {
       return "terminal";
     }
     if (record.expiresAtMs <= Date.now()) {
@@ -116,7 +134,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
     }
     try {
       const result = await deps.client.getQuestion(record.id);
-      if (disposed || !unconfirmed.has(record.id)) {
+      if (disposed || !questions.get(record.id)?.unconfirmed) {
         return "terminal";
       }
       if (!Value.Check(QuestionGetResultSchema, result) || result.question.id !== record.id) {
@@ -126,12 +144,11 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
         finish(record.id, result.question.status);
         return "terminal";
       }
-      unconfirmed.delete(record.id);
-      pending.set(record.id, result.question);
+      update(record.id, { record: result.question, unconfirmed: undefined });
       remember(record.id, result.question);
       return "pending";
     } catch (error) {
-      if (disposed || !unconfirmed.has(record.id)) {
+      if (disposed || !questions.get(record.id)?.unconfirmed) {
         return "terminal";
       }
       const errorRecord = asOptionalObjectRecord(error);
@@ -145,31 +162,18 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
   }
 
   async function recover(record: QuestionRecord) {
-    const current = checking.get(record.id);
+    const current = questions.get(record.id)?.recovery;
     if (current) {
       return current;
     }
     const recovery = recoverOnce(record);
-    checking.set(record.id, recovery);
+    update(record.id, { recovery });
     try {
       return await recovery;
     } finally {
-      if (checking.get(record.id) === recovery) {
-        checking.delete(record.id);
+      if (questions.get(record.id)?.recovery === recovery) {
+        update(record.id, { recovery: undefined });
       }
-    }
-  }
-
-  function updatePendingText(records: QuestionRecord[]) {
-    const record = records[0];
-    const text = records.some((question) => unconfirmed.has(question.id))
-      ? "Answer confirmation unavailable · /question to check"
-      : record
-        ? `Question pending${records.length > 1 ? ` (${records.length})` : ""} · ${Math.max(0, Math.ceil((record.expiresAtMs - Date.now()) / 1_000))}s · /question to open`
-        : "";
-    if (text !== pendingText) {
-      pendingText = text;
-      deps.onPendingChange(text);
     }
   }
 
@@ -180,28 +184,29 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
     clearTimeout(timer);
     timer = undefined;
     const now = Date.now();
-    for (const record of pending.values()) {
+    for (const record of questionRecords()) {
       if (record.expiresAtMs <= now) {
-        if (unconfirmed.has(record.id)) {
+        if (questions.get(record.id)?.unconfirmed) {
           abandon(record);
-        } else if (!resolving.has(record.id)) {
+        } else if (!questions.get(record.id)?.resolving) {
           finish(record.id, "expired");
         }
       }
     }
-    const records = [...pending.values()]
+    const records = questionRecords()
       .filter(matchesSession)
       .toSorted((a, b) => a.createdAtMs - b.createdAtMs || a.id.localeCompare(b.id));
     if (active && !records.some((record) => record.id === active?.id)) {
       closeActive();
     }
-    const record = records.find(
-      (entry) => !collapsed.has(entry.id) && !resolving.has(entry.id) && !unconfirmed.has(entry.id),
-    );
+    const record = records.find(({ id }) => {
+      const state = questions.get(id);
+      return !state?.collapsed && !state?.resolving && !state?.unconfirmed;
+    });
     if (!active && record) {
-      let prompt = drafts.get(record.id);
-      if (!prompt) {
-        prompt = new QuestionPrompt(record, {
+      const prompt =
+        questions.get(record.id)?.prompt ??
+        new QuestionPrompt(record, {
           onSubmit: (answers) =>
             void resolve(record, { id: record.id, answers, resolutionId: randomUUID() }),
           onSkip: () => void resolve(record, { id: record.id, cancel: true }),
@@ -209,9 +214,9 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
             if (active?.id !== record.id) {
               return;
             }
-            for (const question of pending.values()) {
+            for (const question of questionRecords()) {
               if (matchesSession(question)) {
-                collapsed.add(question.id);
+                update(question.id, { collapsed: true });
               }
             }
             closeActive();
@@ -219,12 +224,20 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
           },
           requestRender: deps.requestRender,
         });
-        drafts.set(record.id, prompt);
-      }
+      update(record.id, { prompt });
       active = { id: record.id, handle: deps.openOverlay(prompt, { width: "100%" }) };
     }
-    updatePendingText(records);
-    const expiring = [...pending.values()].filter((entry) => !resolving.has(entry.id));
+    const firstRecord = records[0];
+    const text = records.some((question) => questions.get(question.id)?.unconfirmed)
+      ? "Answer confirmation unavailable · /question to check"
+      : firstRecord
+        ? `Question pending${records.length > 1 ? ` (${records.length})` : ""} · ${Math.max(0, Math.ceil((firstRecord.expiresAtMs - Date.now()) / 1_000))}s · /question to open`
+        : "";
+    if (text !== pendingText) {
+      pendingText = text;
+      deps.onPendingChange(text);
+    }
+    const expiring = questionRecords().filter((entry) => !questions.get(entry.id)?.resolving);
     if (expiring.length > 0) {
       const expiry = Math.min(...expiring.map((entry) => entry.expiresAtMs));
       timer = setTimeout(present, Math.max(1, Math.min(1_000, expiry - now)));
@@ -234,7 +247,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
   }
 
   async function resolve(record: QuestionRecord, params: QuestionResolveParams) {
-    if (disposed || active?.id !== record.id || resolving.has(record.id)) {
+    if (disposed || active?.id !== record.id || questions.get(record.id)?.resolving) {
       return;
     }
     if (record.expiresAtMs <= Date.now()) {
@@ -242,10 +255,10 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
       present();
       return;
     }
-    resolving.add(record.id);
+    update(record.id, { resolving: true });
     closeActive();
-    drafts.get(record.id)?.dispose();
-    drafts.delete(record.id);
+    questions.get(record.id)?.prompt?.dispose();
+    update(record.id, { prompt: undefined });
     present();
     try {
       if (!deps.client.resolveQuestion) {
@@ -271,11 +284,10 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
         return;
       }
       // RPC errors may include submitted values. Never copy them into the terminal or chat.
-      if (!disposed && pending.has(record.id)) {
-        collapsed.add(record.id);
-        unconfirmed.set(record.id, record);
+      if (!disposed && questions.get(record.id)?.record) {
+        update(record.id, { collapsed: true, unconfirmed: record });
         const outcome = await recover(record);
-        if (!disposed && pending.has(record.id) && matchesSession(record)) {
+        if (!disposed && questions.get(record.id)?.record && matchesSession(record)) {
           if (outcome === "pending") {
             deps.chatLog.addSystem("Question is still pending. Use /question to retry.");
           } else if (outcome === "unknown") {
@@ -286,7 +298,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
         }
       }
     } finally {
-      resolving.delete(record.id);
+      update(record.id, { resolving: undefined });
       present();
     }
   }
@@ -296,7 +308,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
       return;
     }
     const startedAtVersion = mutationVersion;
-    await Promise.all([...unconfirmed.values()].map(recover));
+    await Promise.all(questionRecords("unconfirmed").map(recover));
     if (disposed || !deps.client.listQuestions) {
       present();
       return;
@@ -323,21 +335,19 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
         }
       }
     }
-    for (const id of pending.keys()) {
-      if (!next.has(id) && !unconfirmed.has(id) && !resolving.has(id)) {
+    for (const { id } of questionRecords()) {
+      if (!next.has(id) && !questions.get(id)?.unconfirmed && !questions.get(id)?.resolving) {
         remove(id);
       }
     }
     for (const [id, question] of next) {
-      pending.set(id, question);
+      update(id, { record: question });
     }
     present();
   }
 
   async function refresh(): Promise<void> {
-    if (!disposed) {
-      await refreshRunner.run();
-    }
+    return disposed ? undefined : await refreshRunner.run();
   }
 
   return {
@@ -347,7 +357,7 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
       }
       if (event === "question.requested" && Value.Check(QuestionRecordSchema, payload)) {
         if (payload.status === "pending") {
-          pending.set(payload.id, payload);
+          update(payload.id, { record: payload });
           remember(payload.id, payload);
           present();
         }
@@ -369,13 +379,13 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
         return;
       }
       await refresh();
-      for (const record of pending.values()) {
-        if (matchesSession(record) && !unconfirmed.has(record.id)) {
-          collapsed.delete(record.id);
+      for (const record of questionRecords()) {
+        if (matchesSession(record) && !questions.get(record.id)?.unconfirmed) {
+          update(record.id, { collapsed: undefined });
         }
       }
       present();
-      if (!disposed && ![...pending.values()].some(matchesSession)) {
+      if (!disposed && !questionRecords().some(matchesSession)) {
         deps.chatLog.addSystem("No pending question for this session.");
         deps.requestRender();
       }
@@ -387,15 +397,10 @@ export function createTuiQuestionController(deps: TuiQuestionControllerDeps) {
       disposed = true;
       clearTimeout(timer);
       closeActive();
-      for (const prompt of drafts.values()) {
-        prompt.dispose();
+      for (const { prompt } of questions.values()) {
+        prompt?.dispose();
       }
-      drafts.clear();
-      pending.clear();
-      collapsed.clear();
-      resolving.clear();
-      unconfirmed.clear();
-      checking.clear();
+      questions.clear();
       mutations.clear();
       deps.onPendingChange("");
       deps.requestRender();


### PR DESCRIPTION
Related: #143273 #143238

## What Problem This Solves

Cleanup pass over the question subsystem after the TUI question support in #143273. Nothing here changes behavior; it removes duplication that had already started to drift and collapses state that had to be kept consistent by hand.

Three things were wrong structurally. Question shape validation existed twice, once in the Gateway request handler and once reimplemented in the embedded broker, and the two copies had already diverged in their error text. The TUI question controller kept six separate containers keyed by question id, so every mutation had to update several of them in step. And the three pending-question claim guards looked like accidental duplication, which invites someone to merge them.

## Why This Change Was Made

**Shared validation with the policy difference made explicit.** `src/gateway/question-validation.ts` now owns the shape rules both callers share: duplicate ids, option counts, duplicate option labels, secret-store pairing and metadata rules, and URL shape. The one genuine behavior difference is now a named option instead of two divergent copies: the Gateway rejects a masked question that is not bound to the secret store, the local broker accepts one, because plain masked prompts are how local mode works. Each caller keeps its own error type and its own extra rules; the broker still rejects store-bound requests in local mode at its own call site.

**The claim guards are documented, not merged.** Tracing showed three guards with genuinely distinct contracts and other inbound routes that reach the steer path with no TUI pre-claim, so nothing is redundant. Each now carries a one-line comment naming what it owns, so the next reader does not unify them. No logic changed in that commit.

**One map for controller state.** The six per-question containers in `src/tui/tui-questions.ts` collapse into one map of a small record, with a single writer that keeps an entry only while it has a record, is resolving, or has a recovery in flight. The separate `mutations` map stays, because it solves a different problem: reconciling events that arrive during an in-flight list refresh.

## User Impact

No user-visible behavior change. One model-facing string changes: a malformed question rejected by the local broker for duplicate option labels now gets the Gateway's existing wording, which names the offending label. That was the point of sharing the rule, and no test asserted the old text.

## Evidence

- The safety property for the whole pass was that existing tests pass **unmodified**. They do: 1,901 tests across 62 files, plus 102 PTY tests, with no test file touched in the diff.
- `pnpm build` clean; `check:changed` passed (the nested-worktree extension-lint preparation step is a known local guard, and the changed extension files were linted directly).
- The repository's own end-to-end proof, `scripts/dev/tui-questions-proof.ts`, drives a real isolated Gateway plus TUI and a scripted model; it passes.
- Live re-test with a real model on isolated state and ports, both TUI modes: option selection, Esc collapse followed by a plain-text reply answering the pending question, and a masked secret-store request. All flows behave as before the refactor: the prompt renders and resolves in both modes, a collapsed question is still answered by an ordinary composer reply, the masked secret request completes its store write, and the typed value appears in no terminal capture.
- Production line count: +161/−163, net −2. The win is structural rather than in raw lines: six containers become one, and one validator replaces two.
- Codex autoreview at P0–P2 returned a single finding, the broker's duplicate-option-label message text. Rejected deliberately: unifying that message with the Gateway's shipped wording is the intent of the change, it is model-facing error text rather than a contract, and no test or doc asserts the old string.
