### PR TITLE
fix(plugins): skip repaired canonical owners

### DIFF
--- a/src/plugins/update-cohort.test.ts
+++ b/src/plugins/update-cohort.test.ts
@@ -244,10 +244,15 @@ describe("plugin release cohort package reconciliation", () => {
     },
   );
 
-  it("removes the legacy load path after a successful post-core owner migration", async () => {
+  it.each(["update", "repair"])("reconciles the %s owner migration", async (phase) => {
     const legacyRoot = "/plugins/qqbot-legacy";
     const canonicalRoot = "/plugins/openclaw-qqbot";
     const legacyRecords = {
+      unrelated: {
+        source: "npm",
+        spec: "@example/unrelated",
+        installPath: "/plugins/unrelated",
+      },
       qqbot: {
         source: "npm",
         spec: "@openclaw/qqbot@1.9.0",
@@ -260,6 +265,7 @@ describe("plugin release cohort package reconciliation", () => {
       },
     } satisfies Record<string, PluginInstallRecord>;
     const canonicalRecords = {
+      unrelated: legacyRecords.unrelated,
       "openclaw-qqbot": {
         source: "npm",
         spec: "@tencent-connect/openclaw-qqbot@2.0.3",
@@ -294,6 +300,16 @@ describe("plugin release cohort package reconciliation", () => {
           }),
         }),
       );
+    if (phase === "repair") {
+      collectMissingPluginInstallPayloadsMock.mockResolvedValueOnce([
+        { pluginId: "qqbot", installPath: legacyRoot, reason: "missing-package-json" },
+      ]);
+    }
+    updateNpmInstalledPluginsMock.mockImplementation(async ({ config: current }) => ({
+      config: current,
+      changed: false,
+      outcomes: [],
+    }));
     updateNpmInstalledPluginsMock.mockResolvedValueOnce(
       attachPluginInstallOwnerMigrations(
         { config: updatedConfig, changed: true, outcomes: [] },
@@ -307,6 +323,11 @@ describe("plugin release cohort package reconciliation", () => {
       timeoutMs: 60_000,
     });
 
+    if (phase === "repair") {
+      const ordinaryUpdateRequest = updateNpmInstalledPluginsMock.mock.lastCall?.[0];
+      expect(ordinaryUpdateRequest?.config).toEqual(updatedConfig);
+      expect(ordinaryUpdateRequest?.skipIds).toEqual(new Set(["qqbot", "openclaw-qqbot"]));
+    }
     expect(result.changed).toBe(true);
     expect(result.config.channels?.qqbot).toEqual(config.channels.qqbot);
     expect(result.config.plugins?.installs).toEqual(canonicalRecords);

--- a/src/plugins/update-cohort.ts
+++ b/src/plugins/update-cohort.ts
@@ -124,6 +124,7 @@ export async function convergePluginReleaseCohort(params: {
       ...sync.summary.switchedToClawHub,
       ...sync.summary.switchedToNpm,
       ...repairedMissingPayloadIds,
+      ...Object.values(installOwnerMigrations),
     ]),
     versionBoundPluginIds: params.versionBoundPluginIds,
     skipDisabledPlugins: true,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a managed plugin can be processed again during a core update after missing-payload repair has already handled it under a new canonical ID.

## Why This Change Was Made

Carry the repair's existing owner-migration records into the following update pass's skip set. This keeps both the original and repaired owner identities accounted for while preserving normal updates for unrelated plugins.

## User Impact

An already repaired plugin is skipped consistently after its ID changes. Package reconciliation, retained configuration, and unrelated plugin updates keep their existing behavior.

## Evidence

- The regression fails on the original code because the repaired config contains the canonical owner but the following pass skips only the old ID; five control cases pass.
- All 28 focused owner, migration, duplicate, package-reconciliation, and channel-sync cases pass with the repair.
- All 29 canonical changed-file checks pass.
- Fresh independent Codex review found no actionable findings through P2.

The proof establishes repeated processing eligibility and the repaired handoff. It does not claim a measured performance improvement, a second actual reinstall, or a live operator update.
