### PR TITLE
fix(update): preserve cleanup outcomes and settle terminal results

### DIFF
--- a/docs/cli/update/status-and-history.md
+++ b/docs/cli/update/status-and-history.md
@@ -86,6 +86,18 @@ Doctor also shows warnings from the latest run as historical observations: a lat
 repair may already have resolved them. The existing report and history size limits
 still apply.
 
+A foreground updater publishes its final result after required finalization work
+and its local executor have settled. A late ownership or release failure returns
+an error instead of publishing an earlier success. Existing terminal history is
+not overwritten.
+
+Successful installation verification does not imply that obsolete package backups
+were deleted. If the package owner confirms that only obsolete-backup cleanup is
+pending, JSON, history, and human reports include a warning with the retained path
+and follow-up guidance. Unverified recovery, unreadable backup state, and unknown
+completion failures remain errors. Inspect retained paths before manually removing
+obsolete backups; unresolved recovery material is not eligible for this cleanup.
+
 Gateway clients with `operator.admin` can inspect history:
 
 ```bash

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -243,7 +243,8 @@ export function registerGenerationRecoveryTests(
           after: { version: VERSION },
           verification: { serviceRunning: true, runningVersion: VERSION },
         });
-        expect(completedStatus).toBe("rolled-back");
+        // Cleanup is pre-terminal; rollback is recorded only after completion settles.
+        expect(completedStatus).toBe("running");
         expect(record.downtimeMs).toBeGreaterThanOrEqual(0);
         expect(record.confirmedAtMs).toBeGreaterThanOrEqual(before.stoppedAtMs!);
         expect(renderUpdateRunReport(record).headline).toBe(

--- a/src/cli/update-cli/update-command-post-update-recovery.test.ts
+++ b/src/cli/update-cli/update-command-post-update-recovery.test.ts
@@ -811,7 +811,8 @@ describe("failed package update recovery safety", () => {
       });
       expect(rollback).toHaveBeenCalledOnce();
       expect(complete).toHaveBeenCalledOnce();
-      expect(cleanupStatus).toBe("rolled-back");
+      // Cleanup is pre-terminal; rollback is recorded only after completion settles.
+      expect(cleanupStatus).toBe("running");
       expect(recorded.status).toBe("rolled-back");
       expect(renderUpdateRunReport(recorded).headline).toContain("↩️ OpenClaw update rolled back");
       expect(await fs.readFile(configPath, "utf8")).toBe(original);

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -6,12 +6,11 @@ import {
   buildControlPlaneUpdateRestartHealthPendingResult,
   resolveManagedServiceUpdateFailureExitCode,
 } from "../../infra/update-control-plane-sentinel.js";
-import { finishUpdateRun, recordUpdateRunStep } from "../../infra/update-run-ledger.js";
+import { recordUpdateRunStep } from "../../infra/update-run-ledger.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
 import { formatCliCommand } from "../command-format.js";
-import { printResult } from "./progress.js";
 import { tryWriteCompletionCache } from "./shared.js";
 import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import type { FinishUpdateParams } from "./update-command-finish-types.js";
@@ -31,7 +30,6 @@ import {
   writeControlPlaneUpdateRestartSentinelBestEffort,
 } from "./update-command-result.js";
 import { rollbackFailedUpdate } from "./update-command-rollback.js";
-import { completeUpdateCommandRun } from "./update-command-run.js";
 import { UpdateServiceLoadBoundaryError } from "./update-command-service-load.js";
 import { createWindowsTaskAutoStartGuard } from "./update-command-service-maintenance.js";
 import { GatewayServiceUpdateOwnershipError } from "./update-command-service-plan.js";
@@ -44,6 +42,12 @@ import {
   tryInstallShellCompletion,
   type PreManagedServiceStop,
 } from "./update-command-service.js";
+import {
+  deferUpdateCommandTerminalResult,
+  recordVerifiedUpdatePackageCleanup,
+  publishUpdateCommandTerminalResult,
+  resolveSettledUpdateCommandResult,
+} from "./update-command-terminal.js";
 
 export type { FinishUpdateParams } from "./update-command-finish-types.js";
 
@@ -120,22 +124,25 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
   // Restart can let the new Gateway finish the row before CLI finalization resumes.
   // Store the next action before that handoff, and refresh it if recovery changes the outcome.
   recordNextAction(params.result);
-  const printFinalResult = (input: UpdateRunResult) => {
-    assertCurrent();
-    const nextAction = recordNextAction(input);
-    const run = params.opts.run;
-    const downtimeMs = pendingRestartAtMs === undefined ? completedDowntimeMs : undefined;
-    if (run && rolledBack) {
-      finishUpdateRun(
-        run.runId,
-        { status: "rolled-back", reason: input.reason, after: input.after, downtimeMs },
-        { env: run.env },
-      );
+
+  let pendingResult = params.result;
+  let pendingNotify = true;
+  const publishFinalResult = async (failure?: unknown): Promise<UpdateRunResult> => {
+    const settled = await resolveSettledUpdateCommandResult(params, pendingResult, failure);
+    const result = completedResult(settled.result);
+    if (pendingNotify) {
+      await writeControlPlaneUpdateRestartSentinelBestEffort({
+        meta: params.controlPlaneUpdateSentinelMeta,
+        result,
+        jsonMode: Boolean(params.opts.json),
+      });
     }
-    const result = completeUpdateCommandRun(input, run, downtimeMs);
-    printResult(result, params.opts, { nextAction });
-    return result;
+    return publishUpdateCommandTerminalResult(params, result, {
+      rolledBack: rolledBack && !settled.settlementFailed,
+      downtimeMs: pendingRestartAtMs === undefined ? completedDowntimeMs : undefined,
+    });
   };
+  const deferredTerminal = deferUpdateCommandTerminalResult(params.opts.run, publishFinalResult);
   const recoverFailedResult = async (
     initialResult: UpdateRunResult,
     initialRecoverService: boolean,
@@ -241,6 +248,8 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           }
         : {}),
     });
+    pendingResult = finalResult;
+    pendingNotify = notify;
     if (!restoreFailure) {
       try {
         if (
@@ -318,7 +327,8 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
       );
     }
     recordNextAction(finalResult);
-    if (notify) {
+    if (notify && recoverService) {
+      pendingNotify = false;
       await writeControlPlaneUpdateRestartSentinelBestEffort({
         meta: params.controlPlaneUpdateSentinelMeta,
         result: finalResult,
@@ -357,18 +367,16 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         (finalResult.recovery?.serviceRestartSafe === true &&
           finalResult.recovery.service === "healthy"),
     );
-    // Only recovery advances the outcome after persistence; ordinary reports share one snapshot.
-    const reportedResult = printFinalResult(
-      recoverService ? completedResult(finalResult) : finalResult,
-    );
     assertCurrent();
-    if (retireBackup) {
-      await params.packageTransaction
-        ?.complete({ activationVerified: finalResult.status === "ok" }, assertCurrent)
-        .catch((error: unknown) => {
-          assertCurrent();
-          defaultRuntime.error(`Update backup cleanup failed: ${formatErrorMessage(error)}`);
-        });
+    const cleanupFailure = retireBackup
+      ? await recordVerifiedUpdatePackageCleanup(params, finalResult, assertCurrent)
+      : undefined;
+    assertCurrent();
+    pendingResult = completedResult(cleanupFailure?.result ?? finalResult);
+    const reportedResult = deferredTerminal ? pendingResult : await publishFinalResult();
+    if (cleanupFailure) {
+      const { detail } = cleanupFailure;
+      throw new UpdateCommandFailure(reportedResult, 1, detail, { cause: cleanupFailure });
     }
     if (restoreFailure) {
       // Persist the unsafe outcome before unwinding. Keep both failures for

--- a/src/cli/update-cli/update-command-result.ts
+++ b/src/cli/update-cli/update-command-result.ts
@@ -126,7 +126,7 @@ export class UpdateCommandPendingRecoveryFailure extends UpdateCommandFailure {
   }
 }
 
-/** Reporting-only marker: the durable finalizer already committed and printed the outcome. */
+/** Reporting-only marker: the outcome was recorded and printed; no follow-up triage. */
 export class UpdateCommandFinalizedRecoveryFailure extends UpdateCommandFailure {
   constructor(result: UpdateRunResult) {
     super(result, 1);

--- a/src/cli/update-cli/update-command-terminal-outcome.test.ts
+++ b/src/cli/update-cli/update-command-terminal-outcome.test.ts
@@ -1,0 +1,622 @@
+import syncFs from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { writePackageRoot } from "../../infra/package-update-steps.test-support.js";
+import {
+  swapStagedPackageInstall,
+  type PackageUpdateTransaction,
+} from "../../infra/package-update-swap.js";
+import {
+  createPackageSwapFixture,
+  createRetainedPackageSwap,
+} from "../../infra/package-update-swap.test-support.js";
+import * as temporaryRoot from "../../infra/tmp-openclaw-dir.js";
+import { createManagedHandoffLeaseStore } from "../../infra/update-managed-service-handoff-lease.js";
+import { prepareNativePackageStage } from "../../infra/update-native-package-stage.js";
+import { createUpdateRun, finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import { renderUpdateRunReport } from "../../infra/update-run-report.js";
+import type { UpdateStepResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { UpdateCommandOptions } from "./shared.js";
+import { withUpdateCommandExecutor } from "./update-command-executor.js";
+import {
+  finishSuccessfulPackageSwitch,
+  validConfigSnapshot,
+} from "./update-command-post-update.test-support.js";
+import {
+  UpdateCommandFailure,
+  UpdateCommandPendingRecoveryFailure,
+} from "./update-command-result.js";
+import { withUpdateCommandTerminalResult } from "./update-command-terminal.js";
+import { withUpdateFailureTriage } from "./update-command-triage.js";
+
+// Keep the finalizer, swap/completion, executor, SQLite lease, ledger, and both
+// report consumers real. Unrelated plugin/native work has already succeeded.
+vi.mock("./update-command-convergence.js", () => ({
+  convergeUpdatePlugins: async (params: { result: unknown }) => ({
+    resultWithPostUpdate: params.result,
+    postUpdateConfigSnapshot: validConfigSnapshot,
+  }),
+}));
+vi.mock("./update-command-restart-context.js", () => ({
+  prepareUpdateRestart: async () => ({ serviceMutationAllowed: false }),
+}));
+vi.mock("./update-command-service.js", async (original) => ({
+  ...(await original<typeof import("./update-command-service.js")>()),
+  maybeRestartService: async () => "ok",
+  tryInstallShellCompletion: async () => undefined,
+}));
+vi.mock("./shared.js", async (original) => ({
+  ...(await original<typeof import("./shared.js")>()),
+  tryWriteCompletionCache: async () => undefined,
+}));
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+let base: string;
+let temporary: string;
+let jsonOutput: unknown[];
+let humanOutput: string[];
+beforeEach(async () => {
+  base = await fs.realpath(dirs.make("update-terminal-outcome-"));
+  temporary = path.join(base, "private-tmp");
+  await fs.mkdir(temporary, { mode: 0o700 });
+  vi.spyOn(temporaryRoot, "resolvePreferredOpenClawTmpDir").mockReturnValue(temporary);
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(base, "state"));
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(base, "state", "openclaw.json"));
+  vi.stubEnv("OPENCLAW_UPDATE_RUN_HANDOFF", "");
+  jsonOutput = [];
+  humanOutput = [];
+  vi.spyOn(defaultRuntime, "writeJson").mockImplementation((value) => {
+    jsonOutput.push(structuredClone(value));
+  });
+  vi.spyOn(defaultRuntime, "log").mockImplementation((value) => {
+    humanOutput.push(String(value));
+  });
+  vi.spyOn(defaultRuntime, "error").mockImplementation((value) => {
+    humanOutput.push(String(value));
+  });
+});
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+async function createNativeRefusalSwap() {
+  const project = path.join(base, "native", "global");
+  const globalRoot = path.join(project, "5", "node_modules");
+  const packageRoot = path.join(globalRoot, "openclaw");
+  const binDir = path.join(base, "native", "bin");
+  await writePackageRoot(packageRoot, "1.0.0");
+  await fs.mkdir(binDir, { recursive: true });
+  const manifest = path.join(project, "package.json");
+  await fs.writeFile(manifest, '{"dependencies":{"openclaw":"1.0.0"}}');
+  const launcher = path.join(binDir, "openclaw");
+  await fs.writeFile(launcher, "old launcher\n");
+  const installTarget = { manager: "pnpm" as const, command: "pnpm", globalRoot, packageRoot };
+  const native = await prepareNativePackageStage({
+    installTarget,
+    packageName: "openclaw",
+    installSpec: "openclaw@2.0.0",
+    globalBinDir: binDir,
+    env: {},
+  });
+  if (!native) {
+    throw new Error("native fixture stage unavailable");
+  }
+  const candidate = path.join(native.projectRoot, path.relative(project, packageRoot));
+  await writePackageRoot(candidate, "2.0.0");
+  await fs.writeFile(path.join(native.binDir, "openclaw"), "candidate launcher\n");
+  let transaction: PackageUpdateTransaction | undefined;
+  const result = await swapStagedPackageInstall({
+    installTarget,
+    packageName: "openclaw",
+    stage: {
+      prefix: native.projectRoot,
+      layout: { prefix: native.projectRoot, globalRoot: native.globalRoot, binDir: native.binDir },
+      packageRoot: candidate,
+      installTarget: { ...installTarget, globalRoot: native.globalRoot, packageRoot: candidate },
+      native,
+    },
+    onTransaction: (value) => {
+      transaction = value;
+    },
+  });
+  if (!transaction || result.status !== "committed") {
+    throw new Error(`native fixture swap failed: ${result.step.stderrTail}`);
+  }
+  return { packageRoot, globalRoot, launcher, transaction, manifest, result };
+}
+
+async function scenario(
+  kind:
+    | "healthy"
+    | "renamed"
+    | "retained"
+    | "release-failure"
+    | "revoked"
+    | "foreign-revoked"
+    | "link-retained"
+    | "link-retained-once"
+    | "link-authority-read"
+    | "last-cleanup-read"
+    | "link-changed"
+    | "transient-read"
+    | "cleanup-read"
+    | "unverified-completion"
+    | "rollback-refused",
+  json: boolean,
+  repeat = false,
+  deferred = true,
+) {
+  let swap;
+  let nativeManifest: string | undefined;
+  let prerequisiteResult: unknown;
+  let setupInjected = false;
+  if (kind === "rollback-refused") {
+    const native = await createNativeRefusalSwap();
+    nativeManifest = native.manifest;
+    swap = native;
+  } else if (kind === "unverified-completion") {
+    const fixture = await createPackageSwapFixture(base);
+    const rename = fs.rename.bind(fs);
+    const effect = vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+      if (String(args[0]) === fixture.packageRoot) {
+        setupInjected = true;
+        throw Object.assign(new Error("fixture publication move denied"), { code: "EXDEV" });
+      }
+      return rename(...args);
+    });
+    let transaction: PackageUpdateTransaction | undefined;
+    let result;
+    try {
+      result = await swapStagedPackageInstall({
+        ...fixture.params,
+        onTransaction: (value) => {
+          transaction = value;
+        },
+      });
+    } finally {
+      effect.mockRestore();
+    }
+    if (!transaction || result.status !== "failed") {
+      throw new Error("unverified fixture did not retain its failed transaction");
+    }
+    prerequisiteResult = result;
+    swap = { ...fixture, transaction, result };
+  } else if (
+    [
+      "link-retained",
+      "link-retained-once",
+      "link-authority-read",
+      "link-changed",
+      "transient-read",
+    ].includes(kind)
+  ) {
+    const fixture = await createPackageSwapFixture(base);
+    const checkout = path.join(base, "operator-checkout");
+    await fs.rename(fixture.packageRoot, checkout);
+    await fs.symlink(
+      checkout,
+      fixture.packageRoot,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    let transaction: PackageUpdateTransaction | undefined;
+    const result = await swapStagedPackageInstall({
+      ...fixture.params,
+      onTransaction: (value) => {
+        transaction = value;
+      },
+    });
+    if (!transaction || result.status !== "committed") {
+      throw new Error("linked swap failed");
+    }
+    swap = { ...fixture, result, transaction };
+  } else {
+    swap = await createRetainedPackageSwap(base);
+  }
+  const run: NonNullable<UpdateCommandOptions["run"]> = {
+    runId: createUpdateRun({ trigger: "cli" }, { env: process.env }).runId,
+    env: { ...process.env },
+  };
+  const rm = fs.rm.bind(fs);
+  const rename = fs.rename.bind(fs);
+  const unlink = fs.unlink.bind(fs);
+  const readlink = fs.readlink.bind(fs);
+  const shimBackup = (await fs.readdir(swap.globalRoot)).find((entry) =>
+    entry.startsWith(".openclaw.shim-backup-"),
+  );
+  const finalCleanupRoot = shimBackup && path.join(swap.globalRoot, shimBackup);
+  const mutateLease = (sql: string) => {
+    const db = new DatabaseSync(path.join(temporary, "managed-update-handoffs.sqlite"));
+    try {
+      db.exec(sql);
+    } finally {
+      db.close();
+    }
+  };
+  let injected = setupInjected;
+  let failNextLeaseRead = false;
+  const lstat = syncFs.lstatSync.bind(syncFs);
+  vi.spyOn(syncFs, "lstatSync").mockImplementation((...args) => {
+    if (
+      failNextLeaseRead &&
+      String(args[0]) === path.join(temporary, "managed-update-handoffs.sqlite")
+    ) {
+      failNextLeaseRead = false;
+      injected = true;
+      throw Object.assign(new Error("fixture transient lease metadata read failure"), {
+        code: "EIO",
+      });
+    }
+    return lstat(...args);
+  });
+  if (kind === "link-changed") {
+    const other = path.join(base, "replacement-checkout");
+    await fs.mkdir(other);
+    await unlink(swap.transaction.backupRoot);
+    await fs.symlink(
+      other,
+      swap.transaction.backupRoot,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    injected = true;
+  }
+  vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+    if (String(args[0]) === swap.transaction.backupRoot) {
+      if (kind === "renamed" || kind === "retained") {
+        injected = true;
+        throw Object.assign(new Error("fixture obsolete backup deletion denied"), {
+          code: "EACCES",
+        });
+      }
+      await rm(...args);
+      if (kind === "cleanup-read") {
+        failNextLeaseRead = true;
+      }
+      if (kind === "revoked" || kind === "foreign-revoked") {
+        injected = true;
+        mutateLease("UPDATE managed_update_handoffs SET owner = 'replacement'");
+        if (kind === "foreign-revoked") {
+          finishUpdateRun(
+            run.runId,
+            { status: "failed", reason: "foreign-terminal-fact" },
+            { env: run.env },
+          );
+        }
+      }
+      return;
+    }
+    await rm(...args);
+    if (kind === "last-cleanup-read" && String(args[0]) === finalCleanupRoot) {
+      failNextLeaseRead = true;
+    }
+  });
+  vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+    if (kind === "retained" && String(args[0]) === swap.transaction.backupRoot) {
+      throw Object.assign(new Error("fixture fallback rename denied"), { code: "EACCES" });
+    }
+    return rename(...args);
+  });
+  vi.spyOn(fs, "unlink").mockImplementation(async (...args) => {
+    if (
+      (kind === "link-retained" || (kind === "link-retained-once" && !injected)) &&
+      String(args[0]) === swap.transaction.backupRoot
+    ) {
+      injected = true;
+      throw Object.assign(new Error("fixture obsolete link deletion denied"), { code: "EACCES" });
+    }
+    await unlink(...args);
+    if (kind === "transient-read" && String(args[0]) === swap.transaction.backupRoot) {
+      // The real lease owner next reads its real DB path once; its subsequent
+      // reads recover. No executor or transaction method is replaced.
+      failNextLeaseRead = true;
+    }
+  });
+  vi.spyOn(fs, "readlink").mockImplementation(async (...args) => {
+    const value = await readlink(...args);
+    if (
+      kind === "link-authority-read" &&
+      !injected &&
+      String(args[0]) === swap.transaction.backupRoot
+    ) {
+      failNextLeaseRead = true;
+    }
+    return value;
+  });
+  let repeatedCompletion: UpdateStepResult | void = undefined;
+  let repeatedFailure: string | undefined;
+  let failure: unknown;
+  const execute = () =>
+    withUpdateCommandExecutor(run.runId, async (executor) => {
+      run.executorFence = await executor.enter(swap.packageRoot);
+      if (nativeManifest) {
+        await fs.writeFile(
+          nativeManifest,
+          '{"dependencies":{"openclaw":"2.0.0","sibling":"3.0.0"}}',
+        );
+        injected = true;
+        prerequisiteResult = await swap.transaction.rollback(() =>
+          run.executorFence!.assertCurrent(),
+        );
+      }
+      try {
+        await finishSuccessfulPackageSwitch(
+          { packageRoot: swap.packageRoot, run, json },
+          {
+            result: {
+              status: "ok",
+              mode: "npm",
+              root: swap.packageRoot,
+              before: { version: "1.0.0" },
+              after: { version: "2.0.0" },
+              steps: [],
+              durationMs: 0,
+            },
+            packageTransaction: swap.transaction,
+            shouldRestart: false,
+            installKindChanged: false,
+            downgradeRisk: false,
+          },
+        );
+      } finally {
+        if (repeat) {
+          try {
+            repeatedCompletion = await swap.transaction.complete({ activationVerified: true }, () =>
+              run.executorFence!.assertCurrent(),
+            );
+          } catch (error) {
+            repeatedFailure = error instanceof Error ? error.message : String(error);
+          }
+        }
+      }
+      if (kind === "release-failure") {
+        injected = true;
+        // A persistent trigger affects only this disposable lease database and
+        // only the final DELETE. Acquisition and current-owner reads stay real.
+        mutateLease(
+          "CREATE TRIGGER deny_terminal_release BEFORE DELETE ON managed_update_handoffs BEGIN SELECT RAISE(FAIL, 'fixture final lease delete denied'); END",
+        );
+      }
+    });
+  try {
+    if (deferred) {
+      await withUpdateCommandTerminalResult(run, execute);
+    } else {
+      await execute();
+    }
+  } catch (error) {
+    failure = error;
+  }
+  if (kind === "foreign-revoked" && failure instanceof UpdateCommandPendingRecoveryFailure) {
+    vi.spyOn(defaultRuntime, "exit").mockImplementation(() => {
+      throw new Error("fixture CLI exit");
+    });
+    await withUpdateFailureTriage(
+      { json, yes: true, run },
+      { root: swap.packageRoot, env: run.env },
+      async () => {
+        throw failure;
+      },
+    ).catch(() => undefined);
+  }
+  const retainedName = path
+    .basename(swap.transaction.backupRoot)
+    .replace(/^\.openclaw\./, ".openclaw-");
+  const expectedRetained =
+    kind === "renamed" ? path.join(swap.globalRoot, retainedName) : swap.transaction.backupRoot;
+  const retainedExists = await fs.stat(expectedRetained).then(
+    () => true,
+    () => false,
+  );
+  const history = getUpdateRun(run.runId, { env: run.env });
+  const report = history ? renderUpdateRunReport(history).markdown : "missing history";
+  const beforeRepeat = structuredClone(history);
+  finishUpdateRun(
+    run.runId,
+    { status: "failed", reason: "late conflicting outcome" },
+    { env: run.env },
+  );
+  const afterRepeat = getUpdateRun(run.runId, { env: run.env });
+  const observations = {
+    kind,
+    json,
+    deferred,
+    injected,
+    repeatedCompletion,
+    repeatedFailure,
+    prerequisiteResult,
+    exitCode: failure instanceof UpdateCommandFailure ? failure.exitCode : failure ? 1 : 0,
+    failure: failure instanceof Error ? failure.message : failure,
+    expectedRetained,
+    retainedExists,
+    package: JSON.parse(await fs.readFile(path.join(swap.packageRoot, "package.json"), "utf8")),
+    launcher: await fs.readFile(swap.launcher, "utf8"),
+    jsonOutput,
+    humanOutput,
+    history,
+    report,
+    beforeRepeat,
+    afterRepeat,
+    lease: createManagedHandoffLeaseStore().read(swap.packageRoot).kind,
+  };
+  const evidence = process.env.OPENCLAW_TERMINAL_PROOF_DIR;
+  if (evidence) {
+    await fs.mkdir(evidence, { recursive: true });
+    await fs.writeFile(
+      path.join(
+        evidence,
+        `${kind}-${json ? "json" : "human"}${repeat ? "-repeat" : ""}${deferred ? "" : "-direct"}.json`,
+      ),
+      JSON.stringify(observations, null, 2),
+    );
+  }
+  return { ...observations, swap, run };
+}
+
+describe("composed cleanup and terminal outcome", () => {
+  it.each([true, false])(
+    "reports actual retained backup after verified activation (json=%s)",
+    async (json) => {
+      const value = await scenario("renamed", json);
+      expect(value.injected).toBe(true);
+      expect(value.package.version).toBe("2.0.0");
+      expect(value.launcher).toBe("candidate launcher\n");
+      expect(value.exitCode).toBe(0);
+      expect(value.retainedExists).toBe(true);
+      expect(value.history?.status).toBe("succeeded");
+      const output = json ? JSON.stringify(value.jsonOutput) : value.humanOutput.join("\n");
+      expect(output).toContain(value.expectedRetained);
+      expect(JSON.stringify(value.history)).toContain(value.expectedRetained);
+      expect(value.report).toContain(value.expectedRetained);
+      expect(value.afterRepeat).toEqual(value.beforeRepeat);
+    },
+  );
+  it.each([true, false])(
+    "reports original backup when fallback rename is denied (json=%s)",
+    async (json) => {
+      const value = await scenario("retained", json);
+      expect(value.injected).toBe(true);
+      expect(value.retainedExists).toBe(true);
+      expect(value.exitCode).toBe(0);
+      const output = json ? JSON.stringify(value.jsonOutput) : value.humanOutput.join("\n");
+      expect(output).toContain(value.expectedRetained);
+      expect(JSON.stringify(value.history)).toContain(value.expectedRetained);
+      expect(value.report).toContain(value.expectedRetained);
+      expect(value.afterRepeat).toEqual(value.beforeRepeat);
+    },
+  );
+  it.each(["renamed", "retained"] as const)(
+    "keeps repeated completion truthful for %s backup",
+    async (kind) => {
+      const value = await scenario(kind, true, true);
+      expect(value.retainedExists).toBe(true);
+      expect(value.repeatedCompletion).toMatchObject({
+        exitCode: 1,
+        stderrTail: expect.stringContaining(value.expectedRetained),
+      });
+    },
+  );
+  it("caches the first link-retirement outcome after a one-shot deletion failure", async () => {
+    const value = await scenario("link-retained-once", true, true);
+    expect(value.injected).toBe(true);
+    expect(value.repeatedCompletion).toMatchObject({ exitCode: 1 });
+    expect(value.retainedExists).toBe(true);
+    expect(value.exitCode).toBe(1);
+    expect(value.jsonOutput).toHaveLength(1);
+    expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+    expect(value.afterRepeat).toEqual(value.beforeRepeat);
+  });
+  it.each(["link-authority-read", "last-cleanup-read"] as const)(
+    "caches the first retirement authority failure for %s",
+    async (kind) => {
+      const value = await scenario(kind, true, true);
+      expect(value.injected).toBe(true);
+      expect(value.repeatedFailure).toBeDefined();
+      expect(value.exitCode).toBe(1);
+      expect(value.jsonOutput).toHaveLength(1);
+      expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+      expect(value.history?.status).toBe("failed");
+      expect(value.afterRepeat).toEqual(value.beforeRepeat);
+      expect(value.retainedExists).toBe(kind === "link-authority-read");
+    },
+  );
+  it("keeps unqualified link retirement failure hard without deleting its checkout", async () => {
+    const value = await scenario("link-retained", true);
+    expect(value.injected).toBe(true);
+    expect(value.exitCode).toBe(1);
+    expect(value.history?.status).toBe("failed");
+    expect(value.jsonOutput).toHaveLength(1);
+    expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+    expect(value.retainedExists).toBe(true);
+    expect(JSON.stringify(value.jsonOutput)).toContain(value.expectedRetained);
+    // Hard failures use the canonical bounded summary; JSON above retains the full path.
+    expect(JSON.stringify(value.history)).toContain(path.basename(value.expectedRetained));
+    expect(value.report).toContain(path.basename(value.expectedRetained));
+    expect(
+      JSON.parse(await fs.readFile(path.join(base, "operator-checkout", "package.json"), "utf8"))
+        .version,
+    ).toBe("1.0.0");
+  });
+  it.each([
+    "unverified-completion",
+    "rollback-refused",
+    "link-changed",
+    "transient-read",
+    "cleanup-read",
+  ] as const)("keeps producer-qualification failure hard for %s", async (kind) => {
+    const value = await scenario(kind, true);
+    expect(value.injected).toBe(true);
+    if (kind === "rollback-refused") {
+      expect(value.prerequisiteResult).toMatchObject({
+        exitCode: 1,
+        reason: "rollback-project-changed",
+      });
+      expect(value.retainedExists).toBe(true);
+      expect(value.package.version).toBe("2.0.0");
+    }
+    if (kind === "unverified-completion") {
+      expect(value.prerequisiteResult).toMatchObject({ status: "failed" });
+      expect(value.package.version).toBe("1.0.0");
+    }
+    expect(value.exitCode).toBe(1);
+    expect(value.jsonOutput).toHaveLength(1);
+    expect(value.jsonOutput[0]).toMatchObject({
+      status: "error",
+      steps: expect.not.arrayContaining([expect.objectContaining({ advisory: expect.anything() })]),
+    });
+    expect(value.history?.status).toBe("failed");
+    expect(value.afterRepeat).toEqual(value.beforeRepeat);
+  });
+  it("publishes the hard completion result through the direct finalizer fallback", async () => {
+    const value = await scenario("unverified-completion", true, false, false);
+    expect(value.exitCode).toBe(1);
+    expect(value.jsonOutput).toHaveLength(1);
+    expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+    expect(value.history?.status).toBe("failed");
+    expect(value.afterRepeat).toEqual(value.beforeRepeat);
+  });
+  it.each(["release-failure", "revoked"] as const)(
+    "publishes one failed outcome after %s",
+    async (kind) => {
+      const value = await scenario(kind, true);
+      expect(value.injected).toBe(true);
+      expect(value.exitCode).toBe(1);
+      expect(value.package.version).toBe("2.0.0");
+      expect(value.jsonOutput).toHaveLength(1);
+      expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+      expect(value.history?.status).toBe("failed");
+      expect(value.report.toLowerCase()).toContain("failed");
+      expect(value.afterRepeat).toEqual(value.beforeRepeat);
+    },
+  );
+  it("preserves foreign terminal history and emits only the pending failure", async () => {
+    const value = await scenario("foreign-revoked", true);
+    expect(value.exitCode).toBe(1);
+    expect(value.jsonOutput).toHaveLength(1);
+    expect(value.jsonOutput[0]).toMatchObject({ status: "error" });
+    expect(value.history).toMatchObject({ status: "failed", reason: "foreign-terminal-fact" });
+    expect(value.afterRepeat).toEqual(value.beforeRepeat);
+  });
+  it.each([true, false])(
+    "keeps healthy cleanup and terminal output consistent (json=%s)",
+    async (json) => {
+      const value = await scenario("healthy", json);
+      expect(value.exitCode).toBe(0);
+      expect(value.retainedExists).toBe(false);
+      expect(value.history?.status).toBe("succeeded");
+      expect(value.lease).toBe("absent");
+      if (json) {
+        expect(value.jsonOutput).toHaveLength(1);
+        expect(value.jsonOutput[0]).toMatchObject({ status: "ok" });
+      } else {
+        expect(value.humanOutput.join("\n").toLowerCase()).toContain("updated");
+      }
+      expect(value.afterRepeat).toEqual(value.beforeRepeat);
+    },
+  );
+});

--- a/src/cli/update-cli/update-command-terminal-triage.test.ts
+++ b/src/cli/update-cli/update-command-terminal-triage.test.ts
@@ -1,0 +1,257 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { hasErrnoCode } from "../../infra/errno.js";
+import * as temporaryRoot from "../../infra/tmp-openclaw-dir.js";
+import { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } from "../../infra/update-control-plane-sentinel.js";
+import { createManagedHandoffLeaseStore } from "../../infra/update-managed-service-handoff-lease.js";
+import { MANAGED_HANDOFF_RUNTIME_ENTRY } from "../../infra/update-managed-service-handoff-runtime-assets.js";
+import { stageManagedHandoffRuntime } from "../../infra/update-managed-service-handoff-runtime.js";
+import { createUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime, ExitError } from "../../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { UpdateCommandOptions } from "./shared.js";
+import { withUpdateCommandExecutor } from "./update-command-executor.js";
+import {
+  UpdateCommandFailure,
+  UpdateCommandPendingRecoveryFailure,
+} from "./update-command-result.js";
+import {
+  deferUpdateCommandTerminalResult,
+  publishUpdateCommandTerminalResult,
+  resolveSettledUpdateCommandResult,
+  withUpdateCommandTerminalResult,
+} from "./update-command-terminal.js";
+import { withUpdateFailureTriage } from "./update-command-triage.js";
+import { withUpdateCommandRecoveryUnwind } from "./update-command-unwind.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it.each([
+  { name: "revoked-absent", revoked: true, existing: false },
+  { name: "revoked-existing", revoked: true, existing: true },
+  { name: "authorized-failure", revoked: false, existing: true },
+])("preserves settled managed failure disposition: $name", async (trial) => {
+  const root = await fs.realpath(dirs.make("update-terminal-triage-"));
+  const temporary = path.join(root, "private-tmp");
+  const diagnosticDir = path.join(root, "diagnostics");
+  await fs.mkdir(temporary, { mode: 0o700 });
+  await fs.mkdir(diagnosticDir, { mode: 0o700 });
+  // Only choose disposable state. Executor admission, process identities, ledger,
+  // publication, outer triage and the atomic diagnostic writer remain real.
+  vi.spyOn(temporaryRoot, "resolvePreferredOpenClawTmpDir").mockReturnValue(temporary);
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(root, "state", "openclaw.json"));
+  vi.stubEnv("OPENCLAW_UPDATE_RUN_HANDOFF", "1");
+  const metadata = path.join(root, "handoff.json");
+  vi.stubEnv(CONTROL_PLANE_UPDATE_SENTINEL_META_ENV, metadata);
+  const env = { ...process.env };
+  const run: NonNullable<UpdateCommandOptions["run"]> = {
+    runId: createUpdateRun({ trigger: "cli" }, { env }).runId,
+    env,
+  };
+  const owner = randomUUID();
+  const artifact = path.join(diagnosticDir, "update-failure.json");
+  const previous = '{"retained":"original diagnostic"}\n';
+  if (trial.existing) {
+    await fs.writeFile(artifact, previous, { mode: 0o600 });
+  }
+  const priorStat = trial.existing ? await fs.stat(artifact) : undefined;
+  await fs.writeFile(
+    metadata,
+    JSON.stringify({
+      version: 1,
+      meta: { runId: run.runId, handoffId: owner, root, triageContextPath: artifact },
+    }),
+  );
+  stageManagedHandoffRuntime(root);
+  const runtimeEntry = path.join(root, "runtime", MANAGED_HANDOFF_RUNTIME_ENTRY);
+  const databasePath = path.join(temporary, "managed-update-handoffs.sqlite");
+  const leaseOptions = {
+    databasePath,
+    serviceManagerEnv: { PATH: process.env.PATH, SystemRoot: process.env.SystemRoot },
+  };
+  // The helper really acquires and assigns the lease; no borrowed-owner method is mocked.
+  const helper = spawn(
+    process.execPath,
+    [
+      "-e",
+      `
+      const {createManagedHandoffLeaseStore}=require(${JSON.stringify(runtimeEntry)});
+      const store=createManagedHandoffLeaseStore(${JSON.stringify(leaseOptions)});
+      const acquired=store.acquire(${JSON.stringify(root)},${JSON.stringify(owner)},{kind:"update"});
+      if(acquired.kind!=="acquired")throw new Error("helper admission failed");
+      if(!store.bind(acquired.lease,${process.pid}))throw new Error("helper assignment failed");
+      process.once("message",()=>{
+        const current=store.read(${JSON.stringify(root)});
+        const local=current.kind==="current"&&store.bind(current.lease,process.pid);
+        if(!local||!store.release(local))throw new Error("helper release failed");
+        process.disconnect();
+      });
+      process.send("assigned");
+      `,
+    ],
+    { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+  );
+  const exited = once(helper, "exit");
+  let stderr = "";
+  helper.stderr?.on("data", (data) => {
+    stderr += String(data);
+  });
+  try {
+    const ready = await Promise.race([
+      once(helper, "message").then(([message]) => message),
+      exited.then(() => {
+        throw new Error(`helper exited before assignment: ${stderr}`);
+      }),
+    ]);
+    expect(ready).toBe("assigned");
+    const store = createManagedHandoffLeaseStore();
+    const assigned = store.read(root);
+    expect(assigned).toMatchObject({
+      kind: "current",
+      lease: { owner, helper: { pid: helper.pid }, executor: { pid: process.pid } },
+    });
+    const output = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
+    vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+    vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    // These spies call through to the real filesystem, including atomic temp creation.
+    const opened = vi.spyOn(fs, "open");
+    const renamed = vi.spyOn(fs, "rename");
+    const result: UpdateRunResult = {
+      status: "error",
+      mode: "npm",
+      root,
+      reason: "global-install-failed",
+      steps: [],
+      durationMs: 1,
+    };
+    const opts = { json: true, yes: true, run };
+    const target = { root, env };
+    let statusAtPublication: string | undefined;
+    let pendingAtPublication = false;
+    let exit: unknown;
+    await withUpdateFailureTriage(opts, target, () =>
+      withUpdateCommandTerminalResult(run, () =>
+        withUpdateCommandExecutor(run.runId, async (executor) => {
+          run.executorFence = await executor.enter(root);
+          await withUpdateCommandRecoveryUnwind(opts, { triageTarget: target }, async () => {
+            expect(
+              deferUpdateCommandTerminalResult(run, async (failure) => {
+                statusAtPublication = getUpdateRun(run.runId, { env })?.status;
+                pendingAtPublication = failure instanceof UpdateCommandPendingRecoveryFailure;
+                const settled = await resolveSettledUpdateCommandResult(
+                  { opts, root },
+                  result,
+                  failure,
+                );
+                return publishUpdateCommandTerminalResult({ opts }, settled.result, {
+                  rolledBack: false,
+                });
+              }),
+            ).toBe(true);
+            run.executorFence!.assertCurrent();
+            if (trial.revoked) {
+              const db = new DatabaseSync(databasePath);
+              try {
+                db.prepare(
+                  "UPDATE managed_update_handoffs SET owner = ? WHERE install_root = ?",
+                ).run("replacement-owner", root);
+              } finally {
+                db.close();
+              }
+            }
+            throw new UpdateCommandFailure(result, 7, "fixture package failure");
+          });
+        }),
+      ),
+    ).catch((error: unknown) => {
+      exit = error;
+    });
+    const after = await fs.readFile(artifact, "utf8").catch((error: unknown) => {
+      if (hasErrnoCode(error, "ENOENT")) {
+        return null;
+      }
+      throw error;
+    });
+    const afterStat = after === null ? undefined : await fs.stat(artifact);
+    const artifactOpens = opened.mock.calls.filter(
+      ([file, flags]) => path.dirname(String(file)) === diagnosticDir && flags === "wx",
+    ).length;
+    const artifactRenames = renamed.mock.calls.filter(
+      ([, destination]) => String(destination) === artifact,
+    ).length;
+    const recorded = getUpdateRun(run.runId, { env });
+    const observation = {
+      name: trial.name,
+      statusAtPublication,
+      pendingAtPublication,
+      exitCode: exit instanceof ExitError ? exit.code : null,
+      reports: output.mock.calls.map(([value]) => value),
+      artifactBefore: trial.existing ? previous : null,
+      artifactAfter: after,
+      artifactOpens,
+      artifactRenames,
+      recorded,
+      artifactIdentityUnchanged:
+        priorStat && afterStat
+          ? priorStat.ino === afterStat.ino && priorStat.mtimeMs === afterStat.mtimeMs
+          : undefined,
+      leaseAfter: store.read(root),
+    };
+    const evidence = process.env.OPENCLAW_TERMINAL_TRIAGE_PROOF_DIR;
+    if (evidence) {
+      await fs.mkdir(evidence, { recursive: true });
+      await fs.writeFile(
+        path.join(evidence, `${trial.name}.json`),
+        JSON.stringify(observation, null, 2),
+      );
+    }
+    expect(exit).toBeInstanceOf(ExitError);
+    expect(observation.exitCode).toBe(trial.revoked ? 1 : 7);
+    expect(statusAtPublication).toBe("running");
+    expect(pendingAtPublication).toBe(trial.revoked);
+    expect(output).toHaveBeenCalledOnce();
+    expect(output.mock.calls[0]?.[0]).toMatchObject({
+      status: "error",
+      reason: trial.revoked ? "update-executor-settlement-failed" : "global-install-failed",
+    });
+    expect(recorded?.status).toBe("failed");
+    // The borrowed invocation never releases the helper's lease, including after revocation.
+    expect(observation.leaseAfter).toMatchObject({
+      kind: "current",
+      lease: { owner: trial.revoked ? "replacement-owner" : owner },
+    });
+    if (trial.revoked) {
+      expect(artifactOpens).toBe(0);
+      expect(artifactRenames).toBe(0);
+      expect(after).toBe(trial.existing ? previous : null);
+      if (trial.existing) {
+        expect(observation.artifactIdentityUnchanged).toBe(true);
+      }
+    } else {
+      expect(artifactOpens).toBe(1);
+      expect(artifactRenames).toBe(1);
+      expect(JSON.parse(after!)).toMatchObject({
+        result: { status: "error", reason: result.reason },
+      });
+    }
+  } finally {
+    if (helper.connected) {
+      helper.send("release");
+    }
+    const [code] = await exited;
+    expect(code, stderr).toBe(0);
+  }
+});

--- a/src/cli/update-cli/update-command-terminal.ts
+++ b/src/cli/update-cli/update-command-terminal.ts
@@ -8,6 +8,7 @@ import type { FinishUpdateParams } from "./update-command-finish-types.js";
 import {
   recordUpdateResultNextAction,
   UpdateCommandFailure,
+  UpdateCommandFinalizedRecoveryFailure,
   UpdateCommandPendingRecoveryFailure,
 } from "./update-command-result.js";
 import { completeUpdateCommandRun } from "./update-command-run.js";
@@ -52,6 +53,10 @@ export async function withUpdateCommandTerminalResult<T>(
     const result = await owner.publish("error" in outcome ? outcome.error : undefined);
     if ("error" in outcome) {
       const failure = outcome.error;
+      if (failure instanceof UpdateCommandPendingRecoveryFailure) {
+        // Publication does not restore authority for outer failure triage.
+        throw new UpdateCommandFinalizedRecoveryFailure(result);
+      }
       // This report has already been printed. Do not let pending-recovery triage
       // print it a second time or launch recovery using a now-released fence.
       throw new UpdateCommandFailure(

--- a/src/cli/update-cli/update-command-terminal.ts
+++ b/src/cli/update-cli/update-command-terminal.ts
@@ -1,0 +1,189 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import { finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import { assertUpdateRecoveryAdmission } from "../../infra/update-run-recovery-admission.js";
+import type { UpdateRunResult, UpdateStepResult } from "../../infra/update-runner.js";
+import { printResult } from "./progress.js";
+import type { UpdateCommandOptions } from "./shared.js";
+import type { FinishUpdateParams } from "./update-command-finish-types.js";
+import {
+  recordUpdateResultNextAction,
+  UpdateCommandFailure,
+  UpdateCommandPendingRecoveryFailure,
+} from "./update-command-result.js";
+import { completeUpdateCommandRun } from "./update-command-run.js";
+
+type Run = NonNullable<UpdateCommandOptions["run"]>;
+type Publisher = (failure?: unknown) => Promise<UpdateRunResult>;
+const terminalOwners = new WeakMap<Run, { publish?: Publisher }>();
+
+/** Finalization prepares a report; the outer invocation owns its publication. */
+export function deferUpdateCommandTerminalResult(
+  run: Run | undefined,
+  publish: Publisher,
+): boolean {
+  const owner = run && terminalOwners.get(run);
+  if (!owner) {
+    return false;
+  }
+  owner.publish = publish;
+  return true;
+}
+
+export function hasDeferredUpdateCommandTerminalResult(run: Run): boolean {
+  return terminalOwners.get(run)?.publish !== undefined;
+}
+
+/** Enclose the real executor so its final checks and release precede terminal output. */
+export async function withUpdateCommandTerminalResult<T>(
+  run: Run,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const owner: { publish?: Publisher } = {};
+  terminalOwners.set(run, owner);
+  let outcome: { value: T } | { error: unknown };
+  try {
+    outcome = { value: await operation() };
+  } catch (error) {
+    outcome = { error };
+  } finally {
+    terminalOwners.delete(run);
+  }
+  if (owner.publish) {
+    const result = await owner.publish("error" in outcome ? outcome.error : undefined);
+    if ("error" in outcome) {
+      const failure = outcome.error;
+      // This report has already been printed. Do not let pending-recovery triage
+      // print it a second time or launch recovery using a now-released fence.
+      throw new UpdateCommandFailure(
+        result,
+        failure instanceof UpdateCommandFailure ? failure.exitCode : 1,
+        formatErrorMessage(failure),
+        {
+          cause: failure,
+          automaticTriage:
+            failure instanceof UpdateCommandFailure ? failure.automaticTriage : undefined,
+        },
+      );
+    }
+  }
+  if ("error" in outcome) {
+    throw outcome.error;
+  }
+  return outcome.value;
+}
+
+/** Resolve diagnostic output without reusing a released mutation fence. */
+export async function resolveSettledUpdateCommandResult(
+  params: Pick<FinishUpdateParams, "opts" | "ownedManagedUpdateEnv" | "root">,
+  pendingResult: UpdateRunResult,
+  failure?: unknown,
+): Promise<{ result: UpdateRunResult; settlementFailed: boolean }> {
+  const settlementFailed =
+    failure !== undefined &&
+    (!(failure instanceof UpdateCommandFailure) ||
+      failure instanceof UpdateCommandPendingRecoveryFailure);
+  const result: UpdateRunResult = settlementFailed
+    ? {
+        ...pendingResult,
+        status: "error",
+        reason: "update-executor-settlement-failed",
+        steps: [
+          ...pendingResult.steps,
+          {
+            name: "update executor settlement",
+            command: "openclaw update",
+            cwd: pendingResult.root ?? params.root,
+            durationMs: 0,
+            exitCode: 1,
+            stderrTail: formatErrorMessage(failure),
+          },
+        ],
+      }
+    : failure instanceof UpdateCommandFailure
+      ? failure.result
+      : pendingResult;
+  // The mutation owner is now closed. This is diagnostic publication only,
+  // never authority to reopen displaced state or replace another terminal row.
+  try {
+    await assertUpdateRecoveryAdmission({
+      env: params.ownedManagedUpdateEnv ?? params.opts.run?.env,
+    });
+    if (params.opts.run) {
+      await assertUpdateRecoveryAdmission({ env: params.opts.run.env });
+      const prior = getUpdateRun(params.opts.run.runId, { env: params.opts.run.env });
+      if (prior && prior.status !== "running" && settlementFailed) {
+        throw new Error("Update history was already finalized by another owner.");
+      }
+    }
+  } catch (cause) {
+    throw new UpdateCommandPendingRecoveryFailure(result, formatErrorMessage(cause), { cause });
+  }
+  return { result, settlementFailed };
+}
+
+/** Caller verification permits completion; only the producer can qualify a cleanup warning. */
+export async function recordVerifiedUpdatePackageCleanup(
+  params: Pick<FinishUpdateParams, "packageTransaction" | "root">,
+  result: UpdateRunResult,
+  assertCurrent: () => void,
+): Promise<UpdateCommandFailure | void> {
+  const transaction = params.packageTransaction;
+  if (!transaction) {
+    return;
+  }
+  let cleanupFailure: unknown;
+  const retained: UpdateStepResult | void = await transaction
+    .complete({ activationVerified: result.status === "ok" }, assertCurrent)
+    .catch((error: unknown) => {
+      assertCurrent();
+      if (error instanceof UpdateCommandPendingRecoveryFailure) {
+        throw error;
+      }
+      cleanupFailure = error;
+      return {
+        name: "global install backup retention",
+        command: "openclaw update",
+        cwd: result.root ?? params.root,
+        durationMs: 0,
+        exitCode: 1,
+        stderrTail: `Update backup cleanup failed: ${formatErrorMessage(error)}. Inspect ${transaction.backupRoot} before manual cleanup.`,
+      };
+    });
+  assertCurrent();
+  if (!retained) {
+    return;
+  }
+  result.steps = [...result.steps, retained];
+  if (retained.exitCode !== 0 && retained.advisory?.kind !== "recoverable-maintenance") {
+    // A caller's successful activation does not establish recovery/cleanup safety.
+    // Unknown exceptions and unqualified completion refusals must fail the command.
+    return new UpdateCommandFailure(
+      { ...result, status: "error", reason: "package-backup-retention-failed" },
+      1,
+      retained.stderrTail ?? "Package backup completion was not verified.",
+      { cause: cleanupFailure },
+    );
+  }
+  return undefined;
+}
+
+/** Write the terminal ledger and its visible result together after settlement. */
+export function publishUpdateCommandTerminalResult(
+  params: Pick<FinishUpdateParams, "opts" | "coreAlreadyCurrent" | "ownedManagedUpdateEnv">,
+  input: UpdateRunResult,
+  outcome: { rolledBack: boolean; downtimeMs?: number },
+): UpdateRunResult {
+  const nextAction = recordUpdateResultNextAction(params, input);
+  const run = params.opts.run;
+  const { downtimeMs } = outcome;
+  if (run && outcome.rolledBack) {
+    finishUpdateRun(
+      run.runId,
+      { status: "rolled-back", reason: input.reason, after: input.after, downtimeMs },
+      { env: run.env },
+    );
+  }
+  const result = completeUpdateCommandRun(input, run, downtimeMs);
+  printResult(result, params.opts, { nextAction });
+  return result;
+}

--- a/src/cli/update-cli/update-command-unwind.ts
+++ b/src/cli/update-cli/update-command-unwind.ts
@@ -12,6 +12,7 @@ import {
 } from "./update-command-result.js";
 import { completeUpdateCommandRun, failUpdateCommandRun } from "./update-command-run.js";
 import type { UpdateCommandRecoveryState } from "./update-command-service-maintenance.js";
+import { hasDeferredUpdateCommandTerminalResult } from "./update-command-terminal.js";
 
 /** Unwind only legacy updates; pending publication cannot authorize compensation or diagnostics. */
 export async function withUpdateCommandRecoveryUnwind(
@@ -129,7 +130,7 @@ export async function withUpdateCommandRecoveryUnwind(
     failure = mergeWindowsTaskRecoveryFailure(failure, error);
   }
   if (failure) {
-    if (!recoveryState.ledgerHandoffOwned) {
+    if (!recoveryState.ledgerHandoffOwned && !hasDeferredUpdateCommandTerminalResult(run)) {
       if (failure.error instanceof UpdateCommandFailure) {
         completeUpdateCommandRun(failure.error.result, run);
       } else {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -73,6 +73,7 @@ import {
   type ManagedServiceRootRedirect,
 } from "./update-command-service-plan.js";
 import type { UpdateCommandRecoveryState } from "./update-command-service.js";
+import { withUpdateCommandTerminalResult } from "./update-command-terminal.js";
 import { withUpdateFailureTriage } from "./update-command-triage.js";
 import { withUpdateCommandRecoveryUnwind } from "./update-command-unwind.js";
 
@@ -121,15 +122,17 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
       withUpdateFailureTriage({ ...opts, invocationCwd }, recoveryState.triageTarget, async () => {
         await withUpdateInProgressEnv(invocationCwd, async () => {
           executionStarted = true;
-          await withUpdateCommandExecutor(run.runId, (executor) =>
-            withUpdateCommandRecoveryUnwind(opts, recoveryState, () =>
-              updateCommandInternal(
-                opts,
-                recoveryState,
-                invocationCwd,
-                prepared,
-                presentation,
-                executor,
+          await withUpdateCommandTerminalResult(run, () =>
+            withUpdateCommandExecutor(run.runId, (executor) =>
+              withUpdateCommandRecoveryUnwind(opts, recoveryState, () =>
+                updateCommandInternal(
+                  opts,
+                  recoveryState,
+                  invocationCwd,
+                  prepared,
+                  presentation,
+                  executor,
+                ),
               ),
             ),
           );

--- a/src/infra/package-update-swap.ts
+++ b/src/infra/package-update-swap.ts
@@ -349,7 +349,7 @@ export async function swapStagedPackageInstall(params: {
     }
     if (params.onTransaction) {
       retained = true;
-      let completed = false;
+      let retirement: Promise<UpdateStepResult | void> | undefined;
       let rollbackRefused = false;
       let rollbackResult: ReturnType<PackageUpdateTransaction["rollback"]> | undefined;
       let retainedAssertion: (() => void) | undefined;
@@ -378,12 +378,12 @@ export async function swapStagedPackageInstall(params: {
         ...(assertRollbackSafe ? { assertRollbackSafe } : {}),
         rollback: (assertion) => {
           const assertCurrent = retainAuthority(assertion);
-          if (completed) {
+          if (retirement) {
             return Promise.resolve({
               ...step(
                 1,
                 null,
-                "Package transaction is already complete; its backup is no longer retained.",
+                "Package transaction retirement has started; automatic rollback is no longer available.",
               ),
               name: "global install rollback",
               activePackageRoot,
@@ -424,8 +424,8 @@ export async function swapStagedPackageInstall(params: {
         },
         complete: async ({ activationVerified }, assertion): Promise<UpdateStepResult | void> => {
           const assertCurrent = retainAuthority(assertion);
-          if (completed) {
-            return;
+          if (retirement) {
+            return await retirement;
           }
           // Retire backups only after verified activation or restoration. A failed
           // backup move can leave its published copy as the only intact installation.
@@ -443,28 +443,69 @@ export async function swapStagedPackageInstall(params: {
               name: "global install backup retention",
             };
           }
-          const linkRetention = rootLink ? await rootLink.retire(assertCurrent) : null;
-          assertCurrent();
-          if (linkRetention) {
-            return { ...step(1, null, linkRetention), name: "global install backup retention" };
-          }
-          completed = true;
-          if (hadPackage && previousRoot?.kind !== "link") {
-            await discardPackageUpdateBackup(
-              backupRoot,
-              "old package",
-              targetLayout.globalRoot,
-              assertCurrent,
-            );
-          }
-          if (shimBackupDir) {
-            await discardPackageUpdateBackup(
-              shimBackupDir,
-              "shim backup",
-              targetLayout.globalRoot,
-              assertCurrent,
-            );
-          }
+          // Seal automatic rollback once retirement begins, but retain the actual
+          // outcome. A repeated completion must not report a renamed backup gone.
+          retirement = (async () => {
+            const messages: string[] = [];
+            // The filesystem fallback can recheck an assertion after catching it.
+            // A later successful read cannot turn that authority failure into cleanup.
+            let assertionFailure: { cause: unknown } | undefined;
+            const assertRetirementCurrent = () => {
+              if (assertionFailure) {
+                throw assertionFailure.cause;
+              }
+              try {
+                assertCurrent();
+              } catch (cause) {
+                assertionFailure = { cause };
+                throw cause;
+              }
+            };
+            const linkRetention = rootLink ? await rootLink.retire(assertRetirementCurrent) : null;
+            assertRetirementCurrent();
+            if (linkRetention) {
+              return { ...step(1, null, linkRetention), name: "global install backup retention" };
+            }
+            if (hadPackage && previousRoot?.kind !== "link") {
+              const message = await discardPackageUpdateBackup(
+                backupRoot,
+                "old package",
+                targetLayout.globalRoot,
+                assertRetirementCurrent,
+              );
+              if (message) {
+                messages.push(message);
+              }
+            }
+            if (shimBackupDir) {
+              const message = await discardPackageUpdateBackup(
+                shimBackupDir,
+                "shim backup",
+                targetLayout.globalRoot,
+                assertRetirementCurrent,
+              );
+              if (message) {
+                messages.push(message);
+              }
+            }
+            // Capture authority loss during the final filesystem await in the
+            // retirement outcome, not only in the caller's later publication check.
+            assertRetirementCurrent();
+            if (messages.length) {
+              return {
+                ...step(1, null, messages.join("\n")),
+                name: "global install backup retention",
+                // Only this verified obsolete-resource path qualifies the warning.
+                // Recovery refusal and unclassified link outcomes remain hard.
+                advisory: {
+                  kind: "recoverable-maintenance" as const,
+                  message: `Installation verification succeeded; backup cleanup remains pending. ${messages.join("\n")}. Inspect retained paths before removing obsolete backups manually.`,
+                },
+              };
+            }
+            return undefined;
+          })();
+          return await retirement;
         },
       });
     }


### PR DESCRIPTION
Related: #143767, #143791

## What Problem This Solves

Fixes an issue where `openclaw update` could print success and mark history succeeded before the original executor finished its final ownership checks and release. A late release failure then produced a nonzero exit inconsistent with the published result.

The updater also discarded ordinary package-completion outcomes. A denied backup removal or fallback rename could leave files behind without showing their actual retained path, and repeated completion could lose the original failure.

## Why This Change Was Made

Complete verified package cleanup before preparing the report, then publish the terminal result only after the existing outer executor promise settles. Reuse the warning contract landed in #143767. Only the package owner's verified obsolete-directory cleanup can produce a maintenance advisory; unverified recovery, link identity/read failures, authority loss, and unknown exceptions remain errors.

The package transaction retains one completion outcome, including link retirement and the last post-await authority check. Repeated calls preserve that outcome, while the original caller assertion remains mandatory. Existing terminal history remains immutable.

## User Impact

Successful activation with obsolete-backup cleanup pending now reports the actual retained path and a manual follow-up. Late authority or release failures produce one error result instead of an earlier success. Ordinary healthy updates remain successful.

This changes diagnostics and ordinary package cleanup only. It does not introduce recovery storage, change child-custody APIs, or grant full-state retirement authority.

## Evidence

- 21 composed cases passed using the real package swap/transaction, finalizer, executor, SQLite lease, history, and JSON/human report consumers. Faults include a final lease DELETE failure, authority loss during completion, retained and renamed backups, repeated completion, foreign terminal history, unverified restoration, and native project/link refusal.
- The final two review findings were reproduced by three targeted failing cases before repair. All 21 cases then passed.
- `check:changed` passed at frozen source tree `7bb508f9b9b96d56aef70263964bc04a3814c5ca`, including production/test types, dead exports, lint, and repository guards. The published seven-file delta is byte-identical to that tested source on main cbc245824eb821a4f7ad1bc68cad5d143674f84c. That qualification is preserved; the follow-up qualification below covers the new five-file delta.
- P0/P1/P2 independent review on the prior tree found two P2s, both resolved. This is findings-resolved review, not a second scoped-clean review claim.
- All ten canonical warning-contract files and the executor/filesystem/npm-root/native implementation files are unchanged by this residual patch. #143767 is already merged; its changes are not copied into this PR.

The local composed tests use disposable state. They do not claim installed-service, surviving-child, Doctor/plugin effect closure, or whole-journey rollback proof. Those remain separate work.


## Follow-up corrections

- Fixed two existing tests that read history inside cleanup. They now expect `running` there and still require `rolled-back` after completion. The affected routed run passed 211 tests and the changed-file gate.
- Addressed the review finding where an already-published pending recovery failure could enter managed diagnostic triage after executor revocation. The wrapper now retains the existing finalized, exit-only marker. Ordinary authorized failure triage keeps its original metadata and exit code.
- Real helper/borrowed-executor regressions first reproduced unsafe diagnostic creation and replacement in two revoked cases. After the fix, both leave artifacts absent or unchanged, perform zero atomic opens/renames, report once, and exit 1. The authorized control still writes its diagnostic and exits 7.
- The focused follow-up passed 80 tests. After a test-only lint correction, all three new cases passed on final tree `5434dc900c919dadc9b955fab64a563510d12c48`; remaining production and test bytes were unchanged. Required changed-file checks passed on that tree, and a fresh exact-final five-file P0/P1/P2 review was scoped-clean.
- The original CI failure and prior review/test evidence are preserved. Exact-head hosted CI is required for the updated PR before landing. No installed or full-state recovery qualification is implied.
