### PR TITLE
fix: preserve subagent history across parent thread changes

### DIFF
--- a/docs/plugins/sdk-agent-harness/sessions-and-results.md
+++ b/docs/plugins/sdk-agent-harness/sessions-and-results.md
@@ -78,6 +78,15 @@ It accepts a task ID, an optional opaque cursor, and a limit from 1 to 200
 bound connection, and call `assertCurrent()` after awaited work. The Gateway
 rechecks access before returning a page and caps the response at 4 MiB.
 
+Record immutable native history routing facts in task detail when creating the
+task. A later parent turn can replace its current native thread without changing
+the child's source. Preserve the original parent and connection identity across
+progress, completion, and recovery; never reconstruct them from a replacement
+binding. Preserve authorized compaction transfers within the same session
+lifecycle, while rejecting resets and account or connection changes.
+Runtime task detail participates in the Gateway's cursor and
+after-await identity checks.
+
 Keep `childSessionKey` absent for native children: it describes an OpenClaw
 session and also determines lifecycle ownership. Reading history must not adopt
 the child, create another transcript store, or change cancellation and recovery.

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -315,8 +315,11 @@ Codex harness. Select a task to read its messages, thinking, and tool calls;
 select **Show earlier** to load older history. Task activity refreshes the view
 while the subagent runs. The generic fallback label is **Subagent**.
 
-The viewer reads history from the runtime that owns it. If that runtime or its
-parent binding is unavailable, the panel shows an error with a retry action.
+The viewer reads history from the runtime that owns it. New native subagent
+tasks retain their original history source when later turns replace the parent's
+native thread. Changing the parent session or account can make that history
+unavailable. If the runtime or its parent binding is unavailable, the panel shows
+an error with a retry action.
 Tasks without readable history retain their prompt and output inspector.
 
 ## Chat message width

--- a/extensions/codex/harness.task-history.test.ts
+++ b/extensions/codex/harness.task-history.test.ts
@@ -8,6 +8,7 @@ import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import { resolveCodexBindingAppServerConnection } from "./src/app-server/binding-connection.js";
+import { createCodexNativeSubagentHistoryOwner } from "./src/app-server/native-subagent-history-owner.js";
 import {
   buildCodexAppServerConnectionFingerprint,
   buildCodexAppServerRuntimeFingerprint,
@@ -85,7 +86,7 @@ async function fixture(supervised = false) {
     agentId: session.agentId,
     sessionKey: session.sessionKey,
     storePath,
-    entry: { sessionId: session.sessionId, updatedAt: 1 },
+    entry: { sessionId: session.sessionId, lifecycleRevision: "parent-lifecycle", updatedAt: 1 },
   });
   const bindingStore = createCodexTestBindingStore();
   const pluginConfig = supervised ? { supervision: { enabled: true } } : undefined;
@@ -290,6 +291,114 @@ describe("native subagent history through the harness", () => {
     },
   );
 
+  it("keeps completed child history and pagination when the parent starts a replacement thread", async () => {
+    const f = await fixture();
+    f.threads.set("parent-thread", { id: "parent-thread", projectId: null, parentThreadId: null });
+    f.params.task = {
+      ...f.params.task,
+      detail: {
+        nativeHistory: createCodexNativeSubagentHistoryOwner({
+          parentThreadId: f.binding.threadId,
+          sessionId: f.identity.sessionId,
+          binding: f.binding,
+        })!,
+      },
+    };
+    f.items.push(
+      ...Array.from({ length: 5 }, (_, index) =>
+        item(`item-${index}`, { text: `message ${index}` }),
+      ),
+    );
+    const first = await f.read({ limit: 4 });
+    await f.bindingStore.mutate(f.identity, {
+      kind: "set",
+      binding: { ...f.binding, threadId: "replacement-parent" },
+    });
+    const second = await f.read({ cursor: first.nextCursor });
+    expect([...second.messages, ...first.messages]).toMatchObject(
+      Array.from({ length: 5 }, (_, index) => ({ content: [{ text: `message ${index}` }] })),
+    );
+    expect((await f.read()).messages).toEqual([...second.messages, ...first.messages]);
+  });
+
+  it.each(["session", "lifecycle", "account", "connection", "malformed owner"] as const)(
+    "rejects a changed %s before opening the native history store",
+    async (change) => {
+      const f = await fixture();
+      const owner = createCodexNativeSubagentHistoryOwner({
+        parentThreadId: f.binding.threadId,
+        sessionId: f.identity.sessionId,
+        lifecycleRevision: "parent-lifecycle",
+        binding: f.binding,
+      })!;
+      f.params.task = { ...f.params.task, detail: { nativeHistory: owner } };
+      if (change === "session" || change === "lifecycle") {
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey: f.params.task.requesterSessionKey,
+          storePath: f.storePath,
+          entry: {
+            sessionId: change === "session" ? "replacement-session" : f.identity.sessionId,
+            lifecycleRevision: "replacement-lifecycle",
+            updatedAt: 2,
+          },
+        });
+      } else if (change === "malformed owner") {
+        f.params.task = {
+          ...f.params.task,
+          detail: { nativeHistory: { ...owner, connectionFingerprint: "invalid" } },
+        };
+      } else {
+        await f.bindingStore.mutate(f.identity, {
+          kind: "set",
+          binding: {
+            ...f.binding,
+            ...(change === "account"
+              ? { authProfileId: "another-account" }
+              : { appServerRuntimeFingerprint: "another-native-store" }),
+          },
+        });
+      }
+      await expect(f.read()).rejects.toThrow(
+        change === "malformed owner" ? "owner is invalid" : "history owner changed",
+      );
+      expect(native.acquire).not.toHaveBeenCalled();
+      expect(native.request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves history through repeated compaction transfers in the same session lifecycle", async () => {
+    const f = await fixture();
+    const owner = createCodexNativeSubagentHistoryOwner({
+      parentThreadId: f.binding.threadId,
+      sessionId: f.identity.sessionId,
+      lifecycleRevision: "parent-lifecycle",
+      binding: f.binding,
+    })!;
+    f.params.task = { ...f.params.task, detail: { nativeHistory: owner } };
+    f.items.push(item("answer", { text: "Original child result" }));
+    const before = await f.read();
+    let previousSessionId = f.identity.sessionId;
+    for (const sessionId of ["compacted-once", "compacted-twice"]) {
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey: f.params.task.requesterSessionKey,
+        storePath: f.storePath,
+        entry: {
+          sessionId,
+          previousSessionId,
+          lifecycleRevision: "parent-lifecycle",
+          updatedAt: 2,
+        },
+      });
+      await expect(
+        f.bindingStore.adoptSessionGeneration({ ...f.identity, sessionId }, previousSessionId),
+      ).resolves.toBe("adopted");
+      expect(await f.read()).toEqual(before);
+      previousSessionId = sessionId;
+    }
+  });
+
   it("reads nested subagents only after metadata verifies every ancestor back to the bound parent", async () => {
     const f = await fixture();
     f.thread.parentThreadId = "worker-2";
@@ -400,22 +509,29 @@ describe("native subagent history through the harness", () => {
     expect(native.release).toHaveBeenCalledOnce();
   });
 
-  it("rechecks the physical parent session after awaited history reads", async () => {
-    const f = await fixture();
-    const request = native.request.getMockImplementation()!;
-    native.request.mockImplementation(async (method, params) => {
-      const result = await request(method, params);
-      if (method === "thread/items/list") {
-        await upsertSessionEntry({
-          agentId: "main",
-          sessionKey: f.params.task.requesterSessionKey,
-          storePath: f.storePath,
-          entry: { sessionId: "replacement-session", updatedAt: 2 },
-        });
-      }
-      return result;
-    });
-    await expect(f.read()).rejects.toThrow("parent changed");
-    expect(native.release).toHaveBeenCalledOnce();
-  });
+  it.each(["session", "lifecycle"] as const)(
+    "rechecks the parent %s after awaited history reads",
+    async (change) => {
+      const f = await fixture();
+      const request = native.request.getMockImplementation()!;
+      native.request.mockImplementation(async (method, params) => {
+        const result = await request(method, params);
+        if (method === "thread/items/list") {
+          await upsertSessionEntry({
+            agentId: "main",
+            sessionKey: f.params.task.requesterSessionKey,
+            storePath: f.storePath,
+            entry: {
+              sessionId: change === "session" ? "replacement-session" : f.identity.sessionId,
+              lifecycleRevision: "replacement-lifecycle",
+              updatedAt: 2,
+            },
+          });
+        }
+        return result;
+      });
+      await expect(f.read()).rejects.toThrow("parent changed");
+      expect(native.release).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/extensions/codex/src/app-server/native-subagent-history-owner.ts
+++ b/extensions/codex/src/app-server/native-subagent-history-owner.ts
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexAppServerThreadBinding } from "./session-binding.js";
+
+export type CodexNativeSubagentHistoryOwner = {
+  parentThreadId: string;
+  sessionId: string;
+  lifecycleRevision?: string;
+  connectionFingerprint: string;
+};
+
+export function codexNativeSubagentHistoryConnectionFingerprint(
+  binding: CodexAppServerThreadBinding,
+): string | undefined {
+  if (!binding.appServerRuntimeFingerprint) {
+    return undefined;
+  }
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        binding.appServerRuntimeFingerprint,
+        binding.connectionScope ?? null,
+        binding.authProfileId ?? null,
+      ]),
+    )
+    .digest("hex");
+}
+
+export function createCodexNativeSubagentHistoryOwner(params: {
+  parentThreadId: string;
+  sessionId: string;
+  lifecycleRevision?: string;
+  binding: CodexAppServerThreadBinding;
+}): CodexNativeSubagentHistoryOwner | undefined {
+  const connectionFingerprint = codexNativeSubagentHistoryConnectionFingerprint(params.binding);
+  return connectionFingerprint
+    ? {
+        parentThreadId: params.parentThreadId,
+        sessionId: params.sessionId,
+        ...(params.lifecycleRevision ? { lifecycleRevision: params.lifecycleRevision } : {}),
+        connectionFingerprint,
+      }
+    : undefined;
+}
+
+export function readCodexNativeSubagentHistoryOwner(
+  detail: unknown,
+): CodexNativeSubagentHistoryOwner | undefined {
+  const value = asOptionalRecord(detail)?.nativeHistory;
+  if (value === undefined) {
+    return undefined;
+  }
+  const owner = asOptionalRecord(value);
+  if (
+    typeof owner?.parentThreadId !== "string" ||
+    !owner.parentThreadId.trim() ||
+    typeof owner.sessionId !== "string" ||
+    !owner.sessionId.trim() ||
+    (owner.lifecycleRevision !== undefined &&
+      (typeof owner.lifecycleRevision !== "string" || !owner.lifecycleRevision.trim())) ||
+    typeof owner.connectionFingerprint !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(owner.connectionFingerprint)
+  ) {
+    throw new Error("Subagent history owner is invalid.");
+  }
+  return {
+    parentThreadId: owner.parentThreadId,
+    sessionId: owner.sessionId,
+    ...(typeof owner.lifecycleRevision === "string"
+      ? { lifecycleRevision: owner.lifecycleRevision }
+      : {}),
+    connectionFingerprint: owner.connectionFingerprint,
+  };
+}

--- a/extensions/codex/src/app-server/native-subagent-history.ts
+++ b/extensions/codex/src/app-server/native-subagent-history.ts
@@ -4,6 +4,10 @@ import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-s
 import { resolveCodexBindingAppServerConnection } from "./binding-connection.js";
 import { itemToolArgs, itemTranscriptResultText } from "./event-projector-tool-items.js";
 import {
+  codexNativeSubagentHistoryConnectionFingerprint,
+  readCodexNativeSubagentHistoryOwner,
+} from "./native-subagent-history-owner.js";
+import {
   CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
   CODEX_NATIVE_SUBAGENT_TASK_KIND,
 } from "./native-subagent-task-ids.js";
@@ -67,9 +71,20 @@ export async function readCodexNativeSubagentHistory(
   if (!session?.sessionId) {
     throw new Error("Subagent parent session is unavailable.");
   }
+  const sessionId = session.sessionId;
+  const lifecycleRevision = session.lifecycleRevision;
+  const historyOwner = readCodexNativeSubagentHistoryOwner(task.detail);
+  if (
+    historyOwner &&
+    (historyOwner.lifecycleRevision
+      ? historyOwner.lifecycleRevision !== lifecycleRevision
+      : historyOwner.sessionId !== sessionId)
+  ) {
+    throw new Error("Subagent history owner changed; reconnect its parent session.");
+  }
   const identity = sessionBindingIdentity({
     agentId,
-    sessionId: session.sessionId,
+    sessionId,
     sessionKey,
     config: cfg,
   });
@@ -77,11 +92,22 @@ export async function readCodexNativeSubagentHistory(
   if (!binding || binding.pendingSupervisionBranch) {
     throw new Error("Subagent parent thread is unavailable.");
   }
+  if (
+    historyOwner &&
+    historyOwner.connectionFingerprint !== codexNativeSubagentHistoryConnectionFingerprint(binding)
+  ) {
+    throw new Error("Subagent history owner changed; reconnect its parent session.");
+  }
+  // Completion delivery can start a fresh parent thread. Keep the child's original ancestry.
+  // Existing tasks without this locator can still use their unchanged parent binding.
+  const historyParentThreadId = historyOwner?.parentThreadId ?? binding.threadId;
   const assertCurrent = () => {
     params.assertCurrent();
+    const currentSession = readSession();
     const current = options.bindingStore.read(identity);
     if (
-      readSession()?.sessionId !== session.sessionId ||
+      currentSession?.sessionId !== sessionId ||
+      currentSession?.lifecycleRevision !== lifecycleRevision ||
       current?.threadId !== binding.threadId ||
       current?.appServerRuntimeFingerprint !== binding.appServerRuntimeFingerprint ||
       current?.connectionScope !== binding.connectionScope ||
@@ -127,7 +153,7 @@ export async function readCodexNativeSubagentHistory(
       { assertCurrent },
     );
     assertCurrent();
-    if (thread.id !== threadId || threadId === binding.threadId) {
+    if (thread.id !== threadId || threadId === historyParentThreadId) {
       throw new Error("Subagent transcript does not belong to this parent session.");
     }
     // Nested children share the OpenClaw requester, but native lineage records their immediate parent.
@@ -135,7 +161,7 @@ export async function readCodexNativeSubagentHistory(
     let ancestor = thread;
     for (;;) {
       const parentId = parentThreadId(ancestor);
-      if (parentId === binding.threadId) {
+      if (parentId === historyParentThreadId) {
         break;
       }
       if (!parentId || visited.has(parentId) || visited.size >= MAX_SUBAGENT_ANCESTRY_READS) {

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -30,6 +30,7 @@ import {
 import type { CodexAppServerClient } from "./client.js";
 import { projectNormalizedToolItem } from "./event-projector-events.js";
 import { readItem } from "./event-projector-values.js";
+import type { CodexNativeSubagentHistoryOwner } from "./native-subagent-history-owner.js";
 import {
   codexNativeSubagentNotifications as nativeSubagentNotifications,
   type CodexNativeSubagentCompletion,
@@ -74,6 +75,7 @@ type ParentState = {
   nativeCompletionReceipts: Set<string>;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
+  historyOwner?: CodexNativeSubagentHistoryOwner;
   agentId?: string;
   taskRuntime?: AgentHarnessTaskRuntime;
   mirror?: CodexNativeSubagentTaskMirror;
@@ -198,6 +200,7 @@ function registerMonitor(params: {
   parentThreadId: string;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
+  historyOwner?: CodexNativeSubagentHistoryOwner;
   agentId?: string;
   runtime?: NativeSubagentMonitorRuntime;
   retainClient?: () => (() => void) | undefined;
@@ -267,6 +270,7 @@ function registerMonitor(params: {
     parentThreadId: params.parentThreadId,
     requesterSessionKey: params.requesterSessionKey,
     taskRuntimeScope: params.taskRuntimeScope,
+    historyOwner: params.historyOwner,
     agentId: params.agentId,
     claimDirectChild: params.claimDirectChild,
     rejectPendingDirectChild: params.rejectPendingDirectChild,
@@ -372,6 +376,7 @@ class Monitor {
     parentThreadId: string;
     requesterSessionKey?: string;
     taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
+    historyOwner?: CodexNativeSubagentHistoryOwner;
     agentId?: string;
     claimDirectChild?: (threadId: string) => (() => void) | undefined;
     rejectPendingDirectChild?: (threadId: string, reason: string) => void;
@@ -403,6 +408,7 @@ class Monitor {
     }
     state.requesterSessionKey ??= params.requesterSessionKey;
     state.taskRuntimeScope ??= params.taskRuntimeScope;
+    state.historyOwner ??= params.historyOwner;
     state.agentId ??= params.agentId;
     const owner = Symbol("codex-native-subagent-owner");
     state.owners.set(owner, {
@@ -507,6 +513,7 @@ class Monitor {
       {
         parentThreadId: state.parentThreadId,
         requesterSessionKey: state.requesterSessionKey,
+        historyOwner: state.historyOwner,
         agentId: state.agentId,
       },
       state.taskRuntime,

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -12,6 +12,7 @@ function createRuntime() {
     tryCreateRunningTaskRun: vi.fn((params) => ({ taskId: "task-native-subagent", ...params })),
     recordTaskRunProgressByRunId: vi.fn(() => []),
     finalizeTaskRunByRunId: vi.fn(() => []),
+    listTaskRecords: vi.fn(() => []),
   } as unknown as TaskLifecycleRuntime;
 }
 
@@ -72,6 +73,64 @@ describe("CodexNativeSubagentTaskMirror", () => {
       progressSummary: "Subagent is active.",
     });
   });
+
+  it.each([true, false])(
+    "preserves creation-time history ownership through progress, completion and recovery (stamped=%s)",
+    (stamped) => {
+      const runtime = createRuntime();
+      const historyOwner = {
+        parentThreadId: "parent-thread",
+        sessionId: "original-session",
+        connectionFingerprint: "original-connection",
+      };
+      const initial = new CodexNativeSubagentTaskMirror(
+        { parentThreadId: "parent-thread", ...(stamped ? { historyOwner } : {}) },
+        runtime,
+      );
+      const notify = (mirror: CodexNativeSubagentTaskMirror, status: string) =>
+        mirror.handleNotification({
+          method: "item/completed",
+          params: {
+            threadId: "parent-thread",
+            item: {
+              type: "collabAgentToolCall",
+              tool: "spawn_agent",
+              prompt: "Inspect one item",
+              agentsStates: { "child-thread": { status, message: "Lifecycle update" } },
+            },
+          },
+        });
+      notify(initial, "running");
+      const originalTask = vi.mocked(runtime.tryCreateRunningTaskRun).mock.results[0]!.value;
+      expect(originalTask.detail).toEqual(stamped ? { nativeHistory: historyOwner } : undefined);
+      vi.mocked(runtime.listTaskRecords).mockReturnValue([originalTask]);
+      const recovered = new CodexNativeSubagentTaskMirror(
+        {
+          parentThreadId: "parent-thread",
+          historyOwner: {
+            ...historyOwner,
+            sessionId: "replacement-session",
+            connectionFingerprint: "replacement-connection",
+          },
+        },
+        runtime,
+      );
+      notify(recovered, "running");
+      notify(recovered, "completed");
+      expect(vi.mocked(runtime.tryCreateRunningTaskRun).mock.calls[1]![0]).not.toHaveProperty(
+        "detail",
+      );
+      expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalled();
+      expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalled();
+      for (const [update] of [
+        ...vi.mocked(runtime.recordTaskRunProgressByRunId).mock.calls,
+        ...vi.mocked(runtime.finalizeTaskRunByRunId).mock.calls,
+      ]) {
+        expect(update).not.toHaveProperty("detail");
+      }
+      expect(originalTask.detail).toEqual(stamped ? { nativeHistory: historyOwner } : undefined);
+    },
+  );
 
   it("ignores subagent threads spawned by a different parent thread", () => {
     const runtime = createRuntime();

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -7,6 +7,7 @@ import {
   normalizeOptionalString,
   readStringField as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexNativeSubagentHistoryOwner } from "./native-subagent-history-owner.js";
 import { CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX } from "./native-subagent-task-ids.js";
 import type {
   CodexServerNotification,
@@ -24,13 +25,17 @@ import { isJsonObject } from "./protocol.js";
 /** Minimal task-runtime surface needed to mirror native subagent lifecycle. */
 type TaskLifecycleRuntime = Pick<
   AgentHarnessTaskRuntime,
-  "tryCreateRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
+  | "tryCreateRunningTaskRun"
+  | "recordTaskRunProgressByRunId"
+  | "finalizeTaskRunByRunId"
+  | "listTaskRecords"
 >;
 
 /** Stable parent/session context used while mirroring native subagent tasks. */
 type CodexNativeSubagentTaskMirrorParams = {
   parentThreadId: string;
   requesterSessionKey?: string;
+  historyOwner?: CodexNativeSubagentHistoryOwner;
   agentId?: string;
   now?: () => number;
 };
@@ -321,6 +326,11 @@ export class CodexNativeSubagentTaskMirror {
     }
     this.mirrorStateByThreadId.set(threadId, "mirrored");
     const runId = codexNativeSubagentRunId(threadId);
+    // Creation also refreshes existing metadata. Recovery must preserve the original locator,
+    // including its absence on rows created before native history ownership was recorded.
+    const historyOwner = this.params.historyOwner;
+    const stampHistoryOwner =
+      historyOwner && !this.runtime.listTaskRecords().some((task) => task.runId === runId);
     const taskRecord = this.runtime.tryCreateRunningTaskRun({
       sourceId: runId,
       agentId: this.params.agentId,
@@ -333,6 +343,7 @@ export class CodexNativeSubagentTaskMirror {
       startedAt: params.startedAt,
       lastEventAt: this.now(),
       progressSummary: params.progressSummary,
+      ...(stampHistoryOwner ? { detail: { nativeHistory: { ...historyOwner } } } : {}),
     });
     if (!taskRecord) {
       this.mirrorStateByThreadId.set(threadId, "failed");

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -3,6 +3,7 @@ import {
   runAgentCleanupStep,
   type AgentHarnessRuntimeArtifactBinding,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveCodexStartupTimeoutMs } from "./attempt-timeouts.js";
 import { protectCodexAppServerLiveThread } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
@@ -19,6 +20,7 @@ import {
   type CodexNativePreToolUseFailure,
   type CodexNativeHookRelay,
 } from "./native-hook-relay.js";
+import { createCodexNativeSubagentHistoryOwner } from "./native-subagent-history-owner.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
 import type { CodexAttemptPrompt } from "./run-attempt-prompt.js";
@@ -210,11 +212,31 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   };
   const registerNativeSubagentMonitor = (parentThreadId: string) => {
     unregisterNativeSubagentMonitor();
+    const sessionKey = params.sessionKey;
+    const storePath = params.sessionTarget?.storePath;
+    const parentSession =
+      sessionKey && storePath
+        ? getSessionEntry({
+            agentId: sessionAgentId,
+            sessionKey,
+            storePath,
+            readConsistency: "latest",
+            hydrateSkillPromptRefs: false,
+          })
+        : undefined;
     state.nativeSubagentMonitor = codexNativeSubagentMonitorRuntime.register({
       client: state.client,
       parentThreadId,
       requesterSessionKey: params.sessionKey,
       taskRuntimeScope: params.agentHarnessTaskRuntimeScope,
+      historyOwner: createCodexNativeSubagentHistoryOwner({
+        parentThreadId,
+        sessionId: params.sessionId,
+        ...(parentSession?.sessionId === params.sessionId
+          ? { lifecycleRevision: parentSession.lifecycleRevision }
+          : {}),
+        binding: state.thread,
+      }),
       agentId: sessionAgentId,
       retainClient: () => retainSharedCodexAppServerClientIfCurrent(state.client),
       retainParentThread: (protectedThreadId) =>

--- a/src/gateway/server-methods/task-history.test.ts
+++ b/src/gateway/server-methods/task-history.test.ts
@@ -209,7 +209,7 @@ describe("tasks.history", () => {
     },
   );
 
-  it.each(["task identity", "requester access", "harness registration"] as const)(
+  it.each(["task identity", "history owner", "requester access", "harness registration"] as const)(
     "revalidates %s after an asynchronous history read",
     async (change) => {
       await withHistoryState(async () => {
@@ -241,6 +241,13 @@ describe("tasks.history", () => {
             status: "succeeded",
             endedAt: Date.now(),
             childSessionKey: "agent:main:subagent:new-child",
+          });
+        } else if (change === "history owner") {
+          markTaskTerminalById({
+            taskId: task.taskId,
+            status: "succeeded",
+            endedAt: Date.now(),
+            detail: { nativeHistory: { parentThreadId: "different-owner" } },
           });
         } else if (change === "requester access") {
           config = readerConfig;

--- a/src/gateway/server-methods/task-history.ts
+++ b/src/gateway/server-methods/task-history.ts
@@ -30,6 +30,7 @@ function historyBinding(task: TaskRecord): string {
         task.requesterAgentId,
         task.requesterSessionKey,
         task.ownerKey,
+        taskTranscriptSessionKey(task) ? null : task.detail,
       ]),
     )
     .digest("base64url");


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #143747. Live testing on merged main found that delivery of a native subagent's completion can start a replacement parent thread. The history reader then checked the completed child against the replacement and rejected its transcript as unrelated.

## Why This Change Was Made

Capture the original parent thread, session lifecycle, and a hashed connection identity in the existing task detail when the native task is created. History continues to use that original source while rechecking current requester access, session lifecycle, native connection, and bounded child ancestry. Progress, completion, and recovery preserve the first recorded owner.

Compaction transfers within the same lifecycle remain readable. Resets, account/store changes, malformed ownership data, and changes during an awaited read are rejected. Existing tasks without a recorded owner keep the prior binding-based path. The Gateway also includes native task detail in its cursor and asynchronous-read identity fence.

## User Impact

Completed subagent transcripts remain available after later parent turns replace the native thread. The shared sidebar, generic Subagent labels, cancellation, and task delivery continue to use their existing paths.

## Evidence

- Live main reproduction: the child completed, but `tasks.history` returned `Unable to load this task's transcript`; bounded diagnostics identified the parent-lineage rejection after the completion announcement replaced the parent thread.
- The new parent-replacement and asynchronous-owner-change regressions failed on the original readers for the expected reasons.
- All 346 focused Gateway, native history, mirror, monitor, runtime execution, and registration-import tests passed. Coverage includes repeated compaction transfers, immutable recovery metadata, and session/account/store/lifecycle changes.
- Independent review found no actionable P0–P2 issue in the final repair.
- Full build, production/test type checks, scoped lint, and the remaining changed-scope architecture checks passed.
- Real-provider proof on `bef1cb07d92bd2150f29b77524134b1e9278fa0f` passed: managed history traversed 2 pages and native history 4 pages, with four stable message IDs each, exact paginated/full equality, and paired real tool calls/results. A real browser opened both task transcripts through `tasks.history` and expanded their tool output. The fixture uses an isolated Gateway and synthetic profile; unrelated live scenarios remained disabled.

- Reopening proof on the same head passed: the isolated Gateway was stopped and restarted over its existing SQLite state. The actual native task retained its original history metadata; a seeded legacy-shaped native record retained the absence of that metadata. Both real managed/native transcripts were identical before and after restart, passed paginated checks again, and rendered their real tool output in the browser after reopening. This is restart/record-compatibility proof, not an old-binary upgrade campaign.

- Final post-merge replay passed on main `5ae901326b85b094d58339587157900093e0b48d`, including real managed/native history, identical results after Gateway restart, legacy-shaped record preservation, and both browser transcript views. Temporary instrumentation was removed and the task checkout is clean.

### Live managed subagent

![Live managed subagent transcript and process result](https://github.com/user-attachments/assets/ebf0ba11-fb9b-4989-8bff-0c86e6f589c4)

### Live native subagent

![Live native subagent transcript and native command result](https://github.com/user-attachments/assets/a6940a27-6075-4367-b3b3-e1c9c2c9f167)
