### PR TITLE
fix(tests): isolate managed handoff admission fixture

### DIFF
--- a/src/infra/update-managed-service-handoff-retarget.test.ts
+++ b/src/infra/update-managed-service-handoff-retarget.test.ts
@@ -610,6 +610,9 @@ unix(
     const { createManagedHandoffLeaseStore, resolveManagedUpdateLeaseDatabasePath } =
       await import("./update-managed-service-handoff-lease.js");
     const { to } = fixture();
+    const tmpDirOwner = await import("./tmp-openclaw-dir.js");
+    // Common admission and its detached helper must share this fixture's coordinator.
+    vi.spyOn(tmpDirOwner, "resolvePreferredOpenClawTmpDir").mockReturnValue(path.dirname(to));
     const store = createManagedHandoffLeaseStore();
     const reserved = store.acquire(to, "legacy-owner", { kind: "update" });
     expect(reserved.kind).toBe("acquired");
@@ -646,7 +649,8 @@ unix(
         scratch.push(directory);
         const params = JSON.parse(
           fs.readFileSync(path.join(directory, "handoff.json"), "utf8"),
-        ) as { sensitivePaths: string[] };
+        ) as { sensitivePaths: string[]; updateLeaseDatabasePath: string };
+        expect(path.dirname(params.updateLeaseDatabasePath)).toBe(path.dirname(to));
         await expect(cancelManagedServiceUpdateHandoff(identity)).resolves.toBe(
           "restored-in-process",
         );


### PR DESCRIPTION
Related: #143410.

## What Problem This Solves

Parallel model-selection tests can fail with `existing managed handoff lease is incompatible` while the common managed-admission fixture writes an intentionally legacy lease into the shared coordinator database. The failure was captured in [CI job 102797197461](https://github.com/openclaw/openclaw/actions/runs/34454304811/job/102797197461): 14 model cases failed during that fixture's write/reclaim interval. The same producer and config-write guard are present on main.

## Why This Change Was Made

Use the existing temporary-directory resolver seam so common admission and its detached helper share the fixture's private coordinator. Verify the serialized helper database path belongs to that directory, while preserving the existing admission, cancellation, and cleanup assertions.

## User Impact

The legacy-admission fixture can run alongside config-writing test shards without contaminating their shared coordinator. This change contains one test file, +5/-1.

## Evidence

- 35 focused tests passed: 28 retarget cases and seven command-level sibling cases.
- Full changed-file gate passed; fresh independent P2 review is scoped-clean.
- Original Linux CI log and exact merge/source attribution are preserved. Fixed focused proof ran on macOS.
- This repair is separate from the public-repository feature. After landing, that PR will receive fresh CI against corrected main.
