### PR TITLE
refactor: simplify process environment test fixtures

### DIFF
--- a/src/config/env-preserve.test.ts
+++ b/src/config/env-preserve.test.ts
@@ -1,14 +1,13 @@
 // Covers preserved environment-variable config normalization.
 import { describe, it, expect } from "vitest";
 import { restoreEnvVarRefs } from "./env-preserve.js";
-import { createProcessEnvFixture } from "./test-helpers.js";
 
 describe("restoreEnvVarRefs", () => {
-  const env = createProcessEnvFixture({
+  const env = {
     ANTHROPIC_API_KEY: "sk-ant-api03-real-key",
     OPENAI_API_KEY: "sk-openai-real-key",
     MY_TOKEN: "tok-12345",
-  });
+  };
 
   it("restores a simple ${VAR} reference when value matches", () => {
     const incoming = { apiKey: "sk-ant-api03-real-key" };
@@ -80,7 +79,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("handles missing env var (cannot verify match)", () => {
-    const envMissing = createProcessEnvFixture({});
+    const envMissing = {};
     const incoming = { apiKey: "some-value" };
     const parsed = { apiKey: "${MISSING_VAR}" };
     // Can't resolve the template, so keep incoming as-is
@@ -96,7 +95,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("restores partially resolved templates when missing vars remain literal", () => {
-    const partialEnv = createProcessEnvFixture({ API_TOKEN: "secret" });
+    const partialEnv = { API_TOKEN: "secret" };
     const incoming = { value: "secret:${OPTIONAL_SUFFIX}" };
     const parsed = { value: "${API_TOKEN}:${OPTIONAL_SUFFIX}" };
 
@@ -106,10 +105,10 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("rejects structural changes to arrays containing environment references", () => {
-    const duplicateEnv = createProcessEnvFixture({
+    const duplicateEnv = {
       PLUGIN_A: "same-plugin",
       PLUGIN_B: "same-plugin",
-    });
+    };
 
     expect(() =>
       restoreEnvVarRefs(["same-plugin"], ["${PLUGIN_A}", "${PLUGIN_B}"], duplicateEnv),
@@ -117,47 +116,31 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("allows array edits when placeholders are escaped literals", () => {
-    const result = restoreEnvVarRefs(
-      ["${ESCAPED}", "changed"],
-      ["$${ESCAPED}", "literal"],
-      {} as NodeJS.ProcessEnv,
-    );
+    const result = restoreEnvVarRefs(["${ESCAPED}", "changed"], ["$${ESCAPED}", "literal"], {});
 
     expect(result).toEqual(["$${ESCAPED}", "changed"]);
   });
 
   it("restores escaped literals beside real environment-backed array entries", () => {
-    const result = restoreEnvVarRefs(
-      ["secret", "${ESCAPED}"],
-      ["${TOKEN}", "$${ESCAPED}"],
-      createProcessEnvFixture({
-        TOKEN: "secret",
-      }),
-    );
+    const result = restoreEnvVarRefs(["secret", "${ESCAPED}"], ["${TOKEN}", "$${ESCAPED}"], {
+      TOKEN: "secret",
+    });
 
     expect(result).toEqual(["${TOKEN}", "$${ESCAPED}"]);
   });
 
   it("allows appending after stable environment-backed array entries", () => {
-    const result = restoreEnvVarRefs(
-      ["base-plugin", "extra-plugin"],
-      ["${BASE_PLUGIN}"],
-      createProcessEnvFixture({
-        BASE_PLUGIN: "base-plugin",
-      }),
-    );
+    const result = restoreEnvVarRefs(["base-plugin", "extra-plugin"], ["${BASE_PLUGIN}"], {
+      BASE_PLUGIN: "base-plugin",
+    });
 
     expect(result).toEqual(["${BASE_PLUGIN}", "extra-plugin"]);
   });
 
   it("allows removing a unique environment-backed array entry", () => {
-    const result = restoreEnvVarRefs(
-      [],
-      ["${BASE_PLUGIN}"],
-      createProcessEnvFixture({
-        BASE_PLUGIN: "base-plugin",
-      }),
-    );
+    const result = restoreEnvVarRefs([], ["${BASE_PLUGIN}"], {
+      BASE_PLUGIN: "base-plugin",
+    });
 
     expect(result).toEqual([]);
   });
@@ -176,10 +159,10 @@ describe("restoreEnvVarRefs", () => {
           deny: ["${DENIED_PLUGIN}", "keep"],
         },
       },
-      createProcessEnvFixture({
+      {
         BASE_PLUGIN: "base-plugin",
         DENIED_PLUGIN: "demo",
-      }),
+      },
     );
 
     expect(result).toEqual({
@@ -191,13 +174,9 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("allows replacing a unique environment-backed array entry", () => {
-    const result = restoreEnvVarRefs(
-      ["replacement"],
-      ["${BASE_PLUGIN}"],
-      createProcessEnvFixture({
-        BASE_PLUGIN: "base-plugin",
-      }),
-    );
+    const result = restoreEnvVarRefs(["replacement"], ["${BASE_PLUGIN}"], {
+      BASE_PLUGIN: "base-plugin",
+    });
 
     expect(result).toEqual(["replacement"]);
   });
@@ -206,7 +185,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ id: "main", workspace: "/workspace/main", name: "new" }],
       [{ id: "main", workspace: "${WORKSPACE}", name: "old" }],
-      createProcessEnvFixture({ WORKSPACE: "/workspace/main" }),
+      { WORKSPACE: "/workspace/main" },
     );
 
     expect(result).toEqual([{ id: "main", workspace: "${WORKSPACE}", name: "new" }]);
@@ -216,7 +195,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ name: "new", token: "secret" }],
       [{ name: "old", token: "${TOKEN}" }],
-      createProcessEnvFixture({ TOKEN: "secret" }),
+      { TOKEN: "secret" },
     );
 
     expect(result).toEqual([{ name: "new", token: "${TOKEN}" }]);
@@ -226,7 +205,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ match: { peer: { id: "peer-1" } } }, { match: { peer: { id: "peer-2" } } }],
       [{ match: { peer: { id: "${PEER_ID}" } } }],
-      createProcessEnvFixture({ PEER_ID: "peer-1" }),
+      { PEER_ID: "peer-1" },
     );
 
     expect(result).toEqual([
@@ -243,7 +222,7 @@ describe("restoreEnvVarRefs", () => {
           { name: "second", token: "literal" },
         ],
         [{ name: "old", token: "${TOKEN}" }],
-        createProcessEnvFixture({ TOKEN: "secret" }),
+        { TOKEN: "secret" },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -259,10 +238,10 @@ describe("restoreEnvVarRefs", () => {
           { name: "first", token: "${TOKEN_A}" },
           { name: "second", token: "${TOKEN_B}" },
         ],
-        createProcessEnvFixture({
+        {
           TOKEN_A: "secret-a",
           TOKEN_B: "secret-b",
-        }),
+        },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -278,10 +257,10 @@ describe("restoreEnvVarRefs", () => {
           { account: "first", token: "${TOKEN_A}" },
           { account: "second", token: "${TOKEN_B}" },
         ],
-        createProcessEnvFixture({
+        {
           TOKEN_A: "secret-a",
           TOKEN_B: "secret-b",
-        }),
+        },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -296,10 +275,10 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "first", name: "first", match: { peer: { id: "${PEER_A}" } } },
         { agentId: "second", name: "second", match: { peer: { id: "${PEER_B}" } } },
       ],
-      createProcessEnvFixture({
+      {
         PEER_A: "peer-a",
         PEER_B: "peer-b",
-      }),
+      },
     );
 
     expect(result).toEqual([
@@ -312,7 +291,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ agentId: "main", match: { accountId: "next" }, token: "secret" }],
       [{ agentId: "main", match: { accountId: "old" }, token: "${TOKEN}" }],
-      createProcessEnvFixture({ TOKEN: "secret" }),
+      { TOKEN: "secret" },
     );
 
     expect(result).toEqual([{ agentId: "main", match: { accountId: "next" }, token: "${TOKEN}" }]);
@@ -322,7 +301,7 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       [{ accountId: "next", to: "user@example.com" }],
       [{ accountId: "old", to: "${APPROVAL_TARGET}" }],
-      createProcessEnvFixture({ APPROVAL_TARGET: "user@example.com" }),
+      { APPROVAL_TARGET: "user@example.com" },
     );
 
     expect(result).toEqual([{ accountId: "next", to: "${APPROVAL_TARGET}" }]);
@@ -338,10 +317,10 @@ describe("restoreEnvVarRefs", () => {
         { accountId: "old", to: "${APPROVAL_TARGET_A}" },
         { accountId: "second", to: "${APPROVAL_TARGET_B}" },
       ],
-      createProcessEnvFixture({
+      {
         APPROVAL_TARGET_A: "user-a@example.com",
         APPROVAL_TARGET_B: "user-b@example.com",
-      }),
+      },
     );
 
     expect(result).toEqual([
@@ -360,10 +339,10 @@ describe("restoreEnvVarRefs", () => {
         { account: "first", enabled: false, token: "${TOKEN_A}" },
         { account: "second", enabled: true, token: "${TOKEN_B}" },
       ],
-      createProcessEnvFixture({
+      {
         TOKEN_A: "secret-a",
         TOKEN_B: "secret-b",
-      }),
+      },
     );
 
     expect(result).toEqual([
@@ -379,7 +358,7 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "first", match: { peer: { id: "${PEER_A}" } } },
         { agentId: "second", match: { peer: { id: "peer-b" } } },
       ],
-      createProcessEnvFixture({ PEER_A: "peer-a" }),
+      { PEER_A: "peer-a" },
     );
 
     expect(result).toEqual([{ agentId: "second", match: { peer: { id: "peer-b" } } }]);
@@ -393,10 +372,10 @@ describe("restoreEnvVarRefs", () => {
         { agentId: "second", match: { peer: { id: "${PEER_B}" } } },
         { agentId: "retained", match: { peer: { id: "peer-c" } } },
       ],
-      createProcessEnvFixture({
+      {
         PEER_A: "peer-a",
         PEER_B: "peer-b",
-      }),
+      },
     );
 
     expect(result).toEqual([{ agentId: "retained", match: { peer: { id: "peer-c" } } }]);
@@ -413,10 +392,10 @@ describe("restoreEnvVarRefs", () => {
           { id: "duplicate", workspace: "${WORKSPACE_A}", name: "a" },
           { id: "duplicate", workspace: "${WORKSPACE_B}", name: "b" },
         ],
-        createProcessEnvFixture({
+        {
           WORKSPACE_A: "/workspace/a",
           WORKSPACE_B: "/workspace/b",
-        }),
+        },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -429,10 +408,10 @@ describe("restoreEnvVarRefs", () => {
           { id: "duplicate", sessionKey: "${SESSION_A}" },
           { id: "duplicate", sessionKey: "${SESSION_B}" },
         ],
-        createProcessEnvFixture({
+        {
           SESSION_A: "same",
           SESSION_B: "same",
-        }),
+        },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
@@ -444,7 +423,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "duplicate", sessionKey: "${SESSION_KEY}" },
         { id: "duplicate", sessionKey: "literal" },
       ],
-      createProcessEnvFixture({ SESSION_KEY: "secret" }),
+      { SESSION_KEY: "secret" },
     );
 
     expect(result).toEqual([{ id: "duplicate", sessionKey: "literal" }]);
@@ -452,13 +431,9 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects renaming stable ids on env-backed array objects", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        [{ id: "new", token: "secret" }],
-        [{ id: "old", token: "${TOKEN}" }],
-        createProcessEnvFixture({
-          TOKEN: "secret",
-        }),
-      ),
+      restoreEnvVarRefs([{ id: "new", token: "secret" }], [{ id: "old", token: "${TOKEN}" }], {
+        TOKEN: "secret",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -469,7 +444,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "main", workspace: "/workspace/main" },
         { id: "ops", workspace: "${OPS_WORKSPACE}" },
       ],
-      createProcessEnvFixture({ OPS_WORKSPACE: "/workspace/ops" }),
+      { OPS_WORKSPACE: "/workspace/ops" },
     );
 
     expect(result).toEqual([{ id: "main", workspace: "/workspace/main" }]);
@@ -482,7 +457,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "ops", workspace: "${OPS_WORKSPACE}" },
         { id: "main", name: "old" },
       ],
-      createProcessEnvFixture({ OPS_WORKSPACE: "/workspace/ops" }),
+      { OPS_WORKSPACE: "/workspace/ops" },
     );
 
     expect(result).toEqual([{ id: "main", name: "new" }]);
@@ -490,58 +465,38 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects same-index template matches against authored literal duplicates", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["same"],
-        ["${PLUGIN_PATH}", "same"],
-        createProcessEnvFixture({
-          PLUGIN_PATH: "same",
-        }),
-      ),
+      restoreEnvVarRefs(["same"], ["${PLUGIN_PATH}", "same"], {
+        PLUGIN_PATH: "same",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects same-index scalar matches after surrounding array restructuring", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["tail", "secret"],
-        ["old", "${TOKEN}", "tail"],
-        createProcessEnvFixture({
-          TOKEN: "secret",
-        }),
-      ),
+      restoreEnvVarRefs(["tail", "secret"], ["old", "${TOKEN}", "tail"], {
+        TOKEN: "secret",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("allows trailing sibling edits beside a scalar environment reference", () => {
-    const result = restoreEnvVarRefs(
-      ["base-plugin", "replacement"],
-      ["${BASE_PLUGIN}", "old"],
-      createProcessEnvFixture({
-        BASE_PLUGIN: "base-plugin",
-      }),
-    );
+    const result = restoreEnvVarRefs(["base-plugin", "replacement"], ["${BASE_PLUGIN}", "old"], {
+      BASE_PLUGIN: "base-plugin",
+    });
 
     expect(result).toEqual(["${BASE_PLUGIN}", "replacement"]);
   });
 
   it("allows prefix edits before a same-index scalar environment reference", () => {
-    const result = restoreEnvVarRefs(
-      ["new", "base-plugin"],
-      ["old", "${BASE_PLUGIN}"],
-      createProcessEnvFixture({
-        BASE_PLUGIN: "base-plugin",
-      }),
-    );
+    const result = restoreEnvVarRefs(["new", "base-plugin"], ["old", "${BASE_PLUGIN}"], {
+      BASE_PLUGIN: "base-plugin",
+    });
 
     expect(result).toEqual(["new", "${BASE_PLUGIN}"]);
   });
 
   it("restores escaped literal moves without activating the reference", () => {
-    const result = restoreEnvVarRefs(
-      ["literal", "${TOKEN}"],
-      ["$${TOKEN}", "literal"],
-      {} as NodeJS.ProcessEnv,
-    );
+    const result = restoreEnvVarRefs(["literal", "${TOKEN}"], ["$${TOKEN}", "literal"], {});
 
     expect(result).toEqual(["literal", "$${TOKEN}"]);
   });
@@ -550,29 +505,21 @@ describe("restoreEnvVarRefs", () => {
     const result = restoreEnvVarRefs(
       ["secret", "literal", "${ESCAPED}"],
       ["${TOKEN}", "$${ESCAPED}", "literal"],
-      createProcessEnvFixture({ TOKEN: "secret" }),
+      { TOKEN: "secret" },
     );
 
     expect(result).toEqual(["${TOKEN}", "literal", "$${ESCAPED}"]);
   });
 
   it("preserves duplicate escaped literals when their positions stay stable", () => {
-    const result = restoreEnvVarRefs(
-      ["${TOKEN}", "${TOKEN}"],
-      ["$${TOKEN}", "$${TOKEN}"],
-      {} as NodeJS.ProcessEnv,
-    );
+    const result = restoreEnvVarRefs(["${TOKEN}", "${TOKEN}"], ["$${TOKEN}", "$${TOKEN}"], {});
 
     expect(result).toEqual(["$${TOKEN}", "$${TOKEN}"]);
   });
 
   it("rejects ambiguous escaped literal moves beside a new active reference", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["literal", "${TOKEN}", "${TOKEN}"],
-        ["$${TOKEN}", "literal"],
-        {} as NodeJS.ProcessEnv,
-      ),
+      restoreEnvVarRefs(["literal", "${TOKEN}", "${TOKEN}"], ["$${TOKEN}", "literal"], {}),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -586,7 +533,7 @@ describe("restoreEnvVarRefs", () => {
         { id: "escaped", token: "$${TOKEN}", enabled: false },
         { id: "literal", token: "plain" },
       ],
-      {} as NodeJS.ProcessEnv,
+      {},
     );
 
     expect(result).toEqual([
@@ -668,13 +615,9 @@ describe("restoreEnvVarRefs", () => {
 
   it("rejects escaped literal moves onto indexes claimed by real references", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["${B}", "changed"],
-        ["${A}", "$${B}", "tail"],
-        createProcessEnvFixture({
-          A: "x",
-        }),
-      ),
+      restoreEnvVarRefs(["${B}", "changed"], ["${A}", "$${B}", "tail"], {
+        A: "x",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -695,26 +638,18 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("preserves intentional real references beside same-name escaped literals", () => {
-    const result = restoreEnvVarRefs(
-      ["secret", "${TOKEN}"],
-      ["${TOKEN}", "$${TOKEN}"],
-      createProcessEnvFixture({
-        TOKEN: "secret",
-      }),
-    );
+    const result = restoreEnvVarRefs(["secret", "${TOKEN}"], ["${TOKEN}", "$${TOKEN}"], {
+      TOKEN: "secret",
+    });
 
     expect(result).toEqual(["${TOKEN}", "$${TOKEN}"]);
   });
 
   it("rejects ambiguous same-name real and escaped reference reorders", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["${TOKEN}", "secret"],
-        ["${TOKEN}", "$${TOKEN}"],
-        createProcessEnvFixture({
-          TOKEN: "secret",
-        }),
-      ),
+      restoreEnvVarRefs(["${TOKEN}", "secret"], ["${TOKEN}", "$${TOKEN}"], {
+        TOKEN: "secret",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -742,13 +677,9 @@ describe("restoreEnvVarRefs", () => {
 
   it("does not let a same-path active reference mask an activated escaped literal", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["changed-${TOKEN}"],
-        ["${TOKEN}-$${TOKEN}"],
-        createProcessEnvFixture({
-          TOKEN: "secret",
-        }),
-      ),
+      restoreEnvVarRefs(["changed-${TOKEN}"], ["${TOKEN}-$${TOKEN}"], {
+        TOKEN: "secret",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -779,32 +710,24 @@ describe("restoreEnvVarRefs", () => {
           { id: "literal", token: "$${TOKEN}" },
           { id: "active", token: "${TOKEN}" },
         ],
-        createProcessEnvFixture({ TOKEN: "secret" }),
+        { TOKEN: "secret" },
       ),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects replacing a scalar template while adding its resolved value elsewhere", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["replacement", "admin"],
-        ["${ADMIN_ID}", "old"],
-        createProcessEnvFixture({
-          ADMIN_ID: "admin",
-        }),
-      ),
+      restoreEnvVarRefs(["replacement", "admin"], ["${ADMIN_ID}", "old"], {
+        ADMIN_ID: "admin",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
   it("rejects replacing a scalar template while adding its resolved value in a longer array", () => {
     expect(() =>
-      restoreEnvVarRefs(
-        ["old", "replacement", "admin"],
-        ["${ADMIN_ID}", "old"],
-        createProcessEnvFixture({
-          ADMIN_ID: "admin",
-        }),
-      ),
+      restoreEnvVarRefs(["old", "replacement", "admin"], ["${ADMIN_ID}", "old"], {
+        ADMIN_ID: "admin",
+      }),
     ).toThrow("Config write would reorder or modify an array containing environment references");
   });
 
@@ -823,14 +746,14 @@ describe("restoreEnvVarRefs", () => {
     expect(result).toEqual({ apiKey: "sk-ant-api03-real-key" });
   });
 
-  // Edge case: env mutation between read and write (Greptile comment #1)
+  // Edge case: env mutation between read and write
   // Scenario: config.env sets FOO=bar, which gets applied to process.env during loadConfig.
   // Later writeConfigFile runs — the env has changed since the original read.
   it("does not incorrectly restore when env var value changed between read and write", () => {
     // At read time, MY_VAR was "original-value" and resolved ${MY_VAR} → "original-value"
     // Then config.env or external mutation changed MY_VAR to "mutated-value"
     // Caller is writing back "original-value" (the value they got from the read)
-    const mutatedEnv = createProcessEnvFixture({ MY_VAR: "mutated-value" });
+    const mutatedEnv = { MY_VAR: "mutated-value" };
     const incoming = { key: "original-value" };
     const parsed = { key: "${MY_VAR}" };
 
@@ -841,7 +764,7 @@ describe("restoreEnvVarRefs", () => {
   });
 
   it("correctly restores when env var value hasn't changed", () => {
-    const stableEnv = createProcessEnvFixture({ MY_VAR: "stable-value" });
+    const stableEnv = { MY_VAR: "stable-value" };
     const incoming = { key: "stable-value" };
     const parsed = { key: "${MY_VAR}" };
 
@@ -854,7 +777,7 @@ describe("restoreEnvVarRefs", () => {
     // With env snapshots: at read time MY_VAR was "old-value", so incoming is "old-value".
     // Caller changed it to "new-value". Live env also changed to "new-value".
     // But using the READ-TIME snapshot ("old-value"), we correctly see mismatch and keep incoming.
-    const readTimeEnv = createProcessEnvFixture({ MY_VAR: "old-value" });
+    const readTimeEnv = { MY_VAR: "old-value" };
     const incoming = { key: "new-value" }; // caller intentionally changed this
     const parsed = { key: "${MY_VAR}" };
 
@@ -864,7 +787,7 @@ describe("restoreEnvVarRefs", () => {
     expect(result).toEqual({ key: "new-value" });
   });
 
-  // Edge case: $${VAR} escape sequence (Greptile comment #2)
+  // Edge case: $${VAR} escape sequence
   it("handles $${VAR} escape sequence (literal ${VAR} in output)", () => {
     // In the config file: $${ANTHROPIC_API_KEY}
     // substituteString resolves this to literal "${ANTHROPIC_API_KEY}"
@@ -900,7 +823,7 @@ describe("restoreEnvVarRefs", () => {
     const parsed = Object.create({
       toString: "${TEST_VALUE}",
     }) as Record<string, unknown>;
-    const testEnv = createProcessEnvFixture({ TEST_VALUE: "resolved-value" });
+    const testEnv = { TEST_VALUE: "resolved-value" };
 
     expect(restoreEnvVarRefs({ toString: "resolved-value" }, parsed, testEnv)).toEqual({
       toString: "resolved-value",

--- a/src/config/env-substitution.test.ts
+++ b/src/config/env-substitution.test.ts
@@ -405,7 +405,7 @@ describe("resolveConfigEnvVars", () => {
       const warnings: EnvSubstitutionWarning[] = [];
       const result = resolveConfigEnvVars(
         { key: "${MISSING_VAR}", present: "${PRESENT}" },
-        { PRESENT: "ok" } as NodeJS.ProcessEnv,
+        { PRESENT: "ok" },
         { onMissing: (w) => warnings.push(w) },
       );
       expect(result).toEqual({ key: "${MISSING_VAR}", present: "ok" });
@@ -422,7 +422,7 @@ describe("resolveConfigEnvVars", () => {
           },
           gateway: { token: "${GW_TOKEN}" },
         },
-        { GW_TOKEN: "secret" } as NodeJS.ProcessEnv,
+        { GW_TOKEN: "secret" },
         { onMissing: (w) => warnings.push(w) },
       );
       expect(result).toEqual({
@@ -438,9 +438,7 @@ describe("resolveConfigEnvVars", () => {
     });
 
     it("still throws when onMissing is not set", () => {
-      expect(() => resolveConfigEnvVars({ key: "${MISSING}" }, {} as NodeJS.ProcessEnv)).toThrow(
-        MissingEnvVarError,
-      );
+      expect(() => resolveConfigEnvVars({ key: "${MISSING}" }, {})).toThrow(MissingEnvVarError);
     });
   });
 

--- a/src/config/test-helpers.ts
+++ b/src/config/test-helpers.ts
@@ -35,10 +35,6 @@ export async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise
   }
 }
 
-export function createProcessEnvFixture(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return { ...overrides };
-}
-
 export async function writeOpenClawConfig(home: string, config: unknown): Promise<string> {
   const configPath = path.join(home, ".openclaw", "openclaw.json");
   await fs.mkdir(path.dirname(configPath), { recursive: true });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Environment-preservation tests wrapped fresh object literals in a copying fixture builder and carried redundant type assertions. The extra scaffolding obscured the inputs without exercising a separate copying or identity contract.

## Why This Change Was Made

Use the same 44 fresh object literals directly, remove eight redundant casts and the unused helper import, and delete the four-line builder. Preserve the mutation, escaped-reference and time-of-check/time-of-use explanations and every existing test assertion.

## User Impact

No production behavior or public API change. The three test and test-support files add 95 lines and remove 178, for a net reduction of 83 lines. Much of that line reduction is formatter reflow; this is not a runtime performance change.

## Evidence

The original and final versions each passed all 89 cases, with identical test identities: 72 preservation cases and 17 substitution cases. All 106 matcher assertion sites and the explicit failure guard remain. Independent source review is clean through P2.

All 30 normal local changed checks passed, including core and test typechecks, type-aware lint, dead-export scans and the required guards. Source remained unchanged during both test runs and the full check.
