### PR TITLE
fix(zalouser): restore Doctor policy promotion

### DIFF
--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -29,6 +29,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "zalouser",
       "configuredState": {

--- a/extensions/zalouser/src/channel.setup.test.ts
+++ b/extensions/zalouser/src/channel.setup.test.ts
@@ -11,6 +11,10 @@ import { zalouserSetupPlugin } from "./setup-test-helpers.js";
 const zalouserSetupGetStatus = createPluginSetupWizardStatus(zalouserSetupPlugin);
 
 describe("zalouser setup plugin", () => {
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(zalouserSetupPlugin.setupContract.singleAccountKeysToMove).toEqual([]);
+  });
+
   it("builds setup status without an initialized runtime", async () => {
     const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-setup-"));
 

--- a/extensions/zalouser/src/setup-core.ts
+++ b/extensions/zalouser/src/setup-core.ts
@@ -4,6 +4,7 @@ import {
   createDelegatedSetupWizardProxy,
   createPatchedAccountSetupAdapter,
   createSetupTranslator,
+  type ChannelSetupAdapter,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup-runtime";
 
@@ -11,11 +12,14 @@ const t = createSetupTranslator();
 
 const channel = "zalouser" as const;
 
-export const zalouserSetupAdapter = createPatchedAccountSetupAdapter({
-  channelKey: channel,
-  validateInput: () => null,
-  buildPatch: () => ({}),
-});
+export const zalouserSetupAdapter: ChannelSetupAdapter = {
+  ...createPatchedAccountSetupAdapter({
+    channelKey: channel,
+    validateInput: () => null,
+    buildPatch: () => ({}),
+  }),
+  singleAccountKeysToMove: [],
+};
 
 export const zalouserSetupContract = defineChannelSetupContract({
   fields: {},


### PR DESCRIPTION
Closes #143865

## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix --non-interactive` would retain legacy Zalo Personal policies at the channel root when a root profile and named accounts were configured without `accounts.default`.

## Why This Change Was Made

Declare Zalo Personal's existing setup-promotion contract and make it discoverable from the installed package. The explicit empty list preserves channel-specific root settings while allowing the shared Doctor migration to promote common policies.

## User Impact

Doctor now moves common policies into the default account, preserves the root profile and explicit named-account overrides, and copies only missing policies to named accounts. Configurations without named accounts or with an existing default account stay unchanged. Repeat runs do not repeat the migration.

## Evidence

- Built and installed baseline and candidate plugin archives into isolated synthetic state, then ran public `doctor --fix --non-interactive` and `config get channels.zalouser --json` with normal package discovery and no setup preload.
- Baseline `94a2d79bf93411d14783526ad371931fb4c7144c`: `dmPolicy`, `allowFrom`, `groupPolicy`, and `groupAllowFrom` remained at root; no default account was created.
- Candidate: all four policies moved to `accounts.default`; root/named profiles and explicit empty allowlists survived. Missing named-account policies inherited the root values.
- Disabled-plugin discovery, no/empty accounts, existing default, repeat runs, unrelated channel defaults, and malformed channel/account inputs were checked. Invalid input remained rejected without config writes.
- Native coverage showed installed setup discovery without loading the Zalo client or channel runtime. No login, credentials, Gateway, or live channel was used.
- Fresh source-blind acceptance independently repeated eight baseline/candidate fixture pairs: 30 Doctor runs and 30 public readbacks passed the migration contract.
- The contributed regression test failed on baseline for the expected missing declaration. All 37 focused setup/account/Doctor tests passed after repair; formatting and ordinary syntax lint passed.

The minimal proof environment emitted unrelated health warnings for disabled bundled components. A separate existing setup-policy writer issue can affect later default-policy edits; this PR covers Doctor migration. Google Chat and #132254 remain outside this change. Split from the unmerged #112367.
