### PR TITLE
fix(models): use exact configured rows before aliases

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1713,7 +1713,6 @@ src/agents/embedded-agent-runner/model-context-tokens.ts	1
 src/agents/embedded-agent-runner/model.compat.ts	1
 src/agents/embedded-agent-runner/model.configured-fallback.ts	1
 src/agents/embedded-agent-runner/model.configured-overrides.ts	2
-src/agents/embedded-agent-runner/model.inline-provider.ts	2
 src/agents/embedded-agent-runner/model.provider-hooks.ts	10
 src/agents/embedded-agent-runner/model.registry-resolution.ts	6
 src/agents/embedded-agent-runner/model.ts	5

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -117,23 +117,32 @@ export function findInlineModelMatch(params: {
 }) {
   const inlineModels = params.preparedModels ?? buildInlineProviderModels(params.providers);
   const normalizedProvider = normalizeProviderId(params.provider);
-  const find = (normalizeModelId?: (modelId: string) => string) => {
-    const matchesModelId = (entry: { provider: string; id?: string }) =>
-      matchesProviderScopedModelId({
-        candidateId: entry.id,
-        provider: entry.provider,
-        modelId: params.modelId,
-        ...(normalizeModelId ? { normalizeModelId } : {}),
-      });
-    return (
-      inlineModels.find((entry) => entry.provider === params.provider && matchesModelId(entry)) ??
-      inlineModels.find(
-        (entry) =>
-          normalizeProviderId(entry.provider) === normalizedProvider && matchesModelId(entry),
-      )
-    );
+  const providers = new Set([
+    params.provider,
+    ...inlineModels
+      .filter((entry) => normalizeProviderId(entry.provider) === normalizedProvider)
+      .map((entry) => entry.provider),
+  ]);
+  const find = (providerKeys: Iterable<string>, normalizeModelId?: (modelId: string) => string) => {
+    for (const provider of providerKeys) {
+      const match = findConfiguredProviderModel(
+        { models: inlineModels.filter((entry) => entry.provider === provider) },
+        provider,
+        params.modelId,
+        normalizeModelId,
+      );
+      if (match) {
+        return match;
+      }
+    }
+    return undefined;
   };
-  return find() ?? find(createProviderModelCatalogIdNormalizer(params.provider));
+  // Raw matches choose the provider before declared equivalents are considered.
+  const rawMatch = find(providers);
+  return find(
+    rawMatch ? [rawMatch.provider] : providers,
+    createProviderModelCatalogIdNormalizer(params.provider),
+  );
 }
 
 export function resolveConfiguredProviderConfig(

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -160,7 +160,7 @@ export function buildInlineProviderModels(
     // Provider defaults must not mask omissions before exact duplicate rows merge.
     const models = resolveMergedModelProviderModels({
       models: entry?.models,
-      normalizeModelId: (modelId) => modelId,
+      normalizeModelId: (modelId) => modelId.trim(),
     });
     return Array.from(models.values()).map((model) => {
       const transport = resolveInlineProviderTransport({

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -3,6 +3,7 @@
  */
 import { normalizeResolvedPricing } from "@openclaw/llm-core";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { resolveMergedModelProviderModels } from "../../config/model-provider-config.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import type { Api } from "../../llm/types.js";
@@ -156,12 +157,17 @@ export function buildInlineProviderModels(
       stripSecretRefMarkers: true,
     });
     const providerRequest = sanitizeConfiguredModelProviderRequest(entry?.request);
-    return (entry?.models ?? []).map((model) => {
+    // Provider defaults must not mask omissions before exact duplicate rows merge.
+    const models = resolveMergedModelProviderModels({
+      models: entry?.models,
+      normalizeModelId: (modelId) => modelId,
+    });
+    return Array.from(models.values()).map((model) => {
       const transport = resolveInlineProviderTransport({
         api: model.api ?? entry?.api,
-        baseUrl: (model as InlineModelEntry).baseUrl ?? entry?.baseUrl,
+        baseUrl: model.baseUrl ?? entry?.baseUrl,
       });
-      const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
+      const modelHeaders = sanitizeModelHeaders(model.headers, {
         stripSecretRefMarkers: true,
       });
       const requestConfig = resolveProviderRequestConfig({

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -286,7 +286,10 @@ import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/ty
 import type { Model } from "../../llm/types.js";
 import { getModelProviderLocalService } from "../provider-local-service.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
-import { applyConfiguredProviderOverrides } from "./model.configured-overrides.js";
+import {
+  applyConfiguredProviderOverrides,
+  findInlineModelMatch,
+} from "./model.configured-overrides.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
 import {
@@ -2424,6 +2427,81 @@ describe("resolveModel", () => {
     expect(gptModel.baseUrl).toBe("http://localhost:8080/v1");
   });
 
+  it.each([false, true])(
+    "keeps exact configured routes ahead of legacy rows (reversed=%s)",
+    (reverse) => {
+      const exact = { ...makeModel("Model"), baseUrl: "https://exact.example.test/v1" };
+      const legacy = {
+        ...makeModel("custom/Model"),
+        baseUrl: "https://legacy.example.test/v1",
+        headers: { "x-route": "legacy" },
+      };
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://provider.example.test/v1",
+              models: reverse ? [exact, legacy] : [legacy, exact],
+            },
+          },
+        },
+      };
+      for (const row of [exact, legacy]) {
+        const resolved = resolveModelWithRegistry({
+          provider: "custom",
+          modelId: row.id,
+          cfg,
+          modelRegistry: createEmptyAgentDiscoveryStores().modelRegistry,
+          agentDir: state.agentDir(),
+          runtimeHooks: createRuntimeHooks(),
+        });
+        expect.soft(resolved?.id).toBe(row.id);
+        expect.soft(resolved?.baseUrl).toBe(row.baseUrl);
+        expect.soft(resolved?.headers).toEqual(row === legacy ? legacy.headers : undefined);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "merges exact rows before provider defaults (empty headers=%s)",
+    (emptyHeaders) => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            custom: {
+              api: "anthropic-messages",
+              baseUrl: "https://provider.example.test/v1",
+              models: [
+                { ...makeModel("Model"), ...(emptyHeaders ? { headers: {} } : {}) },
+                {
+                  ...makeModel(" Model "),
+                  api: "openai-completions",
+                  baseUrl: "https://duplicate.example.test/v1",
+                  headers: { "x-route": "duplicate" },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const resolved = resolveModelWithRegistry({
+        provider: "custom",
+        modelId: "Model",
+        cfg,
+        modelRegistry: createEmptyAgentDiscoveryStores().modelRegistry,
+        agentDir: state.agentDir(),
+        runtimeHooks: createRuntimeHooks(),
+      });
+      expect.soft(resolved).toMatchObject({
+        id: "Model",
+        api: "openai-completions",
+        baseUrl: "https://duplicate.example.test/v1",
+      });
+      expect.soft(resolved?.headers).toEqual(emptyHeaders ? undefined : { "x-route": "duplicate" });
+    },
+  );
+
   it("preserves normalized inline provider transport when static metadata is merged", async () => {
     const cfg = makeProviderConfig("my-gemini", {
       api: "google-generative-ai",
@@ -4002,6 +4080,45 @@ describe("resolveModel", () => {
       maxTokens: 16000,
     });
   });
+
+  it.each([
+    {
+      label: "exact provider literal",
+      exactId: "trinity-large-thinking",
+      otherId: "arcee-ai/trinity-large-thinking",
+      expectedProvider: "arcee",
+    },
+    {
+      label: "other spelling literal before exact provider equivalent",
+      exactId: "arcee-ai/trinity-large-thinking",
+      otherId: "trinity-large-thinking",
+      expectedProvider: "Arcee",
+    },
+  ])(
+    "preserves provider-spelling lookup order: $label",
+    ({ exactId, otherId, expectedProvider }) => {
+      const matched = findInlineModelMatch({
+        provider: "arcee",
+        modelId: "trinity-large-thinking",
+        providers: {
+          Arcee: {
+            api: "openai-completions",
+            baseUrl: "https://other.example.test/v1",
+            models: [makeModel(otherId)],
+          },
+          arcee: {
+            api: "openai-completions",
+            baseUrl: "https://exact.example.test/v1",
+            models: [makeModel(exactId)],
+          },
+        },
+      });
+      expect.soft(matched?.provider).toBe(expectedProvider);
+      expect
+        .soft(matched?.baseUrl)
+        .toBe(`https://${expectedProvider === "arcee" ? "exact" : "other"}.example.test/v1`);
+    },
+  );
 
   it("prefers exact provider config over normalized alias match when both keys exist", async () => {
     mockDiscoveredModel(discoverModels, {

--- a/src/agents/model-catalog-route.test.ts
+++ b/src/agents/model-catalog-route.test.ts
@@ -328,35 +328,87 @@ describe("projectModelCatalogEntryForRoute", () => {
     });
   });
 
-  it("merges logical overrides from canonical duplicate model rows", () => {
-    const cfg = {
-      models: {
-        providers: {
-          openai: {
-            models: [
-              { id: "openai/gpt-5.5", name: "Configured GPT-5.5" },
-              { id: "gpt-5.5", name: "Ignored duplicate name", contextTokens: 160_000 },
-            ],
+  it.each([
+    { label: "legacy first", legacyFirst: true, exact: true, duplicate: false },
+    { label: "exact first", legacyFirst: false, exact: true, duplicate: false },
+    {
+      label: "legacy first with exact duplicates",
+      legacyFirst: true,
+      exact: true,
+      duplicate: true,
+    },
+    { label: "exact duplicates first", legacyFirst: false, exact: true, duplicate: true },
+    { label: "legacy fallback", legacyFirst: true, exact: false, duplicate: false },
+  ])(
+    "selects logical overrides without cross-spelling merges: $label",
+    ({ legacyFirst, exact, duplicate }) => {
+      const logical: ModelDefinitionConfig = {
+        id: "gpt-5.5",
+        name: "Logical row",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        maxTokens: 4096,
+      };
+      const legacy: ModelDefinitionConfig = {
+        ...logical,
+        id: "openai/gpt-5.5",
+        name: "Legacy row",
+        contextWindow: 900_000,
+        contextTokens: 500_000,
+        reasoning: true,
+        input: ["image"],
+      };
+      const exactRows = exact ? [logical] : [];
+      if (duplicate) {
+        exactRows.push({ ...logical, name: "Ignored duplicate name", contextTokens: 160_000 });
+      }
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: platformRoute.baseUrl,
+              models: legacyFirst ? [legacy, ...exactRows] : [...exactRows, legacy],
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig;
-    const canonicalPolicy: ModelCatalogRoutePolicy = {
-      ...routePolicy,
-      resolveIdentity: (entry) => {
-        const id = entry.id.replace(/^openai\//u, "");
-        return { id, key: `${entry.provider}/${id}` };
-      },
-    };
+      };
+      const canonicalPolicy: ModelCatalogRoutePolicy = {
+        ...routePolicy,
+        resolveIdentity: (entry) => {
+          const id = entry.id.replace(/^openai\//u, "");
+          return { id, key: `${entry.provider}/${id}` };
+        },
+      };
 
-    expect(
-      resolveConfiguredModelCatalogOverrides({
-        cfg,
-        entry: platformEntry,
-        policy: canonicalPolicy,
-      }),
-    ).toEqual({ name: "Configured GPT-5.5", contextTokens: 160_000 });
-  });
+      for (const id of ["gpt-5.5", "openai/gpt-5.5"]) {
+        expect(
+          resolveConfiguredModelCatalogOverrides({
+            cfg,
+            entry: { ...platformEntry, id },
+            policy: canonicalPolicy,
+          }),
+        ).toEqual(
+          exact
+            ? {
+                name: "Logical row",
+                reasoning: false,
+                configuredReasoning: false,
+                input: ["text"],
+                ...(duplicate ? { contextTokens: 160_000 } : {}),
+              }
+            : {
+                name: "Legacy row",
+                reasoning: true,
+                configuredReasoning: true,
+                input: ["image"],
+                contextWindow: 900_000,
+                contextTokens: 500_000,
+              },
+        );
+      }
+    },
+  );
 
   it("preserves literal provider-scoped model ids", () => {
     const cfg = {

--- a/src/agents/model-catalog-route.ts
+++ b/src/agents/model-catalog-route.ts
@@ -3,9 +3,8 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
-  matchesProviderScopedModelId,
+  findConfiguredProviderModel,
   resolveMergedModelProviderConfig,
-  resolveMergedModelProviderModels,
 } from "../config/model-provider-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderModelRouteCandidate } from "../plugin-sdk/provider-model-types.js";
@@ -70,21 +69,15 @@ export function resolveConfiguredModelCatalogOverrides(params: {
   }
   const surface = resolveProviderModelPolicySurface(provider);
   const normalizeConfiguredModelId = (modelId: string) =>
-    params.policy?.resolveIdentity({ provider: params.entry.provider, id: modelId })?.key ??
+    params.policy?.resolveIdentity({ provider: params.entry.provider, id: modelId })?.id ??
     resolveProviderModelCatalogId({ provider, modelId, surface }) ??
     modelId.trim();
-  const modelId =
-    params.policy?.resolveIdentity(params.entry)?.id ??
-    resolveProviderModelCatalogId({ provider, modelId: params.entry.id, surface }) ??
-    params.entry.id.trim();
-  const exactModels = providerConfig.models.filter((candidate) =>
-    matchesProviderScopedModelId({ candidateId: candidate.id, provider, modelId }),
+  const model = findConfiguredProviderModel(
+    providerConfig,
+    provider,
+    normalizeConfiguredModelId(params.entry.id),
+    normalizeConfiguredModelId,
   );
-  // Match the row group execution will use, then retain same-spelling duplicate merges.
-  const model = resolveMergedModelProviderModels({
-    models: exactModels.length > 0 ? exactModels : providerConfig.models,
-    normalizeModelId: normalizeConfiguredModelId,
-  }).get(normalizeConfiguredModelId(modelId));
   const overrides: ModelCatalogLogicalOverrides = {
     ...(model?.name ? { name: model.name } : {}),
     ...(model?.contextWindow !== undefined ? { contextWindow: model.contextWindow } : {}),

--- a/src/config/model-provider-config.test.ts
+++ b/src/config/model-provider-config.test.ts
@@ -1,19 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { setCurrentManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   resolveMergedModelProviderModels,
   createModelProviderRouteOverrideResolver,
+  findConfiguredProviderModel,
 } from "./model-provider-config.js";
 import type { ModelDefinitionConfig } from "./types.models.js";
 
 function model(id: string, fields: Partial<ModelDefinitionConfig> = {}): ModelDefinitionConfig {
-  return { id, ...fields } as ModelDefinitionConfig;
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    maxTokens: 4096,
+    ...fields,
+  };
 }
 
+afterEach(() => setCurrentManifestModelIdNormalizationPolicies(undefined));
+
 describe("resolveMergedModelProviderModels", () => {
-  it("keeps first-row fields and fills only omissions from canonical duplicates", () => {
+  it("keeps first-row fields and fills only omissions from exact duplicate rows", () => {
     const models = resolveMergedModelProviderModels({
       models: [
-        model("openai/gpt-5.5", {
+        model("gpt-5.5", {
           api: "openai-responses",
           headers: {},
         }),
@@ -27,16 +39,17 @@ describe("resolveMergedModelProviderModels", () => {
       normalizeModelId: (modelId) => modelId.replace(/^openai\//u, ""),
     });
 
-    expect(models.get("gpt-5.5")).toEqual({
-      id: "openai/gpt-5.5",
-      api: "openai-responses",
-      baseUrl: "https://relay.example.test/v1",
-      headers: {},
-      params: { azureApiVersion: "2025-01-01" },
-    });
+    expect(models.get("gpt-5.5")).toEqual(
+      model("gpt-5.5", {
+        api: "openai-responses",
+        baseUrl: "https://relay.example.test/v1",
+        headers: {},
+        params: { azureApiVersion: "2025-01-01" },
+      }),
+    );
   });
 
-  it("fills headers when the first canonical row omits them", () => {
+  it("keeps an exact row's omitted headers separate from normalized aliases", () => {
     const models = resolveMergedModelProviderModels({
       models: [
         model("gpt-5.5", { api: "openai-responses" }),
@@ -45,8 +58,133 @@ describe("resolveMergedModelProviderModels", () => {
       normalizeModelId: (modelId) => modelId.replace(/^openai\//u, ""),
     });
 
-    expect(models.get("gpt-5.5")?.headers).toEqual({ "x-route": "custom" });
+    expect(models.get("gpt-5.5")?.headers).toBeUndefined();
   });
+
+  it("keeps the first equivalent row's omissions when there is no exact target", () => {
+    const first = model("alias-a");
+    const second = model("alias-b", { headers: { "x-route": "other-alias" } });
+    const rows = resolveMergedModelProviderModels({
+      models: [first, second],
+      normalizeModelId: () => "canonical",
+    });
+    expect(rows.get("canonical")).toEqual(first);
+    expect(rows.get("alias-b")).toEqual(second);
+  });
+});
+
+describe("configured model row precedence", () => {
+  it.each([false, true])("keeps exact rows ahead of legacy spellings (reversed=%s)", (reverse) => {
+    for (const headers of [undefined, {}]) {
+      const exact = model("Model", {
+        baseUrl: "https://exact.example.test/v1",
+        ...(headers ? { headers } : {}),
+      });
+      const legacy = model("custom/Model", {
+        headers: { "x-route": "legacy" },
+        baseUrl: "https://legacy.example.test/v1",
+      });
+      const models = reverse ? [exact, legacy] : [legacy, exact];
+      const resolve = createModelProviderRouteOverrideResolver({
+        provider: "custom",
+        authoredConfig: { models: { providers: { custom: { baseUrl: "", models } } } },
+      });
+      expect(findConfiguredProviderModel({ models }, "custom", "Model")).toEqual(exact);
+      expect(findConfiguredProviderModel({ models }, "custom", "custom/Model")).toEqual(legacy);
+      expect([resolve("Model"), resolve("custom/Model"), resolve("Model")]).toEqual([
+        "none",
+        "present",
+        "none",
+      ]);
+    }
+  });
+
+  it("uses trimmed same-provider legacy rows only as a final fallback", () => {
+    const legacy = model(" CUSTOM/Model ", { headers: { "x-route": "legacy" } });
+    expect(findConfiguredProviderModel({ models: [legacy] }, "custom", "Model")).toEqual(legacy);
+    expect(findConfiguredProviderModel({ models: [legacy] }, "custom", " CUSTOM/Model ")).toEqual(
+      legacy,
+    );
+    expect(findConfiguredProviderModel({ models: [legacy] }, "custom", "model")).toBeUndefined();
+    expect(findConfiguredProviderModel({ models: [legacy] }, "other", "Model")).toBeUndefined();
+    expect(legacy.id).toBe(" CUSTOM/Model ");
+  });
+
+  it.each([false, true])("keeps exact alias-chain rows stable (reversed=%s)", (reverse) => {
+    const aliases: Record<string, string> = { latest: "middle", middle: "final" };
+    const canonicalizeModelId = (id: string) => aliases[id] ?? id;
+    const models = [
+      model("latest", { headers: { "x-route": "latest" } }),
+      model("middle"),
+      model("final", { headers: {} }),
+    ];
+    if (reverse) {
+      models.reverse();
+    }
+    const indexed = resolveMergedModelProviderModels({
+      models,
+      normalizeModelId: canonicalizeModelId,
+    });
+    const resolve = createModelProviderRouteOverrideResolver({
+      provider: "custom",
+      canonicalizeModelId,
+      authoredConfig: { models: { providers: { custom: { baseUrl: "", models } } } },
+    });
+    for (const id of ["middle", "final", "latest", "middle"]) {
+      const expected = models.find((row) => row.id === id);
+      expect(indexed.get(id)).toEqual(expected);
+      expect(findConfiguredProviderModel({ models }, "custom", id, canonicalizeModelId)).toEqual(
+        expected,
+      );
+      expect(resolve(id)).toBe(id === "latest" ? "present" : "none");
+    }
+  });
+
+  it("keeps caller-declared equivalents ahead of legacy fallback rows", () => {
+    const alias = model("latest", { headers: {} });
+    const models = [model("custom/Model", { headers: { "x-route": "legacy" } }), alias];
+    const canonicalizeModelId = (id: string) =>
+      id === "latest" ? "Model" : id.replace(/^custom\//u, "");
+    expect(findConfiguredProviderModel({ models }, "custom", "Model", canonicalizeModelId)).toEqual(
+      alias,
+    );
+    expect(
+      findConfiguredProviderModel(
+        { models: [alias] },
+        "custom",
+        "custom/Model",
+        canonicalizeModelId,
+      ),
+    ).toBeUndefined();
+    expect(
+      createModelProviderRouteOverrideResolver({
+        provider: "custom",
+        canonicalizeModelId,
+        authoredConfig: { models: { providers: { custom: { baseUrl: "", models } } } },
+      })("Model"),
+    ).toBe("none");
+  });
+
+  it.each([false, true])(
+    "ignores other owners' ambient input aliases (declared=%s)",
+    (declared) => {
+      setCurrentManifestModelIdNormalizationPolicies(
+        new Map([["custom", { aliases: { latest: "Model" } }]]),
+      );
+      const models = [model("latest", { headers: { "x-route": "another-owner" } })];
+      const canonicalizeModelId = declared ? (id: string) => id : undefined;
+      expect(
+        findConfiguredProviderModel({ models }, "custom", "Model", canonicalizeModelId),
+      ).toBeUndefined();
+      expect(
+        createModelProviderRouteOverrideResolver({
+          provider: "custom",
+          canonicalizeModelId,
+          authoredConfig: { models: { providers: { custom: { baseUrl: "", models } } } },
+        })("Model"),
+      ).toBe("none");
+    },
+  );
 });
 
 describe("createModelProviderRouteOverrideResolver", () => {

--- a/src/config/model-provider-config.test.ts
+++ b/src/config/model-provider-config.test.ts
@@ -22,10 +22,10 @@ function model(id: string, fields: Partial<ModelDefinitionConfig> = {}): ModelDe
 afterEach(() => setCurrentManifestModelIdNormalizationPolicies(undefined));
 
 describe("resolveMergedModelProviderModels", () => {
-  it("keeps first-row fields and fills only omissions from exact duplicate rows", () => {
+  it("keeps first-row fields and fills only omissions from canonical duplicates", () => {
     const models = resolveMergedModelProviderModels({
       models: [
-        model("gpt-5.5", {
+        model("openai/gpt-5.5", {
           api: "openai-responses",
           headers: {},
         }),
@@ -40,7 +40,7 @@ describe("resolveMergedModelProviderModels", () => {
     });
 
     expect(models.get("gpt-5.5")).toEqual(
-      model("gpt-5.5", {
+      model("openai/gpt-5.5", {
         api: "openai-responses",
         baseUrl: "https://relay.example.test/v1",
         headers: {},
@@ -49,7 +49,7 @@ describe("resolveMergedModelProviderModels", () => {
     );
   });
 
-  it("keeps an exact row's omitted headers separate from normalized aliases", () => {
+  it("fills headers when the first canonical row omits them", () => {
     const models = resolveMergedModelProviderModels({
       models: [
         model("gpt-5.5", { api: "openai-responses" }),
@@ -58,22 +58,42 @@ describe("resolveMergedModelProviderModels", () => {
       normalizeModelId: (modelId) => modelId.replace(/^openai\//u, ""),
     });
 
-    expect(models.get("gpt-5.5")?.headers).toBeUndefined();
+    expect(models.get("gpt-5.5")?.headers).toEqual({ "x-route": "custom" });
   });
 
-  it("keeps the first equivalent row's omissions when there is no exact target", () => {
-    const first = model("alias-a");
-    const second = model("alias-b", { headers: { "x-route": "other-alias" } });
-    const rows = resolveMergedModelProviderModels({
-      models: [first, second],
-      normalizeModelId: () => "canonical",
-    });
-    expect(rows.get("canonical")).toEqual(first);
-    expect(rows.get("alias-b")).toEqual(second);
-  });
+  it.each([false, true])(
+    "publishes only normalized keys with first-row capabilities (reversed=%s)",
+    (reverse) => {
+      const models = [
+        model("Model", { input: ["text", "image"], contextTokens: 200_000 }),
+        model("model", { input: ["text"], contextTokens: 1_000_000 }),
+      ];
+      if (reverse) {
+        models.reverse();
+      }
+      const indexed = resolveMergedModelProviderModels({
+        models,
+        normalizeModelId: (id) => id.toLowerCase(),
+      });
+      expect([...indexed]).toEqual([["model", models[0]]]);
+    },
+  );
 });
 
 describe("configured model row precedence", () => {
+  it("keeps the first equivalent row's omissions when there is no exact target", () => {
+    const first = model("alias-a");
+    const second = model("alias-b", { headers: { "x-route": "other-alias" } });
+    expect(
+      findConfiguredProviderModel(
+        { models: [first, second] },
+        "custom",
+        "canonical",
+        () => "canonical",
+      ),
+    ).toEqual(first);
+  });
+
   it.each([false, true])("keeps exact rows ahead of legacy spellings (reversed=%s)", (reverse) => {
     for (const headers of [undefined, {}]) {
       const exact = model("Model", {
@@ -121,10 +141,6 @@ describe("configured model row precedence", () => {
     if (reverse) {
       models.reverse();
     }
-    const indexed = resolveMergedModelProviderModels({
-      models,
-      normalizeModelId: canonicalizeModelId,
-    });
     const resolve = createModelProviderRouteOverrideResolver({
       provider: "custom",
       canonicalizeModelId,
@@ -132,7 +148,6 @@ describe("configured model row precedence", () => {
     });
     for (const id of ["middle", "final", "latest", "middle"]) {
       const expected = models.find((row) => row.id === id);
-      expect(indexed.get(id)).toEqual(expected);
       expect(findConfiguredProviderModel({ models }, "custom", id, canonicalizeModelId)).toEqual(
         expected,
       );

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -38,28 +38,17 @@ export function matchesProviderScopedModelId(params: {
 }
 
 /** Uses the same authored row for transport materialization and early auth selection. */
-export function findConfiguredProviderModel(
-  providerConfig: { models?: ModelDefinitionConfig[] } | undefined,
+export function findConfiguredProviderModel<T extends { id: string }>(
+  providerConfig: { models?: readonly T[] } | undefined,
   provider: string,
   modelId: string,
   canonicalizeModelId?: (modelId: string) => string,
 ) {
-  const exact = providerConfig?.models?.find((candidate) =>
-    matchesProviderScopedModelId({ candidateId: candidate.id, provider, modelId }),
-  );
-  return (
-    exact ??
-    (canonicalizeModelId
-      ? providerConfig?.models?.find((candidate) =>
-          matchesProviderScopedModelId({
-            candidateId: candidate.id,
-            provider,
-            modelId,
-            normalizeModelId: canonicalizeModelId,
-          }),
-        )
-      : undefined)
-  );
+  return createConfiguredProviderModelResolver(
+    providerConfig,
+    provider,
+    canonicalizeModelId,
+  )(modelId);
 }
 
 const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
@@ -149,32 +138,59 @@ export function isBuiltInModelProviderOverlayId(providerId: string): boolean {
   return BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS.has(normalizeProviderId(providerId));
 }
 
-/** Indexes configured model rows after caller-owned model-id normalization. */
-export function resolveMergedModelProviderModels(params: {
-  models: readonly ModelDefinitionConfig[] | undefined;
+/** Indexes exact configured rows ahead of caller-owned model-id equivalents. */
+export function resolveMergedModelProviderModels<T extends { id: string }>(params: {
+  models: readonly T[] | undefined;
   normalizeModelId: (modelId: string) => string | undefined;
-}): ReadonlyMap<string, ModelDefinitionConfig> {
-  const models = new Map<string, ModelDefinitionConfig>();
+}): ReadonlyMap<string, T> {
+  const exactRows = new Map<string, T>();
   for (const model of params.models ?? []) {
-    const modelId = params.normalizeModelId(model.id);
-    if (!modelId) {
-      continue;
-    }
-    const existing = models.get(modelId);
-    // Earlier rows stay authoritative, including explicit empty objects;
-    // later duplicates only supply top-level fields the first row omitted.
-    models.set(modelId, existing ? { ...model, ...existing } : model);
+    // Exact selections can inherit omissions only from same-spelling duplicates.
+    const id = model.id.trim();
+    const exact = exactRows.get(id);
+    exactRows.set(id, exact ? { ...model, ...exact } : model);
   }
-  return models;
+  const models = new Map<string, T>();
+  for (const [id, model] of exactRows) {
+    const modelId = params.normalizeModelId(id);
+    if (!modelId) {
+      exactRows.delete(id);
+    } else if (!models.has(modelId)) {
+      models.set(modelId, model);
+    }
+  }
+  return new Map([...models, ...exactRows]);
 }
 
-function normalizeModelId(provider: string, modelId: string): string {
-  const trimmed = modelId.trim();
-  const slashIndex = trimmed.indexOf("/");
-  return slashIndex > 0 &&
-    normalizeProviderId(trimmed.slice(0, slashIndex)) === normalizeProviderId(provider)
-    ? trimmed.slice(slashIndex + 1).trim()
-    : trimmed;
+function createConfiguredProviderModelResolver<T extends { id: string }>(
+  providerConfig: { models?: readonly T[] } | undefined,
+  provider: string,
+  canonicalizeModelId?: (modelId: string) => string,
+): (modelId: string) => T | undefined {
+  const canonicalize = (id: string) =>
+    stripSelfProviderModelPrefix(provider, id) !== id ? id : canonicalizeModelId?.(id).trim() || id;
+  let configuredModels: ReadonlyMap<string, T> | undefined;
+  return (modelId) => {
+    const id = modelId.trim();
+    const rows = (configuredModels ??= resolveMergedModelProviderModels({
+      models: providerConfig?.models,
+      normalizeModelId: (candidate) => canonicalize(candidate.trim()),
+    }));
+    const canonicalId = canonicalize(id);
+    const exact = rows.get(id) ?? rows.get(canonicalId);
+    if (exact) {
+      return exact;
+    }
+    // Declared equivalents precede legacy self-provider prefixes. The selected
+    // namespace itself is never stripped or merged with a legacy row.
+    for (const [candidate, row] of rows) {
+      const legacy = stripSelfProviderModelPrefix(provider, candidate);
+      if (legacy !== candidate && (legacy === id || canonicalize(legacy.trim()) === canonicalId)) {
+        return row;
+      }
+    }
+    return undefined;
+  };
 }
 
 function hasNonEmptyRecord(value: unknown): boolean {
@@ -224,22 +240,16 @@ export function createModelProviderRouteOverrideResolver(params: {
   ) {
     return () => "present";
   }
-  const canonicalize = (modelId: string) => {
-    const normalized = normalizeModelId(params.provider, modelId);
-    const canonical = params.canonicalizeModelId?.(normalized).trim();
-    return canonical || normalized;
-  };
-  let configuredModels: ReadonlyMap<string, ModelDefinitionConfig> | undefined;
+  const findModel = createConfiguredProviderModelResolver(
+    providerConfig,
+    params.provider,
+    params.canonicalizeModelId,
+  );
   return (modelId) => {
     if (!modelId) {
       return "none";
     }
-    // Keep provider-only queries lazy and normalize the query before the first row pass.
-    const canonicalModelId = canonicalize(modelId);
-    const configuredModel = (configuredModels ??= resolveMergedModelProviderModels({
-      models: providerConfig.models,
-      normalizeModelId: canonicalize,
-    })).get(canonicalModelId);
+    const configuredModel = findModel(modelId);
     return configuredModel &&
       (hasNonEmptyRecord(configuredModel.headers) ||
         hasNonEmptyRecord(configuredModel.params) ||

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -138,28 +138,23 @@ export function isBuiltInModelProviderOverlayId(providerId: string): boolean {
   return BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS.has(normalizeProviderId(providerId));
 }
 
-/** Indexes exact configured rows ahead of caller-owned model-id equivalents. */
+/** Indexes configured model rows after caller-owned model-id normalization. */
 export function resolveMergedModelProviderModels<T extends { id: string }>(params: {
   models: readonly T[] | undefined;
   normalizeModelId: (modelId: string) => string | undefined;
 }): ReadonlyMap<string, T> {
-  const exactRows = new Map<string, T>();
-  for (const model of params.models ?? []) {
-    // Exact selections can inherit omissions only from same-spelling duplicates.
-    const id = model.id.trim();
-    const exact = exactRows.get(id);
-    exactRows.set(id, exact ? { ...model, ...exact } : model);
-  }
   const models = new Map<string, T>();
-  for (const [id, model] of exactRows) {
-    const modelId = params.normalizeModelId(id);
+  for (const model of params.models ?? []) {
+    const modelId = params.normalizeModelId(model.id);
     if (!modelId) {
-      exactRows.delete(id);
-    } else if (!models.has(modelId)) {
-      models.set(modelId, model);
+      continue;
     }
+    const existing = models.get(modelId);
+    // Earlier rows stay authoritative, including explicit empty objects;
+    // later duplicates only supply top-level fields the first row omitted.
+    models.set(modelId, existing ? { ...model, ...existing } : model);
   }
-  return new Map([...models, ...exactRows]);
+  return models;
 }
 
 function createConfiguredProviderModelResolver<T extends { id: string }>(
@@ -169,13 +164,27 @@ function createConfiguredProviderModelResolver<T extends { id: string }>(
 ): (modelId: string) => T | undefined {
   const canonicalize = (id: string) =>
     stripSelfProviderModelPrefix(provider, id) !== id ? id : canonicalizeModelId?.(id).trim() || id;
-  let configuredModels: ReadonlyMap<string, T> | undefined;
+  let configuredModels: Map<string, T> | undefined;
   return (modelId) => {
     const id = modelId.trim();
-    const rows = (configuredModels ??= resolveMergedModelProviderModels({
-      models: providerConfig?.models,
-      normalizeModelId: (candidate) => canonicalize(candidate.trim()),
-    }));
+    if (!configuredModels) {
+      const exactRows = resolveMergedModelProviderModels({
+        models: providerConfig?.models,
+        normalizeModelId: (candidate) => candidate.trim(),
+      });
+      configuredModels = new Map();
+      for (const [candidate, row] of exactRows) {
+        const canonical = canonicalize(candidate);
+        if (!configuredModels.has(canonical)) {
+          configuredModels.set(canonical, row);
+        }
+      }
+      // Literal selection owns its row; equivalents never donate omitted fields.
+      for (const [candidate, row] of exactRows) {
+        configuredModels.set(candidate, row);
+      }
+    }
+    const rows = configuredModels;
     const canonicalId = canonicalize(id);
     const exact = rows.get(id) ?? rows.get(canonicalId);
     if (exact) {

--- a/src/plugins/provider-model-routes.test.ts
+++ b/src/plugins/provider-model-routes.test.ts
@@ -407,7 +407,7 @@ describe("provider model route adapter", () => {
     });
   });
 
-  it("captures separate override facts for canonical duplicate rows", () => {
+  it("captures exact row overrides without borrowing an alias endpoint", () => {
     const firstHeaders: Record<string, string> = {};
     const resolveModelRoutes = vi.fn((_context: ProviderResolveModelRoutesContext) => ({
       kind: "indeterminate" as const,
@@ -454,10 +454,8 @@ describe("provider model route adapter", () => {
       ["second", "present"],
       ["missing", "none"],
     ]);
-    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel).toEqual({
-      api: "openai-responses",
-      baseUrl: "https://model.example.test/v1",
-    });
+    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel?.api).toBe("openai-responses");
+    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel).not.toHaveProperty("baseUrl");
   });
 
   it("keeps case-distinct provider keys and unknown model ids separate", () => {

--- a/src/plugins/provider-model-routes.test.ts
+++ b/src/plugins/provider-model-routes.test.ts
@@ -407,7 +407,7 @@ describe("provider model route adapter", () => {
     });
   });
 
-  it("captures exact row overrides without borrowing an alias endpoint", () => {
+  it("captures separate override facts for canonical duplicate rows", () => {
     const firstHeaders: Record<string, string> = {};
     const resolveModelRoutes = vi.fn((_context: ProviderResolveModelRoutesContext) => ({
       kind: "indeterminate" as const,
@@ -454,8 +454,10 @@ describe("provider model route adapter", () => {
       ["second", "present"],
       ["missing", "none"],
     ]);
-    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel?.api).toBe("openai-responses");
-    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel).not.toHaveProperty("baseUrl");
+    expect(resolveModelRoutes.mock.calls[0]?.[0].configuredModel).toEqual({
+      api: "openai-responses",
+      baseUrl: "https://model.example.test/v1",
+    });
   });
 
   it("keeps case-distinct provider keys and unknown model ids separate", () => {


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

A configured model can receive another row's endpoint or request overrides because a legacy-prefixed or equivalent row appears first. Applying provider defaults before duplicate rows merge can also make transport disagree with early auth selection. The catalog adapter additionally passed a provider-qualified key where the resolver expects a model ID.

## Why This Change Was Made

Use one explicit configured-row resolver. Within the selected provider configuration, exact spelling wins and only same-spelling duplicates fill omitted fields; duplicates merge before provider defaults. Preserve explicit empty overrides and existing preferred provider-key selection. The catalog adapter passes the provider-owned logical model ID to the same owner.

Keep the existing normalized-index API separate: its callers still receive only normalized keys and their established first-row merge behavior. Literal priority is private to the explicit resolver. This eight-file repair adds 27 production lines and enables the separate context/inventory cleanups.

## User Impact

Configured requests use the selected row's endpoint, API, and overrides. A neighboring alias cannot donate omitted fields to an exact row. Public catalog overrides follow the same logical selection instead of accidentally choosing a prefixed legacy row.

## Evidence

At `b0d341e5d123bc5077ea1c3b55d44f487dac2bf6`, 312 focused cases, fresh independent P2 review, and the full changed-file gate passed. Coverage includes row precedence, catalog adapters, provider routes, compaction thresholds, harness projections, and an inbound-image flow. The assertion baseline contains only its exact shrink for removed casts.

Review of the previous revision exposed two introduced normalized-index regressions: an image-capable `Model` could select the text-only `model` row, and a 200k model could inherit a 1m row's compaction floor. Both were reproduced against that head, compared with the baseline owner, and repaired by restoring the normalized-index contract. The new two-case map regression table fails on the previous implementation. Existing case-distinct behavior of normalized consumers is preserved; migrating those consumers to literal selection is a separate follow-up.

One canonical `sourcePerformance` build passed at the exact head. Ten compiled loopback HTTP requests verified paths, wire IDs, and headers across exact/legacy rows, duplicate-before-default behavior, and Arcee ordering. Ten compiled logical-override cases verified precedence, omissions, duplicate merging, and legacy fallback; two compiled normalized-index controls verified the retained API. All 9,009 build files were unchanged, no source imports occurred, the listener closed, and child process groups exited. This runtime build excludes UI and declaration generation.

Earlier failures and evidence remain associated with their original heads. Requests to change cross-provider-key selection were checked against the existing contract and rejected; the final review included that contract and found no actionable issue.
