### PR TITLE
refactor(models): compose prepared catalog sources before lookup

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -396,8 +396,15 @@ Custom providers configured under `models.providers` are written into `models.js
 Generated plugin catalogs supply model inventory, not request credentials. Their
 cached API keys, authentication modes, and request headers do not authorize model
 requests. Use a current auth profile or authored request configuration instead.
-The session SDK preserves authored `models.json` keys and headers while merging
-generated model metadata below authored rows.
+Without a current configuration snapshot, the session SDK preserves authored
+`models.json` keys and headers while merging generated metadata below authored rows.
+With a current snapshot, the provider's current declaration owns request settings;
+keys and headers left only in an older file do not regain authority.
+
+Prepared catalogs compose static, generated, authored-file, and current configured
+rows before resolving models. Explicit model routes win over captured routes, which
+win over provider defaults. In replace mode, only current declarations enter the
+catalog; manifest inventory and runtime fallback rows cannot add other models.
 
 Provider aliases in `models.providers.*.models` resolve once before discovery.
 If an alias and its exact destination are both configured, the destination row
@@ -406,8 +413,9 @@ Catalog IDs from `models.json` and plugin discovery stay literal during refresh,
 apart from built-in corrections for retired Google and Together model names.
 
 <AccordionGroup>
-  <Accordion title="Merge mode precedence">
-    For matching provider IDs:
+  <Accordion title="models.json publication merge precedence">
+    The file publication step uses these rules for matching provider IDs. They do
+    not override current-configuration request authority in a prepared runtime:
 
     - A non-empty `baseUrl` already present in the agent `models.json` wins.
     - A non-empty `apiKey` in `models.json` wins only when that provider is not SecretRef-managed in the current config/auth-profile context.

--- a/src/agents/agent-model-discovery.ts
+++ b/src/agents/agent-model-discovery.ts
@@ -1,6 +1,7 @@
 /** Discovers agent models and auth storage with provider/plugin normalization hooks. */
 import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
 import {
@@ -26,6 +27,7 @@ type DiscoverModelsOptions = {
   includePluginCatalogs?: boolean;
   modelsJsonContents?: string | null;
   pluginCatalogs?: readonly PersistedPluginModelCatalog[];
+  staticProviderConfigs?: Readonly<Record<string, ModelProviderConfig>>;
   providerFilter?: string;
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   workspaceDir?: string;
@@ -65,6 +67,7 @@ function createOpenClawModelRegistry(
       ? { modelsJsonContents: options.modelsJsonContents }
       : {}),
     ...(options?.pluginCatalogs !== undefined ? { pluginCatalogs: options.pluginCatalogs } : {}),
+    staticProviderConfigs: options?.staticProviderConfigs,
   };
   const registry = ModelRegistry.create(authStorage, modelsJsonPath, registryOptions);
   const getAll = registry.getAll.bind(registry);

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -101,6 +101,28 @@ describe("prepared model catalog builder", () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([]);
   });
 
+  it.each(["static", "refreshable", "runtime"] as const)(
+    "keeps replace publication closed to %s manifest and augmented inventory",
+    async (discovery) => {
+      mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([
+        { provider: "manifest-provider", id: "augmented-only", name: "Augmented" },
+      ]);
+      const snapshot = await build({
+        config: { models: { mode: "replace", providers: {} } },
+        metadataSnapshot: providerManifestSnapshot({
+          provider: "manifest-provider",
+          discovery,
+          modelIds: ["manifest-only"],
+        }),
+        readOnly: false,
+        includeProviderPluginAugmentation: true,
+      });
+      expect(snapshot.entries).toEqual([]);
+      expect(snapshot.routeVariants).toEqual([]);
+      expect(mocks.augmentModelCatalogWithProviderPlugins).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(["ready", "unavailable", "auth-rejected"] as const)(
     "preserves %s provider membership without replenishing it from metadata",
     async (status) => {
@@ -603,6 +625,7 @@ describe("prepared model catalog builder", () => {
     "keeps %s manifest models available without runtime account discovery",
     async (discovery) => {
       const snapshot = await build({
+        includeProviderPluginAugmentation: false,
         metadataSnapshot: providerManifestSnapshot({
           provider: "manifest-provider",
           discovery,

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -181,6 +181,9 @@ export function loadManifestModelCatalog(params: {
   fallbackToMetadataScan?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
 }): ModelCatalogEntry[] {
+  if (params.config.models?.mode === "replace") {
+    return [];
+  }
   const resolvedSnapshot =
     params.metadataSnapshot ??
     (params.fallbackToMetadataScan === false
@@ -321,15 +324,19 @@ export async function buildPreparedModelCatalogSnapshot(
       config: cfg,
       selection: "supplemental",
     });
-    const supplementalManifestKeys = new Set(
-      supplementalManifestPlan.rows.map((entry) =>
-        buildModelCatalogMergeKey(entry.provider, entry.id),
+    const dynamicManifestKeys = new Set(
+      supplementalManifestPlan.entries.flatMap((entry) =>
+        entry.discovery === "runtime" || entry.discovery === "refreshable"
+          ? entry.rows.map((row) => buildModelCatalogMergeKey(row.provider, row.id))
+          : [],
       ),
     );
     const runtimeDiscoveryProviders = new Set([
       ...observedProviders,
       ...supplementalManifestPlan.entries.flatMap((entry) =>
-        entry.discovery === "runtime" ? [normalizeProviderId(entry.provider)] : [],
+        entry.discovery === "runtime" || entry.discovery === "refreshable"
+          ? [normalizeProviderId(entry.provider)]
+          : [],
       ),
     ]);
     // Runtime declarations describe possible models, not account entitlement.
@@ -337,7 +344,8 @@ export async function buildPreparedModelCatalogSnapshot(
     const discoveredKeys = new Set(models.map(resolveModelCatalogIdentityKey));
     const manifestModels = declaredManifestModels.filter(
       (entry) =>
-        supplementalManifestKeys.has(buildModelCatalogMergeKey(entry.provider, entry.id)) &&
+        (params.includeProviderPluginAugmentation === false ||
+          !dynamicManifestKeys.has(buildModelCatalogMergeKey(entry.provider, entry.id))) &&
         (!observedProviders.has(entry.provider) ||
           discoveredKeys.has(resolveModelCatalogIdentityKey(entry))),
     );
@@ -352,7 +360,11 @@ export async function buildPreparedModelCatalogSnapshot(
     const configuredModels = buildConfiguredModelCatalog(configuredCatalogParams);
     logStage("configured-models-prepared", `entries=${models.length}`);
 
-    if (!params.readOnly && params.includeProviderPluginAugmentation !== false) {
+    if (
+      cfg.models?.mode !== "replace" &&
+      !params.readOnly &&
+      params.includeProviderPluginAugmentation !== false
+    ) {
       const augmentEntries = [...models];
       if (configuredModels.length > 0) {
         mergeCatalogEntries(augmentEntries, configuredModels, {

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -54,7 +54,7 @@ export type SourceModelFields = ReadonlyMap<
   { inputOmitted: boolean; cost: ProviderConfig["models"][number]["cost"] | undefined }
 >;
 
-type ProviderModelCatalog = {
+export type ProviderModelCatalog = {
   api?: string;
   baseUrl?: string;
   headers?: ProviderConfig["headers"];
@@ -74,6 +74,22 @@ type ProviderModelMergeOptions = {
   sourceModelFields?: SourceModelFields;
   preserveConfiguredModelMembership?: boolean;
 };
+
+export function buildSourceModelFields(
+  sourceProviders: Record<string, ProviderConfig> | undefined,
+): SourceModelFields {
+  return new Map(
+    Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
+      (provider.models ?? []).map(
+        (model) =>
+          [
+            JSON.stringify([providerId, model.id.trim()]),
+            { inputOmitted: !Object.hasOwn(model, "input"), cost: model.cost },
+          ] as const,
+      ),
+    ),
+  );
+}
 
 function getProviderModelId(model: unknown): string {
   if (!model || typeof model !== "object") {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -10,11 +10,10 @@ import type { PreparedProviderStaticCatalog } from "../plugins/provider-discover
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
+  buildSourceModelFields,
   mergeProviders,
   mergeWithExistingProviderSecrets,
-  normalizeProviderMapKeys,
   type ExistingProviderConfig,
-  type SourceModelFields,
 } from "./models-config.merge.js";
 import {
   enforceSourceManagedProviderSecrets,
@@ -105,22 +104,6 @@ function buildPluginCatalogWrites(
       encodePluginModelCatalogRelativePath(pluginId),
       `${JSON.stringify({ generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY, providers }, null, 2)}\n`,
     ]),
-  );
-}
-
-function buildSourceModelFields(
-  sourceProviders: Record<string, ProviderConfig> | undefined,
-): SourceModelFields {
-  return new Map(
-    Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
-      (provider.models ?? []).map(
-        (model) =>
-          [
-            JSON.stringify([providerId, model.id.trim()]),
-            { inputOmitted: !Object.hasOwn(model, "input"), cost: model.cost },
-          ] as const,
-      ),
-    ),
   );
 }
 

--- a/src/agents/models-config.providers.catalog.ts
+++ b/src/agents/models-config.providers.catalog.ts
@@ -1,0 +1,131 @@
+/** Materializes authored rows and finalizes catalog rows without credential resolution. */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeConfiguredProviderCatalogModelRef } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { normalizeProviderCatalogModelIdForConfig } from "../config/model-input.js";
+import {
+  getProviderModelId,
+  materializeConfiguredProviderModelRows,
+  mergeNormalizedProviderModel,
+} from "../config/model-provider-rows.js";
+import type { ModelProviderConfig as ProviderConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createConfiguredProviderCatalogModelIdNormalizer,
+  type ModelManifestNormalizationContext,
+} from "./model-ref-shared.js";
+
+type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+type ProviderModelConfig = NonNullable<
+  NonNullable<ModelsConfig["providers"]>[string]["models"]
+>[number];
+
+function normalizeModelCostForCatalog(model: ProviderModelConfig): ProviderModelConfig {
+  const cost = model.cost;
+  if (
+    !cost ||
+    (["input", "output", "cacheRead", "cacheWrite"] as const).every(
+      (key) => cost[key] !== undefined,
+    )
+  ) {
+    return model;
+  }
+  return {
+    ...model,
+    cost: {
+      ...model.cost,
+      input: cost.input ?? 0,
+      output: cost.output ?? 0,
+      cacheRead: cost.cacheRead ?? 0,
+      cacheWrite: cost.cacheWrite ?? 0,
+    },
+  };
+}
+
+function normalizeProviderModelsForConfig(
+  providerKey: string,
+  provider: ProviderConfig,
+): ProviderConfig {
+  if (!Array.isArray(provider.models) || provider.models.length === 0) {
+    return provider;
+  }
+
+  const providerId = normalizeProviderId(providerKey);
+  let mutated = false;
+  const nextModels: ProviderModelConfig[] = [];
+  const seenById = new Map<string, number>();
+  for (const model of provider.models) {
+    const rawId = getProviderModelId(model);
+    const normalizedId = rawId
+      ? normalizeProviderCatalogModelIdForConfig(
+          providerId,
+          normalizeConfiguredProviderCatalogModelRef(rawId),
+        )
+      : rawId;
+    const normalizedModel =
+      normalizedId && normalizedId !== rawId ? { ...model, id: normalizedId } : model;
+    if (normalizedModel !== model) {
+      mutated = true;
+    }
+    const id = getProviderModelId(normalizedModel);
+    if (id) {
+      const existingIndex = seenById.get(id);
+      if (existingIndex !== undefined) {
+        mutated = true;
+        const existing = nextModels.at(existingIndex);
+        if (existing) {
+          nextModels[existingIndex] = mergeNormalizedProviderModel(existing, normalizedModel);
+        }
+        continue;
+      }
+      seenById.set(id, nextModels.length);
+    }
+    nextModels.push(normalizedModel);
+  }
+
+  for (const [index, model] of nextModels.entries()) {
+    const normalized = normalizeModelCostForCatalog(model);
+    if (normalized !== model) {
+      nextModels[index] = normalized;
+      mutated = true;
+    }
+  }
+
+  return mutated ? { ...provider, models: nextModels } : provider;
+}
+
+function normalizeProviderModelMap(
+  providers: ModelsConfig["providers"],
+  normalize: (providerKey: string, provider: ProviderConfig) => ProviderConfig,
+): ModelsConfig["providers"] {
+  if (!providers) {
+    return providers;
+  }
+
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    const normalized = normalize(providerKey, provider);
+    mutated ||= normalized !== provider;
+    next[providerKey] = normalized;
+  }
+
+  return mutated ? next : providers;
+}
+
+/** Resolves authored aliases once, before discovery consumes configured model membership. */
+export function materializeConfiguredProviderCatalogModels(
+  providers: ModelsConfig["providers"],
+  options: ModelManifestNormalizationContext = {},
+): ModelsConfig["providers"] {
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
+  return normalizeProviderModelMap(providers, (providerKey, provider) =>
+    materializeConfiguredProviderModelRows(provider, (id) => normalizeModelId(providerKey, id)),
+  );
+}
+
+/** Finalizes emitted rows without applying authored aliases to their identities. */
+export function normalizeProviderCatalogModelsForConfig(
+  providers: ModelsConfig["providers"],
+): ModelsConfig["providers"] {
+  return normalizeProviderModelMap(providers, normalizeProviderModelsForConfig);
+}

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -14,8 +14,8 @@ import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,
-  normalizeProviders,
-} from "./models-config.providers.normalize.js";
+} from "./models-config.providers.catalog.js";
+import { normalizeProviders } from "./models-config.providers.normalize.js";
 import { resolveApiKeyFromProfiles } from "./models-config.providers.secret-helpers.js";
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
 

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -1,21 +1,8 @@
-/**
- * Materializes authored model rows and finalizes emitted provider catalogs.
- */
+/** Normalizes provider settings and resolves current credential sources. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeConfiguredProviderCatalogModelRef } from "@openclaw/model-catalog-core/provider-model-id-normalization";
-import { normalizeProviderCatalogModelIdForConfig } from "../config/model-input.js";
-import {
-  getProviderModelId,
-  materializeConfiguredProviderModelRows,
-  mergeNormalizedProviderModel,
-} from "../config/model-provider-rows.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
-import {
-  createConfiguredProviderCatalogModelIdNormalizer,
-  type ModelManifestNormalizationContext,
-} from "./model-ref-shared.js";
 import {
   normalizeProviderSpecificConfig,
   resolveProviderConfigApiKeyResolver,
@@ -34,121 +21,6 @@ import {
 } from "./models-config.providers.source-managed.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
-type ProviderModelConfig = NonNullable<
-  NonNullable<ModelsConfig["providers"]>[string]["models"]
->[number];
-
-function normalizeModelCostForCatalog(model: ProviderModelConfig): ProviderModelConfig {
-  const cost = model.cost;
-  if (
-    !cost ||
-    (["input", "output", "cacheRead", "cacheWrite"] as const).every(
-      (key) => cost[key] !== undefined,
-    )
-  ) {
-    return model;
-  }
-  return {
-    ...model,
-    cost: {
-      ...model.cost,
-      input: cost.input ?? 0,
-      output: cost.output ?? 0,
-      cacheRead: cost.cacheRead ?? 0,
-      cacheWrite: cost.cacheWrite ?? 0,
-    },
-  };
-}
-
-function normalizeProviderModelsForConfig(
-  providerKey: string,
-  provider: ProviderConfig,
-): ProviderConfig {
-  if (!Array.isArray(provider.models) || provider.models.length === 0) {
-    return provider;
-  }
-
-  const providerId = normalizeProviderId(providerKey);
-  let mutated = false;
-  const nextModels: ProviderModelConfig[] = [];
-  const seenById = new Map<string, number>();
-  for (const model of provider.models) {
-    const rawId = getProviderModelId(model);
-    const normalizedId = rawId
-      ? normalizeProviderCatalogModelIdForConfig(
-          providerId,
-          normalizeConfiguredProviderCatalogModelRef(rawId),
-        )
-      : rawId;
-    const normalizedModel =
-      normalizedId && normalizedId !== rawId ? { ...model, id: normalizedId } : model;
-    if (normalizedModel !== model) {
-      mutated = true;
-    }
-    const id = getProviderModelId(normalizedModel);
-    if (id) {
-      const existingIndex = seenById.get(id);
-      if (existingIndex !== undefined) {
-        mutated = true;
-        const existing = nextModels.at(existingIndex);
-        if (existing) {
-          nextModels[existingIndex] = mergeNormalizedProviderModel(existing, normalizedModel);
-        }
-        continue;
-      }
-      seenById.set(id, nextModels.length);
-    }
-    nextModels.push(normalizedModel);
-  }
-
-  for (const [index, model] of nextModels.entries()) {
-    const normalized = normalizeModelCostForCatalog(model);
-    if (normalized !== model) {
-      nextModels[index] = normalized;
-      mutated = true;
-    }
-  }
-
-  return mutated ? { ...provider, models: nextModels } : provider;
-}
-
-function normalizeProviderModelMap(
-  providers: ModelsConfig["providers"],
-  normalize: (providerKey: string, provider: ProviderConfig) => ProviderConfig,
-): ModelsConfig["providers"] {
-  if (!providers) {
-    return providers;
-  }
-
-  let mutated = false;
-  const next: Record<string, ProviderConfig> = {};
-  for (const [providerKey, provider] of Object.entries(providers)) {
-    const normalized = normalize(providerKey, provider);
-    mutated ||= normalized !== provider;
-    next[providerKey] = normalized;
-  }
-
-  return mutated ? next : providers;
-}
-
-/** Resolves authored aliases once, before discovery consumes configured model membership. */
-export function materializeConfiguredProviderCatalogModels(
-  providers: ModelsConfig["providers"],
-  options: ModelManifestNormalizationContext = {},
-): ModelsConfig["providers"] {
-  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
-  return normalizeProviderModelMap(providers, (providerKey, provider) =>
-    materializeConfiguredProviderModelRows(provider, (id) => normalizeModelId(providerKey, id)),
-  );
-}
-
-/** Finalizes emitted rows without applying authored aliases to their identities. */
-export function normalizeProviderCatalogModelsForConfig(
-  providers: ModelsConfig["providers"],
-): ModelsConfig["providers"] {
-  return normalizeProviderModelMap(providers, normalizeProviderModelsForConfig);
-}
-
 export function normalizeProviders(params: {
   providers: ModelsConfig["providers"];
   agentDir: string;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -7,7 +7,7 @@ export { resolveImplicitProviders } from "./models-config.providers.implicit.js"
 export {
   materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,
-  normalizeProviders,
-} from "./models-config.providers.normalize.js";
+} from "./models-config.providers.catalog.js";
+export { normalizeProviders } from "./models-config.providers.normalize.js";
 export type { ProviderConfig } from "./models-config.providers.secrets.js";
 export { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -161,12 +161,11 @@ function createFullModelCatalogAccess(params: {
     const current = materializePreparedModelCatalog(
       configured,
       params.agentFacts.runtimeCapabilityModels,
-      configuredRuntimeModels,
     );
     const projected = materializePreparedModelCatalog(
       catalog,
       params.agentFacts.runtimeCapabilityModels,
-      configuredRuntimeModels,
+      current.staticEntries,
     );
     projected.entries = dedupeByKey(
       [...projected.entries, ...current.entries],

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -27,6 +27,7 @@ function createConfiguredModelCatalogSnapshot(params: {
   templateModelRegistry: ModelRegistry;
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
 }): ModelCatalogSnapshot {
+  const replace = params.agentFacts.input.config.models?.mode === "replace";
   const configuredEntries = dedupeByKey(
     [
       ...buildConfiguredModelCatalog({
@@ -37,15 +38,19 @@ function createConfiguredModelCatalogSnapshot(params: {
             : params.templateModelRegistry.getAll().map(modelCatalogRowToEntry),
         manifestPlugins: params.workspaceFacts.pluginMetadataSnapshot,
       }),
-      ...params.configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
-      ...params.agentFacts.configuredModelRefs.flatMap(({ provider, modelId }) => {
-        const model = params.templateModelRegistry.find(provider, modelId);
-        return model ? [modelCatalogRowToEntry(model)] : [];
-      }),
+      ...(replace
+        ? []
+        : params.configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model))),
+      ...(replace
+        ? []
+        : params.agentFacts.configuredModelRefs.flatMap(({ provider, modelId }) => {
+            const model = params.templateModelRegistry.find(provider, modelId);
+            return model ? [modelCatalogRowToEntry(model)] : [];
+          })),
     ],
     resolveModelCatalogIdentityKey,
   );
-  const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
+  const staticEntries = (replace ? [] : params.configuredRuntimeModels).map(({ model }) =>
     modelCatalogRowToEntry(model),
   );
   return {

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -5,6 +5,7 @@ import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { stableStringify } from "@openclaw/normalization-core";
 import type { Result } from "@openclaw/normalization-core/result";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -12,6 +13,7 @@ import {
   getPreparedMessageToolCatalog,
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
+import { resolvePreparedProviderStaticConfigs } from "../plugins/provider-discovery.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { getPluginRegistryInspectionResources } from "../plugins/registry-inspection-resources.js";
 import { capturePluginLifecycleAuthority } from "../plugins/registry-lifecycle.js";
@@ -40,7 +42,6 @@ import {
   parseConfiguredModelVisibilityEntries,
 } from "./model-selection-shared.js";
 import { prepareImplicitProviderStaticCatalog } from "./models-config.providers.implicit.js";
-import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import {
   loadPersistedPluginModelCatalogsReadOnly,
   resolvePluginModelCatalogOwnerPluginId,
@@ -428,28 +429,17 @@ export async function prepareWorkspaceBuildGroup(
         ],
         resolveRuntimeModel: resolveConfiguredManifestModel,
       });
-      const configuredEntryKeys = new Set(
-        configuredCatalogEntries.map(resolveModelCatalogIdentityKey),
-      );
-      for (const configured of configuredRuntimeModels) {
-        configuredEntryKeys.add(
-          resolveModelCatalogIdentityKey({ provider: configured.provider, id: configured.modelId }),
-        );
-      }
       const configuredGeneratedCatalogPluginIds = [
         ...new Set(
-          facts.configuredModelRefs.flatMap(({ provider, modelId }) => {
-            if (
-              configuredEntryKeys.has(resolveModelCatalogIdentityKey({ provider, id: modelId }))
-            ) {
-              return [];
-            }
-            const pluginId = resolvePluginModelCatalogOwnerPluginId({
-              providerId: provider,
-              pluginMetadataSnapshot,
-            });
-            return pluginId ? [pluginId] : [];
-          }),
+          (facts.input.config.models?.mode === "replace" ? [] : facts.providerIds).flatMap(
+            (provider) => {
+              const pluginId = resolvePluginModelCatalogOwnerPluginId({
+                providerId: provider,
+                pluginMetadataSnapshot,
+              });
+              return pluginId ? [pluginId] : [];
+            },
+          ),
         ),
       ].toSorted((left, right) => left.localeCompare(right));
       agentFacts.push({
@@ -600,12 +590,14 @@ function groupConfiguredRegistrySources(
   for (const facts of agentFacts) {
     const modelsJsonContents = captureModelsJsonContents(facts.input.agentDir);
     const oauthProviders = facts.templateAuthStorage.getOAuthProviders();
-    // Capture only unresolved configured catalogs, then group exact bytes and OAuth behavior.
+    // Root files remain authored inventory even when static preparation returned an empty result.
     const pluginCatalogs = loadPersistedPluginModelCatalogsReadOnly(
       facts.input.agentDir,
       facts.configuredGeneratedCatalogPluginIds,
     );
     const key = fingerprintPreparedRuntimeFacts({
+      config: facts.input.config,
+      sourceModels: projectConfigOntoRuntimeSourceSnapshot(facts.input.config).models,
       credentials: facts.credentials,
       modelsJsonContents,
       pluginCatalogs,
@@ -638,6 +630,9 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
 } {
   const catalogs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeCatalogFacts>();
   let registryCount = 0;
+  const staticProviderConfigs = resolvePreparedProviderStaticConfigs(
+    params.pluginGeneration.preparedStaticProviderCatalog,
+  );
   for (const group of groupConfiguredRegistrySources(params.agentFacts)) {
     const representative = group.agentFacts[0];
     if (!representative) {
@@ -651,6 +646,7 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
         includePluginCatalogs: true,
         modelsJsonContents: group.modelsJsonContents,
         pluginCatalogs: group.pluginCatalogs,
+        staticProviderConfigs,
         pluginMetadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
         ...(representative.input.workspaceDir
           ? { workspaceDir: representative.input.workspaceDir }

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -1,5 +1,7 @@
 import { isDeepStrictEqual } from "node:util";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { Model } from "../llm/types.js";
+import { resolvePreparedProviderStaticConfigs } from "../plugins/provider-discovery.js";
 import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinking.js";
 import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
@@ -26,10 +28,7 @@ import type {
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
 import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
-import type {
-  PreparedConfiguredRuntimeModel,
-  PreparedRuntimeCapabilityModel,
-} from "./prepared-model-runtime.configured.js";
+import type { PreparedRuntimeCapabilityModel } from "./prepared-model-runtime.configured.js";
 import {
   acquirePreparedMediaCapabilityProviders,
   buildPreparedPluginModelCatalog,
@@ -50,51 +49,60 @@ export async function prepareFullCatalogFacts(
   agentFacts: PreparedModelRuntimeAgentFacts,
   pluginGeneration: PreparedModelRuntimePluginGeneration,
   catalogMode: PreparedModelRuntimeCatalogMode,
-  catalogSource?: PreparedModelRuntimeCatalogSource,
+  catalogSource: PreparedModelRuntimeCatalogSource,
 ): Promise<PreparedModelRuntimeCatalogFacts> {
   const { env, input, templateAuthStorage } = agentFacts;
   const { pluginMetadataSnapshot, preparedStaticProviderCatalog } = pluginGeneration;
+  const observedProviders = new Set(
+    catalogSource.providerOutcomes?.map(({ provider }) => normalizeProviderId(provider)),
+  );
   const templateModelRegistry = discoverModels(templateAuthStorage, input.agentDir, {
     config: input.config,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     pluginMetadataSnapshot,
     ...(catalogMode === "static" ? { normalizeModels: false } : {}),
-    ...(catalogSource
-      ? {
-          includePluginCatalogs: true,
-          modelsJsonContents: catalogSource.modelsJsonContents,
-          pluginCatalogs: catalogSource.pluginCatalogs,
-        }
-      : {}),
+    includePluginCatalogs: true,
+    modelsJsonContents: catalogSource.modelsJsonContents,
+    pluginCatalogs: catalogSource.pluginCatalogs,
+    staticProviderConfigs: Object.fromEntries(
+      Object.entries(resolvePreparedProviderStaticConfigs(preparedStaticProviderCatalog)).filter(
+        ([provider]) => !observedProviders.has(normalizeProviderId(provider)),
+      ),
+    ),
   });
   const modelCatalog = await buildPreparedPluginModelCatalog({
     agentFacts,
     catalogMode,
     modelRegistry: templateModelRegistry,
-    providerOutcomes: catalogSource?.providerOutcomes,
+    providerOutcomes: catalogSource.providerOutcomes,
     pluginGeneration,
   });
   const providerStaticModels =
-    pluginGeneration.providerStaticModels ??
-    (await loadBundledProviderStaticCatalogContextModels({
-      cfg: input.config,
-      env,
-      metadataSnapshot: pluginMetadataSnapshot,
-      registeredProviders: pluginGeneration.pluginRegistry?.providers,
-      ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-    }));
+    input.config.models?.mode === "replace"
+      ? []
+      : (pluginGeneration.providerStaticModels ??
+        (await loadBundledProviderStaticCatalogContextModels({
+          cfg: input.config,
+          env,
+          metadataSnapshot: pluginMetadataSnapshot,
+          registeredProviders: pluginGeneration.pluginRegistry?.providers,
+          ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
+          ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+        })));
   const configuredRuntimeModels = completeConfiguredRuntimeModels(
     agentFacts,
     pluginGeneration,
     templateModelRegistry,
   );
-  const providerOutcomes = catalogSource?.providerOutcomes ?? [];
+  const providerOutcomes = catalogSource.providerOutcomes ?? [];
   const completeModelCatalog = {
     ...modelCatalog,
-    staticEntries: dedupeByKey(providerStaticModels, resolveModelCatalogIdentityKey).map(
-      modelCatalogRowToEntry,
-    ),
+    staticEntries:
+      input.config.models?.mode === "replace"
+        ? []
+        : dedupeByKey(providerStaticModels, resolveModelCatalogIdentityKey).map(
+            modelCatalogRowToEntry,
+          ),
     ...(providerOutcomes.length > 0 ? { providerOutcomes } : {}),
   };
   if (catalogMode === "live") {
@@ -229,7 +237,7 @@ export function prepareModelCatalogPublication(
 export function materializePreparedModelCatalog(
   snapshot: ModelCatalogSnapshot,
   runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[],
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[] = [],
+  configuredStaticEntries: ModelCatalogSnapshot["staticEntries"] = [],
 ): ModelCatalogSnapshot {
   // Preserve inventory reads before capability preparation when the snapshot has accessors.
   const materialized = { ...snapshot };
@@ -264,13 +272,10 @@ export function materializePreparedModelCatalog(
     });
   materialized.entries = project(sourceEntries);
   materialized.routeVariants = project(snapshot.routeVariants);
-  if (snapshot.staticEntries || configuredRuntimeModels.length > 0) {
+  if (snapshot.staticEntries || configuredStaticEntries.length > 0) {
     materialized.staticEntries = project(
       dedupeByKey(
-        [
-          ...configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
-          ...(snapshot.staticEntries ?? []),
-        ],
+        [...configuredStaticEntries, ...(snapshot.staticEntries ?? [])],
         resolveModelCatalogIdentityKey,
       ),
     );
@@ -321,7 +326,9 @@ export function createPreparedModelRuntimeSnapshot(
   const modelCatalog = materializePreparedModelCatalog(
     catalogFacts.modelCatalog,
     agentFacts.runtimeCapabilityModels,
-    configuredRuntimeModels,
+    input.config.models?.mode === "replace"
+      ? []
+      : configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
   );
   prepareModelCatalogThinkingPolicies({
     catalog: modelCatalog,

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -1,6 +1,7 @@
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { ensureOpenClawModelsJson, planOpenClawModelsJsonSource } from "./models-config.js";
@@ -56,7 +57,9 @@ async function prepareScopedReadOnlyModelCatalogWithMode(
   return materializePreparedModelCatalog(
     modelCatalog,
     agentFactsForInput.runtimeCapabilityModels,
-    configuredRuntimeModels,
+    scopedInput.config.models?.mode === "replace"
+      ? []
+      : configuredRuntimeModels.map(({ model }) => modelCatalogRowToEntry(model)),
   );
 }
 

--- a/src/agents/prepared-model-runtime.sources.test.ts
+++ b/src/agents/prepared-model-runtime.sources.test.ts
@@ -1,0 +1,377 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
+import { PLUGIN_MODEL_CATALOG_GENERATED_BY } from "./plugin-model-catalog.js";
+import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
+import { prepareConfiguredRuntimeFactsBatch } from "./prepared-model-runtime.facts.js";
+import {
+  createPreparedModelRuntimeSnapshot,
+  prepareFullCatalogFacts,
+} from "./prepared-model-runtime.full-catalog.js";
+import { AuthStorage } from "./sessions/auth-storage.js";
+import { ModelRegistry } from "./sessions/model-registry.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const providerId = "prepared-source-fixture";
+const pluginId = "prepared-source-owner";
+const endpoint = "https://prepared.example.invalid/v1";
+const metadata = createPluginMetadataSnapshotFixture({
+  plugins: [{ id: pluginId, providers: [providerId] }],
+});
+
+function model(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    input: ["text"],
+    reasoning: false,
+    contextWindow: 32000,
+    maxTokens: 2048,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+function fixture(mode: "merge" | "replace" = "merge") {
+  const agentDir = tempDirs.make("openclaw-prepared-sources-");
+  const configured: ModelProviderConfig = {
+    api: "openai-completions",
+    baseUrl: endpoint,
+    models: [model("configured-only"), { ...model("shared"), name: "Current shared" }],
+  };
+  const config: OpenClawConfig = { models: { mode, providers: { [providerId]: configured } } };
+  const provider = { id: providerId, pluginId, label: "Prepared source", auth: [] };
+  const staticConfig: ModelProviderConfig = {
+    ...configured,
+    models: [model("curated-only"), { ...model("shared"), maxTokens: 8192 }],
+  };
+  const preparedStaticProviderCatalog: PreparedProviderStaticCatalog = {
+    providers: [provider],
+    entries: [{ provider, result: { provider: staticConfig } }],
+  };
+  const generation = {
+    pluginMetadataSnapshot: metadata,
+    inlineProviderModels: [],
+    configuredCatalogEntries: [],
+    providerStaticModels: [],
+    preparedStaticProviderCatalog,
+  };
+  const facts: PreparedModelRuntimeAgentFacts = {
+    input: { config, agentDir },
+    env: {},
+    authStore: { version: 1, profiles: {} },
+    credentials: {},
+    templateAuthStorage: AuthStorage.inMemory({}),
+    providerIds: [providerId],
+    configuredModelRefs: [],
+    configuredRuntimeModels: [],
+    runtimeCapabilityModels: [],
+    configuredGeneratedCatalogPluginIds: [],
+  };
+  const rootProvider = { ...configured, models: [model("authored-only"), model("shared")] };
+  const modelsJsonContents = JSON.stringify({ providers: { [providerId]: rootProvider } });
+  fs.writeFileSync(path.join(agentDir, "models.json"), modelsJsonContents);
+  return { facts, generation, configured, staticConfig, modelsJsonContents };
+}
+
+describe("prepared catalog source composition", () => {
+  it.each(["merge", "replace"] as const)(
+    "materializes duplicate current declarations once in %s mode",
+    (mode) => {
+      const { facts, generation, configured } = fixture(mode);
+      configured.models = [
+        {
+          ...model("shared"),
+          name: "First current",
+          cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+        },
+        { ...model("shared"), name: "Later duplicate", input: ["text", "image"] },
+      ];
+      const result = prepareConfiguredRuntimeFactsBatch({
+        agentFacts: [facts],
+        pluginGeneration: generation,
+      }).catalogs.get(facts.input)!;
+      const rows = result.templateModelRegistry.getAll().filter((entry) => entry.id === "shared");
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        name: "First current",
+        input: ["text"],
+        cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+      });
+    },
+  );
+  it("does not restore noncurrent runtime fallbacks after replace publication", async () => {
+    const { facts, generation, modelsJsonContents } = fixture("replace");
+    facts.configuredRuntimeModels = [
+      {
+        provider: providerId,
+        modelId: "runtime-only",
+        model: {
+          ...model("runtime-only"),
+          input: ["text"],
+          contextWindow: 32000,
+          provider: providerId,
+          api: "openai-completions",
+          baseUrl: endpoint,
+        },
+      },
+    ];
+    const startup = prepareConfiguredRuntimeFactsBatch({
+      agentFacts: [facts],
+      pluginGeneration: generation,
+    }).catalogs.get(facts.input)!;
+    const full = await prepareFullCatalogFacts(facts, generation, "static", {
+      modelsJsonContents,
+      pluginCatalogs: [],
+    });
+    for (const catalogFacts of [startup, full]) {
+      const snapshot = createPreparedModelRuntimeSnapshot(
+        undefined,
+        facts,
+        generation,
+        catalogFacts,
+        {
+          isCurrent: () => true,
+          withRefreshStatus: (catalog) => catalog,
+          readFullModelCatalog: () => undefined,
+          loadFullModelCatalog: async () => catalogFacts.modelCatalog,
+          loadAuth: async () => ({ authStore: facts.authStore, authModes: {}, credentials: {} }),
+        },
+      );
+      expect
+        .soft(snapshot.modelCatalog.entries.map((entry) => entry.id).toSorted())
+        .toEqual(["configured-only", "shared"]);
+      expect.soft(snapshot.modelCatalog.staticEntries ?? []).toEqual([]);
+    }
+  });
+  it.each([
+    { mode: "merge", ids: ["authored-only", "configured-only", "curated-only", "shared"] },
+    { mode: "replace", ids: ["configured-only", "shared"] },
+  ] as const)("composes the actual startup registry in $mode mode", ({ mode, ids }) => {
+    const { facts, generation } = fixture(mode);
+    const result = prepareConfiguredRuntimeFactsBatch({
+      agentFacts: [facts],
+      pluginGeneration: generation,
+    });
+    const captured = result.catalogs.get(facts.input)!;
+    expect(captured.templateModelRegistry.getError()).toBeUndefined();
+    expect(
+      captured.templateModelRegistry
+        .getAll()
+        .map((entry) => entry.id)
+        .toSorted(),
+    ).toEqual(ids);
+    expect(captured.modelCatalog.entries.map((entry) => entry.id).toSorted()).toEqual(ids);
+    expect(captured.templateModelRegistry.find(providerId, "shared")).toMatchObject({
+      name: "Current shared",
+      maxTokens: 2048,
+      maxTokensSource: "configured",
+    });
+  });
+
+  it("does not share composed registries across different current declarations", () => {
+    const { facts, generation, configured } = fixture();
+    const sibling = {
+      ...facts,
+      input: {
+        ...facts.input,
+        config: {
+          models: {
+            providers: { [providerId]: { ...configured, models: [model("other-current")] } },
+          },
+        },
+      },
+    };
+    const result = prepareConfiguredRuntimeFactsBatch({
+      agentFacts: [facts, sibling],
+      pluginGeneration: generation,
+    });
+    expect(
+      result.catalogs.get(facts.input)!.templateModelRegistry.find(providerId, "configured-only"),
+    ).toBeDefined();
+    expect(
+      result.catalogs.get(facts.input)!.templateModelRegistry.find(providerId, "other-current"),
+    ).toBeUndefined();
+    expect(
+      result.catalogs.get(sibling.input)!.templateModelRegistry.find(providerId, "other-current"),
+    ).toBeDefined();
+    expect(
+      result.catalogs.get(sibling.input)!.templateModelRegistry.find(providerId, "configured-only"),
+    ).toBeUndefined();
+  });
+
+  it("keeps an authored route when the prepared static catalog is empty", () => {
+    const { facts, generation, configured } = fixture();
+    const authoredEndpoint = "https://authored.example.invalid/v1";
+    fs.writeFileSync(
+      path.join(facts.input.agentDir, "models.json"),
+      JSON.stringify({ providers: { [providerId]: { ...configured, baseUrl: authoredEndpoint } } }),
+    );
+    const result = prepareConfiguredRuntimeFactsBatch({
+      agentFacts: [facts],
+      pluginGeneration: { ...generation, preparedStaticProviderCatalog: { entries: [] } },
+    });
+    expect(
+      result.catalogs.get(facts.input)!.templateModelRegistry.find(providerId, "shared"),
+    ).toMatchObject({ baseUrl: authoredEndpoint });
+  });
+
+  it.each(["merge", "replace"] as const)(
+    "keeps full catalog source ownership in %s mode",
+    async (mode) => {
+      const { facts, generation, modelsJsonContents } = fixture(mode);
+      const result = await prepareFullCatalogFacts(facts, generation, "static", {
+        modelsJsonContents,
+        pluginCatalogs: [],
+        providerOutcomes: [{ provider: providerId, status: "ready" }],
+      });
+      expect(result.templateModelRegistry.find(providerId, "curated-only")).toBeUndefined();
+      expect(result.modelCatalog.entries.some((entry) => entry.id === "configured-only")).toBe(
+        true,
+      );
+      expect(result.templateModelRegistry.find(providerId, "authored-only")).toEqual(
+        mode === "merge" ? expect.objectContaining({ id: "authored-only" }) : undefined,
+      );
+    },
+  );
+
+  it("composes captured generated inventory without restoring its request authority", async () => {
+    const { facts, configured, staticConfig, modelsJsonContents } = fixture();
+    const registry = ModelRegistry.create(AuthStorage.inMemory({}), "captured:models.json", {
+      config: facts.input.config,
+      modelsJsonContents,
+      pluginMetadataSnapshot: metadata,
+      staticProviderConfigs: { [providerId]: staticConfig },
+      pluginCatalogs: [
+        {
+          pluginId,
+          contents: JSON.stringify({
+            generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+            providers: {
+              [providerId]: {
+                ...configured,
+                apiKey: "discarded-cache-key",
+                headers: { Authorization: "discarded-cache-header" },
+                models: [model("generated-only")],
+              },
+            },
+          }),
+        },
+      ],
+    });
+    expect(
+      registry
+        .getAll()
+        .map((entry) => entry.id)
+        .toSorted(),
+    ).toEqual(["authored-only", "configured-only", "curated-only", "generated-only", "shared"]);
+    const generated = registry.find(providerId, "generated-only")!;
+    expect(generated).toMatchObject({ maxTokensSource: "discovered" });
+    await expect(registry.getApiKeyAndHeaders(generated)).resolves.toEqual({
+      ok: true,
+      apiKey: undefined,
+      headers: undefined,
+    });
+  });
+
+  it("replaces stale root request settings while keeping request-local forks isolated", async () => {
+    const { facts, configured } = fixture();
+    const registry = ModelRegistry.create(AuthStorage.inMemory({}), "captured:models.json", {
+      config: facts.input.config,
+      pluginCatalogs: [],
+      pluginMetadataSnapshot: metadata,
+      modelsJsonContents: JSON.stringify({
+        providers: {
+          [providerId]: {
+            ...configured,
+            apiKey: "stale-root-key",
+            headers: { "X-Old-Provider": "old" },
+            models: [{ ...model("authored-only"), headers: { "X-Old-Model": "old" } }],
+          },
+        },
+      }),
+    });
+    const selected = registry.find(providerId, "authored-only")!;
+    await expect(registry.getApiKeyAndHeaders(selected)).resolves.toEqual({
+      ok: true,
+      apiKey: undefined,
+      headers: undefined,
+    });
+    const fork = registry.fork(
+      AuthStorage.inMemory({ [providerId]: { type: "api_key", key: "current-request-key" } }),
+    );
+    await expect(fork.getApiKeyAndHeaders(selected)).resolves.toEqual({
+      ok: true,
+      apiKey: "current-request-key",
+      headers: undefined,
+    });
+    await expect(registry.getApiKeyAndHeaders(selected)).resolves.toEqual({
+      ok: true,
+      apiKey: undefined,
+      headers: undefined,
+    });
+  });
+
+  it.each([
+    { sourceKey: "current-config-key", storeKey: undefined, expectedKey: "current-config-key" },
+    {
+      sourceKey: "current-config-key",
+      storeKey: "current-store-key",
+      expectedKey: "current-store-key",
+    },
+    { sourceKey: undefined, storeKey: "current-store-key", expectedKey: "current-store-key" },
+    { sourceKey: undefined, storeKey: undefined, expectedKey: undefined },
+  ])(
+    "uses current request authority for accepted routes ($sourceKey, $storeKey)",
+    async ({ sourceKey, storeKey, expectedKey }) => {
+      const { facts, configured } = fixture();
+      const config = {
+        ...facts.input.config,
+        models: {
+          providers: {
+            [providerId]: { ...configured, apiKey: sourceKey, headers: { "X-Current": "current" } },
+          },
+        },
+      };
+      const registry = ModelRegistry.create(
+        AuthStorage.inMemory(storeKey ? { [providerId]: { type: "api_key", key: storeKey } } : {}),
+        "captured:models.json",
+        {
+          config,
+          modelsJsonContents: null,
+          pluginMetadataSnapshot: metadata,
+          pluginCatalogs: [
+            {
+              pluginId,
+              contents: JSON.stringify({
+                generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+                providers: {
+                  [providerId]: {
+                    ...configured,
+                    baseUrl: "https://accepted.example.invalid/v1",
+                    apiKey: "stale-cache-key",
+                    headers: { "X-Stale": "stale" },
+                    models: [model("shared"), model("generated-only")],
+                  },
+                },
+              }),
+            },
+          ],
+        },
+      );
+      for (const id of ["shared", "generated-only"]) {
+        const selected = registry.find(providerId, id)!;
+        expect(selected.baseUrl).toBe("https://accepted.example.invalid/v1");
+        await expect(registry.getApiKeyAndHeaders(selected)).resolves.toEqual({
+          ok: true,
+          apiKey: expectedKey,
+          headers: { "X-Current": "current" },
+        });
+      }
+    },
+  );
+});

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -409,6 +409,57 @@ describe("prepared model runtime Gateway catalog mode", () => {
     },
   );
 
+  it.each([
+    { live: false, mode: "merge" },
+    { live: true, mode: "merge" },
+    { live: false, mode: "replace" },
+    { live: true, mode: "replace" },
+  ] as const)(
+    "projects current static rows in scoped $mode catalogs (live=$live)",
+    async ({ live, mode }) => {
+      mocks.resolveStaticCatalogModel.mockReturnValue({
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "Configured model",
+        api: "openai-responses",
+        baseUrl: "https://configured.example.test/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 8_192,
+      });
+      const prepare = live
+        ? prepareScopedReadOnlyLiveModelCatalog
+        : prepareScopedReadOnlyModelCatalog;
+      const catalog = await prepare(
+        {
+          config: {
+            agents: { defaults: { model: "openai/gpt-5.5" } },
+            models: { mode },
+          },
+          agentDir: "/tmp/prepared-scoped-static-projection",
+          env: {},
+          readOnly: true,
+        },
+        ["openai"],
+      );
+      expect(catalog.staticEntries).toEqual(
+        mode === "replace"
+          ? []
+          : [
+              expect.objectContaining({
+                provider: "openai",
+                id: "gpt-5.5",
+                name: "Configured model",
+                baseUrl: "https://configured.example.test/v1",
+              }),
+            ],
+      );
+      expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    },
+  );
+
   it("imports and materializes only configured and auth-candidate providers", async () => {
     const config = {
       models: {
@@ -614,7 +665,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     // published metadata generation without starting catalog discovery.
     expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledTimes(2);
     expect(configuredRuntimeModelCount).toBe(1);
-    expect(generatedCatalogReadCount).toBe(0);
+    expect(generatedCatalogReadCount).toBe(1);
     const snapshot = getPreparedModelRuntimeSnapshot({
       agentId: "default",
       config,

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -80,6 +80,44 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it.each([rootUrl, catalogUrl])(
+    "preserves source compatibility without mixing provider defaults at %s",
+    (baseUrl) => {
+      const registry = createRegistry({
+        authored: {
+          ...authored,
+          compat: { maxTokensField: "max_tokens", supportsDeveloperRole: false },
+          models: [{ id: "shared" }, { id: "authored-only" }],
+        },
+        generated: {
+          ...generated,
+          baseUrl,
+          compat: { maxTokensField: "max_completion_tokens" },
+          models: [
+            { id: "shared" },
+            { id: "generated-only" },
+            { id: "model-override", compat: { maxTokensField: "max_tokens" } },
+          ],
+        },
+      });
+      expect(registry.find(provider, "generated-only")?.compat).toEqual({
+        maxTokensField: "max_completion_tokens",
+      });
+      expect(registry.find(provider, "model-override")?.compat).toEqual({
+        maxTokensField: "max_tokens",
+      });
+      expect(registry.find(provider, "authored-only")?.compat).toEqual({
+        maxTokensField: "max_tokens",
+        supportsDeveloperRole: false,
+      });
+      expect(registry.find(provider, "shared")?.compat).toEqual(
+        baseUrl === rootUrl
+          ? { maxTokensField: "max_completion_tokens" }
+          : { maxTokensField: "max_tokens", supportsDeveloperRole: false },
+      );
+    },
+  );
+
   it("keeps model headers separate for literal provider/model pairs with delimiters", async () => {
     const authoredProvider = `${provider}:variant`;
     const registry = createRegistry({

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -138,63 +138,6 @@ describe("ModelRegistry source composition", () => {
   });
 
   it.each([rootUrl, catalogUrl])(
-    "preserves source compatibility without mixing provider defaults at %s",
-    (baseUrl) => {
-      const registry = createRegistry({
-        authored: {
-          ...authored,
-          compat: { maxTokensField: "max_tokens", supportsDeveloperRole: false },
-          models: [{ id: "shared" }, { id: "authored-only" }],
-        },
-        generated: {
-          ...generated,
-          baseUrl,
-          compat: { maxTokensField: "max_completion_tokens" },
-          models: [
-            { id: "shared" },
-            { id: "generated-only" },
-            { id: "model-override", compat: { maxTokensField: "max_tokens" } },
-          ],
-        },
-      });
-      expect(registry.find(provider, "generated-only")?.compat).toEqual({
-        maxTokensField: "max_completion_tokens",
-      });
-      expect(registry.find(provider, "model-override")?.compat).toEqual({
-        maxTokensField: "max_tokens",
-      });
-      expect(registry.find(provider, "authored-only")?.compat).toEqual({
-        maxTokensField: "max_tokens",
-        supportsDeveloperRole: false,
-      });
-      expect(registry.find(provider, "shared")?.compat).toEqual(
-        baseUrl === rootUrl
-          ? { maxTokensField: "max_completion_tokens" }
-          : { maxTokensField: "max_tokens", supportsDeveloperRole: false },
-      );
-    },
-  );
-
-  it("keeps model headers separate for literal provider/model pairs with delimiters", async () => {
-    const authoredProvider = `${provider}:variant`;
-    const registry = createRegistry({
-      authoredProvider,
-      authored: {
-        ...authored,
-        models: [{ id: "shared", headers: { "X-Authored-Model": "private" } }],
-      },
-      generated: { ...generated, models: [{ id: "variant:shared" }] },
-      credentials: { [provider]: { type: "api_key", key: "current-store-key" } },
-    });
-    await expect(
-      registry.getApiKeyAndHeaders(registry.find(provider, "variant:shared")!),
-    ).resolves.toEqual({ ok: true, apiKey: "current-store-key", headers: undefined });
-    await expect(
-      registry.getApiKeyAndHeaders(registry.find(authoredProvider, "shared")!),
-    ).resolves.toMatchObject({ headers: { "X-Authored-Model": "private" } });
-  });
-
-  it.each([rootUrl, catalogUrl])(
     "limits authored request settings to authored endpoints for generated-only rows at %s",
     async (baseUrl) => {
       const registry = createRegistry({

--- a/src/agents/sessions/model-registry.sources.test.ts
+++ b/src/agents/sessions/model-registry.sources.test.ts
@@ -80,6 +80,25 @@ function createRegistry(
 }
 
 describe("ModelRegistry source composition", () => {
+  it("keeps model headers separate for literal provider/model pairs with delimiters", async () => {
+    const authoredProvider = `${provider}:variant`;
+    const registry = createRegistry({
+      authoredProvider,
+      authored: {
+        ...authored,
+        models: [{ id: "shared", headers: { "X-Authored-Model": "private" } }],
+      },
+      generated: { ...generated, models: [{ id: "variant:shared" }] },
+      credentials: { [provider]: { type: "api_key", key: "current-store-key" } },
+    });
+    await expect(
+      registry.getApiKeyAndHeaders(registry.find(provider, "variant:shared")!),
+    ).resolves.toEqual({ ok: true, apiKey: "current-store-key", headers: undefined });
+    await expect(
+      registry.getApiKeyAndHeaders(registry.find(authoredProvider, "shared")!),
+    ).resolves.toMatchObject({ headers: { "X-Authored-Model": "private" } });
+  });
+
   it.each([rootUrl, catalogUrl])(
     "preserves source compatibility without mixing provider defaults at %s",
     (baseUrl) => {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -37,7 +37,7 @@ import {
   normalizeProviderMapKeys,
   type ProviderModelCatalog,
 } from "../models-config.merge.js";
-import { materializeConfiguredProviderCatalogModels } from "../models-config.providers.normalize.js";
+import { materializeConfiguredProviderCatalogModels } from "../models-config.providers.catalog.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
   isGeneratedPluginModelCatalog,

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -4,10 +4,13 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { normalizeResolvedPricing } from "@openclaw/llm-core";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../../config/runtime-source-projection.js";
+import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   AnthropicMessagesCompat,
@@ -21,12 +24,20 @@ import type {
 } from "../../llm/types.js";
 import type { OAuthProviderInterface } from "../../llm/utils/oauth/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { getAgentDir } from "../config.js";
+import { sanitizeModelHeaders } from "../embedded-agent-runner/model.inline-provider.js";
 import { hasUsableCustomProviderApiKey } from "../model-auth-provider-config.js";
 import { parseModelCatalogJson } from "../model-catalog-json.js";
 import { modelTransportRoutesMatch } from "../model-compat-catalog.js";
 import { resolveModelPluginMetadataSnapshot } from "../model-discovery-context.js";
-import { mergeProviderModels } from "../models-config.merge.js";
+import {
+  buildSourceModelFields,
+  mergeProviderModels,
+  normalizeProviderMapKeys,
+  type ProviderModelCatalog,
+} from "../models-config.merge.js";
+import { materializeConfiguredProviderCatalogModels } from "../models-config.providers.normalize.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
   isGeneratedPluginModelCatalog,
@@ -222,10 +233,29 @@ type ModelsConfig = Static<typeof ModelsConfigSchema>;
 type MaxTokensSource = "configured" | "discovered";
 type RegistryProviderSources = Record<
   string,
-  Omit<ModelsConfig["providers"][string], "models"> & {
-    models?: Array<Static<typeof ModelDefinitionSchema> & { maxTokensSource?: MaxTokensSource }>;
-  }
+  ProviderModelCatalog &
+    Pick<ModelsConfig["providers"][string], "apiKey" | "auth" | "authHeader"> & {
+      headers?: Record<string, string>;
+    }
 >;
+
+function captureInventoryProvider(
+  provider: ProviderModelCatalog,
+  source: "static" | "composed",
+): RegistryProviderSources[string] {
+  return {
+    api: provider.api,
+    baseUrl: provider.baseUrl,
+    compat: provider.compat,
+    models: provider.models?.map(({ headers: _headers, ...model }) => ({
+      ...model,
+      api: model.api ?? provider.api,
+      baseUrl: model.baseUrl ?? provider.baseUrl,
+      maxTokensSource: source === "static" ? "discovered" : model.maxTokensSource,
+      compat: source === "static" ? mergeCompat(provider.compat, model.compat) : model.compat,
+    })),
+  };
+}
 
 function formatValidationPath(error: TLocalizedValidationError): string {
   if (error.keyword === "required") {
@@ -275,6 +305,7 @@ type ModelRegistryOptions = {
   includePluginCatalogs?: boolean;
   modelsJsonContents?: string | null;
   pluginCatalogs?: readonly PersistedPluginModelCatalog[];
+  staticProviderConfigs?: Readonly<Record<string, ModelProviderConfig>>;
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   sourceSnapshot?: ModelRegistry;
   workspaceDir?: string;
@@ -339,6 +370,7 @@ export class ModelRegistry {
   private modelsJsonPath: string | undefined;
   private modelsJsonContents: string | null | undefined;
   private pluginCatalogs: readonly PersistedPluginModelCatalog[] | undefined;
+  private staticProviderConfigs: Readonly<Record<string, ModelProviderConfig>> | undefined;
   private pluginMetadataSnapshot: PluginModelCatalogMetadataSnapshot | undefined;
   private includePluginCatalogs = true;
   private baseCatalogSnapshot: ModelRegistryCatalogSnapshot | undefined;
@@ -374,6 +406,7 @@ export class ModelRegistry {
     this.modelsJsonPath = modelsJsonPath;
     this.modelsJsonContents = options.modelsJsonContents;
     this.pluginCatalogs = options.pluginCatalogs;
+    this.staticProviderConfigs = options.staticProviderConfigs;
     this.pluginMetadataSnapshot = resolveModelPluginMetadataSnapshot({
       ...(options.pluginMetadataSnapshot
         ? { pluginMetadataSnapshot: options.pluginMetadataSnapshot }
@@ -471,15 +504,16 @@ export class ModelRegistry {
   private loadModels(): void {
     // Keep authored models.json separate from rebuildable provider catalogs
     // owned by the agent SQLite cache.
+    const replace = this.config?.models?.mode === "replace";
     const customResult =
-      this.modelsJsonPath && this.modelsJsonContents !== null
+      !replace && this.modelsJsonPath && this.modelsJsonContents !== null
         ? this.loadCustomModels(this.modelsJsonPath, {
             ...(this.modelsJsonContents !== undefined ? { contents: this.modelsJsonContents } : {}),
             includePluginCatalogs: this.includePluginCatalogs && this.pluginCatalogs === undefined,
           })
         : emptyCustomModelsResult();
     const capturedPluginResult =
-      this.includePluginCatalogs && this.pluginCatalogs !== undefined
+      !replace && this.includePluginCatalogs && this.pluginCatalogs !== undefined
         ? this.loadCapturedPluginCatalogs(this.pluginCatalogs)
         : emptyCustomModelsResult();
     const errors = [customResult.error, capturedPluginResult.error].filter(
@@ -492,9 +526,62 @@ export class ModelRegistry {
       // Plugin catalog failures can return salvaged models; root failures return empty.
     }
 
-    let combined = this.parseModels(
-      this.mergeProviderSources(capturedPluginResult.providers, customResult.providers),
+    const providers = this.mergeProviderSources(
+      replace
+        ? {}
+        : Object.fromEntries(
+            Object.entries(this.staticProviderConfigs ?? {}).map(([provider, config]) => [
+              provider,
+              captureInventoryProvider(config, "static"),
+            ]),
+          ),
+      capturedPluginResult.providers,
+      customResult.providers,
     );
+    const sourceFields = buildSourceModelFields(
+      materializeConfiguredProviderCatalogModels(
+        this.config && projectConfigOntoRuntimeSourceSnapshot(this.config).models?.providers,
+        { manifestPlugins: this.pluginMetadataSnapshot },
+      ),
+    );
+    for (const [providerId, configured] of Object.entries(
+      normalizeProviderMapKeys(
+        materializeConfiguredProviderCatalogModels(this.config?.models?.providers, {
+          manifestPlugins: this.pluginMetadataSnapshot,
+        }),
+      ),
+    )) {
+      const inherited = providers[providerId];
+      const accepted = new Map(inherited?.models?.map((model) => [model.id, model]));
+      const current: RegistryProviderSources[string] = {
+        api: configured.api,
+        baseUrl: configured.baseUrl,
+        models: configured.models.map((model) => ({
+          ...model,
+          api: model.api ?? accepted.get(model.id)?.api ?? configured.api,
+          baseUrl: model.baseUrl ?? accepted.get(model.id)?.baseUrl ?? configured.baseUrl,
+          maxTokensSource: "configured",
+          headers: sanitizeModelHeaders(model.headers, { stripSecretRefMarkers: true }),
+        })),
+      };
+      providers[providerId] = inherited
+        ? mergeProviderModels(captureInventoryProvider(inherited, "composed"), current, {
+            providerId,
+            modelIdMatching: "exact",
+            sourceModelFields: sourceFields,
+          })
+        : current;
+      this.providerRequestConfigs.delete(providerId);
+      // Current config owns provider request settings, including accepted catalog routes.
+      // File-only callers retain the authored-endpoint scope captured by loadCustomModels.
+      this.storeProviderRequestConfig(providerId, {
+        apiKey: normalizeOptionalSecretInput(configured.apiKey),
+        auth: configured.auth,
+        authHeader: configured.authHeader,
+        headers: sanitizeModelHeaders(configured.headers, { stripSecretRefMarkers: true }),
+      });
+    }
+    let combined = this.parseModels(providers);
 
     // Let OAuth providers modify their models (e.g., update baseUrl)
     for (const oauthProvider of this.authStorage.getOAuthProviders()) {
@@ -738,7 +825,6 @@ export class ModelRegistry {
         }
 
         this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
-        const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
         models.push({
           id: modelDef.id,
           name: modelDef.name ?? modelDef.id,
@@ -748,7 +834,7 @@ export class ModelRegistry {
           reasoning: modelDef.reasoning ?? false,
           thinkingLevelMap: modelDef.thinkingLevelMap,
           input: runtimeInput,
-          cost: modelDef.cost ?? defaultCost,
+          cost: normalizeResolvedPricing(modelDef.cost ?? {}),
           contextWindow: modelDef.contextWindow ?? 128000,
           maxTokens: modelDef.maxTokens ?? 16384,
           ...(modelDef.maxTokens !== undefined

--- a/src/agents/tools/pdf-tool.static-runtime.test.ts
+++ b/src/agents/tools/pdf-tool.static-runtime.test.ts
@@ -24,7 +24,7 @@ describe("PDF tool static prepared runtime", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves a config-inline model when the static registry is empty", async () => {
+  it("resolves a configured model from the static prepared registry", async () => {
     await withOpenClawTestState(
       {
         label: "pdf-static-inline-model",
@@ -75,7 +75,12 @@ describe("PDF tool static prepared runtime", () => {
 
         try {
           const stores = lease.snapshot.createStores();
-          expect(stores.modelRegistry.find("openai", modelId)).toBeUndefined();
+          expect(stores.modelRegistry.find("openai", modelId)).toMatchObject({
+            provider: "openai",
+            id: modelId,
+            api: "openai-responses",
+            baseUrl: "http://127.0.0.1:9/v1",
+          });
           expect(
             lease.snapshot.configuredRuntimeModels.map((entry) => ({
               provider: entry.provider,

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -239,3 +239,13 @@ export async function prepareProviderStaticCatalog(params: {
     entries: Object.freeze(entries),
   });
 }
+
+export function resolvePreparedProviderStaticConfigs(
+  prepared: PreparedProviderStaticCatalog | undefined,
+): Record<string, ModelProviderConfig> {
+  const providers: Record<string, ModelProviderConfig> = {};
+  for (const entry of prepared?.entries ?? []) {
+    Object.assign(providers, normalizePluginDiscoveryResult(entry));
+  }
+  return providers;
+}


### PR DESCRIPTION
Related: #136257, #143664.

AI-assisted.

## What Problem This Solves

Model lookup needed consistent composition of static, generated, authored and current configuration sources while keeping request credentials separate from inventory.

## Why This Change Was Made

Compose these sources in the registry before applying defaults. Current declarations own request settings, and replace mode admits only current declarations. Move catalog-row normalization to its existing responsibility boundary to remove a credential-normalization import cycle.

## User Impact

Explicit routes, sparse metadata and default precedence are preserved. Removing a current key cannot revive an older file key; developer-interface callers without a replacing declaration keep authored-file settings. No operator option or schema change.

## Evidence

The import-cycle check passed on the base, failed before the correction and passed afterward. Four hundred sixty-two tests passed across 33 affected suites. Retained Gateway and recording-service checks covered refresh retention, empty withdrawal, source routes and request isolation; they retain their original build scope.
