### PR TITLE
fix(release): load frozen Anthropic internals safely

### DIFF
--- a/scripts/e2e/anthropic-cache-live.mts
+++ b/scripts/e2e/anthropic-cache-live.mts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import type { Context, Message, Model, StreamFn, Tool } from "@openclaw/ai";
-import { bindsClaudeThinkingPrefix, streamAnthropic } from "@openclaw/ai/internal/anthropic";
 import { Type } from "typebox";
 import { startMockAnthropic } from "./lib/anthropic-cache/mock-provider.mts";
-import { loadAnthropicTransportStream } from "./lib/anthropic-cache/transport-loader.mts";
+import {
+  loadAnthropicProviderInternals,
+  loadAnthropicTransportStream,
+} from "./lib/anthropic-cache/transport-loader.mts";
 
 // Docker runs this with native Node so the imports resolve to the installed
 // candidate packages, without the checkout's TypeScript source aliases.
@@ -232,6 +234,7 @@ async function runLane(name: string, stream: StreamFn, apiKey: string): Promise<
   }
 }
 
+const { bindsClaudeThinkingPrefix, streamAnthropic } = await loadAnthropicProviderInternals();
 assert(!bindsClaudeThinkingPrefix(MODEL), "the live model must exercise transient runtime context");
 const apiKey = mockMode ? "synthetic-cache-probe-key" : process.env.ANTHROPIC_API_KEY;
 assert(apiKey?.trim(), "ANTHROPIC_API_KEY is required; the release cache lane cannot skip");

--- a/scripts/e2e/lib/anthropic-cache/transport-loader.mts
+++ b/scripts/e2e/lib/anthropic-cache/transport-loader.mts
@@ -1,4 +1,13 @@
-import type { StreamFn } from "@openclaw/ai";
+import type { StreamFn, StreamFunction } from "@openclaw/ai";
+
+export type AnthropicStreamFn = StreamFunction<"anthropic-messages">;
+
+type AnthropicProviderInternals = {
+  streamAnthropic: AnthropicStreamFn;
+  bindsClaudeThinkingPrefix?: (model: { id?: string }) => boolean;
+};
+
+type AnthropicProviderImporter = () => Promise<AnthropicProviderInternals>;
 
 type AnthropicTransportImporter = () => Promise<
   Pick<typeof import("@openclaw/ai/transports"), "createAnthropicMessagesTransportStreamFn">
@@ -26,4 +35,19 @@ export async function loadAnthropicTransportStream(
     }
     throw error;
   }
+}
+
+export async function loadAnthropicProviderInternals(
+  importer: AnthropicProviderImporter = () => import("@openclaw/ai/internal/anthropic"),
+): Promise<Required<AnthropicProviderInternals>> {
+  const module = await importer();
+  if (typeof module.streamAnthropic !== "function") {
+    throw new TypeError("candidate package does not export streamAnthropic");
+  }
+  return {
+    streamAnthropic: module.streamAnthropic,
+    // Packages predating the prefix-binding contract cannot expose a model
+    // that requires it. Keep the fallback scoped to that missing capability.
+    bindsClaudeThinkingPrefix: module.bindsClaudeThinkingPrefix ?? (() => false),
+  };
 }

--- a/test/scripts/anthropic-cache-transport-loader.test.ts
+++ b/test/scripts/anthropic-cache-transport-loader.test.ts
@@ -1,6 +1,10 @@
 import type { StreamFn } from "@openclaw/ai";
 import { describe, expect, it, vi } from "vitest";
-import { loadAnthropicTransportStream } from "../../scripts/e2e/lib/anthropic-cache/transport-loader.mts";
+import {
+  type AnthropicStreamFn,
+  loadAnthropicProviderInternals,
+  loadAnthropicTransportStream,
+} from "../../scripts/e2e/lib/anthropic-cache/transport-loader.mts";
 
 describe("loadAnthropicTransportStream", () => {
   it("loads the managed transport when the candidate exports it", async () => {
@@ -38,5 +42,34 @@ describe("loadAnthropicTransportStream", () => {
         throw error;
       }),
     ).rejects.toBe(error);
+  });
+});
+
+describe("loadAnthropicProviderInternals", () => {
+  it("uses the candidate prefix-binding capability when exported", async () => {
+    const stream = vi.fn<AnthropicStreamFn>();
+    const binds = vi.fn(() => true);
+
+    const loaded = await loadAnthropicProviderInternals(async () => ({
+      streamAnthropic: stream,
+      bindsClaudeThinkingPrefix: binds,
+    }));
+
+    expect(loaded.streamAnthropic).toBe(stream);
+    expect(loaded.bindsClaudeThinkingPrefix({ id: "claude-fable-5-1" })).toBe(true);
+  });
+
+  it("treats a missing prefix-binding export as an absent frozen capability", async () => {
+    const stream = vi.fn<AnthropicStreamFn>();
+    const loaded = await loadAnthropicProviderInternals(async () => ({ streamAnthropic: stream }));
+
+    expect(loaded.streamAnthropic).toBe(stream);
+    expect(loaded.bindsClaudeThinkingPrefix({ id: "claude-sonnet-4-6" })).toBe(false);
+  });
+
+  it("rejects candidates missing the provider stream", async () => {
+    await expect(
+      loadAnthropicProviderInternals(async () => ({ streamAnthropic: undefined as never })),
+    ).rejects.toThrow("candidate package does not export streamAnthropic");
   });
 });


### PR DESCRIPTION
## Summary
- replace the static Anthropic internal named import with a capability loader
- preserve the candidate's prefix-binding implementation when present
- treat the missing helper only as the frozen package's absent capability; missing provider streaming remains fatal

## Validation
- `test/scripts/anthropic-cache-transport-loader.test.ts` (6/6)
- `oxfmt`

## Release evidence
Full Validation 34444175696 failed before the cache probe because 7.33's `@openclaw/ai/internal/anthropic` predates `bindsClaudeThinkingPrefix`.
