### PR TITLE
fix: reject unverified Gateway replacements during updates

### DIFF
--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -43,6 +43,15 @@ describe("restart health", () => {
       elapsedMs: 2_000,
     },
     {
+      name: "restarts settling when the boot changes under the same PID",
+      pids: [8000, 8000, 8000, 8000, 8000],
+      bootIds: ["boot-a", "boot-a", "boot-b", "boot-b", "boot-b"],
+      reachable: [true, true, true, true, true],
+      attempts: 6,
+      outcome: "healthy",
+      elapsedMs: 2_000,
+    },
+    {
       name: "keeps the full settle window after the standard readiness deadline",
       pids: [8000, 8000, 8000, 8000, 8000],
       reachable: [false, false, true, true, true],
@@ -76,7 +85,7 @@ describe("restart health", () => {
       outcome: "healthy",
       elapsedMs: 1_000,
     },
-  ])("$name", async ({ platform, pids, reachable, attempts, outcome, elapsedMs }) => {
+  ])("$name", async ({ platform, pids, bootIds, reachable, attempts, outcome, elapsedMs }) => {
     if (platform) {
       Object.defineProperty(process, "platform", { value: platform, configurable: true });
     }
@@ -84,10 +93,12 @@ describe("restart health", () => {
     for (const pid of pids) {
       vi.mocked(service.readRuntime).mockResolvedValueOnce({ status: "running", pid });
     }
-    for (const ok of reachable) {
+    for (const [index, ok] of reachable.entries()) {
       if (ok) {
         callGateway.mockImplementationOnce(
-          gatewayHealthResponse({ server: { version: "2026.8.1" } }),
+          gatewayHealthResponse({
+            server: { version: "2026.8.1", ...(bootIds ? { bootId: bootIds[index] } : {}) },
+          }),
         );
       } else {
         callGateway.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -281,6 +281,17 @@ function withWaitContext(
   return { ...snapshot, waitOutcome, elapsedMs };
 }
 
+export function isSameGatewayRestartGeneration(
+  previous: GatewayRestartSnapshot,
+  current: GatewayRestartSnapshot,
+): boolean {
+  return (
+    previous.runtime.status === current.runtime.status &&
+    previous.runtime.pid === current.runtime.pid &&
+    previous.gatewayBootId === current.gatewayBootId
+  );
+}
+
 export async function waitForGatewayHealthyRestart(params: {
   service: GatewayService;
   port: number;
@@ -339,7 +350,7 @@ export async function waitForGatewayHealthyRestart(params: {
   let postMigrationDeadlineMs: number | undefined;
   let migrationActive = false;
   let nextMigrationActivityPollMs = 0;
-  let healthyStreak: { pid: number | undefined; probes: number } | undefined;
+  let healthyStreak: { snapshot: GatewayRestartSnapshot; probes: number } | undefined;
 
   for (let attempt = 0; ; attempt += 1) {
     params.signal?.throwIfAborted();
@@ -354,10 +365,10 @@ export async function waitForGatewayHealthyRestart(params: {
         (snapshot.runtime.status === "running" &&
           (process.platform === "win32" || typeof snapshot.runtime.pid === "number")));
     if (healthy) {
-      if (healthyStreak && healthyStreak.pid === snapshot.runtime.pid) {
+      if (healthyStreak && isSameGatewayRestartGeneration(healthyStreak.snapshot, snapshot)) {
         healthyStreak.probes += 1;
       } else {
-        healthyStreak = { pid: snapshot.runtime.pid, probes: 1 };
+        healthyStreak = { snapshot, probes: 1 };
       }
       if (healthyStreak.probes >= settleProbes) {
         return withWaitContext(snapshot, "healthy", elapsedMs);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -9340,11 +9340,13 @@ describe("update-cli", () => {
           after: { version: "1.0.0", buildId: "candidate-build" },
         }),
       );
+      mockGatewayHealth("1.0.0", "candidate-gateway", "candidate-build");
       restartHealthTestControl.snapshot = {
         runtime: { status: "running", pid: gatewayFixturePid },
         portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
         healthy: fault === "none",
         staleGatewayPids: [],
+        gatewayBootId: "test-gateway-boot",
         gatewayVersion: "1.0.0",
         gatewayBuildId: "candidate-build",
         expectedVersion: "1.0.0",

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -166,7 +166,11 @@ export function registerGenerationRecoveryTests(
       mocks.health.mockImplementation(async ({ port, expectedVersion }) => ({
         healthy: mocks.running,
         staleGatewayPids: [],
-        runtime: { status: mocks.running ? "running" : "stopped" },
+        runtime: {
+          status: mocks.running ? "running" : "stopped",
+          pid: mocks.running ? 4242 : undefined,
+        },
+        gatewayBootId: "service-boot",
         gatewayVersion: mocks.running ? VERSION : undefined,
         expectedVersion: expectedVersion ?? undefined,
         portUsage: { port, status: mocks.running ? "busy" : "free", listeners: [], hints: [] },

--- a/src/cli/update-cli/update-command-post-update-repair.test.ts
+++ b/src/cli/update-cli/update-command-post-update-repair.test.ts
@@ -71,9 +71,8 @@ vi.mock("../daemon-cli/restart-health-probe.js", async (importOriginal) => ({
   resolveGatewayRestartProbeContext: async () => ({ config: {} }),
   confirmGatewayReachable: async () => ({ reachable: false }),
 }));
-vi.mock("../daemon-cli/restart-health.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../daemon-cli/restart-health.js")>()),
-  waitForGatewayHealthyRestart: async ({ expectedVersion }: { expectedVersion?: string }) => ({
+vi.mock("../daemon-cli/restart-health.js", async (importOriginal) => {
+  const readHealth = async ({ expectedVersion }: { expectedVersion?: string }) => ({
     gatewayBootId: "repair-boot",
     healthy: mocks.healthy && mocks.version === expectedVersion,
     runtime: { status: mocks.healthy ? "running" : "stopped", pid: 4321 },
@@ -82,9 +81,14 @@ vi.mock("../daemon-cli/restart-health.js", async (importOriginal) => ({
     versionMismatch: mocks.version !== expectedVersion,
     portUsage: { status: "free", listeners: [] },
     staleGatewayPids: [],
-  }),
-  waitForGatewayHttpReadiness: mocks.readyz,
-}));
+  });
+  return {
+    ...(await importOriginal<typeof import("../daemon-cli/restart-health.js")>()),
+    waitForGatewayHealthyRestart: readHealth,
+    inspectGatewayRestart: readHealth,
+    waitForGatewayHttpReadiness: mocks.readyz,
+  };
+});
 vi.mock("./update-command-service-recovery.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./update-command-service-recovery.js")>()),
   hasLoadedLaunchdKeepAliveSupervisor: async () => false,

--- a/src/cli/update-cli/update-command-service-recovery.test-support.ts
+++ b/src/cli/update-cli/update-command-service-recovery.test-support.ts
@@ -75,7 +75,8 @@ export function readyRecoveryHealth(
   return {
     healthy: true,
     staleGatewayPids: [],
-    runtime: { status: running ? "running" : "stopped" },
+    runtime: { status: running ? "running" : "stopped", pid: running ? 4242 : undefined },
+    gatewayBootId: "service-boot",
     portUsage: { port, status: "busy", listeners: [], hints: [] },
   };
 }

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it, vi, type Mock } from "vitest";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
@@ -124,7 +125,11 @@ export function registerInstallRootTransitionTests(getFixture: () => InstallRoot
         mocks.health.mockImplementation(async ({ port, expectedBuildId }) => ({
           healthy: mocks.running && (!expectedBuildId || expectedBuildId === servingBuildId),
           staleGatewayPids: [],
-          runtime: { status: mocks.running ? "running" : "stopped" },
+          runtime: {
+            status: mocks.running ? "running" : "stopped",
+            pid: mocks.running ? 4242 : undefined,
+          },
+          gatewayBootId: "service-boot",
           portUsage: { port, status: "busy", listeners: [], hints: [] },
         }));
         mocks.script.mockImplementation(async () => {
@@ -400,7 +405,13 @@ export function registerRestartOutcomeTests(
 
 type PluginMaintenanceFixture = InstallRootTransitionFixture & {
   writeConfig: (version: string) => Promise<void>;
-  mocks: { log: Mock; start: Mock; restart: Mock; doctor: Mock };
+  mocks: {
+    log: Mock;
+    start: Mock;
+    restart: Mock;
+    doctor: Mock;
+    call: Mock<typeof import("../../gateway/call.js").callGateway>;
+  };
 };
 
 export function registerPluginMaintenanceTests(getFixture: () => PluginMaintenanceFixture) {
@@ -424,6 +435,9 @@ export function registerPluginMaintenanceTests(getFixture: () => PluginMaintenan
       expect(before.stopped).toBe(true);
       mocks.events.push("core updated");
       await writeConfig("9999.1.1");
+      mocks.call.mockImplementation(
+        gatewayHealthResponse({ server: { version: "9999.1.1", bootId: "service-boot" } }),
+      );
       mocks.events.push("candidate doctor stamped config");
       const service = resolveGatewayService();
       const state = await readGatewayServiceState(service, { requireEffective: true });

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -199,11 +199,19 @@ beforeEach(async () => {
   run = { runId: createUpdateRun({ trigger: "cli" }, { env: runEnv }).runId, env: runEnv };
   mocks.ports.mockImplementation(async (port) => ({
     port,
-    status: "free",
-    listeners: [],
+    status: process.platform === "linux" && mocks.running ? "busy" : "free",
+    listeners:
+      process.platform === "linux" && mocks.running
+        ? [{ pid: 4242, command: "openclaw-gateway" }]
+        : [],
     hints: [],
   }));
   mocks.call.mockReset();
+  mocks.call.mockImplementation(
+    gatewayHealthResponse({
+      server: { version: VERSION, buildId: "target-build", bootId: "service-boot" },
+    }),
+  );
   mocks.running = true;
   mocks.loaded = true;
   mocks.inLaunchd = false;

--- a/src/cli/update-cli/update-command-verification.test.ts
+++ b/src/cli/update-cli/update-command-verification.test.ts
@@ -1,0 +1,182 @@
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import * as gatewayService from "../../daemon/service.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
+import { recordUpdateRunVerification } from "../../infra/update-run-ledger.js";
+import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
+import {
+  callGateway,
+  inspectPortUsage,
+  makeGatewayService,
+  resetRestartHealthMocks,
+  restoreRestartHealthMocks,
+} from "../daemon-cli/restart-health.test-helpers.js";
+import { verifyUpdatedGateway } from "./update-command-verification.js";
+
+vi.mock("../../infra/update-run-ledger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/update-run-ledger.js")>()),
+  recordUpdateRunStep: vi.fn(),
+  recordUpdateRunVerification: vi.fn(),
+}));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { log: vi.fn(), error: vi.fn() },
+}));
+
+let server: Server;
+let controller: AbortController;
+let pendingVerification: Promise<unknown> | undefined;
+beforeEach(() => {
+  controller = new AbortController();
+  pendingVerification = undefined;
+  vi.clearAllMocks();
+  resetRestartHealthMocks();
+});
+afterEach(async () => {
+  controller.abort();
+  await pendingVerification?.catch(() => {});
+  restoreRestartHealthMocks();
+  server?.closeAllConnections();
+  if (server?.listening) {
+    const closed = once(server, "close");
+    server.close();
+    await closed;
+  }
+});
+
+describe("update readiness generation", () => {
+  it.each([
+    { transition: "unchanged", supplied: false },
+    { transition: "replacement", supplied: false },
+    { transition: "same-pid-new-boot", supplied: false },
+    { transition: "replacement-during-final-health", supplied: false },
+    { transition: "same-pid-new-boot-during-native", supplied: false },
+    { transition: "pidless-new-boot-during-native", supplied: false },
+    { transition: "unchanged-pidless", supplied: false },
+    { transition: "first-final-health-error", supplied: false },
+    { transition: "last-final-health-error", supplied: false },
+    { transition: "unchanged", supplied: true },
+    { transition: "replacement", supplied: true },
+  ] as const)(
+    "binds final readiness to the settled generation: $transition, supplied=$supplied",
+    async ({ transition, supplied }) => {
+      // Keep the real settle, health/hello interpretation and HTTP readiness loop.
+      // Only the service manager/health RPC are synthetic; HTTP uses a local socket.
+      const pidless = transition.includes("pidless");
+      const unchanged = transition.startsWith("unchanged");
+      if (pidless) {
+        mockProcessPlatform("win32");
+      }
+      let runtime: GatewayServiceRuntime = { status: "running", ...(pidless ? {} : { pid: 8000 }) };
+      let bootId = "boot-a";
+      const service = makeGatewayService({ status: "running", pid: 8000 });
+      vi.mocked(service.readRuntime).mockImplementation(async () => {
+        if (transition.endsWith("during-native") && callGateway.mock.calls.length === 13) {
+          bootId = "boot-b";
+        }
+        return { ...runtime };
+      });
+      service.isLoaded = vi.fn(async () => true);
+      vi.spyOn(gatewayService, "resolveGatewayService").mockReturnValue(service);
+      inspectPortUsage.mockImplementation(async (port) => ({
+        port,
+        status: "busy",
+        listeners: [{ pid: runtime.pid, commandLine: "openclaw-gateway" }],
+        hints: [],
+      }));
+      callGateway.mockImplementation(async (opts) => {
+        const response = await gatewayHealthResponse({
+          server: { version: "2026.9.1", buildId: "candidate-build", bootId },
+          ...((transition === "first-final-health-error" && callGateway.mock.calls.length === 13) ||
+          (transition === "last-final-health-error" && callGateway.mock.calls.length === 14)
+            ? { error: new Error("synthetic health failed") }
+            : {}),
+        })(opts);
+        if (
+          transition === "replacement-during-final-health" &&
+          callGateway.mock.calls.length > 12
+        ) {
+          runtime = { status: "running", pid: 8001 };
+        }
+        return response;
+      });
+      const reached = createDeferred();
+      const release = createDeferred();
+      server = createServer((req, res) => {
+        if (req.url === "/readyz") {
+          reached.resolve();
+          void release.promise.then(() => res.writeHead(200).end());
+        } else {
+          res.writeHead(200).end();
+        }
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing loopback listener");
+      }
+      const probeParams = {
+        service,
+        port: address.port,
+        env: { HOME: "/synthetic-home" },
+        expectedVersion: "2026.9.1",
+        expectedBuildId: "candidate-build",
+        requireRunningService: true,
+        settle: { probes: 12 },
+        signal: controller.signal,
+      };
+      const { waitForGatewayHealthyRestart } = await import("../daemon-cli/restart-health.js");
+      const health = supplied ? await waitForGatewayHealthyRestart(probeParams) : undefined;
+      const onVerified = vi.fn();
+      const verification = verifyUpdatedGateway({
+        result: { status: "ok", mode: "npm", steps: [], durationMs: 0 },
+        opts: { json: true, run: { runId: "synthetic-update", env: {} } },
+        serviceEnv: probeParams.env,
+        signal: controller.signal,
+        health,
+        gatewayPort: address.port,
+        expectedVersion: "2026.9.1",
+        expectedBuildId: "candidate-build",
+        requireRunningService: true,
+        onVerified,
+      });
+      pendingVerification = verification;
+      await Promise.race([
+        reached.promise,
+        verification.then(() => {
+          throw new Error("Verifier returned before HTTP readiness");
+        }),
+      ]);
+      expect(callGateway).toHaveBeenCalledTimes(12);
+      if (transition === "replacement" || transition === "same-pid-new-boot") {
+        bootId = "boot-b";
+        runtime = { status: "running", pid: transition === "replacement" ? 8001 : 8000 };
+      }
+      release.resolve();
+      const result = await verification;
+      expect(result.ok).toBe(unchanged);
+      if (unchanged) {
+        expect(onVerified).toHaveBeenCalledOnce();
+        expect(recordUpdateRunVerification).toHaveBeenLastCalledWith(
+          "synthetic-update",
+          expect.objectContaining({
+            ...(pidless ? {} : { pid: 8000 }),
+            settled: true,
+            readyz: true,
+          }),
+          expect.anything(),
+        );
+      } else {
+        expect(onVerified).not.toHaveBeenCalled();
+        expect(recordUpdateRunVerification).not.toHaveBeenCalledWith(
+          "synthetic-update",
+          expect.objectContaining({ settled: true, readyz: true }),
+          expect.anything(),
+        );
+      }
+    },
+  );
+});

--- a/src/cli/update-cli/update-command-verification.ts
+++ b/src/cli/update-cli/update-command-verification.ts
@@ -8,6 +8,8 @@ import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { resolveGatewayRestartProbeContext } from "../daemon-cli/restart-health-probe.js";
 import {
+  inspectGatewayRestart,
+  isSameGatewayRestartGeneration,
   renderRestartDiagnostics,
   waitForGatewayHealthyRestart,
   waitForGatewayHttpReadiness,
@@ -102,6 +104,14 @@ export async function verifyUpdatedGateway(params: {
   };
   assertCurrent();
   const service = resolveGatewayService();
+  const probeParams = {
+    service,
+    port: params.gatewayPort,
+    expectedVersion: params.expectedVersion,
+    ...(params.expectedBuildId ? { expectedBuildId: params.expectedBuildId } : {}),
+    env: params.serviceEnv,
+    ...(params.signal ? { signal: params.signal } : {}),
+  };
   const waitForHealthy = async () => {
     assertCurrent();
     const supervisorKeepsAlive = await hasLoadedLaunchdKeepAliveSupervisor({
@@ -110,14 +120,9 @@ export async function verifyUpdatedGateway(params: {
     });
     assertCurrent();
     const health = await waitForGatewayHealthyRestart({
-      service,
-      port: params.gatewayPort,
-      expectedVersion: params.expectedVersion,
-      ...(params.expectedBuildId ? { expectedBuildId: params.expectedBuildId } : {}),
-      env: params.serviceEnv,
+      ...probeParams,
       requireRunningService: params.requireRunningService,
       settle: { probes: 12 },
-      ...(params.signal ? { signal: params.signal } : {}),
       supervisorKeepsAlive,
     });
     assertCurrent();
@@ -141,6 +146,29 @@ export async function verifyUpdatedGateway(params: {
   });
   assertCurrent();
   const readyz = http.readyz === 200;
+  if (
+    health.healthy &&
+    readyz &&
+    (!params.requireRunningService || health.runtime.status === "running")
+  ) {
+    // HTTP readiness cannot transfer an earlier settle to a replacement boot.
+    const settled = health;
+    const inspected = await inspectGatewayRestart({ ...probeParams, probeContext: context });
+    assertCurrent();
+    // Bracket the final native observation with health/hello probes so a same-PID
+    // or PID-less reboot during that observation cannot inherit the old boot.
+    health = inspected.healthy
+      ? await inspectGatewayRestart({ ...probeParams, probeContext: context })
+      : inspected;
+    assertCurrent();
+    const sameGeneration =
+      isSameGatewayRestartGeneration(settled, inspected) &&
+      isSameGatewayRestartGeneration(inspected, health);
+    if (!sameGeneration) {
+      health.healthy = false;
+      health.probeError = "Gateway process changed during final readiness verification.";
+    }
+  }
   if (launchAgentRecovery?.attempted) {
     defaultRuntime.error(
       launchAgentRecovery.recovered ? launchAgentRecovery.message : launchAgentRecovery.detail,

--- a/src/commands/doctor-update.test-support.ts
+++ b/src/commands/doctor-update.test-support.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   restartUpdatedGateway: vi.fn(),
   stopGatewayService: vi.fn(),
   waitForHealthyRestart: vi.fn(),
+  inspectGatewayRestart: vi.fn(),
   waitForHttpReadiness:
     vi.fn<typeof import("../cli/daemon-cli/restart-health.js").waitForGatewayHttpReadiness>(),
   doctorCommand: vi.fn(),
@@ -87,7 +88,9 @@ vi.mock("../cli/daemon-cli.js", () => ({
 vi.mock("../cli/update-cli/update-command-config-snapshot.js", () => ({
   createUpdateConfigSnapshot: mocks.createUpdateConfigSnapshot,
 }));
-vi.mock("../cli/daemon-cli/restart-health.js", () => ({
+vi.mock("../cli/daemon-cli/restart-health.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../cli/daemon-cli/restart-health.js")>()),
+  inspectGatewayRestart: mocks.inspectGatewayRestart,
   waitForGatewayHealthyRestart: mocks.waitForHealthyRestart,
   waitForGatewayHttpReadiness: mocks.waitForHttpReadiness,
   renderRestartDiagnostics: () => ["gateway not ready"],
@@ -299,12 +302,14 @@ export function installDoctorUpdateTestHooks(): void {
     mocks.revalidateManagedGatewayServiceAfterUpdate.mockImplementation(
       async ({ preManagedServiceStop }) => preManagedServiceStop.serviceUpdateVerdict,
     );
-    mocks.waitForHealthyRestart.mockReset().mockResolvedValue({
+    const healthy = {
       healthy: true,
       runtime: { status: "running" },
       staleGatewayPids: [],
       gatewayVersion: "2026.4.24",
-    });
+    };
+    mocks.waitForHealthyRestart.mockReset().mockResolvedValue(healthy);
+    mocks.inspectGatewayRestart.mockReset().mockResolvedValue(healthy);
     mocks.waitForHttpReadiness.mockReset().mockResolvedValue({ healthz: 200, readyz: 200 });
 
     mocks.doctorCommand.mockReset();


### PR DESCRIPTION
Closes #143841

## What Problem This Solves

Fixes an issue where users updating OpenClaw could see the Gateway reported as verified when a replacement process answered readiness without completing the required health-settle window.

## Why This Change Was Made

Bind the existing bounded settle to native status/PID and Gateway boot identity. After HTTP readiness succeeds, recheck that identity with the existing native-service and health probes. A changed generation or failed probe refuses verification; it does not restart another settle loop. This also covers a same-PID or PID-less Windows reboot during the final native observation.

No package-swap, finalization, lease, storage, protocol, or live-service changes.

## User Impact

An unchanged healthy Gateway still verifies. A replacement boot no longer inherits a previous boot's stability proof. Existing failure diagnostics and recovery instructions remain available.

## Evidence

- On unmodified source main `924381f9f8b3fa7a325b5c03aca4acd0565cd8ff`, the composed verifier incorrectly accepted both a replacement PID/boot and a same-PID new boot after a held `/readyz` response. The unchanged-generation control passed.
- The existing settle-table extension failed on main: a same-PID boot change completed after 1000 ms instead of the required 2000 ms in a three-probe fixture; its other 27 controls passed.
- The new verifier tests retain real settling, hello/health interpretation, and a disposable loopback HTTP server. They cover unchanged and replacement generations, supplied settled snapshots, a replacement during final health, same-PID/PID-less reboots during the final native read, and failure at either final health observation.
- Focused native-service, repair, health-probe, and Windows finalization controls protect healthy siblings. Tests use synthetic native observations; no installed-service reproduction or atomic process-lifetime guarantee is claimed.

Validation: the seven-suite sibling run passed 262 tests; after the final failure-preservation correction, the three directly affected suites passed 53 tests, including all 11 composed controls. All six selected Windows/refusal controls passed. The final frozen-source `check:changed` gate passed, including typechecks, lint, export scans, and runtime-cycle guards. P0–P2 autoreview is clean. Exact-head hosted CI remains a native landing gate. Release-note context: update verification refuses a Gateway generation that did not complete its own stability window.

CI continuation: the first hosted run exposed a Doctor update test mock that omitted the newly used health inspector/comparison exports. The shared fixture is corrected without a production change; all three Doctor suites pass (53 tests), its P0–P2 review is clean, and its changed-file gate passes. The original failed run remains visible; the corrected head must pass fresh CI before landing.
