### PR TITLE
fix(update): reconcile orphaned update runs automatically

### DIFF
--- a/docs/cli/update/repair-and-recovery.md
+++ b/docs/cli/update/repair-and-recovery.md
@@ -97,6 +97,14 @@ openclaw update repair --accept-capabilities
 | `--accept-capabilities`                          | Accept each plugin's reviewed capability changes while repairing plugin state.                                                                                                                                                                                                                   |
 | `--no-restart`                                   | Accepted for parity; repair never restarts the Gateway.                                                                                                                                                                                                                                          |
 
+Untouched, identityless 2026.9.2-era update admissions heal automatically after
+more than 24 hours. Gateway startup, `openclaw update status`, and `openclaw status`
+retain the row as an abandoned failure with reason `legacy-driver-expired` and an
+advisory to run `openclaw update` to retry. The Control UI refreshes the Gateway's
+recovery classification before refusing a suspended config write, so an expired
+orphan does not keep settings or provider sign-in blocked. Live updates and
+pending recovery remain protected. No explicit repair is needed for this shape.
+
 `update repair` first inspects stale update history. When the installed Gateway
 generation is healthy and the only remaining problem is an inactive ledger row,
 repair records `failed` / `abandoned` and exits successfully without Doctor,

--- a/docs/reference/database-schemas/layout.md
+++ b/docs/reference/database-schemas/layout.md
@@ -205,8 +205,24 @@ the inactivity window. It cannot override a live or inconclusive recorded driver
 [2026.9.2 updater](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command.ts#L465)
 does not record adoption: package-manager and registry preflight can
 leave a live updater at its single `requested/in_progress` step. Older writers
-may drop unknown driver JSON fields; identityless rows require explicit recovery.
-`update status` only reports classification and never commits reconciliation.
+may drop unknown driver JSON fields; identityless rows normally require explicit recovery.
+
+An untouched legacy admission expires automatically after more than 24 hours:
+it is still `requested` / `running`, has identical creation and update timestamps,
+no finish timestamp, no recorded driver, and only its initial `requested` step.
+The ledger retains it as `failed` with reason `legacy-driver-expired` and a
+`reconcile:abandoned` step. Startup, `update status`, `status`, and the Control UI's
+update reads reconcile this shape through the same transaction. Status and failure
+reports explain that the update never progressed and recommend `openclaw update`
+to retry. Status retains the latest such advisory even after a newer update finishes.
+This fixed legacy expiry does not establish process death. It is the bounded
+recovery policy for 2026.9.2-era orphan admissions. Younger rows, progressed rows,
+recorded drivers, and retained recovery descriptors keep their existing protections.
+Recording `driver:identity-unavailable` is itself a mutation, so that adoption
+cannot match an untouched admission. All other `update status` history remains
+read-only; the existing 30-minute inactivity window is unchanged.
+Gateway update reads also run the existing automatic dead-driver reconciliation,
+so Control UI admission uses the same recovery decision as its startup watcher.
 
 Explicit new CLI update admission can supersede a legacy row only when it is
 the sole running row, has no current or previous driver identity, and exceeds

--- a/src/cli/update-cli/status.test.ts
+++ b/src/cli/update-cli/status.test.ts
@@ -17,6 +17,7 @@ import {
 import { ABANDONED_UPDATE_RUN_MS } from "../../infra/update-run-timeouts.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { claimOpenClawStateOwnership } from "../../state/openclaw-state-ownership-operations.js";
 import { updateStatusCommand } from "./status.js";
 
 const runtime = vi.hoisted(() => ({
@@ -263,6 +264,52 @@ afterEach(() => {
 });
 
 describe("update status abandoned-run reporting", () => {
+  it.each(["json", "text", "status"])(
+    "preserves readable history when reconciliation is refused through %s",
+    async (surface) => {
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+      const run = createUpdateRun({ trigger: "cli" });
+      clock.mockReturnValue(now);
+      claimOpenClawStateOwnership("test-supervisor", {
+        env: { ...process.env, OPENCLAW_SUPERVISOR_MODE: "external" },
+      });
+      vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "");
+      if (surface === "status") {
+        const rows = buildStatusUpdateRows(null);
+        expect(rows).toContainEqual(
+          expect.objectContaining({
+            Item: "Update run",
+            Value: expect.stringContaining("update in progress: requested"),
+          }),
+        );
+        expect(rows).toContainEqual(
+          expect.objectContaining({
+            Item: "Update reconciliation",
+            Value: expect.stringContaining("externally supervised"),
+          }),
+        );
+      } else {
+        await updateStatusCommand({ json: surface === "json" });
+        if (surface === "json") {
+          const result = runtime.writeJson.mock.lastCall?.[0];
+          expect(result).toMatchObject({
+            activeRun: run,
+            lastRun: run,
+            runReconciliationError: expect.stringContaining("externally supervised"),
+          });
+          expect(result).not.toHaveProperty("runStatusError");
+        } else {
+          const output = runtime.log.mock.calls.flat().join("\n");
+          expect(output).toContain(run.runId);
+          expect(output).toContain("Update run reconciliation failed:");
+          expect(output).not.toContain("Update run status unavailable:");
+        }
+      }
+      expect(getUpdateRun(run.runId)).toEqual(run);
+    },
+  );
+
   it("does not advertise expiry for a legacy admission reserved by recovery", async () => {
     const now = Date.now();
     vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);

--- a/src/cli/update-cli/status.test.ts
+++ b/src/cli/update-cli/status.test.ts
@@ -2,7 +2,9 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { buildStatusUpdateRows } from "../../commands/status-update-restart.js";
 import * as runtimeGuard from "../../infra/runtime-guard.js";
+import { createRetainedUpdateRecovery } from "../../infra/update-retained-recovery.test-support.js";
 import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
   createUpdateRun,
@@ -261,6 +263,61 @@ afterEach(() => {
 });
 
 describe("update status abandoned-run reporting", () => {
+  it("does not advertise expiry for a legacy admission reserved by recovery", async () => {
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+    const legacy = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+    const from = {
+      root: process.env.OPENCLAW_STATE_DIR ?? "/fixture",
+      nodePath: process.execPath,
+      version: "2026.9.2",
+      buildId: null,
+    };
+    createRetainedUpdateRecovery(
+      { runId: legacy.runId, from, to: { ...from, version: "2026.9.3" } },
+      {},
+    );
+    vi.mocked(Date.now).mockReturnValue(now);
+    await updateStatusCommand({ json: true });
+    expect(getUpdateRun(legacy.runId)).toEqual(legacy);
+    expect(runtime.writeJson.mock.lastCall?.[0]).not.toHaveProperty("abandonedRun");
+    expect(runtime.writeJson.mock.lastCall?.[0]).not.toHaveProperty("advisories");
+  });
+
+  it.each(["json", "text", "status"])(
+    "reconciles expired legacy admission through %s",
+    async (surface) => {
+      const now = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+      const legacy = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+      vi.mocked(Date.now).mockReturnValue(now);
+      finishUpdateRun(createUpdateRun({ trigger: "cli" }).runId, { status: "succeeded" });
+      let output: string;
+      if (surface === "status") {
+        output = JSON.stringify(buildStatusUpdateRows(null));
+      } else {
+        await updateStatusCommand({ json: surface === "json" });
+        output =
+          surface === "json"
+            ? JSON.stringify(runtime.writeJson.mock.lastCall?.[0])
+            : runtime.log.mock.calls.flat().join("\n");
+      }
+      expect(getUpdateRun(legacy.runId)).toMatchObject({
+        phase: "finished",
+        status: "failed",
+        reason: "legacy-driver-expired",
+      });
+      expect(output).toContain("treated as abandoned after 24 h");
+      expect(output).toContain("openclaw update");
+      expect(findActiveUpdateRun()).toBeUndefined();
+      // A later read must still surface the advisory after the terminal write.
+      await updateStatusCommand({ json: true });
+      expect(JSON.stringify(runtime.writeJson.mock.lastCall?.[0])).toContain(
+        "treated as abandoned after 24 h",
+      );
+    },
+  );
+
   it.each([true, false])(
     "does not publish partial history when the latest terminal row is unreadable (JSON: %s)",
     async (json) => {

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -9,43 +9,16 @@ import {
   resolveUpdateAvailability,
 } from "../../commands/status.update.js";
 import { readSourceConfigBestEffort } from "../../config/config.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import {
   normalizeUpdateChannel,
   resolveUpdateChannelDisplay,
 } from "../../infra/update-channels.js";
 import { checkUpdateStatus, formatGitInstallLabel } from "../../infra/update-check.js";
-import {
-  inspectUpdateRunAbandonment,
-  staleUpdateRunGuidance,
-} from "../../infra/update-run-activity.js";
-import { findActiveUpdateRun, listUpdateRuns } from "../../infra/update-run-ledger.js";
 import { renderUpdateRunReport } from "../../infra/update-run-report.js";
+import { readUpdateRunStatus } from "../../infra/update-run-status.js";
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { parseTimeoutMsOrExit, resolveUpdateRoot, type UpdateStatusOptions } from "./shared.js";
-
-function readUpdateRunStatus() {
-  try {
-    const activeRun = findActiveUpdateRun();
-    const lastRun = listUpdateRuns({ limit: 1 })[0];
-    const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
-    const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
-    return {
-      ...(activeRun ? { activeRun } : {}),
-      ...(lastRun ? { lastRun } : {}),
-      ...(staleGuidance && activeRun
-        ? { staleRun: { runId: activeRun.runId, guidance: staleGuidance } }
-        : {}),
-      ...(abandonment && activeRun
-        ? { abandonedRun: { runId: activeRun.runId, rule: abandonment } }
-        : {}),
-    };
-  } catch (error) {
-    // History is optional diagnostic context; an unavailable read is not an empty ledger.
-    return { runStatusError: formatErrorMessage(error) };
-  }
-}
 
 /** Print update status in JSON or table form for scripts and humans. */
 export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<void> {
@@ -155,8 +128,13 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
     defaultRuntime.log(theme.warn(`Update run status unavailable: ${runStatus.runStatusError}`));
     defaultRuntime.log("");
   } else {
-    const { activeRun, lastRun, staleRun, abandonedRun } = runStatus;
+    const { activeRun, lastRun, staleRun, abandonedRun, advisories } = runStatus;
     const run = activeRun ?? lastRun;
+    for (const advisory of advisories ?? []) {
+      if (advisory.runId !== run?.runId) {
+        defaultRuntime.log(advisory.message);
+      }
+    }
     if (run) {
       if (staleRun) {
         defaultRuntime.log(`Update ${run.runId}: ${staleRun.guidance}`);

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -124,6 +124,12 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
   );
   defaultRuntime.log("");
 
+  if ("runReconciliationError" in runStatus) {
+    defaultRuntime.log(
+      theme.warn(`Update run reconciliation failed: ${runStatus.runReconciliationError}`),
+    );
+    defaultRuntime.log("");
+  }
   if ("runStatusError" in runStatus) {
     defaultRuntime.log(theme.warn(`Update run status unavailable: ${runStatus.runStatusError}`));
     defaultRuntime.log("");

--- a/src/cli/update-cli/update-repair-command.test.ts
+++ b/src/cli/update-cli/update-repair-command.test.ts
@@ -172,22 +172,25 @@ describe("update repair ledger recovery", () => {
     },
   );
 
-  it("exits successfully when the Gateway already reconciled the abandoned row", async () => {
-    const run = seedRun();
-    finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
+  it.each(["abandoned", "legacy-driver-expired"])(
+    "exits successfully when the Gateway already reconciled the %s row",
+    async (reason) => {
+      const run = seedRun();
+      finishUpdateRun(run.runId, { status: "failed", reason });
 
-    await updateRepairCommand({});
+      await updateRepairCommand({});
 
-    expect(getUpdateRun(run.runId)).toMatchObject({
-      status: "failed",
-      reason: "abandoned",
-      steps: expect.arrayContaining([
-        expect.objectContaining({ step: "reconcile:acknowledged", status: "completed" }),
-      ]),
-    });
-    expect(mocks.finalize).not.toHaveBeenCalled();
-    expect(mocks.runtime.log).toHaveBeenCalledWith(expect.stringContaining("already reconciled"));
-  });
+      expect(getUpdateRun(run.runId)).toMatchObject({
+        status: "failed",
+        reason,
+        steps: expect.arrayContaining([
+          expect.objectContaining({ step: "reconcile:acknowledged", status: "completed" }),
+        ]),
+      });
+      expect(mocks.finalize).not.toHaveBeenCalled();
+      expect(mocks.runtime.log).toHaveBeenCalledWith(expect.stringContaining("already reconciled"));
+    },
+  );
 
   it.each(["repair", "gateway"] as const)(
     "runs full repair on the next invocation after acknowledging %s reconciliation",

--- a/src/cli/update-cli/update-repair-command.ts
+++ b/src/cli/update-cli/update-repair-command.ts
@@ -7,6 +7,7 @@ import { readPackageVersion } from "../../infra/package-json.js";
 import { readBuiltGatewayBuildId } from "../../infra/update-git-runtime.js";
 import {
   inspectUpdateRunAbandonment,
+  isAbandonedUpdateRun,
   isUnacknowledgedAbandonedUpdateRun,
 } from "../../infra/update-run-activity.js";
 import {
@@ -56,8 +57,7 @@ function inspectNewerRecoveryHistory(recoveryRuns: UpdateRunRecord[], env: NodeJ
   const postCoreRuns = history.filter(
     (run) =>
       run.createdAtMs >= oldestRecovery &&
-      run.status === "failed" &&
-      run.reason === "abandoned" &&
+      isAbandonedUpdateRun(run) &&
       !run.steps.some((step) => step.step === "reconcile:acknowledged") &&
       needsPostCoreRepair(run),
   );

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../infra/update-run-ledger.js", () => ({
   findActiveUpdateRun: mocks.findActiveUpdateRun,
   getUpdateRun: mocks.getUpdateRun,
   listUpdateRuns: mocks.listUpdateRuns,
+  reconcileAbandonedUpdateRuns: () => [],
 }));
 vi.mock("../../infra/restart-sentinel.js", () => ({
   readRestartSentinelReadOnly: mocks.readRestartSentinelReadOnly,

--- a/src/commands/status-json-command.test.ts
+++ b/src/commands/status-json-command.test.ts
@@ -71,7 +71,6 @@ describe("runStatusJsonCommand", () => {
     });
     expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(runtime, {
       built: true,
-      updateRunStatus: {},
       input: {
         scan,
         opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234, all: true },

--- a/src/commands/status-json-command.test.ts
+++ b/src/commands/status-json-command.test.ts
@@ -71,6 +71,7 @@ describe("runStatusJsonCommand", () => {
     });
     expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(runtime, {
       built: true,
+      updateRunStatus: {},
       input: {
         scan,
         opts: { deep: true, usage: true, agent: "beta", timeoutMs: 1234, all: true },

--- a/src/commands/status-json-command.ts
+++ b/src/commands/status-json-command.ts
@@ -1,6 +1,7 @@
 // Shared command runner for `openclaw status --json`.
 // It keeps scan execution separate from JSON payload assembly so CLI variants can reuse the same output path.
 
+import { readUpdateRunStatus } from "../infra/update-run-status.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { resolveStatusJsonOutput } from "./status-json-runtime.ts";
 
@@ -36,14 +37,14 @@ export async function runStatusJsonCommand(params: {
     { timeoutMs: params.opts.timeoutMs, all: params.opts.all },
     params.runtime,
   );
-  writeRuntimeJson(
-    params.runtime,
-    await resolveStatusJsonOutput({
+  writeRuntimeJson(params.runtime, {
+    ...(await resolveStatusJsonOutput({
       scan,
       opts: params.opts,
       includeSecurityAudit: params.includeSecurityAudit,
       includePluginCompatibility: params.includePluginCompatibility,
       suppressHealthErrors: params.suppressHealthErrors,
-    }),
-  );
+    })),
+    updateRunStatus: readUpdateRunStatus(),
+  });
 }

--- a/src/commands/status-json-command.ts
+++ b/src/commands/status-json-command.ts
@@ -37,6 +37,7 @@ export async function runStatusJsonCommand(params: {
     { timeoutMs: params.opts.timeoutMs, all: params.opts.all },
     params.runtime,
   );
+  const updateRunStatus = readUpdateRunStatus();
   writeRuntimeJson(params.runtime, {
     ...(await resolveStatusJsonOutput({
       scan,
@@ -45,6 +46,6 @@ export async function runStatusJsonCommand(params: {
       includePluginCompatibility: params.includePluginCompatibility,
       suppressHealthErrors: params.suppressHealthErrors,
     })),
-    updateRunStatus: readUpdateRunStatus(),
+    ...(Object.keys(updateRunStatus).length ? { updateRunStatus } : {}),
   });
 }

--- a/src/commands/status-update-restart.ts
+++ b/src/commands/status-update-restart.ts
@@ -1,9 +1,10 @@
 import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
-import { findActiveUpdateRun, getUpdateRun, listUpdateRuns } from "../infra/update-run-ledger.js";
+import { getUpdateRun } from "../infra/update-run-ledger.js";
 import {
   renderUpdateRunReport,
   updateRunReportInputFromSentinel,
 } from "../infra/update-run-report.js";
+import { readUpdateRunStatus } from "../infra/update-run-status.js";
 
 type Formatter = (value: string) => string;
 
@@ -30,8 +31,17 @@ export function buildStatusUpdateRows(
   payload: RestartSentinelPayload | null | undefined,
   opts: Parameters<typeof formatUpdateRestartStatusValue>[1] = {},
 ) {
-  const run = findActiveUpdateRun() ?? listUpdateRuns({ limit: 1 })[0];
+  const history = readUpdateRunStatus();
+  if ("runStatusError" in history) {
+    return [
+      { Item: "Update run", Value: `Update run status unavailable: ${history.runStatusError}` },
+    ];
+  }
+  const run = history.activeRun ?? history.lastRun;
   const rows = run ? [{ Item: "Update run", Value: renderUpdateRunReport(run).headline }] : [];
+  for (const advisory of history.advisories ?? []) {
+    rows.push({ Item: "Update advisory", Value: advisory.message });
+  }
   // Legacy sentinels lack run IDs; matching prose cannot establish the same occurrence.
   const restart =
     !run || payload?.stats?.runId !== run.runId

--- a/src/commands/status-update-restart.ts
+++ b/src/commands/status-update-restart.ts
@@ -39,6 +39,12 @@ export function buildStatusUpdateRows(
   }
   const run = history.activeRun ?? history.lastRun;
   const rows = run ? [{ Item: "Update run", Value: renderUpdateRunReport(run).headline }] : [];
+  if (history.runReconciliationError) {
+    rows.push({
+      Item: "Update reconciliation",
+      Value: `Update run reconciliation failed: ${history.runReconciliationError}`,
+    });
+  }
   for (const advisory of history.advisories ?? []) {
     rows.push({ Item: "Update advisory", Value: advisory.message });
   }

--- a/src/gateway/server-methods/update-status.test.ts
+++ b/src/gateway/server-methods/update-status.test.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createUpdateRun, finishUpdateRun } from "../../infra/update-run-ledger.js";
+import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
+import { createUpdateRun, finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+import { startUpdateRunWatcher } from "../update-run-watcher.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 import { updateStatusHandlers } from "./update-status.js";
 
@@ -48,6 +50,50 @@ afterEach(async () => {
 });
 
 describe("update history RPCs", () => {
+  it.each(["update.status", "update.runs.get"] as const)(
+    "revalidates recorded dead drivers through %s",
+    async (method) => {
+      const driver = expectDefined(readUpdateRunDriver(), "local driver identity");
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now - 31 * 60_000);
+      const run = createUpdateRun({
+        trigger: "cli",
+        origin: { driver: { ...driver, startIdentity: String(Number(driver.startIdentity) + 1) } },
+      });
+      clock.mockReturnValue(now);
+      await requestUpdateRead(method, method === "update.runs.get" ? { runId: run.runId } : {});
+      expect(getUpdateRun(run.runId)).toMatchObject({ status: "failed", reason: "abandoned" });
+    },
+  );
+
+  it.each(["update.status", "update.runs.get"] as const)(
+    "reconciles expired legacy admission before %s reaches the UI",
+    async (method) => {
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+      const legacy = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+      clock.mockReturnValue(now);
+      const respond = await requestUpdateRead(
+        method,
+        method === "update.runs.get" ? { runId: legacy.runId } : {},
+      );
+      expect(getUpdateRun(legacy.runId)).toMatchObject({
+        phase: "finished",
+        status: "failed",
+        reason: "legacy-driver-expired",
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          [method === "update.status" ? "lastRun" : "run"]: expect.objectContaining({
+            status: "failed",
+            reason: "legacy-driver-expired",
+          }),
+        }),
+      );
+    },
+  );
+
   it("projects distinct active and latest runs and reads persisted history in creation order", async () => {
     expect(await requestUpdateRead("update.status")).toHaveBeenCalledWith(true, {
       sentinel: null,
@@ -113,4 +159,26 @@ describe("update history RPCs", () => {
       );
     }
   });
+});
+
+it("reconciles an expired legacy admission on Gateway watcher startup", async () => {
+  const now = Date.now();
+  const clock = vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+  const legacy = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+  clock.mockReturnValue(now);
+  const broadcast = vi.fn();
+  const watcher = startUpdateRunWatcher({ broadcast, log: { warn: vi.fn() } });
+  try {
+    expect(getUpdateRun(legacy.runId)).toMatchObject({
+      phase: "finished",
+      status: "failed",
+      reason: "legacy-driver-expired",
+    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "update.run.changed",
+      expect.objectContaining({ runId: legacy.runId, status: "failed" }),
+    );
+  } finally {
+    await watcher.stop();
+  }
 });

--- a/src/gateway/server-methods/update-status.test.ts
+++ b/src/gateway/server-methods/update-status.test.ts
@@ -3,6 +3,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import { createUpdateRun, finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { claimOpenClawStateOwnership } from "../../state/openclaw-state-ownership-operations.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
 import { startUpdateRunWatcher } from "../update-run-watcher.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
@@ -22,6 +24,12 @@ vi.mock("../server-restart-sentinel.js", () => ({
 
 type UpdateReadMethod = "update.status" | "update.runs.get" | "update.runs.list";
 
+const warn = vi.fn();
+const logGateway: GatewayRequestContext["logGateway"] = {
+  ...createSubsystemLogger("gateway-test"),
+  warn,
+};
+
 async function requestUpdateRead(method: UpdateReadMethod, params: Record<string, unknown> = {}) {
   const respond = vi.fn<RespondFn>();
   await expectDefined(
@@ -35,6 +43,7 @@ async function requestUpdateRead(method: UpdateReadMethod, params: Record<string
     respond,
     context: {
       getRuntimeConfig: () => ({ update: { channel: "stable" } }),
+      logGateway,
     } as GatewayRequestContext,
   });
   return respond;
@@ -46,10 +55,40 @@ beforeEach(async () => {
 });
 afterEach(async () => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  warn.mockClear();
   await home.restore();
 });
 
 describe("update history RPCs", () => {
+  it.each(["update.status", "update.runs.get"] as const)(
+    "preserves readable history when reconciliation is refused through %s",
+    async (method) => {
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now - 25 * 60 * 60_000);
+      const run = createUpdateRun({ trigger: "cli" });
+      clock.mockReturnValue(now);
+      claimOpenClawStateOwnership("test-supervisor", {
+        env: { ...process.env, OPENCLAW_SUPERVISOR_MODE: "external" },
+      });
+      vi.stubEnv("OPENCLAW_SUPERVISOR_MODE", "");
+      const respond = await requestUpdateRead(
+        method,
+        method === "update.runs.get" ? { runId: run.runId } : {},
+      );
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining(
+          method === "update.runs.get" ? { run } : { activeRun: run, lastRun: run },
+        ),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/reconciliation failed:.*externally supervised/u),
+      );
+      expect(getUpdateRun(run.runId)).toEqual(run);
+    },
+  );
+
   it.each(["update.status", "update.runs.get"] as const)(
     "revalidates recorded dead drivers through %s",
     async (method) => {

--- a/src/gateway/server-methods/update-status.ts
+++ b/src/gateway/server-methods/update-status.ts
@@ -10,13 +10,10 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
 import { gatewayUpdateCampaign } from "../../infra/update-campaign.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
-import { inspectUpdateRunAbandonment } from "../../infra/update-run-activity.js";
 import {
-  findActiveUpdateRun,
-  getUpdateRunAsync,
-  listUpdateRuns,
+  getUpdateRunWithReconciliationAsync,
   listUpdateRunsAsync,
-  reconcileAbandonedUpdateRuns,
+  reconcileAbandonedUpdateRunsAsync,
 } from "../../infra/update-run-ledger.js";
 import {
   getUpdateAvailable,
@@ -68,9 +65,15 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
         );
       }
     }
-    reconcileAbandonedUpdateRuns();
-    const activeRun = findActiveUpdateRun();
-    const [lastRun] = listUpdateRuns({ limit: 1 });
+    try {
+      await reconcileAbandonedUpdateRunsAsync();
+    } catch (error) {
+      context?.logGateway?.warn(
+        `update.status reconciliation failed: ${formatErrorMessage(error)}`,
+      );
+    }
+    const [activeRun] = await listUpdateRunsAsync({ active: true, limit: 1 });
+    const [lastRun] = await listUpdateRunsAsync({ limit: 1 });
     const result = {
       sentinel,
       ...(activeRun ? { activeRun } : {}),
@@ -124,15 +127,13 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
     }
     respond(true, result);
   },
-  "update.runs.get": async ({ params, respond }) => {
+  "update.runs.get": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateUpdateRunsGetParams, "update.runs.get", respond)) {
       return;
     }
-    // Protected rows keep the asynchronous, artifact-preserving read path.
-    let run = await getUpdateRunAsync(params.runId);
-    if (run && inspectUpdateRunAbandonment(run)) {
-      const [reconciled] = reconcileAbandonedUpdateRuns({ runIds: [params.runId] });
-      run = reconciled ?? (await getUpdateRunAsync(params.runId));
+    const { run, reconciliationError } = await getUpdateRunWithReconciliationAsync(params.runId);
+    if (reconciliationError) {
+      context?.logGateway?.warn(`update.runs.get reconciliation failed: ${reconciliationError}`);
     }
     respond(true, { run: run ?? null });
   },

--- a/src/gateway/server-methods/update-status.ts
+++ b/src/gateway/server-methods/update-status.ts
@@ -10,6 +10,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
 import { gatewayUpdateCampaign } from "../../infra/update-campaign.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
+import { inspectUpdateRunAbandonment } from "../../infra/update-run-activity.js";
 import {
   findActiveUpdateRun,
   getUpdateRunAsync,
@@ -127,8 +128,13 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateUpdateRunsGetParams, "update.runs.get", respond)) {
       return;
     }
-    reconcileAbandonedUpdateRuns({ runIds: [params.runId] });
-    respond(true, { run: (await getUpdateRunAsync(params.runId)) ?? null });
+    // Protected rows keep the asynchronous, artifact-preserving read path.
+    let run = await getUpdateRunAsync(params.runId);
+    if (run && inspectUpdateRunAbandonment(run)) {
+      const [reconciled] = reconcileAbandonedUpdateRuns({ runIds: [params.runId] });
+      run = reconciled ?? (await getUpdateRunAsync(params.runId));
+    }
+    respond(true, { run: run ?? null });
   },
   "update.runs.list": async ({ params, respond }) => {
     if (!assertValidParams(params, validateUpdateRunsListParams, "update.runs.list", respond)) {

--- a/src/gateway/server-methods/update-status.ts
+++ b/src/gateway/server-methods/update-status.ts
@@ -15,6 +15,7 @@ import {
   getUpdateRunAsync,
   listUpdateRuns,
   listUpdateRunsAsync,
+  reconcileAbandonedUpdateRuns,
 } from "../../infra/update-run-ledger.js";
 import {
   getUpdateAvailable,
@@ -66,6 +67,7 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
         );
       }
     }
+    reconcileAbandonedUpdateRuns();
     const activeRun = findActiveUpdateRun();
     const [lastRun] = listUpdateRuns({ limit: 1 });
     const result = {
@@ -125,6 +127,7 @@ export const updateStatusHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateUpdateRunsGetParams, "update.runs.get", respond)) {
       return;
     }
+    reconcileAbandonedUpdateRuns({ runIds: [params.runId] });
     respond(true, { run: (await getUpdateRunAsync(params.runId)) ?? null });
   },
   "update.runs.list": async ({ params, respond }) => {

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -14,6 +14,7 @@ import { approveNodePairing, requestNodePairing } from "../infra/device-pairing-
 import { listDevicePairing } from "../infra/device-pairing.js";
 import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../infra/supervisor-markers.js";
+import { createRetainedUpdateRecovery } from "../infra/update-retained-recovery.test-support.js";
 import { createUpdateRun } from "../infra/update-run-ledger.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import {
@@ -474,52 +475,85 @@ describe("gateway role enforcement", () => {
 });
 
 describe("gateway update history", () => {
-  test("keeps authenticated update history reads responsive after closing shared state", async () => {
-    const client = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: "secret",
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
-      clientVersion: "1.0.0",
-      scopes: ["operator.admin"],
-    });
-    try {
-      const run = createUpdateRun({ trigger: "api" });
-      const databasePath = openOpenClawStateDatabase().path;
-      for (const method of ["update.runs.get", "update.runs.list"] as const) {
-        for (const cache of ["warm", "closed"] as const) {
-          openOpenClawStateDatabase();
-          if (cache === "closed") {
-            expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
-          }
-          expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(cache === "warm");
-          const before = readonlyPreparation.prepared.length;
-          const result = await client.request(
-            method,
-            method === "update.runs.get" ? { runId: run.runId } : { limit: 1 },
-          );
-          await Promise.all(readonlyPreparation.turns);
-          expect(result).toEqual(method === "update.runs.get" ? { run } : { runs: [run] });
-          const prepared = readonlyPreparation.prepared
-            .slice(before)
-            .filter((entry) => entry.pathname === databasePath);
-          if (cache === "warm") {
-            expect(prepared).toEqual([]);
-          } else {
-            expect(prepared).toHaveLength(1);
+  test.each(["fresh", "expired", "retained"] as const)(
+    "keeps authenticated update history responsive (%s)",
+    async (shape) => {
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: "secret",
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        clientVersion: "1.0.0",
+        scopes: ["operator.admin"],
+      });
+      try {
+        const clock = vi
+          .spyOn(Date, "now")
+          .mockReturnValue(Date.now() - (shape === "fresh" ? 0 : 25 * 60 * 60_000));
+        const run = createUpdateRun({ trigger: "api" });
+        if (shape === "retained") {
+          const from = {
+            root: process.env.OPENCLAW_STATE_DIR ?? "/fixture",
+            nodePath: process.execPath,
+            version: "2026.9.2",
+            buildId: null,
+          };
+          createRetainedUpdateRecovery({
+            runId: run.runId,
+            from,
+            to: { ...from, version: "2026.9.3" },
+          });
+        }
+        clock.mockRestore();
+        const databasePath = openOpenClawStateDatabase().path;
+        const methods =
+          shape === "fresh" ? ["update.runs.get", "update.runs.list"] : ["update.runs.get"];
+        for (const method of methods) {
+          // Exercise expiry cold first, before a warm read could reconcile the row.
+          for (const cache of ["closed", "warm"] as const) {
+            openOpenClawStateDatabase();
+            if (cache === "closed") {
+              expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
+            }
+            expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(cache === "warm");
+            const before = readonlyPreparation.prepared.length;
+            const result = await client.request(
+              method,
+              method === "update.runs.get" ? { runId: run.runId } : { limit: 1 },
+            );
+            await Promise.all(readonlyPreparation.turns);
+            const expected =
+              shape === "expired"
+                ? expect.objectContaining({
+                    runId: run.runId,
+                    status: "failed",
+                    reason: "legacy-driver-expired",
+                  })
+                : run;
+            expect(result).toEqual(
+              method === "update.runs.get" ? { run: expected } : { runs: [expected] },
+            );
+            const prepared = readonlyPreparation.prepared
+              .slice(before)
+              .filter((entry) => entry.pathname === databasePath);
             expect(
-              prepared[0]?.progressed,
-              "the Gateway isolate must progress while its snapshot child runs",
+              prepared.every((entry) => entry.progressed),
+              "the Gateway isolate must progress during every cold-history snapshot",
             ).toBe(true);
-            expect(prepared[0]?.location).toBeDefined();
-            expect(existsSync(prepared[0]!.location!)).toBe(false);
+            if (cache === "warm") {
+              expect(prepared).toEqual([]);
+            } else {
+              expect(prepared).toHaveLength(1);
+              expect(prepared[0]?.location).toBeDefined();
+              expect(existsSync(prepared[0]!.location!)).toBe(false);
+            }
           }
         }
+      } finally {
+        await client.stopAndWait();
       }
-    } finally {
-      await client.stopAndWait();
-    }
-  });
+    },
+  );
 });
 
 describe("gateway update.run", () => {

--- a/src/infra/update-failure-report-prepare.ts
+++ b/src/infra/update-failure-report-prepare.ts
@@ -9,6 +9,10 @@ import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import { VERSION } from "../version.js";
 import { prepareGithubIssue, type PreparedGithubIssue } from "./github-issue.js";
 import { normalizeUpdateChannel } from "./update-channels.js";
+import {
+  LEGACY_UPDATE_RUN_ADVISORY,
+  LEGACY_UPDATE_RUN_EXPIRED_REASON,
+} from "./update-run-legacy-expiry.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 const UPDATE_REPORT_BODY_MAX_BYTES = 16_000;
@@ -147,6 +151,9 @@ function renderBoundedDiagnostics(
     `Update mode: ${sanitizeReportField(input.result.mode, context)}`,
     `Reason code: ${sanitizeReportField(input.result.reason ?? "unknown", context)}`,
   ];
+  if (input.result.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON) {
+    diagnostics.push(`Advisory: ${LEGACY_UPDATE_RUN_ADVISORY}`);
+  }
   // Reviewed identity facts also bind consent when the run ID stays the same.
   for (const [label, identity] of [
     ["Before", input.result.before],

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -57,6 +57,43 @@ afterEach(() => {
 });
 
 describe("abandoned update runs", () => {
+  it.each(["young", "recovery", "live-driver", "legacy-only"] as const)(
+    "does not request write access for protected %s history",
+    (shape) => {
+      const options = isolatedOptions();
+      const run = createUpdateRun(
+        {
+          trigger: "cli",
+          ...(shape === "legacy-only" ? { origin: { driver: exitedDriver() } } : {}),
+        },
+        options,
+      );
+      if (shape === "recovery") {
+        const from = {
+          root: options.env.OPENCLAW_STATE_DIR,
+          nodePath: process.execPath,
+          version: "2026.9.2",
+          buildId: null,
+        };
+        createRetainedUpdateRecovery(
+          { runId: run.runId, from, to: { ...from, version: "2026.9.3" } },
+          options,
+        );
+      } else if (shape === "live-driver") {
+        adoptUpdateRun(run.runId, options);
+      }
+      const before = getUpdateRun(run.runId, options);
+      vi.advanceTimersByTime((shape === "young" ? 1 : 25) * 60 * 60_000);
+      expect(
+        reconcileAbandonedUpdateRuns(
+          { legacyOnly: shape === "legacy-only" },
+          { ...options, readOnly: true },
+        ),
+      ).toEqual([]);
+      expect(getUpdateRun(run.runId, options)).toEqual(before);
+    },
+  );
+
   it.each([60_000, 24 * 60 * 60_000 - 60_000, 24 * 60 * 60_000, 24 * 60 * 60_000 + 1])(
     "expires only untouched legacy admissions older than 24 hours (age=%s)",
     (age) => {

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -154,6 +154,37 @@ describe("abandoned update runs", () => {
     },
   );
 
+  it.each([
+    { first: "startup reconciliation", reason: "legacy-driver-expired" },
+    { first: "new update admission", reason: "superseded" },
+  ])(
+    "preserves the terminal reason when $first handles a legacy admission first",
+    ({ first, reason }) => {
+      const options = isolatedOptions();
+      const old = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, options);
+      vi.advanceTimersByTime(25 * 60 * 60_000);
+
+      if (first === "startup reconciliation") {
+        expect(reconcileAbandonedUpdateRuns({}, options)).toMatchObject([
+          { runId: old.runId, status: "failed", reason },
+        ]);
+      }
+      createUpdateRun(
+        { trigger: "cli", origin: { driver: currentDriver() }, supersedeStaleIdentityless: true },
+        options,
+      );
+      const terminal = getUpdateRun(old.runId, options);
+      expect(terminal).toMatchObject({
+        status: "failed",
+        phase: "finished",
+        reason,
+        finishedAtMs: Date.now(),
+      });
+      expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+      expect(getUpdateRun(old.runId, options)).toEqual(terminal);
+    },
+  );
+
   it.each(["automatic", "explicit", "supersede"] as const)(
     "preserves a durable run and its descriptor during %s stale-run cleanup",
     (mode) => {

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -57,6 +57,66 @@ afterEach(() => {
 });
 
 describe("abandoned update runs", () => {
+  it.each([60_000, 24 * 60 * 60_000 - 60_000, 24 * 60 * 60_000, 24 * 60 * 60_000 + 1])(
+    "expires only untouched legacy admissions older than 24 hours (age=%s)",
+    (age) => {
+      const options = isolatedOptions();
+      const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, options);
+      vi.advanceTimersByTime(age);
+      const reconciled = reconcileAbandonedUpdateRuns({}, options);
+      if (age <= 24 * 60 * 60_000) {
+        expect(reconciled).toEqual([]);
+        expect(getUpdateRun(run.runId, options)).toEqual(run);
+      } else {
+        expect(reconciled).toMatchObject([
+          {
+            runId: run.runId,
+            phase: "finished",
+            status: "failed",
+            reason: "legacy-driver-expired",
+          },
+        ]);
+        expect(getUpdateRun(run.runId, options)?.steps).toContainEqual(
+          expect.objectContaining({ step: "reconcile:abandoned", detail: "legacy-driver-expired" }),
+        );
+      }
+    },
+  );
+
+  it.each(["progress", "identity-unavailable", "recovery", "live-driver"] as const)(
+    "preserves a day-old admission with %s evidence",
+    (evidence) => {
+      const options = isolatedOptions();
+      const created = createUpdateRun({ trigger: "cli" }, options);
+      if (evidence === "progress") {
+        recordUpdateRunPhase(created.runId, "staging", {}, options);
+      } else if (evidence === "identity-unavailable") {
+        recordUpdateRunStep(
+          created.runId,
+          { step: "driver:identity-unavailable", status: "completed" },
+          options,
+        );
+      } else if (evidence === "live-driver") {
+        adoptUpdateRun(created.runId, options);
+      } else {
+        const from = {
+          root: options.env.OPENCLAW_STATE_DIR,
+          nodePath: process.execPath,
+          version: "2026.9.2",
+          buildId: null,
+        };
+        createRetainedUpdateRecovery(
+          { runId: created.runId, from, to: { ...from, version: "2026.9.3" } },
+          options,
+        );
+      }
+      const before = getUpdateRun(created.runId, options);
+      vi.advanceTimersByTime(25 * 60 * 60_000);
+      expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+      expect(getUpdateRun(created.runId, options)).toEqual(before);
+    },
+  );
+
   it.each(["automatic", "explicit", "supersede"] as const)(
     "preserves a durable run and its descriptor during %s stale-run cleanup",
     (mode) => {

--- a/src/infra/update-run-activity.ts
+++ b/src/infra/update-run-activity.ts
@@ -1,4 +1,8 @@
 import { inspectUpdateRunDriver, type UpdateRunDriver } from "./update-run-driver.js";
+import {
+  isExpiredLegacyUpdateRun,
+  LEGACY_UPDATE_RUN_EXPIRED_REASON,
+} from "./update-run-legacy-expiry.js";
 import type { UpdateRunRecord } from "./update-run-record.js";
 import { ABANDONED_UPDATE_RUN_MS } from "./update-run-timeouts.js";
 
@@ -28,8 +32,7 @@ export function recordedUpdateRunDrivers(record: UpdateRunRecord): UpdateRunDriv
 /** Only a fresh, unacknowledged recovery may substitute for a full repair invocation. */
 export function isUnacknowledgedAbandonedUpdateRun(record: UpdateRunRecord): boolean {
   return (
-    record.status === "failed" &&
-    record.reason === "abandoned" &&
+    isAbandonedUpdateRun(record) &&
     record.finishedAtMs !== null &&
     record.finishedAtMs <= Date.now() &&
     Date.now() - record.finishedAtMs <= ABANDONED_UPDATE_RUN_MS &&
@@ -37,13 +40,23 @@ export function isUnacknowledgedAbandonedUpdateRun(record: UpdateRunRecord): boo
   );
 }
 
-/** Read-only classification; an unobservable process is never presumed dead. */
+export function isAbandonedUpdateRun(record: UpdateRunRecord): boolean {
+  return (
+    record.status === "failed" &&
+    (record.reason === "abandoned" || record.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON)
+  );
+}
+
+/** Recorded drivers require positive death evidence; untouched legacy admissions have a fixed expiry. */
 export function inspectUpdateRunAbandonment(
   record: UpdateRunRecord,
   input: { explicit?: boolean } = {},
 ): string | undefined {
   if (record.status !== "running") {
     return undefined;
+  }
+  if (isExpiredLegacyUpdateRun(record)) {
+    return LEGACY_UPDATE_RUN_EXPIRED_REASON;
   }
   const identityUnavailable = record.steps.some(
     (step) => step.step === "driver:identity-unavailable",

--- a/src/infra/update-run-ledger.ts
+++ b/src/infra/update-run-ledger.ts
@@ -19,6 +19,7 @@ import {
 } from "./kysely-sync.js";
 import {
   inspectUpdateRunAbandonment,
+  isAbandonedUpdateRun,
   isStaleIdentitylessUpdateRun,
   recordedUpdateRunDrivers,
 } from "./update-run-activity.js";
@@ -34,6 +35,7 @@ import {
   sameUpdateRunDriver,
   type UpdateRunDriver,
 } from "./update-run-driver.js";
+import { LEGACY_UPDATE_RUN_EXPIRED_REASON } from "./update-run-legacy-expiry.js";
 import { listUpdateRuns, readUpdateRunRecord as readRun } from "./update-run-reader.js";
 import {
   finishUpdateRunRecord,
@@ -331,8 +333,7 @@ export function acknowledgeAbandonedUpdateRun(runId: string, options: LedgerOpti
     runId,
     (record) => {
       if (
-        record.status === "failed" &&
-        record.reason === "abandoned" &&
+        isAbandonedUpdateRun(record) &&
         !record.steps.some((step) => step.step === "reconcile:acknowledged")
       ) {
         upsertStep(record, {
@@ -348,7 +349,12 @@ export function acknowledgeAbandonedUpdateRun(runId: string, options: LedgerOpti
 
 /** The writer rechecks activity and process identity in the same transaction as terminalization. */
 export function reconcileAbandonedUpdateRuns(
-  input: { explicit?: boolean; runIds?: readonly string[]; requireAllActive?: boolean } = {},
+  input: {
+    explicit?: boolean;
+    runIds?: readonly string[];
+    requireAllActive?: boolean;
+    legacyOnly?: boolean;
+  } = {},
   options: LedgerOptions = {},
 ): UpdateRunRecord[] {
   if (input.runIds?.length === 0) {
@@ -412,7 +418,7 @@ export function reconcileAbandonedUpdateRuns(
         return [];
       }
       return selected.flatMap(({ record, rule }) => {
-        if (!rule) {
+        if (!rule || (input.legacyOnly && rule !== LEGACY_UPDATE_RUN_EXPIRED_REASON)) {
           return [];
         }
         upsertStep(record, {
@@ -421,7 +427,10 @@ export function reconcileAbandonedUpdateRuns(
           endedAtMs: Date.now(),
           detail: rule,
         });
-        finishUpdateRunRecord(record, { status: "failed", reason: "abandoned" });
+        finishUpdateRunRecord(record, {
+          status: "failed",
+          reason: rule === LEGACY_UPDATE_RUN_EXPIRED_REASON ? rule : "abandoned",
+        });
         return [persistRun(db, record, options)];
       });
     },

--- a/src/infra/update-run-ledger.ts
+++ b/src/infra/update-run-ledger.ts
@@ -7,18 +7,21 @@ import {
 } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
 import { runExistingOpenClawStateWriteTransaction } from "../state/openclaw-state-db-existing-write.js";
-import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
+} from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
+import { formatErrorMessage } from "./errors.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import {
-  inspectUpdateRunAbandonment,
   isAbandonedUpdateRun,
   isStaleIdentitylessUpdateRun,
   recordedUpdateRunDrivers,
@@ -36,7 +39,14 @@ import {
   type UpdateRunDriver,
 } from "./update-run-driver.js";
 import { LEGACY_UPDATE_RUN_EXPIRED_REASON } from "./update-run-legacy-expiry.js";
-import { listUpdateRuns, readUpdateRunRecord as readRun } from "./update-run-reader.js";
+import {
+  inspectUpdateRunReconciliation,
+  listUpdateRuns,
+  readUpdateRunReconciliationCandidates,
+  readUpdateRunRecord as readRun,
+  type UpdateRunReconciliationCandidate,
+  type UpdateRunReconciliationInput,
+} from "./update-run-reader.js";
 import {
   finishUpdateRunRecord,
   type FinishUpdateRunResult,
@@ -46,7 +56,6 @@ import {
 } from "./update-run-record.js";
 import { isUpdateRecoveryPending } from "./update-run-recovery-schema.js";
 import { hasStoredUpdateRecovery, readRecoveries } from "./update-run-recovery-store.js";
-import { ABANDONED_UPDATE_RUN_MS } from "./update-run-timeouts.js";
 
 export {
   getLatestUpdateFetchFailure,
@@ -347,92 +356,128 @@ export function acknowledgeAbandonedUpdateRun(runId: string, options: LedgerOpti
   );
 }
 
-/** The writer rechecks activity and process identity in the same transaction as terminalization. */
+function canReconcileCandidates(
+  candidates: UpdateRunReconciliationCandidate[],
+  input: UpdateRunReconciliationInput,
+): boolean {
+  return (
+    candidates.some(
+      ({ rule }) => rule && (!input.legacyOnly || rule === LEGACY_UPDATE_RUN_EXPIRED_REASON),
+    ) &&
+    !(input.explicit && candidates.some(({ record, rule }) => record.status === "running" && !rule))
+  );
+}
+
+/** Prepare eligibility without write access, then revalidate under the writer's transaction. */
 export function reconcileAbandonedUpdateRuns(
-  input: {
-    explicit?: boolean;
-    runIds?: readonly string[];
-    requireAllActive?: boolean;
-    legacyOnly?: boolean;
-  } = {},
+  input: UpdateRunReconciliationInput = {},
   options: LedgerOptions = {},
 ): UpdateRunRecord[] {
   if (input.runIds?.length === 0) {
     return [];
   }
   const candidates =
-    withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(({ db }) => {
-      if (!tableExists(db, "update_runs")) {
-        return [];
-      }
-      let query = getNodeSqliteKysely<LedgerDatabase>(db)
-        .selectFrom("update_runs")
-        .select("run_id")
-        .where("status", "=", "running");
-      if (!input.explicit) {
-        query = query.where("updated_at_ms", "<", Date.now() - ABANDONED_UPDATE_RUN_MS);
-      }
-      if (input.runIds) {
-        query = query.where("run_id", "in", [...input.runIds]);
-      }
-      return executeSqliteQuerySync(db, query.orderBy("run_id")).rows;
-    }, options) ?? [];
-  if (!candidates.length) {
+    withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
+      ({ db }) => readUpdateRunReconciliationCandidates(db, input),
+      options,
+    ) ?? [];
+  return reconcileCandidates(candidates, input, options).reconciled;
+}
+
+export async function reconcileAbandonedUpdateRunsAsync(
+  input: UpdateRunReconciliationInput = {},
+  options: LedgerOptions = {},
+): Promise<UpdateRunRecord[]> {
+  if (input.runIds?.length === 0) {
     return [];
+  }
+  const candidates =
+    (await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+      ({ db }) => readUpdateRunReconciliationCandidates(db, input),
+      options,
+    )) ?? [];
+  return reconcileCandidates(candidates, input, options).reconciled;
+}
+
+/** History remains readable when best-effort reconciliation cannot obtain write access. */
+export async function getUpdateRunWithReconciliationAsync(
+  runId: string,
+  options: LedgerOptions = {},
+): Promise<{ run: UpdateRunRecord | undefined; reconciliationError?: string }> {
+  const candidate = await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+    ({ db }) => {
+      const run = tableExists(db, "update_runs") ? readRun(db, runId) : undefined;
+      return run ? inspectUpdateRunReconciliation(db, run, {}) : undefined;
+    },
+    options,
+  );
+  if (!candidate) {
+    return { run: undefined };
+  }
+  try {
+    const { current } = reconcileCandidates([candidate], {}, options);
+    return { run: current[0] };
+  } catch (error) {
+    return { run: candidate.record, reconciliationError: formatErrorMessage(error) };
+  }
+}
+
+function reconcileCandidates(
+  candidates: UpdateRunReconciliationCandidate[],
+  input: UpdateRunReconciliationInput,
+  options: LedgerOptions,
+): { current: UpdateRunRecord[]; reconciled: UpdateRunRecord[] } {
+  if (!canReconcileCandidates(candidates, input)) {
+    return { current: candidates.map(({ record }) => record), reconciled: [] };
   }
   return runExistingOpenClawStateWriteTransaction(
     ({ db }) => {
+      const selected = candidates.flatMap(({ record }) => {
+        const current = readRun(db, record.runId);
+        return current ? [inspectUpdateRunReconciliation(db, current, input)] : [];
+      });
+      const current = selected.map(({ record }) => record);
       if (
-        input.requireAllActive &&
-        executeSqliteQueryTakeFirstSync(
-          db,
-          getNodeSqliteKysely<LedgerDatabase>(db)
-            .selectFrom("update_runs")
-            .select("run_id")
-            .where("status", "=", "running")
-            .where(
-              "run_id",
-              "not in",
-              candidates.map((candidate) => candidate.run_id),
-            )
-            .limit(1),
-        )
+        !canReconcileCandidates(selected, input) ||
+        (input.requireAllActive &&
+          executeSqliteQueryTakeFirstSync(
+            db,
+            getNodeSqliteKysely<LedgerDatabase>(db)
+              .selectFrom("update_runs")
+              .select("run_id")
+              .where("status", "=", "running")
+              .where(
+                "run_id",
+                "not in",
+                candidates.map(({ record }) => record.runId),
+              )
+              .limit(1),
+          ))
       ) {
-        return [];
+        return { current, reconciled: [] };
       }
-      const selected = candidates.flatMap((candidate) => {
-        const record = readRun(db, candidate.run_id);
-        return record?.status === "running"
-          ? [
-              {
-                record,
-                rule: hasStoredUpdateRecovery(db, record.runId)
-                  ? undefined
-                  : inspectUpdateRunAbandonment(record, input),
-              },
-            ]
-          : [];
-      });
-      // Operator recovery is one selection: renewed activity preserves every selected row.
-      if (input.explicit && selected.some(({ rule }) => !rule)) {
-        return [];
-      }
-      return selected.flatMap(({ record, rule }) => {
-        if (!rule || (input.legacyOnly && rule !== LEGACY_UPDATE_RUN_EXPIRED_REASON)) {
-          return [];
-        }
-        upsertStep(record, {
-          step: "reconcile:abandoned",
-          status: "failed",
-          endedAtMs: Date.now(),
-          detail: rule,
-        });
-        finishUpdateRunRecord(record, {
-          status: "failed",
-          reason: rule === LEGACY_UPDATE_RUN_EXPIRED_REASON ? rule : "abandoned",
-        });
-        return [persistRun(db, record, options)];
-      });
+      const reconciled: UpdateRunRecord[] = [];
+      return {
+        current: selected.map(({ record, rule }) => {
+          if (!rule || (input.legacyOnly && rule !== LEGACY_UPDATE_RUN_EXPIRED_REASON)) {
+            return record;
+          }
+          upsertStep(record, {
+            step: "reconcile:abandoned",
+            status: "failed",
+            endedAtMs: Date.now(),
+            detail: rule,
+          });
+          finishUpdateRunRecord(record, {
+            status: "failed",
+            reason: rule === LEGACY_UPDATE_RUN_EXPIRED_REASON ? rule : "abandoned",
+          });
+          const saved = persistRun(db, record, options);
+          reconciled.push(saved);
+          return saved;
+        }),
+        reconciled,
+      };
     },
     options,
     { schemaSql: schema, operationLabel: "update.run" },

--- a/src/infra/update-run-legacy-expiry.ts
+++ b/src/infra/update-run-legacy-expiry.ts
@@ -1,0 +1,25 @@
+import type { UpdateRunRecord } from "./update-run-record.js";
+
+export const LEGACY_UPDATE_RUN_EXPIRED_REASON = "legacy-driver-expired";
+const LEGACY_UPDATE_RUN_EXPIRY_MS = 24 * 60 * 60_000;
+export const LEGACY_UPDATE_RUN_ADVISORY =
+  "A 2026.9.2-era update never progressed past admission; treated as abandoned after 24 h; run `openclaw update` to retry.";
+
+/** The approved legacy expiry applies only to an untouched, identityless admission. */
+export function isExpiredLegacyUpdateRun(run: UpdateRunRecord): boolean {
+  const initial = run.steps[0];
+  return (
+    run.status === "running" &&
+    run.phase === "requested" &&
+    run.finishedAtMs === null &&
+    run.updatedAtMs === run.createdAtMs &&
+    !run.origin.driver &&
+    !run.origin.previousDrivers?.length &&
+    run.steps.length === 1 &&
+    initial?.step === "requested" &&
+    initial.status === "in_progress" &&
+    initial.startedAtMs === run.createdAtMs &&
+    initial.endedAtMs === undefined &&
+    Date.now() - run.createdAtMs > LEGACY_UPDATE_RUN_EXPIRY_MS
+  );
+}

--- a/src/infra/update-run-reader.ts
+++ b/src/infra/update-run-reader.ts
@@ -12,8 +12,11 @@ import {
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
 } from "./kysely-sync.js";
+import { inspectUpdateRunAbandonment } from "./update-run-activity.js";
 import { decodeRun } from "./update-run-codec.js";
 import type { UpdateFetchFailure, UpdateRunRecord } from "./update-run-record.js";
+import { hasStoredUpdateRecovery } from "./update-run-recovery-store.js";
+import { ABANDONED_UPDATE_RUN_MS } from "./update-run-timeouts.js";
 
 export function readUpdateRunRecord(db: DatabaseSync, runId: string): UpdateRunRecord | undefined {
   const query = getNodeSqliteKysely<Pick<DB, "update_runs">>(db)
@@ -146,4 +149,50 @@ export function getLatestUpdateFetchFailure(
     }
     return latestFailure;
   }, options);
+}
+
+export type UpdateRunReconciliationInput = {
+  explicit?: boolean;
+  runIds?: readonly string[];
+  requireAllActive?: boolean;
+  legacyOnly?: boolean;
+};
+export type UpdateRunReconciliationCandidate = {
+  record: UpdateRunRecord;
+  rule: string | undefined;
+};
+
+export function inspectUpdateRunReconciliation(
+  db: DatabaseSync,
+  record: UpdateRunRecord,
+  input: UpdateRunReconciliationInput,
+): UpdateRunReconciliationCandidate {
+  return {
+    record,
+    rule: hasStoredUpdateRecovery(db, record.runId)
+      ? undefined
+      : inspectUpdateRunAbandonment(record, input),
+  };
+}
+
+export function readUpdateRunReconciliationCandidates(
+  db: DatabaseSync,
+  input: UpdateRunReconciliationInput,
+): UpdateRunReconciliationCandidate[] {
+  if (!tableExists(db, "update_runs")) {
+    return [];
+  }
+  let query = getNodeSqliteKysely<Pick<DB, "update_runs">>(db)
+    .selectFrom("update_runs")
+    .selectAll()
+    .where("status", "=", "running");
+  if (!input.explicit) {
+    query = query.where("updated_at_ms", "<", Date.now() - ABANDONED_UPDATE_RUN_MS);
+  }
+  if (input.runIds) {
+    query = query.where("run_id", "in", [...input.runIds]);
+  }
+  return executeSqliteQuerySync(db, query.orderBy("run_id")).rows.map((row) =>
+    inspectUpdateRunReconciliation(db, decodeRun(row), input),
+  );
 }

--- a/src/infra/update-run-reader.ts
+++ b/src/infra/update-run-reader.ts
@@ -34,7 +34,7 @@ export async function getUpdateRunAsync(
   );
 }
 
-type ListInput = { limit?: number; active?: boolean };
+type ListInput = { limit?: number; active?: boolean; reason?: string };
 
 function readRuns(db: DatabaseSync, input: ListInput): UpdateRunRecord[] {
   if (!tableExists(db, "update_runs")) {
@@ -45,6 +45,9 @@ function readRuns(db: DatabaseSync, input: ListInput): UpdateRunRecord[] {
     .selectAll();
   if (input.active) {
     query = query.where("status", "=", "running");
+  }
+  if (input.reason) {
+    query = query.where("reason", "=", input.reason);
   }
   return executeSqliteQuerySync(
     db,

--- a/src/infra/update-run-report.test.ts
+++ b/src/infra/update-run-report.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { prepareUpdateFailureReport } from "./update-failure-report-prepare.js";
 import type { UpdateRunRecord } from "./update-run-record.js";
 import {
   renderUpdateRunNotice,
@@ -31,6 +32,34 @@ function run(patch: Partial<UpdateRunRecord> = {}): UpdateRunRecord {
 }
 
 describe("update run report", () => {
+  it.each(["status", "failure"])(
+    "includes the legacy expiry advisory in the %s report",
+    async (surface) => {
+      const record = run({ status: "failed", reason: "legacy-driver-expired" });
+      const text =
+        surface === "status"
+          ? renderUpdateRunReport(record).markdown
+          : (
+              await prepareUpdateFailureReport(
+                {
+                  attemptId: record.runId,
+                  result: {
+                    status: "error",
+                    mode: "unknown",
+                    reason: record.reason ?? undefined,
+                    steps: [],
+                    durationMs: 0,
+                  },
+                },
+                { stateDir: "/fixture/state", env: {} },
+              )
+            ).body;
+      expect(text).toContain(
+        "A 2026.9.2-era update never progressed past admission; treated as abandoned after 24 h; run `openclaw update` to retry.",
+      );
+    },
+  );
+
   it.each([
     ["requester-revoked", "A current command owner must start a new update"],
     ["repair-requires-config-change", "run openclaw doctor --fix under your own authority"],

--- a/src/infra/update-run-report.ts
+++ b/src/infra/update-run-report.ts
@@ -2,6 +2,10 @@ import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { UPDATE_RUN_PHASES } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
 import { formatDurationPrecise } from "./format-time/format-duration.ts";
 import type { RestartSentinelPayload } from "./restart-sentinel-store.js";
+import {
+  LEGACY_UPDATE_RUN_ADVISORY,
+  LEGACY_UPDATE_RUN_EXPIRED_REASON,
+} from "./update-run-legacy-expiry.js";
 import type { UpdateRunRecord } from "./update-run-record.js";
 import { updateRunStepsFromResultStep, updateRunWarningMessages } from "./update-run-step.js";
 import type { UpdateRunResult } from "./update-runner-types.js";
@@ -62,6 +66,9 @@ function recoveryHints(run: ReportInput, nextAction?: string): string[] {
   if (run.status !== "failed") {
     return [];
   }
+  if (run.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON) {
+    return [LEGACY_UPDATE_RUN_ADVISORY];
+  }
   const hints: string[] = [];
   if (run.reason === "preflight-insufficient-space") {
     hints.push(
@@ -109,7 +116,10 @@ export function renderUpdateRunReport(
         : "✅ OpenClaw updated.";
       break;
     case "failed":
-      headline = `⚠️ OpenClaw update failed: ${reason}.${running ? ` The gateway is running ${running}.` : ""}`;
+      headline =
+        run.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON
+          ? `ℹ️ OpenClaw update abandoned: ${reason}.`
+          : `⚠️ OpenClaw update failed: ${reason}.${running ? ` The gateway is running ${running}.` : ""}`;
       break;
     case "skipped":
       headline = `ℹ️ OpenClaw update skipped: ${reason}.`;

--- a/src/infra/update-run-status.ts
+++ b/src/infra/update-run-status.ts
@@ -1,0 +1,47 @@
+import { formatErrorMessage } from "./errors.js";
+import { inspectUpdateRunAbandonment, staleUpdateRunGuidance } from "./update-run-activity.js";
+import {
+  findActiveUpdateRun,
+  listUpdateRuns,
+  reconcileAbandonedUpdateRuns,
+} from "./update-run-ledger.js";
+import {
+  LEGACY_UPDATE_RUN_ADVISORY,
+  LEGACY_UPDATE_RUN_EXPIRED_REASON,
+} from "./update-run-legacy-expiry.js";
+
+/** Status heals the bounded legacy defect while other recovery keeps its existing owner. */
+export function readUpdateRunStatus() {
+  try {
+    reconcileAbandonedUpdateRuns({ legacyOnly: true });
+    const activeRun = findActiveUpdateRun();
+    const lastRun = listUpdateRuns({ limit: 1 })[0];
+    const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
+    const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
+    const expired = listUpdateRuns({ limit: 1, reason: LEGACY_UPDATE_RUN_EXPIRED_REASON })[0];
+    return {
+      ...(activeRun ? { activeRun } : {}),
+      ...(lastRun ? { lastRun } : {}),
+      ...(staleGuidance && activeRun
+        ? { staleRun: { runId: activeRun.runId, guidance: staleGuidance } }
+        : {}),
+      ...(abandonment && abandonment !== LEGACY_UPDATE_RUN_EXPIRED_REASON && activeRun
+        ? { abandonedRun: { runId: activeRun.runId, rule: abandonment } }
+        : {}),
+      ...(expired
+        ? {
+            advisories: [
+              {
+                runId: expired.runId,
+                reason: LEGACY_UPDATE_RUN_EXPIRED_REASON,
+                message: LEGACY_UPDATE_RUN_ADVISORY,
+              },
+            ],
+          }
+        : {}),
+    };
+  } catch (error) {
+    // An unavailable history read is not an empty ledger.
+    return { runStatusError: formatErrorMessage(error) };
+  }
+}

--- a/src/infra/update-run-status.ts
+++ b/src/infra/update-run-status.ts
@@ -12,14 +12,20 @@ import {
 
 /** Status heals the bounded legacy defect while other recovery keeps its existing owner. */
 export function readUpdateRunStatus() {
+  let runReconciliationError: string | undefined;
   try {
     reconcileAbandonedUpdateRuns({ legacyOnly: true });
+  } catch (error) {
+    runReconciliationError = formatErrorMessage(error);
+  }
+  try {
     const activeRun = findActiveUpdateRun();
     const lastRun = listUpdateRuns({ limit: 1 })[0];
     const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
     const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
     const expired = listUpdateRuns({ limit: 1, reason: LEGACY_UPDATE_RUN_EXPIRED_REASON })[0];
     return {
+      ...(runReconciliationError ? { runReconciliationError } : {}),
       ...(activeRun ? { activeRun } : {}),
       ...(lastRun ? { lastRun } : {}),
       ...(staleGuidance && activeRun

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -86,6 +86,7 @@ import {
   normalizeLegacyTerminalViewLocation,
   resolveApplicationStartupSettings,
 } from "./startup-settings.ts";
+import { bindUpdateConfigWriteInterlock } from "./update-config-interlock.ts";
 import { openUpdateFailureTriage } from "./update-triage.ts";
 import { createWebPushCapability } from "./web-push.ts";
 
@@ -336,15 +337,7 @@ export function bootstrapApplication(): ApplicationRuntime {
     scopeUpgrade,
     connectionBootstrap,
   });
-  // App-updater interlock: writing config (or restarting the gateway) while
-  // the updater runs can corrupt the install; pause config writes until the
-  // update settles. Wired app-lifetime so page unmounts cannot strand it.
-  const syncConfigWriteSuspension = () => {
-    const update = overlays.snapshot;
-    runtimeConfig.setWritesSuspended(update.updateRunning || update.updateReconciliationPending);
-  };
-  const stopConfigWriteSuspension = overlays.subscribe(syncConfigWriteSuspension);
-  syncConfigWriteSuspension();
+  const stopConfigWriteSuspension = bindUpdateConfigWriteInterlock(overlays, runtimeConfig);
   const navigation = createApplicationNavigationPreferences(
     settings,
     hasSidebarCollapseIntent &&

--- a/ui/src/app/overlays-types.ts
+++ b/ui/src/app/overlays-types.ts
@@ -3,7 +3,11 @@ import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import type { DevicePairSetupAccess, DevicePairSetupLifecycle } from "../lib/device-pair-setup.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "./exec-approval.ts";
 import type { SubmittedUpdateReport } from "./update-failure-report.ts";
-import type { ApplicationStatusBanner, RecordedUpdateAttempt } from "./update-overlay-helpers.ts";
+import type {
+  ApplicationStatusBanner,
+  RecordedUpdateAttempt,
+  createUpdateStatusRefresher,
+} from "./update-overlay-helpers.ts";
 
 export type UpdateFailureReportNotice = {
   attemptId: string;
@@ -41,7 +45,7 @@ export type ApplicationOverlaySnapshot = ApplicationUpdateOverlaySnapshot & {
 export type ApplicationOverlays = {
   readonly snapshot: ApplicationOverlaySnapshot;
   subscribe: (listener: (snapshot: ApplicationOverlaySnapshot) => void) => () => void;
-  refreshUpdateStatus: () => Promise<void>;
+  refreshUpdateStatus: ReturnType<typeof createUpdateStatusRefresher>;
   acknowledgeUpdateRun: () => void;
   runUpdate: (options?: { sessionKey?: string }) => Promise<void>;
   holdUpdate: () => Promise<boolean>;

--- a/ui/src/app/update-config-interlock.test.ts
+++ b/ui/src/app/update-config-interlock.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import {
+  createConfigCapabilityHarness,
+  createConfigServerMock,
+} from "../lib/config/config-test-harness.ts";
+import { createUpdateRunFixture } from "../test-helpers/update-run.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+import { bindUpdateConfigWriteInterlock } from "./update-config-interlock.ts";
+import { updateRunHarness } from "./update-run.test-support.ts";
+
+describe("update config-write interlock", () => {
+  it.each(["legacy-driver-expired", "superseded", "live", "recovery-held"] as const)(
+    "revalidates %s update admission before a config write",
+    async (kind) => {
+      const server = createConfigServerMock();
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        server.request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      const createdAtMs = Date.now() - 25 * 60 * 60_000;
+      let run = createUpdateRunFixture({
+        phase: "requested",
+        createdAtMs,
+        updatedAtMs: createdAtMs,
+        steps: [{ step: "requested", status: "in_progress", startedAtMs: createdAtMs }],
+      });
+      const request = vi.fn(async (method: string) =>
+        method === "update.runs.get" ? { run } : { lastRun: run },
+      );
+      const overlays = createApplicationOverlays(updateRunHarness(request).gateway);
+      const stopInterlock = bindUpdateConfigWriteInterlock(overlays, runtimeConfig);
+      const terminal = kind === "legacy-driver-expired" || kind === "superseded";
+      try {
+        await overlays.refreshUpdateStatus();
+        expect(overlays.snapshot.updateRunning).toBe(true);
+        request.mockClear();
+        if (terminal) {
+          run = {
+            ...run,
+            phase: "finished",
+            status: "failed",
+            reason: kind,
+            updatedAtMs: Date.now(),
+            finishedAtMs: Date.now(),
+          };
+        }
+        runtimeConfig.setRaw('{"count":2}');
+        expect(await runtimeConfig.save()).toBe(terminal);
+        expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(1);
+        expect(overlays.snapshot.updateRunning).toBe(!terminal);
+        expect(overlays.snapshot.updateReconciliationPending).toBe(!terminal);
+        expect(overlays.snapshot.updateRun?.reason).toBe(terminal ? kind : null);
+        expect(server.submissions).toHaveLength(terminal ? 1 : 0);
+      } finally {
+        stopInterlock();
+        overlays.dispose();
+        runtimeConfig.dispose();
+      }
+    },
+  );
+});

--- a/ui/src/app/update-config-interlock.ts
+++ b/ui/src/app/update-config-interlock.ts
@@ -1,0 +1,20 @@
+import type { RuntimeConfigCapability } from "../lib/config/runtime-config-capability.ts";
+import type { ApplicationOverlays } from "./overlays-types.ts";
+
+/** App-lifetime wiring keeps page teardown from stranding the updater's write interlock. */
+export function bindUpdateConfigWriteInterlock(
+  overlays: Pick<ApplicationOverlays, "snapshot" | "subscribe" | "refreshUpdateStatus">,
+  runtimeConfig: Pick<RuntimeConfigCapability, "setWritesSuspended">,
+): () => void {
+  const refreshAdmission = () => overlays.refreshUpdateStatus("completion");
+  const sync = () => {
+    const update = overlays.snapshot;
+    runtimeConfig.setWritesSuspended(
+      update.updateRunning || update.updateReconciliationPending,
+      refreshAdmission,
+    );
+  };
+  const stop = overlays.subscribe(sync);
+  sync();
+  return stop;
+}

--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -1,3 +1,4 @@
+import { LEGACY_UPDATE_RUN_EXPIRED_REASON } from "../../../src/infra/update-run-legacy-expiry.js";
 import type { UpdateRunRecord } from "../../../src/infra/update-run-record.js";
 import { renderUpdateRunReport } from "../../../src/infra/update-run-report.js";
 import { classifyUpdateOutcome } from "../../../src/shared/update-outcome.js";
@@ -302,7 +303,10 @@ export function projectUpdateRunFailure(run: UpdateRunRecord): UpdateFailureTria
     id: run.runId,
     reconciledRecord: { id: run.runId, timestampMs: run.finishedAtMs ?? run.updatedAtMs },
     outcome: "failed",
-    banner: { tone: "danger", text: renderUpdateRunReport(run).markdown },
+    banner: {
+      tone: run.reason === LEGACY_UPDATE_RUN_EXPIRED_REASON ? "warn" : "danger",
+      text: renderUpdateRunReport(run).markdown,
+    },
     attempt: {
       timestampMs: run.finishedAtMs ?? run.updatedAtMs,
       status: run.status,

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -140,7 +140,7 @@ export type ConfigWriteCoordinator = {
   setRaw: (value: string) => void;
   resetDraft: () => void;
   discardDraft: () => Promise<void>;
-  setWritesSuspended: (suspended: boolean) => void;
+  setWritesSuspended: (suspended: boolean, refreshAdmission?: () => Promise<void>) => void;
   waitForPendingWrites: () => Promise<void>;
   save: (options?: RuntimeConfigDispatchOptions) => Promise<boolean>;
   retry: () => Promise<boolean>;

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -15,6 +15,30 @@ import {
 } from "./config-test-harness.ts";
 
 describe("config write coordinator", () => {
+  it.each(["expired", "live", "recovery-held"])(
+    "revalidates %s update admission before a config write",
+    async (kind) => {
+      const server = createConfigServerMock();
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        server.request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      const refresh = vi.fn(async () => {
+        // The Gateway owns expiry and companion recovery evidence; the UI consumes its outcome.
+        runtimeConfig.setWritesSuspended(kind !== "expired", refresh);
+      });
+      runtimeConfig.setWritesSuspended(true, refresh);
+      runtimeConfig.setRaw('{"count":2}');
+      try {
+        expect(await runtimeConfig.save()).toBe(kind === "expired");
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(server.submissions).toHaveLength(kind === "expired" ? 1 : 0);
+      } finally {
+        runtimeConfig.dispose();
+      }
+    },
+  );
+
   it("rebinds a retained draft to an opaque revision when the reconnect base is unchanged", async () => {
     vi.useFakeTimers();
     let hash = "legacy-raw-hash";

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -15,30 +15,6 @@ import {
 } from "./config-test-harness.ts";
 
 describe("config write coordinator", () => {
-  it.each(["expired", "live", "recovery-held"])(
-    "revalidates %s update admission before a config write",
-    async (kind) => {
-      const server = createConfigServerMock();
-      const { runtimeConfig } = createConfigCapabilityHarness(
-        server.request as GatewayBrowserClient["request"],
-      );
-      await runtimeConfig.ensureLoaded();
-      const refresh = vi.fn(async () => {
-        // The Gateway owns expiry and companion recovery evidence; the UI consumes its outcome.
-        runtimeConfig.setWritesSuspended(kind !== "expired", refresh);
-      });
-      runtimeConfig.setWritesSuspended(true, refresh);
-      runtimeConfig.setRaw('{"count":2}');
-      try {
-        expect(await runtimeConfig.save()).toBe(kind === "expired");
-        expect(refresh).toHaveBeenCalledOnce();
-        expect(server.submissions).toHaveLength(kind === "expired" ? 1 : 0);
-      } finally {
-        runtimeConfig.dispose();
-      }
-    },
-  );
-
   it("rebinds a retained draft to an opaque revision when the reconnect base is unchanged", async () => {
     vi.useFakeTimers();
     let hash = "legacy-raw-hash";

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -103,6 +103,7 @@ export function createConfigWriteCoordinator({
   // App-updater interlock: config writes or gateway restarts mid-update can
   // corrupt the install, so all writes pause until the updater settles.
   let writesSuspended = false;
+  let refreshWriteAdmission: (() => Promise<void>) | undefined;
   let writesResumed: (() => void) | null = null;
   let writesResumedPromise: Promise<void> = Promise.resolve();
   const canDispatchConfigMutation = (method: ConfigMethod): boolean => {
@@ -344,7 +345,7 @@ export function createConfigWriteCoordinator({
     unavailable: T,
     options: { flushScheduledDraft?: boolean; canDispatch?: () => boolean } = {},
   ): Promise<T> => {
-    if (writesSuspended) {
+    if (writesSuspended && !refreshWriteAdmission) {
       return Promise.resolve(unavailable);
     }
     const client = state.client;
@@ -358,6 +359,17 @@ export function createConfigWriteCoordinator({
     // to the CURRENT connection epoch; only genuine queuing pays the hop.
     const start = () =>
       run(async () => {
+        if (writesSuspended && refreshWriteAdmission && !isDisposed()) {
+          // The Gateway classifies driver liveness and retained recovery before this interlock can open.
+          await refreshWriteAdmission();
+          if (!writesSuspended) {
+            if (options.flushScheduledDraft) {
+              flushScheduledAutoSave();
+            } else {
+              cancelScheduledAutoSave();
+            }
+          }
+        }
         // Drain before the explicit op — otherwise an apply could race a
         // pending config.set on the same base hash into a CAS failure.
         if (inFlight) {
@@ -569,7 +581,8 @@ export function createConfigWriteCoordinator({
       });
       clearAutoSaveDraftConnection();
     },
-    setWritesSuspended: (suspended) => {
+    setWritesSuspended: (suspended, refreshAdmission) => {
+      refreshWriteAdmission = refreshAdmission;
       if (writesSuspended === suspended) {
         return;
       }
@@ -696,7 +709,10 @@ export function createConfigWriteCoordinator({
       const mutationConnectionEpoch = currentConfigConnectionEpoch(state);
       while (true) {
         if (options.waitForWritesResumed && writesSuspended && !isDisposed()) {
-          await writesResumedPromise;
+          await refreshWriteAdmission?.();
+          if (writesSuspended && !isDisposed()) {
+            await writesResumedPromise;
+          }
         }
         const unavailable: RuntimeConfigExternalMutationResult<T> = {
           ok: false,

--- a/ui/src/lib/config/runtime-config-capability.ts
+++ b/ui/src/lib/config/runtime-config-capability.ts
@@ -47,7 +47,7 @@ export type RuntimeConfigCapability = {
   /** Discards pending edits: reloads from disk when connected, else resets locally. */
   discardDraft: () => Promise<void>;
   /** Pauses/resumes all config writes (autosave + manual) while e.g. the app updater runs. */
-  setWritesSuspended: (suspended: boolean) => void;
+  setWritesSuspended: (suspended: boolean, refreshAdmission?: () => Promise<void>) => void;
   /** Resolves once no config write is in flight (used as an updater barrier). */
   waitForPendingWrites: () => Promise<void>;
   save: (options?: RuntimeConfigDispatchOptions) => Promise<boolean>;


### PR DESCRIPTION
Fixes #139714
Refs #143136
Refs #143859

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users with an untouched, identityless 2026.9.2-era update admission would keep seeing an update in progress and lose Control UI configuration-write access indefinitely, even after the updater was gone. The affected user need not start another update to recover.

## Why This Change Was Made

Peter's 2026-09-10 contract is: “update should always work, best effort, never worse than before.” The approved bounded expiry applies only to a running/requested identityless admission older than 24 hours, with creation equal to last update, no finish timestamp, and only its original in-progress step. The ledger records `failed/legacy-driver-expired` with an abandonment step and retry advisory. Startup and status reads use the same owner; retained recovery, live/inconclusive drivers, and younger or progressed identityless records keep their protections. Existing #143136 dead-driver rules and the 30-minute inactivity window remain unchanged.

A new explicit update is a different scenario: existing admission logic may first terminalize the old row as `failed/superseded`. That is preserved and is not mislabeled as expiry. Either terminal state releases the Control UI write interlock. The browser refreshes authoritative status before refusing a suspended mutation and rechecks the connection before dispatch.

Best-effort reconciliation checks eligibility read-only before requesting write access. Gateway cold snapshots remain asynchronous, and write refusal is reported separately while retaining readable history. No configuration option, dependency, SQLite schema, protocol bump, or retention deletion is added.

## User Impact

Operators regain settings writes automatically through startup/status reconciliation, with this advisory when the bounded expiry applies: “A 2026.9.2-era update never progressed past admission; treated as abandoned after 24 h; run `openclaw update` to retry.” Starting a new update also leaves the old admission terminal, using its existing supersession semantics.

Release-note context: expire untouched legacy update admissions after 24 hours, preserve explicit-update supersession, and release stale Control UI configuration-write suspension.

## Evidence

### Live retained-state proof

All cells ran in isolated Linux arm64 containers with Node 24.19.0, published baselines, real Gateway processes, authenticated browser/RPC flows, and a synthetic model endpoint. Each seeded the same identityless `requested/running` shape, 25 hours old and unmodified since creation.

| Scenario | Recorded outcome | UI save, health, RPC, mock chat | Observed health outage |
| --- | --- | --- | --- |
| A: candidate status against retained 2026.9.3 state, no new update | `failed/legacy-driver-expired`; advisory in both status commands; admission IDs unchanged | Passed | 0 s |
| B: 2026.9.3 → candidate | Unattended success; old row `failed/superseded`; no active run and no false expiry advisory | Passed | 31.100 s (30.100–32.099 s bounds) |
| B sibling: 2026.9.2 → candidate | Unattended success; old row `failed/legacy-driver-expired`; advisory and no active run | Passed | 56.242 s (55.240–57.254 s bounds) |

Phase A first proved the shipped defect: status retained the running row, the editor and Save were disabled, and no `config.set` was submitted. It then invoked candidate `update status` and `status` against that state while the published Gateway continued serving. The same settings save succeeded and persisted. Fixture history was initialized before seeding; no update was invoked after the aged row was seeded. Phase B exercised the actual update and retained-state checks. The sibling ran once. Cleanup shutdown is excluded from the one-second health samples. The updaters' own recorded downtimes were 38.643 s and 64.847 s respectively.

Live artifacts were built from `15c523bd0877bb49b63884aee2629780bc7d3229`. Normal candidate SHA-256: `9591bd253b8b35bbfa7f75a9eda75dfef5bdd5d0573e57f73f8021b2a0ac2cf6`. The 9.3 cell used the maintained first-hop version fixture (`7213e1b612d12a8b4619ddb5c3f113d7bdc0cd50d9f0a878577d28acc9fae51b`); its audited changes are only `package.json` and `dist/build-info.json`. Runtime/UI bytes are unchanged. Phase A and the 9.2 sibling used the normal candidate.

```bash
bash .local/l31/harness/launch.sh 2026.9.3 2026.9.2 phase-a-9.3-final 24 openclaw-phases.tgz 18831 A
bash .local/l31/harness/launch.sh 2026.9.3 2026.9.2 phase-b-9.3-final 24 openclaw-phases-first-hop.tgz 18831 B
bash .local/l31/harness/launch.sh 2026.9.2 2026.9.2 phase-b-9.2 24 openclaw-phases.tgz 18832 B
# Run alongside each cell, using its corresponding evidence directory:
node --import ./scripts/tsx.mjs .local/l31/harness/ui-proof.mjs .local/l31/<cell> both
```

<details>
<summary>Inspected synthetic browser evidence</summary>

Running orphan on shipped 9.3:

![Running legacy admission](https://github.com/user-attachments/assets/d5498faf-9ad2-4eec-b0dd-5175519bdc5a)

Disabled write controls:

![Disabled Save](https://github.com/user-attachments/assets/f587c0ed-a9c2-4094-bfa5-32eb981a6f05)

Persisted settings after a successful candidate `config.set`:

![Accepted settings write](https://github.com/user-attachments/assets/5b39e04d-3edb-4d06-b78d-6491c52c79ea)

</details>

### Tests and final rebase

The four implementation commits initially rebased patch-identically from reviewed head `332c38995cb`; the added commit is test-only. It verifies reconciliation-first versus admission-first precedence, preserves terminal reasons, and exercises the real overlay/interlock for both terminal outcomes and protected running rows. The focused suites passed 96 tests, the test-file changed gate passed, and the full build/package checks passed.

Main moved during live proof. The final rebase onto `cbc245824eb821a4f7ad1bc68cad5d143674f84c` required one import-only resolution in `update-run-report.ts`, preserving both the legacy advisory imports and main's warning helpers from #143767. No further feature behavior changed. The live cells were not rerun after that final rebase; their artifact SHA remains explicit above. Report and precedence suites passed 116 tests after the rebase. The changed-file gate for the resolved report and three test files, plus `git diff --check`, passed:

```bash
node scripts/run-vitest.mjs src/infra/update-run-report.test.ts src/infra/update-run-abandonment.test.ts ui/src/app/update-config-interlock.test.ts ui/src/lib/config/config-write-coordinator.test.ts
```

Earlier regression proof on `46cbea5a` demonstrated four protected-row write-admission failures, three CLI history-loss failures, two Gateway ownership exceptions, and two cold-snapshot responsiveness failures. Those regressions passed after the owner repair. The final precedence tests document the already-correct supersession behavior rather than changing it.

Final head: `8f7c4ad874c1c5a4833c0896759507eafc77ef01`. [Exact-head CI run 34464230234](https://github.com/openclaw/openclaw/actions/runs/34464230234) completed successfully. `node scripts/watch-pr-ci.mjs 143774 8f7c4ad874c1c5a4833c0896759507eafc77ef01` finished GREEN with zero pending checks and 12 superseded checks; GitHub's raw rollup still reported FAILURE. The PR remains unmerged; the lead owns landing.
