### PR TITLE
test(ui): share sidebar drag data fixture

### DIFF
--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -9,22 +9,10 @@ import {
   type SessionGroupMutationResult,
   type SidebarLifecycleState,
 } from "../app-sidebar.ts";
+import { createDataTransferStub } from "../drag-data.ts";
 import { installDialogPolyfill, submitInputDialog } from "../modal-dialog.ts";
 import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
-
-function createDataTransferStub() {
-  const data = new Map<string, string>();
-  return {
-    get types() {
-      return [...data.keys()];
-    },
-    setData: (type: string, value: string) => void data.set(type, value),
-    getData: (type: string) => data.get(type) ?? "",
-    effectAllowed: "none",
-    dropEffect: "none",
-  };
-}
 
 function dispatchDragEvent(
   target: Element,

--- a/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/section-reordering.ts
@@ -7,22 +7,10 @@ import {
   mountSidebar,
   type SidebarLifecycleState,
 } from "../app-sidebar.ts";
+import { createDataTransferStub } from "../drag-data.ts";
 import { gatewayHelloForMethods } from "../gateway-methods.ts";
 import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
-
-function createDataTransferStub() {
-  const data = new Map<string, string>();
-  return {
-    get types() {
-      return [...data.keys()];
-    },
-    setData: (type: string, value: string) => void data.set(type, value),
-    getData: (type: string) => data.get(type) ?? "",
-    effectAllowed: "none",
-    dropEffect: "none",
-  };
-}
 
 function dispatchDragEvent(
   target: Element,

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -7,22 +7,10 @@ import {
   mountSidebar,
   type SidebarLifecycleState,
 } from "../app-sidebar.ts";
+import { createDataTransferStub } from "../drag-data.ts";
 import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 import "../../plugins/control-ui-view.runtime.ts";
-
-function createDataTransferStub() {
-  const data = new Map<string, string>();
-  return {
-    get types() {
-      return [...data.keys()];
-    },
-    setData: (type: string, value: string) => void data.set(type, value),
-    getData: (type: string) => data.get(type) ?? "",
-    effectAllowed: "none",
-    dropEffect: "none",
-  };
-}
 
 function dispatchDragEvent(
   target: Element,

--- a/ui/src/test-helpers/drag-data.ts
+++ b/ui/src/test-helpers/drag-data.ts
@@ -1,0 +1,12 @@
+export function createDataTransferStub() {
+  const data = new Map<string, string>();
+  return {
+    get types() {
+      return [...data.keys()];
+    },
+    setData: (type: string, value: string) => void data.set(type, value),
+    getData: (type: string) => data.get(type) ?? "",
+    effectAllowed: "none",
+    dropEffect: "none",
+  };
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Three sidebar test suites duplicated the same synthetic drag-data factory. Separate copies add maintenance work without protecting different behavior.

## Why This Change Was Made

Put the unchanged factory in a focused 12-line test helper and import it from the three suites. The existing sidebar harness remains unchanged. The same 13 factory calls still allocate fresh objects and Maps; the distinct event dispatchers and their coordinate behavior remain unchanged.

## User Impact

No production behavior or public API change. The four test-support files add 15 lines and remove 39, for a net reduction of 24 lines. The existing file-size limit remains intact.

## Evidence

The original baseline and revised candidate each passed all 352 cases through the same full sidebar entry, with identical identities, order and outcomes. The directly affected suites retain all 38 definitions and 105 assertion sites.

All 19 selected local changed checks passed, including core and UI types, i18n, formatting, lint, styles, and structural guards. Independent Codex review found no actionable issues through P2. The focused module keeps the existing sidebar harness within its unchanged file-size limit.

This is a synthetic drag-data fixture, not native DataTransfer or browser-conformance proof.

The first hosted run failed on an unchanged desktop panel that exceeded the line limit after two upstream changes combined. This branch now includes the canonical repair from #143889; the complete sidebar patch and all four tested file contents are unchanged. Fresh CI on the refreshed head is required before landing.
