### PR TITLE
fix: prevent handoff fixtures from breaking model-command tests

### DIFF
--- a/src/infra/update-managed-service-handoff-retarget.test.ts
+++ b/src/infra/update-managed-service-handoff-retarget.test.ts
@@ -7,6 +7,7 @@ import { afterEach, expect, it, vi } from "vitest";
 import { resolveServiceManagerEnv } from "../daemon/service-process-env.js";
 import * as pidIdentity from "../shared/pid-alive.js";
 import * as nodeSqlite from "./node-sqlite.js";
+import * as tmpDir from "./tmp-openclaw-dir.js";
 import { createManagedHandoffLeaseStore as createStore } from "./update-managed-service-handoff-lease.js";
 import type {
   createManagedHandoffLeaseStore,
@@ -610,6 +611,11 @@ unix(
     const { createManagedHandoffLeaseStore, resolveManagedUpdateLeaseDatabasePath } =
       await import("./update-managed-service-handoff-lease.js");
     const { to } = fixture();
+    // The ordinary parent/helper coordinator is independent of OPENCLAW_STATE_DIR.
+    // Keep its legacy-row admission window private to this fixture.
+    vi.spyOn(tmpDir, "resolvePreferredOpenClawTmpDir").mockReturnValue(
+      path.join(path.dirname(to), "common-coordinator"),
+    );
     const store = createManagedHandoffLeaseStore();
     const reserved = store.acquire(to, "legacy-owner", { kind: "update" });
     expect(reserved.kind).toBe("acquired");


### PR DESCRIPTION
Related: #143759
Closes #143894

## What Problem This Solves

Resolves a problem where unrelated model-command tests fail during concurrent CI shards because a managed-handoff test briefly leaves an intentionally incompatible legacy lease in the shared temporary coordinator. This maintainer-requested validation repair is needed to finish the new Matrix action-owner change in #143759.

The observed failure is [CI run 34444039096, small-3 job](https://github.com/openclaw/openclaw/actions/runs/34444039096/job/102765084654): eight model-selection cases report an incompatible handoff lease while the final retarget admission case is running.

## Why This Change Was Made

Scope that final test's existing temporary-directory resolver to its own fixture. HOME and OPENCLAW_STATE_DIR do not select the ordinary handoff coordinator. The default store, real spawned helper, serialized database path, admission, cancellation, sensitive-file cleanup and lease-row assertions all stay real and unchanged.

The production retained-row guard still rejects incompatible leases. No production code, SQLite schema, runtime configuration, dependency, timeout or assertion is weakened or changed. Production LOC: +0/-0. Tests: +6/-0.

## User Impact

No operator-visible runtime change. Independent test shards can write their own synthetic config without interference from this fixture's legacy-row window.

## Evidence

- Controlled original-order reproduction on exact failing CI merge `c419c8ab706b01d919a3a52bedfd2838634bf65c`, using separate real Node processes in a fresh disposable Linux Testbox: the independent config callback is refused while the fixture's legacy row exists. The only failing assertion occurs after the original real handoff cancellation and cleanup. Native actor exit 1, observer exit 0.
- Identical proof with the six-line fix in a second fresh Testbox: distinct coordinators, config callback succeeds, legacy row remains unchanged during observation, and direct access to that incompatible row still rejects. Both native processes exit 0. Both roles use the same Node24.19.0 executable bytes; root read all complete logs through native close, including explicit generated-worker disposal and zero-unhandled-error receipts.
- All non-shipping observation code was removed afterward. The normal runner passes all 28 retarget and 36 model-selection tests. The same 64 cases also pass after moving this separate repair to current-main snapshot `58080e69543eacffdbbc00323ecd3eb2fb06db71` ([fresh Testbox run](https://github.com/openclaw/openclaw/actions/runs/34456216077)); both shards finish in 18.93 seconds. All completed proof leases are stopped.
- Precommit managed Codex review: scoped-clean through P2, zero findings.
- Separate fresh review of exact signed commit `36022ec4d17836b45765ee54cf0044401e3f951f`: scoped-clean through P2, zero findings.
- All 20 normal changed-file checks passed through the configured Testbox route ([run 34456969549](https://github.com/openclaw/openclaw/actions/runs/34456969549)), including the infra test type graph, all three unused-export scans, and targeted type-aware lint. No baseline, timeout, provider, or check was weakened. The one-shot lease is stopped.

The reproduction is source-level synthetic cross-process proof, not an extracted offending database row from CI or a live-provider test. Original/candidate raw archive SHA256 values are `b07a408bb524f91617acc6f50fed83ad4ca6bdd0d11166d4b626c9961ac2251c` and `71063c30c66773d58d04e4ea4124cd44055daa69cc620f9eb864fbc5bf940dcf`. Do not run the original unisolated fixture against a maintainer's shared coordinator.
