### PR TITLE
refactor(browser): share action execution context

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.interactions.execution.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.execution.ts
@@ -57,11 +57,16 @@ async function executeSingleAction(
     throw new Error(`Batch nesting depth exceeds maximum of ${ACT_MAX_BATCH_DEPTH}`);
   }
   const effectiveTargetId = action.targetId ?? targetId;
+  const interaction = {
+    cdpUrl,
+    targetId: effectiveTargetId,
+    ...navigationPolicy,
+    signal,
+  };
   switch (action.kind) {
     case "click":
       await clickViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         ref: action.ref,
         selector: action.selector,
         doubleClick: action.doubleClick,
@@ -71,102 +76,76 @@ async function executeSingleAction(
         >,
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "clickCoords":
       await clickCoordsViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         x: action.x,
         y: action.y,
         doubleClick: action.doubleClick,
         button: action.button as "left" | "right" | "middle" | undefined,
         delayMs: action.delayMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "type":
       await typeViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         ref: action.ref,
         selector: action.selector,
         text: action.text,
         submit: action.submit,
         slowly: action.slowly,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "press":
       await pressKeyViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         key: action.key,
         delayMs: action.delayMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "hover":
       await hoverViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "scrollIntoView":
       await scrollIntoViewViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "drag":
       await dragViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         startRef: action.startRef,
         startSelector: action.startSelector,
         endRef: action.endRef,
         endSelector: action.endSelector,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "select":
       await selectOptionViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         ref: action.ref,
         selector: action.selector,
         values: action.values,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "fill":
       await fillFormViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         fields: action.fields,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "resize":
@@ -183,8 +162,7 @@ async function executeSingleAction(
         throw new Error("wait --fn is disabled by config (browser.evaluateEnabled=false)");
       }
       await waitForViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
+        ...interaction,
         timeMs: action.timeMs,
         text: action.text,
         textGone: action.textGone,
@@ -193,8 +171,6 @@ async function executeSingleAction(
         loadState: action.loadState,
         fn: action.fn,
         timeoutMs: action.timeoutMs,
-        ...navigationPolicy,
-        signal,
       });
       break;
     case "evaluate":
@@ -202,13 +178,10 @@ async function executeSingleAction(
         throw new Error("act:evaluate is disabled by config (browser.evaluateEnabled=false)");
       }
       return await evaluateViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
-        ...navigationPolicy,
+        ...interaction,
         fn: action.fn,
         ref: action.ref,
         timeoutMs: action.timeoutMs,
-        signal,
       });
     case "close":
       await closePageViaPlaywright({
@@ -218,14 +191,11 @@ async function executeSingleAction(
       break;
     case "batch": {
       const batch = await batchViaPlaywright({
-        cdpUrl,
-        targetId: effectiveTargetId,
-        ...navigationPolicy,
+        ...interaction,
         actions: action.actions,
         stopOnError: action.stopOnError,
         evaluateEnabled,
         depth: depth + 1,
-        signal,
       });
       // A nested batch is one parent action; surface its first failure so each
       // level applies its own stopOnError without discarding the child outcome.


### PR DESCRIPTION
## What Problem This Solves

Browser action maintenance repeats the same target, navigation-policy, and cancellation context across twelve dispatch branches. This maintainer-requested refactor removes that repetition.

## Why This Change Was Made

Prepare the shared operation context once per action, then combine it with each action's explicit arguments. Nested batches retain their effective target and cancellation signal; close and resize retain their existing options.

## User Impact

No intended user-visible change. Browser actions, navigation checks, cancellation, and batch outcomes retain their existing behavior. The change removes 30 production lines from one file without adding helpers or changing tests.

## Evidence

- All 72 existing batch and navigation-guard tests passed before and after the change, including nested policy forwarding, navigation/close aborts, and failure propagation.
- The complete changed-file checks passed, including extension and extension-test typechecks, lint, dependency/boundary checks, unused exports, and import cycles.
- A fresh isolated P0–P2 review found no actionable issues.
- No live browser or operator state was used; transport implementations and public interfaces are unchanged.
