### PR TITLE
fix(backup): exclude private update captures from ordinary exports

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -88,6 +88,15 @@ update those settings to their new locations before restarting. See
 [Restore a full archive](/install/backups#restore-a-full-archive) for the full
 disaster-recovery sequence.
 
+## Private update captures
+
+The managed `<stateDir>.update-captures/` root is excluded from ordinary archives,
+SQLite snapshots, Git backups, and support exports. Selecting a containing or
+nested workspace does not override this rule. Selecting a capture file as config
+or as a database backup source refuses the backup. Unrelated similarly named
+workspace directories remain included. This exclusion does not create captures
+or change ordinary backup sanitization.
+
 ## SQLite snapshots
 
 Use `openclaw backup sqlite` when you need a portable artifact for one OpenClaw-owned SQLite database instead of a broad state archive.

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -93,9 +93,15 @@ disaster-recovery sequence.
 The managed `<stateDir>.update-captures/` root is excluded from ordinary archives,
 SQLite snapshots, Git backups, and support exports. Selecting a containing or
 nested workspace does not override this rule. Selecting a capture file as config
-or as a database backup source refuses the backup. Unrelated similarly named
-workspace directories remain included. This exclusion does not create captures
-or change ordinary backup sanitization.
+or as a database backup source refuses the backup. Other states' captures are
+recognized by the exact sibling layout: `<owner>/` beside
+`<owner>.update-captures/`, with an existing owner directory. Canonical path
+aliases receive the same protection. Unrelated similarly named workspace
+directories remain included; a suffix alone does not establish ownership.
+
+Keep captures at their managed location alongside their owner. Moved, renamed,
+or orphaned captures from another state cannot be identified by this rule.
+This exclusion does not create captures or change ordinary backup sanitization.
 
 ## SQLite snapshots
 

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBackupArchive } from "../infra/backup-create.js";
+import { createGitBackup } from "../snapshot/git-backup.js";
+import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { verifyBackupArchive } from "./backup-verify.js";
+
+describe("private update capture exclusion", () => {
+  let home: TempHomeEnv;
+  let stateDir: string;
+  let captureRoot: string;
+  beforeEach(async () => {
+    home = await createTempHomeEnv("backup-capture-privacy-");
+    stateDir = path.join(home.home, ".openclaw");
+    captureRoot = `${stateDir}.update-captures`;
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+    await fs.mkdir(path.join(captureRoot, "completed"), { recursive: true });
+    await fs.writeFile(path.join(captureRoot, "completed", "private.txt"), "retained raw bytes");
+    await fs.mkdir(`${captureRoot}-notes`);
+    await fs.writeFile(
+      path.join(`${captureRoot}-notes`, "healthy.txt"),
+      "ordinary workspace bytes",
+    );
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await home.restore();
+  });
+
+  it.each(["parent", "nested"])(
+    "excludes captures selected through a %s workspace",
+    async (selection) => {
+      const config = {
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: {
+              workspace: selection === "parent" ? home.home : path.join(captureRoot, "completed"),
+            },
+            healthy: { workspace: `${captureRoot}-notes` },
+          },
+        },
+      };
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify(config));
+      const output = path.join(path.dirname(home.home), `${path.basename(home.home)}.tar.gz`);
+      try {
+        const result = await createBackupArchive({ output });
+        const entries: string[] = [];
+        await tar.t({
+          file: result.archivePath,
+          onReadEntry: (entry) => {
+            entries.push(entry.path);
+          },
+        });
+        expect(entries.some((entry) => entry.endsWith("/private.txt"))).toBe(false);
+        expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
+        await verifyBackupArchive(result.archivePath);
+        expect(await fs.readFile(path.join(captureRoot, "completed", "private.txt"), "utf8")).toBe(
+          "retained raw bytes",
+        );
+      } finally {
+        await fs.rm(output, { force: true });
+      }
+    },
+  );
+
+  it.each(["sqlite", "git"])("refuses capture inputs in %s snapshots", async (kind) => {
+    const databasePath = path.join(captureRoot, "completed", "database.sqlite");
+    const source = new DatabaseSync(databasePath);
+    source.exec(OPENCLAW_STATE_SCHEMA_SQL);
+    source.exec(`PRAGMA user_version=${OPENCLAW_STATE_SCHEMA_VERSION}`);
+    source
+      .prepare(
+        "INSERT INTO schema_meta(meta_key,role,schema_version,created_at,updated_at) VALUES('primary','global',?,1,1)",
+      )
+      .run(OPENCLAW_STATE_SCHEMA_VERSION);
+    source.close();
+    const before = await fs.readFile(databasePath);
+    const database = { path: databasePath, identity: { role: "global" as const } };
+    const repositoryPath = path.join(home.home, "backup-repository");
+    const create =
+      kind === "sqlite"
+        ? createLocalSqliteSnapshotProvider({ repositoryPath }).create(database)
+        : createGitBackup({
+            repositoryPath,
+            stateDir,
+            databases: [database],
+            gitEnv: {
+              ...process.env,
+              GIT_AUTHOR_NAME: "OpenClaw Test",
+              GIT_AUTHOR_EMAIL: "test@example.invalid",
+              GIT_COMMITTER_NAME: "OpenClaw Test",
+              GIT_COMMITTER_EMAIL: "test@example.invalid",
+            },
+          });
+    await expect(create).rejects.toThrow("Private update captures are excluded");
+    expect(await fs.readFile(databasePath)).toEqual(before);
+  });
+
+  it.each([false, true])(
+    "refuses a raw capture selected as config, onlyConfig=%s",
+    async (onlyConfig) => {
+      const configPath = path.join(captureRoot, "completed", "config.json");
+      await fs.writeFile(configPath, "{}");
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+      await expect(createBackupArchive({ onlyConfig, dryRun: true })).rejects.toThrow(
+        "Private update captures are excluded",
+      );
+    },
+  );
+});

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -71,8 +71,70 @@ describe("private update capture exclusion", () => {
     },
   );
 
-  it.each(["sqlite", "git"])("refuses capture inputs in %s snapshots", async (kind) => {
-    const databasePath = path.join(captureRoot, "completed", "database.sqlite");
+  it("excludes another state's paired capture root from a public archive", async () => {
+    const otherState = path.join(home.home, "profile-b");
+    const otherCapture = `${otherState}.update-captures`;
+    const healthy = `${otherCapture}-notes`;
+    // A same-suffix directory without a paired owner is ordinary workspace data.
+    const unowned = path.join(home.home, "research.update-captures");
+    for (const directory of [otherState, path.join(otherCapture, "run"), healthy, unowned]) {
+      await fs.mkdir(directory, { recursive: true });
+    }
+    const privateFile = path.join(otherCapture, "run", "private-b.txt");
+    await fs.writeFile(privateFile, "synthetic private B bytes");
+    await fs.writeFile(path.join(otherCapture, "run", "config.json"), '{"synthetic":"raw B"}');
+    await fs.writeFile(path.join(healthy, "healthy-b.txt"), "healthy B neighbor");
+    await fs.writeFile(path.join(unowned, "research.txt"), "ordinary research");
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: { ownership: "explicit", entries: { main: { workspace: home.home } } },
+      }),
+    );
+    const output = path.join(
+      path.dirname(home.home),
+      `${path.basename(home.home)}-cross-state.tar.gz`,
+    );
+    try {
+      const result = await createBackupArchive({ output });
+      const entries: string[] = [];
+      await tar.t({
+        file: result.archivePath,
+        onReadEntry: (entry) => {
+          entries.push(entry.path);
+        },
+      });
+      await verifyBackupArchive(result.archivePath);
+      expect(entries.some((entry) => entry.endsWith("/healthy-b.txt"))).toBe(true);
+      expect(entries.some((entry) => entry.endsWith("/research.txt"))).toBe(true);
+      expect(await fs.readFile(privateFile, "utf8")).toBe("synthetic private B bytes");
+      expect(entries.some((entry) => entry.includes("/profile-b.update-captures/"))).toBe(false);
+    } finally {
+      await fs.rm(output, { force: true });
+    }
+  });
+
+  it.each([
+    ["sqlite", "current"],
+    ["git", "current"],
+    ["sqlite", "other"],
+    ["git", "other"],
+    ["sqlite", "alias"],
+    ["git", "alias"],
+  ])("refuses capture inputs in %s snapshots from %s state", async (kind, owner) => {
+    let selectedRoot = captureRoot;
+    if (owner !== "current") {
+      const otherState = path.join(home.home, "profile-b");
+      await fs.mkdir(otherState);
+      selectedRoot = `${otherState}.update-captures`;
+      await fs.mkdir(path.join(selectedRoot, "completed"), { recursive: true });
+      if (owner === "alias") {
+        const alias = path.join(home.home, "capture-alias");
+        await fs.symlink(selectedRoot, alias, process.platform === "win32" ? "junction" : "dir");
+        selectedRoot = alias;
+      }
+    }
+    const databasePath = path.join(selectedRoot, "completed", "database.sqlite");
     const source = new DatabaseSync(databasePath);
     source.exec(OPENCLAW_STATE_SCHEMA_SQL);
     source.exec(`PRAGMA user_version=${OPENCLAW_STATE_SCHEMA_VERSION}`);

--- a/src/commands/backup-resource-inventory.ts
+++ b/src/commands/backup-resource-inventory.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isVolatileBackupPath } from "../infra/backup-volatile-filter.js";
 import { hasErrnoCode } from "../infra/errno.js";
+import { isUpdateCapturePath } from "../infra/update-capture-paths.js";
 import type { ResolvedPluginBackupResource } from "../plugins/manifest-backup-resources.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { isPathWithin } from "./cleanup-utils.js";
@@ -197,6 +198,9 @@ export async function createBackupResourceInventory(params: {
 
   const isIncluded = (sourcePath: string): boolean => {
     const candidate = path.resolve(sourcePath);
+    if (isUpdateCapturePath(candidate, stateDir)) {
+      return false;
+    }
     const exclusion = excludedPaths.find((excludedPath) => isPathWithin(candidate, excludedPath));
     if (!exclusion) {
       return true;
@@ -210,6 +214,9 @@ export async function createBackupResourceInventory(params: {
   };
   const isTraversable = (sourcePath: string): boolean => {
     const candidate = path.resolve(sourcePath);
+    if (isUpdateCapturePath(candidate, stateDir)) {
+      return false;
+    }
     return (
       isIncluded(candidate) ||
       protectedPaths.some((protectedPath) => isPathWithin(protectedPath, candidate))

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -14,6 +14,7 @@ import {
   type BackupConfigCapture,
 } from "../infra/backup-config-capture.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { assertNotUpdateCapturePath, isUpdateCapturePath } from "../infra/update-capture-paths.js";
 import {
   resolveActivatedPluginBackupInventory,
   type ActivatedPluginBackupInventory,
@@ -68,7 +69,7 @@ export function resolveRequiredBackupPath(
 }
 
 type BackupAssetKind = "state" | "config" | "credentials" | "workspace" | "agent" | "managed skill";
-type BackupSkipReason = "covered" | "missing" | "regenerable" | "unresolved";
+type BackupSkipReason = "covered" | "missing" | "regenerable" | "unresolved" | "private";
 
 export type BackupAsset = {
   kind: BackupAssetKind;
@@ -191,6 +192,12 @@ async function resolveBackupPlanFromPaths(params: {
   const onlyConfig = params.onlyConfig ?? false;
   const stateDir = params.stateDir;
   const configPath = params.configPath;
+  for (const sourcePath of [
+    configPath,
+    ...(params.configCapture?.files ?? []).map((file) => file.canonicalPath),
+  ]) {
+    assertNotUpdateCapturePath(sourcePath, stateDir);
+  }
   const oauthDir = params.oauthDir;
   const archiveRoot = buildBackupArchiveRoot(params.nowMs);
   const requestedWorkspaceDirs = params.workspaceDirs ?? [];
@@ -355,6 +362,15 @@ async function resolveBackupPlanFromPaths(params: {
   const skipped: SkippedBackupAsset[] = [];
 
   for (const candidate of uniqueCandidates) {
+    if (isUpdateCapturePath(candidate.canonicalPath, stateDir)) {
+      skipped.push({
+        kind: candidate.kind,
+        sourcePath: candidate.canonicalPath,
+        displayPath: shortenHomePath(candidate.canonicalPath),
+        reason: "private",
+      });
+      continue;
+    }
     if (!candidate.exists) {
       if (
         candidate.kind === "agent" &&

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -55,6 +55,7 @@ import {
   type LegacyAuditBackupSnapshot,
 } from "./state-migrations.audit-backup.js";
 import { withLegacyAuditMigrationLease } from "./state-migrations.audit-coordination.js";
+import { isUpdateCapturePath } from "./update-capture-paths.js";
 
 const loadTarRuntime = createLazyRuntimeModule(() => import("tar"));
 
@@ -577,6 +578,14 @@ export async function createBackupArchive(
       const resolvedEntryPath = path.resolve(entryPath);
       if (resolvedEntryPath === manifestPath) {
         return true;
+      }
+      if (
+        isUpdateCapturePath(
+          sourcePathRemaps.get(resolvedEntryPath) ?? resolvedEntryPath,
+          plan.stateDir,
+        )
+      ) {
+        return false;
       }
       const isDirectory =
         "isDirectory" in entryStat ? entryStat.isDirectory() : entryStat.type === "Directory";

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -1,10 +1,39 @@
 // Retained raw update artifacts never enter sanitized backup or support exports.
+import fs from "node:fs";
 import path from "node:path";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { hasErrnoCode } from "./errno.js";
 import { isPathInside } from "./path-guards.js";
 
+const CAPTURE_SUFFIX = ".update-captures";
+
 function resolveUpdateCaptureRoot(stateDir: string): string {
-  return `${path.resolve(stateDir)}.update-captures`;
+  return `${path.resolve(stateDir)}${CAPTURE_SUFFIX}`;
+}
+
+function isPairedCapturePath(candidate: string): boolean {
+  // Only inspect the selected path's ancestors, not other profiles or a global registry.
+  // The sibling directory anchors the reserved layout; it is not writer authority.
+  for (
+    let ancestor = candidate;
+    path.dirname(ancestor) !== ancestor;
+    ancestor = path.dirname(ancestor)
+  ) {
+    const name = path.basename(ancestor);
+    if (name.length <= CAPTURE_SUFFIX.length || !name.endsWith(CAPTURE_SUFFIX)) {
+      continue;
+    }
+    try {
+      if (fs.statSync(ancestor.slice(0, -CAPTURE_SUFFIX.length)).isDirectory()) {
+        return true;
+      }
+    } catch (error) {
+      if (!hasErrnoCode(error, "ENOENT") && !hasErrnoCode(error, "ENOTDIR")) {
+        throw error;
+      }
+    }
+  }
+  return false;
 }
 
 /** Exact managed roots, not a basename filter that hides unrelated workspace files. */
@@ -15,12 +44,13 @@ export function isUpdateCapturePath(sourcePath: string, stateDir: string): boole
   ]);
   const candidate = path.resolve(sourcePath);
   const canonical = resolvePathViaExistingAncestorSync(sourcePath);
-  return [...roots].some((root) => {
+  const isSelectedStateCapture = [...roots].some((root) => {
     const resolvedRoot = resolvePathViaExistingAncestorSync(root);
     return [root, resolvedRoot].some(
       (boundary) => isPathInside(boundary, candidate) || isPathInside(boundary, canonical),
     );
   });
+  return isSelectedStateCapture || isPairedCapturePath(candidate) || isPairedCapturePath(canonical);
 }
 
 export function assertNotUpdateCapturePath(sourcePath: string, stateDir: string): void {

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -1,0 +1,30 @@
+// Retained raw update artifacts never enter sanitized backup or support exports.
+import path from "node:path";
+import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { isPathInside } from "./path-guards.js";
+
+function resolveUpdateCaptureRoot(stateDir: string): string {
+  return `${path.resolve(stateDir)}.update-captures`;
+}
+
+/** Exact managed roots, not a basename filter that hides unrelated workspace files. */
+export function isUpdateCapturePath(sourcePath: string, stateDir: string): boolean {
+  const roots = new Set([
+    resolveUpdateCaptureRoot(stateDir),
+    resolveUpdateCaptureRoot(resolvePathViaExistingAncestorSync(stateDir)),
+  ]);
+  const candidate = path.resolve(sourcePath);
+  const canonical = resolvePathViaExistingAncestorSync(sourcePath);
+  return [...roots].some((root) => {
+    const resolvedRoot = resolvePathViaExistingAncestorSync(root);
+    return [root, resolvedRoot].some(
+      (boundary) => isPathInside(boundary, candidate) || isPathInside(boundary, canonical),
+    );
+  });
+}
+
+export function assertNotUpdateCapturePath(sourcePath: string, stateDir: string): void {
+  if (isUpdateCapturePath(sourcePath, stateDir)) {
+    throw new Error("Private update captures are excluded from backups and support exports.");
+  }
+}

--- a/src/logging/diagnostic-support-export.test.ts
+++ b/src/logging/diagnostic-support-export.test.ts
@@ -46,6 +46,34 @@ describe("diagnostic support export", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  it("excludes capture files selected as config, logs, or a stability bundle", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const capture = `${stateDir}.update-captures`;
+    fs.mkdirSync(capture);
+    const privatePath = path.join(capture, "private.json");
+    const marker = "synthetic-retained-record-not-for-support";
+    fs.writeFileSync(privatePath, JSON.stringify({ agents: { entries: { [marker]: {} } } }));
+    const outputPath = path.join(tempDir, "support.zip");
+    await writeDiagnosticSupportExport({
+      stateDir,
+      env: { OPENCLAW_CONFIG_PATH: privatePath },
+      outputPath,
+      stabilityBundle: privatePath,
+      readLogTail: async () => ({
+        file: privatePath,
+        cursor: 1,
+        size: 1,
+        lines: [JSON.stringify({ msg: marker })],
+        truncated: false,
+        reset: false,
+      }),
+    });
+    const files = await readZipTextEntries(outputPath);
+    expect(Object.values(files).join("\n")).not.toContain(marker);
+    expect(Object.values(files).join("\n")).toContain("Private update captures are excluded");
+    expect(fs.readFileSync(privatePath, "utf8")).toContain(marker);
+  });
+
   it("writes a shareable zip without raw chats, webhook bodies, or secrets", async () => {
     const fakeToken = "sk-test-support-export-secret-token-1234567890";
     const fakeAwsKey = ["AKIA", "IOSFODNN7EXAMPLE"].join("");

--- a/src/logging/diagnostic-support-export.test.ts
+++ b/src/logging/diagnostic-support-export.test.ts
@@ -46,33 +46,46 @@ describe("diagnostic support export", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("excludes capture files selected as config, logs, or a stability bundle", async () => {
-    const stateDir = path.join(tempDir, "state");
-    const capture = `${stateDir}.update-captures`;
-    fs.mkdirSync(capture);
-    const privatePath = path.join(capture, "private.json");
-    const marker = "synthetic-retained-record-not-for-support";
-    fs.writeFileSync(privatePath, JSON.stringify({ agents: { entries: { [marker]: {} } } }));
-    const outputPath = path.join(tempDir, "support.zip");
-    await writeDiagnosticSupportExport({
-      stateDir,
-      env: { OPENCLAW_CONFIG_PATH: privatePath },
-      outputPath,
-      stabilityBundle: privatePath,
-      readLogTail: async () => ({
-        file: privatePath,
-        cursor: 1,
-        size: 1,
-        lines: [JSON.stringify({ msg: marker })],
-        truncated: false,
-        reset: false,
-      }),
-    });
-    const files = await readZipTextEntries(outputPath);
-    expect(Object.values(files).join("\n")).not.toContain(marker);
-    expect(Object.values(files).join("\n")).toContain("Private update captures are excluded");
-    expect(fs.readFileSync(privatePath, "utf8")).toContain(marker);
-  });
+  it.each(["current", "other-state alias"])(
+    "excludes %s capture files selected as config, logs, or a stability bundle",
+    async (owner) => {
+      const stateDir = path.join(tempDir, "state");
+      let capture = `${stateDir}.update-captures`;
+      if (owner !== "current") {
+        const otherState = path.join(tempDir, "other-state");
+        fs.mkdirSync(otherState);
+        capture = `${otherState}.update-captures`;
+      }
+      fs.mkdirSync(capture);
+      if (owner !== "current") {
+        const alias = path.join(tempDir, "capture-alias");
+        fs.symlinkSync(capture, alias, process.platform === "win32" ? "junction" : "dir");
+        capture = alias;
+      }
+      const privatePath = path.join(capture, "private.json");
+      const marker = "synthetic-retained-record-not-for-support";
+      fs.writeFileSync(privatePath, JSON.stringify({ agents: { entries: { [marker]: {} } } }));
+      const outputPath = path.join(tempDir, "support.zip");
+      await writeDiagnosticSupportExport({
+        stateDir,
+        env: { OPENCLAW_CONFIG_PATH: privatePath },
+        outputPath,
+        stabilityBundle: privatePath,
+        readLogTail: async () => ({
+          file: privatePath,
+          cursor: 1,
+          size: 1,
+          lines: [JSON.stringify({ msg: marker })],
+          truncated: false,
+          reset: false,
+        }),
+      });
+      const files = await readZipTextEntries(outputPath);
+      expect(Object.values(files).join("\n")).not.toContain(marker);
+      expect(Object.values(files).join("\n")).toContain("Private update captures are excluded");
+      expect(fs.readFileSync(privatePath, "utf8")).toContain(marker);
+    },
+  );
 
   it("writes a shareable zip without raw chats, webhook bodies, or secrets", async () => {
     const fakeToken = "sk-test-support-export-secret-token-1234567890";

--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -12,6 +12,7 @@ import { buildConfigSchemaCore } from "../config/schema.js";
 import { isMissingPathError } from "../infra/errors.js";
 import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { readRegularFileSync } from "../infra/regular-file.js";
+import { assertNotUpdateCapturePath } from "../infra/update-capture-paths.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { VERSION } from "../version.js";
 import {
@@ -329,6 +330,7 @@ function readConfigExport(options: {
   const redactedConfigPath = redactPathForSupport(options.configPath, options);
   let stat: fs.Stats | undefined;
   try {
+    assertNotUpdateCapturePath(options.configPath, options.stateDir);
     stat = fs.statSync(options.configPath);
     const { buffer } = readRegularFileSync({
       filePath: options.configPath,
@@ -411,10 +413,21 @@ function readStabilityBundle(
   if (target === false) {
     return { status: "missing", dir: "$OPENCLAW_STATE_DIR/logs/stability" };
   }
-  if (target === undefined || target === "latest") {
-    return readLatestDiagnosticStabilityBundleSync({ stateDir });
+  try {
+    if (target !== undefined && target !== "latest") {
+      assertNotUpdateCapturePath(target, stateDir);
+    }
+    const result =
+      target === undefined || target === "latest"
+        ? readLatestDiagnosticStabilityBundleSync({ stateDir })
+        : readDiagnosticStabilityBundleFileSync(target);
+    if (result.status === "found") {
+      assertNotUpdateCapturePath(result.path, stateDir);
+    }
+    return result;
+  } catch (error) {
+    return { status: "failed", error };
   }
-  return readDiagnosticStabilityBundleFileSync(target);
 }
 
 function sanitizeLogTail(tail: LogTailPayload, options: SupportRedactionContext): SanitizedLogTail {
@@ -528,6 +541,7 @@ async function collectSupportLogTail(params: {
       limit: params.limit,
       maxBytes: params.maxBytes,
     });
+    assertNotUpdateCapturePath(tail.file, params.redaction.stateDir);
     return sanitizeLogTail(tail, params.redaction);
   } catch (error) {
     return failedLogTail(error, params.redaction);

--- a/src/snapshot/git-backup.ts
+++ b/src/snapshot/git-backup.ts
@@ -11,6 +11,7 @@ import {
   requireGitCommand as requireGit,
   requireGitCommandOutput,
 } from "../infra/git-exec.js";
+import { assertNotUpdateCapturePath } from "../infra/update-capture-paths.js";
 import { formatCommandOutput, formatCommandResult } from "../process/command-error.js";
 import { spawnCommand } from "../process/exec-spawn.js";
 import { BACKUP_RUN_ERROR_MAX_LENGTH } from "../state/backup-run-records.contract.js";
@@ -275,6 +276,9 @@ export async function createGitBackup(params: {
   now?: Date;
   gitEnv?: NodeJS.ProcessEnv;
 }): Promise<GitBackupCreateResult> {
+  for (const database of params.databases) {
+    assertNotUpdateCapturePath(database.path, params.stateDir);
+  }
   const repositoryPath = path.resolve(params.repositoryPath);
   await initializeGitBackupRepository({
     repositoryPath,

--- a/src/snapshot/openclaw-snapshot-copy.ts
+++ b/src/snapshot/openclaw-snapshot-copy.ts
@@ -1,8 +1,10 @@
 import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
+import { resolveStateDir } from "../config/paths.js";
 import {
   createVerifiedSqliteSnapshot,
   type SqliteSnapshotValidator,
 } from "../infra/sqlite-snapshot.js";
+import { assertNotUpdateCapturePath } from "../infra/update-capture-paths.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
 import { assertOpenClawAgentDatabaseForMaintenance } from "../state/openclaw-agent-db.js";
 import { assertOpenClawStateDatabaseForMaintenance } from "../state/openclaw-state-db.js";
@@ -54,6 +56,7 @@ export async function createOpenClawSnapshotCopy(params: {
   database: SnapshotDatabaseRef;
   targetPath: string;
 }): Promise<{ identity: SnapshotDatabaseIdentity; path: string; userVersion: number }> {
+  assertNotUpdateCapturePath(params.database.path, resolveStateDir());
   const identity = normalizeSnapshotIdentity(params.database.identity);
   const result = await createVerifiedSqliteSnapshot({
     sourcePath: params.database.path,


### PR DESCRIPTION
Related: #142770. Follow-up to #140339.

## What Problem This Solves

Resolves a problem where selecting a workspace containing the managed private capture root includes raw capture files in an ordinary backup. Explicit capture-file inputs can also enter support exports, SQLite snapshots and Git backups. The accepted capture design requires this boundary before enabling capture creation.

## Why This Change Was Made

Exclude the selected state's exact managed `<stateDir>.update-captures/` root and another state's exact paired root through the existing backup inventory, archive traversal, named support inputs, and shared snapshot producer. Explicit nested workspace selection cannot override this exclusion. Config or database backup sources inside those roots are refused. Cross-state recognition checks only the selected path's lexical and canonical ancestors for an exact `<owner>.update-captures` directory paired with an existing `<owner>` directory. Similarly named and unpaired unrelated workspace directories stay included. This directory-layout rule is not writer authority and cannot identify moved, renamed or orphaned captures belonging to another state.

Accepted storage/privacy decision: https://github.com/openclaw/openclaw/pull/140339#issuecomment-5614409997

Accepted prospective transaction-scoped lifetime revision: https://github.com/openclaw/openclaw/pull/140339#issuecomment-5614508856

This is the independent privacy prerequisite. It does not create retained captures, change ordinary snapshot sanitization, add cleanup/pruning, implement replay, or touch #143750/#143752 package mutation ownership. Capture/reopen will follow separately on this boundary.

## User Impact

Managed raw update artifacts cannot be included accidentally in ordinary backup and support exports through these paths. Existing ordinary config/workspace files and backup sanitization remain supported. This is not a guarantee for raw data manually copied outside the managed root.

## Evidence

- Seven new privacy controls fail on unchanged production source for the intended reason: parent/nested workspace archives, full/config-only backup source selection, SQLite/Git snapshot source selection, and support export inputs.
- Final validation on `3d665e6a` passes eleven archive/SQLite/Git controls and all thirteen support-export tests, including ordinary sanitization and healthy-error cases. Six cross-state regressions failed on the previous guard for the intended reasons and pass with this correction. The archive case reads real tar output, verifies the archive, preserves both healthy neighbors, and checks source bytes.
- The existing transient-row sanitization/global-owner control also passes (one selected test; 65 unrelated cases skipped).
- Archive tests read the real tar output and run the existing archive verifier. Snapshot controls use real canonical shared SQLite files. Fixtures retain source bytes.
- The earlier P0/P1/P2 review is preserved. Fresh full-candidate review through P2 found one index-only P1 because the old guard was unstaged; staging the exact reviewed working-tree correction resolved it. The committed bytes match the reviewed candidate, with no unresolved findings. This is scoped review, not universal correctness.
- `node scripts/check-changed.mjs` passed, including core/test typechecks, changed-file lint, formatting, dead-export scans, import-cycle and database/storage guards. Exact-head CI remains a landing gate; its current failures and pending jobs are tracked in the PR checks.
- Scope: 10 files, +353/-4. The cross-state production correction is +32/-2 in the existing shared path guard; no CI, package-mutation or updater files are added.
- Separate CI provisioning correction #143835 is owned independently. Publication does not depend on its source; green exact-head required checks remain necessary for landing. No CI bypass or whole-journey prerequisite is introduced.

## Installed proof

- The existing installed-proof owner verified five public archive cases and three offline support-export cases on exact head `754c650c`, using one unchanged installed package. Source-family receipts and output archive hashes were checked.
- The original include-reference case remains **FAIL** against its required privacy diagnostic. Its fixture referenced a sibling directory outside the config root without `OPENCLAW_INCLUDE_ROOTS`, so config confinement rejected it before the export guard.
- Two local source controls confirm that diagnosis. The original layout produces the saved unresolved-graph error; the same layout with an explicitly allowed include root produces `Private update captures are excluded from backups and support exports.` Both publish nothing and preserve source bytes and identities. No product change was needed. Corrected installed confirmation remains with the same proof owner.
- Six prepared explicit-input SQLite/Git API cases remain unrun because those APIs are not exported by the installed package. Local source tests are not claimed as installed coverage.

No live Gateway or production user data was modified. The installed tests used only synthetic task-owned files in the existing proof runtime. Historical evidence and the failed include assertion remain preserved. Earlier capture proofs and successful installed cases were not rerun.

