### PR TITLE
fix(release): qualify frozen Telegram queue scenario

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -345,6 +345,7 @@ jobs:
             extensions/telegram/src/draft-stream.ts
             qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
             qa/scenarios/channels/telegram-progress-tool-visibility.yaml
+            qa/scenarios/channels/telegram-queue-invalid-mode.yaml
             src/agents/embedded-agent-subscribe.ts
 
       - name: Resolve frozen package Telegram scenarios

--- a/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
+++ b/scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts
@@ -7,6 +7,7 @@ const PARTIAL_FAILURE_RECOVERY_SCENARIO = "telegram-partial-failure-recovery";
 const SETTLED_EMPTY_RESPONSE_SCENARIO = "telegram-empty-response-after-write-recovery";
 const PROGRESS_TOOL_VISIBILITY_SCENARIO = "telegram-progress-tool-visibility";
 const PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO = "telegram-provider-failure-before-output";
+const QUEUE_INVALID_MODE_SCENARIO = "telegram-queue-invalid-mode";
 
 function readSource(sourceRoot: string, relativePath: string): string | undefined {
   try {
@@ -52,6 +53,12 @@ export function isPreProviderFailureBeforeOutputTarget(sourceRoot: string): bool
   );
 }
 
+export function isPreQueueInvalidModeTarget(sourceRoot: string): boolean {
+  return (
+    readSource(sourceRoot, "qa/scenarios/channels/telegram-queue-invalid-mode.yaml") === undefined
+  );
+}
+
 export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): string[] {
   return [
     ...(isPrePartialFailureRecoveryTarget(sourceRoot) ? [PARTIAL_FAILURE_RECOVERY_SCENARIO] : []),
@@ -60,6 +67,7 @@ export function resolveFrozenTelegramScenarioOmissions(sourceRoot: string): stri
     ...(isPreProviderFailureBeforeOutputTarget(sourceRoot)
       ? [PROVIDER_FAILURE_BEFORE_OUTPUT_SCENARIO]
       : []),
+    ...(isPreQueueInvalidModeTarget(sourceRoot) ? [QUEUE_INVALID_MODE_SCENARIO] : []),
   ];
 }
 

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -9,6 +9,7 @@ import {
   isPrePartialFailureRecoveryTarget,
   isPreProgressToolVisibilityTarget,
   isPreProviderFailureBeforeOutputTarget,
+  isPreQueueInvalidModeTarget,
   isPreSettledEmptyResponseTarget,
   resolveFrozenTelegramScenarioOmissions,
 } from "../../scripts/e2e/lib/npm-telegram-live/resolve-target-scenarios.mts";
@@ -475,6 +476,16 @@ describe("package Telegram live Docker E2E", () => {
     expect(isPreProviderFailureBeforeOutputTarget(root)).toBe(false);
   });
 
+  it("omits invalid queue-mode validation until the frozen source owns its scenario", () => {
+    const root = mkTempRoot();
+    const scenario = path.join(root, "qa/scenarios/channels/telegram-queue-invalid-mode.yaml");
+
+    expect(isPreQueueInvalidModeTarget(root)).toBe(true);
+    mkdirSync(path.dirname(scenario), { recursive: true });
+    writeFileSync(scenario, "id: telegram-queue-invalid-mode\n");
+    expect(isPreQueueInvalidModeTarget(root)).toBe(false);
+  });
+
   it("combines only the unsupported frozen Telegram scenario contracts", () => {
     const root = mkTempRoot();
     const writeOwner = (relativePath: string, source: string) => {
@@ -494,12 +505,14 @@ describe("package Telegram live Docker E2E", () => {
       "telegram-empty-response-after-write-recovery",
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
+      "telegram-queue-invalid-mode",
     ]);
     writeOwner("extensions/telegram/src/draft-stream.ts", "waitForInFlight();");
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-empty-response-after-write-recovery",
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
+      "telegram-queue-invalid-mode",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml",
@@ -508,6 +521,7 @@ describe("package Telegram live Docker E2E", () => {
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-progress-tool-visibility",
       "telegram-provider-failure-before-output",
+      "telegram-queue-invalid-mode",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-progress-tool-visibility.yaml",
@@ -515,10 +529,16 @@ describe("package Telegram live Docker E2E", () => {
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([
       "telegram-provider-failure-before-output",
+      "telegram-queue-invalid-mode",
     ]);
     writeOwner(
       "qa/scenarios/channels/telegram-provider-failure-before-output.yaml",
       "id: telegram-provider-failure-before-output\n",
+    );
+    expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual(["telegram-queue-invalid-mode"]);
+    writeOwner(
+      "qa/scenarios/channels/telegram-queue-invalid-mode.yaml",
+      "id: telegram-queue-invalid-mode\n",
     );
     expect(resolveFrozenTelegramScenarioOmissions(root)).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- omit `telegram-queue-invalid-mode` from default package validation only when the frozen target does not own that scenario
- preserve explicit scenario selection
- include the scenario file in the source-capability checkout

## Validation
- `test/scripts/npm-telegram-live.test.ts` (54/54)
- `oxfmt`

## Release evidence
Full Validation 34444175696 applied the post-7.33 queue validation scenario to candidate `fa6539e31587`; the command produced no visible error because that source contract is absent.
