### PR TITLE
fix: release Watch HTTP fixture databases before cleanup

### DIFF
--- a/src/gateway/watch-node-http.test-helpers.ts
+++ b/src/gateway/watch-node-http.test-helpers.ts
@@ -2,7 +2,6 @@ import {
   createServer,
   request as httpRequest,
   type ClientRequest,
-  type Server,
   type ServerResponse,
 } from "node:http";
 import { expect, vi } from "vitest";
@@ -26,7 +25,7 @@ import { createWatchNodeHttpRuntime } from "./watch-node-http.js";
 
 export async function startWatchNodeHttpRuntime(
   baseDir: string,
-  servers: Server[],
+  cleanups: Array<() => Promise<void>>,
   options?: {
     rateLimiter?: AuthRateLimiter;
     abortConnectResponse?: boolean;
@@ -64,6 +63,7 @@ export async function startWatchNodeHttpRuntime(
   const connectHandled = new Promise<void>((resolve) => {
     resolveConnectHandled = resolve;
   });
+  const requests: Array<Promise<PromiseSettledResult<void>[]>> = [];
   const server = createServer((req, res) => {
     const isConnect = req.url === "/api/nodes/watch/connect";
     if (isConnect && options?.onConnectResponseStart) {
@@ -79,24 +79,39 @@ export async function startWatchNodeHttpRuntime(
         return res;
       }) as typeof res.end;
     }
-    void runtime
-      .handleRequest(req, res)
-      .then((handled) => {
-        if (!handled && !res.writableEnded) {
-          res.statusCode = 404;
-          res.end();
-        }
-        if (req.url === "/api/nodes/watch/poll" && !res.writableEnded) {
-          options?.onPollReady?.(res);
-        }
-      })
-      .finally(() => {
-        if (isConnect) {
-          resolveConnectHandled();
-        }
-      });
+    requests.push(
+      Promise.allSettled([
+        runtime
+          .handleRequest(req, res)
+          .then((handled) => {
+            if (!handled && !res.writableEnded) {
+              res.statusCode = 404;
+              res.end();
+            }
+            if (req.url === "/api/nodes/watch/poll" && !res.writableEnded) {
+              options?.onPollReady?.(res);
+            }
+          })
+          .finally(() => {
+            if (isConnect) {
+              resolveConnectHandled();
+            }
+          }),
+      ]),
+    );
   });
-  servers.push(server);
+  cleanups.push(async () => {
+    runtime.close();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    const results = (await Promise.all(requests)).flat();
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
+  });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
   });

--- a/src/gateway/watch-node-http.test.ts
+++ b/src/gateway/watch-node-http.test.ts
@@ -1,4 +1,4 @@
-import { request as httpRequest, type Server, type ServerResponse } from "node:http";
+import { request as httpRequest, type ServerResponse } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -32,6 +32,8 @@ import {
   VOICE_NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   type DeviceBootstrapProfile,
 } from "../shared/device-bootstrap-profile.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import { serializeEventPayload } from "./node-registry.js";
@@ -45,16 +47,42 @@ import {
 } from "./watch-node-http.test-helpers.js";
 
 const tempDirs = createTrackedTempDirs();
-const servers: Server[] = [];
+const cleanups: Array<() => Promise<void>> = [];
+const databasePaths = new Set<string>();
 
 afterEach(async () => {
-  for (const server of servers.splice(0)) {
-    await new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Watch node fixture cleanup failed", { cause: errors[0] });
+  }
+  // Handlers enqueue connection history; drain that writer before closing its database.
+  await withDevicePairingLock(async () => {});
+  for (const databasePath of databasePaths) {
+    closeOpenClawStateDatabaseByPath(databasePath);
   }
   await tempDirs.cleanup();
+  cleanups.length = 0;
+  databasePaths.clear();
 });
+
+async function makeWatchNodeDir(prefix: string): Promise<string> {
+  const baseDir = await tempDirs.make(prefix);
+  databasePaths.add(path.join(baseDir, "watch-identity.sqlite"));
+  databasePaths.add(
+    resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: baseDir }),
+  );
+  return baseDir;
+}
 
 async function createWatchNodeFixture(
   prefix: string,
@@ -62,7 +90,7 @@ async function createWatchNodeFixture(
     bootstrapProfile?: DeviceBootstrapProfile;
   },
 ) {
-  const baseDir = await tempDirs.make(prefix);
+  const baseDir = await makeWatchNodeDir(prefix);
   const identity = loadOrCreateDeviceIdentity({
     path: path.join(baseDir, "watch-identity.sqlite"),
   });
@@ -74,7 +102,7 @@ async function createWatchNodeFixture(
     baseDir,
     identity,
     issued,
-    ...(await startWatchNodeHttpRuntime(baseDir, servers, options)),
+    ...(await startWatchNodeHttpRuntime(baseDir, cleanups, options)),
   };
 }
 
@@ -541,7 +569,7 @@ describe("watch node HTTP transport", () => {
       pruneIntervalMs: 0,
     };
 
-    const abortedBaseDir = await tempDirs.make("openclaw-watch-node-aborted-connect-");
+    const abortedBaseDir = await makeWatchNodeDir("openclaw-watch-node-aborted-connect-");
     const abortedIdentity = loadOrCreateDeviceIdentity({
       path: path.join(abortedBaseDir, "watch-identity.sqlite"),
     });
@@ -551,7 +579,7 @@ describe("watch node HTTP transport", () => {
     });
     const abortedLimiter = createAuthRateLimiter(limiterConfig);
     try {
-      const abortedRuntime = await startWatchNodeHttpRuntime(abortedBaseDir, servers, {
+      const abortedRuntime = await startWatchNodeHttpRuntime(abortedBaseDir, cleanups, {
         rateLimiter: abortedLimiter,
         abortConnectResponse: true,
       });
@@ -603,7 +631,7 @@ describe("watch node HTTP transport", () => {
       abortedLimiter.dispose();
     }
 
-    const completedBaseDir = await tempDirs.make("openclaw-watch-node-completed-connect-");
+    const completedBaseDir = await makeWatchNodeDir("openclaw-watch-node-completed-connect-");
     const completedIdentity = loadOrCreateDeviceIdentity({
       path: path.join(completedBaseDir, "watch-identity.sqlite"),
     });
@@ -613,7 +641,7 @@ describe("watch node HTTP transport", () => {
     });
     const completedLimiter = createAuthRateLimiter(limiterConfig);
     try {
-      const completedRuntime = await startWatchNodeHttpRuntime(completedBaseDir, servers, {
+      const completedRuntime = await startWatchNodeHttpRuntime(completedBaseDir, cleanups, {
         rateLimiter: completedLimiter,
       });
       const connectResponse = await connectWatchNode({
@@ -634,7 +662,7 @@ describe("watch node HTTP transport", () => {
   });
 
   it("restores an uncorrelated bootstrap token when the connect response aborts", async () => {
-    const baseDir = await tempDirs.make("openclaw-watch-node-generic-abort-");
+    const baseDir = await makeWatchNodeDir("openclaw-watch-node-generic-abort-");
     const identity = loadOrCreateDeviceIdentity({
       path: path.join(baseDir, "watch-identity.sqlite"),
     });
@@ -642,7 +670,7 @@ describe("watch node HTTP transport", () => {
       baseDir,
       profile: NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
     });
-    const runtime = await startWatchNodeHttpRuntime(baseDir, servers, {
+    const runtime = await startWatchNodeHttpRuntime(baseDir, cleanups, {
       abortConnectResponse: true,
     });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Watch HTTP tests removed temporary identity and pairing databases while cached SQLite handles were still open. A full Linux run later terminated its gateway-core shard on a WAL sidecar identity mismatch for the first Watch fixture, after all 21 Watch cases had passed.

## Why This Change Was Made

Keep teardown with the fixture owner: close the runtime and server, join complete HTTP handler outcomes, drain the existing pairing-write queue, close the two exact database paths, then remove temporary files. Every registered cleanup is attempted in order; cleanup failures are retained and prevent directory deletion. All direct fixture allocations use the same ownership tracking.

## User Impact

No production or SQLite safety changes. Watch transport tests keep their existing assertions and asynchronous disconnect behavior while releasing fixture databases before deleting their files.

## Evidence

- A safe instrumented baseline preserved all 21 cases and observed 44 live owned database handles after request/write drainage. Diagnostic safety closes ran before unlinking; this was not an unmodified passing baseline or an induced process termination.
- Final normal suite: all 21 cases passed. A separate final observation passed the same ordered 21 cases, with all 44 paths already closed before unlinking and no extra diagnostic closes.
- Five extracted-callback controls passed: held handler promise with a synthetic server-close callback, the actual pairing-lock queue, later cleanup after an earlier failure, ordered aggregate failures, and files preserved when database closure fails.
- Changed-file gate and fresh independent review passed. No case deletion, deadline increase, global database close, or Linux full-run-readiness claim.
