### PR TITLE
fix(ui): redact failed-run sidebar previews

### DIFF
--- a/ui/src/components/session-attention-controller.ts
+++ b/ui/src/components/session-attention-controller.ts
@@ -13,6 +13,7 @@ import {
   setQuestionPromptClient,
 } from "../app/question-prompt.ts";
 import { t } from "../i18n/index.ts";
+import { formatUiExternalText } from "../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
@@ -123,7 +124,7 @@ export class SessionAttentionController implements ReactiveController {
       return SIDEBAR_SESSION_NO_ATTENTION;
     }
     const reason =
-      row.lastRunError?.trim() ||
+      formatUiExternalText(row.lastRunError) ||
       t(
         row.status === "timeout" ? "sessionsView.runErrorTimedOut" : "sessionsView.runErrorUnknown",
       );

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -59,6 +59,26 @@ function agentAttentionRow(
 }
 
 describe("AppSidebar session attention", () => {
+  it("redacts local paths from failed-run previews", async () => {
+    const sessionsHarness = createSessionsHarness("main", [sessionKey]);
+    setRows(sessionsHarness, [
+      failedRow(sessionKey, {
+        lastRunError:
+          "Cannot find module '/Users/example/.local/share/openclaw/dist/status-text-old.mjs' imported from /Users/example/.local/share/openclaw/dist/openclaw-tools-old.mjs",
+      }),
+    ]);
+    const { sidebar } = await mountSidebar(
+      createGateway({} as GatewayBrowserClient),
+      sessionsHarness.sessions,
+    );
+    const row = sidebar.querySelector(`[data-session-key="${sessionKey}"]`);
+
+    expect(row?.textContent).toContain(
+      "Cannot find module '[redacted path]' imported from [redacted path]",
+    );
+    expect(row?.textContent).not.toContain("/Users/example");
+  });
+
   it("projects canonical attention onto Home across row refresh ordering", async () => {
     const mainKey = "agent:main:main";
     const client = {


### PR DESCRIPTION
## Summary

- sanitize persisted failed-run reasons before projecting sidebar attention
- use the same browser-safe redaction path as chat error cards
- cover a realistic missing-module error containing both module and importer paths

## Testing

- `pnpm exec vitest run ui/src/components/app-sidebar.test.ts --project ui`
- `pnpm check:changed`
