### PR TITLE
fix: avoid duplicate Telegram topic routing in cron jobs

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2877,6 +2877,7 @@ describe("cron tool", () => {
           mode: "announce",
           channel: "telegram",
           to: "telegram:-1001234567890:topic:99",
+          threadId: "99",
         },
       },
     });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2363,6 +2363,24 @@ describe("cron tool", () => {
     });
   });
 
+  it("stores a Telegram topic target only in delivery.to when adding from that topic", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-topic-context",
+        agentSessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+        currentDeliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:99",
+          threadId: "99",
+        },
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:-1001234567890:topic:99",
+    });
+  });
+
   it("does not surface lowercased LINE recipients when current delivery context is unavailable (#81628)", async () => {
     // LINE chat IDs are case-sensitive; without current/persisted deliveryContext,
     // cron must not rebuild delivery.to from the lowercased session-key fragment.
@@ -2830,6 +2848,35 @@ describe("cron tool", () => {
           to: null,
           failureDestination: null,
           completionDestination: null,
+        },
+      },
+    });
+  });
+
+  it("drops split Telegram topic routing from updates made in a topic session", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+    });
+    await tool.execute("call-normalize-topic-update", {
+      action: "update",
+      id: "job-topic",
+      job: {
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:99",
+          threadId: "99",
+        },
+      },
+    });
+
+    expect(expectSingleGatewayCallMethod("cron.update")).toEqual({
+      id: "job-topic",
+      patch: {
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:99",
         },
       },
     });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2882,6 +2882,34 @@ describe("cron tool", () => {
     });
   });
 
+  it("preserves a differing explicit Telegram topic override in updates", async () => {
+    const tool = createTestCronTool();
+    await tool.execute("call-preserve-topic-override", {
+      action: "update",
+      id: "job-topic",
+      job: {
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:99",
+          threadId: "42",
+        },
+      },
+    });
+
+    expect(expectSingleGatewayCallMethod("cron.update")).toEqual({
+      id: "job-topic",
+      patch: {
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:-1001234567890:topic:99",
+          threadId: "42",
+        },
+      },
+    });
+  });
+
   it.each([
     ["nested", "worker"],
     ["flat", "worker"],

--- a/src/cron/delivery-context.ts
+++ b/src/cron/delivery-context.ts
@@ -5,6 +5,7 @@ import {
   normalizeDeliveryContext,
   type DeliveryContext,
 } from "../utils/delivery-context.shared.js";
+import { cronDeliveryTargetIncludesTelegramTopic } from "./delivery-topic-routing.js";
 import type { CronDelivery, CronMessageChannel } from "./types.js";
 
 /** Converts an active delivery context into cron announce delivery config. */
@@ -25,6 +26,9 @@ function cronDeliveryFromContext(context?: DeliveryContext): CronDelivery | null
   }
   if (normalized.threadId != null) {
     delivery.threadId = normalized.threadId;
+  }
+  if (cronDeliveryTargetIncludesTelegramTopic(delivery)) {
+    delete delivery.threadId;
   }
   return delivery;
 }

--- a/src/cron/delivery-context.ts
+++ b/src/cron/delivery-context.ts
@@ -5,7 +5,7 @@ import {
   normalizeDeliveryContext,
   type DeliveryContext,
 } from "../utils/delivery-context.shared.js";
-import { cronDeliveryTargetIncludesTelegramTopic } from "./delivery-topic-routing.js";
+import { cronDeliveryHasRedundantTelegramThreadId } from "./delivery-topic-routing.js";
 import type { CronDelivery, CronMessageChannel } from "./types.js";
 
 /** Converts an active delivery context into cron announce delivery config. */
@@ -27,7 +27,7 @@ function cronDeliveryFromContext(context?: DeliveryContext): CronDelivery | null
   if (normalized.threadId != null) {
     delivery.threadId = normalized.threadId;
   }
-  if (cronDeliveryTargetIncludesTelegramTopic(delivery)) {
+  if (cronDeliveryHasRedundantTelegramThreadId(delivery)) {
     delete delivery.threadId;
   }
   return delivery;

--- a/src/cron/delivery-topic-routing.ts
+++ b/src/cron/delivery-topic-routing.ts
@@ -5,7 +5,20 @@ export function cronDeliveryHasRedundantTelegramThreadId(delivery: {
   threadId?: unknown;
 }): boolean {
   const to = typeof delivery.to === "string" ? delivery.to.trim() : "";
-  const telegramTarget = to.replace(/^telegram:/iu, "");
+  let telegramTarget = to;
+  let strippedTelegramPrefix = false;
+  while (true) {
+    if (/^(?:telegram|tg):/iu.test(telegramTarget)) {
+      strippedTelegramPrefix = true;
+      telegramTarget = telegramTarget.replace(/^(?:telegram|tg):/iu, "").trim();
+      continue;
+    }
+    if (strippedTelegramPrefix && /^group:/iu.test(telegramTarget)) {
+      telegramTarget = telegramTarget.replace(/^group:/iu, "").trim();
+      continue;
+    }
+    break;
+  }
   const topicId = /^.+(?::topic:|:)(\d+)$/iu.exec(telegramTarget)?.[1];
   if (
     !topicId ||
@@ -14,7 +27,7 @@ export function cronDeliveryHasRedundantTelegramThreadId(delivery: {
     return false;
   }
   const channel = typeof delivery.channel === "string" ? delivery.channel.trim().toLowerCase() : "";
-  const isTelegram = channel === "telegram" || /^telegram:/iu.test(to);
+  const isTelegram = channel === "telegram" || strippedTelegramPrefix;
   const threadId = String(delivery.threadId).trim();
   if (!isTelegram || !/^\d+$/u.test(threadId)) {
     return false;

--- a/src/cron/delivery-topic-routing.ts
+++ b/src/cron/delivery-topic-routing.ts
@@ -1,12 +1,23 @@
-/** Returns whether a Telegram topic is already encoded in the delivery target. */
-export function cronDeliveryTargetIncludesTelegramTopic(delivery: {
+/** Returns whether delivery.threadId duplicates a Telegram topic encoded in the target. */
+export function cronDeliveryHasRedundantTelegramThreadId(delivery: {
   channel?: unknown;
   to?: unknown;
+  threadId?: unknown;
 }): boolean {
   const to = typeof delivery.to === "string" ? delivery.to.trim() : "";
-  if (!/:topic:[^:]+$/iu.test(to)) {
+  const topicId = /(?::topic:|:)(\d+)$/iu.exec(to)?.[1];
+  if (
+    !topicId ||
+    (typeof delivery.threadId !== "string" && typeof delivery.threadId !== "number")
+  ) {
     return false;
   }
   const channel = typeof delivery.channel === "string" ? delivery.channel.trim().toLowerCase() : "";
-  return channel === "telegram" || /^telegram:/iu.test(to);
+  const isTelegram = channel === "telegram" || /^telegram:/iu.test(to);
+  const threadId = String(delivery.threadId).trim();
+  if (!isTelegram || !/^\d+$/u.test(threadId)) {
+    return false;
+  }
+  const canonicalInteger = (value: string) => value.replace(/^0+(?=\d)/u, "");
+  return canonicalInteger(threadId) === canonicalInteger(topicId);
 }

--- a/src/cron/delivery-topic-routing.ts
+++ b/src/cron/delivery-topic-routing.ts
@@ -1,0 +1,12 @@
+/** Returns whether a Telegram topic is already encoded in the delivery target. */
+export function cronDeliveryTargetIncludesTelegramTopic(delivery: {
+  channel?: unknown;
+  to?: unknown;
+}): boolean {
+  const to = typeof delivery.to === "string" ? delivery.to.trim() : "";
+  if (!/:topic:[^:]+$/iu.test(to)) {
+    return false;
+  }
+  const channel = typeof delivery.channel === "string" ? delivery.channel.trim().toLowerCase() : "";
+  return channel === "telegram" || /^telegram:/iu.test(to);
+}

--- a/src/cron/delivery-topic-routing.ts
+++ b/src/cron/delivery-topic-routing.ts
@@ -5,7 +5,8 @@ export function cronDeliveryHasRedundantTelegramThreadId(delivery: {
   threadId?: unknown;
 }): boolean {
   const to = typeof delivery.to === "string" ? delivery.to.trim() : "";
-  const topicId = /(?::topic:|:)(\d+)$/iu.exec(to)?.[1];
+  const telegramTarget = to.replace(/^telegram:/iu, "");
+  const topicId = /^.+(?::topic:|:)(\d+)$/iu.exec(telegramTarget)?.[1];
   if (
     !topicId ||
     (typeof delivery.threadId !== "string" && typeof delivery.threadId !== "number")

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -521,6 +521,21 @@ describe("normalizeCronJobCreate", () => {
   });
 });
 describe("normalizeCronJobPatch", () => {
+  it("preserves a redundant Telegram thread setter until it can be merged", () => {
+    const normalized = normalizePatch({
+      delivery: {
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "99",
+      },
+    });
+
+    expect(normalized.delivery).toEqual({
+      channel: "telegram",
+      to: "telegram:-1001234567890:topic:99",
+      threadId: "99",
+    });
+  });
   it("normalizes agentTurn model-only payload patches", () => {
     const { payload } = patchAgent({ model: "anthropic/claude-sonnet-4-6" });
     expect(payload.kind).toBe("agentTurn");

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -190,7 +190,10 @@ function coerceTrigger(trigger: UnknownRecord): UnknownRecord {
   };
 }
 
-function coerceDelivery(delivery: UnknownRecord) {
+function coerceDelivery(
+  delivery: UnknownRecord,
+  options?: { preserveRedundantThreadId?: boolean },
+) {
   const next = snapshotOwnCronRecord(delivery);
   const parsed = parseDeliveryInput(next);
   if (parsed.mode !== undefined) {
@@ -219,7 +222,7 @@ function coerceDelivery(delivery: UnknownRecord) {
   } else if ("threadId" in next) {
     delete next.threadId;
   }
-  if (cronDeliveryHasRedundantTelegramThreadId(next)) {
+  if (!options?.preserveRedundantThreadId && cronDeliveryHasRedundantTelegramThreadId(next)) {
     delete next.threadId;
   }
   if ("accountId" in next && next.accountId === null) {
@@ -534,7 +537,9 @@ export function normalizeCronJobInput(
   }
 
   if (isRecord(base.delivery)) {
-    next.delivery = coerceDelivery(base.delivery);
+    next.delivery = coerceDelivery(base.delivery, {
+      preserveRedundantThreadId: !options.applyDefaults,
+    });
   }
 
   if (options.applyDefaults) {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -11,7 +11,7 @@ import { normalizeOptionalAccountId } from "../routing/account-id.js";
 import { sanitizeAgentId } from "../routing/session-key.js";
 import { shouldDefaultCronDeliveryToAnnounce } from "./delivery-defaults.js";
 import { parseDeliveryInput } from "./delivery-field-schemas.js";
-import { cronDeliveryTargetIncludesTelegramTopic } from "./delivery-topic-routing.js";
+import { cronDeliveryHasRedundantTelegramThreadId } from "./delivery-topic-routing.js";
 import { normalizeCronCommandArgv, normalizeCronPayload } from "./normalize-payload.js";
 import { snapshotOwnCronRecord } from "./own-record.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
@@ -219,7 +219,7 @@ function coerceDelivery(delivery: UnknownRecord) {
   } else if ("threadId" in next) {
     delete next.threadId;
   }
-  if (cronDeliveryTargetIncludesTelegramTopic(next)) {
+  if (cronDeliveryHasRedundantTelegramThreadId(next)) {
     delete next.threadId;
   }
   if ("accountId" in next && next.accountId === null) {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -11,6 +11,7 @@ import { normalizeOptionalAccountId } from "../routing/account-id.js";
 import { sanitizeAgentId } from "../routing/session-key.js";
 import { shouldDefaultCronDeliveryToAnnounce } from "./delivery-defaults.js";
 import { parseDeliveryInput } from "./delivery-field-schemas.js";
+import { cronDeliveryTargetIncludesTelegramTopic } from "./delivery-topic-routing.js";
 import { normalizeCronCommandArgv, normalizeCronPayload } from "./normalize-payload.js";
 import { snapshotOwnCronRecord } from "./own-record.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
@@ -216,6 +217,9 @@ function coerceDelivery(delivery: UnknownRecord) {
   } else if (parsed.threadId !== undefined) {
     next.threadId = parsed.threadId;
   } else if ("threadId" in next) {
+    delete next.threadId;
+  }
+  if (cronDeliveryTargetIncludesTelegramTopic(next)) {
     delete next.threadId;
   }
   if ("accountId" in next && next.accountId === null) {

--- a/src/cron/service/initial-delivery.test.ts
+++ b/src/cron/service/initial-delivery.test.ts
@@ -149,35 +149,38 @@ describe("CronService initial delivery", () => {
     }
   });
 
-  it("preserves an independent thread for a provider-prefixed chat target", async () => {
-    const { storePath } = await makeStorePath();
-    const cron = createDirectCronService(storePath);
-    await cron.start();
+  it.each(["telegram:12345", "tg:12345", "telegram:tg:group:12345"])(
+    "preserves an independent thread for provider-prefixed chat target %s",
+    async (to) => {
+      const { storePath } = await makeStorePath();
+      const cron = createDirectCronService(storePath);
+      await cron.start();
 
-    try {
-      const added = await cron.add(
-        createInput({
-          sessionTarget: "isolated",
-          payload: { kind: "agentTurn", message: "hello" },
-          delivery: {
-            mode: "announce",
-            channel: "telegram",
-            to: "telegram:12345",
-            threadId: "12345",
-          },
-        }),
-      );
+      try {
+        const added = await cron.add(
+          createInput({
+            sessionTarget: "isolated",
+            payload: { kind: "agentTurn", message: "hello" },
+            delivery: {
+              mode: "announce",
+              channel: "telegram",
+              to,
+              threadId: "12345",
+            },
+          }),
+        );
 
-      expect(added.delivery).toEqual({
-        mode: "announce",
-        channel: "telegram",
-        to: "telegram:12345",
-        threadId: "12345",
-      });
-    } finally {
-      cron.stop();
-    }
-  });
+        expect(added.delivery).toEqual({
+          mode: "announce",
+          channel: "telegram",
+          to,
+          threadId: "12345",
+        });
+      } finally {
+        cron.stop();
+      }
+    },
+  );
 
   it("normalizes legacy split Telegram topic routing during an unrelated update", async () => {
     const { storePath } = await makeStorePath();

--- a/src/cron/service/initial-delivery.test.ts
+++ b/src/cron/service/initial-delivery.test.ts
@@ -149,6 +149,36 @@ describe("CronService initial delivery", () => {
     }
   });
 
+  it("preserves an independent thread for a provider-prefixed chat target", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createDirectCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add(
+        createInput({
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "telegram:12345",
+            threadId: "12345",
+          },
+        }),
+      );
+
+      expect(added.delivery).toEqual({
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:12345",
+        threadId: "12345",
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
   it("normalizes legacy split Telegram topic routing during an unrelated update", async () => {
     const { storePath } = await makeStorePath();
     const cron = createDirectCronService(storePath);

--- a/src/cron/service/initial-delivery.test.ts
+++ b/src/cron/service/initial-delivery.test.ts
@@ -5,7 +5,8 @@ import {
   createNoopLogger,
   installCronTestHooks,
 } from "../service.test-harness.js";
-import type { CronDelivery, CronJobCreate } from "../types.js";
+import { loadCronStore } from "../store.js";
+import type { CronDelivery, CronJob, CronJobCreate } from "../types.js";
 import { resolveInitialCronDelivery } from "./initial-delivery.js";
 
 function createInput(params: {
@@ -87,6 +88,73 @@ function createDirectCronService(storePath: string) {
 }
 
 describe("CronService initial delivery", () => {
+  it("persists Telegram topic delivery without a duplicate threadId", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createDirectCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add(
+        createInput({
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "telegram:-1001234567890:topic:99",
+            threadId: "99",
+          },
+        }),
+      );
+
+      expect(added.delivery).toEqual({
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+      });
+      await expect(loadCronStore(storePath)).resolves.toMatchObject({
+        jobs: [{ delivery: added.delivery }],
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("normalizes legacy split Telegram topic routing during an unrelated update", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createDirectCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add(
+        createInput({
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+        }),
+      );
+      const legacy = cron.getJob(added.id) as CronJob;
+      legacy.delivery = {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "99",
+      };
+
+      const updated = await cron.update(added.id, { name: "updated topic job" });
+
+      expect(updated.delivery).toEqual({
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+      });
+      await expect(loadCronStore(storePath)).resolves.toMatchObject({
+        jobs: [{ name: "updated topic job", delivery: updated.delivery }],
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
   it.each(["current", "session:project-alpha"] as const)(
     "persists announce delivery for direct %s jobs",
     async (sessionTarget) => {

--- a/src/cron/service/initial-delivery.test.ts
+++ b/src/cron/service/initial-delivery.test.ts
@@ -120,6 +120,35 @@ describe("CronService initial delivery", () => {
     }
   });
 
+  it("normalizes Telegram numeric topic shorthand during creation", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createDirectCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add(
+        createInput({
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "-1001234567890:99",
+            threadId: 99,
+          },
+        }),
+      );
+
+      expect(added.delivery).toEqual({
+        mode: "announce",
+        channel: "telegram",
+        to: "-1001234567890:99",
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
   it("normalizes legacy split Telegram topic routing during an unrelated update", async () => {
     const { storePath } = await makeStorePath();
     const cron = createDirectCronService(storePath);
@@ -149,6 +178,39 @@ describe("CronService initial delivery", () => {
       });
       await expect(loadCronStore(storePath)).resolves.toMatchObject({
         jobs: [{ name: "updated topic job", delivery: updated.delivery }],
+      });
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("preserves a differing explicit Telegram topic during an unrelated update", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createDirectCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add(
+        createInput({
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "hello" },
+        }),
+      );
+      const legacy = cron.getJob(added.id) as CronJob;
+      legacy.delivery = {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "42",
+      };
+
+      const updated = await cron.update(added.id, { name: "updated override job" });
+
+      expect(updated.delivery).toEqual({
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "42",
       });
     } finally {
       cron.stop();

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -1,5 +1,6 @@
 /** Resolves create-time default delivery for new cron jobs. */
 import { shouldDefaultCronDeliveryToAnnounce } from "../delivery-defaults.js";
+import { cronDeliveryTargetIncludesTelegramTopic } from "../delivery-topic-routing.js";
 import type { CronDelivery, CronJobCreate } from "../types.js";
 
 /**
@@ -12,6 +13,11 @@ import type { CronDelivery, CronJobCreate } from "../types.js";
  */
 export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery | undefined {
   if (input.delivery) {
+    if (cronDeliveryTargetIncludesTelegramTopic(input.delivery)) {
+      const delivery = structuredClone(input.delivery);
+      delete delivery.threadId;
+      return delivery;
+    }
     return input.delivery;
   }
   if (

--- a/src/cron/service/initial-delivery.ts
+++ b/src/cron/service/initial-delivery.ts
@@ -1,6 +1,6 @@
 /** Resolves create-time default delivery for new cron jobs. */
 import { shouldDefaultCronDeliveryToAnnounce } from "../delivery-defaults.js";
-import { cronDeliveryTargetIncludesTelegramTopic } from "../delivery-topic-routing.js";
+import { cronDeliveryHasRedundantTelegramThreadId } from "../delivery-topic-routing.js";
 import type { CronDelivery, CronJobCreate } from "../types.js";
 
 /**
@@ -13,7 +13,7 @@ import type { CronDelivery, CronJobCreate } from "../types.js";
  */
 export function resolveInitialCronDelivery(input: CronJobCreate): CronDelivery | undefined {
   if (input.delivery) {
-    if (cronDeliveryTargetIncludesTelegramTopic(input.delivery)) {
+    if (cronDeliveryHasRedundantTelegramThreadId(input.delivery)) {
       const delivery = structuredClone(input.delivery);
       delete delivery.threadId;
       return delivery;

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -2,6 +2,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
+import { normalizeCronJobPatch } from "../normalize.js";
 import { projectCronJobThroughStorageCodec } from "../store/row-codec.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import { applyJobPatch, createJob } from "./jobs.js";
@@ -142,6 +143,32 @@ describe("schedule activation ownership", () => {
 });
 
 describe("applyJobPatch delivery merge", () => {
+  it("applies a redundant thread setter before deduplicating the merged delivery", () => {
+    const job = makeJob({
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "42",
+      },
+    });
+    const patch = normalizeCronJobPatch({
+      delivery: {
+        to: "telegram:-1001234567890:topic:99",
+        threadId: "99",
+      },
+    });
+
+    expect(patch).not.toBeNull();
+    applyJobPatch(job, patch!);
+
+    expect(job.delivery).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:-1001234567890:topic:99",
+    });
+  });
+
   it("threads explicit delivery threadId patches into delivery", () => {
     const job = makeJob();
     const patch = { delivery: { threadId: "99" } } as Parameters<typeof applyJobPatch>[1];

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -7,6 +7,7 @@ import {
 import type { CronConfig } from "../../config/types.cron.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
+import { cronDeliveryTargetIncludesTelegramTopic } from "../delivery-topic-routing.js";
 import { assertCronJobStateTimestamps } from "../persisted-shape.js";
 import type { CronScheduledToolPolicy } from "../scheduled-tool-policy.js";
 import { normalizeCronScriptPayload } from "../script-payload.js";
@@ -394,6 +395,9 @@ export function applyJobPatch(
   if (patch.delivery) {
     const implicitMode = resolveCronDeliveryPlan(job).mode;
     job.delivery = mergeCronDelivery(job.delivery, patch.delivery, implicitMode);
+  }
+  if (job.delivery && cronDeliveryTargetIncludesTelegramTopic(job.delivery)) {
+    delete job.delivery.threadId;
   }
   if ("failureAlert" in patch) {
     job.failureAlert = mergeCronFailureAlert(job.failureAlert, patch.failureAlert);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -7,7 +7,7 @@ import {
 import type { CronConfig } from "../../config/types.cron.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
-import { cronDeliveryTargetIncludesTelegramTopic } from "../delivery-topic-routing.js";
+import { cronDeliveryHasRedundantTelegramThreadId } from "../delivery-topic-routing.js";
 import { assertCronJobStateTimestamps } from "../persisted-shape.js";
 import type { CronScheduledToolPolicy } from "../scheduled-tool-policy.js";
 import { normalizeCronScriptPayload } from "../script-payload.js";
@@ -396,7 +396,7 @@ export function applyJobPatch(
     const implicitMode = resolveCronDeliveryPlan(job).mode;
     job.delivery = mergeCronDelivery(job.delivery, patch.delivery, implicitMode);
   }
-  if (job.delivery && cronDeliveryTargetIncludesTelegramTopic(job.delivery)) {
+  if (job.delivery && cronDeliveryHasRedundantTelegramThreadId(job.delivery)) {
     delete job.delivery.threadId;
   }
   if ("failureAlert" in patch) {


### PR DESCRIPTION
> **Withdrawn September 16, 2026:** The reported failure came from an overly strict local routing audit, which was corrected on September 14. Its 11 isolated tests pass. No OpenClaw delivery defect was established, so this persistence change is no longer needed for #143778. Thanks to ClawSweeper for identifying the unsupported storage-contract assumption.

Related: #143778

## What this changes

Canonicalizes matching Telegram topic identifiers when creating or updating scheduled jobs: if `delivery.to` already contains the same topic as `delivery.threadId`, the separate thread field is removed. A genuinely different explicit thread override keeps its established precedence. Supported repeated Telegram prefixes and both explicit `:topic:<id>` and numeric topic shorthand are covered.

## Corrected diagnosis — September 16, 2026

The `CRON_ROUTING_FAIL` / `CRON_ROUTING_OK` markers in the original report came from an operator-maintained local script, `audit-cron-routing.mjs`, not an OpenClaw health check. Its former rule rejected any separate thread field, even when it matched the topic in `delivery.to`.

That local rule was corrected on September 14 to accept matching string or numeric topic identifiers. Its 11 isolated tests were rerun on September 16: **11 passed, 0 failed**. They cover matching identifiers, differing identifiers, invalid topic/thread values, root destinations, missing explicit destinations, and current/legacy store selection. The stricter rejection rules are local operator policy, not a claim about OpenClaw's supported routing contract.

The original manual removal of `threadId` therefore demonstrated recovery from an overly strict local audit; it did not establish an OpenClaw delivery defect or a requirement to rewrite persisted jobs. The reported operational problem is now resolved in the local audit without this PR.

## Behavior evidence and limits

- A recorded September 14 check against unmodified OpenClaw `v2026.9.4` (`3a9d69db306cd7f081e06254cb89c4bcc14a7107`) exercised the real cron delivery resolver and Telegram outbound adapter through isolated boundary tests. Topic-only, matching duplicate topic fields, differing explicit overrides, and a plain chat with an explicit thread all retained their expected effective destinations. These were boundary tests with a local send substitute, not live Telegram sends.
- Historical verification of this PR head `0fb2f8e059a987149dd456fd5d4d7609bddac8a4` recorded 327 passing focused tests and passing typechecks. Those PR tests were not rerun on September 16.
- Correction to the earlier contributor comment: the added legacy-update test changes a job in an already-running service; it does **not** prove a persisted legacy job was reloaded before editing. Patched fresh-creation and real restart/update proof remain missing if maintainers still want this storage change.

## CI status

The latest run on this PR head is still red. [The failing job](https://github.com/openclaw/openclaw/actions/runs/34481568594/job/102886097684) reported one failure in `extensions/openai/speech-runtime.contract.test.ts`: “aborts stalled OpenAI ordinary synthesis waiting for response body within the caller timeout”, with `ordinary synthesis did not time out`. That shard reported 1 failed, 1,190 passed, and 1 skipped; the merge gate then propagated the failure.

This is strong evidence of an inherited speech-test fixture timing problem rather than a failure caused by the cron-only diff: upstream subsequently repaired this fixture in [0e3d815](https://github.com/openclaw/openclaw/commit/0e3d81537c6a51a7e5cb32622060ef935de63cf9) and [3c194de](https://github.com/openclaw/openclaw/commit/3c194de0e578c214dda988f807ea6b6733032bb8). No failed-job rerun or new green CI result is claimed here.

## Resolution

Closing without merge. The local audit now accepts matching topic identifiers, resolving the original report without rewriting persisted OpenClaw jobs. Any broader canonicalization policy would need its own maintainer-approved rationale and upgrade evidence.
