### PR TITLE
refactor: unify fast-mode state construction

### DIFF
--- a/src/agents/fast-mode.ts
+++ b/src/agents/fast-mode.ts
@@ -48,49 +48,30 @@ export function resolveFastModeState(params: {
     ...params,
     modelParamSources: [agentModelParams, modelParams],
   });
-  const sessionOverride = normalizeFastMode(params.sessionEntry?.fastMode);
-  if (sessionOverride !== undefined) {
-    return {
-      mode: sessionOverride,
-      enabled: sessionOverride === "auto" ? true : sessionOverride,
-      source: "session",
-      fastAutoOnSeconds,
-    };
+  let mode = normalizeFastMode(params.sessionEntry?.fastMode);
+  let source: FastModeSource = "session";
+  if (mode === undefined) {
+    mode = normalizeFastMode(
+      params.agentId && params.cfg
+        ? resolveAgentConfig(params.cfg, params.agentId)?.fastModeDefault
+        : undefined,
+    );
+    source = "agent";
   }
-
-  const agentDefault =
-    params.agentId && params.cfg
-      ? resolveAgentConfig(params.cfg, params.agentId)?.fastModeDefault
-      : undefined;
-  const normalizedAgentDefault = normalizeFastMode(agentDefault);
-  if (normalizedAgentDefault !== undefined) {
-    return {
-      mode: normalizedAgentDefault,
-      enabled: normalizedAgentDefault === "auto" ? true : normalizedAgentDefault,
-      source: "agent",
-      fastAutoOnSeconds,
-    };
-  }
-
-  const configuredRaw =
-    agentModelParams?.fastMode ??
-    agentModelParams?.fast_mode ??
-    modelParams?.fastMode ??
-    modelParams?.fast_mode;
-  const configured = normalizeFastMode(configuredRaw as string | boolean | null | undefined);
-  if (configured !== undefined) {
-    return {
-      mode: configured,
-      enabled: configured === "auto" ? true : configured,
-      source: "config",
-      fastAutoOnSeconds,
-    };
+  if (mode === undefined) {
+    const configuredRaw =
+      agentModelParams?.fastMode ??
+      agentModelParams?.fast_mode ??
+      modelParams?.fastMode ??
+      modelParams?.fast_mode;
+    mode = normalizeFastMode(configuredRaw as string | boolean | null | undefined);
+    source = "config";
   }
 
   return {
-    mode: false,
-    enabled: false,
-    source: "default",
+    mode: mode ?? false,
+    enabled: mode === "auto" || mode === true,
+    source: mode === undefined ? "default" : source,
     fastAutoOnSeconds,
   };
 }


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fast-mode resolution repeats the same returned state in four precedence branches. Maintaining those copies makes it easier for mode, enabled state, source labels, or cutoff reporting to drift during the model-runtime repairs.

## Why This Change Was Made

Select the mode and its source once, then construct one result. Preserve session → agent → model → default precedence, explicit false, auto mode, cutoff resolution, and short-circuit reads. The existing API and model-parameter lookup are unchanged. This maintainer-requested cleanup removes 19 production lines from one file.

## User Impact

Fast-mode selection and `/fast status` behavior remain unchanged.

## Evidence

All 43 existing owner/status tests pass with no test edits, alongside the full changed-file gate and independent P2 review. One canonical `sourcePerformance` runtime build passed at `f17046264efe3f070571e69afb0f19be2bc86a42`; this profile covers runtime assets, not UI or declaration generation.

The compiled SDK resolver passed 280 cases covering precedence combinations, cutoff aliases, defaults, explicit false/auto, and short-circuit reads. Seven actual `/fast status` dispatcher cases also passed with the real resolver. Both paths use the same compiled owner module. Source-import rejection and the negative control passed; source and runtime hashes remained unchanged. The isolated proof used no operator Gateway or external model request.
