### PR TITLE
fix(ci): provision ripgrep for byte-path grep tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1684,6 +1684,7 @@ jobs:
                   if (patterns) {
                     return patterns.some((pattern) => [
                       "src/agents/sessions/tools/index.test.ts",
+                      "src/agents/sessions/tools/grep.byte-path.test.ts",
                       "src/agents/filesystem-tools-output-contract.test.ts",
                     ].some((test) => matchesGlob(test, pattern)));
                   }

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15087,12 +15087,17 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
   it("provisions ripgrep for real filesystem contract selections", () => {
     const contract = "src/agents/filesystem-tools-output-contract.test.ts";
     const nativeTools = "src/agents/sessions/tools/index.test.ts";
+    const bytePaths = "src/agents/sessions/tools/grep.byte-path.test.ts";
     const unrelated = "src/agents/run-wait.test.ts";
     const selections = [
       { targets: [contract] },
       { includePatterns: [contract] },
       { includePatterns: ["src/agents/filesystem-*.test.ts"] },
       { targets: [nativeTools] },
+      { targets: [bytePaths] },
+      { includePatterns: [bytePaths] },
+      { groups: [{ shard_name: "agentic-agents-support", targets: [bytePaths] }] },
+      { groups: [{ shard_name: "agentic-agents-support", includePatterns: [bytePaths] }] },
       { includePatterns: [unrelated] },
       { shardName: "agentic-agents-core-runtime" },
       { shardName: "agentic-agents-support" },
@@ -15122,6 +15127,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       expectDefined(result.outputs.checks_node_core_nondist_matrix, "non-dist Node matrix"),
     ) as { include: { requires_ripgrep?: boolean }[] };
     expect(matrix.include.map((row) => Boolean(row.requires_ripgrep))).toEqual([
+      true,
+      true,
+      true,
+      true,
       true,
       true,
       true,


### PR DESCRIPTION
Related: #143799

## What Problem This Solves

Resolves a problem where CI selects the real byte-filename grep test on a Linux runner without ripgrep, skips installation, and fails with `ripgrep (rg) is not available and could not be downloaded`. Observed in the [privacy export PR CI job](https://github.com/openclaw/openclaw/actions/runs/34448231792/job/102782376355).

## Why This Change Was Made

Add the byte-path test to the existing `requires_ripgrep` selector introduced by #141794. Extend the existing executable manifest regression for direct targets, direct include patterns, grouped targets and grouped include patterns. Existing whole-shard behavior, filesystem contract coverage and unrelated no-ripgrep controls remain unchanged.

This is the separately coordinated CI prerequisite for #143799. No runtime changes, dependency pins, retry policy, runner selection, or privacy/backup source changes. Two files, +10/-0.

## User Impact

CI installs its existing ripgrep dependency before running the selected byte-path grep test. No product behavior changes.

## Evidence

- Baseline `7f0f6d34747c0b35e27beca8e77e885785836baa`: executing the unchanged selector returns false for byte-path selections. Existing native-tools selection returns true; unrelated selection remains false.
- Red: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'provisions ripgrep for real filesystem contract selections'` failed on exactly the four new selection rows before the workflow edit.
- Green: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'provisions ripgrep for real filesystem contract selections|fails and retries quiet Node test shard stalls quickly'` passed both selected tests, including installation condition/order and all 16 selection rows.
- Fresh independent P0/P1/P2 autoreview: scoped-clean, no findings.
- Formatting and `git diff --check` pass. `pnpm check:workflows` passed with the unchanged pinned tools under installed Python 3.13; the initial Python 3.9 bootstrap failure is retained locally. `node scripts/check-changed.mjs -- .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts` passed, including root test types/lint and required guards. Exact-head hosted CI gates native preparation and merge.
- The Linux-only product test is unchanged. The saved GitHub failure is the real runner evidence; local macOS proof executes the workflow manifest, not a claimed Linux product run.

### Hosted CI follow-through

On exact head `392ffcd604fa33c0531cc531e70264057a5e245d`, [CI run 34450691023, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34450691023/attempts/2) and required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34450691023/job/102796641718) passed.

The Ubuntu 24.04 fallback [job 102790730449](https://github.com/openclaw/openclaw/actions/runs/34450691023/job/102790730449) installed ripgrep `14.1.0-1` through the existing install step and passed the real byte-path test in **90 ms**. The first attempt also passed that test in 197 ms.

Two first-attempt jobs failed on unchanged owner code: [concurrent schema teardown](https://github.com/openclaw/openclaw/actions/runs/34450691023/job/102785818137) with `StateDatabaseCoordinatorContentionError`, and [model-selection retained handoff leases](https://github.com/openclaw/openclaw/actions/runs/34450691023/job/102785818148). Their owner files match baseline and observed main `1c72b612a852d7d5ae7cc8615748d19a9cb8a9ad`; original failed logs are preserved. A single failed-job-only retry passed both jobs at the unchanged head: schema test 2.79 s, model-command group 349 passed. No runtime changes, assertion changes, or healthy-job reruns were used.

[ClawSweeper P2 review](https://github.com/openclaw/openclaw/pull/143835#issuecomment-5614992821) found no actionable patch defect.
