### PR TITLE
fix(qa): release live transport leases after gateway stop (7.33)

### DIFF
--- a/extensions/qa-lab/src/channel-driver-lifecycle.test.ts
+++ b/extensions/qa-lab/src/channel-driver-lifecycle.test.ts
@@ -7,12 +7,19 @@ import type { QaTransportAdapter } from "./qa-transport.js";
 
 describe("QA channel driver lifecycle", () => {
   it("runs all lifecycle scenarios through create and cleanup", async () => {
-    const runtimes: Array<{ adapter: QaTransportAdapter; cleanup: () => Promise<void> }> = [];
+    const runtimes: Array<{
+      adapter: QaTransportAdapter;
+      cleanupBeforeGatewayStop: () => Promise<void>;
+      cleanupAfterGatewayStop: () => Promise<void>;
+      cleanupWithoutGateway: () => Promise<void>;
+    }> = [];
     const createAdapter = vi.fn(async () => {
       const id = runtimes.length + 1;
       const runtime = {
         adapter: { id: String(id) } as QaTransportAdapter,
-        cleanup: vi.fn(async () => {}),
+        cleanupBeforeGatewayStop: vi.fn(async () => {}),
+        cleanupAfterGatewayStop: vi.fn(async () => {}),
+        cleanupWithoutGateway: vi.fn(async () => {}),
       };
       runtimes.push(runtime);
       return runtime;
@@ -26,7 +33,7 @@ describe("QA channel driver lifecycle", () => {
 
     const results = await runQaChannelDriverLifecycleScenarios({
       async assertStopped(runtime) {
-        expect(runtime.cleanup).toHaveBeenCalledOnce();
+        expect(runtime.cleanupWithoutGateway).toHaveBeenCalledOnce();
         stoppedIds.push(Number(runtime.adapter.id));
       },
       lifecycle,
@@ -45,7 +52,9 @@ describe("QA channel driver lifecycle", () => {
   it("keeps the running adapter when cleanup fails", async () => {
     const runtime = {
       adapter: {} as QaTransportAdapter,
-      cleanup: vi.fn(async () => {
+      cleanupBeforeGatewayStop: vi.fn(async () => {}),
+      cleanupAfterGatewayStop: vi.fn(async () => {}),
+      cleanupWithoutGateway: vi.fn(async () => {
         throw new Error("cleanup failed");
       }),
     };

--- a/extensions/qa-lab/src/channel-driver-lifecycle.ts
+++ b/extensions/qa-lab/src/channel-driver-lifecycle.ts
@@ -77,7 +77,7 @@ export function createQaChannelDriverLifecycle(
         return;
       }
       const runtime = state.runtime;
-      await runtime.cleanup();
+      await runtime.cleanupWithoutGateway();
       state = { status: "stopped" };
     },
   };

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts
@@ -1,78 +1,86 @@
-// Qa Lab tests cover Slack live adapter message reconciliation.
-import { describe, expect, it } from "vitest";
-import { createQaBusState } from "../../bus-state.js";
-import { testing } from "./adapter.runtime.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("Slack live adapter reconciliation", () => {
-  it("records streamed updates to the same Slack timestamp as bus edits", async () => {
-    const state = createQaBusState();
-    const busMessageIds = new Map<string, string>();
-    const observedText = new Map<string, string>();
-    const messages: Parameters<typeof testing.recordSlackObservedMessage>[0]["messages"] = {
-      addInboundMessage: (input) => state.addInboundMessage(input),
-      addOutboundMessage: (input) => state.addOutboundMessage(input),
-      editMessage: (input) => state.editMessage(input),
-    };
-    const base = {
-      accountId: "sut",
-      busMessageIds,
-      logicalConversationId: "C123",
-      messages,
-      observedText,
-      sutUserId: "U123",
-    };
+const mocks = vi.hoisted(() => ({
+  acquireQaCredentialLease: vi.fn(),
+  createSlackWebClient: vi.fn(() => ({})),
+  createSlackWriteClient: vi.fn(() => ({})),
+  getSlackIdentity: vi.fn(),
+  heartbeatStop: vi.fn(),
+  heartbeatThrowIfFailed: vi.fn(),
+  leaseRelease: vi.fn(),
+  listSlackMessages: vi.fn(),
+}));
 
-    await testing.recordSlackObservedMessage({
-      ...base,
-      message: { text: "QA-", ts: "123.000001", user: "U123" },
+vi.mock("@openclaw/slack/api.js", () => ({
+  createSlackWebClient: mocks.createSlackWebClient,
+  createSlackWriteClient: mocks.createSlackWriteClient,
+}));
+
+vi.mock("../shared/credential-lease.runtime.js", () => ({
+  acquireQaCredentialLease: mocks.acquireQaCredentialLease,
+  startQaCredentialLeaseHeartbeat: () => ({
+    stop: mocks.heartbeatStop,
+    throwIfFailed: mocks.heartbeatThrowIfFailed,
+  }),
+}));
+
+vi.mock("./slack-live.runtime.js", () => ({
+  __testing: {
+    buildSlackQaConfig: vi.fn(() => ({})),
+    getSlackIdentity: mocks.getSlackIdentity,
+    listSlackMessages: mocks.listSlackMessages,
+    listSlackThreadMessages: vi.fn(),
+    parseSlackQaCredentialPayload: vi.fn(),
+    resolveSlackQaRuntimeEnv: vi.fn(),
+    sendSlackChannelMessage: vi.fn(),
+    waitForSlackChannelStable: vi.fn(),
+  },
+}));
+
+import { createSlackQaTransportAdapter } from "./adapter.runtime.js";
+
+describe("Slack QA transport adapter cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.acquireQaCredentialLease.mockResolvedValue({
+      payload: {
+        channelId: "C123",
+        driverBotToken: "driver-token",
+        sutAppToken: "sut-app-token",
+        sutBotToken: "sut-token",
+      },
+      release: mocks.leaseRelease,
     });
-    await testing.recordSlackObservedMessage({
-      ...base,
-      message: { text: "QA-CHANNEL-BASELINE-OK", ts: "123.000001", user: "U123" },
-    });
-
-    const snapshot = state.getSnapshot();
-    expect(snapshot.messages).toHaveLength(1);
-    expect(snapshot.messages[0]?.text).toBe("QA-CHANNEL-BASELINE-OK");
-    expect(snapshot.events.map((event) => event.kind)).toEqual([
-      "outbound-message",
-      "message-edited",
-    ]);
+    mocks.getSlackIdentity
+      .mockResolvedValueOnce({ userId: "U-driver" })
+      .mockResolvedValueOnce({ userId: "U-sut" });
   });
 
-  it("maps observed thread replies to the root bus message", async () => {
-    const state = createQaBusState();
-    const root = state.addInboundMessage({
-      accountId: "sut",
-      conversation: { id: "C123", kind: "channel" },
-      senderId: "U456",
-      text: "root",
-    });
-    const busMessageIds = new Map([["123.000001", root.id]]);
+  it("holds the credential lease until gateway teardown has completed", async () => {
+    let resolvePoll: ((messages: unknown[]) => void) | undefined;
+    mocks.listSlackMessages.mockImplementation(
+      async () =>
+        await new Promise<unknown[]>((resolve) => {
+          resolvePoll = resolve;
+        }),
+    );
 
-    await testing.recordSlackObservedMessage({
-      accountId: "sut",
-      busMessageIds,
-      logicalConversationId: "C123",
-      message: {
-        text: "thread reply",
-        thread_ts: "123.000001",
-        ts: "123.000002",
-        user: "U123",
-      },
-      messages: {
-        addInboundMessage: (input) => state.addInboundMessage(input),
-        addOutboundMessage: (input) => state.addOutboundMessage(input),
-        editMessage: (input) => state.editMessage(input),
-      },
-      observedText: new Map(),
-      sutUserId: "U123",
-    });
+    const adapter = await createSlackQaTransportAdapter({
+      adapterOptions: {},
+      messages: {},
+    } as never);
+    await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
 
-    expect(state.getSnapshot().messages.at(-1)).toMatchObject({
-      direction: "outbound",
-      text: "thread reply",
-      threadId: root.id,
-    });
+    const cleanup = adapter.cleanup?.();
+    resolvePoll?.([]);
+    await cleanup;
+
+    expect(mocks.heartbeatStop).not.toHaveBeenCalled();
+    expect(mocks.leaseRelease).not.toHaveBeenCalled();
+
+    await adapter.cleanupAfterGatewayStop?.();
+
+    expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+    expect(mocks.leaseRelease).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -10,7 +10,9 @@ import { __testing as slackLive } from "./slack-live.runtime.js";
 
 type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
-type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>> & {
+  cleanupAfterGatewayStop?: () => Promise<void>;
+};
 type SlackRuntimeEnv = ReturnType<typeof slackLive.resolveSlackQaRuntimeEnv>;
 type SlackObservedMessage = Awaited<ReturnType<typeof slackLive.listSlackMessages>>[number];
 
@@ -76,8 +78,11 @@ export async function createSlackQaTransportAdapter(
       slackLive.getSlackIdentity(runtimeEnv.sutBotToken),
     ]);
   } catch (error) {
-    await heartbeat.stop();
-    await lease.release();
+    try {
+      await heartbeat.stop();
+    } finally {
+      await lease.release();
+    }
     throw error;
   }
   const driverClient = createSlackWriteClient(runtimeEnv.driverBotToken);
@@ -205,8 +210,13 @@ export async function createSlackQaTransportAdapter(
     async cleanup() {
       stopped = true;
       await polling.catch(() => undefined);
-      await heartbeat.stop();
-      await lease.release();
+    },
+    async cleanupAfterGatewayStop() {
+      try {
+        await heartbeat.stop();
+      } finally {
+        await lease.release();
+      }
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireQaCredentialLease: vi.fn(),
+  callTelegramApi: vi.fn(),
+  flushTelegramUpdates: vi.fn(),
+  heartbeatStop: vi.fn(),
+  heartbeatThrowIfFailed: vi.fn(),
+  leaseRelease: vi.fn(),
+}));
+
+vi.mock("../shared/credential-lease.runtime.js", () => ({
+  acquireQaCredentialLease: mocks.acquireQaCredentialLease,
+  startQaCredentialLeaseHeartbeat: () => ({
+    stop: mocks.heartbeatStop,
+    throwIfFailed: mocks.heartbeatThrowIfFailed,
+  }),
+}));
+
+vi.mock("./telegram-live.runtime.js", () => ({
+  __testing: {
+    buildTelegramQaConfig: vi.fn(() => ({})),
+    callTelegramApi: mocks.callTelegramApi,
+    flushTelegramUpdates: mocks.flushTelegramUpdates,
+    parseTelegramQaCredentialPayload: vi.fn(),
+    resolveTelegramQaRuntimeEnv: vi.fn(),
+    waitForTelegramChannelRunning: vi.fn(),
+  },
+}));
+
+import { createTelegramQaTransportAdapter } from "./adapter.runtime.js";
+
+describe("Telegram QA transport adapter cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.acquireQaCredentialLease.mockResolvedValue({
+      payload: {
+        groupId: "-100123",
+        driverToken: "driver-token",
+        sutToken: "sut-token",
+      },
+      release: mocks.leaseRelease,
+    });
+    mocks.flushTelegramUpdates.mockResolvedValue(0);
+  });
+
+  it("holds the credential lease until gateway teardown has completed", async () => {
+    let getMeCalls = 0;
+    let resolvePoll: ((updates: unknown[]) => void) | undefined;
+    mocks.callTelegramApi.mockImplementation(async (_token: string, method: string) => {
+      if (method === "getMe") {
+        getMeCalls += 1;
+        return getMeCalls === 1
+          ? { id: 1, username: "driver_bot" }
+          : { id: 2, username: "sut_bot" };
+      }
+      if (method === "getUpdates") {
+        return await new Promise<unknown[]>((resolve) => {
+          resolvePoll = resolve;
+        });
+      }
+      throw new Error(`unexpected Telegram API method: ${method}`);
+    });
+
+    const adapter = await createTelegramQaTransportAdapter({
+      adapterOptions: {},
+      messages: {},
+    } as never);
+    await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
+
+    const cleanup = adapter.cleanup?.();
+    resolvePoll?.([]);
+    await cleanup;
+
+    expect(mocks.heartbeatStop).not.toHaveBeenCalled();
+    expect(mocks.leaseRelease).not.toHaveBeenCalled();
+
+    await adapter.cleanupAfterGatewayStop?.();
+
+    expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+    expect(mocks.leaseRelease).toHaveBeenCalledOnce();
+    expect(mocks.heartbeatStop.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.leaseRelease.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("releases the credential lease even when heartbeat shutdown fails", async () => {
+    let getMeCalls = 0;
+    let resolvePoll: ((updates: unknown[]) => void) | undefined;
+    mocks.callTelegramApi.mockImplementation(async (_token: string, method: string) => {
+      if (method === "getMe") {
+        getMeCalls += 1;
+        return { id: getMeCalls, username: `bot_${getMeCalls}` };
+      }
+      if (method === "getUpdates") {
+        return await new Promise<unknown[]>((resolve) => {
+          resolvePoll = resolve;
+        });
+      }
+      throw new Error(`unexpected Telegram API method: ${method}`);
+    });
+    mocks.heartbeatStop.mockRejectedValueOnce(new Error("heartbeat stop failed"));
+
+    const adapter = await createTelegramQaTransportAdapter({
+      adapterOptions: {},
+      messages: {},
+    } as never);
+    await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
+    const cleanup = adapter.cleanup?.();
+    resolvePoll?.([]);
+    await cleanup;
+
+    await expect(adapter.cleanupAfterGatewayStop?.()).rejects.toThrow("heartbeat stop failed");
+    expect(mocks.leaseRelease).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -10,7 +10,9 @@ import { __testing as telegramLive } from "./telegram-live.runtime.js";
 
 type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
-type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>> & {
+  cleanupAfterGatewayStop?: () => Promise<void>;
+};
 type TelegramRuntimeEnv = ReturnType<typeof telegramLive.resolveTelegramQaRuntimeEnv>;
 
 export async function createTelegramQaTransportAdapter(
@@ -25,6 +27,13 @@ export async function createTelegramQaTransportAdapter(
     parsePayload: telegramLive.parseTelegramQaCredentialPayload,
   });
   const heartbeat = startQaCredentialLeaseHeartbeat(credentialLease);
+  const releaseCredentialLease = async () => {
+    try {
+      await heartbeat.stop();
+    } finally {
+      await credentialLease.release();
+    }
+  };
   const runtimeEnv = credentialLease.payload;
   let driverIdentity: { id: number; username?: string };
   let sutIdentity: { id: number; username?: string };
@@ -39,8 +48,7 @@ export async function createTelegramQaTransportAdapter(
       telegramLive.flushTelegramUpdates(runtimeEnv.driverToken),
     ]);
   } catch (error) {
-    await heartbeat.stop();
-    await credentialLease.release();
+    await releaseCredentialLease();
     throw error;
   }
   let stopped = false;
@@ -175,8 +183,9 @@ export async function createTelegramQaTransportAdapter(
     async cleanup() {
       stopped = true;
       await polling.catch(() => undefined);
-      await heartbeat.stop();
-      await credentialLease.release();
+    },
+    async cleanupAfterGatewayStop() {
+      await releaseCredentialLease();
     },
   };
 }

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireQaCredentialLease: vi.fn(),
+  closeDriver: vi.fn(),
+  heartbeatStop: vi.fn(),
+  heartbeatThrowIfFailed: vi.fn(),
+  leaseRelease: vi.fn(),
+  startWhatsAppQaDriverSession: vi.fn(),
+  unpackWhatsAppAuthArchive: vi.fn(),
+}));
+
+vi.mock("@openclaw/whatsapp/api.js", () => ({
+  startWhatsAppQaDriverSession: mocks.startWhatsAppQaDriverSession,
+}));
+
+vi.mock("openclaw/plugin-sdk/temp-path", () => ({
+  resolvePreferredOpenClawTmpDir: () => "/tmp",
+}));
+
+vi.mock("../shared/credential-lease.runtime.js", () => ({
+  acquireQaCredentialLease: mocks.acquireQaCredentialLease,
+  startQaCredentialLeaseHeartbeat: () => ({
+    stop: mocks.heartbeatStop,
+    throwIfFailed: mocks.heartbeatThrowIfFailed,
+  }),
+}));
+
+vi.mock("./whatsapp-live.runtime.js", () => ({
+  __testing: {
+    buildWhatsAppQaConfig: vi.fn(() => ({})),
+    parseWhatsAppQaCredentialPayload: vi.fn(),
+    resolveWhatsAppQaMessageTargets: vi.fn(() => ({
+      driverTarget: "15550000002@s.whatsapp.net",
+      gatewayTarget: "+15550000001",
+    })),
+    resolveWhatsAppQaRuntimeEnv: vi.fn(),
+    unpackWhatsAppAuthArchive: mocks.unpackWhatsAppAuthArchive,
+    waitForWhatsAppChannelStable: vi.fn(),
+  },
+}));
+
+import { createWhatsAppQaTransportAdapter } from "./adapter.runtime.js";
+
+describe("WhatsApp QA transport adapter cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.acquireQaCredentialLease.mockResolvedValue({
+      payload: {
+        driverAuthArchiveBase64: "driver-auth",
+        driverPhoneE164: "+15550000002",
+        sutAuthArchiveBase64: "sut-auth",
+        sutPhoneE164: "+15550000001",
+      },
+      release: mocks.leaseRelease,
+    });
+    vi.spyOn(fs, "mkdtemp").mockResolvedValue("/tmp/qa-auth");
+    vi.spyOn(fs, "rm").mockResolvedValue();
+    mocks.unpackWhatsAppAuthArchive.mockImplementation(
+      async ({ label }: { label: string }) => `/tmp/qa-auth/${label}`,
+    );
+    mocks.startWhatsAppQaDriverSession.mockResolvedValue({
+      close: mocks.closeDriver,
+      getObservedMessages: () => [],
+      sendText: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the lease and gateway auth files until gateway teardown succeeds", async () => {
+    const adapter = await createWhatsAppQaTransportAdapter({
+      adapterOptions: {},
+      messages: {},
+    } as never);
+
+    const cleanup = adapter.cleanup?.();
+    await vi.advanceTimersByTimeAsync(500);
+    await cleanup;
+
+    expect(mocks.closeDriver).toHaveBeenCalledOnce();
+    expect(mocks.heartbeatStop).not.toHaveBeenCalled();
+    expect(mocks.leaseRelease).not.toHaveBeenCalled();
+    expect(fs.rm).not.toHaveBeenCalled();
+
+    await adapter.cleanupAfterGatewayStop?.();
+
+    expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+    expect(mocks.leaseRelease).toHaveBeenCalledOnce();
+    expect(fs.rm).toHaveBeenCalledWith("/tmp/qa-auth", { force: true, recursive: true });
+  });
+
+  it("releases the lease and removes staged auth when initialization cleanup fails", async () => {
+    mocks.startWhatsAppQaDriverSession.mockRejectedValueOnce(new Error("driver start failed"));
+    mocks.heartbeatStop.mockRejectedValueOnce(new Error("heartbeat stop failed"));
+
+    await expect(
+      createWhatsAppQaTransportAdapter({ adapterOptions: {}, messages: {} } as never),
+    ).rejects.toThrow("heartbeat stop failed");
+
+    expect(mocks.leaseRelease).toHaveBeenCalledOnce();
+    expect(fs.rm).toHaveBeenCalledWith("/tmp/qa-auth", { force: true, recursive: true });
+  });
+});

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -14,7 +14,9 @@ import { __testing as whatsappLive } from "./whatsapp-live.runtime.js";
 
 type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
-type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>> & {
+  cleanupAfterGatewayStop?: () => Promise<void>;
+};
 type WhatsAppRuntimeEnv = ReturnType<typeof whatsappLive.resolveWhatsAppQaRuntimeEnv>;
 
 export async function createWhatsAppQaTransportAdapter(
@@ -54,11 +56,17 @@ export async function createWhatsAppQaTransportAdapter(
     sutAuthDir = unpackedSutAuthDir;
     driver = await startWhatsAppQaDriverSession({ authDir: driverAuthDir });
   } catch (error) {
-    await driver?.close().catch(() => undefined);
-    await heartbeat.stop();
-    await lease.release();
-    if (authRoot) {
-      await fs.rm(authRoot, { force: true, recursive: true });
+    try {
+      await driver?.close().catch(() => undefined);
+      await heartbeat.stop();
+    } finally {
+      try {
+        await lease.release();
+      } finally {
+        if (authRoot) {
+          await fs.rm(authRoot, { force: true, recursive: true });
+        }
+      }
     }
     throw error;
   }
@@ -188,9 +196,19 @@ export async function createWhatsAppQaTransportAdapter(
       stopped = true;
       await polling.catch(() => undefined);
       await driver.close();
-      await heartbeat.stop();
-      await lease.release();
-      await fs.rm(authRoot, { force: true, recursive: true });
+    },
+    async cleanupAfterGatewayStop() {
+      // The Gateway still uses SUT auth and the shared lease after the driver closes.
+      // Release them only after the suite confirms Gateway teardown succeeded.
+      try {
+        await heartbeat.stop();
+      } finally {
+        try {
+          await lease.release();
+        } finally {
+          await fs.rm(authRoot, { force: true, recursive: true });
+        }
+      }
     },
   };
 }

--- a/extensions/qa-lab/src/manual-lane.runtime.test.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.test.ts
@@ -2,7 +2,17 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { startQaLabServer, startQaGatewayChild, startQaProviderServer } = vi.hoisted(() => ({
+const {
+  cleanupTransportAfterGatewayStop,
+  cleanupTransportBeforeGatewayStop,
+  createQaTransportAdapter,
+  startQaGatewayChild,
+  startQaLabServer,
+  startQaProviderServer,
+} = vi.hoisted(() => ({
+  cleanupTransportAfterGatewayStop: vi.fn(),
+  cleanupTransportBeforeGatewayStop: vi.fn(),
+  createQaTransportAdapter: vi.fn(),
   startQaLabServer: vi.fn(),
   startQaGatewayChild: vi.fn(),
   startQaProviderServer: vi.fn(),
@@ -20,6 +30,10 @@ vi.mock("./providers/server-runtime.js", () => ({
   startQaProviderServer,
 }));
 
+vi.mock("./qa-transport-registry.js", () => ({
+  createQaTransportAdapter,
+}));
+
 import { runQaManualLane } from "./manual-lane.runtime.js";
 
 describe("runQaManualLane", () => {
@@ -33,9 +47,25 @@ describe("runQaManualLane", () => {
     gatewayStop.mockReset();
     mockStop.mockReset();
     labStop.mockReset();
+    cleanupTransportAfterGatewayStop.mockReset();
+    cleanupTransportBeforeGatewayStop.mockReset();
+    cleanupTransportAfterGatewayStop.mockResolvedValue(undefined);
+    cleanupTransportBeforeGatewayStop.mockResolvedValue(undefined);
+    createQaTransportAdapter.mockReset();
     startQaLabServer.mockReset();
     startQaGatewayChild.mockReset();
     startQaProviderServer.mockReset();
+
+    createQaTransportAdapter.mockResolvedValue({
+      adapter: {
+        buildAgentDelivery: () => ({
+          channel: "qa-channel",
+          to: "dm:qa-operator",
+        }),
+      },
+      cleanupBeforeGatewayStop: cleanupTransportBeforeGatewayStop,
+      cleanupAfterGatewayStop: cleanupTransportAfterGatewayStop,
+    });
 
     startQaLabServer.mockResolvedValue({
       listenUrl: "http://127.0.0.1:43124",
@@ -105,6 +135,14 @@ describe("runQaManualLane", () => {
     });
     expect(result.reply).toBe("Protocol note: mock reply.");
     expect(gatewayStop).toHaveBeenCalledTimes(1);
+    expect(cleanupTransportBeforeGatewayStop).toHaveBeenCalledTimes(1);
+    expect(cleanupTransportAfterGatewayStop).toHaveBeenCalledTimes(1);
+    expect(cleanupTransportBeforeGatewayStop.mock.invocationCallOrder[0]).toBeLessThan(
+      gatewayStop.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(gatewayStop.mock.invocationCallOrder[0]).toBeLessThan(
+      cleanupTransportAfterGatewayStop.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(mockStop).toHaveBeenCalledTimes(1);
     expect(labStop).toHaveBeenCalledTimes(1);
   });
@@ -149,6 +187,7 @@ describe("runQaManualLane", () => {
     ).rejects.toThrow("gateway startup failed");
 
     expect(gatewayStop).not.toHaveBeenCalled();
+    expect(cleanupTransportAfterGatewayStop).toHaveBeenCalledTimes(1);
     expect(mockStop).toHaveBeenCalledTimes(1);
     expect(labStop).toHaveBeenCalledTimes(1);
   });
@@ -169,6 +208,8 @@ describe("runQaManualLane", () => {
     ).rejects.toThrow("gateway stop failed");
 
     expect(gatewayStop).toHaveBeenCalledTimes(1);
+    expect(cleanupTransportBeforeGatewayStop).toHaveBeenCalledTimes(1);
+    expect(cleanupTransportAfterGatewayStop).not.toHaveBeenCalled();
     expect(mockStop).toHaveBeenCalledTimes(1);
     expect(labStop).toHaveBeenCalledTimes(1);
   });

--- a/extensions/qa-lab/src/manual-lane.runtime.ts
+++ b/extensions/qa-lab/src/manual-lane.runtime.ts
@@ -35,12 +35,25 @@ function normalizeManualLaneCleanupError(error: unknown): Error {
   return error instanceof Error ? error : new Error(formatErrorMessage(error));
 }
 
-async function stopManualLaneResources(resources: {
-  gateway?: { stop: () => Promise<void> | void };
+async function stopManualLaneResource(
+  resource: { stop: () => Promise<void> | void } | null | undefined,
+): Promise<Error | undefined> {
+  if (!resource) {
+    return undefined;
+  }
+  try {
+    await resource.stop();
+    return undefined;
+  } catch (error) {
+    return normalizeManualLaneCleanupError(error);
+  }
+}
+
+async function stopManualLaneAuxiliaryResources(resources: {
   lab?: { stop: () => Promise<void> | void };
   mock?: { stop: () => Promise<void> | void } | null;
 }): Promise<Error | undefined> {
-  const stopTasks = [resources.gateway, resources.mock, resources.lab]
+  const stopTasks = [resources.mock, resources.lab]
     .filter((resource): resource is { stop: () => Promise<void> | void } => Boolean(resource))
     .map((resource) => Promise.resolve().then(() => resource.stop()));
   const results = await Promise.allSettled(stopTasks);
@@ -77,7 +90,8 @@ export async function runQaManualLane(params: QaManualLaneParams) {
   let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
   let lab: Awaited<ReturnType<typeof startQaLabServer>> | undefined;
   let mock: Awaited<ReturnType<typeof startQaProviderServer>> | undefined;
-  let transportCleanup: (() => Promise<void>) | undefined;
+  let transportCleanupBeforeGatewayStop: (() => Promise<void>) | undefined;
+  let transportCleanupAfterGatewayStop: (() => Promise<void>) | undefined;
   let result: ManualLaneResult | undefined;
   let cleanupError: Error | undefined;
   let runError: unknown;
@@ -94,7 +108,8 @@ export async function runQaManualLane(params: QaManualLaneParams) {
       state: lab.state,
     });
     const transport = transportFactoryResult.adapter;
-    transportCleanup = transportFactoryResult.cleanup;
+    transportCleanupBeforeGatewayStop = transportFactoryResult.cleanupBeforeGatewayStop;
+    transportCleanupAfterGatewayStop = transportFactoryResult.cleanupAfterGatewayStop;
     mock = await startQaProviderServer(params.providerMode, {
       modelRefs: [params.primaryModel, params.alternateModel],
     });
@@ -171,12 +186,23 @@ export async function runQaManualLane(params: QaManualLaneParams) {
   } catch (error) {
     runError = error;
   } finally {
-    let transportCleanupError: Error | undefined;
-    await transportCleanup?.().catch((error: unknown) => {
-      transportCleanupError = normalizeManualLaneCleanupError(error);
+    let transportCleanupBeforeError: Error | undefined;
+    await transportCleanupBeforeGatewayStop?.().catch((error: unknown) => {
+      transportCleanupBeforeError = normalizeManualLaneCleanupError(error);
     });
-    const resourceCleanupError = await stopManualLaneResources({ gateway, lab, mock });
-    cleanupError = transportCleanupError ?? resourceCleanupError;
+    const gatewayCleanupError = await stopManualLaneResource(gateway);
+    let transportCleanupAfterError: Error | undefined;
+    if (!gatewayCleanupError) {
+      await transportCleanupAfterGatewayStop?.().catch((error: unknown) => {
+        transportCleanupAfterError = normalizeManualLaneCleanupError(error);
+      });
+    }
+    const auxiliaryCleanupError = await stopManualLaneAuxiliaryResources({ lab, mock });
+    cleanupError =
+      transportCleanupBeforeError ??
+      gatewayCleanupError ??
+      transportCleanupAfterError ??
+      auxiliaryCleanupError;
   }
   if (runError) {
     throw new Error(formatErrorMessage(runError), { cause: runError });

--- a/extensions/qa-lab/src/qa-transport-registry.test.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.test.ts
@@ -10,7 +10,10 @@ import {
 } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 
-function createAdapterDefinition(cleanup?: () => Promise<void>) {
+function createAdapterDefinition(
+  cleanup?: () => Promise<void>,
+  cleanupAfterGatewayStop?: () => Promise<void>,
+) {
   const state = createQaBusState();
   return {
     id: "selected",
@@ -32,6 +35,7 @@ function createAdapterDefinition(cleanup?: () => Promise<void>) {
     async handleAction() {},
     createReportNotes: () => [],
     ...(cleanup ? { cleanup } : {}),
+    ...(cleanupAfterGatewayStop ? { cleanupAfterGatewayStop } : {}),
   };
 }
 
@@ -59,7 +63,7 @@ describe("qa transport registry", () => {
     const created = await createQaTransportAdapter(createFactoryContext());
 
     expect(created.adapter.id).toBe("qa-channel");
-    await created.cleanup();
+    await created.cleanupWithoutGateway();
   });
 
   it("selects an injected matching factory", async () => {
@@ -87,7 +91,8 @@ describe("qa transport registry", () => {
 
   it("returns cleanup owned by the selected adapter", async () => {
     const cleanup = vi.fn(async () => undefined);
-    const definition = createAdapterDefinition(cleanup);
+    const cleanupAfterGatewayStop = vi.fn(async () => undefined);
+    const definition = createAdapterDefinition(cleanup, cleanupAfterGatewayStop);
     const factory: QaTransportAdapterFactory = {
       id: "cleanup",
       matches: () => true,
@@ -100,9 +105,16 @@ describe("qa transport registry", () => {
       createFactoryContext({ channelId: "cleanup", driver: "live" }),
     );
 
-    await created.cleanup();
+    await created.cleanupBeforeGatewayStop();
 
     expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanupAfterGatewayStop).not.toHaveBeenCalled();
+
+    await created.cleanupAfterGatewayStop();
+    await created.cleanupWithoutGateway();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanupAfterGatewayStop).toHaveBeenCalledOnce();
   });
 
   it("reports no-match and startup failures with transport context", async () => {

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -25,7 +25,9 @@ export type QaTransportAdapterFactoryResult<
   TAdapter extends QaTransportAdapter = QaTransportAdapter,
 > = {
   adapter: TAdapter;
-  cleanup: () => Promise<void>;
+  cleanupBeforeGatewayStop: () => Promise<void>;
+  cleanupAfterGatewayStop: () => Promise<void>;
+  cleanupWithoutGateway: () => Promise<void>;
 };
 
 export type QaTransportAdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
@@ -101,10 +103,29 @@ export function createQaTransportAdapterFactoryRegistry(
           },
         );
       }
+      let cleanupBeforeGatewayStopComplete = false;
+      let cleanupAfterGatewayStopComplete = false;
+      const cleanupBeforeGatewayStop = async () => {
+        if (cleanupBeforeGatewayStopComplete) {
+          return;
+        }
+        await adapter.cleanup?.();
+        cleanupBeforeGatewayStopComplete = true;
+      };
+      const cleanupAfterGatewayStop = async () => {
+        if (cleanupAfterGatewayStopComplete) {
+          return;
+        }
+        await adapter.cleanupAfterGatewayStop?.();
+        cleanupAfterGatewayStopComplete = true;
+      };
       return {
         adapter,
-        cleanup: async () => {
-          await adapter.cleanup?.();
+        cleanupBeforeGatewayStop,
+        cleanupAfterGatewayStop,
+        cleanupWithoutGateway: async () => {
+          await cleanupBeforeGatewayStop();
+          await cleanupAfterGatewayStop();
         },
       };
     },

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -183,7 +183,9 @@ export function createFailureAwareTransportWaitForCondition(state: QaTransportSt
 
 type QaTransportAdapterDefinition = Awaited<
   ReturnType<NonNullable<QaRunnerCliRegistration["adapterFactory"]>["create"]>
->;
+> & {
+  cleanupAfterGatewayStop?: () => Promise<void>;
+};
 
 export type QaTransportAdapter = Omit<
   QaTransportAdapterDefinition,
@@ -358,6 +360,9 @@ export function createQaStateBackedTransportAdapter(
       ? { createRuntimeEnvPatch: params.createRuntimeEnvPatch }
       : {}),
     ...(params.cleanup ? { cleanup: params.cleanup } : {}),
+    ...(params.cleanupAfterGatewayStop
+      ? { cleanupAfterGatewayStop: params.cleanupAfterGatewayStop }
+      : {}),
   });
   return adapter;
 }

--- a/extensions/qa-lab/src/self-check.ts
+++ b/extensions/qa-lab/src/self-check.ts
@@ -107,7 +107,7 @@ export async function runQaSelfCheckAgainstState(params: {
   });
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
   await fs.writeFile(outputPath, report, "utf8");
-  await transportFactoryResult.cleanup();
+  await transportFactoryResult.cleanupWithoutGateway();
 
   return {
     outputPath,

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -37,6 +37,71 @@ function makeQaSuiteTestLabHandle(): QaLabServerHandle {
 }
 
 describe("qa suite", () => {
+  it("runs the production cleanup plan in dependency order after a failure", async () => {
+    const calls: string[] = [];
+    const failure = new Error("transport close failed");
+    const step = (name: string, error?: Error) => async () => {
+      calls.push(name);
+      if (error) {
+        throw error;
+      }
+    };
+
+    const errors = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+      closeWebSessions: step("web sessions"),
+      cleanupTransportBeforeGatewayStop: step("transport before gateway", failure),
+      cleanupTransportAfterGatewayStop: step("transport after gateway"),
+      stopGateway: step("gateway"),
+      disposeAgentHarnesses: step("agent harnesses"),
+      stopProvider: step("provider"),
+      finishLab: step("lab"),
+    });
+
+    expect(calls).toEqual([
+      "web sessions",
+      "transport before gateway",
+      "gateway",
+      "transport after gateway",
+      "agent harnesses",
+      "provider",
+      "lab",
+    ]);
+    expect(errors).toEqual([failure]);
+  });
+
+  it("keeps the primary suite error as the cause of aggregated cleanup failures", () => {
+    const runError = new Error("gateway infrastructure failed");
+
+    expect(() =>
+      qaSuiteProgressTesting.throwQaSuiteCleanupErrors({
+        cleanupErrors: [new Error("transport cleanup failed")],
+        runFailed: true,
+        runError,
+      }),
+    ).toThrow(expect.objectContaining({ cause: runError }));
+  });
+
+  it("does not release transport credentials when gateway teardown fails", async () => {
+    const calls: string[] = [];
+    const gatewayFailure = new Error("gateway remained alive");
+    const step = (name: string, error?: Error) => async () => {
+      calls.push(name);
+      if (error) {
+        throw error;
+      }
+    };
+
+    const errors = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+      cleanupTransportBeforeGatewayStop: step("transport before gateway"),
+      cleanupTransportAfterGatewayStop: step("transport after gateway"),
+      stopGateway: step("gateway", gatewayFailure),
+      disposeAgentHarnesses: step("agent harnesses"),
+      finishLab: step("lab"),
+    });
+
+    expect(calls).toEqual(["transport before gateway", "gateway", "agent harnesses", "lab"]);
+    expect(errors).toEqual([gatewayFailure]);
+  });
   it("rejects unsupported transport ids before starting the lab", async () => {
     const startLab = vi.fn();
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -295,6 +295,70 @@ async function waitForQaLabReadyOrStopOwned(params: {
   }
 }
 
+async function runQaSuiteCleanupSteps(steps: ReadonlyArray<() => Promise<void>>) {
+  const errors: unknown[] = [];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  return errors;
+}
+
+async function runQaFlowSuiteCleanupPlan(params: {
+  closeWebSessions?: () => Promise<void>;
+  cleanupTransportBeforeGatewayStop: () => Promise<void>;
+  cleanupTransportAfterGatewayStop: () => Promise<void>;
+  stopGateway?: () => Promise<void>;
+  disposeAgentHarnesses: () => Promise<void>;
+  stopProvider?: () => Promise<void>;
+  finishLab: () => Promise<void>;
+}) {
+  const errors = await runQaSuiteCleanupSteps([
+    ...(params.closeWebSessions ? [params.closeWebSessions] : []),
+    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
+    // emit an unhandled response-close rejection during delivery.
+    params.cleanupTransportBeforeGatewayStop,
+  ]);
+  let gatewayStopped = !params.stopGateway;
+  if (params.stopGateway) {
+    const gatewayErrors = await runQaSuiteCleanupSteps([params.stopGateway]);
+    errors.push(...gatewayErrors);
+    gatewayStopped = gatewayErrors.length === 0;
+  }
+  errors.push(
+    ...(await runQaSuiteCleanupSteps([
+      // Never release a credential-backed transport until gateway teardown proves
+      // that the isolated runtime reached its terminal boundary.
+      ...(gatewayStopped ? [params.cleanupTransportAfterGatewayStop] : []),
+      params.disposeAgentHarnesses,
+      ...(params.stopProvider ? [params.stopProvider] : []),
+      params.finishLab,
+    ])),
+  );
+  return errors;
+}
+
+function throwQaSuiteCleanupErrors(params: {
+  cleanupErrors: unknown[];
+  runFailed: boolean;
+  runError: unknown;
+}) {
+  if (params.cleanupErrors.length === 0) {
+    return;
+  }
+  if (params.cleanupErrors.length === 1 && !params.runFailed) {
+    throw params.cleanupErrors[0];
+  }
+  throw new AggregateError(
+    params.runFailed ? [params.runError, ...params.cleanupErrors] : params.cleanupErrors,
+    params.runFailed ? "QA suite and cleanup failed" : "QA suite cleanup failed",
+    params.runFailed ? { cause: params.runError } : undefined,
+  );
+}
+
 function requireQaSuiteStartLab(startLab: QaSuiteStartLabFn | undefined): QaSuiteStartLabFn {
   if (startLab) {
     return startLab;
@@ -972,7 +1036,7 @@ async function runQaRuntimeParitySuite(params: {
       watchUrl: lab.baseUrl,
     } satisfies QaSuiteResult;
   } finally {
-    await transportFactoryResult.cleanup();
+    await transportFactoryResult.cleanupWithoutGateway();
     if (ownsLab) {
       await lab.stop();
     }
@@ -1428,7 +1492,16 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
         });
     };
 
+    let isolatedRunFailed = false;
+    let isolatedRunError: unknown;
+    let parentTransportCleaned = false;
     try {
+      if (params?.channelDriver === "live") {
+        // The parent only renders aggregate artifacts. Release its live credentials
+        // before child workers acquire the same exclusive transport lease.
+        parentTransportCleaned = true;
+        await transportFactoryResult.cleanupWithoutGateway();
+      }
       updateScenarioRun();
       const workerStartStaggerMs =
         params?.workerStartStaggerMs ?? resolveQaSuiteWorkerStartStaggerMs(concurrency);
@@ -1592,12 +1665,24 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
         scenarios,
         watchUrl: lab.baseUrl,
       } satisfies QaSuiteResult;
+    } catch (error) {
+      isolatedRunFailed = true;
+      isolatedRunError = error;
+      throw error;
     } finally {
-      await transportFactoryResult.cleanup();
-      await disposeRegisteredAgentHarnesses();
+      const cleanupSteps: Array<() => Promise<void>> = [
+        ...(!parentTransportCleaned ? [() => transportFactoryResult.cleanupWithoutGateway()] : []),
+        () => disposeRegisteredAgentHarnesses(),
+      ];
       if (ownsLab) {
-        await lab.stop();
+        cleanupSteps.push(() => lab.stop());
       }
+      const cleanupErrors = await runQaSuiteCleanupSteps(cleanupSteps);
+      throwQaSuiteCleanupErrors({
+        cleanupErrors,
+        runFailed: isolatedRunFailed,
+        runError: isolatedRunError,
+      });
     }
   }
 
@@ -1631,6 +1716,8 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
   let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
   let env: QaSuiteEnvironment | undefined;
   let preserveGatewayRuntimeDir: string | undefined;
+  let runFailed = false;
+  let runError: unknown;
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
     const activeMock = await startQaProviderServer(providerMode, {
@@ -1891,28 +1978,38 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
       ...(runtimeParityCell ? { runtimeParityCell } : {}),
     } satisfies QaSuiteResult;
   } catch (error) {
+    runFailed = true;
+    runError = error;
     preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
     throw error;
   } finally {
-    if (env) {
-      await closeQaWebSessions(env.webSessionIds);
-    }
+    const activeEnv = env;
     const keepTemp = process.env.OPENCLAW_QA_KEEP_TEMP === "1" || false;
-    await gateway?.stop({
-      keepTemp,
-      preserveToDir: keepTemp ? undefined : preserveGatewayRuntimeDir,
+    const activeGateway = gateway;
+    const activeMock = mock;
+    const cleanupErrors = await runQaFlowSuiteCleanupPlan({
+      closeWebSessions: activeEnv ? () => closeQaWebSessions(activeEnv.webSessionIds) : undefined,
+      cleanupTransportBeforeGatewayStop: () => transportFactoryResult.cleanupBeforeGatewayStop(),
+      cleanupTransportAfterGatewayStop: () => transportFactoryResult.cleanupAfterGatewayStop(),
+      stopGateway: activeGateway
+        ? () =>
+            activeGateway.stop({
+              keepTemp,
+              preserveToDir: keepTemp ? undefined : preserveGatewayRuntimeDir,
+            })
+        : undefined,
+      disposeAgentHarnesses: () => disposeRegisteredAgentHarnesses(),
+      stopProvider: activeMock ? () => activeMock.stop() : undefined,
+      finishLab: ownsLab
+        ? () => lab.stop()
+        : async () => {
+            lab.setControlUi({
+              controlUiUrl: null,
+              controlUiProxyTarget: null,
+            });
+          },
     });
-    await transportFactoryResult.cleanup();
-    await disposeRegisteredAgentHarnesses();
-    await mock?.stop();
-    if (ownsLab) {
-      await lab.stop();
-    } else {
-      lab.setControlUi({
-        controlUiUrl: null,
-        controlUiProxyTarget: null,
-      });
-    }
+    throwQaSuiteCleanupErrors({ cleanupErrors, runFailed, runError });
   }
 }
 
@@ -1927,12 +2024,14 @@ export const qaSuiteProgressTesting = {
   mergeQaRuntimeEnvPatches,
   parseQaSuiteBooleanEnv,
   remapModelRefForForcedRuntime,
+  runQaFlowSuiteCleanupPlan,
   resolveQaSuiteControlUiEnabled,
   scenarioRequiresControlUi,
   resolveQaSuiteTransportReadyTimeoutMs,
   sanitizeQaSuiteProgressValue,
   shouldRunQaSuiteWithIsolatedScenarioWorkers,
   shouldLogQaSuiteProgress,
+  throwQaSuiteCleanupErrors,
   waitForQaLabReadyOrStopOwned,
   writeQaSuiteArtifacts,
 };


### PR DESCRIPTION
## Summary
- split QA transport cleanup into pre-gateway and post-gateway phases
- stop Telegram, Slack, and WhatsApp observers before gateway shutdown, then release shared credential leases only after shutdown succeeds
- retain WhatsApp gateway auth files until shutdown is confirmed and make initialization rollback release every owned resource
- preserve cleanup error ordering and prevent credential reuse while an old gateway may still be alive

Backport of the lifecycle contract from a676afd54df, adapted to the 7.33 monolithic live-transport adapters.

## Validation
- QA Lab suite: 109 files, 1,415 tests passed
- focused transport and cleanup suite: 34 tests passed
- pnpm check:test-types
- pnpm lint
- git diff --check