### PR TITLE
test: serialize database probe teardown

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1199,14 +1199,17 @@ function runConcurrentSchemaProbe(params: {
     const readyPath = process.env.OPENCLAW_SCHEMA_TEST_READY_PATH;
     const startPath = process.env.OPENCLAW_SCHEMA_TEST_START_PATH;
     const workerIndex = process.env.OPENCLAW_SCHEMA_TEST_WORKER_INDEX;
-    fs.writeFileSync(readyPath, "ready");
-    const deadline = Date.now() + 15_000;
-    while (!fs.existsSync(startPath)) {
-      if (Date.now() >= deadline) {
-        throw new Error("timed out waiting for concurrent schema upgrade start");
+    async function waitForMarker(markerPath, label) {
+      const deadline = Date.now() + 15_000;
+      while (!fs.existsSync(markerPath)) {
+        if (Date.now() >= deadline) {
+          throw new Error(\`timed out waiting for \${label}\`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2));
       }
-      await new Promise((resolve) => setTimeout(resolve, 2));
     }
+    fs.writeFileSync(readyPath, "ready");
+    await waitForMarker(startPath, "concurrent schema upgrade start");
     fs.writeFileSync(enteringPath, \`entering-\${workerIndex}\`);
     try {
       const database = openOpenClawStateDatabase({ path: databasePath });
@@ -1214,9 +1217,17 @@ function runConcurrentSchemaProbe(params: {
       if (integrity?.integrity_check !== "ok") {
         throw new Error("state database integrity check failed");
       }
-    } finally {
-      closeOpenClawStateDatabaseForTest();
+      fs.writeFileSync(readyPath + ".opened", "opened");
+      await waitForMarker(readyPath + ".retire", "schema probe retirement permission");
+    } catch (error) {
+      try {
+        closeOpenClawStateDatabaseForTest();
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], "schema probe and worker cleanup failed");
+      }
+      throw error;
     }
+    closeOpenClawStateDatabaseForTest();
   `;
   const orchestratorSource = `
     import assert from "node:assert/strict";
@@ -1492,6 +1503,21 @@ function runConcurrentSchemaProbe(params: {
       }
       let results;
       try {
+        if (!roundError) {
+          const openedPaths = readyPaths.map((readyPath) => readyPath + ".opened");
+          await waitForMarkers(workers, openedPaths, "successful open markers", round);
+          // Opens contend together; explicit WAL-capable retirement intentionally fails
+          // on contention, so each worker stays live until granted its own close phase.
+          for (const [index, worker] of workers.entries()) {
+            assert.equal(worker.exitCode, null, \`round \${round} worker \${index} exited before retirement\`);
+            assert.equal(worker.signalCode, null, \`round \${round} worker \${index} signaled before retirement\`);
+            fs.writeFileSync(readyPaths[index] + ".retire", "retire");
+            const [result] = await waitForOutcomes([outcomes[index]], round);
+            if (result.error || result.code !== 0) {
+              throw new Error(\`round \${round} worker \${index} retirement failed: \${JSON.stringify(result)}\`);
+            }
+          }
+        }
         results = await waitForOutcomes(outcomes, round);
       } catch (error) {
         roundError = roundError


### PR DESCRIPTION
Related: #143777.

## What Problem This Solves

The concurrent database-initialization test can fail during worker cleanup: one process retires its handle while another still owns the state-lifecycle lock. Explicit retirement intentionally rejects contention, so this cleanup race obscures the initialization behavior being tested.

## Why This Change Was Made

Keep all worker opens concurrent and retain the held-coordinator assertion. Wait for every worker to report a successful open and integrity check, then permit retirement one worker at a time and join its actual close before proceeding. Preserve both the original failure and a cleanup failure when both occur. This changes one test file only; production locking and timeout values are unchanged.

## User Impact

CI tests concurrent initialization without racing unrelated teardown. There is no product behavior change.

## Evidence

The original failure is recorded in [CI job 102769936669](https://github.com/openclaw/openclaw/actions/runs/34445629228/job/102769936669). The original helper is byte-identical at that run and the repair base. One unchanged local baseline passed, consistent with a scheduling-dependent race.

The corrected fresh-database and additive-upgrade probes both ran real child processes successfully. Retained markers show all successful opens precede retirement permission, and each worker exits before the next receives permission. The full file passed 190 tests; its one Linux-only case remains skipped on macOS. Independent P2 review and the full changed-file gate passed. No production schema, concurrency, retry, or timeout change is included.
