### PR TITLE
fix(test): close CLI fixture databases before deleting state

### DIFF
--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -18,6 +18,8 @@ import {
 import type { CliBackendPlugin } from "../plugins/cli-backend.types.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   prepareSystemAgentRunAdmission,
   type PreparedAgentRunAdmission,
@@ -429,6 +431,9 @@ export function createCliRunnerPrepareFixture(prepareCliRun: PrepareCliRun) {
       }
       databasePaths.clear();
       for (const dir of tempDirs) {
+        closeOpenClawStateDatabaseByPath(
+          resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: dir }),
+        );
         fs.rmSync(dir, { recursive: true, force: true });
       }
       tempDirs.clear();

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -53,7 +53,11 @@ import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-trans
 import type { SkillLibraryAuthoringCapability } from "../../skills/library/authoring.js";
 import { buildSkillSnapshot } from "../../skills/loading/workspace-skill-prompt.js";
 import type { SkillSnapshot } from "../../skills/types.js";
-import { closeOpenClawStateDatabaseByPath } from "../../state/openclaw-state-db.js";
+import { closeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { connectUserModelAccount } from "../../state/user-model-accounts.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
@@ -691,6 +695,53 @@ describe("prepareCliRunContext", () => {
     setActiveDegradedSecretOwners([]);
     vi.unstubAllEnvs();
     fixture.cleanup();
+  });
+
+  it("closes owned state handles before removing preparation directories", () => {
+    const sessions = [fixture.session, fixture.createSession()];
+    const ownedState = sessions.map(({ dir }) => ({
+      dir,
+      database: openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: dir } }),
+    }));
+    const unrelatedDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-unrelated-")),
+    );
+    const unrelated = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: unrelatedDir } });
+    const removed: string[] = [];
+    const remove = fs.rmSync;
+    const removal = vi.spyOn(fs, "rmSync").mockImplementation((target, options) => {
+      const owned = ownedState.find(({ dir }) => dir === target);
+      if (owned) {
+        // Refuse unsafe unlink on the original bug, leaving files intact for finally cleanup.
+        expect(owned.database.db.isOpen, "state handle must close before directory removal").toBe(
+          false,
+        );
+        removed.push(owned.dir);
+      }
+      remove(target, options);
+    });
+    try {
+      fixture.cleanup();
+      expect(removed).toEqual(sessions.map(({ dir }) => dir));
+      for (const { dir } of sessions) {
+        expect(fs.existsSync(dir)).toBe(false);
+      }
+      unrelated.db.exec(
+        "CREATE TEMP TABLE cleanup_probe (value INTEGER); INSERT INTO cleanup_probe VALUES (7);",
+      );
+      expect(unrelated.db.prepare("SELECT value FROM cleanup_probe").get()).toEqual({ value: 7 });
+    } finally {
+      removal.mockRestore();
+      for (const { sessionTarget } of sessions) {
+        closeOpenClawAgentDatabaseByPath(sessionTarget.storePath);
+      }
+      for (const { database } of ownedState) {
+        closeOpenClawStateDatabaseByPath(database.path);
+      }
+      fixture.cleanup();
+      closeOpenClawStateDatabaseByPath(unrelated.path);
+      fs.rmSync(unrelatedDir, { recursive: true, force: true });
+    }
   });
 
   it.each(["process", "plugin"] as const)(
@@ -3100,95 +3151,91 @@ describe("prepareCliRunContext", () => {
     "reuses CLI session bindings across new inbound messages with stable binding facts for $name",
     async ({ stableMode, staticPrompt, expectedStrongPrompt }) => {
       const { dir } = fixture.session;
-      try {
-        const getActiveMcpLoopbackRuntime = vi.fn(() => ({
-          port: 31783,
-          ownerToken: "loopback-owner-token",
-          nonOwnerToken: "loopback-non-owner-token",
-        }));
-        const resolveMcpLoopbackScopedTools = vi.fn(() => ({
-          agentId: "main",
-          tools: [
-            {
-              name: "message",
-              label: "Message",
-              description: "Send a message",
-              parameters: { type: "object", properties: {} },
-              execute: vi.fn(),
-            },
-          ],
-        }));
-        setCliRunnerPrepareTestDeps({
-          getActiveMcpLoopbackRuntime,
-          resolveMcpLoopbackScopedTools,
-        });
-        const cliSessionBindingFacts = {
-          extraSystemPromptStatic: staticPrompt,
-          sourceReplyDeliveryMode: stableMode,
-        };
-        const config = createCliBackendConfig({ bundleMcp: true });
-        const first = await fixture.prepare({
-          config,
-          sessionKey: "main",
-          prompt: "first ask",
-          requireExplicitMessageTarget: true,
-          extraSystemPrompt: `volatile msg-1\n\n${staticPrompt}`,
-          sourceReplyDeliveryMode: "message_tool_only",
-          currentMessageId: "msg-1",
-          cliSessionBindingFacts,
-        });
-        const second = await fixture.prepare({
-          config,
-          sessionKey: "main",
-          prompt: "second ask",
-          extraSystemPrompt: `volatile msg-2\n\n${staticPrompt}`,
-          sourceReplyDeliveryMode: stableMode,
-          currentMessageId: "msg-2",
-          cliSessionBindingFacts,
-          cliSessionBinding: {
-            sessionId: "cli-session",
-            extraSystemPromptHash: first.extraSystemPromptHash,
-            messageToolPolicyHash: first.messageToolPolicyHash,
-            promptToolNamesHash: first.promptToolNamesHash,
-            cwdHash: hashCliSessionText(dir),
-            mcpConfigHash: first.preparedBackend.mcpConfigHash,
-            mcpResumeHash: first.preparedBackend.mcpResumeHash,
+      const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      }));
+      const resolveMcpLoopbackScopedTools = vi.fn(() => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "message",
+            label: "Message",
+            description: "Send a message",
+            parameters: { type: "object", properties: {} },
+            execute: vi.fn(),
           },
-        });
+        ],
+      }));
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        resolveMcpLoopbackScopedTools,
+      });
+      const cliSessionBindingFacts = {
+        extraSystemPromptStatic: staticPrompt,
+        sourceReplyDeliveryMode: stableMode,
+      };
+      const config = createCliBackendConfig({ bundleMcp: true });
+      const first = await fixture.prepare({
+        config,
+        sessionKey: "main",
+        prompt: "first ask",
+        requireExplicitMessageTarget: true,
+        extraSystemPrompt: `volatile msg-1\n\n${staticPrompt}`,
+        sourceReplyDeliveryMode: "message_tool_only",
+        currentMessageId: "msg-1",
+        cliSessionBindingFacts,
+      });
+      const second = await fixture.prepare({
+        config,
+        sessionKey: "main",
+        prompt: "second ask",
+        extraSystemPrompt: `volatile msg-2\n\n${staticPrompt}`,
+        sourceReplyDeliveryMode: stableMode,
+        currentMessageId: "msg-2",
+        cliSessionBindingFacts,
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          extraSystemPromptHash: first.extraSystemPromptHash,
+          messageToolPolicyHash: first.messageToolPolicyHash,
+          promptToolNamesHash: first.promptToolNamesHash,
+          cwdHash: hashCliSessionText(dir),
+          mcpConfigHash: first.preparedBackend.mcpConfigHash,
+          mcpResumeHash: first.preparedBackend.mcpResumeHash,
+        },
+      });
 
-        expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
-          1,
-          expect.objectContaining({
-            context: expect.objectContaining({ requireExplicitMessageTarget: true }),
-          }),
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          context: expect.objectContaining({ requireExplicitMessageTarget: true }),
+        }),
+      );
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          context: expect.objectContaining({ requireExplicitMessageTarget: undefined }),
+        }),
+      );
+      expect(first.extraSystemPromptHash).toBe(hashCliSessionText(staticPrompt));
+      expect(first.messageToolPolicyHash).toBeDefined();
+      expect(second.extraSystemPromptHash).toBe(first.extraSystemPromptHash);
+      expect(second.messageToolPolicyHash).toBe(first.messageToolPolicyHash);
+      expect(second.promptToolNamesHash).toBe(first.promptToolNamesHash);
+      if (expectedStrongPrompt) {
+        expect(first.systemPrompt).toContain(
+          "Current source visible reply MUST use `message(action=send)`",
         );
-        expect(resolveMcpLoopbackScopedTools).toHaveBeenNthCalledWith(
-          2,
-          expect.objectContaining({
-            context: expect.objectContaining({ requireExplicitMessageTarget: undefined }),
-          }),
+      } else {
+        expect(first.systemPrompt).toContain(
+          "Current-session final text normally routes to source",
         );
-        expect(first.extraSystemPromptHash).toBe(hashCliSessionText(staticPrompt));
-        expect(first.messageToolPolicyHash).toBeDefined();
-        expect(second.extraSystemPromptHash).toBe(first.extraSystemPromptHash);
-        expect(second.messageToolPolicyHash).toBe(first.messageToolPolicyHash);
-        expect(second.promptToolNamesHash).toBe(first.promptToolNamesHash);
-        if (expectedStrongPrompt) {
-          expect(first.systemPrompt).toContain(
-            "Current source visible reply MUST use `message(action=send)`",
-          );
-        } else {
-          expect(first.systemPrompt).toContain(
-            "Current-session final text normally routes to source",
-          );
-          expect(first.systemPrompt).toContain(
-            "If turn says final private, visible output uses `message(action=send)`",
-          );
-        }
-        expect(second.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
+        expect(first.systemPrompt).toContain(
+          "If turn says final private, visible output uses `message(action=send)`",
+        );
       }
+      expect(second.reusableCliSession).toEqual({ mode: "reuse", sessionId: "cli-session" });
     },
   );
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Long Linux test runs can terminate when a CLI preparation fixture deletes its state directory while the shared-state SQLite connection is still open. The WAL identity guard later sees a deleted sidecar and correctly terminates the process.

## Why This Change Was Made

Close each fixture-owned shared-state database after agent database closure releases its lease, and before removing the directory. Resolve those paths from recorded fixture roots so cleanup preserves unrelated open databases. Remove a redundant per-case directory deletion that bypassed the fixture's teardown owner.

## User Impact

CLI preparation tests release their SQLite resources safely. Runtime SQLite protection and production behavior remain unchanged.

## Evidence

A deterministic regression creates two fixture roots and an unrelated writable state owner. Its removal observer checks real handle closure before forwarding any unlink. Against the original helper it fails at the live-handle assertion without deleting the live database files; test-owned final cleanup then closes them safely. No uninstrumented original full-suite pass is claimed.

All five complete consumer suites pass after the repair: 202 tests, zero failures or skips. The non-isolated single-worker run completes prepare.test.ts before prepare.rooted-execution.test.ts, preserving the observed failure-run order. All existing case identities and assertions remain intact.

The mapped changed gate and independent review validate the final change. The first gate caught unchecked indexes in the new regression; pairing each directory with its database removed those accesses, and the final original-red/candidate-green proof was repeated. This adds 52 net test/support lines and makes no runtime speedup claim.

Exact-head CI passed on attempt 2 of run 34446810813. Attempt 1 failed in the unrelated package-boundary compiler test when tsgo execve aborted with ETXTBSY before compilation. The single retry reran only compact-small-19 and its dependent gate and passed without source changes. The busy inode's underlying cause remains unconfirmed; the original failure is retained.
