### PR TITLE
fix(ai): preserve provider turn headers with explicit sessions

### DIFF
--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -37,8 +37,11 @@ import {
   type MutableAssistantOutput,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
-import { resolveProviderTransportTurnState } from "./provider-transport-turn-state.js";
-import { hasOpencodeSessionHeader, resolveOpencodeSessionHeaders } from "./session-affinity.js";
+import {
+  filterProviderTurnHeadersForExplicitOpencodeSession,
+  resolveProviderTransportTurnState,
+} from "./provider-transport-turn-state.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import {
   createWritableTransportEventStream,
   failTransportStream,
@@ -210,9 +213,11 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           transport: "stream",
         });
         const optionHeaders = resolveOpencodeSessionHeaders(model, options);
-        const turnHeaders = hasOpencodeSessionHeader(model, options)
-          ? undefined
-          : turnState?.headers;
+        const turnHeaders = filterProviderTurnHeadersForExplicitOpencodeSession(
+          model,
+          options,
+          turnState?.headers,
+        );
         // The OpenAI SDK consumes the SSE terminal without yielding it. Observe
         // the raw body so native tool calls can distinguish clean DONE from EOF.
         const doneDetector = createSseDoneDetector();

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -81,9 +81,11 @@ import {
   log,
   resolveOpenAIClientBaseUrl,
 } from "./openai-transport-shared.js";
-import { resolveProviderTransportTurnState } from "./provider-transport-turn-state.js";
+import {
+  filterProviderTurnHeadersForExplicitOpencodeSession,
+  resolveProviderTransportTurnState,
+} from "./provider-transport-turn-state.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
-import { hasOpencodeSessionHeader } from "./session-affinity.js";
 import {
   createWritableTransportEventStream,
   failTransportStream,
@@ -196,13 +198,22 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           transport: websocketMode ? "websocket" : "stream",
         });
         const websocketSessionPolicy = websocketMode ? turnState?.websocket : undefined;
-        const hasExplicitOpencodeSession = hasOpencodeSessionHeader(model, options);
+        const httpTurnHeaders = filterProviderTurnHeadersForExplicitOpencodeSession(
+          model,
+          options,
+          turnState?.headers,
+        );
+        const websocketTurnHeaders = filterProviderTurnHeadersForExplicitOpencodeSession(
+          model,
+          options,
+          websocketSessionPolicy?.headers,
+        );
         const websocketHeaders = websocketMode
           ? buildOpenAIClientHeaders(
               model,
               context,
               options?.headers,
-              hasExplicitOpencodeSession ? undefined : websocketSessionPolicy?.headers,
+              websocketTurnHeaders,
               options?.sessionId,
               options?.cacheRetention,
             )
@@ -211,7 +222,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           model,
           context,
           options?.headers,
-          hasExplicitOpencodeSession ? undefined : turnState?.headers,
+          httpTurnHeaders,
           options?.sessionId,
           options?.cacheRetention,
         );

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -343,6 +343,7 @@ describe("native OpenAI Responses WebSocket client integration", () => {
               headers: {
                 "x-client-request-id": context.sessionId ?? "",
                 "x-openclaw-session-id": context.sessionId ?? "",
+                "x-provider-route": "route-a",
               },
               degradeCooldownMs: 1_000,
             },
@@ -385,6 +386,28 @@ describe("native OpenAI Responses WebSocket client integration", () => {
       );
     },
   );
+
+  it("preserves nonconflicting turn headers with an explicit OpenCode session", async () => {
+    transportState.responseBatches.push([message(completedEvent("resp_accepted", "ok"))]);
+
+    const result = await run(
+      { messages: [userMessage("hello", 1)], tools: [] },
+      {
+        model: {
+          ...model,
+          headers: { "X-OpenCode-Session": "configured-session" },
+        },
+      },
+    );
+
+    expect(result.stopReason).toBe("stop");
+    expect(transportState.websocketOptions[0]?.headers).toMatchObject({
+      "X-OpenCode-Session": "configured-session",
+      "x-client-request-id": "session-1",
+      "x-openclaw-session-id": "session-1",
+      "x-provider-route": "route-a",
+    });
+  });
 
   it("closes the WebSocket when acceptance observation fails", async () => {
     transportState.responseBatches.push([message(completedEvent("resp_rejected", "ignored"))]);

--- a/packages/ai/src/transports/provider-transport-session-headers.test.ts
+++ b/packages/ai/src/transports/provider-transport-session-headers.test.ts
@@ -150,7 +150,10 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
         plugin: {
           ...initialHost.plugin,
           resolveTransportTurnState: ({ context }) => ({
-            headers: { "x-opencode-session": context.turnId },
+            headers: {
+              "x-opencode-session": context.turnId,
+              "x-provider-route": "route-a",
+            },
           }),
         },
       });
@@ -197,6 +200,7 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
         } else {
           expect(sessionHeader).toBe(testCase.expected);
         }
+        expect(requests[0]?.headers.get("x-provider-route")).toBe("route-a");
       }
     },
   );
@@ -220,13 +224,16 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
           ...initialHost.plugin,
           resolveProviderStream: () => undefined,
           resolveTransportTurnState: ({ context }) => ({
-            headers: { "x-opencode-session": context.turnId },
+            headers: {
+              "x-opencode-session": context.turnId,
+              "x-provider-route": "route-a",
+            },
           }),
         },
       });
       const apiRegistry = createApiRegistry();
       registerBuiltInApiProviders(apiRegistry);
-      const sourceModel = {
+      const baseModel = {
         id: "test-model",
         name: "Test model",
         api,
@@ -238,22 +245,42 @@ describe("managed OpenCode conversation headers at fetch egress", () => {
         contextWindow: 128_000,
         maxTokens: 128,
       } satisfies Model;
-      const model = prepareModelForSimpleCompletion({ apiRegistry, model: sourceModel });
 
-      expect(model.api).toBe(api);
-      const provider = apiRegistry.getApiProvider(model.api);
-      if (!provider) {
-        throw new Error(`No provider registered for ${api}`);
+      for (const testCase of [
+        { expected: "generated" },
+        { modelHeaders: { "X-OpenCode-Session": "model-session" }, expected: "model-session" },
+        { headers: { "x-opencode-session": "stream-session" }, expected: "stream-session" },
+      ] as const) {
+        const sourceModel = {
+          ...baseModel,
+          headers: "modelHeaders" in testCase ? testCase.modelHeaders : undefined,
+        };
+        const model = prepareModelForSimpleCompletion({ apiRegistry, model: sourceModel });
+        expect(model.api).toBe(api);
+        const provider = apiRegistry.getApiProvider(model.api);
+        if (!provider) {
+          throw new Error(`No provider registered for ${api}`);
+        }
+        requests.length = 0;
+        const stream = provider.streamSimple(
+          model,
+          { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+          {
+            apiKey: "test-key",
+            headers: "headers" in testCase ? testCase.headers : undefined,
+          },
+        );
+        await stream.result();
+
+        expect(requests).toHaveLength(1);
+        const sessionHeader = requests[0]?.headers.get("x-opencode-session");
+        if (testCase.expected === "generated") {
+          expect(sessionHeader).toBeTruthy();
+        } else {
+          expect(sessionHeader).toBe(testCase.expected);
+        }
+        expect(requests[0]?.headers.get("x-provider-route")).toBe("route-a");
       }
-      const stream = provider.streamSimple(
-        model,
-        { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
-        { apiKey: "test-key" },
-      );
-      await stream.result();
-
-      expect(requests).toHaveLength(1);
-      expect(requests[0]?.headers.get("x-opencode-session")).toBeTruthy();
     },
   );
 });

--- a/packages/ai/src/transports/provider-transport-turn-state.ts
+++ b/packages/ai/src/transports/provider-transport-turn-state.ts
@@ -33,19 +33,35 @@ export function resolveProviderTransportTurnState(
   });
 }
 
+export function filterProviderTurnHeadersForExplicitOpencodeSession(
+  model: Pick<Model, "headers">,
+  options: Pick<StreamOptions, "headers"> | undefined,
+  turnHeaders: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!turnHeaders || !hasOpencodeSessionHeader(model, options)) {
+    return turnHeaders;
+  }
+  const filtered = Object.fromEntries(
+    Object.entries(turnHeaders).filter(([name]) => name.toLowerCase() !== "x-opencode-session"),
+  );
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
 export function resolveProviderSimpleCompletionHeaders(
   model: Model,
   options?: Pick<StreamOptions, "headers" | "sessionId">,
 ) {
   const optionHeaders = resolveOpencodeSessionHeaders(model, options);
-  if (hasOpencodeSessionHeader(model, { headers: optionHeaders })) {
-    return optionHeaders;
-  }
   const turnState = resolveProviderTransportTurnState(model, {
     sessionId: options?.sessionId,
     turnId: randomUUID(),
     attempt: 1,
     transport: "stream",
   });
-  return { ...turnState?.headers, ...optionHeaders };
+  const turnHeaders = filterProviderTurnHeadersForExplicitOpencodeSession(
+    model,
+    { headers: optionHeaders },
+    turnState?.headers,
+  );
+  return { ...turnHeaders, ...optionHeaders };
 }


### PR DESCRIPTION
Related: #143558

## What Problem This Solves

Fixes an issue where OpenCode-backed turns with an explicit session header could lose other provider turn-state headers, including routing metadata, when using managed completions, Responses HTTP or WebSocket, or the simple completion path.

## Why This Change Was Made

Provider turn-state resolution now removes only the conflicting `x-opencode-session` header when the caller supplies an explicit session. All non-conflicting provider headers remain attached, while caller-provided session precedence is unchanged across the affected transports.

## User Impact

Explicit OpenCode sessions retain provider routing and other turn-state metadata instead of silently dropping the entire provider header set.

## Evidence

- Added regression coverage for managed completions, simple completions, Responses HTTP, and Responses WebSocket.
- `oxfmt --check` passes for all five changed files.
- `git diff --check` passes.
- Independent autoreview of the complete corrective patch found no P0-P2 issues.
- Local Vitest and oxlint execution could not start because this task worktree uses a borrowed dependency symlink: the donor install is missing markdown dependencies and the declaration-boundary guard rejects compiler inputs outside the checkout. Exact-head hosted CI is the executable proof path.
