### PR TITLE
perf: avoid empty plugin inventories during updates

### DIFF
--- a/src/plugins/update-cohort.test.ts
+++ b/src/plugins/update-cohort.test.ts
@@ -64,7 +64,7 @@ function pluginRecord(params: {
 
 function installedIndex(params: {
   records: Record<string, PluginInstallRecord>;
-  plugin: InstalledPluginIndexRecord;
+  plugin?: InstalledPluginIndexRecord;
 }): InstalledPluginIndex {
   return {
     version: 1,
@@ -74,7 +74,7 @@ function installedIndex(params: {
     policyHash: "test",
     generatedAtMs: 1,
     installRecords: params.records,
-    plugins: [params.plugin],
+    plugins: params.plugin ? [params.plugin] : [],
     diagnostics: [],
   };
 }
@@ -98,7 +98,56 @@ describe("plugin release cohort package reconciliation", () => {
     }));
   });
 
-  it.each(["missing", "replaced"] as const)(
+  it("keeps updates and payload verification active without initial install owners", async () => {
+    const config = { plugins: { entries: { unrelated: { enabled: false } } } };
+    const records = {
+      introduced: {
+        source: "npm",
+        spec: "@example/introduced",
+        installPath: "/plugins/introduced",
+      },
+    } satisfies Record<string, PluginInstallRecord>;
+    const updatedConfig = { plugins: { ...config.plugins, installs: records } };
+    const remaining = [
+      { pluginId: "introduced", installPath: "/plugins/introduced", reason: "missing-package-dir" },
+    ];
+    // A valid empty index makes the old path fail on unwanted discovery, not a mock error.
+    loadInstalledPluginIndexMock.mockReturnValue(installedIndex({ records: {} }));
+    updateNpmInstalledPluginsMock.mockResolvedValue({
+      config: updatedConfig,
+      changed: true,
+      outcomes: [],
+    });
+    collectMissingPluginInstallPayloadsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(remaining);
+
+    const result = await convergePluginReleaseCohort({
+      config,
+      channel: "stable",
+      timeoutMs: 60_000,
+    });
+
+    expect(syncPluginsForUpdateChannelMock).toHaveBeenCalledOnce();
+    expect(updateNpmInstalledPluginsMock).toHaveBeenCalledOnce();
+    expect(collectMissingPluginInstallPayloadsMock).toHaveBeenCalledTimes(2);
+    expect(collectMissingPluginInstallPayloadsMock).toHaveBeenNthCalledWith(2, {
+      records,
+      config: updatedConfig,
+      skipDisabledPlugins: true,
+      syncOfficialPluginInstalls: true,
+      env: undefined,
+    });
+    expect(result.config).toEqual(updatedConfig);
+    expect(result).toMatchObject({
+      changed: true,
+      npmChanged: true,
+      remainingMissingPayloads: remaining,
+    });
+    expect(loadInstalledPluginIndexMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["missing", "replaced", "replaced after sync introduces its owner"] as const)(
     "reconciles %s payloads against the new package metadata",
     async (state) => {
       const { loadInstalledPluginIndex } = await vi.importActual<
@@ -129,7 +178,7 @@ describe("plugin release cohort package reconciliation", () => {
         );
         fs.writeFileSync(path.join(installPath, "index.js"), "module.exports = {};\n");
       };
-      if (state === "replaced") {
+      if (state !== "missing") {
         writePayload("retired-child");
       }
       const records = {
@@ -161,9 +210,26 @@ describe("plugin release cohort package reconciliation", () => {
         };
       });
 
+      if (state === "replaced after sync introduces its owner") {
+        syncPluginsForUpdateChannelMock.mockResolvedValueOnce({
+          config,
+          changed: true,
+          summary: {
+            switchedToBundled: [],
+            switchedToClawHub: [],
+            switchedToNpm: [],
+            warnings: [],
+            errors: [],
+          },
+        });
+      }
+      const inputConfig =
+        state === "replaced after sync introduces its owner"
+          ? { ...config, plugins: { ...config.plugins, installs: {} } }
+          : config;
       const result = await withPluginCache(createPluginCache(), () =>
         convergePluginReleaseCohort({
-          config,
+          config: inputConfig,
           channel: "stable",
           timeoutMs: 60_000,
           env,
@@ -171,7 +237,7 @@ describe("plugin release cohort package reconciliation", () => {
       );
 
       expect(result.config.plugins?.entries?.unrelated).toEqual({ enabled: false });
-      if (state === "replaced") {
+      if (state !== "missing") {
         expect(result.config.plugins?.entries).not.toHaveProperty("retired-child");
       }
       expect(result.config.plugins?.installs?.cohort?.version).toBe("1.0.0");

--- a/src/plugins/update-cohort.ts
+++ b/src/plugins/update-cohort.ts
@@ -60,20 +60,26 @@ export async function convergePluginReleaseCohort(params: {
   let config = sync.config;
   let changed = sync.changed;
   let npmChanged = false;
-  const beforeIndex = withPluginCache(createPluginCache(), () =>
-    loadInstalledPluginIndex({
-      config,
-      installRecords: config.plugins?.installs ?? {},
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    }),
-  );
-  const packageUpdateSnapshot = capturePluginPackageUpdateSnapshot({
-    index: beforeIndex,
-    installOwners: Object.keys(config.plugins?.installs ?? {}),
-    env: params.env,
-  });
-  if (!packageUpdateSnapshot.ok) {
+  const installOwners = Object.keys(config.plugins?.installs ?? {});
+  // Without prior package owners there is no retired child policy to reconcile.
+  const beforeIndex = installOwners.length
+    ? withPluginCache(createPluginCache(), () =>
+        loadInstalledPluginIndex({
+          config,
+          installRecords: config.plugins?.installs ?? {},
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        }),
+      )
+    : undefined;
+  const packageUpdateSnapshot = beforeIndex
+    ? capturePluginPackageUpdateSnapshot({
+        index: beforeIndex,
+        installOwners,
+        env: params.env,
+      })
+    : undefined;
+  if (packageUpdateSnapshot && !packageUpdateSnapshot.ok) {
     throw new Error(packageUpdateSnapshot.error);
   }
   const installOwnerMigrations: Record<string, string> = {};
@@ -132,29 +138,31 @@ export async function convergePluginReleaseCohort(params: {
   npmChanged ||= update.changed;
   Object.assign(installOwnerMigrations, resolvePluginInstallOwnerMigrations(update));
 
-  // Reinstall can restore the same path. Reconciliation needs new filesystem facts,
-  // including formerly missing files, without retiring a retained runtime generation.
-  const afterIndex = withPluginCache(createPluginCache(), () =>
-    loadInstalledPluginIndex({
+  if (beforeIndex && packageUpdateSnapshot) {
+    // Reinstall can restore the same path. Reconciliation needs new filesystem facts,
+    // including formerly missing files, without retiring a retained runtime generation.
+    const afterIndex = withPluginCache(createPluginCache(), () =>
+      loadInstalledPluginIndex({
+        config,
+        installRecords: config.plugins?.installs ?? {},
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      }),
+    );
+    const reconciled = reconcilePluginPackageUpdateConfig({
       config,
-      installRecords: config.plugins?.installs ?? {},
-      workspaceDir: params.workspaceDir,
+      beforeIndex,
+      afterIndex,
+      snapshot: packageUpdateSnapshot.value,
+      installOwnerMigrations,
       env: params.env,
-    }),
-  );
-  const reconciled = reconcilePluginPackageUpdateConfig({
-    config,
-    beforeIndex,
-    afterIndex,
-    snapshot: packageUpdateSnapshot.value,
-    installOwnerMigrations,
-    env: params.env,
-  });
-  if (!reconciled.ok) {
-    throw new Error(reconciled.error);
+    });
+    if (!reconciled.ok) {
+      throw new Error(reconciled.error);
+    }
+    changed ||= reconciled.config !== config;
+    config = reconciled.config;
   }
-  changed ||= reconciled.config !== config;
-  config = reconciled.config;
 
   return {
     config,


### PR DESCRIPTION
## What Problem This Solves

Updates with no package install owners still build two full plugin inventories solely to reconcile an empty ownership snapshot. A traced update-CLI case spent about 489 ms in those two reads, with no reconciliation work to perform.

## Why This Change Was Made

Derive the owner set after channel synchronization, and skip only the before/after inventory, snapshot and reconciliation pair when it is empty. Synchronization, missing-payload repair, npm updates, owner-migration capture and final payload verification still run. Nonempty owners retain independent fresh inventories and the existing ownership checks.

The guard adds eight production lines and no helper, API, cache or storage mechanism. The tests cover both no initial owners and owners introduced by synchronization, including removal of retired child policy after package replacement.

## User Impact

Empty package reconciliation avoids unnecessary discovery work. Update outcomes, configuration behavior and validation remain unchanged. This is one focused optimization; it does not claim to solve the entire update-CLI CI slowdown.

## Evidence

The new regression failed against original code on exactly two unwanted inventory calls, after the update/result/final-verification assertions had passed. The final 16 unit and real synchronization integration cases passed, including missing/replaced payloads, owner migration, post-sync ownership and the existing isolated registry flow.

All 479 unchanged update-CLI cases passed, with exact name/multiplicity coverage matching the retained main CI inventory. That full local command took 17m11.71s; it is correctness evidence, not a controlled whole-suite performance comparison. No test was removed, filtered, weakened or given a longer timeout in that run.

The full changed-file gate passed. Independent P2 review found no actionable issues. The canonical build passed, including SDK export and CLI bootstrap checks. Exact-head CI is required before landing.
