### PR TITLE
docs(cli): state present bare-spec install behaviour without the launch cutover

### DIFF
--- a/docs/cli/plugins/install.md
+++ b/docs/cli/plugins/install.md
@@ -97,7 +97,7 @@ openclaw plugins install clawhub:openclaw-codex-app-server
 openclaw plugins install clawhub:openclaw-codex-app-server@1.2.3
 ```
 
-Bare npm-safe plugin specs install from npm by default during the launch cutover unless they match an official plugin id:
+Bare npm-safe plugin specs install from npm by default unless they match an official plugin id:
 
 ```bash
 openclaw plugins install openclaw-codex-app-server
@@ -156,7 +156,7 @@ Community ClawHub installs check the selected release's trust record before down
 
 Npm specs are **registry-only** (package name plus optional **exact version** or **dist-tag**). Git/URL/file specs and semver ranges are rejected. Dependency installs run in one managed npm project per plugin with `--ignore-scripts` for safety, even when your shell has global npm install settings. Managed plugin npm projects inherit the npm-compatible parts of OpenClaw's dependency overrides. pnpm parent-child selectors are skipped; npm aliases remain unless the installed npm version rejects them.
 
-Use `npm:<package>` to make npm resolution explicit. Bare package specs also install directly from npm during the launch cutover unless they match an official plugin id.
+Use `npm:<package>` to make npm resolution explicit. Bare package specs also install directly from npm unless they match an official plugin id.
 
 Raw `@openclaw/*` specs that match bundled plugins resolve to the image-owned bundled copy before npm fallback. For example, `openclaw plugins install @openclaw/discord@2026.5.20 --pin` uses the bundled Discord plugin from the current OpenClaw build instead of creating a managed npm override. To force the external npm package, use `openclaw plugins install npm:@openclaw/discord@2026.5.20 --pin`.
 


### PR DESCRIPTION
Removes the last two occurrences of the undated phrase "launch cutover" from `docs/cli/plugins/install.md` and states present behaviour instead.

## Why

There is no cutover to be "during".

- `grep -rni cutover src/` returns **zero** hits — no flag, date, or feature gate.
- The phrase entered in `cf21bcf9bff` (2026-05-02, *fix(plugins): keep bare installs on npm for launch*), which **deleted** the ClawHub-first resolution code rather than scheduling a migration.
- No release note in `docs/releases/` or `CHANGELOG.md` announces an end.
- Present behaviour is `isOpenClawTrustedPluginInstallSpec` in `src/plugins/install-provenance.ts` — a bare spec resolves against bundled sources and the official catalog, and otherwise installs from npm. Unconditional; no time component.

So the wording promises a future change that nothing in the tree schedules, and readers cannot tell whether the documented behaviour is current or temporary.

## What changed

Two prose lines, deleting only the time-relative clause:

```diff
-Bare npm-safe plugin specs install from npm by default during the launch cutover unless they match an official plugin id:
+Bare npm-safe plugin specs install from npm by default unless they match an official plugin id:

-Use `npm:<package>` to make npm resolution explicit. Bare package specs also install directly from npm during the launch cutover unless they match an official plugin id.
+Use `npm:<package>` to make npm resolution explicit. Bare package specs also install directly from npm unless they match an official plugin id.
```

No version is named — the fix is to state the behaviour, not to invent a boundary.

This matches how #143857 (`docs-audit/fix-accuracy-plugins`) phrased the same fix for the six pages under `docs/plugins/` plus `scripts/generate-plugin-inventory-doc.mts` (findings r3-1994 and r3-2041). That PR did not cover `docs/cli/plugins/install.md`; this closes the remainder.

## Checks

- `docs/cli/plugins/install.md` is **not** generated — no script under `scripts/` writes it (unlike `docs/plugins/plugin-inventory.md`, which `scripts/generate-plugin-inventory-doc.mts` owns and #143857 fixes at source).
- `pnpm check:docs` — **rc=0**.
- No heading, anchor, or link changed, so no `<a id>` stubs or glossary sources are needed.
- CODEOWNERS: no rule matches this path.

## Out of scope

`docs/tools/plugin.md` (2 occurrences) and `docs/cli/doctor/lint.md` (an unrelated "pre-cutover gate") still use the word and are left alone.
