### PR TITLE
refactor(signal): remove duplicate group-access test

### DIFF
--- a/extensions/signal/src/monitor/access-policy.test.ts
+++ b/extensions/signal/src/monitor/access-policy.test.ts
@@ -143,23 +143,6 @@ describe("resolveSignalAccessState", () => {
     expect(senderAccess.decision).toBe("allow");
   });
 
-  it("allows group messages through static message sender access groups", async () => {
-    const { groupDecision } = await resolveGroupAccess({
-      groupAllowFrom: ["accessGroup:operators"],
-      groupId: SIGNAL_GROUP_ID,
-      accessGroups: {
-        operators: {
-          type: "message.senders",
-          members: {
-            signal: [SIGNAL_SENDER.e164],
-          },
-        },
-      },
-    });
-
-    expect(groupDecision.decision).toBe("allow");
-  });
-
   it("preserves matched Signal senders in effective group allowlists", async () => {
     const { groupDecision } = await resolveGroupAccess({
       groupAllowFrom: ["accessGroup:operators"],


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Two Signal access-policy cases repeat the same static-group sender-access decision. The weaker case adds no distinct coverage.

## Why This Change Was Made

Remove the weaker case and retain the case with identical resolver inputs and the same allow assertion, plus an assertion that the matched sender remains in the effective group allowlist. All other cases, helpers, and imports remain unchanged.

## User Impact

No runtime or user-visible behavior changes. This removes one test case and 17 lines from one test file; production code is unchanged.

## Evidence

- Full Signal access-policy test file through its owning config: 18 passed, zero skipped, with all four LIVE selectors unset.
- All 19 selected changed checks passed on the exact candidate, without rerunning the gate.
- Targeted formatting and diff checks passed.
- Fresh P2 review: scoped-clean, no accepted/actionable findings, under the current scanner-free policy.

This is local boundary proof, not live Signal or full-repository validation. Hosted CI for exact head `8278179b0d400856dfc473266a185a85688e35aa` passed: https://github.com/openclaw/openclaw/actions/runs/34454829463 (28 success, 19 skipped). Workflow Sanity also passed: https://github.com/openclaw/openclaw/actions/runs/34454770917 (actual actionlint and no-tabs success).
