### PR TITLE
fix(gateway): honor draft visibility for artifact reads

### DIFF
--- a/src/gateway/server-methods/artifacts-session-resolution.test.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  roleClient,
+  rolePolicyConfig,
+  sharingPolicyClient,
+} from "../session-sharing.test-utils.js";
 import {
   ArtifactSessionResolutionError,
   resolveAuthorizedArtifactSession,
@@ -95,55 +99,136 @@ describe("artifact session authorization", () => {
     });
   });
 
-  it("hides foreign artifact sessions behind direct, run, and task selectors", async () => {
+  it.each([
+    { name: "draft without roles", visibility: "draft", cfg: {}, role: undefined },
+    { name: "draft without runtime config", visibility: "draft", cfg: undefined, role: undefined },
+    {
+      name: "shared with a none role",
+      visibility: "shared",
+      cfg: rolePolicyConfig(),
+      role: "none",
+    },
+    {
+      name: "draft with a write role",
+      visibility: "draft",
+      cfg: rolePolicyConfig(),
+      role: "write",
+    },
+  ] as const)(
+    "hides $name artifacts behind direct, run, and task selectors",
+    async ({ visibility, cfg, role }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const viewerProfile = ensureProfileForEmail("viewer@example.com");
+        const ownerProfile = ensureProfileForEmail("owner@example.com");
+        const sessionKey = "agent:main:foreign-artifacts";
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: "session-foreign-artifacts",
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: ownerProfile.id },
+            visibility,
+          },
+        );
+        mocks.getTaskSession.mockImplementation((taskId: string) =>
+          taskId === "task-run"
+            ? { runId: "run-foreign", agentId: "main" }
+            : {
+                requesterSessionKey: sessionKey,
+                requesterAgentId: "main",
+                ownerKey: sessionKey,
+              },
+        );
+        mocks.resolveRunSession.mockReturnValue(sessionKey);
+        const viewer = role
+          ? roleClient(role, "artifact-viewer")
+          : identifiedClient(["operator.read"], viewerProfile.id);
+
+        for (const query of [
+          { sessionKey },
+          { runId: "run-foreign" },
+          { taskId: "task-foreign" },
+          { taskId: "task-run" },
+        ]) {
+          expect(() => resolveAuthorizedArtifactSession(query, cfg, viewer)).toThrowError(
+            expect.objectContaining({
+              shape: {
+                code: "INVALID_REQUEST",
+                message: "no session found for artifact query",
+                details: { type: "artifact_scope_not_found" },
+              },
+            }),
+          );
+        }
+
+        expect(
+          resolveAuthorizedArtifactSession(
+            { sessionKey },
+            cfg,
+            identifiedClient(["operator.read"], ownerProfile.id),
+          ),
+        ).toMatchObject({ sessionKey });
+        expect(
+          resolveAuthorizedArtifactSession(
+            { runId: "run-foreign" },
+            cfg,
+            identifiedClient(["operator.admin"], viewerProfile.id),
+          ),
+        ).toMatchObject({ sessionKey });
+      });
+    },
+  );
+
+  it.each(["shared", "read-only", "suggest"] as const)(
+    "allows reading foreign %s artifacts without participation",
+    async (visibility) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const owner = ensureProfileForEmail("artifact-owner@example.test");
+        const viewer = roleClient("view", "artifact-reader");
+        const sessionKey = "agent:main:readable-artifacts";
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: "session-readable-artifacts",
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: owner.id },
+            visibility,
+          },
+        );
+
+        for (const cfg of [undefined, {}, rolePolicyConfig()]) {
+          expect(resolveAuthorizedArtifactSession({ sessionKey }, cfg, viewer)).toMatchObject({
+            sessionKey,
+          });
+        }
+      });
+    },
+  );
+
+  it("preserves solo and system reads while denying identityless reads with roles", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const viewerProfile = ensureProfileForEmail("viewer@example.com");
-      const sessionKey = "agent:main:foreign-artifacts";
+      const sessionKey = "agent:main:solo-artifacts";
       await upsertSessionEntryCore(
         { agentId: "main", sessionKey },
-        {
-          sessionId: "session-foreign-artifacts",
-          updatedAt: 1,
-          createdActor: { type: "human", source: "profile", id: "owner@example.com" },
-          visibility: "shared",
-        },
+        { sessionId: "session-solo-artifacts", updatedAt: 1, visibility: "draft" },
       );
-      mocks.getTaskSession.mockReturnValue({
-        requesterSessionKey: sessionKey,
-        requesterAgentId: "main",
-        ownerKey: sessionKey,
-      });
-      mocks.resolveRunSession.mockReturnValue(sessionKey);
-      const cfg: OpenClawConfig = {
-        agents: { list: [{ id: "main", default: true }] },
-        gateway: {
-          roles: {
-            default: "guest",
-            definitions: {
-              guest: {
-                sessions: { others: "none" },
-                agents: "*",
-                scopes: ["operator.read"],
-              },
-            },
-          },
-        },
-      };
-      const viewer = identifiedClient(["operator.read"], viewerProfile.id);
-
-      for (const query of [{ sessionKey }, { taskId: "task-foreign" }, { runId: "run-foreign" }]) {
-        expect(() => resolveAuthorizedArtifactSession(query, cfg, viewer)).toThrow(
-          "no session found for artifact query",
-        );
+      const identityless = sharingPolicyClient({});
+      for (const client of [null, identityless, sharingPolicyClient({ user: "gateway-owner" })]) {
+        expect(resolveAuthorizedArtifactSession({ sessionKey }, {}, client)).toMatchObject({
+          sessionKey,
+        });
       }
-
-      expect(
-        resolveAuthorizedArtifactSession(
-          { runId: "run-foreign" },
-          cfg,
-          identifiedClient(["operator.admin"], viewerProfile.id),
-        ),
-      ).toMatchObject({ sessionKey });
+      const cfg = rolePolicyConfig();
+      expect(() => resolveAuthorizedArtifactSession({ sessionKey }, cfg, identityless)).toThrow(
+        "no session found for artifact query",
+      );
+      const system: GatewayClient = {
+        ...identityless,
+        internal: { operatorRoleActor: { kind: "system" } },
+      };
+      expect(resolveAuthorizedArtifactSession({ sessionKey }, cfg, system)).toMatchObject({
+        sessionKey,
+      });
     });
   });
 });

--- a/src/gateway/server-methods/artifacts-session-resolution.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.ts
@@ -10,7 +10,6 @@ import {
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { getTaskSessionLookupByIdForStatus } from "../../tasks/task-status-access.js";
-import { hasOperatorBoundary } from "../operator-role-policy.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import {
@@ -181,13 +180,11 @@ export function resolveAuthorizedArtifactSession(
     sessionKey: query.sessionKey ?? resolved.sessionKey,
     target,
   });
-  const roleVisibilityDenied = Boolean(
-    cfg &&
-    hasOperatorBoundary(client, cfg) &&
+  const visibilityDenied = Boolean(
     target &&
     createSessionListEntryFilter({ client, cfg })?.(target.storeKey, target.entry) === false,
   );
-  if (!error && !roleVisibilityDenied) {
+  if (!error && !visibilityDenied) {
     return resolved;
   }
   throw new ArtifactSessionResolutionError(

--- a/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
+++ b/src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
@@ -1,5 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { expectErrorDetails, expectFields } from "./artifacts.test-support.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { sharingPolicyClient } from "../session-sharing.test-utils.js";
+import {
+  expectErrorDetails,
+  expectFields,
+  expectFirstArtifact,
+  expectOkPayload,
+  requireNonEmptyString,
+  resultImageMessage,
+  runtimeContext,
+} from "./artifacts.test-support.js";
 
 const hoisted = vi.hoisted(() => ({
   loadSessionEntry: vi.fn(),
@@ -62,6 +74,92 @@ describe("managed artifact lifecycle", () => {
       return 1;
     });
   });
+
+  it.each([
+    { name: "list", method: "artifacts.list", managed: false },
+    { name: "get", method: "artifacts.get", managed: false },
+    { name: "inline download", method: "artifacts.download", managed: false },
+    { name: "managed download", method: "artifacts.download", managed: true },
+  ] as const)(
+    "rechecks $name after a shared session becomes draft",
+    async ({ method, managed }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        hoisted.visitSessionMessagesAsync.mockImplementation(async (_scope, visit) => {
+          visit(resultImageMessage(), 2);
+          return 1;
+        });
+        const owner = ensureProfileForEmail("artifact-owner@example.test");
+        const viewer = ensureProfileForEmail("artifact-viewer@example.test");
+        const sessionKey = "agent:main:artifact-visibility";
+        const scope = { agentId: "main", sessionKey };
+        const entry = {
+          sessionId: "session-artifact-visibility",
+          updatedAt: 1,
+          createdActor: { type: "human" as const, source: "profile" as const, id: owner.id },
+        };
+        await upsertSessionEntryCore(scope, { ...entry, visibility: "shared" });
+        const client = sharingPolicyClient({ user: viewer.id, scopes: ["operator.read"] });
+        async function invoke(
+          rpcMethod: "artifacts.list" | "artifacts.get" | "artifacts.download",
+          params: Record<string, unknown>,
+        ) {
+          const calls: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+          await artifactsHandlers[rpcMethod]?.({
+            req: { type: "req", id: rpcMethod, method: rpcMethod, params: {} },
+            params,
+            client,
+            isWebchatConnect: () => false,
+            respond: (ok, payload, error) => calls.push({ ok, payload, error }),
+            context: runtimeContext({}) as never,
+          });
+          return { calls };
+        }
+        const listed = await invoke("artifacts.list", { sessionKey });
+        const inlineArtifactId = requireNonEmptyString(
+          expectFirstArtifact(listed.calls)?.id,
+          "expected visible artifact",
+        );
+        const artifactId = managed
+          ? "artifact_managed_image_11111111-1111-4111-8111-111111111111"
+          : inlineArtifactId;
+        const url = "/api/chat/media/outgoing/fixture/id/full?mediaTicket=fixture-ticket";
+        hoisted.resolveManagedArtifactDownload.mockResolvedValue({
+          artifactId,
+          sessionKey,
+          type: "image",
+          title: "result.png",
+          url,
+          expiresAt: "2026-07-28T05:00:00.000Z",
+        });
+        const params = method === "artifacts.list" ? { sessionKey } : { sessionKey, artifactId };
+        const baseline = await invoke(method, params);
+        expect(baseline.calls).toHaveLength(1);
+        const payload = expectOkPayload(baseline.calls);
+        if (method === "artifacts.download") {
+          expectFields(payload, managed ? { url } : { encoding: "base64", data: "aGVsbG8=" });
+        }
+
+        await upsertSessionEntryCore(scope, { ...entry, updatedAt: 2, visibility: "draft" });
+        vi.clearAllMocks();
+        const denied = await invoke(method, params);
+
+        expect(denied.calls).toEqual([
+          {
+            ok: false,
+            payload: undefined,
+            error: {
+              code: "INVALID_REQUEST",
+              message: "no session found for artifact query",
+              details: { type: "artifact_scope_not_found" },
+            },
+          },
+        ]);
+        expect(hoisted.visitSessionMessagesAsync).not.toHaveBeenCalled();
+        expect(hoisted.resolveManagedArtifactDownload).not.toHaveBeenCalled();
+        expect(hoisted.resolveManagedUrlDownload).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("does not retarget a stale managed artifact id through a different block URL", async () => {
     const artifactId = "artifact_managed_image_11111111-1111-4111-8111-111111111111";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an identified operator could still list, inspect, or request a new download of another operator's session artifacts after that session became a draft, even though chat history correctly stopped displaying it. This occurs without configured Gateway roles.

Found while qualifying selected-conversation media handling for https://github.com/openclaw/openclaw/pull/143610 and https://github.com/openclaw/openclaw/pull/143615. This is an independent repair against `main`, not another layer in that feature stack.

## Why This Change Was Made

Artifact session resolution applied the canonical session visibility filter only when an operator-role boundary existed. Remove that extra condition so artifact reads use the same read-visibility policy as chat history.

The existing resolver remains the single owner for direct session, run, and task selectors and for list, get, inline download, and managed download. No new authorization implementation or fallback is added. Mutation/participation checks are intentionally not used for reads.

## User Impact

New artifact reads consistently honor draft visibility. Owners, administrators, system callers, identityless solo mode, and readers of shared, read-only, and suggest sessions retain their existing behavior. Incognito restrictions and non-disclosing errors remain unchanged.

This does not change the Gateway trust model. `SECURITY.md` treats same-Gateway session visibility as a usability feature, not adversarial user isolation. No configuration, dependency, protocol, persistent-store, schema, or migration changes are included. Previously issued media tickets keep their existing lifetime contract.

## Evidence

- Before the fix: six intended regression failures, with 53 controls passing. No-role and undefined-config draft reads were accepted; all four artifact RPC cases returned content after shared-to-draft.
- After the fix: 81/81 tests passed across `artifacts-session-resolution.test.ts`, `artifacts.managed-lifecycle.test.ts`, `artifacts.test.ts`, and `session-sharing.test.ts`. Covers indirect selectors, role ceilings, owner/admin/system/solo access, incognito, and readable sessions without participation.
- Real child Gateway, synthetic authenticated profiles, local mock provider, and a generated 2x2 PNG: an identified reader downloaded the exact bytes from a shared session; its owner changed visibility through `session.visibility.set`; the reader's fresh list/get/download requests then failed with `artifact_scope_not_found`. The owner's fresh download still returned HTTP 200 with the exact bytes. No baseline ticket was reused to assert revocation.
- That runtime reproduction was first observed at native prerequisite head `0bb08a20c7615c46976bb9861eab7ddc3b7a5de6`, then repeated after applying this exact resolver patch to its independent built clone. The affected resolver and visibility owner are unchanged between that base and this repair's `main` snapshot, `d09401295626bebd53aa84492b91e7909e22487f`. This is real Gateway and HTTP proof with a mock provider, not an installed native-app or external-provider claim.
- Focused lint, formatting, core typechecking, the Gateway test-type graph, and independent review passed. The final lifecycle suite rerun passed 6/6. The worktree's changed-gate runner stopped at its external-dependency declaration guard; typechecks were then run successfully in the independent clone with physical dependencies and byte-identical changed files.
- The earlier [manual exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34455223994) at `48a4649152a64dda68481c7dd8dd04eea81c7ce2` failed in two jobs: tooling-15 stopped emitting output after the task-registry benchmark and hit its 300-second watchdog twice; Windows part 1 hit the unchanged 10-second `npm --version` subprocess deadline in five package-inventory cases. Its first job-only Windows retry, [job 102808829659](https://github.com/openclaw/openclaw/actions/runs/34455223994/job/102808829659), passed on September 10, 2026 at 09:12:31 UTC. The manual run remains failed because tooling-15 is unresolved. No further unchanged tooling retry, timeout increase, or transient-failure claim is included.
- The normal [pull-request CI run](https://github.com/openclaw/openclaw/actions/runs/34458756422) completed successfully at this exact head: 111 successful jobs, 17 intentionally skipped, and no failed jobs. Its required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34458756422/job/102817324746), from GitHub Actions app 15368, passed on September 10, 2026 at 09:26:17 UTC. GitHub reports this PR `CLEAN` and `MERGEABLE`; there are no unresolved review threads. The older manual-run failure remains disclosed above, not relabeled as passing.
- The September 10, 2026 [ClawSweeper review](https://github.com/openclaw/openclaw/pull/143873#issuecomment-5615679151) found no actionable defect, accepted the supplied Gateway/HTTP proof, and listed no remaining review changes. This does not waive required CI.

```json
{"surface":"fresh-artifact-ticket","configuredRoles":false,"baselineStatus":200,"baselineExactBytes":true,"historyDenied":true,"listDenied":true,"getDenied":true,"downloadDenied":true,"newTicketIssued":false,"ownerStatus":200,"ownerExactBytes":true,"reusedBaselineTicket":false}
```

<details>
<summary>Recorded local verification commands</summary>

The tests and lint ran in the repair worktree. Typechecks ran in the independent physical-dependency clone described above, with byte-identical changed files.

```sh
node scripts/run-vitest.mjs \
  src/gateway/server-methods/artifacts-session-resolution.test.ts \
  src/gateway/server-methods/artifacts.test.ts \
  src/gateway/server-methods/artifacts.managed-lifecycle.test.ts \
  src/gateway/session-sharing.test.ts
node scripts/run-vitest.mjs src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/gateway/server-methods/artifacts-session-resolution.test.ts \
  src/gateway/server-methods/artifacts-session-resolution.ts \
  src/gateway/server-methods/artifacts.managed-lifecycle.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-other.json --builders 1
```

</details>

Production: +2/-5 lines. Tests: +229/-46 lines. Three changed files; the oversized general artifact suite is unchanged. The extra tests protect the missing no-role read policy and its RPC lifecycle, without adding test-only production APIs.

Ready for the owner's first manual squash merge. The native stack will then pick up this repair through its normal main refresh, without duplicating the patch; those PRs remain drafts until their outstanding qualification completes. The owner will perform any merge. No merge has been performed and no auto-merge is requested.
