### PR TITLE
docs: add five orphaned pages to the navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1650,6 +1650,7 @@
                 "pages": [
                   "channels/pairing",
                   "channels/access-groups",
+                  "channels/bot-loop-protection",
                   "channels/group-messages",
                   "channels/groups",
                   "channels/ambient-room-events",
@@ -1797,6 +1798,7 @@
                       "plugins/codex-supervision"
                     ]
                   },
+                  "plugins/copilot",
                   {
                     "group": "Meetings and calls",
                     "pages": [
@@ -2203,6 +2205,7 @@
                       "providers/alibaba",
                       "providers/anthropic",
                       "providers/arcee",
+                      "providers/baseten",
                       "providers/bedrock",
                       "providers/bedrock-mantle",
                       "providers/cerebras",
@@ -2641,6 +2644,7 @@
                 "pages": [
                   "security/network-proxy",
                   "security/formal-verification",
+                  "security/incident-response",
                   "security/THREAT-MODEL-ATLAS",
                   "security/THREAT-MODEL-ATLAS/reconnaissance",
                   "security/THREAT-MODEL-ATLAS/initial-access",
@@ -2811,6 +2815,7 @@
                       "cli/promos",
                       "cli/sessions",
                       "cli/tasks",
+                      "cli/transcripts",
                       "cli/wiki"
                     ]
                   },


### PR DESCRIPTION
## What

Five docs pages exist, are linked from other pages, and were absent from `docs/docs.json` navigation entirely — reachable only by search or by following an inbound link. This adds each one to the group its siblings suggest. Nav entries only; no page content, no routes, no redirects change.

| Page | Placed in | Inbound links (files / occurrences) |
| --- | --- | --- |
| `channels/bot-loop-protection` | Channels > Configuration, after `channels/access-groups` | 8 / 11 |
| `cli/transcripts` | Reference > CLI commands > Agents, models, and sessions (alphabetical, between `cli/tasks` and `cli/wiki`) | 7 / 10 |
| `plugins/copilot` | Capabilities > Plugin guides, after the Codex group | 7 / 10 |
| `providers/baseten` | Models > Providers > Chat and coding models (alphabetical, between `arcee` and `bedrock`) | 3 / 3 |
| `security/incident-response` | Gateway & Ops > Security, after `security/formal-verification` | 4 / 4 |

Each was verified absent from the **whole** nav, not just from the group the finding expected: flattening all 1112 English nav routes gives 0 hits for each of the five.

Two placements deviate from what the audit row suggested, with reasons:

- **`security/incident-response`** — the row said "next to `gateway/security/exposure-runbook`". That page is the operator hardening handbook; `security/incident-response` is the project's own report-triage process, and every inbound link to it comes from `security/formal-verification`, `security/CONTRIBUTING-THREAT-MODEL` and `security/THREAT-MODEL-ATLAS` — all in the `Gateway & Ops > Security` group. Placed with its siblings there instead. This also keeps the diff out of `/docs/gateway/security/`, which is CODEOWNERS-gated to secops.
- **`plugins/copilot`** — placed as a bare page after the Codex group rather than inside a subgroup. Copilot SDK harness is the sibling of the Codex harness, and bare pages among subgroups are an existing pattern in this file (`channels/googlechat`, `providers/opencode`).

## Refuted, not fixed

- **`channels/qa-channel` (second half of r3-0900) — refuted.** Its absence from nav is deliberate and machine-enforced. `extensions/qa-channel/package.json` declares `openclaw.channel.exposure.docs: false`, and `findUnexpectedOfficialChannelDocsNavRoutes` in `scripts/write-official-channel-catalog.mts` fails `test/official-channel-catalog.test.ts` if a route so marked appears **anywhere** in the nav. Adding it would have turned a green test red. The page is a private, repo-local synthetic QA transport excluded from packaged installs.
- **r3-0930 "`tools/tts` appears twice in the nav" — refuted.** No route appears twice: flattening all 1112 English routes and running `sort | uniq -d` returns nothing. `tools/tts` appears once, in Capabilities > Tools > Media and documents.
- **r3-2416 "Exec page listed after its two approvals sub-pages" — refuted.** The current order is already `tools/exec`, `tools/exec-approvals`, `tools/exec-approvals-advanced`.

## Group-organisation rows left alone (deliberately)

These are editorial judgments about someone else's IA, and renaming or re-grouping changes what readers have bookmarked. Recorded here rather than acted on:

- **r3-0923** ("Gateway & Ops has two groups named Security") — **the premise does not hold.** The groups are named `Security and sandboxing` (nested under Gateway) and `Security` (top level of the tab). They are not identically named, so this is not the unambiguous duplicate-label defect. The observation underneath it is fair — one is an operator hardening handbook, the other is threat-model and research — and if a maintainer wants it, renaming the second group to `Threat model and research` would be the change. Note this PR's `security/incident-response` placement rests on that same audience split.
- **r3-0925** ("Two pages titled Logging in one group") — **premise does not hold.** `docs/logging.md` is titled `Logging` and `docs/gateway/logging.md` is titled `Gateway logging`; neither sets `sidebarTitle`, so the nav shows two distinct labels. The suggested fix (merge one into the other plus a redirect) is a content merge, out of scope for a nav change.
- **r3-0921** (Release & CI mixes release notes with maintainer CI docs) — splitting the tab is defensible, but `test/scripts/docs-sync-publish.test.ts` pins the exact flattened route list of this tab *and* asserts the tab is the fourth-from-last, and every locale nav is derived from it. That is a maintainer-sized change, not an audit follow-up.
- **r3-0924** (contributor test docs in the Help tab) — moving `help/testing*` beside `reference/test` would move them into the Release & CI tab, which is the same pinned-route-list problem, and Help is where readers currently find them.

## Validation

- `pnpm check:docs` — exit 0 (formatting 1280 files clean, markdownlint 0 issues, mdx, i18n glossary, links, config examples).
- `node scripts/docs-link-audit.mjs --anchors` — 3 broken links, all the pre-existing `maturity/#windows-app-node` ones; unchanged from baseline.
- Every test that reads `docs.json` (6 files, 81 tests, all pass):
  - `test/scripts/docs-sync-publish.test.ts` — pins the exact flattened Release & CI route list. Untouched by this change.
  - `test/official-channel-catalog.test.ts` — the one that refuted `channels/qa-channel`.
  - `test/scripts/render-maturity-docs.test.ts`
  - `src/scripts/docs-link-audit.test.ts`
  - `src/docs/cloud-workers-config.test.ts` ("lists Cloud Workers exactly once in English navigation")
  - `src/agents/docs-path.test.ts` — note this one does **not** run under `vitest.full-core-unit-src.config.ts` (silently zero files); it needs `vitest.agents-core.config.ts`.
- No glossary change needed: no list-item links were added to any markdown doc.
- CODEOWNERS: no rule matches `docs/docs.json`, so no ownership gate.
- Redirects: `docs.json`'s redirect map targets none of the five routes, and nothing is moved, so there is no redirect risk.
