### PR TITLE
fix: keep session reset responsive and stop yielded child work

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.requester-settle-cancel.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-cancel.test.ts
@@ -24,6 +24,7 @@ import {
   setSubagentAnnounceDeliveryDepsForTest,
   type SubagentAnnounceDeliveryDeps,
 } from "./subagent-announce-delivery.runtime.js";
+import { dispatchGatewayMethodInProcess } from "./subagent-announce.runtime.js";
 
 const fixture = useSubagentControlFixture();
 afterEach(() => setSubagentAnnounceDeliveryDepsForTest());
@@ -91,7 +92,8 @@ it.each([
     const waitBeforeExecution =
       phase === "admitted" || phase === "requester reset" || phase === "requester replacement";
     type Dispatch = SubagentAnnounceDeliveryDeps["dispatchGatewayMethodInProcess"];
-    const completed = vi.fn<Dispatch>().mockResolvedValue({
+    const completion = { dispatch: dispatchGatewayMethodInProcess };
+    vi.spyOn(completion, "dispatch").mockResolvedValue({
       status: "ok",
       result: { payloads: [{ text: "The child has settled." }], meta: {} },
     });
@@ -109,7 +111,7 @@ it.each([
       }
       options?.onExecutionStarted?.();
       startedTurns.push(String(params?.sessionKey));
-      return await completed<T>(...args);
+      return await completion.dispatch<T>(...args);
     };
     setSubagentAnnounceDeliveryDepsForTest({ dispatchGatewayMethodInProcess: dispatch });
 

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-cancel.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-cancel.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { getRuntimeConfig } from "../../../config/config.js";
+import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
+import { findTaskByRunId } from "../../../tasks/task-registry.js";
+import { killSessionSubagentRuns } from "../registry/subagent-control-kill.js";
+import { useSubagentControlFixture } from "../registry/subagent-control.test-support.js";
+import { subagentRuns } from "../registry/subagent-registry-memory.js";
+import { markSubagentRunPausedAfterYield } from "../registry/subagent-registry-run-manager.js";
+import { persistSubagentRunsToDiskOrThrow } from "../registry/subagent-registry-state.js";
+import {
+  adoptPausedSubagentRunForFollowUp,
+  markRequesterTurnYielded,
+  markSubagentRunTerminated,
+  registerSubagentRun,
+  settleRequesterAfterSessionSpawns,
+} from "../registry/subagent-registry.js";
+import {
+  settleSubagentRegistryPersistenceWork,
+  writeSubagentSessionEntry,
+} from "../registry/subagent-registry.persistence.test-support.js";
+import { testing as registryTesting } from "../registry/subagent-registry.test-helpers.js";
+import {
+  setSubagentAnnounceDeliveryDepsForTest,
+  type SubagentAnnounceDeliveryDeps,
+} from "./subagent-announce-delivery.runtime.js";
+
+const fixture = useSubagentControlFixture();
+afterEach(() => setSubagentAnnounceDeliveryDepsForTest());
+
+it.each([
+  "pending",
+  "admitted",
+  "unsuppressed",
+  "failed kill",
+  "requester reset",
+  "requester replacement",
+] as const)(
+  "settles a yielded requester's child after %s cancellation without reviving cancelled work",
+  async (phase) => {
+    const owner = "agent:main:main";
+    const requesterKey = "agent:main:subagent:yielded-requester";
+    const nestedKey = "agent:main:subagent:required-child";
+    let storePath = "";
+    for (const [runId, sessionKey, requesterSessionKey] of [
+      ["requester", requesterKey, owner],
+      ["nested", nestedKey, requesterKey],
+    ] as const) {
+      storePath = await writeSubagentSessionEntry({
+        stateDir: fixture.stateDir,
+        agentId: "main",
+        sessionKey,
+        defaultSessionId: `${runId}-session`,
+      });
+      registerSubagentRun({
+        runId,
+        childSessionKey: sessionKey,
+        requesterSessionKey,
+        requesterAgentId: "main",
+        requesterTurnRunId: runId === "nested" ? "requester" : undefined,
+        requesterDisplayKey: requesterSessionKey,
+        task: runId,
+        cleanup: "keep",
+        expectsCompletionMessage: runId === "nested",
+      });
+    }
+    expect(
+      markRequesterTurnYielded({
+        requesterSessionKey: requesterKey,
+        requesterAgentId: "main",
+        requesterTurnRunId: "requester",
+      }),
+    ).toBe(1);
+    expect(markSubagentRunPausedAfterYield({ entry: subagentRuns.get("requester")! })).toBe(true);
+    persistSubagentRunsToDiskOrThrow(subagentRuns, ["requester"]);
+    expect(
+      settleRequesterAfterSessionSpawns({
+        requesterSessionKey: requesterKey,
+        requesterAgentId: "main",
+        requesterTurnRunId: "requester",
+        requesterYielded: true,
+        acceptedSessionSpawns: [
+          { runId: "nested", childSessionKey: nestedKey, expectsCompletionMessage: true },
+        ],
+      }),
+    ).toBe(true);
+
+    const admitted = createDeferredCore();
+    const execute = createDeferredCore();
+    const startedTurns: string[] = [];
+    const waitBeforeExecution =
+      phase === "admitted" || phase === "requester reset" || phase === "requester replacement";
+    type Dispatch = SubagentAnnounceDeliveryDeps["dispatchGatewayMethodInProcess"];
+    const completed = vi.fn<Dispatch>().mockResolvedValue({
+      status: "ok",
+      result: { payloads: [{ text: "The child has settled." }], meta: {} },
+    });
+    const dispatch: Dispatch = async <T>(...args: Parameters<Dispatch>): Promise<T> => {
+      const [, params, options] = args;
+      // Production admission adopts a paused requester before execution starts.
+      adoptPausedSubagentRunForFollowUp({
+        childSessionKey: String(params?.sessionKey),
+        runId: String(params?.idempotencyKey),
+        task: String(params?.message),
+      });
+      admitted.resolve();
+      if (waitBeforeExecution) {
+        await execute.promise;
+      }
+      options?.onExecutionStarted?.();
+      startedTurns.push(String(params?.sessionKey));
+      return await completed<T>(...args);
+    };
+    setSubagentAnnounceDeliveryDepsForTest({ dispatchGatewayMethodInProcess: dispatch });
+
+    if (phase !== "pending") {
+      // A terminal child is skipped by tree cancellation; its yielded requester
+      // still owns the pending synthesis and must fence an already admitted wake.
+      expect(markSubagentRunTerminated({ runId: "nested", reason: "killed" })).toBe(1);
+    }
+    if (waitBeforeExecution) {
+      await registryTesting.sweepOnceForTests();
+      await admitted.promise;
+    }
+    if (phase === "failed kill") {
+      fixture.persist.mockImplementation((runs, changedRunIds) => {
+        if (runs.get("requester")?.killIntent) {
+          throw new Error("requester kill intent rejected");
+        }
+        persistSubagentRunsToDiskOrThrow(runs, changedRunIds);
+      });
+    }
+    if (phase === "requester reset") {
+      await patchSessionEntryCore({ storePath, sessionKey: requesterKey }, (entry) => ({
+        ...entry,
+        lifecycleRevision: "replacement-incarnation",
+      }));
+    }
+    if (phase === "requester replacement") {
+      registerSubagentRun({
+        runId: "replacement",
+        childSessionKey: requesterKey,
+        requesterSessionKey: owner,
+        requesterAgentId: "main",
+        requesterDisplayKey: owner,
+        task: "unrelated replacement",
+        cleanup: "keep",
+        expectsCompletionMessage: false,
+      });
+    }
+    try {
+      if (phase === "pending" || phase === "admitted" || phase === "failed kill") {
+        const result = await killSessionSubagentRuns({
+          cfg: getRuntimeConfig(),
+          sessionKey: owner,
+          agentId: "main",
+        });
+        expect(result.status).toBe(phase === "failed kill" ? "error" : "ok");
+      }
+      execute.resolve();
+      if (!waitBeforeExecution) {
+        await registryTesting.sweepOnceForTests();
+      }
+      await settleSubagentRegistryPersistenceWork();
+      if (phase === "unsuppressed" || phase === "failed kill") {
+        expect(startedTurns).toEqual([requesterKey]);
+      } else {
+        expect(startedTurns).toEqual([]);
+        if (phase === "pending" || phase === "admitted") {
+          expect(findTaskByRunId("requester")?.status).toBe("cancelled");
+          expect(findTaskByRunId("nested")?.status).toBe("cancelled");
+        }
+      }
+      expect(subagentRuns.get("nested")?.requesterSettleWake).toBeUndefined();
+    } finally {
+      execute.resolve();
+      await settleSubagentRegistryPersistenceWork();
+    }
+  },
+);

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
@@ -37,6 +37,7 @@ import { sendSubagentAnnounceDirectly } from "./subagent-announce-direct-deliver
 const startTurn = vi.hoisted(() => vi.fn());
 const deliver = vi.hoisted(() => vi.fn());
 const registryRead = vi.hoisted(() => ({
+  getLatestLiveSubagentRunByChildSessionKey: vi.fn(() => undefined),
   hasDescendantRunAwaitingSettle: vi.fn(() => false),
   listSubagentRunsForRequester: vi.fn<() => SubagentRunRecord[]>(() => []),
   getLatestSubagentRunByChildSessionKey: vi.fn(() => undefined),

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-ownership.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-ownership.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
+
+const { registryRuntimeMock, deliverSpy } = vi.hoisted(() => ({
+  registryRuntimeMock: {
+    countActiveDescendantRuns: vi.fn(() => 0),
+    hasDescendantRunAwaitingSettle: vi.fn(() => false),
+    listSubagentRunsForRequester: vi.fn<() => SubagentRunRecord[]>(() => []),
+    getLatestSubagentRunByChildSessionKey: vi.fn(() => undefined),
+    getLatestLiveSubagentRunByChildSessionKey: vi.fn(() => undefined),
+  },
+  deliverSpy: vi.fn<(params: Record<string, unknown>) => Promise<SubagentAnnounceDeliveryResult>>(),
+}));
+
+vi.mock("../../../config/config.js", () => ({ getRuntimeConfig: () => ({}) }));
+vi.mock("../registry/subagent-registry-read.js", () => registryRuntimeMock);
+vi.mock("../spawn/subagent-depth.js", () => ({ getSubagentDepthFromSessionStore: () => 0 }));
+vi.mock("./subagent-announce.js", () => ({ hasUsableSessionEntry: () => true }));
+vi.mock("./subagent-announce-delivery.js", () => ({
+  deliverSubagentAnnouncement: (params: Record<string, unknown>) => deliverSpy(params),
+  loadRequesterSessionEntry: () => ({
+    entry: { sessionId: "sess-main" },
+    canonicalKey: "agent:main:main",
+  }),
+}));
+
+import {
+  maybeWakeRequesterAfterAllChildrenSettled,
+  type RequesterSettleWakeBatchState,
+} from "./subagent-announce.requester-settle-wake.js";
+
+const REQUESTER = "agent:main:main";
+
+function makeSettledChild(
+  overrides: Pick<SubagentRunRecord, "runId"> & Partial<SubagentRunRecord>,
+): SubagentRunRecord {
+  const { runId, ...record } = overrides;
+  return {
+    runId,
+    childSessionKey: "agent:main:subagent:" + runId,
+    requesterSessionKey: REQUESTER,
+    requesterDisplayKey: "main",
+    task: "investigate",
+    cleanup: "keep",
+    createdAt: 1_000,
+    execution: { status: "terminal", startedAt: 2_000, endedAt: 3_000 },
+    expectsCompletionMessage: true,
+    delivery: { status: "delivered" },
+    requesterSettleWake: { status: "pending", attemptCount: 0 },
+    ...record,
+  };
+}
+
+function transitionBatch(
+  batch: readonly SubagentRunRecord[],
+  state: RequesterSettleWakeBatchState,
+): void {
+  for (const entry of batch) {
+    if (entry.requesterSettleWake) {
+      entry.requesterSettleWake = {
+        ...state,
+        ...(entry.requesterSettleWake.retireAfterSettle ? { retireAfterSettle: true } : {}),
+      };
+    }
+  }
+}
+
+function completeBatch(batch: readonly SubagentRunRecord[], rearmGeneration?: number): void {
+  for (const entry of batch) {
+    if (entry.requesterSettleWake?.rearmGeneration === rearmGeneration) {
+      entry.requesterSettleWake = undefined;
+    }
+  }
+}
+
+function wakeParams() {
+  const settledEntry = registryRuntimeMock
+    .listSubagentRunsForRequester()
+    .find((entry) => entry.runId === "run-b");
+  if (!settledEntry) {
+    throw new Error("The control requires its registered run-b fixture.");
+  }
+  return { requesterSessionKey: REQUESTER, settledEntry, transitionBatch, completeBatch };
+}
+
+beforeEach(() => {
+  registryRuntimeMock.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+  deliverSpy.mockReset().mockResolvedValue({ delivered: true, path: "direct" });
+});
+
+it("closes the frozen requester obligation when reset suppresses an unfinished member", async () => {
+  const batchRunIds = ["run-a", "run-b"];
+  const wake = {
+    status: "pending" as const,
+    attemptCount: 0,
+    batchRunIds,
+    requesterYieldBatch: true as const,
+    rearmGeneration: 7,
+  };
+  const cancelled = makeSettledChild({
+    runId: "run-a",
+    requesterSettleWake: { ...wake },
+    killReconciliation: { killedAt: 3_000, suppressTaskDelivery: true },
+  });
+  // Reset leaves completed records intact, but their shared requester was stopped.
+  const completed = makeSettledChild({
+    runId: "run-b",
+    requesterSettleWake: { ...wake },
+    completion: { required: true, resultText: "completed sibling result" },
+  });
+  registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([cancelled, completed]);
+  expect(await maybeWakeRequesterAfterAllChildrenSettled(wakeParams())).toBe(false);
+  expect(deliverSpy).not.toHaveBeenCalled();
+  expect(cancelled.requesterSettleWake).toBeUndefined();
+  expect(completed.requesterSettleWake).toBeUndefined();
+  expect(completed.completion?.resultText).toBe("completed sibling result");
+});
+
+it("leaves a rearmed yielded batch intact when an older queued wake loses authority", async () => {
+  const child = makeSettledChild({
+    runId: "run-b",
+    requesterSettleWake: {
+      status: "pending",
+      attemptCount: 0,
+      requesterYieldBatch: true,
+      rearmGeneration: 1,
+    },
+  });
+  registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+  const admitted = createDeferred();
+  const execute = createDeferred();
+  const startedTurns: string[] = [];
+  deliverSpy.mockImplementationOnce(async (params) => {
+    admitted.resolve();
+    await execute.promise;
+    const allowed = params.isSourceSessionEffectsAllowed;
+    if (typeof allowed === "function" && !allowed()) {
+      return {
+        delivered: false,
+        path: "none",
+        disposition: "intentional_non_delivery",
+      };
+    }
+    startedTurns.push(REQUESTER);
+    return { delivered: true, path: "direct" };
+  });
+  const pending = maybeWakeRequesterAfterAllChildrenSettled(wakeParams());
+  try {
+    await admitted.promise;
+    transitionBatch([child], {
+      status: "pending",
+      attemptCount: 0,
+      requesterYieldBatch: true,
+      rearmGeneration: 2,
+    });
+    execute.resolve();
+    expect(await pending).toBe(false);
+    expect(startedTurns).toEqual([]);
+    expect(child.requesterSettleWake).toMatchObject({
+      status: "pending",
+      attemptCount: 0,
+      rearmGeneration: 2,
+    });
+    expect(await maybeWakeRequesterAfterAllChildrenSettled(wakeParams())).toBe(true);
+    expect(child.requesterSettleWake).toBeUndefined();
+  } finally {
+    execute.resolve();
+    await pending;
+  }
+});

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -20,6 +20,7 @@ let sessionStore: Record<string, { sessionId?: string; lastChannel?: string; las
 
 const { registryRuntimeMock } = vi.hoisted(() => ({
   registryRuntimeMock: {
+    getLatestLiveSubagentRunByChildSessionKey: vi.fn(() => undefined),
     countActiveDescendantRuns: vi.fn((_rootSessionKey: string) => 0),
     countPendingDescendantRuns: vi.fn((_rootSessionKey: string) => 0),
     isSubagentSessionRunActive: vi.fn((_childSessionKey: string) => true),

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -22,6 +22,7 @@ import { buildAnnounceIdempotencyKey } from "../../announce-idempotency.js";
 import { resolveSubagentRequesterAgentId } from "../../subagent-requester-owner.js";
 import {
   countActiveDescendantRuns,
+  getLatestLiveSubagentRunByChildSessionKey,
   getLatestSubagentRunByChildSessionKey,
   hasDescendantRunAwaitingSettle,
   listSubagentRunsForRequester,
@@ -320,6 +321,34 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
   }
   const batchRunIds = settledBatch.map((entry) => entry.runId).toSorted();
   const selectedState = readSharedBatchState(settledBatch);
+  const getRequesterRun = () =>
+    getLatestLiveSubagentRunByChildSessionKey(
+      requesterSessionKey,
+      (entry) => entry.pauseReason === "sessions_yield",
+    ) ?? getLatestLiveSubagentRunByChildSessionKey(requesterSessionKey);
+  const requesterRun = getRequesterRun();
+  const requesterGeneration = requesterRun?.generation;
+  const requesterCreatedAt = requesterRun?.createdAt;
+  const requesterTaskRunId = requesterRun?.taskRunId ?? requesterRun?.runId;
+  const isBatchDeliveryClosed = () => {
+    const currentRequester = getRequesterRun();
+    return (
+      requesterRun?.killReconciliation?.suppressTaskDelivery === true ||
+      requesterRun?.suppressCompletionDelivery === true ||
+      currentRequester?.killReconciliation?.suppressTaskDelivery === true ||
+      currentRequester?.suppressCompletionDelivery === true ||
+      // This marker is written by requester-wide abort/reset, so even a
+      // completed sibling cannot keep the old frozen obligation alive.
+      settledBatch.some((entry) => entry.killReconciliation?.suppressTaskDelivery === true) ||
+      settledBatch.every((entry) => entry.suppressCompletionDelivery === true)
+    );
+  };
+  if (isBatchDeliveryClosed()) {
+    // Cancellation already owns the task result; only consume its obsolete wake.
+    completeBatch(settledBatch, currentRearmGeneration);
+    finalizeRequesterAttachment(batchRunIds, selectedState);
+    return false;
+  }
   function deferBatch(state: RequesterSettleWakeBatchState): void {
     const countTowardsLimit =
       countActiveDescendantRuns(requesterSessionKey, requesterAgentId) === 0;
@@ -511,6 +540,56 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
     const directIdempotencyKey = buildAnnounceIdempotencyKey(
       attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
     );
+    const requesterSessionId = requesterEntry.sessionId;
+    const requesterLifecycleRevision = requesterEntry.lifecycleRevision;
+    const isRequesterCurrent = () => {
+      const currentRequester = getRequesterRun();
+      // Normal admission adopts a paused requester before execution starts.
+      // Only this admitted continuation may replace its captured task owner.
+      if (
+        (currentRequester !== requesterRun ||
+          currentRequester?.generation !== requesterGeneration ||
+          currentRequester?.createdAt !== requesterCreatedAt) &&
+        (!requesterRun ||
+          !currentRequester ||
+          currentRequester.runId !== directIdempotencyKey ||
+          currentRequester.taskRunId !== requesterTaskRunId ||
+          currentRequester.requesterSessionKey !== requesterRun.requesterSessionKey ||
+          currentRequester.requesterAgentId !== requesterRun.requesterAgentId)
+      ) {
+        return false;
+      }
+      const currentSession = loadRequesterSessionEntry(requesterSessionKey, requesterAgentId).entry;
+      return (
+        currentSession?.sessionId === requesterSessionId &&
+        currentSession?.lifecycleRevision === requesterLifecycleRevision
+      );
+    };
+    const isBatchCurrent = () => {
+      const currentRuns = listSubagentRunsForRequester(requesterSessionKey, { requesterAgentId });
+      return settledBatch.every(
+        (entry) =>
+          currentRuns.includes(entry) &&
+          entry.requesterSettleWake?.rearmGeneration === currentRearmGeneration,
+      );
+    };
+    const isSourceSessionEffectsAllowed = () =>
+      !params.signal?.aborted &&
+      !isGatewayClosed() &&
+      isBatchCurrent() &&
+      isRequesterCurrent() &&
+      !isBatchDeliveryClosed();
+    const settleRevokedBatch = (): boolean => {
+      if (isGatewayClosed() || !isBatchCurrent()) {
+        return true;
+      }
+      if (isBatchDeliveryClosed() || !isRequesterCurrent()) {
+        completeBatch(settledBatch, currentRearmGeneration);
+        finalizeRequesterAttachment(batchRunIds, state);
+        return true;
+      }
+      return false;
+    };
     if (requesterAgentId && state.requesterYieldBatch && state.rearmGeneration !== undefined) {
       transferRequesterFinalAttachment({
         requesterAgentId,
@@ -542,8 +621,12 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
         directIdempotencyKey,
         signal: params.signal,
         resolveGatewayContext,
+        isSourceSessionEffectsAllowed,
       });
     } catch (error) {
+      if (settleRevokedBatch()) {
+        return false;
+      }
       // A transport exception can arrive after gateway admission. Replay the
       // same persisted idempotency key; only a known no-turn result may rotate it.
       const lastError = error instanceof Error ? error.message : String(error);
@@ -583,6 +666,9 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(
       completeBatch(settledBatch, state.rearmGeneration, delivery);
       finalizeRequesterAttachment(batchRunIds, state, delivery, requesterEntry.sessionId);
       return true;
+    }
+    if (settleRevokedBatch()) {
+      return false;
     }
     if (
       delivery.disposition === "ambiguous" ||

--- a/src/agents/subagents/registry/subagent-control-kill-runtime.ts
+++ b/src/agents/subagents/registry/subagent-control-kill-runtime.ts
@@ -184,6 +184,49 @@ export async function killSubagentRun(params: {
   const sessionLifecycleRevision = resolved.entry?.lifecycleRevision;
   const runtime = await subagentKillRuntimeLoader.load();
   let admission: "ready" | "declined" | "busy" = "ready";
+  let killClaim: ReturnType<typeof claimSubagentRunKill>;
+  let preparationResult: Awaited<ReturnType<typeof killSubagentRun>> | undefined;
+  const killOwnerCurrent = () =>
+    isCurrent() &&
+    (!killClaim ||
+      ((params.entry.killIntent === killClaim ||
+        (params.entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
+          params.entry.killReconciliation !== undefined &&
+          params.entry.execution.lifecycleGeneration === killClaim.lifecycleGeneration)) &&
+        (killClaim.lifecycleGeneration === undefined ||
+          isAgentEventLifecycleGenerationCurrent(killClaim.lifecycleGeneration))));
+  const ownsSessionIncarnation = () => {
+    const currentSessionEntry = loadExactSessionEntryReadOnly({
+      storePath: resolved.storePath,
+      sessionKey: childSessionKey,
+      clone: false,
+    })?.entry;
+    return (
+      (currentSessionEntry !== undefined) === (resolved.entry !== undefined) &&
+      currentSessionEntry?.sessionId === sessionId &&
+      currentSessionEntry?.lifecycleRevision === sessionLifecycleRevision
+    );
+  };
+  const releaseChangedSessionKill = (claim: NonNullable<typeof killClaim>) => {
+    try {
+      releaseSubagentRunKillClaim({
+        runId: params.entry.runId,
+        expected: params.entry,
+        claim,
+      });
+    } catch (error) {
+      return {
+        killed: false,
+        sessionId,
+        error: `Subagent session changed and its kill intent could not be released: ${formatErrorMessage(error)}`,
+      };
+    }
+    return {
+      killed: false,
+      sessionId,
+      error: "Subagent session changed while the kill was pending; retry.",
+    };
+  };
   return await runExclusiveSessionLifecycleMutation({
     scope: resolved.storePath,
     identities: [childSessionKey, sessionId],
@@ -202,6 +245,40 @@ export async function killSubagentRun(params: {
       if (!isCurrent()) {
         return;
       }
+      if (
+        params.entry.swarmLaunchPending !== true &&
+        params.entry.execution.restartRecovery === undefined &&
+        !resolveSubagentKillTargetState(params.entry)
+      ) {
+        try {
+          // Active completion must see cancellation before admission interruption.
+          // Pending launch/recovery owners first need the drain to commit their identity.
+          killClaim = claimSubagentRunKill({
+            runId: params.entry.runId,
+            expected: params.entry,
+            sessionId,
+            sessionLifecycleRevision,
+            suppressTaskDelivery: params.suppressTaskDelivery,
+          });
+        } catch (error) {
+          preparationResult = {
+            killed: false,
+            sessionId,
+            error: `Failed to persist subagent kill intent: ${formatErrorMessage(error)}`,
+          };
+          return;
+        }
+        if (killClaim) {
+          if (!ownsSessionIncarnation()) {
+            preparationResult = releaseChangedSessionKill(killClaim);
+            return;
+          }
+          if (!killOwnerCurrent()) {
+            preparationResult = { killed: false, sessionId, superseded: true };
+            return;
+          }
+        }
+      }
       const released = await interruptSessionWorkAdmissions({
         scope: resolved.storePath,
         identities: [childSessionKey, sessionId],
@@ -210,10 +287,28 @@ export async function killSubagentRun(params: {
       admission = released ? "ready" : "busy";
     },
     run: async () => {
+      if (preparationResult) {
+        return preparationResult;
+      }
       if (admission === "declined") {
         return { killed: false, sessionId, declined: true as const };
       }
       if (admission === "busy") {
+        try {
+          if (killClaim) {
+            releaseSubagentRunKillClaim({
+              runId: params.entry.runId,
+              expected: params.entry,
+              claim: killClaim,
+            });
+          }
+        } catch (error) {
+          return {
+            killed: false,
+            sessionId,
+            error: `Subagent remained active and its kill intent could not be released: ${formatErrorMessage(error)}`,
+          };
+        }
         return {
           killed: false,
           sessionId,
@@ -225,27 +320,25 @@ export async function killSubagentRun(params: {
       if (!isCurrent()) {
         return { killed: false, sessionId, superseded: true };
       }
+      if (killClaim && !ownsSessionIncarnation()) {
+        return releaseChangedSessionKill(killClaim);
+      }
       params.refreshDescendants();
       const targetStateAfterRuntimeLoad = resolveSubagentKillTargetState(params.entry);
       if (targetStateAfterRuntimeLoad) {
-        if (
+        const killedTarget =
           params.entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
-          params.entry.suppressAnnounceReason !== "steer-restart"
-        ) {
+          params.entry.suppressAnnounceReason !== "steer-restart";
+        const claimedCurrentKill = killClaim !== undefined && killOwnerCurrent();
+        if (killedTarget && (!killClaim || claimedCurrentKill)) {
           markKilledBestEffort();
         }
-        return { killed: false, sessionId, targetState: targetStateAfterRuntimeLoad };
+        return {
+          killed: killedTarget && claimedCurrentKill,
+          sessionId,
+          targetState: targetStateAfterRuntimeLoad,
+        };
       }
-      let killClaim: ReturnType<typeof claimSubagentRunKill>;
-      const killOwnerCurrent = () =>
-        isCurrent() &&
-        (!killClaim ||
-          ((params.entry.killIntent === killClaim ||
-            (params.entry.endedReason === SUBAGENT_ENDED_REASON_KILLED &&
-              params.entry.killReconciliation !== undefined &&
-              params.entry.execution.lifecycleGeneration === killClaim.lifecycleGeneration)) &&
-            (killClaim.lifecycleGeneration === undefined ||
-              isAgentEventLifecycleGenerationCurrent(killClaim.lifecycleGeneration))));
       const persistAbortedLastRun = (abortedLastRun: boolean, strict = false) =>
         persistSubagentAbortedLastRun({
           childSessionKey,
@@ -262,22 +355,22 @@ export async function killSubagentRun(params: {
           },
           strict,
         });
-      try {
-        // Persist operator intent before aborting runtime work. If terminal
-        // persistence fails, recovery still cannot replay this exact row.
-        killClaim = claimSubagentRunKill({
-          runId: params.entry.runId,
-          expected: params.entry,
-          sessionId,
-          sessionLifecycleRevision,
-          suppressTaskDelivery: params.suppressTaskDelivery,
-        });
-      } catch (error) {
-        return {
-          killed: false,
-          sessionId,
-          error: `Failed to persist subagent kill intent: ${formatErrorMessage(error)}`,
-        };
+      if (!killClaim) {
+        try {
+          killClaim = claimSubagentRunKill({
+            runId: params.entry.runId,
+            expected: params.entry,
+            sessionId,
+            sessionLifecycleRevision,
+            suppressTaskDelivery: params.suppressTaskDelivery,
+          });
+        } catch (error) {
+          return {
+            killed: false,
+            sessionId,
+            error: `Failed to persist subagent kill intent: ${formatErrorMessage(error)}`,
+          };
+        }
       }
       if (!killClaim) {
         return {
@@ -287,52 +380,20 @@ export async function killSubagentRun(params: {
         };
       }
       const claimedKill = killClaim;
-      const ownsSessionIncarnation = () => {
-        const currentSessionEntry = loadExactSessionEntryReadOnly({
-          storePath: resolved.storePath,
-          sessionKey: childSessionKey,
-          clone: false,
-        })?.entry;
-        return (
-          (currentSessionEntry !== undefined) === (resolved.entry !== undefined) &&
-          currentSessionEntry?.sessionId === sessionId &&
-          currentSessionEntry?.lifecycleRevision === sessionLifecycleRevision
-        );
-      };
-      const releaseChangedSessionKill = () => {
-        try {
-          releaseSubagentRunKillClaim({
-            runId: params.entry.runId,
-            expected: params.entry,
-            claim: claimedKill,
-          });
-        } catch (error) {
-          return {
-            killed: false,
-            sessionId,
-            error: `Subagent session changed and its kill intent could not be released: ${formatErrorMessage(error)}`,
-          };
-        }
-        return {
-          killed: false,
-          sessionId,
-          error: "Subagent session changed while the kill was pending; retry.",
-        };
-      };
       try {
         if (!ownsSessionIncarnation()) {
-          return releaseChangedSessionKill();
+          return releaseChangedSessionKill(claimedKill);
         }
         if (!killOwnerCurrent()) {
           return { killed: false, sessionId, superseded: true };
         }
         const active = sessionId ? runtime.isEmbeddedAgentRunActive(sessionId) : false;
         if (!ownsSessionIncarnation()) {
-          return releaseChangedSessionKill();
+          return releaseChangedSessionKill(claimedKill);
         }
         const aborted = sessionId ? runtime.abortEmbeddedAgentRun(sessionId) : false;
         if (!ownsSessionIncarnation()) {
-          return releaseChangedSessionKill();
+          return releaseChangedSessionKill(claimedKill);
         }
         const cleared = runtime.clearSessionQueues([childSessionKey, sessionId]);
         if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
@@ -407,15 +468,17 @@ export async function killSubagentRun(params: {
         };
       } catch (error) {
         return { killed: false, sessionId, error: formatErrorMessage(error) };
-      } finally {
-        // Disposition follows the exact retained claim, not fallible session/ancestor reads.
-        // The captured scheduler capability cannot withdraw a replacement or active launch.
-        if (
-          subagentRuns.get(params.entry.runId) === params.entry &&
-          params.entry.killIntent === claimedKill
-        ) {
-          params.withdrawQueuedReservation();
-        }
+      }
+    },
+    finalize: async () => {
+      // Preparation now owns the claim, including failed drains and persistence.
+      // Only its exact retained claim may withdraw the captured reservation.
+      if (
+        killClaim &&
+        subagentRuns.get(params.entry.runId) === params.entry &&
+        params.entry.killIntent === killClaim
+      ) {
+        params.withdrawQueuedReservation();
       }
     },
   });

--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -383,7 +383,6 @@ async function killSubagentRunTree(
         result.descendants = true;
       }
       if (result.descendants && tree.canTraverse()) {
-        params.scope.refresh();
         await Promise.all(tree.children.map(visit));
       }
     } catch (error) {

--- a/src/agents/subagents/registry/subagent-control.recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-control.recovery.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../gateway/server-methods/chat.abort.test-helpers.js";
 import { sessionMutationHandlers } from "../../../gateway/server-methods/sessions-mutations.js";
 import { loadSessionsRuntimeModule } from "../../../gateway/server-methods/sessions-shared.js";
+import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   registerAgentRunContext,
   clearAgentRunContext,
@@ -311,8 +312,8 @@ it.each(
         const released = await interruptAdmissions(params);
         if (params.scope === storePath && Array.from(params.identities).includes(aKey)) {
           expect(released).toBe(true);
-          // Recovery/reset runs after the real drain but before cancellation
-          // effects, without holding an admission across its bounded deadline.
+          // Recovery/reset runs after the real drain, before the kill owner finishes,
+          // without holding an admission across its bounded deadline.
           entered.resolve();
           await resume.promise;
         }
@@ -367,7 +368,12 @@ it.each(
         }),
       ]);
       expect(sessionLifecycle.isSessionWorkAdmissionActive(storePath, [aKey])).toBe(false);
-      expect(a.killIntent).toBeUndefined();
+      expect(a.killIntent).toMatchObject({
+        reason: "killed",
+        sessionId: "a-session",
+        sessionLifecycleRevision: "a-revision",
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      });
       expect(b.killIntent).toBeUndefined();
       activateSubagentRegistry(gatewayContext.resolveGatewayContext);
       await testing.sweepOnceForTests();

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
@@ -326,6 +326,7 @@ export async function completeSubagentRunAttempt(
         }
         entry.killReconciliation = {
           killedAt: killIntent.requestedAt,
+          taskCancellationAccepted: killOwnsCurrentLifecycle ? true : undefined,
           suppressTaskDelivery: killIntent.suppressTaskDelivery === true ? true : undefined,
         };
       }

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -1018,7 +1018,7 @@ describe("subagent registry lifecycle hardening", () => {
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      killReconciliation: { killedAt: 4_001 },
+      killReconciliation: { killedAt: 4_001, taskCancellationAccepted: true },
       execution: {
         status: "terminal",
         endedAt: 4_001,
@@ -1066,6 +1066,7 @@ describe("subagent registry lifecycle hardening", () => {
       },
     });
     expect(entry.killIntent).toBeUndefined();
+    expect(entry.killReconciliation?.taskCancellationAccepted).toBeUndefined();
   });
 
   it("keeps a natural completion that predates the durable kill intent", async () => {

--- a/src/agents/subagents/registry/subagent-registry-sweep-kill.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweep-kill.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../config/sessions.js";
 import { isAgentEventLifecycleGenerationCurrent } from "../../../infra/agent-events.js";
 import { getAgentRunContext } from "../../../infra/agent-run-registry.js";
-import { runExclusiveSessionLifecycleMutation } from "../../../sessions/session-lifecycle-admission.js";
+import {
+  isSessionLifecycleMutationActive,
+  runExclusiveSessionLifecycleMutation,
+} from "../../../sessions/session-lifecycle-admission.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../../../tasks/detached-task-runtime-contract.js";
 import {
   finalizeTaskRunByRunId,
@@ -201,9 +204,14 @@ export async function reconcileDurableSubagentKillIntent(params: {
   ) {
     return await completeRetiredKill();
   }
+  const identities = [params.entry.childSessionKey, killIntent.sessionId];
+  // A live mutation owns this cancellation; reconcile other rows without waiting behind it.
+  if (isSessionLifecycleMutationActive(storePath, identities)) {
+    return false;
+  }
   try {
     const runtime = await params.loadKillRuntime();
-    if (!ownsCurrentGeneration()) {
+    if (!ownsCurrentGeneration() || isSessionLifecycleMutationActive(storePath, identities)) {
       return false;
     }
     if (!ownsSessionIncarnation()) {
@@ -211,7 +219,7 @@ export async function reconcileDurableSubagentKillIntent(params: {
     }
     return await runExclusiveSessionLifecycleMutation({
       scope: storePath,
-      identities: [params.entry.childSessionKey, killIntent.sessionId],
+      identities,
       run: async () => {
         if (!ownsCurrentGeneration()) {
           return false;

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1267,11 +1267,17 @@ describe("abort detection", () => {
     ]) {
       addSubagentFixture(fixture);
     }
-    let writes = 0;
+    let failedTombstone = false;
     subagentRegistryTesting.setDepsForTest({
-      persistSubagentRunsToDiskOrThrow: () => {
-        writes += 1;
-        if (writes === 2) {
+      persistSubagentRunsToDiskOrThrow: (runs, changedRunIds) => {
+        const first = runs.get("run-persistence-failure-first");
+        if (
+          !failedTombstone &&
+          changedRunIds?.includes("run-persistence-failure-first") &&
+          first?.execution.status === "terminal" &&
+          first.endedReason === "subagent-killed"
+        ) {
+          failedTombstone = true;
           throw new Error("sqlite busy");
         }
       },
@@ -1283,6 +1289,7 @@ describe("abort detection", () => {
         requesterSessionKey: sessionKey,
       }),
     ).resolves.toEqual({ stopped: 1, failed: 1 });
+    expect(failedTombstone).toBe(true);
     expect(getSubagentRunByChildSessionKey(firstChildKey)?.killIntent).toBeDefined();
     expect(getSubagentRunByChildSessionKey(secondChildKey)?.endedReason).toBe("subagent-killed");
     expectSessionLaneCleared(firstChildKey);

--- a/src/gateway/agent-turn/agent-job.execution-settlement.test.ts
+++ b/src/gateway/agent-turn/agent-job.execution-settlement.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
-import { waitForAgentJob } from "./agent-job.js";
+import type { DedupeEntry } from "../server-shared.js";
+import { setGatewayDedupeEntry, waitForAgentJob } from "./agent-job.js";
 
 let runSequence = 0;
 
@@ -14,6 +15,45 @@ describe("waitForAgentJob settled execution", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
   });
+
+  it.each(["ok", "error", "timeout"] as const)(
+    "preserves yielded execution only when chat settles successfully: %s",
+    async (status) => {
+      const runId = `chat-yielded-execution-${runSequence++}`;
+      await waitForAgentJob({ runId, source: "chat", timeoutMs: 0 });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt: 100 } });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 100,
+          endedAt: 200,
+          yielded: true,
+          livenessState: "paused",
+          executionSettled: true,
+        },
+      });
+      await expect(waitForAgentJob({ runId, source: "chat", timeoutMs: 0 })).resolves.toBeNull();
+      setGatewayDedupeEntry({
+        dedupe: new Map<string, DedupeEntry>(),
+        key: `chat:${runId}`,
+        entry: {
+          ts: Date.now(),
+          ok: status === "ok",
+          payload: { runId, status, startedAt: 100, endedAt: 300 },
+        },
+      });
+      await expect(waitForAgentJob({ runId, source: "chat", timeoutMs: 0 })).resolves.toMatchObject(
+        {
+          status,
+          endedAt: 300,
+          yielded: status === "ok" ? true : undefined,
+          livenessState: status === "ok" ? "paused" : undefined,
+        },
+      );
+    },
+  );
 
   it.each([
     {

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -516,6 +516,17 @@ export function setGatewayDedupeEntry(params: {
     return;
   }
   if (incomingObservation.state === "terminal") {
+    const lifecycle = agentJobs.get(key.runId)?.snapshotsBySource.get("lifecycle");
+    if (
+      key.source === "chat" &&
+      incomingObservation.snapshot.status === "ok" &&
+      lifecycle?.status === "ok" &&
+      lifecycle.yielded === true
+    ) {
+      // Chat completion closes delivery, not the runtime's yielded execution.
+      incomingObservation.snapshot.yielded = true;
+      incomingObservation.snapshot.livenessState = lifecycle.livenessState;
+    }
     recordAgentRunSnapshot({
       ...incomingObservation.snapshot,
       runId: key.runId,

--- a/src/gateway/server-methods/chat.reset-visible-yield.test.ts
+++ b/src/gateway/server-methods/chat.reset-visible-yield.test.ts
@@ -1,0 +1,568 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { subagentRuns } from "../../agents/subagents/registry/subagent-registry-memory.js";
+import { settleSubagentRegistryPersistenceWork } from "../../agents/subagents/registry/subagent-registry.persistence.test-support.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../config/config.js";
+import { clearSessionStoreCacheForTest } from "../../config/sessions/store-writer-state.js";
+import { onAgentEvent } from "../../infra/agent-events.js";
+import * as sessionAdmission from "../../sessions/session-lifecycle-admission.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import * as agentJob from "../agent-turn/agent-job.js";
+import { waitForGatewayDispatch } from "../server-in-process-dispatch.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "../test-openai-responses-model.js";
+
+type ResponseInput = {
+  type?: string;
+  role?: string;
+  call_id?: string;
+  output?: string;
+  content?: string | Array<{ type: string; text?: string }>;
+};
+type SpawnReceipt = { status: string; runId: string; childSessionKey: string };
+type WaitResult = Awaited<ReturnType<typeof agentJob.waitForAgentJob>>;
+type ToolItem = {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status: "completed";
+};
+
+function streamReply(
+  response: ServerResponse,
+  item:
+    | ToolItem
+    | {
+        type: "message";
+        id: string;
+        role: "assistant";
+        status: "completed";
+        content: Array<{ type: "output_text"; text: string; annotations: never[] }>;
+      },
+) {
+  const envelope = {
+    id: randomUUID(),
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    status: "completed",
+    model: "gpt-5.4",
+    output: [item],
+    usage: { input_tokens: 64, output_tokens: 32, total_tokens: 96 },
+  };
+  const events: Record<string, unknown>[] = [
+    { type: "response.created", response: { ...envelope, status: "in_progress", output: [] } },
+  ];
+  if (item.type === "function_call") {
+    events.push(
+      { type: "response.output_item.added", output_index: 0, item: { ...item, arguments: "" } },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: item.id,
+        output_index: 0,
+        delta: item.arguments,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: item.id,
+        output_index: 0,
+        arguments: item.arguments,
+      },
+    );
+  } else {
+    events.push({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, content: [] },
+    });
+  }
+  events.push(
+    { type: "response.output_item.done", output_index: 0, item },
+    { type: "response.completed", response: envelope },
+  );
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  response.end(
+    events
+      .map(
+        (event, sequence_number) =>
+          `event: ${event.type}\ndata: ${JSON.stringify({ ...event, sequence_number })}\n\n`,
+      )
+      .join(""),
+  );
+}
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("visible yielded session reset", () => {
+  it(
+    "preserves real chat yield metadata and cancels its held descendant without resuming inference",
+    { timeout: 90_000 },
+    async () => {
+      const home = tempDirs.make("openclaw-visible-yield-reset-");
+      const stateDir = path.join(home, ".openclaw");
+      const workspace = path.join(home, "workspace");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const pluginsDir = path.join(home, "bundled-plugins");
+      const environment = {
+        HOME: home,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_GATEWAY_TOKEN: "visible-yield-reset-test",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: pluginsDir,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      };
+      const envSnapshot = captureEnv(Object.keys(environment));
+      const fixtureAbort = new AbortController();
+      const rootMarker = `fixture://reset/${randomUUID()}`;
+      const requesterMarker = `fixture://reset/${randomUUID()}`;
+      const childMarker = `fixture://reset/${randomUUID()}`;
+      const sessionKey = `agent:main:reset-${randomUUID()}`;
+      const rootCallId = "call_root";
+      const childCallId = "call_child";
+      const resetId = randomUUID();
+      const rootFinished = createDeferred();
+      const nestedOpen = createDeferred();
+      const nestedClosed = createDeferred();
+      const requesterWaitAttached = createDeferred();
+      const requesterYielded = createDeferred();
+      const requesterWaitFinished = createDeferred<WaitResult>();
+      const resetAcknowledged = createDeferred<{ state?: string }>();
+      const attachedChatRuns = new Set<string>();
+      const handlers = new Set<Promise<void>>();
+      const evidence: Array<Record<string, unknown>> = [];
+      const fixtureErrors: string[] = [];
+      let requester: SpawnReceipt | undefined;
+      let child: SpawnReceipt | undefined;
+      let requesterStep = 0;
+      let rootStep = 0;
+      let childRequests = 0;
+      let yieldDispatched = false;
+      let unexpectedInference = 0;
+      let stopping = false;
+      let providerServer: ReturnType<typeof createServer> | undefined;
+      let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+      const bound = <T>(promise: PromiseLike<T>, label: string) =>
+        withTestTimeout(promise, 30_000, label);
+      const snapshot = (): Array<Record<string, unknown>> =>
+        [requester, child].flatMap<Record<string, unknown>>((receipt) => {
+          if (!receipt) {
+            return [];
+          }
+          const run = subagentRuns.get(receipt.runId);
+          if (!run) {
+            return [{ runId: receipt.runId, absent: true }];
+          }
+          return [
+            structuredClone({
+              runId: run.runId,
+              taskRunId: run.taskRunId,
+              generation: run.generation,
+              childSessionKey: run.childSessionKey,
+              requesterSessionKey: run.requesterSessionKey,
+              controllerSessionKey: run.controllerSessionKey,
+              requesterTurnRunId: run.requesterTurnRunId,
+              requesterTurnYielded: run.requesterTurnYielded,
+              execution: run.execution,
+              pauseReason: run.pauseReason,
+              killIntent: run.killIntent,
+              killReconciliation: run.killReconciliation,
+              suppressCompletionDelivery: run.suppressCompletionDelivery,
+              requesterSettleWake: run.requesterSettleWake,
+              cleanupHandled: run.cleanupHandled,
+              cleanupCompletedAt: run.cleanupCompletedAt,
+            }),
+          ];
+        });
+      const record = (kind: string, facts: Record<string, unknown> = {}) => {
+        evidence.push({ at: Date.now(), kind, ...facts, runs: snapshot() });
+      };
+      const originalWait = agentJob.waitForAgentJob;
+      const waiterSpy = vi.spyOn(agentJob, "waitForAgentJob").mockImplementation((params) => {
+        const pending = originalWait(params);
+        if (params.source === "chat") {
+          attachedChatRuns.add(params.runId);
+          if (params.runId === requester?.runId) {
+            requesterWaitAttached.resolve();
+          }
+        }
+        record("wait-attached", { runId: params.runId, source: params.source });
+        void pending.then(
+          (result) => {
+            record("wait-result", { runId: params.runId, source: params.source, result });
+            if (params.source === "chat" && params.runId === requester?.runId) {
+              requesterWaitFinished.resolve(result);
+            }
+          },
+          (error: unknown) => {
+            record("wait-rejected", { runId: params.runId, error: String(error) });
+          },
+        );
+        return pending;
+      });
+      const originalInterrupt = sessionAdmission.interruptSessionWorkAdmissions;
+      const admissionSpy = vi
+        .spyOn(sessionAdmission, "interruptSessionWorkAdmissions")
+        .mockImplementation((params) => {
+          record("admission-interrupt-entry");
+          const pending = originalInterrupt(params);
+          void pending.then(
+            (released) => {
+              record("admission-interrupt-release", { released });
+            },
+            (error: unknown) => {
+              record("admission-interrupt-rejected", { error: String(error) });
+            },
+          );
+          return pending;
+        });
+      const unsubscribe = onAgentEvent((event) => {
+        if (event.stream !== "lifecycle") {
+          return;
+        }
+        record("lifecycle", {
+          runId: event.runId,
+          data: event.data,
+        });
+        if (event.runId === requester?.runId && event.data.yielded === true) {
+          requesterYielded.resolve();
+        }
+      });
+
+      function parseSpawnReceipt(input: ResponseInput[], callId: string): SpawnReceipt {
+        const outputs = input.filter(
+          (item) => item.type === "function_call_output" && item.call_id === callId,
+        );
+        expect(outputs, "one actual spawn receipt").toHaveLength(1);
+        const output = expectDefined(outputs[0], "one actual spawn receipt");
+        expect(output.output).toBeTypeOf("string");
+        const result: SpawnReceipt = JSON.parse(
+          expectDefined(output.output, "spawn receipt output"),
+        );
+        expect(result).toMatchObject({
+          status: "accepted",
+          runId: expect.any(String),
+          childSessionKey: expect.any(String),
+        });
+        record("spawn-receipt", { callId, receipt: result });
+        return result;
+      }
+      function tool(
+        response: ServerResponse,
+        callId: string,
+        name: string,
+        args: Record<string, unknown>,
+        tools: Array<{ name: string }>,
+      ) {
+        expect(
+          tools.some((candidate) => candidate.name === name),
+          `available ${name}`,
+        ).toBe(true);
+        streamReply(response, {
+          type: "function_call",
+          id: `fc_${callId.slice(5)}`,
+          call_id: callId,
+          name,
+          arguments: JSON.stringify(args),
+          status: "completed",
+        });
+      }
+
+      try {
+        await Promise.all(
+          [workspace, stateDir, pluginsDir].map((dir) => fs.mkdir(dir, { recursive: true })),
+        );
+        for (const [key, value] of Object.entries(environment)) {
+          setTestEnvValue(key, value);
+        }
+        providerServer = createServer((request, response) => {
+          const handler = (async () => {
+            const chunks: Buffer[] = [];
+            for await (const chunk of request) {
+              chunks.push(Buffer.from(chunk));
+            }
+            const body: { input: ResponseInput[]; tools: Array<{ name: string }> } = JSON.parse(
+              Buffer.concat(chunks).toString(),
+            );
+            record("provider-request", { body });
+            expect(request.url).toBe("/v1/responses");
+            const marked = body.input
+              .filter((item) => item.role === "user")
+              .map((item) => {
+                const text =
+                  typeof item.content === "string"
+                    ? item.content
+                    : item.content?.map((part) => part.text).join("\n");
+                return [rootMarker, requesterMarker, childMarker].filter((marker) =>
+                  text?.includes(marker),
+                );
+              })
+              .findLast((markers) => markers.length > 0);
+            expect(marked, "one fixture marker in latest marked user message").toHaveLength(1);
+            const marker = marked![0];
+            if (stopping) {
+              throw new Error("provider called during fixture shutdown");
+            }
+            if (marker === requesterMarker && yieldDispatched) {
+              unexpectedInference++;
+              record("unexpected-requester-inference");
+              response.writeHead(400, { "content-type": "application/json" }).end(
+                JSON.stringify({
+                  error: { message: "Fixture refuses requester inference after yield." },
+                }),
+              );
+              return;
+            }
+            if (marker === rootMarker) {
+              if (rootStep++ === 0) {
+                tool(
+                  response,
+                  rootCallId,
+                  "sessions_spawn",
+                  {
+                    task: requesterMarker,
+                    label: "Yielded requester",
+                    visible: true,
+                    context: "isolated",
+                    expectsCompletionMessage: false,
+                  },
+                  body.tools,
+                );
+                return;
+              }
+              expect(rootStep).toBe(2);
+              requester = parseSpawnReceipt(body.input, rootCallId);
+              if (attachedChatRuns.has(requester.runId)) {
+                requesterWaitAttached.resolve();
+              }
+              streamReply(response, {
+                type: "message",
+                id: randomUUID(),
+                role: "assistant",
+                status: "completed",
+                content: [{ type: "output_text", text: "Requester started.", annotations: [] }],
+              });
+              return;
+            }
+            if (marker === requesterMarker) {
+              if (requesterStep++ === 0) {
+                tool(
+                  response,
+                  childCallId,
+                  "sessions_spawn",
+                  {
+                    task: childMarker,
+                    label: "Held child",
+                    visible: true,
+                    context: "isolated",
+                    expectsCompletionMessage: true,
+                  },
+                  body.tools,
+                );
+                return;
+              }
+              expect(requesterStep).toBe(2);
+              child = parseSpawnReceipt(body.input, childCallId);
+              await waitForGatewayDispatch(
+                "nested provider open",
+                nestedOpen.promise,
+                30_000,
+                fixtureAbort.signal,
+              );
+              await waitForGatewayDispatch(
+                "requester chat waiter attached",
+                requesterWaitAttached.promise,
+                30_000,
+                fixtureAbort.signal,
+              );
+              yieldDispatched = true;
+              tool(
+                response,
+                "call_yield",
+                "sessions_yield",
+                { message: "Wait for the nested child." },
+                body.tools,
+              );
+              return;
+            }
+            expect(marker).toBe(childMarker);
+            expect(++childRequests, "held nested request must not replay").toBe(1);
+            response.once("close", () => {
+              record("nested-stream-close", {
+                writableEnded: response.writableEnded,
+                fixtureStopping: stopping,
+              });
+              nestedClosed.resolve();
+            });
+            response.writeHead(200, { "content-type": "text/event-stream" });
+            response.write(
+              `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: randomUUID(), object: "response", status: "in_progress", model: "gpt-5.4", output: [] } })}\n\n`,
+            );
+            record("nested-stream-open");
+            nestedOpen.resolve();
+          })().catch((error: unknown) => {
+            if (!stopping) {
+              fixtureErrors.push(String(error));
+            }
+            if (!response.headersSent) {
+              response.writeHead(400, { "content-type": "application/json" });
+            }
+            response.end(JSON.stringify({ error: { message: "Fixture contract failed." } }));
+          });
+          handlers.add(handler);
+          void handler.finally(() => handlers.delete(handler));
+        });
+        const server = providerServer;
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("provider did not bind loopback port");
+        }
+        const provider = buildMockOpenAiResponsesProvider(`http://127.0.0.1:${address.port}/v1`);
+        gateway = await startGatewayWithClient({
+          configPath,
+          token: environment.OPENCLAW_GATEWAY_TOKEN,
+          cfg: {
+            agents: {
+              defaults: {
+                workspace,
+                skipBootstrap: true,
+                model: { primary: provider.modelRef },
+                models: {
+                  [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
+                },
+                subagents: { maxSpawnDepth: 2, maxConcurrent: 4 },
+              },
+              entries: { main: { default: true } },
+            },
+            tools: {
+              profile: "full",
+              codeMode: false,
+              allow: ["sessions_spawn", "sessions_yield"],
+            },
+            models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+            gateway: { auth: { mode: "token", token: environment.OPENCLAW_GATEWAY_TOKEN } },
+          },
+          onEvent: (event) => {
+            if (event.event !== "chat") {
+              return;
+            }
+            const payload = event.payload as {
+              runId?: string;
+              sessionKey?: string;
+              state?: string;
+            };
+            if (payload.sessionKey !== sessionKey) {
+              return;
+            }
+            if (
+              payload.runId === resetId &&
+              (payload.state === "final" || payload.state === "error")
+            ) {
+              resetAcknowledged.resolve(payload);
+            } else if (payload.state === "final") {
+              rootFinished.resolve();
+            }
+          },
+        });
+        const started = await gateway.client.request<{ status: string }>("chat.send", {
+          sessionKey,
+          message: rootMarker,
+          deliver: false,
+          idempotencyKey: randomUUID(),
+        });
+        expect(started.status).toBe("started");
+        await bound(rootFinished.promise, "root did not finish");
+        await bound(
+          requesterYielded.promise,
+          "requester did not emit a real yield lifecycle event",
+        );
+        const waitResult = await bound(
+          requesterWaitFinished.promise,
+          "real requester chat waiter did not finish",
+        );
+        record("before-reset", { waitResult });
+        expect
+          .soft(waitResult, "chat waiter must retain actual yield metadata")
+          .toMatchObject({ status: "ok", yielded: true });
+        await gateway.client.request(
+          "chat.send",
+          { sessionKey, message: "/new", deliver: false, idempotencyKey: resetId },
+          { timeoutMs: 30_000 },
+        );
+        const reset = await bound(resetAcknowledged.promise, "reset did not acknowledge");
+        expect(reset.state).toBe("final");
+        record("reset-acknowledged");
+        await bound(nestedClosed.promise, "reset did not close nested provider stream");
+        await bound(
+          settleSubagentRegistryPersistenceWork(),
+          "registry work did not settle after reset",
+        );
+        // The reported continuation arrived 127 ms after acknowledgement on 2026-09-10.
+        // This window observes absence after synchronization with real cancellation.
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1_000);
+        });
+        record("observation-complete");
+        expect(fixtureErrors, "provider fixture failures").toEqual([]);
+        expect(unexpectedInference, "requester must not reach inference after reset").toBe(0);
+        expect(evidence.find((event) => event.kind === "nested-stream-close")).toMatchObject({
+          writableEnded: false,
+          fixtureStopping: false,
+        });
+        const tasks = await gateway.client.request<{
+          tasks: Array<{ runId: string; status: string }>;
+        }>("tasks.list", { agentId: "main" });
+        record("public-cancelled-tasks", { tasks });
+        expect(tasks.tasks.find((task) => task.runId === requester?.runId)).toMatchObject({
+          status: "cancelled",
+        });
+        expect(tasks.tasks.find((task) => task.runId === child?.runId)).toMatchObject({
+          status: "cancelled",
+        });
+      } finally {
+        record("fixture-cleanup-start", { fixtureErrors, unexpectedInference });
+        stopping = true;
+        fixtureAbort.abort();
+        providerServer?.closeAllConnections();
+        if (gateway) {
+          await disconnectGatewayClient(gateway.client).catch(() => undefined);
+          await gateway.server.close().catch(() => undefined);
+        }
+        if (providerServer?.listening) {
+          const server = providerServer;
+          await new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          });
+        }
+        await Promise.allSettled(handlers);
+        unsubscribe();
+        waiterSpy.mockRestore();
+        admissionSpy.mockRestore();
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+        clearSessionStoreCacheForTest();
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        envSnapshot.restore();
+      }
+    },
+  );
+});

--- a/src/gateway/server-methods/chat.reset-visible-yield.test.ts
+++ b/src/gateway/server-methods/chat.reset-visible-yield.test.ts
@@ -11,6 +11,7 @@ import { settleSubagentRegistryPersistenceWork } from "../../agents/subagents/re
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../config/config.js";
 import { clearSessionStoreCacheForTest } from "../../config/sessions/store-writer-state.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
+import { getAgentRunContext } from "../../infra/agent-run-registry.js";
 import * as sessionAdmission from "../../sessions/session-lifecycle-admission.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
@@ -59,7 +60,7 @@ function streamReply(
     output: [item],
     usage: { input_tokens: 64, output_tokens: 32, total_tokens: 96 },
   };
-  const events: Record<string, unknown>[] = [
+  const events: Array<{ type: string } & Record<string, unknown>> = [
     { type: "response.created", response: { ...envelope, status: "in_progress", output: [] } },
   ];
   if (item.type === "function_call") {
@@ -145,12 +146,16 @@ describe("visible yielded session reset", () => {
       const attachedChatRuns = new Set<string>();
       const handlers = new Set<Promise<void>>();
       const evidence: Array<Record<string, unknown>> = [];
+      const failureTrace: Array<Record<string, unknown>> = [];
+      const runAliases = new Map<string, number>();
+      const fixtureStartedAt = Date.now();
       const fixtureErrors: string[] = [];
       let requester: SpawnReceipt | undefined;
       let child: SpawnReceipt | undefined;
       let requesterStep = 0;
       let rootStep = 0;
       let childRequests = 0;
+      let providerRequests = 0;
       let yieldDispatched = false;
       let unexpectedInference = 0;
       let stopping = false;
@@ -238,6 +243,31 @@ describe("visible yielded session reset", () => {
           runId: event.runId,
           data: event.data,
         });
+        if (!runAliases.has(event.runId)) {
+          runAliases.set(event.runId, runAliases.size + 1);
+        }
+        const context = getAgentRunContext(event.runId);
+        failureTrace.push({
+          kind: "lifecycle",
+          elapsedMs: Date.now() - fixtureStartedAt,
+          run: runAliases.get(event.runId),
+          owner:
+            context?.sessionKey === sessionKey
+              ? "root"
+              : event.runId === requester?.runId
+                ? "requester"
+                : event.runId === child?.runId
+                  ? "child"
+                  : "other",
+          phase:
+            ["start", "finishing", "end", "error", "timeout"].find(
+              (phase) => phase === event.data.phase,
+            ) ?? "other",
+          yielded: event.data.yielded === true,
+          aborted: event.data.aborted === true,
+          contextPresent: context !== undefined,
+          isHeartbeat: context?.isHeartbeat,
+        });
         if (event.runId === requester?.runId && event.data.yielded === true) {
           requesterYielded.resolve();
         }
@@ -300,6 +330,45 @@ describe("visible yielded session reset", () => {
             );
             record("provider-request", { body });
             expect(request.url).toBe("/v1/responses");
+            failureTrace.push({
+              kind: "provider-request",
+              elapsedMs: Date.now() - fixtureStartedAt,
+              request: ++providerRequests,
+              rootStep,
+              requesterStep,
+              childRequests,
+              yieldDispatched,
+              resetAcknowledged: evidence.some((event) => event.kind === "reset-acknowledged"),
+              stopping,
+              input: body.input.map((item) => {
+                const text =
+                  typeof item.content === "string"
+                    ? item.content
+                    : item.content?.map((part) => part.text).join("\n");
+                return {
+                  type:
+                    ["message", "function_call", "function_call_output", "reasoning"].find(
+                      (type) => type === item.type,
+                    ) ?? "other",
+                  role:
+                    ["system", "developer", "user", "assistant", "tool"].find(
+                      (role) => role === item.role,
+                    ) ?? "other",
+                  form:
+                    item.content === undefined
+                      ? "absent"
+                      : typeof item.content === "string"
+                        ? "string"
+                        : "parts",
+                  textLength: text?.length,
+                  markers: [
+                    ...(text?.includes(rootMarker) ? ["root"] : []),
+                    ...(text?.includes(requesterMarker) ? ["requester"] : []),
+                    ...(text?.includes(childMarker) ? ["child"] : []),
+                  ],
+                };
+              }),
+            });
             const marked = body.input
               .filter((item) => item.role === "user")
               .map((item) => {
@@ -521,8 +590,13 @@ describe("visible yielded session reset", () => {
           setTimeout(resolve, 1_000);
         });
         record("observation-complete");
-        expect(fixtureErrors, "provider fixture failures").toEqual([]);
-        expect(unexpectedInference, "requester must not reach inference after reset").toBe(0);
+        expect(fixtureErrors, `provider fixture failures: ${JSON.stringify(failureTrace)}`).toEqual(
+          [],
+        );
+        expect(
+          unexpectedInference,
+          `requester must not reach inference after reset: ${JSON.stringify(failureTrace)}`,
+        ).toBe(0);
         expect(evidence.find((event) => event.kind === "nested-stream-close")).toMatchObject({
           writableEnded: false,
           fixtureStopping: false,


### PR DESCRIPTION
Closes #143389. Related: #143620. Thanks @aleps001 for profiling and @zhangguiping-xydt for the related traversal repair.

## What Problem This Solves

/new resets slowed down when history contained many completed child runs. A yielded child could also start another turn after reset acknowledged cancellation.

## Why This Change Was Made

Traversal no longer refreshes the whole tree at each node. Existing ownership checks remain. Completion retains actual yield and accepted-cancellation facts, and reconciliation defers to an active session cancellation before retiring obsolete wake requests.

## User Impact

Resets stay responsive while active and yielded child work remains cancelled. Completed results, task records, and unrelated conversations remain available. Configuration, schemas, and the existing reconciliation grace are unchanged.

## Evidence

Real Gateway chat, child spawning, yielding, and /new checks used a recording provider. A matched 64-node reset improved from 2.180 to 0.220 seconds with all records retained and zero requests during reset. Active and yielded cancellation passed 390-second observation windows without new provider requests. The production repair passed 173 focused tests; the test follow-up passed 37. One staged continuous-integration run observed an unexplained request that smaller reruns did not reproduce; its strict assertion remains. The reported 82-second workload was not reproduced, and a single memory sample was higher after the repair.
