### PR TITLE
fix(active-memory): inter-session deliveries trigger pointless recall runs

### DIFF
--- a/docs/concepts/active-memory/how-it-works.md
+++ b/docs/concepts/active-memory/how-it-works.md
@@ -40,6 +40,11 @@ inference feature:
 | Generic internal `agent-command` paths                              | No                                                       |
 | Sub-agent/internal helper execution                                 | No                                                       |
 
+Inter-session messages and child completion deliveries do not run Active
+Memory, even when they arrive in a visible conversation. OpenClaw uses their
+typed delivery origin to skip recall. Later human messages in that same
+conversation remain eligible under the usual targeting and session rules.
+
 Use it when the session is persistent and user-facing, the agent has
 meaningful long-term memory to search, and continuity/personalization matter
 more than raw prompt determinism: stable preferences, recurring habits,

--- a/docs/plugins/hooks/prompt-and-session.md
+++ b/docs/plugins/hooks/prompt-and-session.md
@@ -144,6 +144,23 @@ by the emitter, so hooks can scope metrics, side effects, or state to a specific
 scheduled job. Do not assume every agent event carries it. `ctx.jobId` is not
 part of the `before_tool_call` tool context.
 
+For `before_prompt_build`, `ctx.inputProvenance` carries the host-classified
+origin of the turn's user-role input on the embedded, CLI, Codex, and Copilot
+prompt paths. Its `kind` is `external_user`, `inter_session`, or
+`internal_system`. Optional source fields are `originSessionId`,
+`sourceSessionKey`, `sourceChannel`, and `sourceTool`.
+
+The field is optional. It is absent when the producer does not supply a
+classification, including ordinary human turns on some paths. Absence does
+not prove human origin. Other hook events may omit it even when prompt hooks
+receive it.
+
+`ctx.trigger === "user"` is a run trigger, not an origin classification.
+Inter-session deliveries such as `sessions_send`, `subagent_settle`, and
+`subagent_announce` can retain that trigger. Use typed provenance to
+distinguish those inputs; do not parse prompt prefixes. Provenance describes
+origin and does not grant authority to use tools or access another session.
+
 For channel-originated runs, `ctx.channel` and `ctx.messageProvider` identify
 the provider surface such as `discord` or `telegram`, while `ctx.channelId` is
 the conversation target identifier when OpenClaw can derive one from the

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -794,6 +794,52 @@ describe("active-memory plugin", () => {
     expect(hasInfoLine("active-memory: recall skipped reason=policy-disabled")).toBe(true);
   });
 
+  it("skips recall for inter-session deliveries that reuse the user trigger", async () => {
+    const result = await runPromptBuild(
+      {
+        prompt:
+          "[Inter-session message] sourceSession=agent:main:other sourceTool=sessions_send isUser=false\nHandoff payload",
+      },
+      {
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:other",
+          sourceTool: "sessions_send",
+        },
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
+    expect(hasInfoLine("active-memory: recall skipped reason=session-ineligible")).toBe(true);
+  });
+
+  it("skips recall for subagent settlement deliveries into a visible session", async () => {
+    const result = await runPromptBuild(
+      { prompt: "[Subagent Context] subagent_settle\nTask finished" },
+      {
+        inputProvenance: {
+          kind: "inter_session",
+          sourceTool: "subagent_settle",
+        },
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(hasInfoLine("active-memory: recall skipped reason=session-ineligible")).toBe(true);
+  });
+
+  it("still recalls for external-user provenance", async () => {
+    const result = await runPromptBuild(
+      { prompt: "what wings should i order?" },
+      { inputProvenance: { kind: "external_user" } },
+    );
+
+    expectPrependContextContains(result, "lemon pepper wings");
+  });
+
   it("does not inject recall that completes after the turn authority closes", async () => {
     let releaseRecall: () => void = () => {
       throw new Error("recall gate was not initialized");

--- a/extensions/active-memory/session-policy.ts
+++ b/extensions/active-memory/session-policy.ts
@@ -222,8 +222,14 @@ function isEligibleInteractiveSession(ctx: {
   sessionId?: string;
   messageProvider?: string;
   channelId?: string;
+  inputProvenance?: { kind?: string };
 }): boolean {
   if (ctx.trigger !== "user") {
+    return false;
+  }
+  // Inter-session deliveries retain the user trigger. Their typed origin keeps
+  // them out of human-message recall.
+  if (ctx.inputProvenance?.kind === "inter_session") {
     return false;
   }
   // Exclude only canonical dreaming-narrative session keys (bare or agent-prefixed).

--- a/extensions/active-memory/session-policy.ts
+++ b/extensions/active-memory/session-policy.ts
@@ -222,8 +222,16 @@ function isEligibleInteractiveSession(ctx: {
   sessionId?: string;
   messageProvider?: string;
   channelId?: string;
+  inputProvenance?: { kind?: string };
 }): boolean {
   if (ctx.trigger !== "user") {
+    return false;
+  }
+  // Inter-session deliveries (sessions_send handoffs, subagent settlement and
+  // announce events) reuse the user trigger but are routing data, not a human
+  // message. Their payload is already present in the session transcript, so a
+  // recall sub-agent run would only add model spend and turn latency.
+  if (ctx.inputProvenance?.kind === "inter_session") {
     return false;
   }
   // Exclude only canonical dreaming-narrative session keys (bare or agent-prefixed).

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -114,6 +114,7 @@ export async function prepareCodexAttemptContext(
       ? { modelProviderId: params.provider, modelId: params.modelId }
       : {}),
     trigger: params.trigger,
+    inputProvenance: params.inputProvenance,
     ...buildAgentHookContextChannelFields({
       sessionKey: contextSessionKey,
       messageChannel: params.messageChannel,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3414,6 +3414,7 @@ describe("runCodexAppServerAttempt", () => {
     sessionManager.appendMessage(assistantMessage("previous turn", Date.now()));
     const harness = createStartedThreadHarness();
     const params = createParams(sessionFile, workspaceDir, { provider: "openai" });
+    params.inputProvenance = { kind: "inter_session", sourceTool: "sessions_send" };
     params.config = {
       ...params.config,
       agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
@@ -3445,6 +3446,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(hookContext).toMatchObject({
       modelProviderId: params.provider,
       modelId: params.modelId,
+      inputProvenance: { kind: "inter_session", sourceTool: "sessions_send" },
     });
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as { developerInstructions?: string } | undefined;

--- a/extensions/copilot/src/attempt-prepare.ts
+++ b/extensions/copilot/src/attempt-prepare.ts
@@ -91,6 +91,7 @@ export function prepareCopilotAttemptContext(
     modelProviderId: modelRef.provider,
     modelId: modelRef.id,
     trigger: input.trigger,
+    inputProvenance: input.inputProvenance,
     foregroundPromptContext: buildEmbeddedForegroundPromptContext(
       { ...input, agentId: sessionAgentId },
       input.agentDir ?? resolveAgentDir(input.config ?? {}, sessionAgentId),

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -703,6 +703,7 @@ describe("runCopilotAttempt", () => {
   it("runs generic prompt and lifecycle hooks through the standard harness helpers", async () => {
     const params = makeParams({
       agentAccountId: "account-a",
+      inputProvenance: { kind: "inter_session", sourceTool: "subagent_settle" },
       sandboxSessionKey: "agent:agent-1:policy",
     });
     const beforePromptBuild = vi.fn(() => ({
@@ -747,6 +748,7 @@ describe("runCopilotAttempt", () => {
       expect.objectContaining({ prompt: "hello" }),
       expect.objectContaining({
         accountId: "account-a",
+        inputProvenance: { kind: "inter_session", sourceTool: "subagent_settle" },
         runId: "run-1",
         sessionId: "session-1",
         sessionKey: params.sessionKey,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -41,6 +41,7 @@ import type {
   CliBackendPlugin,
 } from "../../plugins/cli-backend.types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { HookRunner } from "../../plugins/hooks.js";
 import {
   clearMemoryPluginState,
   registerTestMemoryPromptBuilder,
@@ -2529,6 +2530,18 @@ describe("prepareCliRunContext", () => {
     expect(context.params.prompt).toContain("isUser=false");
     expect(context.params.prompt).toContain("trusted hook context");
     expect(context.params.prompt).toContain("foreign reply text");
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trigger: "user",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:slack:dm:U123",
+          sourceChannel: "slack",
+          sourceTool: "sessions_send",
+        },
+      }),
+    );
   });
 
   it("applies agent_turn_prepare-only context on the CLI path", async () => {
@@ -2582,7 +2595,7 @@ describe("prepareCliRunContext", () => {
   it("applies before_prompt_build hook context for CLI preparation", async () => {
     const hookRunner = {
       hasHooks: vi.fn((_hookName: string) => true),
-      runBeforePromptBuild: vi.fn(async () => ({
+      runBeforePromptBuild: vi.fn<HookRunner["runBeforePromptBuild"]>(async () => ({
         prependContext: "prompt prepend",
         systemPrompt: "prompt system",
         prependSystemContext: "prompt prepend system",
@@ -2602,15 +2615,11 @@ describe("prepareCliRunContext", () => {
       `${wrappedPluginSystemContext("prompt prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
     );
     expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
-    const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
-      [unknown, unknown]
-    >;
-    const promptContext = beforePromptBuildCalls[0]?.[1] as
-      | { channel?: string; chatId?: string; senderId?: string }
-      | undefined;
+    const promptContext = hookRunner.runBeforePromptBuild.mock.calls[0]?.[1];
     expect(promptContext?.channel).toBe("discord");
     expect(promptContext?.chatId).toBe("room-1");
     expect(promptContext?.senderId).toBe("user-789");
+    expect(promptContext?.inputProvenance).toBeUndefined();
   });
 
   it("applies turn-authorized prompt enrichment after CLI tool preparation", async () => {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2529,6 +2529,18 @@ describe("prepareCliRunContext", () => {
     expect(context.params.prompt).toContain("isUser=false");
     expect(context.params.prompt).toContain("trusted hook context");
     expect(context.params.prompt).toContain("foreign reply text");
+    const interSessionHookCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
+      [unknown, unknown]
+    >;
+    expect(interSessionHookCalls[0]?.[1]).toMatchObject({
+      trigger: "user",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:slack:dm:U123",
+        sourceChannel: "slack",
+        sourceTool: "sessions_send",
+      },
+    });
   });
 
   it("applies agent_turn_prepare-only context on the CLI path", async () => {
@@ -2606,11 +2618,17 @@ describe("prepareCliRunContext", () => {
       [unknown, unknown]
     >;
     const promptContext = beforePromptBuildCalls[0]?.[1] as
-      | { channel?: string; chatId?: string; senderId?: string }
+      | {
+          channel?: string;
+          chatId?: string;
+          senderId?: string;
+          inputProvenance?: { kind: string };
+        }
       | undefined;
     expect(promptContext?.channel).toBe("discord");
     expect(promptContext?.chatId).toBe("room-1");
     expect(promptContext?.senderId).toBe("user-789");
+    expect(promptContext?.inputProvenance).toBeUndefined();
   });
 
   it("applies turn-authorized prompt enrichment after CLI tool preparation", async () => {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1007,6 +1007,7 @@ async function prepareCliRunContextWithinReadFence(
     modelProviderId: params.provider,
     modelId,
     trigger: params.trigger,
+    inputProvenance: params.inputProvenance,
     ...buildAgentHookContextChannelFields(params),
   };
   const promptBuildHookRunner = skipsTurnPreparation ? undefined : getGlobalHookRunner();

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.provenance.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.provenance.test.ts
@@ -1,0 +1,123 @@
+// #143821: prompt-build hook context must carry the turn's typed input provenance so
+// plugins can distinguish inter-session deliveries from human messages.
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import type { PluginHookAgentContext } from "../../../plugins/hook-types.js";
+import { createHookRunner } from "../../../plugins/hooks.js";
+import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
+import {
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../../sessions/agent-session-loop-correctness.test-support.js";
+import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-build.js";
+import { forgetPromptBuildDrainCacheForRun } from "./attempt-prompt-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+vi.mock("../../../plugins/host-hook-state.js", () => ({
+  drainPluginNextTurnInjectionContext: vi.fn(async () => ({ queuedInjections: [] })),
+}));
+
+registerAgentSessionLoopTestLifecycle();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function assembleWithCapturedHookCtx(
+  runId: string,
+  attemptOverrides?: Partial<EmbeddedRunAttemptParams>,
+) {
+  const { session, sessionManager, modelRegistry } = await createTestSession();
+  const admission = prepareSystemAgentRunAdmission({}, runId, "main", "provenance-hook-test");
+  onTestFinished(() => {
+    admission.close();
+    forgetPromptBuildDrainCacheForRun(runId);
+  });
+  const attempt: EmbeddedRunAttemptParams = {
+    admittedRunContext: await admission.admit("embedded"),
+    authStorage: modelRegistry.authStorage,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry,
+    config: {},
+    model: testModel,
+    modelId: testModel.id,
+    provider: testModel.provider,
+    thinkLevel: "off",
+    prompt: "Handoff payload",
+    transcriptPrompt: "Handoff payload",
+    runId,
+    sessionId: runId,
+    sessionKey: `agent:main:${runId}`,
+    sessionFile: "",
+    sessionPersistence: "detached",
+    trigger: "user",
+    timeoutMs: 10_000,
+    workspaceDir: "/tmp/provenance-hook-test",
+    ...attemptOverrides,
+  };
+  const captured: PluginHookAgentContext[] = [];
+  const hookRunner = createHookRunner({
+    hooks: [],
+    plugins: [],
+    typedHooks: [
+      {
+        pluginId: "provenance-hook-test",
+        hookName: "before_prompt_build",
+        source: "test",
+        handler: async (_event: unknown, ctx: PluginHookAgentContext) => {
+          captured.push(ctx);
+        },
+      },
+    ],
+  });
+  await prepareEmbeddedAttemptPromptAssembly({
+    attempt,
+    activeSession: session,
+    sessionManager,
+    hookRunner,
+    hookAgentId: "main",
+    diagnosticTrace: { traceId: "11111111111111111111111111111111" },
+    isRawModelRun: false,
+    sessionAgentId: "main",
+    runtimeModel: testModel.id,
+    systemPromptText: "Base system prompt",
+    applyPromptBuildToolsAllow: () => [],
+    setActiveSessionSystemPrompt: vi.fn(),
+    setLeasedSteering: vi.fn(),
+  });
+  return captured;
+}
+
+describe("prompt-build hook context input provenance", () => {
+  it("exposes inter-session provenance on the before_prompt_build context", async () => {
+    const captured = await assembleWithCapturedHookCtx("provenance-hook-inter-session", {
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:session-a",
+        sourceTool: "sessions_send",
+      },
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      trigger: "user",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:session-a",
+        sourceTool: "sessions_send",
+      },
+    });
+  });
+
+  it("leaves provenance undefined for ordinary human turns", async () => {
+    const captured = await assembleWithCapturedHookCtx("provenance-hook-human-turn");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ trigger: "user" });
+    expect(captured[0]?.inputProvenance).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.provenance.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.provenance.test.ts
@@ -1,0 +1,122 @@
+// #143821: prompt-build hook context must carry the turn's typed input provenance so
+// plugins can distinguish inter-session deliveries from human messages.
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createHookRunner } from "../../../plugins/hooks.js";
+import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
+import {
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../../sessions/agent-session-loop-correctness.test-support.js";
+import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-build.js";
+import { forgetPromptBuildDrainCacheForRun } from "./attempt-prompt-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+vi.mock("../../../plugins/host-hook-state.js", () => ({
+  drainPluginNextTurnInjectionContext: vi.fn(async () => ({ queuedInjections: [] })),
+}));
+
+registerAgentSessionLoopTestLifecycle();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function assembleWithCapturedHookCtx(
+  runId: string,
+  attemptOverrides?: Partial<EmbeddedRunAttemptParams>,
+) {
+  const { session, sessionManager, modelRegistry } = await createTestSession();
+  const admission = prepareSystemAgentRunAdmission({}, runId, "main", "provenance-hook-test");
+  onTestFinished(() => {
+    admission.close();
+    forgetPromptBuildDrainCacheForRun(runId);
+  });
+  const attempt: EmbeddedRunAttemptParams = {
+    admittedRunContext: await admission.admit("embedded"),
+    authStorage: modelRegistry.authStorage,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry,
+    config: {},
+    model: testModel,
+    modelId: testModel.id,
+    provider: testModel.provider,
+    thinkLevel: "off",
+    prompt: "Handoff payload",
+    transcriptPrompt: "Handoff payload",
+    runId,
+    sessionId: runId,
+    sessionKey: `agent:main:${runId}`,
+    sessionFile: "",
+    sessionPersistence: "detached",
+    trigger: "user",
+    timeoutMs: 10_000,
+    workspaceDir: "/tmp/provenance-hook-test",
+    ...attemptOverrides,
+  };
+  const captured: unknown[] = [];
+  const hookRunner = createHookRunner({
+    hooks: [],
+    plugins: [],
+    typedHooks: [
+      {
+        pluginId: "provenance-hook-test",
+        hookName: "before_prompt_build",
+        source: "test",
+        handler: async (_event: unknown, ctx: unknown) => {
+          captured.push(ctx);
+        },
+      },
+    ],
+  });
+  await prepareEmbeddedAttemptPromptAssembly({
+    attempt,
+    activeSession: session,
+    sessionManager,
+    hookRunner,
+    hookAgentId: "main",
+    diagnosticTrace: { traceId: "11111111111111111111111111111111" },
+    isRawModelRun: false,
+    sessionAgentId: "main",
+    runtimeModel: testModel.id,
+    systemPromptText: "Base system prompt",
+    applyPromptBuildToolsAllow: () => [],
+    setActiveSessionSystemPrompt: vi.fn(),
+    setLeasedSteering: vi.fn(),
+  });
+  return captured;
+}
+
+describe("prompt-build hook context input provenance", () => {
+  it("exposes inter-session provenance on the before_prompt_build context", async () => {
+    const captured = await assembleWithCapturedHookCtx("provenance-hook-inter-session", {
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:session-a",
+        sourceTool: "sessions_send",
+      },
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      trigger: "user",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:session-a",
+        sourceTool: "sessions_send",
+      },
+    });
+  });
+
+  it("leaves provenance undefined for ordinary human turns", async () => {
+    const captured = await assembleWithCapturedHookCtx("provenance-hook-human-turn");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ trigger: "user" });
+    expect((captured[0] as { inputProvenance?: unknown }).inputProvenance).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -153,6 +153,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     modelProviderId: attempt.model.provider,
     modelId: attempt.model.id,
     trigger: attempt.trigger,
+    inputProvenance: attempt.inputProvenance,
     ...buildAgentHookContextChannelFields(attempt),
     ...buildAgentHookContextIdentityFields({
       trigger: attempt.trigger,

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -29,6 +29,7 @@ export type AgentHarnessHookContext = {
   messageProvider?: string;
   accountId?: string;
   trigger?: string;
+  inputProvenance?: PluginHookAgentContext["inputProvenance"];
   channelId?: string;
   contextTokenBudget?: number;
   contextWindowSource?: PluginHookContextWindowSource;
@@ -58,6 +59,7 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...(params.accountId ? { accountId: params.accountId } : {}),
     ...(params.channel ? { channel: params.channel } : {}),
     ...(params.trigger ? { trigger: params.trigger } : {}),
+    ...(params.inputProvenance ? { inputProvenance: params.inputProvenance } : {}),
     ...(params.channelId ? { channelId: params.channelId } : {}),
     ...(params.contextTokenBudget ? { contextTokenBudget: params.contextTokenBudget } : {}),
     ...(params.contextWindowSource ? { contextWindowSource: params.contextWindowSource } : {}),

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -14,6 +14,7 @@ import type { PrepareAssistantTranscriptMessage } from "../config/sessions/trans
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TtsAutoMode } from "../config/types.tts.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import type {
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
@@ -319,6 +320,11 @@ export type PluginHookAgentContext = {
   senderId?: string;
   trigger?: string;
   channelId?: string;
+  /**
+   * Typed origin of the turn's user-role input. Absent when the producer did not
+   * supply a classification; absence does not establish human origin.
+   */
+  inputProvenance?: InputProvenance;
   /** Resolved effective context-token budget after model/config/agent caps. */
   contextTokenBudget?: number;
   /** Source that supplied the resolved context-token budget. */

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -14,6 +14,7 @@ import type { PrepareAssistantTranscriptMessage } from "../config/sessions/trans
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TtsAutoMode } from "../config/types.tts.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import type {
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
@@ -319,6 +320,12 @@ export type PluginHookAgentContext = {
   senderId?: string;
   trigger?: string;
   channelId?: string;
+  /**
+   * Typed origin of the turn's user-role input. Present when the host classified
+   * the input (e.g. inter-session handoffs reuse the user trigger); absent for
+   * ordinary human turns from paths without provenance.
+   */
+  inputProvenance?: InputProvenance;
   /** Resolved effective context-token budget after model/config/agent caps. */
   contextTokenBudget?: number;
   /** Source that supplied the resolved context-token budget. */


### PR DESCRIPTION
AI-assisted.

Closes #143821

## What Problem This Solves

Active Memory starts an unnecessary recall when another session sends a message or a child returns a result to a visible conversation. These deliveries retain the broad `user` trigger, so the plugin previously treated them like eligible conversational input.

## Why This Change Was Made

Carry the existing typed input provenance through embedded, CLI, Codex, and Copilot prompt hooks and the shared harness context. Active Memory's existing eligibility check excludes `inter_session` input before recall. The public hook guide documents producer coverage, unchanged trigger values, and that missing provenance does not prove human origin.

## User Impact

Inter-session deliveries preserve their payload and normal reply without starting recall. Later human messages in the same conversation still recall memory. Existing session, tool-authority, privacy, cancellation, and model-selection rules remain in place.

## Evidence

Matched isolated Gateway runs used baseline `e9ab9c9997bb` and candidate `0c848080ff88`, with the candidate compiled by [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34482972809/job/102890526288). The same real WebChat sequence exercised `sessions_send`, a genuine announcing child, a genuine yielded child settlement, and a later human message in one persistent receiver.

| Receiving turn | Baseline recalls | Candidate recalls |
| --- | ---: | ---: |
| Initial human | 1 | 1 |
| `sessions_send` | 1 | 0 |
| Human requesting announcing child | 1 | 1 |
| `subagent_announce` | 1 | 0 |
| Human requesting yielded child | 1 | 1 |
| `subagent_settle` | 1 | 0 |
| Later human | 1 | 1 |

All three candidate delivery paths retain typed provenance, once-only payload/reply behavior, and the same receiving session. Four grounded human recalls remain. Deterministic endpoints drive these real tools and Gateway paths; this proves routing and recall behavior, not independent model reasoning.

- An independent source-blind run confirmed the full candidate sequence, live `always` configuration, typed origins, and normal owned shutdown.
- Six new regression failures were verified on unchanged baseline production code; three human controls passed.
- All 739 focused candidate tests passed across Active Memory, embedded, CLI, Codex, and Copilot. Native formatting, syntax/boundary lint, documentation parsing, and `git diff --check` passed.
- The separately observed optional agent-to-agent follow-up still fails before prompt entry with `Async work scope is closed` on both builds. It is not counted as successful announcement or recall-skip proof; both required real child paths completed normally.
- CLI, Codex, and Copilot propagation have focused/source coverage; the real receiving-session run uses the embedded Gateway route.

The staging build passed. Its broader manual CI run also recorded failures in catalog parity, board iframe reporting, a reset-test fixture receiving an unexpected heartbeat, and generated locale navigation. These remain recorded separately from the passing product proof; final PR checks are tracked on the published head.

The original contribution and [contributor-reported live model evidence](https://github.com/openclaw/openclaw/pull/143903#issuecomment-5618161707) remain credited to @LiuwqGit. This revision also supplies the requested public contract documentation.
