### PR TITLE
fix: stop oversized worker manifest reads early

### DIFF
--- a/src/gateway/worker-environments/workspace-sync-inventory-limits.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory-limits.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
+import { workspaceStatIdentity } from "./workspace-hash-memo.js";
 import {
   MAX_WORKSPACE_GIT_CANDIDATES,
   MAX_WORKSPACE_INVENTORY_ENTRIES,
@@ -13,11 +14,16 @@ import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-async function gitWorkspace(name: string) {
-  const root = tempDirs.make(`${name}-`);
+async function manifestWorkspace(name: string) {
+  const root = await fs.realpath(tempDirs.make(`${name}-`));
   const home = path.join(root, "home");
   const workspace = path.join(root, "workspace");
   await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
+  return { root, home, workspace };
+}
+
+async function gitWorkspace(name: string) {
+  const { home, workspace } = await manifestWorkspace(name);
   await fs.writeFile(path.join(workspace, ".gitignore"), "");
   for (const args of [
     ["init", "--quiet"],
@@ -44,6 +50,161 @@ async function gitWorkspace(name: string) {
   ).stdout.trim();
   return { home, workspace, baseCommit };
 }
+
+it.each([
+  { firstSize: 8, secondSize: 11, cached: true, accepted: true },
+  { firstSize: 8, secondSize: 12, cached: true, accepted: false },
+  { firstSize: 12, secondSize: 7, cached: false, accepted: true },
+])(
+  "budgets opened files ($firstSize + $secondSize) and symlink bytes with cached=$cached",
+  async ({ firstSize, secondSize, cached, accepted }) => {
+    const { root, home, workspace } = await manifestWorkspace("openclaw-manifest-open-budget");
+    const first = path.join(workspace, "a.txt");
+    const second = path.join(workspace, "b.txt");
+    const auditPath = path.join(root, "handles.json");
+    const contents = Buffer.alloc(8, 65);
+    await Promise.all([fs.writeFile(first, contents), fs.writeFile(second, contents)]);
+    await fs.symlink("a.txt", path.join(workspace, "link"));
+    const memo = cached
+      ? [
+          [
+            workspaceStatIdentity("worker", await fs.stat(first, { bigint: true })),
+            createHash("sha256").update(contents).digest("hex"),
+          ],
+        ]
+      : [];
+    // Keep real descriptors and hashing; resize only after inventory, at open.
+    const prelude = String.raw`{
+      const io = require("node:fs");
+      const sizes = new Map(${JSON.stringify([
+        [first, firstSize],
+        [second, secondSize],
+      ])});
+      const handles = [];
+      const open = io.promises.open.bind(io.promises);
+      io.promises.open = async (...args) => {
+        const size = sizes.get(args[0]);
+        if (size !== undefined && io.statSync(args[0]).size !== size) {
+          io.truncateSync(args[0], size);
+        }
+        const handle = await open(...args);
+        if (size !== undefined) handles.push(handle);
+        return handle;
+      };
+      process.once("exit", () => io.writeFileSync(
+        ${JSON.stringify(auditPath)}, JSON.stringify(handles.map((handle) => handle.fd === -1)),
+      ));
+    }
+    `;
+    // Scale the existing limit so this race uses bytes, not GiB of I/O.
+    const script = REMOTE_WORKSPACE_MANIFEST_JS.replace(
+      `const MAX_WORKSPACE_INVENTORY_TOTAL_BYTES = ${MAX_WORKSPACE_INVENTORY_TOTAL_BYTES};`,
+      "const MAX_WORKSPACE_INVENTORY_TOTAL_BYTES = 24;",
+    );
+    expect(script).not.toBe(REMOTE_WORKSPACE_MANIFEST_JS);
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", prelude + script, workspace, "", "all", "memo-v1"],
+      { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: home }, input: JSON.stringify(memo) },
+    );
+    expect(JSON.parse(await fs.readFile(auditPath, "utf8"))).toEqual([true, true]);
+    const manifestRoot = path.join(home, ".openclaw-worker", "manifests");
+    if (!accepted) {
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("eligible byte limit");
+      expect(result.stdout).toBe("");
+      expect(await fs.readdir(manifestRoot)).toEqual([]);
+      return;
+    }
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const response = JSON.parse(result.stdout) as {
+      manifestRef: string;
+      metrics: { contentHashCount: number; memoHitCount: number };
+    };
+    expect(response.metrics).toMatchObject({
+      contentHashCount: cached ? 1 : 2,
+      memoHitCount: cached ? 1 : 0,
+    });
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(manifestRoot, `${response.manifestRef.slice(7)}.json`), "utf8"),
+    ) as { entries: Array<{ path: string; type: string; size?: number; target?: string }> };
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({ path: "a.txt", type: "file", size: firstSize }),
+      expect.objectContaining({ path: "b.txt", type: "file", size: secondSize }),
+      expect.objectContaining({ path: "link", type: "symlink", target: "a.txt" }),
+    ]);
+  },
+);
+
+it("stops hashing a growing file at its opened size and settles its stream and handle", async () => {
+  const { root, home, workspace } = await manifestWorkspace("openclaw-manifest-stream-budget");
+  const target = path.join(workspace, "growing.txt");
+  const auditPath = path.join(root, "stream.json");
+  await fs.writeFile(target, "12345678");
+  const prelude = String.raw`{
+    const io = require("node:fs");
+    const crypto = require("node:crypto");
+    const target = ${JSON.stringify(target)};
+    const audit = { consumed: 0, hashed: 0, grew: false, streamClosed: false };
+    let opened;
+    let reading;
+    const createHash = crypto.createHash.bind(crypto);
+    crypto.createHash = (...args) => {
+      const hash = createHash(...args);
+      const update = hash.update.bind(hash);
+      hash.update = (chunk, ...options) => {
+        audit.hashed += chunk.length;
+        return update(chunk, ...options);
+      };
+      return hash;
+    };
+    const open = io.promises.open.bind(io.promises);
+    io.promises.open = async (...args) => {
+      const handle = await open(...args);
+      if (args[0] !== target) return handle;
+      opened = handle;
+      const createReadStream = handle.createReadStream.bind(handle);
+      handle.createReadStream = (options) => {
+        const stream = createReadStream({ ...options, highWaterMark: 2 });
+        reading = stream;
+        stream.on("data", (chunk) => {
+          audit.consumed += chunk.length;
+          if (!audit.grew) {
+            audit.grew = true;
+            io.appendFileSync(target, Buffer.alloc(64));
+          }
+        });
+        stream.once("close", () => { audit.streamClosed = true; });
+        return stream;
+      };
+      return handle;
+    };
+    process.once("exit", () => io.writeFileSync(${JSON.stringify(auditPath)}, JSON.stringify({
+      ...audit, handleClosed: opened.fd === -1, streamDestroyed: reading.destroyed,
+    })));
+  }
+  `;
+  const result = await runCommandWithTimeout(
+    [process.execPath, "-e", prelude + REMOTE_WORKSPACE_MANIFEST_JS, workspace],
+    { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: home } },
+  );
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toContain("file changed while it was being read");
+  expect(result.stdout).toBe("");
+  const audit = JSON.parse(await fs.readFile(auditPath, "utf8")) as {
+    consumed: number;
+    hashed: number;
+  };
+  expect(audit).toMatchObject({
+    grew: true,
+    handleClosed: true,
+    streamClosed: true,
+    streamDestroyed: true,
+  });
+  expect(audit.consumed).toBeLessThan(72);
+  expect(audit.hashed).toBeLessThanOrEqual(8);
+  expect((await fs.stat(target)).size).toBe(72);
+  expect(await fs.readdir(path.join(home, ".openclaw-worker", "manifests"))).toEqual([]);
+});
 
 it("rejects a full workspace above 4 GiB before hashing its files", async () => {
   const { home, workspace, baseCommit } = await gitWorkspace("openclaw-manifest-byte-budget");

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -352,6 +352,11 @@ function assertSerializedManifestBudget(baseCommit, entries) {
   }
 }
 async function hashFiles(entries) {
+  // Inventory file sizes can change before open; reserve their actual sizes below.
+  let openedBytes = entries.reduce(
+    (bytes, entry) => bytes + (entry.type === "symlink" ? Buffer.byteLength(entry.target) : 0),
+    0,
+  );
   for (const entry of entries) {
     if (entry.type !== "file") {
       continue;
@@ -364,6 +369,11 @@ async function hashFiles(entries) {
     try {
       const before = await handle.stat({ bigint: true });
       if (!before.isFile()) fail("worker workspace file changed while it was being read");
+      const size = Number(before.size);
+      openedBytes += size;
+      if (openedBytes > MAX_WORKSPACE_INVENTORY_TOTAL_BYTES) {
+        fail("worker workspace manifest exceeds its eligible byte limit");
+      }
       const identity = workspaceStatIdentity("worker", before);
       let sha256 = hashMemo.get(identity);
       if (sha256) {
@@ -372,7 +382,10 @@ async function hashFiles(entries) {
         const hashStartedAt = performance.now();
         const hash = crypto.createHash("sha256");
         const stream = handle.createReadStream({ autoClose: false });
+        let bytesRead = 0;
         for await (const chunk of stream) {
+          bytesRead += chunk.length;
+          if (bytesRead > size) fail("worker workspace file changed while it was being read");
           hash.update(chunk);
         }
         sha256 = hash.digest("hex");


### PR DESCRIPTION
Related: #134931

## What Problem This Solves

Fixes excessive worker filesystem reads when files grow after workspace inventory or while a completed turn's manifest is being captured. An oversized result could be rejected only after hashing its contents.

## Why This Change Was Made

The existing sequential capture now accounts for each opened file's current size, including memo hits, alongside symlink target bytes before reading. A streaming file that exceeds its opened size fails before the extra chunk is hashed. The existing 4 GiB limit, manifest format, memo identity, and cleanup owners are preserved.

## User Impact

Growing or oversized workspaces fail promptly with the existing diagnostic, without publishing a partial manifest. Stable files that grow or shrink before opening remain supported within the total limit.

## Evidence

- Two regressions fail on the original code; 37 focused and sibling cases pass after the repair, covering memo hits, aggregate boundaries, pre-open growth/shrinkage, streaming growth, and stream/descriptor cleanup.
- A real Node 24.20.0 run of the generated script at its normal limit used a sparse file grown to 4,294,967,297 bytes (4,096 bytes allocated). The original reached its first content-read attempt and was stopped by the fixture; the fix rejected the byte limit with zero content-read attempts and a closed handle. No multi-gigabyte read was performed.
- Fresh independent review is clean through P2, and the full changed-file gate passed, including production/test typechecks and selected repository guards.

This is a two-file extraction with 13 added production lines. Runtime evidence uses the actual generated remote script and local filesystem; it is not a cloud-provider experiment.
