### PR TITLE
fix(update): accept shipped managed-service handoffs without serviceManagerUid

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -195,6 +195,11 @@ that change the target of the global package link. The helper retains the
 original installation identity for recovery; a child running from a different
 installation is still rejected.
 
+Updates from stable 2026.9.2 and 2026.9.3 retain support for their service handoff
+records, which predate the recorded Linux service-manager UID. The candidate
+still revalidates service ownership, profile, unit, and protected launcher data.
+When the handoff records a manager UID, a different UID blocks service mutation.
+
 The Gateway core auto-updater requires a managed service restart path. It hands
 the CLI update to a detached helper before activation. A foreground
 Gateway keeps update hints but leaves installation and activation to the

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -2,13 +2,15 @@ import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { readScheduledTaskRuntime } from "../../daemon/schtasks-runtime.js";
-import type { GatewayService } from "../../daemon/service.js";
+import { readGatewayServiceState, type GatewayService } from "../../daemon/service.js";
 import {
   createMockGatewayService,
   mockSystemAccountHome,
 } from "../../daemon/service.test-helpers.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
 import * as openClawTmp from "../../infra/tmp-openclaw-dir.js";
 import { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } from "../../infra/update-control-plane-sentinel.js";
@@ -18,7 +20,11 @@ import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import { withUpdateCommandExecutor } from "./update-command-executor.js";
-import { maybeStopManagedServiceBeforeMutableUpdate } from "./update-command-service-maintenance.js";
+import {
+  maybeStopManagedServiceBeforeMutableUpdate,
+  revalidateManagedGatewayServiceAfterUpdate,
+  type PreManagedServiceStop,
+} from "./update-command-service-maintenance.js";
 
 const mocks = vi.hoisted(() => ({
   service: vi.fn<() => GatewayService>(),
@@ -47,6 +53,7 @@ afterEach(() => vi.restoreAllMocks());
 
 async function withServiceHome(run: (home: string) => Promise<void>): Promise<void> {
   const home = await makeTempWorkspace("openclaw-update-service-");
+  vi.spyOn(openClawTmp, "resolvePreferredOpenClawTmpDir").mockReturnValue(home);
   try {
     await withEnvAsync(
       {
@@ -425,6 +432,89 @@ it.each([
       await expect(next).rejects.toThrow(/ownership|manager identity/);
     }
     expect(stop).toHaveBeenCalledTimes(scenario.uid === 2001 ? 1 : 0);
+  }),
+);
+
+it.each([
+  "shipped handoff",
+  "matching UID",
+  "mismatching UID",
+  "unavailable manager",
+  "different unit",
+  "different profile",
+  "foreign executable",
+  "changed protected command",
+])("revalidates the shipped managed-service stop record: %s", (scenario) =>
+  withServiceHome(async (home) => {
+    mockProcessPlatform("linux");
+    const root = process.cwd();
+    const command = {
+      programArguments: [process.execPath, path.join(root, "openclaw.mjs"), "gateway"],
+      environment: { HOME: home },
+    };
+    // v2026.9.2/v2026.9.3 forward this stop record to the fresh migration finalizer.
+    const before: PreManagedServiceStop = {
+      stoppedAtMs: 1,
+      stopped: true,
+      inspected: true,
+      runtimeInspected: true,
+      running: true,
+      offline: false,
+      serviceEnv: { HOME: home },
+      serviceDefinitionEnv: command.environment,
+      serviceNodeRunner: process.execPath,
+      serviceUpdateVerdict: {
+        kind: "owned",
+        root,
+        fingerprint: sha256Hex(stableStringify(command)),
+        refreshDefinition: scenario !== "changed protected command",
+      },
+    };
+    if (scenario === "matching UID" || scenario === "mismatching UID") {
+      before.serviceManagerUid = scenario === "matching UID" ? 2001 : 3002;
+    }
+    const service = createMockGatewayService({
+      readCommand: async () => ({
+        ...command,
+        programArguments:
+          scenario === "foreign executable"
+            ? [process.execPath, path.join(home, "other", "openclaw.mjs"), "gateway"]
+            : scenario === "changed protected command"
+              ? [...command.programArguments, "--verbose"]
+              : command.programArguments,
+        environment: {
+          ...command.environment,
+          ...(scenario === "different unit" ? { OPENCLAW_SYSTEMD_UNIT: "other-gateway" } : {}),
+          ...(scenario === "different profile"
+            ? {
+                OPENCLAW_PROFILE: "other",
+                OPENCLAW_STATE_DIR: path.join(home, ".openclaw-other"),
+                OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw-other", "openclaw.json"),
+              }
+            : {}),
+        },
+      }),
+      readRuntime: async () => ({
+        status: "stopped",
+        systemd: { managerUid: scenario === "unavailable manager" ? undefined : 2001 },
+      }),
+      isLoaded: async () => true,
+    });
+    const state = await readGatewayServiceState(service, {
+      env: before.serviceEnv,
+      requireEffective: true,
+      requireLoadedCommand: true,
+    });
+    const revalidated = revalidateManagedGatewayServiceAfterUpdate({
+      state,
+      root,
+      preManagedServiceStop: before,
+    });
+    if (scenario === "shipped handoff" || scenario === "matching UID") {
+      await expect(revalidated).resolves.toMatchObject({ kind: "owned", refreshDefinition: true });
+    } else {
+      await expect(revalidated).rejects.toThrow(/ownership or manager identity changed/);
+    }
   }),
 );
 

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -149,6 +149,7 @@ function matchesStoppedService(
         : resolveSystemdServiceName;
   // Explicit default metadata selects the same manager; protected command hashes
   // still pin the effective launcher and its environment through normalization.
+  // Stable 2026.9.2/2026.9.3 handoffs omit the UID; compare it when recorded.
   return Boolean(
     before.serviceEnv &&
     state.command &&
@@ -158,8 +159,8 @@ function matchesStoppedService(
       resolveGatewayProfileSuffix(state.env.OPENCLAW_PROFILE) &&
     resolveName(before.serviceEnv) === resolveName(state.env) &&
     (process.platform !== "linux" ||
-      (before.serviceManagerUid !== undefined &&
-        before.serviceManagerUid === observedSystemdManagerUid(state))) &&
+      before.serviceManagerUid === undefined ||
+      before.serviceManagerUid === observedSystemdManagerUid(state)) &&
     (refreshDefinition ||
       ("fingerprint" in inspection && inspection.fingerprint === verdict.fingerprint)),
   );


### PR DESCRIPTION
Refs #140339

## What Problem This Solves

Fixes an issue where users updating from stable 2026.9.2 or 2026.9.3 could reach candidate Doctor successfully, then fail with `state-migrated-no-rollback` and leave their managed Gateway stopped.

The 2026.9.3 upgrade matrix passed on `39c61a3b25ea2b7656598aea55898ee1947baf71` on September 9, then failed on `4a749c19150f83897cf673681b1092f9146befda` after #140339 added mandatory recorded manager-UID comparison. This is a stable-tag upgrade compatibility regression.

## Why This Change Was Made

The shipped stop record carries `serviceEnv`, `serviceDefinitionEnv`, and `serviceUpdateVerdict: {kind, root, fingerprint, refreshDefinition}`; 2026.9.3 also carries `serviceNodeRunner`. Neither release records `serviceManagerUid`.

The owning service revalidator now compares the UID when the handoff records one. It keeps live manager inspection, installation ownership, profile/unit identity, and protected-command fingerprint checks. A supplied different UID still refuses mutation. The restart context already retains the freshly observed UID after revalidation for subsequent checks. This preserves #140339's native-identity protection without inventing missing historical evidence.

## User Impact

Release-note context: restores unattended managed-service updates from stable 2026.9.2 and 2026.9.3 while preserving refusal when a recorded Linux service-manager UID changes. No configuration, schema, dependencies, protocol, or persistent recovery semantics change.

## Evidence

The exact shipped-record regression failed before the fix:

```text
GatewayServiceUpdateOwnershipError: Gateway service ownership or manager identity changed; inspect it before restarting manually.
Tests 1 failed | 41 passed (42)
```

After the fix, the same owner suite passes all 42 cases, including the shipped record, matching/mismatching UIDs, unavailable manager, changed unit/profile, foreign executable, protected launcher drift, and existing executor controls.

```sh
node scripts/run-vitest.mjs src/cli/update-cli/update-command-service-maintenance.test.ts
node scripts/check-changed.mjs
pnpm build
pnpm docs:check-mdx
```

The owner suite now uses its own temporary lease store. Broader local service integration/repair suites hit pre-existing incompatible retained handoff leases in the host's shared temporary store (102 failed, 48 passed, one unhandled error); their files and the retained host data were left unchanged. Those failures are not claimed as passing proof.

### Installed upgrade matrix

Both cells passed unattended on commit `f25f229303623d49b8eb5bbe57b3ded326508301`, using the copied L19 container harness, Node 24.19.0, its systemd shim, and mock inference. Each returned `update.exit=0`; Doctor, deep status, update status, state capture, and mock chat all returned zero. Both serving RPC build IDs matched the installed candidate. Neither cell created a recovery-start command, and both containers were removed.

| Published source | Candidate version | Result | Reported downtime |
| --- | --- | --- | --- |
| 2026.9.3 | 2026.9.99-first-hop.0 | PASS | 45.761 s |
| 2026.9.2 | 2026.9.3 | PASS | 83.127 s |

The maintained first-hop fixture changed only `package.json` and `dist/build-info.json`; runtime bytes remained identical. Normal candidate SHA-256: `ec90f9e5592081702086c1f4c6eb111c14cb8feaa4f0de2f1a5face89aedf4b6`. First-hop SHA-256: `3200a0c2d4dfd5f65580ccaad77f80725639145f6c8f0660f0fee88dbb887809`.

```sh
node scripts/package-openclaw-for-docker.mjs --skip-build --allow-unreleased-changelog --output-dir .local/l19/package --output-name l37-current.tgz
node scripts/e2e/lib/update-first-hop-package-fixtures.mjs first-hop-tarball .local/l19/package/l37-current.tgz .local/l19/package/l37-first-hop.tgz 0
bash .local/l19/launch.sh 2026.9.3 2026.9.2 l37-2026.9.3-node24 24 l37-first-hop.tgz
bash .local/l19/launch.sh 2026.9.2 2026.9.1 l37-2026.9.2-node24 24 l37-current.tgz
```

This is installed-package upgrade proof using the supplied service-manager shim and mock model, not real systemd/launchd or live-provider coverage. Independent autoreview and landing remain with the campaign lead, as requested.

### CI

Exact-head [CI run 34453290978](https://github.com/openclaw/openclaw/actions/runs/34453290978) passed for `f25f229303623d49b8eb5bbe57b3ded326508301`: watcher `GREEN`, GitHub rollup `SUCCESS`, zero pending checks. The final running shard was `checks-node-compact-small-18`; no CI repair or new push was needed. Initial metadata reads timed out through the GitHub cache, then attachment and final verification succeeded.
