### PR TITLE
fix(state): tolerate transient locks during read-only access

### DIFF
--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -1,8 +1,12 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { hasNodeErrorCode } from "../infra/path-guards.js";
 import * as sqliteReadOnly from "../infra/sqlite-readonly-location.js";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -38,6 +42,68 @@ function createOptions(stateDir: string) {
 afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
+});
+
+it("waits for a transient database lock before a fresh read-only schema inspection", async () => {
+  await withTempDir("openclaw-state-readonly-busy-", async (stateDir) => {
+    const options = createOptions(stateDir);
+    await fsp.mkdir(path.dirname(options.path), { recursive: true });
+    const setup = new DatabaseSync(options.path);
+    try {
+      setup.exec("CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('committed');");
+    } finally {
+      setup.close();
+    }
+    const before = fs.readFileSync(options.path);
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          import { DatabaseSync } from "node:sqlite";
+          const db = new DatabaseSync(process.argv[1]);
+          db.exec("BEGIN EXCLUSIVE; UPDATE held SET value = 'uncommitted';");
+          process.once("message", () => {
+            setTimeout(() => {
+              db.exec("ROLLBACK");
+              db.close();
+              process.disconnect();
+            }, 200);
+          });
+          process.send({ locked: true });
+        `,
+        options.path,
+      ],
+      { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+    );
+    let stderr = "";
+    const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => {
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      },
+    );
+    try {
+      expectDefined(child.stderr, "SQLite lock child stderr pipe").on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      const [ready] = await once(child, "message", { signal: AbortSignal.timeout(10_000) });
+      expect(ready).toEqual({ locked: true });
+      // The child releases independently while the synchronous reader waits inside SQLite.
+      child.send({ release: true });
+      const rows = withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+        expect(() => db.exec("INSERT INTO held VALUES ('unexpected')")).toThrow(/readonly/);
+        expect(db.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+        return db.prepare("SELECT value FROM held").all();
+      }, options);
+      expect(rows).toEqual([{ value: "committed" }]);
+      expect(await closed, stderr).toEqual({ code: 0, signal: null });
+      expect(fs.readFileSync(options.path)).toEqual(before);
+    } finally {
+      await stopChildProcess(child, 5_000);
+      await closed;
+    }
+  });
 });
 
 describe.each(["admission", "explicit", "async"] as const)("%s read-only state reads", (mode) => {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -121,8 +121,8 @@ function withOpenClawStateReadOnlyLocation<T>(
     const db = openNodeSqliteDatabase(location, { readOnly: true });
     let closeSchemaReadAdmission: (() => void) | undefined;
     try {
-      closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
       db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+      closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
       assertSupportedStateSchemaVersion(db, pathname);
       return operation({ db, path: pathname });
     } finally {


### PR DESCRIPTION
Related: #143832, #142522, #143661

## What Problem This Solves

Fixes an issue where users reading shared state, including plugin-discovery state used by Doctor, could receive `database is locked` immediately when another connection briefly held an exclusive database lock.

## Why This Change Was Made

Legacy catalog admission performs a schema query before the caller reads any rows. Install the existing 5,000 ms SQLite busy timeout before that admission query so the entire fresh read follows the established timeout. Read-only access, malformed legacy-index handling, source-handle exclusion, and cleanup retain their existing behavior.

## User Impact

Fresh shared-state readers can wait for transient lock contention within the existing timeout instead of failing before that timeout is active.

## Evidence

- The new cross-process regression failed on unchanged main production code with `SQLITE_BUSY` at the same legacy catalog query as the CI failure. Its writer deliberately uses a rollback-journal exclusive transaction; the original CI writer remains unidentified.
- The complete read-only and exclusion files passed all 25 cases after the one-line reorder, including malformed-index admission and source preservation. After a test-only nullable-pipe type correction, the focused contention regression passed again.
- Independent P2 review of the final source found no actionable findings.
- Final changed checks passed, including core/test types, lint, schema and architecture guards.
- Standalone Linux API proof passed on Blacksmith Testbox ([run 34459489877](https://github.com/openclaw/openclaw/actions/runs/34459489877), Node 24.19.0 / SQLite 3.53.3): `readConfigMachineState` returned committed state after the synthetic exclusive lock released; integrity, read-only enforcement, unchanged source bytes, natural child exit, and temporary-state cleanup passed. The exact production source hash was verified. The lease is independently confirmed completed; the backing Actions session may show canceled because one-shot Testbox cleanup owns its lifecycle. A post-success portal-sync warning did not change the successful command or completed lease.

Exact-head CI [run 34461387969](https://github.com/openclaw/openclaw/actions/runs/34461387969) completed successfully on attempt 3, including the required CI gate. Attempt 1 hit an existing Windows worker-transform case deadline; attempt 2 passed those cases but hit a separate native-executable fixture cleanup EPERM. After source/owner investigation and independently reviewed native Windows diagnostics (48 passes, three expected skips, no cleanup failure capture), each recovery was separately authorized for the exact failed job at the unchanged head. Attempt 3 passed both transform rows (104,906 ms and 107,015 ms) and the native-owner explicit case (833 ms). No source, assertion, order, or deadline was changed for these recoveries. The cleanup diagnostics are non-reproduction evidence; they establish neither the lock holder nor a fixture repair.

The test verifies committed rows, rejects writes through the read-only connection, checks integrity and unchanged database bytes, and joins its child process. The separate Doctor test fixture environment weakness is outside this repair.

This narrow extraction preserves the shared-state repair contributed by @pash-openai in [commit 06bc7600](https://github.com/openclaw/openclaw/pull/143661/commits/06bc7600edc2853d360fcc55bf3233a2db0b3ad3) on #143661, together with independently developed regression and Linux proof. The broader Slack and queued-turn work remains in that PR and was not tested as part of this change.

Co-authored-by: pash <pash@openai.com>
