### PR TITLE
fix(telegram): respect routed agent thinking defaults

### DIFF
--- a/extensions/telegram/src/bot-native-command-builtins.test.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.test.ts
@@ -442,6 +442,44 @@ describe("Telegram native command built-ins", () => {
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
+  it.each(["high", "off"] as const)(
+    "uses the routed agent's per-model %s thinking default",
+    async (thinking) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            thinkingDefault: "medium",
+            models: { "openai/gpt-5.5": { params: { thinking: "low" } } },
+          },
+          entries: {
+            main: {},
+            alpha: {
+              models: { "openai/gpt-5.5": { params: { thinking } } },
+            },
+          },
+        },
+        bindings: [{ agentId: "alpha", match: { channel: "telegram", accountId: "default" } }],
+      };
+      const { handler, sendMessage } = registerAndResolveCommandHandler({
+        commandName: "think",
+        cfg,
+        allowFrom: ["*"],
+      });
+      await handler(createTelegramPrivateCommandContext());
+
+      expectSendMessageCall({
+        sendMessage,
+        chatId: 100,
+        textIncludes: `Current thinking level: ${thinking}.\nChoose level for /think.`,
+        requireReplyMarkup: true,
+        label: "routed agent model thinking menu",
+      });
+      expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not load the session store when a native argument menu is skipped", async () => {
     const { handler } = registerAndResolveCommandHandler({
       commandName: "think",

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -217,6 +217,7 @@ async function resolveTelegramThinkMenuCurrentLevel(params: {
   const defaultModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
   return await resolveThinkingDefaultWithRuntimeCatalog({
     cfg: params.cfg,
+    agentId: params.agentId,
     provider: params.provider ?? defaultModel.provider,
     model: params.model ?? defaultModel.model,
     agentRuntime: params.agentRuntime,

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -39,6 +39,7 @@ export async function resolveThinkingDefaultWithRuntimeCatalogCore(params: {
   cfg: OpenClawConfig;
   provider: string;
   model: string;
+  agentId?: string;
   loadRuntimeCatalog: () => Promise<ModelCatalogEntry[]>;
   agentRuntime?: string | null;
 }): Promise<ThinkLevel> {
@@ -60,6 +61,7 @@ export async function resolveThinkingDefaultWithRuntimeCatalogCore(params: {
       : configuredCatalog;
   return resolveThinkingDefault({
     cfg: params.cfg,
+    agentId: params.agentId,
     provider: params.provider,
     model: params.model,
     catalog,


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where Telegram's bare `/think` menu shows the shared thinking default instead of the per-model default configured for the routed agent. An agent configured for `high` or `off` could incorrectly show the shared `low` value.

## Why This Change Was Made

Carry the routed agent ID through the existing runtime-catalog thinking-default resolver. The repair adds three production lines and retains the existing model, runtime, and session behavior.

## User Impact

The `/think` menu displays the correct default for the agent handling that conversation.

## Evidence

Both new high/off regressions failed before the repair; all 14 Telegram cases and 9 SDK sibling cases pass. The complete changed-file gate and independent P2 review passed.

One canonical `gatewayWatch` build with the OpenAI and Telegram plugins passed at `8182500e17f47be5e914c2a056ea0eecaeea0c8e`. This profile covers runtime assets, not UI or declaration generation. Exact-head readiness and the canonical Telegram doctor passed.

Two fresh isolated Telegram Test Server DM runs each sent bare `/think` once. The resulting menus showed the configured `high` and `off` values, with zero model requests. Both runners exited successfully; leases were released, ports closed, and credential/Gateway scratch removed. The initial launcher-only path mismatch was corrected outside the source tree before any doctor, lease, or send occurred; source and build stayed unchanged.
