### PR TITLE
fix(daemon): report not-yet-run Windows Scheduled Task as unknown, not stopped

### DIFF
--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -95,12 +95,19 @@ function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
 } {
   const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
   if (normalizedResult != null) {
-    return RUNNING_RESULT_CODES.has(normalizedResult)
-      ? { status: "running" }
-      : {
-          status: "stopped",
-          detail: `Task Last Run Result=${parsed.lastRunResult}; treating as not running.`,
-        };
+    if (RUNNING_RESULT_CODES.has(normalizedResult)) {
+      return { status: "running" };
+    }
+    if (NOT_YET_RUN_RESULT_CODES.has(normalizedResult)) {
+      return {
+        status: "unknown",
+        detail: `Task Last Run Result=${parsed.lastRunResult}; task has not run yet.`,
+      };
+    }
+    return {
+      status: "stopped",
+      detail: `Task Last Run Result=${parsed.lastRunResult}; treating as not running.`,
+    };
   }
   return parsed.status?.trim()
     ? { status: "unknown", detail: UNKNOWN_STATUS_DETAIL }

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -120,6 +120,24 @@ describe("scheduled task runtime derivation", () => {
     });
   });
 
+  it("treats not-yet-run result code (0x41303) as unknown, not stopped", async () => {
+    await expect(
+      readRuntimeFromQueryOutput(taskQueryOutput(["Status: Ready", "Last Run Result: 0x41303"])),
+    ).resolves.toMatchObject({
+      status: "unknown",
+      detail: "Task Last Run Result=0x41303; task has not run yet.",
+    });
+  });
+
+  it("treats not-yet-run decimal result code (267011) as unknown, not stopped", async () => {
+    await expect(
+      readRuntimeFromQueryOutput(taskQueryOutput(["Status: Ready", "Last Run Result: 267011"])),
+    ).resolves.toMatchObject({
+      status: "unknown",
+      detail: "Task Last Run Result=267011; task has not run yet.",
+    });
+  });
+
   it("detects running via result code when status is localized (German)", async () => {
     await expect(
       readRuntimeFromQueryOutput(


### PR DESCRIPTION
## Problem

On Windows the Gateway service runtime is derived from a Scheduled Task query. `parseSchtasksQuery` reads the task's numeric `Last Run Result`, and `deriveScheduledTaskRuntimeStatus` (in `src/daemon/schtasks-runtime.ts`) mapped **every** numeric result that was not a "running" code to `stopped`.

`SCHED_S_TASK_HAS_NOT_RUN` (`0x41303`, decimal `267011`) is the state of a task that has been registered but never launched. It was therefore reported as `stopped`, i.e. "the service ran and exited".

## User impact

Right after a fresh install (or after re-registering the task), and before its first launch, `openclaw gateway status` / the service status surfaces the Gateway as **stopped** with the detail "treating as not running". The user sees a healthy, scheduled service as failed/exited and is pushed toward reinstall / manual start. Any consumer that keys on `status === "stopped"` ("not running" messaging or automation) misfires.

The actual state ("registered, never ran yet") and the state the user is shown ("stopped") diverge inside `deriveScheduledTaskRuntimeStatus`: it has no notion of the not-yet-run result code, so it cannot distinguish "never ran" from "ran and exited".

## Root cause

`src/daemon/schtasks-runtime.ts` -> `deriveScheduledTaskRuntimeStatus`:

```
const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
if (normalizedResult != null) {
  return RUNNING_RESULT_CODES.has(normalizedResult)
    ? { status: "running" }
    : { status: "stopped", detail: `...; treating as not running.` };   // <- 0x41303 falls here
}
```

This function is the source-of-truth owner of the business status: it is the boundary that turns the raw `schtasks` `Last Run Result` into the `GatewayServiceRuntime.status` the CLI/UI display. The bug lives here, not in the CLI or channel that renders the string.

## Fix

At the owner boundary, recognize the not-yet-run result code and report `unknown` (with an explicit detail) instead of the generic `stopped`:

- Add `export const NOT_YET_RUN_RESULT_CODES = new Set(["0x41303"])`. The existing `normalizeTaskResultCode` canonicalizes decimal `267011` to `0x41303`, so both spellings match.
- Return `{ status: "unknown", detail: `Task Last Run Result=<x>; task has not run yet.` }` before the `stopped` fallback.

No string special-casing was added in the UI, channel, or CLI. Diff: +19 / -6 in `src/daemon/schtasks-runtime.ts`.

## Non-goals

- No change to running (`0x41301`) or real exit-code (`0x0`, non-zero) behavior.
- No change to the locale-dependent "no numeric result" fallback.
- No schema, config, protocol, or public API change.
- No refactor of the service-status pipeline; no auto-start/repair of the task.

## Regression test

`src/daemon/schtasks.test.ts` gains two cases:

- `treats not-yet-run result code (0x41303) as unknown, not stopped`
- `treats not-yet-run decimal result code (267011) as unknown, not stopped`

Both assert `status: "unknown"` plus the new detail; both fail against pre-fix code (which returned `stopped`).

Harness note: the repository Vitest harness could not execute inside this sandbox — its shared non-isolated runner aborts on `test/setup-openclaw-runtime.ts` with `Vitest failed to find the runner` on both Node 22.20 and Node 24.19 (unrelated to this change). The near-real runtime proof below is therefore the primary evidence.

## Runtime proof

Near-real runtime, real code path: the REAL `readScheduledTaskRuntime` (`src/daemon/schtasks.ts`) is driven end-to-end through the REAL child-process pipeline (`resolveSafeChildProcessInvocation` -> `execa`, `shell: false`). Only the OS `schtasks.exe` binary is replaced by a PATH shim `schtasks.cmd` that emits the exact `/Query /TN <task> /V /FO LIST` output Windows produces (`Status: Ready` plus a given `Last Run Result`). Harness: `_tmp/proofs/schtasks-not-yet-run.proof.mjs`.

**Before** (`src/daemon/schtasks-runtime.ts` from `origin/main`) — `_tmp/proofs/schtasks-not-yet-run_before.log`:

```
Last Run Result=0x41303  (SCHED_S_TASK_HAS_NOT_RUN (hex)) -> status=stopped | detail=Task Last Run Result=0x41303; treating as not running.
Last Run Result=267011   (SCHED_S_TASK_HAS_NOT_RUN (decimal)) -> status=stopped | detail=Task Last Run Result=267011; treating as not running.
Last Run Result=0x0      (ran and exited 0 (control)) -> status=stopped | detail=Task Last Run Result=0x0; treating as not running.
Last Run Result=0x41301  (currently running (control)) -> status=running | detail=(none)
```

**After** (this branch) — `_tmp/proofs/schtasks-not-yet-run_after.log`:

```
Last Run Result=0x41303  (SCHED_S_TASK_HAS_NOT_RUN (hex)) -> status=unknown | detail=Task Last Run Result=0x41303; task has not run yet.
Last Run Result=267011   (SCHED_S_TASK_HAS_NOT_RUN (decimal)) -> status=unknown | detail=Task Last Run Result=267011; task has not run yet.
Last Run Result=0x0      (ran and exited 0 (control)) -> status=stopped | detail=Task Last Run Result=0x0; treating as not running.
Last Run Result=0x41301  (currently running (control)) -> status=running | detail=(none)
```

The two controls (`0x0` exited, `0x41301` running) are byte-identical before and after; only the never-run codes change, and only in the intended way (`stopped` -> `unknown`).

## Compatibility/risk

- Additive and low-risk. The only behavior change is for result code `0x41303`/`267011`: its reported status changes `stopped` -> `unknown` and its detail string changes.
- `unknown` is an existing status already produced when the locale-dependent status cannot be resolved to a numeric result, so every consumer already handles it.
- Running and real exit-code cases are unchanged.
- Backward compatible: no callers, schemas, or configs are modified.
