### PR TITLE
docs: fix and reciprocate cross-page links across install, help, reference, start, and web

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -52,6 +52,10 @@
     "target": "密钥管理"
   },
   {
+    "source": "SecretRef credential surface",
+    "target": "SecretRef 凭据覆盖面"
+  },
+  {
     "source": "Secrets runtime model",
     "target": "密钥运行时模型"
   },
@@ -242,6 +246,10 @@
   {
     "source": "Gateway protocol",
     "target": "Gateway 协议"
+  },
+  {
+    "source": "RPC adapters",
+    "target": "RPC 适配器"
   },
   {
     "source": "Gateway RPC methods",
@@ -484,6 +492,10 @@
     "target": "入门指南"
   },
   {
+    "source": "Personal assistant setup",
+    "target": "个人助理设置"
+  },
+  {
     "source": "Quick start",
     "target": "快速开始"
   },
@@ -636,6 +648,10 @@
     "target": "模型提供商"
   },
   {
+    "source": "Models FAQ",
+    "target": "模型常见问题"
+  },
+  {
     "source": "Quick rules",
     "target": "快速规则"
   },
@@ -708,6 +724,18 @@
     "target": "VPS 托管"
   },
   {
+    "source": "Ansible",
+    "target": "Ansible"
+  },
+  {
+    "source": "Kubernetes",
+    "target": "Kubernetes"
+  },
+  {
+    "source": "Cloudflare Containers",
+    "target": "Cloudflare Containers"
+  },
+  {
     "source": "Fly.io",
     "target": "Fly.io"
   },
@@ -722,6 +750,10 @@
   {
     "source": "Linux server",
     "target": "Linux 服务器"
+  },
+  {
+    "source": "macOS VMs",
+    "target": "macOS 虚拟机"
   },
   {
     "source": "Platforms",
@@ -770,6 +802,10 @@
   {
     "source": "Credits",
     "target": "致谢"
+  },
+  {
+    "source": "OpenClaw lore",
+    "target": "OpenClaw 传说"
   },
   {
     "source": "Features",
@@ -1146,6 +1182,10 @@
   {
     "source": "Release policy",
     "target": "发布策略"
+  },
+  {
+    "source": "Full release validation",
+    "target": "完整发布验证"
   },
   {
     "source": "Release notes",
@@ -1600,6 +1640,10 @@
     "target": "迁移"
   },
   {
+    "source": "Backups",
+    "target": "备份"
+  },
+  {
     "source": "Migrating from Hermes",
     "target": "从 Hermes 迁移"
   },
@@ -1610,6 +1654,14 @@
   {
     "source": "Agent workspace",
     "target": "Agent 工作区"
+  },
+  {
+    "source": "Default AGENTS.md",
+    "target": "默认 AGENTS.md"
+  },
+  {
+    "source": "Bootstrapping",
+    "target": "引导初始化"
   },
   {
     "source": "Migration",
@@ -1646,6 +1698,14 @@
   {
     "source": "Testing",
     "target": "测试"
+  },
+  {
+    "source": "Tests",
+    "target": "测试"
+  },
+  {
+    "source": "Scripts",
+    "target": "脚本"
   },
   {
     "source": "Update and plugin tests",
@@ -1922,6 +1982,10 @@
   {
     "source": "Control UI",
     "target": "Control UI"
+  },
+  {
+    "source": "Hosted embeds",
+    "target": "托管嵌入"
   },
   {
     "source": "Control UI URLs",
@@ -2598,6 +2662,10 @@
   {
     "source": "Session management",
     "target": "会话管理"
+  },
+  {
+    "source": "Transcript hygiene",
+    "target": "转录净化"
   },
   {
     "source": "Session tools",

--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -207,3 +207,4 @@ Human-friendly detail and the stable reason code follow on subsequent lines in t
 
 - [Secrets management](/gateway/secrets)
 - [Auth storage](/concepts/oauth)
+- [SecretRef credential surface](/reference/secretref-credential-surface) - which credential fields accept a SecretRef instead of a raw secret value

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -122,4 +122,10 @@ Every section heading from the previous single-page version keeps its anchor her
   <Card title="Configuration reference" icon="sliders" href="/gateway/config-channels#imessage">
     Full iMessage field reference.
   </Card>
+  <Card title="RPC adapters" icon="plug" href="/reference/rpc">
+    The line-delimited JSON-RPC stdio protocol OpenClaw speaks to `imsg rpc`.
+  </Card>
+  <Card title="macOS VMs" icon="display" href="/install/macos-vm">
+    Run OpenClaw in a sandboxed macOS VM, local or hosted, when you want iMessage isolated from your main Mac.
+  </Card>
 </CardGroup>

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -512,4 +512,5 @@ Related global options:
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
 - [Channel Routing](/channels/channel-routing) - session routing for messages
+- [RPC adapters](/reference/rpc) - the signal-cli JSON-RPC-over-HTTP daemon pattern behind this channel
 - [Security](/gateway/security) - access model and hardening

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -238,6 +238,9 @@ Suggested `.gitignore` starter:
 
 ## Related
 
+- [Backups](/install/backups) - archives, per-database snapshots, scheduling, and offsite copies of state and workspace
+- [Bootstrapping](/start/bootstrapping) - the first-run ritual that seeds a new workspace and its identity files
+- [Default AGENTS.md](/reference/AGENTS.default) - the default agent instructions and skills roster placed in the workspace
 - [Heartbeat](/gateway/heartbeat) - heartbeat monitors and cron scratch
 - [Sandboxing](/gateway/sandboxing) - workspace access in sandboxed environments
 - [Session](/concepts/session) - session storage paths

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -463,3 +463,4 @@ The slot is exclusive at run time - only one registered context engine is resolv
 - [Plugin Architecture](/plugins/architecture) - registering context engine plugins
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview
+- [Session management deep dive](/reference/session-management-compaction) - the session store, transcript events, and auto-compaction internals

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -155,3 +155,4 @@ They complement each other -- pruning keeps tool output lean between compaction 
 - [Session management](/concepts/session)
 - [Session tools](/concepts/session-tool)
 - [Context engine](/concepts/context-engine)
+- [Transcript hygiene](/reference/transcript-hygiene) - in-memory, provider-specific transcript sanitization applied before a run

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -346,5 +346,6 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 
 - [Session pruning](/concepts/session-pruning)
 - [Session tools](/concepts/session-tool)
+- [Transcript hygiene](/reference/transcript-hygiene) - in-memory, provider-specific transcript sanitization applied before a run
 - [Command queue](/concepts/queue)
 - [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - per-agent sandbox and tool restrictions, including session visibility

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -175,5 +175,6 @@ _Related: [Configuration Examples](/gateway/configuration-examples) · [Configur
 - [Gateway runbook](/gateway)
 - [`openclaw config`](/cli/config) — read and write these settings from the CLI
 - [`openclaw configure`](/cli/configure) — guided editor for these settings
+- [Docker](/install/docker) — container deployment, its environment variables, and the mounted config and state paths
 - [Security audit checks](/gateway/security/audit-checks) — what the audit flags in this configuration
 - [Trusted proxy auth](/gateway/trusted-proxy-auth) — configuring the Gateway behind a reverse proxy

--- a/docs/gateway/sandboxing/podman-backend.md
+++ b/docs/gateway/sandboxing/podman-backend.md
@@ -6,6 +6,8 @@ read_when: "You are using Podman instead of Docker for sandboxed tool execution.
 
 Selecting the native Podman CLI as a built-in backend, the Docker settings it reuses, and its rootless user-mapping rules.
 
+This page covers Podman as the sandbox backend for agent tool execution. Running the Gateway itself in a rootless Podman container is a separate setup: see [Podman](/install/podman).
+
 ## Podman backend
 
 Use `sandbox.backend: "podman"` to select the native `podman` CLI directly. This is a built-in backend, not a plugin. It does not probe or select Docker, even when the `docker` executable is installed.

--- a/docs/gateway/security/dependency-locking.md
+++ b/docs/gateway/security/dependency-locking.md
@@ -68,3 +68,7 @@ tar -tf /tmp/openclaw-plugin-pack/openclaw-discord-<version>.tgz | grep -E '^pac
 ```
 
 The `node_modules` entries prove that the plugin carries its bundled runtime payload. The final check proves that neither npm lockfile format ships in the tarball.
+
+## Related
+
+- [Release performance sweep](/reference/release-performance-sweep) - the May 2026 package-size, dependency, and shrinkwrap audit this policy came out of

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -85,6 +85,7 @@ still resolves. Each entry points at the page that now holds the content.
 ## Related
 
 - [FAQ](/help/faq) - the main FAQ (models, sessions, gateway, security, more)
+- [Models FAQ](/help/faq-models) - model defaults, selection, aliases, switching, failover, and auth profiles
 - [Install overview](/install)
 - [Getting started](/start/getting-started)
 - [Troubleshooting](/help/troubleshooting)

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -31,6 +31,7 @@ Fastest path to unstuck, by symptom:
 - [Testing](/help/testing) - test suites and Docker runners
 - [Update and plugin tests](/help/testing-updates-plugins) - package update, migration, and plugin install validation
 - [Live tests](/help/testing-live) - network-touching provider and CLI smokes
+- [Scripts](/help/scripts) - helper scripts under `scripts/` and when to prefer the CLI
 
 ## Community and meta
 

--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -90,3 +90,4 @@ entry points at the page that now holds the content.
 ## Related
 
 - [Testing](/help/testing) - unit, integration, QA, and Docker suites
+- [Tests](/reference/test) - index of the testing reference, one page per reader job

--- a/docs/help/testing-updates-plugins.md
+++ b/docs/help/testing-updates-plugins.md
@@ -459,3 +459,9 @@ Start with the artifact identity:
 
 Prefer rerunning the failed exact lane with the same package artifact over
 rerunning the whole release umbrella.
+
+## Related
+
+- [Tests](/reference/test) - index of the testing reference, one page per reader job
+- [Testing](/help/testing) - the full testing kit: suites, live lanes, and Docker runners
+- [Release policy](/reference/RELEASING) - the release process this checklist gates

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -382,6 +382,7 @@ first with `openclaw database preflight`; see
 
 - [Agent workspace](/concepts/agent-workspace#git-backup-recommended-private) for keeping workspace files in a private git repository
 - [Backup CLI reference](/cli/backup)
+- [Cloudflare Containers](/install/cloudflare) — continuous Litestream replication to R2 for an ephemeral container deployment
 - [Database schemas](/reference/database-schemas)
 - [Migrating between machines](/install/migrating)
 - [Updating](/install/updating)

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -199,3 +199,4 @@ Beta and dev builds may **not** include a macOS app release. That is fine:
 
 - [Updating](/install/updating)
 - [Installer internals](/install/installer)
+- [Release policy](/reference/RELEASING) - how releases are cut and published into these channels

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -350,5 +350,8 @@ docker compose exec openclaw-gateway sh -lc 'node dist/index.js gateway health -
 
 - [Install Overview](/install) — all installation methods
 - [Podman](/install/podman) — Podman alternative to Docker
+- [Kubernetes](/install/kubernetes) — a minimal Kustomize starting point for running the Gateway on a cluster
+- [Ansible](/install/ansible) — automated server deployment with Tailscale VPN and firewall isolation
+- [Cloudflare Containers](/install/cloudflare) — experimental Worker plus container deployment with Litestream backups to R2
 - [Updating](/install/updating) — keeping OpenClaw up to date
 - [Configuration](/gateway/configuration) — gateway configuration after install

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -148,5 +148,6 @@ In-place plugin upgrades preserve the same plugin id and config keys but may mov
 - [`openclaw migrate`](/cli/migrate): CLI reference for cross-system imports.
 - [Install overview](/install): all installation methods.
 - [Doctor](/gateway/doctor): post-migration health check.
+- [Updating](/install/updating): updating an existing install in place, plus rollback strategy.
 - [Uninstall](/install/uninstall): removing OpenClaw cleanly.
 - [`openclaw backup`](/cli/backup) — create the archive this migration restores

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -18,6 +18,9 @@ adds native widget-panel, camera, screen, notification, and computer-control com
 to the same node-host command surface used by `openclaw node run`. Do not start a
 second CLI node on that Mac; the app runs the matching CLI node-host runtime as
 an internal worker and remains the sole Gateway connection and node identity.
+The app's **Instances** UI shows each device under a friendly hardware name; see
+[Device model database](/reference/device-models) for how Apple model
+identifiers are vendored and mapped.
 
 Nodes are **peripherals**, not gateways: they don't run the gateway service, and channel messages (Telegram, WhatsApp, etc.) land on the gateway, not on nodes.
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -263,5 +263,6 @@ own docs.
 
 - [Platforms](/platforms)
 - [Getting started](/start/getting-started)
+- [Onboarding](/start/onboarding) - the macOS app's first-run flow: where the Gateway runs, runtime install, and connecting a provider
 - [Gateway](/gateway)
 - [Exec approvals](/tools/exec-approvals)

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -1204,3 +1204,5 @@ Maintainers use the private release docs in [`openclaw/maintainers/release/READM
 ## Related
 
 - [Release channels](/install/development-channels)
+- [Full release validation](/reference/full-release-validation) - the release product-validation umbrella and its child workflows
+- [Update and plugin tests](/help/testing-updates-plugins) - proving the installable package updates real user state before a release

--- a/docs/reference/credits.md
+++ b/docs/reference/credits.md
@@ -27,5 +27,5 @@ MIT, copyright OpenClaw Foundation. Third-party notices for incorporated or adap
 
 ## Related
 
-- [Token use and costs](/reference/token-use)
-- [Release policy](/reference/RELEASING)
+- [OpenClaw lore](/start/lore) - the backstory behind the name, the shell, and the space lobster
+- [Pull request review flow](/reference/pull-request-review-flow) - how a contribution moves through Barnacle and ClawSweeper review

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -101,5 +101,5 @@ The normalized/stored assistant content block is a structured `canvas` item:
 
 ## Related
 
-- [RPC adapters](/reference/rpc)
+- [Hosted embeds](/web/control-ui/chat#hosted-embeds) - how the Control UI renders `[embed ...]` and its iframe sandbox policy
 - [Typebox](/concepts/typebox)

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -121,3 +121,4 @@ when a `memory/` folder exists.
 ## Related
 
 - [Agent workspace](/concepts/agent-workspace)
+- [Bootstrapping](/start/bootstrapping) - the first-run ritual this template drives, and when the file is removed

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -199,5 +199,6 @@ Full reference: [Environment variables](/help/environment).
 - [Install overview](/install)
 - [Channels overview](/channels)
 - [Setup](/start/setup)
+- [Personal assistant setup](/start/openclaw) - end-to-end guide to a dedicated number that behaves like an always-on assistant
 - [Triage](/cli/triage)
 - [Troubleshooting](/help/troubleshooting)

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -68,7 +68,7 @@ Use these hubs to discover more of the documentation, including deep dives and r
 ## Providers + ingress
 
 - [Chat channels hub](/channels)
-- [Model providers hub](/providers/models)
+- [Model providers hub](/providers)
 - [Discord](/channels/discord)
 - [iMessage](/channels/imessage)
 - [Mattermost](/channels/mattermost)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -136,3 +136,6 @@ diagnostics, see [Linux memory pressure and OOM kills](/platforms/linux#memory-p
 - [DigitalOcean](/install/digitalocean)
 - [Fly.io](/install/fly)
 - [Hetzner](/install/hetzner)
+- [Ansible](/install/ansible) — automated deployment to remote Debian/Ubuntu servers with Tailscale VPN and firewall isolation
+- [Kubernetes](/install/kubernetes) — a minimal Kustomize starting point when you run the Gateway on a cluster instead of a single VPS
+- [macOS VMs](/install/macos-vm) — a sandboxed macOS VM when you need macOS itself (iMessage) rather than a Linux host

--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -97,6 +97,8 @@ The **Typography** block lets you choose an **Interface** face and a separate **
 
 Appearance also has a Text size setting. It applies to chat text, composer text, tool cards, and chat sidebars, and keeps text inputs at least 16px so mobile Safari does not auto-zoom on focus.
 
+Appearance also carries the **Lobster visits** and **Lobster sounds** toggles and the Lobsterdex. Both toggles are browser-local. See [The Lobster](/web/lobster) for what the sidebar visitor does and how to turn it off for good.
+
 When your connection is bound to an authenticated Gateway profile, theme, theme mode, and accent color are saved to that profile instead of the gateway config. They follow you across devices without changing anyone else's appearance, override gateway-wide `ui.prefs` values, and update your connected clients live. Connections without an authenticated profile continue syncing these preferences through the gateway config exactly as before. Language and chat display preferences remain gateway-config preferences for every connection. Each browser keeps a local mirror for instant boot, and text size remains browser-local. An explicitly read-only connection applies preference changes only in that browser. Changes made while offline remain queued until a later connection can write their applicable preferences; on a read-only reconnect, they continue to behave as browser-local preferences. See [Configuration reference](/gateway/configuration-reference#ui).
 
 ## Manage plugins

--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -80,3 +80,9 @@ Collected observations from people who spend too much time watching their sideba
 ## Privacy
 
 Everything on this page happens locally in your browser: the randomness, the schedule, the Lobsterdex. No lobster data leaves your machine. OpenClaw does not know which lobsters you have met, and frankly it is jealous.
+
+## Related
+
+- [Control UI](/web/control-ui) - the dashboard the lobster wanders into
+- [Settings](/web/control-ui/settings#appearance-themes) - the Control UI Appearance panel that holds the visits and sounds toggles
+- [OpenClaw lore](/start/lore) - why there is a lobster at all


### PR DESCRIPTION
Closes the open `link`-kind docs-audit findings for `docs/install/`, `docs/platforms/`, `docs/nodes/`, `docs/help/`, `docs/web/`, `docs/start/` and `docs/reference/`. Each row was re-verified against the current tree first; a third of them turned out to be already-satisfied or stale after this week's page splits, and those are refuted below rather than "fixed".

## Fixed

**Wrong target (1)**
- `r5-0270` `docs/start/hubs.md` — the "Model providers hub" entry linked `/providers/models` ("Model provider quickstart", a starter-set duplicate) instead of `/providers` ("Provider directory", the full list). Repointed; label unchanged.

**Missing entry on a hub (1)**
- `r3-1718` `docs/help/index.md` — added `Scripts` under Testing.

**One-directional cross-reference (2)**
- `r3-1703` / `r3-1696` (Related half) — `docs/help/faq-first-run.md` now links the Models FAQ back.

**Missing reciprocal links (19)** — each description written from the target page's own opening lines, not from the link text:
- `r3-1721` Docker link added to `docs/gateway/configuration.md`.
- `r3-1726` (backlink half) Updating added to `docs/install/migrating.md` Related.
- `r3-1735` (agent-workspace half) Backups added to `docs/concepts/agent-workspace.md`.
- `r3-1738` Cloudflare Containers added to `docs/install/docker.md` and `docs/install/backups.md`.
- `r3-1741` `/install/podman` linked from `docs/gateway/sandboxing/podman-backend.md`, worded to keep the two apart: that page is the **sandbox backend for agent tool execution**, `/install/podman` is **running the Gateway itself** in a rootless container.
- `r3-1751` Kubernetes added to `docs/install/docker.md` and `docs/vps.md`.
- `r3-1762` macOS VMs added to `docs/channels/imessage.md` and `docs/vps.md`.
- `r3-1766` Ansible added to `docs/install/docker.md` and `docs/vps.md`.
- `r3-2210` `docs/reference/RELEASING.md` Related now carries both pages it cites inline (Full release validation, Update and plugin tests); `docs/install/development-channels.md` and `docs/help/testing-updates-plugins.md` link back.
- `r3-2214` `/reference/test` linked from `docs/help/testing-live.md` and `docs/help/testing-updates-plugins.md` (the latter had no Related section; one was added).
- `r3-2223` Session management deep dive added to `docs/concepts/context-engine.md`.
- `r3-2236` (dependency-locking half) `docs/gateway/security/dependency-locking.md` gained a Related section pointing at the release performance sweep — that page's own frontmatter already names this one as the policy it informs.
- `r3-2243` Transcript hygiene added to `docs/concepts/session.md` and `docs/concepts/session-pruning.md`.
- `r3-2250` SecretRef credential surface added to `docs/auth-credential-semantics.md`.
- `r3-2252` Default AGENTS.md added to `docs/concepts/agent-workspace.md`.
- `r3-2258` Device model database linked from the macOS node-mode paragraph in `docs/nodes/index.md`.
- `r3-2259` RPC adapters added to `docs/channels/signal.md` and `docs/channels/imessage.md`.
- `r3-2315` Personal assistant setup added to `docs/start/getting-started.md`.
- `r3-2328` Onboarding added to `docs/platforms/macos.md`.
- `r3-2335` Bootstrapping added to `docs/concepts/agent-workspace.md` and `docs/reference/templates/BOOTSTRAP.md`.
- `r3-2542` The Lobster linked from the Control UI Appearance section (`docs/web/control-ui/settings.md`); `docs/web/lobster.md` gained a Related section.

**Off-topic Related links (2)**
- `r3-2256` `docs/reference/rich-output-protocol.md` — `/reference/rpc` is about the signal-cli/imsg JSON-RPC adapters and has nothing to do with `[embed ...]`. Replaced with `/web/control-ui/chat#hosted-embeds`, the section that actually renders it.
- `r3-2262` `docs/reference/credits.md` — replaced "Token use and costs" (a homonym: this page is contributor credits, not API credits) and "Release policy" with the lore page and the pull-request review flow. **The suggested fix names a "contributing page"; no such route exists in the docs tree** (`CONTRIBUTING.md` is repo-root, and `docs/security/CONTRIBUTING-THREAT-MODEL.md` is a threat-model doc), so `/reference/pull-request-review-flow` is the nearest real equivalent.

## Refuted, with evidence

- `r3-1688` — "URL-encoded commas may not match the generated slug". They match. The content moved to `docs/help/testing/qa-runners.md:296`; its target `/concepts/qa-e2e-automation#buzz%2C-…` resolves because `qa-e2e-automation.md:56` authors **both** id forms as stubs. `docs-link-audit --anchors` reports 0 errors on that link. The suggested de-encoding is the same change that produced `fragment not found` in three earlier rows.
- `r3-1721` (anchor half) — `#bonjour-%2F-mdns` is the slug this repo's parser emits for `## Bonjour / mDNS`, and `docs/install/docker.md:324` authors both forms. No defect.
- `r3-1726` (self-link half) — `docs/install/updating.md` was split into `docs/install/updating/`; the line-532 self-link no longer exists. The Doctor backlink also already exists, via `docs/gateway/doctor/config-migrations.md:30`.
- `r3-1731` — `docs/install/uninstall.md:139` already links `[Installer internals](/install/installer)`.
- `r3-1776` — `docs/install/uninstall.md` Related already carries `` [`openclaw uninstall`](/cli/uninstall) ``. The "line 42" location no longer exists in that shape.
- `r3-1696` (anchor half) — `docs/help/faq-first-run.md:30` already carries `<a id="i-am-stuck" />`, and the accordion now lives on the child page with a resolving anchor.
- `r3-2233` — premise is stale. `docs/reference/prompt-caching.md` Related lists Token use and costs, API usage and costs, and Usage tracking; it does **not** list `/concepts/session-pruning`, so there is no one-directional pair to reciprocate.
- `r3-2236` (first half) — "No page in the docs tree links to this page" is false: `docs/reference/full-release-validation.md:52` links it. Only the dependency-locking backlink was genuinely missing, and that is fixed above.
- `r5-0157` — stale after the split. `docs/reference/database-schemas.md` is now a 79-line index whose only outbound links are its own seven children; the "five pages that this page links" no longer exist on it, and the page has 30+ inbound links across the tree.
- `r5-0266` — doubly false. The repo's parser **does** generate ids from `<Accordion title=…>` (verified with `parseDocsDocument` on `docs/install/docker/compose-operations.md`, which yields `permissions-and-eacces`), and `docs/install/docker.md:331` additionally authors an explicit `<a id="permissions-and-eacces" />` stub. `/install/docker#permissions-and-eacces` resolves today.

## Partially done

- `r3-1735` — the finding says "two Related targets do not link back". One is Agent workspace (fixed here). The other is Database schemas, whose reciprocity is the subject of `r5-0157` and is refuted above (that page is now a split index).
- `r3-2259` — the fix names Signal and iMessage; both are done. `/gateway/protocol`, the third page `rpc.md` links, still does not link back and is left alone.

## Glossary sources added (17, append-only)

`check-docs-i18n-glossary.mts` gates every newly introduced list-item link label in a changed English doc. Each source below is an existing page title, sidebar title, or heading — nothing was coined to satisfy the checker — and each was inserted **beside a related existing entry** rather than at the end of the array, so concurrent PRs touch different regions of the file:

| Source | Inserted after |
| --- | --- |
| SecretRef credential surface | Secrets management |
| RPC adapters | Gateway protocol |
| Personal assistant setup | Getting started |
| Models FAQ | Model providers |
| Cloudflare Containers, Kubernetes, Ansible | VPS hosting |
| macOS VMs | Linux server |
| OpenClaw lore | Credits |
| Full release validation | Release policy |
| Backups | Migrating |
| Bootstrapping, Default AGENTS.md | Agent workspace |
| Scripts, Tests | Testing |
| Hosted embeds | Control UI |
| Transcript hygiene | Session management |

Two labels were reworded to reuse sources that already existed rather than add new ones: `Pull request review flow` (the page title) instead of "PR review flow", and `Settings` + `#appearance-themes` instead of "Control UI settings".

## Validation

Base: `git merge-base HEAD origin/main` = `5d27eeb6d5c`.

- `pnpm check:docs` — **exit 0** (format:docs:check 1280 files clean, markdownlint-cli2 1279 files, lint:templates, docs:check-mdx, docs:check-i18n-glossary, docs:check-links, docs:check-config-examples).
- `pnpm format:check` (repo-wide oxfmt, 36,245 files) — **exit 0**.
- `node scripts/docs-link-audit.mjs` — 13,092 internal links, **0 broken** (baseline at the merge-base: 13,054 / 0).
- `node scripts/docs-link-audit.mjs --anchors` — 13,364 links, **3 broken**, the pre-existing `maturity/#windows-app-node` trio. Baseline measured in a clean worktree at the merge-base: identical 3.
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — 1 file / 33 tests passed.
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — 8 files / 16 tests passed.
- `code-docs-anchors.mjs` (docs anchors referenced from source, invisible to `docs-link-audit`) — 151 references checked, 5 dead at `HEAD`, **byte-identical to the same run at `origin/main`**. No regression.
- `.github/labeler.yml`: no change needed — this PR adds no new directories.

CODEOWNERS review will be requested from `@openclaw/openclaw-secops` (`docs/gateway/sandboxing/podman-backend.md`, `docs/gateway/security/dependency-locking.md`) and `@openclaw/openclaw-release-managers` (`docs/reference/RELEASING.md`).
