### PR TITLE
fix: retain executable model identities in catalogs

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -40,11 +40,19 @@ function providerManifestSnapshot(params: {
   discovery: "static" | "refreshable" | "runtime";
   modelIds: string[];
   aliases?: string[];
+  modelAliases?: Record<string, string>;
 }): PluginMetadataSnapshot {
   const plugin = createPluginManifestRecordFixture({
     id: params.provider,
     origin: "bundled",
     providers: [params.provider],
+    ...(params.modelAliases
+      ? {
+          modelIdNormalization: {
+            providers: { [params.provider]: { aliases: params.modelAliases } },
+          },
+        }
+      : {}),
     modelCatalog: {
       aliases: Object.fromEntries(
         (params.aliases ?? []).map((alias) => [alias, { provider: params.provider }]),
@@ -116,6 +124,39 @@ describe("prepared model catalog builder", () => {
       expect(snapshot.authoritative).toBe(status === "ready");
     },
   );
+
+  it("preserves executable registry identities that are also input aliases", async () => {
+    const snapshot = await build({
+      entries: [{ provider: "custom", id: "middle", name: "Middle", input: ["text", "image"] }],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "custom",
+        discovery: "runtime",
+        modelIds: [],
+        modelAliases: { latest: "middle", middle: "final" },
+      }),
+    });
+    expect(snapshot.entries).toMatchObject([{ id: "middle", input: ["text", "image"] }]);
+    expect(snapshot.entries).toHaveLength(1);
+  });
+
+  it("keeps runtime catalog entitlement attached to emitted identities", async () => {
+    mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
+      { provider: "custom", id: "latest", name: "Enriched middle", contextWindow: 64000 },
+      { provider: "custom", id: "denied", name: "Unobserved model", contextWindow: 128000 },
+    ]);
+    const snapshot = await build({
+      entries: [{ provider: "custom", id: "middle", name: "Middle", contextWindow: 32000 }],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "custom",
+        discovery: "runtime",
+        modelIds: ["middle", "final", "denied"],
+        modelAliases: { latest: "middle", middle: "final" },
+      }),
+      readOnly: false,
+    });
+    expect(snapshot.entries).toMatchObject([{ id: "middle", contextWindow: 64000 }]);
+    expect(snapshot.entries).toHaveLength(1);
+  });
 
   it("projects and sorts one lifecycle registry generation", async () => {
     const snapshot = await build({

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -282,8 +282,10 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("suppress-resolver-ready");
 
     for (const entry of entries) {
-      const rawId = entry.id.trim();
-      if (!rawId) {
+      // Registry IDs name executable models. Reinterpreting them as input
+      // aliases would move their capabilities onto another model.
+      const id = entry.id.trim();
+      if (!id) {
         continue;
       }
       const rawProvider = entry.provider.trim();
@@ -291,7 +293,6 @@ export async function buildPreparedModelCatalogSnapshot(
         continue;
       }
       const provider = normalizeProvider(rawProvider);
-      const id = normalizeModelId(provider, rawId);
       const baseUrl = entry.baseUrl?.trim();
       if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
         continue;
@@ -387,14 +388,9 @@ export async function buildPreparedModelCatalogSnapshot(
       });
       if (supplemental.length > 0) {
         // Explicitly configured rows are user-authorized even when live
-        // discovery omits them; normalize both sets to preserve their routes.
+        // discovery omits them; compare emitted identities to preserve their routes.
         const accountVisibleModelKeys = new Set(
-          [...models, ...configuredModels].map((entry) =>
-            resolveModelCatalogIdentityKey({
-              provider: entry.provider,
-              id: normalizeModelId(entry.provider, entry.id),
-            }),
-          ),
+          [...models, ...configuredModels].map(resolveModelCatalogIdentityKey),
         );
         const normalizedSupplemental: ModelCatalogEntry[] = [];
         for (const entry of supplemental) {


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where building a model catalog normalizes an executable registry ID again as authored input. With aliases `latest → middle → final`, an existing `middle` model can become `final`, carrying its capabilities with it. Repeating that normalization in the account-visible set also prevents valid metadata enrichment of the selected model.

## Why This Change Was Made

Keep emitted registry IDs literal and derive enrichment eligibility directly from emitted identities. Authored supplemental IDs still normalize at their existing boundary. Provider equivalence, suppression, ordering, and exclusion of unobserved models remain intact. Two production hunks remove four lines.

## User Impact

The selected registry model retains its identity and capabilities. Runtime catalog enrichment applies to that model without introducing models the account did not expose.

## Evidence

Both original regressions failed on the baseline; applying only the registry-ID change left the enrichment failure intact. The reviewed patch was replayed without conflicts or changes onto main containing the shared test-fixture repairs in #143813 and #143875 and the UI lint repair in #143889. The earlier failures were in those baseline checks; the catalog patch remains unchanged.

Fresh validation at `1c32db0c8fb4f5d3fe1c6e1073c944fe794bb39c` passed 56 catalog/route tests, the full changed-file gate, and one canonical `sourcePerformance` runtime build. The independent P2 review remains applicable to the identical patch.

The freshly compiled catalog used a real registered provider augmentation hook: `middle` stayed literal and enriched from 32K to 64K on the same API route; vision remained intact; the unobserved model stayed excluded; borrowed inputs stayed unchanged; registrations were removed by rollback. The refreshed proof passed on its first attempt. It made no external provider request. This runtime build profile excludes UI and declaration generation. Original source, builds, and failure evidence were retained with their original revision identities.
