### PR TITLE
refactor: share prepared completion cleanup

### DIFF
--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
 /**
  * Simple completion runtime preparation.
@@ -17,12 +16,7 @@ import {
 } from "../plugins/provider-hook-runtime.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
-import {
-  AsyncWorkScope,
-  captureAsyncWorkTracker,
-  getAsyncWorkSignal,
-} from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
+import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import {
   resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
@@ -636,11 +630,6 @@ async function acquirePreparedSimpleCompletionModel(
     context: PreparedSimpleCompletionResolverContext,
   ) => Promise<PreparedSimpleCompletionModel>,
 ): Promise<AcquiredSimpleCompletionModel> {
-  const result = createDeferredCore<AcquiredSimpleCompletionModel>();
-  const trackOwner = captureAsyncWorkTracker();
-  const parentSignal = getAsyncWorkSignal();
-  const work = new AsyncWorkScope();
-  let runInContext = work.run(() => AsyncLocalStorage.snapshot());
   let releaseRuntime: (() => void) | undefined;
   let setupSettled = false;
   let callerReleased = true;
@@ -651,7 +640,14 @@ async function acquirePreparedSimpleCompletionModel(
       release?.();
     }
   };
-  const prepare = async () => {
+  return await runWithAsyncWorkResources(async (onAcquired, captureWorkContext) => {
+    // Host work includes setup only; host close releases adopted model claims after drainage.
+    onAcquired({
+      release: () => {
+        setupSettled = true;
+        releaseWhenUnused();
+      },
+    });
     const context = await acquirePreparedSimpleCompletionRuntime(
       params,
       runtimePluginSelections,
@@ -660,7 +656,7 @@ async function acquirePreparedSimpleCompletionModel(
       },
     );
     const prepared = await withPluginRuntimeGenerationScope(context.preparedModelRuntime, () => {
-      runInContext = AsyncLocalStorage.snapshot();
+      captureWorkContext();
       return prepareModel(context);
     });
     if ("error" in prepared) {
@@ -674,32 +670,7 @@ async function acquirePreparedSimpleCompletionModel(
         releaseWhenUnused();
       },
     };
-  };
-  // Host work includes setup only; host close releases adopted model claims after drainage.
-  void trackOwner(async () => {
-    const closeFromParent = () => runInContext(() => work.beginClose(parentSignal?.reason));
-    parentSignal?.addEventListener("abort", closeFromParent, { once: true });
-    if (parentSignal?.aborted) {
-      closeFromParent();
-    }
-    try {
-      result.resolve(await work.track(prepare));
-    } catch (error) {
-      result.reject(error);
-    } finally {
-      try {
-        await AsyncWorkScope.runWhenAllIdle(
-          () => [work],
-          () => runInContext(() => work.drain()),
-        );
-      } finally {
-        parentSignal?.removeEventListener("abort", closeFromParent);
-        setupSettled = true;
-        releaseWhenUnused();
-      }
-    }
-  }).catch(result.reject);
-  return await result.promise;
+  });
 }
 
 export { completeWithPreparedSimpleCompletionModel } from "./simple-completion-execution.js";


### PR DESCRIPTION
Related: #130706, #142100. Follows #143716.

## What Problem This Solves

Prepared completion acquisition duplicates the tracked cleanup lifecycle already shared by isolated completions and TTS. That duplication makes it harder to maintain the requirement that setup work and the acquired caller both finish before model resources are released.

## Why This Change Was Made

Use the existing shared async-work resource owner. Keep the release state, successful caller callback, captured runtime context, and both release conditions unchanged. This maintainer-requested cleanup changes one production file and removes 29 lines.

## User Impact

Prepared completions retain their existing result timing and resource lifetime with one cleanup implementation.

## Evidence

The reviewed patch was replayed without conflicts or changes onto main containing #143813 and the separate test-fixture and UI-lint repairs #143875 and #143889. Fresh validation at `859c1d72b3f13e50d822829cce4e400a777703f5` passed 37 focused cases, the full changed-file gate, and one canonical `sourcePerformance` runtime build. All seven prior review source inputs remain identical, so the independent P2 review remains applicable.

Two freshly compiled ordinary acquisition cases passed with the caller releasing before cleanup drained and with cleanup draining before caller release. Both completed a loopback request, kept the resource open while either condition remained outstanding, and observed exactly one disposal afterward. Each loaded 2,881 compiled imports and no checkout-source files. The build uses its natural new commit metadata; no artifact was restamped. This runtime profile excludes UI and declarations.

Run generations own selected plugin resources, following #143725. An older external proof initially asserted caller-owned raw-resource behavior; that failure and the correction to the current owner contract remain preserved in the original evidence. The refreshed proof uses the corrected contract unchanged. Ephemeral ownership remains covered by existing source tests.
