### PR TITLE
docs(plugins): correct stale discovery alias and Claude bundle capability claims

### DIFF
--- a/docs/plugins/architecture-internals/provider-hooks.md
+++ b/docs/plugins/architecture-internals/provider-hooks.md
@@ -284,8 +284,9 @@ static catalog rows automatically from `defaultModel`, `models`, and
 
 Compatibility:
 
-- `discovery` still works as a legacy alias, but emits a deprecation warning
-- if both `catalog` and `discovery` are registered, OpenClaw uses `catalog`
-  and emits a warning
+- `discovery` was a legacy alias for `catalog`. OpenClaw removed the alias and
+  the deprecation warnings it emitted
+- rename `discovery` to `catalog`. A provider plugin that still registers
+  `discovery` publishes no catalog rows
 - `augmentModelCatalog` is deprecated; bundled providers should publish
   supplemental rows through `registerModelCatalogProvider`

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -340,9 +340,10 @@ bundles as trusted content for the features they do expose.
     not wired, that is a product limit, not a broken install.
   </Accordion>
 
-  <Accordion title="Claude command files do not appear">
+  <Accordion title="Claude command, agent, or output-style files do not appear">
     Make sure the bundle is enabled and the markdown files are inside a detected
-    `commands/` or `skills/` root.
+    `skills/`, `commands/`, `agents/`, or `output-styles/` root. All four load
+    through the same skill loader.
   </Accordion>
 
   <Accordion title="Claude settings do not apply">

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -74,20 +74,22 @@ detected but not wired.
 
 ### Supported now
 
-| Feature       | How it maps                                                                                       | Applies to     |
-| ------------- | ------------------------------------------------------------------------------------------------- | -------------- |
-| Skill content | Bundle skill roots load as normal OpenClaw skills                                                 | All formats    |
-| Commands      | `commands/` and `.cursor/commands/` treated as skill roots                                        | Claude, Cursor |
-| Hook packs    | OpenClaw-style `HOOK.md` + `handler.ts` layouts                                                   | Claude, Codex  |
-| MCP tools     | Bundle MCP config merged into embedded OpenClaw settings; supported stdio and HTTP servers loaded | All formats    |
-| Env contract  | `PLUGIN_ROOT` and `PLUGIN_DATA` env vars plus placeholder expansion for stdio MCP servers         | Agent Plugins  |
-| LSP servers   | Claude `.lsp.json` and manifest-declared `lspServers` merged into embedded OpenClaw LSP defaults  | Claude         |
-| Settings      | Claude `settings.json` imported as embedded OpenClaw defaults                                     | Claude         |
+| Feature                  | How it maps                                                                                       | Applies to     |
+| ------------------------ | ------------------------------------------------------------------------------------------------- | -------------- |
+| Skill content            | Bundle skill roots load as normal OpenClaw skills                                                 | All formats    |
+| Commands                 | `commands/` and `.cursor/commands/` treated as skill roots                                        | Claude, Cursor |
+| Agents and output styles | Claude `agents/` and `output-styles/` treated as skill roots                                      | Claude         |
+| Hook packs               | OpenClaw-style `HOOK.md` + `handler.ts` layouts                                                   | Claude, Codex  |
+| MCP tools                | Bundle MCP config merged into embedded OpenClaw settings; supported stdio and HTTP servers loaded | All formats    |
+| Env contract             | `PLUGIN_ROOT` and `PLUGIN_DATA` env vars plus placeholder expansion for stdio MCP servers         | Agent Plugins  |
+| LSP servers              | Claude `.lsp.json` and manifest-declared `lspServers` merged into embedded OpenClaw LSP defaults  | Claude         |
+| Settings                 | Claude `settings.json` imported as embedded OpenClaw defaults                                     | Claude         |
 
 #### Skill content
 
 - Bundle skill roots load as normal OpenClaw skill roots.
-- Claude `commands/` roots are treated as additional skill roots.
+- Claude `commands/`, `agents/`, and `output-styles/` roots are treated as
+  additional skill roots.
 - Cursor `.cursor/commands/` roots are treated as additional skill roots.
 
 Claude markdown command files and Cursor command markdown both work through the
@@ -211,7 +213,7 @@ them:
 
 These are recognized and shown in diagnostics, but OpenClaw does not run them:
 
-- Claude `agents`, `hooks/hooks.json` automation, `outputStyles`
+- Claude `hooks/hooks.json` automation
 - Cursor `.cursor/agents`, `.cursor/hooks.json`, `.cursor/rules`
 - Codex `.app.json` metadata beyond capability reporting
 
@@ -267,11 +269,11 @@ These are recognized and shown in diagnostics, but OpenClaw does not run them:
     Two detection modes:
 
     - **Manifest-based:** `.claude-plugin/plugin.json`
-    - **Manifestless:** default Claude layout (`skills/`, `commands/`, `agents/`, `hooks/`, `.mcp.json`, `.lsp.json`, `settings.json`)
+    - **Manifestless:** default Claude layout (`skills/`, `commands/`, `agents/`, `output-styles/`, `hooks/`, `.mcp.json`, `.lsp.json`, `settings.json`)
 
     Claude-specific behavior:
 
-    - `commands/` is treated as skill content
+    - `commands/`, `agents/`, and `output-styles/` are treated as skill content
     - `settings.json` is imported into embedded OpenClaw settings (shell override keys are sanitized)
     - `.mcp.json` exposes supported stdio tools to embedded OpenClaw
     - `.lsp.json` plus manifest-declared `lspServers` paths load into embedded OpenClaw LSP defaults

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -269,7 +269,13 @@ These are recognized and shown in diagnostics, but OpenClaw does not run them:
     Two detection modes:
 
     - **Manifest-based:** `.claude-plugin/plugin.json`
-    - **Manifestless:** default Claude layout (`skills/`, `commands/`, `agents/`, `output-styles/`, `hooks/`, `.mcp.json`, `.lsp.json`, `settings.json`)
+    - **Manifestless:** default Claude layout (`skills/`, `commands/`, `agents/`, `hooks/`, `.mcp.json`, `.lsp.json`, `settings.json`)
+
+    `output-styles/` is not a detection marker. A bundle whose only content is
+    `output-styles/` is not recognized as a Claude bundle. Add
+    `.claude-plugin/plugin.json`, or one of the markers above, so detection
+    succeeds. Detection runs before manifest loading, so an undetected
+    directory never reaches the component paths below.
 
     Claude-specific behavior:
 


### PR DESCRIPTION
Two lower-confidence observations from an earlier audit round, tested against source before touching anything. Both held; both were doc defects, not code defects.

## 1. `docs/plugins/architecture-internals/provider-hooks.md` — the `discovery` alias

The page claimed:

> - `discovery` still works as a legacy alias, but emits a deprecation warning
> - if both `catalog` and `discovery` are registered, OpenClaw uses `catalog` and emits a warning

Both statements were true once and are false now.

The alias existed on `ProviderPlugin` as `discovery?: ProviderPluginDiscovery`, and `src/plugins/provider-validation.ts` really did emit both warnings — `provider "<id>" uses deprecated discovery; use catalog` and `provider "<id>" registered both catalog and discovery; using catalog`. All of it was deleted in **c7e7ac2728917f085aff0ad50755fd39aa57f2b3** — *refactor: remove expired plugin compatibility surfaces (#111451)*, 2026-07-19 — which also dropped `resolveProviderCatalogHook`'s `?? provider.discovery` fallback and the `prefers catalog over discovery when both exist` test.

On `main` today:

- `src/plugins/provider-discovery.ts:24-26` — `resolveProviderCatalogHook` returns `provider.catalog`, full stop
- `grep -rn "discovery?:" src/plugins/provider-plugin.types.ts` — no matches
- neither warning string exists anywhere in `src/`, `packages/`, or `extensions/`

So a provider plugin that still registers `discovery` publishes no catalog rows **and** is told nothing about why. The page now says that, which is the part a plugin author actually needs. The `augmentModelCatalog` bullet is untouched — `provider-plugin.types.ts:454-456` still marks it `@deprecated` in favour of `registerModelCatalogProvider`.

## 2. `docs/plugins/bundles.md` — Claude `agents` and `outputStyles`

The page listed Claude `agents` and `outputStyles` under **"Detected but not executed"**, described as "recognized and shown in diagnostics, but OpenClaw does not run them".

The observation that prompted this was that `isBundleCapabilitySupported` returns `true` for both. That alone would not have settled it, so here is what `true` means: its two callers are `inspectBundlePluginArtifact`, which sorts capabilities into `mapped` vs `unavailable`, and `recordBundleDiagnostics`, which emits `bundle capability detected but not wired into OpenClaw yet: <capability>` for exactly the `false` ones. `true` *is* the "wired" side — it is the negation of the doc's category, not a weaker sense of "supported".

And the loading path agrees. `src/plugins/bundle-manifest.ts:427-433`:

```ts
const skillRoots = resolveClaudeComponentPaths(raw, "skills", params.rootDir, ["skills"]);
const commands = resolveClaudeComponentPaths(raw, "commands", params.rootDir, ["commands"]);
const agents = resolveClaudeComponentPaths(raw, "agents", params.rootDir, ["agents"]);
const outputStyles = resolveClaudeComponentPaths(raw, "outputStyles", params.rootDir, ["output-styles"]);
const skills = mergeBundlePathLists(skillRoots, commands, agents, outputStyles);
```

`agents/` and `output-styles/` go into the manifest's `skills` list by the same call that puts `commands/` there — and the page already documented `commands/` as a supported skill root. `src/plugins/bundle-claude-inspect.test.ts:170` asserts `skills: ["skill-packs", "extra-commands", "agents", "output-styles"]`, and `bundle-capability-support.ts:16-17` states the split in a comment: Claude merges agent directories into the runtime skill roots, Cursor detects `.cursor/agents` and never loads it.

So the Cursor row in that list is correct and stays. The Claude row loses `agents` and `outputStyles`, and they move to the supported table, the skill-content bullets, and the Claude bundle accordion. `output-styles/` is also added to the manifestless default layout, where it was missing.

**Claude `hooks/hooks.json` stays in "detected but not executed"** even though `isBundleCapabilitySupported("claude", "hooks")` is also `true`. That `true` is about OpenClaw-style hook packs (`HOOK.md` + `handler.ts`) declared by a Claude bundle, which the supported table already credits to Claude and Codex. The `hooks/hooks.json` default path is a file, not a hook-pack collection directory, and the page's own Hook packs section says it "remains in the declared capabilities, but does not appear as a supported hook". Consistent — nothing to change.

## Nothing was changed in code

Neither finding is a code defect. In both cases the source is the intended behaviour and the docs had drifted behind it.

## Validation

- `pnpm check:docs` — exit 0 (formatting 1280 files clean, markdownlint, lint:templates, mdx, i18n glossary, links, config examples)
- `node scripts/docs-link-audit.mjs --anchors` — 3 broken links, all the pre-existing `maturity/#windows-app-node` ones; `checked_internal_links=13410`
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — 1 file / 33 tests passed
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — 8 files / 16 tests passed
- `npx vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/bundle-claude-inspect.test.ts src/plugins/bundle-manifest.test.ts` — 2 files / 39 tests passed (evidence for §2, not a change of mine)

No glossary entries needed: no `title:` frontmatter changed and no new `/`-route list-item link labels were introduced. No headings renamed, so no anchors moved. Neither page is generated — `scripts/generate-plugin-inventory-doc.mts` owns only `docs/plugins/plugin-inventory.md`, `docs/plugins/reference.md`, and `docs/plugins/reference/`. No CODEOWNERS team matches either path.
