### PR TITLE
fix(deepseek): preserve object-union tool arguments

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3239,7 +3239,7 @@ src/plugin-sdk/provider-entry.ts	3
 src/plugin-sdk/provider-onboard.ts	5
 src/plugin-sdk/provider-stream-shared.ts	14
 src/plugin-sdk/provider-stream.ts	1
-src/plugin-sdk/provider-tools.ts	10
+src/plugin-sdk/provider-tools.ts	9
 src/plugin-sdk/qa-channel-protocol.ts	1
 src/plugin-sdk/qa-channel.ts	15
 src/plugin-sdk/qa-lab.ts	2

--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -30,7 +30,7 @@ const decimalTools = [
 ];
 
 describe("validateToolArguments", () => {
-  it.each(["anyOf", "oneOf", "TypeBox"])(
+  it.each(["anyOf", "oneOf", "TypeBox", "type-array integer/null", "type-array null/integer"])(
     "keeps invalid non-null values out of a nullable integer %s",
     (union) => {
       const tool: Tool = {
@@ -44,7 +44,12 @@ describe("validateToolArguments", () => {
             : {
                 type: "object",
                 properties: {
-                  limit: { [union]: [{ type: "integer", minimum: 1 }, { type: "null" }] },
+                  limit:
+                    union === "type-array integer/null"
+                      ? { type: ["integer", "null"], minimum: 1 }
+                      : union === "type-array null/integer"
+                        ? { type: ["null", "integer"], minimum: 1 }
+                        : { [union]: [{ type: "integer", minimum: 1 }, { type: "null" }] },
                 },
               },
       };
@@ -70,6 +75,115 @@ describe("validateToolArguments", () => {
       }
     },
   );
+
+  it.each([
+    { name: "object/null", types: ["object", "null"] },
+    { name: "null/object", types: ["null", "object"] },
+  ])("keeps invalid non-null values out of a $name type array", ({ types }) => {
+    const tool: Tool = {
+      name: "nullable-parent",
+      description: "Accept an object or null without replacing rejected scalar input",
+      parameters: {
+        type: "object",
+        properties: {
+          parent: {
+            type: types,
+            properties: {
+              kind: { type: "string", enum: ["page"] },
+              count: { type: "integer", minimum: 1 },
+            },
+            required: ["kind", "count"],
+            additionalProperties: false,
+          },
+        },
+        required: ["parent"],
+        additionalProperties: false,
+      },
+    };
+    const validate = (parent: unknown) =>
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "nullable-parent-call",
+        name: tool.name,
+        arguments: { parent },
+      });
+
+    expect(validate(null)).toEqual({ parent: null });
+    const parent = { kind: "page", count: "2" };
+    for (const input of [parent, JSON.stringify(parent)]) {
+      expect(validate(input)).toEqual({ parent: { kind: "page", count: 2 } });
+    }
+    for (const input of [false, 0, "", [], { kind: "wrong", count: 2 }]) {
+      expect(() => validate(input)).toThrow(/Validation failed for tool "nullable-parent"/);
+    }
+  });
+
+  const numericConversions = [
+    { input: "2.5", output: 2.5 },
+    { input: false, output: 0 },
+    { input: 0, output: 0 },
+  ];
+  const stringConversions = [
+    { input: false, output: "false" },
+    { input: 0, output: "0" },
+    { input: "", output: "" },
+    { input: "existing", output: "existing" },
+  ];
+
+  it.each([
+    { name: "number/null", types: ["number", "null"], conversions: numericConversions },
+    { name: "null/number", types: ["null", "number"], conversions: numericConversions },
+    { name: "string/null", types: ["string", "null"], conversions: stringConversions },
+    { name: "null/string", types: ["null", "string"], conversions: stringConversions },
+  ])("retains valid non-null coercions in a $name type array", ({ types, conversions }) => {
+    const tool: Tool = {
+      name: "nullable-value",
+      description: "Keep conversions into a supported non-null alternative",
+      parameters: {
+        type: "object",
+        properties: { value: { type: types } },
+        required: ["value"],
+      },
+    };
+    const validate = (value: unknown) =>
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "nullable-value-call",
+        name: tool.name,
+        arguments: { value },
+      });
+
+    expect(validate(null)).toEqual({ value: null });
+    for (const { input, output } of conversions) {
+      expect(validate(input)).toEqual({ value: output });
+    }
+  });
+
+  it.each([
+    { name: "a null type", type: "null" },
+    { name: "a single-member null type array", type: ["null"] },
+  ])("preserves existing coercion for $name", ({ type }) => {
+    const tool: Tool = {
+      name: "null-only",
+      description: "Retain the existing null-only conversion contract",
+      parameters: {
+        type: "object",
+        properties: { value: { type } },
+        required: ["value"],
+      },
+    };
+
+    for (const value of [null, false, 0, ""]) {
+      expect(
+        validateToolArguments(tool, {
+          type: "toolCall",
+          id: "null-only-call",
+          name: tool.name,
+          arguments: { value },
+        }),
+      ).toEqual({ value: null });
+    }
+  });
 
   it.each(decimalTools)("coerces strict decimal numeric strings for $label", ({ tool }) => {
     expect(

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -290,6 +290,9 @@ function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown
     schemaTypes.some((schemaType) => matchesJsonType(nextValue, schemaType));
   if (schemaTypes.length > 0 && !matchesUnionMember) {
     for (const schemaType of schemaTypes) {
+      if (schemaType === "null" && nextValue !== null && schemaTypes.length > 1) {
+        continue;
+      }
       const candidate = coercePrimitiveByType(nextValue, schemaType);
       if (candidate !== nextValue) {
         nextValue = candidate;

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -3349,8 +3349,12 @@ function resolvePreciseChangedTestTargets(
   options: ChangedTestTargetOptions & { skipImportGraph?: boolean },
 ) {
   const cwd = options.cwd ?? process.cwd();
+  const pluginSdkInclude = resolvePluginSdkLightIncludePattern(changedPath);
   const mappedTargets =
     SOURCE_TEST_TARGETS.get(changedPath) ??
+    (pluginSdkInclude
+      ? pluginSdkLightTestFiles.filter((file) => path.matchesGlob(file, pluginSdkInclude))
+      : null) ??
     (/^extensions\/[^/]+\/openclaw\.plugin\.json$/u.test(changedPath)
       ? [changedPath, DOCS_CONFIG_EXAMPLES_TEST_TARGET]
       : null) ??

--- a/src/plugin-sdk/provider-tools.nullable.test.ts
+++ b/src/plugin-sdk/provider-tools.nullable.test.ts
@@ -1,0 +1,245 @@
+import { validateToolArguments } from "@openclaw/llm-core/validation";
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool, ProviderNormalizeToolSchemasContext } from "./plugin-entry.js";
+import { buildProviderToolCompatFamilyHooks } from "./provider-tools.js";
+
+describe("buildProviderToolCompatFamilyHooks", () => {
+  function tool(parameters: AnyAgentTool["parameters"], name: string): AnyAgentTool {
+    return {
+      name,
+      label: name,
+      description: "",
+      parameters,
+      execute: async () => {
+        throw new Error("Schema tests must not execute tools");
+      },
+    };
+  }
+
+  function objectSchema(
+    properties: Record<string, unknown>,
+    overrides: Record<string, unknown> = {},
+  ) {
+    return { type: "object", properties, ...overrides };
+  }
+
+  function deepSeekContext(tools: AnyAgentTool[]): ProviderNormalizeToolSchemasContext {
+    return {
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      tools,
+    };
+  }
+
+  function validateDeepSeekTool(normalized: AnyAgentTool[], args: Record<string, unknown>) {
+    const normalizedTool = expectDefined(normalized[0], "normalized DeepSeek tool");
+    return validateToolArguments(normalizedTool, {
+      type: "toolCall",
+      id: "call-deepseek-probe",
+      name: normalizedTool.name,
+      arguments: args,
+    });
+  }
+
+  const nullablePage = {
+    type: "object",
+    properties: {
+      kind: { type: "string", enum: ["page"] },
+      page_id: { type: "string" },
+    },
+    required: ["kind", "page_id"],
+    additionalProperties: false,
+  };
+  const nullableDatabase = {
+    type: "object",
+    properties: {
+      kind: { type: "string", enum: ["database"] },
+      database_id: { type: "string" },
+    },
+    required: ["kind", "database_id"],
+    additionalProperties: false,
+  };
+  const pageParent = { kind: "page", page_id: "page-1" };
+  const databaseParent = { kind: "database", database_id: "database-1" };
+
+  it.each([
+    {
+      name: "one object and null",
+      parentSchema: { oneOf: [nullablePage, { type: "null" }] },
+      acceptsNull: true,
+      validParents: [pageParent],
+    },
+    {
+      name: "multiple objects and null",
+      parentSchema: { anyOf: [nullablePage, nullableDatabase, { type: "null" }] },
+      acceptsNull: true,
+      validParents: [pageParent, databaseParent],
+    },
+    {
+      name: "a nullable object branch and another object",
+      parentSchema: { anyOf: [{ anyOf: [nullablePage, { type: "null" }] }, nullableDatabase] },
+      acceptsNull: true,
+      validParents: [pageParent, databaseParent],
+    },
+    {
+      name: "an explicit outer object constraint",
+      parentSchema: {
+        type: "object",
+        anyOf: [nullablePage, nullableDatabase, { type: "null" }],
+      },
+      acceptsNull: false,
+      validParents: [pageParent, databaseParent],
+    },
+    {
+      name: "a nullable type whose literal restriction excludes null",
+      parentSchema: {
+        anyOf: [
+          { ...nullablePage, type: ["object", "null"], enum: [pageParent] },
+          nullableDatabase,
+        ],
+      },
+      acceptsNull: false,
+      validParents: [pageParent, databaseParent],
+    },
+  ])(
+    "validates nested object alternatives with $name",
+    ({ parentSchema, acceptsNull, validParents }) => {
+      const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+      const normalized = hooks.normalizeToolSchemas(
+        deepSeekContext([
+          tool(objectSchema({ parent: parentSchema }, { required: ["parent"] }), "nullable-parent"),
+        ]),
+      );
+      expect(hooks.inspectToolSchemas(deepSeekContext(normalized))).toStrictEqual([]);
+      if (acceptsNull) {
+        expect(validateDeepSeekTool(normalized, { parent: null })).toEqual({ parent: null });
+      } else {
+        expect(() => validateDeepSeekTool(normalized, { parent: null })).toThrow(
+          /Validation failed for tool "nullable-parent"/,
+        );
+      }
+      for (const parent of validParents) {
+        expect(validateDeepSeekTool(normalized, { parent })).toEqual({ parent });
+      }
+      for (const args of [
+        {},
+        { parent: false },
+        { parent: 0 },
+        { parent: "" },
+        { parent: {} },
+        { parent: { kind: "unknown" } },
+        { parent: "not an object" },
+      ]) {
+        expect(() => validateDeepSeekTool(normalized, args)).toThrow(
+          /Validation failed for tool "nullable-parent"/,
+        );
+      }
+    },
+  );
+
+  const otherPageParent = { kind: "page", page_id: "page-2" };
+
+  it.each([
+    {
+      name: "a branch-local enum",
+      branch: { enum: [pageParent] },
+      outer: {},
+      acceptsNull: true,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "a branch-local const",
+      branch: { const: pageParent },
+      outer: {},
+      acceptsNull: true,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "an intersecting branch-local const and enum",
+      branch: { const: pageParent, enum: [pageParent, otherPageParent] },
+      outer: {},
+      acceptsNull: true,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "a disjoint branch-local const and enum",
+      branch: { const: pageParent, enum: [otherPageParent] },
+      outer: {},
+      acceptsNull: true,
+      validParents: [],
+      invalidParents: [pageParent, otherPageParent],
+    },
+    {
+      name: "an outer enum excluding null",
+      branch: { enum: [pageParent, otherPageParent] },
+      outer: { enum: [pageParent] },
+      acceptsNull: false,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "an outer enum allowing null",
+      branch: { enum: [pageParent, otherPageParent] },
+      outer: { enum: [pageParent, null] },
+      acceptsNull: true,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "an outer object const",
+      branch: { enum: [pageParent, otherPageParent] },
+      outer: { const: pageParent },
+      acceptsNull: false,
+      validParents: [pageParent],
+      invalidParents: [otherPageParent],
+    },
+    {
+      name: "an outer null const",
+      branch: { enum: [pageParent, otherPageParent] },
+      outer: { const: null },
+      acceptsNull: true,
+      validParents: [],
+      invalidParents: [pageParent, otherPageParent],
+    },
+  ])("preserves object/null literal restrictions with $name", (testCase) => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const normalized = hooks.normalizeToolSchemas(
+      deepSeekContext([
+        tool(
+          objectSchema(
+            {
+              parent: {
+                anyOf: [{ ...nullablePage, ...testCase.branch }, { type: "null" }],
+                ...testCase.outer,
+              },
+            },
+            { required: ["parent"] },
+          ),
+          "literal-null-parent",
+        ),
+      ]),
+    );
+
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized))).toStrictEqual([]);
+    if (testCase.acceptsNull) {
+      expect(validateDeepSeekTool(normalized, { parent: null })).toEqual({ parent: null });
+    } else {
+      expect(() => validateDeepSeekTool(normalized, { parent: null })).toThrow(
+        /Validation failed for tool "literal-null-parent"/,
+      );
+    }
+    for (const parent of testCase.validParents) {
+      expect(validateDeepSeekTool(normalized, { parent })).toEqual({ parent });
+    }
+    for (const parent of [...testCase.invalidParents, false, 0, ""]) {
+      expect(() => validateDeepSeekTool(normalized, { parent })).toThrow(
+        /Validation failed for tool "literal-null-parent"/,
+      );
+    }
+  });
+});

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -1,3 +1,5 @@
+import { validateToolArguments } from "@openclaw/llm-core/validation";
+import { expectDefined } from "@openclaw/normalization-core";
 // Provider tool tests cover tool schema conversion and provider payload compatibility.
 import { describe, expect, it } from "vitest";
 import { findSourceImportBackedges } from "../../test/helpers/source-import-closure.js";
@@ -75,6 +77,19 @@ describe("buildProviderToolCompatFamilyHooks", () => {
       modelId: "deepseek-v4-pro",
       modelApi: "openai-completions",
       baseUrl: null,
+    });
+  }
+
+  function validateDeepSeekTool(
+    normalized: ReturnType<typeof normalizeDeepSeekToolSchemas>,
+    args: Record<string, unknown>,
+  ) {
+    const normalizedTool = expectDefined(normalized[0], "normalized DeepSeek tool");
+    return validateToolArguments(normalizedTool, {
+      type: "toolCall",
+      id: "call-deepseek-probe",
+      name: normalizedTool.name,
+      arguments: args,
     });
   }
 
@@ -230,7 +245,7 @@ describe("buildProviderToolCompatFamilyHooks", () => {
   });
 
   it("preserves string-const unions as a flat enum for the deepseek family", () => {
-    // Regression for https://github.com/openclaw/openclaw/issues/86468 —
+    // Regression for https://github.com/openclaw/openclaw/issues/86468.
     // Typebox `Type.Union([Type.Literal(...)])` collapses to anyOf of consts;
     // the previous normalizer kept only the first const, hiding every other
     // literal from the model.
@@ -287,6 +302,442 @@ describe("buildProviderToolCompatFamilyHooks", () => {
         { required: ["mode"] },
       ),
     );
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+  });
+
+  it("keeps every object variant of a union expressible for the deepseek family", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/143790.
+    // Notion's create-pages `parent` is an anyOf of three object variants.
+    // Keeping only the first variant narrowed the schema to `page_id`, so the
+    // model could not express a database or data-source parent and every such
+    // call was rejected by our own argument validator before it reached the
+    // server.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema(
+          {
+            pages: { type: "array", items: { type: "object" } },
+            parent: {
+              description: "The parent under which the new pages will be created.",
+              anyOf: [
+                {
+                  type: "object",
+                  properties: {
+                    page_id: { type: "string" },
+                    type: { type: "string", enum: ["page_id"] },
+                  },
+                  required: ["page_id"],
+                  additionalProperties: {},
+                },
+                {
+                  type: "object",
+                  properties: {
+                    database_id: { type: "string" },
+                    type: { type: "string", enum: ["database_id"] },
+                  },
+                  required: ["database_id"],
+                  additionalProperties: {},
+                },
+                {
+                  type: "object",
+                  properties: {
+                    data_source_id: { type: "string" },
+                    type: { type: "string", enum: ["data_source_id"] },
+                  },
+                  required: ["data_source_id"],
+                  additionalProperties: {},
+                },
+              ],
+            },
+          },
+          { required: ["pages"] },
+        ),
+        "notion__notion-create-pages",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+
+    // Every branch stays expressible, and the discriminator pools its values so
+    // the model can name any of them. The per-branch keys stay unconstrained:
+    // each is declared by one variant and permitted by the others through
+    // `additionalProperties`, so constraining one would reject a call those
+    // variants accepted. The live Notion schema documents each of them, and any
+    // annotation survives here.
+    expect(parameters.properties.parent).toEqual({
+      description: "The parent under which the new pages will be created.",
+      type: "object",
+      properties: {
+        page_id: {},
+        database_id: {},
+        data_source_id: {},
+        type: { type: "string", enum: ["page_id", "database_id", "data_source_id"] },
+      },
+    });
+    // No branch's key is required any more, because no key is required by all
+    // of them. The root's own `required` is untouched.
+    expect(parameters.required).toEqual(["pages"]);
+    // The provider still sees no union keyword.
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+  });
+
+  it("does not narrow a key that an open variant accepts without declaring", () => {
+    // Review finding on #143819: taking a property from a later variant can
+    // narrow the first one. Branch A permits arbitrary extras through
+    // `additionalProperties` and accepts `{a: "x", b: {nested: true}}`; branch B
+    // declares `b` as a string. Imposing that constraint would reject a call the
+    // first variant accepted, so the key has to stay unconstrained, and the
+    // assertion runs through the real argument validator rather than the shape.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          parent: {
+            anyOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: {},
+              },
+              {
+                type: "object",
+                properties: { b: { type: "string" } },
+                required: ["b"],
+              },
+            ],
+          },
+        }),
+        "open-variant",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const validate = (args: Record<string, unknown>) =>
+      validateToolArguments(normalized[0] as never, {
+        type: "toolCall",
+        id: "call-open-variant",
+        name: "open-variant",
+        arguments: args,
+      });
+
+    // Accepted by branch A before this change, so it must stay accepted.
+    expect(() => validate({ parent: { a: "x", b: { nested: true } } })).not.toThrow();
+    // And the variant that first-variant selection made unreachable is callable.
+    expect(() => validate({ parent: { b: "y" } })).not.toThrow();
+  });
+
+  it("keeps a property whose name collides with Object.prototype", () => {
+    // Review finding on #143819: the accumulator was a plain object, so reading
+    // `properties["constructor"]` returned the inherited function, enum pooling
+    // failed, and the real definition was dropped while the name stayed in
+    // `required`. Both variants are closed here, so nothing is relaxed and the
+    // assertions are purely about own-property accumulation.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          options: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  constructor: { type: "string" },
+                  toString: { type: "string" },
+                },
+                required: ["constructor", "toString"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  constructor: { type: "string" },
+                  toString: { type: "string" },
+                },
+                required: ["constructor"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        }),
+        "prototype-keys",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: {
+        options: { properties: Record<string, unknown>; required?: string[] };
+      };
+    };
+
+    const props = parameters.properties.options.properties;
+    expect(props["constructor"]).toEqual({ type: "string" });
+    expect(props["toString"]).toEqual({ type: "string" });
+    expect(parameters.properties.options.required).toEqual(["constructor"]);
+  });
+
+  it("does not narrow a key a variant accepts through patternProperties", () => {
+    // Review finding on #143819: `additionalProperties: false` does not make a
+    // variant reject an undeclared key that its `patternProperties` cover.
+    // Branch A accepts an object-valued `b` that way, and branch B declares `b`
+    // as a string. Copying B's constraint would reject a call A accepted.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          parent: {
+            anyOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+                patternProperties: { "^b$": { type: "object" } },
+              },
+              {
+                type: "object",
+                properties: { b: { type: "string" } },
+                required: ["b"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        }),
+        "patterned-variant",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: { parent: { properties: Record<string, unknown> } };
+    };
+    const props = parameters.properties.parent.properties;
+
+    // A key the pattern covers stays unconstrained, while a declared key keeps
+    // its own definition.
+    expect(props["b"]).toEqual({});
+    expect(props["a"]).toEqual({ type: "string" });
+
+    const validate = (args: Record<string, unknown>) =>
+      validateToolArguments(normalized[0] as never, {
+        type: "toolCall",
+        id: "call-patterned-variant",
+        name: "patterned-variant",
+        arguments: args,
+      });
+
+    // Accepted by branch A before this change, so it must stay accepted.
+    expect(() => validate({ parent: { a: "x", b: { nested: true } } })).not.toThrow();
+    // And the branch that declares `b` is still callable.
+    expect(() => validate({ parent: { b: "y" } })).not.toThrow();
+  });
+
+  it.each([
+    { name: "unchanged sibling", mode: { type: "string" } },
+    {
+      name: "normalized sibling",
+      mode: { anyOf: [{ type: "string" }, { type: "integer" }] },
+    },
+  ])("keeps an own __proto__ property with a $name", ({ mode }) => {
+    // A changing child forces the recursive walker to return its copied record,
+    // so own-key preservation must hold before object-union accumulation too.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const branch = (description: string) => ({
+      type: "object",
+      properties: Object.fromEntries<unknown>([
+        ["__proto__", { type: "string", description }],
+        ["mode", mode],
+      ]),
+      required: ["__proto__"],
+      additionalProperties: false,
+    });
+    const input = objectSchema({
+      options: { anyOf: [branch("first"), branch("second")] },
+    });
+    const before = structuredClone(input);
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext([tool(input, "proto-keys")]));
+    const parameters = normalized[0]?.parameters as {
+      properties: { options: { properties: Record<string, unknown>; required?: string[] } };
+    };
+    const props = parameters.properties.options.properties;
+
+    expect(Object.hasOwn(props, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(props, "__proto__")?.value).toEqual({
+      type: "string",
+      description: "first",
+    });
+    expect(parameters.properties.options.required).toEqual(["__proto__"]);
+    expect(JSON.stringify(parameters)).toContain('"__proto__"');
+    expect(input).toEqual(before);
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+
+    const valid = JSON.parse('{"options":{"__proto__":"literal","mode":"x"}}');
+    expect(validateDeepSeekTool(normalized, valid)).toEqual(valid);
+    expect(() =>
+      validateDeepSeekTool(
+        normalized,
+        JSON.parse('{"options":{"__proto__":{"wrong":"shape"},"mode":"x"}}'),
+      ),
+    ).toThrow(/Validation failed for tool "proto-keys"/);
+  });
+
+  it.each([
+    {
+      union: "anyOf",
+      name: "intersecting const and enum",
+      middle: { const: "database", enum: ["database", "excluded"] },
+      expectedKinds: ["page", "database", "data_source"],
+      validParents: [
+        { kind: "page", page_id: "page-1" },
+        { kind: "database", database_id: "database-1" },
+        { kind: "data_source", data_source_id: "data-source-1" },
+      ],
+      invalidKinds: ["excluded"],
+    },
+    {
+      union: "oneOf",
+      name: "disjoint const and enum",
+      middle: { const: "discarded", enum: ["excluded"] },
+      expectedKinds: ["page", "data_source"],
+      validParents: [
+        { kind: "page", page_id: "page-1" },
+        { kind: "data_source", data_source_id: "data-source-1" },
+      ],
+      invalidKinds: ["discarded", "excluded"],
+    },
+  ])("pools literal discriminators in $union with $name", (testCase) => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const branch = (kind: Record<string, unknown>, id: string) => ({
+      type: "object",
+      properties: { kind: { type: "string", ...kind }, [id]: { type: "string" } },
+      required: ["kind", id],
+      additionalProperties: false,
+    });
+    const normalized = hooks.normalizeToolSchemas(
+      deepSeekContext([
+        tool(
+          objectSchema({
+            parent: {
+              [testCase.union]: [
+                branch({ const: "page", description: "First category" }, "page_id"),
+                branch({ ...testCase.middle, description: "Second category" }, "database_id"),
+                branch({ enum: ["data_source"], description: "Third category" }, "data_source_id"),
+              ],
+            },
+          }),
+          "literal-parent",
+        ),
+      ]),
+    );
+
+    expect(normalized[0]?.parameters).toMatchObject({
+      properties: {
+        parent: {
+          properties: {
+            kind: {
+              type: "string",
+              description: "First category",
+              enum: testCase.expectedKinds,
+            },
+          },
+          required: ["kind"],
+        },
+      },
+    });
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+    for (const parent of testCase.validParents) {
+      expect(validateDeepSeekTool(normalized, { parent })).toEqual({ parent });
+    }
+    for (const kind of testCase.invalidKinds) {
+      expect(() =>
+        validateDeepSeekTool(normalized, { parent: { kind, database_id: "database-1" } }),
+      ).toThrow(/Validation failed for tool "literal-parent"/);
+    }
+  });
+
+  it("keeps the first conflicting property definition while merging the other properties", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const firstKind = { type: "string", enum: ["page"], description: "First category" };
+    const normalized = hooks.normalizeToolSchemas(
+      deepSeekContext([
+        tool(
+          objectSchema({
+            parent: {
+              anyOf: [
+                {
+                  type: "object",
+                  properties: { kind: firstKind, page_id: { type: "string" } },
+                  required: ["kind", "page_id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    kind: { type: "integer", enum: [7] },
+                    database_id: { type: "string" },
+                  },
+                  required: ["kind", "database_id"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          }),
+          "conflicting-parent",
+        ),
+      ]),
+    );
+
+    expect(normalized[0]?.parameters).toMatchObject({
+      properties: {
+        parent: {
+          properties: {
+            kind: firstKind,
+            page_id: { type: "string" },
+            database_id: { type: "string" },
+          },
+          required: ["kind"],
+        },
+      },
+    });
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+    const first = { parent: { kind: "page", page_id: "page-1" } };
+    expect(validateDeepSeekTool(normalized, first)).toEqual(first);
+    expect(() =>
+      validateDeepSeekTool(normalized, { parent: { kind: 7, database_id: "database-1" } }),
+    ).toThrow(/Validation failed for tool "conflicting-parent"/);
+  });
+
+  it("falls back when object variants cannot be flattened into one schema", () => {
+    // Object/scalar mixtures retain the existing first-variant selection.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          mixed: {
+            anyOf: [
+              { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+              { type: "string" },
+            ],
+          },
+        }),
+        "mixed-union",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as { properties: Record<string, unknown> };
+
+    expect(parameters.properties.mixed).toEqual({
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    });
     expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
   });
 

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -290,6 +290,114 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
   });
 
+  it("keeps every object variant of a union expressible for the deepseek family", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/143790 —
+    // Notion's create-pages `parent` is an anyOf of three object variants.
+    // Keeping only the first variant narrowed the schema to `page_id`, so the
+    // model could not express a database or data-source parent and every such
+    // call was rejected by our own argument validator before it reached the
+    // server.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema(
+          {
+            pages: { type: "array", items: { type: "object" } },
+            parent: {
+              description: "The parent under which the new pages will be created.",
+              anyOf: [
+                {
+                  type: "object",
+                  properties: {
+                    page_id: { type: "string" },
+                    type: { type: "string", enum: ["page_id"] },
+                  },
+                  required: ["page_id"],
+                  additionalProperties: {},
+                },
+                {
+                  type: "object",
+                  properties: {
+                    database_id: { type: "string" },
+                    type: { type: "string", enum: ["database_id"] },
+                  },
+                  required: ["database_id"],
+                  additionalProperties: {},
+                },
+                {
+                  type: "object",
+                  properties: {
+                    data_source_id: { type: "string" },
+                    type: { type: "string", enum: ["data_source_id"] },
+                  },
+                  required: ["data_source_id"],
+                  additionalProperties: {},
+                },
+              ],
+            },
+          },
+          { required: ["pages"] },
+        ),
+        "notion__notion-create-pages",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+
+    // Every branch stays expressible, and the discriminator pools its values so
+    // the model can name any of them.
+    expect(parameters.properties.parent).toEqual({
+      description: "The parent under which the new pages will be created.",
+      type: "object",
+      properties: {
+        page_id: { type: "string" },
+        database_id: { type: "string" },
+        data_source_id: { type: "string" },
+        type: { type: "string", enum: ["page_id", "database_id", "data_source_id"] },
+      },
+    });
+    // No branch's key is required any more, because no key is required by all
+    // of them. The root's own `required` is untouched.
+    expect(parameters.required).toEqual(["pages"]);
+    // The provider still sees no union keyword.
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+  });
+
+  it("falls back when object variants cannot be flattened into one schema", () => {
+    // A union that mixes an object with a scalar, or whose variants disagree
+    // about a property's shape, cannot be represented as a single object
+    // schema. Those keep the previous behaviour rather than a guess, so the
+    // flattening above stays narrow.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          mixed: {
+            anyOf: [
+              { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+              { type: "string" },
+            ],
+          },
+        }),
+        "mixed-union",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as { properties: Record<string, unknown> };
+
+    expect(parameters.properties.mixed).toEqual({
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    });
+    expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+  });
+
   it("normalizes parameter-free and typed-object schemas for the openai family", () => {
     const tools = [tool({}, "ping"), tool({ type: "object" }, "exec")];
     const normalized = normalizeOpenAITools(tools);

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -468,6 +468,94 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     expect(parameters.properties.options.required).toEqual(["constructor"]);
   });
 
+  it("does not narrow a key a variant accepts through patternProperties", () => {
+    // Review finding on #143819: `additionalProperties: false` does not make a
+    // variant reject an undeclared key that its `patternProperties` cover.
+    // Branch A accepts an object-valued `b` that way, and branch B declares `b`
+    // as a string. Copying B's constraint would reject a call A accepted.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          parent: {
+            anyOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+                patternProperties: { "^b$": { type: "object" } },
+              },
+              {
+                type: "object",
+                properties: { b: { type: "string" } },
+                required: ["b"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        }),
+        "patterned-variant",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: { parent: { properties: Record<string, unknown> } };
+    };
+    const props = parameters.properties.parent.properties;
+
+    // A key the pattern covers stays unconstrained, while a declared key keeps
+    // its own definition.
+    expect(props["b"]).toEqual({});
+    expect(props["a"]).toEqual({ type: "string" });
+
+    const validate = (args: Record<string, unknown>) =>
+      validateToolArguments(normalized[0] as never, {
+        type: "toolCall",
+        id: "call-patterned-variant",
+        name: "patterned-variant",
+        arguments: args,
+      });
+
+    // Accepted by branch A before this change, so it must stay accepted.
+    expect(() => validate({ parent: { a: "x", b: { nested: true } } })).not.toThrow();
+    // And the branch that declares `b` is still callable.
+    expect(() => validate({ parent: { b: "y" } })).not.toThrow();
+  });
+
+  it("keeps an own __proto__ property through accumulation and serialization", () => {
+    // Review finding on #143819: writing `properties["__proto__"]` on a plain
+    // object runs the inherited setter, so the definition was lost while the
+    // name could stay in `required`. The accumulator is prototype-free now, and
+    // the definition has to survive into the serialized provider schema.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const branch = (description: string) =>
+      JSON.parse(
+        `{"type":"object","properties":{"__proto__":{"type":"string","description":"${description}"}},"required":["__proto__"]}`,
+      ) as Record<string, unknown>;
+    const tools = [
+      tool(
+        objectSchema({
+          options: { anyOf: [branch("first"), branch("second")] },
+        }),
+        "proto-keys",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: { options: { properties: Record<string, unknown>; required?: string[] } };
+    };
+    const props = parameters.properties.options.properties;
+
+    const protoKey = "__proto__";
+    expect(Object.hasOwn(props, protoKey)).toBe(true);
+    expect(props[protoKey]).toEqual({ type: "string", description: "first" });
+    expect(parameters.properties.options.required).toEqual([protoKey]);
+    expect(JSON.stringify(parameters)).toContain('"__proto__"');
+  });
+
   it("falls back when object variants cannot be flattened into one schema", () => {
     // A union that mixes an object with a scalar, or whose variants disagree
     // about a property's shape, cannot be represented as a single object

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -231,7 +231,7 @@ describe("buildProviderToolCompatFamilyHooks", () => {
   });
 
   it("preserves string-const unions as a flat enum for the deepseek family", () => {
-    // Regression for https://github.com/openclaw/openclaw/issues/86468 —
+    // Regression for https://github.com/openclaw/openclaw/issues/86468.
     // Typebox `Type.Union([Type.Literal(...)])` collapses to anyOf of consts;
     // the previous normalizer kept only the first const, hiding every other
     // literal from the model.
@@ -292,7 +292,7 @@ describe("buildProviderToolCompatFamilyHooks", () => {
   });
 
   it("keeps every object variant of a union expressible for the deepseek family", () => {
-    // Regression for https://github.com/openclaw/openclaw/issues/143790 —
+    // Regression for https://github.com/openclaw/openclaw/issues/143790.
     // Notion's create-pages `parent` is an anyOf of three object variants.
     // Keeping only the first variant narrowed the schema to `page_id`, so the
     // model could not express a database or data-source parent and every such

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -1,3 +1,4 @@
+import { validateToolArguments } from "@openclaw/llm-core/validation";
 // Provider tool tests cover tool schema conversion and provider payload compatibility.
 import { describe, expect, it } from "vitest";
 import { findSourceImportBackedges } from "../../test/helpers/source-import-closure.js";
@@ -349,14 +350,18 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     };
 
     // Every branch stays expressible, and the discriminator pools its values so
-    // the model can name any of them.
+    // the model can name any of them. The per-branch keys stay unconstrained:
+    // each is declared by one variant and permitted by the others through
+    // `additionalProperties`, so constraining one would reject a call those
+    // variants accepted. The live Notion schema documents each of them, and any
+    // annotation survives here.
     expect(parameters.properties.parent).toEqual({
       description: "The parent under which the new pages will be created.",
       type: "object",
       properties: {
-        page_id: { type: "string" },
-        database_id: { type: "string" },
-        data_source_id: { type: "string" },
+        page_id: {},
+        database_id: {},
+        data_source_id: {},
         type: { type: "string", enum: ["page_id", "database_id", "data_source_id"] },
       },
     });
@@ -365,6 +370,101 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     expect(parameters.required).toEqual(["pages"]);
     // The provider still sees no union keyword.
     expect(hooks.inspectToolSchemas(deepSeekContext(normalized as never))).toStrictEqual([]);
+  });
+
+  it("does not narrow a key that an open variant accepts without declaring", () => {
+    // Review finding on #143819: taking a property from a later variant can
+    // narrow the first one. Branch A permits arbitrary extras through
+    // `additionalProperties` and accepts `{a: "x", b: {nested: true}}`; branch B
+    // declares `b` as a string. Imposing that constraint would reject a call the
+    // first variant accepted, so the key has to stay unconstrained, and the
+    // assertion runs through the real argument validator rather than the shape.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          parent: {
+            anyOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: {},
+              },
+              {
+                type: "object",
+                properties: { b: { type: "string" } },
+                required: ["b"],
+              },
+            ],
+          },
+        }),
+        "open-variant",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const validate = (args: Record<string, unknown>) =>
+      validateToolArguments(normalized[0] as never, {
+        type: "toolCall",
+        id: "call-open-variant",
+        name: "open-variant",
+        arguments: args,
+      });
+
+    // Accepted by branch A before this change, so it must stay accepted.
+    expect(() => validate({ parent: { a: "x", b: { nested: true } } })).not.toThrow();
+    // And the variant that first-variant selection made unreachable is callable.
+    expect(() => validate({ parent: { b: "y" } })).not.toThrow();
+  });
+
+  it("keeps a property whose name collides with Object.prototype", () => {
+    // Review finding on #143819: the accumulator was a plain object, so reading
+    // `properties["constructor"]` returned the inherited function, enum pooling
+    // failed, and the real definition was dropped while the name stayed in
+    // `required`. Both variants are closed here, so nothing is relaxed and the
+    // assertions are purely about own-property accumulation.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      tool(
+        objectSchema({
+          options: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  constructor: { type: "string" },
+                  toString: { type: "string" },
+                },
+                required: ["constructor", "toString"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  constructor: { type: "string" },
+                  toString: { type: "string" },
+                },
+                required: ["constructor"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        }),
+        "prototype-keys",
+      ),
+    ];
+
+    const normalized = hooks.normalizeToolSchemas(deepSeekContext(tools));
+    const parameters = normalized[0]?.parameters as {
+      properties: {
+        options: { properties: Record<string, unknown>; required?: string[] };
+      };
+    };
+
+    expect(parameters.properties.options.properties.constructor).toEqual({ type: "string" });
+    expect(parameters.properties.options.properties.toString).toEqual({ type: "string" });
+    expect(parameters.properties.options.required).toEqual(["constructor"]);
   });
 
   it("falls back when object variants cannot be flattened into one schema", () => {

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -462,8 +462,9 @@ describe("buildProviderToolCompatFamilyHooks", () => {
       };
     };
 
-    expect(parameters.properties.options.properties.constructor).toEqual({ type: "string" });
-    expect(parameters.properties.options.properties.toString).toEqual({ type: "string" });
+    const props = parameters.properties.options.properties;
+    expect(props["constructor"]).toEqual({ type: "string" });
+    expect(props["toString"]).toEqual({ type: "string" });
     expect(parameters.properties.options.required).toEqual(["constructor"]);
   });
 

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   cleanSchemaForGemini,
   cleanSchemaForLlamacppGbnf,
@@ -253,19 +254,16 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
       ? "oneOf"
       : undefined;
 
-  let changed = false;
-  const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    if (key === "anyOf" || key === "oneOf") {
-      if (key === unionKey) {
-        changed = true;
-        continue;
-      }
-    }
-    const next = normalizeDeepSeekSchema(value);
-    normalized[key] = next;
-    changed ||= next !== value;
-  }
+  let changed = unionKey !== undefined;
+  const normalized = Object.fromEntries(
+    Object.entries(record)
+      .filter(([key]) => key !== unionKey)
+      .map(([key, value]) => {
+        const next = normalizeDeepSeekSchema(value);
+        changed ||= next !== value;
+        return [key, next];
+      }),
+  );
 
   if (!unionKey) {
     return changed ? normalized : schema;
@@ -274,7 +272,19 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
   const variants = record[unionKey] as unknown[];
   const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
   const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
-  const hasNullVariant = nonNullVariants.length < normalizedVariants.length;
+  const hasNullVariant =
+    nonNullVariants.length < normalizedVariants.length ||
+    nonNullVariants.some((entry) => {
+      if (
+        !isObjectSchemaVariant(entry) ||
+        !Array.isArray(entry.type) ||
+        !entry.type.includes("null")
+      ) {
+        return false;
+      }
+      const literals = readLiteralSchemaValues(entry);
+      return literals === undefined || literals.includes(null);
+    });
 
   // Preserve string-const unions as a flat string enum so DeepSeek tool
   // callers still see every allowed literal. Without this, a Typebox
@@ -293,16 +303,32 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     return merged;
   }
 
-  const selected = nonNullVariants[0] ?? normalizedVariants[0];
-  if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
+  // Selecting the first object would make valid later branches fail local validation.
+  const selected =
+    nonNullVariants.length > 1 && nonNullVariants.every(isObjectSchemaVariant)
+      ? (flattenObjectVariants(nonNullVariants) ?? nonNullVariants[0])
+      : (nonNullVariants[0] ?? normalizedVariants[0]);
+  if (!isSchemaRecord(selected)) {
     return normalized;
   }
 
+  const nullableObject =
+    hasNullVariant && nonNullVariants.length > 0 && nonNullVariants.every(isObjectSchemaVariant);
+  let selectedSchema = selected;
+  if (nullableObject) {
+    // Lift branch constraints before applying the outer schema's restrictions.
+    selectedSchema = { ...selected, type: ["object", "null"] };
+    const literals = readLiteralSchemaValues(selected);
+    if (literals) {
+      selectedSchema.enum = literals.includes(null) ? literals : [...literals, null];
+      delete selectedSchema.const;
+    }
+  }
   const merged = {
-    ...(selected as Record<string, unknown>),
+    ...selectedSchema,
     ...normalized,
   };
-  if (hasNullVariant) {
+  if (hasNullVariant && !nullableObject) {
     merged.nullable = true;
   }
   return merged;
@@ -314,6 +340,198 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
   }
   const record = entry as Record<string, unknown>;
   return typeof record.const === "string";
+}
+
+function isObjectSchemaVariant(entry: unknown): entry is Record<string, unknown> {
+  return (
+    isSchemaRecord(entry) &&
+    (entry.type === "object" ||
+      (Array.isArray(entry.type) &&
+        entry.type.includes("object") &&
+        entry.type.every((type) => type === "object" || type === "null")))
+  );
+}
+
+/**
+ * Keys that only document a schema. Everything else is a constraint, so this is
+ * what survives when a property has to stay unconstrained.
+ */
+const SCHEMA_ANNOTATION_KEYS = new Set([
+  "$comment",
+  "default",
+  "deprecated",
+  "description",
+  "example",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly",
+]);
+
+/**
+ * Flattens a union of object schemas into one object schema, keeping every
+ * branch expressible: the union of the variants' properties, and the
+ * intersection of their `required` lists.
+ *
+ * A property that discriminates the variants differs only by its literals
+ * (`type: { enum: ["page_id"] }` in one variant, `["database_id"]` in another),
+ * so its values are pooled into a single enum. Without that pooling the
+ * flattened schema would still pin the discriminator to the first variant and
+ * the tool would stay unusable for the others.
+ *
+ * Missing property maps retain the previous single-variant selection.
+ * Conflicting property constraints retain their first definition.
+ */
+function flattenObjectVariants(
+  variants: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
+  // SAFETY: Object.create(null) is typed as any; every key written below is a schema keyword string.
+  const properties: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+  let required: string[] | undefined;
+  for (const variant of variants) {
+    const variantProperties = variant.properties;
+    if (
+      !variantProperties ||
+      typeof variantProperties !== "object" ||
+      Array.isArray(variantProperties)
+    ) {
+      return undefined;
+    }
+    for (const [key, value] of Object.entries(variantProperties)) {
+      // Own-property membership, not a prototype-chain read: a key named
+      // `constructor` or `toString` would otherwise look already present and
+      // its real definition would be dropped.
+      if (!Object.hasOwn(properties, key)) {
+        properties[key] = value;
+        continue;
+      }
+      const existing = properties[key];
+      if (isDeepStrictEqual(existing, value)) {
+        continue;
+      }
+      const pooled = poolLiteralEnum(existing, value);
+      if (pooled) {
+        properties[key] = pooled;
+      }
+      // Otherwise keep the first definition. Widening it would mean putting a
+      // union keyword back, which is the one thing DeepSeek will not accept.
+    }
+    const variantRequired = Array.isArray(variant.required)
+      ? variant.required.filter((key): key is string => typeof key === "string")
+      : [];
+    required =
+      required === undefined
+        ? variantRequired
+        : required.filter((key) => variantRequired.includes(key));
+  }
+  // A variant that does not declare a key can still accept it, either by
+  // allowing additional properties or through a `patternProperties` pattern.
+  // Constraining such a key would reject calls the variant accepted, so keep
+  // what documents it and drop what constrains it.
+  for (const key of Object.keys(properties)) {
+    if (variants.some((variant) => acceptsUndeclaredKey(variant, key))) {
+      properties[key] = schemaAnnotationsOnly(properties[key]);
+    }
+  }
+  const flattened: Record<string, unknown> = { type: "object", properties };
+  if (required && required.length > 0) {
+    flattened.required = required;
+  }
+  return flattened;
+}
+
+/**
+ * Whether a variant accepts a key it does not declare.
+ *
+ * `additionalProperties` only constrains keys that no `properties` entry and no
+ * `patternProperties` pattern covers, so a pattern match widens acceptance even
+ * when `additionalProperties` is false. Ignoring that would copy another
+ * variant's constraint onto a key this variant accepted.
+ */
+function acceptsUndeclaredKey(variant: Record<string, unknown>, key: string): boolean {
+  const declared = variant.properties;
+  if (isSchemaRecord(declared) && Object.hasOwn(declared, key)) {
+    return false;
+  }
+  if (variant.additionalProperties !== false) {
+    return true;
+  }
+  return matchesPatternProperty(variant.patternProperties, key);
+}
+
+/** Whether a variant's `patternProperties` covers the key. */
+function matchesPatternProperty(patternProperties: unknown, key: string): boolean {
+  if (!isSchemaRecord(patternProperties)) {
+    return false;
+  }
+  return Object.keys(patternProperties).some((pattern) => {
+    try {
+      return new RegExp(pattern).test(key);
+    } catch {
+      // An uncompilable pattern covers nothing, so it cannot widen acceptance
+      // and must not make the merge throw.
+      return false;
+    }
+  });
+}
+
+/** Keeps only the keys that document a property, dropping every constraint. */
+function schemaAnnotationsOnly(schema: unknown): Record<string, unknown> {
+  if (!isSchemaRecord(schema)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(schema).filter(([key]) => SCHEMA_ANNOTATION_KEYS.has(key)),
+  );
+}
+
+function readLiteralSchemaValues(schema: Record<string, unknown>): unknown[] | undefined {
+  const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+  if (Object.hasOwn(schema, "const")) {
+    if (!enumValues) {
+      return [schema.const];
+    }
+    return enumValues.some((value) => isDeepStrictEqual(value, schema.const)) ? [schema.const] : [];
+  }
+  return enumValues;
+}
+
+/** Pools the values of two property schemas that differ only by their literals. */
+function poolLiteralEnum(left: unknown, right: unknown): Record<string, unknown> | undefined {
+  if (!isSchemaRecord(left) || !isSchemaRecord(right)) {
+    return undefined;
+  }
+  const leftValues = readLiteralSchemaValues(left);
+  const rightValues = readLiteralSchemaValues(right);
+  if (!leftValues || !rightValues) {
+    return undefined;
+  }
+  if (!isDeepStrictEqual(literalValidationConstraints(left), literalValidationConstraints(right))) {
+    return undefined;
+  }
+  const combined = [...leftValues, ...rightValues];
+  const values = combined.filter(
+    (value, index) =>
+      combined.findIndex((candidate) => isDeepStrictEqual(candidate, value)) === index,
+  );
+  if (values.length === 0) {
+    return undefined;
+  }
+  const merged: Record<string, unknown> = { ...left, enum: values };
+  delete merged.const;
+  return merged;
+}
+
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function literalValidationConstraints(schema: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(schema).filter(
+      ([key]) => key !== "const" && key !== "enum" && !SCHEMA_ANNOTATION_KEYS.has(key),
+    ),
+  );
 }
 
 /**

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -306,6 +306,7 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     nonNullVariants.length > 1 &&
     nonNullVariants.every((entry) => isObjectSchemaVariant(entry))
   ) {
+    // SAFETY: isObjectSchemaVariant accepted each entry above, which is true only of a non-null non-array object.
     const flattenedVariants = flattenObjectVariants(nonNullVariants as Record<string, unknown>[]);
     if (flattenedVariants) {
       const merged: Record<string, unknown> = {
@@ -346,6 +347,7 @@ function isObjectSchemaVariant(entry: unknown): entry is Record<string, unknown>
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     return false;
   }
+  // SAFETY: the guard above rejected null, non-object and array values, so this is a plain schema record.
   return (entry as Record<string, unknown>).type === "object";
 }
 
@@ -428,6 +430,7 @@ function flattenObjectVariants(
     const acceptedWithoutDeclaring = variants.some(
       (variant) =>
         variant.additionalProperties !== false &&
+        // SAFETY: the guard earlier in this function proved variant.properties is a non-null non-array object.
         !Object.hasOwn(variant.properties as Record<string, unknown>, key),
     );
     if (acceptedWithoutDeclaring) {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -385,7 +385,8 @@ const SCHEMA_ANNOTATION_KEYS = new Set([
 function flattenObjectVariants(
   variants: Record<string, unknown>[],
 ): Record<string, unknown> | undefined {
-  const properties: Record<string, unknown> = {};
+  // SAFETY: Object.create(null) is typed as any; every key written below is a schema keyword string.
+  const properties: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   let required: string[] | undefined;
   for (const variant of variants) {
     const variantProperties = variant.properties;
@@ -423,17 +424,12 @@ function flattenObjectVariants(
         ? variantRequired
         : required.filter((key) => variantRequired.includes(key));
   }
-  // A variant that does not declare a key still accepts it when that variant
-  // allows additional properties, so constraining such a key would reject calls
-  // the variant accepted. Keep what documents it and drop what constrains it.
+  // A variant that does not declare a key can still accept it, either by
+  // allowing additional properties or through a `patternProperties` pattern.
+  // Constraining such a key would reject calls the variant accepted, so keep
+  // what documents it and drop what constrains it.
   for (const key of Object.keys(properties)) {
-    const acceptedWithoutDeclaring = variants.some(
-      (variant) =>
-        variant.additionalProperties !== false &&
-        // SAFETY: the guard earlier in this function proved variant.properties is a non-null non-array object.
-        !Object.hasOwn(variant.properties as Record<string, unknown>, key),
-    );
-    if (acceptedWithoutDeclaring) {
+    if (variants.some((variant) => acceptsUndeclaredKey(variant, key))) {
       properties[key] = schemaAnnotationsOnly(properties[key]);
     }
   }
@@ -442,6 +438,41 @@ function flattenObjectVariants(
     flattened.required = required;
   }
   return flattened;
+}
+
+/**
+ * Whether a variant accepts a key it does not declare.
+ *
+ * `additionalProperties` only constrains keys that no `properties` entry and no
+ * `patternProperties` pattern covers, so a pattern match widens acceptance even
+ * when `additionalProperties` is false. Ignoring that would copy another
+ * variant's constraint onto a key this variant accepted.
+ */
+function acceptsUndeclaredKey(variant: Record<string, unknown>, key: string): boolean {
+  const declared = variant.properties;
+  if (isSchemaRecord(declared) && Object.hasOwn(declared, key)) {
+    return false;
+  }
+  if (variant.additionalProperties !== false) {
+    return true;
+  }
+  return matchesPatternProperty(variant.patternProperties, key);
+}
+
+/** Whether a variant's `patternProperties` covers the key. */
+function matchesPatternProperty(patternProperties: unknown, key: string): boolean {
+  if (!isSchemaRecord(patternProperties)) {
+    return false;
+  }
+  return Object.keys(patternProperties).some((pattern) => {
+    try {
+      return new RegExp(pattern).test(key);
+    } catch {
+      // An uncompilable pattern covers nothing, so it cannot widen acceptance
+      // and must not make the merge throw.
+      return false;
+    }
+  });
 }
 
 /** Keeps only the keys that document a property, dropping every constraint. */

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   cleanSchemaForGemini,
   cleanSchemaForLlamacppGbnf,
@@ -293,6 +294,31 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     return merged;
   }
 
+  // DeepSeek rejects `anyOf`/`oneOf` outright, so a union has to be rewritten
+  // into a single schema. Taking one variant is right for scalars, but for a
+  // union of object schemas it silently narrows the tool: the model can no
+  // longer express any branch but the first, and our own argument validator
+  // then rejects calls the server would have accepted. Notion's create-pages
+  // `parent` is this shape (page_id | database_id | data_source_id), which left
+  // the tool unable to create a database row at all.
+  // https://github.com/openclaw/openclaw/issues/143790
+  if (
+    nonNullVariants.length > 1 &&
+    nonNullVariants.every((entry) => isObjectSchemaVariant(entry))
+  ) {
+    const flattenedVariants = flattenObjectVariants(nonNullVariants as Record<string, unknown>[]);
+    if (flattenedVariants) {
+      const merged: Record<string, unknown> = {
+        ...flattenedVariants,
+        ...normalized,
+      };
+      if (hasNullVariant) {
+        merged.nullable = true;
+      }
+      return merged;
+    }
+  }
+
   const selected = nonNullVariants[0] ?? normalizedVariants[0];
   if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
     return normalized;
@@ -314,6 +340,105 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
   }
   const record = entry as Record<string, unknown>;
   return typeof record.const === "string";
+}
+
+function isObjectSchemaVariant(entry: unknown): entry is Record<string, unknown> {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return false;
+  }
+  return (entry as Record<string, unknown>).type === "object";
+}
+
+/**
+ * Flattens a union of object schemas into one object schema, keeping every
+ * branch expressible: the union of the variants' properties, and the
+ * intersection of their `required` lists.
+ *
+ * A property that discriminates the variants differs only by its literals
+ * (`type: { enum: ["page_id"] }` in one variant, `["database_id"]` in another),
+ * so its values are pooled into a single enum. Without that pooling the
+ * flattened schema would still pin the discriminator to the first variant and
+ * the tool would stay unusable for the others.
+ *
+ * Returns undefined when the variants cannot be flattened, so the caller keeps
+ * the previous single-variant behaviour rather than emitting something wrong.
+ * This mirrors `flattenUnionSchema` on the MCP loopback path.
+ */
+function flattenObjectVariants(
+  variants: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
+  const properties: Record<string, unknown> = {};
+  let required: string[] | undefined;
+  for (const variant of variants) {
+    const variantProperties = variant.properties;
+    if (
+      !variantProperties ||
+      typeof variantProperties !== "object" ||
+      Array.isArray(variantProperties)
+    ) {
+      return undefined;
+    }
+    for (const [key, value] of Object.entries(variantProperties)) {
+      const existing = properties[key];
+      if (existing === undefined) {
+        properties[key] = value;
+        continue;
+      }
+      if (isDeepStrictEqual(existing, value)) {
+        continue;
+      }
+      const pooled = poolLiteralEnum(existing, value);
+      if (pooled) {
+        properties[key] = pooled;
+      }
+      // Otherwise keep the first definition. Widening it would mean putting a
+      // union keyword back, which is the one thing DeepSeek will not accept.
+    }
+    const variantRequired = Array.isArray(variant.required)
+      ? variant.required.filter((key): key is string => typeof key === "string")
+      : [];
+    required =
+      required === undefined
+        ? variantRequired
+        : required.filter((key) => variantRequired.includes(key));
+  }
+  const flattened: Record<string, unknown> = { type: "object", properties };
+  if (required && required.length > 0) {
+    flattened.required = required;
+  }
+  return flattened;
+}
+
+/** Pools the values of two property schemas that differ only by their literals. */
+function poolLiteralEnum(left: unknown, right: unknown): Record<string, unknown> | undefined {
+  if (!isSchemaRecord(left) || !isSchemaRecord(right)) {
+    return undefined;
+  }
+  const leftValues = Array.isArray(left.enum) ? left.enum : undefined;
+  const rightValues = Array.isArray(right.enum) ? right.enum : undefined;
+  if (!leftValues || !rightValues) {
+    return undefined;
+  }
+  const leftRest = withoutEnumKeyword(left);
+  if (!isDeepStrictEqual(leftRest, withoutEnumKeyword(right))) {
+    return undefined;
+  }
+  const values = [...new Set([...leftValues, ...rightValues])];
+  return values.length > 0 ? { ...leftRest, enum: values } : undefined;
+}
+
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function withoutEnumKeyword(schema: Record<string, unknown>): Record<string, unknown> {
+  const rest: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key !== "enum") {
+      rest[key] = value;
+    }
+  }
+  return rest;
 }
 
 /**

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -350,6 +350,22 @@ function isObjectSchemaVariant(entry: unknown): entry is Record<string, unknown>
 }
 
 /**
+ * Keys that only document a schema. Everything else is a constraint, so this is
+ * what survives when a property has to stay unconstrained.
+ */
+const SCHEMA_ANNOTATION_KEYS = new Set([
+  "$comment",
+  "default",
+  "deprecated",
+  "description",
+  "example",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly",
+]);
+
+/**
  * Flattens a union of object schemas into one object schema, keeping every
  * branch expressible: the union of the variants' properties, and the
  * intersection of their `required` lists.
@@ -379,11 +395,14 @@ function flattenObjectVariants(
       return undefined;
     }
     for (const [key, value] of Object.entries(variantProperties)) {
-      const existing = properties[key];
-      if (existing === undefined) {
+      // Own-property membership, not a prototype-chain read: a key named
+      // `constructor` or `toString` would otherwise look already present and
+      // its real definition would be dropped.
+      if (!Object.hasOwn(properties, key)) {
         properties[key] = value;
         continue;
       }
+      const existing = properties[key];
       if (isDeepStrictEqual(existing, value)) {
         continue;
       }
@@ -402,11 +421,38 @@ function flattenObjectVariants(
         ? variantRequired
         : required.filter((key) => variantRequired.includes(key));
   }
+  // A variant that does not declare a key still accepts it when that variant
+  // allows additional properties, so constraining such a key would reject calls
+  // the variant accepted. Keep what documents it and drop what constrains it.
+  for (const key of Object.keys(properties)) {
+    const acceptedWithoutDeclaring = variants.some(
+      (variant) =>
+        variant.additionalProperties !== false &&
+        !Object.hasOwn(variant.properties as Record<string, unknown>, key),
+    );
+    if (acceptedWithoutDeclaring) {
+      properties[key] = schemaAnnotationsOnly(properties[key]);
+    }
+  }
   const flattened: Record<string, unknown> = { type: "object", properties };
   if (required && required.length > 0) {
     flattened.required = required;
   }
   return flattened;
+}
+
+/** Keeps only the keys that document a property, dropping every constraint. */
+function schemaAnnotationsOnly(schema: unknown): Record<string, unknown> {
+  if (!isSchemaRecord(schema)) {
+    return {};
+  }
+  const annotations: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (SCHEMA_ANNOTATION_KEYS.has(key)) {
+      annotations[key] = value;
+    }
+  }
+  return annotations;
 }
 
 /** Pools the values of two property schemas that differ only by their literals. */

--- a/test/vitest/vitest.plugin-sdk-paths.mjs
+++ b/test/vitest/vitest.plugin-sdk-paths.mjs
@@ -38,14 +38,20 @@ const pluginSdkLightEntries = [
   },
 ];
 
-const pluginSdkLightIncludePatternByFile = new Map(
-  pluginSdkLightEntries.flatMap(({ source, test }) => [
+const providerToolsNullableTest = "src/plugin-sdk/provider-tools.nullable.test.ts";
+const pluginSdkLightIncludePatternByFile = new Map([
+  ...pluginSdkLightEntries.flatMap(({ source, test }) => [
     [source, test],
     [test, test],
   ]),
-);
+  ["src/plugin-sdk/provider-tools.ts", "src/plugin-sdk/provider-tools{,.nullable}.test.ts"],
+  [providerToolsNullableTest, providerToolsNullableTest],
+]);
 
-export const pluginSdkLightTestFiles = pluginSdkLightEntries.map(({ test }) => test);
+export const pluginSdkLightTestFiles = [
+  ...pluginSdkLightEntries.map(({ test }) => test),
+  providerToolsNullableTest,
+];
 
 export function isPluginSdkLightTarget(file) {
   return pluginSdkLightIncludePatternByFile.has(normalizeRepoPath(file));


### PR DESCRIPTION
## What Problem This Solves

DeepSeek kept only the first object alternative in MCP tool schemas. Valid Notion-style database and data-source parent arguments then failed local validation before reaching the tool.

Merge supported object properties, keep common required keys, and pool compatible discriminator literals. Preserve permissive keys, descriptions, and own prototype-shaped keys. Keep object/null alternatives usable by the local validator, including literal and outer constraints. Shared type-array coercion now preserves genuine null without turning invalid non-null values into null; valid conversions and null-only behavior remain supported.

The flattened schema remains an approximation. Conflicting property shapes retain the first definition, shared annotations retain the first annotation, and the tool owner still enforces original whole-object constraints that the flattened schema cannot express. Primitive and mixed-union selection remains unchanged.

## Evidence

- 86 focused owner and sibling tests pass; selecting the production normalizer runs all 40 provider cases.
- Independent public Gateway validation covers 125 cases with bundled DeepSeek/OpenAI routing, captured model requests and actual MCP receipts. Baseline rejects the valid later parent branches; candidate delivers all three exactly once. Negative cases remain local rejections or explicit tool-owner errors, as applicable.
- Runtime proof uses commit `a243f9793987b9091a356ea984b43107dbdd180c`. The later assertion-baseline count reduction changes no runtime, dependency, test, or fixture input.
- The hosted candidate build and artifact checks passed: https://github.com/openclaw/openclaw/actions/runs/34500899684/job/102951656517. Full PR CI and exact-head review remain separate gates.

The public validation uses synthetic loopback providers and a local MCP server. The contributor's earlier live Notion report recorded successful data-source page creation and archival; that remains attributed contributor evidence. All six contributor commits are preserved.

Fixes #143790.
