### PR TITLE
refactor: remove the Responses transport test global

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -659,7 +659,7 @@ function resolveAzureDeploymentName(model: Model): string {
   });
 }
 
-export function createAzureOpenAIClient(
+function createAzureOpenAIClient(
   model: Model,
   apiKey: string,
   defaultHeaders: Record<string, string>,

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -13,7 +13,7 @@ import {
   buildOpenAIResponsesReasoningReplayMetadata,
   suppressOpenAIResponsesCompaction,
 } from "./openai-responses-compaction-replay.js";
-import { stringifyRedactedEvent, stringifyRedactedPayload } from "./openai-responses-debug.js";
+import { stringifyRedactedEvent, summarizeResponsesPayload } from "./openai-responses-debug.js";
 import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
 import {
   processResponsesStream,
@@ -1041,8 +1041,19 @@ describe("OpenAI Responses compaction replay", () => {
     const secret = "opaque-preview-compaction";
     const value = { input: [{ type: "compaction", encrypted_content: secret }] };
 
-    expect(stringifyRedactedPayload(value)).not.toContain(secret);
-    expect(stringifyRedactedEvent(value)).not.toContain(secret);
-    expect(stringifyRedactedPayload(value)).toContain("<opaque data omitted>");
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
+    try {
+      const payload = summarizeResponsesPayload(value);
+      expect(payload).not.toContain(secret);
+      expect(stringifyRedactedEvent(value)).not.toContain(secret);
+      expect(payload).toContain("<opaque data omitted>");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
   });
 });

--- a/packages/ai/src/transports/openai-responses-debug.ts
+++ b/packages/ai/src/transports/openai-responses-debug.ts
@@ -151,7 +151,7 @@ function readResponsesToolDisplayName(tool: unknown): string {
   return typeof type === "string" && type !== "function" ? type : "";
 }
 
-export function summarizeResponsesTools(tools: unknown): string {
+function summarizeResponsesTools(tools: unknown): string {
   if (!Array.isArray(tools)) {
     return "count=0";
   }
@@ -163,7 +163,7 @@ export function summarizeResponsesTools(tools: unknown): string {
   return `count=${tools.length}${shown ? ` ${label}=${shown}` : ""}`;
 }
 
-export function stringifyRedactedPayload(value: unknown): string {
+function stringifyRedactedPayload(value: unknown): string {
   try {
     const encoded = JSON.stringify(value, (key, child) =>
       key === "encrypted_content" ? "<opaque data omitted>" : child,
@@ -381,7 +381,7 @@ function buildResponsesFailedFailureFields(
   return fields;
 }
 
-export function buildResponsesFailedNoDetailsObservation(
+function buildResponsesFailedNoDetailsObservation(
   event: Record<string, unknown>,
   model: Model,
   response: Record<string, unknown> | undefined = isRecord(event.response)
@@ -419,7 +419,7 @@ export function buildResponsesFailedNoDetailsObservation(
   };
 }
 
-export function summarizeResponsesFailedNoDetailsObservation(
+function summarizeResponsesFailedNoDetailsObservation(
   observation: ResponsesFailedNoDetailsObservation,
 ): string {
   const requestIds = observation.requestIdHashes.join(",");

--- a/packages/ai/src/transports/openai-responses-transport.ts
+++ b/packages/ai/src/transports/openai-responses-transport.ts
@@ -1,74 +1,7 @@
-import { formatModelTransportDebugBaseUrl } from "./model-transport-url.js";
 /** OpenAI Responses transport facade. */
-import {
+export {
   createAzureOpenAIResponsesTransportStreamFn,
-  createAzureOpenAIClient,
-  createOpenAIResponsesClient,
   createOpenAIResponsesTransportStreamFn,
 } from "./openai-responses-client.js";
-import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
-import {
-  buildResponsesFailedNoDetailsObservation,
-  normalizeResponsesFailedEvent,
-  summarizeResponsesFailedNoDetailsObservation,
-  summarizeResponsesPayload,
-  summarizeResponsesTools,
-  stringifyRedactedEvent,
-  stringifyRedactedPayload,
-} from "./openai-responses-debug.js";
-import {
-  buildOpenAIResponsesParams,
-  sanitizeOpenAICodexResponsesParams,
-} from "./openai-responses-params-internal.js";
-import {
-  createResponsesStreamWithEncryptedContentRetry,
-  isInvalidEncryptedContentError,
-  resolveAzureOpenAIApiVersion,
-} from "./openai-responses-replay-internal.js";
-import { processResponsesStream } from "./openai-responses-stream-internal.js";
-import {
-  assertCodeModeResponsesToolSurface,
-  buildOpenAIClientHeaders,
-  buildOpenAISdkClientOptions,
-  buildOpenAISdkRequestOptions,
-  enforceCodeModeResponsesToolSurface,
-  getCompat,
-} from "./openai-transport-params.js";
-
-export { createAzureOpenAIResponsesTransportStreamFn, createOpenAIResponsesTransportStreamFn };
 export { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-compact-request.js";
 export { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
-
-const responsesTesting = {
-  getCompat,
-  assertCodeModeResponsesToolSurface,
-  buildOpenAIResponsesParams,
-  buildOpenAIClientHeaders,
-  buildOpenAISdkClientOptions,
-  buildOpenAISdkRequestOptions,
-  createAzureOpenAIClient,
-  createOpenAIResponsesClient,
-  enforceCodeModeResponsesToolSurface,
-  sanitizeOpenAICodexResponsesParams,
-  processResponsesStream,
-  formatModelTransportDebugBaseUrl,
-  buildResponsesFailedNoDetailsObservation,
-  buildOpenAIResponsesReasoningReplayMetadata,
-  isInvalidEncryptedContentError,
-  normalizeResponsesFailedEvent,
-  createResponsesStreamWithEncryptedContentRetry,
-  resolveAzureOpenAIApiVersion,
-  summarizeResponsesFailedNoDetailsObservation,
-  summarizeResponsesPayload,
-  summarizeResponsesTools,
-  stringifyRedactedEvent,
-  stringifyRedactedPayload,
-};
-
-declare global {
-  var openclawOpenAIResponsesTransportTestApi: typeof responsesTesting | undefined;
-}
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  globalThis.openclawOpenAIResponsesTransportTestApi = responsesTesting;
-}

--- a/src/agents/auth-profiles/session-override.model-endpoint.test.ts
+++ b/src/agents/auth-profiles/session-override.model-endpoint.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterAll, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -10,18 +10,6 @@ import { resolveModelWithRegistry } from "../embedded-agent-runner/model.registr
 import { AuthStorage } from "../sessions/auth-storage.js";
 import { ModelRegistry } from "../sessions/model-registry.js";
 import { resolveSessionAuthSelection } from "./session-override.js";
-
-const transportTestApiKey = "openclawOpenAIResponsesTransportTestApi";
-const transportTestApi = Object.getOwnPropertyDescriptor(globalThis, transportTestApiKey);
-
-afterAll(() => {
-  // Arcee's Jiti graph republishes this API with a different transport host than Vite's.
-  if (transportTestApi) {
-    Object.defineProperty(globalThis, transportTestApiKey, transportTestApi);
-  } else {
-    Reflect.deleteProperty(globalThis, transportTestApiKey);
-  }
-});
 
 it.each([
   {

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -1,12 +1,15 @@
+import { getAiTransportHost } from "@openclaw/ai";
 import {
   buildTransportAwareSimpleStreamFn,
+  createAzureOpenAIResponsesTransportStreamFn,
   createBoundaryAwareStreamFnForModel,
   createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
   resolveTransportAwareSimpleApi,
 } from "@openclaw/ai/transports";
 import type { Api, Model } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
+import { logResponsesFailedNoDetails } from "../../packages/ai/src/transports/openai-responses-debug.js";
 import {
   resolveAzureOpenAIApiVersion,
   type OpenAIResponsesOutput,
@@ -24,13 +27,23 @@ import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 describe("openai transport stream", () => {
   it("keeps bounded redacted diagnostics UTF-16 well-formed", () => {
-    const payload = testing.stringifyRedactedPayload(`${"x".repeat(7_998)}🚀tail`);
-    const event = testing.stringifyRedactedEvent(`${"x".repeat(1_998)}🚀tail`);
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
+    try {
+      const payload = testing.summarizeResponsesPayload({ input: `${"x".repeat(7_989)}🚀tail` });
+      const event = testing.stringifyRedactedEvent(`${"x".repeat(1_998)}🚀tail`);
 
-    expect(payload).toContain(`${"x".repeat(7_998)}…<truncated>`);
-    expect(event).toContain(`${"x".repeat(1_998)}…<truncated>`);
-    expect(payload).not.toContain("\uD83D");
-    expect(event).not.toContain("\uD83D");
+      expect(payload).toContain(`payload={"input":"${"x".repeat(7_989)}…<truncated>`);
+      expect(event).toContain(`${"x".repeat(1_998)}…<truncated>`);
+      expect(payload).not.toContain("\uD83D");
+      expect(event).not.toContain("\uD83D");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
   });
 
   it("fails Azure Responses streams when headers arrive but no first event follows", async () => {
@@ -86,8 +99,8 @@ describe("openai transport stream", () => {
       },
     };
 
-    const observation = testing.buildResponsesFailedNoDetailsObservation(event, model);
-    const summary = testing.summarizeResponsesFailedNoDetailsObservation(observation);
+    const observation = testing.normalizeResponsesFailedEvent(event, model).observation;
+    assert(observation);
 
     expect(observation.providerRuntimeFailureKind).toBe("no_error_details");
     expect(observation.responseId).toBe("resp_failed_123");
@@ -96,8 +109,15 @@ describe("openai transport stream", () => {
     expect(observation.metadataKeys).toEqual(["api_key", "litellm_request_id"]);
     expect(observation.requestIdHashes).toHaveLength(6);
     expect(observation.requestIdHashes.join(",")).toContain("sha256:");
-    expect(summary).toContain("responseId=resp_failed_123");
-    expect(summary).toContain("requestIds=");
+    const logWarn = vi.spyOn(getAiTransportHost(), "logWarn").mockImplementation(() => {});
+    try {
+      logResponsesFailedNoDetails(observation);
+      expect(logWarn).toHaveBeenCalledOnce();
+      expect(logWarn.mock.calls[0]?.[1]).toContain("responseId=resp_failed_123");
+      expect(logWarn.mock.calls[0]?.[1]).toContain("requestIds=");
+    } finally {
+      logWarn.mockRestore();
+    }
     expect(JSON.stringify(observation)).not.toContain("litellm_req_plaintext_123");
     expect(JSON.stringify(observation)).not.toContain("provider_req_plaintext_456");
     expect(JSON.stringify(observation)).not.toContain("provider_req_nested_789");
@@ -894,11 +914,13 @@ describe("openai transport stream", () => {
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "tools";
     try {
       expect(
-        testing.summarizeResponsesTools([
-          { type: "function", name: "exec" },
-          { type: "function", function: { name: "wait" } },
-        ]),
-      ).toBe("count=2 names=exec,wait");
+        testing.summarizeResponsesPayload({
+          tools: [
+            { type: "function", name: "exec" },
+            { type: "function", function: { name: "wait" } },
+          ],
+        }),
+      ).toContain("tools=count=2 names=exec,wait");
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
@@ -913,24 +935,26 @@ describe("openai transport stream", () => {
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "tools";
     try {
       expect(
-        testing.summarizeResponsesTools([
-          {
-            type: "function",
-            get function(): { name: string } {
-              throw new Error("responses debug tool function getter exploded");
-            },
-          },
-          {
-            type: "function",
-            function: {
-              get name(): string {
-                throw new Error("responses debug nested name getter exploded");
+        testing.summarizeResponsesPayload({
+          tools: [
+            {
+              type: "function",
+              get function(): { name: string } {
+                throw new Error("responses debug tool function getter exploded");
               },
             },
-          },
-          { type: "function", function: { name: "wait" } },
-        ]),
-      ).toBe("count=3 names=wait");
+            {
+              type: "function",
+              function: {
+                get name(): string {
+                  throw new Error("responses debug nested name getter exploded");
+                },
+              },
+            },
+            { type: "function", function: { name: "wait" } },
+          ],
+        }),
+      ).toContain("tools=count=3 names=wait");
     } finally {
       if (previous === undefined) {
         delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
@@ -1444,33 +1468,60 @@ describe("openai transport stream", () => {
   it.each([
     {
       baseUrl: "https://project.services.ai.azure.com/api/projects/demo/openai/v1",
-      clientName: "OpenAI",
+      azureApiVersion: null,
     },
-    { baseUrl: "https://example.openai.azure.com", clientName: "AzureOpenAI" },
-  ])("preserves $clientName routing and prepared headers", async ({ baseUrl, clientName }) => {
-    const model = {
-      ...createAzureResponsesModel(),
-      baseUrl,
-    };
-    const requests: Request[] = [];
-    const client = testing.createAzureOpenAIClient(
-      model,
-      "test-key",
-      { session_id: "prepared-affinity" },
-      async (input, init) => {
-        requests.push(new Request(input, init));
-        return Response.json({
-          id: "resp_fixture",
-          object: "response",
-          status: "completed",
-          output: [],
+    { baseUrl: "https://example.openai.azure.com", azureApiVersion: "preview" },
+  ])(
+    "preserves Azure routing and prepared headers for $baseUrl",
+    async ({ baseUrl, azureApiVersion }) => {
+      const previousApiVersion = process.env.AZURE_OPENAI_API_VERSION;
+      const model = {
+        ...createAzureResponsesModel(),
+        baseUrl,
+      };
+      const requests: Request[] = [];
+      const fetchOwner = vi
+        .spyOn(getAiTransportHost(), "buildModelFetch")
+        .mockReturnValue(async (input, init) => {
+          requests.push(new Request(input, init));
+          return new Response(
+            `data: ${JSON.stringify({
+              type: "response.completed",
+              response: { id: "resp_fixture", status: "completed", output: [] },
+            })}\n\n`,
+            { headers: { "content-type": "text/event-stream" } },
+          );
         });
-      },
-    );
-    await client.responses.create({ model: model.id, input: "hello" });
-    expect(client.constructor.name).toBe(clientName);
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.headers.get("session_id")).toBe("prepared-affinity");
-  });
+      process.env.AZURE_OPENAI_API_VERSION = "preview";
+      try {
+        const stream = await createAzureOpenAIResponsesTransportStreamFn()(
+          model,
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 1 }],
+          },
+          { apiKey: "test-key", headers: { session_id: "prepared-affinity" } },
+        );
+        const result = await stream.result();
+        expect(result.stopReason).toBe("stop");
+        expect(requests).toHaveLength(1);
+        const request = requests[0];
+        assert(request);
+        const url = new URL(request.url);
+        expect(url.origin + url.pathname).toBe(`${baseUrl}/responses`);
+        expect(url.searchParams.get("api-version")).toBe(azureApiVersion);
+        expect(request.headers.get(azureApiVersion ? "api-key" : "authorization")).toBe(
+          azureApiVersion ? "test-key" : "Bearer test-key",
+        );
+        expect(request.headers.get("session_id")).toBe("prepared-affinity");
+      } finally {
+        fetchOwner.mockRestore();
+        if (previousApiVersion === undefined) {
+          delete process.env.AZURE_OPENAI_API_VERSION;
+        } else {
+          process.env.AZURE_OPENAI_API_VERSION = previousApiVersion;
+        }
+      }
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/openai-transport-stream.test-support.ts
+++ b/src/agents/openai-transport-stream.test-support.ts
@@ -1,14 +1,48 @@
 import "./ai-transport-runtime-host.js";
-import "@openclaw/ai/transports";
+import { formatModelTransportDebugBaseUrl } from "../../packages/ai/src/transports/model-transport-url.js";
+import { createOpenAIResponsesClient } from "../../packages/ai/src/transports/openai-responses-client.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "../../packages/ai/src/transports/openai-responses-compaction-replay.js";
+import {
+  normalizeResponsesFailedEvent,
+  summarizeResponsesPayload,
+  stringifyRedactedEvent,
+} from "../../packages/ai/src/transports/openai-responses-debug.js";
+import {
+  buildOpenAIResponsesParams,
+  sanitizeOpenAICodexResponsesParams,
+} from "../../packages/ai/src/transports/openai-responses-params-internal.js";
+import {
+  createResponsesStreamWithEncryptedContentRetry,
+  isInvalidEncryptedContentError,
+  resolveAzureOpenAIApiVersion,
+} from "../../packages/ai/src/transports/openai-responses-replay-internal.js";
+import { processResponsesStream } from "../../packages/ai/src/transports/openai-responses-stream-internal.js";
+import {
+  assertCodeModeResponsesToolSurface,
+  buildOpenAIClientHeaders,
+  buildOpenAISdkClientOptions,
+  buildOpenAISdkRequestOptions,
+  enforceCodeModeResponsesToolSurface,
+  getCompat,
+} from "../../packages/ai/src/transports/openai-transport-params.js";
 
-const responsesTesting = globalThis.openclawOpenAIResponsesTransportTestApi;
-if (!responsesTesting) {
-  throw new Error("OpenAI transport test APIs are unavailable outside test mode");
-}
-
-type OpenAIResponsesTransportTestApi = NonNullable<
-  typeof globalThis.openclawOpenAIResponsesTransportTestApi
->;
-
-// Keep declaration emit on the public test-API names instead of transport internals.
-export const testing: OpenAIResponsesTransportTestApi = responsesTesting;
+export const testing = {
+  getCompat,
+  assertCodeModeResponsesToolSurface,
+  buildOpenAIResponsesParams,
+  buildOpenAIClientHeaders,
+  buildOpenAISdkClientOptions,
+  buildOpenAISdkRequestOptions,
+  createOpenAIResponsesClient,
+  enforceCodeModeResponsesToolSurface,
+  sanitizeOpenAICodexResponsesParams,
+  processResponsesStream,
+  formatModelTransportDebugBaseUrl,
+  buildOpenAIResponsesReasoningReplayMetadata,
+  isInvalidEncryptedContentError,
+  normalizeResponsesFailedEvent,
+  createResponsesStreamWithEncryptedContentRetry,
+  resolveAzureOpenAIApiVersion,
+  summarizeResponsesPayload,
+  stringifyRedactedEvent,
+};

--- a/test/non-isolated-runner.test-api-fixtures.ts
+++ b/test/non-isolated-runner.test-api-fixtures.ts
@@ -18,7 +18,6 @@ const remainingKeys = [
   "openclaw.diagnosticRunActivityTestApi",
 ].filter((key) => Object.hasOwn(globalThis, Symbol.for(key)));
 expect(remainingKeys, "completed-file test API publications").toEqual([]);
-expect(Object.hasOwn(globalThis, "openclawOpenAIResponsesTransportTestApi")).toBe(false);
 for (const key of [Symbol.for("fixture.foreignTestApi"), Symbol.for("openclaw.google.vertexAdcTestApi"), "openclaw.staleAuthOrderTestApi"]) {
   expect(Reflect.get(globalThis, key)).toBe("foreign");
   Reflect.deleteProperty(globalThis, key);
@@ -32,7 +31,6 @@ ${observeCleanup}
 const { createBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.test-support.ts")});
 const { isBeforeToolCallBlockedError } = await import(${sourcePath("agents/agent-tools.before-tool-call.wrapper.ts")});
 const { repairStaleConfiguredAuthOrders } = await import(${sourcePath("commands/doctor/shared/stale-auth-order.test-support.ts")});
-const { testing: responses } = await import(${sourcePath("agents/openai-transport-stream.test-support.ts")});
 const registry = await import(${sourcePath("agents/bash-process-registry.ts")});
 const { resetProcessRegistryForTests } = await import(${sourcePath("agents/bash-process-registry.test-support.ts")});
 const { createProcessSessionFixture } = await import(${sourcePath("agents/bash-process-registry.test-helpers.ts")});
@@ -54,8 +52,6 @@ describe("${generation} test API consumers", () => {
     expect(blocked.message).toBe(message);
     expect(isBeforeToolCallBlockedError(blocked)).toBe(true);
     expect(isBeforeToolCallBlockedError(new Error(message))).toBe(false);
-    expect(responses.isInvalidEncryptedContentError({ code: "invalid_encrypted_content" })).toBe(true);
-    expect(responses.isInvalidEncryptedContentError(new Error("unrelated"))).toBe(false);
     registry.addSession(createProcessSessionFixture({ id: "captured", backgrounded: true }));
     replacement.addSession(createProcessSessionFixture({ id: "replacement", backgrounded: true }));
     try {

--- a/test/repository-test-api-publications.ts
+++ b/test/repository-test-api-publications.ts
@@ -8,8 +8,6 @@ const publications: Record<string, string | symbol> = {
   "extensions/memory-lancedb/lancedb-runtime.ts": Symbol.for(
     "openclaw.memoryLanceDbRuntimeTestApi",
   ),
-  "packages/ai/src/transports/openai-responses-transport.ts":
-    "openclawOpenAIResponsesTransportTestApi",
   "src/agents/agent-hooks/compaction-safeguard.ts": Symbol.for(
     "openclaw.compactionSafeguardTestApi",
   ),


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

The Responses transport publishes a process-global object solely for tests. That extra production plumbing can bind test helpers to another module graph, requiring a compensating save/restore workaround when Jiti and Vite load different transport hosts.

## Why This Change Was Made

Keep the four existing transport facade exports and remove the test global and its unused imports. Tests import their owning modules and exercise the real summary, logging and streaming boundaries. Runtime function bodies remain unchanged. This maintainer-requested cleanup removes 67 production lines and the obsolete global cleanup entry.

## User Impact

OpenAI and Azure transport behavior stays the same, with fewer test-only paths in runtime code.

## Evidence

All 242 tests across 18 files pass, preserving redaction, UTF-16 bounds, failure observations, Azure routing, endpoint/account behavior and runner cleanup. Independent P2 review and the complete normal changed-file gate passed.

A normal full `pnpm build` passed at `13e4586efff81f0c4d4af0859d129409161f6f81`, including package/unified/plugin-SDK declarations, SDK checks and UI. Compiled public OpenAI and Azure transports each completed a synthetic loopback SSE request with the expected route, authentication, prepared affinity, text events, terminal text and usage. Test-mode import and both requests left the retired global absent. Source and build hashes remained unchanged; all proof processes exited.
