### PR TITLE
fix: open chat desktops on their assigned machines

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -67,11 +67,11 @@ See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatch
 
 ## Viewing the session desktop
 
-Open **Desktop** from a session to view its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. By default, the pop-out window keeps the session in its link, so both viewers follow placement changes and disconnect from the previous machine when the session moves or stops. A stopped cloud session does not switch either viewer to the Gateway desktop.
+Open **Desktop** from a session to connect directly to its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. The chat panel shows connection progress or a retry action instead of offering unrelated machines. The pop-out window keeps the session in its link, so both viewers follow placement changes and disconnect from the previous machine when the session moves or stops. A stopped cloud session does not switch either viewer to the Gateway desktop.
 
 If you choose a source in the Desktop picker, the panel keeps that choice when the session's placement changes. **Open desktop in new window** opens that source and requests the panel's current view-only or control mode. Desktop links contain no credentials and do not grant control; the new viewer still performs its normal authentication and permission checks.
 
-The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. The global Desktop command in the command palette still opens the machine picker, including on chat pages.
+The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. The command palette's Desktop action also follows the current session on chat pages. Outside chat, it opens the machine picker.
 
 To enter text from your local clipboard, take control and choose **Keyboard** before pasting with **Command+V** on macOS or **Ctrl+V** on Windows and Linux. The Keyboard field sends the pasted text to the remote desktop; shortcuts directed at the desktop canvas still operate on the remote machine. Keyboard input stays disabled until the control connection is ready.
 

--- a/ui/src/components/desktop/desktop-panel-credentials.ts
+++ b/ui/src/components/desktop/desktop-panel-credentials.ts
@@ -1,4 +1,22 @@
+import type { DesktopObserveResult } from "@openclaw/gateway-protocol";
+import type { DesktopCredentials } from "./desktop-panel-connection.ts";
+
 const DESKTOP_CREDENTIALS_REQUIRED_CODE = "DESKTOP_CREDENTIALS_REQUIRED";
+
+export function rfbCredentials(
+  observed: DesktopObserveResult,
+  saved: DesktopCredentials | undefined,
+): DesktopCredentials | undefined {
+  if (observed.preauthenticated) {
+    return undefined;
+  }
+  // Worker responses can carry a password without an auth discriminator.
+  return observed.vncPassword
+    ? { password: observed.vncPassword }
+    : observed.auth === "vnc-password"
+      ? saved
+      : undefined;
+}
 
 /** Reads the host-observe retry contract without exposing credential material. */
 export function desktopCredentialRequirement(

--- a/ui/src/components/desktop/desktop-panel-session.test.ts
+++ b/ui/src/components/desktop/desktop-panel-session.test.ts
@@ -1,0 +1,115 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import type { DesktopClient } from "./desktop-client.ts";
+import {
+  clickPanelButton,
+  createConnectionHandle,
+  createGatewayClient,
+  createPanel,
+  desktopEnvironment,
+} from "./desktop-panel.test-support.ts";
+
+describe("session desktop connection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes the worker observe password to the desktop client without an auth discriminator", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "environments.list") {
+        return { environments: [desktopEnvironment] };
+      }
+      return {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=worker",
+        expiresAtMs: 60_000,
+        control: false,
+        vncPassword: "synthetic-worker-password",
+      };
+    });
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      options.onConnect?.();
+      return createConnectionHandle();
+    });
+    const panel = createPanel();
+    panel.client = createGatewayClient(request).client;
+    panel.available = true;
+    panel.documentMode = true;
+    panel.desktopClientFactory = () => ({ connect });
+    document.body.append(panel);
+
+    await waitForFast(() =>
+      expect(panel.renderRoot.querySelector(".desktop-environment button")).not.toBeNull(),
+    );
+    clickPanelButton(panel);
+    await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+    expect(connect.mock.calls[0]?.[0].credentials).toEqual({
+      password: "synthetic-worker-password",
+    });
+  });
+
+  it("opens only the session desktop without waiting for global inventory and retries its status", async () => {
+    const pending = createDeferred<typeof desktopEnvironment>();
+    let environment = pending.promise;
+    const request = vi.fn(async (method: string) => {
+      if (method === "environments.status") {
+        return environment;
+      }
+      if (method === "desktop.observe") {
+        return {
+          transport: "rfb",
+          wsPath: "/desktop/observe?token=session",
+          expiresAtMs: 60_000,
+          control: false,
+        };
+      }
+      throw new Error("Global inventory unavailable");
+    });
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      options.onConnect?.();
+      return createConnectionHandle();
+    });
+    const panel = createPanel();
+    panel.client = createGatewayClient(request).client;
+    panel.available = true;
+    panel.embedded = true;
+    panel.presented = true;
+    panel.sessionKey = "agent:main:cloud";
+    panel.requestedSource = desktopEnvironment.id;
+    panel.desktopClientFactory = () => ({ connect });
+    document.body.append(panel);
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("environments.status", {
+        environmentId: desktopEnvironment.id,
+      }),
+    );
+    expect(panel.renderRoot.querySelector(".desktop-picker")).toBeNull();
+    expect(panel.renderRoot.querySelectorAll(".desktop-environment")).toHaveLength(0);
+    expect(connect).not.toHaveBeenCalled();
+
+    pending.reject(new Error("Desktop is still starting"));
+    await waitForFast(() =>
+      expect(panel.renderRoot.textContent).toContain("Desktop is still starting"),
+    );
+    expect(panel.renderRoot.querySelector(".desktop-picker")).toBeNull();
+    environment = Promise.resolve(desktopEnvironment);
+    clickPanelButton(panel, ".desktop-status button");
+    await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenLastCalledWith("desktop.observe", {
+      source: { kind: "environment", environmentId: desktopEnvironment.id },
+      control: false,
+    });
+    expect(request.mock.calls.some(([method]) => method === "environments.list")).toBe(false);
+    expect(panel.renderRoot.querySelector(".desktop-picker")).toBeNull();
+  });
+});

--- a/ui/src/components/desktop/desktop-panel-view.ts
+++ b/ui/src/components/desktop/desktop-panel-view.ts
@@ -88,11 +88,23 @@ export function renderDesktopPanelHeader(options: {
 }
 
 export function renderDesktopPicker(options: {
+  automatic: boolean;
   environments: EnvironmentSummary[];
   loading: boolean;
   onConnect: (environmentId: string) => void;
   onRefresh: () => void;
 }) {
+  if (options.automatic) {
+    return html`<div class="desktop-status" role="status">
+      ${
+        options.loading
+          ? t("desktop.connecting")
+          : html`<button class="desktop-button" type="button" @click=${options.onRefresh}>
+              ${t("common.retry")}
+            </button>`
+      }
+    </div>`;
+  }
   return html`
     <div class="desktop-toolbar">
       <span>${t("desktop.pickerTitle")}</span>

--- a/ui/src/components/desktop/desktop-panel.test-support.ts
+++ b/ui/src/components/desktop/desktop-panel.test-support.ts
@@ -1,0 +1,78 @@
+import { vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
+import type { DesktopConnectionHandle } from "./desktop-client.ts";
+import "./desktop-panel.ts";
+
+type DesktopPanelElement = HTMLElementTagNameMap["openclaw-desktop-panel"];
+
+export const desktopEnvironment = {
+  id: "worker-desktop-1",
+  type: "worker",
+  status: "available",
+  desktop: true,
+  worker: {
+    providerId: "crabbox",
+    state: "attached",
+    ageMs: 1_000,
+    attachedSessionIds: ["main"],
+    tunnelStatus: "connected",
+    desktopApps: [],
+  },
+} as const;
+
+export function createPanel() {
+  return document.createElement("openclaw-desktop-panel");
+}
+
+export function createConnectionHandle(overrides: Partial<DesktopConnectionHandle> = {}) {
+  return {
+    disconnect: vi.fn(),
+    disableInput: vi.fn(),
+    sendBackspace: vi.fn(),
+    sendKeyboardEvent: vi.fn(),
+    sendText: vi.fn(),
+    setScaleViewport: vi.fn(),
+    ...overrides,
+  } satisfies DesktopConnectionHandle;
+}
+
+export function clickPanelButton(
+  panel: DesktopPanelElement,
+  selector = ".desktop-environment button",
+): void {
+  const button = panel.renderRoot.querySelector<HTMLButtonElement>(selector);
+  if (!button) {
+    throw new Error(`expected Desktop button: ${selector}`);
+  }
+  button.click();
+}
+
+export async function settleTasks(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
+  await Promise.resolve();
+}
+
+export function createGatewayClient(request: unknown) {
+  const listeners = new Set<GatewayEventListener>();
+  const unsubscribe = vi.fn((listener: GatewayEventListener) => listeners.delete(listener));
+  return {
+    client: {
+      gatewayUrl: "ws://gateway.test",
+      request,
+      addEventListener(listener: GatewayEventListener) {
+        listeners.add(listener);
+        return () => unsubscribe(listener);
+      },
+    } as unknown as GatewayBrowserClient,
+    emit(event: string, payload: unknown) {
+      for (const listener of Array.from(listeners)) {
+        if (listeners.has(listener)) {
+          listener({ type: "event", event, payload });
+        }
+      }
+    },
+    unsubscribe,
+  };
+}

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -2,89 +2,18 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import {
-  GatewayRequestError,
-  type GatewayBrowserClient,
-  type GatewayEventListener,
-} from "../../api/gateway.ts";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DesktopClient, DesktopConnectionHandle } from "./desktop-client.ts";
-import "./desktop-panel.ts";
-
-type DesktopPanelElement = HTMLElementTagNameMap["openclaw-desktop-panel"];
-
-const desktopEnvironment = {
-  id: "worker-desktop-1",
-  type: "worker",
-  status: "available",
-  desktop: true,
-  worker: {
-    providerId: "crabbox",
-    state: "attached",
-    ageMs: 1_000,
-    attachedSessionIds: ["main"],
-    tunnelStatus: "connected",
-    desktopApps: [],
-  },
-} as const;
-
-function createPanel() {
-  return document.createElement("openclaw-desktop-panel");
-}
-
-function createConnectionHandle(overrides: Partial<DesktopConnectionHandle> = {}) {
-  return {
-    disconnect: vi.fn(),
-    disableInput: vi.fn(),
-    sendBackspace: vi.fn(),
-    sendKeyboardEvent: vi.fn(),
-    sendText: vi.fn(),
-    setScaleViewport: vi.fn(),
-    ...overrides,
-  } satisfies DesktopConnectionHandle;
-}
-
-function clickPanelButton(
-  panel: DesktopPanelElement,
-  selector = ".desktop-environment button",
-): void {
-  const button = panel.renderRoot.querySelector<HTMLButtonElement>(selector);
-  if (!button) {
-    throw new Error(`expected Desktop button: ${selector}`);
-  }
-  button.click();
-}
-
-async function settleTasks(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    window.setTimeout(resolve, 0);
-  });
-  await Promise.resolve();
-}
-
-function createGatewayClient(request: unknown) {
-  const listeners = new Set<GatewayEventListener>();
-  const unsubscribe = vi.fn((listener: GatewayEventListener) => listeners.delete(listener));
-  return {
-    client: {
-      gatewayUrl: "ws://gateway.test",
-      request,
-      addEventListener(listener: GatewayEventListener) {
-        listeners.add(listener);
-        return () => unsubscribe(listener);
-      },
-    } as unknown as GatewayBrowserClient,
-    emit(event: string, payload: unknown) {
-      for (const listener of Array.from(listeners)) {
-        if (listeners.has(listener)) {
-          listener({ type: "event", event, payload });
-        }
-      }
-    },
-    unsubscribe,
-  };
-}
+import {
+  clickPanelButton,
+  createConnectionHandle,
+  createGatewayClient,
+  createPanel,
+  desktopEnvironment,
+  settleTasks,
+} from "./desktop-panel.test-support.ts";
 
 describe("embedded desktop panel presentation", () => {
   beforeEach(() => {
@@ -99,10 +28,10 @@ describe("embedded desktop panel presentation", () => {
   it("follows the session desktop and retires its connection before resolving a new placement", async () => {
     const replacement = { ...desktopEnvironment, id: "worker-desktop-2" };
     let refresh: Promise<void> | undefined;
-    const request = vi.fn(async (method: string) => {
-      if (method === "environments.list") {
+    const request = vi.fn(async (method: string, params?: { environmentId?: string }) => {
+      if (method === "environments.status") {
         await refresh;
-        return { environments: [desktopEnvironment, replacement] };
+        return params?.environmentId === replacement.id ? replacement : desktopEnvironment;
       }
       return {
         transport: "rfb",
@@ -127,6 +56,9 @@ describe("embedded desktop panel presentation", () => {
     document.body.append(panel);
 
     await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenCalledWith("environments.status", {
+      environmentId: desktopEnvironment.id,
+    });
     expect(request).toHaveBeenCalledWith("desktop.observe", {
       source: { kind: "environment", environmentId: desktopEnvironment.id },
       control: false,
@@ -152,6 +84,9 @@ describe("embedded desktop panel presentation", () => {
     expect(disconnect).toHaveBeenCalledTimes(2);
     expect(connect).toHaveBeenCalledTimes(2);
     expect(request.mock.calls.some(([method]) => method === "sessions.describe")).toBe(false);
+    expect(request.mock.calls.some(([method]) => method === "environments.list")).toBe(false);
+    expect(panel.renderRoot.querySelector(".desktop-picker")).toBeNull();
+    expect(panel.renderRoot.textContent).toContain("The requested desktop is unavailable");
   });
 
   it.each(
@@ -454,7 +389,7 @@ describe("embedded desktop panel presentation", () => {
     },
   );
 
-  it("keeps an explicit picker selection and control across presence and placement updates", async () => {
+  it("keeps a standalone picker selection and control across presence updates", async () => {
     const selected = { ...desktopEnvironment, id: "worker-manual" };
     let environments = [desktopEnvironment, selected];
     const request = vi.fn(async (method: string, params?: { control?: boolean }) =>
@@ -477,7 +412,6 @@ describe("embedded desktop panel presentation", () => {
     panel.available = true;
     panel.embedded = true;
     panel.presented = true;
-    panel.sessionKey = "agent:main:desktop";
     panel.requestedSource = desktopEnvironment.id;
     const onFocusTargetChange = vi.fn();
     panel.onFocusTargetChange = onFocusTargetChange;
@@ -488,7 +422,6 @@ describe("embedded desktop panel presentation", () => {
     await panel.updateComplete;
     environments = [];
     gateway.emit("presence", { presence: [] });
-    gateway.emit("sessions.changed", { sessionKey: panel.sessionKey });
     await waitForFast(() =>
       expect(panel.renderRoot.querySelectorAll(".desktop-environment")).toHaveLength(0),
     );
@@ -516,12 +449,9 @@ describe("embedded desktop panel presentation", () => {
     const selectedFocus = { kind: "desktop", source: selected.id, control: true };
     expect(onFocusTargetChange).toHaveBeenLastCalledWith(selectedFocus);
 
-    // The chat owner reports a stopped placement, then a ready placement, in the same session.
-    for (const target of [null, desktopEnvironment.id]) {
-      panel.requestedSource = target;
-      await panel.updateComplete;
-      await settleTasks();
-    }
+    environments = [desktopEnvironment];
+    gateway.emit("presence", { presence: [] });
+    await settleTasks();
     expect({
       connected: selectedConnection?.isCurrent(),
       connections: connect.mock.calls.length,

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -2,7 +2,6 @@ import type {
   DesktopObserveResult,
   DesktopSource,
   EnvironmentSummary,
-  EnvironmentsListResult,
   WorkerDesktopLaunchResult,
 } from "@openclaw/gateway-protocol";
 import type { ControlUiFocusBuildTarget } from "@openclaw/session-url-contract";
@@ -29,7 +28,7 @@ import {
   type ObservedDesktopConnection,
   type PendingDesktopConnection,
 } from "./desktop-panel-connection.ts";
-import { desktopCredentialRequirement } from "./desktop-panel-credentials.ts";
+import { desktopCredentialRequirement, rfbCredentials } from "./desktop-panel-credentials.ts";
 import { DesktopPanelFullscreenController } from "./desktop-panel-fullscreen-controller.ts";
 import { desktopPanelLayout } from "./desktop-panel-layout.ts";
 import { type DesktopPanelState, renderDesktopPanelRecovery } from "./desktop-panel-state.ts";
@@ -43,7 +42,7 @@ import {
   renderDesktopPicker,
 } from "./desktop-panel-view.ts";
 import { DesktopSessionController } from "./desktop-session-controller.ts";
-import { desktopSourceForEnvironment } from "./desktop-source.ts";
+import { desktopSourceForEnvironment, loadDesktopEnvironments } from "./desktop-source.ts";
 
 registerDesktopEnglish();
 
@@ -106,7 +105,8 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     () => {
       // Inventory refresh advances operationId; active viewers and credential prompts keep their owner.
       if (
-        this.state === "picker" &&
+        (this.state === "picker" ||
+          (this.state === "inventory-error" && this.usesAutomaticSource)) &&
         !this.suppressed &&
         (this.embedded ? this.presented : this.documentMode || this.dockLayout.open)
       ) {
@@ -225,8 +225,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       if (detail?.environmentId) {
         void this.connectRequestedEnvironment(detail.environmentId);
       } else {
-        // An untargeted shell command opens the picker, overriding this presentation's session default.
-        this.returnToPicker();
+        this.returnToPicker(this.sessionKey !== null ? "pending" : "picker");
         void this.refreshEnvironments();
       }
       return;
@@ -303,11 +302,17 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     this.errorText = null;
     let refreshed = false;
     try {
-      const result = await client.request<EnvironmentsListResult>("environments.list", {});
+      // Chat already owns placement. Avoid waiting for unrelated workers' provisioning catalogs.
+      const sessionTarget =
+        this.embedded && this.sessionKey !== null && this.sourceSelection === "pending";
+      const environments = await loadDesktopEnvironments(
+        client,
+        sessionTarget ? this.requestedSource : undefined,
+      );
       if (operationId !== this.operationId) {
         return false;
       }
-      this.environments = result.environments.filter((environment) => environment.desktop === true);
+      this.environments = environments.filter((environment) => environment.desktop === true);
       refreshed = true;
     } catch (error) {
       if (operationId === this.operationId) {
@@ -404,13 +409,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         return;
       }
       this.controlling = observed.control;
-      const credentials = observed.preauthenticated
-        ? undefined
-        : observed.vncPassword
-          ? { password: observed.vncPassword }
-          : observed.auth === "vnc-password"
-            ? this.credentials
-            : undefined;
+      const credentials = rfbCredentials(observed, this.credentials);
       if (
         observed.auth === "vnc-password" &&
         observed.preauthenticated !== true &&
@@ -425,10 +424,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       if (observed.auth === "ard-account") {
         this.credentialAuth = "ard-account";
       }
-      await this.connectObserved(
-        { environmentId, control, observed, operationId },
-        observed.auth === "vnc-password" ? credentials : undefined,
-      );
+      await this.connectObserved({ environmentId, control, observed, operationId }, credentials);
     } catch (error) {
       const requiredAuth = desktopCredentialRequirement(error);
       if (requiredAuth && operationId === this.operationId) {
@@ -620,6 +616,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       this.noticeText,
     );
     const picker = renderDesktopPicker({
+      automatic: this.usesAutomaticSource && this.embedded && this.sessionKey !== null,
       environments: this.environments,
       loading: this.loading,
       onRefresh: () => void this.refreshEnvironments(),
@@ -682,7 +679,13 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       showApps: this.source?.kind === "environment",
       onLaunch: (app) => void this.launchApp(app),
       onTakeControl: () => void this.connectEnvironment(this.environmentId, true),
-      onDisconnect: () => this.returnToPicker(),
+      onDisconnect: () => {
+        if (this.embedded && this.sessionKey !== null && this.environmentId !== null) {
+          this.handleDesktopDisconnect(this.environmentId, { clean: true });
+        } else {
+          this.returnToPicker();
+        }
+      },
     });
     const dock = this.dockLayout.dock;
     const style =

--- a/ui/src/components/desktop/desktop-source.ts
+++ b/ui/src/components/desktop/desktop-source.ts
@@ -1,4 +1,27 @@
-import type { DesktopSource, EnvironmentSummary } from "@openclaw/gateway-protocol";
+import type {
+  DesktopSource,
+  EnvironmentSummary,
+  EnvironmentsListResult,
+} from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+
+export async function loadDesktopEnvironments(
+  client: Pick<GatewayBrowserClient, "request">,
+  sessionTarget: string | null | undefined,
+): Promise<EnvironmentSummary[]> {
+  // A session without placement has no desktop; only the global picker needs full inventory.
+  if (sessionTarget === null) {
+    return [];
+  }
+  if (sessionTarget !== undefined) {
+    return [
+      await client.request<EnvironmentSummary>("environments.status", {
+        environmentId: sessionTarget,
+      }),
+    ];
+  }
+  return (await client.request<EnvironmentsListResult>("environments.list", {})).environments;
+}
 
 export function desktopSourceForEnvironment(
   environment: Pick<EnvironmentSummary, "id">,

--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -60,6 +60,7 @@ function scenario(): ControlUiMockGatewayScenario {
       "browser.request",
       "desktop.observe",
       "environments.list",
+      "environments.status",
       "sessions.diff",
       "tasks.list",
       "terminal.open",
@@ -77,9 +78,7 @@ function scenario(): ControlUiMockGatewayScenario {
         control: false,
         auth: "vnc-password",
       },
-      "environments.list": {
-        environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
-      },
+      "environments.status": { id: "gateway", type: "local", status: "available", desktop: true },
       "sessions.diff": {
         sessionKey,
         root: "/workspace/openclaw",

--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -13,7 +13,7 @@ import {
   createControlUiE2eSuite,
   holdModuleResponse,
 } from "./control-ui-e2e-suite.test-support.ts";
-import { installDesktopClientFake } from "./desktop-rfb-test-support.ts";
+import { installDesktopClientFake, installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "chat sidebar cold-open invariant",
@@ -61,6 +61,7 @@ function coldOpenScenario(): ControlUiMockGatewayScenario {
       "chat.startup",
       "desktop.observe",
       "environments.list",
+      "environments.status",
       "session.discussion.info",
       "session.discussion.open",
       "sessions.companion.state",
@@ -314,30 +315,46 @@ async function seedRetainedDesktopSlot(page: Page) {
   );
 }
 
+const retainedDesktopEnvironment = {
+  id: "worker-desktop-1",
+  type: "worker",
+  status: "available",
+  desktop: true,
+  worker: {
+    providerId: "crabbox",
+    state: "attached",
+    ageMs: 1_000,
+    attachedSessionIds: [RETAINED_DESKTOP_SESSION_KEY],
+    tunnelStatus: "connected",
+    desktopApps: [],
+  },
+};
+
 function retainedDesktopScenario(): ControlUiMockGatewayScenario {
   return {
     ...coldOpenScenario(),
     sessionKey: RETAINED_DESKTOP_SESSION_KEY,
     methodResponses: {
       ...coldOpenScenario().methodResponses,
-      "environments.list": {
-        environments: [
+      "sessions.list": {
+        count: 1,
+        defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+        path: "",
+        sessions: [
           {
-            id: "worker-desktop-1",
-            type: "worker",
-            status: "available",
-            desktop: true,
-            worker: {
-              providerId: "crabbox",
-              state: "attached",
-              ageMs: 1_000,
-              attachedSessionIds: [RETAINED_DESKTOP_SESSION_KEY],
-              tunnelStatus: "connected",
-              desktopApps: [],
-            },
+            key: RETAINED_DESKTOP_SESSION_KEY,
+            kind: "direct",
+            label: "Retained desktop",
+            placement: { state: "active", environmentId: retainedDesktopEnvironment.id },
+            updatedAt: Date.now(),
           },
         ],
+        ts: Date.now(),
       },
+      "environments.list": {
+        environments: [retainedDesktopEnvironment],
+      },
+      "environments.status": retainedDesktopEnvironment,
       "desktop.observe": {
         transport: "rfb",
         wsPath: "/desktop/observe?token=retained",
@@ -567,19 +584,75 @@ suite.define(() => {
 
       expect(await desktop.evaluate((element) => element.isConnected)).toBe(true);
       expect(await gateway.getRequests("environments.list")).toHaveLength(0);
+      expect(await gateway.getRequests("environments.status")).toHaveLength(0);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
 
+      await installDesktopClientFake(desktop);
+      await gateway.deferNext("environments.status");
       await clickSidebarTab(page, "Desktop");
-      await expect
-        .poll(async () => (await gateway.getRequests("environments.list")).length)
-        .toBe(1);
+      const target = await gateway.waitForRequest("environments.status");
+      expect(target.params).toEqual({ environmentId: retainedDesktopEnvironment.id });
       await clickSidebarTab(page, "Files");
+      await gateway.resolveDeferred("environments.status", retainedDesktopEnvironment);
+      await page.evaluate(() => Promise.resolve());
       expect(await desktop.evaluate((element) => element.isConnected)).toBe(true);
-      expect(await gateway.getRequests("environments.list")).toHaveLength(1);
+      expect(await gateway.getRequests("environments.status")).toHaveLength(1);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
+      expect(await desktop.getAttribute("data-connect-count")).toBeNull();
 
       await clickSidebarTab(page, "Desktop");
       await expect
-        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .poll(async () => (await gateway.getRequests("environments.status")).length)
         .toBe(2);
+      await expect.poll(() => desktop.getAttribute("data-connect-count")).toBe("1");
+      expect(await gateway.getRequests("environments.list")).toHaveLength(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps a visible Desktop connected when another split pane takes focus", async () => {
+    const context = await suite.newBrowserContext({
+      serviceWorkers: "block",
+      viewport: { width: 2200, height: 1000 },
+    });
+    try {
+      const page = await context.newPage();
+      await installMockGateway(page, retainedDesktopScenario());
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, RETAINED_DESKTOP_SESSION_KEY));
+      await waitForControlUiGatewayReady(page);
+      const rfb = await installScriptedRfbServer(page);
+      await openChatSidePanelType(page, "Desktop");
+      const desktop = page.locator("openclaw-desktop-panel").first();
+      await expect.poll(() => rfb.events()).toEqual(["authenticated:1"]);
+      await desktop.locator("canvas").waitFor({ state: "visible" });
+
+      await page.getByRole("button", { name: "Open split view", exact: true }).click();
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      await panes.last().locator(".agent-chat__composer-combobox textarea").click();
+      await expect
+        .poll(() =>
+          panes.last().evaluate((pane) => (pane as HTMLElement & { active: boolean }).active),
+        )
+        .toBe(true);
+      await expect
+        .poll(() =>
+          panes.first().evaluate((pane) => (pane as HTMLElement & { active: boolean }).active),
+        )
+        .toBe(false);
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      expect(await desktop.locator("canvas").isVisible()).toBe(true);
+      expect(await rfb.events()).not.toContain("closed:1");
+
+      await panes.first().locator(".side-panel__minimize").click();
+      await expect.poll(() => rfb.events()).toContain("closed:1");
+      expect(await desktop.locator("canvas").count()).toBe(0);
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -592,14 +665,15 @@ suite.define(() => {
       const gateway = await installMockGateway(page, retainedDesktopScenario());
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, RETAINED_DESKTOP_SESSION_KEY));
       await waitForControlUiGatewayReady(page);
+      await gateway.deferNext("environments.status");
       await openChatSidePanelType(page, "Desktop");
 
       const desktop = page.locator("openclaw-desktop-panel");
-      await desktop.getByText("worker-desktop-1", { exact: true }).waitFor();
+      await gateway.waitForRequest("environments.status");
       await installDesktopClientFake(desktop);
       await gateway.deferNext("desktop.observe");
       const observeCount = (await gateway.getRequests("desktop.observe")).length;
-      await desktop.getByRole("button", { name: "Connect", exact: true }).click();
+      await gateway.resolveDeferred("environments.status", retainedDesktopEnvironment);
       await gateway.waitForRequest("desktop.observe", { after: observeCount });
 
       await openChatSidePanelType(page, "Files");
@@ -614,33 +688,32 @@ suite.define(() => {
       expect(await desktop.getAttribute("data-connect-count")).toBeNull();
       expect(await desktop.evaluate((element) => element.isConnected)).toBe(true);
 
-      const inventoryBeforeReactivation = (await gateway.getRequests("environments.list")).length;
+      const inventoryBeforeReactivation = (await gateway.getRequests("environments.status")).length;
       await clickSidebarTab(page, "Desktop");
       await expect
-        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .poll(async () => (await gateway.getRequests("environments.status")).length)
         .toBe(inventoryBeforeReactivation + 1);
-      await desktop.getByText("Desktop sources", { exact: true }).waitFor();
 
-      await desktop.getByRole("button", { name: "Connect", exact: true }).click();
       await expect.poll(() => desktop.getAttribute("data-connect-count")).toBe("1");
       await clickSidebarTab(page, "Files");
 
       expect(await desktop.evaluate((element) => element.isConnected)).toBe(true);
       expect(await desktop.getAttribute("data-disconnect-count")).toBe("1");
 
-      const inventoryBeforeSecondReactivation = (await gateway.getRequests("environments.list"))
+      const inventoryBeforeSecondReactivation = (await gateway.getRequests("environments.status"))
         .length;
       const observeBeforeSecondReactivation = (await gateway.getRequests("desktop.observe")).length;
       await clickSidebarTab(page, "Desktop");
       await expect
-        .poll(async () => (await gateway.getRequests("environments.list")).length)
+        .poll(async () => (await gateway.getRequests("environments.status")).length)
         .toBe(inventoryBeforeSecondReactivation + 1);
-      await desktop.getByText("Desktop sources", { exact: true }).waitFor();
+      await expect.poll(() => desktop.getAttribute("data-connect-count")).toBe("2");
 
       expect(await gateway.getRequests("desktop.observe")).toHaveLength(
-        observeBeforeSecondReactivation,
+        observeBeforeSecondReactivation + 1,
       );
-      expect(await desktop.getAttribute("data-connect-count")).toBe("1");
+      expect(await desktop.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+      expect(await gateway.getRequests("environments.list")).toHaveLength(0);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -147,8 +147,8 @@ suite.define(() => {
         };
         const gateway = await installMockGateway(page, {
           sessionKey,
-          deferredMethods: ["environments.list"],
-          featureMethods: ["desktop.observe", "environments.list"],
+          deferredMethods: ["environments.status"],
+          featureMethods: ["desktop.observe", "environments.list", "environments.status"],
           methodResponses: {
             "sessions.list": chatSessionListResponse([session]),
             "desktop.observe": {
@@ -168,27 +168,29 @@ suite.define(() => {
         }
         const panel = page.locator("openclaw-desktop-panel");
         await panel.waitFor({ state: "attached" });
-        await gateway.waitForRequest("environments.list");
         await installDesktopClientFake(panel);
+        const sessionEnvironment = {
+          id: initialState === "offline" ? "node:workstation" : "worker-cloud",
+          type: initialState === "offline" ? "node" : "worker",
+          status: "available",
+          desktop: true,
+        };
         const inventory = {
           environments: [
             gatewayEnvironment,
-            {
-              id: initialState === "offline" ? "node:workstation" : "worker-cloud",
-              type: initialState === "offline" ? "node" : "worker",
-              status: "available",
-              desktop: true,
-            },
+            sessionEnvironment,
             { id: "node:maintenance", type: "node", status: "available", desktop: true },
           ],
         };
-        await gateway.resolveDeferred(
-          "environments.list",
-          initialState === "active" ? inventory : { environments: [gatewayEnvironment] },
-        );
         await gateway.setMethodResponse("environments.list", inventory);
         if (initialState !== "active") {
-          await panel.getByText("Desktop sources", { exact: true }).waitFor();
+          await panel
+            .getByText("The requested desktop is unavailable. Retry when the machine is ready.", {
+              exact: true,
+            })
+            .waitFor();
+          await panel.getByRole("button", { name: "Retry", exact: true }).waitFor();
+          expect(await gateway.getRequests("environments.status")).toHaveLength(0);
           expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
           await gateway.setSessionsListResponse(
             chatSessionListResponse([
@@ -207,6 +209,11 @@ suite.define(() => {
           await gateway.emitGatewayEvent("sessions.changed", { sessionKey });
         }
 
+        const target = await gateway.waitForRequest("environments.status");
+        expect(target.params).toEqual({ environmentId: sessionEnvironment.id });
+        expect(await gateway.getRequests("environments.list")).toHaveLength(0);
+        expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+        await gateway.resolveDeferred("environments.status", sessionEnvironment);
         const observed = await gateway.waitForRequest("desktop.observe");
         expect(observed.params).toEqual({
           source:
@@ -224,12 +231,13 @@ suite.define(() => {
           path: path.join(artifactDirectory, `chat-session-${initialState}-connected.png`),
         });
 
-        await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
-        await panel
-          .locator(".desktop-environment")
-          .filter({ hasText: "node:maintenance" })
-          .getByRole("button", { name: "Connect", exact: true })
-          .click();
+        await page.evaluate(() => {
+          window.dispatchEvent(
+            new CustomEvent("openclaw:desktop-toggle", {
+              detail: { open: true, environmentId: "node:maintenance" },
+            }),
+          );
+        });
         expect((await gateway.waitForRequest("desktop.observe", { after: 1 })).params).toEqual({
           source: { kind: "node", nodeId: "maintenance" },
           control: false,
@@ -403,7 +411,7 @@ suite.define(() => {
       );
 
       await panel
-        .getByText("The requested desktop source is unavailable. Choose another source.", {
+        .getByText("The requested desktop is unavailable. Retry when the machine is ready.", {
           exact: true,
         })
         .waitFor();
@@ -542,7 +550,7 @@ suite.define(() => {
       );
 
       await panel
-        .getByText("The requested desktop source is unavailable. Choose another source.", {
+        .getByText("The requested desktop is unavailable. Retry when the machine is ready.", {
           exact: true,
         })
         .waitFor();

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -139,7 +139,7 @@ suite.define(() => {
   });
 
   it.each(["local", "active"] as const)(
-    "opens the global desktop picker on a %s chat session",
+    "opens only the assigned desktop on a %s chat session",
     async (placement) => {
       await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
         const inventory = {
@@ -153,6 +153,8 @@ suite.define(() => {
           methodResponses: {
             "sessions.list": sessionsList(placement),
             "environments.list": inventory,
+            "environments.status":
+              placement === "local" ? inventory.environments[0] : workerDesktopEnvironment,
             "desktop.observe": {
               transport: "rfb",
               wsPath: "/desktop/observe?token=palette-session",
@@ -166,15 +168,26 @@ suite.define(() => {
         await openPalette(page);
         expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(1);
 
+        await gateway.deferNext("environments.status");
         await page.getByRole("option", { name: "Desktop", exact: true }).click();
         const panel = page.locator("openclaw-desktop-panel");
         await panel.locator("section[aria-label='Desktop']").waitFor();
-        await panel.getByText("Desktop sources", { exact: true }).waitFor();
-        await gateway.waitForRequest("environments.list");
+        const target = await gateway.waitForRequest("environments.status");
+        expect(target.params).toEqual({
+          environmentId: placement === "local" ? "gateway" : workerDesktopEnvironment.id,
+        });
+        expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+        expect(await panel.getByRole("button", { name: "Connect", exact: true }).count()).toBe(0);
         expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
-
-        await activateChatHeaderPanelAction(page, "Desktop");
-        await activateChatHeaderPanelAction(page, "Desktop");
+        if (placement === "active") {
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "session-desktop-connecting.png"),
+          });
+        }
+        await gateway.resolveDeferred(
+          "environments.status",
+          placement === "local" ? inventory.environments[0] : workerDesktopEnvironment,
+        );
         await panel.getByLabel("VNC password", { exact: true }).waitFor();
         const observation = await gateway.waitForRequest("desktop.observe");
         expect(observation.params).toEqual({
@@ -185,7 +198,7 @@ suite.define(() => {
           control: false,
         });
 
-        await gateway.setMethodResponse("environments.list", {
+        await gateway.setMethodResponse("environments.status", {
           __mockError: {
             code: "UNAVAILABLE",
             message: "desktop inventory temporarily unavailable",
@@ -194,10 +207,19 @@ suite.define(() => {
         await openPalette(page);
         await page.getByRole("option", { name: "Desktop", exact: true }).click();
         await panel.getByRole("alert").filter({ hasText: "inventory" }).waitFor();
-        await gateway.setMethodResponse("environments.list", inventory);
+        await gateway.setMethodResponse(
+          "environments.status",
+          placement === "local" ? inventory.environments[0] : workerDesktopEnvironment,
+        );
         await panel.getByRole("button", { name: "Retry", exact: true }).click();
-        await panel.getByText("Desktop sources", { exact: true }).waitFor();
-        expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+        await panel.getByLabel("VNC password", { exact: true }).waitFor();
+        expect(await gateway.getRequests("desktop.observe")).toHaveLength(2);
+        expect(await panel.getByText("Desktop sources", { exact: true }).count()).toBe(0);
+
+        await activateChatHeaderPanelAction(page, "Desktop");
+        await activateChatHeaderPanelAction(page, "Desktop");
+        await panel.getByLabel("VNC password", { exact: true }).waitFor();
+        expect(await gateway.getRequests("desktop.observe")).toHaveLength(3);
       });
     },
   );

--- a/ui/src/i18n/locales/en-desktop.ts
+++ b/ui/src/i18n/locales/en-desktop.ts
@@ -21,7 +21,7 @@ const enDesktop = {
     refreshing: "Refreshing…",
     loading: "Loading desktop sources…",
     empty: "No desktop-capable sources are available.",
-    sourceUnavailable: "The requested desktop source is unavailable. Choose another source.",
+    sourceUnavailable: "The requested desktop is unavailable. Retry when the machine is ready.",
     connect: "Connect",
     connecting: "Connecting to desktop…",
     takeControl: "Take control",

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -136,8 +136,9 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
     const companionThread = this.sessionCompanionThreads.view(state.sessionKey, currentAgentId);
     const browserPresented =
       this.active && this.presented && isSidebarSlotVisible(sidebarLayout, "browser");
+    // Another pane can own keyboard focus while this desktop remains visible.
     const desktopPresented =
-      this.active && this.presented && isSidebarSlotVisible(sidebarLayout, "desktop");
+      this.presented && this.visuallyPresented && isSidebarSlotVisible(sidebarLayout, "desktop");
     const desktopRefreshOnPresentation = !this.pendingPanelToggleRequests.has("desktop");
     const desktopSource = resolveChatPaneDesktopTarget(selectedSession);
     const desktopFocusKey = JSON.stringify([


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening Desktop from a chat could show the Gateway and unrelated workers instead of connecting to that session's machine. Desktop startup also waited for unrelated provider catalogs, some worker connections stalled during VNC authentication, and moving keyboard focus between visible split panes could disconnect the desktop.

## Why This Change Was Made

Chat Desktop now follows the session's assigned machine through a targeted environment lookup and shows one connection status or a retry action. Worker-supplied VNC passwords reach the connection client even when the response has no auth discriminator, and stream lifetime follows actual panel visibility. Standalone machine selection, explicit source links, permission checks, and session placement changes retain their existing ownership boundaries.

## User Impact

Users can open their chat's desktop without choosing between unrelated machines. Connections avoid unnecessary catalog loading, authenticate correctly with worker-provided credentials, and stay visible when focus moves to another split pane. A missing or stopped session machine never falls back to another desktop.

## Evidence

- Regression failures reproduced before the fix: dropped worker password, global inventory lookup, and disappearing desktop canvas after a split-focus change.
- 62 focused component tests and all 47 desktop/sidebar/pop-out browser scenarios passed on the final source tree (109 tests). The complete browser set was rerun on the published head.
- Hosted CI caught a missed fixture in the existing rail-navigation suite. Its gateway desktop response now uses the targeted status RPC; both light and dark navigation variants pass with their connection assertions unchanged.
- `node scripts/check-changed.mjs` passed for the implementation, including core/UI type checks, lint, i18n, and source guards. The subsequent fixture-only correction passed focused browser tests, lint, formatting, and independent review.
- Independent review found no actionable P0–P2 findings.
- Screenshots below use inspected synthetic mocked Gateway data. The before capture reproduces the original three-source picker; the after capture shows automatic connection progress with no machine choices.

The live Gateway has not been restarted or deployed as part of this PR.

### Before

![Chat Desktop offers three unrelated sources](https://github.com/user-attachments/assets/a5b4eea1-b9bd-4092-814e-6a6940dfd78d)

### After

![Chat Desktop automatically connects to its assigned machine](https://github.com/user-attachments/assets/c1a14970-229e-4f49-95d2-15a5d06c72b0)
