### PR TITLE
fix: continue submitted turns across worker runtime updates

### DIFF
--- a/docs/gateway/cloud-workers/session-lifecycle.md
+++ b/docs/gateway/cloud-workers/session-lifecycle.md
@@ -10,6 +10,8 @@ What `sessions.dispatch` does, how completed turns are reconciled back to the Ga
 
 Gateway updates retain an attached cloud machine and install the new worker bundle in place. The Gateway stops the old worker and revokes its credential before admitting the new build. The machine's workspace, installed packages, and desktop remain available. Failed installation retains the lease for recovery rather than allocating a replacement. The node must support the current bundle installer and reconnect before recovery can finish.
 
+If a submitted turn encounters the old build before execution starts, OpenClaw releases that unstarted claim, refreshes the runtime, and retries admission once with fresh authority. The session and original submission stay intact. Work already handed to a worker is never replayed through this admission retry.
+
 For node-backed sessions interrupted by a restart, recovery settles pending workspace results and retires the interrupted turn while retaining the machine. The resumed turn receives fresh authority; it does not replay the interrupted tool call automatically. Explicit Stop, Move, and failed-provider cleanup retain their normal teardown behavior.
 
 Workspace manifest downloads use gzip when the node supports it and remain compatible with uncompressed transfers. Both the compressed response and its decoded manifest stay within the 64 MiB safety limit; the node verifies the decoded manifest before changing the workspace.

--- a/src/gateway/worker-environments/worker-turn-launcher-build-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-build-recovery.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { STALE_WORKER_BUILD_REASON, StaleWorkerBuildError } from "./admission.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import type { WorkerTurnTunnelHandle } from "./tunnel-contract.js";
+import {
+  ENVIRONMENT_ID,
+  MANIFEST_REF,
+  OWNER_EPOCH,
+  SESSION_ID,
+  SESSION_KEY,
+  attachedEnvironment,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  credential,
+  database,
+  measureLaunchTurn,
+  openSessionManager,
+  placements,
+  root,
+  seedActivePlacement,
+  sessionTarget,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+  type WorkerTurnEnvironmentService,
+} from "./worker-turn-launcher.test-support.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+
+function createBuildRecoveryHarness(
+  options: {
+    rejection?: "recorded" | "admission" | "launch" | "handoff";
+    repeated?: boolean;
+    pendingResult?: boolean;
+    refreshInPlace?: boolean;
+    withoutRecorder?: boolean;
+    afterReconcile?: () => void | Promise<void>;
+  } = {},
+) {
+  seedActivePlacement();
+  const rejection = options.rejection ?? "admission";
+  let environment = attachedEnvironment();
+  const retire = () => {
+    environment = {
+      ...environment,
+      state: "failed",
+      leaseId: null,
+      sshEndpoint: null,
+      sharedHost: null,
+      ownerEpoch: OWNER_EPOCH + 1,
+      attachedSessionIds: [],
+      tunnelStatus: "stopped",
+      error: STALE_WORKER_BUILD_REASON,
+    };
+  };
+  if (rejection === "recorded") {
+    retire();
+  }
+  let replaced = false;
+  const launchTurn = vi.fn<WorkerTurnTunnelHandle["launchTurn"]>(async (request) => {
+    if (rejection === "launch" && (!replaced || options.repeated)) {
+      throw new StaleWorkerBuildError();
+    }
+    request.onDispatchReady?.();
+    if (rejection === "handoff") {
+      throw new StaleWorkerBuildError();
+    }
+    const leafId = openSessionManager().appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "Continued on the replacement worker" }],
+        timestamp: 51,
+      }),
+    );
+    createWorkerSessionPlacementGate(placements).updateAckCursors({
+      claim: request.turnClaim,
+      transcriptSeq: 2,
+      liveSeq: 1,
+    });
+    return {
+      stdout: JSON.stringify({
+        status: "completed",
+        transcriptLeafId: leafId,
+        transcriptNextSeq: (placements.get(SESSION_ID)?.lastTranscriptAckCursor ?? 0) + 1,
+      }),
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    };
+  });
+  const destroy = vi.fn(async () => environment);
+  const environments: WorkerTurnEnvironmentService &
+    Parameters<typeof createWorkerPlacementDispatchService>[0]["environments"] = {
+    ...unusedEnvironments(),
+    prepareProjectIntent: async () => {
+      throw new Error("unexpected prepared intent");
+    },
+    assertPreparedIntentCurrent: vi.fn(),
+    getPreparedCandidates: () => [],
+    schedulePreparedRefill: vi.fn(),
+    bindPreparedWorkspace: async () => {
+      throw new Error("unexpected prepared binding");
+    },
+    recordError: vi.fn(() => {
+      throw new Error("unexpected provisioning interruption");
+    }),
+    supportsProviderExecutionMode: vi.fn(() => true),
+    get: () => environment,
+    acquireTurnCredential: async (claim) => {
+      if (options.pendingResult) {
+        placements.markWorkspaceResultPending(claim);
+      }
+      return credential();
+    },
+    acknowledgeCredentialDelivery: vi.fn(() => true),
+    startTunnel: async () => {
+      if (rejection !== "handoff" && rejection !== "launch" && (!replaced || options.repeated)) {
+        throw new StaleWorkerBuildError();
+      }
+      return {
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+        runWorkspaceCommand: vi.fn(),
+        quiesceWorkspace: async () => ({
+          assertActive: async () => {},
+          resume: async () => {},
+        }),
+        measureLaunchTurn,
+        launchTurn,
+        syncWorkspace: vi.fn(),
+        reconcileWorkspace: async (request) => {
+          if (request.source.kind !== "local") {
+            throw new Error("expected a local workspace source");
+          }
+          request.source.journal.commit(MANIFEST_REF);
+          return {
+            manifestRef: MANIFEST_REF,
+            changed: false,
+            verifyStable: async () => {},
+            verifyLocalStable: async () => {},
+          };
+        },
+        stop: async () => {},
+      };
+    },
+    stopTunnel: vi.fn(async () => {}),
+    destroy,
+    requestDestroy: destroy,
+    attachSession: vi.fn(async () => {
+      throw new Error("unexpected worker session attachment");
+    }),
+    create: vi.fn(async () => {
+      throw new Error("unexpected worker environment creation");
+    }),
+    createFromProfileSnapshot: vi.fn(async () => {
+      throw new Error("unexpected inherited worker environment creation");
+    }),
+    reconcileOnce: async () => retire(),
+    reconcileEnvironment: vi.fn(),
+  };
+  const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
+  const dispatch = createWorkerPlacementDispatchService({
+    placements,
+    environments,
+    runnerAvailability: { read: () => undefined, version: () => 0 },
+    runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+    runRecoveryBarrier: async ({ run }) => await run({ kind: "local", path: root }),
+    runActivationBarrier: async ({ activate }) => activate(),
+    runMoveBarrier: async ({ begin }) => begin(),
+    resolveMoveDestination: async () => undefined,
+    runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
+    runReclaimBarrier: async ({ begin, reclaim }) =>
+      await reclaim({ kind: "local", path: root }, begin()),
+    runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+    workspaceOperations,
+    resolveWorkspace: async () => ({ kind: "local", path: root }),
+    reportWorkspaceResultConflict: async () => {},
+    resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
+  });
+  const redispatchReclaimed = vi.fn(async () => {
+    replaced = true;
+    environment = attachedEnvironment();
+    seedActivePlacement();
+    const placement = placements.get(SESSION_ID);
+    if (placement?.state !== "active") {
+      throw new Error("replacement did not activate");
+    }
+    return placement;
+  });
+  const provider = createWorkerSessionTurnPlacementProvider({
+    environments,
+    placements,
+    reconcileActivePlacement: async (environmentId) => {
+      if (!options.pendingResult) {
+        if (options.refreshInPlace) {
+          createWorkerSessionPlacementGate(placements).assertWorkerRuntimeRefresh({
+            sessionId: SESSION_ID,
+            environmentId,
+            ownerEpoch: OWNER_EPOCH,
+          });
+          const bundleHash = "b".repeat(64);
+          environment = {
+            ...environment,
+            bootstrapReceipt: { ...environment.bootstrapReceipt!, bundleHash },
+          };
+          database.db
+            .prepare(
+              "UPDATE worker_session_placements SET worker_bundle_hash = ? WHERE session_id = ?",
+            )
+            .run(bundleHash, SESSION_ID);
+          replaced = true;
+        } else {
+          await dispatch.reconcileActive(environmentId);
+        }
+      }
+      await options.afterReconcile?.();
+    },
+    redispatchReclaimed,
+    workspaceOperations,
+  });
+  const runId = "run-build-recovery";
+  const input = turn(runId);
+  const recorder = createUserTurnTranscriptRecorder({
+    target: { ...sessionTarget, sessionEntry: undefined },
+    input: { text: input.prompt },
+  });
+  const originalClaimIds: string[] = [];
+  const onAdmitted = vi.fn(() => {
+    const claim = placements.get(SESSION_ID)?.turnClaim;
+    if (!claim) {
+      throw new Error("admitted turn has no claim");
+    }
+    originalClaimIds.push(claim.claimId);
+  });
+  const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+  const onUserMessagePersisted = vi.fn();
+  return {
+    environments,
+    launchTurn,
+    redispatchReclaimed,
+    onAdmitted,
+    originalClaimIds,
+    runLocal,
+    onUserMessagePersisted,
+    reclaim: () =>
+      dispatch.reclaim({ sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main" }),
+    execute: (abortSignal?: AbortSignal, assertRunCurrent?: () => void) =>
+      provider.executeTurn(
+        { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId },
+        {
+          ...input,
+          ...(options.withoutRecorder ? {} : { userTurnTranscriptRecorder: recorder }),
+          onUserMessagePersisted,
+          ...(abortSignal ? { abortSignal } : {}),
+        },
+        runLocal,
+        onAdmitted,
+        assertRunCurrent,
+      ),
+  };
+}
+
+describe("worker turn launcher build recovery", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(cleanupWorkerTurnLauncherTest);
+
+  it.each([false, true])(
+    "persists fallback input once after pre-handoff rejection (refreshInPlace=%s)",
+    async (refreshInPlace) => {
+      const harness = createBuildRecoveryHarness({
+        rejection: "launch",
+        withoutRecorder: true,
+        refreshInPlace,
+      });
+      await harness.execute();
+      expect(harness.launchTurn).toHaveBeenCalledTimes(2);
+      expect(harness.onUserMessagePersisted).toHaveBeenCalledOnce();
+      expect(
+        openSessionManager()
+          .buildSessionContext()
+          .messages.filter((message) => message.role === "user"),
+      ).toHaveLength(1);
+      expect(harness.launchTurn.mock.calls[1]?.[0].plan.assignment.initialMessages).toEqual([]);
+    },
+  );
+
+  it("continues the submitted turn after refreshing the same machine", async () => {
+    const harness = createBuildRecoveryHarness({ refreshInPlace: true });
+    const before = placements.get(SESSION_ID);
+    const result = await harness.execute();
+    expect(result.payloads).toEqual([{ text: "Continued on the replacement worker" }]);
+    expect(harness.redispatchReclaimed).not.toHaveBeenCalled();
+    expect(harness.launchTurn).toHaveBeenCalledOnce();
+    expect(harness.onAdmitted).toHaveBeenCalledOnce();
+    expect(harness.launchTurn.mock.calls[0]?.[0].turnClaim.claimId).not.toBe(
+      harness.originalClaimIds[0],
+    );
+    expect(placements.get(SESSION_ID)).toMatchObject({
+      state: "active",
+      environmentId: before?.environmentId,
+      activeOwnerEpoch: before?.activeOwnerEpoch,
+      generation: before?.generation,
+      workerBundleHash: "b".repeat(64),
+      turnClaim: null,
+    });
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+    expect(harness.runLocal).not.toHaveBeenCalled();
+    expect(
+      openSessionManager()
+        .buildSessionContext()
+        .messages.filter((message) => message.role === "user"),
+    ).toHaveLength(1);
+  });
+
+  it.each(["recorded", "admission"] as const)(
+    "continues the same turn with a fresh claim after a %s build rejection",
+    async (rejection) => {
+      const harness = createBuildRecoveryHarness({ rejection });
+      const result = await harness.execute(new AbortController().signal);
+      expect(result.payloads).toEqual([{ text: "Continued on the replacement worker" }]);
+      expect(harness.redispatchReclaimed).toHaveBeenCalledOnce();
+      expect(harness.onAdmitted).toHaveBeenCalledOnce();
+      expect(harness.launchTurn).toHaveBeenCalledOnce();
+      expect(harness.launchTurn.mock.calls[0]?.[0].turnClaim.claimId).not.toBe(
+        harness.originalClaimIds[0],
+      );
+      expect(harness.runLocal).not.toHaveBeenCalled();
+      expect(
+        openSessionManager()
+          .buildSessionContext()
+          .messages.filter((message) => message.role === "user"),
+      ).toHaveLength(1);
+      expect(placements.get(SESSION_ID)).toMatchObject({
+        state: "active",
+        turnClaim: null,
+        terminalReason: null,
+        recoveryError: null,
+      });
+    },
+  );
+
+  it.each(
+    (["cancelled", "superseded", "replaced"] as const).flatMap((outcome) =>
+      [false, true].map((refreshInPlace) => ({ outcome, refreshInPlace })),
+    ),
+  )(
+    "does not retry a turn $outcome during reconciliation (refreshInPlace=$refreshInPlace)",
+    async ({ outcome, refreshInPlace }) => {
+      const controller = new AbortController();
+      const closed = new Error("original run closed");
+      let current = true;
+      const harness = createBuildRecoveryHarness({
+        refreshInPlace,
+        afterReconcile: async () => {
+          if (outcome === "cancelled") {
+            controller.abort(closed);
+          } else if (outcome === "superseded") {
+            current = false;
+          } else {
+            if (refreshInPlace) {
+              await harness.reclaim();
+            }
+            seedActivePlacement();
+          }
+        },
+      });
+      await expect(
+        harness.execute(controller.signal, () => {
+          if (!current) {
+            throw closed;
+          }
+        }),
+      ).rejects.toThrow(outcome === "replaced" ? STALE_WORKER_BUILD_REASON : closed.message);
+      expect(harness.redispatchReclaimed).not.toHaveBeenCalled();
+      expect(harness.launchTurn).not.toHaveBeenCalled();
+      expect(placements.get(SESSION_ID)).toMatchObject({
+        state: refreshInPlace || outcome === "replaced" ? "active" : "reclaimed",
+        turnClaim: null,
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "attempts build recovery only once (refreshInPlace=%s)",
+    async (refreshInPlace) => {
+      const harness = createBuildRecoveryHarness({ repeated: true, refreshInPlace });
+      await expect(harness.execute()).rejects.toThrow(STALE_WORKER_BUILD_REASON);
+      expect(harness.redispatchReclaimed).toHaveBeenCalledTimes(refreshInPlace ? 0 : 1);
+      expect(harness.onAdmitted).toHaveBeenCalledOnce();
+      expect(harness.launchTurn).not.toHaveBeenCalled();
+      expect(placements.get(SESSION_ID)).toMatchObject({
+        state: refreshInPlace ? "active" : "reclaimed",
+        turnClaim: null,
+      });
+    },
+  );
+
+  it("does not retry a build error after worker handoff", async () => {
+    const harness = createBuildRecoveryHarness({ rejection: "handoff" });
+    await expect(harness.execute()).rejects.toThrow(STALE_WORKER_BUILD_REASON);
+    expect(harness.redispatchReclaimed).not.toHaveBeenCalled();
+    expect(harness.launchTurn).toHaveBeenCalledOnce();
+    expect(placements.get(SESSION_ID)).toMatchObject({ state: "failed", turnClaim: null });
+  });
+
+  it("leaves a pending result fenced for its recovery owner instead of replacing the worker", async () => {
+    const harness = createBuildRecoveryHarness({ pendingResult: true });
+    await expect(harness.execute()).rejects.toThrow(STALE_WORKER_BUILD_REASON);
+    expect(harness.redispatchReclaimed).not.toHaveBeenCalled();
+    expect(harness.launchTurn).not.toHaveBeenCalled();
+    expect(placements.listPendingWorkspaceResults()).toEqual([
+      expect.objectContaining({ sessionId: SESSION_ID, recoveryRequestedAtMs: expect.any(Number) }),
+    ]);
+    expect(placements.get(SESSION_ID)).toMatchObject({
+      state: "active",
+      turnClaim: { claimId: harness.originalClaimIds[0] },
+    });
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -11,8 +11,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { recoverStuckDiagnosticSession } from "../../logging/diagnostic-stuck-session-recovery.runtime.js";
 import type { SpawnResult } from "../../process/exec.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
-import { STALE_WORKER_BUILD_REASON, StaleWorkerBuildError } from "./admission.js";
-import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { placementTurnOwner } from "./placement-record.js";
 import {
   WorkerRunnerCapacityError,
@@ -43,7 +41,6 @@ import {
   type WorkerTurnEnvironmentService,
   type WorkerTurnLauncherOptions,
 } from "./worker-turn-launcher.test-support.js";
-import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 
 describe("worker turn launcher failure recovery", () => {
   beforeEach(setupWorkerTurnLauncherTest);
@@ -316,189 +313,6 @@ describe("worker turn launcher failure recovery", () => {
       expect(destroy).not.toHaveBeenCalled();
     },
   );
-
-  it("projects a stale Gateway build teardown and records its durable placement reason", async () => {
-    seedActivePlacement();
-    const terminalReason = `cloud worker disappeared: ${STALE_WORKER_BUILD_REASON}`;
-    const staleEnvironment: NonNullable<ReturnType<WorkerTurnEnvironmentService["get"]>> = {
-      ...attachedEnvironment(),
-      state: "failed" as const,
-      leaseId: null,
-      sshEndpoint: null,
-      sharedHost: null,
-      ownerEpoch: OWNER_EPOCH + 1,
-      attachedSessionIds: [],
-      tunnelStatus: "stopped",
-      error: STALE_WORKER_BUILD_REASON,
-    };
-    const environments: WorkerTurnEnvironmentService = {
-      ...unusedEnvironments(),
-      get: vi.fn(() => staleEnvironment),
-    };
-    const reconcileActivePlacement = vi.fn(async () => {
-      const active = placements.get(SESSION_ID);
-      if (active?.state !== "active") {
-        throw new Error("expected active stale-build placement");
-      }
-      const draining = placements.startDrain({
-        sessionId: active.sessionId,
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-        expectedGeneration: active.generation,
-      });
-      if (draining.state !== "draining") {
-        throw new Error("expected draining stale-build placement");
-      }
-      const reconciling = placements.startReconcile({
-        sessionId: draining.sessionId,
-        environmentId: draining.environmentId,
-        ownerEpoch: draining.activeOwnerEpoch,
-        expectedGeneration: draining.generation,
-      });
-      if (reconciling.state !== "reconciling") {
-        throw new Error("expected reconciling stale-build placement");
-      }
-      placements.fail({
-        sessionId: reconciling.sessionId,
-        expectedGeneration: reconciling.generation,
-        recoveryError: terminalReason,
-      });
-    });
-    const provider = createWorkerSessionTurnPlacementProvider({
-      environments,
-      placements,
-      reconcileActivePlacement,
-    });
-
-    await expect(
-      provider.executeTurn(
-        {
-          sessionId: SESSION_ID,
-          sessionKey: SESSION_KEY,
-          agentId: "main",
-          runId: "run-stale-worker-build",
-        },
-        turn("run-stale-worker-build"),
-        async () => ({ meta: { durationMs: 1 } }),
-      ),
-    ).rejects.toThrow(`Worker turn rejected in placement failed: ${terminalReason}`);
-    expect(reconcileActivePlacement).toHaveBeenCalledWith(ENVIRONMENT_ID);
-    expect(placements.get(SESSION_ID)).toMatchObject({
-      state: "failed",
-      recoveryError: terminalReason,
-      terminalReason,
-      turnClaim: null,
-    });
-  });
-
-  it("terminalizes a stale build rejected during live tunnel admission", async () => {
-    seedActivePlacement();
-    const terminalReason = `cloud worker disappeared: ${STALE_WORKER_BUILD_REASON}`;
-    let environment = attachedEnvironment();
-    const stopTunnel = vi.fn(async () => {});
-    const destroy = vi.fn(async () => environment);
-    const reconcileOnce = vi.fn(async () => {
-      environment = {
-        ...environment,
-        state: "failed",
-        leaseId: null,
-        sshEndpoint: null,
-        sharedHost: null,
-        ownerEpoch: OWNER_EPOCH + 1,
-        attachedSessionIds: [],
-        tunnelStatus: "stopped",
-        error: STALE_WORKER_BUILD_REASON,
-      };
-    });
-    const environments: WorkerTurnEnvironmentService &
-      Parameters<typeof createWorkerPlacementDispatchService>[0]["environments"] = {
-      ...unusedEnvironments(),
-      prepareProjectIntent: async () => {
-        throw new Error("unexpected prepared intent");
-      },
-      assertPreparedIntentCurrent: vi.fn(),
-      getPreparedCandidates: () => [],
-      schedulePreparedRefill: vi.fn(),
-      bindPreparedWorkspace: async () => {
-        throw new Error("unexpected prepared binding");
-      },
-      recordError: vi.fn(() => {
-        throw new Error("unexpected provisioning interruption");
-      }),
-      supportsProviderExecutionMode: vi.fn(() => true),
-      get: vi.fn(() => environment),
-      acquireTurnCredential: vi.fn(async () => credential()),
-      acknowledgeCredentialDelivery: vi.fn(() => true),
-      startTunnel: vi.fn(async () => {
-        throw new StaleWorkerBuildError();
-      }),
-      stopTunnel,
-      destroy,
-      requestDestroy: destroy,
-      attachSession: vi.fn(async () => {
-        throw new Error("unexpected worker session attachment");
-      }),
-      create: vi.fn(async () => {
-        throw new Error("unexpected worker environment creation");
-      }),
-      createFromProfileSnapshot: vi.fn(async () => {
-        throw new Error("unexpected inherited worker environment creation");
-      }),
-      reconcileOnce,
-      reconcileEnvironment: vi.fn(),
-    };
-    const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
-    const dispatch = createWorkerPlacementDispatchService({
-      placements,
-      environments,
-      runnerAvailability: { read: () => undefined, version: () => 0 },
-      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
-      runRecoveryBarrier: async ({ run }) => await run({ kind: "local", path: root }),
-      runActivationBarrier: async ({ activate }) => activate(),
-      runMoveBarrier: async ({ begin }) => begin(),
-      resolveMoveDestination: async () => undefined,
-      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
-      runReclaimBarrier: async ({ begin, reclaim }) =>
-        await reclaim({ kind: "local", path: root }, begin()),
-      runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
-      workspaceOperations,
-      resolveWorkspace: async () => ({ kind: "local" as const, path: root }),
-      reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
-    });
-    const provider = createWorkerSessionTurnPlacementProvider({
-      environments,
-      placements,
-      reconcileActivePlacement: dispatch.reconcileActive,
-      workspaceOperations,
-    });
-
-    await expect(
-      provider.executeTurn(
-        {
-          sessionId: SESSION_ID,
-          sessionKey: SESSION_KEY,
-          agentId: "main",
-          runId: "run-live-stale-worker-build",
-        },
-        turn("run-live-stale-worker-build"),
-        async () => ({ meta: { durationMs: 1 } }),
-      ),
-    ).rejects.toThrow(`Worker turn rejected in placement failed: ${terminalReason}`);
-
-    expect(reconcileOnce).toHaveBeenCalledOnce();
-    expect(placements.get(SESSION_ID)).toMatchObject({
-      state: "failed",
-      recoveryError: terminalReason,
-      terminalReason,
-      turnClaim: null,
-    });
-    expect(placements.get(SESSION_ID)).not.toMatchObject({
-      state: "active",
-      recoveryError: null,
-      terminalReason: null,
-    });
-  });
 
   it("keeps an active placement when tunnel startup fails before remote handoff", async () => {
     seedActivePlacement();

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -169,14 +169,8 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       let admissionReported = false;
       let userMessagePersisted = inputTurn.suppressNextUserMessagePersistence === true;
       for (;;) {
-        let turn: typeof inputTurn = {
-          ...inputTurn,
-          ...(userMessagePersisted ? { suppressNextUserMessagePersistence: true } : {}),
-          onUserMessagePersisted: (message) => {
-            userMessagePersisted = true;
-            inputTurn.onUserMessagePersisted?.(message);
-          },
-        };
+        // Remote-exec temporarily updates the caller's prompt for attachments.
+        let turn = inputTurn;
         assertAdmissionCurrent();
         if (
           ["requested", "provisioning", "syncing", "starting"].includes(routablePlacement.state)
@@ -333,7 +327,15 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
               turn,
             });
             activeWorkerTurn.signal.throwIfAborted();
-            turn = { ...turn, abortSignal: activeWorkerTurn.signal };
+            turn = {
+              ...turn,
+              abortSignal: activeWorkerTurn.signal,
+              ...(userMessagePersisted ? { suppressNextUserMessagePersistence: true } : {}),
+              onUserMessagePersisted: (message) => {
+                userMessagePersisted = true;
+                inputTurn.onUserMessagePersisted?.(message);
+              },
+            };
             activeWorkerTurns.set(turnClaim.sessionId, activeWorkerTurn);
           }
           // Release queued-context retention only after the placement claim is durable.

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -140,9 +140,8 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       return await executeLocalTurn({ claim, placements: options.placements, runLocal });
     },
     async executeTurn(claim, inputTurn, runLocal, onAdmitted, assertRunCurrent) {
-      let turn = inputTurn;
       const current = options.placements.get(claim.sessionId);
-      if (!current && turn.modelRun === true && !claim.sessionKey?.trim()) {
+      if (!current && inputTurn.modelRun === true && !claim.sessionKey?.trim()) {
         return await runLocal();
       }
       if (!current || current.state === "local") {
@@ -160,12 +159,24 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       let assertInitialSetupCurrent: (() => void) | undefined;
       // Every admission wait retains the caller's authority, not only initial setup.
       const assertAdmissionCurrent = () => {
+        inputTurn.abortSignal?.throwIfAborted();
         assertRunCurrent?.();
         assertInitialSetupCurrent?.();
       };
       let placement: ActiveWorkerPlacement;
       let turnClaim: WorkerSessionTurnClaim;
+      let recoveredStaleBuild = false;
+      let admissionReported = false;
+      let userMessagePersisted = inputTurn.suppressNextUserMessagePersistence === true;
       for (;;) {
+        let turn: typeof inputTurn = {
+          ...inputTurn,
+          ...(userMessagePersisted ? { suppressNextUserMessagePersistence: true } : {}),
+          onUserMessagePersisted: (message) => {
+            userMessagePersisted = true;
+            inputTurn.onUserMessagePersisted?.(message);
+          },
+        };
         assertAdmissionCurrent();
         if (
           ["requested", "provisioning", "syncing", "starting"].includes(routablePlacement.state)
@@ -285,155 +296,208 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           placement = admitted.placement;
           turnClaim = admitted.turnClaim;
         }
-        break;
-      }
-      // Placement and session storage own the workspace; caller paths may be stale.
-      let workspace: WorkerSessionWorkspace;
-      try {
-        assertAdmissionCurrent();
-        workspace = await options.resolveWorkspace(identity);
-        assertAdmissionCurrent();
-      } catch (error) {
-        await releaseClaimIfOwned(options.placements, turnClaim);
-        throw error;
-      }
-      const remoteExec = placement.executionMode === "remote-exec";
-      if (remoteExec) {
-        const refreshed = options.placements.get(claim.sessionId);
-        if (
-          refreshed?.state !== "active" ||
-          refreshed.executionMode !== "remote-exec" ||
-          refreshed.environmentId !== placement.environmentId ||
-          refreshed.activeOwnerEpoch !== placement.activeOwnerEpoch ||
-          refreshed.generation !== turnClaim.placementGeneration
-        ) {
-          await releaseClaimIfOwned(options.placements, turnClaim);
-          throw new Error("Remote-exec placement changed during turn admission");
-        }
-        placement = refreshed;
-      }
-      let activeWorkerTurn: ActiveWorkerTurn | undefined;
-      let handedOff = false;
-      let terminalAtMs: number | undefined;
-      try {
-        if (!remoteExec) {
-          activeWorkerTurn = createWorkerTurnRunOwner({
-            placements: options.placements,
-            claim: turnClaim,
-            sessionKey: placement.sessionKey,
-            turn,
-          });
-          activeWorkerTurn.signal.throwIfAborted();
-          turn = { ...turn, abortSignal: activeWorkerTurn.signal };
-          activeWorkerTurns.set(turnClaim.sessionId, activeWorkerTurn);
-        }
-        // Release queue protection only after the placement claim is durable.
-        onAdmitted?.();
-        const executionParams = {
-          environments: options.environments,
-          onHandoff: () => {
-            handedOff = true;
-          },
-          onTerminal: () => {
-            terminalAtMs = Date.now();
-          },
-          placement,
-          placements: options.placements,
-          workspace,
-          ...(options.prepareAcceptedWorkspacePublication
-            ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }
-            : {}),
-          ...(options.publishAcceptedWorkspace
-            ? { publishAcceptedWorkspace: options.publishAcceptedWorkspace }
-            : {}),
-          workspaceOperations: options.workspaceOperations,
-          turn,
-          turnClaim,
-        };
-        return remoteExec
-          ? await executeRemoteExecTurn({ ...executionParams, runLocal, assertRunCurrent })
-          : await executeWorkerTurn(executionParams);
-      } catch (error) {
-        if (error instanceof StaleWorkerBuildError) {
-          await options.reconcileActivePlacement(placement.environmentId);
-          const reconciled = options.placements.get(placement.sessionId);
-          if (reconciled) {
-            requireActivePlacement(reconciled);
-          }
-        }
-        const pendingWorkspaceResult = options.placements
-          .listPendingWorkspaceResults()
-          .find(
-            (pending) =>
-              pending.sessionId === turnClaim.sessionId &&
-              pending.claimId === turnClaim.claimId &&
-              pending.runId === turnClaim.runId,
-          );
-        if (pendingWorkspaceResult) {
-          if (turnClaim.owner.kind === "local") {
-            // The Gateway-owned run is already terminal. Atomically record the
-            // reconciliation failure before teardown so reclaim cannot see live work.
-            options.placements.failWorkspaceResultAndReleaseTurn(pendingWorkspaceResult, error);
-          } else {
-            // A recovery sweep owns the still-live worker claim. Teardown here
-            // could discard the terminal event's durably fenced file results.
-            options.placements.handoffWorkspaceResultRecovery(turnClaim);
-          }
-          await options.reconcileActivePlacement(placement.environmentId);
-          throw error;
-        }
-        if (
-          error instanceof WorkerRunnerCapacityError ||
-          (error instanceof WorkerRunnerUnavailableError && !handedOff) ||
-          // Canceling the exact worker turn must not destroy its reusable placement.
-          (!remoteExec && handedOff && turn.abortSignal?.aborted) ||
-          // Recovery precedes launch; only this admission claim belongs to the attempt.
-          (error instanceof WorkerWorkspaceReconciliationError && !handedOff) ||
-          (error instanceof WorkerTurnExecutionError &&
-            options.placements.validateTurnClaim(turnClaim))
-        ) {
+        // Placement and session storage own the workspace; caller paths may be stale.
+        let workspace: WorkerSessionWorkspace;
+        try {
+          assertAdmissionCurrent();
+          workspace = await options.resolveWorkspace(identity);
+          assertAdmissionCurrent();
+        } catch (error) {
           await releaseClaimIfOwned(options.placements, turnClaim);
           throw error;
         }
-        const settledPlacement = options.placements.get(turnClaim.sessionId);
-        if (
-          (remoteExec || error instanceof WorkerTurnExecutionError) &&
-          settledPlacement?.state === "active" &&
-          settledPlacement.environmentId === placement.environmentId &&
-          settledPlacement.activeOwnerEpoch === placement.activeOwnerEpoch &&
-          settledPlacement.turnClaim === null
-        ) {
-          // Reconciliation already released this turn. Neither runtime's model
-          // error may turn its reusable placement into box teardown.
-          throw error;
+        const remoteExec = placement.executionMode === "remote-exec";
+        if (remoteExec) {
+          const refreshed = options.placements.get(claim.sessionId);
+          if (
+            refreshed?.state !== "active" ||
+            refreshed.executionMode !== "remote-exec" ||
+            refreshed.environmentId !== placement.environmentId ||
+            refreshed.activeOwnerEpoch !== placement.activeOwnerEpoch ||
+            refreshed.generation !== turnClaim.placementGeneration
+          ) {
+            await releaseClaimIfOwned(options.placements, turnClaim);
+            throw new Error("Remote-exec placement changed during turn admission");
+          }
+          placement = refreshed;
         }
-        if (handedOff) {
-          const terminalOwner = activeWorkerTurn;
-          await failHandedOffTurn({
+        let activeWorkerTurn: ActiveWorkerTurn | undefined;
+        let handedOff = false;
+        let terminalAtMs: number | undefined;
+        try {
+          if (!remoteExec) {
+            activeWorkerTurn = createWorkerTurnRunOwner({
+              placements: options.placements,
+              claim: turnClaim,
+              sessionKey: placement.sessionKey,
+              turn,
+            });
+            activeWorkerTurn.signal.throwIfAborted();
+            turn = { ...turn, abortSignal: activeWorkerTurn.signal };
+            activeWorkerTurns.set(turnClaim.sessionId, activeWorkerTurn);
+          }
+          // Release queued-context retention only after the placement claim is durable.
+          if (!admissionReported) {
+            onAdmitted?.();
+            admissionReported = true;
+          }
+          const executionParams = {
             environments: options.environments,
-            placements: options.placements,
+            onHandoff: () => {
+              handedOff = true;
+            },
+            onTerminal: () => {
+              terminalAtMs = Date.now();
+            },
             placement,
-            turnClaim,
-            error,
-            ...(terminalOwner && terminalAtMs !== undefined
-              ? {
-                  terminal: {
-                    observedAtMs: terminalAtMs,
-                    registerRecovery: (recover: () => string | undefined) => {
-                      terminalOwner.recoverTerminal = recover;
-                    },
-                  },
-                }
+            placements: options.placements,
+            workspace,
+            ...(options.prepareAcceptedWorkspacePublication
+              ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }
               : {}),
-          });
-        } else {
-          await releaseClaimIfOwned(options.placements, turnClaim);
-        }
-        throw error;
-      } finally {
-        activeWorkerTurn?.dispose();
-        if (activeWorkerTurn && activeWorkerTurns.get(turnClaim.sessionId) === activeWorkerTurn) {
-          activeWorkerTurns.delete(turnClaim.sessionId);
+            ...(options.publishAcceptedWorkspace
+              ? { publishAcceptedWorkspace: options.publishAcceptedWorkspace }
+              : {}),
+            workspaceOperations: options.workspaceOperations,
+            turn,
+            turnClaim,
+          };
+          return remoteExec
+            ? await executeRemoteExecTurn({ ...executionParams, runLocal, assertRunCurrent })
+            : await executeWorkerTurn(executionParams);
+        } catch (error) {
+          if (error instanceof StaleWorkerBuildError) {
+            const canRecoverBuild =
+              !handedOff &&
+              options.placements.validateTurnClaim(turnClaim) &&
+              !options.placements
+                .listPendingWorkspaceResults()
+                .some((pending) => pending.sessionId === placement.sessionId);
+            if (canRecoverBuild) {
+              // This claim never launched work. Release it so runtime refresh does not
+              // mistake admission for an executing turn that must finish first.
+              try {
+                assertAdmissionCurrent();
+                turn.abortSignal?.throwIfAborted();
+              } finally {
+                await releaseClaimIfOwned(options.placements, turnClaim);
+              }
+              assertAdmissionCurrent();
+              turn.abortSignal?.throwIfAborted();
+              // Reconciliation may supersede the placement captured by initial setup.
+              assertInitialSetupCurrent = undefined;
+            }
+            await options.reconcileActivePlacement(placement.environmentId);
+            const reconciled = options.placements.get(placement.sessionId);
+            if (canRecoverBuild) {
+              assertAdmissionCurrent();
+              turn.abortSignal?.throwIfAborted();
+            }
+            const refreshedInPlace =
+              reconciled?.state === "active" &&
+              matchesWorkerPlacementTarget(reconciled, placement) &&
+              reconciled.turnClaim === null &&
+              reconciled.workerBundleHash !== placement.workerBundleHash &&
+              reconciled.remoteWorkspaceDir === placement.remoteWorkspaceDir;
+            const reclaimedSameOwner =
+              reconciled?.state === "reclaimed" &&
+              reconciled.environmentId === placement.environmentId &&
+              reconciled.activeOwnerEpoch === placement.activeOwnerEpoch &&
+              reconciled.generation === placement.generation + 3;
+            if (
+              canRecoverBuild &&
+              !recoveredStaleBuild &&
+              (refreshedInPlace || reclaimedSameOwner) &&
+              reconciled.executionMode === placement.executionMode &&
+              reconciled.agentId === identity.agentId &&
+              reconciled.sessionKey === identity.sessionKey
+            ) {
+              assertAdmissionCurrent();
+              recoveredStaleBuild = true;
+              routablePlacement = reconciled;
+              continue;
+            }
+            if (canRecoverBuild && reconciled?.state === "reclaimed") {
+              throw error;
+            }
+            if (reconciled) {
+              requireActivePlacement(reconciled);
+            }
+          }
+          const pendingWorkspaceResult = options.placements
+            .listPendingWorkspaceResults()
+            .find(
+              (pending) =>
+                pending.sessionId === turnClaim.sessionId &&
+                pending.claimId === turnClaim.claimId &&
+                pending.runId === turnClaim.runId,
+            );
+          if (pendingWorkspaceResult) {
+            if (turnClaim.owner.kind === "local") {
+              // The Gateway-owned run is already terminal. Atomically record the
+              // reconciliation failure before teardown so reclaim cannot see live work.
+              options.placements.failWorkspaceResultAndReleaseTurn(pendingWorkspaceResult, error);
+            } else {
+              // A recovery sweep owns the still-live worker claim. Teardown here
+              // could discard the terminal event's durably fenced file results.
+              options.placements.handoffWorkspaceResultRecovery(turnClaim);
+            }
+            await options.reconcileActivePlacement(placement.environmentId);
+            throw error;
+          }
+          if (
+            error instanceof WorkerRunnerCapacityError ||
+            (error instanceof WorkerRunnerUnavailableError && !handedOff) ||
+            // Canceling the exact worker turn must not destroy its reusable placement.
+            (!remoteExec && handedOff && turn.abortSignal?.aborted) ||
+            // Recovery precedes launch; only this admission claim belongs to the attempt.
+            (error instanceof WorkerWorkspaceReconciliationError && !handedOff) ||
+            (error instanceof WorkerTurnExecutionError &&
+              options.placements.validateTurnClaim(turnClaim))
+          ) {
+            await releaseClaimIfOwned(options.placements, turnClaim);
+            throw error;
+          }
+          const settledPlacement = options.placements.get(turnClaim.sessionId);
+          if (
+            (remoteExec || error instanceof WorkerTurnExecutionError) &&
+            settledPlacement?.state === "active" &&
+            settledPlacement.environmentId === placement.environmentId &&
+            settledPlacement.activeOwnerEpoch === placement.activeOwnerEpoch &&
+            settledPlacement.turnClaim === null
+          ) {
+            // Reconciliation already released this turn. Neither runtime's model
+            // error may turn its reusable placement into box teardown.
+            throw error;
+          }
+          if (handedOff) {
+            const terminalOwner = activeWorkerTurn;
+            await failHandedOffTurn({
+              environments: options.environments,
+              placements: options.placements,
+              placement,
+              turnClaim,
+              error,
+              ...(terminalOwner && terminalAtMs !== undefined
+                ? {
+                    terminal: {
+                      observedAtMs: terminalAtMs,
+                      registerRecovery: (recover: () => string | undefined) => {
+                        terminalOwner.recoverTerminal = recover;
+                      },
+                    },
+                  }
+                : {}),
+            });
+          } else {
+            await releaseClaimIfOwned(options.placements, turnClaim);
+          }
+          throw error;
+        } finally {
+          activeWorkerTurn?.dispose();
+          if (activeWorkerTurn && activeWorkerTurns.get(turnClaim.sessionId) === activeWorkerTurn) {
+            activeWorkerTurns.delete(turnClaim.sessionId);
+          }
         }
       }
     },

--- a/test/e2e/qa-lab/runtime/paired-node-worker-upgrade-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-upgrade-wire.e2e.test.ts
@@ -1,0 +1,342 @@
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import type { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { writeBuildInfo } from "../../../../scripts/write-build-info.js";
+import { hasErrnoCode } from "../../../../src/infra/errno.js";
+import {
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../../../src/infra/kysely-sync.js";
+import { withOpenClawStateDatabaseReadOnly } from "../../../../src/state/openclaw-state-db-readonly.js";
+import type { DB as StateDatabase } from "../../../../src/state/openclaw-state-db.generated.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import { PROOF_TIMEOUT_MS } from "./cloud-worker-midturn-loss-fixture.js";
+import { startPairedNodeWorkerLifecycleProvider } from "./paired-node-worker-lifecycle-provider.js";
+import {
+  closeWireServer,
+  connectWireClient,
+  createPairedNodeWorkerHost,
+  createPublishedWireWorkspace,
+  startPairedNodeWorkerGateway,
+  type PairedNodeWorkerHost,
+  type WireGateway,
+  wireMessageText,
+} from "./paired-node-worker-wire-fixture.js";
+
+const SESSION_KEY = "agent:qa:paired-node-worker-upgrade";
+const RESULT_FILE = "completed-before-upgrade.txt";
+const RESULT_BYTES = "Completed worker result must survive the Gateway update.\n";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type DescribedSession = {
+  sessionId?: string;
+  execCwd?: string;
+  spawnedCwd?: string;
+  placement?: {
+    state?: string;
+    environmentId?: string;
+    activeOwnerEpoch?: number;
+    workerBundleHash?: string;
+    remoteWorkspaceDir?: string;
+  };
+};
+
+async function describeSession(gateway: WireGateway): Promise<DescribedSession> {
+  const result = (await gateway.call("sessions.describe", { key: SESSION_KEY })) as {
+    session?: DescribedSession;
+  };
+  return result.session ?? {};
+}
+
+function pendingResult(gateway: WireGateway, runId: string) {
+  return withOpenClawStateDatabaseReadOnly(
+    ({ db }) =>
+      executeSqliteQueryTakeFirstSync(
+        db,
+        getNodeSqliteKysely<StateDatabase>(db)
+          .selectFrom("worker_workspace_pending_results")
+          .select(["run_id", "recovery_requested_at_ms"])
+          .where("run_id", "=", runId),
+      ),
+    { env: gateway.runtimeEnv },
+  );
+}
+
+describe("paired node worker Gateway upgrade wire", () => {
+  it(
+    "recovers a completed workspace after a same-version build update and continues the same session",
+    { timeout: PROOF_TIMEOUT_MS + 180_000 },
+    async () => {
+      const root = tempDirs.make("openclaw-paired-node-upgrade-");
+      const runtimeRoot = path.join(root, "runtime");
+      // Each test owns its deployment bytes; a simulated rebuild must never rewrite shared dist.
+      await fs.mkdir(runtimeRoot);
+      await fs.cp(path.join(process.cwd(), "dist"), path.join(runtimeRoot, "dist"), {
+        recursive: true,
+        dereference: false,
+      });
+      await fs.cp(
+        path.join(process.cwd(), "docs", "reference", "templates"),
+        path.join(runtimeRoot, "docs", "reference", "templates"),
+        { recursive: true },
+      );
+      // Dependency links stay on the installed tree, but plugin self-imports must use this
+      // Gateway's copied modules rather than creating another set of runtime singletons.
+      const pluginRoot = path.join(runtimeRoot, "dist", "extensions");
+      for (const plugin of await fs.readdir(pluginRoot, { withFileTypes: true })) {
+        if (!plugin.isDirectory()) {
+          continue;
+        }
+        const selfLink = path.join(pluginRoot, plugin.name, "node_modules", "openclaw");
+        const stat = await fs.lstat(selfLink).catch((error: unknown) => {
+          if (!hasErrnoCode(error, "ENOENT")) {
+            throw error;
+          }
+          return undefined;
+        });
+        if (stat?.isSymbolicLink()) {
+          await fs.unlink(selfLink);
+          await fs.symlink(runtimeRoot, selfLink, "junction");
+        }
+      }
+      for (const file of [
+        "package.json",
+        "openclaw.mjs",
+        "node-version.mjs",
+        "node-sqlite.mjs",
+        "node-runtime-update.mjs",
+      ]) {
+        await fs.copyFile(path.join(process.cwd(), file), path.join(runtimeRoot, file));
+      }
+      await fs.symlink(
+        path.join(process.cwd(), "node_modules"),
+        path.join(runtimeRoot, "node_modules"),
+        "junction",
+      );
+      const provider = await startPairedNodeWorkerLifecycleProvider([]);
+      const published = await createPublishedWireWorkspace(root);
+      let blockedUploads = 0;
+      const unavailableTransfer = createServer((_request, response) => {
+        blockedUploads += 1;
+        response.writeHead(503).end("Gateway updating");
+      });
+      await new Promise<void>((resolve) => {
+        unavailableTransfer.listen(0, "127.0.0.1", resolve);
+      });
+      const address = unavailableTransfer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("transfer outage server did not bind");
+      }
+      const unavailableUrl = `ws://127.0.0.1:${address.port}`;
+      const gatewayOwner = createQaGatewayChild();
+      let gateway: WireGateway | undefined;
+      let operator: GatewayClient | undefined;
+      let operatorHelloCount = 0;
+      let workerNode: PairedNodeWorkerHost | undefined;
+      let transferUnavailable = false;
+      let phase = "starting the packaged Gateway";
+      const failures: unknown[] = [];
+      try {
+        gateway = await startPairedNodeWorkerGateway({
+          owner: gatewayOwner,
+          providerBaseUrl: provider.baseUrl,
+          repoRoot: runtimeRoot,
+        });
+        phase = "pairing the worker node";
+        operator = await connectWireClient({
+          gateway,
+          role: "operator",
+          identity: null,
+          onHelloOk: () => {
+            operatorHelloCount += 1;
+          },
+        });
+        workerNode = await createPairedNodeWorkerHost({
+          gateway,
+          operator,
+          root,
+          bundlePrewarm: true,
+          workspaceGatewayUrl: (frame) => {
+            const input = JSON.parse(frame.paramsJSON ?? "{}") as {
+              transfer?: { direction?: string };
+            };
+            return transferUnavailable && input.transfer?.direction === "upload"
+              ? unavailableUrl
+              : gateway!.wsUrl;
+          },
+        });
+        await operator.request("sessions.create", {
+          key: SESSION_KEY,
+          agentId: "qa",
+          worktree: true,
+          worktreeName: "paired-node-upgrade",
+          worktreeBaseRef: "main",
+          cwd: published.source,
+        });
+        const created = await describeSession(gateway);
+        expect(created.sessionId).toBeTruthy();
+        phase = "dispatching the original worker build";
+        await gateway.call(
+          "sessions.dispatch",
+          {
+            key: SESSION_KEY,
+            deviceId: workerNode.identity.deviceId,
+          },
+          { timeoutMs: PROOF_TIMEOUT_MS },
+        );
+        const before = await describeSession(gateway);
+        expect(before.placement).toMatchObject({
+          state: "active",
+          environmentId: expect.any(String),
+          activeOwnerEpoch: expect.any(Number),
+        });
+        expect(before.placement?.workerBundleHash).toMatch(/^[a-f0-9]{64}$/u);
+        const remoteWorkspaceDir = before.placement?.remoteWorkspaceDir;
+        if (!remoteWorkspaceDir) {
+          throw new Error("node placement omitted its workspace");
+        }
+        await fs.writeFile(path.join(remoteWorkspaceDir, RESULT_FILE), RESULT_BYTES);
+        transferUnavailable = true;
+        phase = "retaining the completed result during the upload outage";
+        const runId = `paired-node-upgrade-before-${Date.now()}`;
+        const started = await operator.request("chat.send", {
+          sessionKey: SESSION_KEY,
+          message: "Reply exactly: UPGRADE-BEFORE",
+          deliver: false,
+          idempotencyKey: runId,
+        });
+        expect(started).toMatchObject({ runId, status: "started" });
+        const firstTurn = await operator.request(
+          "agent.wait",
+          { runId, timeoutMs: PROOF_TIMEOUT_MS },
+          { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+        );
+        expect(blockedUploads, JSON.stringify(firstTurn)).toBeGreaterThan(0);
+        const activeGateway = gateway;
+        await vi.waitFor(
+          () => {
+            expect(pendingResult(activeGateway, runId)).toMatchObject({
+              run_id: runId,
+              recovery_requested_at_ms: expect.any(Number),
+            });
+          },
+          { timeout: PROOF_TIMEOUT_MS, interval: 100 },
+        );
+        const localDir = created.execCwd ?? created.spawnedCwd;
+        if (!localDir) {
+          throw new Error("session omitted its canonical workspace");
+        }
+        await expect(fs.access(path.join(localDir, RESULT_FILE))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        await workerNode.disconnect();
+        const pidBefore = gateway.pid;
+        const operatorHelloBeforeRestart = operatorHelloCount;
+        phase = "restarting the Gateway with the replacement build";
+        await gateway.restartAfterStateMutation(async () => {
+          // An inert change in the owned fixture makes a genuinely different content-addressed
+          // worker artifact at the same package version and protocol, as a minor rebuild does.
+          await fs.appendFile(
+            path.join(runtimeRoot, "dist", "worker", "worker.mjs"),
+            "\n// QA same-version rebuild\n",
+          );
+          writeBuildInfo({ rootDir: runtimeRoot });
+        });
+        expect(gateway.pid).not.toBe(pidBefore);
+        phase = "waiting for the operator's authenticated reconnect";
+        await vi.waitFor(
+          () => expect(operatorHelloCount).toBeGreaterThan(operatorHelloBeforeRestart),
+          { timeout: 30_000, interval: 100 },
+        );
+        transferUnavailable = false;
+        await workerNode.connect();
+        phase = "recovering the old build's pending workspace";
+        await vi.waitFor(
+          async () => {
+            expect(pendingResult(activeGateway, runId)).toBeUndefined();
+            const recovered = await describeSession(activeGateway);
+            expect(recovered.sessionId).toBe(created.sessionId);
+            const recoveredDir = recovered.execCwd ?? recovered.spawnedCwd;
+            expect(recoveredDir).toBeTruthy();
+            expect(await fs.readFile(path.join(recoveredDir!, RESULT_FILE), "utf8")).toBe(
+              RESULT_BYTES,
+            );
+          },
+          { timeout: PROOF_TIMEOUT_MS, interval: 100 },
+        );
+
+        phase = "continuing the same session on the replacement worker build";
+        const continuation = `paired-node-upgrade-after-${Date.now()}`;
+        await operator.request("chat.send", {
+          sessionKey: SESSION_KEY,
+          message: "Reply exactly: UPGRADE-AFTER",
+          deliver: false,
+          idempotencyKey: continuation,
+        });
+        const completed = await operator.request<{ status?: string }>(
+          "agent.wait",
+          {
+            runId: continuation,
+            timeoutMs: PROOF_TIMEOUT_MS,
+          },
+          { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
+        );
+        expect(completed, gateway.logs().slice(-12_000)).toMatchObject({ status: "ok" });
+        const after = await describeSession(gateway);
+        expect(after.sessionId).toBe(created.sessionId);
+        expect(after.placement).toMatchObject({
+          state: "active",
+          environmentId: before.placement?.environmentId,
+          activeOwnerEpoch: before.placement?.activeOwnerEpoch,
+          remoteWorkspaceDir,
+        });
+        expect(after.placement?.workerBundleHash).not.toBe(before.placement?.workerBundleHash);
+        expect(
+          await fs.readFile(path.join(after.placement!.remoteWorkspaceDir!, RESULT_FILE), "utf8"),
+        ).toBe(RESULT_BYTES);
+        const history = await operator.request<{ messages?: unknown[] }>("chat.history", {
+          sessionKey: SESSION_KEY,
+          limit: 100,
+        });
+        for (const marker of ["UPGRADE-BEFORE", "UPGRADE-AFTER"]) {
+          expect(
+            history.messages?.filter(
+              (message) =>
+                (message as { role?: unknown }).role === "assistant" &&
+                wireMessageText(message).includes(marker),
+            ),
+          ).toHaveLength(1);
+        }
+      } catch (error) {
+        failures.push(
+          new Error(
+            `Gateway upgrade proof failed while ${phase}: ${String(error)}\n${gateway?.logs().slice(-12_000) ?? ""}`,
+            { cause: error },
+          ),
+        );
+      } finally {
+        const cleanup = await Promise.allSettled([
+          workerNode?.stop() ?? Promise.resolve(),
+          operator?.stopAndWait({ timeoutMs: 2_000 }) ?? Promise.resolve(),
+          stopQaGatewayFixture(gatewayOwner),
+          provider.stop(),
+          closeWireServer(published.server),
+          closeWireServer(unavailableTransfer),
+        ]);
+        failures.push(
+          ...cleanup.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+        );
+      }
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "paired node Gateway upgrade proof failed");
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
@@ -144,6 +144,7 @@ export async function connectWireClient(params: {
   identity: DeviceIdentity | null;
   includeApprovals?: boolean;
   onEvent?: (event: WireGatewayEvent) => void;
+  onHelloOk?: () => void;
   timeoutMs?: number;
 }): Promise<GatewayClient> {
   const { GatewayClient } = await import("openclaw/plugin-sdk/gateway-runtime");
@@ -197,7 +198,10 @@ export async function connectWireClient(params: {
       deviceIdentity: params.identity,
       requestTimeoutMs: PROOF_TIMEOUT_MS,
       onEvent: params.onEvent,
-      onHelloOk: () => finish(),
+      onHelloOk: () => {
+        params.onHelloOk?.();
+        finish();
+      },
       onConnectError: (error) => finish(error),
       onClose: (code, reason) => finish(new Error(`Gateway closed (${code}): ${reason}`)),
     });
@@ -273,6 +277,7 @@ type WireWorkerHostOptions = {
   containerEngine?: NodeWorkerContainerEngine;
   containerImage?: string;
   workerGatewayUrl?: string;
+  workspaceGatewayUrl?: (frame: NodeInvokeRequestPayload) => string;
   workerEnv?: NodeJS.ProcessEnv;
   bundlePrewarm?: boolean;
   bundleRetention?: boolean;
@@ -391,7 +396,7 @@ export async function createPairedNodeWorkerHost(
       gatewayUrl:
         frame.command === NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND
           ? (options.workerGatewayUrl ?? options.gateway.wsUrl)
-          : options.gateway.wsUrl,
+          : (options.workspaceGatewayUrl?.(frame) ?? options.gateway.wsUrl),
     })
       .then(async () => await options.afterInvoke?.(frame, host))
       .catch((error: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a turn submitted during a Gateway worker-build update could fail before execution instead of continuing in the existing session. The turn claimed the old runtime before admission checked its build, so the runtime updater treated that unstarted claim as work that must finish first.

Builds on #143858, which refreshes cloud worker runtimes on their existing machines and preserves pending workspace results.

## Why This Change Was Made

Release only the exact unstarted claim before reconciling a stale build, then retry admission once with fresh turn authority. An in-place refresh must retain the same placement, environment, epoch, and workspace while publishing a changed bundle; an already-reclaimed owner can use the existing replacement path. Cancellation, current-run checks, and session serialization remain enforced, and work already handed to a worker is not replayed.

Prompt persistence carries across the retry, including callers without a recorder. Remote-exec retains its shared turn object so prepared attachment prompts reach its caller and cleanup restores them. Existing runtime and pending-result owners remain unchanged; there are no storage, protocol, or configuration changes.

## User Impact

A submitted turn can continue through a compatible runtime update without resetting the conversation or submitting it again. Surviving cloud machines retain their workspace, installed packages, and desktop through the existing in-place update flow. Actual installation failures and lost workers still produce actionable errors.

## Evidence

- Current-main regression fails at the real owner guard with `Worker runtime refresh is waiting for the current turn to finish`. The patched submission continues with fresh authority and unchanged machine/placement/workspace identity.
- 255 worker-turn tests pass across 22 files, including cancellation, ownership changes, bounded retry, handoff, recorder-free persistence, attachment delivery, and computer cleanup. Existing provider runtime-refresh and reclaim-lifecycle tests also passed.
- Full changed checks, final delta checks, and independent reviews pass. Broad CI exposed a shared-input regression during development; its 24 existing attachment/computer failures reproduce before the correction and pass unchanged afterward.
- The final source passes a Linux real-process build and upgrade scenario: actual HTTP 503 upload interruption, same-version worker bundle change, Gateway restart, exact file recovery, unchanged environment ID/epoch/workspace, unchanged session/history, and successful next turn. Model responses are deterministic fixtures. [Testbox execution](https://github.com/openclaw/openclaw/actions/runs/34467061884).

<details>
<summary>Direct terminal proof</summary>

Current-main admission regression:

```text
Error: Worker runtime refresh is waiting for the current turn to finish
at Object.assertWorkerRuntimeRefresh (placement-worker-gate.ts:112)
```

Final focused coverage:

```text
 Test Files  22 passed (22)
      Tests  255 passed (255)
```

Final exact-source Linux build and same-machine scenario:

```text
✓ recovers a completed workspace after a same-version build update and continues the same session
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  136.49s
[test] passed 1 Vitest shard in 138.37s
blacksmith run summary sync=delegated command=11m0.306s total=11m0.634s exit=0
```

The tested launcher matches the committed source (SHA-256 `6409109fc97122087fca85390cab9ea340594aec8cba658da0a3c58dc053b2f4`). The runner reports `exitCode: 0` and `runStatus: succeeded`; its external portal synchronization timed out after the successful command. The task-owned lease is stopped. This ad hoc Testbox proof is separate from required exact-head PR CI.

</details>
