### PR TITLE
refactor: share thinking-default policy resolution

### DIFF
--- a/src/agents/model-thinking-default-core.ts
+++ b/src/agents/model-thinking-default-core.ts
@@ -3,15 +3,8 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import {
-  resolveSupportedThinkingLevel,
-  resolveThinkingDefaultForModel,
-  resolveThinkingProfile,
-} from "../auto-reply/thinking.js";
-import {
-  resolveThinkingDefaultForModelCore,
-  type ThinkLevel,
-} from "../auto-reply/thinking.shared.js";
+import { resolveThinkingDefaultForModel } from "../auto-reply/thinking.js";
+import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderThinkingPolicySource } from "../plugins/provider-thinking.types.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
@@ -124,29 +117,11 @@ export function resolveThinkingDefaultCore(
   ) {
     return "adaptive";
   }
-  const fallbackParams = {
+  return resolveThinkingDefaultForModel({
     provider: params.provider,
     model: params.model,
     catalog,
     agentRuntime: params.agentRuntime,
-  };
-  if (!params.providerPolicySource) {
-    return resolveThinkingDefaultForModel(fallbackParams);
-  }
-  const profile = resolveThinkingProfile({
-    ...fallbackParams,
-    providerPolicySource: params.providerPolicySource,
-  });
-  if (profile.defaultLevel) {
-    return profile.defaultLevel;
-  }
-  const fallback = resolveThinkingDefaultForModelCore(fallbackParams);
-  if (fallback === "off") {
-    return "off";
-  }
-  return resolveSupportedThinkingLevel({
-    ...fallbackParams,
-    level: "medium",
     providerPolicySource: params.providerPolicySource,
   });
 }

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -347,12 +347,14 @@ export function resolveThinkingDefaultForModel(params: {
   model: string;
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
+  providerPolicySource?: ProviderThinkingPolicySource;
 }): ThinkLevel {
   const profile = resolveThinkingProfile({
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
     agentRuntime: params.agentRuntime,
+    providerPolicySource: params.providerPolicySource,
   });
   if (profile.defaultLevel) {
     return profile.defaultLevel;

--- a/src/gateway/session-utils-model.thinking-default.test.ts
+++ b/src/gateway/session-utils-model.thinking-default.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderThinkingRegistry } from "../plugins/provider-thinking.types.js";
 import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
 
 describe("Gateway all-null thinking map", () => {
@@ -32,6 +33,46 @@ describe("Gateway all-null thinking map", () => {
 
     expect(profile.thinkingLevels).toEqual([]);
     expect(profile.thinkingDefault).toBeUndefined();
+  });
+});
+
+describe("Gateway captured thinking defaults", () => {
+  const provider = "captured-thinking-default-fixture";
+  const captured: ProviderThinkingRegistry = {
+    providers: [
+      {
+        provider: {
+          id: provider,
+          resolveThinkingProfile: () => ({
+            // Medium stays supported so clamping cannot hide a lost policy source.
+            levels: [{ id: "off" }, { id: "low" }, { id: "medium" }],
+            defaultLevel: "low",
+          }),
+        },
+      },
+    ],
+  };
+
+  it.each([
+    { name: "captured", source: captured, expected: "low" },
+    { name: "active", source: "active" as const, expected: "medium" },
+    { name: "ordinary", source: undefined, expected: "medium" },
+    { name: "active or bundled", source: "active-or-bundled" as const, expected: "medium" },
+  ])("uses the $name source for its default", ({ source, expected }) => {
+    const profile = resolveGatewayModelThinkingProfile({
+      cfg: {},
+      agentId: "main",
+      provider,
+      model: "reasoner",
+      agentRuntime: "openclaw",
+      providerPolicySource: source,
+      modelCatalog: [
+        { provider, id: "reasoner", name: "Reasoner", api: "openai-completions", reasoning: true },
+      ],
+    });
+
+    expect(profile.thinkingDefault).toBe(expected);
+    expect(profile.thinkingLevels.map(({ id }) => id)).toContain(expected);
   });
 });
 


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Captured thinking defaults duplicate the generic resolver's profile-default and fallback logic. Keeping two implementations aligned makes it easier to lose the prepared provider policy or choose a different fallback during model-runtime changes.

## Why This Change Was Made

Pass the existing captured policy source into the generic resolver and reuse its result. Preserve the live Gateway adapter, configured overrides, provider-family handling, and active-only versus bundled policy lookup. This maintainer-requested cleanup removes 23 production lines across two files.

## User Impact

Thinking defaults and supported levels remain consistent with the selected provider-policy source.

## Evidence

All 237 focused owner/Gateway tests pass, with clean P2 review and the full changed-file gate. A missing-forwarding control failed only the captured-default case; restoring the candidate passed it while retaining the ordinary/active controls.

One canonical `sourcePerformance` runtime build passed at `bf2051646d7bb0621957a59b3c63cc3d94e0005e`. Six compiled cases called the actual Gateway thinking-profile boundary: the captured source returned low, active/ordinary/active-or-bundled controls returned medium, and configured medium/off overrides remained authoritative. All 2,241 guarded imports were compiled, with no source imports; the child exited and its process group disappeared. This runtime profile does not build UI or declarations. No operator Gateway or external model request was used.
