### PR TITLE
fix(tests): restore config drainage suite collection

### DIFF
--- a/src/config/write-lock.drainage.test.ts
+++ b/src/config/write-lock.drainage.test.ts
@@ -32,6 +32,7 @@ vi.mock("../shared/pid-alive.js", async (original) => ({
   getFileLockProcessStartTime: () => 123,
 }));
 vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  DEFAULT_POSIX_TMP_ROOT: "/tmp/openclaw",
   resolvePreferredOpenClawTmpDir: () => fixture.root,
 }));
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the config write-lock drainage suite fails during collection in a fresh module graph, before any drainage cases run.

## Why This Change Was Made

The temporary-directory mock now includes the real module's default-path constant, which logging reads during initialization. The fixture-specific resolver and every assertion remain unchanged.

## User Impact

Developers can run the drainage coverage independently of cached logging imports. No production behavior changes.

## Evidence

The full Linux run reported the missing export. A temporary fresh-module control reproduced that collection failure; the same control with this repair passed all eight cases. The control was removed, and the ordinary drainage and writer-exclusion suites passed all 16 cases. The ordinary original focused run also passed, confirming the import-context sensitivity.

The changed-file gate and independent review passed. This adds one test line; no overall runtime improvement is claimed.
