### PR TITLE
fix: deliver 7.33 generated media on message-tool routes

### DIFF
--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -838,6 +838,7 @@ export class CodexAppServerEventProjector {
       messagingToolSourceReplyPayloads: toolTelemetry.messagingToolSourceReplyPayloads ?? [],
       heartbeatToolResponse: toolTelemetry.heartbeatToolResponse,
       toolMediaUrls: this.buildToolMediaUrls(toolTelemetry),
+      hostOwnedToolMediaUrls: this.buildHostOwnedMediaUrls(toolTelemetry),
       toolAudioAsVoice: toolTelemetry.toolAudioAsVoice,
       successfulCronAdds: toolTelemetry.successfulCronAdds,
       cloudCodeAssistFormatError: false,
@@ -1610,6 +1611,16 @@ export class CodexAppServerEventProjector {
       }
     }
     return mediaUrls.size > 0 ? [...mediaUrls] : toolTelemetry.toolMediaUrls;
+  }
+
+  private buildHostOwnedMediaUrls(
+    toolTelemetry: CodexAppServerToolTelemetry,
+  ): string[] | undefined {
+    if ((toolTelemetry.messagingToolSentMediaUrls?.length ?? 0) > 0) {
+      return undefined;
+    }
+    const mediaUrls = [...this.nativeGeneratedMediaUrlsByItemId.values()];
+    return mediaUrls.length > 0 ? mediaUrls : undefined;
   }
 
   private async maybeEndReasoning(): Promise<void> {
@@ -2537,7 +2548,6 @@ function readNonNegativeInteger(record: JsonObject, key: string): number | undef
   const value = readNumber(record, key);
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
-
 
 function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
   const error = record.error;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3991,6 +3991,9 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
     expect(result.assistantTexts).toEqual([]);
     expect(result.toolMediaUrls).toEqual(["/tmp/codex-home/generated_images/session-1/ig_123.png"]);
+    expect(result.hostOwnedToolMediaUrls).toEqual([
+      "/tmp/codex-home/generated_images/session-1/ig_123.png",
+    ]);
   });
 
   it("does not complete on unscoped turn/completed notifications", async () => {

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -43,6 +43,7 @@ const loggerWarnMock = vi.fn();
 let refreshRuntimeAuthOnFirstPromptError = false;
 let clearRuntimeConfigSnapshot: typeof import("../config/config.js").clearRuntimeConfigSnapshot;
 let setRuntimeConfigSnapshot: typeof import("../config/config.js").setRuntimeConfigSnapshot;
+let getReplyPayloadMetadata: typeof import("../auto-reply/reply-payload.js").getReplyPayloadMetadata;
 
 vi.mock("openclaw/plugin-sdk/llm", async () => {
   const actual =
@@ -180,6 +181,7 @@ beforeAll(async () => {
   vi.useRealTimers();
   vi.resetModules();
   installRunEmbeddedMocks();
+  ({ getReplyPayloadMetadata } = await import("../auto-reply/reply-payload.js"));
   ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } = await import("../config/config.js"));
   ({ runEmbeddedAgent } = await import("./embedded-agent-runner/run.js"));
   ({ SessionManager } = await import("openclaw/plugin-sdk/agent-sessions"));
@@ -1053,6 +1055,41 @@ describe("runEmbeddedAgent", () => {
     expect(result.payloads?.[0]?.text).toBe(
       "I'll inspect the files, make the change, and run the checks.",
     );
+  });
+
+  it("preserves harness-owned media provenance through terminal preparation", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedAgentRunnerOpenAiConfig(["mock-1"]);
+    runEmbeddedAttemptMock.mockResolvedValueOnce(
+      makeEmbeddedRunnerAttempt({
+        toolMediaUrls: ["/tmp/generated.png"],
+        hostOwnedToolMediaUrls: ["/tmp/generated.png"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      sessionId: "session:test",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "generate an image",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("host-owned-media"),
+      sourceReplyDeliveryMode: "message_tool_only",
+      enqueue: immediateEnqueue,
+    });
+
+    expect(result.payloads).toHaveLength(1);
+    expect(result.payloads?.[0]).toMatchObject({
+      mediaUrls: ["/tmp/generated.png"],
+      mediaUrl: "/tmp/generated.png",
+    });
+    expect(getReplyPayloadMetadata(result.payloads?.[0] ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
   });
 
   it("handles prompt error paths without dropping user state", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3728,6 +3728,7 @@ async function runEmbeddedAgentInternal(
           const payloadsWithToolMedia = mergeAttemptToolMediaPayloads({
             payloads,
             toolMediaUrls: attempt.toolMediaUrls,
+            hostOwnedToolMediaUrls: attempt.hostOwnedToolMediaUrls,
             toolAudioAsVoice: attempt.toolAudioAsVoice,
             toolTrustedLocalMedia: attempt.toolTrustedLocalMedia,
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -65,6 +65,106 @@ describe("mergeAttemptToolMediaPayloads", () => {
     ]);
   });
 
+  it("marks harness-owned media when source replies require the message tool", () => {
+    const [mediaReply] =
+      mergeAttemptToolMediaPayloads({
+        toolMediaUrls: ["/tmp/generated.png"],
+        hostOwnedToolMediaUrls: ["/tmp/generated.png"],
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mediaReply).toEqual({
+      mediaUrls: ["/tmp/generated.png"],
+      mediaUrl: "/tmp/generated.png",
+      audioAsVoice: undefined,
+      trustedLocalMedia: undefined,
+    });
+    expect(getReplyPayloadMetadata(mediaReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
+  });
+
+  it("does not mark generic tool media as host-owned", () => {
+    const [mediaReply] =
+      mergeAttemptToolMediaPayloads({
+        toolMediaUrls: ["/tmp/reply.opus"],
+        toolAudioAsVoice: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mediaReply).toEqual({
+      mediaUrls: ["/tmp/reply.opus"],
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: undefined,
+    });
+    expect(getReplyPayloadMetadata(mediaReply ?? {})).toBeUndefined();
+  });
+
+  it("ignores host-owned provenance outside the delivered tool media set", () => {
+    const [mediaReply] =
+      mergeAttemptToolMediaPayloads({
+        toolMediaUrls: ["/tmp/tool.png"],
+        hostOwnedToolMediaUrls: ["/tmp/forged.png"],
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mediaReply).toMatchObject({
+      mediaUrls: ["/tmp/tool.png"],
+      mediaUrl: "/tmp/tool.png",
+    });
+    expect(getReplyPayloadMetadata(mediaReply ?? {})).toBeUndefined();
+  });
+
+  it("keeps generic and host-owned media in separate delivery payloads", () => {
+    const [genericReply, hostOwnedReply] =
+      mergeAttemptToolMediaPayloads({
+        toolMediaUrls: ["/tmp/reply.opus", "/tmp/generated.png"],
+        hostOwnedToolMediaUrls: ["/tmp/generated.png"],
+        toolAudioAsVoice: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(genericReply).toEqual({
+      mediaUrls: ["/tmp/reply.opus"],
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: undefined,
+    });
+    expect(getReplyPayloadMetadata(genericReply ?? {})).toBeUndefined();
+    expect(hostOwnedReply).toEqual({
+      mediaUrls: ["/tmp/generated.png"],
+      mediaUrl: "/tmp/generated.png",
+      audioAsVoice: undefined,
+      trustedLocalMedia: undefined,
+    });
+    expect(getReplyPayloadMetadata(hostOwnedReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
+  });
+
+  it("keeps host-owned media deliverable beside suppressed assistant text", () => {
+    const [textReply, mediaReply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [{ text: "Done" }],
+        toolMediaUrls: ["/tmp/generated.png"],
+        hostOwnedToolMediaUrls: ["/tmp/generated.png"],
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(textReply).toEqual({ text: "Done" });
+    expect(getReplyPayloadMetadata(textReply ?? {})).toBeUndefined();
+    expect(mediaReply).toEqual({
+      mediaUrls: ["/tmp/generated.png"],
+      mediaUrl: "/tmp/generated.png",
+      audioAsVoice: undefined,
+      trustedLocalMedia: undefined,
+    });
+    expect(getReplyPayloadMetadata(mediaReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
+  });
+
   it("preserves reply metadata when attaching tool media to a visible reply", () => {
     const visibleReply = setReplyPayloadMetadata(
       { text: "done" },

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -5,6 +5,7 @@ import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-opti
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  markReplyPayloadForSourceSuppressionDelivery,
 } from "../../../auto-reply/reply-payload.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
 
@@ -19,6 +20,7 @@ type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number
 export function mergeAttemptToolMediaPayloads(params: {
   payloads?: EmbeddedRunPayload[];
   toolMediaUrls?: string[];
+  hostOwnedToolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -27,9 +29,39 @@ export function mergeAttemptToolMediaPayloads(params: {
   const mediaUrls = Array.from(
     new Set(params.toolMediaUrls?.map((url) => url.trim()).filter(Boolean) ?? []),
   );
+  const mediaUrlSet = new Set(mediaUrls);
+  const hostOwnedMediaUrls = Array.from(
+    new Set(
+      params.hostOwnedToolMediaUrls
+        ?.map((url) => url.trim())
+        .filter((url) => url.length > 0 && mediaUrlSet.has(url)) ?? [],
+    ),
+  );
   if (mediaUrls.length === 0 && !params.toolAudioAsVoice && !params.toolTrustedLocalMedia) {
     return params.payloads;
   }
+
+  const buildMediaPayload = (urls: string[], includeAudio: boolean): EmbeddedRunPayload => ({
+    mediaUrls: urls.length ? urls : undefined,
+    mediaUrl: urls[0],
+    audioAsVoice: (includeAudio && params.toolAudioAsVoice) || undefined,
+    trustedLocalMedia: params.toolTrustedLocalMedia || undefined,
+  });
+  const shouldSplitHostOwnedMedia =
+    params.sourceReplyDeliveryMode === "message_tool_only" && hostOwnedMediaUrls.length > 0;
+  const hostOwnedMediaUrlSet = new Set(hostOwnedMediaUrls);
+  const mergeableMediaUrls = shouldSplitHostOwnedMedia
+    ? mediaUrls.filter((url) => !hostOwnedMediaUrlSet.has(url))
+    : mediaUrls;
+  const appendHostOwnedMedia = (nextPayloads: EmbeddedRunPayload[]): EmbeddedRunPayload[] => {
+    if (!shouldSplitHostOwnedMedia) {
+      return nextPayloads;
+    }
+    return [
+      ...nextPayloads,
+      markReplyPayloadForSourceSuppressionDelivery(buildMediaPayload(hostOwnedMediaUrls, false)),
+    ];
+  };
 
   const payloads = params.payloads?.length ? [...params.payloads] : [];
   const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning && !payload.isError);
@@ -42,9 +74,14 @@ export function mergeAttemptToolMediaPayloads(params: {
       // Message-tool-only source replies are transcript mirrors of a send that
       // already happened elsewhere; attaching generated media here would create
       // a duplicate channel delivery.
-      return payloads;
+      return appendHostOwnedMedia(payloads);
     }
-    const mergedMediaUrls = Array.from(new Set([...(payload.mediaUrls ?? []), ...mediaUrls]));
+    if (mergeableMediaUrls.length === 0 && shouldSplitHostOwnedMedia) {
+      return appendHostOwnedMedia(payloads);
+    }
+    const mergedMediaUrls = Array.from(
+      new Set([...(payload.mediaUrls ?? []), ...mergeableMediaUrls]),
+    );
     payloads[payloadIndex] = copyReplyPayloadMetadata(payload, {
       ...payload,
       mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
@@ -52,17 +89,15 @@ export function mergeAttemptToolMediaPayloads(params: {
       audioAsVoice: payload.audioAsVoice || params.toolAudioAsVoice || undefined,
       trustedLocalMedia: payload.trustedLocalMedia || params.toolTrustedLocalMedia || undefined,
     });
-    return payloads;
+    return appendHostOwnedMedia(payloads);
+  }
+
+  if (shouldSplitHostOwnedMedia) {
+    const genericMediaPayload =
+      mergeableMediaUrls.length > 0 ? [buildMediaPayload(mergeableMediaUrls, true)] : [];
+    return appendHostOwnedMedia([...payloads, ...genericMediaPayload]);
   }
 
   // Reasoning-only turns still need a concrete media payload so channel delivery sees the attachment.
-  return [
-    ...payloads,
-    {
-      mediaUrls: mediaUrls.length ? mediaUrls : undefined,
-      mediaUrl: mediaUrls[0],
-      audioAsVoice: params.toolAudioAsVoice || undefined,
-      trustedLocalMedia: params.toolTrustedLocalMedia || undefined,
-    },
-  ];
+  return [...payloads, buildMediaPayload(mergeableMediaUrls, true)];
 }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -226,6 +226,8 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   heartbeatToolResponse?: HeartbeatToolResponse;
   toolMediaUrls?: string[];
+  /** Native artifacts owned by the agent harness, restricted to toolMediaUrls. */
+  hostOwnedToolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
   hasToolMediaBlockReply?: boolean;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -5543,6 +5543,91 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
+  it("routes marked host media for message-tool-only queued followups", async () => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [
+          setReplyPayloadMetadataForTest(
+            { mediaUrl: "/tmp/generated.png" },
+            { deliverDespiteSourceReplySuppression: true },
+          ),
+        ],
+      },
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      mediaUrl: "/tmp/generated.png",
+    });
+  });
+
+  it("does not route marked host media for message-tool-only queued room events", async () => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [
+          setReplyPayloadMetadataForTest(
+            { mediaUrl: "/tmp/generated.png" },
+            { deliverDespiteSourceReplySuppression: true },
+          ),
+        ],
+      },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "room_event",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not route marked host media when queued followup send policy denies delivery", async () => {
+    const queued = baseQueuedRun("discord");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      sendPolicy: "deny",
+    };
+    await runMessagingCase({
+      agentResult: {
+        payloads: [
+          setReplyPayloadMetadataForTest(
+            { mediaUrl: "/tmp/generated.png" },
+            { deliverDespiteSourceReplySuppression: true },
+          ),
+        ],
+      },
+      queued: {
+        ...queued,
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        run: {
+          ...queued.run,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      } as FollowupRun,
+      runnerOverrides: { sessionEntry, sessionKey: "main" },
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
+
   it("lets provider followup route hooks force dispatcher delivery", async () => {
     resolveProviderFollowupFallbackRouteMock.mockReturnValue({
       route: "dispatcher",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1750,6 +1750,25 @@ export function createFollowupRunner(params: {
       }
 
       if (run.sourceReplyDeliveryMode === "message_tool_only") {
+        const suppressionDeliverablePayloads = deliveryPayloads.filter(
+          (payload) =>
+            getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true,
+        );
+        if (suppressionDeliverablePayloads.length > 0) {
+          if (isRoomEventFollowup()) {
+            return;
+          }
+          await sendRunPayloads(
+            suppressionDeliverablePayloads,
+            effectiveQueued,
+            {
+              provider: providerUsed,
+              modelId: modelUsed,
+            },
+            { runId },
+          );
+          return;
+        }
         logVerbose(
           "followup queue: automatic source delivery suppressed by sourceReplyDeliveryMode: message_tool_only",
         );


### PR DESCRIPTION
## Summary

- backport host-owned generated-media provenance from #110893 to the frozen 7.33 runner
- deliver only explicitly host-owned artifacts through message-tool-only source suppression
- preserve room-event silence and session send-policy denial

## Validation

- `tool-media-payloads.test.ts`: 11 passed
- Codex native generated-image projection: 1 passed
- embedded runner provenance bridge: 1 passed
- followup delivery/suppression policy: 3 passed
- formatting and `git diff --check`

## Release evidence

Full Validation run 34444175696 timed out waiting for the Matrix generated-image `m.image` after image generation completed. The candidate predates #110893, so its generated artifact was suppressed on the Matrix message-tool-only route.
