### PR TITLE
refactor(doctor): carry the migration blocker from execution

### DIFF
--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -2810,7 +2810,7 @@ async function runLegacyStateMigrationSteps(
   entries: Array<{ id: string; result: MigrationMessages }>;
   receipts: LegacyStateMigrationStepReceipt[];
   deferredSteps: LegacyStateMigrationStep[];
-  halted: boolean;
+  haltedBy: LegacyStateMigrationStep | undefined;
 }> {
   const sources: MigrationMessages[] = [];
   const sharedSources: MigrationMessages[] = [];
@@ -2820,7 +2820,7 @@ async function runLegacyStateMigrationSteps(
   const entries: Array<{ id: string; result: MigrationMessages }> = [];
   const receipts: LegacyStateMigrationStepReceipt[] = [];
   const deferredSteps: LegacyStateMigrationStep[] = [];
-  let halted = false;
+  let haltedBy: LegacyStateMigrationStep | undefined;
 
   // Later owners require the SQLite commit and verified source archive of
   // every preceding owner; migration planning must never run steps in parallel.
@@ -2858,7 +2858,7 @@ async function runLegacyStateMigrationSteps(
       options?.onUnexpectedFailure?.(error);
       sources.push(result);
       (step.phase === "shared" ? sharedSources : finalSources).push(result);
-      halted = true;
+      haltedBy = step;
       receipts.push(
         ...blockedStepReceipts({
           steps: steps.slice(index + 1),
@@ -2878,7 +2878,7 @@ async function runLegacyStateMigrationSteps(
       (step.phase === "shared" ? sharedNoticeSources : finalNoticeSources).push(result);
     }
     if (receipt.outcome === "refused") {
-      halted = true;
+      haltedBy = step;
       receipts.push(
         ...blockedStepReceipts({
           steps: steps.slice(index + 1),
@@ -2899,7 +2899,7 @@ async function runLegacyStateMigrationSteps(
     entries,
     receipts,
     deferredSteps,
-    halted,
+    haltedBy,
   };
 }
 
@@ -2945,15 +2945,7 @@ export async function runLegacyStateMigrations(params: {
   }
   const preparationSteps = [stateSchemaStep, pluginInstallIndexStep];
   const preparation = await runLegacyStateMigrationSteps(preparationSteps, params.onStepReceipt);
-  if (preparation.halted) {
-    const blocker = preparationSteps.find((step) =>
-      preparation.receipts.some(
-        (receipt) => receipt.id === step.id && receipt.outcome === "refused",
-      ),
-    );
-    if (!blocker) {
-      throw new Error("legacy state preparation halted without a refusal receipt");
-    }
+  if (preparation.haltedBy) {
     const notices = mergeNotices(preparation.sources);
     return {
       changes: preparation.sources.flatMap((source) => source.changes),
@@ -2964,7 +2956,7 @@ export async function runLegacyStateMigrations(params: {
         ...preparation.receipts,
         ...blockedStepReceipts({
           steps: remainingSteps,
-          blocker,
+          blocker: preparation.haltedBy,
           onStepReceipt: params.onStepReceipt,
         }),
       ],
@@ -3320,7 +3312,7 @@ async function executeLegacyStateMigrations(
       }
     },
   });
-  if (stateDirMigration?.halted && stateDirStep) {
+  if (stateDirMigration?.haltedBy && stateDirStep) {
     const notices = mergeNotices([stateDirResult]);
     logStateMigrationResult(
       { changes: stateDirResult.changes, warnings: stateDirResult.warnings, notices },
@@ -3386,18 +3378,10 @@ async function executeLegacyStateMigrations(
     notices: mergeNotices([stateDirResult, ...stateSchemaMigration.sources]),
   };
   stateSchemaMigration.receipts.unshift(...(stateDirMigration?.receipts ?? []));
-  if (stateSchemaMigration.halted) {
+  if (stateSchemaMigration.haltedBy) {
     // A failed canonical schema repair is an error: runtime cannot safely open this store.
     if (mode !== "doctor" && stateSchemaResult.warnings.length > 0) {
       onUnexpectedFailure(new Error(formatStartupMigrationFailure(stateSchemaResult.warnings)));
-    }
-    const blocker = statePreparationSteps.find((step) =>
-      stateSchemaMigration.receipts.some(
-        (receipt) => receipt.id === step.id && receipt.outcome === "refused",
-      ),
-    );
-    if (!blocker) {
-      throw new Error("legacy state preparation halted without a refusal receipt");
     }
     const pendingPreludeSteps = [
       configMachineStateStep,
@@ -3413,7 +3397,7 @@ async function executeLegacyStateMigrations(
       ...(stateSchema.notices?.length ? { notices: stateSchema.notices } : {}),
       stepReceipts: await completeBlockedPlanReceipts({
         receipts: stateSchemaMigration.receipts,
-        blocker,
+        blocker: stateSchemaMigration.haltedBy,
         pendingPreludeSteps,
       }),
     };
@@ -3436,7 +3420,7 @@ async function executeLegacyStateMigrations(
     changes: [],
     warnings: [],
   };
-  if (configMachineStateMigration.halted) {
+  if (configMachineStateMigration.haltedBy) {
     return {
       mode,
       migrated: stateSchema.changes.length > 0,
@@ -3512,7 +3496,7 @@ async function executeLegacyStateMigrations(
       executionOptions,
     );
     preludeReceipts.push(...execution.receipts);
-    preludeHalted ||= execution.halted;
+    preludeHalted ||= execution.haltedBy !== undefined;
     return execution.entries[0]?.result ?? { changes: [], warnings: [] };
   };
   const pendingPreludeAfter = (
@@ -3660,7 +3644,7 @@ async function executeLegacyStateMigrations(
     executionOptions,
   );
   preludeReceipts.push(...detectionExecution.receipts);
-  if (detectionExecution.halted || !detected) {
+  if (detectionExecution.haltedBy || !detected) {
     preludeReceipts.push(
       ...blockedStepReceipts({
         steps: buildUnresolvedBlockedMigrationSteps({
@@ -3708,15 +3692,7 @@ async function executeLegacyStateMigrations(
     undefined,
     executionOptions,
   );
-  if (eagerMigrations.halted) {
-    const blocker = eagerMigrationSteps.find((step) =>
-      eagerMigrations.receipts.some(
-        (receipt) => receipt.id === step.id && receipt.outcome === "refused",
-      ),
-    );
-    if (!blocker) {
-      throw new Error("legacy state migration execution halted without a refusal receipt");
-    }
+  if (eagerMigrations.haltedBy) {
     const completed = [
       stateSchema,
       configMachineState,
@@ -3744,7 +3720,7 @@ async function executeLegacyStateMigrations(
         ...eagerMigrations.receipts,
         ...blockedStepReceipts({
           steps: remainingMigrationSteps,
-          blocker,
+          blocker: eagerMigrations.haltedBy,
           onStepReceipt: params.onStepReceipt,
         }),
       ],


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

This maintainer-requested cleanup reduces duplicated bookkeeping in Doctor's migration failure handling.

## Why This Change Was Made

Return the exact stopping step from the private runner instead of reconstructing it from receipt IDs in three callers. This removes 24 production code lines while preserving callback sequencing, receipt order, and stage-specific reporting.

## User Impact

No intended user-visible behavior change. Doctor still stops after a refused migration and closes the remaining receipts before returning or rethrowing the original automatic failure. Migration authority and persisted-state semantics are unchanged.

## Evidence

- The same 163 existing migration tests across three suites passed before and after the change.
- `node scripts/check-changed.mjs -- src/infra/state-migrations.doctor.ts` passed, including core/test typechecks, lint, and boundary guards.
- Fresh managed Codex review found no actionable P0–P2 findings.

Focused test command:

```sh
node scripts/run-vitest.mjs src/infra/state-migrations.test.ts src/infra/state-migrations.caller-mode.refusal.test.ts src/infra/state-migrations.caller-mode.execution.test.ts
```

### Stored-data compatibility

This change replaces a private in-memory halt boolean with the stopping step reference at the same two assignments. It changes no SQLite schema, persisted representation, migration action, store selection, retention, public receipt shape, or upgrade contract. The hosted technical review confirms this; its generated data-model checklist is not applicable to the actual diff.

The same before/after test run includes these existing cases:

- `returns thrown-step receipts and stops later Doctor mutations` and `closes receipts before rethrowing automatic $blockerId failure` in `state-migrations.caller-mode.refusal.test.ts`: preserve ordered receipt closure, later legacy files, and the original automatic exception identity.
- `preserves SQLite artifacts while closing the tail after a schema refusal` in `state-migrations.caller-mode.execution.test.ts`: verifies that closing blocked receipts preserves the SQLite artifacts observed at the refusal callback.
- `halts direct Doctor execution after an unanticipated state-schema refusal` in `state-migrations.caller-mode.execution.test.ts`: preserves refusal of a newer schema and leaves the later voice-wake source untouched.

No live migration or new data-model compatibility result is claimed.
