### PR TITLE
refactor: remove the model planner test shell

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1854,7 +1854,7 @@ src/agents/model-selection-shared.ts	1
 src/agents/model-tool-support.ts	1
 src/agents/models-config-state.ts	1
 src/agents/models-config.merge.ts	2
-src/agents/models-config.plan.ts	4
+src/agents/models-config.plan.ts	3
 src/agents/models-config.providers.policy.lookup.ts	1
 src/agents/modes/interactive/theme/theme.ts	11
 src/agents/node-plugin-tools.ts	1

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { testing as externalAuthTesting } from "./auth-profiles/external-auth.test-support.js";
 import {
@@ -10,10 +10,8 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./auth-profiles/runtime-snapshots.js";
 import { unsetEnv, withTempEnv } from "./models-config.e2e-harness.js";
-import {
-  planOpenClawModelsJsonWithDeps,
-  resolveProvidersForModelsJsonWithDeps,
-} from "./models-config.plan.test-support.js";
+import { planModelsJsonForTest } from "./models-config.plan.test-support.js";
+import * as modelsConfigProviders from "./models-config.providers.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 import { encodePluginModelCatalogRelativePath } from "./plugin-model-catalog.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
@@ -66,6 +64,7 @@ vi.mock("./model-auth-env-vars.js", () => ({
 const TEST_ENV_VAR = "OPENCLAW_MODELS_CONFIG_TEST_ENV";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   providerRuntimeMocks.normalizeProviderConfigWithPlugin.mockReset();
   providerRuntimeMocks.normalizeProviderConfigWithPlugin.mockReturnValue(undefined);
   providerRuntimeMocks.resolveProviderConfigApiKeyWithPlugin.mockReset();
@@ -130,30 +129,6 @@ function createImplicitGoogleVertexProvider(): ProviderConfig {
   };
 }
 
-async function resolveProvidersForConfigEnvTest(params: {
-  cfg: OpenClawConfig;
-  onResolveImplicitProviders: (env: NodeJS.ProcessEnv) => void;
-}) {
-  // Config env vars are materialized into the discovery env before implicit
-  // provider resolution.
-  const env = createConfigRuntimeEnv(params.cfg);
-  return await resolveProvidersForModelsJsonWithDeps(
-    {
-      cfg: params.cfg,
-      agentDir: "/tmp/openclaw-models-config-env-vars-test",
-      env,
-    },
-    {
-      resolveImplicitProviders: async ({ env: discoveryEnv }) => {
-        params.onResolveImplicitProviders(discoveryEnv);
-        return {
-          openrouter: createImplicitOpenRouterProvider(),
-        };
-      },
-    },
-  );
-}
-
 function createConfigEnvVarsConfig(): OpenClawConfig {
   return {
     models: { providers: {} },
@@ -166,18 +141,7 @@ function createConfigEnvVarsConfig(): OpenClawConfig {
   };
 }
 
-async function resolveProvidersAndCaptureDiscoveryEnv(cfg: OpenClawConfig) {
-  let discoveryEnv: NodeJS.ProcessEnv | undefined;
-  const providers = await resolveProvidersForConfigEnvTest({
-    cfg,
-    onResolveImplicitProviders: (env) => {
-      discoveryEnv = env;
-    },
-  });
-  return { discoveryEnv, providers };
-}
-
-let unauthenticatedProviderWritePlan: Awaited<ReturnType<typeof planOpenClawModelsJsonWithDeps>>;
+let unauthenticatedProviderWritePlan: Awaited<ReturnType<typeof planModelsJsonForTest>>;
 let unauthenticatedProviderParsed: { providers?: Record<string, unknown> };
 let googleVertexProfileCatalogPlan: Awaited<ReturnType<typeof planGoogleVertexProfileCatalog>>;
 
@@ -204,30 +168,21 @@ async function planGoogleVertexProfileCatalog() {
       },
     ]);
 
-    return await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: {
-          agents: {
-            defaults: {
-              models: {
-                "google-vertex/gemini-2.5-pro": {},
-              },
-              model: { primary: "google-vertex/gemini-2.5-pro" },
+    return await planModelsJsonForTest({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "google-vertex/gemini-2.5-pro": {},
             },
+            model: { primary: "google-vertex/gemini-2.5-pro" },
           },
-          models: { providers: {} },
         },
-        agentDir,
-        env: {},
-        existingRaw: "",
-        existingParsed: null,
+        models: { providers: {} },
       },
-      {
-        resolveImplicitProviders: async () => ({
-          "google-vertex": createImplicitGoogleVertexProvider(),
-        }),
-      },
-    );
+      agentDir,
+      env: {},
+    });
   } finally {
     externalAuthTesting.resetResolveExternalAuthProfilesForTest();
     clearRuntimeAuthProfileStoreSnapshots();
@@ -235,10 +190,22 @@ async function planGoogleVertexProfileCatalog() {
 }
 
 beforeAll(async () => {
-  // Reused no-auth write plan proves generated providers stay serializable
-  // even when discovery returns auth-only provider shells.
-  unauthenticatedProviderWritePlan = await planOpenClawModelsJsonWithDeps(
-    {
+  const discovery = vi.spyOn(modelsConfigProviders, "resolveImplicitProviders");
+  try {
+    // Reused no-auth write plan proves generated providers stay serializable
+    // even when discovery returns auth-only provider shells.
+    discovery.mockResolvedValue({
+      openai: createImplicitOpenAiProvider(),
+      oauth: createImplicitOpenAiProvider({ auth: "oauth" }),
+      role: createImplicitOpenAiProvider({ auth: "aws-sdk" }),
+      empty: createImplicitOpenAiProvider({ apiKey: "" }),
+      "auth-only": createImplicitOpenAiProvider({
+        baseUrl: "https://auth.example/v1",
+        api: "openai-responses",
+        models: [],
+      }),
+    });
+    unauthenticatedProviderWritePlan = await planModelsJsonForTest({
       cfg: { models: { providers: {} } },
       agentDir: "/tmp/openclaw-models-config-env-vars-test",
       env: {},
@@ -249,177 +216,115 @@ beforeAll(async () => {
           "empty-existing": createImplicitOpenAiProvider({ apiKey: "" }),
         },
       },
-    },
-    {
-      resolveImplicitProviders: async () => ({
-        openai: createImplicitOpenAiProvider(),
-        oauth: createImplicitOpenAiProvider({ auth: "oauth" }),
-        role: createImplicitOpenAiProvider({ auth: "aws-sdk" }),
-        empty: createImplicitOpenAiProvider({ apiKey: "" }),
-        "auth-only": createImplicitOpenAiProvider({
-          baseUrl: "https://auth.example/v1",
-          api: "openai-responses",
-          models: [],
-        }),
-      }),
-    },
-  );
-  if (unauthenticatedProviderWritePlan.action !== "write") {
-    throw new Error("Expected models.json write plan");
+    });
+    if (unauthenticatedProviderWritePlan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    unauthenticatedProviderParsed = JSON.parse(unauthenticatedProviderWritePlan.contents) as {
+      providers?: Record<string, unknown>;
+    };
+    // Retain this expensive plan so the assertion test does not repeat the same
+    // auth-profile and catalog planning pass.
+    discovery.mockResolvedValue({ "google-vertex": createImplicitGoogleVertexProvider() });
+    googleVertexProfileCatalogPlan = await planGoogleVertexProfileCatalog();
+  } finally {
+    discovery.mockRestore();
   }
-  unauthenticatedProviderParsed = JSON.parse(unauthenticatedProviderWritePlan.contents) as {
-    providers?: Record<string, unknown>;
-  };
-  // Retain this expensive plan so the assertion test does not repeat the same
-  // auth-profile and catalog planning pass.
-  googleVertexProfileCatalogPlan = await planGoogleVertexProfileCatalog();
 });
 
 describe("models-config", () => {
   it("keeps the implicit provider catalog when explicit baseUrl is blank", async () => {
-    let observedConfig: OpenClawConfig | undefined;
-    const providers = await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg: {
-          models: {
-            providers: {
-              openai: {
-                baseUrl: "   ",
-                apiKey: "OPENAI_API_KEY",
-                models: [],
-              },
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({ openai: createImplicitOpenAiProvider() });
+    const plan = await planModelsJsonForTest({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "   ",
+              apiKey: "OPENAI_API_KEY",
+              models: [],
             },
           },
         },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
       },
-      {
-        resolveImplicitProviders: async ({ config }) => {
-          observedConfig = config;
-          return { openai: createImplicitOpenAiProvider() };
-        },
-      },
-    );
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+    });
 
-    expect(observedConfig?.models?.providers?.openai?.baseUrl).toBeUndefined();
+    expect(discovery.mock.calls[0]?.[0].config?.models?.providers?.openai?.baseUrl).toBeUndefined();
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const { providers } = JSON.parse(plan.contents) as {
+      providers: Record<string, ProviderConfig>;
+    };
     expect(providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
     expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY");
     expect(providers.openai?.models?.[0]?.id).toBe("gpt-5.5");
   });
 
-  it("threads plugin metadata snapshots into implicit provider discovery", async () => {
-    const pluginMetadataSnapshot = {
-      index: { plugins: [{ pluginId: "zai", enabled: true }] },
-      normalizePluginId: (pluginId: string) => pluginId,
-      manifestRegistry: { plugins: [], diagnostics: [] },
-      owners: { providers: new Map() },
-    } as unknown as Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-    let observedSnapshot:
-      | Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">
-      | undefined;
-
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
-        pluginMetadataSnapshot,
-      },
-      {
-        resolveImplicitProviders: async ({ pluginMetadataSnapshot: receivedSnapshot }) => {
-          observedSnapshot = receivedSnapshot;
-          return {};
-        },
-      },
-    );
-
-    expect(observedSnapshot).toBe(pluginMetadataSnapshot);
-  });
-
   it("threads workspace scope into implicit provider discovery", async () => {
-    let observedWorkspaceDir: string | undefined;
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({});
 
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
-        workspaceDir: "/tmp/openclaw-workspace",
-      },
-      {
-        resolveImplicitProviders: async ({ workspaceDir }) => {
-          observedWorkspaceDir = workspaceDir;
-          return {};
-        },
-      },
+    await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      workspaceDir: "/tmp/openclaw-workspace",
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+    });
+
+    expect(discovery).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/openclaw-workspace" }),
     );
-
-    expect(observedWorkspaceDir).toBe("/tmp/openclaw-workspace");
   });
 
   it("threads startup provider discovery scope into implicit provider discovery", async () => {
-    let observedProviderIds: readonly string[] | undefined;
-    let observedEntriesOnly: boolean | undefined;
-    let observedTimeoutMs: number | undefined;
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({});
 
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
+    await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      providerDiscoveryProviderIds: ["openai"],
+      providerDiscoveryEntriesOnly: true,
+      providerDiscoveryTimeoutMs: 5000,
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+    });
+
+    expect(discovery).toHaveBeenCalledWith(
+      expect.objectContaining({
         providerDiscoveryProviderIds: ["openai"],
         providerDiscoveryEntriesOnly: true,
         providerDiscoveryTimeoutMs: 5000,
-      },
-      {
-        resolveImplicitProviders: async ({
-          providerDiscoveryProviderIds,
-          providerDiscoveryEntriesOnly,
-          providerDiscoveryTimeoutMs,
-        }) => {
-          observedProviderIds = providerDiscoveryProviderIds;
-          observedEntriesOnly = providerDiscoveryEntriesOnly;
-          observedTimeoutMs = providerDiscoveryTimeoutMs;
-          return {};
-        },
-      },
+      }),
     );
-
-    expect(observedProviderIds).toEqual(["openai"]);
-    expect(observedEntriesOnly).toBe(true);
-    expect(observedTimeoutMs).toBe(5000);
   });
 
   it("threads plugin metadata snapshots through models.json planning", async () => {
-    const pluginMetadataSnapshot = {
-      index: { plugins: [{ pluginId: "zai", enabled: true }] },
-      normalizePluginId: (pluginId: string) => pluginId,
-      manifestRegistry: { plugins: [], diagnostics: [] },
-      owners: { providers: new Map() },
-    } as unknown as Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-    let observedSnapshot:
-      | Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">
-      | undefined;
+    const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: "zai" }],
+    });
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({});
 
-    await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
-        existingRaw: "",
-        existingParsed: null,
-        pluginMetadataSnapshot,
-      },
-      {
-        resolveImplicitProviders: async ({ pluginMetadataSnapshot: receivedSnapshot }) => {
-          observedSnapshot = receivedSnapshot;
-          return {};
-        },
-      },
-    );
+    await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      pluginMetadataSnapshot,
+    });
 
-    expect(observedSnapshot).toBe(pluginMetadataSnapshot);
+    expect(discovery.mock.calls[0]?.[0].pluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
   });
 
   it.each([
@@ -428,42 +333,27 @@ describe("models-config", () => {
   ])(
     "threads provider policy metadata only from a $label plugin snapshot",
     async ({ pluginIds, expectedRegistry }) => {
-      const manifestRegistry = { plugins: [], diagnostics: [] };
       const pluginMetadataSnapshot = {
-        index: { plugins: [] },
-        manifestRegistry,
-        owners: {
-          providers: new Map(),
-          modelCatalogProviders: new Map(),
-          setupProviders: new Map(),
-        },
+        ...createPluginMetadataSnapshotFixture(),
         ...(pluginIds ? { pluginIds } : {}),
-      } as unknown as Pick<
-        PluginMetadataSnapshot,
-        "index" | "manifestRegistry" | "owners" | "pluginIds"
-      >;
+      };
+      const { manifestRegistry } = pluginMetadataSnapshot;
       providerRuntimeMocks.resolveProviderConfigApiKeyWithPlugin.mockReturnValue(
         "POLICY_ALIAS_API_KEY",
       );
+      vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
+        "policy-alias": createImplicitOpenAiProvider({
+          baseUrl: "https://policy.example/v1",
+          apiKey: undefined,
+        }),
+      });
 
-      await planOpenClawModelsJsonWithDeps(
-        {
-          cfg: { models: { providers: {} } },
-          agentDir: "/tmp/openclaw-models-config-policy-registry-test",
-          env: {},
-          existingRaw: "",
-          existingParsed: null,
-          pluginMetadataSnapshot,
-        },
-        {
-          resolveImplicitProviders: async () => ({
-            "policy-alias": createImplicitOpenAiProvider({
-              baseUrl: "https://policy.example/v1",
-              apiKey: undefined,
-            }),
-          }),
-        },
-      );
+      await planModelsJsonForTest({
+        cfg: { models: { providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-policy-registry-test",
+        env: {},
+        pluginMetadataSnapshot,
+      });
 
       const normalizeParams =
         providerRuntimeMocks.normalizeProviderConfigWithPlugin.mock.calls.find(
@@ -517,19 +407,18 @@ describe("models-config", () => {
   });
 
   it("treats empty replace-mode provider sets as authoritative", async () => {
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { mode: "replace", providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
-        existingRaw: `${JSON.stringify({ providers: { stale: {} } }, null, 2)}\n`,
-        existingParsed: { providers: { stale: {} } },
-      },
-      {
-        resolveImplicitProviders: async () => ({}),
-      },
-    );
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({});
+    const plan = await planModelsJsonForTest({
+      cfg: { models: { mode: "replace", providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      existingRaw: `${JSON.stringify({ providers: { stale: {} } }, null, 2)}\n`,
+      existingParsed: { providers: { stale: {} } },
+    });
 
+    expect(discovery).not.toHaveBeenCalled();
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
       throw new Error("Expected models.json write plan");
@@ -539,38 +428,25 @@ describe("models-config", () => {
   });
 
   it("moves plugin-owned provider catalogs into plugin-scoped files", async () => {
-    const pluginMetadataSnapshot = {
-      index: { plugins: [{ pluginId: "zai", enabled: true }] },
-      normalizePluginId: (pluginId: string) => pluginId,
-      manifestRegistry: { plugins: [], diagnostics: [] },
-      owners: {
-        providers: new Map([["zai", ["zai"]]]),
-        modelCatalogProviders: new Map([["zai", ["zai"]]]),
-        setupProviders: new Map(),
-      },
-    } as unknown as Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: { ZAI_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
-        existingRaw: "",
-        existingParsed: null,
-        pluginMetadataSnapshot,
-      },
-      {
-        resolveImplicitProviders: async () => ({
-          zai: createImplicitOpenAiProvider({
-            baseUrl: "https://api.z.ai/api/paas/v4",
-            apiKey: "ZAI_API_KEY",
-          }),
-          custom: createImplicitOpenAiProvider({
-            baseUrl: "https://custom.example/v1",
-            apiKey: "CUSTOM_API_KEY",
-          }),
-        }),
-      },
-    );
+    const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: "zai", providers: ["zai"] }],
+    });
+    vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
+      zai: createImplicitOpenAiProvider({
+        baseUrl: "https://api.z.ai/api/paas/v4",
+        apiKey: "ZAI_API_KEY",
+      }),
+      custom: createImplicitOpenAiProvider({
+        baseUrl: "https://custom.example/v1",
+        apiKey: "CUSTOM_API_KEY",
+      }),
+    });
+    const plan = await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: { ZAI_API_KEY: "sk-test" },
+      pluginMetadataSnapshot,
+    });
 
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
@@ -589,20 +465,14 @@ describe("models-config", () => {
   });
 
   it("falls back to canonical env markers when provider runtime has no api-key policy", async () => {
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: { OPENAI_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
-        existingRaw: "",
-        existingParsed: null,
-      },
-      {
-        resolveImplicitProviders: async () => ({
-          openai: createImplicitOpenAiProvider(),
-        }),
-      },
-    );
+    vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
+      openai: createImplicitOpenAiProvider(),
+    });
+    const plan = await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: { OPENAI_API_KEY: "sk-test" },
+    });
 
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
@@ -615,50 +485,30 @@ describe("models-config", () => {
   });
 
   it("normalizes retired Gemini ids preserved from existing models.json rows", async () => {
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { mode: "merge", providers: {} } },
-        agentDir: "/tmp/openclaw-models-config-env-vars-test",
-        env: {},
-        existingRaw: "",
-        existingParsed: {
-          providers: {
-            google: {
-              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-              api: "google-generative-ai",
-              apiKey: "GOOGLE_API_KEY", // pragma: allowlist secret
-              models: [
-                {
-                  id: "gemini-3-pro-preview",
-                  name: "Gemini 3 Pro",
-                  input: ["text"],
-                },
-              ],
-            },
-          },
-        },
-      },
-      {
-        resolveImplicitProviders: async () => ({
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            api: "openai-responses",
-            apiKey: "OPENAI_API_KEY", // pragma: allowlist secret
+    vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
+      openai: createImplicitOpenAiProvider({ apiKey: "OPENAI_API_KEY" }),
+    });
+    const plan = await planModelsJsonForTest({
+      cfg: { models: { mode: "merge", providers: {} } },
+      agentDir: "/tmp/openclaw-models-config-env-vars-test",
+      env: {},
+      existingParsed: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+            api: "google-generative-ai",
+            apiKey: "GOOGLE_API_KEY", // pragma: allowlist secret
             models: [
               {
-                id: "gpt-5.5",
-                name: "GPT-5.5",
+                id: "gemini-3-pro-preview",
+                name: "Gemini 3 Pro",
                 input: ["text"],
-                reasoning: true,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 400000,
-                maxTokens: 128000,
               },
             ],
           },
-        }),
+        },
       },
-    );
+    });
 
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
@@ -693,35 +543,29 @@ describe("models-config", () => {
   });
 
   it("keeps google-vertex static catalog rows when discovery supplies the ADC marker", async () => {
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: {
-          agents: {
-            defaults: {
-              models: {
-                "google-vertex/gemini-2.5-pro": {},
-              },
-              model: { primary: "google-vertex/gemini-2.5-pro" },
+    // Provider discovery owns ADC detection; this planner test only proves
+    // the resulting marker and static rows survive models.json planning.
+    vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
+      "google-vertex": {
+        ...createImplicitGoogleVertexProvider(),
+        apiKey: "gcp-vertex-credentials",
+      },
+    });
+    const plan = await planModelsJsonForTest({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "google-vertex/gemini-2.5-pro": {},
             },
+            model: { primary: "google-vertex/gemini-2.5-pro" },
           },
-          models: { providers: {} },
         },
-        agentDir: "/tmp/openclaw-google-vertex-adc-models",
-        env: {},
-        existingRaw: "",
-        existingParsed: null,
+        models: { providers: {} },
       },
-      {
-        // Provider discovery owns ADC detection; this planner test only proves
-        // the resulting marker and static rows survive models.json planning.
-        resolveImplicitProviders: async () => ({
-          "google-vertex": {
-            ...createImplicitGoogleVertexProvider(),
-            apiKey: "gcp-vertex-credentials",
-          },
-        }),
-      },
-    );
+      agentDir: "/tmp/openclaw-google-vertex-adc-models",
+      env: {},
+    });
 
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
@@ -741,11 +585,26 @@ describe("models-config", () => {
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({ openrouter: createImplicitOpenRouterProvider() });
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);
-      const { discoveryEnv, providers } = await resolveProvidersAndCaptureDiscoveryEnv(
-        createConfigEnvVarsConfig(),
-      );
+      const cfg = createConfigEnvVarsConfig();
+      const plan = await planModelsJsonForTest({
+        cfg,
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: createConfigRuntimeEnv(cfg),
+        pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+      });
+      const discoveryEnv = discovery.mock.calls[0]?.[0].env;
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const { providers } = JSON.parse(plan.contents) as {
+        providers: Record<string, ProviderConfig>;
+      };
 
       expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
       expect(process.env[TEST_ENV_VAR]).toBeUndefined();
@@ -756,6 +615,9 @@ describe("models-config", () => {
   });
 
   it("does not overwrite already-set host env vars while ensuring models.json", async () => {
+    const discovery = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({ openrouter: createImplicitOpenRouterProvider() });
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       await withEnvAsync(
         {
@@ -763,9 +625,21 @@ describe("models-config", () => {
           [TEST_ENV_VAR]: "from-host",
         },
         async () => {
-          const { discoveryEnv, providers } = await resolveProvidersAndCaptureDiscoveryEnv(
-            createConfigEnvVarsConfig(),
-          );
+          const cfg = createConfigEnvVarsConfig();
+          const plan = await planModelsJsonForTest({
+            cfg,
+            agentDir: "/tmp/openclaw-models-config-env-vars-test",
+            env: createConfigRuntimeEnv(cfg),
+            pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+          });
+          const discoveryEnv = discovery.mock.calls[0]?.[0].env;
+          expect(plan.action).toBe("write");
+          if (plan.action !== "write") {
+            throw new Error("Expected models.json write plan");
+          }
+          const { providers } = JSON.parse(plan.contents) as {
+            providers: Record<string, ProviderConfig>;
+          };
 
           expect(discoveryEnv?.OPENROUTER_API_KEY).toBe("from-host");
           expect(discoveryEnv?.[TEST_ENV_VAR]).toBe("from-host");

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -9,14 +9,14 @@ import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.
 import type { ProviderPlugin } from "../plugins/types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { planOpenClawModelsJsonSource } from "./models-config.js";
-import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.test-support.js";
+import { planModelsJsonForTest } from "./models-config.plan.test-support.js";
+import * as modelsConfigProviders from "./models-config.providers.js";
 import { createPreparedModelCatalogWorkerInput } from "./prepared-model-catalog-worker.js";
 
-afterEach(clearRuntimeConfigSnapshot);
-
-type ResolveImplicitProviders = NonNullable<
-  NonNullable<Parameters<typeof planOpenClawModelsJsonWithDeps>[1]>["resolveImplicitProviders"]
->;
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearRuntimeConfigSnapshot();
+});
 
 function model(id: string, input: Array<"text" | "image"> = ["text"]) {
   return {
@@ -67,27 +67,24 @@ describe("models config input presence", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    const resolveImplicitProviders = vi.fn<ResolveImplicitProviders>(async () => ({
+    vi.spyOn(modelsConfigProviders, "resolveImplicitProviders").mockResolvedValue({
       "model-input-fixture": {
         ...configuredProvider,
         models: [model("vision-model", ["text", "image"])],
       },
-    }));
+    });
 
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: sourceModels.length ? sourceConfigForSecrets : cfg,
-        discoveryAuthConfig: cfg,
-        sourceConfigForSecrets,
-        agentDir: "/tmp/openclaw-model-input-presence",
-        // Model-ID policies are part of this prepared merge fixture, not ambient discovery.
-        pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
-        env: { MODEL_INPUT_FIXTURE_KEY: "default" },
-        existingRaw: "",
-        existingParsed: {},
-      },
-      { resolveImplicitProviders },
-    );
+    const plan = await planModelsJsonForTest({
+      cfg: sourceModels.length ? sourceConfigForSecrets : cfg,
+      discoveryAuthConfig: cfg,
+      sourceConfigForSecrets,
+      agentDir: "/tmp/openclaw-model-input-presence",
+      // Model-ID policies are part of this prepared merge fixture, not ambient discovery.
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+      env: { MODEL_INPUT_FIXTURE_KEY: "default" },
+      existingRaw: "",
+      existingParsed: {},
+    });
 
     expect(plan.action).toBe("write");
     if (plan.action !== "write") {
@@ -253,7 +250,7 @@ describe("models config input presence", () => {
       );
       // Workers retain the captured pair after losing the parent's process-local snapshot.
       clearRuntimeConfigSnapshot();
-      const plan = await planOpenClawModelsJsonWithDeps({
+      const plan = await planModelsJsonForTest({
         ...options,
         cfg: cloned.sourceConfigForSecrets,
         discoveryAuthConfig: cloned.input.config,

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -1,27 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import "./models-config.plan.js";
-import type { SourceModelFields } from "./models-config.merge.js";
-import type { PreparedModelsConfigContext } from "./models-config.plan.js";
-import type { ProviderConfig } from "./models-config.providers.secrets.js";
+import { planOpenClawModelsJson, type PreparedModelsConfigContext } from "./models-config.plan.js";
 
-type ResolveImplicitProvidersForModelsJson = (params: {
-  agentDir: string;
-  config: OpenClawConfig;
-  discoveryAuthConfig?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  workspaceDir?: string;
-  explicitProviders: Record<string, ProviderConfig>;
-  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-  providerDiscoveryProviderIds?: readonly string[];
-  providerDiscoveryTimeoutMs?: number;
-  providerDiscoveryEntriesOnly?: boolean;
-  sourceModelFields?: SourceModelFields;
-}) => Promise<Record<string, ProviderConfig>>;
-
-type PreparedPlanParams = Parameters<
-  typeof import("./models-config.plan.js").planOpenClawModelsJson
->[0];
+type PreparedPlanParams = Parameters<typeof planOpenClawModelsJson>[0];
 type FlatPreparedContext = Omit<
   PreparedModelsConfigContext,
   "discoveryAuthConfig" | "sourceConfigForSecrets" | "envFingerprint"
@@ -29,63 +9,30 @@ type FlatPreparedContext = Omit<
   discoveryAuthConfig?: OpenClawConfig;
   sourceConfigForSecrets?: OpenClawConfig;
 };
-type PlanParams = Omit<PreparedPlanParams, "context"> & FlatPreparedContext;
-type PlanResult = Awaited<
-  ReturnType<typeof import("./models-config.plan.js").planOpenClawModelsJson>
->;
-type ResolveProvidersParams = FlatPreparedContext & { authStore?: PreparedPlanParams["authStore"] };
-type PlanDeps = { resolveImplicitProviders?: ResolveImplicitProvidersForModelsJson };
-
-type ModelsConfigPlanTestApi = {
-  planOpenClawModelsJsonWithDeps(params: PreparedPlanParams, deps?: PlanDeps): Promise<PlanResult>;
-  resolveProvidersForModelsJsonWithDeps(
-    params: Pick<PreparedPlanParams, "context" | "authStore">,
-    deps?: PlanDeps,
-  ): Promise<Record<string, ProviderConfig>>;
-};
-
-function getTestApi(): ModelsConfigPlanTestApi {
-  return (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.modelsConfigPlanTestApi")
-  ] as ModelsConfigPlanTestApi;
-}
-
-function prepareTestContext(params: FlatPreparedContext): PreparedModelsConfigContext {
-  return {
-    ...params,
-    discoveryAuthConfig: params.discoveryAuthConfig ?? params.cfg,
-    sourceConfigForSecrets: params.sourceConfigForSecrets ?? params.cfg,
-    envFingerprint: params.env,
+type PlanParams = Omit<PreparedPlanParams, "context" | "existingRaw" | "existingParsed"> &
+  FlatPreparedContext & {
+    existingRaw?: string;
+    existingParsed?: unknown;
   };
+
+export function planModelsJsonForTest(params: PlanParams) {
+  const {
+    authStore,
+    existingRaw = "",
+    existingParsed = null,
+    pluginCatalogs,
+    ...contextParams
+  } = params;
+  return planOpenClawModelsJson({
+    context: {
+      ...contextParams,
+      discoveryAuthConfig: params.discoveryAuthConfig ?? params.cfg,
+      sourceConfigForSecrets: params.sourceConfigForSecrets ?? params.cfg,
+      envFingerprint: params.env,
+    },
+    ...(authStore ? { authStore } : {}),
+    existingRaw,
+    existingParsed,
+    ...(pluginCatalogs ? { pluginCatalogs } : {}),
+  });
 }
-
-export const planOpenClawModelsJsonWithDeps = async (
-  params: PlanParams,
-  deps?: PlanDeps,
-): Promise<PlanResult> => {
-  const { authStore, existingRaw, existingParsed, pluginCatalogs, ...contextParams } = params;
-  return await getTestApi().planOpenClawModelsJsonWithDeps(
-    {
-      context: prepareTestContext(contextParams),
-      ...(authStore ? { authStore } : {}),
-      existingRaw,
-      existingParsed,
-      ...(pluginCatalogs ? { pluginCatalogs } : {}),
-    },
-    deps,
-  );
-};
-
-export const resolveProvidersForModelsJsonWithDeps = async (
-  params: ResolveProvidersParams,
-  deps?: PlanDeps,
-): Promise<Record<string, ProviderConfig>> => {
-  const { authStore, ...contextParams } = params;
-  return await getTestApi().resolveProvidersForModelsJsonWithDeps(
-    {
-      context: prepareTestContext(contextParams),
-      ...(authStore ? { authStore } : {}),
-    },
-    deps,
-  );
-};

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -59,25 +59,6 @@ export type PreparedModelsConfigContext = Readonly<{
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
 }>;
 
-/** Dependency hook for resolving implicit model providers while planning models.json. */
-type ResolveImplicitProvidersForModelsJson = (params: {
-  agentDir: string;
-  authStore?: AuthProfileStore;
-  config: OpenClawConfig;
-  discoveryAuthConfig?: OpenClawConfig;
-  discoveryAuthEnv?: NodeJS.ProcessEnv;
-  sourceConfigForSecrets?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  workspaceDir?: string;
-  explicitProviders: Record<string, ProviderConfig>;
-  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-  preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
-  providerDiscoveryProviderIds?: readonly string[];
-  providerDiscoveryTimeoutMs?: number;
-  providerDiscoveryEntriesOnly?: boolean;
-  sourceModelFields?: SourceModelFields;
-}) => Promise<Record<string, ProviderConfig>>;
-
 /**
  * Planned models.json result. When present, pluginCatalogWrites is the complete
  * replacement set; omission means the plan is non-authoritative for plugin catalogs.
@@ -155,16 +136,11 @@ function buildSourceModelFields(
   return fields;
 }
 
-/** Resolves providers for models.json with injectable implicit-provider discovery. */
-async function resolveProvidersForModelsJsonWithDeps(
-  params: {
-    context: PreparedModelsConfigContext;
-    authStore?: AuthProfileStore;
-  },
-  deps?: {
-    resolveImplicitProviders?: ResolveImplicitProvidersForModelsJson;
-  },
-): Promise<Record<string, ProviderConfig>> {
+/** Resolves providers for models.json. */
+async function resolveProvidersForModelsJson(params: {
+  context: PreparedModelsConfigContext;
+  authStore?: AuthProfileStore;
+}): Promise<Record<string, ProviderConfig>> {
   const { context } = params;
   const { agentDir, env } = context;
   const explicitProviders = stripBlankProviderBaseUrls(context.cfg.models?.providers ?? {});
@@ -179,8 +155,7 @@ async function resolveProvidersForModelsJsonWithDeps(
   if (cfg.models?.mode === "replace") {
     return mergeProviders({ implicit: {}, explicit: explicitProviders });
   }
-  const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
-  const implicitProviders = await resolveImplicitProvidersImpl({
+  const implicitProviders = await resolveImplicitProviders({
     agentDir,
     ...(params.authStore ? { authStore: params.authStore } : {}),
     config: cfg,
@@ -306,28 +281,20 @@ function collectGeneratedCatalogProviders(params: {
   return providers;
 }
 
-/** Plans root and plugin-owned model catalog writes with injectable provider discovery. */
-async function planOpenClawModelsJsonWithDeps(
-  params: {
-    context: PreparedModelsConfigContext;
-    authStore?: AuthProfileStore;
-    existingRaw: string;
-    existingParsed: unknown;
-    pluginCatalogs?: readonly PersistedPluginModelCatalog[];
-  },
-  deps?: {
-    resolveImplicitProviders?: ResolveImplicitProvidersForModelsJson;
-  },
-): Promise<ModelsJsonPlan> {
+/** Plans root and plugin-owned model catalog writes for the current runtime. */
+export async function planOpenClawModelsJson(params: {
+  context: PreparedModelsConfigContext;
+  authStore?: AuthProfileStore;
+  existingRaw: string;
+  existingParsed: unknown;
+  pluginCatalogs?: readonly PersistedPluginModelCatalog[];
+}): Promise<ModelsJsonPlan> {
   const { context } = params;
   const { cfg, agentDir, env } = context;
-  const providers = await resolveProvidersForModelsJsonWithDeps(
-    {
-      context,
-      ...(params.authStore ? { authStore: params.authStore } : {}),
-    },
-    deps,
-  );
+  const providers = await resolveProvidersForModelsJson({
+    context,
+    ...(params.authStore ? { authStore: params.authStore } : {}),
+  });
 
   if (Object.keys(providers).length === 0) {
     if (cfg.models?.mode === "replace") {
@@ -420,19 +387,5 @@ async function planOpenClawModelsJsonWithDeps(
     action: "write",
     contents: nextContents,
     pluginCatalogWrites,
-  };
-}
-
-/** Plans root and plugin-owned model catalog writes for the current runtime. */
-export async function planOpenClawModelsJson(
-  params: Parameters<typeof planOpenClawModelsJsonWithDeps>[0],
-): Promise<ModelsJsonPlan> {
-  return planOpenClawModelsJsonWithDeps(params);
-}
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.modelsConfigPlanTestApi")] = {
-    planOpenClawModelsJsonWithDeps,
-    resolveProvidersForModelsJsonWithDeps,
   };
 }

--- a/src/agents/models-config.provider-policy-registry.test.ts
+++ b/src/agents/models-config.provider-policy-registry.test.ts
@@ -41,7 +41,9 @@ vi.mock("./model-auth-env-vars.js", () => ({
   }),
 }));
 
-let planOpenClawModelsJsonWithDeps: typeof import("./models-config.plan.test-support.js").planOpenClawModelsJsonWithDeps;
+let planModelsJsonForTest: typeof import("./models-config.plan.test-support.js").planModelsJsonForTest;
+let modelsConfigProviders: typeof import("./models-config.providers.js");
+let resolveImplicitProvidersSpy: MockInstance | undefined;
 let loadPluginManifestRegistrySpy: MockInstance | undefined;
 let loadBundledPluginPublicArtifactModuleFromCandidatesSyncSpy: MockInstance | undefined;
 let bundledPluginsDir: string;
@@ -76,10 +78,12 @@ beforeAll(async () => {
         }),
       };
     });
-  ({ planOpenClawModelsJsonWithDeps } = await import("./models-config.plan.test-support.js"));
+  ({ planModelsJsonForTest } = await import("./models-config.plan.test-support.js"));
+  modelsConfigProviders = await import("./models-config.providers.js");
 });
 
 afterAll(() => {
+  resolveImplicitProvidersSpy?.mockRestore();
   loadPluginManifestRegistrySpy?.mockRestore();
   loadBundledPluginPublicArtifactModuleFromCandidatesSyncSpy?.mockRestore();
   if (originalBundledPluginsDir === undefined) {
@@ -111,26 +115,24 @@ describe("models-config provider policy registry", () => {
       "index" | "manifestRegistry" | "owners" | "pluginIds"
     >;
 
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: { models: { providers: {} } },
-        agentDir: "/tmp/openclaw-provider-policy-registry-test/agent",
-        env: {},
-        existingRaw: "",
-        existingParsed: null,
-        pluginMetadataSnapshot,
-      },
-      {
-        resolveImplicitProviders: async () => ({
-          "x-ai": {
-            baseUrl: "https://mock.example/v1",
-            api: "openai-responses",
-            apiKey: "OPENAI_API_KEY",
-            models: [],
-          },
-        }),
-      },
-    );
+    resolveImplicitProvidersSpy = vi
+      .spyOn(modelsConfigProviders, "resolveImplicitProviders")
+      .mockResolvedValue({
+        "x-ai": {
+          baseUrl: "https://mock.example/v1",
+          api: "openai-responses",
+          apiKey: "OPENAI_API_KEY",
+          models: [],
+        },
+      });
+    const plan = await planModelsJsonForTest({
+      cfg: { models: { providers: {} } },
+      agentDir: "/tmp/openclaw-provider-policy-registry-test/agent",
+      env: {},
+      existingRaw: "",
+      existingParsed: null,
+      pluginMetadataSnapshot,
+    });
 
     expect(plan.action).toBe("write");
     expect(

--- a/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
+++ b/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
-import { resolveProvidersForModelsJsonWithDeps } from "./models-config.plan.test-support.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { planModelsJsonForTest } from "./models-config.plan.test-support.js";
+import * as providers from "./models-config.providers.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 function createExplicitProvider(): ProviderConfig {
   return {
@@ -42,81 +46,38 @@ function createImplicitProvider(): ProviderConfig {
 }
 
 describe("models-config plan: replace mode skips implicit discovery", () => {
-  it("skips implicit discovery when models.mode === 'replace'", async () => {
+  it.each([
+    { mode: "replace", calls: 0, providerIds: ["explicit"] },
+    { mode: "merge", calls: 1, providerIds: ["explicit", "openrouter"] },
+    { mode: undefined, calls: 1, providerIds: ["explicit", "openrouter"] },
+  ] as const)("plans providers with models.mode=$mode", async ({ mode, calls, providerIds }) => {
     const explicitProvider = createExplicitProvider();
     const cfg: OpenClawConfig = {
       models: {
-        mode: "replace",
+        ...(mode ? { mode } : {}),
         providers: { explicit: explicitProvider },
       },
     };
 
-    const resolveImplicitSpy = vi.fn(async () => ({
-      openrouter: createImplicitProvider(),
-    }));
+    const resolveImplicitSpy = vi
+      .spyOn(providers, "resolveImplicitProviders")
+      .mockResolvedValue({ openrouter: createImplicitProvider() });
 
-    const result = await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg,
-        agentDir: "/tmp/openclaw-models-config-replace-test",
-        env: {},
-      },
-      { resolveImplicitProviders: resolveImplicitSpy },
-    );
+    const plan = await planModelsJsonForTest({
+      cfg,
+      agentDir: "/tmp/openclaw-models-config-replace-test",
+      env: {},
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+    });
 
-    expect(resolveImplicitSpy).not.toHaveBeenCalled();
-    expect(Object.keys(result)).toEqual(["explicit"]);
-    expect(result.explicit).toEqual(explicitProvider);
-  });
-
-  it("still resolves implicit when models.mode === 'merge'", async () => {
-    const explicitProvider = createExplicitProvider();
-    const cfg: OpenClawConfig = {
-      models: {
-        mode: "merge",
-        providers: { explicit: explicitProvider },
-      },
-    };
-
-    const resolveImplicitSpy = vi.fn(async () => ({
-      openrouter: createImplicitProvider(),
-    }));
-
-    const result = await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg,
-        agentDir: "/tmp/openclaw-models-config-replace-test",
-        env: {},
-      },
-      { resolveImplicitProviders: resolveImplicitSpy },
-    );
-
-    expect(resolveImplicitSpy).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result).toSorted()).toEqual(["explicit", "openrouter"]);
-  });
-
-  it("still resolves implicit when models.mode is undefined (defaults to merge)", async () => {
-    const explicitProvider = createExplicitProvider();
-    const cfg: OpenClawConfig = {
-      models: {
-        providers: { explicit: explicitProvider },
-      },
-    };
-
-    const resolveImplicitSpy = vi.fn(async () => ({
-      openrouter: createImplicitProvider(),
-    }));
-
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg,
-        agentDir: "/tmp/openclaw-models-config-replace-test",
-        env: {},
-      },
-      { resolveImplicitProviders: resolveImplicitSpy },
-    );
-
-    expect(resolveImplicitSpy).toHaveBeenCalledTimes(1);
+    expect(resolveImplicitSpy).toHaveBeenCalledTimes(calls);
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error(`Expected write plan, got ${plan.action}`);
+    }
+    const generated = JSON.parse(plan.contents) as { providers: Record<string, ProviderConfig> };
+    expect(Object.keys(generated.providers).toSorted()).toEqual(providerIds);
+    expect(generated.providers.explicit).toEqual(explicitProvider);
   });
 
   it("forwards resolved runtime config separately from source config", async () => {
@@ -140,18 +101,19 @@ describe("models-config plan: replace mode skips implicit discovery", () => {
         },
       },
     };
-    const resolveImplicitSpy = vi.fn(async () => ({}));
+    const resolveImplicitSpy = vi
+      .spyOn(providers, "resolveImplicitProviders")
+      .mockResolvedValue({});
 
-    await resolveProvidersForModelsJsonWithDeps(
-      {
-        cfg,
-        discoveryAuthConfig,
-        agentDir: "/tmp/openclaw-models-config-auth-test",
-        env: {},
-      },
-      { resolveImplicitProviders: resolveImplicitSpy },
-    );
+    const plan = await planModelsJsonForTest({
+      cfg,
+      discoveryAuthConfig,
+      agentDir: "/tmp/openclaw-models-config-auth-test",
+      env: {},
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
+    });
 
+    expect(resolveImplicitSpy).toHaveBeenCalledOnce();
     expect(resolveImplicitSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         config: expect.objectContaining({
@@ -164,7 +126,14 @@ describe("models-config plan: replace mode skips implicit discovery", () => {
           }),
         }),
         discoveryAuthConfig,
+        sourceConfigForSecrets: cfg,
       }),
     );
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error(`Expected write plan, got ${plan.action}`);
+    }
+    const generated = JSON.parse(plan.contents) as { providers: Record<string, ProviderConfig> };
+    expect(Object.keys(generated.providers)).toEqual(["explicit"]);
   });
 });

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -48,7 +48,7 @@ let clearRuntimeConfigSnapshot: typeof import("../config/io.js").clearRuntimeCon
 let setRuntimeConfigSnapshot: typeof import("../config/io.js").setRuntimeConfigSnapshot;
 let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
 let resetModelsJsonReadyCacheForTest: typeof import("./models-config-state.test-support.js").resetModelsJsonReadyCacheForTest;
-let planOpenClawModelsJsonWithDeps: typeof import("./models-config.plan.test-support.js").planOpenClawModelsJsonWithDeps;
+let planModelsJsonForTest: typeof import("./models-config.plan.test-support.js").planModelsJsonForTest;
 let readGeneratedModelsJson: typeof import("./models-config.test-utils.js").readGeneratedModelsJson;
 const fixtureSuite = createFixtureSuite("openclaw-models-runtime-source-");
 
@@ -58,7 +58,7 @@ beforeAll(async () => {
     await import("../config/io.js"));
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
   ({ resetModelsJsonReadyCacheForTest } = await import("./models-config-state.test-support.js"));
-  ({ planOpenClawModelsJsonWithDeps } = await import("./models-config.plan.test-support.js"));
+  ({ planModelsJsonForTest } = await import("./models-config.plan.test-support.js"));
   ({ readGeneratedModelsJson } = await import("./models-config.test-utils.js"));
 });
 
@@ -228,19 +228,14 @@ async function planGeneratedProviders(params: {
   sourceConfigForSecrets: OpenClawConfig;
 }) {
   // Planner assertions avoid filesystem noise for marker-projection cases.
-  const plan = await planOpenClawModelsJsonWithDeps(
-    {
-      cfg: params.config,
-      sourceConfigForSecrets: params.sourceConfigForSecrets,
-      agentDir: "/tmp/openclaw-models-plan",
-      env: {},
-      existingRaw: "",
-      existingParsed: null,
-    },
-    {
-      resolveImplicitProviders: async () => ({}),
-    },
-  );
+  const plan = await planModelsJsonForTest({
+    cfg: params.config,
+    sourceConfigForSecrets: params.sourceConfigForSecrets,
+    agentDir: "/tmp/openclaw-models-plan",
+    env: {},
+    existingRaw: "",
+    existingParsed: null,
+  });
   expect(plan.action).toBe("write");
   if (plan.action !== "write") {
     throw new Error(`expected models.json write plan, got ${plan.action}`);

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -1,13 +1,10 @@
 // Verifies GitHub Copilot profile token fallback and implicit provider planning.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
-import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.test-support.js";
+import { planModelsJsonForTest } from "./models-config.plan.test-support.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 import { createProviderAuthResolver } from "./models-config.providers.secrets.js";
-
-type ResolveImplicitProvidersForModelsJson = NonNullable<
-  NonNullable<Parameters<typeof planOpenClawModelsJsonWithDeps>[1]>["resolveImplicitProviders"]
->;
 
 vi.mock("./model-auth-env.js", () => ({
   resolveEnvApiKey: () => null,
@@ -35,12 +32,16 @@ vi.mock("./models-config.providers.js", () => ({
   enforceSourceManagedProviderSecrets: ({ providers }: { providers: unknown }) => providers,
   normalizeProviderCatalogModelsForConfig: (providers: unknown) => providers,
   normalizeProviders: ({ providers }: { providers: unknown }) => providers,
-  resolveImplicitProviders: async ({
-    explicitProviders,
-  }: {
-    explicitProviders?: Record<string, unknown>;
-  }) => explicitProviders ?? {},
+  resolveImplicitProviders: vi.fn(),
 }));
+
+const resolveImplicitProvidersMock = vi.mocked(resolveImplicitProviders);
+
+beforeEach(() => {
+  resolveImplicitProvidersMock
+    .mockReset()
+    .mockImplementation(async ({ explicitProviders }) => explicitProviders ?? {});
+});
 
 describe("models-config", () => {
   it("uses the first github-copilot profile when env tokens are missing", () => {
@@ -108,35 +109,28 @@ describe("models-config", () => {
   });
 
   it("passes explicit provider config to implicit discovery so plugins can skip duplicates", async () => {
-    const resolveImplicitProviders = vi.fn<ResolveImplicitProvidersForModelsJson>(
-      async ({ explicitProviders }) => {
-        expect(explicitProviders.vllm?.baseUrl).toBe("http://127.0.0.1:8000/v1");
-        return {};
-      },
-    );
+    resolveImplicitProvidersMock.mockImplementationOnce(async ({ explicitProviders }) => {
+      expect(explicitProviders?.vllm?.baseUrl).toBe("http://127.0.0.1:8000/v1");
+      return {};
+    });
 
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: {
-          models: {
-            providers: {
-              vllm: {
-                baseUrl: "http://127.0.0.1:8000/v1",
-                api: "openai-completions",
-                models: [],
-              },
+    const plan = await planModelsJsonForTest({
+      cfg: {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              api: "openai-completions",
+              models: [],
             },
           },
         },
-        agentDir: "/tmp/openclaw-agent",
-        env: { VLLM_API_KEY: "test-vllm-key" } as NodeJS.ProcessEnv,
-        existingRaw: "",
-        existingParsed: null,
       },
-      { resolveImplicitProviders },
-    );
+      agentDir: "/tmp/openclaw-agent",
+      env: { VLLM_API_KEY: "test-vllm-key" } as NodeJS.ProcessEnv,
+    });
 
-    expect(resolveImplicitProviders).toHaveBeenCalledOnce();
+    expect(resolveImplicitProvidersMock).toHaveBeenCalledOnce();
     expect(plan).toEqual({
       action: "write",
       pluginCatalogWrites: {},
@@ -176,31 +170,27 @@ describe("models-config", () => {
       2,
     )}\n`;
 
-    const plan = await planOpenClawModelsJsonWithDeps(
-      {
-        cfg: {
-          models: {
-            providers: {
-              kilocode: kilocodeProvider,
-            },
+    resolveImplicitProvidersMock.mockResolvedValueOnce({});
+    const plan = await planModelsJsonForTest({
+      cfg: {
+        models: {
+          providers: {
+            kilocode: kilocodeProvider,
           },
         },
-        sourceConfigForSecrets: {
-          models: {
-            providers: {
-              kilocode: kilocodeProvider,
-            },
+      },
+      sourceConfigForSecrets: {
+        models: {
+          providers: {
+            kilocode: kilocodeProvider,
           },
         },
-        agentDir: "/tmp/openclaw-agent",
-        env: {} as NodeJS.ProcessEnv,
-        existingRaw: existingContents,
-        existingParsed: JSON.parse(existingContents),
       },
-      {
-        resolveImplicitProviders: async () => ({}),
-      },
-    );
+      agentDir: "/tmp/openclaw-agent",
+      env: {} as NodeJS.ProcessEnv,
+      existingRaw: existingContents,
+      existingParsed: JSON.parse(existingContents),
+    });
 
     expect(plan).toEqual({ action: "noop", pluginCatalogWrites: {} });
   });
@@ -254,26 +244,13 @@ describe("models-config", () => {
   });
 });
 
-function createCopilotImplicitResolver(
-  provider: ProviderConfig,
-): ResolveImplicitProvidersForModelsJson {
-  // Models planner receives implicit Copilot providers from the auth exchange layer.
-  return async () => ({ "github-copilot": provider });
-}
-
 async function planCopilotWithImplicitProvider(params: { provider: ProviderConfig }) {
-  return await planOpenClawModelsJsonWithDeps(
-    {
-      cfg: { models: { providers: {} } },
-      agentDir: "/tmp/openclaw-agent",
-      env: {} as NodeJS.ProcessEnv,
-      existingRaw: "",
-      existingParsed: null,
-    },
-    {
-      resolveImplicitProviders: createCopilotImplicitResolver(params.provider),
-    },
-  );
+  resolveImplicitProvidersMock.mockResolvedValueOnce({ "github-copilot": params.provider });
+  return await planModelsJsonForTest({
+    cfg: { models: { providers: {} } },
+    agentDir: "/tmp/openclaw-agent",
+    env: {} as NodeJS.ProcessEnv,
+  });
 }
 
 function expectCopilotProviderFromPlan(

--- a/test/repository-test-api-publications.ts
+++ b/test/repository-test-api-publications.ts
@@ -41,7 +41,6 @@ const publications: Record<string, string | symbol> = {
   "src/agents/media-generation-task-status-shared.ts": Symbol.for(
     "openclaw.mediaGenerationDuplicateGuardTestApi",
   ),
-  "src/agents/models-config.plan.ts": Symbol.for("openclaw.modelsConfigPlanTestApi"),
   "src/agents/prepared-model-runtime.ts": Symbol.for("openclaw.preparedModelRuntimeTestApi"),
   "src/agents/session-suspension.ts": Symbol.for("openclaw.sessionSuspensionTestApi"),
   "src/agents/sessions/tools/bash.ts": Symbol.for("openclaw.bashToolTestApi"),


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Model-catalog planning retains a test-only global and dependency-injection wrappers around its real implementation. Tests reaching those private paths need duplicate signatures and can miss behavior at the public planning boundary.

## Why This Change Was Made

Export the existing implementation directly under the unchanged public planner name, keep provider resolution private, and move discovery substitution into suite-owned mocks. Remove the test global, forwarding wrapper and duplicate dependency types. Planning, normalization, merging, secret handling and persistence behavior remain unchanged. This maintainer-requested cleanup removes 47 production lines.

## User Impact

Catalog generation keeps the same behavior with fewer test-only runtime paths.

## Evidence

Fresh validation at `f727ae56a139b8b20190d81feff6db4d89566695` passed all 58 focused tests, independent P2 review against the current writer context, and the full changed-file gate. The replay preserves main's earlier writer and Responses test-global removals. Production and the retained planner test suites are unchanged from the originally reviewed cleanup.

One canonical `sourcePerformance` build and five compiled public ensure/ModelRegistry scenarios passed, covering merge, replace, unchanged writes, and credential markers. The proof loaded 803 distribution modules, imported no checkout TypeScript, and made no provider HTTP calls. All child processes joined and isolated state was removed; source and build metadata stayed unchanged. This runtime profile excludes UI and declaration generation.

The previous CI failure was caused by a shared legacy-handoff fixture contaminating concurrent model-config tests. The current main base contains the independently landed fixture repair in #143875 and the UI lint repair in #143889. Its original failure evidence remains preserved; no production workaround or test assertion was weakened.
