### PR TITLE
chore: cover update owner revocation before acknowledgment

### DIFF
--- a/src/gateway/server-methods/update-owner.test.ts
+++ b/src/gateway/server-methods/update-owner.test.ts
@@ -8,6 +8,7 @@ import type { GatewayRequestContext } from "./types.js";
 import {
   adoptUpdateCampaignMock,
   detectRespawnSupervisorMock,
+  initializeGatewayUpdateStatusMock,
   runGatewayUpdateMock,
   scheduleGatewaySigusr1RestartMock,
   sendGatewayLifecycleNoticeMock,
@@ -123,6 +124,39 @@ describe("update.run current owner authority", () => {
       }),
     );
   });
+
+  it.each([false, true])(
+    "refuses before acknowledgement after discovery revokes ownership (managed=%s)",
+    async (managed) => {
+      detectRespawnSupervisorMock.mockReturnValue(managed ? "launchd" : null);
+      initializeGatewayUpdateStatusMock.mockImplementationOnce(async () => {
+        config = { commands: { ownerAllowFrom: ["replacement"] } };
+        return {
+          root: "/tmp/openclaw",
+          status: { root: "/tmp/openclaw", installKind: "git", packageManager: "pnpm" },
+          installReceipt: null,
+        };
+      });
+
+      const result = await runOwnerTool(
+        createGatewayTool({ senderIsOwner: true, requesterSenderId: "owner" }),
+      );
+
+      expect(result.details).toMatchObject({
+        ok: false,
+        reason: "owner_required",
+        ackDelivered: false,
+      });
+      expect(listUpdateRuns()).toEqual([
+        expect.objectContaining({ phase: "finished", status: "failed", reason: "owner_required" }),
+      ]);
+      expect(sendGatewayLifecycleNoticeMock).not.toHaveBeenCalled();
+      expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+      expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+      expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+      expect(sentinelState.capturedPayload).toBeUndefined();
+    },
+  );
 
   it.each([false, true])("rechecks after awaited acknowledgement (managed=%s)", async (managed) => {
     detectRespawnSupervisorMock.mockReturnValue(managed ? "launchd" : null);


### PR DESCRIPTION
## What Problem This Solves

The update owner suite covers revocation before dispatch and during acknowledgment, but not while asynchronous update discovery is still running. A regression at that earlier boundary could acknowledge an update for a revoked chat owner even if a later check still prevents mutation.

## Why This Change Was Made

Add two cases to the existing owner suite, covering managed and direct execution. Discovery changes the configured external owner before returning. Both cases require a durable `owner_required` failure with no acknowledgment, updater, helper, restart or sentinel effect.

This tests the existing policy. It does not change internal/channel-less requester authority or make socket disconnect cancel admitted updates.

## User Impact

No behavior change. Regression coverage protects the refusal-before-acknowledgment contract for externally configured update owners.

## Evidence

- Existing focused suite before the change: 8/8 passing.
- Focused suite with the change: 10/10 passing.
- P0/P1/P2 scoped review: no actionable findings.
- The handler and temporary SQLite run ledger are real; discovery, lifecycle notification, update execution and handoff effects use the existing mocks. This is not an installed/native update proof.
