### PR TITLE
fix(ui): recover locale imports after source errors

### DIFF
--- a/ui/config/control-ui-locales.ts
+++ b/ui/config/control-ui-locales.ts
@@ -127,7 +127,11 @@ export function controlUiLocaleModulesPlugin(): Plugin {
       const memoryPath = path.join(i18nAssetsDir, `${request.locale}.tm.jsonl`);
       while (true) {
         const activeCache = catalogCache;
-        activeCache.sourceCatalogLoad ??= loadCurrentSourceCatalog();
+        activeCache.sourceCatalogLoad ??= loadCurrentSourceCatalog().catch((error: unknown) => {
+          // A later request can retry a corrected source without a watched-file change.
+          activeCache.sourceCatalogLoad = null;
+          throw error;
+        });
         let sourceCatalogResult: Awaited<ReturnType<typeof loadCurrentSourceCatalog>>;
         try {
           sourceCatalogResult = await activeCache.sourceCatalogLoad;

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -797,9 +797,10 @@ describe("Control UI Vite config", () => {
   });
 
   it.each([
-    { name: "resolved", outcome: "resolve" as const },
-    { name: "rejected", outcome: "reject" as const },
-  ])("discards a stale $name source-catalog generation", async ({ outcome }) => {
+    { name: "stale resolved", outcome: "resolve" as const, invalidate: true },
+    { name: "stale rejected", outcome: "reject" as const, invalidate: true },
+    { name: "current rejected", outcome: "reject" as const, invalidate: false },
+  ])("recovers a $name source-catalog generation", async ({ outcome, invalidate }) => {
     const staleImport = deferred<{
       loadControlUiSourceCatalog: () => ReturnType<typeof loadControlUiSourceCatalog>;
     }>();
@@ -826,12 +827,14 @@ describe("Control UI Vite config", () => {
           () => (registrations++ === 0 ? staleLoader : currentLoader) as never,
           async () => {
             const { load, watchChange } = controlUiLocaleModuleHooks();
-            const baseSourcePromise = loadControlUiLocaleModuleSource(
+            let baseSourcePromise = loadControlUiLocaleModuleSource(
               load,
               "\0virtual:openclaw-control-ui-locale/fr",
             );
             await vi.waitFor(() => expect(staleLoader.import).toHaveBeenCalledOnce());
-            await watchChange.call({} as never, "src/config/schema.hints.ts", {} as never);
+            if (invalidate) {
+              await watchChange.call({} as never, "src/config/schema.hints.ts", {} as never);
+            }
             if (outcome === "resolve") {
               staleImport.resolve({
                 loadControlUiSourceCatalog: () => ({
@@ -840,7 +843,15 @@ describe("Control UI Vite config", () => {
                 }),
               });
             } else {
-              staleImport.reject(new Error("stale source failure"));
+              const error = new Error("source import failed");
+              staleImport.reject(error);
+              if (!invalidate) {
+                await expect(baseSourcePromise).rejects.toBe(error);
+                baseSourcePromise = loadControlUiLocaleModuleSource(
+                  load,
+                  "\0virtual:openclaw-control-ui-locale/fr",
+                );
+              }
             }
             const baseSource = await baseSourcePromise;
             const configHintsSource = await loadControlUiLocaleModuleSource(


### PR DESCRIPTION
Related: #143376

## What Problem This Solves

A failed locale source-catalog import stays cached. If it fails before its source files are watched, correcting the source and requesting the locale module again still returns the old error until an unrelated watched-file change clears the cache.

## Why This Change Was Made

Clear a rejected source promise once at its producer and rethrow the original error. A later request can then load corrected source. Successful imports still share one promise, and an obsolete generation only clears its own cache. Partition caching and watcher behavior stay unchanged.

The repair adds four production lines and extends an existing regression table with one case.

## User Impact

Locale module requests can recover after source corrections without an unrelated file edit. The original failure still reaches the caller; the change adds no automatic retry loop or fallback catalog.

## Evidence

- The new permanent case fails on original production while both stale-generation controls pass. The same test source passes after the repair.
- 108 focused Vite/build/chunk/locale cases across six files and all 20 canonical changed-file checks pass.
- A real Vite 8.2.2/tsx 4.23.13 fixture reproduces old-version recovery versus current-version cached failure after repairing an outside-UI source file. The unchanged driver succeeds on the candidate before any watch event, and its genuine filesystem-watch control also succeeds.
- Fresh independent Codex review found no actionable findings through P2.

The real-plugin fixture uses synthetic catalog input, middleware mode, and no network listener. A paired callback control confirmed that its initial missing source watches came from the fixture’s outer TypeScript loader; removing that loader restored source watches without a product change. Full default ui:dev/HMR behavior remains outside this proof.
