### PR TITLE
refactor(ui): reuse session response type owners

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -23,9 +23,12 @@ import type {
   SessionsCompactionRestoreResult as ProtocolSessionsCompactionRestoreResult,
 } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { PresenceEntry as ProtocolPresenceEntry } from "../../../packages/gateway-protocol/src/schema/snapshot.js";
-import type { GatewaySessionRow as GatewayWireSessionRow } from "../../../src/gateway/session-utils.types.js";
 import type {
-  GatewayAgentRuntime,
+  GatewaySessionRow as GatewayWireSessionRow,
+  GatewaySessionsDefaults as GatewayWireSessionsDefaults,
+  SessionsPatchResult as GatewayWireSessionsPatchResult,
+} from "../../../src/gateway/session-utils.types.js";
+import type {
   GatewayAgentRow as SharedGatewayAgentRow,
   GatewayContextWindowOption,
   GatewayThinkingLevelOption,
@@ -206,19 +209,7 @@ export type ConfigSnapshot = {
 
 export type PresenceEntry = ProtocolPresenceEntry;
 
-export type GatewaySessionsDefaults = {
-  modelProvider: string | null;
-  model: string | null;
-  contextTokens: number | null;
-  contextWindow?: string;
-  contextWindows?: GatewayContextWindowOption[];
-  contextWindowDefault?: string;
-  agentRuntime?: GatewayAgentRuntime;
-  thinkingLevels?: GatewayThinkingLevelOption[];
-  thinkingOptions?: string[];
-  thinkingDefault?: string;
-  modelSelectionTarget?: "session" | "agent" | "global";
-};
+export type GatewaySessionsDefaults = GatewayWireSessionsDefaults;
 
 export type GatewayAgentRow = SharedGatewayAgentRow;
 export type { GatewayContextWindowOption, GatewayThinkingLevelOption };
@@ -303,17 +294,8 @@ export type SessionsPatchResult = SessionsPatchResultBase<{
   verboseLevel?: string;
   reasoningLevel?: string;
   elevatedLevel?: string;
-}> & {
-  resolved?: {
-    modelProvider?: string;
-    model?: string;
-    agentRuntime?: GatewayAgentRuntime;
-    contextWindow?: string;
-    contextWindows?: GatewayContextWindowOption[];
-    thinkingLevel?: string;
-    thinkingLevels?: GatewayThinkingLevelOption[];
-  };
-};
+}> &
+  Pick<GatewayWireSessionsPatchResult, "resolved">;
 
 export type { CostUsageSummary, SessionsUsageResult } from "../pages/usage/data-types.ts";
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI repeats the Gateway's session-default fields and resolved patch metadata. Both describe the same responses, but separate field inventories can drift.

## Why This Change Was Made

Reuse the existing Gateway type owner through the module the UI already imports. Keep the exported UI names and intentionally narrower UI patch-entry shape; `Pick` preserves the optional resolved property's modifiers and exact-optional semantics.

Production LOC: +8/-26, net 18 removed. No runtime expression, public payload shape, configuration, dependency, schema, protocol or persistence change. No new tests or abstraction.

## User Impact

No intended runtime or visual change. UI and Gateway continue to share their existing response contract, while the UI's narrower patch-entry contract stays separate.

## Evidence

Refreshed proof targets commit `c7c28f73f51abecaabc6c75d64751c91b72c8d52` on parent `3e6b53c492d9bd6019983efea1c890b35a930146`; the one-file afterimage is unchanged by the rebase.

- The current canonical unfiltered `pnpm tsgo:ui` passed, as did all five unchanged metadata-reconciliation cases.
- Fresh paired TypeScript 6.0.3 proof checked all 101 exported UI types under both exact-optional settings: 16 programs, six intentional controls covering required fields, readonly properties and nested arrays, literal domains, narrow entry, and explicit undefined. All contract verdicts were as expected; the explicit-undefined control differs only when exact-optional checking is enabled.
- Both target modules emitted the same 11 JavaScript bytes, and a deliberate value-export control emitted different bytes. The custom imported programs are **not wholly typecheck-clean**: each original/candidate pair retains exactly 1 source diagnostic with exact-optional checking disabled and 16,595 with it enabled. Diagnostic parity passed, but `fullProgramGreen=false` in both settings. The canonical UI check above is separate green proof.
- The normal configured changed gate passed all 19 phases on Linux Testbox, including core-test type graphs, UI types, unused-export scans, formatting and targeted lint. [Testbox holder](https://github.com/openclaw/openclaw/actions/runs/34467233574): verified source `c7c28f73…` and tree `6126ee6b…`, command exit 0 in 22m32.326s. The provider reports the lease completed and the sync capsule was removed. Provider-owned cleanup may cancel the backing Actions holder; command success is established by the source-bound wrapper result, not the holder conclusion.
- Fresh authenticated exact-commit managed review returned scoped-clean through P2, with no findings across two evidence passes. The first pass was provisional pending the second; the second concluded contract preservation. Aggregate reported confidence remains 0.2, not a high-confidence whole-program verdict.

Exact-head hosted CI and native preparation remain required before landing. This evidence does not claim a full application build, full runtime test suite, or whole-program exact-optional typecheck success.
