### PR TITLE
feat: identify holders of slow session lifecycle queues

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -284,6 +284,54 @@ OpenTelemetry log export is enabled, using the same bounded attributes as file
 logs. Configure `diagnostics.otel.logsExporter` to choose OTLP, stdout JSONL, or
 both sinks.
 
+### Lifecycle queue waits
+
+When process diagnostics are enabled, the `sessions/lifecycle` logger emits
+`session lifecycle queue waiting` once when a queue acquisition is still pending
+after one second. It identifies the `mutation` or `lifecycle` queue and samples
+its current holder at that instant. The holder can have changed since the
+waiter entered the queue. A delayed timer that runs after acquisition emits no
+holder sample.
+
+`operationId` and `holderOperationId` identify diagnostic operation instances
+within `diagnosticEpoch`, PID and thread. Operations use the fixed boundary
+labels `lifecycle`, `mutation` and `compaction`; they do not name arbitrary
+callers. Existing request traces appear in `operationTraceId`/`operationSpanId`
+and separate `holderTraceId`/`holderSpanId` fields when present. Missing trace
+fields remain unknown; no new trace or audit execution identity is created.
+
+`identityHash` is a salted digest of the already-normalized store/session
+identity. It correlates only inside the same JavaScript runtime isolate and
+diagnostic epoch. Raw session keys and paths are omitted. The digest is
+operational correlation, not anonymization or authorization evidence.
+
+`slow session lifecycle operation` records operations taking at least one
+second through their actual queued work's settlement. It separates
+`mutationQueueWaitMs`, `lifecycleQueueWaitMs`, `completionDelayMs` and
+`phaseDurationsMs.prepare`, `.run` and `.finalize`. The holder's current
+`holderPhase` can also identify activation, admission or release work. A
+`lifecycle` operation describes its queue attempt after the existing active-
+mutation idle wait; that prior idle wait is not measured here. Calls with no
+normalized identities have no queue and emit no queue-operation summary. A
+caller can cancel before all of its queued work unwinds; `signalAborted`
+reports the signal without claiming that the holder has released.
+
+The tracker preserves outer ownership across reentrant work and retires a
+holder only when its actual queue callback exits. Its state weakly follows
+existing queue objects; it does not create another execution queue. Per
+runtime isolate, it retains at most 128 holder descriptors and 32 one-shot
+wait timers, and emits at most 60 records per minute. The queue timing owner
+explicitly distinguishes reentry, so unobserved outer holders stay unknown at
+capacity or after enablement. `omittedObservations` on a later record reports
+suppressed observations; missing records never prove no wait.
+
+Elapsed intervals can include asynchronous waits and nested work, so phase
+and queue totals need not form a disjoint partition. A holder sample identifies
+who owns that queue at the sampled instant, not every predecessor responsible
+for the entire wait or which work consumed CPU. These are ordinary performance
+logs. They do not use or change [audit identity](/gateway/audit), decisions,
+retention, principal attribution or admission authority.
+
 ### Slow agent database opens
 
 The `slow OpenClaw agent database open` warning includes `phaseDurationsMs` when

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -14,8 +14,10 @@ import {
   isGatewaySubordinateWorkAdmissionClosed,
 } from "../process/gateway-work-admission.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import { runQueuedStoreWrite, type StoreWriterQueue } from "../shared/store-writer-queue.js";
+import type { StoreWriterQueue } from "../shared/store-writer-queue.js";
+import { createLifecycleDiagnosticOperation } from "./session-lifecycle-diagnostics.js";
 import { decodeSessionIdentity, normalizeSessionIdentities } from "./session-lifecycle-identity.js";
+import { createSessionIdentityLockRunner } from "./session-lifecycle-locks.js";
 import {
   clearSessionWorkAdmissionHandoffs,
   createSessionWorkAdmissionHandoff,
@@ -88,8 +90,6 @@ const SESSION_LIFECYCLE_ADMISSION_STATE = resolveGlobalSingleton(
   }),
 );
 const {
-  lifecycleQueues: SESSION_LIFECYCLE_QUEUES,
-  mutationQueues: SESSION_LIFECYCLE_MUTATION_QUEUES,
   activeAdmissions: ACTIVE_SESSION_WORK_ADMISSIONS,
   activeMutations: ACTIVE_SESSION_LIFECYCLE_MUTATIONS,
   activeMutationKinds: ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS,
@@ -101,25 +101,9 @@ const {
 const ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS =
   (SESSION_LIFECYCLE_ADMISSION_STATE.activeMutationRuns ??= new Set());
 
-async function runWithSessionIdentityLocks<T>(
-  identities: readonly string[],
-  index: number,
-  run: () => Promise<T>,
-  kind: "lifecycle" | "mutation" = "lifecycle",
-): Promise<T> {
-  const identity = identities[index];
-  if (!identity) {
-    return await run();
-  }
-  return await runQueuedStoreWrite({
-    queues: kind === "mutation" ? SESSION_LIFECYCLE_MUTATION_QUEUES : SESSION_LIFECYCLE_QUEUES,
-    storePath: identity,
-    label:
-      kind === "mutation" ? "runExclusiveSessionLifecycleMutation" : "runExclusiveSessionLifecycle",
-    reentrant: true,
-    fn: async () => await runWithSessionIdentityLocks(identities, index + 1, run, kind),
-  });
-}
+const runWithSessionIdentityLocks = createSessionIdentityLockRunner(
+  SESSION_LIFECYCLE_ADMISSION_STATE,
+);
 
 function hasActiveSessionLifecycleMutation(identities: readonly string[]): boolean {
   return identities.some((identity) => (ACTIVE_SESSION_LIFECYCLE_MUTATIONS.get(identity) ?? 0) > 0);
@@ -198,13 +182,19 @@ async function runExclusiveSessionLifecycle<T>(params: {
       await waitForNormalizedSessionLifecycleMutationIdle(identities, params.signal);
       continue;
     }
-    const attempt = await runWithSessionIdentityLocks(identities, 0, async () => {
-      params.signal?.throwIfAborted();
-      if (hasActiveSessionLifecycleMutation(identities)) {
-        return { blocked: true as const };
-      }
-      return { blocked: false as const, value: await params.run() };
-    });
+    const diagnostic = createLifecycleDiagnosticOperation("lifecycle", params.signal);
+    const attempt = await runWithSessionIdentityLocks(
+      identities,
+      async () => {
+        params.signal?.throwIfAborted();
+        if (hasActiveSessionLifecycleMutation(identities)) {
+          return { blocked: true as const };
+        }
+        return { blocked: false as const, value: await params.run() };
+      },
+      diagnostic,
+      "run",
+    );
     if (!attempt.blocked) {
       return attempt.value;
     }
@@ -231,35 +221,38 @@ export async function runExclusiveSessionLifecycleMutation<T>(
   const signal = params.signal;
   signal?.throwIfAborted();
   const callerAdmissions = new Set(CURRENT_SESSION_WORK_ADMISSIONS.getStore());
+  const diagnostic = createLifecycleDiagnosticOperation(params.kind ?? "mutation", signal);
   const mutationRun: SessionLifecycleMutationOwner = { identities };
   let mutationActivated = false;
   let removeAbortListener = () => {};
   let releaseWorkAdmissions: (() => void) | undefined;
   const mutation = runWithSessionIdentityLocks(
     identities,
-    0,
     async () =>
       await CURRENT_SESSION_WORK_ADMISSIONS.run(callerAdmissions, async () => {
-        await runWithSessionIdentityLocks(identities, 0, async () => {
-          signal?.throwIfAborted();
-          mutationActivated = true;
-          removeAbortListener();
-          ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS.add(mutationRun);
-          for (const identity of identities) {
-            ACTIVE_SESSION_LIFECYCLE_MUTATIONS.set(
-              identity,
-              (ACTIVE_SESSION_LIFECYCLE_MUTATIONS.get(identity) ?? 0) + 1,
-            );
-            if (params.kind) {
-              const kinds = ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.get(identity) ?? new Map();
-              kinds.set(params.kind, (kinds.get(params.kind) ?? 0) + 1);
-              ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.set(identity, kinds);
+        await runWithSessionIdentityLocks(
+          identities,
+          async () => {
+            signal?.throwIfAborted();
+            mutationActivated = true;
+            removeAbortListener();
+            ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS.add(mutationRun);
+            for (const identity of identities) {
+              const activeCount = ACTIVE_SESSION_LIFECYCLE_MUTATIONS.get(identity) ?? 0;
+              ACTIVE_SESSION_LIFECYCLE_MUTATIONS.set(identity, activeCount + 1);
+              if (params.kind) {
+                const kinds = ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.get(identity) ?? new Map();
+                kinds.set(params.kind, (kinds.get(params.kind) ?? 0) + 1);
+                ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.set(identity, kinds);
+              }
             }
-          }
-        });
+          },
+          diagnostic,
+        );
         // Cancellation may abandon a queued contender, but never an active
         // mutation whose caller must observe cleanup and completion.
         try {
+          diagnostic?.mark("prepare");
           await params.prepare?.({
             // The same mutation owner fences ingress through every awaited cleanup step.
             // Removing this owner below reopens admission for an explicit later request.
@@ -268,45 +261,54 @@ export async function runExclusiveSessionLifecycleMutation<T>(
               releaseWorkAdmissions = closeNormalizedSessionWorkAdmissions(identities, reason);
             },
           });
-          return await runWithSessionIdentityLocks(identities, 0, params.run);
+          diagnostic?.mark("run-admission");
+          return await runWithSessionIdentityLocks(identities, params.run, diagnostic, "run");
         } finally {
           // Resource finalization is part of the mutation: successors remain
           // fenced until rollback or exact-generation cleanup has completed.
           try {
+            diagnostic?.mark("finalize");
             await params.finalize?.();
           } finally {
-            await runWithSessionIdentityLocks(identities, 0, async () => {
-              for (const identity of identities) {
-                if (params.kind) {
-                  const kinds = ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.get(identity);
-                  const remainingKindCount = (kinds?.get(params.kind) ?? 1) - 1;
-                  if (remainingKindCount > 0) {
-                    kinds?.set(params.kind, remainingKindCount);
-                  } else {
-                    kinds?.delete(params.kind);
-                    if (kinds?.size === 0) {
-                      ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.delete(identity);
+            diagnostic?.mark("release");
+            await runWithSessionIdentityLocks(
+              identities,
+              async () => {
+                for (const identity of identities) {
+                  if (params.kind) {
+                    const kinds = ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.get(identity);
+                    const remainingKindCount = (kinds?.get(params.kind) ?? 1) - 1;
+                    if (remainingKindCount > 0) {
+                      kinds?.set(params.kind, remainingKindCount);
+                    } else {
+                      kinds?.delete(params.kind);
+                      if (kinds?.size === 0) {
+                        ACTIVE_SESSION_LIFECYCLE_MUTATION_KINDS.delete(identity);
+                      }
                     }
                   }
+                  const remaining = (ACTIVE_SESSION_LIFECYCLE_MUTATIONS.get(identity) ?? 1) - 1;
+                  if (remaining > 0) {
+                    ACTIVE_SESSION_LIFECYCLE_MUTATIONS.set(identity, remaining);
+                    continue;
+                  }
+                  ACTIVE_SESSION_LIFECYCLE_MUTATIONS.delete(identity);
+                  const waiters = SESSION_LIFECYCLE_IDLE_WAITERS.get(identity);
+                  SESSION_LIFECYCLE_IDLE_WAITERS.delete(identity);
+                  for (const resolve of waiters ?? []) {
+                    resolve();
+                  }
                 }
-                const remaining = (ACTIVE_SESSION_LIFECYCLE_MUTATIONS.get(identity) ?? 1) - 1;
-                if (remaining > 0) {
-                  ACTIVE_SESSION_LIFECYCLE_MUTATIONS.set(identity, remaining);
-                  continue;
-                }
-                ACTIVE_SESSION_LIFECYCLE_MUTATIONS.delete(identity);
-                const waiters = SESSION_LIFECYCLE_IDLE_WAITERS.get(identity);
-                SESSION_LIFECYCLE_IDLE_WAITERS.delete(identity);
-                for (const resolve of waiters ?? []) {
-                  resolve();
-                }
-              }
-              ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS.delete(mutationRun);
-              releaseWorkAdmissions?.();
-            });
+                ACTIVE_SESSION_LIFECYCLE_MUTATION_RUNS.delete(mutationRun);
+                releaseWorkAdmissions?.();
+              },
+              diagnostic,
+            );
           }
         }
       }),
+    diagnostic,
+    "activation",
     "mutation",
   );
   if (!signal) {
@@ -407,10 +409,7 @@ export function isCompetingSessionWorkAdmissionActive(
   );
 }
 
-type SessionWorkAdmissionReleaseParams = {
-  scope: string;
-  identities: Iterable<string | undefined>;
-};
+type SessionWorkAdmissionReleaseParams = SessionLifecycleMutationTarget;
 
 /** Completion of the currently active turns that own a session. */
 export function getSessionWorkAdmissionRelease(

--- a/src/sessions/session-lifecycle-diagnostics.test.ts
+++ b/src/sessions/session-lifecycle-diagnostics.test.ts
@@ -1,0 +1,582 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  areDiagnosticsEnabledForProcess,
+  setDiagnosticsEnabledForProcess,
+} from "../infra/diagnostic-events.js";
+import {
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../infra/diagnostic-trace-context.js";
+import { flushLogger, resetLogger, setLoggerOverride } from "../logging/logger.js";
+import {
+  beginSessionWorkAdmission,
+  runExclusiveSessionLifecycleMutation,
+} from "./session-lifecycle-admission.js";
+
+const traces = {
+  first: { traceId: "1".repeat(32), spanId: "1".repeat(16) },
+  second: { traceId: "2".repeat(32), spanId: "2".repeat(16) },
+  waiter: {
+    traceId: "3".repeat(32),
+    spanId: "3".repeat(16),
+    parentSpanId: "4".repeat(16),
+    traceFlags: "01",
+  },
+} satisfies Record<string, DiagnosticTraceContext>;
+let clock = 120_000;
+let directory: string;
+let logFile: string;
+let diagnosticsWereEnabled: boolean;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function records(message: string): Promise<Record<string, unknown>[]> {
+  await flushLogger();
+  return fs
+    .readFileSync(logFile, "utf8")
+    .split("\n")
+    .flatMap((line) => {
+      if (!line) {
+        return [];
+      }
+      const record: unknown = JSON.parse(line);
+      if (!isRecord(record) || record.message !== message) {
+        return [];
+      }
+      const fields = Object.values(record).find(
+        (value): value is Record<string, unknown> => isRecord(value) && "operationId" in value,
+      );
+      return [
+        {
+          ...fields,
+          traceId: record.traceId,
+          spanId: record.spanId,
+          parentSpanId: record.parentSpanId,
+          traceFlags: record.traceFlags,
+        },
+      ];
+    });
+}
+
+async function advance(ms: number) {
+  clock += ms;
+  await vi.advanceTimersByTimeAsync(ms);
+}
+
+function hold(
+  kind: "lifecycle" | "mutation",
+  target: { scope: string; identities: string[] },
+  trace?: DiagnosticTraceContext,
+) {
+  const entered = createDeferred();
+  const release = createDeferred();
+  const params = {
+    ...target,
+    run: async () => {
+      entered.resolve();
+      await release.promise;
+    },
+  };
+  const promise = runWithDiagnosticTraceContext(trace, () =>
+    kind === "lifecycle"
+      ? beginSessionWorkAdmission({
+          ...target,
+          assertAllowed: params.run,
+          revalidateAllowed: () => {},
+        }).then((lease) => lease.release())
+      : runExclusiveSessionLifecycleMutation(params),
+  );
+  return { entered: entered.promise, release: release.resolve, promise };
+}
+
+beforeEach(() => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-lifecycle-diagnostics-"));
+  logFile = path.join(directory, "runtime.log");
+  fs.writeFileSync(logFile, "");
+  diagnosticsWereEnabled = areDiagnosticsEnabledForProcess();
+  setDiagnosticsEnabledForProcess(true);
+  resetLogger();
+  setLoggerOverride({ level: "warn", consoleLevel: "silent", file: logFile });
+  clock += 120_000;
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+});
+
+afterEach(async () => {
+  await flushLogger();
+  expect(vi.getTimerCount()).toBe(0);
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  setDiagnosticsEnabledForProcess(diagnosticsWereEnabled);
+  setLoggerOverride(null);
+  resetLogger();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+it("reports the current holder after turnover and preserves the waiter's trace and FIFO order", async () => {
+  const target = { scope: "private-store-path", identities: ["private-session-key"] };
+  const firstStarted = createDeferred();
+  const secondStarted = createDeferred();
+  const releaseFirst = createDeferred();
+  const releaseSecond = createDeferred();
+  const order: string[] = [];
+  const first = runWithDiagnosticTraceContext(traces.first, () =>
+    runExclusiveSessionLifecycleMutation({
+      ...target,
+      run: async () => {
+        order.push("first");
+        firstStarted.resolve();
+        await releaseFirst.promise;
+      },
+    }),
+  );
+  await firstStarted.promise;
+  const second = runWithDiagnosticTraceContext(traces.second, () =>
+    runExclusiveSessionLifecycleMutation({
+      ...target,
+      run: async () => {
+        order.push("second");
+        secondStarted.resolve();
+        await releaseSecond.promise;
+      },
+    }),
+  );
+  const waiter = runWithDiagnosticTraceContext(traces.waiter, () =>
+    runExclusiveSessionLifecycleMutation({
+      ...target,
+      run: async () => {
+        order.push("waiter");
+      },
+    }),
+  );
+  try {
+    await advance(500);
+    releaseFirst.resolve();
+    await secondStarted.promise;
+    await advance(500);
+    const waiting = await records("session lifecycle queue waiting");
+    expect(waiting).toHaveLength(1);
+    expect(waiting[0]).toMatchObject({
+      operationTraceId: traces.waiter.traceId,
+      holderTraceId: traces.second.traceId,
+      traceId: traces.waiter.traceId,
+      parentSpanId: traces.waiter.parentSpanId,
+      traceFlags: traces.waiter.traceFlags,
+      queueKind: "mutation",
+      holderPhase: "run",
+      holderObserved: true,
+      waitMs: 1_000,
+    });
+    expect(waiting[0]?.identityHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(waiting)).not.toContain(target.scope);
+    expect(JSON.stringify(waiting)).not.toContain(target.identities[0]);
+    expect(order).toEqual(["first", "second"]);
+  } finally {
+    releaseFirst.resolve();
+    releaseSecond.resolve();
+    await Promise.allSettled([first, second, waiter]);
+  }
+  expect(order).toEqual(["first", "second", "waiter"]);
+});
+
+it("distinguishes mutation and lifecycle holders of the same normalized identity", async () => {
+  const target = { scope: "namespace-store", identities: ["namespace-session"] };
+  const lifecycle = hold("lifecycle", target, traces.first);
+  await lifecycle.entered;
+  const mutation = hold("mutation", target, traces.second);
+  const waiter = hold("mutation", target, traces.waiter);
+  try {
+    await advance(1_000);
+    const waiting = await records("session lifecycle queue waiting");
+    expect(waiting).toHaveLength(2);
+    expect(waiting).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          queueKind: "lifecycle",
+          operationTraceId: traces.second.traceId,
+          holderTraceId: traces.first.traceId,
+          holderPhase: "run",
+        }),
+        expect.objectContaining({
+          queueKind: "mutation",
+          operationTraceId: traces.waiter.traceId,
+          holderTraceId: traces.second.traceId,
+          holderPhase: "activation",
+        }),
+      ]),
+    );
+    expect(new Set(waiting.map((record) => record.identityHash)).size).toBe(1);
+  } finally {
+    lifecycle.release();
+    mutation.release();
+    waiter.release();
+    await Promise.allSettled([lifecycle.promise, mutation.promise, waiter.promise]);
+  }
+});
+
+it.each([true, false])(
+  "preserves an outer holder through reentry when initially enabled=%s",
+  async (initiallyEnabled) => {
+    const target = { scope: `reentry-store-${initiallyEnabled}`, identities: ["reentry-session"] };
+    const outerStarted = createDeferred();
+    const beginNested = createDeferred();
+    const nestedStarted = createDeferred();
+    const releaseNested = createDeferred();
+    const nestedDone = createDeferred();
+    const releaseOuter = createDeferred();
+    setDiagnosticsEnabledForProcess(initiallyEnabled);
+    const outer = runWithDiagnosticTraceContext(traces.first, () =>
+      runExclusiveSessionLifecycleMutation({
+        ...target,
+        run: async () => {
+          outerStarted.resolve();
+          await beginNested.promise;
+          await runWithDiagnosticTraceContext(traces.second, () =>
+            runExclusiveSessionLifecycleMutation({
+              ...target,
+              run: async () => {
+                nestedStarted.resolve();
+                await releaseNested.promise;
+              },
+            }),
+          );
+          nestedDone.resolve();
+          await releaseOuter.promise;
+        },
+      }),
+    );
+    await outerStarted.promise;
+    setDiagnosticsEnabledForProcess(true);
+    beginNested.resolve();
+    await nestedStarted.promise;
+    const waiter = hold("mutation", target, traces.waiter);
+    try {
+      await advance(500);
+      releaseNested.resolve();
+      await nestedDone.promise;
+      await advance(500);
+      const waiting = await records("session lifecycle queue waiting");
+      expect(waiting).toHaveLength(1);
+      expect(waiting[0]).toMatchObject({
+        operationTraceId: traces.waiter.traceId,
+        holderObserved: initiallyEnabled,
+      });
+      expect(waiting[0]?.holderTraceId).toBe(initiallyEnabled ? traces.first.traceId : undefined);
+      expect(waiting[0]?.holderTraceId).not.toBe(traces.second.traceId);
+    } finally {
+      beginNested.resolve();
+      releaseNested.resolve();
+      releaseOuter.resolve();
+      waiter.release();
+      await Promise.allSettled([outer, waiter.promise]);
+    }
+  },
+);
+
+it("measures prepare and finalize separately while successors wait for real finalization", async () => {
+  const target = { scope: "phase-store", identities: ["phase-session"] };
+  const prepareStarted = createDeferred();
+  const releasePrepare = createDeferred();
+  const finalizeStarted = createDeferred();
+  const releaseFinalize = createDeferred();
+  const first = runWithDiagnosticTraceContext(traces.first, () =>
+    runExclusiveSessionLifecycleMutation({
+      ...target,
+      prepare: async () => {
+        prepareStarted.resolve();
+        await releasePrepare.promise;
+      },
+      run: async () => {
+        clock += 30;
+      },
+      finalize: async () => {
+        finalizeStarted.resolve();
+        await releaseFinalize.promise;
+      },
+    }),
+  );
+  await prepareStarted.promise;
+  await advance(200);
+  releasePrepare.resolve();
+  await finalizeStarted.promise;
+  const waiter = hold("mutation", target, traces.waiter);
+  try {
+    await advance(1_000);
+    expect(await records("session lifecycle queue waiting")).toEqual([
+      expect.objectContaining({
+        operationTraceId: traces.waiter.traceId,
+        holderTraceId: traces.first.traceId,
+        holderPhase: "finalize",
+      }),
+    ]);
+  } finally {
+    releasePrepare.resolve();
+    releaseFinalize.resolve();
+    waiter.release();
+    await Promise.allSettled([first, waiter.promise]);
+  }
+  const completed = await records("slow session lifecycle operation");
+  expect(completed).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        operationTraceId: traces.first.traceId,
+        phaseDurationsMs: { prepare: 200, run: 30, finalize: 1_000 },
+        mutationQueueWaitMs: 0,
+        lifecycleQueueWaitMs: 0,
+      }),
+      expect.objectContaining({
+        operationTraceId: traces.waiter.traceId,
+        mutationQueueWaitMs: 1_000,
+      }),
+    ]),
+  );
+});
+
+it("retains a partially acquired holder after caller cancellation until its callback unwinds", async () => {
+  const scope = "partial-cancellation-store";
+  const blocker = hold("lifecycle", { scope, identities: ["b"] }, traces.first);
+  await blocker.entered;
+  const controller = new AbortController();
+  const cancelledRun = vi.fn(async () => {});
+  const cancelled = runWithDiagnosticTraceContext(traces.second, () =>
+    runExclusiveSessionLifecycleMutation({
+      scope,
+      identities: ["a", "b"],
+      signal: controller.signal,
+      run: cancelledRun,
+    }),
+  );
+  await advance(0);
+  const error = new Error("cancel queued mutation");
+  controller.abort(error);
+  await expect(cancelled).rejects.toBe(error);
+  const waiter = hold("mutation", { scope, identities: ["a"] }, traces.waiter);
+  try {
+    await advance(1_000);
+    expect(await records("session lifecycle queue waiting")).toEqual([
+      expect.objectContaining({
+        operationTraceId: traces.waiter.traceId,
+        holderTraceId: traces.second.traceId,
+        holderPhase: "activation",
+        holderSignalAborted: true,
+      }),
+    ]);
+    expect(cancelledRun).not.toHaveBeenCalled();
+  } finally {
+    blocker.release();
+    waiter.release();
+    await Promise.allSettled([blocker.promise, cancelled, waiter.promise]);
+  }
+  await expect(
+    runExclusiveSessionLifecycleMutation({
+      scope,
+      identities: ["a", "b"],
+      run: async () => "next",
+    }),
+  ).resolves.toBe("next");
+});
+
+it("stops pending and terminal emissions when diagnostics are disabled without changing results", async () => {
+  const target = { scope: "disabled-store", identities: ["disabled-session"] };
+  const holder = hold("mutation", target, traces.first);
+  await holder.entered;
+  const waiter = hold("mutation", target, traces.waiter);
+  try {
+    setDiagnosticsEnabledForProcess(false);
+    await advance(1_000);
+  } finally {
+    holder.release();
+    waiter.release();
+    await Promise.all([holder.promise, waiter.promise]);
+  }
+  expect(await records("session lifecycle queue waiting")).toEqual([]);
+  expect(await records("slow session lifecycle operation")).toEqual([]);
+  await expect(
+    runExclusiveSessionLifecycleMutation({
+      ...target,
+      run: async () => "disabled-fast-path",
+    }),
+  ).resolves.toBe("disabled-fast-path");
+});
+
+it("bounds holder, timer and log state without exposing private identities or inventing reentrant holders", async () => {
+  const holders = Array.from({ length: 128 }, (_, index) =>
+    hold("lifecycle", { scope: `bounded-holder-${index}`, identities: ["session"] }),
+  );
+  await Promise.all(holders.map((holder) => holder.entered));
+  const target = { scope: "sensitive-capacity-store", identities: ["sensitive-capacity-session"] };
+  const outerStarted = createDeferred();
+  const beginNested = createDeferred();
+  const nestedStarted = createDeferred();
+  const releaseNested = createDeferred();
+  const releaseOuter = createDeferred();
+  const outer = beginSessionWorkAdmission({
+    ...target,
+    assertAllowed: async () => {
+      outerStarted.resolve();
+      await beginNested.promise;
+      const nested = await runWithDiagnosticTraceContext(traces.second, () =>
+        beginSessionWorkAdmission({
+          ...target,
+          assertAllowed: async () => {
+            nestedStarted.resolve();
+            await releaseNested.promise;
+          },
+          revalidateAllowed: () => {},
+        }),
+      );
+      nested.release();
+      await releaseOuter.promise;
+    },
+    revalidateAllowed: () => {},
+  }).then((lease) => lease.release());
+  await outerStarted.promise;
+  holders[0]!.release();
+  await holders[0]!.promise;
+  beginNested.resolve();
+  await nestedStarted.promise;
+  const waiters = Array.from({ length: 33 }, () => hold("lifecycle", target));
+  try {
+    await advance(0);
+    expect(vi.getTimerCount()).toBe(32);
+    await advance(1_000);
+    const waiting = await records("session lifecycle queue waiting");
+    expect(waiting).toHaveLength(32);
+    expect(waiting.every((row) => row.holderObserved === false)).toBe(true);
+    expect(waiting.every((row) => row.holderTraceId === undefined)).toBe(true);
+    expect(waiting.every((row) => row.operationTraceId === undefined)).toBe(true);
+    expect(new Set(waiting.map((row) => row.identityHash)).size).toBe(1);
+    expect(waiting[0]?.identityHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(waiting)).not.toContain(target.scope);
+    expect(JSON.stringify(waiting)).not.toContain(target.identities[0]);
+    expect(
+      waiting.some(
+        (row) => typeof row.omittedObservations === "number" && row.omittedObservations > 0,
+      ),
+    ).toBe(true);
+  } finally {
+    beginNested.resolve();
+    releaseNested.resolve();
+    releaseOuter.resolve();
+    holders.forEach((holder) => holder.release());
+    waiters.forEach((waiter) => waiter.release());
+    await Promise.allSettled([
+      outer,
+      ...holders.map((holder) => holder.promise),
+      ...waiters.map((waiter) => waiter.promise),
+    ]);
+  }
+  const waiting = await records("session lifecycle queue waiting");
+  const completed = await records("slow session lifecycle operation");
+  expect(waiting.length + completed.length).toBe(60);
+  await advance(60_000);
+  const later = hold("mutation", { scope: "after-budget", identities: ["session"] });
+  await later.entered;
+  await advance(1_000);
+  later.release();
+  await later.promise;
+  const after = await records("slow session lifecycle operation");
+  expect(after.at(-1)?.omittedObservations).toBeGreaterThan(0);
+});
+
+it("shares live holder observations across separately loaded module graphs", async () => {
+  const target = { scope: "fresh-module-store", identities: ["fresh-module-session"] };
+  const holder = hold("mutation", target, traces.first);
+  await holder.entered;
+  // Reset the dependency graph too; query-busting only admission would reuse its diagnostic module.
+  vi.resetModules();
+  const second = await import("./session-lifecycle-admission.js");
+  const freshLogging = await import("../logging/logger.js");
+  const freshDiagnostics = await import("../infra/diagnostic-events.js");
+  freshLogging.setLoggerOverride({ level: "warn", consoleLevel: "silent", file: logFile });
+  freshDiagnostics.setDiagnosticsEnabledForProcess(true);
+  const waiterRan = vi.fn(async () => {});
+  const waiter = runWithDiagnosticTraceContext(traces.waiter, () =>
+    second.runExclusiveSessionLifecycleMutation({ ...target, run: waiterRan }),
+  );
+  try {
+    expect(second.runExclusiveSessionLifecycleMutation).not.toBe(
+      runExclusiveSessionLifecycleMutation,
+    );
+    await advance(1_000);
+    await freshLogging.flushLogger();
+    expect(await records("session lifecycle queue waiting")).toEqual([
+      expect.objectContaining({
+        operationTraceId: traces.waiter.traceId,
+        holderTraceId: traces.first.traceId,
+        holderObserved: true,
+      }),
+    ]);
+    expect(waiterRan).not.toHaveBeenCalled();
+  } finally {
+    holder.release();
+    await Promise.allSettled([holder.promise, waiter]);
+    await freshLogging.flushLogger();
+    freshDiagnostics.setDiagnosticsEnabledForProcess(diagnosticsWereEnabled);
+    freshLogging.setLoggerOverride(null);
+    freshLogging.resetLogger();
+  }
+  expect(waiterRan).toHaveBeenCalledOnce();
+});
+
+it("preserves operation errors and queue release when the native logging sink throws", async () => {
+  vi.resetModules();
+  const logging = await import("../logging/logger.js");
+  const diagnostics = await import("../infra/diagnostic-events.js");
+  logging.setLoggerOverride({ level: "warn", consoleLevel: "silent", file: logFile });
+  diagnostics.setDiagnosticsEnabledForProcess(true);
+  const logger = logging.getLogger();
+  const overwrite = expectDefined(logger.settings.overwrite, "native logger overwrite settings");
+  const previousTransport = overwrite.transportJSON;
+  const failedSink = vi.fn(() => {
+    throw new Error("diagnostic sink unavailable");
+  });
+  overwrite.transportJSON = failedSink;
+  const lifecycle = await import("./session-lifecycle-admission.js");
+  const started = createDeferred();
+  const release = createDeferred();
+  const operationError = new Error("original operation failure");
+  const target = { scope: "failed-sink-store", identities: ["failed-sink-session"] };
+  const first = lifecycle.runExclusiveSessionLifecycleMutation({
+    ...target,
+    run: async () => {
+      started.resolve();
+      await release.promise;
+      throw operationError;
+    },
+  });
+  const firstOutcome = first.catch((error: unknown) => error);
+  await started.promise;
+  const second = lifecycle.runExclusiveSessionLifecycleMutation({
+    ...target,
+    run: async () => "next operation",
+  });
+  try {
+    await advance(1_000);
+    expect(failedSink).toHaveBeenCalled();
+    release.resolve();
+    await expect(firstOutcome).resolves.toBe(operationError);
+    await expect(second).resolves.toBe("next operation");
+    expect(lifecycle.getActiveSessionLifecycleMutationCount()).toBe(0);
+  } finally {
+    release.resolve();
+    await Promise.allSettled([first, second]);
+    if (previousTransport) {
+      overwrite.transportJSON = previousTransport;
+    } else {
+      delete overwrite.transportJSON;
+    }
+    await logging.flushLogger();
+    diagnostics.setDiagnosticsEnabledForProcess(diagnosticsWereEnabled);
+    logging.setLoggerOverride(null);
+    logging.resetLogger();
+  }
+});

--- a/src/sessions/session-lifecycle-diagnostics.test.ts
+++ b/src/sessions/session-lifecycle-diagnostics.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined, isRecord } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import {
@@ -33,10 +33,6 @@ let clock = 120_000;
 let directory: string;
 let logFile: string;
 let diagnosticsWereEnabled: boolean;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 async function records(message: string): Promise<Record<string, unknown>[]> {
   await flushLogger();

--- a/src/sessions/session-lifecycle-diagnostics.ts
+++ b/src/sessions/session-lifecycle-diagnostics.ts
@@ -1,0 +1,270 @@
+import { createHash, randomBytes } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
+import { areDiagnosticsEnabledForProcess } from "../infra/diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  isValidDiagnosticSpanId,
+  isValidDiagnosticTraceFlags,
+  isValidDiagnosticTraceId,
+  runWithDiagnosticTraceContext,
+} from "../infra/diagnostic-trace-context.js";
+import { createFixedWindowBudget } from "../infra/fixed-window-rate-limit.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { StoreWriterQueue, StoreWriterTiming } from "../shared/store-writer-queue.js";
+
+type QueueKind = "lifecycle" | "mutation";
+type Operation = QueueKind | "compaction";
+type Phase =
+  | "admission"
+  | "activation"
+  | "prepare"
+  | "run-admission"
+  | "run"
+  | "finalize"
+  | "release";
+type Holder = { operation: LifecycleDiagnosticOperation; acquiredAt: number };
+const SLOW_MS = 1_000;
+const MAX_HOLDERS = 128;
+const MAX_WATCHERS = 32;
+const log = createSubsystemLogger("sessions/lifecycle");
+
+function state() {
+  return resolveGlobalSingleton(Symbol.for("openclaw.sessionLifecycleDiagnostics"), () => ({
+    salt: randomBytes(16),
+    epoch: randomBytes(8).toString("hex"),
+    sequence: 0,
+    watchers: 0,
+    omitted: 0,
+    holders: new WeakMap<StoreWriterQueue, Holder>(),
+    trackedHolders: 0,
+    budget: createFixedWindowBudget({
+      maxRequests: 60,
+      windowMs: 60_000,
+      now: () => performance.now(),
+    }),
+  }));
+}
+
+function emit(
+  message: string,
+  operation: LifecycleDiagnosticOperation,
+  fields: () => Record<string, unknown>,
+) {
+  const current = state();
+  try {
+    if (!areDiagnosticsEnabledForProcess() || !log.isEnabled("warn")) {
+      return;
+    }
+    if (!current.budget.consume().allowed) {
+      current.omitted++;
+      return;
+    }
+    const trace = operation.traceId
+      ? {
+          traceId: operation.traceId,
+          spanId: operation.spanId,
+          parentSpanId: operation.parentSpanId,
+          traceFlags: operation.traceFlags,
+        }
+      : undefined;
+    runWithDiagnosticTraceContext(trace, () => {
+      log.warn(message, {
+        pid: process.pid,
+        threadId,
+        isMainThread,
+        diagnosticEpoch: current.epoch,
+        omittedObservations: current.omitted,
+        ...fields(),
+      });
+    });
+    current.omitted = 0;
+  } catch {
+    // Diagnostic hashing or logging cannot replace the operation's result.
+    current.omitted++;
+  }
+}
+
+export type LifecycleDiagnosticOperation = {
+  readonly id: number;
+  readonly operation: Operation;
+  readonly rootQueue: QueueKind;
+  readonly signal?: AbortSignal;
+  readonly traceId?: string;
+  readonly spanId?: string;
+  readonly parentSpanId?: string;
+  readonly traceFlags?: string;
+  phase: Phase;
+  mark: (phase: Phase) => void;
+  finish: (finishedAt?: number) => void;
+  queueWaitMs: Record<QueueKind, number>;
+};
+
+export function createLifecycleDiagnosticOperation(
+  operation: Operation,
+  signal?: AbortSignal,
+): LifecycleDiagnosticOperation | undefined {
+  try {
+    if (!areDiagnosticsEnabledForProcess()) {
+      return undefined;
+    }
+    const current = state();
+    const trace = getActiveDiagnosticTraceContext();
+    const traceId = trace?.traceId;
+    const spanId = trace?.spanId;
+    const parentSpanId = trace?.parentSpanId;
+    const traceFlags = trace?.traceFlags;
+    const startedAt = performance.now();
+    let phaseStartedAt = startedAt;
+    const phaseDurationsMs = { prepare: 0, run: 0, finalize: 0 };
+    const result: LifecycleDiagnosticOperation = {
+      id: ++current.sequence,
+      operation,
+      rootQueue: operation === "lifecycle" ? "lifecycle" : "mutation",
+      ...(signal ? { signal } : {}),
+      ...(isValidDiagnosticTraceId(traceId) ? { traceId } : {}),
+      ...(isValidDiagnosticSpanId(spanId) ? { spanId } : {}),
+      ...(isValidDiagnosticSpanId(parentSpanId) ? { parentSpanId } : {}),
+      ...(isValidDiagnosticTraceFlags(traceFlags) ? { traceFlags } : {}),
+      phase: "admission",
+      queueWaitMs: { lifecycle: 0, mutation: 0 },
+      mark(phase) {
+        const now = performance.now();
+        if (result.phase === "prepare" || result.phase === "run" || result.phase === "finalize") {
+          phaseDurationsMs[result.phase] += now - phaseStartedAt;
+        }
+        result.phase = phase;
+        phaseStartedAt = now;
+      },
+      finish(finishedAt) {
+        result.mark("release");
+        const elapsedMs = performance.now() - startedAt;
+        if (elapsedMs < SLOW_MS) {
+          return;
+        }
+        emit("slow session lifecycle operation", result, () => ({
+          operationId: result.id,
+          operation: result.operation,
+          operationTraceId: result.traceId,
+          operationSpanId: result.spanId,
+          elapsedMs: Math.round(elapsedMs),
+          ...(finishedAt !== undefined
+            ? { completionDelayMs: Math.round(performance.now() - finishedAt) }
+            : {}),
+          mutationQueueWaitMs: Math.round(result.queueWaitMs.mutation),
+          lifecycleQueueWaitMs: Math.round(result.queueWaitMs.lifecycle),
+          phaseDurationsMs: Object.fromEntries(
+            Object.entries(phaseDurationsMs).map(([phase, value]) => [phase, Math.round(value)]),
+          ),
+          signalAborted: signal?.aborted ?? false,
+        }));
+      },
+    };
+    return result;
+  } catch {
+    return undefined;
+  }
+}
+
+export function beginLifecycleDiagnosticQueue(
+  operation: LifecycleDiagnosticOperation,
+  kind: QueueKind,
+  queues: Map<string, StoreWriterQueue>,
+  identity: string,
+) {
+  const current = state();
+  const enqueuedAt = performance.now();
+  const timing: StoreWriterTiming = {};
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const stopWatching = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+      current.watchers--;
+    }
+    removeAbortListener?.();
+    removeAbortListener = undefined;
+  };
+  return {
+    timing,
+    watch() {
+      // Idle and reentrant callbacks start synchronously before watch is called.
+      if (timing.startedAt !== undefined || operation.signal?.aborted) {
+        return;
+      }
+      if (current.watchers >= MAX_WATCHERS) {
+        current.omitted++;
+        return;
+      }
+      current.watchers++;
+      timer = setTimeout(() => {
+        stopWatching();
+        if (timing.startedAt !== undefined || operation.signal?.aborted) {
+          return;
+        }
+        const now = performance.now();
+        const queue = queues.get(identity);
+        const holder = queue && current.holders.get(queue);
+        // This is the holder now, never a predecessor remembered at enqueue.
+        emit("session lifecycle queue waiting", operation, () => ({
+          operationId: operation.id,
+          operation: operation.operation,
+          operationTraceId: operation.traceId,
+          operationSpanId: operation.spanId,
+          queueKind: kind,
+          identityHash: createHash("sha256").update(current.salt).update(identity).digest("hex"),
+          waitMs: Math.round(now - enqueuedAt),
+          holderObserved: Boolean(holder),
+          ...(holder
+            ? {
+                holderOperationId: holder.operation.id,
+                holderOperation: holder.operation.operation,
+                holderPhase: holder.operation.phase,
+                holderTraceId: holder.operation.traceId,
+                holderSpanId: holder.operation.spanId,
+                holderElapsedMs: Math.round(now - holder.acquiredAt),
+                holderSignalAborted: holder.operation.signal?.aborted ?? false,
+              }
+            : {}),
+        }));
+      }, SLOW_MS);
+      timer.unref();
+      const onAbort = () => stopWatching();
+      operation.signal?.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => operation.signal?.removeEventListener("abort", onAbort);
+    },
+    enter() {
+      stopWatching();
+      const queue = queues.get(identity);
+      if (!queue) {
+        current.omitted++;
+        return undefined;
+      }
+      // Only the queue owner can distinguish real acquisition from reentry into an unobserved holder.
+      if (timing.reentrant !== false || current.holders.has(queue)) {
+        return undefined;
+      }
+      if (current.trackedHolders >= MAX_HOLDERS) {
+        current.omitted++;
+        return undefined;
+      }
+      const holder: Holder = { operation, acquiredAt: performance.now() };
+      current.holders.set(queue, holder);
+      current.trackedHolders++;
+      return () => {
+        if (current.holders.get(queue) === holder) {
+          current.holders.delete(queue);
+          current.trackedHolders--;
+        }
+      };
+    },
+    finish() {
+      stopWatching();
+      if (timing.startedAt !== undefined) {
+        operation.queueWaitMs[kind] += timing.startedAt - enqueuedAt;
+      }
+    },
+  };
+}

--- a/src/sessions/session-lifecycle-locks.ts
+++ b/src/sessions/session-lifecycle-locks.ts
@@ -1,0 +1,68 @@
+import { runQueuedStoreWrite, type StoreWriterQueue } from "../shared/store-writer-queue.js";
+import {
+  beginLifecycleDiagnosticQueue,
+  type LifecycleDiagnosticOperation,
+} from "./session-lifecycle-diagnostics.js";
+
+export function createSessionIdentityLockRunner(state: {
+  lifecycleQueues: Map<string, StoreWriterQueue>;
+  mutationQueues: Map<string, StoreWriterQueue>;
+}) {
+  return async function runWithSessionIdentityLocks<T>(
+    identities: readonly string[],
+    run: () => Promise<T>,
+    diagnostic?: LifecycleDiagnosticOperation,
+    entryPhase?: "activation" | "run",
+    kind: "lifecycle" | "mutation" = "lifecycle",
+    index = 0,
+  ): Promise<T> {
+    const identity = identities[index];
+    if (!identity) {
+      if (entryPhase) {
+        diagnostic?.mark(entryPhase);
+      }
+      return await run();
+    }
+    const queues = kind === "mutation" ? state.mutationQueues : state.lifecycleQueues;
+    const observation =
+      diagnostic && beginLifecycleDiagnosticQueue(diagnostic, kind, queues, identity);
+    const pending = runQueuedStoreWrite({
+      queues,
+      storePath: identity,
+      label:
+        kind === "mutation"
+          ? "runExclusiveSessionLifecycleMutation"
+          : "runExclusiveSessionLifecycle",
+      reentrant: true,
+      timing: observation?.timing,
+      fn: async () => {
+        const releaseObservation = observation?.enter();
+        try {
+          return await runWithSessionIdentityLocks(
+            identities,
+            run,
+            diagnostic,
+            entryPhase,
+            kind,
+            index + 1,
+          );
+        } finally {
+          if (index === 0 && kind === diagnostic?.rootQueue) {
+            diagnostic.mark("release");
+          }
+          // Callback lifetime remains authoritative even if an outer caller cancels.
+          releaseObservation?.();
+        }
+      },
+    });
+    observation?.watch();
+    try {
+      return await pending;
+    } finally {
+      observation?.finish();
+      if (index === 0 && kind === diagnostic?.rootQueue) {
+        diagnostic.finish(observation?.timing.finishedAt);
+      }
+    }
+  };
+}

--- a/src/shared/store-writer-queue.test.ts
+++ b/src/shared/store-writer-queue.test.ts
@@ -47,8 +47,8 @@ it("marks idle and reentrant execution without deferring either callback", async
     expect(order).toEqual(["outer", "inner"]);
     expect(outerTiming.startedAt).toBe(0);
     expect(await pending).toBe("result");
-    expect(innerTiming).toEqual({ startedAt: 5, finishedAt: 10 });
-    expect(outerTiming).toEqual({ startedAt: 0, finishedAt: 15 });
+    expect(innerTiming).toEqual({ startedAt: 5, finishedAt: 10, reentrant: true });
+    expect(outerTiming).toEqual({ startedAt: 0, finishedAt: 15, reentrant: false });
     expect(queues.size).toBe(0);
   } finally {
     await pending.catch(() => {});

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -25,7 +25,7 @@ export type StoreWriterQueue = {
 type StoreWriterQueues = Map<string, StoreWriterQueue>;
 
 /** Request-owned monotonic timestamps; queued work may be rejected without entering. */
-export type StoreWriterTiming = { startedAt?: number; finishedAt?: number };
+export type StoreWriterTiming = { startedAt?: number; finishedAt?: number; reentrant?: boolean };
 
 type ActiveStoreWriter = {
   active: boolean;
@@ -60,6 +60,7 @@ async function runActiveStoreWriter<T>(
 ): Promise<T> {
   const writer = { active: true, parent: activeStoreWriters.getStore(), queues, storePath };
   if (timing) {
+    timing.reentrant = false;
     timing.startedAt = performance.now();
   }
   try {
@@ -143,6 +144,7 @@ export async function runQueuedStoreWrite<T>(params: {
   // active lane; ordinary async children must queue behind the current writer.
   if (params.reentrant === true && isActiveStoreWriter(params.queues, params.storePath)) {
     if (params.timing) {
+      params.timing.reentrant = true;
       params.timing.startedAt = performance.now();
     }
     try {


### PR DESCRIPTION
Closes #143885

## What Problem This Solves

Operators investigating slow session admission or session mutations cannot tell which operation currently holds the lifecycle queue. A waiter can remain queued through several holders, and a cancelled caller can return before its acquired queues finish unwinding, so the predecessor or caller's completion is insufficient to identify the current owner.

## Why This Change Was Made

Add bounded performance diagnostics that sample the actual queue holder after a one-second wait. They distinguish mutation and lifecycle queues, retain existing waiter and holder trace IDs separately, and retire ownership when the real queue callback exits. The queue producer explicitly identifies reentry, including when diagnostics were enabled after the outer operation began. Terminal records separate queue waits, preparation, execution, finalization, and completion delay.

The tracker uses the existing diagnostics switch, fixed operation categories, and ephemeral salted identity digests. It retains at most 128 holder descriptors and 32 one-shot wait timers and emits at most 60 records per fixed minute window. The private identity-lock helper now owns the recursive acquisition path; shared queues, public admission APIs, awaits, cancellation, and finalization ordering remain intact. These records provide operational correlation without creating audit identity or admission authority.

## User Impact

With diagnostics enabled, slow lifecycle waits expose the current holder, its phase, existing trace context when available, and whether its signal was aborted. Operators can distinguish queue contention from long preparation or finalization while raw session keys and store paths stay out of these records. Missing or capacity-limited observations remain unknown. The logging reference documents the fields and their interpretation.

## Evidence

- The current-holder regression fails on the original source because no holder warning is emitted; queue cleanup and FIFO progression remain intact. All 52 focused diagnostic, lifecycle admission, pending-admission, and shared queue tests pass. They cover turnover, queue namespaces, reentry after enablement, partial-acquisition cancellation, finalization, bounds/privacy, duplicate module graphs, and a throwing native logging sink.
- The full changed-file gate and `git diff --check` pass. Fresh isolated review through P2 found no actionable issues.
- [Ordinary Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34454952675) passed build, Gateway startup, real CLI session creation/update with `expectedSessionId`, RPC and offline readback, restart/readback, and complete process/listener/lease cleanup. The native interactive payload and wrapper exited 0; the controller Actions workflow is marked cancelled. Its controller status is separate from the required PR CI gate. Source bytes, modes, carrier identity, and the index/worktree reconciled before and after execution. This fast user path emitted no lifecycle warnings; focused tests prove the slow-observation boundary.
- A 32-process B/C/C/B comparison measured warm public admission and the real SQLite-backed `sessions.patch` handler with diagnostics enabled and disabled. All source/runtime/configuration receipts, process closures, 16 allocation profiles, and 16 closed database readbacks passed. Latency and allocation profiling ran separately.

On Node 24.20.0, enabled admission p50 increased from 15.042 to 17.542 µs (**+2.501 µs, +16.62%**), and p95 from 21.792 to 25.937 µs (**+19.02%**). Disabled admission p50 changed by -0.14% and p95 by +0.67%, within observed repeat variation. Sampled JavaScript allocation increased by 4,209 bytes/admission (+8.49%) enabled and 643 bytes (+1.30%) disabled; patch allocation increased by 1.27% enabled and 0.17% disabled. Sampling includes common harness allocations and collected objects; it is not exact or native allocation accounting.

Patch latency remains **inconclusive** under variable background load on the 32-logical-CPU host: raw medians fell in both modes, while disabled p95 rose 66%. These measurements establish neither a patch speedup nor latency equivalence. They cover warm direct-owner/handler behavior, excluding startup and WebSocket/provider transport.
