### PR TITLE
fix(test): isolate Doctor managed runtime files

### DIFF
--- a/src/flows/doctor-health.test-support.ts
+++ b/src/flows/doctor-health.test-support.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
-import { expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createConfigIO } from "../config/io.factory.js";
 import { hashConfigRaw } from "../config/io.read-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -16,11 +17,23 @@ const mocks = vi.hoisted(() => ({
   service: vi.fn(),
   probePortUsage: vi.fn<(typeof import("../infra/ports-probe.js"))["probePortUsage"]>(),
   packageRoot: vi.fn<() => string | undefined>(),
+  runtimeTmpDir: vi.fn<() => string>(),
   restartedHealthy: true,
   emulateNativeInstall: true,
   servicePlatform: undefined as NodeJS.Platform | undefined,
   taskDefinitelyStopped: vi.fn(() => true),
   startupFallbackRuntime: vi.fn<() => Promise<{ status: string } | null>>(async () => null),
+}));
+
+const runtimeDirs = useAutoCleanupTempDirTracker(afterEach);
+beforeEach(() => {
+  mocks.runtimeTmpDir.mockReturnValue(runtimeDirs.make("openclaw-doctor-runtime-"));
+});
+
+// The synthetic manager's leases and locks belong to its private fixture root.
+vi.mock("../infra/tmp-openclaw-dir.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/tmp-openclaw-dir.js")>()),
+  resolvePreferredOpenClawTmpDir: mocks.runtimeTmpDir,
 }));
 
 vi.mock("@clack/prompts", () => ({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Doctor tests emulate a native service manager but still use the process-wide managed-handoff database and service lock directory. Parallel workers can therefore affect these fixtures despite their isolated config and state directories.

## Why This Change Was Made

Give each case a private runtime directory through the existing preferred-temp-root mock pattern used by handoff fixtures. The synthetic manager and the real lease and service-lock owners resolve the same case-owned root, which is removed after consumer teardown. Lease safety checks and production behavior remain unchanged.

## User Impact

Doctor's synthetic-manager tests no longer depend on shared managed runtime files. All existing cases and assertions remain intact.

## Evidence

A controlled, filtered 18-row run verified 18 distinct private directories and actual lease resolver paths before operations, then verified no service lock remained before forwarding real directory removal. All 18 passed and their roots were removed. The temporary observer was removed before final proof.

The normal five consumer suites passed: 120 tests, zero failures or skips, with the 18-row multi-agent table's order preserved. The mapped changed gate and independent review validate the final source.

This adds 13 net test/support lines. The original parallel Linux run's exact unsafe-file stat cause remains unconfirmed; this fixes the demonstrated fixture-isolation gap without weakening the lease guard or claiming a production permissions repair. No unmodified test was run against the operator's shared managed state.
