### PR TITLE
refactor(cli): simplify inference command registration

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2232,7 +2232,7 @@ src/cli/acp-cli.ts	7
 src/cli/attach-cli.ts	3
 src/cli/capability-cli/audio.ts	3
 src/cli/capability-cli/embedding.ts	3
-src/cli/capability-cli/image.ts	12
+src/cli/capability-cli/image.ts	10
 src/cli/capability-cli/model.ts	4
 src/cli/capability-cli/shared.ts	4
 src/cli/capability-cli/tts.ts	6

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -324,57 +324,40 @@ export function registerImageCapabilityCommands(capability: Command): void {
     });
   });
 
-  image
-    .command("describe")
-    .description("Describe one image file")
-    .requiredOption("--file <path>", "Image file")
-    .option("--prompt <text>", "Prompt hint")
-    .option("--model <provider/model>", "Model override")
-    .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
-    .option(
-      "--agent <id>",
-      "Agent whose saved provider auth is used (default: agents.defaults.systemAgent.agentId, then the sole agent)",
-    )
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const result = await runImageDescribe({
-          capability: "image.describe",
-          files: [String(opts.file)],
-          model: opts.model as string | undefined,
-          prompt: opts.prompt as string | undefined,
-          timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
-          agent: resolveCapabilityAgentOption(command, opts.agent),
+  for (const [commandName, description] of [
+    ["describe", "Describe one image file"],
+    ["describe-many", "Describe multiple image files"],
+  ] as const) {
+    const describe = image.command(commandName).description(description);
+    const multiple = commandName === "describe-many";
+    if (multiple) {
+      describe.requiredOption("--file <path>", "Image file", collectOption);
+    } else {
+      describe.requiredOption("--file <path>", "Image file");
+    }
+    describe
+      .option("--prompt <text>", "Prompt hint")
+      .option("--model <provider/model>", "Model override")
+      .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
+      .option(
+        "--agent <id>",
+        "Agent whose saved provider auth is used (default: agents.defaults.systemAgent.agentId, then the sole agent)",
+      )
+      .option("--json", "Output JSON", false)
+      .action(async (opts, command) => {
+        await runCommandWithRuntime(defaultRuntime, async () => {
+          const result = await runImageDescribe({
+            capability: `image.${commandName}`,
+            files: multiple ? (opts.file as string[]) : [String(opts.file)],
+            model: opts.model as string | undefined,
+            prompt: opts.prompt as string | undefined,
+            timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
+            agent: resolveCapabilityAgentOption(command, opts.agent),
+          });
+          emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatEnvelopeForText);
         });
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatEnvelopeForText);
       });
-    });
-
-  image
-    .command("describe-many")
-    .description("Describe multiple image files")
-    .requiredOption("--file <path>", "Image file", collectOption)
-    .option("--prompt <text>", "Prompt hint")
-    .option("--model <provider/model>", "Model override")
-    .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
-    .option(
-      "--agent <id>",
-      "Agent whose saved provider auth is used (default: agents.defaults.systemAgent.agentId, then the sole agent)",
-    )
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const result = await runImageDescribe({
-          capability: "image.describe-many",
-          files: opts.file as string[],
-          model: opts.model as string | undefined,
-          prompt: opts.prompt as string | undefined,
-          timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
-          agent: resolveCapabilityAgentOption(command, opts.agent),
-        });
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatEnvelopeForText);
-      });
-    });
+  }
 
   registerLocalProvidersCommand(
     image,

--- a/src/cli/capability-cli/web.ts
+++ b/src/cli/capability-cli/web.ts
@@ -56,14 +56,7 @@ async function runWebSearchCommand(params: { query: string; provider?: string; l
   });
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer web search",
-    targetIds: scopedTargets.targetIds,
-    ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
-    ...(scopedTargets.forcedActivePaths
-      ? { forcedActivePaths: scopedTargets.forcedActivePaths }
-      : {}),
-    ...(scopedTargets.optionalActivePaths
-      ? { optionalActivePaths: scopedTargets.optionalActivePaths }
-      : {}),
+    ...scopedTargets,
     config: rawConfig,
   });
   const result = await runWebSearch({
@@ -94,14 +87,7 @@ async function runWebFetchCommand(params: { url: string; provider?: string; form
   });
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer web fetch",
-    targetIds: scopedTargets.targetIds,
-    ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
-    ...(scopedTargets.forcedActivePaths
-      ? { forcedActivePaths: scopedTargets.forcedActivePaths }
-      : {}),
-    ...(scopedTargets.optionalActivePaths
-      ? { optionalActivePaths: scopedTargets.optionalActivePaths }
-      : {}),
+    ...scopedTargets,
     config: rawConfig,
   });
   const resolved = resolveWebFetchDefinition({

--- a/src/cli/command-secret-resolution.coverage.test.ts
+++ b/src/cli/command-secret-resolution.coverage.test.ts
@@ -30,6 +30,10 @@ function hasSupportedTargetIdsWiring(source: string): boolean {
     /targetIds:\s*getAgentRuntimeCommandSecretTargetIds\(/m.test(source) ||
     /targetIds:\s*getCapabilityWeb(Fetch|Search)CommandSecretTargetIds\(/m.test(source) ||
     /targetIds:\s*scopedTargets\.targetIds/m.test(source) ||
+    (/\bconst\s+scopedTargets\s*=\s*getCapabilityWeb(?:Fetch|Search)CommandSecretTargets\(/m.test(
+      source,
+    ) &&
+      /\bresolveLocalCapabilityRuntimeConfig\(\{[^}]*\.\.\.scopedTargets\s*[,}]/m.test(source)) ||
     source.includes("collectStatusScanOverview({")
   );
 }
@@ -53,6 +57,15 @@ describe("command secret resolution coverage", () => {
     const source = await readCommandSource("src/cli/capability-cli/shared.ts");
     expect(source).toContain("resolveCommandConfigWithSecrets({");
     expect(source).toMatch(/targetIds:\s*params\.targetIds/m);
+  });
+
+  it("rejects prepared Web target scopes from an unrelated producer", async () => {
+    const source = await readCommandSource("src/cli/capability-cli/web.ts");
+    const unrelatedSource = source.replaceAll(
+      /getCapabilityWeb(?:Fetch|Search)CommandSecretTargets/g,
+      "getUnrelatedCommandSecretTargets",
+    );
+    expect(hasSupportedTargetIdsWiring(unrelatedSource)).toBe(false);
   });
 
   it.each(SECRET_TARGET_CALLSITES)(


### PR DESCRIPTION
## What Problem This Solves

The inference CLI duplicates the registration of single- and multiple-image description commands and repeats its prepared Web secret-target projections. Maintaining those copies creates extra places for command behavior to drift. This is a maintainer-requested cleanup.

## Why This Change Was Made

Share the two image-description registrations in their existing order while retaining separate scalar and collector-bearing `--file` options, and forward the canonical prepared Web target scopes directly. Teach the existing secret-wiring coverage guard to recognize that form only when both the canonical Web producer binding and scope forwarding into the shared resolver are present; a negative case rejects an unrelated producer.

## User Impact

No user-visible behavior change. Command names, help, option order, repeated-file behavior, agent selection, Web secret scopes, runtime error handling, and output remain the same. The final change removes 30 production code lines and adds 12 test code lines, for a net reduction of 18 maintained code lines, with no new runtime helper.

## Evidence

- The same 280 existing capability CLI, lazy-loading, and shared-helper tests passed before and after the production cleanup. That proof is carried forward through the test-only repair by verifying unchanged production source hashes.
- All 18 comparisons using real Commander 15.0.0 registration matched byte-for-byte across `infer` and `capability`, including help, option order, missing files, and repeated scalar/collected files. The production hashes remain unchanged. Selected actions were replaced to isolate parsing; no live inference requests were made.
- The original secret-wiring coverage spec reproduced the hosted failure: 17 of 18 cases passed, with Web scope recognition failing. The corrected complete spec passes all 19 cases, including rejection of an unrelated scope producer. Separate recognition checks reject missing forwarding, forwarding outside the resolver, and missing canonical binding.
- The complete changed-file gate passed over all four paths. The initial assertion-ratchet refusal was corrected by the exact baseline reduction from 12 to 10. Fresh managed P0–P2 review of the full candidate found no actionable findings; formatting and `git diff --check` passed.
- Initial hosted CI failures are preserved: [check-lint-core-2](https://github.com/openclaw/openclaw/actions/runs/34463464478/job/102826682076) failed before lint when a Matrix dependency binary download returned HTTP 500 and its installer raised an error; [checks-node-compact-large-10](https://github.com/openclaw/openclaw/actions/runs/34463464478/job/102826683059) exposed the source-guard recognition failure repaired here. No dependency change or old-head retry was made. The repaired head `f282382f743` passed [CI run 34465786500](https://github.com/openclaw/openclaw/actions/runs/34465786500), including both previously failing jobs.
