### PR TITLE
fix(slack): honor relay proxy settings without direct fallback

### DIFF
--- a/docs/channels/slack/transports.md
+++ b/docs/channels/slack/transports.md
@@ -58,6 +58,8 @@ Relay mode separates Slack ingress from the OpenClaw gateway. A trusted router o
 
 The relay URL must use `wss://` unless it targets localhost. Treat the bearer token and router route table as part of the Slack authorization boundary: routed events enter the normal Slack message handler as authorized activations. A router-provided `slack_identity` in the websocket `hello` frame can set the default outbound username and icon; an explicit identity supplied by the caller still wins. The relay connection reconnects with the same bounded backoff timing as Socket Mode and clears the router-provided identity whenever it disconnects.
 
+Relay WebSocket connections honor the Gateway host's proxy environment (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, lowercase variants, and `NO_PROXY`). A `wss://` relay uses an HTTP `CONNECT` tunnel when a proxy is configured. A matching `NO_PROXY` entry or a localhost `ws://` URL connects directly. Proxy errors are reported instead of silently falling back to a direct relay connection.
+
 ## Socket Mode transport tuning
 
 OpenClaw sets the Slack SDK client pong timeout to 15 seconds for Socket Mode. This is a fixed internal default and is not operator-configurable.

--- a/docs/channels/slack/transports.md
+++ b/docs/channels/slack/transports.md
@@ -56,7 +56,7 @@ Relay mode separates Slack ingress from the OpenClaw gateway. A trusted router o
 }
 ```
 
-The relay URL must use `wss://` unless it targets localhost. Treat the bearer token and router route table as part of the Slack authorization boundary: routed events enter the normal Slack message handler as authorized activations. A router-provided `slack_identity` in the websocket `hello` frame can set the default outbound username and icon; an explicit identity supplied by the caller still wins. The relay connection reconnects with the same bounded backoff timing as Socket Mode and clears the router-provided identity whenever it disconnects.
+The relay URL must use `wss://` unless it targets localhost. Treat the bearer token and router route table as part of the Slack authorization boundary: routed events enter the normal Slack message handler as authorized activations. A router-provided `slack_identity` in the websocket `hello` frame can set the default outbound username and icon; an explicit identity supplied by the caller still wins. The relay connection reconnects with the same bounded backoff timing as Socket Mode and clears the router-provided identity whenever it disconnects. The relay websocket honors the gateway host's standard proxy environment (`HTTPS_PROXY`, `HTTP_PROXY`, lowercase variants, `NO_PROXY`): a `wss://` relay URL is dialed through the configured proxy with an HTTP `CONNECT` tunnel, and a `NO_PROXY` match or a localhost `ws://` URL connects directly.
 
 ## Socket Mode transport tuning
 

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import net, { type AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import type { Duplex } from "node:stream";
 import tls from "node:tls";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
@@ -377,6 +380,205 @@ async function createRelayProxyFixture(mode: "tunnel" | "stall" = "tunnel") {
   };
 }
 
+// Second self-signed loopback certificate for an https:// proxy hop. It is never
+// added to the default CA store, so trust for the proxy can only come from the
+// managed-proxy CA file.
+const PROXY_TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIBtTCCAVugAwIBAgIUN8NgmbHQwympZgnlu0iBZS3MF7EwCgYIKoZIzj0EAwIw
+ITEfMB0GA1UEAwwWc2xhY2stcmVsYXktcHJveHkudGVzdDAgFw0yNjA5MTAxNzI1
+MDJaGA8yMTI2MDgxNzE3MjUwMlowITEfMB0GA1UEAwwWc2xhY2stcmVsYXktcHJv
+eHkudGVzdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDKtZlDF6UbLFOIY6bxd
+mri83ylDIKS6A7hkd4l+rug8b4gWPMyhSp1CFXP1hjBPGtLV729x+BZz8Uja3hKu
+8Q+jbzBtMB0GA1UdDgQWBBQi9VQMcgWKV/XyG88d+DbNTYBChTAfBgNVHSMEGDAW
+gBQi9VQMcgWKV/XyG88d+DbNTYBChTAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8A
+AAEwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEA41GXetcy2kD9
+KRex7/5RE+NU0dPOL/O8CRHwb+E3wxgCIFDhc4Vg3fcHr5ikIEP/MoPmW3bzY6Zr
+JsM7IY73LbvH
+-----END CERTIFICATE-----`;
+const PROXY_TEST_TLS_KEY = [
+  "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
+  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgfNkHctgW5/YMXhIV",
+  "IsfB7B4SdGLfJ29gyMPdKS42FsyhRANCAAQyrWZQxelGyxTiGOm8XZq4vN8pQyCk",
+  "ugO4ZHeJfq7oPG+IFjzMoUqdQhVz9YYwTxrS1e9vcfgWc/FI2t4SrvEP",
+  "-----END PRIVATE KEY-----",
+].join("\n");
+
+const PROXY_TEST_CREDENTIALS = { username: "relay-user", password: "relay-pass" };
+
+/**
+ * Relay plus a CONNECT proxy that can require Basic credentials (407 otherwise)
+ * and terminate TLS itself. Same relay side as createRelayProxyFixture; the
+ * proxy additionally records the Proxy-Authorization outcome and TCP/TLS counts.
+ */
+async function createRelayGatedProxyFixture(options: {
+  credentials?: { username: string; password: string };
+  tls?: boolean;
+}) {
+  const sockets = new Set<Duplex>();
+  const track = (socket: Duplex) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  };
+  const tunneledPorts = new Set<number>();
+  const upgrades: Array<{ via: "proxy" | "direct"; authorization?: string; url?: string }> = [];
+  const connects: Array<{
+    target?: string;
+    authorizationPresent: boolean;
+    proxyAuthorization: "missing" | "valid" | "invalid";
+  }> = [];
+  let relayConnections = 0;
+  let proxyConnections = 0;
+  let proxySecureConnections = 0;
+  const expectedProxyAuthorization = options.credentials
+    ? `Basic ${Buffer.from(`${options.credentials.username}:${options.credentials.password}`).toString("base64")}`
+    : undefined;
+  const relayHttps = https.createServer({ key: RELAY_TEST_TLS_KEY, cert: RELAY_TEST_TLS_CERT });
+  relayHttps.on("connection", (socket) => {
+    relayConnections += 1;
+    track(socket);
+  });
+  const relay = new WebSocketServer({ server: relayHttps, path: "/gateway/ws" });
+  relay.on("connection", (_socket, request) => {
+    upgrades.push({
+      via: tunneledPorts.has(request.socket.remotePort ?? -1) ? "proxy" : "direct",
+      authorization: request.headers.authorization,
+      url: request.url,
+    });
+  });
+  const reject = (_request: http.IncomingMessage, response: http.ServerResponse) => {
+    response.writeHead(403).end();
+  };
+  const proxy = options.tls
+    ? https.createServer({ key: PROXY_TEST_TLS_KEY, cert: PROXY_TEST_TLS_CERT }, reject)
+    : http.createServer(reject);
+  proxy.on("connection", (socket) => {
+    proxyConnections += 1;
+    track(socket);
+  });
+  proxy.on("secureConnection", () => {
+    proxySecureConnections += 1;
+  });
+  proxy.on("connect", (request, clientSocket, head) => {
+    track(clientSocket);
+    const header = request.headers["proxy-authorization"];
+    const proxyAuthorization =
+      header === undefined
+        ? "missing"
+        : header === expectedProxyAuthorization
+          ? "valid"
+          : "invalid";
+    connects.push({
+      target: request.url,
+      authorizationPresent: Boolean(request.headers.authorization),
+      proxyAuthorization,
+    });
+    if (expectedProxyAuthorization !== undefined && proxyAuthorization !== "valid") {
+      clientSocket.end(
+        "HTTP/1.1 407 Proxy Authentication Required\r\n" +
+          'Proxy-Authenticate: Basic realm="relay"\r\n' +
+          "Connection: close\r\n\r\n",
+      );
+      return;
+    }
+    const target = new URL(`http://${request.url}`);
+    const targetSocket = net.connect(Number(target.port), target.hostname, () => {
+      tunneledPorts.add(targetSocket.localPort ?? -1);
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        targetSocket.write(head);
+      }
+      clientSocket.pipe(targetSocket);
+      targetSocket.pipe(clientSocket);
+    });
+    track(targetSocket);
+    targetSocket.on("error", () => clientSocket.destroy());
+    clientSocket.on("error", () => targetSocket.destroy());
+    clientSocket.on("close", () => targetSocket.destroy());
+  });
+  const listen = (server: http.Server | https.Server) =>
+    new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+  const relayPort = await listen(relayHttps);
+  const proxyPort = await listen(proxy);
+  return {
+    relay,
+    upgrades,
+    connects,
+    relayConnections: () => relayConnections,
+    proxyConnections: () => proxyConnections,
+    proxySecureConnections: () => proxySecureConnections,
+    url: `wss://127.0.0.1:${relayPort}/gateway/ws`,
+    target: `127.0.0.1:${relayPort}`,
+    proxyHost: `127.0.0.1:${proxyPort}`,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      for (const client of relay.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        relay.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        relayHttps.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        proxy.close(() => resolve());
+      });
+    },
+  };
+}
+
+/** Greets the next relay connection with hello plus one routed event; resolves with its ack. */
+function expectRelayAck(relay: WebSocketServer, deliveryId: string): Promise<unknown> {
+  const ack = deferred<unknown>();
+  relay.once("connection", (socket) => {
+    socket.on("message", (data) => {
+      ack.resolve(JSON.parse(rawDataToString(data)));
+    });
+    socket.send(JSON.stringify({ type: "hello", slack_identity: { username: "Relay Proof" } }));
+    socket.send(
+      JSON.stringify({
+        type: "slack_event",
+        delivery_id: deliveryId,
+        route: { kind: "channel_default", key: "T1:C1" },
+        payload: { event: { type: "message", channel: "C1", text: "hello", ts: "1.000001" } },
+      }),
+    );
+  });
+  return ack.promise;
+}
+
+/** Runs the relay monitor against a fixture; `stopped` settles with the monitor's rejection, if any. */
+function startRelayMonitor(
+  fixture: { url: string },
+  setStatus?: (status: Record<string, unknown>) => void,
+) {
+  const abortController = new AbortController();
+  const acceptRelayEvent = vi.fn(async () => {});
+  const monitor = monitorSlackRelaySource({
+    config: { url: fixture.url, authToken: "relay-secret", gatewayId: "pash" },
+    acceptRelayEvent,
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    identityHealth: { lifecycle: "ready", lastError: null },
+    abortSignal: abortController.signal,
+    setStatus,
+  });
+  const stopped = monitor.then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+  return {
+    acceptRelayEvent,
+    stop: async () => {
+      abortController.abort();
+      return await stopped;
+    },
+  };
+}
+
 describe("Slack relay proxy environment", () => {
   let originalCertificates: string[];
 
@@ -521,6 +723,144 @@ describe("Slack relay proxy environment", () => {
     } finally {
       abortController.abort();
       await monitor;
+      await fixture.close();
+    }
+  });
+
+  it("sends proxy URL credentials as Proxy-Authorization and acks through the tunnel", async () => {
+    const fixture = await createRelayGatedProxyFixture({ credentials: PROXY_TEST_CREDENTIALS });
+    vi.stubEnv(
+      "HTTPS_PROXY",
+      `http://${PROXY_TEST_CREDENTIALS.username}:${PROXY_TEST_CREDENTIALS.password}@${fixture.proxyHost}`,
+    );
+    const ack = expectRelayAck(fixture.relay, "authenticated-delivery");
+    const monitor = startRelayMonitor(fixture);
+    try {
+      await expect(ack).resolves.toEqual({ type: "ack", delivery_id: "authenticated-delivery" });
+      expect(fixture.connects).toEqual([
+        { target: fixture.target, authorizationPresent: false, proxyAuthorization: "valid" },
+      ]);
+      expect(fixture.relayConnections()).toBe(1);
+      expect(fixture.upgrades).toEqual([
+        { via: "proxy", authorization: "Bearer relay-secret", url: "/gateway/ws?gateway_id=pash" },
+      ]);
+      expect(monitor.acceptRelayEvent).toHaveBeenCalledTimes(1);
+    } finally {
+      expect(await monitor.stop()).toBeUndefined();
+      await fixture.close();
+    }
+  });
+
+  it(
+    "retries a 407 from the proxy with wrong credentials and never reaches the relay",
+    { timeout: 15_000 },
+    async () => {
+      const fixture = await createRelayGatedProxyFixture({ credentials: PROXY_TEST_CREDENTIALS });
+      vi.stubEnv(
+        "HTTPS_PROXY",
+        `http://${PROXY_TEST_CREDENTIALS.username}:wrong-pass@${fixture.proxyHost}`,
+      );
+      const disconnects: Array<Record<string, unknown>> = [];
+      const secondDisconnect = deferred<void>();
+      const monitor = startRelayMonitor(fixture, (status) => {
+        if (status.connected === false) {
+          disconnects.push(status);
+          if (disconnects.length === 2) {
+            secondDisconnect.resolve();
+          }
+        }
+      });
+      try {
+        // The second disconnect is the backoff retry after the first 407.
+        await secondDisconnect.promise;
+        expect(fixture.connects).toEqual([
+          { target: fixture.target, authorizationPresent: false, proxyAuthorization: "invalid" },
+          { target: fixture.target, authorizationPresent: false, proxyAuthorization: "invalid" },
+        ]);
+        for (const status of disconnects) {
+          expect(status).toMatchObject({
+            lifecycle: "recovering",
+            lastError: expect.stringContaining("HTTP/1.1 407 Proxy Authentication Required"),
+          });
+        }
+        expect(fixture.relayConnections()).toBe(0);
+        expect(fixture.upgrades).toEqual([]);
+        expect(monitor.acceptRelayEvent).not.toHaveBeenCalled();
+      } finally {
+        expect(await monitor.stop()).toMatchObject({ name: "AbortError" });
+        await fixture.close();
+      }
+    },
+  );
+
+  it("keeps a NO_PROXY match direct when the proxy URL carries credentials", async () => {
+    const fixture = await createRelayGatedProxyFixture({ credentials: PROXY_TEST_CREDENTIALS });
+    vi.stubEnv(
+      "HTTPS_PROXY",
+      `http://${PROXY_TEST_CREDENTIALS.username}:${PROXY_TEST_CREDENTIALS.password}@${fixture.proxyHost}`,
+    );
+    vi.stubEnv("NO_PROXY", "127.0.0.1");
+    const ack = expectRelayAck(fixture.relay, "bypassed-delivery");
+    const monitor = startRelayMonitor(fixture);
+    try {
+      await expect(ack).resolves.toEqual({ type: "ack", delivery_id: "bypassed-delivery" });
+      expect(fixture.proxyConnections()).toBe(0);
+      expect(fixture.connects).toEqual([]);
+      expect(fixture.upgrades).toEqual([
+        { via: "direct", authorization: "Bearer relay-secret", url: "/gateway/ws?gateway_id=pash" },
+      ]);
+    } finally {
+      expect(await monitor.stop()).toBeUndefined();
+      await fixture.close();
+    }
+  });
+
+  it("dials an https:// proxy over TLS trusted through the managed-proxy CA file", async () => {
+    const fixture = await createRelayGatedProxyFixture({ tls: true });
+    const caDir = fs.mkdtempSync(path.join(os.tmpdir(), "slack-relay-proxy-ca-"));
+    const caFile = path.join(caDir, "proxy-ca.pem");
+    fs.writeFileSync(caFile, PROXY_TEST_TLS_CERT, "utf8");
+    vi.stubEnv("HTTPS_PROXY", `https://${fixture.proxyHost}`);
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
+    vi.stubEnv("OPENCLAW_PROXY_CA_FILE", caFile);
+    const ack = expectRelayAck(fixture.relay, "tls-proxied-delivery");
+    const monitor = startRelayMonitor(fixture);
+    try {
+      await expect(ack).resolves.toEqual({ type: "ack", delivery_id: "tls-proxied-delivery" });
+      expect(fixture.proxySecureConnections()).toBe(1);
+      expect(fixture.connects).toEqual([
+        { target: fixture.target, authorizationPresent: false, proxyAuthorization: "missing" },
+      ]);
+      expect(fixture.upgrades).toEqual([
+        { via: "proxy", authorization: "Bearer relay-secret", url: "/gateway/ws?gateway_id=pash" },
+      ]);
+    } finally {
+      expect(await monitor.stop()).toBeUndefined();
+      await fixture.close();
+      fs.rmSync(caDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an untrusted https:// proxy certificate before sending CONNECT", async () => {
+    const fixture = await createRelayGatedProxyFixture({ tls: true });
+    vi.stubEnv("HTTPS_PROXY", `https://${fixture.proxyHost}`);
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", undefined);
+    vi.stubEnv("OPENCLAW_PROXY_CA_FILE", undefined);
+    const firstStatus = deferred<Record<string, unknown>>();
+    const monitor = startRelayMonitor(fixture, (status) => firstStatus.resolve(status));
+    try {
+      await expect(firstStatus.promise).resolves.toMatchObject({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: expect.stringContaining("DEPTH_ZERO_SELF_SIGNED_CERT"),
+      });
+      expect(fixture.proxyConnections()).toBe(1);
+      expect(fixture.proxySecureConnections()).toBe(0);
+      expect(fixture.connects).toEqual([]);
+      expect(fixture.relayConnections()).toBe(0);
+      expect(fixture.upgrades).toEqual([]);
+    } finally {
+      expect(await monitor.stop()).toMatchObject({ name: "AbortError" });
       await fixture.close();
     }
   });

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -1,12 +1,16 @@
-import type { AddressInfo } from "node:net";
+import http, { Agent as HttpAgent } from "node:http";
+import https from "node:https";
+import net, { type AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { describe, expect, it, vi } from "vitest";
-import { WebSocketServer } from "ws";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
 import {
   buildRelayWebSocketOptions,
   buildRelayWebSocketUrl,
   monitorSlackRelaySource,
   parseRelayFrame,
+  resolveRelayProxyAgent,
   SlackRelayMalformedFrameError,
   SLACK_RELAY_MAX_PAYLOAD_BYTES,
   type SlackRelayIdentity,
@@ -51,7 +55,9 @@ describe("Slack relay source", () => {
       }),
     ).toThrow("must include its websocket path");
 
-    expect(buildRelayWebSocketOptions("secret")).toMatchObject({
+    expect(
+      buildRelayWebSocketOptions("secret", "wss://router.example.com/gateway/ws?gateway_id=pash"),
+    ).toMatchObject({
       headers: { Authorization: "Bearer secret" },
       maxPayload: SLACK_RELAY_MAX_PAYLOAD_BYTES,
       perMessageDeflate: false,
@@ -241,5 +247,213 @@ describe("Slack relay source", () => {
     it("parses array frames", () => {
       expect(parseRelayFrame(relayFrame("[1, 2, 3]"))).toEqual([1, 2, 3]);
     });
+  });
+});
+
+// Self-signed loopback certificate (SAN: 127.0.0.1, localhost; valid to 2126)
+// so the proxied and direct wss:// dials below terminate real TLS on 127.0.0.1.
+const RELAY_TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIBpzCCAUygAwIBAgIUezTxOxdfUphW7GSOPN3w6ppcqe0wCgYIKoZIzj0EAwIw
+GzEZMBcGA1UEAwwQc2xhY2stcmVsYXkudGVzdDAgFw0yNjA5MDkxNzUzMzBaGA8y
+MTI2MDgxNjE3NTMzMFowGzEZMBcGA1UEAwwQc2xhY2stcmVsYXkudGVzdDBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABKYC/MK+pREkCGg+imE4JGALlFu2aVQP7XJN
+Ckezs+JewV/OAxB4RzXVcgSgGKP6USQaDBnoBBEy+34QH2zXtJ2jbDBqMB0GA1Ud
+DgQWBBSI3WK70K2Wh3wnN+TdlErOoIKmQzAfBgNVHSMEGDAWgBSI3WK70K2Wh3wn
+N+TdlErOoIKmQzAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwDAYDVR0TBAUw
+AwEB/zAKBggqhkjOPQQDAgNJADBGAiEAphAGvWPFTevL7rEy7dBjoTVAk/oT93Mm
+qvz6jsUI73ACIQDLLDdqa0x1RevRJ98Y1vQad1mNK9Yk4Oh6k2HkafQ9tg==
+-----END CERTIFICATE-----`;
+const RELAY_TEST_TLS_KEY = [
+  "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
+  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgnzhEeRMhzEsaGPOM",
+  "xvBVdxlMJ7ANKKYd4P6pIl1KgpWhRANCAASmAvzCvqURJAhoPophOCRgC5RbtmlU",
+  "D+1yTQpHs7PiXsFfzgMQeEc11XIEoBij+lEkGgwZ6AQRMvt+EB9s17Sd",
+  "-----END PRIVATE KEY-----",
+].join("\n");
+
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "https_proxy",
+  "http_proxy",
+  "all_proxy",
+  "no_proxy",
+] as const;
+
+describe("Slack relay proxy environment", () => {
+  const relayUrl = "wss://router.example.com/gateway/ws?gateway_id=pash";
+
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, undefined);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("dials directly when the environment names no proxy", () => {
+    expect(resolveRelayProxyAgent(relayUrl)).toBeUndefined();
+    const options = buildRelayWebSocketOptions("secret", relayUrl);
+    expect(options).not.toHaveProperty("agent");
+    expect(options).toMatchObject({
+      headers: { Authorization: "Bearer secret" },
+      handshakeTimeout: 30_000,
+      maxPayload: SLACK_RELAY_MAX_PAYLOAD_BYTES,
+      perMessageDeflate: false,
+    });
+  });
+
+  it("attaches an env proxy agent to a wss:// dial", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.example.internal:3128");
+    const agent = resolveRelayProxyAgent(relayUrl);
+    expect(agent).toBeInstanceOf(HttpAgent);
+    const options = buildRelayWebSocketOptions("secret", relayUrl);
+    expect(options.agent).toBeInstanceOf(HttpAgent);
+    expect(options).toMatchObject({
+      headers: { Authorization: "Bearer secret" },
+      handshakeTimeout: 30_000,
+      maxPayload: SLACK_RELAY_MAX_PAYLOAD_BYTES,
+      perMessageDeflate: false,
+    });
+  });
+
+  it("falls back to HTTP_PROXY and lowercase variants for a wss:// dial", () => {
+    vi.stubEnv("HTTP_PROXY", "http://proxy.example.internal:3128");
+    expect(resolveRelayProxyAgent(relayUrl)).toBeInstanceOf(HttpAgent);
+    vi.stubEnv("HTTP_PROXY", undefined);
+    vi.stubEnv("https_proxy", "http://proxy.example.internal:3128");
+    expect(resolveRelayProxyAgent(relayUrl)).toBeInstanceOf(HttpAgent);
+  });
+
+  it("keeps a NO_PROXY match on a direct dial", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.example.internal:3128");
+    vi.stubEnv("NO_PROXY", "localhost,.example.com");
+    expect(resolveRelayProxyAgent(relayUrl)).toBeUndefined();
+    expect(buildRelayWebSocketOptions("secret", relayUrl)).not.toHaveProperty("agent");
+    expect(resolveRelayProxyAgent("wss://router.example.net/gateway/ws")).toBeInstanceOf(HttpAgent);
+  });
+
+  it("never proxies a plaintext ws:// dial", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.example.internal:3128");
+    vi.stubEnv("HTTP_PROXY", "http://proxy.example.internal:3128");
+    const localUrl = buildRelayWebSocketUrl({
+      url: "ws://127.0.0.1:18080/gateway/ws",
+      authToken: "secret",
+      gatewayId: "pash",
+    });
+    expect(resolveRelayProxyAgent(localUrl)).toBeUndefined();
+    expect(buildRelayWebSocketOptions("secret", localUrl)).not.toHaveProperty("agent");
+  });
+
+  it("dials directly when the proxy URL uses an unsupported protocol", () => {
+    vi.stubEnv("HTTPS_PROXY", "socks5://proxy.example.internal:1080");
+    expect(resolveRelayProxyAgent(relayUrl)).toBeUndefined();
+  });
+
+  it("tunnels the relay upgrade through the env CONNECT proxy and bypasses it on NO_PROXY", async () => {
+    const sockets = new Set<Duplex>();
+    const track = (socket: Duplex) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    };
+    const tunneledPorts = new Set<number>();
+    const upgrades: Array<{ via: "proxy" | "direct"; authorization?: string; url?: string }> = [];
+    const connects: string[] = [];
+
+    const relayHttps = https.createServer({ key: RELAY_TEST_TLS_KEY, cert: RELAY_TEST_TLS_CERT });
+    relayHttps.on("connection", track);
+    const relay = new WebSocketServer({ server: relayHttps, path: "/gateway/ws" });
+    relay.on("connection", (socket, request) => {
+      upgrades.push({
+        via: tunneledPorts.has(request.socket.remotePort ?? -1) ? "proxy" : "direct",
+        authorization: request.headers.authorization,
+        url: request.url,
+      });
+      socket.close();
+    });
+
+    const proxy = http.createServer((_request, response) => {
+      response.writeHead(403).end();
+    });
+    proxy.on("connection", track);
+    proxy.on("connect", (request, clientSocket, head) => {
+      track(clientSocket);
+      connects.push(request.url ?? "");
+      const target = new URL(`http://${request.url}`);
+      const targetSocket = net.connect(Number(target.port), target.hostname, () => {
+        tunneledPorts.add(targetSocket.localPort ?? -1);
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (head.length > 0) {
+          targetSocket.write(head);
+        }
+        clientSocket.pipe(targetSocket);
+        targetSocket.pipe(clientSocket);
+      });
+      track(targetSocket);
+      targetSocket.on("error", () => clientSocket.destroy());
+      clientSocket.on("error", () => targetSocket.destroy());
+    });
+
+    const listen = (server: http.Server | https.Server) =>
+      new Promise<number>((resolve) => {
+        server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+      });
+    const relayPort = await listen(relayHttps);
+    const proxyPort = await listen(proxy);
+    const dial = async () => {
+      const url = buildRelayWebSocketUrl({
+        url: `https://127.0.0.1:${relayPort}/gateway/ws`,
+        authToken: "secret",
+        gatewayId: "pash",
+      });
+      const options = buildRelayWebSocketOptions("secret", url);
+      const ws = new WebSocket(url, { ...options, ca: RELAY_TEST_TLS_CERT });
+      await new Promise<void>((resolve, reject) => {
+        ws.once("open", resolve);
+        ws.once("error", reject);
+      });
+      await new Promise<void>((resolve) => {
+        ws.once("close", () => resolve());
+      });
+      return options;
+    };
+
+    try {
+      vi.stubEnv("HTTPS_PROXY", `http://127.0.0.1:${proxyPort}`);
+      const proxied = await dial();
+      expect(connects).toEqual([`127.0.0.1:${relayPort}`]);
+      expect(upgrades).toEqual([
+        {
+          via: "proxy",
+          authorization: "Bearer secret",
+          url: "/gateway/ws?gateway_id=pash",
+        },
+      ]);
+      expect(proxied.agent).toBeInstanceOf(HttpAgent);
+
+      vi.stubEnv("NO_PROXY", "127.0.0.1");
+      const bypassed = await dial();
+      expect(bypassed).not.toHaveProperty("agent");
+      expect(connects).toHaveLength(1);
+      expect(upgrades).toHaveLength(2);
+      expect(upgrades[1]).toMatchObject({ via: "direct", authorization: "Bearer secret" });
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => {
+        relay.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        relayHttps.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        proxy.close(() => resolve());
+      });
+    }
   });
 });

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -3,6 +3,7 @@ import https from "node:https";
 import net, { type AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
 import tls from "node:tls";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
@@ -411,7 +412,7 @@ describe("Slack relay proxy environment", () => {
       });
       fixture.relay.once("connection", (socket) => {
         socket.on("message", (data) => {
-          const frame: unknown = JSON.parse(data.toString());
+          const frame: unknown = JSON.parse(rawDataToString(data));
           receivedAcks.push(frame);
           ack.resolve(frame);
         });

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -2,10 +2,10 @@ import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import net, { type AddressInfo } from "node:net";
-import os from "node:os";
 import path from "node:path";
 import type { Duplex } from "node:stream";
 import tls from "node:tls";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
@@ -580,6 +580,7 @@ function startRelayMonitor(
 }
 
 describe("Slack relay proxy environment", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let originalCertificates: string[];
 
   beforeEach(() => {
@@ -746,8 +747,9 @@ describe("Slack relay proxy environment", () => {
       ]);
       expect(monitor.acceptRelayEvent).toHaveBeenCalledTimes(1);
     } finally {
-      expect(await monitor.stop()).toBeUndefined();
+      const stopped = await monitor.stop();
       await fixture.close();
+      expect(stopped).toBeUndefined();
     }
   });
 
@@ -787,8 +789,9 @@ describe("Slack relay proxy environment", () => {
         expect(fixture.upgrades).toEqual([]);
         expect(monitor.acceptRelayEvent).not.toHaveBeenCalled();
       } finally {
-        expect(await monitor.stop()).toMatchObject({ name: "AbortError" });
+        const stopped = await monitor.stop();
         await fixture.close();
+        expect(stopped).toMatchObject({ name: "AbortError" });
       }
     },
   );
@@ -810,14 +813,15 @@ describe("Slack relay proxy environment", () => {
         { via: "direct", authorization: "Bearer relay-secret", url: "/gateway/ws?gateway_id=pash" },
       ]);
     } finally {
-      expect(await monitor.stop()).toBeUndefined();
+      const stopped = await monitor.stop();
       await fixture.close();
+      expect(stopped).toBeUndefined();
     }
   });
 
   it("dials an https:// proxy over TLS trusted through the managed-proxy CA file", async () => {
     const fixture = await createRelayGatedProxyFixture({ tls: true });
-    const caDir = fs.mkdtempSync(path.join(os.tmpdir(), "slack-relay-proxy-ca-"));
+    const caDir = tempDirs.make("slack-relay-proxy-ca-");
     const caFile = path.join(caDir, "proxy-ca.pem");
     fs.writeFileSync(caFile, PROXY_TEST_TLS_CERT, "utf8");
     vi.stubEnv("HTTPS_PROXY", `https://${fixture.proxyHost}`);
@@ -835,9 +839,9 @@ describe("Slack relay proxy environment", () => {
         { via: "proxy", authorization: "Bearer relay-secret", url: "/gateway/ws?gateway_id=pash" },
       ]);
     } finally {
-      expect(await monitor.stop()).toBeUndefined();
+      const stopped = await monitor.stop();
       await fixture.close();
-      fs.rmSync(caDir, { recursive: true, force: true });
+      expect(stopped).toBeUndefined();
     }
   });
 
@@ -860,8 +864,9 @@ describe("Slack relay proxy environment", () => {
       expect(fixture.relayConnections()).toBe(0);
       expect(fixture.upgrades).toEqual([]);
     } finally {
-      expect(await monitor.stop()).toMatchObject({ name: "AbortError" });
+      const stopped = await monitor.stop();
       await fixture.close();
+      expect(stopped).toMatchObject({ name: "AbortError" });
     }
   });
 });

--- a/extensions/slack/src/monitor/relay-source.test.ts
+++ b/extensions/slack/src/monitor/relay-source.test.ts
@@ -1,6 +1,9 @@
-import type { AddressInfo } from "node:net";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { describe, expect, it, vi } from "vitest";
+import http from "node:http";
+import https from "node:https";
+import net, { type AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
+import tls from "node:tls";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
   buildRelayWebSocketOptions,
@@ -51,8 +54,11 @@ describe("Slack relay source", () => {
       }),
     ).toThrow("must include its websocket path");
 
-    expect(buildRelayWebSocketOptions("secret")).toMatchObject({
+    expect(
+      buildRelayWebSocketOptions("secret", "wss://router.example.com/gateway/ws?gateway_id=pash"),
+    ).toMatchObject({
       headers: { Authorization: "Bearer secret" },
+      handshakeTimeout: 30_000,
       maxPayload: SLACK_RELAY_MAX_PAYLOAD_BYTES,
       perMessageDeflate: false,
     });
@@ -151,7 +157,7 @@ describe("Slack relay source", () => {
         gatewayId: "pash",
       },
       acceptRelayEvent,
-      runtime: { error: runtimeError, log: vi.fn() } as unknown as RuntimeEnv,
+      runtime: { error: runtimeError, log: vi.fn(), exit: vi.fn() },
       abortSignal: abortController.signal,
       identityHealth: { lifecycle: "blocked", lastError: "request_timeout" },
       setIdentity: (identity) => identities.push(identity),
@@ -241,5 +247,280 @@ describe("Slack relay source", () => {
     it("parses array frames", () => {
       expect(parseRelayFrame(relayFrame("[1, 2, 3]"))).toEqual([1, 2, 3]);
     });
+  });
+});
+
+// Self-signed loopback certificate (SAN: 127.0.0.1, localhost; valid to 2126)
+// so the proxied and direct wss:// dials below terminate real TLS on 127.0.0.1.
+const RELAY_TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIBpzCCAUygAwIBAgIUezTxOxdfUphW7GSOPN3w6ppcqe0wCgYIKoZIzj0EAwIw
+GzEZMBcGA1UEAwwQc2xhY2stcmVsYXkudGVzdDAgFw0yNjA5MDkxNzUzMzBaGA8y
+MTI2MDgxNjE3NTMzMFowGzEZMBcGA1UEAwwQc2xhY2stcmVsYXkudGVzdDBZMBMG
+ByqGSM49AgEGCCqGSM49AwEHA0IABKYC/MK+pREkCGg+imE4JGALlFu2aVQP7XJN
+Ckezs+JewV/OAxB4RzXVcgSgGKP6USQaDBnoBBEy+34QH2zXtJ2jbDBqMB0GA1Ud
+DgQWBBSI3WK70K2Wh3wnN+TdlErOoIKmQzAfBgNVHSMEGDAWgBSI3WK70K2Wh3wn
+N+TdlErOoIKmQzAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwDAYDVR0TBAUw
+AwEB/zAKBggqhkjOPQQDAgNJADBGAiEAphAGvWPFTevL7rEy7dBjoTVAk/oT93Mm
+qvz6jsUI73ACIQDLLDdqa0x1RevRJ98Y1vQad1mNK9Yk4Oh6k2HkafQ9tg==
+-----END CERTIFICATE-----`;
+const RELAY_TEST_TLS_KEY = [
+  "-----BEGIN PRIVATE KEY-----", // pragma: allowlist secret
+  "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgnzhEeRMhzEsaGPOM",
+  "xvBVdxlMJ7ANKKYd4P6pIl1KgpWhRANCAASmAvzCvqURJAhoPophOCRgC5RbtmlU",
+  "D+1yTQpHs7PiXsFfzgMQeEc11XIEoBij+lEkGgwZ6AQRMvt+EB9s17Sd",
+  "-----END PRIVATE KEY-----",
+].join("\n");
+
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "https_proxy",
+  "http_proxy",
+  "all_proxy",
+  "no_proxy",
+] as const;
+
+async function createRelayProxyFixture(mode: "tunnel" | "stall" = "tunnel") {
+  const sockets = new Set<Duplex>();
+  const track = (socket: Duplex) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  };
+  const tunneledPorts = new Set<number>();
+  const upgrades: Array<{
+    via: "proxy" | "direct";
+    authorization?: string;
+    url?: string;
+    extensions?: string;
+  }> = [];
+  const connects: Array<{ target?: string; authorizationPresent: boolean }> = [];
+  const connectStarted = deferred<void>();
+  const proxyClosed = deferred<void>();
+  const relayHttps = https.createServer({ key: RELAY_TEST_TLS_KEY, cert: RELAY_TEST_TLS_CERT });
+  relayHttps.on("connection", track);
+  const relay = new WebSocketServer({ server: relayHttps, path: "/gateway/ws" });
+  relay.on("connection", (_socket, request) => {
+    upgrades.push({
+      via: tunneledPorts.has(request.socket.remotePort ?? -1) ? "proxy" : "direct",
+      authorization: request.headers.authorization,
+      url: request.url,
+      extensions: request.headers["sec-websocket-extensions"],
+    });
+  });
+  const proxy = http.createServer((_request, response) => {
+    response.writeHead(403).end();
+  });
+  proxy.on("connection", track);
+  proxy.on("connect", (request, clientSocket, head) => {
+    connects.push({
+      target: request.url,
+      authorizationPresent: Boolean(request.headers.authorization),
+    });
+    clientSocket.once("close", () => proxyClosed.resolve());
+    connectStarted.resolve();
+    if (mode === "stall") {
+      // CONNECT detaches HTTP's half-close handler; finish after the client aborts.
+      clientSocket.once("end", () => clientSocket.end());
+      clientSocket.resume();
+      return;
+    }
+    const target = new URL(`http://${request.url}`);
+    const targetSocket = net.connect(Number(target.port), target.hostname, () => {
+      tunneledPorts.add(targetSocket.localPort ?? -1);
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        targetSocket.write(head);
+      }
+      clientSocket.pipe(targetSocket);
+      targetSocket.pipe(clientSocket);
+    });
+    track(targetSocket);
+    targetSocket.on("error", () => clientSocket.destroy());
+    clientSocket.on("error", () => targetSocket.destroy());
+    clientSocket.on("close", () => targetSocket.destroy());
+  });
+  const listen = (server: http.Server | https.Server) =>
+    new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+  const relayPort = await listen(relayHttps);
+  const proxyPort = await listen(proxy);
+  return {
+    relay,
+    upgrades,
+    connects,
+    connectStarted: connectStarted.promise,
+    proxyClosed: proxyClosed.promise,
+    url: `wss://127.0.0.1:${relayPort}/gateway/ws`,
+    target: `127.0.0.1:${relayPort}`,
+    proxyUrl: `http://127.0.0.1:${proxyPort}`,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      for (const client of relay.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        relay.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        relayHttps.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        proxy.close(() => resolve());
+      });
+    },
+  };
+}
+
+describe("Slack relay proxy environment", () => {
+  let originalCertificates: string[];
+
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, undefined);
+    }
+    originalCertificates = tls.getCACertificates("default");
+    tls.setDefaultCACertificates([...originalCertificates, RELAY_TEST_TLS_CERT]);
+  });
+
+  afterEach(() => {
+    tls.setDefaultCACertificates(originalCertificates);
+    vi.unstubAllEnvs();
+  });
+
+  it.each([false, true])(
+    "delivers through the monitor with destination-only auth and durable acknowledgement (NO_PROXY=%s)",
+    async (bypass) => {
+      const fixture = await createRelayProxyFixture();
+      vi.stubEnv("HTTPS_PROXY", fixture.proxyUrl);
+      if (bypass) {
+        vi.stubEnv("NO_PROXY", "127.0.0.1");
+      }
+      const accepted = deferred<void>();
+      const releaseAcceptance = deferred<void>();
+      const ack = deferred<unknown>();
+      const receivedAcks: unknown[] = [];
+      const identities: Array<SlackRelayIdentity | undefined> = [];
+      const acceptRelayEvent = vi.fn(async () => {
+        accepted.resolve();
+        await releaseAcceptance.promise;
+      });
+      fixture.relay.once("connection", (socket) => {
+        socket.on("message", (data) => {
+          const frame: unknown = JSON.parse(data.toString());
+          receivedAcks.push(frame);
+          ack.resolve(frame);
+        });
+        socket.send(JSON.stringify({ type: "hello", slack_identity: { username: "Relay Proof" } }));
+        socket.send(
+          JSON.stringify({
+            type: "slack_event",
+            delivery_id: "proxied-delivery",
+            route: { kind: "channel_default", key: "T1:C1" },
+            payload: { event: { type: "message", channel: "C1", text: "hello", ts: "1.000001" } },
+          }),
+        );
+      });
+      const abortController = new AbortController();
+      const monitor = monitorSlackRelaySource({
+        config: { url: fixture.url, authToken: "relay-secret", gatewayId: "pash" },
+        acceptRelayEvent,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        identityHealth: { lifecycle: "ready", lastError: null },
+        abortSignal: abortController.signal,
+        setIdentity: (identity) => identities.push(identity),
+      });
+      try {
+        await accepted.promise;
+        expect(fixture.connects).toEqual(
+          bypass ? [] : [{ target: fixture.target, authorizationPresent: false }],
+        );
+        expect(fixture.upgrades).toEqual([
+          {
+            via: bypass ? "direct" : "proxy",
+            authorization: "Bearer relay-secret",
+            url: "/gateway/ws?gateway_id=pash",
+            extensions: undefined,
+          },
+        ]);
+        expect(acceptRelayEvent).toHaveBeenCalledWith({
+          deliveryId: "proxied-delivery",
+          message: expect.objectContaining({ channel: "C1", text: "hello" }),
+        });
+        expect(receivedAcks).toEqual([]);
+        releaseAcceptance.resolve();
+        await expect(ack.promise).resolves.toEqual({
+          type: "ack",
+          delivery_id: "proxied-delivery",
+        });
+        expect(identities).toContainEqual({ username: "Relay Proof" });
+      } finally {
+        releaseAcceptance.resolve();
+        abortController.abort();
+        await monitor;
+        await fixture.close();
+      }
+      expect(identities.at(-1)).toBeUndefined();
+    },
+  );
+
+  it("reports invalid proxy configuration without a direct relay connection", async () => {
+    const fixture = await createRelayProxyFixture();
+    vi.stubEnv("HTTPS_PROXY", "socks5://proxy.example.test:1080");
+    const firstStatus = deferred<Record<string, unknown>>();
+    const abortController = new AbortController();
+    const monitor = monitorSlackRelaySource({
+      config: { url: fixture.url, authToken: "relay-secret", gatewayId: "pash" },
+      acceptRelayEvent: vi.fn(async () => {}),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      identityHealth: { lifecycle: "ready", lastError: null },
+      abortSignal: abortController.signal,
+      setStatus: (status) => firstStatus.resolve(status),
+    });
+    const stopped = monitor.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await expect(firstStatus.promise).resolves.toMatchObject({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: expect.stringContaining("Unsupported proxy protocol"),
+      });
+      expect(fixture.upgrades).toEqual([]);
+    } finally {
+      abortController.abort();
+      await stopped;
+      await fixture.close();
+    }
+    expect(await stopped).toMatchObject({ name: "AbortError" });
+  });
+
+  it("aborts a stalled CONNECT without an unhandled socket error", async () => {
+    const fixture = await createRelayProxyFixture("stall");
+    vi.stubEnv("HTTPS_PROXY", fixture.proxyUrl);
+    const abortController = new AbortController();
+    const monitor = monitorSlackRelaySource({
+      config: { url: fixture.url, authToken: "relay-secret", gatewayId: "pash" },
+      acceptRelayEvent: vi.fn(async () => {}),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      identityHealth: { lifecycle: "ready", lastError: null },
+      abortSignal: abortController.signal,
+    });
+    try {
+      await fixture.connectStarted;
+      abortController.abort();
+      await monitor;
+      await fixture.proxyClosed;
+      expect(fixture.upgrades).toEqual([]);
+    } finally {
+      abortController.abort();
+      await monitor;
+      await fixture.close();
+    }
   });
 });

--- a/extensions/slack/src/monitor/relay-source.ts
+++ b/extensions/slack/src/monitor/relay-source.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements relay-backed inbound event transport.
 import { Buffer } from "node:buffer";
 import { isIP } from "node:net";
+import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   computeBackoff,
   sleepWithAbort,
@@ -104,7 +105,7 @@ function openRelayWebSocket(
   }
   return new Promise((resolve, reject) => {
     const url = buildRelayWebSocketUrl(config);
-    const ws = new WebSocket(url, buildRelayWebSocketOptions(config.authToken));
+    const ws = new WebSocket(url, buildRelayWebSocketOptions(config.authToken, url));
 
     const cleanup = () => {
       ws.off("open", onOpen);
@@ -126,7 +127,7 @@ function openRelayWebSocket(
       reject(new Error(formatRelayClose(code, reason)));
     };
     const onAbort = () => {
-      cleanup();
+      // Keep terminal listeners until ws emits the error from closing a connecting socket.
       closeRelayWebSocket(ws);
       reject(new Error("Slack relay websocket aborted during connect"));
     };
@@ -232,8 +233,13 @@ async function handleRelayFrame(params: {
   sendRelayAck(params.ws, event.deliveryId);
 }
 
-export function buildRelayWebSocketOptions(authToken: string): ClientOptions {
+export function buildRelayWebSocketOptions(authToken: string, url: string): ClientOptions {
+  // ws supplies createConnection, bypassing Node's global proxy agent.
+  const agent = url.startsWith("wss:")
+    ? createNodeProxyAgent({ mode: "env", targetUrl: url, protocol: "https" })
+    : undefined;
   return {
+    ...(agent ? { agent } : {}),
     headers: {
       Authorization: `Bearer ${authToken}`,
     },

--- a/extensions/slack/src/monitor/relay-source.ts
+++ b/extensions/slack/src/monitor/relay-source.ts
@@ -1,6 +1,8 @@
 // Slack plugin module implements relay-backed inbound event transport.
 import { Buffer } from "node:buffer";
+import type { Agent as HttpAgent } from "node:http";
 import { isIP } from "node:net";
+import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   computeBackoff,
   sleepWithAbort,
@@ -104,7 +106,7 @@ function openRelayWebSocket(
   }
   return new Promise((resolve, reject) => {
     const url = buildRelayWebSocketUrl(config);
-    const ws = new WebSocket(url, buildRelayWebSocketOptions(config.authToken));
+    const ws = new WebSocket(url, buildRelayWebSocketOptions(config.authToken, url));
 
     const cleanup = () => {
       ws.off("open", onOpen);
@@ -232,8 +234,10 @@ async function handleRelayFrame(params: {
   sendRelayAck(params.ws, event.deliveryId);
 }
 
-export function buildRelayWebSocketOptions(authToken: string): ClientOptions {
+export function buildRelayWebSocketOptions(authToken: string, url: string): ClientOptions {
+  const agent = resolveRelayProxyAgent(url);
   return {
+    ...(agent ? { agent } : {}),
     headers: {
       Authorization: `Bearer ${authToken}`,
     },
@@ -241,6 +245,27 @@ export function buildRelayWebSocketOptions(authToken: string): ClientOptions {
     maxPayload: SLACK_RELAY_MAX_PAYLOAD_BYTES,
     perMessageDeflate: false,
   };
+}
+
+/**
+ * Resolve the env proxy agent for a wss:// relay dial, or undefined for a direct dial.
+ *
+ * ws always hands its own createConnection to https.request, and Node skips the
+ * global agent (the only place NODE_USE_ENV_PROXY applies) whenever a request
+ * supplies createConnection without an agent, so the proxy environment has to
+ * be attached here. A NO_PROXY match and ws:// URLs (loopback-only in relay
+ * mode) keep the direct dial.
+ */
+export function resolveRelayProxyAgent(url: string): HttpAgent | undefined {
+  if (!url.startsWith("wss:")) {
+    return undefined;
+  }
+  try {
+    return createNodeProxyAgent({ mode: "env", targetUrl: url, protocol: "https" });
+  } catch {
+    // Unsupported or malformed proxy URL; dial directly, as the Web API client does.
+    return undefined;
+  }
 }
 
 export function buildRelayWebSocketUrl(config: SlackRelaySourceConfig): string {

--- a/src/infra/net/node-proxy-agent.test.ts
+++ b/src/infra/net/node-proxy-agent.test.ts
@@ -1,4 +1,5 @@
 // Node proxy agent tests cover shared Node HTTP(S) proxy agent construction.
+import { inspect } from "node:util";
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../../test-utils/env.js";
 import { createNodeProxyAgent, resolveEnvNodeProxyUrlForTarget } from "./node-proxy-agent.js";
@@ -56,6 +57,29 @@ describe("resolveEnvNodeProxyUrlForTarget", () => {
 });
 
 describe("createNodeProxyAgent", () => {
+  it.each(["env", "explicit"] as const)(
+    "keeps malformed %s proxy credentials out of errors",
+    (mode) => {
+      const proxyUrl = "https://qa-user:qa-password@[invalid";
+      withProxyEnv({ HTTPS_PROXY: proxyUrl }, () => {
+        let error: unknown;
+        try {
+          if (mode === "env") {
+            createNodeProxyAgent({ mode, targetUrl: "https://collector.example.test" });
+          } else {
+            createNodeProxyAgent({ mode, proxyUrl });
+          }
+        } catch (cause) {
+          error = cause;
+        }
+        expect(error).toMatchObject({ message: expect.stringContaining("Invalid proxy URL") });
+        const rendered = inspect(error, { depth: null });
+        expect(rendered).not.toContain("qa-user");
+        expect(rendered).not.toContain("qa-password");
+      });
+    },
+  );
+
   it("preserves caller Node agent options on env proxy agents", () => {
     withProxyEnv({ HTTPS_PROXY: "http://proxy.example:8080" }, () => {
       const agent = createNodeProxyAgent({

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -52,11 +52,9 @@ function proxyUrlWithDefaultScheme(proxyUrl: string, protocol: NodeProxyProtocol
   let parsed: URL;
   try {
     parsed = new URL(withScheme);
-  } catch (error) {
-    throw new Error(
-      `Invalid proxy URL ${JSON.stringify(proxyUrl)}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
+  } catch {
+    // URL parse errors retain the input, which can contain proxy credentials.
+    throw new Error("Invalid proxy URL. Use an HTTP or HTTPS proxy URL.");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(`${UNSUPPORTED_PROXY_PROTOCOL_MESSAGE} Got ${parsed.protocol}`);


### PR DESCRIPTION
Slack relay mode dialed secure WebSockets directly even when the Gateway host configured an HTTP proxy. The WebSocket client supplies its own connection function, so Node's global proxy agent did not apply.

Pass the relay URL to the existing shared proxy agent. Preserve direct connections for matching bypass rules and local plaintext relays. Report proxy setup errors through the existing recovery path, keep terminal socket listeners during connecting aborts, and sanitize malformed proxy diagnostics at their shared producer so credentials cannot reach error output.

Validation uses the actual Gateway and bundled Slack plugin, a local TLS relay, an HTTP CONNECT proxy, and synthetic Slack events. The baseline connected directly with zero relay CONNECT requests. The repaired Gateway tunnels the authenticated connection, acknowledges two delivery IDs on the same socket, and retains one durable message record. This proves transport and durable admission; the fixture does not request a model reply.

Focused validation: 47 passing tests across relay, durable ingress, shared proxy, and provider HTTP behavior; ordinary syntax lint and the changed documentation check pass.

Gateway controls cover proxy precedence, bypass rules, local plaintext, rejected CONNECT without direct fallback, reconnect backoff, stalled-connect abort, handshake timeout, payload rejection, disabled compression, and relay identity clearing after channel stop. Independent runtime acceptance passed 15 executions, including socket closure and a full post-stop retry interval.

Additional relay-monitor tests cover Basic proxy authentication, rejected credentials without direct fallback, authenticated bypass, and HTTPS proxy certificate trust.
