### PR TITLE
fix(update): report temporary state snapshot cleanup failures

### DIFF
--- a/src/infra/update-candidate-state.cleanup.test.ts
+++ b/src/infra/update-candidate-state.cleanup.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { runCommandBuffered } from "../process/exec.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+
+let root: string;
+beforeEach(async () => {
+  root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-cleanup-")));
+});
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const cases = [
+  { cleanup: "healthy", readError: false },
+  { cleanup: "transient", readError: false },
+  { cleanup: "persistent", readError: false },
+  { cleanup: "healthy", readError: true },
+  { cleanup: "persistent", readError: true },
+] as const;
+
+it.each(
+  (["versions", "snapshot"] as const).flatMap((mode) =>
+    cases.map(({ cleanup, readError }) => ({ mode, cleanup, readError })),
+  ),
+)(
+  "$mode: $cleanup cleanup with readError=$readError",
+  async (scenario) => {
+    const { mode } = scenario;
+    const fixture = path.join(root, `${scenario.cleanup}-${scenario.readError}`);
+    const stateDir = path.join(fixture, "source");
+    const source = path.join(stateDir, "state", "openclaw.sqlite");
+    const cache = path.join(fixture, "cache");
+    const attemptsPath = path.join(fixture, "attempts.jsonl");
+    await fs.mkdir(path.dirname(source), { recursive: true });
+    await fs.mkdir(cache);
+    const db = openNodeSqliteDatabase(source);
+    try {
+      db.exec(
+        "PRAGMA user_version = 3; CREATE TABLE evidence(value TEXT); INSERT INTO evidence VALUES ('source preserved');",
+      );
+      if (scenario.readError) {
+        db.exec("CREATE TABLE agent_databases (not_path TEXT);");
+      }
+    } finally {
+      db.close();
+    }
+    const sentinel = path.join(cache, "unrelated.txt");
+    await fs.writeFile(sentinel, "unrelated preserved");
+    const sourceBytes = await fs.readFile(source);
+    const sourceEntries = await fs.readdir(path.dirname(source));
+    const preload = path.join(fixture, "deletion-fault.mjs");
+    // Fault only this child's raw snapshot, leaving actual copy/read/cleanup owners intact.
+    await fs.writeFile(
+      preload,
+      `
+      import fs from "node:fs";
+      import path from "node:path";
+      const remove = fs.rmSync;
+      const cache = ${JSON.stringify(cache)};
+      const attemptsPath = ${JSON.stringify(attemptsPath)};
+      const fault = ${JSON.stringify(scenario.cleanup)};
+      let attempts = 0;
+      fs.rmSync = (location, options) => {
+        const directory = String(location);
+        if (path.dirname(directory) !== path.join(cache, "openclaw") ||
+            !path.basename(directory).startsWith("openclaw-sqlite-readonly-" + process.pid + "-")) {
+          return remove(location, options);
+        }
+        attempts++;
+        const snapshot = path.join(directory, "database.sqlite");
+        const before = fs.existsSync(snapshot);
+        const fail = fault === "persistent" || (fault === "transient" && attempts === 1);
+        if (!fail) remove(location, options);
+        fs.appendFileSync(attemptsPath, JSON.stringify({directory, before, after: fs.existsSync(snapshot), failed: fail}) + "\\n");
+        if (fail) throw Object.assign(new Error("owned snapshot removal denied"), {code: "EACCES"});
+      };
+    `,
+    );
+    const result = await runCommandBuffered(
+      [
+        process.execPath,
+        "--import",
+        pathToFileURL(preload).href,
+        ...resolveRuntimeWorkerArgv(
+          resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.updateCandidateState),
+        ),
+      ],
+      {
+        input: JSON.stringify({
+          mode,
+          stateDir,
+          targetStateDir: path.join(fixture, "candidate"),
+          candidateRoot: path.join(fixture, "package"),
+          config: {},
+        }),
+        env: { XDG_CACHE_HOME: cache },
+        timeoutMs: 30_000,
+        killGraceMs: 500,
+        maxOutputBytes: { stdout: 1024 * 1024, stderr: 20_000 },
+      },
+    );
+    const attempts = (await fs.readFile(attemptsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            directory: string;
+            before: boolean;
+            after: boolean;
+            failed: boolean;
+          },
+      );
+    const retained = await fs.readdir(path.join(cache, "openclaw"));
+    console.log(
+      JSON.stringify({
+        ...scenario,
+        code: result.code,
+        termination: result.termination,
+        stdout: result.stdout.toString(),
+        stderr: result.stderr.toString(),
+        attempts,
+        retained,
+      }),
+    );
+    expect(await fs.readFile(source)).toEqual(sourceBytes);
+    expect(await fs.readdir(path.dirname(source))).toEqual(sourceEntries);
+    expect(await fs.readFile(sentinel, "utf8")).toBe("unrelated preserved");
+    expect(attempts).toHaveLength(scenario.cleanup === "healthy" ? 1 : 2);
+    expect(attempts.every((attempt) => attempt.before)).toBe(true);
+    expect(attempts.at(-1)?.after).toBe(scenario.cleanup === "persistent");
+    expect(retained).toHaveLength(scenario.cleanup === "persistent" ? 1 : 0);
+    if (scenario.cleanup === "healthy" && !scenario.readError) {
+      expect(result.code, result.stderr.toString()).toBe(0);
+      const output = JSON.parse(result.stdout.toString());
+      expect(mode === "versions" ? output : output.versions).toContainEqual({
+        path: source,
+        userVersion: 3,
+        contentVersion: 3,
+      });
+    } else {
+      expect(result.code, result.stdout.toString()).toBe(1);
+      expect(result.stdout.toString()).toBe("");
+      if (scenario.readError) {
+        expect(result.stderr.toString()).toContain('no such column: "path"');
+      }
+      if (scenario.cleanup !== "healthy") {
+        expect(result.stderr.toString()).toContain("snapshot cleanup failed");
+        expect(result.stderr.toString()).toContain(attempts[0]!.directory);
+      }
+    }
+  },
+  30_000,
+);

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -119,11 +119,27 @@ async function withStateDatabaseSnapshot<T>(
   // The sync snapshot never attaches SQLite to the live family. Production runs
   // in our dedicated child so filesystem closes cannot release updater locks.
   const snapshot = prepareSqliteReadOnlyLocationSyncInProcess(file);
+  let outcome: { value: T } | { cause: unknown };
   try {
-    return await read(snapshot.location);
-  } finally {
-    snapshot.cleanup();
+    outcome = { value: await read(snapshot.location) };
+  } catch (cause) {
+    outcome = { cause };
   }
+  if (!snapshot.cleanup()) {
+    // The exit retry is best-effort, not proof that this private copy was removed.
+    const readFailure =
+      "cause" in outcome
+        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+        : "";
+    throw new Error(
+      `${readFailure}State database snapshot cleanup failed: ${path.dirname(snapshot.location)}. Check directory permissions and available storage before retrying.`,
+      "cause" in outcome ? outcome : undefined,
+    );
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }
 
 async function collectStateDatabasePaths(input: StateInput): Promise<string[]> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where updates could accept state inspection or a rehearsal snapshot even when deletion of the temporary raw database copy failed. The worker returned successful JSON and exited zero while a source-sized private copy could remain on disk.

## Why This Change Was Made

The existing snapshot consumer now checks its cleanup result before returning success. A failure names the owned temporary directory and suggests checking storage and permissions. If reading also failed, that original diagnostic and error cause are preserved.

The existing process-exit retry is unchanged. This adds no sweeper, cleanup store, background work, retention policy, or deletion of other captures.

## User Impact

Update state inspection now reports cleanup failure instead of silently accepting it. Healthy cleanup behaves as before. A transient exit retry can still recover the copy, but it does not retroactively certify an inspection that already failed cleanup.

## Evidence

- Reproduced on canonical main `924381f9f8b3fa7a325b5c03aca4acd0565cd8ff` through both real worker modes. Deletion failure was injected only for each child's synthetic raw snapshot. Persistent failure produced exit 0 and successful JSON while the private copy remained after process exit.
- Added 10 table-driven worker controls covering healthy cleanup, transient exit-retry recovery, persistent failure, and preservation of a real registry-read error with and without cleanup failure.
- Fixed behavior: cleanup failures return exit 1 with empty stdout and the owned path. Read failures remain visible. Source bytes, directory entries, and unrelated files remain unchanged; parent test cleanup runs after child settlement.
- `node scripts/run-vitest.mjs src/infra/update-candidate-state.cleanup.test.ts src/infra/update-candidate-state.test.ts src/infra/sqlite-readonly-location.test.ts`: 92 passed, 1 platform skip.
- Full `node scripts/check-changed.mjs -- src/infra/update-candidate-state.ts src/infra/update-candidate-state.cleanup.test.ts` passed on committed head `01c3c6129c3587051004ba61889be2b0c4cb4b19`.
- Final 10-case worker regression and changed-file lint: passed. Independent P2 autoreview on the final control flow: scoped-clean, no actionable findings.

Production delta: +19/-3 in one existing consumer. No runtime flags, database schema, snapshot primitive, package cleanup, or export-path changes. Persistent filesystem failure can still leave the owned copy; this correction makes that failure visible and does not promise durable reclamation.

### Post-activation recovery consequence

Cleanup failure uses the existing inspection-error policy: post-activation inspection returns `rollback-state-unverified`, keeps the candidate installed, and refuses automatic package rollback. It does not assert that schemas changed. A later successful process-exit retry removes the copy but does not change the failed worker result.

A separate bounded composed probe on this exact head exercised the real source worker, `inspectActivatedUpdateState`, and `rollbackFailedUpdate`. Both transient and persistent failures were checked through the forwarded-block and direct-reinspection paths: all refused rollback, retained the candidate root, preserved source bytes/family entries, and never reached the package-transaction tripwire. Transient exit retries removed both owned copies; persistent failures were measured after child settlement and then removed with the disposable parent fixture. The fixture used no service and a private package-shaped source entry; this is not installed-package or service-recovery proof. Healthy inspection still passed. No production recovery policy or package-restoration code was changed.
