### PR TITLE
feat(ui): edit advanced cloud worker profiles and repository defaults

### DIFF
--- a/docs/gateway/cloud-workers/per-project-default-profiles.md
+++ b/docs/gateway/cloud-workers/per-project-default-profiles.md
@@ -20,6 +20,8 @@ Use `cloudWorkers.projectProfiles` to select a default profile from a managed se
 }
 ```
 
+In **Settings → Cloud workers → Repositories**, add, edit, or delete repository defaults by selecting a configured profile. The editor validates repository identities and refuses mappings to missing profiles.
+
 An explicit `profileId` or `deviceId` in `sessions.dispatch` always wins. A target-less project-profile lookup requires `operator.admin`. Deleting a profile from the Cloud workers settings also removes project defaults that reference it. If a manually configured mapping names a profile that is not present in `cloudWorkers.profiles`, dispatch fails closed and names both the repository key and missing profile. A worktree with no `origin` or no matching mapping returns a typed `INVALID_REQUEST` without provisioning or falling back to another target.
 
 The enrolled node stores its identity, durable device token, endpoint, worker bundles, and workspaces under an isolated per-lease state directory on the disposable box. Provision replay first adopts the fixed Crabbox lease, then either resumes that node state or reuses the still-pending setup credential. It never mints a second environment identity for the same operation.

--- a/docs/gateway/config-cloud-workers.md
+++ b/docs/gateway/config-cloud-workers.md
@@ -21,6 +21,8 @@ Node-backed providers return an authenticated node device id for either `worker-
 
 ### Crabbox profile
 
+In **Settings → Cloud workers**, the profile editor's **Advanced** group edits warm images, setup environment names, ready workers, and suspend-after duration. The page also exposes the shared **Prepared pool** cap. Clearing optional values restores their defaults; selecting **Auto** for warm images restores automatic selection. These changes require a Gateway restart.
+
 The bundled `crabbox` provider provisions a disposable machine through the local Crabbox CLI, enrolls it as an ephemeral outbound node, and returns the same node transport for OpenClaw `worker-turn` or Codex `remote-exec`. One configured profile can therefore be selected by both harnesses; the selected session runtime determines its execution semantics. The inner `settings.provider` selects the Crabbox backend; it is separate from the outer OpenClaw provider id.
 
 ```json5

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -206,6 +206,8 @@ suite.define(() => {
       await page
         .getByLabel("Setup environment names", { exact: true })
         .fill("BUILD_TAG, CACHE_DIR");
+      await page.getByLabel("Setup command", { exact: true }).fill("");
+      await page.getByLabel("Setup command", { exact: true }).fill("install-node");
       await page.getByLabel("Ready workers", { exact: true }).fill("2");
       await page.getByLabel("Suspend after", { exact: true }).fill("2h");
       await waitForSettledFormControls(page, [

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -64,7 +64,7 @@ async function waitForConfigPatch(
 }
 
 suite.define(() => {
-  it("adds and edits profiles while distinguishing advertised state", async () => {
+  it("adds advanced profiles and repository defaults while distinguishing advertised state", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -116,15 +116,11 @@ suite.define(() => {
       const machineClass = page.getByRole("textbox", { name: "Machine class", exact: true });
       await expect.poll(() => machineClass.inputValue()).toBe("");
       expect(await machineClass.getAttribute("list")).toBeNull();
-      expect(
-        await page
-          .locator("openclaw-cloud-workers-page datalist, openclaw-cloud-workers-page option")
-          .count(),
-      ).toBe(0);
+      expect(await page.locator("openclaw-cloud-workers-page datalist").count()).toBe(0);
       for (const invalidClass of ["", " ", "x".repeat(129)]) {
         await machineClass.fill(invalidClass);
         await waitForSettledFormControls(page, [{ locator: machineClass, value: invalidClass }]);
-        await page.getByRole("button", { name: "Save" }).click();
+        await page.getByRole("button", { name: "Save", exact: true }).click();
         await expect
           .poll(() => page.getByRole("alert").textContent())
           .toBe("Enter a machine class of 1 to 128 characters.");
@@ -134,7 +130,7 @@ suite.define(() => {
       await waitForSettledFormControls(page, [{ locator: machineClass, value: "standard" }]);
       await gateway.deferNext("config.patch");
       const addRequestCount = (await gateway.getRequests("config.patch")).length;
-      await page.getByRole("button", { name: "Save" }).click();
+      await page.getByRole("button", { name: "Save", exact: true }).click();
       const addPatch = await waitForConfigPatch(gateway, addRequestCount);
       expect(addPatch).toEqual({
         cloudWorkers: {
@@ -142,6 +138,8 @@ suite.define(() => {
             "build-fleet": {
               provider: "crabbox",
               install: "bundle",
+              readyWorkers: null,
+              suspendAfter: null,
               settings: {
                 provider: "hetzner",
                 target: null,
@@ -149,6 +147,8 @@ suite.define(() => {
                 ttl: "8h",
                 idleTimeout: "45m",
                 setup: null,
+                setupEnv: null,
+                warmImage: null,
                 desktop: null,
                 binary: null,
               },
@@ -201,6 +201,13 @@ suite.define(() => {
         .locator("wa-switch")
         .click();
       await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox-draft");
+      await page.getByLabel("Warm images", { exact: true }).selectOption("off");
+      await page.getByLabel("Setup command", { exact: true }).fill("install-node");
+      await page
+        .getByLabel("Setup environment names", { exact: true })
+        .fill("BUILD_TAG, CACHE_DIR");
+      await page.getByLabel("Ready workers", { exact: true }).fill("2");
+      await page.getByLabel("Suspend after", { exact: true }).fill("2h");
       await waitForSettledFormControls(page, [
         { locator: machineClass, value: "batch/ARM64.v2" },
         { locator: page.getByLabel("Crabbox backend"), value: "daytona" },
@@ -210,12 +217,17 @@ suite.define(() => {
           checked: true,
         },
         { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox-draft" },
+        { locator: page.getByLabel("Warm images", { exact: true }), value: "off" },
+        { locator: page.getByLabel("Setup command", { exact: true }), value: "install-node" },
+        { locator: page.getByLabel("Setup environment names"), value: "BUILD_TAG, CACHE_DIR" },
+        { locator: page.getByLabel("Ready workers", { exact: true }), value: "2" },
+        { locator: page.getByLabel("Suspend after", { exact: true }), value: "2h" },
       ]);
       expect(await page.getByRole("combobox", { name: "Machine class", exact: true }).count()).toBe(
         0,
       );
       expect(await machineClass.getAttribute("list")).toBeNull();
-      const saveButton = page.getByRole("button", { name: "Save" });
+      const saveButton = page.getByRole("button", { name: "Save", exact: true });
       // Saved temporarily hides Apply changes; wait for the applied revision so
       // its background config.get cannot consume the foreground refresh gate.
       await expect
@@ -255,13 +267,17 @@ suite.define(() => {
             "build-fleet": {
               provider: "crabbox",
               install: "bundle",
+              readyWorkers: 2,
+              suspendAfter: "2h",
               settings: {
                 provider: "daytona",
                 target: null,
                 class: "batch/ARM64.v2",
                 ttl: "12h",
                 idleTimeout: "45m",
-                setup: null,
+                setup: "install-node",
+                setupEnv: ["BUILD_TAG", "CACHE_DIR"],
+                warmImage: false,
                 desktop: true,
                 binary: "/opt/bin/crabbox-draft",
               },
@@ -271,12 +287,17 @@ suite.define(() => {
       });
       const editedFleet = {
         ...buildFleet,
+        readyWorkers: 2,
+        suspendAfter: "2h",
         settings: {
           ...buildFleet.settings,
           provider: "daytona",
           class: "batch/ARM64.v2",
           ttl: "12h",
           idleTimeout: "45m",
+          setup: "install-node",
+          setupEnv: ["BUILD_TAG", "CACHE_DIR"],
+          warmImage: false,
           desktop: true,
           binary: "/opt/bin/crabbox-draft",
         },
@@ -317,7 +338,7 @@ suite.define(() => {
       ]);
       await gateway.deferNext("config.patch");
       const pendingRequestCount = (await gateway.getRequests("config.patch")).length;
-      await page.getByRole("button", { name: "Save" }).click();
+      await page.getByRole("button", { name: "Save", exact: true }).click();
       const pendingPatch = await waitForConfigPatch(gateway, pendingRequestCount);
       expect(pendingPatch).toEqual({
         cloudWorkers: {
@@ -325,6 +346,8 @@ suite.define(() => {
             pending: {
               provider: "crabbox",
               install: "bundle",
+              readyWorkers: null,
+              suspendAfter: null,
               settings: {
                 provider: "aws",
                 target: null,
@@ -332,6 +355,8 @@ suite.define(() => {
                 ttl: "8h",
                 idleTimeout: "45m",
                 setup: null,
+                setupEnv: null,
+                warmImage: null,
                 desktop: null,
                 binary: null,
               },
@@ -372,6 +397,42 @@ suite.define(() => {
         .getByRole("button", { name: "Edit", exact: true })
         .click();
       await expect.poll(() => machineClass.inputValue()).toBe("custom");
+      await page.getByRole("button", { name: "Cancel", exact: true }).click();
+      await page.getByRole("button", { name: "Add repository", exact: true }).click();
+      const repository = page.getByLabel("Repository identity", { exact: true });
+      const defaultProfile = page.getByLabel("Default profile", { exact: true });
+      await repository.fill("GitHub.com/Acme/App.git");
+      await defaultProfile.selectOption("build-fleet");
+      await waitForSettledFormControls(page, [
+        { locator: repository, value: "GitHub.com/Acme/App.git" },
+        { locator: defaultProfile, value: "build-fleet" },
+      ]);
+      await gateway.deferNext("config.patch");
+      const repositoryRequestCount = (await gateway.getRequests("config.patch")).length;
+      await page.getByRole("button", { name: "Save repository", exact: true }).click();
+      expect(await waitForConfigPatch(gateway, repositoryRequestCount)).toEqual({
+        cloudWorkers: { projectProfiles: { "github.com/acme/app": "build-fleet" } },
+      });
+      const repositoryConfig = {
+        cloudWorkers: {
+          profiles: { "build-fleet": editedFleet, pending },
+          projectProfiles: { "github.com/acme/app": "build-fleet" },
+        },
+      };
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse(repositoryConfig, "cloud-workers-5"),
+      );
+      await gateway.resolveDeferred("config.patch", {
+        ok: true,
+        hash: "cloud-workers-5",
+        config: repositoryConfig,
+      });
+      await page.getByText("github.com/acme/app", { exact: true }).waitFor();
+      await page
+        .locator("openclaw-cloud-worker-repositories")
+        .getByText("Gateway restart required.", { exact: true })
+        .waitFor();
     } finally {
       await context.close();
     }
@@ -410,7 +471,7 @@ suite.define(() => {
       ]);
 
       await gateway.deferNext("config.patch");
-      await editor.getByRole("button", { name: "Save" }).click();
+      await editor.getByRole("button", { name: "Save", exact: true }).click();
       await gateway.waitForRequest("config.patch");
       await expect.poll(() => profileId.isDisabled()).toBe(true);
 
@@ -430,7 +491,9 @@ suite.define(() => {
       await expect.poll(() => backend.isEnabled()).toBe(true);
       await expect.poll(() => profileId.inputValue()).toBe("reconnect-proof");
       await expect.poll(() => backend.inputValue()).toBe("hetzner");
-      await expect.poll(() => editor.getByRole("button", { name: "Save" }).isEnabled()).toBe(true);
+      await expect
+        .poll(() => editor.getByRole("button", { name: "Save", exact: true }).isEnabled())
+        .toBe(true);
       await expect
         .poll(() => editor.getByRole("button", { name: "Cancel" }).isEnabled())
         .toBe(true);
@@ -446,7 +509,7 @@ suite.define(() => {
 
       await gateway.deferNext("config.patch");
       const retryRequestCount = (await gateway.getRequests("config.patch")).length;
-      await editor.getByRole("button", { name: "Save" }).click();
+      await editor.getByRole("button", { name: "Save", exact: true }).click();
       const retryPatch = await waitForConfigPatch(gateway, retryRequestCount);
       expect(retryPatch).toMatchObject({
         cloudWorkers: {
@@ -600,7 +663,7 @@ suite.define(() => {
         });
         await gateway.waitForRequest("config.get", { after: configGetCount });
         await pendingRow.getByText(description, { exact: false }).waitFor();
-        const saveButton = editor.getByRole("button", { name: "Save" });
+        const saveButton = editor.getByRole("button", { name: "Save", exact: true });
         await expect.poll(() => saveButton.isEnabled()).toBe(true);
         await saveButton.click();
         await expect
@@ -650,6 +713,7 @@ suite.define(() => {
         await pendingRow.getByRole("button", { name: "Delete" }).click();
         const confirmation = await waitForConfirmModal(page);
         await expect.poll(() => confirmation.textContent()).toContain("Delete profile pending?");
+        await expect.poll(() => confirmation.textContent()).toContain("Repository defaults");
         expect(await gateway.getRequests("config.patch")).toHaveLength(0);
         await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
         await expect.poll(async () => (await gateway.getRequests("config.patch")).length).toBe(1);

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -132,6 +132,7 @@ const enSettings = {
       backend: "Enter a Crabbox backend, such as aws, azure, or hetzner.",
       target:
         "Use an operating system ID of up to 64 characters without surrounding spaces, or choose Provider default.",
+      warmImage: "Warm images require Linux. Choose Linux, Auto, or Off before saving.",
       machineClass: "Enter a machine class of 1 to 128 characters.",
       ttl: "Enter a positive Go duration for max lifetime, such as 8h or 90m.",
       idleTimeout: "Enter a positive Go duration for idle stop, such as 45m.",
@@ -146,7 +147,7 @@ const enSettings = {
         "Choose an existing cloud worker profile. Add a profile first if none are configured.",
       preparedPool: "Enter a non-negative whole number or leave the field empty.",
       settingsSaveFailed: "These settings were not saved. Reload the config and try again.",
-      setupEnvRequiresSetup: "Enter a setup command before adding setup environment names.",
+      setupEnvRequiresSetup: "Enter a setup command or clear the setup environment names.",
       readyWorkers: "Enter a whole number of zero or more, or leave ready workers empty.",
       suspendAfter:
         "Enter a duration of at least 1m, such as 45m or 2h, or leave suspend after empty.",

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -48,7 +48,8 @@ const enSettings = {
     editProfile: "Edit profile",
     editAction: "Edit",
     deleteTitle: "Delete cloud worker profile",
-    deleteConfirm: "Delete profile {profile}? New cloud sessions cannot use it after restart.",
+    deleteConfirm:
+      "Delete profile {profile}? Repository defaults that use this profile will also be removed. New cloud sessions cannot use it after restart.",
     advertised: "Advertised",
     restartRequired: "Restart required",
     adminRequired: "Administrator access is required to manage cloud worker profiles.",
@@ -61,6 +62,24 @@ const enSettings = {
     idleFact: "Idle stop: {value}",
     desktopFact: "Desktop: {value}",
     providerList: "View supported backends",
+    advanced: "Advanced",
+    preparedPool: "Prepared pool",
+    preparedPoolHelp:
+      "Maximum unassigned workers across projects and profiles. Leave empty for the default of 4; zero drains unused reserves and stops refill. Reserves incur running-machine charges.",
+    savePool: "Save pool",
+    repositories: "Repositories",
+    repositoriesHelp:
+      "Choose the default cloud worker profile for each repository. Explicit session profile choices take precedence.",
+    repositoriesEmpty: "No repository defaults are configured.",
+    addRepository: "Add repository",
+    editRepository: "Edit repository",
+    saveRepository: "Save repository",
+    repositoryIdentity: "Repository identity",
+    repositoryIdentityHelp:
+      "Enter host/owner/repo or a Git remote URL. Saved identities use lowercase and omit the trailing .git.",
+    repositoryProfile: "Default profile",
+    selectProfile: "Choose a profile",
+    warmImage: { auto: "Auto", on: "On", off: "Off" },
     fields: {
       profileId: "Profile ID",
       profileIdHelp: "Use letters, numbers, hyphens, or underscores.",
@@ -89,6 +108,18 @@ const enSettings = {
       binary: "Crabbox binary",
       binaryHelp: "Optional absolute path to the Crabbox executable on the gateway.",
       binaryPlaceholder: "/usr/local/bin/crabbox",
+      warmImage: "Warm images",
+      warmImageHelp:
+        "Auto enables images for Linux when a machine class is known and no setup environment names are set. Images incur provider snapshot storage charges.",
+      setupEnv: "Setup environment names",
+      setupEnvHelp:
+        "Up to 16 unique POSIX environment variable names, separated by commas or whitespace. Requires a setup command. Values come from the gateway environment.",
+      readyWorkers: "Ready workers",
+      readyWorkersHelp:
+        "Prepares unassigned workers per eligible project after a successful session. Leave empty for one; zero disables reserves. Ready workers incur running-machine charges.",
+      suspendAfter: "Suspend after",
+      suspendAfterHelp:
+        "Reclaim an idle worker after a duration such as 45m or 2h (minimum 1m). Leave empty to keep workers running.",
       actions: "Save profile",
       actionsHelp: "Saving updates the config; the gateway must restart before using it.",
     },
@@ -105,6 +136,20 @@ const enSettings = {
       ttl: "Enter a positive Go duration for max lifetime, such as 8h or 90m.",
       idleTimeout: "Enter a positive Go duration for idle stop, such as 45m.",
       binary: "Enter an absolute Crabbox binary path or leave the field empty.",
+      setupEnv:
+        "Enter at most 16 unique POSIX environment variable names. CRABBOX_ENV_ALLOW is reserved.",
+      repository: "Enter a valid repository identity, such as github.com/acme/app.",
+      repositoryExists: "This repository already has a default. Edit its existing mapping.",
+      repositoryMissing:
+        "This repository mapping changed or was removed. Reload the config and try again.",
+      repositoryProfile:
+        "Choose an existing cloud worker profile. Add a profile first if none are configured.",
+      preparedPool: "Enter a non-negative whole number or leave the field empty.",
+      settingsSaveFailed: "These settings were not saved. Reload the config and try again.",
+      setupEnvRequiresSetup: "Enter a setup command before adding setup environment names.",
+      readyWorkers: "Enter a whole number of zero or more, or leave ready workers empty.",
+      suspendAfter:
+        "Enter a duration of at least 1m, such as 45m or 2h, or leave suspend after empty.",
       saveFailed: "The profile was not saved. Reload the config and try again.",
       deleteFailed: "The profile was not deleted. Reload the config and try again.",
     },

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -90,6 +90,9 @@ describe("cloud worker settings state", () => {
     ["backend", { backend: " " }],
     ["target", { target: "x".repeat(65) }],
     ["target", { target: " linux " }],
+    ...["macos", "windows/wsl2", "windows/normal"].map(
+      (target) => ["warmImage", { target, warmImage: "on" }] as const,
+    ),
     ["machineClass", { machineClass: "" }],
     ["machineClass", { machineClass: "x".repeat(129) }],
     ["ttl", { ttl: "tomorrow" }],
@@ -396,6 +399,29 @@ describe("cloud worker settings state", () => {
           "cloudWorkers.profiles.production.settings.warmImage",
           warmImage === "on",
         );
+      }
+    },
+  );
+
+  it.each(["", "linux", "macos", "windows/wsl2", "windows/normal"])(
+    "validates warm images after changing an existing profile target to %s",
+    (target) => {
+      const config = { cloudWorkers: { profiles: { production: configuredProfile } } };
+      for (const warmImage of ["auto", "on", "off"] as const) {
+        const draft = {
+          ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]),
+          target,
+          warmImage,
+        };
+        const built = buildCloudWorkerUpsertPatch(config, draft, "production");
+        if (warmImage === "on" && target && target !== "linux") {
+          expect(built).toEqual({ error: "warmImage" });
+        } else {
+          expect(requirePatch(built).patch).toHaveProperty(
+            "cloudWorkers.profiles.production.settings.warmImage",
+            warmImage === "auto" ? null : warmImage === "on",
+          );
+        }
       }
     },
   );

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyMergePatch } from "../../../../src/config/merge-patch.js";
+import { CloudWorkersConfigSchema } from "../../../../src/config/zod-schema.cloud-workers.js";
 import {
   buildCloudWorkerDeletePatch,
   buildCloudWorkerUpsertPatch,
@@ -68,6 +69,10 @@ describe("cloud worker settings state", () => {
         ttl: "24h",
         idleTimeout: "60m",
         setup: "install-node",
+        setupEnv: "QA_WORKER_FLAG",
+        warmImage: "auto",
+        readyWorkers: "",
+        suspendAfter: "30m",
         desktop: true,
         binary: "/opt/crabbox",
       },
@@ -90,6 +95,17 @@ describe("cloud worker settings state", () => {
     ["ttl", { ttl: "tomorrow" }],
     ["idleTimeout", { idleTimeout: "0m" }],
     ["binary", { binary: "relative/crabbox" }],
+    ...["-1", "1.5", "Infinity", "9007199254740992"].map(
+      (readyWorkers) => ["readyWorkers", { readyWorkers }] as const,
+    ),
+    ...[
+      "A A",
+      "A,1BAD",
+      "A-B",
+      "CRABBOX_ENV_ALLOW",
+      Array.from({ length: 17 }, (_, index) => `VAR_${index}`).join(","),
+    ].map((setupEnv) => ["setupEnv", { setup: "true", setupEnv }] as const),
+    ["setupEnvRequiresSetup", { setupEnv: "BUILD_FLAG" }],
   ] as const)("returns %s for an invalid add draft", (expected, patch) => {
     const draft = {
       ...createCloudWorkerDraft(),
@@ -110,6 +126,7 @@ describe("cloud worker settings state", () => {
       ttl: "8h",
       idleTimeout: "45m",
       setup: "",
+      setupEnv: "",
       desktop: false,
       binary: "",
     };
@@ -121,6 +138,8 @@ describe("cloud worker settings state", () => {
             production: {
               provider: "crabbox",
               install: "npm",
+              readyWorkers: null,
+              suspendAfter: "30m",
               settings: {
                 provider: "hetzner",
                 target: "linux",
@@ -129,6 +148,7 @@ describe("cloud worker settings state", () => {
                 idleTimeout: "45m",
                 setup: null,
                 setupEnv: null,
+                warmImage: null,
                 desktop: null,
                 binary: null,
               },
@@ -187,12 +207,12 @@ describe("cloud worker settings state", () => {
           },
         },
       });
-      expect(built.replacePaths).toEqual([]);
+      expect(built.replacePaths).toEqual(["cloudWorkers.profiles.production.settings.setupEnv"]);
     },
   );
 
   it.each([{ setupEnv: undefined }, { setupEnv: [] }])(
-    "keeps empty setup environment unchanged ($setupEnv)",
+    "omits empty setup environment ($setupEnv)",
     ({ setupEnv }) => {
       const { setupEnv: _setupEnv, ...settings } = configuredProfile.settings;
       const existingSettings = { ...settings, ...(setupEnv ? { setupEnv } : {}) };
@@ -200,13 +220,15 @@ describe("cloud worker settings state", () => {
       const config = { cloudWorkers: { profiles: { production: profile } } };
       const draft = { ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]), setup: "" };
       const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
-      const { setup: _setup, ...retainedSettings } = existingSettings;
+      const { setup: _setup, setupEnv: _emptyEnv, ...retainedSettings } = existingSettings;
       expect(applyMergePatch(config, built.patch)).toEqual({
         cloudWorkers: {
           profiles: { production: { ...profile, settings: retainedSettings } },
         },
       });
-      expect(built.replacePaths).toEqual([]);
+      expect(built.replacePaths).toEqual(
+        setupEnv ? ["cloudWorkers.profiles.production.settings.setupEnv"] : [],
+      );
     },
   );
 
@@ -228,6 +250,7 @@ describe("cloud worker settings state", () => {
   ])("rejects an edit after its authoritative profile $name", ({ replacement }) => {
     const config = { cloudWorkers: { profiles: { production: replacement } } };
     const draft = createCloudWorkerDraft({
+      ...createCloudWorkerDraft(),
       id: "production",
       providerId: "crabbox",
       install: "bundle",
@@ -286,6 +309,8 @@ describe("cloud worker settings state", () => {
             "build-fleet": {
               provider: "crabbox",
               install: "bundle",
+              readyWorkers: null,
+              suspendAfter: null,
               settings: {
                 provider: "hetzner",
                 target: null,
@@ -293,6 +318,8 @@ describe("cloud worker settings state", () => {
                 ttl: "8h",
                 idleTimeout: "45m",
                 setup: null,
+                setupEnv: null,
+                warmImage: null,
                 desktop: null,
                 binary: null,
               },
@@ -303,6 +330,130 @@ describe("cloud worker settings state", () => {
       replacePaths: [],
     });
     expect(applyMergePatch(config, built.patch)).toMatchObject(config);
+  });
+
+  it.each([
+    ["+1h", false],
+    [".5h", false],
+    ["1m1us", false],
+    ["59s", false],
+    ["60s", true],
+    ["45m", true],
+    ["2h", true],
+    ["1d", true],
+    ["1H", true],
+  ] as const)("matches the suspendAfter schema for %s", (suspendAfter, accepted) => {
+    const draft = {
+      ...createCloudWorkerDraft(),
+      id: "test",
+      backend: "aws",
+      machineClass: "standard",
+      suspendAfter,
+    };
+    expect(
+      CloudWorkersConfigSchema.safeParse({
+        profiles: { test: { provider: "crabbox", suspendAfter } },
+      }).success,
+    ).toBe(accepted);
+    expect(validateCloudWorkerDraft(draft, {}, null)).toBe(accepted ? null : "suspendAfter");
+  });
+
+  it.each(["auto", "on", "off"] as const)(
+    "patches warm images as %s and replaces setup names",
+    (warmImage) => {
+      const config = {
+        cloudWorkers: {
+          profiles: {
+            production: {
+              ...configuredProfile,
+              readyWorkers: 3,
+              settings: { ...configuredProfile.settings, warmImage: true },
+            },
+          },
+        },
+      };
+      const draft = {
+        ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]),
+        warmImage,
+        setupEnv: "BUILD_FLAG, CACHE_MODE\nEXTRA",
+        readyWorkers: "0",
+        suspendAfter: "2h",
+      };
+      const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
+      const merged = applyMergePatch(config, built.patch);
+      expect(merged).toHaveProperty("cloudWorkers.profiles.production.readyWorkers", 0);
+      expect(merged).toHaveProperty("cloudWorkers.profiles.production.suspendAfter", "2h");
+      expect(merged).toHaveProperty("cloudWorkers.profiles.production.settings.setupEnv", [
+        "BUILD_FLAG",
+        "CACHE_MODE",
+        "EXTRA",
+      ]);
+      expect(built.replacePaths).toEqual(["cloudWorkers.profiles.production.settings.setupEnv"]);
+      if (warmImage === "auto") {
+        expect(merged).not.toHaveProperty("cloudWorkers.profiles.production.settings.warmImage");
+      } else {
+        expect(merged).toHaveProperty(
+          "cloudWorkers.profiles.production.settings.warmImage",
+          warmImage === "on",
+        );
+      }
+    },
+  );
+
+  it("accepts sixteen setup names without dropping or reordering them", () => {
+    const names = Array.from({ length: 16 }, (_, index) => `BUILD_${index}`);
+    const draft = {
+      ...createCloudWorkerDraft(),
+      id: "build",
+      backend: "aws",
+      machineClass: "standard",
+      setup: "true",
+      setupEnv: names.join(" , "),
+    };
+    const built = requirePatch(buildCloudWorkerUpsertPatch({}, draft, null));
+    expect(built.patch).toHaveProperty("cloudWorkers.profiles.build.settings.setupEnv", names);
+  });
+
+  it("removes cleared advanced fields while retaining the rest of the profile", () => {
+    const profile = {
+      ...configuredProfile,
+      readyWorkers: 2,
+      settings: { ...configuredProfile.settings, warmImage: false },
+    };
+    const config = { cloudWorkers: { profiles: { production: profile } } };
+    const draft = {
+      ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]),
+      readyWorkers: "",
+      suspendAfter: "",
+      warmImage: "auto" as const,
+      setupEnv: "",
+    };
+    const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
+    expect(built.patch).toMatchObject({
+      cloudWorkers: {
+        profiles: {
+          production: {
+            readyWorkers: null,
+            suspendAfter: null,
+            settings: { warmImage: null, setupEnv: null },
+          },
+        },
+      },
+    });
+    const merged = applyMergePatch(config, built.patch);
+    for (const path of [
+      "readyWorkers",
+      "suspendAfter",
+      "settings.warmImage",
+      "settings.setupEnv",
+    ]) {
+      expect(merged).not.toHaveProperty(`cloudWorkers.profiles.production.${path}`);
+    }
+    expect(merged).toHaveProperty(
+      "cloudWorkers.profiles.production.settings.opaque",
+      configuredProfile.settings.opaque,
+    );
+    expect(merged).toHaveProperty("cloudWorkers.profiles.production.install", "npm");
   });
 
   it("deletes only the target and its project defaults with exact array intent", () => {

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { parseDurationMs } from "../../../../src/cli/parse-duration.js";
 import { collectBaseArrayPaths } from "../../../../src/config/patch-replace-paths.js";
 
 type CloudWorkerConfigPatch = { patch: Record<string, unknown>; replacePaths: string[] };
@@ -12,22 +13,17 @@ export type CloudWorkerProfileDraft = {
   ttl: string;
   idleTimeout: string;
   setup: string;
+  setupEnv: string;
+  warmImage: "auto" | "on" | "off";
+  readyWorkers: string;
+  suspendAfter: string;
   desktop: boolean;
   binary: string;
 };
 
-export type ConfiguredCloudWorkerProfile = {
-  id: string;
+export type ConfiguredCloudWorkerProfile = CloudWorkerProfileDraft & {
   providerId: string;
   install: "bundle" | "npm";
-  backend: string;
-  target: string;
-  machineClass: string;
-  ttl: string;
-  idleTimeout: string;
-  setup: string;
-  desktop: boolean;
-  binary: string;
 };
 
 export type CloudWorkerDraftError =
@@ -39,7 +35,11 @@ export type CloudWorkerDraftError =
   | "machineClass"
   | "ttl"
   | "idleTimeout"
-  | "binary";
+  | "binary"
+  | "setupEnv"
+  | "setupEnvRequiresSetup"
+  | "readyWorkers"
+  | "suspendAfter";
 
 type CloudWorkerProfileStatus = "advertised" | "restart-required" | "loading";
 
@@ -84,6 +84,11 @@ export function readCloudWorkerProfiles(
           ttl: stringSetting(settings, "ttl"),
           idleTimeout: stringSetting(settings, "idleTimeout"),
           setup: stringSetting(settings, "setup"),
+          setupEnv: Array.isArray(settings.setupEnv) ? settings.setupEnv.join(", ") : "",
+          warmImage:
+            settings.warmImage === true ? "on" : settings.warmImage === false ? "off" : "auto",
+          readyWorkers: typeof raw.readyWorkers === "number" ? String(raw.readyWorkers) : "",
+          suspendAfter: stringSetting(raw, "suspendAfter"),
           desktop: settings.desktop === true,
           binary: stringSetting(settings, "binary"),
         },
@@ -103,9 +108,17 @@ export function createCloudWorkerDraft(
     ttl: profile?.ttl || "8h",
     idleTimeout: profile?.idleTimeout || "45m",
     setup: profile?.setup ?? "",
+    setupEnv: profile?.setupEnv ?? "",
+    warmImage: profile?.warmImage ?? "auto",
+    readyWorkers: profile?.readyWorkers ?? "",
+    suspendAfter: profile?.suspendAfter ?? "",
     desktop: profile?.desktop ?? false,
     binary: profile?.binary ?? "",
   };
+}
+
+function parseSetupEnv(value: string): string[] {
+  return value.split(/[,\s]+/u).filter(Boolean);
 }
 
 export function validateCloudWorkerDraft(
@@ -139,6 +152,35 @@ export function validateCloudWorkerDraft(
   if (!GO_DURATION_PATTERN.test(draft.idleTimeout.trim())) {
     return "idleTimeout";
   }
+  const setupEnv = parseSetupEnv(draft.setupEnv);
+  if (
+    setupEnv.length > 16 ||
+    new Set(setupEnv).size !== setupEnv.length ||
+    setupEnv.some((name) => !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) || name === "CRABBOX_ENV_ALLOW")
+  ) {
+    return "setupEnv";
+  }
+  if (setupEnv.length && !draft.setup.trim()) {
+    return "setupEnvRequiresSetup";
+  }
+  const readyWorkers = draft.readyWorkers.trim();
+  if (
+    readyWorkers &&
+    (!/^\d+$/u.test(readyWorkers) || !Number.isSafeInteger(Number(readyWorkers)))
+  ) {
+    return "readyWorkers";
+  }
+  const suspendAfter = draft.suspendAfter.trim();
+  if (suspendAfter) {
+    // Keep the config schema's parser and minimum; TTL uses a different provider grammar.
+    try {
+      if (!/(?:ms|s|m|h|d)$/i.test(suspendAfter) || parseDurationMs(suspendAfter) < 60_000) {
+        return "suspendAfter";
+      }
+    } catch {
+      return "suspendAfter";
+    }
+  }
   const binary = draft.binary.trim();
   if (binary && !binary.startsWith("/") && !WINDOWS_ABSOLUTE_PATH_PATTERN.test(binary)) {
     return "binary";
@@ -168,8 +210,7 @@ export function buildCloudWorkerUpsertPatch(
     return { error: "profileMissing" };
   }
   const setup = draft.setup.trim();
-  const clearSetupEnv =
-    !setup && Array.isArray(existingSettings.setupEnv) && existingSettings.setupEnv.length > 0;
+  const setupEnv = parseSetupEnv(draft.setupEnv);
   // Omitted settings merge in place; resending opaque nulls would delete them.
   const settings = {
     provider: draft.backend.trim(),
@@ -178,23 +219,24 @@ export function buildCloudWorkerUpsertPatch(
     ttl: draft.ttl.trim(),
     idleTimeout: draft.idleTimeout.trim(),
     setup: setup || null,
-    ...(clearSetupEnv ? { setupEnv: null } : {}),
+    setupEnv: setupEnv.length ? setupEnv : null,
+    warmImage: draft.warmImage === "auto" ? null : draft.warmImage === "on",
     desktop: draft.desktop ? true : null,
     binary: draft.binary.trim() || null,
   };
   const profile = {
     provider: normalizeOptionalString(existing.provider) ?? "crabbox",
     install: existing.install === "npm" ? "npm" : "bundle",
+    readyWorkers: draft.readyWorkers.trim() ? Number(draft.readyWorkers) : null,
+    suspendAfter: draft.suspendAfter.trim() || null,
     settings,
   };
   return {
     patch: { cloudWorkers: { profiles: { [id]: profile } } },
-    replacePaths: clearSetupEnv
-      ? collectBaseArrayPaths(
-          existingSettings.setupEnv,
-          `cloudWorkers.profiles.${id}.settings.setupEnv`,
-        )
-      : [],
+    replacePaths: collectBaseArrayPaths(
+      existingSettings.setupEnv,
+      `cloudWorkers.profiles.${id}.settings.setupEnv`,
+    ),
   };
 }
 

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -32,6 +32,7 @@ export type CloudWorkerDraftError =
   | "profileMissing"
   | "backend"
   | "target"
+  | "warmImage"
   | "machineClass"
   | "ttl"
   | "idleTimeout"
@@ -141,6 +142,9 @@ export function validateCloudWorkerDraft(
   }
   if (draft.target !== draft.target.trim() || draft.target.length > 64) {
     return "target";
+  }
+  if (draft.warmImage === "on" && draft.target && draft.target !== "linux") {
+    return "warmImage";
   }
   const machineClass = draft.machineClass.trim();
   if (!machineClass || machineClass.length > 128) {

--- a/ui/src/pages/cloud-workers/cloud-worker-repositories-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-repositories-config.test.ts
@@ -1,0 +1,180 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "../../../../src/config/merge-patch.js";
+import {
+  buildCloudWorkerPreparedPoolPatch,
+  buildCloudWorkerRepositoryDeletePatch,
+  buildCloudWorkerRepositoryUpsertPatch,
+  readCloudWorkerPreparedPool,
+  readCloudWorkerRepositories,
+  type CloudWorkerRepositoryPatch,
+} from "./cloud-worker-repositories-config.ts";
+
+const config = {
+  cloudWorkers: {
+    profiles: { production: { provider: "crabbox" }, small: { provider: "crabbox" } },
+    projectProfiles: { "github.com/acme/app": "production", "github.com/acme/docs": "small" },
+    preparedPool: { maxTotal: 8 },
+  },
+};
+
+function requirePatch(result: CloudWorkerRepositoryPatch) {
+  if ("error" in result) {
+    throw new Error(result.error);
+  }
+  return result;
+}
+
+describe("cloud worker repository defaults", () => {
+  it("reads configured defaults without discarding a missing profile", () => {
+    expect(readCloudWorkerRepositories(null)).toEqual([]);
+    expect(
+      readCloudWorkerRepositories({
+        cloudWorkers: { projectProfiles: { "github.com/acme/app": "removed" } },
+      }),
+    ).toEqual([{ repository: "github.com/acme/app", profileId: "removed" }]);
+  });
+
+  it.each([
+    "github.com/ACME/New.git",
+    "https://github.com/acme/new.git",
+    "git@github.com:acme/new.git",
+    "ssh://git@github.com:22/acme/new.git",
+  ])("adds the normalized identity for %s without resending other mappings", (repository) => {
+    const built = requirePatch(
+      buildCloudWorkerRepositoryUpsertPatch(config, { repository, profileId: "small" }, null),
+    );
+    expect(built).toEqual({
+      patch: { cloudWorkers: { projectProfiles: { "github.com/acme/new": "small" } } },
+      replacePaths: [],
+    });
+    expect(applyMergePatch(config, built.patch)).toEqual({
+      cloudWorkers: {
+        ...config.cloudWorkers,
+        projectProfiles: { ...config.cloudWorkers.projectProfiles, "github.com/acme/new": "small" },
+      },
+    });
+  });
+
+  it("changes the profile and moves the identity while preserving unrelated mappings", () => {
+    const built = requirePatch(
+      buildCloudWorkerRepositoryUpsertPatch(
+        config,
+        { repository: "github.com/acme/new", profileId: "small" },
+        { repository: "github.com/acme/app", profileId: "production" },
+      ),
+    );
+    expect(applyMergePatch(config, built.patch)).toEqual({
+      cloudWorkers: {
+        ...config.cloudWorkers,
+        projectProfiles: { "github.com/acme/new": "small", "github.com/acme/docs": "small" },
+      },
+    });
+    const retarget = requirePatch(
+      buildCloudWorkerRepositoryUpsertPatch(
+        config,
+        { repository: "github.com/acme/app", profileId: "small" },
+        { repository: "github.com/acme/app", profileId: "production" },
+      ),
+    );
+    expect(retarget.patch).toEqual({
+      cloudWorkers: { projectProfiles: { "github.com/acme/app": "small" } },
+    });
+  });
+
+  it.each([
+    ["", "small", null, "repository"],
+    ["https://github.com/acme/../new", "small", null, "repository"],
+    ["https://github.com/acme/%2e%2e/new", "small", null, "repository"],
+    ["github.com/ACME/App.git", "small", null, "repositoryExists"],
+    ["github.com/acme/docs", "small", "github.com/acme/app", "repositoryExists"],
+    ["github.com/acme/new", "removed", null, "repositoryProfile"],
+    ["github.com/acme/new", "", null, "repositoryProfile"],
+    ["github.com/acme/new", "small", "github.com/acme/removed", "repositoryMissing"],
+  ])("refuses invalid or stale mappings (%s, %s, %s)", (repository, profileId, original, error) => {
+    expect(
+      buildCloudWorkerRepositoryUpsertPatch(
+        config,
+        { repository: repository ?? "", profileId: profileId ?? "" },
+        original ? { repository: original, profileId: "production" } : null,
+      ),
+    ).toEqual({ error });
+  });
+
+  it("rejects an edit after another update retargets the mapping", () => {
+    const changed = {
+      cloudWorkers: {
+        ...config.cloudWorkers,
+        projectProfiles: { ...config.cloudWorkers.projectProfiles, "github.com/acme/app": "small" },
+      },
+    };
+    expect(
+      buildCloudWorkerRepositoryDeletePatch(changed, {
+        repository: "github.com/acme/app",
+        profileId: "production",
+      }),
+    ).toEqual({ error: "repositoryMissing" });
+    expect(
+      buildCloudWorkerRepositoryUpsertPatch(
+        changed,
+        { repository: "github.com/acme/new", profileId: "production" },
+        { repository: "github.com/acme/app", profileId: "production" },
+      ),
+    ).toEqual({ error: "repositoryMissing" });
+  });
+
+  it("deletes only the requested mapping and refuses a stale delete", () => {
+    const built = requirePatch(
+      buildCloudWorkerRepositoryDeletePatch(config, {
+        repository: "github.com/acme/app",
+        profileId: "production",
+      }),
+    );
+    expect(applyMergePatch(config, built.patch)).toEqual({
+      cloudWorkers: {
+        ...config.cloudWorkers,
+        projectProfiles: { "github.com/acme/docs": "small" },
+      },
+    });
+    expect(
+      buildCloudWorkerRepositoryDeletePatch(config, {
+        repository: "github.com/acme/missing",
+        profileId: "production",
+      }),
+    ).toEqual({
+      error: "repositoryMissing",
+    });
+  });
+});
+
+describe("cloud worker prepared pool", () => {
+  it.each(["0", "3", " 12 "])(
+    "sets the global cap to %s while preserving profiles and defaults",
+    (value) => {
+      const built = requirePatch(buildCloudWorkerPreparedPoolPatch(value));
+      const next = applyMergePatch(config, built.patch);
+      expect(next).toEqual({
+        cloudWorkers: { ...config.cloudWorkers, preparedPool: { maxTotal: Number(value) } },
+      });
+      if (!isRecord(next)) {
+        throw new Error("Expected merged config");
+      }
+      expect(readCloudWorkerPreparedPool(next)).toBe(String(Number(value)));
+    },
+  );
+
+  it("removes a configured cap when the field is emptied", () => {
+    const built = requirePatch(buildCloudWorkerPreparedPoolPatch(" "));
+    const next = applyMergePatch(config, built.patch);
+    expect(next).toEqual({ cloudWorkers: { ...config.cloudWorkers, preparedPool: {} } });
+    if (!isRecord(next)) {
+      throw new Error("Expected merged config");
+    }
+    expect(readCloudWorkerPreparedPool(next)).toBe("");
+    expect(readCloudWorkerPreparedPool(null)).toBe("");
+  });
+
+  it.each(["-1", "0.5", "NaN", "1e2", "9007199254740992"])("rejects invalid cap %s", (value) => {
+    expect(buildCloudWorkerPreparedPoolPatch(value)).toEqual({ error: "preparedPool" });
+  });
+});

--- a/ui/src/pages/cloud-workers/cloud-worker-repositories-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-repositories-config.ts
@@ -1,0 +1,101 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeCloudRepo } from "../../../../src/config/cloud-worker-project-profiles.js";
+
+export type CloudWorkerRepository = { repository: string; profileId: string };
+type CloudWorkerRepositoryError =
+  | "repository"
+  | "repositoryExists"
+  | "repositoryMissing"
+  | "repositoryProfile"
+  | "preparedPool";
+export type CloudWorkerRepositoryPatch =
+  | { patch: Record<string, unknown>; replacePaths: string[] }
+  | { error: CloudWorkerRepositoryError };
+
+function cloudWorkerConfig(config: Readonly<Record<string, unknown>> | null) {
+  return isRecord(config?.cloudWorkers) ? config.cloudWorkers : {};
+}
+
+function repositoryRecords(config: Readonly<Record<string, unknown>>) {
+  const cloudWorkers = cloudWorkerConfig(config);
+  return isRecord(cloudWorkers.projectProfiles) ? cloudWorkers.projectProfiles : {};
+}
+
+export function readCloudWorkerRepositories(
+  config: Readonly<Record<string, unknown>> | null,
+): CloudWorkerRepository[] {
+  return Object.entries(repositoryRecords(config ?? {}))
+    .flatMap(([repository, profileId]) =>
+      typeof profileId === "string" ? [{ repository, profileId }] : [],
+    )
+    .toSorted((left, right) => left.repository.localeCompare(right.repository));
+}
+
+export function readCloudWorkerPreparedPool(config: Readonly<Record<string, unknown>> | null) {
+  const cloudWorkers = cloudWorkerConfig(config);
+  const pool = isRecord(cloudWorkers.preparedPool) ? cloudWorkers.preparedPool : {};
+  return typeof pool.maxTotal === "number" ? String(pool.maxTotal) : "";
+}
+
+export function buildCloudWorkerPreparedPoolPatch(maxTotal: string): CloudWorkerRepositoryPatch {
+  const value = maxTotal.trim();
+  if (value && (!/^\d+$/u.test(value) || !Number.isSafeInteger(Number(value)))) {
+    return { error: "preparedPool" };
+  }
+  return {
+    patch: { cloudWorkers: { preparedPool: { maxTotal: value ? Number(value) : null } } },
+    replacePaths: [],
+  };
+}
+
+export function buildCloudWorkerRepositoryUpsertPatch(
+  config: Readonly<Record<string, unknown>>,
+  draft: CloudWorkerRepository,
+  original: CloudWorkerRepository | null,
+): CloudWorkerRepositoryPatch {
+  const repository = normalizeCloudRepo(draft.repository);
+  if (!repository || normalizeCloudRepo(`https://${repository}`) !== repository) {
+    return { error: "repository" };
+  }
+  const records = repositoryRecords(config);
+  if (original && records[original.repository] !== original.profileId) {
+    return { error: "repositoryMissing" };
+  }
+  if (repository !== original?.repository && Object.hasOwn(records, repository)) {
+    return { error: "repositoryExists" };
+  }
+  const profiles = cloudWorkerConfig(config).profiles;
+  if (
+    !isRecord(profiles) ||
+    !Object.hasOwn(profiles, draft.profileId) ||
+    !isRecord(profiles[draft.profileId])
+  ) {
+    return { error: "repositoryProfile" };
+  }
+  return {
+    patch: {
+      cloudWorkers: {
+        projectProfiles: {
+          ...(original && original.repository !== repository
+            ? { [original.repository]: null }
+            : {}),
+          [repository]: draft.profileId,
+        },
+      },
+    },
+    replacePaths: [],
+  };
+}
+
+export function buildCloudWorkerRepositoryDeletePatch(
+  config: Readonly<Record<string, unknown>>,
+  original: CloudWorkerRepository,
+): CloudWorkerRepositoryPatch {
+  if (repositoryRecords(config)[original.repository] !== original.profileId) {
+    return { error: "repositoryMissing" };
+  }
+  return {
+    patch: { cloudWorkers: { projectProfiles: { [original.repository]: null } } },
+    replacePaths: [],
+  };
+}

--- a/ui/src/pages/cloud-workers/cloud-worker-repositories.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-repositories.ts
@@ -1,0 +1,341 @@
+import { consume } from "@lit/context";
+import { html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import {
+  renderSettingsEmpty,
+  renderSettingsRow,
+  renderSettingsSection,
+} from "../../components/settings-ui.ts";
+import { t } from "../../i18n/index.ts";
+import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
+import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
+import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
+import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { readCloudWorkerProfiles } from "./cloud-worker-config.ts";
+import {
+  buildCloudWorkerPreparedPoolPatch,
+  buildCloudWorkerRepositoryDeletePatch,
+  buildCloudWorkerRepositoryUpsertPatch,
+  readCloudWorkerPreparedPool,
+  readCloudWorkerRepositories,
+  type CloudWorkerRepository,
+  type CloudWorkerRepositoryPatch,
+} from "./cloud-worker-repositories-config.ts";
+
+registerSettingsEnglish();
+
+class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
+  @consume({ context: applicationContext, subscribe: true })
+  private context!: ApplicationContext;
+
+  @property({ type: Boolean }) canManage = false;
+  @state() private editor: {
+    original: CloudWorkerRepository | null;
+    draft: CloudWorkerRepository;
+  } | null = null;
+  @state() private poolDraft: string | null = null;
+  @state() private busy = false;
+  @state() private error: string | null = null;
+  @state() private notice: string | null = null;
+
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    invalidateRequests: () => {
+      this.editor = null;
+      this.poolDraft = null;
+      this.busy = false;
+      this.error = null;
+      this.notice = null;
+    },
+  });
+  private readonly subscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.runtimeConfig,
+    (runtimeConfig) => runtimeConfig.subscribe(() => this.requestUpdate()),
+  );
+
+  override disconnectedCallback() {
+    this.subscriptions.clear();
+    super.disconnectedCallback();
+  }
+
+  private config() {
+    return resolveEditableSnapshotConfig(this.context?.runtimeConfig.state.configSnapshot);
+  }
+
+  private editable() {
+    return this.canManage && !this.busy;
+  }
+
+  private async save(
+    build: (config: Readonly<Record<string, unknown>>) => CloudWorkerRepositoryPatch,
+  ): Promise<boolean> {
+    const scope = this.gateway.capture();
+    const runtimeConfig = this.context.runtimeConfig;
+    if (!scope || !this.editable()) {
+      return false;
+    }
+    this.busy = true;
+    this.error = null;
+    this.notice = null;
+    const isCurrent = () =>
+      this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
+    try {
+      const patched = await runtimeConfig.patchFromSnapshot((base) => {
+        const built = build(base);
+        return "error" in built
+          ? { error: t(`cloudWorkersPage.errors.${built.error}`) }
+          : {
+              options: {
+                raw: built.patch,
+                replacePaths: built.replacePaths,
+                note: "cloud workers: update repository defaults or prepared pool",
+                canDispatch: () =>
+                  isCurrent() &&
+                  canCallGatewayMethod(this.gateway.snapshot, "config.patch", "operator.admin"),
+              },
+            };
+      });
+      if (!isCurrent()) {
+        return false;
+      }
+      if (!patched) {
+        this.error =
+          runtimeConfig.state.lastError ?? t("cloudWorkersPage.errors.settingsSaveFailed");
+        return false;
+      }
+      this.notice = t("labsPage.restartRequired");
+      return true;
+    } catch (error) {
+      if (isCurrent()) {
+        this.error = formatUiError(error);
+      }
+      return false;
+    } finally {
+      if (isCurrent()) {
+        this.busy = false;
+      }
+    }
+  }
+
+  private openEditor(mapping?: CloudWorkerRepository) {
+    if (!this.editable()) {
+      return;
+    }
+    this.editor = {
+      original: mapping ?? null,
+      draft: mapping ?? {
+        repository: "",
+        profileId: readCloudWorkerProfiles(this.config())[0]?.id ?? "",
+      },
+    };
+    this.error = null;
+    this.notice = null;
+  }
+
+  private changeDraft(patch: Partial<CloudWorkerRepository>) {
+    if (this.editor) {
+      this.editor = { ...this.editor, draft: { ...this.editor.draft, ...patch } };
+      this.error = null;
+    }
+  }
+
+  private async saveRepository() {
+    const editor = this.editor;
+    if (
+      editor &&
+      (await this.save((base) =>
+        buildCloudWorkerRepositoryUpsertPatch(base, editor.draft, editor.original),
+      ))
+    ) {
+      this.editor = null;
+    }
+  }
+
+  private async savePool() {
+    const value = this.poolDraft ?? readCloudWorkerPreparedPool(this.config());
+    if (await this.save(() => buildCloudWorkerPreparedPoolPatch(value))) {
+      this.poolDraft = null;
+    }
+  }
+
+  private renderEditor() {
+    if (!this.editor) {
+      return nothing;
+    }
+    const draft = this.editor.draft;
+    const profiles = readCloudWorkerProfiles(this.config());
+    const missingProfile = !profiles.some((profile) => profile.id === draft.profileId);
+    return renderSettingsSection(
+      {
+        title: t(
+          this.editor.original === null
+            ? "cloudWorkersPage.addRepository"
+            : "cloudWorkersPage.editRepository",
+        ),
+      },
+      [
+        renderSettingsRow({
+          title: t("cloudWorkersPage.repositoryIdentity"),
+          description: t("cloudWorkersPage.repositoryIdentityHelp"),
+          control: html`<input
+            class="settings-input mono"
+            aria-label=${t("cloudWorkersPage.repositoryIdentity")}
+            autocomplete="off"
+            spellcheck="false"
+            .value=${draft.repository}
+            ?disabled=${!this.editable()}
+            @input=${(event: Event) => {
+              if (event.currentTarget instanceof HTMLInputElement) {
+                this.changeDraft({ repository: event.currentTarget.value });
+              }
+            }}
+          />`,
+        }),
+        renderSettingsRow({
+          title: t("cloudWorkersPage.repositoryProfile"),
+          control: html`<select
+            class="settings-select"
+            aria-label=${t("cloudWorkersPage.repositoryProfile")}
+            .value=${draft.profileId}
+            ?disabled=${!this.editable()}
+            @change=${(event: Event) => {
+              if (event.currentTarget instanceof HTMLSelectElement) {
+                this.changeDraft({ profileId: event.currentTarget.value });
+              }
+            }}
+          >
+            ${missingProfile ? html`<option value=${draft.profileId} selected>${draft.profileId || t("cloudWorkersPage.selectProfile")}</option>` : nothing}
+            ${profiles.map((profile) => html`<option value=${profile.id} ?selected=${draft.profileId === profile.id}>${profile.id}</option>`)}
+          </select>`,
+        }),
+        missingProfile
+          ? html`<div class="callout warning" role="alert">
+              ${t("cloudWorkersPage.errors.repositoryProfile")}
+            </div>`
+          : nothing,
+        renderSettingsRow({
+          title: t("cloudWorkersPage.saveRepository"),
+          control: html` <button
+              class="btn btn--sm"
+              type="button"
+              ?disabled=${this.busy}
+              @click=${() => {
+                this.editor = null;
+                this.error = null;
+              }}
+            >
+              ${t("common.cancel")}
+            </button>
+            <button
+              class="btn btn--sm primary"
+              type="button"
+              ?disabled=${!this.editable()}
+              @click=${() => void this.saveRepository()}
+            >
+              ${t("cloudWorkersPage.saveRepository")}
+            </button>`,
+        }),
+      ],
+    );
+  }
+
+  override render() {
+    const config = this.config();
+    const repositories = readCloudWorkerRepositories(config);
+    const editable = this.editable();
+    return html`
+      ${renderSettingsSection(
+        {},
+        renderSettingsRow({
+          title: t("cloudWorkersPage.preparedPool"),
+          description: t("cloudWorkersPage.preparedPoolHelp"),
+          control: html`<input
+              class="settings-input"
+              type="number"
+              min="0"
+              step="1"
+              aria-label=${t("cloudWorkersPage.preparedPool")}
+              .value=${this.poolDraft ?? readCloudWorkerPreparedPool(config)}
+              ?disabled=${!editable}
+              @input=${(event: Event) => {
+                if (event.currentTarget instanceof HTMLInputElement) {
+                  this.poolDraft = event.currentTarget.value;
+                  this.error = null;
+                }
+              }}
+              @keydown=${(event: KeyboardEvent) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void this.savePool();
+                }
+              }}
+            />
+            <button
+              class="btn btn--sm"
+              type="button"
+              ?disabled=${!editable}
+              @click=${() => void this.savePool()}
+            >
+              ${t("cloudWorkersPage.savePool")}
+            </button>`,
+        }),
+      )}
+      ${renderSettingsSection(
+        {
+          title: t("cloudWorkersPage.repositories"),
+          description: t("cloudWorkersPage.repositoriesHelp"),
+          count: repositories.length,
+          actions: html`<button
+            class="btn btn--sm primary"
+            type="button"
+            ?disabled=${!editable}
+            @click=${() => this.openEditor()}
+          >
+            ${t("cloudWorkersPage.addRepository")}
+          </button>`,
+        },
+        repositories.length
+          ? repositories.map((mapping) =>
+              renderSettingsRow({
+                title: html`<code>${mapping.repository}</code>`,
+                description: mapping.profileId,
+                control: html` <button
+                    class="btn btn--sm"
+                    type="button"
+                    ?disabled=${!editable}
+                    @click=${() => this.openEditor(mapping)}
+                  >
+                    ${t("cloudWorkersPage.editAction")}
+                  </button>
+                  <button
+                    class="btn btn--sm danger"
+                    type="button"
+                    ?disabled=${!editable}
+                    @click=${() => void this.save((base) => buildCloudWorkerRepositoryDeletePatch(base, mapping))}
+                  >
+                    ${t("common.delete")}
+                  </button>`,
+              }),
+            )
+          : renderSettingsEmpty(t("cloudWorkersPage.repositoriesEmpty")),
+      )}
+      ${this.renderEditor()}
+      ${this.error ? html`<div class="callout warning" role="alert">${this.error}</div>` : nothing}
+      ${this.notice ? html`<div class="callout warning" role="status">${this.notice}</div>` : nothing}
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-cloud-worker-repositories")) {
+  customElements.define("openclaw-cloud-worker-repositories", CloudWorkerRepositories);
+}
+
+export function renderCloudWorkerRepositories(canManage: boolean) {
+  return html`<openclaw-cloud-worker-repositories
+    .canManage=${canManage}
+  ></openclaw-cloud-worker-repositories>`;
+}

--- a/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
@@ -191,6 +191,21 @@ describe("Cloud Workers mutation requests", () => {
           setup.dispatchEvent(new Event("input", { bubbles: true }));
           await waitForFast(() => expect(actionButton(page, "Save").disabled).toBe(false));
           actionButton(page, "Save").click();
+          await waitForFast(() =>
+            expect(page.textContent).toContain(
+              "Enter a setup command or clear the setup environment names.",
+            ),
+          );
+          expect(patches).toHaveLength(0);
+          const setupEnv = expectDefined(
+            page.querySelector<HTMLInputElement>('input[aria-label="Setup environment names"]'),
+            "Setup environment names editor",
+          );
+          expect(setupEnv.value).toBe("QA_WORKER_FLAG");
+          setupEnv.value = "";
+          setupEnv.dispatchEvent(new Event("input", { bubbles: true }));
+          await waitForFast(() => expect(actionButton(page, "Save").disabled).toBe(false));
+          actionButton(page, "Save").click();
         }
         await waitForFast(() => expect(patches).toHaveLength(1));
         expect(patches[0]).toMatchObject({

--- a/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
@@ -147,9 +147,12 @@ describe("Cloud Workers mutation requests", () => {
       provider.append(page);
       document.body.append(provider);
       try {
-        await waitForFast(() =>
-          expect(page.querySelectorAll(".settings-row code")).toHaveLength(2),
-        );
+        await waitForFast(() => {
+          const profiles = [...page.querySelectorAll(".settings-section")].find((section) =>
+            section.querySelector("h2")?.textContent?.trim().startsWith("Profiles"),
+          );
+          expect(profiles?.querySelectorAll(".settings-row code")).toHaveLength(2);
+        });
         const row = expectDefined(
           [...page.querySelectorAll(".settings-row")].find(
             (entry) => entry.querySelector("code")?.textContent === "pending",

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -190,11 +190,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
   }
 
   private patchDraft(patch: Partial<CloudWorkerProfileDraft>) {
-    this.draft = {
-      ...this.draft,
-      ...patch,
-      ...(patch.setup !== undefined && !patch.setup.trim() ? { setupEnv: "" } : {}),
-    };
+    this.draft = { ...this.draft, ...patch };
     this.formError = null;
   }
 

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -37,6 +37,7 @@ import {
   type CloudWorkerProfileDraft,
   type ConfiguredCloudWorkerProfile,
 } from "./cloud-worker-config.ts";
+import { renderCloudWorkerRepositories } from "./cloud-worker-repositories.ts";
 
 registerSettingsEnglish();
 
@@ -189,7 +190,11 @@ class CloudWorkersPage extends OpenClawLightDomElement {
   }
 
   private patchDraft(patch: Partial<CloudWorkerProfileDraft>) {
-    this.draft = { ...this.draft, ...patch };
+    this.draft = {
+      ...this.draft,
+      ...patch,
+      ...(patch.setup !== undefined && !patch.setup.trim() ? { setupEnv: "" } : {}),
+    };
     this.formError = null;
   }
 
@@ -545,6 +550,50 @@ class CloudWorkersPage extends OpenClawLightDomElement {
             @input=${(event: Event) => this.patchDraft({ binary: formControlValue(event) })}
           />`,
         }),
+        renderSettingsSection({ title: t("cloudWorkersPage.advanced") }, [
+          renderSettingsRow({
+            title: t("cloudWorkersPage.fields.warmImage"),
+            description: t("cloudWorkersPage.fields.warmImageHelp"),
+            control: html`<select
+              class="settings-select"
+              aria-label=${t("cloudWorkersPage.fields.warmImage")}
+              .value=${this.draft.warmImage}
+              ?disabled=${busy}
+              @change=${(event: Event) => {
+                const value = formControlValue(event);
+                if (value === "auto" || value === "on" || value === "off") {
+                  this.patchDraft({ warmImage: value });
+                }
+              }}
+            >
+              ${(["auto", "on", "off"] as const).map(
+                (value) => html`
+                  <option value=${value} ?selected=${this.draft.warmImage === value}>
+                    ${t(`cloudWorkersPage.warmImage.${value}`)}
+                  </option>
+                `,
+              )}
+            </select>`,
+          }),
+          ...(["setupEnv", "readyWorkers", "suspendAfter"] as const).map((field) =>
+            renderSettingsRow({
+              title: t(`cloudWorkersPage.fields.${field}`),
+              description: t(`cloudWorkersPage.fields.${field}Help`),
+              control: html`<input
+                class="settings-input mono"
+                aria-label=${t(`cloudWorkersPage.fields.${field}`)}
+                type=${field === "readyWorkers" ? "number" : "text"}
+                min=${field === "readyWorkers" ? "0" : nothing}
+                step=${field === "readyWorkers" ? "1" : nothing}
+                autocomplete="off"
+                spellcheck="false"
+                .value=${this.draft[field]}
+                ?disabled=${busy}
+                @input=${(event: Event) => this.patchDraft({ [field]: formControlValue(event) })}
+              />`,
+            }),
+          ),
+        ]),
         ...(this.formError
           ? [
               renderSettingsRow({
@@ -619,7 +668,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
         },
         rows,
       )}
-      ${this.renderEditor()}
+      ${this.renderEditor()} ${renderCloudWorkerRepositories(canManage)}
     `);
     return html`
       ${renderSettingsPageHeader({


### PR DESCRIPTION
## Problem

Settings → Cloud workers could edit only part of a profile and could not manage repository defaults or the shared prepared-worker cap. Operators had to edit config manually for these ordinary settings.

## Solution

Add an Advanced group for warm-image selection, setup environment names, ready workers, and suspend-after duration. Preserve each duration field's existing parser, including the suspend-after minimum of one minute. Empty optional fields remove their saved keys through the existing `config.patch` flow, with explicit array replacement intent for setup environment names.

Add a Prepared pool row and a Repositories section in a separate component. Repository identities use the canonical normalizer, selections must name configured profiles, and edits/deletes reject mappings changed since the editor or row was displayed. Profile deletion continues removing referencing defaults and now explains that cascade in its confirmation. Update the two relevant documentation pages.

## Impact

Operators can configure these fields and repository defaults from the same settings page. The defaults remain one ready worker per eligible project and a shared cap of four; zero disables the corresponding reserves. Saves retain the existing restart-required notice. Provider, install, and unrelated config values are preserved. No new config keys, schemas, Gateway methods, or dependencies are introduced.

## Evidence

- `pnpm install` — passed.
- `node scripts/run-vitest.mjs ui/src/pages/cloud-workers/` — passed, 94 tests across 3 files. Covers optional-key removal, duration/schema parity, setup-name validation, pool cap changes, repository CRUD, missing-profile refusal, stale mapping protection, and profile-delete cascade.
- `node scripts/run-vitest.mjs ui/src/e2e/cloud-workers-settings.e2e.test.ts` — passed, 8 Chromium tests against the mock Gateway, including exact advanced-field and repository-add `config.patch` payloads.
- `node scripts/check-changed.mjs` — passed, including core-test/UI typechecking, i18n, unused-export scans, and lint. Earlier attempts exposed two test narrowing errors and one unused type export; all were corrected before the passing run.
- `pnpm ui:i18n:baseline` — passed; no generated locale changes required.
- `pnpm ui:build` — passed.
- `pnpm ui:check-performance` — passed: startup JavaScript 352,569 bytes gzip, below the 353,107-byte limit; startup CSS 45,637 bytes gzip.
- `git diff --check` — passed.

Independent Codex autoreview is clean through P2. Its stale-mapping finding was reproduced with a failing test and repaired before the clean review; the later unused-export cleanup only removed a type export.

Proof uses the mock Gateway; no live cloud workers were provisioned. Live Crabbox proof of the snapshot flow follows in the companion PRs.

## Review follow-up

Clearing and retyping a setup command preserves its environment names. Removing the command while names remain shows an error until the names are explicitly removed. Explicit warm images are rejected for non-Linux profiles, including changes to an existing profile's operating system; Auto and Off remain available.

Both defects were reproduced before repair. The repaired head passed 94 focused tests, 8 browser E2E tests, changed-file checks, the i18n baseline, and independent review through P2. Before/after visual evidence is below.

## Screenshots

Mock Gateway fixture with two profiles and two repository defaults (synthetic data).

| Before: profile editor | After: profile editor with Advanced group |
| --- | --- |
| ![before profile editor](https://github.com/user-attachments/assets/ff5241bf-f947-4ffb-a669-639aff0a57e5) | ![after profile editor](https://github.com/user-attachments/assets/e9e7ae93-ea02-4bd6-8fb0-745641a7fd2e) |

| Before: page | After: Prepared pool row and Repositories section |
| --- | --- |
| ![before page](https://github.com/user-attachments/assets/def4890a-7ab6-48fc-996a-45a9d6507262) | ![after page](https://github.com/user-attachments/assets/edc67e64-73b3-428f-a7a3-96fe7cd5deee) |

