### PR TITLE
refactor(ui): share desktop panel render inputs

### DIFF
--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -652,16 +652,13 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         void this.connectEnvironment(this.environmentId, this.controlling);
       },
     });
+    const content = { state: this.state, notice, picker, credentials, recovery } as const;
     if (this.documentMode) {
       return renderDesktopDocumentView({
-        state: this.state,
+        ...content,
         controlling: this.controlling,
         scaleViewport: this.scaleViewport,
         keyboardInputValue: this.mobileKeyboard.value,
-        notice,
-        picker,
-        credentials,
-        recovery,
         onControlToggle: () => void this.connectEnvironment(this.environmentId, !this.controlling),
         onKeyboardFocus: () => this.mobileKeyboard.focus(),
         onKeyboardEvent: (event) => this.mobileKeyboard.handleKeyboardEvent(event),
@@ -716,14 +713,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
                 onClose: () => this.closePanel(),
               })
         }
-        ${renderDesktopPanelContent({
-          state: this.state,
-          notice,
-          picker,
-          recovery,
-          credentials,
-          connection,
-        })}
+        ${renderDesktopPanelContent({ ...content, connection })}
       </section>
     `;
   }


### PR DESCRIPTION
Maintainer-requested cleanup of desktop rendering inputs.

## What Problem This Solves

The desktop panel repeats the same five prepared content properties in its document and docked rendering paths. Maintaining both lists duplicates the input contract of their shared content renderer.

## Why This Change Was Made

Prepare one content record per render and pass it to the existing helpers. The document path still returns before docked controls are constructed, and both paths receive the same values.

## User Impact

This is a maintenance cleanup. Desktop markup, callbacks, and lifecycle behavior remain the same, with ten fewer production lines to maintain.

## Evidence

- All 49 existing component/session/document-style cases and 19 canonical changed-file checks pass.
- The configured lint passes; no test, limit, baseline, or suppression is changed.
- Fresh independent Codex review found no actionable findings through P2.
- The existing render helpers were checked for synchronous state mutation before sharing their prepared inputs.
