### PR TITLE
fix(state): doctor --fix crashes with 'database is not open' when migration rollback cannot complete

### DIFF
--- a/src/state/openclaw-database-open-error.test.ts
+++ b/src/state/openclaw-database-open-error.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
+  repairOpenClawStateDatabaseSchema,
 } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
@@ -88,3 +89,43 @@ it.each(["state", "agent"] as const)(
     }
   },
 );
+
+it("returns doctor repair warnings when rollback cleanup already closed the state database", () => {
+  const env = { OPENCLAW_STATE_DIR: roots.make("state-repair-rollback-cleanup-") };
+  const pathname = resolveOpenClawStateSqlitePath(env);
+  openOpenClawStateDatabase({ env });
+  closeOpenClawStateDatabaseForTest();
+  const primary = new Error("synthetic repair transaction lost its transaction");
+  let intercepted = 0;
+  const transaction = vi
+    .spyOn(transactions, "runSqliteImmediateTransactionSync")
+    .mockImplementation((db, operation, transactionOptions) => {
+      if (db.location() !== pathname) {
+        return runTransaction(db, operation, transactionOptions);
+      }
+      intercepted += 1;
+      observed.add(db);
+      return runTransaction(
+        db,
+        () => {
+          expect(db.isTransaction).toBe(true);
+          db.exec("ROLLBACK");
+          throw primary;
+        },
+        transactionOptions,
+      );
+    });
+  try {
+    const result = repairOpenClawStateDatabaseSchema({ env });
+    expect(intercepted).toBe(1);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Failed migrating shared state database schema");
+    expect(result.warnings[0]).toContain("synthetic repair transaction lost its transaction");
+    const [failedDb] = observed;
+    assert(failedDb);
+    expect(failedDb.isOpen).toBe(false);
+  } finally {
+    transaction.mockRestore();
+  }
+});

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -279,9 +279,12 @@ function repairStateSchema(
   } finally {
     if (db.isOpen) {
       db.exec("PRAGMA foreign_keys = ON;");
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      // Rollback cleanup may have closed the handle after an unrecoverable
+      // transaction failure; double-close throws ERR_INVALID_STATE and would
+      // discard the diagnostic warnings returned by the catch above.
+      db.close();
     }
-    clearNodeSqliteKyselyCacheForDatabase(db);
-    db.close();
     if (!ownershipRefused) {
       ensureOpenClawStatePermissions(pathname, env);
     }


### PR DESCRIPTION
Relates to gap finding: gap-repairstateschema-close-guard (pattern-scan follow-up to #143574)

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` against a shared state database whose schema migration fails with an unrecoverable transaction state (for example a rollback that cannot complete) would see an unrelated crash — `Error: database is not open` (`ERR_INVALID_STATE`) — instead of the doctor diagnostic explaining that the schema repair failed and why.

## Why This Change Was Made

`repairStateSchema` (the doctor `--fix` repair path in `src/state/openclaw-state-db.ts`) returns graceful `{ changes, warnings }` results when repair fails, but its `finally` block called `db.close()` without an `isOpen` guard. When rollback cleanup (`discardUnsafeConnection` in `src/infra/sqlite-transaction.ts`) has already closed the handle after an unrecoverable transaction failure, that double-close throws `ERR_INVALID_STATE`, and the `finally` throw discards the diagnostic warnings the `catch` had constructed. #143574 added the same `isOpen` guard to the sibling paths (`ensureSchema`/`ensureAgentSchema` PRAGMA restore and the agent-db close) and missed this one.

The fix folds `clearNodeSqliteKyselyCacheForDatabase(db)` and `db.close()` into the existing `if (db.isOpen)` guard in that `finally`. This is semantically equivalent: the only way the handle is already closed at that point is `discardUnsafeConnection`, which clears the Kysely statement cache itself before closing. A comment records the invariant so the guard is not "simplified" away.

## User Impact

`openclaw doctor --fix` now surfaces the actual schema-repair failure ("Failed migrating shared state database schema at `<path>`: `<original error>`") instead of a confusing `database is not open` crash when the migration transaction cannot be rolled back cleanly. No behavior change on success paths or on failures where the database handle is still open.

## Evidence

### Before fix

E2E reproduction against real code (synthetic migration failure injected at the transaction boundary, forced rollback, then a primary error — same mechanism as an unrecoverable rollback):

```
$ node --import tsx /tmp/repro-candidate1.mjs
canonical db opened ok
doctor repair outcome: {
  "threw": true,
  "code": "ERR_INVALID_STATE",
  "message": "database is not open",
  "name": "Error"
}
CONFIRMED: repairStateSchema catch-return discarded by finally double-close
```

The new regression test also fails pre-fix at `src/state/openclaw-state-db.ts:299` (the unguarded `db.close()`), satisfying fail-pre-fix:

```
 ❯ repairStateSchema src/state/openclaw-state-db.ts:299:8
 Serialized Error: { code: 'ERR_INVALID_STATE' }
```

### After fix

Same reproduction now returns the intended doctor diagnostic:

```
$ node --import tsx /tmp/repro-candidate1.mjs
canonical db opened ok
doctor repair outcome: {
  "returned": {
    "changes": [],
    "warnings": [
      "Failed migrating shared state database schema at /tmp/repro-state-gGNuQN/state/openclaw.sqlite: Error: synthetic migration failure"
    ]
  }
}
```

Focused validation:

- `pnpm test src/state/openclaw-database-open-error.test.ts src/state/openclaw-state-db.test.ts` → 191/191 passed (188 pre-existing baseline + 3, including the new regression test)
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed files>` → 0 errors
- `oxfmt --check` on changed files → clean
- `node scripts/run-tsgo.mts -p tsconfig.core.json --incremental …` and the `tsconfig.core.test.state-logging` test shard → typecheck clean

What was not tested: a live `openclaw doctor --fix` run against a genuinely corrupted database with an unrecoverable rollback — that failure state cannot be constructed naturally; the function contract is covered by the spy-based regression test plus the e2e reproduction above.
