### PR TITLE
fix(channels): Slack native progress shows two task cards for one exec call

### DIFF
--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -1,4 +1,8 @@
-import type { ChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  buildChannelProgressDraftLine,
+  type ChannelProgressDraftLine,
+  mergeChannelProgressDraftLine,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it } from "vitest";
 import {
   buildSlackProgressStreamChunks,
@@ -853,6 +857,78 @@ describe("native Slack progress stream chunks", () => {
       taskUpdate(expect.stringMatching(/^cmd_1_[a-f0-9]{8}$/u), "🛠️ Exec", "in_progress"),
       taskUpdate(expect.stringMatching(/^cmd_2_[a-f0-9]{8}$/u), "🛠️ Exec", "in_progress"),
     ]);
+  });
+
+  it("keeps one native task for a tool call across its start, command and output lines", () => {
+    // The agent keys one exec call's tool item and command item separately
+    // (tool:<call>, command:<call>). The compositor merges them into one line
+    // by call; the task id must follow that line, or Slack opens a second card.
+    const options = { commandText: "raw" as const };
+    const events = [
+      buildChannelProgressDraftLine(
+        {
+          event: "tool",
+          toolCallId: "call-1",
+          name: "exec",
+          phase: "start",
+          args: { command: "pnpm test" },
+        },
+        options,
+      ),
+      buildChannelProgressDraftLine(
+        {
+          event: "item",
+          itemId: "command:call-1",
+          itemKind: "command",
+          toolCallId: "call-1",
+          name: "exec",
+          phase: "start",
+          status: "running",
+          meta: "run tests",
+        },
+        options,
+      ),
+      buildChannelProgressDraftLine(
+        {
+          event: "command-output",
+          itemId: "command:call-1",
+          toolCallId: "call-1",
+          name: "exec",
+          phase: "end",
+          title: "command run tests",
+          exitCode: 0,
+        },
+        options,
+      ),
+    ];
+    let lines: ChannelProgressDraftLine[] = [];
+    let snapshot = EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT;
+    const emitted: unknown[][] = [];
+    for (const line of events) {
+      if (!line) {
+        throw new Error("expected exec progress line");
+      }
+      lines = mergeChannelProgressDraftLine(lines, line, { maxLines: 8 });
+      const reconciled = reconcileSlackNativeTaskChunks({
+        previous: snapshot,
+        chunks: buildSlackProgressStreamChunks({ lines }),
+      });
+      snapshot = reconciled.snapshot;
+      emitted.push(reconciled.chunks ?? []);
+    }
+
+    expect([...snapshot.tasks.keys()]).toHaveLength(1);
+    const taskId = expect.stringMatching(/^tool_call_1_[a-f0-9]{8}$/u);
+    expect(emitted[0]).toContainEqual(
+      taskUpdate(taskId, "Exec", "in_progress", { details: "run tests" }),
+    );
+    expect(emitted[1]).toEqual([]);
+    expect(emitted[2]).toContainEqual(
+      expect.objectContaining({ type: "task_update", id: taskId, status: "complete" }),
+    );
+    expect(emitted[2]).not.toContainEqual(
+      expect.objectContaining({ type: "task_update", status: "in_progress" }),
+    );
   });
 
   it("keeps id-derived native task ids stable when completion changes visible status text", () => {

--- a/src/channels/progress-draft-compositor.quiet.test.ts
+++ b/src/channels/progress-draft-compositor.quiet.test.ts
@@ -263,6 +263,67 @@ describe("createChannelProgressDraftCompositor quiet drafts", () => {
     },
   );
 
+  it.each([
+    {
+      order: "tool item, then command output",
+      failures: ["tool", "command"],
+      recovery: "command",
+    },
+    {
+      order: "command output, then tool item",
+      failures: ["command", "tool"],
+      recovery: "tool",
+    },
+  ] as const)(
+    "clears a quiet failure whose stored id came from an earlier item family ($order)",
+    async ({ failures, recovery }) => {
+      const update = vi.fn();
+      const progress = createTestProgressDraftCompositor({
+        entry: {
+          streaming: {
+            mode: "progress",
+            progress: { toolProgress: false, maxLines: 3, commentary: true, label: false },
+          },
+        },
+        update,
+      });
+      // The agent keys one exec call's item families separately (tool:<call>,
+      // command:<call>); the merged line keeps the id of whichever reported first.
+      const push = (family: "tool" | "command", outcome: "failed" | "completed") =>
+        family === "tool"
+          ? progress.pushItemEvent({
+              itemId: "tool:call-1",
+              toolCallId: "call-1",
+              kind: "tool",
+              name: "exec",
+              status: outcome,
+            })
+          : progress.pushCommandOutputEvent({
+              phase: "end",
+              itemId: "command:call-1",
+              toolCallId: "call-1",
+              exitCode: outcome === "failed" ? 1 : 0,
+            });
+      try {
+        await progress.pushPlanProgress([
+          { step: "Inspect", status: "completed" },
+          { step: "Repair", status: "in_progress" },
+        ]);
+        for (const family of failures) {
+          await push(family, "failed");
+          expect(update.mock.lastCall?.[0]).toMatch(/failed|exit 1/);
+        }
+        expect(update.mock.lastCall?.[1]?.lines).toHaveLength(1);
+        await push(recovery, "completed");
+        expect(update.mock.lastCall?.[0]).toContain("Repair");
+        expect(update.mock.lastCall?.[0]).not.toMatch(/failed|exit 1/);
+        expect(update.mock.lastCall?.[1]?.lines).toHaveLength(0);
+      } finally {
+        progress.cancel();
+      }
+    },
+  );
+
   it.each(["failed", "error", "blocked"])(
     "flushes and retains explicit %s status while tool progress is enabled",
     async (status) => {

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -26,6 +26,7 @@ import {
   isChannelProgressDraftWorkToolName,
   mergeChannelProgressDraftLineForStreaming,
   normalizeChannelProgressDraftLineIdentity,
+  removeChannelProgressDraftLineForStreaming,
   resolveChannelProgressDraftLabel,
   resolveChannelProgressDraftMaxLineChars,
   resolveChannelProgressDraftMaxLines,
@@ -420,8 +421,8 @@ export function createChannelProgressDraftCompositor(params: {
           toolProgress: !quietProgress,
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
         })
-      : typeof line === "object" && line.id
-        ? removeChannelProgressDraftLine(lines, line.id)
+      : typeof progressLine === "object"
+        ? removeChannelProgressDraftLineForStreaming(lines, progressLine)
         : lines;
     const lineChanged = nextLines !== lines;
     const hasUnconfirmedRender = formatDraftText(nextLines) !== lastRenderedText;

--- a/src/channels/streaming.lifecycle.test.ts
+++ b/src/channels/streaming.lifecycle.test.ts
@@ -2,6 +2,7 @@
  * Tests channel streaming helper lifecycle and event forwarding.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeChannelProgressDraftLine } from "./progress-draft-lines.js";
 import {
   buildChannelProgressDraftLine,
   createChannelProgressDraftGate,
@@ -12,6 +13,7 @@ import {
   isChannelProgressDraftWorkToolName,
   isPotentialTruncatedFinal,
   mergeChannelProgressDraftLine,
+  removeChannelProgressDraftLineForStreaming,
   resolveChannelPreviewStreamMode,
   resolveChannelProgressDraftMaxLineChars,
   resolveChannelProgressDraftMaxLines,
@@ -595,8 +597,10 @@ describe("channel-streaming", () => {
     );
 
     expect(updated).toHaveLength(1);
+    // The line keeps the id it was created with; later item families for the
+    // same call replace its content through the correlation key.
     expect(updated[0]).toMatchObject({
-      id: "tool:call-1-output",
+      id: "tool:call-1",
       kind: "command-output",
       detail: "install dependencies",
       status: "completed",
@@ -643,6 +647,113 @@ describe("channel-streaming", () => {
       },
     ]);
     expect(recoveredUpdated[0]).not.toHaveProperty("detail");
+  });
+
+  it("keeps one line id while a tool call's item families replace the line", () => {
+    // The agent keys one exec call's tool item and command item separately
+    // (tool:<call>, command:<call>); the progress line for the call must not
+    // change id when the later families take it over.
+    const options = { commandText: "raw" as const };
+    const toolLine = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      options,
+    );
+    const commandItemLine = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "command:call-1",
+        itemKind: "command",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        status: "running",
+        meta: "run tests",
+      },
+      options,
+    );
+    const outputLine = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command run tests",
+        exitCode: 0,
+      },
+      options,
+    );
+    if (!toolLine || !commandItemLine || !outputLine) {
+      throw new Error("expected exec progress lines");
+    }
+    expect(toolLine.id).toBe("tool:call-1");
+    expect(commandItemLine.id).toBe("command:call-1");
+    expect(outputLine.id).toBe("command:call-1");
+
+    const running = mergeChannelProgressDraftLine([toolLine], commandItemLine, { maxLines: 4 });
+    expect(running).toHaveLength(1);
+    expect(running[0]).toMatchObject({ id: "tool:call-1", kind: "item", status: "running" });
+
+    const finished = mergeChannelProgressDraftLine(running, outputLine, { maxLines: 4 });
+    expect(finished).toHaveLength(1);
+    expect(finished[0]).toMatchObject({
+      id: "tool:call-1",
+      kind: "command-output",
+      status: "completed",
+    });
+
+    // A later event for the same call still finds the line.
+    const again = mergeChannelProgressDraftLine(finished, outputLine, { maxLines: 4 });
+    expect(again).toHaveLength(1);
+    expect(again[0]?.id).toBe("tool:call-1");
+  });
+
+  it("removes a correlated line whose id came from an earlier item family", () => {
+    const toolLine = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "tool:call-1",
+      toolCallId: "call-1",
+      name: "exec",
+      status: "failed",
+    });
+    const failedOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-1",
+      toolCallId: "call-1",
+      phase: "end",
+      exitCode: 1,
+    });
+    const recoveredOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-1",
+      toolCallId: "call-1",
+      phase: "end",
+      exitCode: 0,
+    });
+    const unrelatedOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-2",
+      toolCallId: "call-2",
+      phase: "end",
+      exitCode: 0,
+    });
+    if (!toolLine || !failedOutput || !recoveredOutput || !unrelatedOutput) {
+      throw new Error("expected exec progress lines");
+    }
+    const failed = mergeChannelProgressDraftLine([toolLine], failedOutput, { maxLines: 4 });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.id).toBe("tool:call-1");
+
+    // The stored id is tool:call-1; the recovery arrives as command:call-1.
+    expect(removeChannelProgressDraftLine(failed, recoveredOutput.id ?? "")).toBe(failed);
+    expect(removeChannelProgressDraftLineForStreaming(failed, unrelatedOutput)).toBe(failed);
+    expect(removeChannelProgressDraftLineForStreaming(failed, recoveredOutput)).toEqual([]);
   });
 
   it("starts progress drafts after the initial delay", async () => {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1243,6 +1243,26 @@ export function mergeChannelProgressDraftLineForStreaming<
   );
 }
 
+/**
+ * Removes the stored line an event addresses, matched the way the merge path
+ * matches it. A stored line can carry the id of an earlier item family for the
+ * same tool call (`tool:<call>` while the event arrives as `command:<call>`),
+ * so an id-only comparison would miss it.
+ */
+export function removeChannelProgressDraftLineForStreaming<
+  TLine extends string | ChannelProgressDraftLine,
+>(lines: TLine[], line: TLine): TLine[] {
+  const lineKeys = resolveProgressDraftLineMergeKeys(line);
+  if (lineKeys.length === 0) {
+    return lines;
+  }
+  const next = lines.filter(
+    (entry) => !resolveProgressDraftLineMergeKeys(entry).some((key) => lineKeys.includes(key)),
+  );
+  // Reference equality is part of the caller contract; redraw work only runs after a real removal.
+  return next.length === lines.length ? lines : next;
+}
+
 function mergeProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(
   lines: TLine[],
   line: TLine,
@@ -1260,11 +1280,12 @@ function mergeProgressDraftLine<TLine extends string | ChannelProgressDraftLine>
       resolveProgressDraftLineMergeKeys(entry).some((entryKey) => lineKeys.includes(entryKey)),
     );
     if (existingIndex >= 0) {
-      const replacement = mergeProgressDraftLineUpdate(
-        expectDefined(lines[existingIndex], "lines entry at existing index"),
-        line,
+      const existing = expectDefined(lines[existingIndex], "lines entry at existing index");
+      const replacement = keepProgressDraftLineId(
+        existing,
+        mergeProgressDraftLineUpdate(existing, line),
       );
-      if (replacement === lines[existingIndex]) {
+      if (replacement === existing) {
         return lines;
       }
       const next = [...lines];
@@ -1326,6 +1347,33 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
     progressDraftLineCorrelationKeys.get(line) ?? progressDraftLineCorrelationKeys.get(previous),
   );
   return replacement;
+}
+
+/**
+ * A line keeps the id it was created with. The agent keys one tool call's
+ * item families separately (`tool:<call>`, `command:<call>`) and correlation
+ * merges them into one line; a channel that keys native rows on the line id
+ * (Slack task cards) would otherwise open a new row when a later family
+ * takes the line over. Later events still match through the correlation key.
+ */
+function keepProgressDraftLineId<TLine extends string | ChannelProgressDraftLine>(
+  previous: TLine,
+  replacement: TLine,
+): TLine {
+  if (typeof previous !== "object" || typeof replacement !== "object") {
+    return replacement;
+  }
+  const previousId = previous.id?.trim();
+  if (!previousId || previousId === replacement.id) {
+    return replacement;
+  }
+  const kept = { ...replacement, id: previousId };
+  setProgressDraftLineCorrelationKey(
+    kept,
+    progressDraftLineCorrelationKeys.get(replacement) ??
+      progressDraftLineCorrelationKeys.get(previous),
+  );
+  return kept;
 }
 
 function resolveProgressDraftLineMergeKeys(line: string | ChannelProgressDraftLine): string[] {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching Slack native progress (`streaming.mode: progress` with the native transport) would see two task cards for every `exec` call: a first card that stayed at the tool's start title ("🛠️ Exec") and was marked complete early, and a second card that carried the command's real completion. The pair appeared for every command a run executed, so a turn with five commands showed ten cards. Nothing in the Slack plugin's settings changes it.

## Why This Change Was Made

The agent keys one exec call's items separately in its item stream: the tool item is `tool:<call>` and the command item is `command:<call>`. The shared progress compositor already merges the tool line, the command item and the command output into one progress line for the call through the command correlation key, but the merged line took the id of whichever event replaced it, so the line's id changed from `tool:<call>` to `command:<call>` while the call was running. Slack keys its native task rows on the line id, so the id change opened a second row and the reconciler completed the first as "dropped out".

A progress line now keeps the id it was created with: `mergeChannelProgressDraftLine` restores the existing line's id on a correlation-matched replacement (`keepProgressDraftLineId` in `src/channels/streaming.ts`). The replacement still carries the newest content and status, later events for the same call still find the line through the correlation key, and the ids the builders put on individual lines are unchanged, so callers that address lines by their public item id keep working. The one existing expectation that pinned the merged line to the newest id (`keeps public command progress ids while replacing by command correlation`) now pins it to the line's first id; the ids on the built lines it asserts before merging are untouched.

Alternative considered: making the builders emit `tool:<call>` for command items and command output. Not chosen because the item ids on built lines are the agent's public item identities (the existing lifecycle test guards them), and Matrix's recovered-command flow (#89920) relies on replacement by correlation regardless of id.

## User Impact

In Slack native progress, one exec call renders as one task card that moves from in progress to complete or error in place. Other channels render the merged line text and see no change. Nothing is configurable and no defaults change.

## Evidence

Failing before, passing after. The new tests were run against the unpatched `upstream/main` source (`9865df761`) and then with the change:

```
### BEFORE (upstream/main source, new tests) ###
 × channels  src/channels/streaming.lifecycle.test.ts > channel-streaming > keeps public command progress ids while replacing by command correlation
 × channels  src/channels/streaming.lifecycle.test.ts > channel-streaming > keeps one line id while a tool call's item families replace the line
AssertionError: expected { id: 'tool:call-1-output', …(7) } to match object { id: 'tool:call-1', …(4) }
AssertionError: expected { id: 'command:call-1', …(7) } to match object { id: 'tool:call-1', …(2) }
 Tests  2 failed | 28 passed (30)
 × extension-slack  extensions/slack/src/progress-blocks.test.ts > native Slack progress stream chunks > keeps one native task for a tool call across its start, command and output lines
AssertionError: expected [ 'command_call_1_1710f6c0', …(1) ] to have a length of 1 but got 2
 Tests  1 failed | 47 passed (48)
### AFTER (patched) ###
 Tests  30 passed (30)   src/channels/streaming.lifecycle.test.ts
 Tests  48 passed (48)   extensions/slack/src/progress-blocks.test.ts
```

Reproduction of the user-visible effect: one exec call's events (tool start, tool item start, command item start, command output end), built with the real line builders (`buildChannelProgressDraftLine`, `commandText: raw`), merged with `mergeChannelProgressDraftLine`, and rendered through the Slack plugin's `buildSlackProgressStreamChunks` + `reconcileSlackNativeTaskChunks`, printing every chunk the Slack stream would receive.

```
### repro on unpatched upstream/main ###
[tool start] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"in_progress","details":"run tests"}
[item start (tool)] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
[item start (command)] event.id=command:call-1 event.detail="run tests" merged.id=command:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"in_progress","details":"run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"complete"}
[command-output end] event.id=command:call-1 event.detail="command run tests" merged.id=command:call-1 merged.detail="command run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — command run tests"}
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"complete","details":" · command run tests"}
task rows in Slack snapshot:
  command_call_1_1710f6c0: title="Exec" status=complete details="run tests · command run tests"
  tool_call_1_c8e12bee: title="Exec" status=complete details="run tests"
### repro with the fix ###
[tool start] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"in_progress","details":"run tests"}
[item start (tool)] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
[item start (command)] event.id=command:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
[command-output end] event.id=command:call-1 event.detail="command run tests" merged.id=tool:call-1 merged.detail="command run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — command run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"complete","details":" · command run tests"}
task rows in Slack snapshot:
  tool_call_1_c8e12bee: title="Exec" status=complete details="run tests · command run tests"
```

Before: the compositor line is one line throughout (`lines=1`), but its id flips at the command item, Slack receives a second `task_update` id and completes the first, and the final snapshot holds two rows. After: the merged line keeps `tool:call-1`, Slack receives one task id from start to completion, and the snapshot holds one row. The details suffix still appended on completion (`" · command run tests"`) is a separate defect in the command-output line's detail, fixed in a companion PR (#143880); this change does not alter details.

Live observation that motivated this: Slack, OpenClaw `2026.8.1-beta.3`, native progress streaming, every exec call rendered as two cards ("🛠 Exec" and "Exec") on 2026-09-09.

Tests:

- `src/channels/streaming.lifecycle.test.ts`: `keeps one line id while a tool call's item families replace the line` (tool line → command item → command output: one line, id `tool:call-1` at each step, kind and status follow the newest event, a repeated output event still matches); `keeps public command progress ids while replacing by command correlation` now expects the merged line to keep `tool:call-1` (its pre-merge assertions on the built lines' ids are unchanged).
- `extensions/slack/src/progress-blocks.test.ts`: `keeps one native task for a tool call across its start, command and output lines` (real builders and merge feeding the Slack chunk builder and reconciler: one task id matching `tool_call_1_<hash>`, the command item produces no chunk, completion updates the same id and never reopens a row).

Results (Node 26.7.0, pnpm 12.3.4, `upstream/main` `9865df761`):

- `node scripts/run-vitest.mjs src/channels/streaming.lifecycle.test.ts`: 30 passed.
- `node scripts/run-vitest.mjs extensions/slack/src/progress-blocks.test.ts`: 48 passed.
- `node scripts/run-vitest.mjs src/channels`: 214 files, 2351 tests passed.
- `pnpm test:extension slack`: 156 files, 2922 tests passed (run with `HTTP_PROXY`/`HTTPS_PROXY` unset; with HTTP proxy environment variables exported, 5 unrelated loopback-server tests in `send.upload.test.ts` and `provider.transport-credentials.test.ts` fail on this machine before and after the change).
- Other channels that render the shared compositor lines, run the same way: `pnpm test:extension matrix` 70 files, 1381 tests passed; `pnpm test:extension telegram` 220 files, 4078 tests passed; `pnpm test:extension discord` 266 files, 3703 tests passed; `pnpm test:extension msteams` 1603 tests passed.
- `oxfmt --check` on the three changed files: clean. `oxlint` (repo `.oxlintrc.json`) on the three changed files: no findings.
- Re-run after rebasing onto `upstream/main` `d09401295` (2026-09-10): `src/channels/streaming.lifecycle.test.ts` 30 passed; `extensions/slack/src/progress-blocks.test.ts` 48 passed; `node scripts/run-vitest.mjs src/channels` 2373 tests passed; `pnpm test:extension slack` 156 files, 2922 tests passed. The rebase applied without conflicts; the only textual difference is a hunk header, since `main` moved the merge into `mergeProgressDraftLine` (#142802), which both `mergeChannelProgressDraftLine` and `mergeChannelProgressDraftLineForStreaming` now share.
- `pnpm check:changed --base upstream/main`: exit 0 with every lane run (conflict markers, ratchets, format changed files, plugin boundaries, wrapper shadowing, core tsgo graph boundary, typecheck core, typecheck core tests, typecheck extension tests, coercion helper declaration guard, deprecated API usage, dead export scan, lint core changed files, lint extension changed file, and the runtime guards). The lint lanes and the `scripts/run-oxlint.mjs` wrapper only complete from a checkout outside an ancestor `node_modules` install (this run used a detached worktree of the same commit under `/private/tmp`); in a checkout nested under `~/node_modules` the declaration-boundary preparation refuses to run and that one lane reports failed.

Not tested:

- The Mattermost plugin's test project as a whole (its runner exits silently for the whole project here; a single file runs); Mattermost feeds the same compositor through `pushCommandOutputEvent`.
- A live Slack run of this build; the reproduction drives the Slack plugin's chunk builder and reconciler with real builder output but does not call `chat.appendStream`.
- Channels other than Slack beyond their unit suites; they render the merged line text and do not key on the line id.
- A tool call whose start line has already left the rolling compositor window before its output arrives; that line is rebuilt with the output's own id, as before.

### Live rendering (2026-09-10, this fix applied on top of the reasoning-cards branch)

One exec call's events — `onToolStart(exec, command "run tests")`, item `tool:call-1`,
item `command:call-1`, `onCommandOutput(title "command run tests", exit 0)` — fed
through the real `dispatchPreparedSlackMessage` with a real `@slack/web-api` client
(`streaming.progress.commandText: "raw"`, native task cards), before and after this
change, same workspace and thread.

Before (`feat/slack-reasoning-cards` without this fix, `1789011841.664119`):
`chat.startStream` opens `tool_call_1_c8e12bee` ("Exec", details "run tests"); the next
append opens `command_call_1_1710f6c0` and completes `tool_call_1`; the command output
completes `command_call_1`. Slack renders two `Exec` rows.

After (`1789021925.291649`): every event lands on `tool_call_1_c8e12bee`; 1 start,
1 row append (`complete`), 1 answer append, 1 stop, all `ok`. Slack renders one `Exec`
row that moves from in progress to complete in place, plan title `Exec — run tests`.

### Screenshots

Captured from the Slack web client during the live runs above (a test workspace, cropped to one thread reply, plan block expanded). Full sets, with a manifest per run, are on the fork's [evidence branch](https://github.com/n1hility/openclaw/tree/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots).

Before (cards build without this fix): one exec call renders two `Exec` rows; the second also shows the appended detail addressed by the companion PR.

![Before (cards build without this fix): one exec call renders two `Exec` rows; the second also shows the appended detail addressed by the companion PR](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/first-run/sc3-unfixed.png)

After (this fix and the companion detail fix applied): one `Exec` row, completed in place.

![After (this fix and the companion detail fix applied): one `Exec` row, completed in place](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/first-run/sc3-fixed.png)

Final synthetic-driver run, same scenario: one card for one exec call.

![Final synthetic-driver run, same scenario: one card for one exec call](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/final2/r3-s3-one-exec-card.png)



## Review follow-up: quiet-mode recovery


**Finding.** With `progress.toolProgress: false` the compositor stores only attention lines and clears a stored failure when a later, non-attention event for the same line arrives. That clear went through `removeChannelProgressDraftLine(lines, line.id)`, which compares stored ids only. Once a line keeps the id it was created with, a failed exec call whose tool item (`tool:call-1`) reported first stays stored under `tool:call-1` while the successful command output arrives as `command:call-1`; the success never matched, so the failure stayed on the draft. The mirror order (failed output first under `command:call-1`, then a failed tool item, then a completed tool item under `tool:call-1`) misses the same way.

**Fix.** Quiet-mode removal now resolves the stored line the same way the merge path does: `removeChannelProgressDraftLineForStreaming` (in `src/channels/streaming.ts`, next to `mergeChannelProgressDraftLineForStreaming`) matches on the line's correlation key or id, and the compositor's quiet removal branch calls it instead of the id-only helper. Display ids are unchanged, the builders' per-line ids are unchanged, and nothing new is exported from the plugin SDK (`src/plugin-sdk/channel-outbound.ts` re-exports the same names as before).

**Failing before** (new tests in `src/channels/progress-draft-compositor.quiet.test.ts`, run against the previously reviewed head):

```
 ×  channels  src/channels/progress-draft-compositor.quiet.test.ts > … > clears a quiet failure whose stored id came from an earlier item family (tool item, then command output)
   → expected '🛠️ exit 1\n✅ Inspect\n▸ Repair' not to match /failed|exit 1/
 ×  channels  src/channels/progress-draft-compositor.quiet.test.ts > … > clears a quiet failure whose stored id came from an earlier item family (command output, then tool item)
   → expected '🛠️ Exec: failed\n✅ Inspect\n▸ Repair' not to match /failed|exit 1/

 Test Files  1 failed (1)
      Tests  2 failed | 19 passed (21)
```

The same two tests pass on `main` without this change (21 passed), so they are a regression test for the id change, not a pre-existing gap.

**Passing after** (`node scripts/run-vitest.mjs …`):

| Suite | Result |
|---|---|
| `src/channels/streaming.lifecycle.test.ts` | 31 passed (includes a new direct test: the id-only helper leaves the correlated line in place, the streaming helper removes it and leaves an unrelated call alone) |
| `src/channels/progress-draft-compositor.quiet.test.ts` | 21 passed (2 new) |
| `src/channels/progress-draft-lines.test.ts` | 3 passed |
| `extensions/slack/src/progress-blocks.test.ts` | 48 passed |
| `test:contracts:channels` (surface / config / registry / session) | 203 / 45 / 196 / 32 passed |

`oxfmt --check` and `oxlint --type-aware` (core tsconfig) on the changed files: clean. `git diff --check`: clean.

**Live Slack, quiet progress (real `dispatchPreparedSlackMessage`, real `@slack/web-api` stream).** Config `progress: { toolProgress: false, style: "card" }`; scripted events: failed exec tool item (`tool:call-1`), failed command output (`command:call-1`, exit 1), successful command output (`command:call-1`, exit 0), final reply. The captured stream calls, times relative to dispatch start:

| | Failure card opens | Exit 1 update | Card cleared |
|---|---|---|---|
| Before (fix removed) | `chat.startStream` 0.7 s, `Exec — failed`, `error` | `chat.appendStream` 2.8 s, `Exec — exit 1`, `error` | not until end of turn: 8.1 s, in the same `appendStream` that completes the summary task, immediately before the final reply |
| After | `chat.startStream` 0.6 s, `Exec — failed`, `error` | `chat.appendStream` 2.7 s, `Exec — exit 1`, `error` | 5.4 s, its own `appendStream` at the successful output: `Recovered: Exec — exit 1`, `complete` |

Both runs: one stream, every call `ok: true`, no dispatch error, one card for the call throughout (one attention task id). The end-of-turn read-back (`conversations.replies`) is identical for both builds, since the plugin's turn-end reconciliation completes every open task; the difference is that with the fix the recovery clears the card when the call succeeds rather than 2.7 s later when the reply lands.

**Not tested.** The live run used the explicit `style: "card"` surface; the default quiet surface for Slack (`style: "compact"`, an editable text draft replaced by a separately posted final message) was not driven live because the harness stubs that transport. The unit tests above cover the compositor's quiet removal for both event orders regardless of channel surface. No other channel was driven live.


## Compatibility

Keeping the first id for a correlated tool call changes which stored id a later event finds. Every consumer that addresses a stored progress line by id was audited on current main:

- `mergeChannelProgressDraftLine` / `mergeChannelProgressDraftLineForStreaming` are exported but have no callers outside `src/channels/progress-draft-compositor.ts` (four call sites, all merge paths that now share the preserved id).
- `removeChannelProgressDraftLine` is called from two places in the compositor: the quiet-mode recovery branch, and the internal `clearLine` helper.
- Quiet-mode recovery was the one consumer that removed by the incoming event's id. It now calls a new module-level helper, `removeChannelProgressDraftLineForStreaming`, that resolves the stored line through the same correlation identity the merge path uses, so a successful command output clears a failure that was stored under the tool item's id (regression tests added for both event orders).
- `clearLine` is used only for approval lines (`approval:<approvalId>`) and for commentary retraction (a commentary line id derived from the commentary item). Neither belongs to the `tool:` / `command:` families, so the preserved id cannot strand them.

No channel plugin removes or re-addresses progress lines by id; channels consume the compositor's rendered snapshot. The plugin-sdk surface is unchanged: the new helper lives beside the existing `ForStreaming` merge helper, which the SDK never re-exported, and the id-only `removeChannelProgressDraftLine` keeps its behavior for any external caller.

## Merge order

This PR and #143880 both edit the correlated-line merge path in `src/channels/streaming.ts` (and its lifecycle test) and conflict textually. Suggested order: this PR first; #143880 then rebases cleanly and I will push that rebase as soon as this lands. Either order works functionally, the tests in each PR are independent.
