### PR TITLE
docs(i18n): resolve glossary term conflicts and locale nav staleness

### DIFF
--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -34,8 +34,8 @@ Edit English docs in `openclaw/openclaw` and push to `main`. The sync, translati
 ## Files in this folder
 
 - `glossary.<lang>.json` — preferred term mappings used as prompt guidance.
-- `zh-Hans-navigation.json` — curated zh-Hans tab and group labels overlaid onto the current English navigation tree during publish sync.
-- `ar-navigation.json`, `de-navigation.json`, `es-navigation.json`, `fr-navigation.json`, `id-navigation.json`, `it-navigation.json`, `ja-navigation.json`, `ko-navigation.json`, `pl-navigation.json`, `pt-BR-navigation.json`, and `tr-navigation.json` — starter locale labels kept alongside the source repo. Publish sync clones the full English navigation tree, prefixes locale routes, and overlays translated labels by matching shared page anchors.
+- `zh-Hans-navigation.json` — curated zh-Hans tab and group labels overlaid onto the current English navigation tree during publish sync. It labels all 11 published tabs. 8 of 57 top-level groups still show their English label because no translated label exists for them yet.
+- `ar-navigation.json`, `de-navigation.json`, `es-navigation.json`, `fr-navigation.json`, `id-navigation.json`, `it-navigation.json`, `ja-navigation.json`, `ko-navigation.json`, `pl-navigation.json`, `pt-BR-navigation.json`, and `tr-navigation.json` — starter locale labels kept alongside the source repo. Publish sync clones the full English navigation tree, prefixes locale routes, and overlays translated labels by matching shared page anchors. Each starter file currently labels 1 tab and 2 groups, so these locales publish an almost fully English sidebar. Extend a starter file to translate more of the sidebar.
 - `<lang>.tm.jsonl` — translation memory keyed by workflow, prompt version, language, and text hash.
 
 ### Locale code mapping
@@ -74,7 +74,17 @@ Only three locales differ between the two code families: `zh-Hans`/`zh-CN`,
 places. `scripts/docs-i18n` builds the glossary path from the
 directory code (`-lang`), so a glossary must be named `glossary.<dir>.json`, not
 `glossary.<language>.json`. Locales without a navigation file fall back to the
-cloned English tree with route prefixes only.
+cloned English tree with route prefixes only. `composeLocaleNav` in
+`scripts/docs-sync-publish.mjs` prints a warning for each expected navigation file
+that is absent, so the fallback is visible in the sync log.
+
+### The ClawHub tab is excluded from every locale navigation
+
+`cloneEnglishLanguageNav` in `scripts/docs-sync-publish.mjs` drops the `ClawHub`
+tab before it prefixes locale routes. Every locale sidebar therefore omits that
+tab and its pages. ClawHub English docs are authored in `openclaw/clawhub` and
+are copied into the publish tree at publish time (`--clawhub-repo`), so most of
+them have no file in this repository and no locale translation to link to.
 
 In this repo, generated locale TM files such as `docs/.i18n/zh-CN.tm.jsonl`, `docs/.i18n/zh-TW.tm.jsonl`, `docs/.i18n/ja-JP.tm.jsonl`, `docs/.i18n/es.tm.jsonl`, `docs/.i18n/pt-BR.tm.jsonl`, `docs/.i18n/ko.tm.jsonl`, `docs/.i18n/de.tm.jsonl`, `docs/.i18n/fr.tm.jsonl`, `docs/.i18n/ar.tm.jsonl`, `docs/.i18n/it.tm.jsonl`, `docs/.i18n/vi.tm.jsonl`, `docs/.i18n/nl.tm.jsonl`, `docs/.i18n/fa.tm.jsonl`, `docs/.i18n/tr.tm.jsonl`, `docs/.i18n/uk.tm.jsonl`, `docs/.i18n/id.tm.jsonl`, `docs/.i18n/pl.tm.jsonl`, and `docs/.i18n/th.tm.jsonl` are intentionally no longer committed.
 
@@ -85,7 +95,7 @@ In this repo, generated locale TM files such as `docs/.i18n/zh-CN.tm.jsonl`, `do
 ```json
 {
   "source": "troubleshooting",
-  "target": "故障排除"
+  "target": "故障排查"
 }
 ```
 
@@ -93,6 +103,12 @@ Fields:
 
 - `source`: English (or source) phrase to prefer.
 - `target`: preferred translation output.
+
+Lookup in `scripts/check-docs-i18n-glossary.mts` is exact and case-sensitive.
+Two entries whose `source` values differ only in case are therefore two separate
+terms. Give them the same `target` when they name the same thing. Keep the
+targets different only when the case itself carries meaning, as it does for a
+display name and its identifier (`Cohere` and `cohere`, `Meta` and `meta`).
 
 ## Translation mechanics
 

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1249,7 +1249,7 @@
   },
   {
     "source": "troubleshooting",
-    "target": "故障排除"
+    "target": "故障排查"
   },
   {
     "source": "FAQ",
@@ -1877,7 +1877,7 @@
   },
   {
     "source": "Multi-agent sandbox and tools",
-    "target": "多 Agent 沙盒和工具"
+    "target": "多智能体沙箱与工具"
   },
   {
     "source": "Exec tool",

--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -63,6 +63,10 @@
         {
           "group": "高级",
           "pages": ["zh-CN/install/development-channels"]
+        },
+        {
+          "group": "运行时",
+          "pages": ["zh-CN/install/node-compatibility", "zh-CN/install/bun-compatibility"]
         }
       ]
     },
@@ -78,7 +82,6 @@
           "pages": [
             "zh-CN/channels/discord",
             "zh-CN/channels/feishu",
-            "zh-CN/channels/grammy",
             "zh-CN/channels/googlechat",
             "zh-CN/channels/imessage",
             "zh-CN/channels/line",
@@ -117,7 +120,6 @@
         {
           "group": "代理运行时",
           "pages": [
-            "zh-CN/pi",
             "zh-CN/concepts/architecture",
             "zh-CN/concepts/agent",
             "zh-CN/concepts/agent-loop",
@@ -179,14 +181,12 @@
           "group": "内置工具",
           "pages": [
             "zh-CN/tools/apply-patch",
-            "zh-CN/brave-search",
             "zh-CN/tools/elevated",
             "zh-CN/tools/exec",
             "zh-CN/tools/exec-approvals",
             "zh-CN/tools/firecrawl",
             "zh-CN/tools/llm-task",
             "zh-CN/tools/lobster",
-            "zh-CN/perplexity",
             "zh-CN/tools/reactions",
             "zh-CN/tools/thinking",
             "zh-CN/tools/web"
@@ -224,7 +224,6 @@
             "zh-CN/plugins/voice-call",
             "zh-CN/plugins/zalouser",
             "zh-CN/plugins/manifest",
-            "zh-CN/plugins/agent-tools",
             "zh-CN/prose"
           ]
         },
@@ -243,8 +242,23 @@
             "zh-CN/nodes/camera",
             "zh-CN/nodes/talk",
             "zh-CN/nodes/voicewake",
-            "zh-CN/nodes/location-command",
-            "zh-CN/tts"
+            "zh-CN/nodes/location-command"
+          ]
+        },
+        {
+          "group": "插件",
+          "pages": [
+            "zh-CN/plugins/manage-plugins",
+            "zh-CN/plugins/community",
+            "zh-CN/plugins/bundles"
+          ]
+        },
+        {
+          "group": "构建插件",
+          "pages": [
+            "zh-CN/plugins/building-plugins",
+            "zh-CN/plugins/feature-plugins",
+            "zh-CN/plugins/tool-plugins"
           ]
         }
       ]
@@ -300,10 +314,7 @@
             "zh-CN/platforms/linux",
             "zh-CN/platforms/windows",
             "zh-CN/platforms/android",
-            "zh-CN/platforms/ios",
-            "zh-CN/platforms/digitalocean",
-            "zh-CN/platforms/oracle",
-            "zh-CN/platforms/raspberry-pi"
+            "zh-CN/platforms/ios"
           ]
         },
         {
@@ -315,7 +326,6 @@
             "zh-CN/platforms/mac/voice-overlay",
             "zh-CN/platforms/mac/webchat",
             "zh-CN/platforms/mac/canvas",
-            "zh-CN/platforms/mac/child-process",
             "zh-CN/platforms/mac/health",
             "zh-CN/platforms/mac/icon",
             "zh-CN/platforms/mac/logging",
@@ -365,7 +375,6 @@
               "group": "协议与 API",
               "pages": [
                 "zh-CN/gateway/protocol",
-                "zh-CN/gateway/bridge-protocol",
                 "zh-CN/gateway/openai-http-api",
                 "zh-CN/gateway/openresponses-http-api",
                 "zh-CN/gateway/tools-invoke-http-api",
@@ -376,7 +385,6 @@
             {
               "group": "网络与发现",
               "pages": [
-                "zh-CN/gateway/network-model",
                 "zh-CN/gateway/pairing",
                 "zh-CN/gateway/discovery",
                 "zh-CN/gateway/bonjour"
@@ -388,7 +396,6 @@
           "group": "远程访问",
           "pages": [
             "zh-CN/gateway/remote",
-            "zh-CN/gateway/remote-gateway-readme",
             "zh-CN/gateway/tailscale"
           ]
         },
@@ -482,7 +489,6 @@
         {
           "group": "技术参考",
           "pages": [
-            "zh-CN/reference/wizard",
             "zh-CN/reference/token-use",
             "zh-CN/reference/api-usage-costs",
             "zh-CN/reference/transcript-hygiene",
@@ -502,6 +508,14 @@
         {
           "group": "项目",
           "pages": ["zh-CN/reference/credits"]
+        },
+        {
+          "group": "插件参考",
+          "pages": [
+            "zh-CN/plugins/plugin-inventory",
+            "zh-CN/plugins/reference",
+            "zh-CN/plugins/dependency-resolution"
+          ]
         }
       ]
     },
@@ -551,8 +565,6 @@
             "zh-CN/help/environment",
             "zh-CN/help/debugging",
             "zh-CN/help/testing",
-            "zh-CN/help/scripts",
-            "zh-CN/debug/node-issue",
             "zh-CN/diagnostics/flags"
           ]
         },
@@ -566,11 +578,19 @@
         },
         {
           "group": "开发者设置",
-          "pages": ["zh-CN/start/setup", "zh-CN/pi-dev"]
+          "pages": ["zh-CN/start/setup"]
         },
         {
           "group": "文档元信息",
           "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory", "zh-CN/AGENTS"]
+        },
+        {
+          "group": "常见问题",
+          "pages": ["zh-CN/help/faq-first-run", "zh-CN/help/faq-models"]
+        },
+        {
+          "group": "测试",
+          "pages": ["zh-CN/help/testing-updates-plugins", "zh-CN/help/testing-live"]
         }
       ]
     }

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -96,5 +96,5 @@ Feishu/Lark does not support native slash-command menus, so send these as plain 
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -259,7 +259,7 @@ openclaw channels status
 ## Related
 
 - [Channels Overview](/channels) — all supported channels
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Gateway configuration](/gateway/configuration)
 - [Groups](/channels/groups) — group chat behavior and mention gating
 - [Pairing](/channels/pairing) — DM authentication and pairing flow

--- a/docs/channels/imessage-from-bluebubbles.md
+++ b/docs/channels/imessage-from-bluebubbles.md
@@ -230,4 +230,4 @@ The reply cache lives in SQLite plugin state. `openclaw doctor --fix` imports an
 - [iMessage](/channels/imessage) — full iMessage channel reference, including `imsg launch` setup and capability detection.
 - `/channels/bluebubbles` — legacy URL that redirects to this migration guide.
 - [Pairing](/channels/pairing) — DM authentication and pairing flow.
-- [Channel Routing](/channels/channel-routing) — how the gateway picks a channel for outbound replies.
+- [Channel routing](/channels/channel-routing) — how the gateway picks a channel for outbound replies.

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -116,7 +116,7 @@ Every section heading from the previous single-page version keeps its anchor her
   <Card title="Groups" icon="users" href="/channels/groups">
     Group chat behavior and mention gating.
   </Card>
-  <Card title="Channel Routing" icon="route" href="/channels/channel-routing">
+  <Card title="Channel routing" icon="route" href="/channels/channel-routing">
     Session routing for messages.
   </Card>
   <Card title="Configuration reference" icon="sliders" href="/gateway/config-channels#imessage">

--- a/docs/channels/imessage/troubleshooting.md
+++ b/docs/channels/imessage/troubleshooting.md
@@ -122,5 +122,5 @@ openclaw channels status --probe --channel imessage
 - [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) — config translation table and step-by-step cutover
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -304,5 +304,5 @@ Default account supports:
 - [Channels Overview](/channels) — all supported channels
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -458,5 +458,5 @@ link-local, and private-network targets.
 - [Channels Overview](/channels) — all supported channels
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -183,5 +183,5 @@ Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Pl
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -598,7 +598,7 @@ Account values override top-level fields; `channels.mattermost.defaultAccount` p
 
 ## Related
 
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Channels Overview](/channels) - all supported channels
 - [Groups](/channels/groups) - group chat behavior and mention gating
 - [Pairing](/channels/pairing) - DM authentication and pairing flow

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -131,7 +131,7 @@ Every section heading from the previous single-page version keeps its anchor her
   <Card title="Groups" icon="users" href="/channels/groups">
     Group chat behavior and mention gating.
   </Card>
-  <Card title="Channel Routing" icon="route" href="/channels/channel-routing">
+  <Card title="Channel routing" icon="route" href="/channels/channel-routing">
     Session routing for messages.
   </Card>
   <Card title="Configuration reference" icon="sliders" href="/gateway/config-channels/workplace-chat">

--- a/docs/channels/msteams/troubleshooting.md
+++ b/docs/channels/msteams/troubleshooting.md
@@ -122,5 +122,5 @@ Teams markdown is more limited than Slack or Discord:
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -171,5 +171,5 @@ Provider options:
 - [Channels Overview](/channels) — all supported channels
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/nostr.md
+++ b/docs/channels/nostr.md
@@ -237,5 +237,5 @@ docker run -p 7777:7777 ghcr.io/hoytech/strfry
 - [Channels Overview](/channels) — all supported channels
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -511,6 +511,6 @@ Related global options:
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [RPC adapters](/reference/rpc) - the signal-cli JSON-RPC-over-HTTP daemon pattern behind this channel
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -200,5 +200,5 @@ but duplicate exact paths are still rejected fail-closed. Prefer explicit per-ac
 
 - [Channels Overview](/channels) — all supported channels
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/tlon.md
+++ b/docs/channels/tlon.md
@@ -334,5 +334,5 @@ Full configuration: [Configuration](/gateway/configuration)
 - [Channels Overview](/channels) — all supported channels
 - [Pairing](/channels/pairing) — DM authentication and pairing flow
 - [Groups](/channels/groups) — group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -398,7 +398,7 @@ When replying in a Twitch conversation, omit `to` to use the current conversatio
 
 ## Related
 
-- [Channel Routing](/channels/channel-routing) — session routing for messages
+- [Channel routing](/channels/channel-routing) — session routing for messages
 - [Channels Overview](/channels) — all supported channels
 - [Groups](/channels/groups) — group chat behavior and mention gating
 - [Pairing](/channels/pairing) — DM authentication and pairing flow

--- a/docs/channels/wechat.md
+++ b/docs/channels/wechat.md
@@ -176,7 +176,7 @@ openclaw gateway restart
 
 - Channel overview: [Chat Channels](/channels)
 - Pairing: [Pairing](/channels/pairing)
-- Channel routing: [Channel Routing](/channels/channel-routing)
+- Channel routing: [Channel routing](/channels/channel-routing)
 - Plugin architecture: [Plugin Architecture](/plugins/architecture)
 - Channel plugin SDK: [Channel Plugin SDK](/plugins/sdk-channel-plugins)
 - External package: [@tencent-weixin/openclaw-weixin](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin)

--- a/docs/channels/yuanbao.md
+++ b/docs/channels/yuanbao.md
@@ -354,5 +354,5 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -176,5 +176,5 @@ Env option: `ZALO_BOT_TOKEN=...` resolves the default account's token only.
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -222,5 +222,5 @@ For multi-account setups, prefer setting `profile` on each account in config so 
 - [Channels Overview](/channels) - all supported channels
 - [Pairing](/channels/pairing) - DM authentication and pairing flow
 - [Groups](/channels/groups) - group chat behavior and mention gating
-- [Channel Routing](/channels/channel-routing) - session routing for messages
+- [Channel routing](/channels/channel-routing) - session routing for messages
 - [Security](/gateway/security) - access model and hardening

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -340,7 +340,7 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
   store schema, transcripts, send policy, origin metadata, and advanced config
 - [Multi-Agent](/concepts/multi-agent) - routing and session isolation across agents
 - [Background Tasks](/automation/tasks) - how detached work creates task records with session references
-- [Channel Routing](/channels/channel-routing) - how inbound messages are routed to sessions
+- [Channel routing](/channels/channel-routing) - how inbound messages are routed to sessions
 
 ## Related
 

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -571,5 +571,5 @@ openclaw logs --follow
 
 - [Sandboxing](/gateway/sandboxing) - modes, scopes, and backend comparison
 - [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) - debugging blocked tools
-- [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools) - per-agent overrides
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - per-agent overrides
 - [Sandbox CLI](/cli/sandbox) - `openclaw sandbox` commands

--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -115,7 +115,7 @@ nmap -p- YOUR_SERVER_IP
 
 Only port 22 (SSH) should be open. Gateway and Docker stay locked down.
 
-Docker is installed for agent sandboxes (isolated tool execution), not for running the gateway. See [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools) for sandbox configuration.
+Docker is installed for agent sandboxes (isolated tool execution), not for running the gateway. See [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) for sandbox configuration.
 
 ## Manual installation
 
@@ -224,4 +224,4 @@ For detailed security architecture and troubleshooting, see the openclaw-ansible
 - [openclaw-ansible](https://github.com/openclaw/openclaw-ansible): full deployment guide
 - [Docker](/install/docker): containerized gateway setup
 - [Sandboxing](/gateway/sandboxing): agent sandbox configuration
-- [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools): per-agent isolation
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools): per-agent isolation

--- a/docs/install/docker/sandbox-and-troubleshooting.md
+++ b/docs/install/docker/sandbox-and-troubleshooting.md
@@ -19,7 +19,7 @@ For full configuration, images, security notes, and multi-agent profiles:
 
 - [Sandboxing](/gateway/sandboxing) -- complete sandbox reference
 - [OpenShell](/gateway/openshell) -- OpenShell-managed local or remote sandbox backend
-- [Multi-Agent Sandbox and Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides
 
 ### Quick enable
 

--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -515,6 +515,9 @@ function composeLocaleNav(locale, englishNav) {
   }
   const overlayPath = path.join(SOURCE_DOCS_DIR, ".i18n", locale.navFile);
   if (!fs.existsSync(overlayPath)) {
+    console.warn(
+      `docs-sync-publish: missing navigation overlay ${locale.navFile} for locale ${locale.language}; publishing the English sidebar labels for that locale.`,
+    );
     return cloned;
   }
   return applyLocaleNavLabelOverlay(cloned, readJson(overlayPath));


### PR DESCRIPTION
## What this does

Closes the mechanically decidable half of the open `i18n` audit findings. Every
change here is justified by a measurement, not by a judgement about Chinese.
Anything that needed a native zh reviewer was left alone and is listed at the
bottom.

29 files: 25 English docs (link labels), `docs/.i18n/glossary.zh-CN.json`,
`docs/.i18n/zh-Hans-navigation.json`, `docs/.i18n/README.md`,
`scripts/docs-sync-publish.mjs`.

### CODEOWNERS

Last-match-wins simulation over the full file list: **no file in this PR is owned
by `@openclaw/openclaw-secops` or `@openclaw/openclaw-release-managers`.** The
deferred STE fix in `docs/gateway/secrets-plan-contract.md` (`r5-0018`) is *not*
included here — see "Deferred" below.

## Fixed

### `r3-0996` (partial) — competing English spellings

Two pages were referenced under two spellings. Inbound link labels now match the
target page's own `title:` frontmatter:

| Page | Canonical `title:` | Was also written | Files |
| --- | --- | --- | --- |
| `/channels/channel-routing` | `Channel routing` | `Channel Routing` | 22 |
| `/tools/multi-agent-sandbox-tools` | `Multi-agent sandbox and tools` | `Multi-Agent Sandbox and Tools` | 3 |

No heading text changed, so **no anchor changed** — the diff is link labels and
two `<Card title=…>` attributes only. `checked_internal_links` is 13367 before
and after.

`docs/maturity/**` is deliberately excluded. Its "Channel Routing" spellings are
generated: `familyTitle()` in `scripts/qa/render-maturity-docs.ts` title-cases
the route slug (`channel-routing` -> `Channel Routing`). Hand-editing generated
output would be reverted by the next render.

### `r3-0995` (partial) — case variants mapping to different targets

`scripts/check-docs-i18n-glossary.mts` looks up sources with an exact,
case-sensitive `Set.has`. Merging entries or making the lookup case-insensitive
(the fix as written in the ledger) would drop sources the checker still needs and
would collide the identifier pairs below. So both entries are **kept** and their
targets are made equal. No entry is added, removed or reordered.

| Source pair | Was | Now | Evidence for the choice |
| --- | --- | --- | --- |
| `troubleshooting` / `Troubleshooting` | 故障排除 / 故障排查 | both 故障排查 | 故障排查 appears in 25 targets in this file, 故障排除 in 2 |
| `Multi-agent sandbox and tools` / `Multi-Agent Sandbox and Tools` | 多 Agent 沙盒和工具 / 多智能体沙箱与工具 | both 多智能体沙箱与工具 | 沙箱 in 17 targets vs 沙盒 in 1; 智能体 in 36 |

Case-variant groups with differing targets: **7 -> 5**. Of the 5 remaining, 4 are
refuted below and 1 is deferred.

### `r3-0992` — stale anchors in the zh-Hans overlay

Removed the 16 page anchors with no `.md`/`.mdx` on disk (`pi`, `pi-dev`,
`tts`, `brave-search`, `perplexity`, `channels/grammy`, `debug/node-issue`,
`gateway/bridge-protocol`, `gateway/network-model`,
`gateway/remote-gateway-readme`, `platforms/digitalocean`, `platforms/oracle`,
`platforms/raspberry-pi`, `platforms/mac/child-process`, `plugins/agent-tools`,
`reference/wizard`) and the duplicate `help/scripts`.

The duplicate was resolved by matching the English nav: `help/scripts` sits in
`Release & CI / Testing and CI` with `reference/test` and `ci`, which is the
overlay's 测试与 CI group. The copy in 环境与调试 was the stray one.

**This removal is provably output-neutral.** The overlay supplies labels only —
`applyLocaleNavLabelOverlay` uses its `pages` lists purely as matching keys and
never emits them. Simulating `composeLocaleNav` against `docs/docs.json` before
and after gives a byte-identical list of 11 tab labels and 57 group labels.

### `r3-0993` (partial) — untranslated groups in the zh-Hans sidebar

Measured on the current tree: 11 of 11 tabs are labelled, **14** of 57 top-level
groups still publish an English label (the ledger's "13 of 55" has drifted).

Six of those 14 already had an approved target in `glossary.zh-CN.json`, so this
PR applies the project's own glossary rather than translating anything:

`Runtimes`->运行时, `Plugins`->插件, `Building plugins`->构建插件,
`Plugin reference`->插件参考, `FAQ`->常见问题, `Testing`->测试.

Overlay groups were added with page anchors not already used elsewhere in the
file, so no existing group loses its match. Simulation confirms **exactly six**
label changes and nothing else. Untranslated groups: **14 -> 8**.

### `r3-0991` (partial) — silent fallback to an English sidebar

`composeLocaleNav` now warns when a locale declares a navigation overlay that is
absent, naming the file and the locale, instead of returning the English clone
silently.

### `r3-1001` — README does not mention the ClawHub tab drop

Added a section recording that `cloneEnglishLanguageNav` filters the `ClawHub`
tab out of every locale navigation, and that ClawHub pages are authored in
`openclaw/clawhub` and supplied at publish time via `--clawhub-repo`.

Also fixed the README's glossary example, which used the very entry this PR
changed (`troubleshooting` -> 故障排除), and documented the case-sensitivity rule
for glossary sources.

## Refuted, with evidence

### `r3-0995` — 4 of the 7 "conflicts" are not conflicts

`ClawRouter`/`clawrouter`, `Cohere`/`cohere`, `Meta`/`meta`, `Baseten`/`baseten`
are identity mappings that preserve case on purpose: the capitalised form is the
display name, the lowercase form is the literal provider id.
`docs/providers/meta.md:15` reads `| Provider id | `meta` |`. Merging them, or
making the lookup case-insensitive as the ledger's `fix` proposes, would make the
glossary rewrite an identifier. **These are left as they are, deliberately.**

### `r3-0994` — the `ru` claim no longer holds

The ledger says "ru lacks Plugin (`grep -c Plugin glossary.ru.json` returns 0)".
`glossary.ru.json` currently carries `Plugin` -> `Plugin`. Of the 22-term base
set shared by the 16 identical small glossaries, `zh-TW` and `ru` are missing
**none**. The rest of the finding stands (see Deferred).

### `r3-0997` — the proposed fix cannot be a gate yet

"Add a full-tree mode that checks every glossary file against every English title
and link label." Measured: the English tree yields **1,850** distinct
glossary-candidate terms under the checker's own extraction rules. A full-tree
run would report **1,836 missing of 1,850** for each of 18 locales, 1,819 for
`zh-TW`, and 815 for `zh-CN` — about 35,600 findings. The mode is not
implementable as a passing check until the glossaries are populated, which is
`r3-0994`. Deferred as blocked on it, not done as written.

## Deferred

| Finding | Why |
| --- | --- |
| `r3-0995` (`Channel Routing` / `Channel routing`) | **Needs a native zh reviewer.** The two targets are 频道路由 and 渠道路由. The file is split 23 targets using 频道 against 19 using 渠道, and the split does not decompose by meaning — `Channel overview` is 频道概览 while `Channels overview` is 渠道概览 for what is the same page. Picking one is a decision about Chinese and about a house convention for the whole file. Not made here. |
| `r3-0996` (remainder) | Tree-wide renames outside this shard, each needing a product-naming decision first. Current counts, code spans excluded: `subagent` 609 / `sub-agent` 230 (192 files); `env var` 210 / `environment variable` 151 (236 files); `QQBot` 63 / `QQ Bot` 48 / `QQ bot` 8; `TaskFlow` 40 / `Task Flow` 47; `hot reload` 36 / `hot-reload` 28. Each should be its own PR. |
| `r3-0994` | Confirmed: 20 glossaries, union 1,191 sources, only **12** common to all. `zh-CN` is missing 9 of the shared base set (`ACP`, `Active Memory`, `Cron`, `Mintlify`, `Node`, `Plugin`, `TUI`, `TaskFlow`, `Webhook`). All 17 small glossaries map these to themselves. Copying identity mappings into `zh-CN` would contradict the file's own usage — it already renders `Plugins` as 插件 and `node pairing` as 节点配对 — so the 9 targets **need a native zh reviewer**, not a default. |
| `r3-0990` | Confirmed unchanged: each of the 11 starter files holds 1 tab, 2 groups, 3 pages against 11 tabs and 57 groups in English. Closing it means translating ~57 labels into 11 languages. Needs 11 native reviewers. The coverage gap is now stated in the README so it is not silent. |
| `r3-0993` (remainder) | 8 groups still English: `Advanced setup`, `Developer and self-hosted`, `Regional platforms`, `Nodes and media`, `Codex harness`, `Plugin SDK reference`, `Plugin maintainer reference`, `Contributing`. No glossary target exists for any of them. Needs a native zh reviewer. (`Codex harness` maps to itself in the glossary, so it may be correct as-is.) |
| `r3-0991` (remainder) | The 8 missing navigation files still need writing, which is translation work per locale. The silent-failure half is fixed. |
| `r5-0018` | **Not included.** No file in this PR is secops-owned, so carrying the `docs/gateway/secrets-plan-contract.md` fix would import a `@openclaw/openclaw-secops` review gate onto 29 otherwise-unowned files — the same gate that made #143770 revert it. It needs its own secops-routed PR. |

## Validation

Base: `git merge-base HEAD origin/main` = `924381f9f8b`.

- `pnpm check:docs` — **exit 0**. Covers `format:docs:check` (1280 files clean),
  `lint:docs` (markdownlint-cli2, 1279 files, 0 issues), `lint:templates`,
  `docs:check-mdx` (1293 files), `docs:check-i18n-glossary`, `docs:check-links`
  (13094 links, 0 broken), `docs:check-config-examples`.
- `npx tsx scripts/check-docs-i18n-glossary.mts` — exit 0, run against a real
  merge base (not the no-merge-base skip path).
- `node scripts/docs-link-audit.mjs --anchors` — 13367 links, **3** broken.
  Baseline measured in a detached worktree at `924381f9f8b`: 13367 links, the
  **same 3** `#windows-app-node` errors. Net new: 0.
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts test/scripts/docs-sync-publish.test.ts` — 2 files, 44 tests, passed.
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — 8 files, 16 tests, passed.

No files were added or removed, so `.github/labeler.yml` needs no new glob.
