### PR TITLE
fix: keep moved capture directories out of exports

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -99,9 +99,21 @@ recognized by the exact sibling layout: `<owner>/` beside
 aliases receive the same protection. Unrelated similarly named workspace
 directories remain included; a suffix alone does not establish ownership.
 
-Keep captures at their managed location alongside their owner. Moved, renamed,
-or orphaned captures from another state cannot be identified by this rule.
-This exclusion does not create captures or change ordinary backup sanitization.
+Marked private directories remain excluded after their owner is removed or
+renamed, or the marked directory is moved or copied. Keep the marker with the
+whole directory. Files copied out without it are not recognized by this rule.
+The fixed `.openclaw-private-update-capture` file contains exactly
+`openclaw-private-update-capture-v1` followed by a newline. Export checks inspect
+only selected paths and their ancestors, including canonical aliases. They do
+not parse workspace manifests or scan for other state roots. A malformed or
+unreadable marker refuses export of that selection; a support bundle reports
+the refusal without including that input.
+
+The marker is an exclusion instruction, not proof of artifact ownership or
+permission to reopen, adopt, or delete it. Producers must durably write it before
+raw data, including in each independently movable staging or capture directory.
+Cleanup must preserve it until private contents are gone. This exclusion does
+not create captures, change retention, or change ordinary backup sanitization.
 
 ## SQLite snapshots
 

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -3,19 +3,26 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetConfigRuntimeState } from "../config/config.js";
 import { createBackupArchive } from "../infra/backup-create.js";
 import { createGitBackup } from "../snapshot/git-backup.js";
 import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.js";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { backupGitCreateCommand } from "./backup-git.js";
+import { backupSqliteCreateCommand } from "./backup-sqlite.js";
 import { verifyBackupArchive } from "./backup-verify.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 describe("private update capture exclusion", () => {
   let home: TempHomeEnv;
   let stateDir: string;
   let captureRoot: string;
   beforeEach(async () => {
+    resetConfigRuntimeState();
     home = await createTempHomeEnv("backup-capture-privacy-");
     stateDir = path.join(home.home, ".openclaw");
     captureRoot = `${stateDir}.update-captures`;
@@ -30,6 +37,7 @@ describe("private update capture exclusion", () => {
     );
   });
   afterEach(async () => {
+    resetConfigRuntimeState();
     vi.unstubAllEnvs();
     await home.restore();
   });
@@ -394,6 +402,122 @@ describe("private update capture exclusion", () => {
     await expect(create).rejects.toThrow("Private update captures are excluded");
     expect(await fs.readFile(databasePath)).toEqual(before);
   });
+
+  it.each(["valid", "invalid"])(
+    "refuses a %s marked agent root selection before canonicalization",
+    async (mode) => {
+      const marked = path.join(home.home, "marked-agent-parent");
+      const target = path.join(home.home, "external-agent");
+      await fs.mkdir(marked);
+      await fs.mkdir(target);
+      const marker = path.join(marked, ".openclaw-private-update-capture");
+      const markerBytes = mode === "valid" ? "openclaw-private-update-capture-v1\n" : "incomplete";
+      await fs.writeFile(marker, markerBytes);
+      await fs.writeFile(path.join(target, "agent-private.txt"), "synthetic private agent bytes");
+      const alias = path.join(marked, "agent");
+      await fs.symlink(target, alias, process.platform === "win32" ? "junction" : "dir");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            ownership: "explicit",
+            entries: { main: { agentDir: alias, workspace: `${captureRoot}-notes` } },
+          },
+        }),
+      );
+      const output = path.join(path.dirname(home.home), `${path.basename(home.home)}-agent.tar.gz`);
+      try {
+        await expect(createBackupArchive({ output })).rejects.toThrow("Private update capture");
+        await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(await fs.readFile(path.join(target, "agent-private.txt"), "utf8")).toBe(
+          "synthetic private agent bytes",
+        );
+        expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);
+      } finally {
+        await fs.rm(output, { force: true });
+      }
+    },
+  );
+
+  it.each([
+    ["sqlite", "global"],
+    ["git", "global"],
+    ["sqlite", "agent"],
+    ["git", "agent"],
+  ])(
+    "refuses lexical markers before %s %s database selection and keeps healthy aliases usable",
+    async (kind, role) => {
+      const target = path.join(home.home, "external-database");
+      await fs.mkdir(target);
+      const marked =
+        role === "global"
+          ? path.join(stateDir, "state")
+          : path.join(home.home, "marked-agent-parent");
+      await fs.mkdir(marked, { recursive: true });
+      const marker = path.join(marked, ".openclaw-private-update-capture");
+      const databasePath = path.join(
+        target,
+        role === "global" ? "openclaw.sqlite" : "openclaw-agent.sqlite",
+      );
+      const version =
+        role === "global" ? OPENCLAW_STATE_SCHEMA_VERSION : OPENCLAW_AGENT_SCHEMA_VERSION;
+      const db = new DatabaseSync(databasePath);
+      db.exec(role === "global" ? OPENCLAW_STATE_SCHEMA_SQL : OPENCLAW_AGENT_SCHEMA_SQL);
+      db.exec(`PRAGMA user_version=${version}`);
+      db.prepare(
+        "INSERT INTO schema_meta(meta_key,role,schema_version,agent_id,created_at,updated_at) VALUES('primary',?,?,?,1,1)",
+      ).run(role, version, role === "agent" ? "main" : null);
+      db.close();
+      const alias =
+        role === "global" ? path.join(marked, "openclaw.sqlite") : path.join(marked, "agent");
+      await fs.symlink(
+        role === "global" ? databasePath : target,
+        alias,
+        role === "global" ? "file" : process.platform === "win32" ? "junction" : "dir",
+      );
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            ownership: "explicit",
+            entries: {
+              main: {
+                ...(role === "agent" ? { agentDir: alias } : {}),
+                workspace: `${captureRoot}-notes`,
+              },
+            },
+          },
+        }),
+      );
+      for (const key of ["GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"]) vi.stubEnv(key, "OpenClaw Test");
+      for (const key of ["GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"])
+        vi.stubEnv(key, "test@example.invalid");
+      const runtime = createTestRuntime();
+      const repository = path.join(home.home, "command-backup");
+      const create = () =>
+        kind === "sqlite"
+          ? backupSqliteCreateCommand(runtime, {
+              repository,
+              ...(role === "global" ? { global: true } : { agent: "main" }),
+            })
+          : backupGitCreateCommand(runtime, {
+              repository,
+              ...(role === "global" ? { global: true } : { agents: ["main"] }),
+            });
+      const before = await fs.readFile(databasePath);
+      for (const bytes of ["incomplete", "openclaw-private-update-capture-v1\n"]) {
+        await fs.writeFile(marker, bytes);
+        await expect(create()).rejects.toThrow("Private update capture");
+        await expect(fs.stat(repository)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(await fs.readFile(databasePath)).toEqual(before);
+        expect(await fs.readFile(marker, "utf8")).toBe(bytes);
+      }
+      // Only remove this fixture-owned marker. The same ordinary alias must remain usable.
+      await fs.unlink(marker);
+      await expect(create()).resolves.toBeDefined();
+      expect((await fs.readdir(repository)).length).toBeGreaterThan(0);
+    },
+  );
 
   it.each([false, true])(
     "refuses a raw capture selected as config, onlyConfig=%s",

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -489,9 +489,12 @@ describe("private update capture exclusion", () => {
           },
         }),
       );
-      for (const key of ["GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"]) vi.stubEnv(key, "OpenClaw Test");
-      for (const key of ["GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"])
+      for (const key of ["GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"]) {
+        vi.stubEnv(key, "OpenClaw Test");
+      }
+      for (const key of ["GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"]) {
         vi.stubEnv(key, "test@example.invalid");
+      }
       const runtime = createTestRuntime();
       const repository = path.join(home.home, "command-backup");
       const create = () =>

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -114,6 +114,114 @@ describe("private update capture exclusion", () => {
     }
   });
 
+  it.each(["parent", "nested alias"])(
+    "excludes marked orphaned and relocated artifacts from a %s workspace",
+    async (selection) => {
+      const otherState = path.join(home.home, "profile-b");
+      const orphanedRoot = `${otherState}.update-captures`;
+      const moved = path.join(home.home, "relocated-artifact");
+      const movedRoot = path.join(home.home, "relocated-root");
+      const healthy = path.join(home.home, "research.update-captures");
+      for (const directory of [otherState, orphanedRoot, moved, movedRoot, healthy]) {
+        await fs.mkdir(directory);
+      }
+      // Fixed producer contract, independent of the implementation's constants.
+      for (const directory of [orphanedRoot, moved, movedRoot]) {
+        await fs.writeFile(
+          path.join(directory, ".openclaw-private-update-capture"),
+          "openclaw-private-update-capture-v1\n",
+        );
+        await fs.writeFile(path.join(directory, "raw.txt"), "synthetic retained bytes");
+      }
+      await fs.rename(otherState, `${otherState}-renamed`);
+      await fs.writeFile(path.join(healthy, "healthy.txt"), "ordinary workspace bytes");
+      await fs.writeFile(
+        path.join(healthy, "manifest.json"),
+        '{"schema":"openclaw.update-capture.v1"}',
+      );
+      const alias = path.join(home.home, "artifact-alias");
+      await fs.symlink(moved, alias, process.platform === "win32" ? "junction" : "dir");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            ownership: "explicit",
+            entries: {
+              main: { workspace: selection === "parent" ? home.home : alias },
+              healthy: { workspace: healthy },
+            },
+          },
+        }),
+      );
+      const output = path.join(
+        path.dirname(home.home),
+        `${path.basename(home.home)}-marker.tar.gz`,
+      );
+      try {
+        const result = await createBackupArchive({ output });
+        const entries: string[] = [];
+        await tar.t({
+          file: result.archivePath,
+          onReadEntry: (entry) => {
+            entries.push(entry.path);
+          },
+        });
+        expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
+        expect(entries.some((entry) => entry.endsWith("/manifest.json"))).toBe(true);
+        expect(entries.some((entry) => entry.endsWith("/raw.txt"))).toBe(false);
+        await verifyBackupArchive(result.archivePath);
+        for (const directory of [orphanedRoot, moved, movedRoot]) {
+          expect(await fs.readFile(path.join(directory, "raw.txt"), "utf8")).toBe(
+            "synthetic retained bytes",
+          );
+        }
+      } finally {
+        await fs.rm(output, { force: true });
+      }
+    },
+  );
+
+  it.each(["unpaired", "current", "other"])(
+    "refuses publication for an invalid privacy marker in a %s capture directory",
+    async (owner) => {
+      const workspace = owner === "unpaired" ? path.join(home.home, "workspace") : home.home;
+      const otherState = path.join(home.home, "other-state");
+      if (owner === "other") {
+        await fs.mkdir(otherState);
+      }
+      const privateDir =
+        owner === "current"
+          ? captureRoot
+          : owner === "other"
+            ? `${otherState}.update-captures`
+            : path.join(workspace, "incomplete");
+      await fs.mkdir(privateDir, { recursive: true });
+      await fs.writeFile(path.join(privateDir, ".openclaw-private-update-capture"), "incomplete");
+      await fs.writeFile(path.join(privateDir, "raw.txt"), "synthetic incomplete bytes");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: { ownership: "explicit", entries: { main: { workspace } } },
+        }),
+      );
+      const output = path.join(
+        path.dirname(home.home),
+        `${path.basename(home.home)}-invalid.tar.gz`,
+      );
+      try {
+        await expect(createBackupArchive({ output })).rejects.toThrow(
+          "Private update capture marker",
+        );
+        await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(await fs.readFile(path.join(privateDir, "raw.txt"), "utf8")).toBe(
+          "synthetic incomplete bytes",
+        );
+      } finally {
+        await fs.rm(output, { force: true });
+      }
+    },
+  );
+
   it.each([
     ["sqlite", "current"],
     ["git", "current"],
@@ -121,6 +229,8 @@ describe("private update capture exclusion", () => {
     ["git", "other"],
     ["sqlite", "alias"],
     ["git", "alias"],
+    ["sqlite", "marked relocated alias"],
+    ["git", "marked relocated alias"],
   ])("refuses capture inputs in %s snapshots from %s state", async (kind, owner) => {
     let selectedRoot = captureRoot;
     if (owner !== "current") {
@@ -133,6 +243,16 @@ describe("private update capture exclusion", () => {
         await fs.symlink(selectedRoot, alias, process.platform === "win32" ? "junction" : "dir");
         selectedRoot = alias;
       }
+    }
+    if (owner === "marked relocated alias") {
+      const moved = path.join(home.home, "relocated");
+      await fs.rename(selectedRoot, moved);
+      await fs.writeFile(
+        path.join(moved, ".openclaw-private-update-capture"),
+        "openclaw-private-update-capture-v1\n",
+      );
+      await fs.symlink(moved, selectedRoot, process.platform === "win32" ? "junction" : "dir");
+      await fs.rmdir(path.join(home.home, "profile-b"));
     }
     const databasePath = path.join(selectedRoot, "completed", "database.sqlite");
     const source = new DatabaseSync(databasePath);

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -181,6 +181,115 @@ describe("private update capture exclusion", () => {
     },
   );
 
+  it("does not promote a managed skill through a marked lexical parent", async () => {
+    const skills = path.join(stateDir, "skills");
+    const external = path.join(home.home, "external-skill");
+    await fs.mkdir(skills);
+    await fs.mkdir(external);
+    const marker = path.join(skills, ".openclaw-private-update-capture");
+    await fs.writeFile(marker, "openclaw-private-update-capture-v1\n");
+    const skill = "---\nname: demo\ndescription: Synthetic private skill\n---\n";
+    await fs.writeFile(path.join(external, "SKILL.md"), skill);
+    await fs.symlink(
+      external,
+      path.join(skills, "demo"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: { main: { workspace: `${captureRoot}-notes` } },
+        },
+      }),
+    );
+    const output = path.join(path.dirname(home.home), `${path.basename(home.home)}-skill.tar.gz`);
+    try {
+      const result = await createBackupArchive({ output });
+      const entries: string[] = [];
+      await tar.t({
+        file: result.archivePath,
+        onReadEntry: (entry) => {
+          entries.push(entry.path);
+        },
+      });
+      expect(entries.some((entry) => entry.endsWith("/SKILL.md"))).toBe(false);
+      expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
+      await verifyBackupArchive(result.archivePath);
+      expect(await fs.readFile(path.join(external, "SKILL.md"), "utf8")).toBe(skill);
+      expect(await fs.readFile(marker, "utf8")).toBe("openclaw-private-update-capture-v1\n");
+    } finally {
+      await fs.rm(output, { force: true });
+    }
+  });
+
+  it.each(["valid", "invalid with duplicate", "valid with duplicate"])(
+    "checks a %s lexical marker before deduplicating an outward workspace alias",
+    async (mode) => {
+      const outside = path.join(home.home, "unmarked-target");
+      const marked = path.join(home.home, "marked-parent");
+      await fs.mkdir(outside);
+      await fs.mkdir(marked);
+      const marker = path.join(marked, ".openclaw-private-update-capture");
+      const markerBytes = mode.startsWith("invalid")
+        ? "incomplete"
+        : "openclaw-private-update-capture-v1\n";
+      await fs.writeFile(marker, markerBytes);
+      const raw = path.join(outside, "outward.txt");
+      await fs.writeFile(raw, "synthetic outward bytes");
+      const alias = path.join(marked, "workspace");
+      await fs.symlink(outside, alias, process.platform === "win32" ? "junction" : "dir");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            ownership: "explicit",
+            entries: {
+              main: { workspace: alias },
+              healthy: { workspace: `${captureRoot}-notes` },
+              ...(mode.includes("duplicate") ? { independent: { workspace: outside } } : {}),
+            },
+          },
+        }),
+      );
+      const output = path.join(
+        path.dirname(home.home),
+        `${path.basename(home.home)}-outward.tar.gz`,
+      );
+      try {
+        if (mode.startsWith("invalid")) {
+          await expect(createBackupArchive({ output })).rejects.toThrow(
+            "Private update capture marker",
+          );
+          await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          const result = await createBackupArchive({ output });
+          const entries: string[] = [];
+          await tar.t({
+            file: result.archivePath,
+            onReadEntry: (entry) => {
+              entries.push(entry.path);
+            },
+          });
+          expect(entries.some((entry) => entry.endsWith("/outward.txt"))).toBe(
+            mode.includes("duplicate"),
+          );
+          expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
+          await verifyBackupArchive(result.archivePath);
+          expect(result.skipped).toContainEqual(
+            expect.objectContaining({ kind: "workspace", sourcePath: alias, reason: "private" }),
+          );
+        }
+        expect(await fs.readFile(raw, "utf8")).toBe("synthetic outward bytes");
+        expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);
+        expect(await fs.realpath(alias)).toBe(await fs.realpath(outside));
+      } finally {
+        await fs.rm(output, { force: true });
+      }
+    },
+  );
+
   it.each(["unpaired", "current", "other"])(
     "refuses publication for an invalid privacy marker in a %s capture directory",
     async (owner) => {

--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -3,6 +3,7 @@ import { listAgentIds, resolveConfiguredAgentId } from "../agents/agent-scope-co
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { assertNotUpdateCapturePath } from "../infra/update-capture-paths.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import type { GitBackupIdentity } from "../snapshot/git-backup-codec.js";
@@ -71,14 +72,17 @@ async function resolveCreateDatabases(runtime: RuntimeEnv, options: BackupGitCre
     identity: GitBackupIdentity;
   }> = [];
   if (options.all || options.global) {
+    const selectedPath = resolveOpenClawStateSqlitePath();
+    assertNotUpdateCapturePath(selectedPath, resolveStateDir());
     databases.push({
-      path: await fs.realpath(resolveOpenClawStateSqlitePath()),
+      path: await fs.realpath(selectedPath),
       identity: { role: "global" },
     });
   }
   // Config owns both the current roster and each agent root; durable registry
   // rows can retain stale paths after an agent moves or is removed.
   for (const { agentId, databasePath } of agents) {
+    assertNotUpdateCapturePath(databasePath, resolveStateDir());
     let resolvedPath: string;
     try {
       resolvedPath = await fs.realpath(databasePath);

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -350,8 +350,23 @@ async function resolveBackupPlanFromPaths(params: {
   }
 
   const uniqueCandidates: BackupAssetCandidate[] = [];
+  const skipped: SkippedBackupAsset[] = [];
   const seenCanonicalPaths = new Set<string>();
   for (const candidate of [...candidates].toSorted(compareCandidates)) {
+    // Check both the original selection and the already resolved target before deduplication.
+    const privateSelection = isUpdateCapturePath(candidate.sourcePath, stateDir);
+    const privateTarget =
+      candidate.canonicalPath !== candidate.sourcePath &&
+      isUpdateCapturePath(candidate.canonicalPath, stateDir);
+    if (privateSelection || privateTarget) {
+      skipped.push({
+        kind: candidate.kind,
+        sourcePath: candidate.sourcePath,
+        displayPath: shortenHomePath(candidate.sourcePath),
+        reason: "private",
+      });
+      continue;
+    }
     if (seenCanonicalPaths.has(candidate.canonicalPath)) {
       continue;
     }
@@ -359,18 +374,8 @@ async function resolveBackupPlanFromPaths(params: {
     uniqueCandidates.push(candidate);
   }
   const included: BackupAsset[] = [];
-  const skipped: SkippedBackupAsset[] = [];
 
   for (const candidate of uniqueCandidates) {
-    if (isUpdateCapturePath(candidate.canonicalPath, stateDir)) {
-      skipped.push({
-        kind: candidate.kind,
-        sourcePath: candidate.canonicalPath,
-        displayPath: shortenHomePath(candidate.canonicalPath),
-        reason: "private",
-      });
-      continue;
-    }
     if (!candidate.exists) {
       if (
         candidate.kind === "agent" &&
@@ -485,6 +490,10 @@ function resolveManagedSkillSymlinkTargetCandidates(params: {
     allowedSymlinkTargetRealPaths: [],
   });
   for (const candidate of discovered.candidates) {
+    // Preserve the operator's lexical selection before promoting its real target.
+    if (isUpdateCapturePath(candidate.skillDir, params.stateDir)) {
+      continue;
+    }
     if (
       !loadSingleSkillDirectory({
         skillDir: candidate.skillDir,

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -29,6 +29,7 @@ import {
 } from "../skills/loading/skill-root-discovery.js";
 import { tryRealpath } from "../skills/loading/symlink-targets.js";
 import { recordBackupRunOutcome } from "../state/backup-run-records.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
 import {
   createBackupResourceInventory,
@@ -48,6 +49,8 @@ export function recordBackupOutcomeBestEffort(
   params: Parameters<typeof recordBackupRunOutcome>[0],
 ): void {
   try {
+    // A rejected private input must not be reopened for best-effort outcome writes.
+    assertNotUpdateCapturePath(resolveOpenClawStateSqlitePath(), resolveStateDir());
     recordBackupRunOutcome(params);
   } catch (error) {
     const label = params.kind === "git" ? "Git backup" : "backup";
@@ -574,7 +577,9 @@ export async function resolveBackupAgentRoot(
   config: OpenClawConfig,
   agentId: string,
 ): Promise<BackupAgentRoot> {
-  const sourcePath = await canonicalizePathForContainment(resolveAgentDir(config, agentId));
+  const selectedPath = resolveAgentDir(config, agentId);
+  assertNotUpdateCapturePath(selectedPath, resolveStateDir());
+  const sourcePath = await canonicalizePathForContainment(selectedPath);
   return {
     agentId,
     sourcePath,

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, resolveStateDir } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { assertNotUpdateCapturePath } from "../infra/update-capture-paths.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.js";
@@ -172,14 +173,17 @@ async function resolveSnapshotDatabase(
     throw new Error("Choose a SQLite snapshot source: --global or --agent <id>.");
   }
   if (options.global === true) {
+    const selectedPath = resolveOpenClawStateSqlitePath();
+    assertNotUpdateCapturePath(selectedPath, resolveStateDir());
     return {
-      path: await fs.realpath(resolveOpenClawStateSqlitePath()),
+      path: await fs.realpath(selectedPath),
       identity: { role: "global" },
     };
   }
   const config = getRuntimeConfig({ skipPluginValidation: true });
   const agentId = resolveConfiguredAgentId(config, normalizeAgentId(rawAgentId));
   const agentRoot = await resolveBackupAgentRoot(config, agentId);
+  assertNotUpdateCapturePath(agentRoot.databasePath, resolveStateDir());
   return {
     path: await fs.realpath(agentRoot.databasePath),
     identity: { role: "agent", agentId },

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -569,6 +569,7 @@ export async function createBackupArchive(
     // collect violations there and reject only after tar settles.
     const unexpectedSqliteSourcePaths: string[] = [];
     let archiveSymlinkViolation: Error | undefined;
+    let archivePrivacyViolation: Error | undefined;
     const tarFilter = (
       entryPath: string,
       entryStat: import("node:fs").Stats | import("tar").ReadEntry,
@@ -641,6 +642,7 @@ export async function createBackupArchive(
         skippedVolatileCount = 0;
         unexpectedSqliteSourcePaths.length = 0;
         archiveSymlinkViolation = undefined;
+        archivePrivacyViolation = undefined;
         const prepared = await writeArchiveStreamToFile({
           archivePath: attemptTempArchivePath,
           createArchiveStream: (reportProgress) =>
@@ -670,7 +672,15 @@ export async function createBackupArchive(
                 ),
                 filter: (entryPath, entryStat) => {
                   reportProgress({ phase: "traversal", entryPath });
-                  return tarFilter(entryPath, entryStat);
+                  try {
+                    return tarFilter(entryPath, entryStat);
+                  } catch (error) {
+                    // A malformed marker must reject publication after tar settles,
+                    // not throw out of its asynchronous traversal callback.
+                    archivePrivacyViolation =
+                      error instanceof Error ? error : new Error(String(error));
+                    return false;
+                  }
                 },
                 onWriteEntry: (entry) => {
                   const sourceEntryPath = entry.path;
@@ -725,7 +735,7 @@ export async function createBackupArchive(
           ? new Error(
               `SQLite state appeared after snapshot discovery: ${unexpectedSqliteSourcePath}. Retry backup so it can be snapshotted.`,
             )
-          : archiveSymlinkViolation;
+          : (archivePrivacyViolation ?? archiveSymlinkViolation);
         if (!archiveValidationError) {
           try {
             await plan.configCapture?.assertRootAlias?.();

--- a/src/infra/update-capture-paths.test.ts
+++ b/src/infra/update-capture-paths.test.ts
@@ -1,0 +1,118 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertNotUpdateCapturePath } from "./update-capture-paths.js";
+
+// These bytes are the producer contract, not an inferred JSON schema.
+const markerName = ".openclaw-private-update-capture";
+const markerContent = "openclaw-private-update-capture-v1\n";
+
+describe("private capture marker admission", () => {
+  let root: string;
+  let marker: string;
+  let source: string;
+  let stateDir: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "capture-marker-"));
+    marker = path.join(root, markerName);
+    source = path.join(root, "raw.txt");
+    stateDir = path.join(root, "unrelated-state");
+    fs.writeFileSync(source, "synthetic retained bytes");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each(["empty", "version", "oversized", "directory", "symlink", "dangling symlink"])(
+    "refuses a present %s marker without treating the artifact as ordinary data",
+    (kind) => {
+      if (kind === "directory") {
+        fs.mkdirSync(marker);
+      } else if (kind.includes("symlink")) {
+        fs.symlinkSync(kind === "symlink" ? source : path.join(root, "missing"), marker);
+      } else {
+        fs.writeFileSync(
+          marker,
+          kind === "empty"
+            ? ""
+            : kind === "version"
+              ? "openclaw-private-update-capture-v2\n"
+              : "x".repeat(4096),
+        );
+      }
+      expect(() => assertNotUpdateCapturePath(source, stateDir)).toThrow(
+        "Private update capture marker",
+      );
+      expect(fs.readFileSync(source, "utf8")).toBe("synthetic retained bytes");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("refuses a FIFO marker without opening it", () => {
+    execFileSync("mkfifo", [marker]);
+    const open = vi.spyOn(fs, "openSync");
+    expect(() => assertNotUpdateCapturePath(source, stateDir)).toThrow(
+      "Private update capture marker",
+    );
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "refuses an unreadable marker",
+    () => {
+      fs.writeFileSync(marker, markerContent, { mode: 0o000 });
+      try {
+        expect(() => assertNotUpdateCapturePath(source, stateDir)).toThrow(
+          "Private update capture marker",
+        );
+      } finally {
+        fs.chmodSync(marker, 0o600);
+      }
+    },
+  );
+
+  it("does not let a valid child marker hide a malformed ancestor marker", () => {
+    fs.writeFileSync(marker, "invalid");
+    const child = path.join(root, "child");
+    fs.mkdirSync(child);
+    fs.writeFileSync(path.join(child, markerName), markerContent);
+    expect(() => assertNotUpdateCapturePath(path.join(child, "raw.txt"), stateDir)).toThrow(
+      "Private update capture marker",
+    );
+  });
+
+  it("refuses marker replacement during a bounded read even with identical bytes", () => {
+    fs.writeFileSync(marker, markerContent);
+    const original = fs.statSync(marker, { bigint: true });
+    const read = fs.readSync.bind(fs);
+    let replaced = false;
+    vi.spyOn(fs, "readSync").mockImplementation(
+      (
+        descriptor: number,
+        buffer: NodeJS.ArrayBufferView,
+        offsetOrOptions: number | fs.ReadOptions = {},
+        length?: number,
+        position?: fs.ReadPosition | null,
+      ) => {
+        const options =
+          typeof offsetOrOptions === "number"
+            ? { offset: offsetOrOptions, length, position }
+            : offsetOrOptions;
+        const result = read(descriptor, buffer, options);
+        const opened = fs.fstatSync(descriptor, { bigint: true });
+        if (!replaced && opened.dev === original.dev && opened.ino === original.ino) {
+          replaced = true;
+          fs.renameSync(marker, `${marker}.old`);
+          fs.writeFileSync(marker, markerContent);
+        }
+        return result;
+      },
+    );
+    expect(() => assertNotUpdateCapturePath(source, stateDir)).toThrow(
+      "Private update capture marker",
+    );
+    expect(replaced).toBe(true);
+  });
+});

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -1,9 +1,80 @@
 // Retained raw update artifacts never enter sanitized backup or support exports.
 import fs from "node:fs";
 import path from "node:path";
+import { openRootFileSync, readFileDescriptorBoundedSync } from "./boundary-file-read.js";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { hasErrnoCode } from "./errno.js";
+import { sameFileMutationFingerprint } from "./file-descriptor.js";
 import { isPathInside } from "./path-guards.js";
+import {
+  UPDATE_CAPTURE_PRIVACY_MARKER,
+  UPDATE_CAPTURE_PRIVACY_MARKER_CONTENT,
+} from "./update-capture-privacy-marker.js";
+
+const MARKER_BYTES = Buffer.from(UPDATE_CAPTURE_PRIVACY_MARKER_CONTENT);
+
+function hasPrivacyMarker(directory: string): boolean {
+  const markerPath = path.join(directory, UPDATE_CAPTURE_PRIVACY_MARKER);
+  let before: fs.BigIntStats;
+  try {
+    before = fs.lstatSync(markerPath, { bigint: true });
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
+      return false;
+    }
+    throw new Error("Private update capture marker is unreadable; export refused.", {
+      cause: error,
+    });
+  }
+  try {
+    if (!before.isFile()) {
+      throw new Error("Marker must be a regular file");
+    }
+    const canonicalDirectory = resolvePathViaExistingAncestorSync(directory);
+    const opened = openRootFileSync({
+      absolutePath: path.join(canonicalDirectory, UPDATE_CAPTURE_PRIVACY_MARKER),
+      rootPath: canonicalDirectory,
+      boundaryLabel: "private update capture marker",
+      maxBytes: MARKER_BYTES.length,
+    });
+    if (!opened.ok) {
+      throw new Error("Marker cannot be safely opened", { cause: opened.error });
+    }
+    try {
+      const bytes = readFileDescriptorBoundedSync(opened.fd, MARKER_BYTES.length);
+      const after = fs.fstatSync(opened.fd, { bigint: true });
+      const current = fs.lstatSync(markerPath, { bigint: true });
+      if (
+        !bytes.equals(MARKER_BYTES) ||
+        !current.isFile() ||
+        !sameFileMutationFingerprint(before, after) ||
+        !sameFileMutationFingerprint(after, current)
+      ) {
+        throw new Error("Marker is invalid or changed during read");
+      }
+    } finally {
+      fs.closeSync(opened.fd);
+    }
+    return true;
+  } catch (error) {
+    throw new Error("Private update capture marker is invalid or unreadable; export refused.", {
+      cause: error,
+    });
+  }
+}
+
+function isMarkedCapturePath(candidate: string): boolean {
+  // Only selected ancestors. Never parse workspace manifests or enumerate roots.
+  let marked = false;
+  for (let ancestor = candidate; ; ancestor = path.dirname(ancestor)) {
+    if (hasPrivacyMarker(ancestor)) {
+      marked = true;
+    }
+    if (path.dirname(ancestor) === ancestor) {
+      return marked;
+    }
+  }
+}
 
 const CAPTURE_SUFFIX = ".update-captures";
 
@@ -44,13 +115,23 @@ export function isUpdateCapturePath(sourcePath: string, stateDir: string): boole
   ]);
   const candidate = path.resolve(sourcePath);
   const canonical = resolvePathViaExistingAncestorSync(sourcePath);
+  // A valid child marker or legacy root must not hide a malformed ancestor.
+  // Evaluate both alias spellings before any exclusion can short-circuit.
+  const marked = isMarkedCapturePath(candidate);
+  const canonicalMarked = canonical !== candidate && isMarkedCapturePath(canonical);
   const isSelectedStateCapture = [...roots].some((root) => {
     const resolvedRoot = resolvePathViaExistingAncestorSync(root);
     return [root, resolvedRoot].some(
       (boundary) => isPathInside(boundary, candidate) || isPathInside(boundary, canonical),
     );
   });
-  return isSelectedStateCapture || isPairedCapturePath(candidate) || isPairedCapturePath(canonical);
+  return (
+    marked ||
+    canonicalMarked ||
+    isSelectedStateCapture ||
+    isPairedCapturePath(candidate) ||
+    isPairedCapturePath(canonical)
+  );
 }
 
 export function assertNotUpdateCapturePath(sourcePath: string, stateDir: string): void {

--- a/src/infra/update-capture-privacy-marker.ts
+++ b/src/infra/update-capture-privacy-marker.ts
@@ -1,0 +1,4 @@
+// Producer contract: durably create these bytes before raw staging in the root
+// and each independently movable artifact. This marker grants exclusion only.
+export const UPDATE_CAPTURE_PRIVACY_MARKER = ".openclaw-private-update-capture";
+export const UPDATE_CAPTURE_PRIVACY_MARKER_CONTENT = "openclaw-private-update-capture-v1\n";

--- a/src/logging/diagnostic-support-export.test.ts
+++ b/src/logging/diagnostic-support-export.test.ts
@@ -46,7 +46,7 @@ describe("diagnostic support export", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it.each(["current", "other-state alias"])(
+  it.each(["current", "other-state alias", "marked relocated alias"])(
     "excludes %s capture files selected as config, logs, or a stability bundle",
     async (owner) => {
       const stateDir = path.join(tempDir, "state");
@@ -61,6 +61,18 @@ describe("diagnostic support export", () => {
         const alias = path.join(tempDir, "capture-alias");
         fs.symlinkSync(capture, alias, process.platform === "win32" ? "junction" : "dir");
         capture = alias;
+      }
+      if (owner === "marked relocated alias") {
+        const original = `${path.join(tempDir, "other-state")}.update-captures`;
+        const moved = path.join(tempDir, "relocated");
+        fs.renameSync(original, moved);
+        fs.unlinkSync(capture);
+        fs.symlinkSync(moved, capture, process.platform === "win32" ? "junction" : "dir");
+        fs.rmdirSync(path.join(tempDir, "other-state"));
+        fs.writeFileSync(
+          path.join(moved, ".openclaw-private-update-capture"),
+          "openclaw-private-update-capture-v1\n",
+        );
       }
       const privatePath = path.join(capture, "private.json");
       const marker = "synthetic-retained-record-not-for-support";


### PR DESCRIPTION
Related: #143799

## What Problem This Solves

Fixes an issue where backups or support exports could include private update-capture files after the original state directory was removed or a retained capture directory was relocated. The paired-root exclusion introduced in #143799 cannot identify those paths on its own.

## Why This Change Was Made

The existing shared export guard now recognizes a fixed, versioned, exclusion-only marker in a selected directory or its ancestors. It checks lexical and canonical paths, reads only the bounded regular marker file without following marker symlinks, and rejects malformed, unreadable or changed markers. It never parses workspace manifests or scans other state roots. Archive planning checks original lexical selections and their canonical targets before deduplication, including managed-skill target promotion. Archive traversal errors are carried through to a publication refusal after tar settles.

The producer contract is `.openclaw-private-update-capture` containing exactly `openclaw-private-update-capture-v1\n`. Producers must durably write it before raw data in each independently movable container. Producer creation, capture/reopen, lifecycle eligibility and deletion are separate work. The marker grants exclusion only, not ownership or authority. This patch creates no captures and changes no retention policy.

## User Impact

Marked directories remain excluded after owner removal, relocation or copying with their markers intact. Explicit SQLite/Git inputs and support-export aliases get the same protection. Healthy siblings, similarly named directories and ordinary manifest files remain usable. Unmarked files copied out of protected directories are outside this classification rule.

## Evidence

- Six new real-caller regressions failed on the original guard: enclosing/nested archive selection, malformed-marker publication refusal, explicit SQLite/Git inputs, and support config/log/stability inputs.
- Nine new reader controls failed on the original guard: malformed/type/version/size cases, unreadable marker, FIFO refusal without opening it, and identical-byte replacement during a bounded read.
- Initial marker candidate: 32 affected archive/snapshot/support tests plus ten reader controls passed. The subsequent lexical-admission correction passed all 22 archive/privacy cases plus three healthy managed-skill archive controls. The unchanged reader/support results remain applicable and were not replayed. Original failure logs are preserved.
- Initial P0/P1/P2 review found one short-circuit inconsistency. It was reproduced in three additional controls and fixed by validating full marker ancestry before legacy exclusion. The original finding is preserved. The unused-export gate also required moving the shared constants into a format-only module with a real production consumer. Final required changed-source checks passed, including core/test typechecks, unused-export scans, lint and repository guards. Exact-head CI is required before native landing.
- Later ClawSweeper review found lexical workspace ancestry lost before canonical deduplication. Four real-archive regressions reproduced that issue and the same planner's managed-skill target-promotion route. The correction checks both original and resolved selections before deduplication, excludes marked outward aliases, refuses malformed marked selections even with duplicate canonical targets, and preserves independently selected healthy targets. That candidate received a scoped-clean P0/P1/P2 review; the subsequent selector correction is reviewed separately below. The required changed-source checks passed, including core/test types, unused-export scans, lint and repository guards. Exact-head CI and native landing remain mandatory.
- Tests use disposable synthetic data. No installed artifact was built here; the existing installed-proof owner retains that separate job. No historical/manual capture or evidence was deleted.


## Selector review correction

Head `1d52df6ac822bf7a22e46a2cbc53e795c88b2850` also checks original agent roots and global/agent SQLite/Git database paths before canonicalization. Best-effort outcome recording cannot reopen a rejected private global database. This keeps the same exclusion-only marker contract and does not modify producer or lifecycle code.

Six new actual archive/SQLite/Git command cases fail before the correction and pass after it. They verify refusal without repository publication or source-byte mutation for valid and malformed marked selectors, then healthy operation for the same ordinary alias after removing only its disposable fixture marker. The existing 22 archive cases were not rerun for this addition; earlier reader/support/skill passes are preserved. A first attempt exposed a fixture runtime-cache mistake and a first repair exposed outcome-recording source mutation; both failures are preserved. Two missing test-loop braces found by lint were fixed mechanically without production or behavioral changes.

Fresh full-candidate review through P2 reported one `--only-config` finding. The original config path is already guarded before that early return. Two actual public `createBackupArchive({onlyConfig:true})` controls, with valid and malformed markers, both refuse with the expected diagnostic, no archive and unchanged sources. The finding is rejected with this evidence; the raw findings verdict is retained, not relabeled as a clean review. No actionable finding remains from that review. Exact-head CI and native preparation/merge gates remain mandatory.

Current measured scope: 10 files, +636/-21. No raw capture creation, retention change, historical deletion or installed build.
