### PR TITLE
perf(plugins): avoid metadata generation imports for path resolution

### DIFF
--- a/src/plugins/bundled-channel-runtime.ts
+++ b/src/plugins/bundled-channel-runtime.ts
@@ -1,7 +1,7 @@
 /** Loads bundled channel plugin runtime entries and setup metadata. */
 import path from "node:path";
 import { isVitestRuntimeEnv } from "../infra/env.js";
-import { resolveBundledPluginGeneratedPath } from "./bundled-plugin-metadata.js";
+import { resolveBundledPluginGeneratedPath } from "./bundled-plugin-scan.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import { pluginCacheExistsSync } from "./plugin-cache-files.js";

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -7,10 +7,8 @@ import { assert, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { expectNoReaddirSyncDuring } from "../test-utils/fs-scan-assertions.js";
 import { listGitTrackedFiles, toRepoRelativePath } from "../test-utils/repo-files.js";
 import { collectBundledChannelConfigsCore } from "./bundled-channel-config-metadata.js";
-import {
-  listBundledPluginMetadata,
-  resolveBundledPluginGeneratedPath,
-} from "./bundled-plugin-metadata.js";
+import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
+import { resolveBundledPluginGeneratedPath } from "./bundled-plugin-scan.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 
 type BundledPluginMetadata = ReturnType<typeof listBundledPluginMetadata>[number];

--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -2,11 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { tryReadJsonSync } from "../infra/json-files.js";
-import { isPathInside } from "../infra/path-guards.js";
 import { collectBundledChannelConfigsCore } from "./bundled-channel-config-metadata.js";
 import {
+  type BundledPluginPathPair,
   collectBundledPluginPublicSurfaceArtifacts,
   collectBundledPluginRuntimeSidecarArtifacts,
   deriveBundledPluginIdHint,
@@ -33,11 +32,6 @@ const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const RUNNING_FROM_BUILT_ARTIFACT =
   CURRENT_MODULE_PATH.includes(`${path.sep}dist${path.sep}`) ||
   CURRENT_MODULE_PATH.includes(`${path.sep}dist-runtime${path.sep}`);
-
-type BundledPluginPathPair = {
-  source: string;
-  built: string;
-};
 
 /** Metadata collected from a bundled plugin package and manifest. */
 type BundledPluginMetadata = {
@@ -198,120 +192,4 @@ export function findBundledPluginMetadataById(
   },
 ): BundledPluginMetadata | undefined {
   return listBundledPluginMetadata(params).find((entry) => entry.manifest.id === pluginId);
-}
-
-function listBundledPluginEntryBaseDirs(params: {
-  rootDir: string;
-  pluginDirName?: string;
-  scanDir?: string;
-}): string[] {
-  const scanPluginRoot = params.scanDir
-    ? path.resolve(params.scanDir, params.pluginDirName ?? "")
-    : undefined;
-  const baseDirs = [
-    ...(scanPluginRoot ? [path.resolve(scanPluginRoot, "dist")] : []),
-    ...(scanPluginRoot ? [scanPluginRoot] : []),
-    path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
-    path.resolve(params.rootDir, "dist-runtime", "extensions", params.pluginDirName ?? ""),
-    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? "", "dist"),
-    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
-  ];
-  return uniqueStrings(baseDirs);
-}
-
-function listBundledPluginEntryRoots(params: {
-  rootDir: string;
-  pluginDirName?: string;
-  scanDir?: string;
-}): string[] {
-  const roots = [
-    ...(params.scanDir ? [path.resolve(params.scanDir, params.pluginDirName ?? "")] : []),
-    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
-    path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
-    path.resolve(params.rootDir, "dist-runtime", "extensions", params.pluginDirName ?? ""),
-  ];
-  return uniqueStrings(roots);
-}
-
-function listBundledPluginEntrySearchPaths(
-  entry: BundledPluginPathPair,
-  params: {
-    rootDir: string;
-    pluginDirName?: string;
-    scanDir?: string;
-  },
-): string[] {
-  const paths: string[] = [];
-  const roots = listBundledPluginEntryRoots(params);
-  for (const rawEntry of [entry.built, entry.source]) {
-    if (typeof rawEntry !== "string" || rawEntry.length === 0) {
-      continue;
-    }
-    if (!path.isAbsolute(rawEntry)) {
-      paths.push(rawEntry);
-      continue;
-    }
-    const normalizedEntry = path.normalize(rawEntry);
-    for (const root of roots) {
-      if (!isPathInside(root, normalizedEntry)) {
-        continue;
-      }
-      const relativeEntry = path.relative(root, normalizedEntry);
-      const builtEntry = rewriteBundledPluginEntryToBuiltPath(relativeEntry);
-      if (builtEntry) {
-        paths.push(builtEntry);
-      }
-      paths.push(relativeEntry);
-    }
-  }
-  return uniqueStrings(paths);
-}
-
-/** Resolves a generated runtime path for a bundled plugin entry. */
-export function resolveBundledPluginGeneratedPath(
-  rootDir: string,
-  entry: BundledPluginPathPair | undefined,
-  pluginDirName?: string,
-  scanDir?: string,
-): string | null {
-  if (!entry) {
-    return null;
-  }
-  const entryOrder = listBundledPluginEntrySearchPaths(entry, {
-    rootDir,
-    pluginDirName,
-    ...(scanDir ? { scanDir } : {}),
-  });
-  const baseDirs = listBundledPluginEntryBaseDirs({
-    rootDir,
-    pluginDirName,
-    ...(scanDir ? { scanDir } : {}),
-  });
-  for (const baseDir of baseDirs) {
-    for (const entryPath of entryOrder) {
-      const candidate = resolveBundledPluginEntryCandidate(baseDir, entryPath);
-      if (!candidate) {
-        continue;
-      }
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return null;
-}
-
-function normalizeRelativePluginEntryPath(entryPath: string): string {
-  return entryPath.replace(/^\.\//u, "");
-}
-
-function resolveBundledPluginEntryCandidate(baseDir: string, entryPath: string): string | null {
-  const normalizedEntryPath = normalizeRelativePluginEntryPath(entryPath);
-  const candidate = path.isAbsolute(normalizedEntryPath)
-    ? path.normalize(normalizedEntryPath)
-    : path.resolve(baseDir, normalizedEntryPath);
-  if (!isPathInside(baseDir, candidate)) {
-    return null;
-  }
-  return candidate;
 }

--- a/src/plugins/bundled-plugin-scan.ts
+++ b/src/plugins/bundled-plugin-scan.ts
@@ -2,8 +2,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
-import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
+import {
+  normalizeTrimmedStringList,
+  uniqueStrings,
+} from "../../packages/normalization-core/src/string-normalization.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { PUBLIC_SURFACE_SOURCE_EXTENSIONS } from "./public-surface-runtime.js";
+
+export type BundledPluginPathPair = {
+  source: string;
+  built: string;
+};
 
 const RUNTIME_SIDECAR_ARTIFACTS = new Set([
   "helper-api.js",
@@ -135,4 +144,120 @@ export function resolveBundledPluginScanDir(params: {
     return builtDir;
   }
   return undefined;
+}
+
+function listBundledPluginEntryBaseDirs(params: {
+  rootDir: string;
+  pluginDirName?: string;
+  scanDir?: string;
+}): string[] {
+  const scanPluginRoot = params.scanDir
+    ? path.resolve(params.scanDir, params.pluginDirName ?? "")
+    : undefined;
+  const baseDirs = [
+    ...(scanPluginRoot ? [path.resolve(scanPluginRoot, "dist")] : []),
+    ...(scanPluginRoot ? [scanPluginRoot] : []),
+    path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
+    path.resolve(params.rootDir, "dist-runtime", "extensions", params.pluginDirName ?? ""),
+    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? "", "dist"),
+    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
+  ];
+  return uniqueStrings(baseDirs);
+}
+
+function listBundledPluginEntryRoots(params: {
+  rootDir: string;
+  pluginDirName?: string;
+  scanDir?: string;
+}): string[] {
+  const roots = [
+    ...(params.scanDir ? [path.resolve(params.scanDir, params.pluginDirName ?? "")] : []),
+    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
+    path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
+    path.resolve(params.rootDir, "dist-runtime", "extensions", params.pluginDirName ?? ""),
+  ];
+  return uniqueStrings(roots);
+}
+
+function listBundledPluginEntrySearchPaths(
+  entry: BundledPluginPathPair,
+  params: {
+    rootDir: string;
+    pluginDirName?: string;
+    scanDir?: string;
+  },
+): string[] {
+  const paths: string[] = [];
+  const roots = listBundledPluginEntryRoots(params);
+  for (const rawEntry of [entry.built, entry.source]) {
+    if (typeof rawEntry !== "string" || rawEntry.length === 0) {
+      continue;
+    }
+    if (!path.isAbsolute(rawEntry)) {
+      paths.push(rawEntry);
+      continue;
+    }
+    const normalizedEntry = path.normalize(rawEntry);
+    for (const root of roots) {
+      if (!isPathInside(root, normalizedEntry)) {
+        continue;
+      }
+      const relativeEntry = path.relative(root, normalizedEntry);
+      const builtEntry = rewriteBundledPluginEntryToBuiltPath(relativeEntry);
+      if (builtEntry) {
+        paths.push(builtEntry);
+      }
+      paths.push(relativeEntry);
+    }
+  }
+  return uniqueStrings(paths);
+}
+
+/** Resolves a generated runtime path for a bundled plugin entry. */
+export function resolveBundledPluginGeneratedPath(
+  rootDir: string,
+  entry: BundledPluginPathPair | undefined,
+  pluginDirName?: string,
+  scanDir?: string,
+): string | null {
+  if (!entry) {
+    return null;
+  }
+  const entryOrder = listBundledPluginEntrySearchPaths(entry, {
+    rootDir,
+    pluginDirName,
+    ...(scanDir ? { scanDir } : {}),
+  });
+  const baseDirs = listBundledPluginEntryBaseDirs({
+    rootDir,
+    pluginDirName,
+    ...(scanDir ? { scanDir } : {}),
+  });
+  for (const baseDir of baseDirs) {
+    for (const entryPath of entryOrder) {
+      const candidate = resolveBundledPluginEntryCandidate(baseDir, entryPath);
+      if (!candidate) {
+        continue;
+      }
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function normalizeRelativePluginEntryPath(entryPath: string): string {
+  return entryPath.replace(/^\.\//u, "");
+}
+
+function resolveBundledPluginEntryCandidate(baseDir: string, entryPath: string): string | null {
+  const normalizedEntryPath = normalizeRelativePluginEntryPath(entryPath);
+  const candidate = path.isAbsolute(normalizedEntryPath)
+    ? path.normalize(normalizedEntryPath)
+    : path.resolve(baseDir, normalizedEntryPath);
+  if (!isPathInside(baseDir, candidate)) {
+    return null;
+  }
+  return candidate;
 }


### PR DESCRIPTION
## What Problem This Solves

Bundled channel path resolution imports the full plugin metadata generator for one filesystem helper. That eagerly loads synthetic channel-config generation on a runtime path that only needs source/build path selection.

## Why This Change Was Made

Move the unchanged generated-path resolver, path-pair type and adjacent ordering/containment helpers into the existing bundled-plugin scan module. Point the runtime caller and existing path tests at that owner. Metadata listing and schema generation remain on their existing paths.

No path precedence, containment, fallback, registry, cache, configuration or public SDK behavior changes. The old internal resolver export is removed. Production is net +3 lines from imports/type sharing; tests are net -2, with no assertion or scenario removed.

## User Impact

Runtime path resolution avoids loading unused metadata-generation code. In a source-only, same-checkout A/B/A comparison, all 13 question-authority cases passed in the same order. Complete wrapper time was 97.59s / 84.60s / 93.15s: about 9–13% lower with this change. The first case was 31.80s / 30.69s / 31.52s, so most of the observed gain was file setup. These local results do not claim a whole-CI or universal startup improvement.

## Evidence

All 42 focused metadata, synthetic-config/public-surface and bundled-channel runtime cases passed, including source/built/direct-scan priority and containment. The three benchmark runs preserved all 13 existing cases, deadlines and assertions; source and dependency seals matched, and temporary roots and workers were cleaned up.

Independent P2 review found no actionable issues, and all changed-file gates passed. The canonical build passed, including SDK exports and CLI bootstrap checks. The standard built iMessage import profile passed at 100.7 MB peak RSS (54.1 MB above its empty-process baseline); this is artifact validation, not a comparative memory claim. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34452572364) passed at d5fb3f1112494d51cef4413692e84b618373ad47.

The two before-merge items and rank-up request in the September 10 ClawSweeper review are now addressed by the completed canonical build and standard affected-plugin import profile above. Packaged startup speed was not compared; the timing claim remains limited to the controlled source-checkout test runs.
