### PR TITLE
fix: restore desktop checks after concurrent UI fixes

### DIFF
--- a/ui/src/components/desktop/desktop-panel-credentials.ts
+++ b/ui/src/components/desktop/desktop-panel-credentials.ts
@@ -1,7 +1,19 @@
-import type { DesktopObserveResult } from "@openclaw/gateway-protocol";
+import type { DesktopObserveResult, DesktopSource } from "@openclaw/gateway-protocol";
 import type { DesktopCredentials } from "./desktop-panel-connection.ts";
 
 const DESKTOP_CREDENTIALS_REQUIRED_CODE = "DESKTOP_CREDENTIALS_REQUIRED";
+
+export function forObserve(
+  source: DesktopSource,
+  auth: "vnc-password" | "ard-account" | undefined,
+  saved: DesktopCredentials | undefined,
+): DesktopCredentials | undefined {
+  return source.kind !== "environment" &&
+    saved?.password &&
+    (auth === "vnc-password" || (auth === "ard-account" && saved.username))
+    ? saved
+    : undefined;
+}
 
 export function rfbCredentials(
   observed: DesktopObserveResult,

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -28,7 +28,7 @@ import {
   type ObservedDesktopConnection,
   type PendingDesktopConnection,
 } from "./desktop-panel-connection.ts";
-import { desktopCredentialRequirement, rfbCredentials } from "./desktop-panel-credentials.ts";
+import * as desktopAuth from "./desktop-panel-credentials.ts";
 import { DesktopPanelFullscreenController } from "./desktop-panel-fullscreen-controller.ts";
 import { desktopPanelLayout } from "./desktop-panel-layout.ts";
 import { type DesktopPanelState, renderDesktopPanelRecovery } from "./desktop-panel-state.ts";
@@ -393,23 +393,17 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     }
     this.controlTakeoverRecoveryUsed = options.takeoverRecovery === true;
     try {
-      const observeCredentials =
-        source.kind !== "environment" &&
-        this.credentials?.password &&
-        (this.credentialAuth === "vnc-password" ||
-          (this.credentialAuth === "ard-account" && this.credentials.username))
-          ? this.credentials
-          : undefined;
+      const supplied = desktopAuth.forObserve(source, this.credentialAuth, this.credentials);
       const observed = await client.request<DesktopObserveResult>("desktop.observe", {
         source,
         control,
-        ...(observeCredentials ? { credentials: observeCredentials } : {}),
+        ...(supplied ? { credentials: supplied } : {}),
       });
       if (operationId !== this.operationId) {
         return;
       }
       this.controlling = observed.control;
-      const credentials = rfbCredentials(observed, this.credentials);
+      const credentials = desktopAuth.rfbCredentials(observed, this.credentials);
       if (
         observed.auth === "vnc-password" &&
         observed.preauthenticated !== true &&
@@ -426,7 +420,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       }
       await this.connectObserved({ environmentId, control, observed, operationId }, credentials);
     } catch (error) {
-      const requiredAuth = desktopCredentialRequirement(error);
+      const requiredAuth = desktopAuth.desktopCredentialRequirement(error);
       if (requiredAuth && operationId === this.operationId) {
         this.connection.disconnect();
         this.credentialAuth = requiredAuth;


### PR DESCRIPTION
Related: #143831, #143828

## What Problem This Solves

Fixes the desktop panel lint failure after two independently validated desktop fixes landed together. Their combined result reached 703 counted lines against the existing 700-line limit; the merged behavior still passed its component tests.

## Why This Change Was Made

The existing outbound credential predicate now lives beside the inbound credential and credential-recovery rules in the desktop credential helper. The panel continues to omit the credentials field unless the same source, password, and authentication conditions allow it. No runtime behavior, permission, protocol, or lint limit changes.

## User Impact

Restores the repository check while preserving automatic session desktop selection, worker authentication, and named control-takeover notices.

## Evidence

- Reproduced the merged-main lint error: 703 lines, maximum 700.
- The same 66 desktop component tests pass before and after the extraction.
- Independent review found no actionable P0–P2 findings.
- `node scripts/check-changed.mjs` passed, including the original line limit, core/UI type checks, lint, and source guards.

This follow-up does not change the UI appearance; the inspected visual evidence remains in #143831.
