### PR TITLE
test(image-generation): simplify response fixtures

### DIFF
--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -15,16 +15,9 @@ const {
 
 installProviderHttpMockCleanup();
 
-function jsonResponse(payload: unknown): Response {
-  return new Response(JSON.stringify(payload), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 function mockGeneratedPngResponse() {
   postJsonRequestMock.mockResolvedValue({
-    response: jsonResponse({
+    response: Response.json({
       data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
     }),
     release: vi.fn(async () => {}),
@@ -33,7 +26,7 @@ function mockGeneratedPngResponse() {
 
 function mockEditedPngResponse() {
   postMultipartRequestMock.mockResolvedValue({
-    response: jsonResponse({
+    response: Response.json({
       data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
     }),
     release: vi.fn(async () => {}),

--- a/src/image-generation/openai-compatible-image-provider.test.ts
+++ b/src/image-generation/openai-compatible-image-provider.test.ts
@@ -67,13 +67,6 @@ vi.mock("openclaw/plugin-sdk/provider-http", async () => {
   };
 });
 
-function jsonResponse(payload: unknown): Response {
-  return new Response(JSON.stringify(payload), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 function requireFirstRequestHeaders(mock: ReturnType<typeof vi.fn>): Headers {
   const [call] = mock.mock.calls;
   if (!call) {
@@ -151,8 +144,8 @@ function mockGeneratedResponse() {
       },
     ],
   };
-  postJsonRequestMock.mockResolvedValue({ response: jsonResponse(payload), release });
-  postMultipartRequestMock.mockResolvedValue({ response: jsonResponse(payload), release });
+  postJsonRequestMock.mockResolvedValue({ response: Response.json(payload), release });
+  postMultipartRequestMock.mockResolvedValue({ response: Response.json(payload), release });
   return release;
 }
 
@@ -225,12 +218,13 @@ describe("OpenAI-compatible image provider helper", () => {
           providers: {
             sample: {
               baseUrl: "https://sample.example/v1/",
+              models: [],
               request: { allowPrivateNetwork: true },
             },
           },
         },
       },
-    } as never);
+    });
 
     const apiKeyParams = requireFirstCallArg(resolveApiKeyForProviderMock) as { provider?: string };
     expect(apiKeyParams.provider).toBe("sample");
@@ -268,7 +262,7 @@ describe("OpenAI-compatible image provider helper", () => {
   it("accepts valid multi-image JSON above the generic provider JSON cap", async () => {
     const imageBytes = Buffer.alloc(3 * 1024 * 1024 + 64 * 1024, 1);
     postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({
+      response: Response.json({
         data: Array.from({ length: 4 }, () => ({
           b64_json: imageBytes.toString("base64"),
         })),
@@ -282,7 +276,7 @@ describe("OpenAI-compatible image provider helper", () => {
       model: "sample-image",
       prompt: "large",
       count: 4,
-      cfg: {} as never,
+      cfg: {},
     });
 
     expect(result.images.map((image) => image.buffer.byteLength)).toEqual([
@@ -296,7 +290,7 @@ describe("OpenAI-compatible image provider helper", () => {
   it("honors configured generated media caps above the default image limit", async () => {
     const imageBytes = Buffer.alloc(7 * 1024 * 1024, 1);
     postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({
+      response: Response.json({
         data: [{ b64_json: imageBytes.toString("base64") }],
       }),
       release: vi.fn(async () => {}),
@@ -307,7 +301,7 @@ describe("OpenAI-compatible image provider helper", () => {
       provider: "sample",
       model: "sample-image",
       prompt: "large",
-      cfg: { agents: { defaults: { mediaMaxMb: 8 } } } as never,
+      cfg: { agents: { defaults: { mediaMaxMb: 8 } } },
     });
 
     expect(result.images).toHaveLength(1);
@@ -316,7 +310,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("rejects oversized OpenAI-compatible image JSON", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({
+      response: Response.json({
         data: [{ b64_json: "x".repeat(35 * 1024 * 1024) }],
       }),
       release: vi.fn(async () => {}),
@@ -328,7 +322,7 @@ describe("OpenAI-compatible image provider helper", () => {
         provider: "sample",
         model: "sample-image",
         prompt: "too large",
-        cfg: {} as never,
+        cfg: {},
       }),
     ).rejects.toThrow("sample.image-generation: JSON response exceeds");
   });
@@ -342,7 +336,7 @@ describe("OpenAI-compatible image provider helper", () => {
       model: "sample-image",
       prompt: "edit it",
       inputImages: [{ buffer: Buffer.from("source"), mimeType: "image/png" }],
-      cfg: {} as never,
+      cfg: {},
     });
 
     const multipartRequest = requireFirstCallArg(postMultipartRequestMock) as {
@@ -357,7 +351,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("honors default operation timeouts and empty-response errors", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({ data: [] }),
+      response: Response.json({ data: [] }),
       release: vi.fn(async () => {}),
     });
     const provider = createProvider({
@@ -371,7 +365,7 @@ describe("OpenAI-compatible image provider helper", () => {
         model: "sample-image",
         prompt: "empty",
         timeoutMs: 123,
-        cfg: {} as never,
+        cfg: {},
       }),
     ).rejects.toThrow("Sample response missing image data");
 
@@ -389,7 +383,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("wraps malformed successful image responses with provider-owned errors", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: jsonResponse({ data: { b64_json: "not-an-array" } }),
+      response: Response.json({ data: { b64_json: "not-an-array" } }),
       release: vi.fn(async () => {}),
     });
     const provider = createProvider();
@@ -399,7 +393,7 @@ describe("OpenAI-compatible image provider helper", () => {
         provider: "sample",
         model: "sample-image",
         prompt: "bad shape",
-        cfg: {} as never,
+        cfg: {},
       }),
     ).rejects.toThrow("Sample image generation response malformed");
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Image-generation tests duplicated native JSON response construction and used casts that obscured fixture contracts. One sample provider fixture omitted its required models collection.

## Why This Change Was Made

Replace two private factories with nine native `Response.json()` calls, remove seven casts, and explicitly provide an empty models collection in the sample fixture. Keep native response bodies and the existing transport mocks. The core tests retain the actual JSON reader; the LiteLLM tests retain their mocked JSON reader over native responses.

## User Impact

No production behavior or public API change, and no runtime option is removed. The two test files add 17 lines and remove 30, for a net reduction of 13 lines.

## Evidence

Original and candidate runs each passed all 22 cases: 13 LiteLLM cases and nine core cases, with matching identities and outcomes. All 58 static assertion sites remain. The explicit empty models collection is an intentional fixture input correction.

All 23 selected local changed checks passed, including core and plugin test types, formatting, lint, and structural guards. Independent Codex review found no actionable issues through P2. The source remained unchanged during validation.

This is mocked-transport test proof. It does not establish live provider behavior or make the two JSON reader paths equivalent.
