### PR TITLE
fix: keep background completion wakes alive after replies

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -26,6 +26,8 @@ Setting `heartbeat.every: "0m"` also disables only the recurring cadence. A targ
 
 Targeted event wakes retain the same per-agent rate limits when recurring cadence is disabled: a 30-second minimum between event turns, and a flood guard after five starts within 60 seconds. Deferred work resumes when its guard expires. Config reloads preserve this accounting without enrolling the agent in recurring or broadcast heartbeats.
 
+Transcript markers distinguish `[OpenClaw heartbeat poll]` from an exec completion, cron wake, or session event. Scheduled polls use the configured heartbeat session (the agent's main session by default); targeted completion events return to the session that owns the work. Event markers retain their source provenance without copying internal instructions into chat history. Silent acknowledgment pairs remain hidden.
+
 Troubleshooting: [Automations](/automation/cron-jobs#troubleshooting)
 
 ## Quick start (beginner)

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -5,7 +5,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 // Coverage for context-engine bootstrap, assembly, and turn finalization.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../../../auto-reply/heartbeat.js";
+import { INTERNAL_WAKE_TRANSCRIPT_PROMPTS } from "../../../auto-reply/heartbeat.js";
 import {
   appendTranscriptMessage,
   createSessionEntryWithTranscript,
@@ -757,7 +757,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   it("filters heartbeat response-tool transcript artifacts before normal prompt snapshots", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
     const sessionMessages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat, timestamp: 1 },
       {
         role: "assistant",
         content: [
@@ -826,7 +826,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       "heartbeat_respond",
       "notify=false",
       '"notify":false',
-      HEARTBEAT_TRANSCRIPT_PROMPT,
+      INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat,
     ]) {
       expect(assembledMessagesJson).not.toContain(artifact);
       expect(snapshotJson).not.toContain(artifact);
@@ -837,7 +837,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   it("filters interrupted prompt-only heartbeat artifacts before normal prompt snapshots", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
     const sessionMessages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat, timestamp: 1 },
     ] as AgentMessage[];
 
     const result = await createContextEngineAttemptRunner({
@@ -860,15 +860,15 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
     const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
     const snapshotJson = JSON.stringify(result.messagesSnapshot);
-    expect(assembledMessagesJson).not.toContain(HEARTBEAT_TRANSCRIPT_PROMPT);
-    expect(snapshotJson).not.toContain(HEARTBEAT_TRANSCRIPT_PROMPT);
+    expect(assembledMessagesJson).not.toContain(INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat);
+    expect(snapshotJson).not.toContain(INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat);
     expect(result.finalPromptText).toBe("what model are you");
   });
 
   it("filters pending notify=true heartbeat response-tool calls before normal prompt snapshots", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
     const sessionMessages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat, timestamp: 1 },
       {
         role: "assistant",
         content: [
@@ -909,7 +909,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
     const snapshotJson = JSON.stringify(result.messagesSnapshot);
     for (const artifact of [
-      HEARTBEAT_TRANSCRIPT_PROMPT,
+      INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat,
       "heartbeat_respond",
       '"notify":true',
       "Build is blocked on missing credentials.",
@@ -923,7 +923,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   it("preserves visible heartbeat alerts in normal prompt snapshots", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
     const sessionMessages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat, timestamp: 1 },
       {
         role: "assistant",
         content: [
@@ -970,7 +970,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
     const snapshotJson = JSON.stringify(result.messagesSnapshot);
     for (const visibleContext of [
-      HEARTBEAT_TRANSCRIPT_PROMPT,
+      INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat,
       "HEARTBEAT.md says check deployment",
       "Build is blocked on a failing release check.",
     ]) {
@@ -983,7 +983,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   it("preserves visible heartbeat response-tool notifications in normal prompt snapshots", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
     const sessionMessages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat, timestamp: 1 },
       {
         role: "assistant",
         content: [

--- a/src/agents/session-activity-notes.ts
+++ b/src/agents/session-activity-notes.ts
@@ -1,7 +1,7 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../auto-reply/heartbeat.js";
+import { INTERNAL_WAKE_TRANSCRIPT_PROMPTS } from "../auto-reply/heartbeat.js";
 import { HEARTBEAT_TOKEN, isSilentReplyPayloadText } from "../auto-reply/tokens.js";
 import { normalizeAgentPlanSteps } from "../channels/streaming.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
@@ -194,7 +194,7 @@ export function flushSessionActivityAssistantNote(
   if (
     !visible ||
     visible === HEARTBEAT_TOKEN ||
-    visible === HEARTBEAT_TRANSCRIPT_PROMPT ||
+    Object.values(INTERNAL_WAKE_TRANSCRIPT_PROMPTS).some((prompt) => visible === prompt) ||
     isSilentReplyPayloadText(visible)
   ) {
     return;

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -204,13 +204,18 @@ describe("isHeartbeatOkResponse", () => {
 });
 
 describe("filterHeartbeatTranscriptArtifacts", () => {
-  it("removes no-op heartbeat pairs", () => {
+  it.each([
+    "[OpenClaw heartbeat poll]",
+    "[OpenClaw exec completion]",
+    "[OpenClaw cron wake]",
+    "[OpenClaw session event]",
+  ])("removes no-op wake pairs for %s", (marker) => {
     const messages = [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: HEARTBEAT_PROMPT },
       { role: "assistant", content: "NO_REPLY" },
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: marker },
       { role: "assistant", content: "HEARTBEAT_OK" },
       { role: "user", content: "What time is it?" },
       { role: "assistant", content: "It is 3pm." },

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -9,7 +9,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS,
   HEARTBEAT_RESPONSE_TOOL_PROMPT,
   HEARTBEAT_PROMPT,
-  HEARTBEAT_TRANSCRIPT_PROMPT,
+  INTERNAL_WAKE_TRANSCRIPT_PROMPTS,
   resolveHeartbeatPromptForResponseTool,
 } from "./heartbeat.js";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "./reply/delivery-hints.js";
@@ -83,7 +83,7 @@ describe("isHeartbeatUserMessage", () => {
     expect(
       isHeartbeatUserMessage({
         role: "user",
-        content: HEARTBEAT_TRANSCRIPT_PROMPT,
+        content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat,
       }),
     ).toBe(true);
 
@@ -234,7 +234,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     (_label, reasoningBlock) => {
       const nextUserMessage = { role: "user", content: "What time is it?" };
       const messages = [
-        { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+        { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
         {
           role: "assistant",
           content: [reasoningBlock, { type: "text", text: "HEARTBEAT_OK" }],
@@ -256,7 +256,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
           content: [
             {
               type: "input_text",
-              text: `${deliveryHint} ${HEARTBEAT_TRANSCRIPT_PROMPT}`,
+              text: `${deliveryHint} ${INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat}`,
             },
           ],
         },
@@ -281,7 +281,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes prompt-only interrupted heartbeat spans", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "user", content: "what model are you" },
     ];
 
@@ -292,7 +292,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes interrupted helper-only heartbeat spans", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -319,7 +319,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes heartbeat response-tool spans and preserves the next real user message", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
@@ -372,7 +372,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes native OpenAI Responses heartbeat function-call spans", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -425,7 +425,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes assistant continuations after heartbeat response-tool results", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
@@ -443,7 +443,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes pre-terminal assistant text once a heartbeat ack arrives", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "Checking heartbeat status..." },
       { role: "assistant", content: "HEARTBEAT_OK" },
       { role: "user", content: "what model are you" },
@@ -456,7 +456,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves structured notify=true heartbeat response-tool alerts", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -483,7 +483,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves notify=true heartbeat response-tool alerts followed by a final ack", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -511,7 +511,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves top-level notify=true heartbeat response-tool calls followed by a final ack", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: null,
@@ -541,7 +541,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves OpenAI Responses notify=true heartbeat calls keyed by call_id", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -574,7 +574,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves Anthropic-style notify=true heartbeat calls keyed by tool_use_id", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -606,7 +606,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves Anthropic-style notify=true heartbeat calls completed by mixed user turns", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -639,7 +639,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes pending notify=true heartbeat response-tool calls without tool results", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -661,7 +661,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes failed notify=true heartbeat response-tool calls", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -689,7 +689,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes Anthropic-style failed notify=true heartbeat calls keyed by tool_use_id", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -722,7 +722,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes Anthropic-style error result heartbeat calls keyed by tool_use_id", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -754,7 +754,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("does not treat unrelated helper tool results as completed notify=true responses", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -787,7 +787,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("removes heartbeat response-tool spans with notify=false even when alert fields are present", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -831,7 +831,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     };
     const assistantMessage = { role: "assistant", content: "I am OpenClaw." };
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [
@@ -859,15 +859,15 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("stops a no-op span before a later visible heartbeat alert", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "Build is blocked on a failing release check." },
       { role: "user", content: "what changed while I was away?" },
     ];
 
     expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "Build is blocked on a failing release check." },
       { role: "user", content: "what changed while I was away?" },
     ]);
@@ -875,14 +875,14 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("stops a prompt-only span before a later visible heartbeat alert", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "Build is blocked on a failing release check." },
       { role: "user", content: "what changed while I was away?" },
     ];
 
     expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       { role: "assistant", content: "Build is blocked on a failing release check." },
       { role: "user", content: "what changed while I was away?" },
     ]);
@@ -890,7 +890,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("does not remove across a real user message", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       createHeartbeatNoChangeMessage(),
       {
         role: "toolResult",
@@ -919,7 +919,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves helper tool turns when the heartbeat produces a visible alert", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
@@ -940,7 +940,7 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
 
   it("preserves top-level helper tool turns when the heartbeat produces a visible alert", () => {
     const messages = [
-      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
       {
         role: "assistant",
         content: null,

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -7,7 +7,7 @@ import { HEARTBEAT_RESPONSE_TOOL_NAME } from "./heartbeat-tool-response.js";
 import {
   HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS,
   HEARTBEAT_RESPONSE_TOOL_PROMPT,
-  HEARTBEAT_TRANSCRIPT_PROMPT,
+  INTERNAL_WAKE_TRANSCRIPT_PROMPTS,
   isHeartbeatAcknowledgementText,
   resolveHeartbeatPromptForResponseTool,
 } from "./heartbeat.js";
@@ -314,12 +314,13 @@ export function isHeartbeatUserMessage(
     return false;
   }
   const normalizedHeartbeatPrompt = heartbeatPrompt?.trim();
-  if (trimmed === HEARTBEAT_TRANSCRIPT_PROMPT) {
+  const transcriptPrompts = Object.values(INTERNAL_WAKE_TRANSCRIPT_PROMPTS);
+  if (transcriptPrompts.some((prompt) => trimmed === prompt)) {
     return true;
   }
   if (
     MESSAGE_TOOL_DELIVERY_HINTS.some((prefix) => trimmed.startsWith(prefix)) &&
-    trimmed.endsWith(HEARTBEAT_TRANSCRIPT_PROMPT)
+    transcriptPrompts.some((prompt) => trimmed.endsWith(prompt))
   ) {
     return true;
   }

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -14,6 +14,12 @@ export const HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS =
   "Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.";
 export const HEARTBEAT_RESPONSE_TOOL_PROMPT = `${HEARTBEAT_CONTEXT_PROMPT} ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS}`;
 export const HEARTBEAT_TRANSCRIPT_PROMPT = "[OpenClaw heartbeat poll]";
+export const INTERNAL_WAKE_TRANSCRIPT_PROMPTS = {
+  heartbeat: HEARTBEAT_TRANSCRIPT_PROMPT,
+  exec: "[OpenClaw exec completion]",
+  cron: "[OpenClaw cron wake]",
+  event: "[OpenClaw session event]",
+} as const;
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -13,9 +13,8 @@ export const HEARTBEAT_PROMPT = `${HEARTBEAT_CONTEXT_PROMPT} If nothing needs at
 export const HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS =
   "Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.";
 export const HEARTBEAT_RESPONSE_TOOL_PROMPT = `${HEARTBEAT_CONTEXT_PROMPT} ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS}`;
-export const HEARTBEAT_TRANSCRIPT_PROMPT = "[OpenClaw heartbeat poll]";
 export const INTERNAL_WAKE_TRANSCRIPT_PROMPTS = {
-  heartbeat: HEARTBEAT_TRANSCRIPT_PROMPT,
+  heartbeat: "[OpenClaw heartbeat poll]",
   exec: "[OpenClaw exec completion]",
   cron: "[OpenClaw cron wake]",
   event: "[OpenClaw session event]",

--- a/src/auto-reply/internal-turn-source.ts
+++ b/src/auto-reply/internal-turn-source.ts
@@ -1,10 +1,31 @@
 import { isStringOption } from "../utils/string-readers.js";
+import { INTERNAL_WAKE_TRANSCRIPT_PROMPTS } from "./heartbeat.js";
 import type { MsgContext } from "./templating.js";
 
 type InternalTurnContext = Pick<
   MsgContext,
   "InternalTurnSource" | "Provider" | "Surface" | "OriginatingChannel"
 >;
+
+/** Keep wake history compact while preserving the producer's actual event identity. */
+export function resolveInternalTurnTranscript(
+  ctx: Pick<MsgContext, "InputProvenance" | "InternalTurnSource">,
+) {
+  const provenance =
+    ctx.InputProvenance?.kind === "internal_system"
+      ? ctx.InputProvenance
+      : { kind: "internal_system" as const, sourceTool: ctx.InternalTurnSource ?? "heartbeat" };
+  const source = provenance.sourceTool ?? ctx.InternalTurnSource ?? "heartbeat";
+  const text =
+    source === "heartbeat"
+      ? INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat
+      : source === "exec" || source === "exec-event"
+        ? INTERNAL_WAKE_TRANSCRIPT_PROMPTS.exec
+        : source === "cron"
+          ? INTERNAL_WAKE_TRANSCRIPT_PROMPTS.cron
+          : INTERNAL_WAKE_TRANSCRIPT_PROMPTS.event;
+  return { text, provenance };
+}
 
 function legacyInternalTurnSource(value: string | undefined): MsgContext["InternalTurnSource"] {
   switch (value) {

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -28,6 +28,7 @@ import {
 } from "../../sessions/user-turn-transcript.js";
 import { buildChannelUserTurnSender } from "../../sessions/user-turn-transcript.metadata.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
+import { resolveInternalTurnTranscript } from "../internal-turn-source.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
@@ -302,7 +303,12 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
           ...(sourceTurnId ? { idempotencyKey: sourceTurnId } : {}),
           ...(inputProvenance && !isHeartbeat ? { provenance: inputProvenance } : {}),
           ...(isHeartbeat
-            ? { provenance: { kind: "internal_system" as const, sourceTool: "heartbeat" } }
+            ? {
+                provenance: resolveInternalTurnTranscript({
+                  InputProvenance: inputProvenance,
+                  InternalTurnSource: ctx.InternalTurnSource ?? sessionCtx.InternalTurnSource,
+                }).provenance,
+              }
             : {}),
           ...(transport ? { transport } : {}),
           ...(userTurnMediaForPersistence.length > 0 ? { media: userTurnMediaForPersistence } : {}),

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -3789,9 +3789,15 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.sourceReplyDeliveryMode).toBe("message_tool_only");
   });
 
-  it.each(["heartbeat", "cron", "exec"] as const)(
-    "keeps %s heartbeat metadata out of the model prompt",
-    async (source) => {
+  it.each([
+    ["heartbeat", undefined, "heartbeat", "[OpenClaw heartbeat poll]"],
+    ["cron", undefined, "cron", "[OpenClaw cron wake]"],
+    ["exec", undefined, "exec", "[OpenClaw exec completion]"],
+    ["heartbeat", "background-task", "background-task", "[OpenClaw session event]"],
+    ["heartbeat", "exec-event", "exec-event", "[OpenClaw exec completion]"],
+  ] as const)(
+    "keeps %s wake metadata private and preserves %s event provenance",
+    async (source, suppliedSourceTool, expectedSourceTool, transcriptPrompt) => {
       const heartbeatPrompt = "Read HEARTBEAT.md and run any due maintenance.";
       const syntheticConversationInfo =
         'Conversation info:\n```json\n{"chat_id":"discord:channel-123"}\n```';
@@ -3804,6 +3810,14 @@ describe("runPreparedReply media-only handling", () => {
           RawBody: heartbeatPrompt,
           CommandBody: heartbeatPrompt,
           InternalTurnSource: source,
+          ...(suppliedSourceTool
+            ? {
+                InputProvenance: {
+                  kind: "internal_system" as const,
+                  sourceTool: suppliedSourceTool,
+                },
+              }
+            : {}),
           ChatType: "direct",
           OriginatingChannel: "discord",
           OriginatingTo: "discord:channel-123",
@@ -3827,10 +3841,10 @@ describe("runPreparedReply media-only handling", () => {
         OriginatingChannel: "discord",
         OriginatingTo: "discord:channel-123",
       });
-      expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
-      expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
+      expect(call?.transcriptCommandBody).toBe(transcriptPrompt);
+      expect(call?.followupRun.transcriptPrompt).toBe(transcriptPrompt);
       expect(call?.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
-        provenance: { kind: "internal_system", sourceTool: "heartbeat" },
+        provenance: { kind: "internal_system", sourceTool: expectedSourceTool },
       });
     },
   );

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -9,7 +9,7 @@ import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-d
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../heartbeat.js";
+import { resolveInternalTurnTranscript } from "../internal-turn-source.js";
 import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendChannelPromptContext } from "./channel-prompt-context.js";
@@ -216,7 +216,10 @@ export function buildReplyPromptEnvelopeBase(
   const effectiveBaseBody =
     roomEventBody ?? (params.hasUserBody ? resetModelBody : MEDIA_ONLY_USER_TEXT);
   const transcriptBody = params.isHeartbeat
-    ? HEARTBEAT_TRANSCRIPT_PROMPT
+    ? resolveInternalTurnTranscript({
+        InputProvenance: params.ctx.InputProvenance ?? params.sessionCtx.InputProvenance,
+        InternalTurnSource: params.ctx.InternalTurnSource ?? params.sessionCtx.InternalTurnSource,
+      }).text
     : params.isBareSessionReset
       ? softResetTail || `[OpenClaw session ${params.startupAction}]`
       : (roomEventBody ?? (params.hasUserBody ? params.baseBody : MEDIA_ONLY_USER_TEXT));

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../auto-reply/heartbeat.js";
+import { INTERNAL_WAKE_TRANSCRIPT_PROMPTS } from "../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveSessionStorePathCore,
@@ -286,7 +286,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
     fs.writeFileSync(
       path.join(sessionsDir, "heartbeat-session.jsonl"),
       [
-        JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+        JSON.stringify({
+          message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+        }),
         JSON.stringify({ message: { role: "assistant", content: "HEARTBEAT_OK" } }),
         "",
       ].join("\n"),
@@ -340,7 +342,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
     fs.writeFileSync(
       path.join(sessionsDir, "mixed-session.jsonl"),
       [
-        JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+        JSON.stringify({
+          message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+        }),
         JSON.stringify({ message: { role: "assistant", content: "HEARTBEAT_OK" } }),
         JSON.stringify({ message: { role: "user", content: "hello from telegram" } }),
         "",
@@ -371,7 +375,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
     const transcriptPath = path.join(sessionsDir, "large-heartbeat-session.jsonl");
     const heartbeatLine = `${JSON.stringify({
-      message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
     })}\n${JSON.stringify({ message: { role: "assistant", content: "HEARTBEAT_OK" } })}\n`;
     // >64 KiB so the sync scanner must read more than one chunk.
     const repeats = Math.ceil((80 * 1024) / heartbeatLine.length);
@@ -424,7 +428,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
     const maxChars = getTranscriptRecordMaxChars();
     const oversizedRecord = `${"x".repeat(maxChars + 1)}\n`;
     const heartbeatLine = `${JSON.stringify({
-      message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
     })}\n`;
     fs.writeFileSync(transcriptPath, `${oversizedRecord}${heartbeatLine}`);
 
@@ -498,7 +502,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
       fs.writeFileSync(
         transcriptPath,
         [
-          JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+          JSON.stringify({
+            message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+          }),
           JSON.stringify({ message: { role: "user", content: "real follow-up" } }),
           "",
         ].join("\n"),
@@ -521,7 +527,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
       fs.writeFileSync(
         transcriptPath,
         [
-          JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+          JSON.stringify({
+            message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+          }),
           JSON.stringify({ message: { role: "user", content: "real follow-up" } }),
           "",
         ].join("\n"),
@@ -544,7 +552,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
     try {
       const transcriptPath = path.join(tempDir, "session.jsonl");
       const heartbeatMessages = Array.from({ length: 400 }, () =>
-        JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+        JSON.stringify({
+          message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+        }),
       );
       fs.writeFileSync(
         transcriptPath,
@@ -568,7 +578,9 @@ describe("doctor transcript and heartbeat session repairs", () => {
       fs.writeFileSync(
         transcriptPath,
         [
-          JSON.stringify({ message: { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT } }),
+          JSON.stringify({
+            message: { role: "user", content: INTERNAL_WAKE_TRANSCRIPT_PROMPTS.heartbeat },
+          }),
           JSON.stringify({ message: { role: "assistant", content: "HEARTBEAT_OK" } }),
           "",
         ].join("\n"),

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -85,6 +85,19 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
         : prepared.hasCronEvents
           ? "cron"
           : "heartbeat",
+      InputProvenance: {
+        kind: "internal_system",
+        sourceTool: prepared.hasExecCompletion
+          ? "exec"
+          : prepared.hasCronEvents
+            ? "cron"
+            : opts.intent === "scheduled" ||
+                !wake.wakeSource ||
+                wake.wakeSource === "interval" ||
+                wake.wakeSource === "manual"
+              ? "heartbeat"
+              : wake.wakeSource,
+      },
       SessionKey: runSessionKey,
       AgentId: agentId,
     } satisfies MsgContext;

--- a/src/infra/heartbeat-runner.event-routing.test.ts
+++ b/src/infra/heartbeat-runner.event-routing.test.ts
@@ -237,6 +237,7 @@ describe("Heartbeat event routing", () => {
         expect(getFirstReplyContext(replySpy)).toMatchObject({
           SessionKey: isolatedKey,
           InternalTurnSource: "exec",
+          InputProvenance: { kind: "internal_system", sourceTool: "exec" },
           MessageThreadId: expectedThreadId,
           OriginatingChannel: "telegram",
           OriginatingTo: target(expectedThreadId),
@@ -435,6 +436,10 @@ describe("Heartbeat event routing", () => {
       const context = getFirstReplyContext(replySpy);
       expect(context.SessionKey).toBe(queue === "shared" ? baseKey : isolatedKey);
       expect(context.InternalTurnSource).toBe(dedicated === "none" ? "heartbeat" : dedicated);
+      expect(context.InputProvenance).toEqual({
+        kind: "internal_system",
+        sourceTool: dedicated === "none" ? "hook" : dedicated,
+      });
       if (queue === "legacy") {
         expect(legacyRowRemovedAtReply).toBe(dedicated !== "exec");
       }
@@ -648,45 +653,52 @@ describe("Heartbeat event routing", () => {
     });
   });
 
-  it("keeps Telegram topic routing for isolated scheduled heartbeats", async () => {
-    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
-      const cfg = createLastTargetConfig({ tmpDir, storePath, isolatedSession: true });
-      const sessionKey = resolveMainSessionKey(cfg);
-      await writeTelegramSessionStore(storePath, sessionKey, {
-        lastTo: "-100155462274",
-        deliveryContext: {
-          channel: "telegram",
+  it.each([false, true])(
+    "keeps scheduled heartbeat routing with isolation=%s",
+    async (isolated) => {
+      await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+        const cfg = createLastTargetConfig({ tmpDir, storePath, isolatedSession: isolated });
+        const sessionKey = resolveMainSessionKey(cfg);
+        await writeTelegramSessionStore(storePath, sessionKey, {
+          lastTo: "-100155462274",
+          deliveryContext: {
+            channel: "telegram",
+            to: "-100155462274",
+            threadId: 42,
+          },
+          chatType: "group",
+        });
+
+        const sendTelegram = vi.fn().mockResolvedValue({
+          messageId: "m1",
+          chatId: "-100155462274",
+        });
+        replySpy.mockResolvedValue({ text: "Topic heartbeat" });
+
+        const result = await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          reason: "timer",
+          deps: {
+            getReplyFromConfig: replySpy,
+            telegram: sendTelegram,
+          },
+        });
+
+        expect(result.status).toBe("ran");
+        const replyCtx = getFirstReplyContext(replySpy);
+        expect(replyCtx.SessionKey).toBe(isolated ? `${sessionKey}:heartbeat` : sessionKey);
+        expect(replyCtx.InputProvenance).toEqual({
+          kind: "internal_system",
+          sourceTool: "heartbeat",
+        });
+        expect(replyCtx.MessageThreadId).toBe(42);
+        expectTelegramSend(sendTelegram, {
           to: "-100155462274",
-          threadId: 42,
-        },
-        chatType: "group",
+          text: "Topic heartbeat",
+          messageThreadId: 42,
+        });
       });
-
-      const sendTelegram = vi.fn().mockResolvedValue({
-        messageId: "m1",
-        chatId: "-100155462274",
-      });
-      replySpy.mockResolvedValue({ text: "Topic heartbeat" });
-
-      const result = await runHeartbeatOnce({
-        cfg,
-        agentId: "main",
-        reason: "timer",
-        deps: {
-          getReplyFromConfig: replySpy,
-          telegram: sendTelegram,
-        },
-      });
-
-      expect(result.status).toBe("ran");
-      const replyCtx = getFirstReplyContext(replySpy);
-      expect(replyCtx.SessionKey).toBe(`${sessionKey}:heartbeat`);
-      expect(replyCtx.MessageThreadId).toBe(42);
-      expectTelegramSend(sendTelegram, {
-        to: "-100155462274",
-        text: "Topic heartbeat",
-        messageThreadId: 42,
-      });
-    });
-  });
+    },
+  );
 });

--- a/src/infra/heartbeat-runner.live.test.ts
+++ b/src/infra/heartbeat-runner.live.test.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawTestInstance } from "../../test/helpers/openclaw-test-instance.js";
+import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import { mergeWorkspaceSetupState } from "../agents/workspace-state-store.js";
+import { ensureAgentWorkspace } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { GatewayClient } from "../gateway/client.js";
+import {
+  connectTestGatewayClient,
+  ensurePairedTestGatewayClientIdentity,
+} from "../gateway/gateway-cli-backend.live-helpers.js";
+import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
+import { loadGatewaySessionEntryReadOnly } from "../gateway/session-utils.js";
+import { extractPayloadText } from "../gateway/test-helpers.agent-results.js";
+import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+
+const enabled = isLiveTestEnabled() && process.env.OPENCLAW_LIVE_SESSION_EVENT_WAKE === "1";
+const describeLive = enabled ? describe : describe.skip;
+const TURN_TIMEOUT_MS = 180_000;
+const MODEL = "openai/gpt-5.6-sol";
+
+async function readMessages(sessionKey: string): Promise<unknown[]> {
+  const { storePath, entry } = loadGatewaySessionEntryReadOnly(sessionKey);
+  if (!entry?.sessionId) {
+    return [];
+  }
+  return readSessionMessagesAsync(
+    { storePath, sessionEntry: entry, sessionId: entry.sessionId, sessionKey },
+    { mode: "full", reason: "live completion and heartbeat routing verification" },
+  );
+}
+
+function messagesWithRole(messages: unknown[], role: string): string {
+  return JSON.stringify(messages.filter((message) => asOptionalRecord(message)?.role === role));
+}
+
+describeLive("session event wake through a live Gateway", () => {
+  it("continues a completed foreground session for exec results and keeps monitor polls on main", async () => {
+    if (!process.env.OPENAI_API_KEY?.trim()) {
+      throw new Error("OPENCLAW_LIVE_SESSION_EVENT_WAKE requires OPENAI_API_KEY");
+    }
+    const instance = await createOpenClawTestInstance({
+      name: "live-session-event-wake",
+      env: {
+        ...Object.fromEntries(listKnownProviderAuthEnvVarNames().map((name) => [name, undefined])),
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        OPENCLAW_AGENT_RUNTIME: "openclaw",
+        OPENCLAW_ALLOW_SLOW_REPLY_TESTS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_SKIP_CRON: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_EXEC_SHELL_SNAPSHOT: "0",
+      },
+    });
+    let client: GatewayClient | undefined;
+    const sessionKey = `agent:main:live-completion-${randomUUID()}`;
+    const mainSessionKey = "agent:main:main";
+    const nonce = randomUUID();
+    const startedReply = `STARTED-${nonce}`;
+    const completionReply = `COMPLETION-${nonce}`;
+    const monitorReply = `MAIN-MONITOR-${nonce}`;
+    const workspace = instance.state.workspaceDir;
+    const gatePath = path.join(workspace, "release-command");
+    try {
+      instance.state.applyEnv();
+      await ensureAgentWorkspace({ dir: workspace, ensureBootstrapFiles: true });
+      await fs.rm(path.join(workspace, "BOOTSTRAP.md"), { force: true });
+      mergeWorkspaceSetupState(workspace, { setupCompletedAt: new Date().toISOString() });
+      await fs.writeFile(
+        path.join(workspace, "AGENTS.md"),
+        "Follow exact reply instructions. This workspace contains only synthetic live-test data.\n",
+      );
+      // The external gate establishes foreground-final-before-process-exit ordering.
+      await fs.writeFile(
+        path.join(workspace, "completion-gate.cjs"),
+        [
+          'const fs = require("node:fs");',
+          'fs.writeFileSync("command-started", "started");',
+          "const deadline = Date.now() + 180000;",
+          "const timer = setInterval(() => {",
+          '  if (fs.existsSync("release-command")) {',
+          "    clearInterval(timer);",
+          `    console.log(${JSON.stringify(completionReply)});`,
+          '    fs.writeFileSync("command-completed", "completed");',
+          "  } else if (Date.now() > deadline) {",
+          "    clearInterval(timer);",
+          '    console.error("Live fixture gate was not released");',
+          "    process.exitCode = 1;",
+          "  }",
+          "}, 50);",
+        ].join("\n"),
+      );
+      const config: OpenClawConfig = {
+        gateway: {
+          mode: "local",
+          port: instance.port,
+          auth: { mode: "token", token: instance.gatewayToken },
+          controlUi: { enabled: false },
+        },
+        plugins: { allow: ["openai"] },
+        secrets: { providers: { default: { source: "env" } } },
+        models: {
+          providers: {
+            openai: {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            workspace,
+            skipBootstrap: true,
+            thinkingDefault: "low",
+            timeoutSeconds: 170,
+            model: { primary: MODEL },
+            models: { [MODEL]: { agentRuntime: { id: "openclaw" } } },
+            sandbox: { mode: "off" },
+            heartbeat: {
+              every: "24h",
+              target: "none",
+              prompt: `Call heartbeat_respond with outcome progress, notify false, summary ${monitorReply}. Do no other work.`,
+            },
+          },
+        },
+        tools: {
+          codeMode: true,
+          exec: { host: "gateway", mode: "full", notifyOnExit: true },
+        },
+      };
+      await instance.state.writeConfig(config);
+      const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
+        displayName: "live-session-event-wake",
+      });
+      await instance.startGateway();
+      client = await connectTestGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        deviceIdentity,
+        requestTimeoutMs: TURN_TIMEOUT_MS,
+      });
+      const response = await client.request<{ status?: string; result?: unknown }>(
+        "agent",
+        {
+          sessionKey,
+          idempotencyKey: randomUUID(),
+          deliver: false,
+          timeout: 170,
+          message: [
+            "Start the existing completion-gate.cjs fixture using the shell exec tool, command node completion-gate.cjs, with background true and timeoutSeconds 180.",
+            "Use Code Mode to invoke the shell exec tool. Do not read, modify, or run any other file. Do not poll or wait for the process.",
+            `Once exec returns its running session, reply exactly ${startedReply} and end this turn.`,
+            "Handle its later completion silently with NO_REPLY; this fixture disables notification delivery.",
+          ].join("\n"),
+        },
+        { expectFinal: true, timeoutMs: TURN_TIMEOUT_MS },
+      );
+      expect(response.status).toBe("ok");
+      expect(extractPayloadText(response.result)).toContain(startedReply);
+      expect(await fs.readFile(path.join(workspace, "command-started"), "utf8")).toBe("started");
+      const foregroundMessages = await readMessages(sessionKey);
+      expect(messagesWithRole(foregroundMessages, "assistant")).not.toContain(completionReply);
+      await expect(fs.access(path.join(workspace, "command-completed"))).rejects.toThrow();
+
+      await fs.writeFile(gatePath, "release");
+      await vi.waitFor(
+        async () => {
+          expect(instance.logs()).not.toContain("Async work scope is closed");
+          const continued = (await readMessages(sessionKey)).slice(foregroundMessages.length);
+          expect(continued).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                role: "assistant",
+                provider: "openai",
+                stopReason: "stop",
+                content: expect.arrayContaining([
+                  expect.objectContaining({ type: "text", text: "NO_REPLY" }),
+                ]),
+              }),
+            ]),
+          );
+        },
+        { timeout: TURN_TIMEOUT_MS, interval: 1_000 },
+      );
+      const completedMessages = await readMessages(sessionKey);
+      const completionUsers = messagesWithRole(
+        completedMessages.slice(foregroundMessages.length),
+        "user",
+      );
+      expect(completionUsers).toContain("[OpenClaw exec completion]");
+      expect(completionUsers).not.toContain("[OpenClaw heartbeat poll]");
+      expect(await fs.readFile(path.join(workspace, "command-completed"), "utf8")).toBe(
+        "completed",
+      );
+      expect(await readMessages(mainSessionKey)).toEqual([]);
+
+      const jobs = await client.request<{
+        jobs: Array<{
+          id: string;
+          agentId?: string;
+          payload: { kind: string };
+          sessionTarget: string;
+        }>;
+      }>("cron.list", { includeDisabled: true });
+      const monitor = jobs.jobs.find((job) => job.payload.kind === "heartbeat");
+      expect(monitor).toMatchObject({ sessionTarget: "main" });
+      if (!monitor) {
+        throw new Error("Gateway did not create its main-session heartbeat monitor");
+      }
+      const forced = await client.request<{ ok: boolean }>("cron.run", {
+        id: monitor.id,
+        mode: "force",
+      });
+      expect(forced.ok).toBe(true);
+      await vi.waitFor(
+        async () => {
+          const mainMessages = await readMessages(mainSessionKey);
+          expect(messagesWithRole(mainMessages, "user")).toContain("[OpenClaw heartbeat poll]");
+          expect(messagesWithRole(mainMessages, "assistant")).toContain(monitorReply);
+        },
+        { timeout: TURN_TIMEOUT_MS, interval: 1_000 },
+      );
+      expect(await readMessages(sessionKey)).toEqual(completedMessages);
+      expect(instance.logs()).not.toContain("Async work scope is closed");
+    } finally {
+      try {
+        await client?.stopAndWait({ timeoutMs: 1_000 });
+      } finally {
+        await instance.cleanup();
+      }
+    }
+  }, 600_000);
+});

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -215,7 +215,7 @@ export function setupTelegramHeartbeatPluginRuntimeForTests() {
 
 export type HeartbeatReplyContext = Pick<
   MsgContext,
-  "InternalTurnSource" | "SessionKey" | "MessageThreadId" | "Body"
+  "InternalTurnSource" | "InputProvenance" | "SessionKey" | "MessageThreadId" | "Body"
 >;
 
 export const mockCallAt = (

--- a/src/infra/session-event-wake.transcript-context.test.ts
+++ b/src/infra/session-event-wake.transcript-context.test.ts
@@ -3,7 +3,12 @@ import {
   getOwnedSessionTranscriptWriterFence,
   withOwnedSessionTranscriptWrites,
 } from "../config/sessions/transcript-write-context.js";
-import { requestSessionEventWake, setSessionEventWakeHandler } from "./session-event-wake.js";
+import { AsyncWorkScope, trackAsyncWork } from "../shared/async-work-scope.js";
+import {
+  requestSessionEventWake,
+  requestSessionEventWakeAndWait,
+  setSessionEventWakeHandler,
+} from "./session-event-wake.js";
 
 let dispose = () => {};
 
@@ -36,4 +41,36 @@ it("dispatches outside the requesting attempt transcript context", async () => {
       }),
   );
   expect(await observedFence).toBeUndefined();
+});
+
+it("dispatches queued sessions after the requesting attempt closes its work scope", async () => {
+  const executed: string[] = [];
+  dispose = setSessionEventWakeHandler(async (request) => {
+    try {
+      await trackAsyncWork(() => executed.push(request.sessionKey!));
+      return { status: "ran", durationMs: 0 };
+    } catch (error) {
+      return { status: "failed", reason: String(error) };
+    }
+  });
+  const request = (sessionKey: string) =>
+    requestSessionEventWakeAndWait({
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      sessionKey,
+      coalesceMs: 0,
+    });
+  const foreground = new AsyncWorkScope();
+  const originating = "agent:main:dashboard:originating";
+  const unrelated = "agent:main:dashboard:unrelated";
+  const first = foreground.run(() => request(originating));
+  const second = request(unrelated);
+  await foreground.drain();
+
+  expect(await Promise.all([first, second])).toEqual([
+    { status: "ran", durationMs: 0 },
+    { status: "ran", durationMs: 0 },
+  ]);
+  expect(executed).toEqual([originating, unrelated]);
 });

--- a/src/infra/session-event-wake.ts
+++ b/src/infra/session-event-wake.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runWithoutOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
-import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import { runWithGatewayDetachedWorkAdmission } from "../process/gateway-work-admission.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { normalizeHeartbeatWakeReason } from "./heartbeat-reason.js";
@@ -317,7 +317,7 @@ function createSessionEventWakeRuntime() {
         let result: SessionEventWakeResult;
         let onAbort: (() => void) | undefined;
         try {
-          result = await runWithGatewayIndependentRootWorkAdmission(() => {
+          result = await runWithGatewayDetachedWorkAdmission(() => {
             signal.throwIfAborted();
             // Subscribe before calling the handler: it can synchronously replace its owner.
             const aborted = new Promise<never>((_resolve, reject) => {

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -314,7 +314,6 @@ it("uses the supplied origin when a continuation has no live parent", async () =
   expect(getActiveGatewayRootWorkHolders()).toEqual(["runtime:detached"]);
   releaseContinuation();
   await continuation;
-  await nextTurn();
   expect(getActiveGatewayRootWorkHolders()).toEqual([]);
 });
 
@@ -351,8 +350,8 @@ it.each(["admission", "continuation"] as const)(
     });
     await handlerReturned.promise;
     root.release();
+    const foregroundClosed = foreground.drain();
     try {
-      await foreground.drain();
       await nextTurn();
       expect(settled).toBe(true);
       expect(backgroundSignal).toBeDefined();
@@ -363,6 +362,7 @@ it.each(["admission", "continuation"] as const)(
       releaseChild.resolve();
       await child;
       await background;
+      await foregroundClosed;
       await nextTurn();
     }
     expect(backgroundSignal?.aborted).toBe(true);

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -1,6 +1,12 @@
 // Covers root work counting and reversible suspension admission transitions.
 import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  AsyncWorkScope,
+  captureAsyncWorkTracker,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import {
   beginGatewayRestartSignalAdmission,
@@ -308,8 +314,62 @@ it("uses the supplied origin when a continuation has no live parent", async () =
   expect(getActiveGatewayRootWorkHolders()).toEqual(["runtime:detached"]);
   releaseContinuation();
   await continuation;
+  await nextTurn();
   expect(getActiveGatewayRootWorkHolders()).toEqual([]);
 });
+
+it.each(["admission", "continuation"] as const)(
+  "retains independent %s through descendant cleanup after its requester closes",
+  async (kind) => {
+    const foreground = new AsyncWorkScope();
+    const root = tryBeginGatewayRootWorkAdmission("foreground")!;
+    const releaseChild = createDeferredCore();
+    const handlerReturned = createDeferredCore();
+    let child: Promise<void> | undefined;
+    let track: ReturnType<typeof captureAsyncWorkTracker> | undefined;
+    let backgroundSignal: AbortSignal | undefined;
+    let settled = false;
+    const run = async () => {
+      track = captureAsyncWorkTracker();
+      backgroundSignal = getAsyncWorkSignal();
+      child = trackAsyncWork(async () => {
+        await releaseChild.promise;
+        await trackAsyncWork(() => {});
+      });
+      handlerReturned.resolve();
+      return "completed";
+    };
+    const background = root.run(async () =>
+      foreground.run(() =>
+        kind === "admission"
+          ? runWithGatewayIndependentRootWorkAdmission(run, "background")
+          : runWithGatewayIndependentRootWorkContinuation(run, "background"),
+      ),
+    );
+    void background.then(() => {
+      settled = true;
+    });
+    await handlerReturned.promise;
+    root.release();
+    try {
+      await foreground.drain();
+      await nextTurn();
+      expect(settled).toBe(true);
+      expect(backgroundSignal).toBeDefined();
+      expect(backgroundSignal).not.toBe(foreground.signal);
+      expect(backgroundSignal?.aborted).toBe(false);
+      expect(getActiveGatewayRootWorkHolders()).toEqual(["background"]);
+    } finally {
+      releaseChild.resolve();
+      await child;
+      await background;
+      await nextTurn();
+    }
+    expect(backgroundSignal?.aborted).toBe(true);
+    await expect(track?.(() => {})).rejects.toThrow("Async work scope is closed");
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  },
+);
 
 it("retains an admitted request root across its handler return", async () => {
   const root = tryBeginGatewayRootWorkAdmission();

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -25,6 +25,7 @@ import {
   retainGatewayRootWorkAdmissionContinuation,
   resetGatewayWorkAdmission,
   rollbackGatewayRestartSignalFence,
+  runWithGatewayDetachedWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
   runWithGatewayIndependentRootWorkContinuation,
   runWithRetainedGatewayRootWork,
@@ -317,59 +318,52 @@ it("uses the supplied origin when a continuation has no live parent", async () =
   expect(getActiveGatewayRootWorkHolders()).toEqual([]);
 });
 
-it.each(["admission", "continuation"] as const)(
-  "retains independent %s through descendant cleanup after its requester closes",
-  async (kind) => {
-    const foreground = new AsyncWorkScope();
-    const root = tryBeginGatewayRootWorkAdmission("foreground")!;
-    const releaseChild = createDeferredCore();
-    const handlerReturned = createDeferredCore();
-    let child: Promise<void> | undefined;
-    let track: ReturnType<typeof captureAsyncWorkTracker> | undefined;
-    let backgroundSignal: AbortSignal | undefined;
-    let settled = false;
-    const run = async () => {
-      track = captureAsyncWorkTracker();
-      backgroundSignal = getAsyncWorkSignal();
-      child = trackAsyncWork(async () => {
-        await releaseChild.promise;
-        await trackAsyncWork(() => {});
-      });
-      handlerReturned.resolve();
-      return "completed";
-    };
-    const background = root.run(async () =>
-      foreground.run(() =>
-        kind === "admission"
-          ? runWithGatewayIndependentRootWorkAdmission(run, "background")
-          : runWithGatewayIndependentRootWorkContinuation(run, "background"),
-      ),
-    );
-    void background.then(() => {
-      settled = true;
+it("retains detached work through descendant cleanup after its requester closes", async () => {
+  const foreground = new AsyncWorkScope();
+  const root = tryBeginGatewayRootWorkAdmission("foreground")!;
+  const releaseChild = createDeferredCore();
+  const handlerReturned = createDeferredCore();
+  let child: Promise<void> | undefined;
+  let track: ReturnType<typeof captureAsyncWorkTracker> | undefined;
+  let backgroundSignal: AbortSignal | undefined;
+  let settled = false;
+  const run = async () => {
+    track = captureAsyncWorkTracker();
+    backgroundSignal = getAsyncWorkSignal();
+    child = trackAsyncWork(async () => {
+      await releaseChild.promise;
+      await trackAsyncWork(() => {});
     });
-    await handlerReturned.promise;
-    root.release();
-    const foregroundClosed = foreground.drain();
-    try {
-      await nextTurn();
-      expect(settled).toBe(true);
-      expect(backgroundSignal).toBeDefined();
-      expect(backgroundSignal).not.toBe(foreground.signal);
-      expect(backgroundSignal?.aborted).toBe(false);
-      expect(getActiveGatewayRootWorkHolders()).toEqual(["background"]);
-    } finally {
-      releaseChild.resolve();
-      await child;
-      await background;
-      await foregroundClosed;
-      await nextTurn();
-    }
-    expect(backgroundSignal?.aborted).toBe(true);
-    await expect(track?.(() => {})).rejects.toThrow("Async work scope is closed");
-    expect(getActiveGatewayRootWorkCount()).toBe(0);
-  },
-);
+    handlerReturned.resolve();
+    return "completed";
+  };
+  const background = root.run(async () =>
+    foreground.run(() => runWithGatewayDetachedWorkAdmission(run, "background")),
+  );
+  void background.then(() => {
+    settled = true;
+  });
+  await handlerReturned.promise;
+  root.release();
+  const foregroundClosed = foreground.drain();
+  try {
+    await nextTurn();
+    expect(settled).toBe(true);
+    expect(backgroundSignal).toBeDefined();
+    expect(backgroundSignal).not.toBe(foreground.signal);
+    expect(backgroundSignal?.aborted).toBe(false);
+    expect(getActiveGatewayRootWorkHolders()).toEqual(["background"]);
+  } finally {
+    releaseChild.resolve();
+    await child;
+    await background;
+    await foregroundClosed;
+    await nextTurn();
+  }
+  expect(backgroundSignal?.aborted).toBe(true);
+  await expect(track?.(() => {})).rejects.toThrow("Async work scope is closed");
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+});
 
 it("retains an admitted request root across its handler return", async () => {
   const root = tryBeginGatewayRootWorkAdmission();

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { GatewaySuspension } from "../../packages/gateway-protocol/src/schema/gateway-suspend.js";
 import { racePromiseWithAbortSignal } from "../infra/abort-signal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
@@ -89,7 +90,10 @@ export type GatewayRestartSignalAdmissionLease = {
 
 const GATEWAY_ROOT_WORK_ORIGIN_MAX_CHARS = 80;
 
-function createGatewayRootWorkAdmission(origin: string): GatewayRootWorkAdmissionLease {
+function createGatewayRootWorkAdmission(
+  origin: string,
+  independentWork = false,
+): GatewayRootWorkAdmissionLease {
   const normalizedOrigin = origin
     .trim()
     .replaceAll(/\s+/g, " ")
@@ -105,7 +109,9 @@ function createGatewayRootWorkAdmission(origin: string): GatewayRootWorkAdmissio
     ownsRoot: true,
     release,
     run: async <T>(run: () => Promise<T>) =>
-      await GATEWAY_WORK_ADMISSION_STATE.currentRootWork.run(admission, run),
+      await GATEWAY_WORK_ADMISSION_STATE.currentRootWork.run(admission, () =>
+        independentWork ? runWithIndependentAsyncWork(admission, run) : run(),
+      ),
   };
 }
 
@@ -123,6 +129,37 @@ function createGatewayRootWorkRelease(admission: GatewayRootWorkAdmission): () =
     admission.released = true;
     GATEWAY_WORK_ADMISSION_STATE.activeRootWork.delete(admission);
   };
+}
+
+async function runWithIndependentAsyncWork<T>(
+  admission: GatewayRootWorkAdmission,
+  run: () => Promise<T>,
+): Promise<T> {
+  // Timers can inherit a completed request's scope. Retain cleanup under this
+  // independent root without delaying its caller's existing result boundary.
+  admission.references += 1;
+  const releaseWork = createGatewayRootWorkRelease(admission);
+  const result = createDeferredCore<T>();
+  const work = new AsyncWorkScope();
+  void work
+    .run(async () => {
+      try {
+        result.resolve(await work.track(run));
+      } catch (error) {
+        result.reject(error);
+      } finally {
+        try {
+          await AsyncWorkScope.runWhenAllIdle(
+            () => [work],
+            () => work.drain(),
+          );
+        } finally {
+          releaseWork();
+        }
+      }
+    })
+    .catch(result.reject);
+  return await result.promise;
 }
 
 function invalidateSuspendAdmission(): void {
@@ -373,7 +410,7 @@ export function tryBeginGatewayIndependentRootWorkAdmission(
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission(origin);
+  return createGatewayRootWorkAdmission(origin, true);
 }
 
 async function waitForGatewayWorkAdmissionChange(signal?: AbortSignal): Promise<void> {
@@ -445,7 +482,7 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   if (!parent || parent.released) {
     return runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
-  const admission = createGatewayRootWorkAdmission(origin);
+  const admission = createGatewayRootWorkAdmission(origin, true);
   return admission.run(run).finally(admission.release);
 }
 

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -92,7 +92,7 @@ const GATEWAY_ROOT_WORK_ORIGIN_MAX_CHARS = 80;
 
 function createGatewayRootWorkAdmission(
   origin: string,
-  independentWork = false,
+  detachedWork = false,
 ): GatewayRootWorkAdmissionLease {
   const normalizedOrigin = origin
     .trim()
@@ -110,7 +110,7 @@ function createGatewayRootWorkAdmission(
     release,
     run: async <T>(run: () => Promise<T>) =>
       await GATEWAY_WORK_ADMISSION_STATE.currentRootWork.run(admission, () =>
-        independentWork ? runWithIndependentAsyncWork(admission, run) : run(),
+        detachedWork ? runWithDetachedAsyncWork(admission, run) : run(),
       ),
   };
 }
@@ -131,12 +131,12 @@ function createGatewayRootWorkRelease(admission: GatewayRootWorkAdmission): () =
   };
 }
 
-async function runWithIndependentAsyncWork<T>(
+async function runWithDetachedAsyncWork<T>(
   admission: GatewayRootWorkAdmission,
   run: () => Promise<T>,
 ): Promise<T> {
   // Timers can inherit a completed request's scope. Retain cleanup under this
-  // independent root without delaying its caller's existing result boundary.
+  // detached root without delaying its caller's existing result boundary.
   admission.references += 1;
   const releaseWork = createGatewayRootWorkRelease(admission);
   const result = createDeferredCore<T>();
@@ -399,7 +399,7 @@ export function tryBeginGatewayPreparedRestartRootWorkAdmission(): GatewayRootWo
   return createGatewayRootWorkAdmission("restart-prepared");
 }
 
-/** Independent detached work counts separately even when launched by an admitted parent. */
+/** Independent roots count separately even when launched by an admitted parent. */
 export function tryBeginGatewayIndependentRootWorkAdmission(
   origin = "independent",
 ): GatewayRootWorkAdmissionLease | null {
@@ -410,7 +410,7 @@ export function tryBeginGatewayIndependentRootWorkAdmission(
   ) {
     return null;
   }
-  return createGatewayRootWorkAdmission(origin, true);
+  return createGatewayRootWorkAdmission(origin);
 }
 
 async function waitForGatewayWorkAdmissionChange(signal?: AbortSignal): Promise<void> {
@@ -439,10 +439,29 @@ export async function beginGatewayRootWorkAdmissionWhenOpen(
   }
 }
 
-export async function runWithGatewayIndependentRootWorkAdmission<T>(
+/** Keeps the caller's async-resource owner, including server shutdown cancellation. */
+export function runWithGatewayIndependentRootWorkAdmission<T>(
   run: () => Promise<T>,
   origin?: string,
   signal?: AbortSignal,
+): Promise<T> {
+  return runWithGatewayNewRootWorkAdmission(run, origin, signal, false);
+}
+
+/** Delayed producers outlive their triggering request and own their async cleanup. */
+export function runWithGatewayDetachedWorkAdmission<T>(
+  run: () => Promise<T>,
+  origin?: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  return runWithGatewayNewRootWorkAdmission(run, origin, signal, true);
+}
+
+async function runWithGatewayNewRootWorkAdmission<T>(
+  run: () => Promise<T>,
+  origin: string | undefined,
+  signal: AbortSignal | undefined,
+  detachedWork: boolean,
 ): Promise<T> {
   while (true) {
     // Cancellation retires admission only; an admitted operation still owns its full completion.
@@ -450,7 +469,9 @@ export async function runWithGatewayIndependentRootWorkAdmission<T>(
     if (GATEWAY_WORK_ADMISSION_STATE.restartDraining) {
       throw new GatewayDrainingError("gateway is draining for restart");
     }
-    const admission = tryBeginGatewayIndependentRootWorkAdmission(origin);
+    const admission = isGatewayWorkAdmissionClosed()
+      ? null
+      : createGatewayRootWorkAdmission(origin ?? "independent", detachedWork);
     if (admission) {
       try {
         return await admission.run(run);
@@ -482,7 +503,7 @@ export function runWithGatewayIndependentRootWorkContinuation<T>(
   if (!parent || parent.released) {
     return runWithGatewayIndependentRootWorkAdmission(run, origin);
   }
-  const admission = createGatewayRootWorkAdmission(origin, true);
+  const admission = createGatewayRootWorkAdmission(origin);
   return admission.run(run).finally(admission.release);
 }
 

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -86,10 +86,10 @@ export class AsyncWorkScope {
     run: () => T | Promise<T>,
   ): Promise<T> {
     let scopes = selectScopes();
-    do {
+    while (scopes.some((scope) => scope.pending.size > 0)) {
       await Promise.allSettled(scopes.flatMap((scope) => [...scope.pending]));
       scopes = selectScopes();
-    } while (scopes.some((scope) => scope.pending.size > 0));
+    }
     return run();
   }
 

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -87,7 +87,7 @@ export class AsyncWorkScope {
   ): Promise<T> {
     let scopes = selectScopes();
     while (scopes.some((scope) => scope.pending.size > 0)) {
-      await Promise.allSettled(scopes.flatMap((scope) => [...scope.pending]));
+      await Promise.allSettled(scopes.flatMap((scope) => Array.from(scope.pending)));
       scopes = selectScopes();
     }
     return run();

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -19,7 +19,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import {
   getGatewayRestartDrainSignal,
-  runWithGatewayIndependentRootWorkAdmission,
+  runWithGatewayDetachedWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { recordSkillExperienceReviewOutcome } from "./collection-review-state.js";
@@ -107,7 +107,7 @@ export async function runSkillExperienceReview(
 ): Promise<void> {
   // The foreground root has closed by the idle timer's callback. Admit this
   // detached review independently; a real Gateway drain still refuses it.
-  await runWithGatewayIndependentRootWorkAdmission(
+  await runWithGatewayDetachedWorkAdmission(
     () => runSkillExperienceReviewInner(candidate),
     "skills:experience-review",
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a completed chat could later show “Async work scope is closed” when a background completion woke it. A shared wake timer could carry a finished foreground turn's work scope into several sessions. Those event-driven turns were also recorded as generic heartbeat polls, making ordinary completion handling look like a scheduled heartbeat in an unrelated chat.

## Why This Change Was Made

Delayed event dispatch and skill review explicitly acquire a fresh async-work scope, with a separate admission reference retaining cleanup without delaying their logical result. Ordinary independent admissions keep their caller's resource owner, preserving server shutdown cancellation for setup and plugin reload. Already idle scopes finish cleanup immediately, so completed work is no longer counted as active. Wake producers retain their event provenance through compact transcript markers for exec completions, cron wakes, and session events.

## User Impact

Background completions can resume their originating chats after the foreground answer has finished. Scheduled heartbeats still use the agent's main session by default, existing explicit session overrides remain supported, and silent acknowledgments stay hidden.

## Evidence

- A real-timer regression reproduced the original closed-scope error in both the originating session and another queued session before the fix; it passes with the fix.
- The new producer-provenance regression produced 13 intended failures on the pre-fix source; existing routing assertions passed.
- Focused tests cover scope drainage, prompt-result timing, suspension/replacement, event routing and provenance, and silent transcript filtering.
- `pnpm build` passed, including the Control UI build.
- Live OpenAI/OpenClaw-runtime proof passed with a real isolated Gateway and QuickJS Code Mode. An external gate held a background process until the foreground final reply; its subsequent exec completion produced a successful provider turn in the originating session. A forced scheduler-owned heartbeat ran in main without adding another turn to that session.
- The final build and live test were repeated successfully after CI exposed and the patch fixed an extra idle-queue microtask; the original cron root-count assertion passes unchanged.
- Clean Linux Testbox validation passed all 36 Gateway setup and plugin lifecycle tests; the one-shot lease was stopped after command success.
- Deslop completed; independent review found no actionable P0–P2 findings.
- Final `node scripts/check-changed.mjs` passed all selected gates after the explicit detached-boundary correction.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34462128274) passed. An unrelated desktop lint regression was separately fixed by #143889; a zero-job GitHub startup failure was recovered by reopening, and a conflict-free rebase brought in the UI fix without changing this PR's aggregate patch.
