### PR TITLE
fix: keep model auth facts case-sensitive

### DIFF
--- a/src/agents/auth-profiles/runtime-materializations.ts
+++ b/src/agents/auth-profiles/runtime-materializations.ts
@@ -60,7 +60,7 @@ export function recordRuntimeAuthMaterialization(params: {
   const provider = normalizeProviderId(params.provider);
   const fact: RuntimeAuthMaterialization = {
     provider,
-    modelId: params.modelId.trim().toLowerCase(),
+    modelId: params.modelId.trim(),
     modelApi: params.modelApi.trim().toLowerCase(),
     modelBaseUrl: params.modelBaseUrl.trim(),
     requestTransportOverrides: params.requestTransportOverrides,

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -116,75 +116,78 @@ describe("runtime auth profile snapshots", () => {
     }
   });
 
-  it("publishes successful-auth facts without impersonating credential rotation", () => {
-    const agentDir = "/tmp/openclaw-auth-runtime-materialized";
-    const pluginStoreListener = vi.fn();
-    const materializationListener = vi.fn();
-    setRuntimeAuthProfileStoreSnapshot(createStore("materialized"), agentDir);
-    const unregisterStore = registerRuntimeAuthProfileStoreMutationListener(pluginStoreListener);
-    const unregisterMaterialization =
-      registerRuntimeAuthMaterializationMutationListener(materializationListener);
-    try {
-      const materialization = {
-        agentDir,
-        provider: "openai",
-        modelId: "gpt-5.4",
-        modelApi: "openai-chatgpt-responses",
-        modelBaseUrl: "https://chatgpt.com/backend-api/codex",
-        requestTransportOverrides: "none",
-        authMode: "oauth",
-        runtimeOwnerId: "codex",
-        authProfileId: "openai:default",
-      } as const;
-      expect(recordRuntimeAuthMaterialization(materialization)).toBe(true);
-      expect(recordRuntimeAuthMaterialization(materialization)).toBe(false);
-      expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
-        {
+  it.each(["Model", "model"])(
+    "publishes %s auth facts without impersonating credential rotation",
+    (modelId) => {
+      const agentDir = "/tmp/openclaw-auth-runtime-materialized";
+      const pluginStoreListener = vi.fn();
+      const materializationListener = vi.fn();
+      setRuntimeAuthProfileStoreSnapshot(createStore("materialized"), agentDir);
+      const unregisterStore = registerRuntimeAuthProfileStoreMutationListener(pluginStoreListener);
+      const unregisterMaterialization =
+        registerRuntimeAuthMaterializationMutationListener(materializationListener);
+      try {
+        const materialization = {
+          agentDir,
           provider: "openai",
-          modelId: "gpt-5.4",
+          modelId,
           modelApi: "openai-chatgpt-responses",
           modelBaseUrl: "https://chatgpt.com/backend-api/codex",
           requestTransportOverrides: "none",
           authMode: "oauth",
           runtimeOwnerId: "codex",
           authProfileId: "openai:default",
-        },
-      ]);
-      const sibling = { ...materialization, modelId: "gpt-5.5" };
-      const distinctOwner = { ...materialization, runtimeOwnerId: "other-harness" };
-      recordRuntimeAuthMaterialization(sibling);
-      recordRuntimeAuthMaterialization(distinctOwner);
-      expect(
-        revokeRuntimeAuthMaterializations({
-          agentDir,
-          provider: "openai",
-          runtimeOwnerId: "codex",
-        }),
-      ).toBe(true);
-      expect(
-        revokeRuntimeAuthMaterializations({
-          agentDir,
-          provider: "openai",
-          runtimeOwnerId: "codex",
-        }),
-      ).toBe(false);
-      expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
-        expect.objectContaining({ runtimeOwnerId: "other-harness", modelId: "gpt-5.4" }),
-      ]);
-      expect(materializationListener).toHaveBeenCalledTimes(4);
-      expect(pluginStoreListener).not.toHaveBeenCalled();
+        } as const;
+        expect(recordRuntimeAuthMaterialization(materialization)).toBe(true);
+        expect(recordRuntimeAuthMaterialization(materialization)).toBe(false);
+        expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
+          {
+            provider: "openai",
+            modelId,
+            modelApi: "openai-chatgpt-responses",
+            modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+            requestTransportOverrides: "none",
+            authMode: "oauth",
+            runtimeOwnerId: "codex",
+            authProfileId: "openai:default",
+          },
+        ]);
+        const sibling = { ...materialization, modelId: modelId === "Model" ? "model" : "Model" };
+        const distinctOwner = { ...materialization, runtimeOwnerId: "other-harness" };
+        expect(recordRuntimeAuthMaterialization(sibling)).toBe(true);
+        recordRuntimeAuthMaterialization(distinctOwner);
+        expect(
+          revokeRuntimeAuthMaterializations({
+            agentDir,
+            provider: "openai",
+            runtimeOwnerId: "codex",
+          }),
+        ).toBe(true);
+        expect(
+          revokeRuntimeAuthMaterializations({
+            agentDir,
+            provider: "openai",
+            runtimeOwnerId: "codex",
+          }),
+        ).toBe(false);
+        expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([
+          expect.objectContaining({ runtimeOwnerId: "other-harness", modelId }),
+        ]);
+        expect(materializationListener).toHaveBeenCalledTimes(4);
+        expect(pluginStoreListener).not.toHaveBeenCalled();
 
-      recordRuntimeAuthMaterialization(materialization);
+        recordRuntimeAuthMaterialization(materialization);
 
-      setRuntimeAuthProfileStoreSnapshot(createStore("replaced"), agentDir);
-      expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([]);
-      expect(pluginStoreListener).toHaveBeenCalledOnce();
-    } finally {
-      unregisterMaterialization();
-      unregisterStore();
-      clearRuntimeAuthProfileStoreSnapshots();
-    }
-  });
+        setRuntimeAuthProfileStoreSnapshot(createStore("replaced"), agentDir);
+        expect(getPreparedRuntimeAuthMaterializations(agentDir)).toEqual([]);
+        expect(pluginStoreListener).toHaveBeenCalledOnce();
+      } finally {
+        unregisterMaterialization();
+        unregisterStore();
+        clearRuntimeAuthProfileStoreSnapshots();
+      }
+    },
+  );
 
   it("notifies listeners only when credential ownership changes", () => {
     const agentDir = "/tmp/openclaw-auth-runtime-listener";

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -165,66 +165,73 @@ describe("createModelAuthAvailabilityResolver", () => {
     },
   );
 
-  it("keeps successful harness auth scoped to the exact model route", () => {
-    const materialization = {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
-      requestTransportOverrides: "none",
-      authMode: "oauth",
-      runtimeOwnerId: "codex",
-    } as const;
-    const store = authStore({
-      "openai:default": {
-        type: "api_key",
+  it.each([
+    ["gpt-5.4", "gpt-5.5"],
+    ["Model", "model"],
+    ["model", "Model"],
+  ])(
+    "keeps successful harness auth scoped to the exact model route %s",
+    (modelId, otherModelId) => {
+      const materialization = {
         provider: "openai",
-        keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-      },
-    });
+        modelId,
+        modelApi: "openai-chatgpt-responses",
+        modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+        requestTransportOverrides: "none",
+        authMode: "oauth",
+        runtimeOwnerId: "codex",
+      } as const;
+      const store = authStore({
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      });
 
-    expect(
-      evaluate({
-        store,
-        ref: { modelId: "gpt-5.4" },
-        preparedRuntimeAuthMaterializations: [materialization],
-      }),
-    ).toMatchObject({
-      availability: true,
-      evidence: "runtime",
-      selectedRoute: subscriptionRoute,
-    });
-    expect(
-      evaluate({
-        store,
-        ref: { modelId: "gpt-5.5" },
-        preparedRuntimeAuthMaterializations: [materialization],
-      }).availability,
-    ).not.toBe(true);
-    expect(
-      evaluate({
-        cfg: {
-          models: {
-            providers: {
-              openai: {
-                auth: "api-key",
-                apiKey: "configured-platform-key",
-                baseUrl: "https://api.openai.com/v1",
-                models: [],
+      expect(
+        evaluate({
+          store,
+          ref: { modelId },
+          preparedRuntimeAuthMaterializations: [materialization],
+        }),
+      ).toMatchObject({
+        availability: true,
+        evidence: "runtime",
+        selectedRoute: subscriptionRoute,
+      });
+      expect(
+        evaluate({
+          store,
+          ref: { modelId: otherModelId },
+          preparedRuntimeAuthMaterializations: [materialization],
+        }).availability,
+      ).not.toBe(true);
+      expect(
+        evaluate({
+          cfg: {
+            models: {
+              providers: {
+                openai: {
+                  auth: "api-key",
+                  apiKey: "configured-platform-key",
+                  baseUrl: "https://api.openai.com/v1",
+                  models: [],
+                },
               },
             },
           },
-        },
-        store,
-        ref: { modelId: "gpt-5.4" },
-        preparedRuntimeAuthMaterializations: [materialization],
-      }),
-    ).toMatchObject({
-      availability: true,
-      evidence: "provider-config",
-      selectedRoute: platformRoute,
-    });
-  });
+          store,
+          ref: { modelId },
+          preparedRuntimeAuthMaterializations: [materialization],
+        }),
+      ).toMatchObject({
+        availability: true,
+        evidence: "provider-config",
+        selectedRoute: platformRoute,
+      });
+    },
+  );
 
   it.each([
     { label: "matching", authProfileId: "openai:default", availability: true },

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -1100,9 +1100,7 @@ export function createModelAuthAvailabilityResolver(
       ref.preferredProfileId,
       ref.pinnedProfileId,
     );
-    const materializedModelId = ref.modelId
-      ? normalizeModelIdForProvider(provider, ref.modelId)?.toLowerCase()
-      : undefined;
+    const materializedModelId = normalizeModelIdForProvider(provider, ref.modelId ?? "");
     const materialized =
       !modelLock &&
       !ref.pinnedProfileId &&


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where runtime authentication evidence for a case-sensitive model ID can satisfy a differently cased model. The recorder and availability reader both lowercase IDs, collapsing distinct custom models such as `Model` and `model`.

## Why This Change Was Made

Preserve model-ID case when recording and matching runtime auth facts. Keep trimming and existing provider normalization, profile restrictions, route compatibility, revocation and the 64-fact bound. The two production changes remove two lines; there is no persistent storage or configuration change.

## User Impact

A successful authentication result applies to the exact model that established it. Differently cased custom models remain separate.

## Evidence

Four intended baseline failures were reproduced. All 72 focused producer, reader and publication cases pass, along with the complete changed-file gate and independent P2 review.

A fresh canonical `sourcePerformance` runtime build passed at `2fb44fd507797fdbc19200adbde22c28347992db`. Compiled proof used the real bundled custom-route policy and two authenticated synthetic loopback requests preserving `Model` and `model`. After each request, the production recorder and availability reader accepted only its exact model case, rejected the opposite case, retained trimming and suppressed duplicate facts. Both fact scopes were revoked and verified empty; the server and isolated state were removed. All 2,476 imports were compiled, with no source imports.

This is compiled loopback plus recorder/reader boundary proof; it does not exercise the native harness lifecycle. The runtime build profile covers runtime assets, not UI or declaration generation.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34446322907) passed.
