### PR TITLE
docs(tools): fix concrete ux defects in docs/tools

### DIFF
--- a/docs/tools/apply-patch.md
+++ b/docs/tools/apply-patch.md
@@ -20,9 +20,23 @@ The tool accepts a single `input` string that wraps one or more file operations:
 @@ optional change context
 -old line
 +new line
+*** Update File: src/old-name.ts
+*** Move to: src/new-name.ts
+@@
+ context line
+-old line
++new line
+*** Update File: src/tail.ts
+@@
++appended last line
+*** End of File
 *** Delete File: obsolete.txt
 *** End Patch
 ```
+
+`*** Move to:` goes on the line directly after its `*** Update File:` header.
+`*** End of File` goes after the hunk lines it terminates, marking that the hunk
+runs to the end of the file.
 
 ## Parameters
 

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -107,6 +107,11 @@ systemctl --user enable --now openclaw-browser.service
 
 ### Verify the browser works
 
+These calls go to the OpenClaw browser control service, not to the Chrome CDP
+port used above. Its port is derived from `gateway.port` (default `18791` =
+gateway port + 2), so adjust the number if you moved the Gateway port. `jq` only
+pretty-prints the response; drop the pipe if you do not have it installed.
+
 ```bash
 curl -s http://127.0.0.1:18791/ | jq '{running, pid, chosenBrowser}'
 curl -s -X POST http://127.0.0.1:18791/start
@@ -128,7 +133,7 @@ On Raspberry Pi, older VPS hosts, or slow storage, use a manually launched
 browser with `attachOnly` when Chrome needs more time to expose its CDP HTTP
 endpoint or become ready than the managed-browser deadline permits.
 
-### Problem: No Chrome tabs found for profile="user"
+## Problem: No Chrome tabs found for profile="user"
 
 You are using the `user` (`existing-session` / Chrome MCP) profile and no
 tabs are open to attach to.

--- a/docs/tools/code-mode/internals.md
+++ b/docs/tools/code-mode/internals.md
@@ -9,7 +9,7 @@ read_when:
 
 ## Runtime status
 
-|                     |                                                                                             |
+| Aspect              | Value                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------- |
 | Runtime             | [`quickjs-wasi`](https://github.com/vercel-labs/quickjs-wasi)                               |
 | Default state       | disabled                                                                                    |

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -22,6 +22,7 @@ The [Control UI](/web/control-ui) already highlights inline tool diffs and sessi
   <Step title="Install the plugin">
     ```bash
     openclaw plugins install clawhub:@openclaw/diffs
+    openclaw gateway restart
     ```
 
     `diffs` and its language pack ship as separate packages rather than with

--- a/docs/tools/elevated.md
+++ b/docs/tools/elevated.md
@@ -52,13 +52,13 @@ Send `/elevated` with no argument to see the current level.
   <Step title="Set the level">
     Send a directive-only message to set the session default:
 
-    ```
+    ```text
     /elevated full
     ```
 
     Or use it inline (applies to that message only):
 
-    ```
+    ```text
     /elevated on run the deployment script
     ```
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -87,22 +87,22 @@ Notes:
 
 ## Config
 
-| Key                                  | Default                  | Notes                                                                                                                                                   |
-| ------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tools.exec.timeoutSeconds`          | `1800`                   | Default per-command exec timeout in seconds. Per-call `timeoutSeconds` overrides it; per-call `timeoutSeconds: 0` disables the exec process timeout.    |
-| `tools.exec.host`                    | `auto`                   | Resolves to `sandbox` when a sandbox runtime is active, `gateway` otherwise.                                                                            |
-| `tools.exec.mode`                    | host-derived             | Canonical policy knob. See [Modes](#modes) below.                                                                                                       |
-| `tools.exec.reviewer.model`          | configured agent primary | Optional provider/model override for `mode=auto` review.                                                                                                |
-| `tools.exec.reviewer.timeoutMs`      | `30000`                  | Per-stage timeout for reviewer model preparation and completion before human fallback.                                                                  |
-| `tools.exec.node`                    | unset                    |                                                                                                                                                         |
-| `tools.exec.notifyOnExit`            | `true`                   | When true, backgrounded exec sessions enqueue a system event and request a heartbeat on exit.                                                           |
-| `tools.exec.approvalRunningNoticeMs` | `10000`                  | Emit a single "running" notice when an approval-gated exec runs longer than this (`0` disables).                                                        |
-| `tools.exec.strictInlineEval`        | `false`                  | See [Inline eval](#inline-eval-strictinlineeval).                                                                                                       |
-| `tools.exec.commandHighlighting`     | `false`                  | When true, approval prompts can highlight parser-derived command spans in the command text. Set globally or per agent; does not change approval policy. |
-| `tools.exec.pathPrepend`             | unset                    | List of directories to prepend to `PATH` for exec runs (gateway + sandbox only).                                                                        |
-| `tools.exec.safeBins`                | unset                    | Stdin-only safe binaries that can run without explicit allowlist entries. See [Safe bins](/tools/exec-approvals-advanced#safe-bins-stdin-only).         |
-| `tools.exec.safeBinTrustedDirs`      | `/bin`, `/usr/bin`       | Additional explicit directories trusted for `safeBins` path checks. `PATH` entries are never auto-trusted.                                              |
-| `tools.exec.safeBinProfiles`         | unset                    | Optional custom argv policy per safe bin (`minPositional`, `maxPositional`, `allowedValueFlags`, `deniedFlags`).                                        |
+| Key                                  | Default                  | Notes                                                                                                                                                              |
+| ------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tools.exec.timeoutSeconds`          | `1800`                   | Default per-command exec timeout in seconds. Per-call `timeoutSeconds` overrides it; per-call `timeoutSeconds: 0` disables the exec process timeout.               |
+| `tools.exec.host`                    | `auto`                   | Resolves to `sandbox` when a sandbox runtime is active, `gateway` otherwise.                                                                                       |
+| `tools.exec.mode`                    | host-derived             | Canonical policy knob. See [Modes](#modes) below.                                                                                                                  |
+| `tools.exec.reviewer.model`          | configured agent primary | Optional provider/model override for `mode=auto` review.                                                                                                           |
+| `tools.exec.reviewer.timeoutMs`      | `30000`                  | Per-stage timeout for reviewer model preparation and completion before human fallback.                                                                             |
+| `tools.exec.node`                    | unset                    | Selects which paired node runs `host=node` commands, by id, name, or IP. Only needed when more than one eligible node is connected; see [Parameters](#parameters). |
+| `tools.exec.notifyOnExit`            | `true`                   | When true, backgrounded exec sessions enqueue a system event and request a heartbeat on exit.                                                                      |
+| `tools.exec.approvalRunningNoticeMs` | `10000`                  | Emit a single "running" notice when an approval-gated exec runs longer than this (`0` disables).                                                                   |
+| `tools.exec.strictInlineEval`        | `false`                  | See [Inline eval](#inline-eval-strictinlineeval).                                                                                                                  |
+| `tools.exec.commandHighlighting`     | `false`                  | When true, approval prompts can highlight parser-derived command spans in the command text. Set globally or per agent; does not change approval policy.            |
+| `tools.exec.pathPrepend`             | unset                    | List of directories to prepend to `PATH` for exec runs (gateway + sandbox only).                                                                                   |
+| `tools.exec.safeBins`                | unset                    | Stdin-only safe binaries that can run without explicit allowlist entries. See [Safe bins](/tools/exec-approvals-advanced#safe-bins-stdin-only).                    |
+| `tools.exec.safeBinTrustedDirs`      | `/bin`, `/usr/bin`       | Additional explicit directories trusted for `safeBins` path checks. `PATH` entries are never auto-trusted.                                                         |
+| `tools.exec.safeBinProfiles`         | unset                    | Optional custom argv policy per safe bin (`minPositional`, `maxPositional`, `allowedValueFlags`, `deniedFlags`).                                                   |
 
 No-approval host exec is the default for gateway and node (`mode=full`) — this comes from the host-policy defaults, not from `host=auto`. If you want approvals/allowlist behavior, set `tools.exec.mode` and tighten the host approvals file; see [Exec approvals](/tools/exec-approvals#yolo-mode-no-approval). To force gateway or node routing regardless of sandbox state, set `tools.exec.host` or use `/exec host=...`.
 

--- a/docs/tools/goal.md
+++ b/docs/tools/goal.md
@@ -9,7 +9,7 @@ read_when:
 title: "Goal"
 ---
 
-# Goal
+<a id="goal" />
 
 A **goal** is one durable objective attached to the current OpenClaw session.
 It gives the agent and the operator a shared target for long-running work,

--- a/docs/tools/grok-search.md
+++ b/docs/tools/grok-search.md
@@ -37,6 +37,9 @@ Skip it to enable or change `x_search` later in config.
 
 ## Sign in or get an API key
 
+The `xai` plugin that provides Grok web search ships with OpenClaw, so there is
+no `openclaw plugins install` step. Start at the credential you already have.
+
 <Steps>
   <Step title="Use xAI OAuth">
     If you already signed in with xAI during onboarding or model auth, choose

--- a/docs/tools/kimi-search.md
+++ b/docs/tools/kimi-search.md
@@ -12,7 +12,15 @@ grounded-response providers, rather than returning a ranked result list.
 
 ## Setup
 
+The `moonshot` plugin does not ship with OpenClaw; install it first.
+
 <Steps>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install @openclaw/moonshot-provider
+    openclaw gateway restart
+    ```
+  </Step>
   <Step title="Create a key">
     Get an API key from [Moonshot AI](https://platform.moonshot.cn/).
   </Step>

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -46,7 +46,11 @@ configured host.
 1. Create an [Ollama API key](https://docs.ollama.com/api/authentication#api-keys)
    and set `OLLAMA_API_KEY` in the Gateway environment.
 2. Set `models.providers.ollama.baseUrl` to `https://ollama.com`; see
-   [Config](#config).
+   [Config](#config). This is the shared Ollama model-provider host, so it also
+   sends your Ollama **model** traffic to `https://ollama.com` instead of a
+   local daemon. To move web search alone, set
+   `plugins.entries.ollama.config.webSearch.baseUrl` to `https://ollama.com`
+   and leave `models.providers.ollama.baseUrl` pointing at your local host.
 3. Run `openclaw configure --section web` and select **Ollama Web Search**.
 
 Hosted search does not require a local Ollama daemon or `ollama signin`.

--- a/docs/tools/permission-modes.md
+++ b/docs/tools/permission-modes.md
@@ -25,6 +25,10 @@ openclaw approvals get
 openclaw gateway restart
 ```
 
+`openclaw approvals get` prints the requested policy, the host policy sources
+behind it, and the effective result. Use it to confirm the `tools.exec.mode`
+write landed in the source you expect before the restart applies it.
+
 Then verify the effective policy:
 
 ```bash

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -24,6 +24,11 @@ action. Behavior varies by channel.
   channels that support it.
 - Set `remove: true` to remove one specific emoji (requires non-empty
   `emoji`).
+- `clearAll: true` is a Feishu/Lark-only flag that removes every reaction the
+  bot placed on the message; it is paired with an empty `emoji`.
+- `emoji-list` is a separate `message` tool action, not a `react` parameter. It
+  lists the standard and custom reactions allowed in the current chat, and the
+  same per-channel `actions.reactions` toggle gates both it and `react`.
 - On channels with status reactions, `trackToolCalls: true` on a reaction lets
   the runtime reuse that reacted message for the same turn's status lifecycle.
   Discord keeps the chosen reaction stable during work and signals actual

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -27,8 +27,9 @@ action. Behavior varies by channel.
 - `clearAll: true` is a Feishu/Lark-only flag that removes every reaction the
   bot placed on the message; it is paired with an empty `emoji`.
 - `emoji-list` is a separate `message` tool action, not a `react` parameter. It
-  lists the standard and custom reactions allowed in the current chat, and the
-  same per-channel `actions.reactions` toggle gates both it and `react`.
+  reports the emoji a channel will accept. What it returns and which
+  per-channel action toggle enables it both vary by channel; see the channel
+  pages under [Channels](/channels).
 - On channels with status reactions, `trackToolCalls: true` on a reaction lets
   the runtime reuse that reacted message for the same turn's status lifecycle.
   Discord keeps the chosen reaction stable during work and signals actual
@@ -51,7 +52,7 @@ action. Behavior varies by channel.
   </Accordion>
 
   <Accordion title="Telegram">
-    - Use `emoji-list` to find allowed standard reactions and numeric custom emoji identifiers.
+    - Use `emoji-list` to find allowed standard reactions and numeric custom emoji identifiers. On Telegram, `channels.telegram.actions.reactions` gates both `react` and `emoji-list`, and `emoji-list` returns the reactions allowed in the current chat.
     - Empty `emoji` removes the bot's reactions.
     - `remove: true` also removes reactions but still requires a non-empty `emoji` for tool validation.
 

--- a/docs/tools/screen.md
+++ b/docs/tools/screen.md
@@ -16,7 +16,7 @@ The tool is exposed only when the originating client advertises the
 `ui-commands` capability. At least one capable Control UI must still be
 connected when the tool runs; otherwise the Gateway returns `UNAVAILABLE`.
 
-A client advertises `ui-commands` in the `capabilities` list it sends during the
+A client advertises `ui-commands` in the `caps` array it sends during the
 Gateway connect handshake (see
 [Gateway protocol](/gateway/protocol/rpc-methods#rpc-method-families)). The
 bundled Control UI advertises it already, so there is nothing to turn on there.

--- a/docs/tools/screen.md
+++ b/docs/tools/screen.md
@@ -16,6 +16,13 @@ The tool is exposed only when the originating client advertises the
 `ui-commands` capability. At least one capable Control UI must still be
 connected when the tool runs; otherwise the Gateway returns `UNAVAILABLE`.
 
+A client advertises `ui-commands` in the `capabilities` list it sends during the
+Gateway connect handshake (see
+[Gateway protocol](/gateway/protocol/rpc-methods#rpc-method-families)). The
+bundled Control UI advertises it already, so there is nothing to turn on there.
+A client that does not advertise it is never offered `screen`, so the tool is
+absent rather than failing at call time.
+
 ## Actions
 
 | Action                            | Effect                                     | Optional inputs                                |

--- a/docs/tools/searxng-search.md
+++ b/docs/tools/searxng-search.md
@@ -23,6 +23,7 @@ Advantages:
   <Step title="Install the plugin">
     ```bash
     openclaw plugins install @openclaw/searxng-plugin
+    openclaw gateway restart
     ```
   </Step>
   <Step title="Run a SearXNG instance">

--- a/docs/tools/steer.md
+++ b/docs/tools/steer.md
@@ -13,6 +13,9 @@ sidebarTitle: "Steer"
 cannot accept steering, OpenClaw sends the message as a normal prompt instead
 of dropping it.
 
+`/tell` is an alias of `/steer`. The two names are interchangeable everywhere
+on this page.
+
 ## Current session
 
 Use top-level `/steer` to target the active run for the current session:


### PR DESCRIPTION
## What this is

The open `ux` audit findings for `docs/tools/` are 127 rows, all `minor`. `ux` is the softest category in this program, and most of these rows are stylistic preferences rather than defects. This PR deliberately works **16 of the 127** — the subset where the finding names something a reader would get *wrong* — and leaves the rest as an explicit queue with reasons rather than churning a directory other people are actively editing.

15 files, +77/-22.

## Fixed (16 findings)

| Finding | Page | What was actually wrong |
| --- | --- | --- |
| r3-2453 | `goal.md` | Body `# Goal` duplicated the frontmatter `title: "Goal"`, rendering two H1s. Only 2 of 68 `docs/tools` pages do this. Replaced with an `<a id="goal" />` stub so the published `#goal` anchor survives. |
| r3-2526 | `steer.md` | `/tell` appeared in a quick-start code sample before the page ever said what it is. It is a `textAlias` of `/steer` (`src/auto-reply/commands-registry.shared.ts:412`). Now stated in the intro. |
| r3-2516 | `kimi-search.md` | **The documented setup could not work.** The page configures `plugins.entries.moonshot` but has no install step; `moonshot` is listed under *Official external packages* in `docs/plugins/plugin-inventory.md:277`, not bundled. Added the install step. |
| r3-2513 | `grok-search.md` | Converse of the above: `xai` **is** bundled (`plugin-inventory.md:171`, "included in OpenClaw"), but every sibling provider page opens with an install step, so a reader could not tell. Now stated. |
| r3-2502 | `searxng-search.md` | Install fence lacked `openclaw gateway restart`, which duckduckgo, exa, firecrawl, lobster, parallel and perplexity all have. Added. |
| r5-0050 | `diffs.md` | Same gap, same fix. |
| r3-2519 | `ollama-search.md` | Hosted step 2 says to set `models.providers.ollama.baseUrl` to `https://ollama.com`. That is the shared **model provider** host, so following the step silently redirects the reader's Ollama model traffic to the cloud. The page already documents the scoped `plugins.entries.ollama.config.webSearch.baseUrl` alternative 25 lines below but never connects the two. Named the side effect and pointed at the scoped option. |
| r3-2508 | `reactions.md` | `clearAll` (Feishu accordion) and `emoji-list` (Telegram accordion) are used with no definition anywhere on the page. `clearAll` is a real `react` param (`extensions/feishu/src/channel.ts`); `emoji-list` is a *separate* `message` action (`src/infra/outbound/message-action-spec.ts:55`), not a react parameter — easy to misread. Both now defined in **How it works**. |
| r3-2492 | `browser-linux-troubleshooting.md` | The whole page uses CDP port **18800**, then the verify step silently switches to **18791** — which reads as a typo. It is the browser control service port, *derived from `gateway.port`* (`docs/tools/browser/configuration.md:165`), so it is not even a constant. Also `jq` was an unstated dependency. Both explained. |
| r3-2491 | `browser-linux-troubleshooting.md` | `### Problem: No Chrome tabs found` was an H3 nested under `## Problem: Failed to start Chrome CDP`, so an unrelated problem read as a sub-part of the first. Promoted to H2; anchor id is unchanged (verified below). |
| r3-2530 | `apply-patch.md` | `*** Move to:` and `*** End of File` are named in Notes as usable markers but never appear in the format block — the only place the page shows where a marker goes. A reader could not tell whether `*** End of File` precedes or follows its hunk lines. Extended the block with both. **Verified**: the format block, extracted from the shipped markdown, applies cleanly against the real `createApplyPatchTool` (add + update + rename + EOF-append + delete all succeeded). |
| r3-2413 (part) | `exec.md` | `tools.exec.node` was the only row of a 14-row config table with an empty Notes cell. Filled from the page's own line 68. |
| r3-2488 | `permission-modes.md` | `openclaw approvals get` sits between a config write and a restart with no stated purpose or expected output. Said what it prints (wording taken from `exec-approvals.md:70`) and why it is there. |
| r3-2337 (part) | `code-mode/internals.md` | The Runtime status table has a literally empty header row — the only such table in `docs/tools`. Gave it labels. |
| r3-2527 (part) | `screen.md` | The page gates the tool on the client advertising `ui-commands` but never says how that happens. It is sent in the `capabilities` list of the Gateway connect handshake (`ui/src/api/gateway.ts:485`, `packages/gateway-protocol/src/client-info.ts:92`); the bundled Control UI already does it. |
| r3-2493 | `elevated.md` | Two directive fences untagged. 5 of 478 `docs/tools` fences are untagged and `MD040` is disabled in `config/markdownlint-cli2.jsonc:56`, so nothing catches it. Tagged as `text`, matching `steer.md`. This is the weakest item here and I am flagging it as cosmetic rather than pretending otherwise. |

## Refuted (9 findings, with evidence)

- **r3-2469** (`web-fetch.md`, "quick start shows a JavaScript pseudo-call a reader cannot run") — the `await tool({...})` shape is the house convention for model-facing tool calls across 6 pages (`web.md`, `brave-search.md`, `exa-search.md`, `perplexity-search.md`, `swarm.md`). Worse, **the suggested fix is the breaking change**: it proposes `/tool web_fetch url=...`, and there is no `/tool` slash command — the builtin registry has no such entry. Applying the fix would document a command that does not exist.
- **r3-2457** (`goal.md`, "documents a status reserved for a future feature; remove the `usage_limited` entries") — `usage_limited` is implemented and reachable today: `src/config/sessions/goals-transitions.ts:127`, `src/config/sessions/goals.ts:105`, `src/tui/tui-formatters.ts:566`, `src/shared/session-goal-display.ts:40,67`. Removing it would delete documentation of a status the TUI renders.
- **r3-2510** (`reactions.md`, "'not yet' with no version scope") — the sentence mirrors the source comment at `extensions/nextcloud-talk/src/message-actions.ts:75-82` and is currently accurate; `remove: true` still throws. Naming a release would mean inventing one.
- **r3-2489** (`permission-modes.md`, "Codex Guardian mapping does not map to the posture names in mcp.md") — different axes. The table maps Codex *config fields* (`approvalPolicy`, `sandbox`) to values; `mcp.md:98`'s `full-permission`/`workspace`/`guarded`/`read-only` are *session permission postures* (documented at `/gateway/permission-modes`, already linked from line 52). Adding "one row per posture" would conflate the two.
- **r3-2490** (`browser-linux-troubleshooting.md`, "add an introductory paragraph") — a preference. Nothing is misread without it.
- **r3-2518** (`kimi-search.md`, "delete lines 66-70") — those lines state which values are *defaults*; the config block shows them as explicit settings. Deleting would lose information, not duplicate it.
- **r3-2521** (`ollama-search.md`) and **r3-2524** (`duckduckgo-search.md`) — both ask to collapse the "never auto-selected" rule into a link. It is a selection-precedence rule stated in a Note on a security-adjacent selection path; dedup here trades a stated rule for a hop.
- **r3-2502 (second half)** — asked to replace the auto-detection bullets with a link. Those bullets state an ordering rule (order 200, key-free providers never win implicitly). Left intact; only the install-step half was applied.
- **r3-2514, r3-2515** (`grok-search.md`) — near-duplicate prose. Real redundancy, but deleting the `## How it works` heading drops a published anchor for no reader gain.

## Deferred (1)

- **r3-2355** (`tts.md:20`, ffmpeg prerequisite) — `tts.md` was split into `docs/tools/tts/` today, so the target line no longer exists. `ffmpeg` is now documented at `docs/tools/tts/configuration.md:303` and `docs/tools/tts/output.md:43` (WhatsApp voice notes have no transcode fallback, so it is a genuine hard prerequisite), but `tts/quickstart.md` does not mention it. Whether the new quickstart needs a prerequisite line belongs with whoever owns that split, not with this PR.

## Not attempted (101)

The remaining 101 rows fall into four buckets, none of which meet the "a reader would get this wrong" bar:

1. **Restructuring / splitting** (~20): "split per the split plan", "move section X to page Y", "promote H3s to H2", "reorder for flow" — `browser-control.md`, `exec.md`, `image-generation.md`, `show-widget.md`, `exec-approvals-advanced.md`, `secrets.md`, `self-learning.md`, `lobster.md`, `ask-user.md`, `creating-skills.md`, `swarm.md`, `music-generation.md`, `goal.md` (r3-2454), `index.md` (r3-2475), `custodian-skills.md`, `mcp.md`, `multi-agent-sandbox-tools.md` (r3-2463), `thinking.md` (r3-2431/2433), `tool-search.md` (r3-2441), `self-learning.md` (r3-2436).
2. **Version-scope wording** (~15): "remove `today`/`currently`/`yet`, name the release" — r3-2451, r3-2345, r3-2354, r3-2340, r3-2494, r3-2485, r3-2483, r3-2462, r3-2474, r3-2499, r3-2533, r3-2363, r3-2471, r3-2484, r3-2500. `docs/AGENTS.md` has **no** rule against time-relative wording, so these are auditor preference, not a house-rule violation; and "name the release" requires dating archaeology per row and then asserting a version in prose, which is a worse failure mode than a vague adverb. Worth doing as **one deliberate sweep with a written rule**, not scattered across a stylistic PR.
3. **Deduplication across pages** (~40): "stated twice", "repeats the sibling page", "keep one copy and link". Individually plausible, collectively the highest-risk churn in the set — several of these repeats are rule chains and precedence lists that the brief explicitly says not to reorder.
4. **Table/prose reformatting** (~26): "table wraps at 210 characters", "paragraph exceeds six sentences", "convert to ParamField", "convert the table to a list". Pure presentation.

I would rather hand back a checkable 16 than a 127-row diff that no reviewer can audit. Full per-id disposition is in the report accompanying this PR.

## Validation

- `pnpm check:docs` — **exit 0** (formatting 1280 files clean, markdownlint 0 issues in 1279 files, MDX check 1292 files, config-fence validation).
- `node scripts/docs-link-audit.mjs` — `broken_links=0` over 13,095 links.
- `node scripts/docs-link-audit.mjs --anchors` — 3 broken, all the known pre-existing `maturity/#windows-app-node` ones; none in changed files.
- `npx tsx scripts/check-docs-i18n-glossary.mts` — exit 0. **No glossary entries needed**: no new `/`-route list-item link labels were introduced (the one added link, in `screen.md`, reuses the label already present in that page's Related list).
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — 1 file / 33 tests passed.
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — 8 files / 16 tests passed.
- **Anchor proof**: ids enumerated with `parseDocsDocument` across all 15 files before and after. **Zero ids lost.** One id added (`install-the-plugin`, the new `<Step>` in `kimi-search.md`). `#goal` preserved by the `<a id>` stub; the H3→H2 promotion in `browser-linux-troubleshooting.md` left its slug untouched.
- **CODEOWNERS**: last-match-wins simulated over the file list before editing. No rule in `.github/CODEOWNERS` matches any `docs/tools/**` path, so no secops or release-manager gate.

## Notes on the brief

Two premises did not hold, both worth recording:

- The brief warned that most `docs/tools/` pages were split into child directories today. True for `browser`, `tts`, `code-mode`, `acp-agents`, `subagents`, `skill-workshop` — but the other ~62 pages are intact, so most ledger line numbers in this cluster were still usable. Only `r3-2355` and `r3-2337` needed relocating.
- The expected refutation rate for `ux` was "higher than 30-50%". Of the 26 rows I examined closely, 9 were refuted outright and 4 more were half-refuted — roughly 50%. The other 101 were not examined individually; I am not claiming they are wrong, only that they are not defects.
