### PR TITLE
fix(gateway): restore CPU diagnostics on Linux Bun

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -83,6 +83,11 @@ core equivalents: `1` means one CPU core fully occupied over the interval, and
 parallel work can produce values above `1`. It is not a percentage of the host's
 total CPU capacity.
 
+The Control UI's **System busyness** overlay reads the same sampler through
+`status.eventLoop` on both Node and Bun. Its CPU percentage uses `100%` for one
+fully occupied core. CPU and delay show a dash until the first sample completes;
+a persistent dash means the telemetry is unavailable, not zero CPU usage.
+
 Event-loop delay and utilization describe the main thread separately. A `cpu`
 degradation reason reports process CPU pressure with delay co-evidence; it does
 not identify the thread consuming CPU or prove a main-thread hang. Inspect the

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -46,6 +46,7 @@ MOCK_REQUEST_LOG=""
 LOCAL_AGENT_LOG=""
 GATEWAY_LOG=""
 GATEWAY_HEALTH_LOG=""
+GATEWAY_STATUS_LOG=""
 GATEWAY_AGENT_LOG=""
 DIRECT_BUN_LOG=""
 
@@ -74,6 +75,7 @@ dump_debug_logs() {
     "$LOCAL_AGENT_LOG" \
     "$GATEWAY_LOG" \
     "$GATEWAY_HEALTH_LOG" \
+    "$GATEWAY_STATUS_LOG" \
     "$GATEWAY_AGENT_LOG" \
     "$DIRECT_BUN_LOG" >&2 || true
 }
@@ -305,6 +307,7 @@ NODE
   LOCAL_AGENT_LOG="$SMOKE_DIR/local-agent.log"
   GATEWAY_LOG="$SMOKE_DIR/gateway.log"
   GATEWAY_HEALTH_LOG="$SMOKE_DIR/gateway-health.json"
+  GATEWAY_STATUS_LOG="$SMOKE_DIR/gateway-status.json"
   GATEWAY_AGENT_LOG="$SMOKE_DIR/gateway-agent.log"
   DIRECT_BUN_LOG="$SMOKE_DIR/direct-bun.log"
 
@@ -430,6 +433,13 @@ NODE
     "$success_marker" \
     "$GATEWAY_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
+  run_installed_cli gateway call status \
+    --params '{"includeChannelSummary":false}' \
+    --token "$OPENCLAW_GATEWAY_TOKEN" \
+    --json >"$GATEWAY_STATUS_LOG" 2>&1
+  node scripts/e2e/lib/bun-global-install/assertions.mjs \
+    assert-gateway-diagnostics \
+    "$GATEWAY_STATUS_LOG"
 
   echo "bun-global-install-smoke: Bun $bun_version install with $runtime_label CLI, local agent, and Gateway runtime OK"
 

--- a/scripts/e2e/lib/bun-global-install/assertions.mjs
+++ b/scripts/e2e/lib/bun-global-install/assertions.mjs
@@ -16,7 +16,7 @@ const PARENT_TERMINATION_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
 
 const usage = () => {
   console.error(
-    "Usage: assertions.mjs <run-with-timeout|assert-bun-version|assert-image-providers|assert-openclaw-trusted|assert-release-versions|configure-runtime|assert-agent-turn> [...]",
+    "Usage: assertions.mjs <run-with-timeout|assert-bun-version|assert-image-providers|assert-openclaw-trusted|assert-release-versions|configure-runtime|assert-gateway-diagnostics|assert-agent-turn> [...]",
   );
   process.exit(2);
 };
@@ -304,6 +304,22 @@ if (mode === "configure-runtime") {
   applyMockOpenAiModelConfig(config, { mockPort });
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  process.exit(0);
+}
+
+if (mode === "assert-gateway-diagnostics") {
+  const [outputPath] = args;
+  if (!outputPath) {
+    usage();
+  }
+  const { eventLoop } = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  for (const metric of ["cpuCoreRatio", "utilization", "delayP99Ms", "delayMaxMs", "intervalMs"]) {
+    const value = eventLoop?.[metric];
+    if (!Number.isFinite(value) || value < 0 || (metric === "intervalMs" && value === 0)) {
+      throw new Error(`Gateway status is missing a valid eventLoop.${metric} measurement`);
+    }
+  }
+  console.log("bun-global-install-smoke: Gateway CPU and event-loop diagnostics OK");
   process.exit(0);
 }
 

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -112,8 +112,8 @@ export function createGatewayEventLoopHealthMonitor(
   let firstDegradedAtMs: number | null = null;
 
   try {
-    // Match Node's interval delay histogram range and precision.
-    histogram = createHistogram({ lowest: 1_000n, highest: 2n ** 63n - 1n, figures: 3 });
+    // The default range covers 104 days; the int64 maximum fails on Linux Bun.
+    histogram = createHistogram({ lowest: 1_000, figures: 3 });
   } catch {
     histogram = null;
   }

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2651,6 +2651,10 @@ if (args[0] === "--version") {
   console.log(JSON.stringify({ payloads: [{ text: process.env.SUCCESS_MARKER }] }));
 } else if (args[0] === "gateway" && args[1] === "health") {
   console.log('{"ok":true}');
+} else if (args[0] === "gateway" && args[1] === "call" && args[2] === "status") {
+  console.log(JSON.stringify({ eventLoop: {
+    cpuCoreRatio: 0.1, utilization: 0.2, delayP99Ms: 20, delayMaxMs: 21, intervalMs: 1000,
+  } }));
 } else if (args[0] === "gateway") {
   const port = Number(args[args.indexOf("--port") + 1]);
   http.createServer((_req, res) => {


### PR DESCRIPTION
Closes #143800.

## What Problem This Solves

Fixes an issue where users opening **System busyness** saw permanent dashes for CPU and event-loop delay when their Gateway ran on Linux Bun 1.4.2. Memory and disk readings continued to work.

## Why This Change Was Made

The sampler requested a histogram upper bound of `2^63 - 1`, which fails initialization on the observed Linux Bun runtime and silently disables sampling. Use the standard histogram range (about 104 days) and a numeric lower bound compatible with Node. Sampling cadence, CPU units, and degradation classification stay unchanged. No persistent data model or schema changes: the smoke assertion only reads a task-owned JSON capture of the existing RPC.

## User Impact

CPU and event-loop delay appear after the first completed sampling window. The Bun runtime smoke flow now requires finite sampled telemetry through the installed Gateway's `status` RPC.

## Evidence

- Reproduced on Linux x64 / Bun 1.4.2: original histogram initialization throws `TypeError: Failed to initialize histogram`; the original sampler returns no snapshot.
- Final sampler on the same Linux runtime: CPU 0.7% idle → 93.4% during a controlled 1.25-second CPU load → 0.4% after recovery; delay reports the stall and clears its degraded state after recovery. The new diagnostics assertion rejects the original sample and accepts the repaired sample.
- Real isolated Gateway with the rebuilt Control UI, verified through Chrome: CPU and delay values render and their sparklines accumulate samples. The production Gateway was inspected without restart.
- 19 sampler tests and 122 installer-tooling tests pass. The numeric lower bound also preserves Node compatibility with the numeric default upper bound.
- Independent review through P2: no actionable findings.
- Full build, rebuilt Control UI, and `pnpm check:changed` pass on the committed source. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34448659262). Full packaged Bun install smoke has not been rerun in this task.
