### PR TITLE
test(ui): await history skeleton final styles

### DIFF
--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -125,13 +125,15 @@ suite.define(() => {
       expect(revealDelay.delay).toBeGreaterThanOrEqual(480);
       expect(revealDelay.previousVisible).toBe(false);
       expect(revealDelay.delay).toBeLessThan(1_000);
-      expect(
-        await loader.evaluate((node) => ({
-          opacity: getComputedStyle(node).opacity,
-          duration: getComputedStyle(node).animationDuration,
-          reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
-        })),
-      ).toEqual({ opacity: "1", duration: "1e-05s", reduced: true });
+      await expect
+        .poll(() =>
+          loader.evaluate((node) => ({
+            opacity: getComputedStyle(node).opacity,
+            duration: getComputedStyle(node).animationDuration,
+            reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
+          })),
+        )
+        .toEqual({ opacity: "1", duration: "1e-05s", reduced: true });
       expect(
         await page
           .locator(".chat-pane-cache__pane--visible")


### PR DESCRIPTION
Related: #143776

## What Problem This Solves

The chat-history E2E test can sample a reveal animation mid-frame and fail even though reduced-motion styles are correct. CI observed opacity 0.57088 immediately after visibility became visible, while the expected animation duration and motion preference were already active.

## Why This Change Was Made

Wait for the same complete style object with the existing polling default. Preserve the 480–1000 ms reveal bounds, controlled animation-frame samples, previous-content checks, actions, and exact opacity/duration/preference assertions.

## User Impact

CI verifies the animation's final state reliably. Production code, CSS, animation timing, and test timeouts are unchanged.

## Evidence

- [The original CI failure](https://github.com/openclaw/openclaw/actions/runs/34446001171/job/102771051861) supplies the failing observation. The tested merge and relevant test/style/component/harness source were verified against both parents and current main.
- All six history E2E cases, 12 existing skeleton cases, and 18 canonical changed-file checks pass.
- Fresh independent Codex review found no actionable findings through P2.

This repair is separate from locale-cache behavior. No test actions are replayed, animation is not disabled, and all original assertions remain.
