### PR TITLE
refactor(telegram): remove duplicate group-history test

### DIFF
--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -103,52 +103,6 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
     expect(ctx?.ctxPayload.InboundEventKind).toBe("user_request");
   });
 
-  it("keeps room events as context for the next direct group request", async () => {
-    const groupHistories = new Map();
-    const cfg = {
-      messages: { groupChat: { unmentionedInbound: "room_event", mentionPatterns: [] } },
-    };
-    await buildTelegramMessageContextForTest({
-      cfg,
-      message: { ...buildForumMessage(99), text: "side chatter" },
-      historyLimit: 10,
-      groupHistories,
-      resolveGroupActivation: () => false,
-      resolveGroupRequireMention: () => false,
-      resolveTelegramGroupConfig: () => ({
-        groupConfig: { requireMention: false },
-        topicConfig: undefined,
-      }),
-    });
-
-    const ctx = await buildTelegramMessageContextForTest({
-      cfg,
-      message: {
-        ...buildForumMessage(99),
-        message_id: 2,
-        text: "replying directly",
-        reply_to_message: {
-          message_id: 10,
-          chat: { id: -1001234567890, type: "supergroup", title: "Forum", is_forum: true },
-          from: { id: 7, first_name: "Bot", username: "bot", is_bot: true },
-          text: "previous bot message",
-        },
-      },
-      historyLimit: 10,
-      groupHistories,
-      resolveGroupActivation: () => false,
-      resolveGroupRequireMention: () => false,
-      resolveTelegramGroupConfig: () => ({
-        groupConfig: { requireMention: false },
-        topicConfig: undefined,
-      }),
-    });
-
-    expect(ctx?.ctxPayload.InboundEventKind).toBe("user_request");
-    expect(JSON.stringify(ctx?.ctxPayload.ChannelStructuredContext)).toContain("side chatter");
-    expect(ctx?.ctxPayload.Body).not.toContain("side chatter");
-  });
-
   it("keeps room events as context with default group history mode", async () => {
     const groupHistories = new Map();
     const cfg = {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

This maintainer-requested test audit removes duplicated Telegram room-event history coverage that adds maintenance work without protecting an additional scenario.

## Why This Change Was Made

Remove the weaker repeated two-turn case. The retained default-group-history test uses the same configuration, messages, history map, and three assertions, and additionally checks `InboundHistory`. All other cases, imports, helpers, and production code remain unchanged.

## User Impact

No user-visible or runtime behavior change. One redundant test case and 46 test lines are removed while the stronger history coverage remains.

## Evidence

- Full Telegram require-mention test file through its owning configuration: 12 passed, zero skipped.
- All 19 selected changed checks passed, including formatting, extension-test typechecking, and final lint.
- Fresh P2 review: scoped-clean, no actionable findings.
- One test file changed, with no production, configuration, or stored-format changes.

No live Telegram or Gateway execution, or local full-repository test run, is claimed.
