### PR TITLE
fix(channels): Slack task cards repeat the command text when a command finishes

### DIFF
--- a/extensions/slack/src/progress-blocks.command-output.test.ts
+++ b/extensions/slack/src/progress-blocks.command-output.test.ts
@@ -1,0 +1,121 @@
+import {
+  buildChannelProgressDraftLine,
+  type ChannelProgressDraftLine,
+  mergeChannelProgressDraftLine,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackProgressStreamChunks,
+  EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
+  reconcileSlackNativeTaskChunks,
+} from "./progress-blocks.js";
+
+describe("native Slack progress command output details", () => {
+  it("does not append a restated command detail when the command output line arrives", () => {
+    // Slack appends task details; the output line's detail is the agent's item
+    // title ("command <meta>") for the command the row already shows.
+    const options = { commandText: "raw" as const };
+    const start = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      options,
+    );
+    const commandItem = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "command:call-1",
+        itemKind: "command",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        status: "running",
+        meta: "run tests",
+      },
+      options,
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command run tests",
+        exitCode: 0,
+      },
+      options,
+    );
+    if (!start || !commandItem || !output) {
+      throw new Error("expected exec progress lines");
+    }
+    let lines: ChannelProgressDraftLine[] = [];
+    let snapshot = EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT;
+    const emitted: unknown[][] = [];
+    for (const line of [start, commandItem, output]) {
+      lines = mergeChannelProgressDraftLine(lines, line, { maxLines: 8 });
+      const reconciled = reconcileSlackNativeTaskChunks({
+        previous: snapshot,
+        chunks: buildSlackProgressStreamChunks({ lines }),
+      });
+      snapshot = reconciled.snapshot;
+      emitted.push(reconciled.chunks ?? []);
+    }
+
+    expect(emitted[0]).toContainEqual(
+      expect.objectContaining({ type: "task_update", status: "in_progress", details: "run tests" }),
+    );
+    const finished = (emitted[2] ?? []).filter(
+      (chunk) => (chunk as { status?: string }).status === "complete",
+    );
+    expect(finished).toHaveLength(1);
+    expect(finished[0]).not.toHaveProperty("details");
+    const rows = [...snapshot.tasks.values()].filter((row) => row.details);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((row) => row.details?.rendered === "run tests")).toBe(true);
+  });
+
+  it("sends the command output detail when the row showed none", () => {
+    const start = buildChannelProgressDraftLine(
+      { event: "tool", toolCallId: "call-1", name: "exec", phase: "start" },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command pnpm test",
+        exitCode: 0,
+      },
+      { commandText: "raw" },
+    );
+    if (!start || !output) {
+      throw new Error("expected exec progress lines");
+    }
+    const first = reconcileSlackNativeTaskChunks({
+      previous: EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
+      chunks: buildSlackProgressStreamChunks({ lines: [start] }),
+    });
+    const lines = mergeChannelProgressDraftLine([start], output, { maxLines: 8 });
+    const finished = reconcileSlackNativeTaskChunks({
+      previous: first.snapshot,
+      chunks: buildSlackProgressStreamChunks({ lines }),
+    });
+
+    expect(first.chunks?.[1]).not.toHaveProperty("details");
+    expect(finished.chunks).toContainEqual(
+      expect.objectContaining({
+        type: "task_update",
+        status: "complete",
+        details: "command pnpm test",
+      }),
+    );
+  });
+});

--- a/extensions/slack/src/progress-blocks.command-output.test.ts
+++ b/extensions/slack/src/progress-blocks.command-output.test.ts
@@ -79,6 +79,60 @@ describe("native Slack progress command output details", () => {
     expect(rows.every((row) => row.details?.rendered === "run tests")).toBe(true);
   });
 
+  it.each([
+    { flags: ["pty"], exitCode: 0 },
+    { flags: ["elevated"], exitCode: 1 },
+    { flags: ["pty", "elevated"], exitCode: 0 },
+  ])("does not append flagged details for $flags on exit $exitCode", ({ flags, exitCode }) => {
+    const meta = ["run tests", ...flags].join(" · ");
+    const detail = [...flags, "run tests"].join(" · ");
+    // Item metadata includes the execution flags before completion arrives.
+    const start = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "tool:flagged",
+        toolCallId: "flagged",
+        itemKind: "tool",
+        name: "exec",
+        phase: "start",
+        status: "running",
+        meta,
+      },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:flagged",
+        toolCallId: "flagged",
+        name: "exec",
+        phase: "end",
+        title: "command " + meta,
+        exitCode,
+      },
+      { commandText: "raw" },
+    );
+    if (!start || !output) {
+      throw new Error("expected flagged command progress");
+    }
+    const first = reconcileSlackNativeTaskChunks({
+      previous: EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
+      chunks: buildSlackProgressStreamChunks({ lines: [start] }),
+    });
+    const finished = reconcileSlackNativeTaskChunks({
+      previous: first.snapshot,
+      chunks: buildSlackProgressStreamChunks({
+        lines: mergeChannelProgressDraftLine([start], output, { maxLines: 8 }),
+      }),
+    });
+    expect(finished.snapshot.tasks.size).toBe(1);
+    expect([...finished.snapshot.tasks.values()][0]?.details?.rendered).toBe(detail);
+    const update = finished.chunks?.find((chunk) => chunk.type === "task_update");
+    expect(update).toMatchObject({ status: exitCode === 0 ? "complete" : "error" });
+    expect(update).not.toHaveProperty("details");
+    expect(finished.chunks?.some((chunk) => chunk.type === "plan_update")).toBe(false);
+  });
+
   it("sends the command output detail when the row showed none", () => {
     const start = buildChannelProgressDraftLine(
       { event: "tool", toolCallId: "call-1", name: "exec", phase: "start" },

--- a/extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts
@@ -1,0 +1,363 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { Bot } from "grammy";
+import {
+  createPluginStateKeyedStoreForTests,
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { TelegramMessageContext } from "./bot-message-context.js";
+import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+import { setTelegramRuntime } from "./runtime.js";
+import {
+  clearTelegramRuntimeForTest,
+  resetTelegramReplyFenceForTest,
+} from "./runtime.test-support.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+type RecordedBotApiCall = { method: string; fields: Record<string, unknown> };
+type ReplyResolver = NonNullable<Parameters<typeof dispatchInboundMessage>[0]["replyResolver"]>;
+
+const BOT_TOKEN = "123456:telegram-progress-http-fixture";
+const CHAT_ID = 123;
+
+describe("Telegram progress command detail through the shared dispatcher and Telegram HTTP", () => {
+  let server: Server;
+  let apiRoot: string;
+  let nextMessageId = 0;
+  let inboundSequence = 0;
+  const sockets = new Set<Socket>();
+  const calls: RecordedBotApiCall[] = [];
+
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      let body = "";
+      request.on("data", (chunk: Buffer) => {
+        body += chunk.toString("utf8");
+      });
+      request.on("end", () => {
+        const fields = request.headers["content-type"]?.includes("application/json")
+          ? (JSON.parse(body) as Record<string, unknown>)
+          : Object.fromEntries(new URLSearchParams(body));
+        const method = request.url?.split("/").at(-1) ?? "";
+        calls.push({ method, fields });
+        response.setHeader("content-type", "application/json");
+        if (method === "sendMessage" || method === "editMessageText") {
+          const messageId =
+            typeof fields.message_id === "number" ? fields.message_id : ++nextMessageId;
+          response.end(
+            JSON.stringify({
+              ok: true,
+              result: {
+                message_id: messageId,
+                date: 1_700_000_000,
+                chat: { id: CHAT_ID, type: "private" },
+                text: typeof fields.text === "string" ? fields.text : "",
+              },
+            }),
+          );
+          return;
+        }
+        response.end(JSON.stringify({ ok: true, result: true }));
+      });
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+    nextMessageId = 0;
+    resetPluginStateStoreForTests({ closeDatabase: false });
+    resetTelegramReplyFenceForTest();
+    setTelegramRuntime({
+      state: {
+        openKeyedStore: ((options) =>
+          createPluginStateKeyedStoreForTests(
+            "telegram",
+            options,
+          )) as TelegramRuntime["state"]["openKeyedStore"],
+        openSyncKeyedStore: ((options) =>
+          createPluginStateSyncKeyedStoreForTests(
+            "telegram",
+            options,
+          )) as TelegramRuntime["state"]["openSyncKeyedStore"],
+      },
+      channel: {},
+    } as TelegramRuntime);
+  });
+
+  async function waitForBotApiCall(predicate: (call: RecordedBotApiCall) => boolean) {
+    const deadline = Date.now() + 5_000;
+    while (!calls.some(predicate)) {
+      if (Date.now() > deadline) {
+        throw new Error("timed out waiting for a Bot API call");
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 25);
+      });
+    }
+  }
+
+  afterAll(async () => {
+    clearTelegramRuntimeForTest();
+    resetPluginStateStoreForTests();
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  function createContext(): TelegramMessageContext {
+    const text = "Run the failing command.";
+    // Each turn is a new inbound message; a repeated id is dropped as a duplicate.
+    const inboundMessageId = 456 + inboundSequence++;
+    const base = {
+      ctxPayload: {
+        Body: text,
+        BodyForAgent: text,
+        RawBody: text,
+        CommandBody: text,
+        ChatType: "direct",
+        From: String(CHAT_ID),
+        To: String(CHAT_ID),
+        MessageSid: String(inboundMessageId),
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: `agent:default:telegram:direct:${CHAT_ID}`,
+        Timestamp: 1_700_000_000_000,
+      },
+      primaryCtx: { message: { chat: { id: CHAT_ID, type: "private" } } },
+      msg: { chat: { id: CHAT_ID, type: "private" }, message_id: inboundMessageId },
+      chatId: CHAT_ID,
+      isGroup: false,
+      isForum: false,
+      groupConfig: undefined,
+      resolvedThreadId: undefined,
+      replyThreadId: undefined,
+      threadSpec: { id: undefined, scope: "none" },
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: {
+        agentId: "default",
+        accountId: "default",
+        sessionKey: `agent:default:telegram:direct:${CHAT_ID}`,
+      },
+      skillFilter: undefined,
+      sendTyping: async () => undefined,
+      sendRecordVoice: async () => undefined,
+      sendChatActionHandler: { sendChatAction: async () => undefined },
+      ackReactionPromise: null,
+      reactionApi: null,
+      statusReactionController: null,
+      accountId: "default",
+      turn: {
+        storePath: "/tmp/openclaw/telegram-progress-http-sessions.json",
+        recordInboundSession: async () => undefined,
+        record: { onRecordError: () => undefined },
+      },
+    };
+    return base as unknown as TelegramMessageContext;
+  }
+
+  type ReplyResolverOptions = Parameters<ReplyResolver>[1];
+
+  async function dispatchProgressTurn(
+    emitEvents: (options: ReplyResolverOptions) => Promise<void>,
+  ) {
+    const replyResolver: ReplyResolver = async (_ctx, options) => {
+      await options?.onReplyStart?.();
+      await options?.onAssistantMessageStart?.();
+      await emitEvents(options);
+      // The final answer follows the finished progress edit, as a model that
+      // answers after reading the command output does. Earlier edits may flush
+      // first (attention statuses bypass the edit throttle).
+      await waitForBotApiCall(
+        (call) => call.method === "editMessageText" && String(call.fields.text).includes("exit 2"),
+      );
+      return { text: "The command failed." };
+    };
+    const telegramCfg = {
+      botToken: BOT_TOKEN,
+      apiRoot,
+      streaming: { mode: "progress", progress: { toolProgress: true, commandText: "raw" } },
+    } as const;
+    const cfg = { channels: { telegram: telegramCfg } };
+    const errors: string[] = [];
+
+    const result = await dispatchTelegramMessage({
+      context: createContext(),
+      bot: new Bot(BOT_TOKEN, { client: { apiRoot } }),
+      cfg,
+      runtime: {
+        log: () => undefined,
+        error: (...args: unknown[]) => {
+          errors.push(args.map(String).join(" "));
+        },
+        exit: () => {
+          throw new Error("exit");
+        },
+      },
+      replyToMode: "off",
+      streamMode: "progress",
+      textLimit: 4096,
+      telegramCfg,
+      opts: {
+        token: BOT_TOKEN,
+        dispatchReplyFromConfig: async (params) =>
+          await dispatchInboundMessage({
+            ctx: params.ctx,
+            cfg: params.cfg,
+            dispatcher: params.dispatcher,
+            replyOptions: params.replyOptions,
+            onSessionMetadataChanges: params.onSessionMetadataChanges,
+            replyResolver,
+          }),
+      },
+    });
+
+    expect(errors).toEqual([]);
+    expect(result).toEqual({ kind: "completed" });
+    return calls
+      .filter((call) => call.method === "sendMessage" || call.method === "editMessageText")
+      .map((call) => [call.method, call.fields.message_id ?? null, call.fields.text] as const);
+  }
+
+  it("keeps the raw command text on the finished progress line instead of the output title", async () => {
+    // Same event sequence as the dispatch unit fixture: the exec tool starts with
+    // command "false", then its output event restates the command as its item
+    // title ("command false") and reports a nonzero exit.
+    const revisions = await dispatchProgressTurn(async (options) => {
+      await options?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        toolCallId: "exec-1",
+        args: { command: "false" },
+      });
+      await options?.onCommandOutput?.({
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        exitCode: 2,
+      });
+    });
+
+    // One progress message: sent with the running command line, edited in place
+    // with the finished line, then the final answer arrives as its own message.
+    expect(revisions).toEqual([
+      ["sendMessage", null, "<b>Working</b>\n<b>🛠️ Exec</b> false"],
+      ["editMessageText", 1, "<b>Working</b>\n<b>🛠️ Exec</b> false <i>exit 2</i>"],
+      ["sendMessage", null, "The command failed."],
+    ]);
+    for (const call of calls) {
+      expect(call.fields.text ?? "").not.toContain("command false");
+    }
+  });
+
+  it("keeps the command text through the embedded producer's terminal command item", async () => {
+    // The embedded exec producer's event order for one failing command: the
+    // tool start, the tool and command items opening, a status-only output
+    // projected from the tool result, the tool and command items ending with a
+    // terminal status, then the command_output event titled "command false".
+    const revisions = await dispatchProgressTurn(async (options) => {
+      await options?.onToolStart?.({
+        itemId: "tool:exec-1",
+        name: "exec",
+        phase: "start",
+        toolCallId: "exec-1",
+        args: { command: "false" },
+      });
+      await options?.onItemEvent?.({
+        itemId: "tool:exec-1",
+        kind: "tool",
+        title: "exec false",
+        phase: "start",
+        status: "running",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        commandBearing: true,
+      });
+      await options?.onItemEvent?.({
+        itemId: "command:exec-1",
+        kind: "command",
+        title: "command false",
+        phase: "start",
+        status: "running",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+      });
+      await options?.onCommandOutput?.({
+        phase: "end",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        status: "failed",
+        exitCode: 2,
+      });
+      await options?.onItemEvent?.({
+        itemId: "tool:exec-1",
+        kind: "tool",
+        title: "exec false",
+        phase: "end",
+        status: "failed",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        commandBearing: true,
+      });
+      await options?.onItemEvent?.({
+        itemId: "command:exec-1",
+        kind: "command",
+        title: "command false",
+        phase: "end",
+        status: "failed",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        summary: "No such file or directory",
+      });
+      await options?.onCommandOutput?.({
+        itemId: "command:exec-1",
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        status: "failed",
+        exitCode: 2,
+      });
+    });
+
+    // Intermediate item revisions may coalesce under the edit throttle, so the
+    // sequence is checked by shape: the progress message opens with the running
+    // command line, every edit targets that message and keeps the command text,
+    // the last edit carries the exit status, and the final answer is separate.
+    expect(revisions[0]).toEqual(["sendMessage", null, "<b>Working</b>\n<b>🛠️ Exec</b> false"]);
+    expect(revisions.at(-1)).toEqual(["sendMessage", null, "The command failed."]);
+    const edits = revisions.filter(([method]) => method === "editMessageText");
+    expect(edits.length).toBeGreaterThan(0);
+    for (const [, messageId, text] of edits) {
+      expect(messageId).toBe(1);
+      expect(text).toContain("<b>🛠️ Exec</b> false");
+    }
+    expect(edits.at(-1)?.[2]).toBe("<b>Working</b>\n<b>🛠️ Exec</b> false <i>exit 2</i>");
+    for (const call of calls) {
+      expect(call.fields.text ?? "").not.toContain("command false");
+    }
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -558,10 +558,115 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
       },
     });
 
+    // The finished line keeps the command text shown at start; the output
+    // event's item title ("command false") does not relabel it.
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
       telegramProgressPreview(
-        "Shelling\n\n🛠️ exit 2; command false",
-        "<b>Shelling</b>\n<b>🛠️ Exec</b> command false <i>exit 2</i>",
+        "Shelling\n\n🛠️ exit 2; false",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b> false <i>exit 2</i>",
+      ),
+    );
+  });
+
+  it("keeps the command text through the embedded producer's terminal command item", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      // The embedded exec producer's event order for one failing command.
+      await replyOptions?.onToolStart?.({
+        itemId: "tool:exec-1",
+        name: "exec",
+        phase: "start",
+        toolCallId: "exec-1",
+        args: { command: "false" },
+      });
+      await replyOptions?.onItemEvent?.({
+        itemId: "tool:exec-1",
+        kind: "tool",
+        title: "exec false",
+        phase: "start",
+        status: "running",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        commandBearing: true,
+      });
+      await replyOptions?.onItemEvent?.({
+        itemId: "command:exec-1",
+        kind: "command",
+        title: "command false",
+        phase: "start",
+        status: "running",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+      });
+      await replyOptions?.onCommandOutput?.({
+        phase: "end",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        status: "failed",
+        exitCode: 2,
+      });
+      await replyOptions?.onItemEvent?.({
+        itemId: "tool:exec-1",
+        kind: "tool",
+        title: "exec false",
+        phase: "end",
+        status: "failed",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        commandBearing: true,
+      });
+      await replyOptions?.onItemEvent?.({
+        itemId: "command:exec-1",
+        kind: "command",
+        title: "command false",
+        phase: "end",
+        status: "failed",
+        name: "exec",
+        meta: "false",
+        toolCallId: "exec-1",
+        summary: "No such file or directory",
+      });
+      await replyOptions?.onCommandOutput?.({
+        itemId: "command:exec-1",
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        status: "failed",
+        exitCode: 2,
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { toolProgress: true, label: "Shelling", commandText: "raw" },
+        },
+      },
+    });
+
+    const previews = draftStream.updatePreview.mock.calls.map((call) => call[0]?.text ?? "");
+    expect(previews.length).toBeGreaterThan(0);
+    for (const preview of previews) {
+      expect(preview).toContain("<b>🛠️ Exec</b> false");
+      expect(preview).not.toContain("command false");
+    }
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ exit 2; false",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b> false <i>exit 2</i>",
       ),
     );
   });

--- a/src/channels/streaming.command-item.test.ts
+++ b/src/channels/streaming.command-item.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChannelProgressDraftLine,
+  formatChannelProgressDraftText,
+  mergeChannelProgressDraftLine,
+  type ChannelProgressDraftLine,
+} from "./streaming.js";
+
+// The embedded exec producer describes one command through several events
+// that all correlate to command:<toolCallId>: the tool start (with args), the
+// tool and command items opening as running, a status-only command output
+// projected from the tool result, the tool and command items ending with a
+// terminal status (the command item carries the output as its summary), and
+// finally the command_output event whose title is the item title
+// ("command <meta>"). The line the reader watches must keep the command text
+// through every step.
+function buildEmbeddedExecSequence(params: {
+  status: "failed" | "completed";
+  exitCode: number;
+}): Array<{ step: string; line: ChannelProgressDraftLine }> {
+  const options = { commandText: "raw" as const };
+  const build = (
+    step: string,
+    input: Parameters<typeof buildChannelProgressDraftLine>[0],
+  ): { step: string; line: ChannelProgressDraftLine } => {
+    const line = buildChannelProgressDraftLine(input, options);
+    if (!line) {
+      throw new Error(`expected a progress line for ${step}`);
+    }
+    return { step, line };
+  };
+  const common = { toolCallId: "call-1", name: "exec" };
+  return [
+    build("tool start", {
+      event: "tool",
+      ...common,
+      itemId: "tool:call-1",
+      phase: "start",
+      args: { command: "pnpm test" },
+    }),
+    build("tool item start", {
+      event: "item",
+      ...common,
+      itemId: "tool:call-1",
+      itemKind: "tool",
+      title: "exec run tests",
+      phase: "start",
+      status: "running",
+      meta: "run tests",
+      commandBearing: true,
+    }),
+    build("command item start", {
+      event: "item",
+      ...common,
+      itemId: "command:call-1",
+      itemKind: "command",
+      title: "command run tests",
+      phase: "start",
+      status: "running",
+      meta: "run tests",
+    }),
+    build("tool result output", {
+      event: "command-output",
+      ...common,
+      phase: "end",
+      status: params.status,
+      exitCode: params.exitCode,
+    }),
+    build("tool item end", {
+      event: "item",
+      ...common,
+      itemId: "tool:call-1",
+      itemKind: "tool",
+      title: "exec run tests",
+      phase: "end",
+      status: params.status,
+      meta: "run tests",
+      commandBearing: true,
+    }),
+    build("command item end", {
+      event: "item",
+      ...common,
+      itemId: "command:call-1",
+      itemKind: "command",
+      title: "command run tests",
+      phase: "end",
+      status: params.status,
+      meta: "run tests",
+      summary: "3 tests failed",
+    }),
+    build("command output", {
+      event: "command-output",
+      ...common,
+      itemId: "command:call-1",
+      phase: "end",
+      title: "command run tests",
+      status: params.status,
+      exitCode: params.exitCode,
+    }),
+  ];
+}
+
+describe("channel-streaming embedded command items", () => {
+  it.each([
+    { status: "failed" as const, exitCode: 1, finalStatus: "exit 1", text: "🛠️ exit 1; run tests" },
+    { status: "completed" as const, exitCode: 0, finalStatus: "completed", text: "🛠️ run tests" },
+  ])(
+    "keeps the shown command detail through the terminal command item ($status)",
+    ({ status, exitCode, finalStatus, text }) => {
+      let lines: ChannelProgressDraftLine[] = [];
+      for (const { step, line } of buildEmbeddedExecSequence({ status, exitCode })) {
+        lines = mergeChannelProgressDraftLine(lines, line, { maxLines: 4 });
+        expect(lines, step).toHaveLength(1);
+        expect(lines[0]?.detail, step).toBe("run tests");
+      }
+
+      expect(lines[0]).toMatchObject({
+        kind: "command-output",
+        detail: "run tests",
+        status: finalStatus,
+        text,
+      });
+      expect(
+        formatChannelProgressDraftText({
+          lines,
+          entry: { streaming: { progress: { label: false } } },
+        }),
+      ).toBe(text);
+    },
+  );
+
+  it("still replaces an ended line whole when the output names no command", () => {
+    // A recovered run reports its outcome without a title; the stale failure
+    // text of the ended line must not survive as the recovered line's detail.
+    const endedLine = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "command:call-2",
+        toolCallId: "call-2",
+        itemKind: "command",
+        name: "exec",
+        phase: "end",
+        status: "failed",
+        progressText: "install dependencies failed",
+      },
+      { commandText: "raw" },
+    );
+    const recoveredOutput = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-2",
+        toolCallId: "call-2",
+        name: "exec",
+        phase: "end",
+        exitCode: 0,
+      },
+      { commandText: "raw" },
+    );
+    if (!endedLine || !recoveredOutput) {
+      throw new Error("expected recovered command progress lines");
+    }
+    expect(endedLine.detail).toBe("install dependencies failed");
+
+    const merged = mergeChannelProgressDraftLine([endedLine], recoveredOutput, { maxLines: 4 });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ kind: "command-output", status: "completed" });
+    expect(merged[0]).not.toHaveProperty("detail");
+  });
+});

--- a/src/channels/streaming.command-item.test.ts
+++ b/src/channels/streaming.command-item.test.ts
@@ -129,6 +129,99 @@ describe("channel-streaming embedded command items", () => {
     },
   );
 
+  describe.each([false, true])("flagged command descriptions (markdown=%s)", (markdown) => {
+    it.each([
+      { flags: ["pty"], exitCode: 0 },
+      { flags: ["elevated"], exitCode: 1 },
+      { flags: ["pty", "elevated"], exitCode: 0 },
+      { flags: ["pty", "elevated"], exitCode: 1 },
+    ])("keeps $flags through terminal items and exit $exitCode", ({ flags, exitCode }) => {
+      const meta = ["run tests", ...flags].join(" · ");
+      const detail = [...flags, markdown ? "`run tests`" : "run tests"].join(" · ");
+      const options = { commandText: "raw" as const, markdown };
+      const common = { toolCallId: "flagged-call", name: "exec" };
+      const inputs: Parameters<typeof buildChannelProgressDraftLine>[0][] = [
+        {
+          event: "item",
+          ...common,
+          itemId: "tool:flagged-call",
+          itemKind: "tool",
+          phase: "start",
+          status: "running",
+          meta,
+        },
+        {
+          event: "item",
+          ...common,
+          itemId: "command:flagged-call",
+          itemKind: "command",
+          phase: "end",
+          status: exitCode === 0 ? "completed" : "failed",
+          meta,
+        },
+        {
+          event: "command-output",
+          ...common,
+          itemId: "command:flagged-call",
+          phase: "end",
+          title: "command " + meta,
+          exitCode,
+        },
+      ];
+      let lines: ChannelProgressDraftLine[] = [];
+      for (const input of inputs) {
+        const line = buildChannelProgressDraftLine(input, options);
+        if (!line) {
+          throw new Error("expected flagged command progress");
+        }
+        lines = mergeChannelProgressDraftLine(lines, line, { maxLines: 4 });
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatchObject({ id: "tool:flagged-call", detail });
+      }
+      expect(lines[0]).toMatchObject({
+        kind: "command-output",
+        status: exitCode === 0 ? "completed" : "exit 1",
+        text: "🛠️ " + (exitCode === 0 ? "" : "exit 1; ") + detail,
+      });
+    });
+  });
+
+  it("keeps a flagged output title when it describes different work", () => {
+    const previous = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "command:other",
+        toolCallId: "other",
+        itemKind: "command",
+        name: "exec",
+        status: "running",
+        meta: "inspect files · pty",
+      },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:other",
+        toolCallId: "other",
+        name: "exec",
+        phase: "end",
+        title: "command run tests · pty",
+        exitCode: 0,
+      },
+      { commandText: "raw" },
+    );
+    if (!previous || !output) {
+      throw new Error("expected command progress");
+    }
+    expect(mergeChannelProgressDraftLine([previous], output, { maxLines: 4 })[0]?.detail).toBe(
+      "pty · command run tests",
+    );
+    expect(mergeChannelProgressDraftLine([], output, { maxLines: 4 })[0]?.detail).toBe(
+      "pty · command run tests",
+    );
+  });
+
   it("still replaces an ended line whole when the output names no command", () => {
     // A recovered run reports its outcome without a title; the stale failure
     // text of the ended line must not survive as the recovered line's detail.

--- a/src/channels/streaming.lifecycle.test.ts
+++ b/src/channels/streaming.lifecycle.test.ts
@@ -712,48 +712,6 @@ describe("channel-streaming", () => {
     expect(again[0]?.id).toBe("tool:call-1");
   });
 
-  it("removes a correlated line whose id came from an earlier item family", () => {
-    const toolLine = buildChannelProgressDraftLine({
-      event: "item",
-      itemId: "tool:call-1",
-      toolCallId: "call-1",
-      name: "exec",
-      status: "failed",
-    });
-    const failedOutput = buildChannelProgressDraftLine({
-      event: "command-output",
-      itemId: "command:call-1",
-      toolCallId: "call-1",
-      phase: "end",
-      exitCode: 1,
-    });
-    const recoveredOutput = buildChannelProgressDraftLine({
-      event: "command-output",
-      itemId: "command:call-1",
-      toolCallId: "call-1",
-      phase: "end",
-      exitCode: 0,
-    });
-    const unrelatedOutput = buildChannelProgressDraftLine({
-      event: "command-output",
-      itemId: "command:call-2",
-      toolCallId: "call-2",
-      phase: "end",
-      exitCode: 0,
-    });
-    if (!toolLine || !failedOutput || !recoveredOutput || !unrelatedOutput) {
-      throw new Error("expected exec progress lines");
-    }
-    const failed = mergeChannelProgressDraftLine([toolLine], failedOutput, { maxLines: 4 });
-    expect(failed).toHaveLength(1);
-    expect(failed[0]?.id).toBe("tool:call-1");
-
-    // The stored id is tool:call-1; the recovery arrives as command:call-1.
-    expect(removeChannelProgressDraftLine(failed, recoveredOutput.id ?? "")).toBe(failed);
-    expect(removeChannelProgressDraftLineForStreaming(failed, unrelatedOutput)).toBe(failed);
-    expect(removeChannelProgressDraftLineForStreaming(failed, recoveredOutput)).toEqual([]);
-  });
-
   it("keeps the shown command detail when command output restates the command", () => {
     // The output event's title is the agent's item title ("command <meta>"),
     // a second description of the command the tool line already shows.

--- a/src/channels/streaming.lifecycle.test.ts
+++ b/src/channels/streaming.lifecycle.test.ts
@@ -712,6 +712,240 @@ describe("channel-streaming", () => {
     expect(again[0]?.id).toBe("tool:call-1");
   });
 
+  it("removes a correlated line whose id came from an earlier item family", () => {
+    const toolLine = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "tool:call-1",
+      toolCallId: "call-1",
+      name: "exec",
+      status: "failed",
+    });
+    const failedOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-1",
+      toolCallId: "call-1",
+      phase: "end",
+      exitCode: 1,
+    });
+    const recoveredOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-1",
+      toolCallId: "call-1",
+      phase: "end",
+      exitCode: 0,
+    });
+    const unrelatedOutput = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command:call-2",
+      toolCallId: "call-2",
+      phase: "end",
+      exitCode: 0,
+    });
+    if (!toolLine || !failedOutput || !recoveredOutput || !unrelatedOutput) {
+      throw new Error("expected exec progress lines");
+    }
+    const failed = mergeChannelProgressDraftLine([toolLine], failedOutput, { maxLines: 4 });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.id).toBe("tool:call-1");
+
+    // The stored id is tool:call-1; the recovery arrives as command:call-1.
+    expect(removeChannelProgressDraftLine(failed, recoveredOutput.id ?? "")).toBe(failed);
+    expect(removeChannelProgressDraftLineForStreaming(failed, unrelatedOutput)).toBe(failed);
+    expect(removeChannelProgressDraftLineForStreaming(failed, recoveredOutput)).toEqual([]);
+  });
+
+  it("keeps the shown command detail when command output restates the command", () => {
+    // The output event's title is the agent's item title ("command <meta>"),
+    // a second description of the command the tool line already shows.
+    const toolLine = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      { commandText: "raw" },
+    );
+    const failedOutput = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command run tests",
+        exitCode: 1,
+      },
+      { commandText: "raw" },
+    );
+    const completedOutput = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command run tests",
+        exitCode: 0,
+      },
+      { commandText: "raw" },
+    );
+    if (!toolLine || !failedOutput || !completedOutput) {
+      throw new Error("expected exec progress lines");
+    }
+    expect(toolLine.detail).toBe("run tests");
+    expect(failedOutput.detail).toBe("command run tests");
+
+    const failed = mergeChannelProgressDraftLine([toolLine], failedOutput, { maxLines: 4 });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      kind: "command-output",
+      detail: "run tests",
+      status: "exit 1",
+      text: "🛠️ exit 1; run tests",
+    });
+
+    const completed = mergeChannelProgressDraftLine([toolLine], completedOutput, { maxLines: 4 });
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({
+      kind: "command-output",
+      detail: "run tests",
+      status: "completed",
+      text: "🛠️ run tests",
+    });
+
+    const capitalizedOutput = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "Command  run tests",
+        exitCode: 1,
+      },
+      { commandText: "raw" },
+    );
+    if (!capitalizedOutput) {
+      throw new Error("expected exec progress line");
+    }
+    const capitalized = mergeChannelProgressDraftLine([toolLine], capitalizedOutput, {
+      maxLines: 4,
+    });
+    expect(capitalized[0]).toMatchObject({ detail: "run tests", text: "🛠️ exit 1; run tests" });
+  });
+
+  it("keeps the line's detail when command output repeats it exactly", () => {
+    const toolLine = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "run tests",
+        exitCode: 1,
+      },
+      { commandText: "raw" },
+    );
+    if (!toolLine || !output) {
+      throw new Error("expected exec progress lines");
+    }
+    expect(toolLine.detail).toBe("run tests");
+    expect(output.detail).toBe("run tests");
+
+    const merged = mergeChannelProgressDraftLine([toolLine], output, { maxLines: 4 });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual({ ...output, id: expect.any(String) });
+    expect(merged[0]).toMatchObject({
+      kind: "command-output",
+      detail: "run tests",
+      status: "exit 1",
+      text: "🛠️ exit 1; run tests",
+    });
+  });
+
+  it("replaces the shown detail when command output carries a different one", () => {
+    // Only a restatement of the shown command is dropped; a command-output
+    // line that carries its own text (output, a different description) must
+    // not lose it to the earlier detail.
+    const toolLine = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "3 tests failed",
+        exitCode: 1,
+      },
+      { commandText: "raw" },
+    );
+    if (!toolLine || !output) {
+      throw new Error("expected exec progress lines");
+    }
+    expect(toolLine.detail).toBe("run tests");
+    expect(output.detail).toBe("3 tests failed");
+
+    const merged = mergeChannelProgressDraftLine([toolLine], output, { maxLines: 4 });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      kind: "command-output",
+      detail: "3 tests failed",
+      status: "exit 1",
+      text: "🛠️ exit 1; 3 tests failed",
+    });
+  });
+
+  it("keeps the command output's own detail when the line showed none", () => {
+    const toolLine = buildChannelProgressDraftLine(
+      { event: "tool", toolCallId: "call-1", name: "exec", phase: "start" },
+      { commandText: "raw" },
+    );
+    const output = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        itemId: "command:call-1",
+        toolCallId: "call-1",
+        name: "exec",
+        phase: "end",
+        title: "command pnpm test",
+        exitCode: 2,
+      },
+      { commandText: "raw" },
+    );
+    if (!toolLine || !output) {
+      throw new Error("expected exec progress lines");
+    }
+    expect(toolLine.detail).toBeUndefined();
+
+    const merged = mergeChannelProgressDraftLine([toolLine], output, { maxLines: 4 });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual({ ...output, id: expect.any(String) });
+    expect(merged[0]).toMatchObject({ detail: "command pnpm test", status: "exit 2" });
+  });
+
   it("starts progress drafts after the initial delay", async () => {
     vi.useFakeTimers();
     const onStart = vi.fn(async () => {});

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -328,7 +328,14 @@ export function isChannelProgressPriorityLine(line: string | ChannelProgressDraf
   );
 }
 
-const progressDraftLineCorrelationKeys = new WeakMap<ChannelProgressDraftLine, string>();
+type ProgressDraftLineMetadata = {
+  correlationKey?: string;
+  commandDetailCandidate?: string;
+};
+const progressDraftLineMetadata = new WeakMap<
+  ChannelProgressDraftLine,
+  ProgressDraftLineMetadata
+>();
 
 function compactStrings(values: readonly (string | undefined | null)[]): string[] {
   return values.map((value) => value?.replace(/\s+/g, " ").trim()).filter(Boolean) as string[];
@@ -352,6 +359,7 @@ function buildNamedProgressLine(
   options?: ChannelProgressLineOptions,
   fields?: {
     correlationKey?: string;
+    commandDetailCandidate?: string;
     id?: string;
     status?: string;
   },
@@ -376,18 +384,34 @@ function buildNamedProgressLine(
     ...(fields?.status ? { status: fields.status } : {}),
     toolName: display.name,
   };
-  setProgressDraftLineCorrelationKey(line, fields?.correlationKey);
+  setProgressDraftLineMetadata(line, fields?.correlationKey, fields?.commandDetailCandidate);
   return line;
 }
 
-function setProgressDraftLineCorrelationKey(
+function setProgressDraftLineMetadata(
   line: ChannelProgressDraftLine,
   correlationKey: string | undefined,
+  commandDetailCandidate?: string,
 ): void {
   const normalized = correlationKey?.trim();
-  if (normalized) {
-    progressDraftLineCorrelationKeys.set(line, normalized);
+  if (normalized || commandDetailCandidate) {
+    progressDraftLineMetadata.set(line, { correlationKey: normalized, commandDetailCandidate });
   }
+}
+
+function copyProgressDraftLineMetadata(
+  source: ChannelProgressDraftLine,
+  target: ChannelProgressDraftLine,
+  previous?: ChannelProgressDraftLine,
+): void {
+  const metadata = progressDraftLineMetadata.get(source);
+  // Only correlation may fall back: the candidate belongs to the incoming output.
+  setProgressDraftLineMetadata(
+    target,
+    metadata?.correlationKey ??
+      (previous && progressDraftLineMetadata.get(previous)?.correlationKey),
+    metadata?.commandDetailCandidate,
+  );
 }
 
 function itemKindToToolName(kind: string | undefined): string | undefined {
@@ -472,8 +496,15 @@ function buildCommandOutputProgressLine(
   const name = input.name ?? "exec";
   const correlationKey = resolveCommandProgressCorrelationKey(input);
   const detail = options?.commandText === "raw" ? compactStrings([input.title]) : [];
+  // Compare a possible restatement before the formatter moves flags or adds Markdown.
+  // Keep the actual title intact unless it matches an already displayed command.
+  const commandMeta = detail[0]?.match(/^command\s+(.+)$/i)?.[1];
+  const commandDetailCandidate = commandMeta
+    ? formatToolAggregateParts(name, [commandMeta], { markdown: options?.markdown }).detail
+    : undefined;
   const line = buildNamedProgressLine(input.event, name, detail, options, {
     correlationKey,
+    commandDetailCandidate,
     id: resolveProgressDraftLineId(input, { useToolCallIdFallback: true }),
     status,
   });
@@ -489,14 +520,14 @@ function buildCommandOutputProgressLine(
       detail: status,
       text: formatToolAggregate(name, [status], { markdown: options?.markdown }),
     };
-    setProgressDraftLineCorrelationKey(statusLine, correlationKey);
+    copyProgressDraftLineMetadata(line, statusLine);
     return statusLine;
   }
   const statusLine = {
     ...line,
     text: formatToolAggregate(name, [status, line.detail], { markdown: options?.markdown }),
   };
-  setProgressDraftLineCorrelationKey(statusLine, correlationKey);
+  copyProgressDraftLineMetadata(line, statusLine);
   return statusLine;
 }
 
@@ -623,7 +654,7 @@ export function buildChannelProgressDraftLine(
         label: input.title?.trim() || input.itemKind?.trim() || "Update",
         ...(input.status ? { status: input.status } : {}),
       };
-      setProgressDraftLineCorrelationKey(line, correlationKey);
+      setProgressDraftLineMetadata(line, correlationKey);
       return line;
     }
     case "plan": {
@@ -1290,22 +1321,8 @@ function limitProgressDraftLines<TLine extends string | ChannelProgressDraftLine
     .toReversed();
 }
 
-/**
- * Command output reports the outcome of the command the line already shows.
- * With command text on, its own detail is the agent's item title ("command
- * <meta>"), a restatement of the detail the tool line carries, so the detail
- * the reader has been watching stays and the status carries the result. The
- * shown detail is kept only when the incoming detail is such a restatement:
- * empty, the line's own status, the shown detail itself, or the shown detail
- * behind a "command" prefix (whitespace collapsed, prefix case-insensitive).
- * Any other incoming detail replaces the shown one, so a command-output line
- * that ever carries real output or a different description is not discarded
- * here. A line that already ended (a failed nested command) is replaced whole
- * when the output names no command, so a recovered run does not keep the
- * stale failure text; the embedded producer ends the command item before its
- * output arrives, and that output names the shown command, so the shown
- * detail stays through the terminal item.
- */
+// Preserve a matching command description, including after its terminal item.
+// Titleless recovery must still replace terminal failure text rather than retain it.
 function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraftLine>(
   previous: TLine,
   line: TLine,
@@ -1317,15 +1334,17 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
     return line;
   }
   const previousDetail = previous.detail?.trim();
+  const incomingDetail = line.detail?.trim();
   if (
     !previousDetail ||
     previousDetail === previous.status ||
-    line.detail?.trim() === previousDetail ||
-    !isRestatedCommandDetail(line.detail, previousDetail, line.status)
+    incomingDetail === previousDetail ||
+    (incomingDetail &&
+      incomingDetail !== line.status &&
+      progressDraftLineMetadata.get(line)?.commandDetailCandidate !== previousDetail)
   ) {
     return line;
   }
-  const incomingDetail = line.detail?.trim();
   if (
     isTerminalProgressStatus(previous.status) &&
     (!incomingDetail || incomingDetail === line.status)
@@ -1337,33 +1356,8 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
     detail: previousDetail,
   };
   replacement.text = getProgressDraftLineText(replacement);
-  setProgressDraftLineCorrelationKey(
-    replacement,
-    progressDraftLineCorrelationKeys.get(line) ?? progressDraftLineCorrelationKeys.get(previous),
-  );
+  copyProgressDraftLineMetadata(line, replacement, previous);
   return replacement;
-}
-
-/**
- * True when a command-output line's detail only restates the detail the line
- * already shows: it is empty, it is the line's own status, or after collapsing
- * whitespace it equals the shown detail with or without a leading "command".
- */
-function isRestatedCommandDetail(
-  detail: string | undefined,
-  shownDetail: string,
-  status: string,
-): boolean {
-  const incoming = detail?.replace(/\s+/g, " ").trim();
-  if (!incoming || incoming === status) {
-    return true;
-  }
-  const shown = shownDetail.replace(/\s+/g, " ").trim();
-  if (incoming === shown) {
-    return true;
-  }
-  const prefix = incoming.slice(0, "command ".length);
-  return prefix.toLowerCase() === "command " && incoming.slice(prefix.length) === shown;
 }
 
 /**
@@ -1385,11 +1379,7 @@ function keepProgressDraftLineId<TLine extends string | ChannelProgressDraftLine
     return replacement;
   }
   const kept = { ...replacement, id: previousId };
-  setProgressDraftLineCorrelationKey(
-    kept,
-    progressDraftLineCorrelationKeys.get(replacement) ??
-      progressDraftLineCorrelationKeys.get(previous),
-  );
+  copyProgressDraftLineMetadata(replacement, kept, previous);
   return kept;
 }
 
@@ -1397,7 +1387,7 @@ function resolveProgressDraftLineMergeKeys(line: string | ChannelProgressDraftLi
   if (typeof line !== "object") {
     return [];
   }
-  const keys = [progressDraftLineCorrelationKeys.get(line), line.id]
+  const keys = [progressDraftLineMetadata.get(line)?.correlationKey, line.id]
     .map((key) => key?.trim())
     .filter((key): key is string => Boolean(key));
   return [...new Set(keys)];

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1290,6 +1290,22 @@ function limitProgressDraftLines<TLine extends string | ChannelProgressDraftLine
     .toReversed();
 }
 
+/**
+ * Command output reports the outcome of the command the line already shows.
+ * With command text on, its own detail is the agent's item title ("command
+ * <meta>"), a restatement of the detail the tool line carries, so the detail
+ * the reader has been watching stays and the status carries the result. The
+ * shown detail is kept only when the incoming detail is such a restatement:
+ * empty, the line's own status, the shown detail itself, or the shown detail
+ * behind a "command" prefix (whitespace collapsed, prefix case-insensitive).
+ * Any other incoming detail replaces the shown one, so a command-output line
+ * that ever carries real output or a different description is not discarded
+ * here. A line that already ended (a failed nested command) is replaced whole
+ * when the output names no command, so a recovered run does not keep the
+ * stale failure text; the embedded producer ends the command item before its
+ * output arrives, and that output names the shown command, so the shown
+ * detail stays through the terminal item.
+ */
 function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraftLine>(
   previous: TLine,
   line: TLine,
@@ -1297,18 +1313,22 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
   if (typeof previous !== "object" || typeof line !== "object") {
     return line;
   }
-  if (
-    line.kind !== "command-output" ||
-    !line.status ||
-    (line.detail && line.detail !== line.status)
-  ) {
+  if (line.kind !== "command-output" || !line.status) {
     return line;
   }
   const previousDetail = previous.detail?.trim();
   if (
     !previousDetail ||
     previousDetail === previous.status ||
-    isTerminalProgressStatus(previous.status)
+    line.detail?.trim() === previousDetail ||
+    !isRestatedCommandDetail(line.detail, previousDetail, line.status)
+  ) {
+    return line;
+  }
+  const incomingDetail = line.detail?.trim();
+  if (
+    isTerminalProgressStatus(previous.status) &&
+    (!incomingDetail || incomingDetail === line.status)
   ) {
     return line;
   }
@@ -1322,6 +1342,28 @@ function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraf
     progressDraftLineCorrelationKeys.get(line) ?? progressDraftLineCorrelationKeys.get(previous),
   );
   return replacement;
+}
+
+/**
+ * True when a command-output line's detail only restates the detail the line
+ * already shows: it is empty, it is the line's own status, or after collapsing
+ * whitespace it equals the shown detail with or without a leading "command".
+ */
+function isRestatedCommandDetail(
+  detail: string | undefined,
+  shownDetail: string,
+  status: string,
+): boolean {
+  const incoming = detail?.replace(/\s+/g, " ").trim();
+  if (!incoming || incoming === status) {
+    return true;
+  }
+  const shown = shownDetail.replace(/\s+/g, " ").trim();
+  if (incoming === shown) {
+    return true;
+  }
+  const prefix = incoming.slice(0, "command ".length);
+  return prefix.toLowerCase() === "command " && incoming.slice(prefix.length) === shown;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching Slack native progress with command text enabled (`streaming.progress.commandText: raw`) would see a finished command's task card show its command twice, as "run tests · command run tests", the second copy prefixed with the word "command", and the plan header switch to "Exec — command run tests" at the same moment. It happened for every command a run executed. In channels that render the progress draft as text, the same event changed the finished line's detail from "run tests" to "command run tests".

## Why This Change Was Made

The command output event describes its command through the agent's item title (`command <meta>`), which the shared progress line builder uses as the output line's detail when command text is on. That is a second description of the command whose detail the progress line already shows from the tool start. The compositor's merge (`mergeProgressDraftLineUpdate` in `src/channels/streaming.ts`) kept the shown detail only when the output line had none, so an output line with its own copy replaced "run tests" with "command run tests". Slack's native task rows append `details` text per `task_update` instead of replacing it, so the Slack card joined the two.

Command output now keeps the detail the reader has been watching and carries the result in the status; an output line whose detail already equals the shown one is used as is. The shown detail is kept only when the incoming detail is a restatement of it: empty, the line's own status, the shown detail itself, or the shown detail behind a `command` prefix (whitespace collapsed, prefix case-insensitive). Any other incoming detail replaces the shown one as before, so a command-output line that ever carries real output or a different description is not discarded by this merge. The existing guard is unchanged: a line that already ended (a failed nested command, the Matrix recovery case in #89920) is still replaced whole so a recovered run does not keep the stale failure text, and an output line arriving for a line that showed no detail keeps its own. The change is in the shared compositor rather than the Slack plugin because the compositor owns what a command line says (it already kept the shown detail for the no-detail case), every text-rendering channel sees the same flip, and Slack's reconciler already treats a restated detail as no-op once the strings agree.

Alternative considered: teaching the Slack reconciler to hold a row's details once shown. Not chosen because it would leave the text channels showing the relabeled command and would need a per-row policy crossing the chunk boundary; fixing the producer removes the divergence for every channel.

## User Impact

A command's task card in Slack keeps the command text it showed at start and only changes state when the command finishes; the plan header no longer relabels the command. Text-rendering channels show the same command text before and after completion. Nothing is configurable and no defaults change.

## Evidence

Slack's append semantics: the `chat.appendStream` reference (https://docs.slack.dev/reference/methods/chat.appendStream) documents append-on-write only for `markdown_text` and says nothing about how repeated `task_update` chunks with the same `id` combine `details`; the repository's own live verification (#125168, 2026-08-17: two `task_update` chunks for one id with `details: "detA"`/`"detB"` read back as `"detAdetB"`) is recorded in the comment above `resolveTaskFieldDelta` in `extensions/slack/src/progress-blocks.ts`, and the reconciler streams details as append-only deltas because of it.

Failing before, passing after. The new tests were run against the unpatched `upstream/main` source (`9865df761`) and then with the change:

```
### BEFORE (upstream/main source, new tests) ###
 × channels  src/channels/streaming.lifecycle.test.ts > channel-streaming > keeps the shown command detail when command output restates the command
AssertionError: expected { id: 'command:call-1', …(7) } to match object { kind: 'command-output', …(3) }
   (received detail: "command run tests", text: "🛠️ exit 1; command run tests"; expected detail: "run tests", text: "🛠️ exit 1; run tests")
 Tests  1 failed | 30 passed (31)
 × extension-slack  extensions/slack/src/progress-blocks.test.ts > native Slack progress stream chunks > does not append a restated command detail when the command output line arrives
AssertionError: expected { type: 'task_update', …(4) } to not have property "details"
   (received details: " · command run tests")
 Tests  1 failed | 48 passed (49)
### AFTER (patched) ###
 Tests  33 passed (33)   src/channels/streaming.lifecycle.test.ts
 Tests  2 passed (2)     extensions/slack/src/progress-blocks.command-output.test.ts
```

The restatement guard is narrow on purpose: a merge that keeps the shown detail for any command-output line with a status would silently drop a line that carried real output. The guard test was run against an earlier draft of the merge that kept the shown detail unconditionally, and then against this change:

```
### BEFORE (draft merge: shown detail kept for any command-output detail) ###
 × channels  src/channels/streaming.lifecycle.test.ts > channel-streaming > replaces the shown detail when command output carries a different one
AssertionError: expected { id: 'command:call-1', …(7) } to match object { kind: 'command-output', …(3) }
  {
-   "detail": "3 tests failed",
+   "detail": "run tests",
    "kind": "command-output",
    "status": "exit 1",
-   "text": "🛠️ exit 1; 3 tests failed",
+   "text": "🛠️ exit 1; run tests",
  }
 Tests  1 failed | 32 passed (33)
### AFTER (restatement-only guard) ###
 Tests  33 passed (33)   src/channels/streaming.lifecycle.test.ts
```

Reproduction of the user-visible effect: one exec call's events (tool start, tool item start, command item start, command output end), built with the real line builders (`buildChannelProgressDraftLine`, `commandText: raw`), merged with `mergeChannelProgressDraftLine`, and rendered through the Slack plugin's `buildSlackProgressStreamChunks` + `reconcileSlackNativeTaskChunks`, printing every chunk the Slack stream would receive and the rendered row text the reconciler tracks.

```
### repro on unpatched upstream/main ###
[tool start] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"in_progress","details":"run tests"}
[item start (tool)] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
[item start (command)] event.id=command:call-1 event.detail="run tests" merged.id=command:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"in_progress","details":"run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"complete"}
[command-output end] event.id=command:call-1 event.detail="command run tests" merged.id=command:call-1 merged.detail="command run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — command run tests"}
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"complete","details":" · command run tests"}
task rows in Slack snapshot:
  command_call_1_1710f6c0: title="Exec" status=complete details="run tests · command run tests"
  tool_call_1_c8e12bee: title="Exec" status=complete details="run tests"
### repro with the fix ###
[tool start] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"plan_update","title":"Exec — run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"in_progress","details":"run tests"}
[item start (tool)] event.id=tool:call-1 event.detail="run tests" merged.id=tool:call-1 merged.detail="run tests" lines=1
[item start (command)] event.id=command:call-1 event.detail="run tests" merged.id=command:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"in_progress","details":"run tests"}
  -> slack chunk {"type":"task_update","id":"tool_call_1_c8e12bee","title":"Exec","status":"complete"}
[command-output end] event.id=command:call-1 event.detail="command run tests" merged.id=command:call-1 merged.detail="run tests" lines=1
  -> slack chunk {"type":"task_update","id":"command_call_1_1710f6c0","title":"Exec","status":"complete"}
task rows in Slack snapshot:
  command_call_1_1710f6c0: title="Exec" status=complete details="run tests"
  tool_call_1_c8e12bee: title="Exec" status=complete details="run tests"
```

Before: the output event's detail "command run tests" replaces the merged line's detail, Slack receives a details delta `" · command run tests"` and the row reads "run tests · command run tests"; the plan header follows. After: the merged line keeps "run tests", the completion update carries only the status change, the row still reads "run tests" and the plan header does not change. The two rows for one call visible in both captures are a separate defect in the merged line's id, fixed in a companion PR (#143879); this change does not alter ids.

Live observation that motivated this: Slack, OpenClaw `2026.8.1-beta.3`, native progress streaming, a finished exec card's details read "<detail> · command <detail>" on 2026-09-09.

Tests:

- `src/channels/streaming.lifecycle.test.ts`: `keeps the shown command detail when command output restates the command` (tool line detail "run tests"; output lines titled "command run tests" with exit 1 and exit 0 merge to detail "run tests", texts "🛠️ exit 1; run tests" and "🛠️ run tests"; a title "Command  run tests" with doubled whitespace and a capitalized prefix merges the same way); `keeps the line's detail when command output repeats it exactly` (output titled "run tests" is used as is, detail "run tests"); `replaces the shown detail when command output carries a different one` (output titled "3 tests failed" merges to detail "3 tests failed", text "🛠️ exit 1; 3 tests failed"; this is the guard against a future output line losing its own text); `keeps the command output's own detail when the line showed none` (a tool line without detail followed by output with a title keeps the output line, detail "command run tests"). The existing `keeps public command progress ids while replacing by command correlation` still covers the recovered failed line being replaced whole. The two tests that check the output line is used as is compare the merged line to the output line structurally (`toEqual` with the id left open) rather than by object identity, so this branch stacks with the companion id fix (#143879, which returns a copy of the merged line carrying the original id) in either order; with that fix cherry-picked on top, this file runs 34 passed and `extensions/slack/src/progress-blocks.test.ts` (48) and `progress-blocks.command-output.test.ts` (2) pass.
- `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts`: `renders command status without command output in Telegram progress draft previews` now expects the finished line to read `🛠️ exit 2; false` (the command text the tool line showed) instead of `🛠️ exit 2; command false`; the test's purpose, keeping the command's output text out of the preview, is unchanged.
- `extensions/slack/src/progress-blocks.command-output.test.ts` (new file; `progress-blocks.test.ts` is at the `max-lines` limit): `does not append a restated command detail when the command output line arrives` (real builders and merge feeding the Slack chunk builder and reconciler: the first render carries `details: "run tests"`, the completing update carries no `details`, every tracked row still renders "run tests"); `sends the command output detail when the row showed none` (a row without details receives `details: "command run tests"` on completion).

Results (Node 26.7.0, pnpm 12.3.4, `upstream/main` `9865df761`):

- `node scripts/run-vitest.mjs src/channels/streaming.lifecycle.test.ts`: 33 passed.
- `node scripts/run-vitest.mjs extensions/slack/src/progress-blocks.command-output.test.ts`: 2 passed.
- `node scripts/run-vitest.mjs src/channels`: 214 files, 2354 tests passed.
- `pnpm test:extension slack`: 157 files, 2923 tests passed (run with `HTTP_PROXY`/`HTTPS_PROXY` unset; with HTTP proxy environment variables exported, 5 unrelated loopback-server tests in `send.upload.test.ts` and `provider.transport-credentials.test.ts` fail on this machine before and after the change).
- Other channels that render the shared compositor lines, run the same way: `pnpm test:extension matrix` 70 files, 1381 tests passed; `pnpm test:extension telegram` 220 files, 4078 tests passed; `pnpm test:extension discord` 266 files, 3703 tests passed; `pnpm test:extension msteams` 1603 tests passed. Before the Telegram expectation above was updated, that one Telegram test failed with `🛠️ Exec false exit 2` received where `🛠️ Exec command false exit 2` was expected; no other suite changed.
- `oxfmt --check` on the changed files: clean. `oxlint` (repo `.oxlintrc.json`) on the changed files: no findings.
- Re-run after rebasing onto `upstream/main` `d09401295` (2026-09-10, squashed to one commit): `src/channels/streaming.lifecycle.test.ts` 33 passed; `extensions/slack/src/progress-blocks.command-output.test.ts` + `progress-blocks.test.ts` 49 passed; `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts` 19 passed; `node scripts/run-vitest.mjs src/channels` 214 files, 2376 tests passed; `pnpm test:extension slack` 157 files, 2923 tests passed; the rebase applied without conflicts.
- `pnpm check:changed --base upstream/main`: exit 0 with every lane run (conflict markers, ratchets, format changed files, plugin boundaries, wrapper shadowing, core tsgo graph boundary, typecheck core, typecheck core tests, typecheck extension tests, coercion helper declaration guard, deprecated API usage, dead export scan, lint core changed files, lint extension changed file, and the runtime guards). The lint lanes and the `scripts/run-oxlint.mjs` wrapper only complete from a checkout outside an ancestor `node_modules` install (this run used a detached worktree of the same commit under `/private/tmp`); in a checkout nested under `~/node_modules` the declaration-boundary preparation refuses to run and that one lane reports failed.

Not tested:

- The Mattermost plugin's test project as a whole (its runner exits silently for the whole project here; a single file runs); Mattermost feeds the same compositor through `pushCommandOutputEvent`.
- A live Slack run of this build; the reproduction drives the Slack plugin's chunk builder and reconciler with real builder output but does not call `chat.appendStream`.
- A command output line arriving after its call's line has left the rolling compositor window; with no line to merge into, the output line's own detail is shown, as before.
- A live producer whose command-output title differs from the shown detail in substance (a CLI backend that titles the output from arguments the tool line did not show); the merge rule for that case, replace the shown detail, is covered by the unit test above but was not observed from a backend.

### Live rendering (2026-09-10, this fix applied on top of the reasoning-cards branch)

Same live fixture as the id fix (real dispatcher, real `@slack/web-api` client,
`commandText: "raw"`), before and after.

Before (`1789011841.664119`): the command-output event appends
`details: " · command run tests"` and `plan_update "Exec — command run tests"`; Slack's
read-back of the row shows `details: "run tests · command run tests"`, confirming that
repeated `task_update` chunks for one id append their `details`, and the header is
relabeled.

After (`1789021925.291649`): the command-output event carries no `details` delta and no
header change; the row reads `Exec` / `run tests` from start to completion and the plan
title stays `Exec — run tests`.

### Screenshots

Captured from the Slack web client during the live runs above (a test workspace, cropped to one thread reply, plan block expanded). Full sets, with a manifest per run, are on the fork's [evidence branch](https://github.com/n1hility/openclaw/tree/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots).

Before (cards build without this fix): the completed row reads `run tests · command run tests` and the header is relabeled `Exec — command run tests`.

![Before (cards build without this fix): the completed row reads `run tests · command run tests` and the header is relabeled `Exec — command run tests`](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/first-run/sc3-unfixed.png)

After (this fix and the companion id fix applied): the row keeps `run tests` and the header stays `Exec — run tests`.

![After (this fix and the companion id fix applied): the row keeps `run tests` and the header stays `Exec — run tests`](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/first-run/sc3-fixed.png)

Final synthetic-driver run, same scenario.

![Final synthetic-driver run, same scenario](https://raw.githubusercontent.com/n1hility/openclaw/f8b16d429ab4cea8a7d0a0cb44be1d773594ff71/screenshots/final2/r3-s3-one-exec-card.png)

## Telegram

The changed merge is shared, so Telegram's finished progress line changes too: with `commandText: "raw"` and tool progress on, the line for a failing command now keeps the command text and adds the status (`Exec false exit 2`) instead of relabeling it (`Exec command false exit 2`).

**Changed expectation, before/after** (`extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts`, "renders command status without command output", mocked draft stream):

```
src/channels/streaming.ts from main:  1 failed
  Expected "<b>Shelling</b><br><b>🛠️ Exec</b> false <i>exit 2</i>"
  Received "<b>Shelling</b><br><b>🛠️ Exec</b> command false <i>exit 2</i>"
PR head:                              1 passed
```

**Telegram loopback Bot API proof — head `f4954f1a285c93cb4652d17c751ccd752b37a3ac`**

The Telegram Test Server lane needs the maintainer-held userbot lease, so this
is the next strongest evidence: the real Telegram dispatch path driven end to
end against a loopback HTTP server that stands in for `api.telegram.org`, with
the captured Bot API payloads asserted exactly. It is an executable regression
in the PR, `extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts`,
in the style of the existing `reply-scaffolding.telegram-http.test.ts`.

**What runs for real**

- `dispatchTelegramMessage` with its default deps (no `vi.mock`), including the
  Telegram draft state, progress state, delivery and cleanup paths.
- The shared channel-turn runner (`runChannelInboundEvent`) and the shared reply
  dispatch (`dispatchInboundMessage` → `dispatchReplyFromConfig` with the
  buffered block dispatcher), so `onToolStart` / `onCommandOutput` reach the
  Telegram callbacks through the same wrapping production uses.
- The shared progress compositor (`src/channels/progress-draft-compositor.ts`)
  and the line merge in `src/channels/streaming.ts` that this PR changes.
- The Telegram progress formatter (`renderTelegramProgressDraftPreview`), the
  Telegram draft stream (`createTelegramDraftStream`, with its 1 s edit
  throttle) and the grammY `Bot` HTTP client.

Stubbed: only the Bot API HTTP endpoint (a `node:http` loopback server that
returns a `message_id` for `sendMessage`, echoes the target `message_id` for
`editMessageText`, answers `ok: true` to everything else, and records every
payload) and the model (a reply resolver that emits the fixture events below
and then a final answer). Plugin state uses the in-memory test store the
existing dispatch tests use.

Configuration: DM, `streaming: { mode: "progress", progress: { toolProgress: true, commandText: "raw" } }`,
`replyToMode: "off"`, `richMessages` off. Identifiers are synthetic fixtures;
message aliases are used below.

Event sequence (the same one the dispatch unit fixture uses): `onReplyStart`,
`onAssistantMessageStart`, `onToolStart` for `exec` with `args.command = "false"`,
then `onCommandOutput` with `title: "command false"`, output text and
`exitCode: 2`. The resolver returns the final answer after the throttled
progress edit has reached the Bot API, as a model that answers after reading
the command output does. A final that arrives inside the throttle window
supersedes the pending edit, so the finished line is not sent at all in either
version; the test covers the case where it is shown.

**Recorded Bot API sequence at the PR head**

| Revision | Method | Message | Text (HTML) |
| --- | --- | --- | --- |
| R1 | `sendMessage` | M1 | `<b>Working</b>` ⏎ `<b>🛠️ Exec</b> false` |
| R2 | `editMessageText` | M1 | `<b>Working</b>` ⏎ `<b>🛠️ Exec</b> false <i>exit 2</i>` |
| R3 | `sendMessage` | M2 | `The command failed.` |

The test asserts this sequence exactly (method, target `message_id`, text):
the progress message is sent once with the running command line, edited in
place with the finished line, and the final answer is a separate message. It
also asserts that no recorded payload contains `command false`.

**Failing before, passing after**

With `src/channels/streaming.ts` swapped to `upstream/main` (identical to the
PR parent for this file) and everything else at the PR head, the same test
fails on R2; the finished line relabels the command:

```text
 FAIL  extension-telegram  extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts
 > keeps the raw command text on the finished progress line instead of the output title
AssertionError: expected [ [ 'sendMessage', null, …(1) ], …(2) ] to deeply equal [ … ]
@@ -7,11 +7,11 @@
    [
      "editMessageText",
      1,
      "<b>Working</b>
- <b>🛠️ Exec</b> false <i>exit 2</i>",
+ <b>🛠️ Exec</b> command false <i>exit 2</i>",
    ],
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

At the PR head:

```sh
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts \
  extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts \
  extensions/telegram/src/reply-scaffolding.telegram-http.test.ts
```

- 3 files, **40 passed**: loopback proof 2, dispatch progress-updates 20,
  reply-scaffolding Telegram HTTP 18.
- Telegram extension suite (all `extensions/telegram` vitest files except the
  `*.e2e.test.ts` / `*.live.test.ts` files and `sticker-cache.selection.test.ts`,
  which need a built runtime or live credentials): 221 files,
  **4,094 passed**, 0 failed.
- Extension test typecheck (`test/tsconfig/tsconfig.extensions.test.json`),
  `oxfmt --check`, `oxlint --type-aware --tsconfig extensions/tsconfig.json`,
  `git diff --check`, and the extension import-boundary scripts
  (`check-no-extension-test-core-imports`, `check-extension-plugin-sdk-boundary`
  in both modes, `check-telegram-grammy-types-imports`) all pass.

**Not tested**

- Real Telegram servers: neither `api.telegram.org` nor the Test DC. The
  loopback server accepts every payload; Telegram-side validation of the HTML
  and of edit semantics is not exercised.
- The Test Server userbot recorder (TDLib timeline), so no observed-client
  evidence for this change.
- Group, supergroup and forum-topic chats; reply quoting (`replyToMode` other
  than `off`); `richMessages`; media; the `*.e2e.test.ts`, `*.live.test.ts` and
  `sticker-cache.selection.test.ts` Telegram files.
- Live command execution: the exit status is the fixture's `exitCode: 2`. The
  claim under test is that the finished line keeps the command text the tool
  line showed and appends the exit status, whatever that status is.

**Telegram Test Server run.** The repository's Test Server recorder (`.agents/skills/telegram-e2e-userbot`) leases its bot token and pre-authorized userbot session from the project's credential broker, which is maintainer-only, so I cannot produce that capture from outside. Recipe for a maintainer run on this head, DM, progress mode, raw command text, tool progress on:

```
export TELEGRAM_E2E_SKILL_DIR="$PWD/.agents/skills/telegram-e2e-userbot"
node "$TELEGRAM_E2E_SKILL_DIR/scripts/telegram-test-doctor.mjs"          # expect ok: true
E2E_TELEGRAM_CONFIG_PATCH='{"streaming":{"mode":"progress","progress":{"toolProgress":true,"commandText":"raw"}}}' \
node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" \
  --backend mock --dm --timeout-ms 60000 --gateway-port <p1> --mock-port <p2> \
  --text 'Run the OPENCLAW_E2E_DRAFTPROOF scenario.' \
  --record events.ndjson --output summary.json
```

Judge in `summary.json`: successive `edit` rows on one `botApiMessageId` show the raw command text at start and the same text plus the exit status at completion, with no revision reading `command <text>`. The stock DRAFTPROOF fixture runs `sleep 3 && echo openclaw-draft-proof` (exit 0), which proves the stable text; a fixture whose tool call is `exec {command: "false"}` also proves the nonzero-exit status. Happy to run it myself if a lease can be granted.

## Review follow-up: the full embedded exec sequence

**Embedded exec sequence: terminal command item before the output — head `f4954f1a285c93cb4652d17c751ccd752b37a3ac`**

**The sequence**

The embedded exec producer (`src/agents/embedded-agent-subscribe.handlers.tools.*.ts`)
describes one command through events that all correlate to `command:<toolCallId>`,
in this order as they reach a channel with `commandText: "raw"`:

| # | Callback | Payload (exec, command `false`) |
| --- | --- | --- |
| 1 | `onToolStart` | `itemId: tool:exec-1`, `args.command: "false"` |
| 2 | `onItemEvent` | `tool:exec-1`, kind `tool`, status `running`, `meta: "false"`, `commandBearing: true` |
| 3 | `onItemEvent` | `command:exec-1`, kind `command`, title `command false`, status `running`, `meta: "false"` |
| 4 | `onCommandOutput` | projected from the tool result (`buildCommandOutputFromToolResultEvent`): no title, status `failed`, `exitCode: 2` |
| 5 | `onItemEvent` | `tool:exec-1`, kind `tool`, phase `end`, status `failed`, `meta: "false"` |
| 6 | `onItemEvent` | `command:exec-1`, kind `command`, phase `end`, status `failed`, `meta: "false"`, `summary: <output>` |
| 7 | `onCommandOutput` | `command_output` stream: `command:exec-1`, title `command false`, status `failed`, `exitCode: 2` |

Steps 5 and 6 are the "terminal command item": they replace the shown line
whole (item lines are not merged field by field) and leave it with a terminal
status. Step 7 then arrives with the restated detail `command false`.

**Why it mattered**

The previous revision kept the shown detail for a restated output only while
the shown line had not ended; an ended line was replaced whole so a recovered
run (a failed nested command followed by a titleless recovery output, the
Matrix case) would not keep stale failure text. In the embedded sequence the
command item ends before its output arrives, so step 7 hit that rule and the
finished line still read `Exec command false exit 2`. The two-event fixtures
(tool start, then output) did not cover it.

**The change**

`src/channels/streaming.ts`, `mergeProgressDraftLineUpdate`: the ended-line
rule now applies only when the output carries no command of its own (empty
detail, or detail equal to its status). An output that names the shown
command, exactly or behind a `command` prefix, keeps the shown detail through
the terminal item. Every other rule is unchanged: a different detail still
replaces the shown one, a line that showed no detail keeps the output's own,
and the recovery case still drops the stale text.

```ts
  const incomingDetail = line.detail?.trim();
  if (
    isTerminalProgressStatus(previous.status) &&
    (!incomingDetail || incomingDetail === line.status)
  ) {
    return line;
  }
```

**Coverage added**

- `src/channels/streaming.command-item.test.ts` (new): walks the seven-step
  sequence through `mergeChannelProgressDraftLine` for a failed (`exit 1`) and
  a completed (`exit 0`) command, asserting the detail is `run tests` after
  every step and the final line is `🛠️ exit 1; run tests` / `🛠️ run tests`;
  plus the recovery case (ended line, titleless completed output → no detail).
- `extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts`: the
  same sequence through the Telegram dispatch fixture; every preview contains
  `<b>🛠️ Exec</b> false`, none contains `command false`, the last is
  `<b>🛠️ Exec</b> false <i>exit 2</i>`.
- `extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts`:
  a second scenario over the real dispatcher → compositor → Telegram formatter →
  draft stream → grammY → loopback Bot API path (only the HTTP endpoint and the
  model are stubbed). Recorded at the head:

  | Revision | Method | Message | Text (HTML) |
  | --- | --- | --- | --- |
  | R1 | `sendMessage` | M1 | `<b>Working</b>` ⏎ `<b>🛠️ Exec</b> false` |
  | R2 | `editMessageText` | M1 | `<b>Working</b>` ⏎ `<b>🛠️ Exec</b> false <i>failed</i>` |
  | R3 | `editMessageText` | M1 | `<b>Working</b>` ⏎ `<b>🛠️ Exec</b> false <i>exit 2</i>` |
  | R4 | `sendMessage` | M2 | `The command failed.` |

  R2 is the terminal item (attention statuses bypass the edit throttle); R3 is
  the throttled finished revision. The assertions are by shape (opening line,
  every edit on M1 keeps the command text, last edit carries `exit 2`, final is
  a separate message, no payload contains `command false`) because the
  intermediate item revisions may coalesce under the throttle.

**Before / after**

Before, with `src/channels/streaming.ts` from `upstream/main` (identical to the
PR parent for this file):

```text
src/channels/streaming.command-item.test.ts
  × keeps the shown command detail through the terminal command item (failed)
  × keeps the shown command detail through the terminal command item (completed)
  ✓ still replaces an ended line whole when the output names no command
AssertionError: command output: expected 'command run tests' to be 'run tests'

extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
  × keeps the command text through the embedded producer's terminal command item
Received: "<b>Shelling</b><br><b>🛠️ Exec</b> command false <i>exit 2</i>"

extensions/telegram/src/bot-message-dispatch.progress-command-detail.telegram-http.test.ts
  × keeps the raw command text on the finished progress line instead of the output title
  × keeps the command text through the embedded producer's terminal command item
+ <b>🛠️ Exec</b> command false <i>exit 2</i>",
```

The previous PR revision (before this source change) failed the same three
new scenarios with the same `command false` / `command run tests` texts; its
own two-event scenarios passed.

After, at the head:

- `node scripts/run-vitest.mjs src/channels/streaming.command-item.test.ts src/channels/streaming.lifecycle.test.ts src/channels/progress-draft-compositor.test.ts` — 3 files, **78 passed** (3 + 33 + 42).
- `node scripts/run-vitest.mjs src/channels` — 215 files, **2,379 passed**.
- `node scripts/run-vitest.mjs <loopback> <progress-updates> <reply-scaffolding.telegram-http>` — 3 files, **40 passed** (2 + 20 + 18).
- Telegram extension suite (all `extensions/telegram` vitest files except `*.e2e.test.ts`, `*.live.test.ts` and `sticker-cache.selection.test.ts`, which need a built runtime or live credentials): 221 files, **4,094 passed**, 0 failed.
- Extension test typecheck (`test/tsconfig/tsconfig.extensions.test.json`) passes. Core test typecheck (`scripts/run-tsgo-core-test-shards.mjs`) passes.
- `oxfmt --check`, `oxlint --type-aware` (`tsconfig.json` for the `src/` files, `extensions/tsconfig.json` for the extension files), `git diff --check`: pass.

**Not tested**

- A live embedded agent run: the seven events are replayed from the producer's
  emit order in `embedded-agent-subscribe.handlers.tools.{start,completion}.ts`
  and the runner's projection in `agent-runner-event-handler.ts`, not captured
  from a model-driven turn.
- Real Telegram servers, the Test Server userbot recorder, group and topic
  chats, reply quoting, rich messages, media.
- Other producers' item orders (CLI candidates, ACP/Codex adapters) beyond the
  existing lifecycle fixtures.
- The approval-blocked branch (`command` item ending `blocked` with no output).

## Merge order

#143879 is merged as ce40be4769a369d6ed3fd4c84434411605fa67dc. This PR has been rebased onto main containing that identity fix, with both sets of progress tests retained. The P2 follow-up below is built on that rebased branch.

<!-- roboclaw:p2-command-detail -->
## Maintainer follow-up: flagged command details

HEAD **f6ff47f6bc5342efcc1ccacd0c8b077caf4aaa1c** fixes the remaining PTY/elevated-command P2. This supersedes the earlier rendered-prefix implementation description: the builder derives a comparison candidate from the raw output title and formats it with the same owner before merging. The actual output detail is retained for unrelated or free-standing titles. Private correlation/candidate metadata survives status, detail, and stable-ID clones; only correlation can fall back to the previous line. No public API, configuration, or schema change. The P2 follow-up removes 10 net production lines.

Before/after proof used a fresh secretless AWS Crabbox (no IAM role, no Tailscale, no credential hydration), testing the patch atop f5cefc8e6c0a6569e9dddc34ebeeb37f3a98fcac:

- Before: 8 new flagged/Markdown core cases failed; 4 existing/guard cases passed. The 3 new Slack flagged-detail cases also failed before the fix.
- After: **110 core/channel tests, 53 Slack tests, and 22 Telegram tests passed (185 total)**, including terminal-item ordering, stable IDs, quiet recovery, unrelated titles, and the existing Telegram loopback HTTP scenarios.
- Repository oxfmt and git diff --check passed. A final test-only brace cleanup was checked with the same trusted oxfmt 0.65.0 and main-owned configuration; no local dependency install was performed. Fresh independent source review found no P0-P2 issues.
- Proof runs: https://crabbox.openclaw.ai/portal/runs/run_53d90555db01d61d667e2ae58533b009 (failing core regression) and https://crabbox.openclaw.ai/portal/runs/run_1f65c97bccd743823ad14e9fc406ce68 (Slack before/after plus repaired regressions). The task-owned runner was released.

Fresh CI must validate this published HEAD. These tests are not live Telegram proof; the Telegram Test Server capture remains outstanding. No merge is requested by this update.

