### PR TITLE
fix(agents): report subscription billing copy for CLI backend runs

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -262,6 +262,7 @@ async function runPreparedCliAgentOwned(
     model: context.modelId,
     sessionId: params.sessionId,
     lane: params.lane,
+    ...(context.cliAuthMode ? { authMode: context.cliAuthMode } : {}),
   };
   const sessionBindingDisabled = context.preparedBackend.backend.sessionMode === "none";
   const preparedContextAgentMeta =

--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -9,8 +9,6 @@ import {
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { applyCliSessionBindingResult, getCliSessionBinding } from "../cli-session.js";
 import { renderBillingReplyCopy } from "../failover/user-copy.js";
-import { appendFailedCandidateAttempt } from "../model-fallback-attempt.js";
-import type { FallbackAttempt } from "../model-fallback.types.js";
 import {
   buildBlockedCliRunResult,
   buildCliRunResult,
@@ -235,20 +233,20 @@ describe("settleCliBackendOutcome failover auth mode", () => {
   });
 
   it("renders subscription billing copy for a subscription-auth CLI run", () => {
-    const error = settle({
-      provider: "claude-cli",
-      model: "claude-sonnet-5",
-      sessionId: "sess-1",
-      authMode: "oauth",
-    });
-    const attempts: FallbackAttempt[] = [];
-    appendFailedCandidateAttempt({
-      attempts,
-      candidate: { provider: "claude-cli", model: "claude-sonnet-5" },
-      error,
-    });
-    expect(renderBillingReplyCopy({ attempts })).toContain(
-      "check your account for subscription or usage limits",
-    );
+    // The settled error carries authMode ("carries..." case above); the reply
+    // copy selects it from the attempt record, so build that record directly.
+    expect(
+      renderBillingReplyCopy({
+        attempts: [
+          {
+            provider: "claude-cli",
+            model: "claude-sonnet-5",
+            reason: "billing",
+            error: "Credit balance is too low",
+            authMode: "oauth",
+          },
+        ],
+      }),
+    ).toContain("check your account for subscription or usage limits");
   });
 });

--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -8,7 +8,14 @@ import {
 } from "../cli-runner.js";
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { applyCliSessionBindingResult, getCliSessionBinding } from "../cli-session.js";
-import { buildBlockedCliRunResult, buildCliRunResult } from "./cli-run-settlement.js";
+import { renderBillingReplyCopy } from "../failover/user-copy.js";
+import { appendFailedCandidateAttempt } from "../model-fallback-attempt.js";
+import type { FallbackAttempt } from "../model-fallback.types.js";
+import {
+  buildBlockedCliRunResult,
+  buildCliRunResult,
+  settleCliBackendOutcome,
+} from "./cli-run-settlement.js";
 
 describe("isCliBindingFlushed", () => {
   const workspaceDir = "/tmp/openclaw-workspace";
@@ -180,4 +187,68 @@ describe("CLI native continuity projection", () => {
       );
     },
   );
+});
+
+describe("settleCliBackendOutcome failover auth mode", () => {
+  const billingRunError = new Error("Credit balance is too low");
+
+  const settle = (failoverContext: {
+    provider: string;
+    model: string;
+    sessionId: string;
+    authMode?: string;
+  }): unknown => {
+    try {
+      settleCliBackendOutcome({
+        runResult: undefined,
+        runError: billingRunError,
+        runFailed: true,
+        cleanupError: undefined,
+        deliveredMessagingSideEffect: false,
+        failoverContext,
+      });
+    } catch (error) {
+      return error;
+    }
+    return undefined;
+  };
+
+  it("carries the selected credential's auth mode into the thrown failover error", () => {
+    expect(
+      settle({
+        provider: "claude-cli",
+        model: "claude-sonnet-5",
+        sessionId: "sess-1",
+        authMode: "oauth",
+      }),
+    ).toMatchObject({ reason: "billing", authMode: "oauth" });
+  });
+
+  it("leaves the auth mode unset for unprofiled runs", () => {
+    expect(
+      settle({
+        provider: "claude-cli",
+        model: "claude-sonnet-5",
+        sessionId: "sess-1",
+      }),
+    ).toMatchObject({ reason: "billing", authMode: undefined });
+  });
+
+  it("renders subscription billing copy for a subscription-auth CLI run", () => {
+    const error = settle({
+      provider: "claude-cli",
+      model: "claude-sonnet-5",
+      sessionId: "sess-1",
+      authMode: "oauth",
+    });
+    const attempts: FallbackAttempt[] = [];
+    appendFailedCandidateAttempt({
+      attempts,
+      candidate: { provider: "claude-cli", model: "claude-sonnet-5" },
+      error,
+    });
+    expect(renderBillingReplyCopy({ attempts })).toContain(
+      "check your account for subscription or usage limits",
+    );
+  });
 });

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -21,6 +21,7 @@ import { resolveAuthProfileFailureReason } from "../embedded-agent-runner/run/au
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
 import { mergeAttemptToolMediaPayloads } from "../embedded-agent-runner/run/tool-media-payloads.js";
 import { coerceToFailoverError, isFailoverError } from "../failover-error.js";
+import type { FailoverErrorContext } from "../failover-error.js";
 import { recordAgentCleanupFailure } from "../run-cleanup-timeout.js";
 import { CliAuthProfilePreparationError } from "./auth-profile-preparation-error.js";
 import { runCliCleanup } from "./cleanup.js";
@@ -685,7 +686,7 @@ export function settleCliBackendOutcome(params: {
   cleanupError: Error | undefined;
   deliveredMessagingSideEffect: boolean;
   diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle;
-  failoverContext: { provider: string; model: string; sessionId: string; lane?: string };
+  failoverContext: FailoverErrorContext & { provider: string; model: string; sessionId: string };
 }): EmbeddedAgentRunResult {
   const {
     cleanupError,

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -82,6 +82,7 @@ export async function executeCliProcess(params: {
     model: context.modelId,
     sessionId: runParams.sessionId,
     lane: runParams.lane,
+    ...(context.cliAuthMode ? { authMode: context.cliAuthMode } : {}),
   };
   const outputErrorContext = { ...failoverContext, runId: runParams.runId };
   // buildCliArgs emits this option only for an actual checkpointed resume.

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1478,7 +1478,7 @@ describe("prepareCliRunContext", () => {
         resolveApiKeyForProfile,
       });
 
-      await fixture.prepare({
+      const context = await fixture.prepare({
         sessionKey: "agent:main:main",
         agentDir,
         provider: "claude-cli",
@@ -1492,6 +1492,9 @@ describe("prepareCliRunContext", () => {
         expect.objectContaining({ authProfileId: undefined, authCredential: undefined }),
       );
       expect(resolveApiKeyForProfile).not.toHaveBeenCalled();
+      // Native ownership clears the selected profile below, so the subscription
+      // semantics must already be captured for failover copy.
+      expect(context.cliAuthMode).toBe(credential.type);
     },
   );
 

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -68,6 +68,7 @@ import { externalCliDiscoveryForProviderAuth } from "../auth-profiles/external-c
 import { buildOAuthRefreshFailureLoginCommand } from "../auth-profiles/oauth-refresh-failure.js";
 import { resolveApiKeyForProfile } from "../auth-profiles/oauth.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
+import { resolveSubscriptionAuthModeForProfiles } from "../auth-profiles/profile-list.js";
 import { isSetupCredentialAccessible } from "../auth-profiles/setup-access.js";
 import { loadAuthProfileStoreForRuntime } from "../auth-profiles/store-runtime.js";
 import { resolveRuntimeAuthProfileAgentDir } from "../auth-profiles/store.js";
@@ -844,6 +845,16 @@ async function prepareCliRunContextWithinReadFence(
   ) {
     throw new Error("This saved sign-in is inactive. Test and activate it in Model Setup.");
   }
+  // Failover copy needs the selected credential's subscription semantics even
+  // when the native backend owns the credential itself and the profile id is
+  // cleared below. API-key profiles stay unset on purpose: their billing
+  // failures correctly keep the API-key wording.
+  const cliAuthMode = authStore
+    ? resolveSubscriptionAuthModeForProfiles({
+        store: authStore,
+        profileIds: [effectiveAuthProfileId],
+      })
+    : undefined;
   // Claude owns its native login and single-use refresh-token family. Never
   // preflight, refresh, or forward OpenClaw's snapshot; the installed Claude
   // process validates and refreshes its own current login.
@@ -2229,6 +2240,7 @@ async function prepareCliRunContextWithinReadFence(
         bindQuestionAnswerAuthority,
         effectiveAuthProfileId,
         ...(authStore ? { authProfileStore: authStore } : {}),
+        ...(cliAuthMode ? { cliAuthMode } : {}),
         agentDir,
         started,
         workspaceDir,
@@ -2352,6 +2364,7 @@ async function prepareCliRunContextWithinReadFence(
       bindQuestionAnswerAuthority,
       effectiveAuthProfileId,
       ...(authStore ? { authProfileStore: authStore } : {}),
+      ...(cliAuthMode ? { cliAuthMode } : {}),
       agentDir,
       started,
       workspaceDir,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -376,6 +376,14 @@ export type PreparedCliRunContext = {
   effectiveAuthProfileId?: string;
   /** Selected profile snapshot used only for terminal health settlement. */
   authProfileStore?: AuthProfileStore;
+  /**
+   * Subscription semantics of the credential selected at prepare time, captured
+   * before native-auth handling clears the profile id. Failover copy reads this
+   * so billing failures on oauth/token-backed CLI runs do not suggest topping up
+   * an API key the gateway never had. API-key-backed and unprofiled runs stay
+   * unset.
+   */
+  cliAuthMode?: "oauth" | "token";
   agentDir?: string;
   started: number;
   workspaceDir: string;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -656,7 +656,7 @@ export function describeFailoverError(err: unknown): {
   };
 }
 
-type FailoverErrorContext = {
+export type FailoverErrorContext = {
   provider?: string;
   model?: string;
   profileId?: string;

--- a/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
@@ -150,7 +150,9 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
     if (result.kind !== "final") {
       throw new Error("expected the failed turn to settle into a final failure reply");
     }
-    return result.payload.text;
+    const text = result.payload.text;
+    expect(text, "final failure reply should carry text").toBeTruthy();
+    return text ?? "";
   }
 
   it("reports subscription billing copy when a subscription-backed CLI run fails billing", async () => {

--- a/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
@@ -69,6 +69,8 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
     cliBackendsTesting.resetDepsForTest();
   });
 
+  // Harness auth selection reads the run's agentDir while CLI prepare resolves
+  // the state-derived dir, so the fixture must align them before seeding.
   async function seedAuthProfile(profileId: string, credential: AuthProfileCredential) {
     await updateAuthProfileStoreWithLock({
       agentDir,
@@ -125,6 +127,8 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
   function createClaudeCliFollowupRun() {
     const followupRun = createFollowupRun();
     followupRun.run.agentId = "agent";
+    // Credential selection and CLI prepare must see the same profile store.
+    followupRun.run.agentDir = agentDir;
     followupRun.run.provider = "claude-cli";
     followupRun.run.model = claudeCliModel;
     followupRun.run.skillsSnapshot = { prompt: "", skills: [], version: 0 };
@@ -132,11 +136,12 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
     return followupRun;
   }
 
-  async function runTurnAndReadFailureReplyText(): Promise<string> {
+  async function runTurnAndReadFailureReplyText(
+    followupRun: ReturnType<typeof createClaudeCliFollowupRun>,
+  ): Promise<string> {
     registerBillingFailureClaudeCliBackend();
     runRealCliRunnerForOnce();
     useClaudeCliFallback();
-    const followupRun = createClaudeCliFollowupRun();
     followupRun.run.authProfileId = "claude-cli:work";
     followupRun.run.authProfileIdSource = "auto";
     const executeAgentTurn = await getExecuteAgentTurnForTest();
@@ -156,6 +161,7 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
   }
 
   it("reports subscription billing copy when a subscription-backed CLI run fails billing", async () => {
+    const followupRun = createClaudeCliFollowupRun();
     await seedAuthProfile("claude-cli:work", {
       type: "oauth",
       provider: "claude-cli",
@@ -164,7 +170,7 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
       expires: Date.now() + 3_600_000,
     });
 
-    const replyText = await runTurnAndReadFailureReplyText();
+    const replyText = await runTurnAndReadFailureReplyText(followupRun);
 
     expect(replyText).toContain("check your account for subscription or usage limits");
     expect(replyText).toContain(`claude-cli (${claudeCliModel})`);
@@ -172,13 +178,14 @@ describe("executeAgentTurn: CLI billing failure reply copy", () => {
   }, 60_000);
 
   it("keeps the API-key billing copy for an API-key-backed CLI run", async () => {
+    const followupRun = createClaudeCliFollowupRun();
     await seedAuthProfile("claude-cli:work", {
       type: "api_key",
       provider: "claude-cli",
       key: "test-claude-key",
     });
 
-    const replyText = await runTurnAndReadFailureReplyText();
+    const replyText = await runTurnAndReadFailureReplyText(followupRun);
 
     expect(replyText).toContain("API key has run out of credits");
     expect(replyText).not.toContain("check your account for subscription or usage limits");

--- a/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-billing-reply.cli-child.test.ts
@@ -1,0 +1,184 @@
+// Proves the billing reply copy end to end: a real CLI backend run fails with
+// a billing error, and the user-visible reply must describe the credential the
+// run actually used. A subscription-backed (oauth) CLI profile must render the
+// subscription wording, while an API-key profile keeps the API-key wording.
+// The candidate chain is pinned to claude-cli; the CLI process, settlement,
+// failover error, and reply rendering are the real implementations.
+import { mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveAgentDir } from "../../agents/agent-scope-config.js";
+import { clearAuthProfileMigrationDiagnostics } from "../../agents/auth-profiles/legacy-source-diagnostic.js";
+import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store-runtime.js";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { TemplateContext } from "../templating.js";
+import {
+  setupAgentRunnerExecutionTestState,
+  getExecuteAgentTurnForTest,
+  createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  initialFallbackAttemptOptions,
+  loadActualRunCliAgentForTest,
+} from "./agent-runner-execution.test-support.js";
+import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
+
+const state = await setupAgentRunnerExecutionTestState();
+
+// A claude CLI whose run ends in the real failure shape: a stream-json result
+// record marked is_error carrying a billing refusal.
+const billingFailureCliProgram = String.raw`
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  if (!input.trim()) process.exit(2);
+  const events = [
+    {
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      result: "Credit balance is too low",
+    },
+  ];
+  process.stdout.write(events.map((event) => JSON.stringify(event)).join("\n") + "\n");
+});
+`;
+
+const claudeCliModel = "claude-opus-4-6";
+
+describe("executeAgentTurn: CLI billing failure reply copy", () => {
+  let stateDir: string;
+  let agentDir: string;
+
+  beforeEach(() => {
+    stateDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-cli-billing-reply-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    agentDir = resolveAgentDir({}, "agent");
+    mkdirSync(agentDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    clearAuthProfileMigrationDiagnostics();
+    cliBackendsTesting.resetDepsForTest();
+  });
+
+  async function seedAuthProfile(profileId: string, credential: AuthProfileCredential) {
+    await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (store) => {
+        store.profiles[profileId] = credential;
+        return true;
+      },
+    });
+  }
+
+  function registerBillingFailureClaudeCliBackend() {
+    // The stub backend keeps the core one-shot JSONL transport so the run
+    // exercises the real CLI process execution and settlement path.
+    const backend = {
+      id: "claude-cli",
+      modelProvider: "anthropic",
+      pluginId: "anthropic",
+      bundleMcp: false,
+      config: {
+        command: process.execPath,
+        args: ["-e", billingFailureCliProgram],
+        input: "stdin" as const,
+        output: "jsonl" as const,
+        jsonlDialect: "claude-stream-json" as const,
+        sessionMode: "none" as const,
+        systemPromptWhen: "never" as const,
+      },
+    };
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: ({ backend: id }) =>
+        id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
+      resolveRuntimeCliBackends: () => [backend],
+    });
+  }
+
+  function runRealCliRunnerForOnce() {
+    state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
+      return await (
+        await loadActualRunCliAgentForTest()
+      )(params);
+    });
+  }
+
+  function useClaudeCliFallback() {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", claudeCliModel, initialFallbackAttemptOptions(params)),
+      provider: "claude-cli",
+      model: claudeCliModel,
+      attempts: [],
+    }));
+  }
+
+  function createClaudeCliFollowupRun() {
+    const followupRun = createFollowupRun();
+    followupRun.run.agentId = "agent";
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = claudeCliModel;
+    followupRun.run.skillsSnapshot = { prompt: "", skills: [], version: 0 };
+    followupRun.run.timeoutMs = 10_000;
+    return followupRun;
+  }
+
+  async function runTurnAndReadFailureReplyText(): Promise<string> {
+    registerBillingFailureClaudeCliBackend();
+    runRealCliRunnerForOnce();
+    useClaudeCliFallback();
+    const followupRun = createClaudeCliFollowupRun();
+    followupRun.run.authProfileId = "claude-cli:work";
+    followupRun.run.authProfileIdSource = "auto";
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      }),
+    );
+    expect(result.kind).toBe("final");
+    if (result.kind !== "final") {
+      throw new Error("expected the failed turn to settle into a final failure reply");
+    }
+    return result.payload.text;
+  }
+
+  it("reports subscription billing copy when a subscription-backed CLI run fails billing", async () => {
+    await seedAuthProfile("claude-cli:work", {
+      type: "oauth",
+      provider: "claude-cli",
+      access: "stub-access-token",
+      refresh: "stub-refresh-token",
+      expires: Date.now() + 3_600_000,
+    });
+
+    const replyText = await runTurnAndReadFailureReplyText();
+
+    expect(replyText).toContain("check your account for subscription or usage limits");
+    expect(replyText).toContain(`claude-cli (${claudeCliModel})`);
+    expect(replyText).not.toContain("API key has run out of credits");
+  }, 60_000);
+
+  it("keeps the API-key billing copy for an API-key-backed CLI run", async () => {
+    await seedAuthProfile("claude-cli:work", {
+      type: "api_key",
+      provider: "claude-cli",
+      key: "test-claude-key",
+    });
+
+    const replyText = await runTurnAndReadFailureReplyText();
+
+    expect(replyText).toContain("API key has run out of credits");
+    expect(replyText).not.toContain("check your account for subscription or usage limits");
+  }, 60_000);
+});


### PR DESCRIPTION
Fixes #143707.

Related: #122512 (classifies additional claude-cli usage-limit texts as billing; orthogonal — that PR widens which failures are classified as billing, this one fixes the copy shown once a failure is).

## What Problem This Solves

A CLI backend run (claude-cli, codex-cli) that fails with a billing-classified error always renders the API-key wording:

> ⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.

For a subscription/OAuth-backed CLI run no API key exists, so the copy asks the operator to do something impossible.

## Why This Change Was Made

`settleCliBackendOutcome` coerces the raw CLI error through `coerceToFailoverError(runError, failoverContext)`, and that context carried only `provider`/`model`/`sessionId`/`lane`. `coerceToFailoverError` sets `authMode: context?.authMode`, so the resulting `FailoverError` — and every fallback attempt record derived from it via `describeFailoverError` — carried no auth mode. `renderBillingReplyCopy` only renders subscription wording from an attempt (or top-level error) whose `authMode` is `oauth`/`token`, so CLI runs always fell through to the API-key default.

The fix captures the selected profile's subscription semantics at prepare time and threads it through both CLI failover contexts (`runPreparedCliAgentOwned` and `executeCliProcess`). The capture happens before native-auth handling clears the selected profile id (`anthropic:claude-cli`), because those runs are exactly the subscription-backed ones. API-key-backed profiles and unprofiled runs stay unset, keeping the existing copy for them.

The branch is rebased onto current main, whose harness auth-selection refactor (`resolveHarnessAuthProfileSelection`/`resolveCliExecutionAuthProfileId`) now owns CLI profile selection ahead of `run.authProfileId`; the capture points and the end-to-end fixture are adapted to that flow (the run's agent dir is aligned with the state-derived dir CLI prepare resolves, so harness selection and CLI prepare read the same profile store).

## User Impact

A claude-cli run whose selected auth profile comes from the gateway's profile store — the forwarded/saved-profile path the harness selection and `prepareCliRunContext` resolve — now renders subscription wording when it hits a billing-classified failure:

> ⚠️ claude-cli (claude-sonnet-5) returned a billing error — check your account for subscription or usage limits, then try again.

instead of instructions to top up an API key the gateway never had.

## Scope

Proven end to end in this PR: a claude-cli run with a saved subscription-backed (oauth) profile from the seeded SQLite auth store, and the api_key profile contrast. The production change is backend-generic (the failover context carries `authMode` for any CLI backend), but the paths below are not exercised by this PR and are not claimed as fixed:

- **Native Claude login without a forwarded profile.** When the CLI uses the machine's own login instead of a stored profile, harness selection may not surface a profile id for `prepareCliRunContext` to capture; whether such runs get subscription wording depends on how that path resolves auth, and it remains unverified here.
- **codex-cli.** No end-to-end run was attached for the codex backend; it inherits the same fix shape but its own auth-profile semantics are untested here.

## Evidence

Pre-fix red, rerun at head `56748b7a1da` (2026-09-11): with the six production files reverted to their `origin/main` state, the same end-to-end oauth run settles into `⚠️ API provider returned a billing error — your API key has run out of credits…` — the original defect reproduced at the reply boundary — while the api_key case stays unchanged.

Real CLI backend failure through the changed runner (`agent-runner-cli-billing-reply.cli-child.test.ts`, head `56748b7a1da`): a real `executeAgentTurn` drives the real CLI runner — harness auth selection resolves the profile from a seeded SQLite auth store under an isolated state dir, `prepareCliRunContext` captures its subscription semantics, the runner spawns a claude stub child process whose stream-json result record is a real failure shape (`type: "result"`, `is_error: true`, "Credit balance is too low"), and the real settlement classifies and throws the `FailoverError`. The observed user reply is read from the settled failure payload the dispatcher renders:

- oauth profile `claude-cli:work` → reply contains `check your account for subscription or usage limits` and `claude-cli (claude-opus-4-6)`, and does not contain the API-key wording.
- api_key profile `claude-cli:work` → reply contains `API key has run out of credits` and does not contain the subscription wording.

The candidate chain is pinned to one claude-cli candidate (the fallback runner is not part of the changed surface); process spawn, output parsing, settlement, failover classification, and reply rendering are the real implementations.

Post-fix, focused suites pass: prepare (172), cli-run-settlement (16, including three new cases), and the new child-level billing reply suite (2). Unprofiled runs keep `authMode` unset.

Typecheck (tsgo core plus the messaging test shard, both exit 0) and type-aware `oxlint` pass on the changed files.
