### PR TITLE
docs: STE pass on terminology consistency and run-on sentences

### DIFF
--- a/docs/announcements/bluebubbles-imessage.md
+++ b/docs/announcements/bluebubbles-imessage.md
@@ -61,7 +61,7 @@ If your config still contains `channels.bluebubbles`, migrate it to `channels.im
    }
    ```
 
-5. Restart the gateway and verify:
+5. Restart the Gateway and verify:
 
    ```bash
    openclaw channels status --probe

--- a/docs/channels/a2a.md
+++ b/docs/channels/a2a.md
@@ -169,15 +169,15 @@ binding, and the stable peer binding takes precedence over broader A2A account o
 
 Agent Card discovery is intentionally public: anyone who can reach the gateway can read the instance description and exposed agent IDs. Use `exposeAgents` to limit disclosure, and expose the gateway through HTTPS when it is reachable over an untrusted network.
 
-Every JSON-RPC request requires a configured peer bearer token; there is no unauthenticated mode. Each authenticated peer is also the sender identity used for normal OpenClaw channel ingress policy. Use different high-entropy tokens for each peer, keep tokens out of source control, and rotate tokens by updating the gateway environment and restarting.
+Every JSON-RPC request requires a configured peer bearer token. There is no unauthenticated mode. Each authenticated peer is also the sender identity used for normal OpenClaw channel ingress policy. Use different high-entropy tokens for each peer, keep tokens out of source control, and rotate tokens by updating the gateway environment and restarting.
 
-A2A peers send tasks, not user commands. Messages beginning with `/` are rejected with `TASK_STATE_REJECTED` and an explanation. Command-like text inside an ordinary task stays literal; it cannot change session settings or resolve approvals. This also applies when the peer sets the protocol message role to `ROLE_USER`: that field does not authenticate a human user.
+A2A peers send tasks, not user commands. Messages beginning with `/` are rejected with `TASK_STATE_REJECTED` and an explanation. Command-like text inside an ordinary task stays literal. It cannot change session settings or resolve approvals. This also applies when the peer sets the protocol message role to `ROLE_USER`: that field does not authenticate a human user.
 
-Ordinary tasks retain the tools and permissions of their routed agent. Work requiring approval still needs an authorized operator's decision through a supported user channel or the Control UI. Existing integrations that sent slash commands over A2A must use plain-text tasks for agent work and an authorized user surface for commands; there is no peer command opt-in.
+Ordinary tasks retain the tools and permissions of their routed agent. Work requiring approval still needs an authorized operator's decision through a supported user channel or the Control UI. Existing integrations that sent slash commands over A2A must use plain-text tasks for agent work and an authorized user surface for commands. There is no peer command opt-in.
 
 While an exec approval is pending, the original task stays working. After the operator decides, that same agent run receives the result and completes the task through its original reply path. An inbound peer does not need an outbound `url` to receive that completion through `GetTask`.
 
-Requests are limited to 1 MiB, JSON-RPC batches to 30 entries, and serialized JSON-RPC responses to 1 MiB. Extracted message text is capped at 64 KiB and includes an explicit truncation marker when shortened. The default sliding-window limit is 30 requests per minute for each peer; schema-invalid requests count toward that limit. Set `rateLimitPerMinute` to `0` only on a separately protected network. Rate-limited requests return a JSON-RPC error while keeping HTTP status 200.
+Requests are limited to 1 MiB, JSON-RPC batches to 30 entries, and serialized JSON-RPC responses to 1 MiB. Extracted message text is capped at 64 KiB and includes an explicit truncation marker when shortened. The default sliding-window limit is 30 requests per minute for each peer. Schema-invalid requests count toward that limit. Set `rateLimitPerMinute` to `0` only on a separately protected network. Rate-limited requests return a JSON-RPC error while keeping HTTP status 200.
 
 Outbound destinations come only from operator-configured peer URLs. Inbound callers cannot supply a proxy target or redirect OpenClaw to another destination.
 
@@ -185,7 +185,7 @@ Outbound destinations come only from operator-configured peer URLs. Inbound call
 
 The current plugin supports text messages and structured JSON data parts, which are appended as compact JSON text. File URL and raw binary parts are ignored. Streaming, server-sent events, push notifications, task cancellation, task listing, extended Agent Cards, and multi-tenant routing are not supported.
 
-Tasks remain in memory only. Completed and other terminal tasks are retained for up to 24 hours, with a maximum of 500 retained entries; restarting the gateway discards all tasks and task history.
+Tasks remain in memory only. Completed and other terminal tasks are retained for up to 24 hours, with a maximum of 500 retained entries. Restarting the gateway discards all tasks and task history.
 
 ## Related
 

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -36,7 +36,7 @@ openclaw plugins install ./path/to/local/line-plugin
 2. Create (or pick) a Provider and add a **Messaging API** channel.
 3. Copy the **Channel access token** and **Channel secret** from the channel settings.
 4. Enable **Use webhook** in the Messaging API settings.
-5. Set the webhook URL to your gateway endpoint (HTTPS required):
+5. Set the webhook URL to your Gateway endpoint (HTTPS required):
 
 ```text
 https://gateway-host/line/webhook
@@ -415,7 +415,7 @@ link-local, and private-network targets.
 - **Webhook verification fails:** ensure the webhook URL is HTTPS and the
   `channelSecret` matches the LINE console.
 - **No inbound events:** confirm the webhook path matches `channels.line.webhookPath`
-  and that the gateway is reachable from LINE.
+  and that the Gateway is reachable from LINE.
 - **Media download errors:** raise `channels.line.mediaMaxMb` if media exceeds the
   default limit.
 - **Pushes refused with HTTP 429:** Run

--- a/docs/channels/matrix-push-rules.md
+++ b/docs/channels/matrix-push-rules.md
@@ -18,7 +18,7 @@ If you only want stock Matrix notification behavior, use `streaming.mode: "parti
 - bot user = the OpenClaw Matrix account that sends the reply
 - use the recipient user's access token for the API calls below
 - match `sender` in the push rule against the bot user's full MXID
-- the recipient account must already have working pushers; quiet preview rules only work when normal Matrix push delivery is healthy
+- the recipient account must already have working pushers. Quiet preview rules only work when normal Matrix push delivery is healthy
 
 ## Steps
 
@@ -124,7 +124,7 @@ To remove the rule later, `DELETE` the same rule URL with the recipient's token.
 
 Push rules are keyed by `ruleId`: re-running `PUT` against the same ID updates a single rule. For multiple OpenClaw bots notifying the same recipient, create one rule per bot with a distinct sender match.
 
-New user-defined `override` rules are inserted ahead of server-default suppress rules, so no extra ordering parameter is needed. The rule only affects text-only preview edits that can be finalized in place; media replies, stale-preview fallbacks, and final texts that would activate Matrix mentions are delivered as normal notifying messages instead.
+New user-defined `override` rules are inserted ahead of server-default suppress rules, so no extra ordering parameter is needed. The rule only affects text-only preview edits that can be finalized in place. Media replies, stale-preview fallbacks, and final texts that would activate Matrix mentions are delivered as normal notifying messages instead.
 
 ## Homeserver notes
 
@@ -139,7 +139,7 @@ New user-defined `override` rules are inserted ahead of server-default suppress 
   </Accordion>
 
   <Accordion title="Tuwunel">
-    Same flow as Synapse; no Tuwunel-specific config is needed for the finalized preview marker.
+    Same flow as Synapse. No Tuwunel-specific config is needed for the finalized preview marker.
 
     If notifications disappear while the user is active on another device, check whether `suppress_push_when_active` is enabled. Tuwunel added this option in 1.4.2 (September 2025) and it can intentionally suppress pushes to other devices while one device is active.
 

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -32,11 +32,11 @@ not change a remote Gateway over RPC. To change the server, run the command on
 that host using its profile/config. Enable, disable, and config written by a new
 install or link can activate immediately in the default `hybrid`
 [reload mode](/gateway/configuration#reload-modes). `off` requires a manual
-restart. Hook files and metadata are not watched; restart after editing them or
+restart. Hook files and metadata are not watched. Restart after editing them or
 updating existing hook code.
 
 `--agent <id>` selects the agent workspace used for inspection. It is required
-when configured agents do not have an implicit owner; blank or unknown IDs
+when configured agents do not have an implicit owner. Blank or unknown IDs
 fail. The option works before or after `list`, `info`, `check`, `enable`, and
 `disable`. It does not scope the persisted hook entry to that agent and is not
 supported on install/update. See
@@ -98,14 +98,14 @@ openclaw hooks info <name> [--agent <id>] [--json]
 ```
 
 Accepts a hook name or its metadata `hookKey`. Exact hook names take precedence
-over matching keys; a key must identify a single hook. Shows source, descriptor
+over matching keys. A key must identify a single hook. Shows source, descriptor
 and handler paths, homepage, events, unknown-event warnings, blocked reason, and
-per-requirement status. A missing or ambiguous hook exits with code 1; an
+per-requirement status. A missing or ambiguous hook exits with code 1. An
 ambiguous selector lists candidates so you can choose a unique name or key.
 
 JSON includes the list fields plus `filePath`, `baseDir`, `handlerPath`,
 `hookKey`, `always`, `requirements`, `configChecks`, and normalized `install`
-options. Each config check has `path` and `satisfied`; each install option has
+options. Each config check has `path` and `satisfied`. Each install option has
 `id`, `kind`, `label`, and `bins`. Install options are descriptive metadata, not
 a command to install dependencies automatically.
 
@@ -132,12 +132,12 @@ openclaw hooks enable <name> [--agent <id>]
 Discovers the hook locally, then writes
 `hooks.internal.entries.<hookKey>.enabled = true` and
 `hooks.internal.enabled = true` in local config. Other fields in that entry are
-preserved. Exact hook names take precedence over matching keys; ambiguous key
+preserved. Exact hook names take precedence over matching keys. Ambiguous key
 matches fail without writing.
 
 Enable fails for a missing hook, a plugin-managed hook, or unmet runtime
 requirements. It can enable a currently disabled workspace hook. This does not
-prove a valid module export or event subscription; inspect `info` and the
+prove a valid module export or event subscription. Inspect `info` and the
 Gateway logs too.
 
 The entry is **global**, even with `--agent`: it applies wherever that key is
@@ -145,7 +145,7 @@ discovered. Adding named entries can narrow a previously open-ended directory
 selection. See [Configuration](/automation/hooks/configuration#configuration).
 
 The running Gateway reloads the selection in `hybrid` mode. If a selected hook
-cannot load, it keeps the previous handlers; inspect Gateway logs. Reload does
+cannot load, it keeps the previous handlers. Inspect Gateway logs. Reload does
 not replay `gateway:startup`, so `boot-md` runs on the next Gateway start.
 
 ## Disable a hook
@@ -156,7 +156,7 @@ openclaw hooks disable <name> [--agent <id>]
 
 Writes `hooks.internal.entries.<hookKey>.enabled = false`. It does not remove the
 hook files or change the master switch. Missing/ambiguous and plugin-managed
-hooks are rejected; missing runtime requirements do not prevent disabling.
+hooks are rejected. Missing runtime requirements do not prevent disabling.
 In `hybrid` mode, subsequent events use the updated selection. An event already
 running finishes with its original handlers.
 
@@ -179,7 +179,7 @@ openclaw plugins update <id>
 
 A pack declares hook directories in `package.json` under `openclaw.hooks`.
 A local directory without `package.json` can contain a single `HOOK.md` and
-handler. Copied hook packs are installed into `<stateDir>/hooks/<id>`; their
+handler. Copied hook packs are installed into `<stateDir>/hooks/<id>`. Their
 hooks are enabled in config and install provenance is recorded in shared SQLite
 state. That config can activate the hooks immediately in `hybrid` mode. Do not author
 `hooks.internal.installs` in `openclaw.json`.
@@ -187,8 +187,8 @@ state. That config can activate the hooks immediately in `hybrid` mode. Do not a
 For the npm hook-pack path, specs are registry-only: package name with an
 optional exact version or dist-tag. Git/URL/file specs, npm aliases, and semver
 ranges are not npm registry specs. Bare specs and `@latest` stay on the stable
-track; a prerelease resolution requires an explicit prerelease version or a
-non-latest tag such as `@beta` or `@rc`. Use `npm:` to select npm explicitly; the
+track. A prerelease resolution requires an explicit prerelease version or a
+non-latest tag such as `@beta` or `@rc`. Use `npm:` to select npm explicitly. The
 unified installer supports other plugin sources described in
 [`openclaw plugins`](/cli/plugins).
 
@@ -196,7 +196,7 @@ Supported local archives are `.zip`, `.tgz`, `.tar.gz`, and `.tar`. Copied hook
 packs resolve runtime packages from `dependencies` and `optionalDependencies`,
 including packs with only optional dependencies. Packages listed only in
 `devDependencies` are omitted. npm pack and dependency installation use
-`--ignore-scripts`; this does not sandbox the installed handler.
+`--ignore-scripts`. This does not sandbox the installed handler.
 The download always creates an archive in OpenClaw's temporary workspace,
 regardless of npm's `dry-run` or `pack-destination` settings.
 
@@ -210,17 +210,17 @@ regardless of npm's `dry-run` or `pack-destination` settings.
 | `--acknowledge-install-policy-warning` | Acknowledge an operator `security.installPolicy` warning without its prompt. Blocks and policy failures still stop the install.             |
 
 Interactive non-ClawHub installs ask you to confirm trust. Noninteractive
-installs require `--force`; neither `plugins install` nor the `hooks install`
+installs require `--force`. Neither `plugins install` nor the `hooks install`
 alias accepts a `--yes` flag. `--force` is also not a substitute for
 acknowledging an install-policy warning. Review the source before supplying
 either acknowledgement.
 
 <Warning>
-A linked hook runs directly from the supplied path; linking does not copy it
+A linked hook runs directly from the supplied path. Linking does not copy it
 or create a symlink. A single-hook root loads its own `HOOK.md` and handler.
 A pack loads only the hook directories listed in `openclaw.hooks`, including
 nested paths such as `./hooks/my-hook`. Declared paths must stay inside the
-pack and point directly to hooks; discovery does not recurse into nested packs
+pack and point directly to hooks. Discovery does not recurse into nested packs
 or collections, or scan unlisted children, even when all declared paths are rejected.
 
 Only link trusted code. Extra directories still make directory-hook name
@@ -233,12 +233,12 @@ editing existing hook code or metadata, check `hooks list`, and
 ### Update behavior
 
 Updates use tracked npm install records. A tracked hook-pack ID uses its stored
-spec; a matching npm package spec can select a new version/tag. Local path and
+spec. A matching npm package spec can select a new version/tag. Local path and
 archive records are not refreshed by the npm hook updater.
 
 `--dry-run` reports what would change without installing or rewriting config.
 `--all` selects **both plugins and hook packs** in the unified updater, including
-when reached through the deprecated alias; it is not a hooks-only bulk command.
+when reached through the deprecated alias. It is not a hooks-only bulk command.
 
 When an applicable stored integrity hash differs from the downloaded artifact,
 the updater warns and asks for confirmation in the terminal. No CLI flag answers
@@ -276,12 +276,12 @@ jq 'select(.action == "new")' ~/.openclaw/logs/commands.log
 ```
 
 Use `<stateDir>/logs/commands.log` for a custom state directory. These records
-contain session and sender identifiers; protect access and arrange retention or
+contain session and sender identifiers. Protect access and arrange retention or
 rotation. The hook does not rotate them.
 
 ## Notes
 
-Report commands support `--json`; success JSON goes directly to stdout. Failures
+Report commands support `--json`. Success JSON goes directly to stdout. Failures
 use the standard [CLI JSON failure envelope](/cli#json-failures), and missing
 hook info also includes the requested `hook` name. Reports do not execute a hook
 as a test.

--- a/docs/cli/webhooks.md
+++ b/docs/cli/webhooks.md
@@ -35,9 +35,9 @@ openclaw webhooks gmail setup --account you@example.com --project my-gcp-project
 openclaw webhooks gmail setup --account you@example.com --hook-url https://gateway.example.com/hooks/gmail
 ```
 
-Authenticates `gcloud`, enables the required APIs, creates or updates the Pub/Sub topic/subscription and push endpoint, starts the Gmail watch, and writes `hooks.gmail` with `hooks.enabled: true` and the Gmail preset. Missing `gcloud`, `gog`, and Tailscale dependencies can be installed automatically on macOS with Homebrew; other platforms need them installed first. The Gmail account must already be authorized in `gog`.
+Authenticates `gcloud`, enables the required APIs, creates or updates the Pub/Sub topic/subscription and push endpoint, starts the Gmail watch, and writes `hooks.gmail` with `hooks.enabled: true` and the Gmail preset. Missing `gcloud`, `gog`, and Tailscale dependencies can be installed automatically on macOS with Homebrew. Other platforms need them installed first. The Gmail account must already be authorized in `gog`.
 
-Setup changes cloud resources, exposure settings, and local config; it is not a read-only check. Re-running it can apply the CLI defaults over saved Gmail settings. It prints `Next: openclaw webhooks gmail run`; use that only if the Gateway-managed watcher is not already running.
+Setup changes cloud resources, exposure settings, and local config. It is not a read-only check. Re-running it can apply the CLI defaults over saved Gmail settings. It prints `Next: openclaw webhooks gmail run`. Use that only if the Gateway-managed watcher is not already running.
 
 <Warning>
 This command connects Gmail transport but does not create a restricted reader agent or the session-key policy required by the templated preset. Without a custom Gmail mapping that sets `agentId`, inbound email runs as the default agent with that agent's effective workspace, sandbox, and tool policy. Complete [Configure a restricted Gmail reader](/automation/cron-jobs#configure-a-restricted-gmail-reader-recommended) before running setup for an untrusted inbox.
@@ -96,7 +96,7 @@ This command connects Gmail transport but does not create a restricted reader ag
 
 <Warning>Setup output is sensitive: `--json` includes `hookToken` and `pushToken`, and the push endpoint printed in either format can contain its token. Redact output before sharing it.</Warning>
 
-Command failures show bounded tails from both stdout and stderr, with terminal colors and progress redraws removed. Exit codes and recorded termination reasons distinguish timeouts, signals, and output limits; exit code `124` alone does not mean a timeout. An omission marker (`…`) indicates truncated output. These diagnostics can still contain sensitive command output: redact them before sharing.
+Command failures show bounded tails from both stdout and stderr, with terminal colors and progress redraws removed. Exit codes and recorded termination reasons distinguish timeouts, signals, and output limits. Exit code `124` alone does not mean a timeout. An omission marker (`…`) indicates truncated output. These diagnostics can still contain sensitive command output: redact them before sharing.
 
 `--port`, `--max-bytes`, and `--renew-minutes` require positive integers, without unit suffixes. `--include-body` has no negative CLI flag: set `hooks.gmail.includeBody: false` and let `run` inherit it.
 
@@ -106,13 +106,13 @@ Command failures show bounded tails from both stdout and stderr, with terminal c
 openclaw webhooks gmail run --account you@example.com
 ```
 
-Starts the Gmail watch and runs `gog gmail watch serve` plus periodic watch renewal in the foreground. Unexpected serve-process exits continue to restart after 5 seconds. A bind conflict stops restarts; run only one watcher per listener and stop the other watcher before retrying. Ctrl-C or SIGTERM cancels pending restarts and renewal work and shuts down the serve process tree. Investigate repeated exits in the logs.
+Starts the Gmail watch and runs `gog gmail watch serve` plus periodic watch renewal in the foreground. Unexpected serve-process exits continue to restart after 5 seconds. A bind conflict stops restarts. Run only one watcher per listener and stop the other watcher before retrying. Ctrl-C or SIGTERM cancels pending restarts and renewal work and shuts down the serve process tree. Investigate repeated exits in the logs.
 
 `run` accepts the same Pub/Sub, OpenClaw delivery, `gog gmail watch serve`, and Tailscale flags as `setup`, except:
 
-- `--account` is **optional** on `run`; it falls back to `hooks.gmail.account`.
+- `--account` is **optional** on `run`. It falls back to `hooks.gmail.account`.
 - `run` does **not** accept `--project`, `--push-endpoint`, or `--json`.
-- Unspecified flags inherit the matching `hooks.gmail.*` setting; `--hook-token` inherits `hooks.token`.
+- Unspecified flags inherit the matching `hooks.gmail.*` setting. `--hook-token` inherits `hooks.token`.
 - Account, full topic path, hook token, and push token must be supplied or configured. `run` does not generate missing tokens, provision Pub/Sub resources, or rewrite config.
 - Other fields use the setup defaults when no saved setting exists, except `--tailscale`, which defaults to `off` rather than `funnel`.
 

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -70,10 +70,10 @@ Amazon Bedrock, Google, Microsoft Foundry, OAuth, proxies, Vertex, and other
 cache-TTL-eligible routes keep client-side pruning. New pruning rounds are gated
 on both a time check and a context-size check:
 
-1. Wait for the cache TTL to expire (default 5 minutes when set manually; see [Smart defaults](#smart-defaults) for the Anthropic auto-default). Each successful model request refreshes the in-memory clock to its request start time, including tool-loop requests before turn settlement. Failed requests do not refresh it. Before the TTL elapses, no new pruning occurs; existing projections still replay unchanged.
+1. Wait for the cache TTL to expire. When you turn on `cache-ttl` mode and set no `ttl`, the TTL is 5 minutes. The bundled Anthropic plugin seeds `1h` instead, see [Smart defaults](#smart-defaults). Each successful model request refreshes the in-memory clock to its request start time, including tool-loop requests before turn settlement. Failed requests do not refresh it. Before the TTL elapses, no new pruning occurs. Existing projections still replay unchanged.
 2. Once the TTL has elapsed, estimate total context size against the model's context window. Below roughly 30% usage, pruning is skipped and the TTL clock keeps running.
 3. **Soft-trim** oversized tool results: results over 4,000 characters keep their first and last 1,500 characters with `...` in between.
-4. If context usage is still at or above roughly 50% and at least 50,000 characters of prunable tool content remain, **hard-clear** those results: replace their content with a placeholder (default `[Old tool result content cleared]`, configurable via `agents.defaults.contextPruning.hardClear.placeholder`; set `hardClear.enabled: false` to skip this step).
+4. If context usage is still at or above roughly 50% and at least 50,000 characters of prunable tool content remain, **hard-clear** those results. A hard clear replaces the content of each result with a placeholder. The default placeholder is `[Old tool result content cleared]`, and `agents.defaults.contextPruning.hardClear.placeholder` changes it. Set `hardClear.enabled: false` to skip this step.
 5. Record each changed result as a session projection and reset the pruning TTL clock. Follow-up requests reuse the same projected bytes, including tool-loop continuations and later turns.
 
 The TTL gates new pruning rounds, not replay of previous projections. Projections

--- a/docs/gateway/discovery.md
+++ b/docs/gateway/discovery.md
@@ -1,5 +1,5 @@
 ---
-summary: "Node discovery and transports (Bonjour, Tailscale, SSH) for finding the gateway"
+summary: "Node discovery and transports (Bonjour, Tailscale, SSH) for finding the Gateway"
 read_when:
   - Implementing or changing Bonjour discovery/advertising
   - Adjusting remote connection modes (direct vs SSH)
@@ -9,10 +9,10 @@ title: "Discovery and transports"
 
 OpenClaw has two related but distinct discovery problems:
 
-1. **Operator remote control**: the macOS menu bar app controlling a gateway running elsewhere.
-2. **Node pairing**: iOS/Android (and future nodes) finding a gateway and pairing securely.
+1. **Operator remote control**: the macOS menu bar app controlling a Gateway running elsewhere.
+2. **Node pairing**: iOS/Android (and future nodes) finding a Gateway and pairing securely.
 
-All network discovery/advertising lives in the **Node Gateway**
+All network discovery/advertising lives in the **Gateway**
 (`openclaw gateway`); clients (mac app, iOS) are consumers only.
 
 ## Terms
@@ -31,7 +31,7 @@ Protocol details: [Gateway protocol](/gateway/protocol).
 ## Why direct and SSH both exist
 
 - **Direct WS** is the best UX on the same network and within a tailnet: LAN
-  auto-discovery via Bonjour, pairing tokens and ACLs owned by the gateway,
+  auto-discovery via Bonjour, pairing tokens and ACLs owned by the Gateway,
   and no shell access required.
 - **SSH** is the universal fallback: works anywhere you have SSH access, even
   across unrelated networks, survives multicast/mDNS issues, and needs no new
@@ -42,19 +42,19 @@ Protocol details: [Gateway protocol](/gateway/protocol).
 ### 1) Bonjour / DNS-SD
 
 Multicast Bonjour is best-effort and does not cross networks. OpenClaw also
-supports browsing the same gateway beacon via a configured wide-area DNS-SD
+supports browsing the same Gateway beacon via a configured wide-area DNS-SD
 domain, so discovery can cover both `local.` on the same LAN and a configured
 unicast DNS-SD domain for cross-network discovery.
 
-The **gateway** advertises its WS endpoint via Bonjour when the bundled
-`bonjour` plugin is enabled; clients browse and show a "pick a gateway" list,
+The **Gateway** advertises its WS endpoint via Bonjour when the bundled
+`bonjour` plugin is enabled; clients browse and show a "pick a Gateway" list,
 then store the chosen endpoint.
 
 Troubleshooting and beacon details: [Bonjour](/gateway/bonjour).
 
 #### Service beacon details
 
-- Service type: `_openclaw-gw._tcp` (gateway transport beacon).
+- Service type: `_openclaw-gw._tcp` (Gateway transport beacon).
 - TXT keys (non-secret):
 
   | Key                         | Notes                                                                                                                                                            |
@@ -104,13 +104,13 @@ Enable, disable, and override:
 
 ### 2) Tailnet (cross-network)
 
-For gateways on different physical networks, Bonjour will not help. The
+For Gateways on different physical networks, Bonjour will not help. The
 recommended direct target is a Tailscale MagicDNS name (preferred) or a
 stable tailnet IP.
 
-If the gateway detects it is running under Tailscale, it publishes
+If the Gateway detects it is running under Tailscale, it publishes
 `tailnetDns` as an optional hint for clients (including wide-area beacons).
-The macOS app prefers MagicDNS names over raw Tailscale IPs for gateway
+The macOS app prefers MagicDNS names over raw Tailscale IPs for Gateway
 discovery, which stays reliable when tailnet IPs change (node restarts,
 CGNAT reassignment) since MagicDNS resolves to the current IP automatically.
 
@@ -128,14 +128,14 @@ tailnet/public routes:
 ### 3) Manual / SSH target
 
 When there is no direct route (or direct is disabled), clients can always
-connect via SSH by forwarding the loopback gateway port. See
+connect via SSH by forwarding the loopback Gateway port. See
 [Remote access](/gateway/remote).
 
 ## Transport selection (client policy)
 
 1. If a paired direct endpoint is configured and reachable, use it.
-2. Else, if discovery finds a gateway on `local.` or the configured wide-area
-   domain, offer a one-tap "Use this gateway" choice and save it as the
+2. Else, if discovery finds a Gateway on `local.` or the configured wide-area
+   domain, offer a one-tap "Use this Gateway" choice and save it as the
    direct endpoint.
 3. Else, if a tailnet DNS/IP is configured, try direct. For mobile nodes on
    tailnet/public routes, direct means a secure endpoint, not plaintext
@@ -144,18 +144,18 @@ connect via SSH by forwarding the loopback gateway port. See
 
 ## Pairing and auth (direct transport)
 
-The gateway is the source of truth for node/client admission:
+The Gateway is the source of truth for node/client admission:
 
-- Pairing requests are created/approved/rejected in the gateway (see
+- Pairing requests are created/approved/rejected in the Gateway (see
   [Gateway pairing](/gateway/pairing)).
-- The gateway enforces auth (token/keypair), scopes/ACLs (it is not a raw
+- The Gateway enforces auth (token/keypair), scopes/ACLs (it is not a raw
   proxy to every method), and rate limits.
 
 ## Responsibilities by component
 
 - **Gateway**: advertises discovery beacons, owns pairing decisions, hosts
   the WS endpoint.
-- **macOS app**: helps you pick a gateway, shows pairing prompts, uses SSH
+- **macOS app**: helps you pick a Gateway, shows pairing prompts, uses SSH
   only as a fallback.
 - **iOS/Android nodes**: browse Bonjour as a convenience, connect to the
   paired Gateway WS.

--- a/docs/gateway/secrets-plan-contract.md
+++ b/docs/gateway/secrets-plan-contract.md
@@ -127,10 +127,8 @@ No writes are committed for an invalid plan: target resolution and path validati
 ## Runtime and audit scope notes
 
 - Ref-only SQLite auth-profile entries (`keyRef`/`tokenRef`) are included in runtime credential resolution and audit coverage.
-- `secrets apply` writes supported `openclaw.json` targets and SQLite auth-profile targets. Two optional scrub passes are on by default. Set either option to `false` in the plan to skip that pass.
-  - `scrubEnv` removes migrated plaintext values from `.env` files in the effective state and active-config directories.
-  - `scrubAuthProfilesForProviderTargets` clears plaintext/unused-ref residue in auth stores for providers a plan just migrated.
-- `scrubLegacyAuthJson` is a deprecated plan input and is always disabled. Doctor owns legacy `auth.json` migration. `secrets apply` does not read or rewrite it.
+- `secrets apply` writes supported `openclaw.json` targets and SQLite auth-profile targets. Two optional scrub passes are on by default: `scrubEnv` removes migrated plaintext values from `.env` files in the effective state and active-config directories; `scrubAuthProfilesForProviderTargets` clears plaintext/unused-ref residue in auth stores for providers a plan just migrated. Set either option to `false` in the plan to skip that pass.
+- `scrubLegacyAuthJson` is a deprecated plan input and is always disabled. Doctor owns legacy `auth.json` migration; `secrets apply` does not read or rewrite it.
 
 ## Operator checks
 

--- a/docs/gateway/secrets-plan-contract.md
+++ b/docs/gateway/secrets-plan-contract.md
@@ -127,8 +127,10 @@ No writes are committed for an invalid plan: target resolution and path validati
 ## Runtime and audit scope notes
 
 - Ref-only SQLite auth-profile entries (`keyRef`/`tokenRef`) are included in runtime credential resolution and audit coverage.
-- `secrets apply` writes supported `openclaw.json` targets and SQLite auth-profile targets. Two optional scrub passes are on by default: `scrubEnv` removes migrated plaintext values from `.env` files in the effective state and active-config directories; `scrubAuthProfilesForProviderTargets` clears plaintext/unused-ref residue in auth stores for providers a plan just migrated. Set either option to `false` in the plan to skip that pass.
-- `scrubLegacyAuthJson` is a deprecated plan input and is always disabled. Doctor owns legacy `auth.json` migration; `secrets apply` does not read or rewrite it.
+- `secrets apply` writes supported `openclaw.json` targets and SQLite auth-profile targets. Two optional scrub passes are on by default. Set either option to `false` in the plan to skip that pass.
+  - `scrubEnv` removes migrated plaintext values from `.env` files in the effective state and active-config directories.
+  - `scrubAuthProfilesForProviderTargets` clears plaintext/unused-ref residue in auth stores for providers a plan just migrated.
+- `scrubLegacyAuthJson` is a deprecated plan input and is always disabled. Doctor owns legacy `auth.json` migration. `secrets apply` does not read or rewrite it.
 
 ## Operator checks
 

--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -211,8 +211,7 @@ To go fully dark, disable the existing startup update check:
 This stops both tiers and every automatic update request: no update request, no
 feature statistics, and no update notice, even when `update.auto.enabled` is
 `true`. Setting `OPENCLAW_NO_AUTO_UPDATE=1` also prevents automatic update
-requests and applies. Explicit update commands remain available when you choose
-to run them.
+requests. Explicit update commands remain available when you choose to run them.
 
 See [Configuration reference](/gateway/config-observability#telemetry) for
 the full `telemetry` configuration and

--- a/docs/install/digitalocean.md
+++ b/docs/install/digitalocean.md
@@ -69,7 +69,7 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
     openclaw onboard --install-daemon
     ```
 
-    The wizard walks you through model auth, channel setup, gateway token generation, and daemon installation (systemd user service).
+    The wizard walks you through model auth, channel setup, Gateway token generation, and daemon installation (systemd user service).
 
   </Step>
 
@@ -83,7 +83,7 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
     ```
   </Step>
 
-  <Step title="Verify the gateway">
+  <Step title="Verify the Gateway">
     ```bash
     openclaw status
     systemctl --user status openclaw-gateway.service
@@ -92,7 +92,7 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
   </Step>
 
   <Step title="Access the Control UI">
-    The gateway binds to loopback by default. Pick one of these options.
+    The Gateway binds to loopback by default. Pick one of these options.
 
     **Option A: SSH tunnel (simplest)**
 
@@ -114,7 +114,7 @@ DigitalOcean is a straightforward paid VPS path. For cheaper or free options:
 
     Then open `https://<magicdns>/` from any device on your tailnet.
 
-    Tailscale Serve authenticates Control UI and WebSocket traffic via tailnet identity headers, which assumes the gateway host itself is trusted. HTTP API endpoints still follow the gateway's normal auth mode (token/password) regardless. To require explicit shared-secret credentials over Serve, set `gateway.auth.allowTailscale: false` and use `gateway.auth.mode: "token"` or `"password"`.
+    Tailscale Serve authenticates Control UI and WebSocket traffic via tailnet identity headers, which assumes the Gateway host itself is trusted. HTTP API endpoints still follow the Gateway's normal auth mode (token/password) regardless. To require explicit shared-secret credentials over Serve, set `gateway.auth.allowTailscale: false` and use `gateway.auth.mode: "token"` or `"password"`.
 
   </Step>
 </Steps>

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -1,15 +1,15 @@
 ---
 summary: "Optional Docker-based setup and onboarding for OpenClaw"
 read_when:
-  - You want a containerized gateway instead of local installs
+  - You want a containerized Gateway instead of local installs
   - You are validating the Docker flow
   - You are migrating from ClawDock shell helpers
 title: "Docker"
 ---
 
-Docker is **optional**. Use it for an isolated, throwaway gateway environment or a host without local installs. If you already develop on your own machine, use the normal install flow instead.
+Docker is **optional**. Use it for an isolated, throwaway Gateway environment or a host without local installs. If you already develop on your own machine, use the normal install flow instead.
 
-The default Docker sandbox backend uses only the `docker` CLI. Set the backend to `"podman"` to select native Podman directly. Sandboxing is off by default and does not require the gateway itself to run in a container. SSH and OpenShell sandbox backends are also available; see [Sandboxing](/gateway/sandboxing).
+The default Docker sandbox backend uses only the `docker` CLI. Set the backend to `"podman"` to select native Podman directly. Sandboxing is off by default and does not require the Gateway itself to run in a container. SSH and OpenShell sandbox backends are also available; see [Sandboxing](/gateway/sandboxing).
 
 Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting) for the one-cell-per-tenant model.
 
@@ -20,7 +20,7 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
 - Enough disk for images and logs
 - On a VPS/public host, review [Security hardening for network exposure](/gateway/security), especially the Docker `DOCKER-USER` firewall chain
 
-## Containerized gateway
+## Containerized Gateway
 
 <Steps>
   <Step title="Build the image">
@@ -30,7 +30,7 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
     ./scripts/docker/setup.sh
     ```
 
-    This builds the gateway image locally as `openclaw:local`. To use a pre-built image instead:
+    This builds the Gateway image locally as `openclaw:local`. To use a pre-built image instead:
 
     ```bash
     export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest"
@@ -57,7 +57,7 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
     ./scripts/docker/setup.sh --offline
     ```
 
-    `--offline` verifies `OPENCLAW_IMAGE` already exists locally, disables implicit Compose pulls/builds, then runs the normal flow: `.env` sync, permission fixes, onboarding, gateway config sync, Compose startup.
+    `--offline` verifies `OPENCLAW_IMAGE` already exists locally, disables implicit Compose pulls/builds, then runs the normal flow: `.env` sync, permission fixes, onboarding, Gateway config sync, Compose startup.
 
     If `OPENCLAW_SANDBOX=1`, offline setup also checks the configured default and per-agent sandbox images on the daemon behind `OPENCLAW_DOCKER_SOCKET`, including the browser-contract label on Docker-backed browser images. If a required image is missing or stale, setup exits without changing sandbox config rather than reporting a broken success.
 
@@ -67,11 +67,11 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
     The setup script runs onboarding automatically:
 
     - prompts for provider API keys
-    - generates a gateway token and writes it to `.env`
+    - generates a Gateway token and writes it to `.env`
     - creates the legacy auth-profile secret key directory
-    - starts the gateway via Docker Compose
+    - starts the Gateway via Docker Compose
 
-    Pre-start onboarding and config writes run through `openclaw-gateway` directly (with `--no-deps --entrypoint node`), since `openclaw-cli` shares the gateway's network namespace and only works once the gateway container exists.
+    Pre-start onboarding and config writes run through `openclaw-gateway` directly (with `--no-deps --entrypoint node`), since `openclaw-cli` shares the Gateway's network namespace and only works once the Gateway container exists.
 
   </Step>
 
@@ -164,22 +164,22 @@ Run `docker compose` from the repo root. If you enabled `OPENCLAW_EXTRA_MOUNTS` 
 ### Upgrading container images
 
 When you replace the OpenClaw image but keep the same mounted state/config, the
-new gateway runs startup-safe upgrade migrations and plugin convergence before
+new Gateway runs startup-safe upgrade migrations and plugin convergence before
 readiness. Routine image upgrades should not require a separate
 `openclaw doctor --fix` pass.
 
-If startup cannot complete those repairs safely, the gateway exits instead of
+If startup cannot complete those repairs safely, the Gateway exits instead of
 reporting healthy. With a restart policy, Docker, Podman, or Kubernetes may show
-the gateway container restarting. Keep the mounted state volume, then run the
+the Gateway container restarting. Keep the mounted state volume, then run the
 same image once with `openclaw doctor --fix` as the container command, using the
-same state/config mounts the gateway uses:
+same state/config mounts the Gateway uses:
 
 ```bash
 docker run --rm -v <openclaw-state>:/home/node/.openclaw <image> openclaw doctor --fix
 podman run --rm -v <openclaw-state>:/home/node/.openclaw <image> openclaw doctor --fix
 ```
 
-After doctor finishes, restart the gateway container with its default command.
+After doctor finishes, restart the Gateway container with its default command.
 In Kubernetes, run the same command in a one-off Job or debug pod mounted to the
 same PVC, then restart the Deployment or StatefulSet.
 
@@ -209,7 +209,7 @@ plugins must compile successfully; unselected external plugin source and
 runtime output are pruned.
 
 For example, these commands build separate, multi-architecture standalone
-FakeCo gateway images for ClickClack, Slack, and Microsoft Teams. ClawRouter is
+FakeCo Gateway images for ClickClack, Slack, and Microsoft Teams. ClawRouter is
 already part of the root OpenClaw runtime, so the ClickClack image selects only
 `clickclack`. The explicit empty browser argument keeps the default image free
 of Chromium:
@@ -252,8 +252,8 @@ docker buildx imagetools inspect \
 # Deploy: registry.example.com/fakeco/openclaw-clickclack@sha256:<manifest-digest>
 ```
 
-These images are for standalone OCI-based gateways and generic Docker users.
-Crabhelm-managed gateways do not consume them: that delivery path builds a
+These images are for standalone OCI-based Gateways and generic Docker users.
+Crabhelm-managed Gateways do not consume them: that delivery path builds a
 separate x86_64 appliance archive containing an OpenClaw npm tarball and pins
 the Node, archive, and manifest digests. Build that appliance independently
 from the same landed OpenClaw source.
@@ -351,4 +351,4 @@ docker compose exec openclaw-gateway sh -lc 'node dist/index.js gateway health -
 - [Install Overview](/install) — all installation methods
 - [Podman](/install/podman) — Podman alternative to Docker
 - [Updating](/install/updating) — keeping OpenClaw up to date
-- [Configuration](/gateway/configuration) — gateway configuration after install
+- [Configuration](/gateway/configuration) — Gateway configuration after install

--- a/docs/install/docker/compose-operations.md
+++ b/docs/install/docker/compose-operations.md
@@ -51,7 +51,7 @@ needed. See [Manual flow](/install/docker#manual-flow) for setup and extra mount
 | Inspect config   | `docker compose run --rm openclaw-cli config get <path>`           |
 
 Start the gateway before using the shell or CLI commands. For a custom host port,
-adjust the printed dashboard URL as described in [Containerized gateway](/install/docker#containerized-gateway).
+adjust the printed dashboard URL as described in [Containerized Gateway](/install/docker#containerized-gateway).
 Use [Health checks](/install/docker#health-checks) to verify the gateway and
 [Update OpenClaw](/install/docker-vm-runtime#update-openclaw) for image updates.
 

--- a/docs/install/northflank.mdx
+++ b/docs/install/northflank.mdx
@@ -6,7 +6,7 @@ read_when:
 title: "Northflank"
 ---
 
-Deploy OpenClaw on Northflank with a one-click template and access it through the web Control UI. This is the easiest "no terminal on the server" path: Northflank runs the gateway for you.
+Deploy OpenClaw on Northflank with a one-click template and access it through the web Control UI. This is the easiest "no terminal on the server" path: Northflank runs the Gateway for you.
 
 ## How to get started
 
@@ -44,5 +44,5 @@ Use the Control UI at `/openclaw`, or run `openclaw onboard` via SSH for channel
 ## Next steps
 
 - Set up messaging channels: [Channels](/channels)
-- Configure the gateway: [Gateway configuration](/gateway/configuration)
+- Configure the Gateway: [Gateway configuration](/gateway/configuration)
 - Keep OpenClaw up to date: [Updating](/install/updating)

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -2,7 +2,7 @@
 summary: "Android app (node): pairing, connection recovery, chat, voice, and device commands"
 read_when:
   - Pairing or reconnecting the Android node
-  - Debugging Android gateway discovery or auth
+  - Debugging Android Gateway discovery or auth
   - Mirroring or controlling an Android device from a remote Mac
   - Verifying chat history parity across clients
 title: "Android app"
@@ -28,7 +28,7 @@ New replies stay in view while you are at the end of the settings conversation. 
 
 System control (launchd/systemd) lives on the Gateway host — see [Gateway](/gateway).
 
-## Simultaneous gateway sessions
+## Simultaneous Gateway sessions
 
 Pair each Gateway once, then open **Settings → Gateway**. The checkmark marks
 the focused Gateway and each switch controls whether a non-focused Gateway's
@@ -82,7 +82,7 @@ Mac are in different locations but share a private Tailscale network.
 
 - Install Tailscale on the Android device and the Mac, and connect both to the same tailnet.
 - On Android, enable **Developer options** and **USB debugging**. Android 16 places **Wireless
-  debugging** under **Settings > System > Developer options**. See [Android developer
+  debugging** under **Settings → System → Developer options**. See [Android developer
   options](https://developer.android.com/studio/debug/dev-options).
 - Install scrcpy and ADB on the Mac:
 
@@ -106,7 +106,7 @@ adb tcpip 5555
 
 You can now disconnect USB. If port 5555 stops listening after a device reboot or debugging reset,
 repeat this local setup step. Android 11 and later can also establish the initial trust with
-**Wireless debugging > Pair device with pairing code** and `adb pair`.
+**Wireless debugging → Pair device with pairing code** and `adb pair`.
 
 ### Allow only the controller Mac
 
@@ -155,7 +155,7 @@ private network path.
   peer reachability, not that policy permits this TCP port. Test with
   `nc -vz <android-tailnet-ip> 5555` from the Mac.
 - `unauthorized`: unlock Android and approve the remote Mac's ADB key, or remove the stale workstation
-  under **Wireless debugging > Paired devices** and pair it again.
+  under **Wireless debugging → Paired devices** and pair it again.
 - `Connection refused`: reconnect locally and run `adb tcpip 5555` again.
 - More than one device listed: keep the explicit `--serial <android-tailnet-ip>:5555` argument.
 
@@ -180,12 +180,12 @@ For Tailscale or public hosts, Android requires a secure endpoint:
 ### Prerequisites
 
 - Gateway running on another machine (or reachable via SSH).
-- Android device/emulator can reach the gateway WebSocket:
+- Android device/emulator can reach the Gateway WebSocket:
   - Same LAN with mDNS/NSD, **or**
   - Same Tailscale tailnet using Wide-Area Bonjour / unicast DNS-SD (see below), **or**
-  - Manual gateway host/port (fallback)
+  - Manual Gateway host/port (fallback)
 - Tailnet/public mobile pairing does **not** use raw tailnet IP `ws://` endpoints. Use Tailscale Serve or another `wss://` URL instead.
-- The `openclaw` CLI available on the gateway machine (or via SSH), to approve pairing requests.
+- The `openclaw` CLI available on the Gateway machine (or via SSH), to approve pairing requests.
 
 ### 1. Start the Gateway
 
@@ -207,7 +207,7 @@ This gives Android a secure `wss://` / `https://` endpoint. A plain `gateway.bin
 
 ### 2. Verify discovery (optional)
 
-From the gateway machine:
+From the Gateway machine:
 
 ```bash
 dns-sd -B _openclaw-gw._tcp local.
@@ -225,9 +225,9 @@ That shows `local.` plus the configured wide-area domain in one pass, using the 
 
 #### Cross-network discovery via unicast DNS-SD
 
-Android NSD/mDNS discovery does not cross networks. If the Android node and the gateway are on different networks but connected via Tailscale, use Wide-Area Bonjour / unicast DNS-SD instead. Discovery alone is not sufficient for tailnet/public Android pairing — the discovered route still needs a secure endpoint (`wss://` or Tailscale Serve):
+Android NSD/mDNS discovery does not cross networks. If the Android node and the Gateway are on different networks but connected via Tailscale, use Wide-Area Bonjour / unicast DNS-SD instead. Discovery alone is not sufficient for tailnet/public Android pairing — the discovered route still needs a secure endpoint (`wss://` or Tailscale Serve):
 
-1. Set up a DNS-SD zone (example `openclaw.internal.`) on the gateway host and publish `_openclaw-gw._tcp` records.
+1. Set up a DNS-SD zone (example `openclaw.internal.`) on the Gateway host and publish `_openclaw-gw._tcp` records.
 2. Configure Tailscale split DNS for your chosen domain pointing at that DNS server.
 
 Details and example CoreDNS config: [Bonjour](/gateway/bonjour).
@@ -236,14 +236,14 @@ Details and example CoreDNS config: [Bonjour](/gateway/bonjour).
 
 In the Android app:
 
-- The app keeps its gateway connection alive via a **foreground service** (persistent notification).
+- The app keeps its Gateway connection alive via a **foreground service** (persistent notification).
 - During first-run setup, choose **Scan QR or setup code** or **Set up manually**.
 - After setup, open **Settings → Gateway**. **Add Gateway** lets you scan or paste a setup code, or connect to a discovered Gateway.
 - If discovery is blocked, use **Manual Gateway** on that page: enter the host and port, select **Connection security**, and tap **Save & Connect**. Private LAN hosts support `ws://`; for Tailscale/public hosts, use **Secure (TLS)** with a `wss://` / Tailscale Serve endpoint.
 
 Gateway tokens, bootstrap tokens, passwords, and setup codes are masked and accept paste. The app requests password input with autocorrection disabled, but cannot guarantee how a third-party keyboard stores or learns from input.
 
-After the first successful pairing, Android auto-reconnects on launch to the active paired gateway (best-effort for discovered gateways, which must be visible on the network).
+After the first successful pairing, Android auto-reconnects on launch to the active paired Gateway (best-effort for discovered Gateways, which must be visible on the network).
 
 Android retries temporary connection losses automatically. For a fresh attempt with the saved endpoint, open **Settings → Gateway** and tap **Reconnect**. **Disconnect** stops the connections and suppresses automatic reconnect for the current app session; it does not forget the pairing. Authentication or pairing errors can pause retries until you address the reported problem.
 
@@ -258,14 +258,14 @@ with `openclaw qr`, then scan or paste it on that page and reconnect. Operators
 who want the reduced profile can select **Limited access** in Control UI or run
 `openclaw qr --limited`.
 
-### Manage paired gateways
+### Manage paired Gateways
 
-The app keeps a registry of every gateway it has paired with, so you can keep operator sessions connected and change focus without pairing again:
+The app keeps a registry of every Gateway it has paired with, so you can keep operator sessions connected and change focus without pairing again:
 
-- **Settings → Gateway** lists paired gateways in the **Gateways** section, with a checkmark beside the focused one. Tap another entry to focus it; the other enabled operator sessions remain connected.
+- **Settings → Gateway** lists paired Gateways in the **Gateways** section, with a checkmark beside the focused one. Tap another entry to focus it; the other enabled operator sessions remain connected.
 - Each switch controls whether that non-focused Gateway stays connected while the app is in the foreground. The focused Gateway remains enabled and owns the phone's node connection and device capabilities.
 - Credentials, device tokens, TLS trust, chat history, and queued offline messages are stored per Gateway. Changing focus never mixes state between Gateways, and messages queued while offline are delivered only to the Gateway they were written for.
-- **Forget** removes a gateway's registry entry together with its credentials, device tokens, TLS pin, and cached chats.
+- **Forget** removes a Gateway's registry entry together with its credentials, device tokens, TLS pin, and cached chats.
 
 The **Channels**, **Dreaming**, **Health** logs, **Skills**, and **Usage** pages keep their last loaded data while refreshing. A failed first load shows an error rather than empty counts or default health values. When refreshes overlap, only the latest request updates the page's data, error, and progress. Disconnecting clears the displayed summaries.
 
@@ -273,13 +273,13 @@ On **Health**, **Chat: Not ready** means chat health is unconfirmed or its check
 
 ### Presence alive beacons
 
-After the authenticated node session connects, and when the app moves to the background while the foreground service is still connected, Android calls `node.event` with `event: "node.presence.alive"`. The gateway records this as `lastSeenAtMs`/`lastSeenReason` on the paired node/device metadata only after the authenticated node device identity is known.
+After the authenticated node session connects, and when the app moves to the background while the foreground service is still connected, Android calls `node.event` with `event: "node.presence.alive"`. The Gateway records this as `lastSeenAtMs`/`lastSeenReason` on the paired node/device metadata only after the authenticated node device identity is known.
 
-The app counts the beacon as successfully recorded only when the gateway response includes `handled: true`. Older gateways may acknowledge `node.event` with `{ "ok": true }`; that response is compatible but does not count as a durable last-seen update.
+The app counts the beacon as successfully recorded only when the Gateway response includes `handled: true`. Older Gateways may acknowledge `node.event` with `{ "ok": true }`; that response is compatible but does not count as a durable last-seen update.
 
 ### 4. Approve pairing (CLI)
 
-On the gateway machine:
+On the Gateway machine:
 
 ```bash
 openclaw devices list
@@ -345,10 +345,10 @@ Open **Home** from the sidebar's **Pages** menu to chat, or select an existing s
 - **Refresh chat** in chat actions reloads history and rechecks Gateway health without clearing pending messages. Chat readiness is separate from the Gateway connection: an empty connected thread shows **Chat not ready** while health is unconfirmed or a check has failed. Use **Refresh chat** to check again; **Gateway offline** indicates a disconnected Gateway. History failures do not stop subsequent health checks. Once Android observes a recovered run finish, a delayed history response does not bring back that run's Stop button or partial reply.
 - Send: `chat.send`. Outside an active Talk session, you can send text or staged attachments while the agent is working. A new draft brings back **Send**; clearing it restores **Stop**. The Gateway applies the existing [queue mode](/concepts/queue), so steering does not require stopping the current run. Sending remains disabled while another submission, attachment staging, or microphone capture owns the draft.
 - Queued message controls: **Delete** removes the local queued copy, including when a reconnect refresh is still finishing. It does not undo a message already accepted by the Gateway; use **Stop** to cancel an active turn.
-- Durable sending: every send (text, picked images, and voice notes) is journaled to a per-gateway on-device outbox before any network attempt, so app termination cannot lose submitted input. Sends queued while offline deliver in order on reconnect with stable idempotency keys, and a send is retired only after the turn is visible in canonical `chat.history` — an acknowledgement alone is not treated as proof of delivery. Acknowledged reconnect sends show the same streaming progress as online sends; requests that never reach the socket queue remain queued for the next connection. Ambiguous outcomes (lost acknowledgement, app killed mid-send, gateway restart before the transcript write) surface as visible rows with explicit **Retry**/**Delete** instead of auto-resending. If refreshed history changes branches, earlier queued input keeps its text and attachments but requires explicit retry; input admitted after that history is displayed can send normally when reconnecting to the same branch. Slash commands never auto-replay across a reconnect; they park for explicit retry. The queue is bounded (50 messages and 48 MB of attachment bytes per gateway) and unsent rows expire after 48 hours. Composer drafts that were never submitted are not process-durable.
+- Durable sending: every send (text, picked images, and voice notes) is journaled to a per-gateway on-device outbox before any network attempt, so app termination cannot lose submitted input. Sends queued while offline deliver in order on reconnect with stable idempotency keys, and a send is retired only after the turn is visible in canonical `chat.history` — an acknowledgement alone is not treated as proof of delivery. Acknowledged reconnect sends show the same streaming progress as online sends; requests that never reach the socket queue remain queued for the next connection. Ambiguous outcomes (lost acknowledgement, app killed mid-send, Gateway restart before the transcript write) surface as visible rows with explicit **Retry**/**Delete** instead of auto-resending. If refreshed history changes branches, earlier queued input keeps its text and attachments but requires explicit retry; input admitted after that history is displayed can send normally when reconnecting to the same branch. Slash commands never auto-replay across a reconnect; they park for explicit retry. The queue is bounded (50 messages and 48 MB of attachment bytes per Gateway) and unsent rows expire after 48 hours. Composer drafts that were never submitted are not process-durable.
 - Image input works through the picker and Android Sharesheet. Assistant-generated images resolve through the paired Gateway connection, render inline with a full-screen preview, and retain only their small artifact references in the offline transcript cache. Downloads are capped at 12 MiB and decoded to bounded display bitmaps.
 - Push updates (best-effort): `chat.subscribe` -> `event:"chat"`
-- Listen: long-press an assistant message and choose **Listen** to hear it; audio renders via gateway `tts.speak` with the configured TTS provider chain, and on-device system TTS is used when the gateway cannot render audio. Playback stops on session switch, new chat, app backgrounding, or chat close.
+- Listen: long-press an assistant message and choose **Listen** to hear it; audio renders via Gateway `tts.speak` with the configured TTS provider chain, and on-device system TTS is used when the Gateway cannot render audio. Playback stops on session switch, new chat, app backgrounding, or chat close.
 
 ### 7. Camera
 
@@ -362,14 +362,14 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   transcript into the draft. Long-press the microphone to record a voice-note
   attachment. The UI reports unavailable recognition, missing permission,
   busy/network failures, and no-speech outcomes instead of silently dropping
-  the attempt. If dictation is unavailable and a gateway is selected,
+  the attempt. If dictation is unavailable and a Gateway is selected,
   **Record voice note** offers a new recording while keeping the draft. It does
   not recover speech from the failed dictation attempt or send anything
   automatically.
 - Start continuous **Talk** from the Chat waveform. Dictation, voice-note
   recording, and Talk are mutually exclusive microphone paths.
 - Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
-- By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured gateway Talk provider. It inherits the session's thinking setting. Local system TTS is used only when `talk.speak` is unavailable.
+- By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured Gateway Talk provider. It inherits the session's thinking setting. Local system TTS is used only when `talk.speak` is unavailable.
 - Gateway config changes refresh Android's cached Talk settings on the next use, without reconnecting or interrupting an active capture.
 - Android Talk uses realtime Gateway relay only when `talk.realtime.mode` is `realtime` and `talk.realtime.transport` is `gateway-relay`.
 - Enable **Settings → Voice → Listen for wake words** for foreground on-device
@@ -378,7 +378,7 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   synchronized with the current Gateway.
 - Additional Android command families (availability depends on device, permissions, and user settings):
   - `device.status`, `device.info`, `device.permissions`, `device.health`
-  - `device.apps` only when **Settings > Phone Capabilities > Installed Apps** is enabled; it lists launcher-visible apps by default (pass `includeNonLaunchable` for the full list).
+  - `device.apps` only when **Settings → Phone Capabilities → Installed Apps** is enabled; it lists launcher-visible apps by default (pass `includeNonLaunchable` for the full list).
   - `notifications.list`, `notifications.actions` (see [Notification forwarding](#notification-forwarding) below)
   - `photos.latest`
   - `contacts.search`, `contacts.add`
@@ -389,7 +389,7 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
 
 ### 9. Workspace files (read-only)
 
-Open **Work** from the sidebar's **Pages** menu to find the **Files** card. It browses the active agent's workspace through the read-only `agents.workspace.list` / `agents.workspace.get` gateway RPCs: directory drill-down, text and image previews, and export through the Android share sheet. There are no write operations, and previews are size-capped by the gateway.
+Open **Work** from the sidebar's **Pages** menu to find the **Files** card. It browses the active agent's workspace through the read-only `agents.workspace.list` / `agents.workspace.get` Gateway RPCs: directory drill-down, text and image previews, and export through the Android share sheet. There are no write operations, and previews are size-capped by the Gateway.
 
 If the app cannot prepare a file or open the share sheet, it shows **Could not share file** and keeps the preview open so you can retry or go back.
 
@@ -435,7 +435,7 @@ App Actions availability depends on the device, Google Play Services version, an
 
 ## Notification forwarding
 
-Android can forward device notifications to the gateway as `node.event` items. This is configured **on the device**, in the app's Settings sheet — not in gateway/`openclaw.json` config.
+Android can forward device notifications to the Gateway as `node.event` items. This is configured **on the device**, in the app's Settings sheet — not in Gateway/`openclaw.json` config.
 
 | Setting                     | Description                                                                                                                                                                                            |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -7,7 +7,7 @@ read_when:
   - Setting up standalone Apple Watch voice
   - Enabling or troubleshooting the direct Apple Watch node
   - Running the iOS app from source
-  - Debugging gateway discovery or iOS node commands
+  - Debugging Gateway discovery or iOS node commands
   - Choosing colors for native chat sessions
 title: "iOS app"
 ---
@@ -19,22 +19,22 @@ Availability: iPhone app builds are distributed through Apple channels when enab
 - Connects to a Gateway over WebSocket (LAN or tailnet).
 - Exposes node capabilities: Screen snapshot, Camera capture, Location, Talk mode, Voice wake, and opt-in Health summaries.
 - Receives `node.invoke` commands and reports node status events.
-- Browses the selected agent's workspace read-only from the Agents surface (Files): directory drill-down, syntax-highlighted text previews, image previews, and share-sheet export. No write operations; previews are size-capped by the gateway.
-- Keeps a small read-only offline cache of recent chat sessions and transcripts per paired gateway: cold opens paint the last known transcript immediately and refresh once the gateway responds, recent chats stay browsable while disconnected, and reset/forget purges the protected local cache.
+- Browses the selected agent's workspace read-only from the Agents surface (Files): directory drill-down, syntax-highlighted text previews, image previews, and share-sheet export. No write operations; previews are size-capped by the Gateway.
+- Keeps a small read-only offline cache of recent chat sessions and transcripts per paired Gateway: cold opens paint the last known transcript immediately and refresh once the Gateway responds, recent chats stay browsable while disconnected, and reset/forget purges the protected local cache.
 - Queues text messages sent while disconnected in a durable per-gateway outbox (up to 50): queued bubbles show in the transcript, flush in order on reconnect with idempotent retries, remain durable until canonical history confirms the send, retry with backoff before surfacing a retry/delete action, and expire instead of sending after 48 hours offline; reset/forget clears the queue with the cache.
 - Chat is the single text-and-voice surface. Chat actions can open the full Sessions screen without leaving Chat and can show or hide assistant reasoning and tool activity. Tap the microphone for draft dictation, open its menu to record a voice note, or use the inline Talk control for realtime voice; the Talk control animates from live microphone or playback level while listening or speaking.
 - Chat accepts images from the photo picker, camera, Files, paste, and the iOS share sheet. Assistant-generated images render inline from short-lived Gateway artifact URLs, open in a full-screen preview, and remain available after reconnect or history reload without storing image bytes in the transcript cache.
 - Renders completed Mermaid code fences as inline diagrams, with source/copy controls and a full-screen zoomable preview. Diagram rendering uses bundled assets and works offline.
 - Long-press a message or open its actions menu and choose **Select Text** to select and copy any span in a native text view; code fences show a copy button that copies the raw code.
 - **Settings** opens the Dashboard settings pages when connected with `operator.admin`; the native Gateway screen remains available for connection and pairing.
-- Speaks assistant messages on demand: long-press a message in Chat and choose **Listen**. The app plays supported gateway `tts.speak` clips with the configured TTS provider and falls back to on-device speech when gateway audio is unavailable or unplayable. Playback stops on session switch or backgrounding.
+- Speaks assistant messages on demand: long-press a message in Chat and choose **Listen**. The app plays supported Gateway `tts.speak` clips with the configured TTS provider and falls back to on-device speech when Gateway audio is unavailable or unplayable. Playback stops on session switch or backgrounding.
 
 ## Settings
 
 Open **Settings** in the sidebar to use the same Dashboard settings pages as the
 web and macOS apps. A connected operator session with `operator.admin` is required.
 The toolbar's **Gateway** button opens the native connection screen, including
-setup, paired gateways, manual connection, and advanced connection options.
+setup, paired Gateways, manual connection, and advanced connection options.
 **Approvals** opens the native approval inbox and shows the pending count.
 
 The Gateway must serve Dashboard pages that support the companion iOS app.
@@ -147,10 +147,10 @@ creation has a token or password auth path.
 3. In the iOS app, open **Settings** -> **Gateway**, scan the QR code (or paste
    the setup code), and connect.
 
-   Paired gateways remain in the **Gateways** list. The checkmark identifies
-   the focused gateway; use the bolt control on another row to keep its
+   Paired Gateways remain in the **Gateways** list. The checkmark identifies
+   the focused Gateway; use the bolt control on another row to keep its
    operator session connected at the same time. Switching focus does not
-   disconnect other enabled gateways. Only the focused gateway receives the
+   disconnect other enabled Gateways. Only the focused Gateway receives the
    iPhone's capability-bearing node session, so camera, screen, location, and
    other device commands always have one unambiguous owner. iOS may suspend
    these foreground connections after the app enters the background.
@@ -165,7 +165,7 @@ creation has a token or password auth path.
    then reconnect to enable settings and upgrades.
 
 The Control UI button requires an already paired session with `operator.admin`.
-As a terminal fallback, pick a discovered gateway in the iOS app (or enable
+As a terminal fallback, pick a discovered Gateway in the iOS app (or enable
 Manual Host and enter host/port), then approve the request on the Gateway host:
 
 ```bash
@@ -406,7 +406,7 @@ resolved notification, and whenever a resolve acknowledgement may have been
 lost. Actions stay unavailable until that readback confirms whether the
 request remains pending.
 
-Approval ownership is bound to the selected Gateway. Switching gateways cannot
+Approval ownership is bound to the selected Gateway. Switching Gateways cannot
 apply an old prompt to the replacement connection. Gateways that predate the
 unified approval methods fall back to the shipped exec-specific methods;
 retained terminal state and richer cross-surface results require an updated
@@ -473,9 +473,9 @@ Direct watchOS node commands:
 
 ## Relay-backed push for official builds
 
-Official distributed iOS builds use an external push relay instead of publishing the raw APNs token to the gateway. Official App Store builds from the public release lane use the hosted relay at `https://ios-push-relay.openclaw.ai`; this base URL is hardcoded for App Store distribution and does not read any override.
+Official distributed iOS builds use an external push relay instead of publishing the raw APNs token to the Gateway. Official App Store builds from the public release lane use the hosted relay at `https://ios-push-relay.openclaw.ai`; this base URL is hardcoded for App Store distribution and does not read any override.
 
-Custom relay deployments require a deliberately separate iOS build/deployment path whose relay URL matches the gateway relay URL. The App Store release lane never accepts a custom relay URL. If you're using a custom relay build, set the matching gateway relay URL:
+Custom relay deployments require a deliberately separate iOS build/deployment path whose relay URL matches the Gateway relay URL. The App Store release lane never accepts a custom relay URL. If you're using a custom relay build, set the matching Gateway relay URL:
 
 ```json5
 {
@@ -495,32 +495,32 @@ How the flow works:
 
 - The iOS app registers with the relay using App Attest and a StoreKit app transaction JWS.
 - The relay returns an opaque relay handle plus a registration-scoped send grant.
-- The iOS app fetches the paired gateway identity (`gateway.identity.get`) and includes it in relay registration, so the relay-backed registration is delegated to that specific gateway.
-- The app forwards that relay-backed registration to the paired gateway with `push.apns.register`.
-- The gateway uses that stored relay handle for `push.test`, background wakes, and wake nudges.
-- If the app later connects to a different gateway or a build with a different relay base URL, it refreshes the relay registration instead of reusing the old binding.
+- The iOS app fetches the paired Gateway identity (`gateway.identity.get`) and includes it in relay registration, so the relay-backed registration is delegated to that specific Gateway.
+- The app forwards that relay-backed registration to the paired Gateway with `push.apns.register`.
+- The Gateway uses that stored relay handle for `push.test`, background wakes, and wake nudges.
+- If the app later connects to a different Gateway or a build with a different relay base URL, it refreshes the relay registration instead of reusing the old binding.
 
-What the gateway does **not** need for this path: no deployment-wide relay token, no direct APNs key for official App Store relay-backed sends.
+What the Gateway does **not** need for this path: no deployment-wide relay token, no direct APNs key for official App Store relay-backed sends.
 
 Expected operator flow:
 
 1. Install the official iOS app.
-2. Optional: set `gateway.push.apns.relay.baseUrl` on the gateway only when using a deliberately separate custom relay build.
-3. Pair the app to the gateway and let it finish connecting.
+2. Optional: set `gateway.push.apns.relay.baseUrl` on the Gateway only when using a deliberately separate custom relay build.
+3. Pair the app to the Gateway and let it finish connecting.
 4. The app publishes `push.apns.register` once it has an APNs token, the operator session is connected, and relay registration succeeds.
 5. After that, `push.test`, reconnect wakes, and wake nudges can use the stored relay-backed registration.
 
 ## Background alive beacons
 
-When iOS wakes the app for a silent push, background refresh, or significant-location event, the app attempts a short node reconnect and then calls `node.event` with `event: "node.presence.alive"`. The gateway records this as `lastSeenAtMs`/`lastSeenReason` on the paired node/device metadata only after the authenticated node device identity is known.
+When iOS wakes the app for a silent push, background refresh, or significant-location event, the app attempts a short node reconnect and then calls `node.event` with `event: "node.presence.alive"`. The Gateway records this as `lastSeenAtMs`/`lastSeenReason` on the paired node/device metadata only after the authenticated node device identity is known.
 
-The app treats a background wake as successfully recorded only when the gateway response includes `handled: true`. Older gateways may acknowledge `node.event` with `{ "ok": true }`; that response is compatible but does not count as a durable last-seen update.
+The app treats a background wake as successfully recorded only when the Gateway response includes `handled: true`. Older Gateways may acknowledge `node.event` with `{ "ok": true }`; that response is compatible but does not count as a durable last-seen update.
 
 Background refresh wakes are requested through the system BackgroundTasks scheduler whenever the app moves to the background, after a silent push that could not be applied, and again after each refresh run; iOS decides when they actually execute. They stop if Background App Refresh is turned off for OpenClaw in iOS Settings, leaving push and significant-location wakes.
 
 Compatibility note:
 
-- `OPENCLAW_APNS_RELAY_BASE_URL` still works as a temporary env override for the gateway (`gateway.push.apns.relay.baseUrl` is the config-first path).
+- `OPENCLAW_APNS_RELAY_BASE_URL` still works as a temporary env override for the Gateway (`gateway.push.apns.relay.baseUrl` is the config-first path).
 - The App Store release build's push mode hardcodes the hosted relay host and never reads a relay-URL override — the `OPENCLAW_PUSH_RELAY_BASE_URL` build-time env var only affects local/sandbox iOS build modes.
 
 ## Authentication and trust flow
@@ -528,19 +528,19 @@ Compatibility note:
 The relay exists to enforce two constraints direct APNs-on-gateway cannot provide for official iOS builds:
 
 - Only genuine OpenClaw iOS builds distributed through Apple can use the hosted relay.
-- A gateway can send relay-backed pushes only for iOS devices that paired with that specific gateway.
+- A Gateway can send relay-backed pushes only for iOS devices that paired with that specific Gateway.
 
 Hop by hop:
 
-1. `iOS app -> gateway`: the app pairs with the gateway through the normal Gateway auth flow, giving it an authenticated node session plus an authenticated operator session. The operator session calls `gateway.identity.get`.
+1. `iOS app -> gateway`: the app pairs with the Gateway through the normal Gateway auth flow, giving it an authenticated node session plus an authenticated operator session. The operator session calls `gateway.identity.get`.
 2. `iOS app -> relay`: the app calls the relay registration endpoints over HTTPS with App Attest proof plus a StoreKit app transaction JWS. The relay validates the bundle ID, App Attest proof, and Apple distribution proof, and requires the official/production distribution path — this is what blocks local Xcode/dev builds from using the hosted relay, since a local build cannot satisfy the official Apple distribution proof.
-3. `gateway identity delegation`: before relay registration, the app fetches the paired gateway identity from `gateway.identity.get` and includes it in the relay registration payload. The relay returns a relay handle and a registration-scoped send grant delegated to that gateway identity.
-4. `gateway -> relay`: the gateway stores the relay handle and send grant from `push.apns.register`. On `push.test`, reconnect wakes, and wake nudges, the gateway signs the send request with its own device identity; the relay verifies both the stored send grant and the gateway signature against the delegated gateway identity from registration. Another gateway cannot reuse that stored registration, even if it somehow obtains the handle.
-5. `relay -> APNs`: the relay owns the production APNs credentials and the raw APNs token for the official build. The gateway never stores the raw APNs token for relay-backed official builds; the relay sends the final push to APNs on behalf of the paired gateway.
+3. `gateway identity delegation`: before relay registration, the app fetches the paired Gateway identity from `gateway.identity.get` and includes it in the relay registration payload. The relay returns a relay handle and a registration-scoped send grant delegated to that Gateway identity.
+4. `gateway -> relay`: the Gateway stores the relay handle and send grant from `push.apns.register`. On `push.test`, reconnect wakes, and wake nudges, the Gateway signs the send request with its own device identity; the relay verifies both the stored send grant and the Gateway signature against the delegated Gateway identity from registration. Another Gateway cannot reuse that stored registration, even if it somehow obtains the handle.
+5. `relay -> APNs`: the relay owns the production APNs credentials and the raw APNs token for the official build. The Gateway never stores the raw APNs token for relay-backed official builds; the relay sends the final push to APNs on behalf of the paired Gateway.
 
-Why this design was created: to keep production APNs credentials out of user gateways, avoid storing raw official-build APNs tokens on the gateway, allow hosted relay usage only for official OpenClaw iOS builds, and prevent one gateway from sending wake pushes to iOS devices owned by a different gateway.
+Why this design was created: to keep production APNs credentials out of user Gateways, avoid storing raw official-build APNs tokens on the Gateway, allow hosted relay usage only for official OpenClaw iOS builds, and prevent one Gateway from sending wake pushes to iOS devices owned by a different Gateway.
 
-Local/manual builds remain on direct APNs. If you are testing those builds without the relay, the gateway still needs direct APNs credentials:
+Local/manual builds remain on direct APNs. If you are testing those builds without the relay, the Gateway still needs direct APNs credentials:
 
 ```bash
 export OPENCLAW_APNS_TEAM_ID="TEAMID"
@@ -566,7 +566,7 @@ Do not commit the `.p8` file or place it under the repo checkout.
 
 ### Bonjour (LAN)
 
-The iOS app browses `_openclaw-gw._tcp` on `local.` and, when configured, the same wide-area DNS-SD discovery domain. Same-LAN gateways appear automatically from `local.`; cross-network discovery can use the configured wide-area domain without changing the beacon type.
+The iOS app browses `_openclaw-gw._tcp` on `local.` and, when configured, the same wide-area DNS-SD discovery domain. Same-LAN Gateways appear automatically from `local.`; cross-network discovery can use the configured wide-area domain without changing the beacon type.
 
 ### Tailnet (cross-network)
 
@@ -574,22 +574,22 @@ If mDNS is blocked, use a unicast DNS-SD zone (choose a domain; example: `opencl
 
 ### Manual host/port
 
-Open **Settings -> Gateway**, enable **Use Manual Gateway**, and enter the gateway host + port (default `18789`).
+Open **Settings → Gateway**, enable **Use Manual Gateway**, and enter the Gateway host + port (default `18789`).
 
-## Multiple gateways
+## Multiple Gateways
 
-The app keeps a registry of every gateway it has paired with, so you can switch between them without pairing again:
+The app keeps a registry of every Gateway it has paired with, so you can switch between them without pairing again:
 
-- **Settings -> Gateway** shows a **Paired Gateways** list with the active gateway marked. Tap an entry to switch; the app tears down the current sessions and reconnects to the selected gateway.
-- Credentials, TLS trust decisions, per-gateway preferences, and cached chat history are stored per gateway. Switching never mixes state between gateways, and push registration follows the active gateway.
-- Swipe a paired gateway (or use its context menu) to **Forget** it, which removes its credentials, device tokens, TLS pin, and cached chats.
-- Discovered gateways must be visible on the network to switch to them; manual gateways reconnect by saved host and port.
+- **Settings → Gateway** shows a **Paired Gateways** list with the active Gateway marked. Tap an entry to switch; the app tears down the current sessions and reconnects to the selected Gateway.
+- Credentials, TLS trust decisions, per-gateway preferences, and cached chat history are stored per Gateway. Switching never mixes state between Gateways, and push registration follows the active Gateway.
+- Swipe a paired Gateway (or use its context menu) to **Forget** it, which removes its credentials, device tokens, TLS pin, and cached chats.
+- Discovered Gateways must be visible on the network to switch to them; manual Gateways reconnect by saved host and port.
 
 ## Computer Use relationship
 
 The iOS app is a mobile node surface, not a Codex Computer Use backend. Codex Computer Use and `cua-driver mcp` control a local macOS desktop through MCP tools; the iOS app exposes iPhone capabilities through OpenClaw node commands such as `camera.*`, `screen.*`, `location.*`, and `talk.*`.
 
-Agents can still operate the iOS app through OpenClaw by invoking node commands, but those calls go through the gateway node protocol and follow iOS foreground/background limits. Use [Codex Computer Use](/plugins/codex-computer-use) for local desktop control and this page for iOS node capabilities.
+Agents can still operate the iOS app through OpenClaw by invoking node commands, but those calls go through the Gateway node protocol and follow iOS foreground/background limits. Use [Codex Computer Use](/plugins/codex-computer-use) for local desktop control and this page for iOS node capabilities.
 
 ## Voice wake + talk mode
 
@@ -607,14 +607,14 @@ chat and starts the same Talk path as the inline Talk control.
 1. Open OpenClaw and [pair and connect to your Gateway](/platforms/ios#quick-start-pair-+-connect)
    first. Live voice uses your existing [Talk mode voice provider configuration](/nodes/talk);
    the shortcut does not configure a provider or bypass pairing.
-2. In **Shortcuts > Apps > OpenClaw**, choose **Start Live Voice**. You can also
+2. In **Shortcuts → Apps → OpenClaw**, choose **Start Live Voice**. You can also
    ask Siri: **"Start live voice with OpenClaw"**.
 3. Allow microphone access when iOS prompts. Unlock your iPhone if asked, and
    keep OpenClaw in the foreground while Talk starts. The shortcut does not
    bypass iOS unlock or foreground restrictions.
 
 For quick access, save a shortcut containing **Start Live Voice**, then assign
-it under **Settings > Action Button > Shortcut** on a supported iPhone, or use
+it under **Settings → Action Button → Shortcut** on a supported iPhone, or use
 **Add to Home Screen** in Shortcuts. Background voice remains subject to the
 same iOS limits as Talk started inside the app.
 

--- a/docs/platforms/mac/canvas.md
+++ b/docs/platforms/mac/canvas.md
@@ -9,7 +9,7 @@ doc-schema-version: 1
 ---
 
 The macOS app includes a native panel for presenting hosted widget documents.
-The Canvas plugin owns this presentation path; it is not a standalone visual
+The Canvas plugin owns this presentation path. It is not a standalone visual
 workspace or an A2UI push target.
 
 The recommended agent path is [`show_widget`](/tools/show-widget) with
@@ -67,7 +67,7 @@ openclaw nodes canvas hide --node <id>
 
 Hosted paths under `/__openclaw__/canvas/` are resolved through the node
 session's current scoped `pluginSurfaceUrls.canvas` URL. The app refreshes that
-short-lived capability before navigation; callers should pass the document
+short-lived capability before navigation. Callers should pass the document
 path, not construct or copy a capability URL.
 
 The app-local scheme remains available for app-owned content:
@@ -100,7 +100,7 @@ warns and retains the source locator for retry. It may move the older setting
 into the plugin config while preserving the path. A root that already points to
 canonical storage, including through a symlink, needs no copy.
 
-Fix the reported permissions or target conflict, then rerun the command; do not
+Fix the reported permissions or target conflict, then rerun the command. Do not
 remove the root setting yourself. Hosted routes serve only the canonical folder,
 so remaining legacy documents are unavailable until migration completes.
 

--- a/docs/platforms/mac/health.md
+++ b/docs/platforms/mac/health.md
@@ -35,25 +35,25 @@ The health row uses these states:
 
 The summary can read "Telegram ready", "Telegram running", or
 "linked · auth 12m". The app honors the Gateway's startup and reconnect grace
-windows; transient transport flags alone do not mark a channel degraded.
+windows. Transient transport flags alone do not mark a channel degraded.
 Reported failures such as a stale socket or unavailable inbound processing
 still take precedence over a ready-looking connection.
 
-A missing HTTP status does not by itself mean a timeout; the app preserves
+A missing HTTP status does not by itself mean a timeout. The app preserves
 the Gateway's reported probe error.
 
 ## How health refresh works
 
 The app calls the Gateway's `health` RPC over its existing WebSocket
 connection (not a CLI shell-out) every ~60s and on demand. This reads the
-Gateway's health snapshot; it does not request an active channel probe or
+Gateway's health snapshot. It does not request an active channel probe or
 send messages. The app caches the last
 good snapshot and the last error separately so the UI loads instantly and
 does not flicker while offline.
 
 The native health row follows the Primary Gateway.
-Switching Primary immediately clears the previous Gateway's cached status;
-delayed replies from that Gateway cannot replace the new results. Reconnecting
+Switching Primary immediately clears the previous Gateway's cached status.
+Delayed replies from that Gateway cannot replace the new results. Reconnecting
 to the same Gateway retains its last good health snapshot while a fresh check
 runs. Connection errors stay with the Gateway that reported them.
 

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -1,12 +1,12 @@
 ---
-summary: "macOS app flow for controlling a remote OpenClaw gateway"
+summary: "macOS app flow for controlling a remote OpenClaw Gateway"
 read_when:
   - Setting up or debugging remote mac control
   - Signing in to a Gateway from the Mac app or opening it from a website
 title: "Remote control"
 ---
 
-This flow lets the macOS app act as a full remote control for an OpenClaw gateway running on another host (desktop/server). The app connects directly to trusted LAN/Tailnet gateway URLs, or manages an SSH tunnel when the remote gateway is loopback-only. Health checks, Voice Wake forwarding, and Web Chat reuse the same remote configuration from the native **Connection** window.
+This flow lets the macOS app act as a full remote control for an OpenClaw Gateway running on another host (desktop/server). The app connects directly to trusted LAN/Tailnet Gateway URLs, or manages an SSH tunnel when the remote Gateway is loopback-only. Health checks, Voice Wake forwarding, and WebChat reuse the same remote configuration from the native **Connection** window.
 
 ## Connect with your browser
 
@@ -84,18 +84,18 @@ the primary connection.
 
 - **Local (this Mac)**: everything runs on the laptop; no SSH involved.
 - **Remote over SSH (default)**: OpenClaw commands run on the remote host. The app opens an SSH connection with `-o BatchMode`, your chosen identity/key, and a local port-forward.
-- **Remote direct (ws/wss)**: no SSH tunnel; the app connects to the gateway URL directly (LAN, Tailscale, Tailscale Serve, or a public HTTPS reverse proxy).
+- **Remote direct (ws/wss)**: no SSH tunnel; the app connects to the Gateway URL directly (LAN, Tailscale, Tailscale Serve, or a public HTTPS reverse proxy).
 
 ## Remote transports
 
-- **SSH tunnel** (default): uses `ssh -N -L ...` to forward the gateway port to localhost. The gateway sees the node's IP as `127.0.0.1` because the tunnel is loopback.
-- **Direct (ws/wss)**: connects straight to the gateway URL. The gateway sees the real client IP.
+- **SSH tunnel** (default): uses `ssh -N -L ...` to forward the Gateway port to localhost. The Gateway sees the node's IP as `127.0.0.1` because the tunnel is loopback.
+- **Direct (ws/wss)**: connects straight to the Gateway URL. The Gateway sees the real client IP.
 
 The app disables SSH connection multiplexing and post-authentication backgrounding for its own SSH processes so it can monitor and restart the exact process, even if the selected alias enables `ControlMaster` or `ForkAfterAuthentication`.
 
-SSH host-key verification is strict by default because gateway credentials travel through this tunnel. To opt into a managed SSH alias's own trust behavior, set `--ssh-host-key-policy openssh` via `openclaw-mac primary set`, or set `gateway.remote.sshHostKeyPolicy` to `"openssh"` directly. Review the alias and any matching `Host *` or system configuration before opting in. Changing the SSH target (in the app or via `openclaw-mac`) resets the policy back to `strict` unless you explicitly opt in again for the new target.
+SSH host-key verification is strict by default because Gateway credentials travel through this tunnel. To opt into a managed SSH alias's own trust behavior, set `--ssh-host-key-policy openssh` via `openclaw-mac primary set`, or set `gateway.remote.sshHostKeyPolicy` to `"openssh"` directly. Review the alias and any matching `Host *` or system configuration before opting in. Changing the SSH target (in the app or via `openclaw-mac`) resets the policy back to `strict` unless you explicitly opt in again for the new target.
 
-In SSH tunnel mode, discovered LAN/tailnet hostnames save as `gateway.remote.sshTarget`. The app keeps `gateway.remote.url` on the local tunnel endpoint (for example `ws://127.0.0.1:18789`) so CLI, Web Chat, and the local node-host service all use the same loopback transport. When discovery returns both raw Tailnet IPs and stable hostnames, the app prefers Tailscale MagicDNS or LAN names so connections survive address changes better. If the local tunnel port differs from the remote gateway port, set `gateway.remote.remotePort` to the port on the remote host.
+In SSH tunnel mode, discovered LAN/tailnet hostnames save as `gateway.remote.sshTarget`. The app keeps `gateway.remote.url` on the local tunnel endpoint (for example `ws://127.0.0.1:18789`) so CLI, WebChat, and the local node-host service all use the same loopback transport. When discovery returns both raw Tailnet IPs and stable hostnames, the app prefers Tailscale MagicDNS or LAN names so connections survive address changes better. If the local tunnel port differs from the remote Gateway port, set `gateway.remote.remotePort` to the port on the remote host.
 
 The Mac app's node combines native capabilities with system, browser, plugin, skill, and MCP commands from its bundled private worker. Connecting the app to a remote Gateway needs no external CLI or separate node-service installation on this Mac. An already-installed headless node service remains separate: the app preserves its start/stop and managed update/recovery behavior. Optional [cookie sync](/platforms/macos#sync-cookies-to-a-remote-computer) still uses an external CLI and reports a feature-specific error when it is missing.
 
@@ -261,19 +261,21 @@ To configure from the UI instead:
 1. Choose **Connection…** from the menu bar and select the **Connection** tab.
 2. Under **OpenClaw runs**, pick **Remote** and set:
    - **Transport**: **SSH tunnel** or **Direct (ws/wss)**.
-   - **SSH target**: `user@host` (optional `:port`). If the gateway is on the same LAN and advertises Bonjour, pick it from the discovered list to auto-fill this field.
+   - **SSH target**: `user@host` (optional `:port`). If the Gateway is on the same LAN and advertises Bonjour, pick it from the discovered list to auto-fill this field.
    - **Gateway URL** (Direct only): `wss://gateway.example.ts.net` (or `ws://...` for local/LAN).
    - **Identity file** (advanced): path to your key.
    - **Project root** (advanced): remote checkout path used for commands.
    - **CLI path** (advanced): optional path to a runnable `openclaw` entrypoint/binary (auto-filled when advertised).
 3. Hit **Test remote**. The app checks SSH reachability when applicable, then authenticates and calls the Gateway health RPC. Connection, authentication, and pairing errors appear here; this check does not require a CLI on this Mac.
-4. Health checks and Web Chat now run through the selected transport automatically.
+4. Health checks and WebChat now run through the selected transport automatically.
 
-## Web Chat
+<a id="web-chat" />
 
-- **SSH tunnel**: connects to the gateway over the forwarded WebSocket control port (default 18789).
-- **Direct (ws/wss)**: connects straight to the configured gateway URL.
-- There is no separate Web Chat HTTP server.
+## WebChat
+
+- **SSH tunnel**: connects to the Gateway over the forwarded WebSocket control port (default 18789).
+- **Direct (ws/wss)**: connects straight to the configured Gateway URL.
+- There is no separate WebChat HTTP server.
 
 ## Permissions
 
@@ -301,8 +303,8 @@ The Dashboard error page shows the attempted address without embedded credential
 | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `exit 127` / not found                           | `openclaw` is not on PATH for non-login shells. Add it to `/etc/paths`, your shell rc, or symlink into `/usr/local/bin`/`/opt/homebrew/bin`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Health probe failed                              | Check SSH reachability, PATH, and that Baileys (WhatsApp) is logged in (`openclaw status --json`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| Web Chat stuck                                   | Confirm the gateway is running on the remote host and the forwarded port matches the gateway WS port; the UI requires a healthy WS connection.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| Node IP shows `127.0.0.1`                        | Expected with the SSH tunnel. Switch **Transport** to **Direct (ws/wss)** if you want the gateway to see the real client IP.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| WebChat stuck                                    | Confirm the Gateway is running on the remote host and the forwarded port matches the Gateway WS port; the UI requires a healthy WS connection.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Node IP shows `127.0.0.1`                        | Expected with the SSH tunnel. Switch **Transport** to **Direct (ws/wss)** if you want the Gateway to see the real client IP.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Dashboard works but Mac capabilities are offline | The operator/control connection is healthy, but the companion node connection is not connected or is missing its command surface. Open the menu bar device section and check whether the Mac is `paired · disconnected`. Direct `wss://` operator and node connections use the same configured or stored certificate policy. For trusted `wss://*.ts.net` Tailscale Serve endpoints, stale stored leaf pins are replaced after certificate rotation and retried automatically. Configured pins never rotate automatically; update `gateway.remote.tlsFingerprint` after reviewing the new certificate, or switch to **Remote over SSH**. |
 | Voice Wake                                       | Trigger phrases forward automatically in remote mode; no separate forwarder is needed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -29,7 +29,7 @@ openclaw onboard
 `models.providers.llama-cpp.localService` is the ownership discriminator. If
 it exists, OpenClaw manages the process. Without it, `baseUrl` identifies an
 existing endpoint. Switching choices rewrites ownership-specific state on the
-same provider; it never creates another provider namespace.
+same provider. It never creates another provider namespace.
 
 ## Managed local server
 
@@ -45,13 +45,13 @@ prepares a loopback endpoint, and checks inference before saving the new
 default. Guided activation also asks the model to read a temporary file through
 an OpenClaw tool and return its contents. The tool check uses an isolated
 workspace without your agent's bootstrap instructions. A plain text reply alone
-does not pass that check. Each verification check has a 90-second deadline;
-changing `agents.defaults.timeoutSeconds` does not extend setup verification.
+does not pass that check. Each verification check has a 90-second deadline.
+Changing `agents.defaults.timeoutSeconds` does not extend setup verification.
 Failures identify whether the response check or tool-use check timed out.
 
 Managed local models automatically use structured [Tool Search](/tools/tool-search)
-unless you have explicitly configured it. Optional capabilities remain available;
-their schemas load as needed, reducing the input the model must process before
+unless you have explicitly configured it. Optional capabilities remain available.
+Their schemas load as needed, reducing the input the model must process before
 replying. Setup does not enable lean mode. Normal chats still
 include your agent's instructions. On CPU-only hosts, the first reply can take
 several minutes even after setup verification succeeds.
@@ -84,7 +84,7 @@ configurations and cached custom models remain supported.
 
 The chat download also includes your configured local embedding model, or
 EmbeddingGemma by default (about 0.3 GB). Leave additional disk space for the
-runtime and download staging; setup checks this before offering a new model.
+runtime and download staging. Setup checks this before offering a new model.
 When the cache and runtime use independent volumes, setup checks each volume's
 free space separately. Shared storage pools and volumes whose independence cannot
 be established use a combined reserve.
@@ -157,7 +157,7 @@ Add a model under `models.providers.llama-cpp.models`, select its
 
 `modelPath` accepts local paths, cache-relative filenames, full `hf:` file
 URIs, and HTTPS GGUF URLs that publish a SHA-256 response digest. The default
-cache is `~/.openclaw/models/llama.cpp`; a configured `modelCacheDir` remains
+cache is `~/.openclaw/models/llama.cpp`. A configured `modelCacheDir` remains
 authoritative for managed setup.
 
 ## Existing llama-server
@@ -193,14 +193,14 @@ manager, or machine owns the process.
 </Steps>
 
 OpenClaw reads `/health`, `/models` (falling back to `/v1/models`), and
-`/props`. Router property probes use `autoload=false`; discovery never loads,
+`/props`. Router property probes use `autoload=false`. Discovery never loads,
 wakes, unloads, downloads, or reloads models. Explicit configured model rows
 remain authoritative over discovered rows with the same ID.
 
 Refreshing a configured external server reports authentication rejection or
 unavailability when discovery fails. Previously discovered models remain visible
 only while their endpoint and credentials are unchanged. A successful empty list
-removes discovered rows; explicit configured models remain. Restore the server or
+removes discovered rows. Explicit configured models remain. Restore the server or
 correct its credentials, then refresh again to recover the live inventory.
 
 ### Authentication and endpoint replacement
@@ -260,7 +260,7 @@ shape is:
 
 Custom provider IDs may also point at llama-server through the generic
 OpenAI-compatible path. They remain custom providers and should declare the
-`llamacpp` tool-schema profile explicitly; see [custom provider capability
+`llamacpp` tool-schema profile explicitly. See [custom provider capability
 declarations](/gateway/config-tools#custom-provider-capability-declarations).
 
 ## Requests and local embeddings
@@ -292,7 +292,7 @@ embedding model.
 ## Troubleshooting
 
 - Managed setup: run `openclaw doctor` and `openclaw memory status --deep`.
-- Existing server: inspect `/health`, `/models`, and `/props`; HTTP 503 means
+- Existing server: inspect `/health`, `/models`, and `/props`. HTTP 503 means
   the model is still loading.
 - Missing tools: verify both tool capability flags in `/props` and use a
   tool-capable Jinja chat template.

--- a/docs/plugins/plugin-permission-requests.md
+++ b/docs/plugins/plugin-permission-requests.md
@@ -75,8 +75,8 @@ export default definePluginEntry({
 
 Write prompt text for the person who will approve the action:
 
-- Keep `title` short and action-focused; the Gateway caps it at 80 characters.
-- Keep `description` specific and bounded; the Gateway caps it at 512
+- Keep `title` short and action-focused. The Gateway caps it at 80 characters.
+- Keep `description` specific and bounded. The Gateway caps it at 512
   characters.
 - Include the action, target, and risk. Do not include secrets, tokens, or
   private payloads that should not appear in chat approval surfaces.
@@ -93,7 +93,7 @@ Write prompt text for the person who will approve the action:
 Set `requireApproval.scope` when your plugin knows the consequences of an
 operation. Scope is typed, optional, and display-only: it helps reviewers
 understand the action but never grants permission or changes the approval
-decision. The plugin declaring the approval supplies these facts; channels never
+decision. The plugin declaring the approval supplies these facts. Channels never
 infer scope from commands, titles, or message text.
 
 For an email to three external recipients, include the destination, total
@@ -140,7 +140,7 @@ requireApproval: {
 }
 ```
 
-Message audiences can be `internal` or `external`; external-post visibility can
+Message audiences can be `internal` or `external`. External-post visibility can
 be `public` or `restricted`. Recipient previews contain at most five identities.
 All strings are sanitized and bounded before display: targets and recipient
 identities are limited to 128 characters, payment amounts to 40, and currencies
@@ -164,7 +164,7 @@ available approval surfaces, and waits for a decision.
 Only the exact `allow-once` and `allow-always` decisions permitted by the
 request allow execution. Unknown, malformed, mismatched, missing, and timed-out
 decisions fail closed. The legacy `timeoutBehavior` field remains accepted for
-plugin compatibility but is deprecated and ignored; do not set it in new hooks.
+plugin compatibility but is deprecated and ignored. Do not set it in new hooks.
 
 `allow-always` is only durable when the requesting plugin or runtime implements
 that persistence. For ordinary `before_tool_call.requireApproval` hooks,

--- a/docs/plugins/teams-meetings.md
+++ b/docs/plugins/teams-meetings.md
@@ -26,7 +26,7 @@ join button. It recognizes the consumer launcher and Chrome's
 
 Tenant policy may require sign-in, email verification, organizer admission, or
 a browser device-permission decision. The plugin reports these as
-`manualAction`; complete the requested step in the same OpenClaw Chrome profile,
+`manualAction`. Complete the requested step in the same OpenClaw Chrome profile,
 then retry status or speech. It does not bypass tenant policy.
 
 The consumer web client has been live-validated through the interstitial,
@@ -38,7 +38,7 @@ policy.
 ## Tool and Gateway surface
 
 The `teams_meetings` tool supports `join`, `leave`, `status`, `transcript`, and
-`speak`. Gateway methods use `teamsmeetings.*`; the node command is
+`speak`. Gateway methods use `teamsmeetings.*`. The node command is
 `teamsmeetings.chrome`.
 
 ## Related

--- a/docs/plugins/zalouser.md
+++ b/docs/plugins/zalouser.md
@@ -6,9 +6,9 @@ read_when:
 title: "Zalo personal plugin"
 ---
 
-Zalo Personal support for OpenClaw via a plugin that uses native `zca-js` to
-automate a normal Zalo user account. No external `zca`/`openzca` CLI binary is
-required.
+The zalouser plugin adds unofficial Zalo Personal support to OpenClaw. It uses
+native `zca-js` to automate a normal Zalo user account. No external
+`zca`/`openzca` CLI binary is required.
 
 <Warning>
 Unofficial automation may lead to account suspension or ban. Use at your own risk.

--- a/docs/plugins/zoom-meetings.md
+++ b/docs/plugins/zoom-meetings.md
@@ -25,7 +25,7 @@ navigation. In-call state uses Zoom's Leave control.
 
 Zoom can disable browser join or require authentication, email verification, a
 passcode, CAPTCHA completion, host admission, or browser device permissions.
-The plugin reports these as `manualAction`; complete the requested step in the
+The plugin reports these as `manualAction`. Complete the requested step in the
 same OpenClaw Chrome profile, then retry status or speech. It does not bypass
 Zoom policy.
 
@@ -38,7 +38,7 @@ DOM identifier is available.
 ## Tool and Gateway surface
 
 The `zoom_meetings` tool supports `join`, `leave`, `status`, `transcript`, and
-`speak`. Gateway methods use `zoommeetings.*`; the node command is
+`speak`. Gateway methods use `zoommeetings.*`. The node command is
 `zoommeetings.chrome`.
 
 ## Related

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -165,7 +165,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
     | **low** / **medium** / **high** / **xhigh** / **adaptive** / **max** | `high`                       |
 
     <Warning>
-    Avoid combining Medium 3.5 reasoning mode with `temperature: 0`; the Mistral HTTP API has been reported to reject `reasoning_effort="high"` plus `temperature: 0` with a 400 response. Leave temperature unset, or turn thinking off/minimal so OpenClaw sends `reasoning_effort: "none"` before you set a low temperature.
+    Avoid combining Medium 3.5 reasoning mode with `temperature: 0`. The Mistral HTTP API has been reported to reject `reasoning_effort="high"` plus `temperature: 0` with a 400 response. Leave temperature unset, or turn thinking off/minimal so OpenClaw sends `reasoning_effort: "none"` before you set a low temperature.
     </Warning>
 
     Example model-scoped config for Medium 3.5 reasoning:
@@ -186,7 +186,7 @@ OpenClaw defaults Mistral realtime STT to `pcm_mulaw` at 8 kHz so Voice Call can
     ```
 
     <Note>
-    Other Mistral catalog models do not use this parameter. Mistral's native Magistral models are deprecated; use adjustable reasoning on Mistral Small 4 or Mistral Medium 3.5 for current API models.
+    Other Mistral catalog models do not use this parameter. Mistral's native Magistral models are deprecated. Use adjustable reasoning on Mistral Small 4 or Mistral Medium 3.5 for current API models.
     </Note>
 
   </Accordion>

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -236,7 +236,7 @@ onboarding.
       </Step>
     </Steps>
 
-    Kimi Code K3 always uses adaptive thinking when reasoning is enabled and
+    Kimi Coding K3 always uses adaptive thinking when reasoning is enabled and
     defaults to high effort. `/think minimal|low` maps to low effort,
     `/think medium|high|adaptive` maps to high effort, and `/think xhigh|max`
     maps to max effort. `/think off` sends `thinking.type: "disabled"`.
@@ -322,7 +322,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
     `/think max`, sends `reasoning_effort: "max"`, and ignores stale lower or
     `off` settings.
 
-    Kimi Code K3 exposes `/think off|minimal|low|medium|high|adaptive|xhigh|max`.
+    Kimi Coding K3 exposes `/think off|minimal|low|medium|high|adaptive|xhigh|max`.
     Its Anthropic-compatible endpoint receives `thinking.type: "disabled"` for
     off. Every enabled level uses adaptive thinking; minimal/low maps to low
     effort, medium/high/adaptive maps to high effort, and xhigh/max maps to max

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -26,7 +26,7 @@ The [Control UI](/web/control-ui) already highlights inline tool diffs and sessi
 
     `diffs` and its language pack ship as separate packages rather than with
     OpenClaw, so the install needs a scoped locator. The `clawhub:` prefix
-    selects the ClawHub copy of `@openclaw/diffs`; use
+    selects the ClawHub copy of `@openclaw/diffs`. Use
     `npm:@openclaw/diffs` to install from npm instead.
 
   </Step>
@@ -165,11 +165,11 @@ Install the Diff Viewer Language Pack plugin for more languages (Astro, Vue, Sve
 openclaw plugins install clawhub:@openclaw/diffs-language-pack
 ```
 
-Without the pack, unsupported languages still render as readable plain text. See [Diffs Language Pack plugin](/plugins/reference/diffs-language-pack) and [Shiki languages](https://shiki.style/languages) for the upstream catalog.
+Without the pack, unsupported languages still render as readable plain text. See [Diff Viewer Language Pack plugin](/plugins/reference/diffs-language-pack) and [Shiki languages](https://shiki.style/languages) for the upstream catalog.
 
 ## Output details contract
 
-All successful results include `changed`: identical before/after input returns `false` without creating an artifact; rendered results return `true`.
+All successful results include `changed`: identical before/after input returns `false` without creating an artifact. Rendered results return `true`.
 
 <AccordionGroup>
   <Accordion title="Viewer fields (view and both modes)">
@@ -212,7 +212,14 @@ The viewer shows rows like `N unmodified lines`. Expand controls only appear whe
 
 ### Multi-file navigation
 
-Patches that touch more than one file start with a changed-files summary card: total `+N` / `-N` counts, per-file counts, added/deleted/renamed badges, and anchor links that jump to each file. Rendered PNG/PDF files keep the per-file header counts but drop the interactive view toggles, since those are dead controls in a static file.
+Patches that touch more than one file start with a changed-files summary card. The card shows:
+
+- total `+N` / `-N` counts
+- per-file counts
+- added, deleted, and renamed badges
+- anchor links that jump to each file
+
+Rendered PNG/PDF files keep the per-file header counts but drop the interactive view toggles, since those are dead controls in a static file.
 
 ## Plugin defaults
 
@@ -297,8 +304,8 @@ Supported `defaults` keys: `fontFamily`, `fontSize`, `lineSpacing`, `layout`, `s
 
 ## Artifact lifecycle and storage
 
-- Viewer HTML and metadata live in the shared `state/openclaw.sqlite` database under the Diffs plugin blob namespace. HTML is gzip-compressed; SQLite stores only a SHA-256 hash of the random URL token, not the token itself.
-- Rendered PNG/PDF files remain temporary materializations under `$TMPDIR/openclaw-diffs` because channel delivery requires a file path. SQLite owns their expiry metadata; no JSON sidecars are written.
+- Viewer HTML and metadata live in the shared `state/openclaw.sqlite` database under the Diffs plugin blob namespace. HTML is gzip-compressed. SQLite stores only a SHA-256 hash of the random URL token, not the token itself.
+- Rendered PNG/PDF files remain temporary materializations under `$TMPDIR/openclaw-diffs` because channel delivery requires a file path. SQLite owns their expiry metadata. OpenClaw writes no JSON sidecars.
 - Default artifact TTL: 30 minutes. Maximum accepted TTL: 6 hours.
 - Cleanup runs opportunistically after each artifact create call. Expired SQLite rows are deleted first, followed by any corresponding PNG/PDF directory.
 - A fallback sweep removes rowless temporary folders older than 24 hours. Legacy `meta.json`, `file-meta.json`, and `viewer.html` caches are not imported or read.
@@ -325,7 +332,7 @@ URL resolution order: tool-call `baseUrl` (after strict validation) -> plugin `v
   <Accordion title="Viewer hardening">
     - Loopback-only by default.
     - Tokenized viewer paths with strict ID and token pattern validation.
-    - Viewer response CSP: `default-src 'none'`; scripts/assets only from self; no outbound `connect-src`.
+    - Viewer response CSP: `default-src 'none'`. Scripts and assets load only from self. The viewer makes no outbound `connect-src` requests.
     - Remote miss throttling when remote access is enabled: 40 failures per 60 seconds triggers a 60-second lockout (`429 Too Many Requests`).
 
   </Accordion>
@@ -380,7 +387,7 @@ Common failure text: `Diff PNG/PDF rendering requires a Chromium-compatible brow
 
   </Accordion>
   <Accordion title="Unmodified-lines row has no expand button">
-    Expected for patch input that lacks expandable context; not a viewer failure.
+    Expected for patch input that lacks expandable context. This is not a viewer failure.
   </Accordion>
   <Accordion title="Artifact not found">
     - Artifact expired due to TTL.

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -324,7 +324,11 @@ The viewer document resolves these assets relative to the viewer URL, so an opti
 
 URL resolution order: tool-call `baseUrl` (after strict validation) -> plugin `viewerBaseUrl` -> `gateway.publicOrigin` -> the existing bind-aware Gateway fallback.
 
-`baseUrl` rules: must be `http://` or `https://`; query and hash are rejected; origin plus optional base path is allowed.
+`baseUrl` rules:
+
+- The scheme must be `http://` or `https://`.
+- A `baseUrl` that carries a query string or a hash is rejected.
+- An origin plus an optional base path is allowed.
 
 ## Security model
 

--- a/docs/tools/exa-search.md
+++ b/docs/tools/exa-search.md
@@ -7,9 +7,10 @@ read_when:
 title: "Exa search"
 ---
 
-[Exa AI](https://exa.ai/) is a `web_search` provider with neural, keyword, and
-hybrid search modes plus built-in content extraction (highlights, text,
-summaries).
+[Exa AI](https://exa.ai/) is a `web_search` provider. It offers the `auto`,
+`neural`, `fast`, `deep`, `deep-reasoning`, and `instant` search modes described
+in [Search modes](#search-modes). It also has built-in content extraction
+(highlights, text, summaries).
 
 ## Install plugin
 


### PR DESCRIPTION
## What

An ASD-STE100 pass over 27 docs pages, closing 34 `ste` audit findings. The batch is grouped by the two most objectively checkable rules in `.audit/ste-policy.md`: **one word / one meaning** (scan-checklist item 1) and **run-on sentences** joined by semicolons (item 5, Rule 8.1), plus four concrete single-sentence defects.

No fact, hedge, scope qualifier or number changed. Every rewrite keeps the original clause order, so precedence and strictness statements read in the same sequence.

## Measurement

`.audit/ste-lint.py --summary` on the **same 27-file boundary**, before (blobs at the merge-base) and after:

| | hard violations | words | hard per 100 words |
|---|---|---|---|
| before | 372 | 31,958 | **1.16** |
| after | 292 | 32,015 | **0.91** |

Flagged semicolons across the same 27 files: 265 -> 191. The remaining 191 are on lines no finding in this batch names (for example `platforms/ios` 56 and `platforms/android` 36, whose findings are terminology-only). `cli/hooks` went 20 -> 0 and `plugins/llama-cpp` 9 -> 0.

None of the 27 files contains an HTML entity (`&lt;`, `&gt;`, `&amp;`, `&#nn;`), so the known artefact where the linter counts an entity's `;` as a banned semicolon does not affect either number here.

The density is reported alongside the raw count deliberately: `ste-lint.py` aggregates per file, so its totals move with the file list, not only with the text. Both runs above use the identical file list (`git diff --name-only`), one against `git show HEAD:<path>` copies and one against the working tree.

## Anchors

Ids enumerated with `parseDocsDocument` before and after, for all 27 files. Exactly one file differs:

```
- docs/platforms/mac/remote.md  ... troubleshooting,web-chat,whatsapp-...
+ docs/platforms/mac/remote.md  ... troubleshooting,web-chat,webchat,whatsapp-...
```

`## Web Chat` became `## WebChat` (the tree writes `WebChat` 157 times and `Web Chat` 7). The old id is preserved with an `<a id="web-chat" />` stub per `docs/AGENTS.md`, so published links keep resolving. **No id was dropped anywhere.** Every other heading change in this PR is a capitalization that leaves the slug identical.

## Validators

- `pnpm check:docs` -> **exit 0** (format, markdownlint incl. `.mdx`, lint:templates, check-mdx, i18n glossary, check-links, config examples)
- `node scripts/docs-link-audit.mjs --anchors` -> **3 broken links**, all the pre-existing `/maturity/taxonomy#windows-app-node` ones. No new fragment errors.
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` -> 1 file / 33 tests passed
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` -> 8 files / 16 tests passed

No glossary entry was needed: no new `/`-route list-item link label and no changed page `title:`.

`.github/CODEOWNERS`: **no changed path is owned by anyone.** The first revision of this PR touched `docs/gateway/secrets-plan-contract.md`, which `@openclaw/openclaw-secops` owns; ClawSweeper blocked on that ownership and offered "or omit that restricted-path edit". That edit is now reverted to the merge-base blob (`git diff <merge-base> -- docs/gateway/secrets-plan-contract.md` is empty), so the PR touches no restricted path. Finding `r5-0018` is deferred to a secops-routed PR rather than closed here. Not a split, so no `.github/labeler.yml` gap is created.

## Findings closed (34)

**One word, one meaning**

- `r3-1004` `announcements/bluebubbles-imessage` — `gateway` -> `Gateway`.
- `r3-1082` `channels/line` — `Gateway` normalized. *Dead-letter half refuted, see below.*
- `r3-1671` `gateway/discovery` — the single `Node Gateway` is now `Gateway`; 18 prose lines normalized.
- `r3-1722` `install/docker` — 16 lines plus the `## Containerized gateway` heading (slug unchanged) and its cross-page link label.
- `r3-1774` `install/digitalocean`, `r3-1783` `install/northflank` — same normalization.
- `r3-1842` `platforms/android` — `Gateway`/`Gateways` normalized; four menu paths moved from `>` to `→`.
- `r3-1846` `platforms/ios` — same; `Settings -> Gateway` and `Shortcuts > Apps > ...` now use `→`.
- `r3-1855` `platforms/mac/remote` — `Web Chat` -> `WebChat` (with the anchor stub) and `gateway` -> `Gateway`.
- `r3-2117` `providers/moonshot` — `Kimi Code K3` -> `Kimi Coding K3` in prose at L239 and L325. The two `Kimi Code` link labels are vendor product titles (`kimi.com/code/console`, the vendor model table) and are left alone, exactly as the finding's own fix says.

Hyphenated attributive compounds (`per-gateway`, `gateway-host`, `gateway-side`) stay lowercase. The tree prefers lowercase for them, and `docs/AGENTS.md` mandates `user@gateway-host` as a literal placeholder.

**Run-on sentences (Rule 8.1)**

- `r5-0014` `cli/hooks` — 20 semicolon sentences split.
- `r5-0015` `cli/webhooks` — 6 lines, 7 semicolons.
- `r5-0017` `channels/matrix-push-rules` — L127 split into one sentence per delivery case, plus L21 and L142.
- `r5-0019` `channels/a2a` — 5 sentences in Security and Limitations. Clause order preserved, so "requires a configured peer bearer token" still precedes "there is no unauthenticated mode".
- `r5-0025` `plugins/plugin-permission-requests` — 5 lines.
- `r5-0030` `plugins/llama-cpp` — 9 lines.
- `r5-0032` `platforms/mac/canvas` — 3 lines.
- `r5-0034` `platforms/mac/health` — 4 lines.
- `r5-0037` `plugins/teams-meetings`, `r5-0040` `plugins/zoom-meetings` — 2 lines each.
- `r5-0054` `providers/mistral` — L168 and L189.
- `r5-0016` `concepts/session-pruning` — step 4 split into four sentences; the placeholder key gets its own sentence.

**Concrete defects**

- `r3-1674` `gateway/telemetry` — the dangling `and applies` is gone. (It had drifted from L197 to L214.)
- `r3-2077` `plugins/zalouser` — the opening fragment now has a subject and verb. The finding's suggested wording dropped "to automate a normal Zalo user account"; that fact is kept in a second sentence instead.
- `r5-0013` `concepts/session-pruning` — "default 5 minutes when set manually" is replaced by the actual rule. `resolveCacheTtlPruningSettings` in `src/agents/embedded-agent-runner/tool-result-truncation.ts` sets `ttlMs = 5 * 60_000` when `mode: "cache-ttl"` is on and `ttl` is unset; the Anthropic plugin seeds `1h`. Both are now stated.
- `r5-0057` `tools/exa-search` — the intro claimed "neural, keyword, and hybrid search modes". The Search modes table lists `auto`, `neural`, `fast`, `deep`, `deep-reasoning`, `instant`. There is no `keyword` or `hybrid` id. The intro now names the table's ids.

## Findings refuted (5 whole, 3 in part)

**`r3-1167` `cli/update.md` — refuted.** The finding is "The page alternates Gateway and gateway for the same component", at line 383. The page is **198 lines**. It contains four `Gateway` occurrences, all capitalized, and one lowercase `gateway`, inside the route of `[Gateway logging](/gateway/logging)`. There is no rotation to fix; the page was rewritten after the audit ran.

**`r5-0142` `ci.md` — refuted.** The finding is "The page uses both 'canceled' and 'cancelled', including both spellings in one paragraph." `grep -c cancel docs/ci.md` returns **0** on an 84-line page. The paragraph described no longer exists.

**`r3-1727` `install/updating.md` — refuted.** The finding claims "'Doctor' and 'doctor' name the same tool 12 and 15 times outside code". Outside code fences, inline code, link targets and URLs, the page now has **9** `Doctor` and **1** `doctor`. The single lowercase use is the heading `### Run doctor`, which names the `openclaw doctor` command that the very next fence runs — correct lowercase usage for a command name, not rotation. The policy says not to force changes onto compliant text.

**`r3-1941` `plugins/codex-harness-reference.md` and `r3-1956` `plugins/codex-harness-runtime.md` — refuted.** Both findings say the pages spell one component `App Server`, `app-server` and `app server`. Neither page now contains `App Server` or `app server`. Every occurrence is `app-server`; the only capitalized forms are sentence-initial `App-server` and link labels that match their target pages' own headings. Both pages have since been split into `/plugins/codex-harness-reference/*` and `/plugins/codex-harness-runtime/*` children, which is when the spelling was unified.

**`r3-1082` `channels/line.md` — dead-letter half refuted, Gateway half fixed.** The finding says the page uses "three spellings of dead-letter". The page uses the hyphenated form 11 times as an adjective or verb (`dead-letter age floor`, `the event dead-letters`) and the spaced form twice as a plural noun. Both spaced uses are correct and one cannot be changed:

> ... see [Inbound dead letters](/cli/channels#inbound-dead-letters) ...

`## Inbound dead letters` is the actual heading on `/cli/channels`. `docs/AGENTS.md` and finding `r3-1972` both ask link labels to match their target's title, so rewriting this label would break a rule to satisfy a spelling preference. The other spaced use, "A stall is not itself a dead letter", is a noun and takes no hyphen in ordinary English. Hyphenated modifier plus unhyphenated noun is one convention, not three spellings.

**`r5-0052` `tools/diffs.md` — 10 of 12 fixed, 2 long-sentence violations refuted.** The semicolons at L29, L172, L300, L301, L328 and L383 are split, the changed-files summary card at L215 became a four-item list, and the three `baseUrl` validation rules that were joined by two semicolons became a three-item list. The page goes from 14 hard violations at 1.8 per 100 words to 4 at 1.1. Two flagged sentences are left alone:

> `javascript`, `typescript`, `tsx`, `jsx`, `json`, `markdown`, `yaml`, `css`, ... and `toml`.

> Install the Diff Viewer Language Pack plugin for more languages (Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, ... INI, diff, and more):

The linter counts these at 30 and 38 words, but the word count is entirely enumeration. The first has no verb and no clause at all; the second is a nine-word imperative followed by a parenthetical list. STE's sentence cap exists to stop multi-clause parse ambiguity (`.audit/ste-policy.md`: "Long compound or subordinate-clause sentences"). Neither sentence has a second clause to mis-attach. Splitting them would add sentences without removing any ambiguity, and the policy's own boundary says: "Shorten past the point of clarity. Stop when the sentence is unambiguous, not when it is shortest."

**`r5-0193` `plugins/reference/diffs-language-pack.md` — naming half fixed on the editable page, length half refuted, cross-page half not fixable in docs.**

- `docs/plugins/reference/**` is a **generated** tree (`docs/AGENTS.md`: "Generated docs, never hand-edit ... come from `pnpm plugins:inventory:gen`"). Its title `Diffs Language Pack plugin reference` comes from the plugin manifest and cannot be hand-edited.
- `docs/tools/diffs.md` is hand-authored, and it used **both** names: `Diff Viewer Language Pack plugin` (L100, L162) and `Diffs Language Pack plugin` (L168). L168 is normalized, so the page now uses one name.
- The remaining cross-page difference has two authoritative sources: `scripts/lib/official-external-plugin-catalog.json` carries `"label": "Diff Viewer Language Pack"`, and `extensions/diffs-language-pack` describes itself as `Diffs Language Pack`. Reconciling them is a code change to one of those two sources, not a docs prose edit. Flagging rather than guessing.
- The 30-word sentence is the `Examples include Astro, Vue, ...` enumeration, refuted for the same reason as the `tools/diffs` pair above.

## Deferred (1)

- `r5-0018` `gateway/secrets-plan-contract` — the fix (turn the two scrub passes into a two-item list, split the L131 semicolon) was written, validated and then reverted, because `.github/CODEOWNERS` routes that file to `@openclaw/openclaw-secops` and this PR has no secops involvement to point at. It needs its own PR with that team on it. Nothing else in the batch touches an owned path.

## Not attempted (117 of the 152 open `ste` rows)

Left as a clean queue. They fall into three groups:

1. **Whole-page rate findings** — roughly 60 rows of the form "the hard rate is N per 100 words, shorten the long sentences". Each needs a full sentence-by-sentence pass over one page with a judgement call per sentence; they do not batch. Note that the rate figures in the ledger are stale in at least three cases measured here (`ci.md`, `cli/update.md`, `install/updating.md` all shrank or were rewritten), so a later round should re-measure before rewriting.
2. **Concept-naming findings** — rows like `r3-1352` (six names for one sub-agent), `r3-1912` (six terms for one compatibility surface), `r3-2382` (five names for one approvals record). Each requires deciding which term is canonical, which is a maintainer-facing vocabulary decision rather than a mechanical normalization, and several would change headings.
3. **Two rows that should be resolved before any work is done on them**: `r3-0981` asks whether `docs/reference/templates/AGENTS.md` is in STE scope at all (it is agent prompt text, and `config/markdownlint-cli2.jsonc` already excludes `docs/reference/templates/**`), and `r3-1974` asks to convert a 25-item event list on `plugins/workboard` into a table, which is a layout change rather than an STE one.
