### PR TITLE
refactor(media): share image request resource ownership

### DIFF
--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -25,8 +24,8 @@ import {
 import { isSecretRef } from "../config/types.secrets.js";
 import { complete } from "../llm/stream.js";
 import type { AssistantMessage, Context, Model, ProviderStreamOptions } from "../llm/types.js";
-import { AsyncWorkScope, getAsyncWorkSignal, trackAsyncWork } from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
+import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import { getResolvedImageRuntimeContext, resolveImageRuntime } from "./image-model-runtime.js";
 import type {
   ImageDescriptionRequest,
@@ -418,196 +417,168 @@ async function describeImagesWithModelInternal(
   params: ImagesDescriptionRequest,
   options: { onPayload?: ProviderStreamOptions["onPayload"] } = {},
 ): Promise<ImagesDescriptionResult> {
-  const reported = createDeferredCore<ImagesDescriptionResult>();
-  const parentSignal = getAsyncWorkSignal();
-  // Admit drainage before setup; reporting a deadline does not settle provider work.
-  void trackAsyncWork(async () => {
-    const work = new AsyncWorkScope();
-    const runInScope = work.run(() => AsyncLocalStorage.snapshot());
-    const closeWork = () => runInScope(() => work.beginClose(parentSignal?.reason));
-    parentSignal?.addEventListener("abort", closeWork, { once: true });
-    if (parentSignal?.aborted) {
-      closeWork();
-    }
-    let releaseRuntime: (() => void) | undefined;
+  return await runWithAsyncWorkResources(async (onAcquired) => {
     let assertResourcesOpen: (() => void) | undefined;
+    const prompt = params.prompt ?? "Describe the image.";
+    params.signal?.throwIfAborted();
+    const startedAtMs = Date.now();
+    const controller = new AbortController();
+    const requestSignal = params.signal
+      ? AbortSignal.any([params.signal, controller.signal])
+      : controller.signal;
+    const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
+    const allowPrivateNetwork = resolveConfiguredProviderAllowPrivateNetwork(
+      params.cfg,
+      params.provider,
+    );
+    let runtimeValue: string;
+    let model: Model | undefined;
+    const resolutionTask = trackAsyncWork(() =>
+      resolveImageRuntime({ ...params, signal: requestSignal }, (resources) => {
+        onAcquired(resources);
+        assertResourcesOpen = resources.assertResourcesOpen;
+      }),
+    );
+
     try {
-      reported.resolve(
-        await work.track(async () => {
-          const prompt = params.prompt ?? "Describe the image.";
-          params.signal?.throwIfAborted();
-          const startedAtMs = Date.now();
-          const controller = new AbortController();
-          const requestSignal = params.signal
-            ? AbortSignal.any([params.signal, controller.signal])
-            : controller.signal;
-          const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
-          const allowPrivateNetwork = resolveConfiguredProviderAllowPrivateNetwork(
-            params.cfg,
-            params.provider,
-          );
-          let runtimeValue: string;
-          let model: Model | undefined;
-          const resolutionTask = work.track(() =>
-            resolveImageRuntime({ ...params, signal: requestSignal }, (resources) => {
-              releaseRuntime = resources.release;
-              assertResourcesOpen = resources.assertResourcesOpen;
-            }),
-          );
-
-          try {
-            const resolved = await withImageDescriptionTimeout({
-              controller,
-              signal: params.signal,
-              timeoutMs: configuredTimeoutMs,
-              createTimeoutError: (timeoutMs) =>
-                buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
-              task: resolutionTask,
-            });
-            runtimeValue = resolved.runtimeValue;
-            model = resolved.model;
-          } catch (err) {
-            params.signal?.throwIfAborted();
-            if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
-              throw err;
-            }
-            const fallback = await withImageDescriptionTimeout({
-              controller,
-              signal: params.signal,
-              timeoutMs: configuredTimeoutMs,
-              createTimeoutError: (timeoutMs) =>
-                buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
-              task: work.track(() => resolveMinimaxVlmFallbackRuntime(params)),
-            });
-            return await describeImagesWithMinimax({
-              assertResourcesOpen,
-              runtimeValue: fallback.runtimeValue,
-              provider: params.provider,
-              modelId: params.model,
-              modelBaseUrl: fallback.modelBaseUrl,
-              prompt,
-              timeoutMs: params.timeoutMs,
-              images: params.images,
-              allowPrivateNetwork,
-              signal: params.signal,
-            });
-          }
-
-          const apiKey = runtimeValue;
-          params.signal?.throwIfAborted();
-          assertResourcesOpen?.();
-          const setupDurationMs = Date.now() - startedAtMs;
-
-          if (isMinimaxVlmModel(model.provider, model.id)) {
-            return await describeImagesWithMinimax({
-              assertResourcesOpen,
-              runtimeValue,
-              provider: model.provider,
-              modelId: model.id,
-              modelBaseUrl: model.baseUrl,
-              prompt,
-              timeoutMs: params.timeoutMs,
-              images: params.images,
-              request: getModelProviderRequestTransport(model),
-              signal: params.signal,
-            });
-          }
-
-          const resolvedRuntimeContext = getResolvedImageRuntimeContext(model);
-          // Prepared auth may carry sentinel-protected request headers. Resolve them only at this
-          // final direct-completion boundary so provider SDKs never receive sentinel placeholders.
-          const requestModel = unwrapModelHeaderSentinelsForProviderEgress(
-            model,
-            "image description provider request",
-          );
-          const providerStreamFn = registerProviderStreamForModel({
-            model: requestModel,
-            cfg: resolvedRuntimeContext?.cfg ?? params.cfg,
-            agentDir: resolvedRuntimeContext?.agentDir ?? params.agentDir,
-            wrapProviderStream: true,
-            ...(resolvedRuntimeContext?.workspaceDir
-              ? { workspaceDir: resolvedRuntimeContext.workspaceDir }
-              : params.workspaceDir
-                ? { workspaceDir: params.workspaceDir }
-                : {}),
-          });
-
-          const context = buildImageContext(prompt, params.images, {
-            promptInUserContent: shouldPlaceImagePromptInUserContent(model),
-          });
-
-          const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
-          const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
-            params.signal?.throwIfAborted();
-            assertResourcesOpen?.();
-            const payloadHandler = composeImageDescriptionPayloadHandlers(
-              onPayload,
-              options.onPayload,
-            );
-            const timeoutMs = configuredTimeoutMs;
-            const headers = buildImageRequestHeaders(requestModel);
-            const streamOptions = {
-              apiKey,
-              maxTokens,
-              signal: requestSignal,
-              ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-              ...(headers ? { headers } : {}),
-              ...(payloadHandler ? { onPayload: payloadHandler } : {}),
-            };
-            const task: Promise<AssistantMessage> = work.track(() =>
-              providerStreamFn
-                ? (async () =>
-                    await (await providerStreamFn(requestModel, context, streamOptions)).result())()
-                : complete(requestModel, context, streamOptions),
-            );
-            return await withImageDescriptionTimeout({
-              controller,
-              signal: params.signal,
-              timeoutMs,
-              createTimeoutError: (requestTimeoutMs) =>
-                buildImageDescriptionTimeoutError({
-                  phase: "request",
-                  timeoutMs: requestTimeoutMs,
-                  setupDurationMs,
-                }),
-              task,
-            });
-          };
-
-          const message = await completeImage();
-          try {
-            const text = coerceImageAssistantText({
-              message,
-              provider: model.provider,
-              model: model.id,
-            });
-            return { text, model: model.id };
-          } catch (err) {
-            if (!isImageModelNoTextError(err) || !hasImageReasoningOnlyResponse(message)) {
-              throw err;
-            }
-          }
-
-          params.signal?.throwIfAborted();
-          const retryMessage = await completeImage(disableReasoningForImageRetryPayload);
-          const text = coerceImageAssistantText({
-            message: retryMessage,
-            provider: model.provider,
-            model: model.id,
-          });
-          return { text, model: model.id };
-        }),
-      );
-    } catch (error) {
-      reported.reject(error);
-    } finally {
-      await work.runWhenIdle(() => undefined);
-      await runInScope(() => work.drain());
-      parentSignal?.removeEventListener("abort", closeWork);
-      releaseRuntime?.();
+      const resolved = await withImageDescriptionTimeout({
+        controller,
+        signal: params.signal,
+        timeoutMs: configuredTimeoutMs,
+        createTimeoutError: (timeoutMs) =>
+          buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+        task: resolutionTask,
+      });
+      runtimeValue = resolved.runtimeValue;
+      model = resolved.model;
+    } catch (err) {
+      params.signal?.throwIfAborted();
+      if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
+        throw err;
+      }
+      const fallback = await withImageDescriptionTimeout({
+        controller,
+        signal: params.signal,
+        timeoutMs: configuredTimeoutMs,
+        createTimeoutError: (timeoutMs) =>
+          buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+        task: trackAsyncWork(() => resolveMinimaxVlmFallbackRuntime(params)),
+      });
+      return await describeImagesWithMinimax({
+        assertResourcesOpen,
+        runtimeValue: fallback.runtimeValue,
+        provider: params.provider,
+        modelId: params.model,
+        modelBaseUrl: fallback.modelBaseUrl,
+        prompt,
+        timeoutMs: params.timeoutMs,
+        images: params.images,
+        allowPrivateNetwork,
+        signal: params.signal,
+      });
     }
-  }).catch((error: unknown) => reported.reject(error));
-  return await reported.promise;
+
+    const apiKey = runtimeValue;
+    params.signal?.throwIfAborted();
+    assertResourcesOpen?.();
+    const setupDurationMs = Date.now() - startedAtMs;
+
+    if (isMinimaxVlmModel(model.provider, model.id)) {
+      return await describeImagesWithMinimax({
+        assertResourcesOpen,
+        runtimeValue,
+        provider: model.provider,
+        modelId: model.id,
+        modelBaseUrl: model.baseUrl,
+        prompt,
+        timeoutMs: params.timeoutMs,
+        images: params.images,
+        request: getModelProviderRequestTransport(model),
+        signal: params.signal,
+      });
+    }
+
+    const resolvedRuntimeContext = getResolvedImageRuntimeContext(model);
+    // Prepared auth may carry sentinel-protected request headers. Resolve them only at this
+    // final direct-completion boundary so provider SDKs never receive sentinel placeholders.
+    const requestModel = unwrapModelHeaderSentinelsForProviderEgress(
+      model,
+      "image description provider request",
+    );
+    const providerStreamFn = registerProviderStreamForModel({
+      model: requestModel,
+      cfg: resolvedRuntimeContext?.cfg ?? params.cfg,
+      agentDir: resolvedRuntimeContext?.agentDir ?? params.agentDir,
+      wrapProviderStream: true,
+      ...(resolvedRuntimeContext?.workspaceDir
+        ? { workspaceDir: resolvedRuntimeContext.workspaceDir }
+        : params.workspaceDir
+          ? { workspaceDir: params.workspaceDir }
+          : {}),
+    });
+
+    const context = buildImageContext(prompt, params.images, {
+      promptInUserContent: shouldPlaceImagePromptInUserContent(model),
+    });
+
+    const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
+    const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
+      params.signal?.throwIfAborted();
+      assertResourcesOpen?.();
+      const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);
+      const timeoutMs = configuredTimeoutMs;
+      const headers = buildImageRequestHeaders(requestModel);
+      const streamOptions = {
+        apiKey,
+        maxTokens,
+        signal: requestSignal,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        ...(headers ? { headers } : {}),
+        ...(payloadHandler ? { onPayload: payloadHandler } : {}),
+      };
+      const task: Promise<AssistantMessage> = trackAsyncWork(() =>
+        providerStreamFn
+          ? (async () =>
+              await (await providerStreamFn(requestModel, context, streamOptions)).result())()
+          : complete(requestModel, context, streamOptions),
+      );
+      return await withImageDescriptionTimeout({
+        controller,
+        signal: params.signal,
+        timeoutMs,
+        createTimeoutError: (requestTimeoutMs) =>
+          buildImageDescriptionTimeoutError({
+            phase: "request",
+            timeoutMs: requestTimeoutMs,
+            setupDurationMs,
+          }),
+        task,
+      });
+    };
+
+    const message = await completeImage();
+    try {
+      const text = coerceImageAssistantText({
+        message,
+        provider: model.provider,
+        model: model.id,
+      });
+      return { text, model: model.id };
+    } catch (err) {
+      if (!isImageModelNoTextError(err) || !hasImageReasoningOnlyResponse(message)) {
+        throw err;
+      }
+    }
+
+    params.signal?.throwIfAborted();
+    const retryMessage = await completeImage(disableReasoningForImageRetryPayload);
+    const text = coerceImageAssistantText({
+      message: retryMessage,
+      provider: model.provider,
+      model: model.id,
+    });
+    return { text, model: model.id };
+  });
 }
 
 function toImagesDescriptionRequest(params: ImageDescriptionRequest): ImagesDescriptionRequest {


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Image completion duplicates resource acquisition, result reporting, cancellation forwarding, and drainage already handled by the shared async resource owner. Keeping a second copy makes lifetime fixes harder to apply consistently.

## Why This Change Was Made

Use the existing shared owner for image completion and keep setup, fallback, and provider work tracked inside it. Preserve immediate resource transfer, admission checks, timeouts, model selection, transport policy, and returned results. The one-file refactor removes 29 production lines.

## User Impact

Image results and cancellation behavior stay the same. Outstanding provider work retains its resources until it settles and drains, even when the caller has already received cancellation.

## Evidence

All 66 existing image tests, the full changed-file gate, and independent P2 review passed. A canonical `sourcePerformance` build passed at `a173153b0138a4cd3bc4359d55e1a72dc2ca8d9e`; this profile builds runtime assets, not UI or package declarations.

Two compiled requests through the public media-understanding SDK used one synthetic configuration and generation. Success preserved the caller-held lease. For cancellation, the supplying lease was released and disposable runtime closure began while the provider remained held; the native resource stayed readable and drainage stayed pending until provider settlement, followed by one disposal. Existing source tests cover timeout and broader cleanup cases; the compiled proof does not separately claim timeout coverage. No operator Gateway or external model service was used.
