### PR TITLE
fix(ci): isolate legacy handoff fixtures from concurrent config tests

### DIFF
--- a/src/infra/update-managed-service-handoff-retarget.test.ts
+++ b/src/infra/update-managed-service-handoff-retarget.test.ts
@@ -610,6 +610,11 @@ unix(
     const { createManagedHandoffLeaseStore, resolveManagedUpdateLeaseDatabasePath } =
       await import("./update-managed-service-handoff-lease.js");
     const { to } = fixture();
+    const tmpDirOwner = await import("./tmp-openclaw-dir.js");
+    // Keep the legacy fixture row away from concurrent config writers.
+    vi.spyOn(tmpDirOwner, "resolvePreferredOpenClawTmpDir").mockReturnValue(
+      path.join(path.dirname(to), "coordinator"),
+    );
     const store = createManagedHandoffLeaseStore();
     const reserved = store.acquire(to, "legacy-owner", { kind: "update" });
     expect(reserved.kind).toBe("acquired");


### PR DESCRIPTION
Related: #143832

## What Problem This Solves

Resolves a problem where concurrent CI model-command tests fail with `existing managed handoff lease is incompatible` while a managed-handoff regression test is running. This maintainer-requested fixture repair is required to validate #143832 independently of an existing baseline defect. [The observed CI job](https://github.com/openclaw/openclaw/actions/runs/34450754996/job/102786053112) failed eight model-selection cases.

## Why This Change Was Made

The legacy-reclamation case briefly writes a version-1 lease into the default shared handoff database. Unrelated config writers scan that database for retained custody and reject the unsupported row. Redirect this case's coordinator into its existing temporary fixture before creating the store. The parent passes the resolved database path explicitly to its helper, preserving real cross-process reclamation, cancellation, and cleanup.

## User Impact

CI can run these tests concurrently without sharing the synthetic legacy lease. This changes only test isolation; production behavior and its fail-closed lease checks are unchanged.

## Evidence

- A deterministic Linux probe paused the existing case after writing its legacy row and invoked a separate process using the real config-write lock. Both baseline `5a7eb757` and cancellation candidate `b725cedb` failed with the same incompatibility error; cleanup completed.
- With the isolated coordinator, the identical overlap probe passed. The full retarget suite (28 tests) and model-selection suite (36 tests) then ran concurrently through the CI shard runner: **64 passed**.
- [Blacksmith Testbox execution](https://github.com/openclaw/openclaw/actions/runs/34454278404): command exit 0. Its backing Actions session may show canceled after normal lease cleanup; that session conclusion is distinct from the successful command result.
- Changed-file checks and independent P2 review passed with no actionable findings.

The deterministic probe exercises the initial config guard; the observed CI stack also reached the same retained-custody guard during lock release. This is boundary proof for test contamination, not evidence about production latency or the broader noncanceled wait cycle tracked separately from #143832.
