### PR TITLE
fix(ui): restore pinned sidebar session drag ordering

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -288,7 +288,9 @@ export function renderRecentSession(params: {
     method: "sessions.groups.put",
     requiredScope: "operator.write",
   });
-  const rowDraggable = !session.isChild && groupWriteAccess.allowed;
+  // Pinned rows reorder inside the browser-local navigation zone; only rows
+  // that can move between session groups require Gateway group-write access.
+  const rowDraggable = !session.isChild && (session.pinned || groupWriteAccess.allowed);
   const marqueeLabelTemplate = html`<span
     ${display ? ref(restartHoverMarqueeIfHovered) : nothing}
     class="sidebar-recent-session__name hover-marquee"

--- a/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/sidebar-zone.ts
@@ -8,6 +8,7 @@ import {
   type SidebarLifecycleState,
 } from "../app-sidebar.ts";
 import { createDataTransferStub } from "../drag-data.ts";
+import { gatewayHelloForMethods } from "../gateway-methods.ts";
 import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 import "../../plugins/control-ui-view.runtime.ts";
@@ -340,6 +341,55 @@ describe("AppSidebar interleaved zone", () => {
     dispatchDragEvent(target, "drop", dataTransfer, 11);
 
     expect(onUpdate).toHaveBeenCalledWith(["route:tasks", "route:usage", "route:plugins"]);
+  });
+
+  it("reorders a pinned session without requiring session-group write access", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    gateway.publish({ hello: gatewayHelloForMethods([], ["operator.read"]) });
+    const sessions = createSessionsHarness("main", [
+      "agent:main:main",
+      "agent:main:alpha",
+      "agent:main:beta",
+    ]);
+    const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+    sidebar.connected = true;
+    const result = sessions.sessions.state.result;
+    if (!result) {
+      throw new Error("expected session list");
+    }
+    sessions.publish({
+      result: {
+        ...result,
+        sessions: result.sessions.map((row) =>
+          row.key === "agent:main:alpha" ? Object.assign({}, row, { pinned: true }) : row,
+        ),
+      },
+    });
+    sidebar.sidebarEntries = ["route:usage", "session:agent:main:alpha", "route:plugins"];
+    const onUpdate = vi.fn();
+    sidebar.onUpdateSidebarEntries = onUpdate;
+    await sidebar.updateComplete;
+    const source = sidebar.querySelector<HTMLElement>('[data-session-key="agent:main:alpha"]');
+    if (!source) {
+      throw new Error("expected pinned Alpha session row");
+    }
+    const target = zoneEntry(sidebar, "route:usage");
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue({
+      top: 10,
+      height: 20,
+    } as DOMRect);
+    const dataTransfer = createDataTransferStub();
+
+    expect(source.getAttribute("draggable")).toBe("true");
+    dispatchDragEvent(source, "dragstart", dataTransfer);
+    dispatchDragEvent(target, "dragover", dataTransfer, 11);
+    dispatchDragEvent(target, "drop", dataTransfer, 11);
+
+    expect(onUpdate).toHaveBeenCalledWith([
+      "session:agent:main:alpha",
+      "route:usage",
+      "route:plugins",
+    ]);
   });
 
   it("pins and inserts a session dropped from Threads", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could not drag a pinned session to reposition it among Control UI sidebar items when the Gateway did not advertise session-group writes. Route and plugin items remained reorderable, making pinned-session dragging appear to be controlled by inter-group drag precedence.

## Why This Change Was Made

Pinned session ordering is a browser-local navigation-zone preference, so pinned rows now remain draggable independently of `sessions.groups.put`. Unpinned session rows still require group-write access before they can initiate cross-group moves.

## User Impact

Users can again reorder pinned sessions among sidebar pages and plugin destinations even when session-group mutation is unavailable or read-only.

## Evidence

- Added a regression test that reproduces the missing-group-write state, performs the pinned-session drag/drop, and verifies the persisted sidebar order. The test fails before the fix because the pinned row renders `draggable="false"`.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 353 tests passed.
- `node scripts/check-changed.mjs` — passed UI/core typechecks, formatting, i18n verification, dead-export scans, and lint.
- Autoreview: scoped-clean, no accepted/actionable findings.
