### PR TITLE
fix: honor merged provider runtime policy

### DIFF
--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -69,6 +69,81 @@ afterEach(() => {
 });
 
 describe("resolveModelRuntimePolicy", () => {
+  it.each(["custom", ""])("merges trimmed provider policy entries for provider %j", (provider) => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          custom: { baseUrl: "https://custom.example/v1", models: [] },
+          " custom ": {
+            baseUrl: "https://custom.example/v1",
+            agentRuntime: { id: "openclaw" },
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(resolveModelRuntimePolicy({ config, provider, modelId: "custom/qwen-local" })).toEqual({
+      policy: { id: "openclaw" },
+      source: "provider",
+      ...(provider ? {} : { matchedProvider: "custom" }),
+    });
+  });
+
+  it.each([
+    {
+      name: "keeps model policy when later provider rows are omitted",
+      later: {},
+      expected: { policy: { id: "model-runtime" }, source: "model" },
+    },
+    {
+      name: "uses provider policy when later provider rows are explicitly empty",
+      later: { models: [] },
+      expected: { policy: { id: "openclaw" }, source: "provider" },
+    },
+  ])("$name", ({ later, expected }) => {
+    // Authored provider overlays can omit the model list before materialization.
+    const config = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            models: [createModelConfig("model-runtime")],
+          },
+          " custom ": {
+            baseUrl: "https://custom.example/v1",
+            agentRuntime: { id: "openclaw" },
+            ...later,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({ config, provider: "custom", modelId: "qwen-local" }),
+    ).toEqual(expected);
+  });
+
+  it.each([false, true])(
+    "keeps differently cased provider groups separate (reverse=%s)",
+    (reverse) => {
+      const common = { baseUrl: "https://custom.example/v1", models: [] };
+      const lowerCase = { ...common, agentRuntime: { id: "openclaw" } };
+      const otherCase = { ...common, agentRuntime: { id: "auto" } };
+      const config: OpenClawConfig = {
+        models: {
+          providers: reverse
+            ? { " custom ": lowerCase, " Custom ": otherCase }
+            : { " Custom ": otherCase, " custom ": lowerCase },
+        },
+      };
+
+      expect(
+        resolveModelRuntimePolicy({ config, provider: "custom", modelId: "qwen-local" }),
+      ).toEqual({ policy: { id: "openclaw" }, source: "provider" });
+    },
+  );
+
   it("ignores the QA force-runtime override when the private QA gate is unset", () => {
     deleteTestEnvValue("OPENCLAW_BUILD_PRIVATE_QA");
     setTestEnvValue("OPENCLAW_QA_FORCE_RUNTIME", "openclaw");

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -7,6 +7,7 @@
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { resolveMergedModelProviderConfig } from "../config/model-provider-config.js";
 import type { AgentModelEntryConfig } from "../config/types.agent-defaults.js";
 import type { AgentRuntimePolicyConfig } from "../config/types.agents-shared.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
@@ -60,27 +61,6 @@ type AgentModelRuntimePolicyResolution = ResolvedModelRuntimePolicy & {
 
 function hasRuntimePolicy(value: AgentRuntimePolicyConfig | undefined): boolean {
   return Boolean(value?.id?.trim());
-}
-
-function resolveProviderConfig(
-  config: OpenClawConfig | undefined,
-  provider: string | undefined,
-): ModelProviderConfig | undefined {
-  if (!config?.models?.providers || !provider?.trim()) {
-    return undefined;
-  }
-  const providers = config.models.providers;
-  const direct = providers[provider];
-  if (direct) {
-    return direct;
-  }
-  const normalizedProvider = normalizeProviderId(provider);
-  for (const [candidateProvider, providerConfig] of Object.entries(providers)) {
-    if (normalizeProviderId(candidateProvider) === normalizedProvider) {
-      return providerConfig;
-    }
-  }
-  return undefined;
 }
 
 function normalizeModelIdForProvider(
@@ -258,7 +238,9 @@ export function resolveModelRuntimePolicy(
   if (agentModelPolicy.policy) {
     return agentModelPolicy;
   }
-  const providerConfig = resolveProviderConfig(params.config, effectiveProvider);
+  const providerConfig = effectiveProvider
+    ? resolveMergedModelProviderConfig(params.config, effectiveProvider)
+    : undefined;
   const modelConfig = resolveModelConfig({
     providerConfig,
     provider: effectiveProvider,


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where runtime-policy selection ignores settings from a later provider entry with the same trimmed key. The private lookup used a direct property or first normalized match, disagreeing with the existing merged provider-config owner.

## Why This Change Was Made

Use the canonical merged provider configuration and remove the duplicate lookup. Preserve model/agent/wildcard/provider precedence, inferred-provider ambiguity, and separate case-distinct provider groups. Omitted model arrays retain earlier rows; explicit empty arrays remain authoritative. This two-file repair removes 18 production lines.

## User Impact

Runtime selection uses the same effective provider settings as route and authentication preparation.

## Evidence

Six baseline cases demonstrated four intended failures and two controls. All 74 focused policy, harness-policy and runtime-alias cases pass, along with the full changed-file gate and independent P2 review.

A canonical `sourcePerformance` runtime build passed at `b66f032ec35a657dc507d5ebf757acbb11672e17`. Twelve compiled cases called the actual policy and harness-selection functions, covering trimmed explicit/inferred provider merges, omitted/empty model arrays, case order, precedence, ambiguous/absent providers, and the existing override gate. The strict source-import guard passed and the child process group exited. This runtime profile does not build UI or declarations; no external model request was needed for policy selection.
