### PR TITLE
fix(ui): remove unused desktop launch response type

### DIFF
--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -2,7 +2,6 @@ import type {
   DesktopObserveResult,
   DesktopSource,
   EnvironmentSummary,
-  WorkerDesktopLaunchResult,
 } from "@openclaw/gateway-protocol";
 import type { ControlUiFocusBuildTarget } from "@openclaw/session-url-contract";
 import { html, nothing } from "lit";
@@ -594,10 +593,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     this.launchingApp = app;
     this.launchErrorText = null;
     try {
-      await client.request<WorkerDesktopLaunchResult>("desktop.launch", {
-        source,
-        app,
-      });
+      await client.request("desktop.launch", { source, app });
       if (operationId !== this.launchOperationId) {
         return;
       }


### PR DESCRIPTION
Related: #143883 and #143831.

## What Problem This Solves

Core lint fails because the desktop panel reached 703 counted lines against the existing 700-line limit after the session-desktop autoconnect change. This blocks otherwise unrelated pull requests, including [CI run 34456580334](https://github.com/openclaw/openclaw/actions/runs/34456580334/job/102805014956).

## Why This Change Was Made

Remove the unused response type import and type argument from the awaited app-launch request. The same request fits naturally on one line, bringing the panel to 699 counted lines while preserving its payload and lifecycle checks.

## User Impact

This type-only cleanup restores the existing lint gate and preserves desktop launch behavior and appearance.

## Evidence

- TypeScript and esbuild output match before/after after whitespace and comment normalization.
- All 46 desktop-panel tests passed. The targeted real-browser app launch/takeover/source-change case passed; 22 unrelated cases were intentionally unselected.
- Fresh independent P2 review passed. Full changed-file gate passed.
