### PR TITLE
docs: close remaining cross-link gaps across concepts, gateway, and security

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -56,6 +56,10 @@
     "target": "SecretRef 凭据覆盖面"
   },
   {
+    "source": "Auth credential semantics",
+    "target": "认证凭据语义"
+  },
+  {
     "source": "Secrets runtime model",
     "target": "密钥运行时模型"
   },
@@ -382,6 +386,10 @@
   {
     "source": "Diagnostics export",
     "target": "诊断导出"
+  },
+  {
+    "source": "Diagnostics flags",
+    "target": "诊断标志"
   },
   {
     "source": "Agent harness plugins",
@@ -2240,6 +2248,14 @@
     "target": "网络代理"
   },
   {
+    "source": "Network",
+    "target": "网络"
+  },
+  {
+    "source": "Proxy",
+    "target": "代理"
+  },
+  {
     "source": "Node troubleshooting",
     "target": "节点故障排查"
   },
@@ -2302,6 +2318,14 @@
   {
     "source": "Threat model",
     "target": "威胁模型"
+  },
+  {
+    "source": "Contributing to the threat model",
+    "target": "参与威胁模型贡献"
+  },
+  {
+    "source": "Formal verification",
+    "target": "形式化验证"
   },
   {
     "source": "Reconnaissance (AML.TA0002)",

--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -314,3 +314,4 @@ reject the turn. The completed result records the runtime that actually ran.
 - [Models](/concepts/models)
 - [Status](/cli/status)
 - [Code Mode](/tools/code-mode) — an experimental, opt-in agent-runtime feature
+- [Agent runtime architecture](/agent-runtime-architecture) — code layout, module boundaries, and how the built-in runtime is selected

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -153,3 +153,4 @@ Details: [Gateway protocol](/gateway/protocol), [Pairing](/channels/pairing),
 - [Gateway Protocol](/gateway/protocol) — WebSocket protocol contract
 - [Queue](/concepts/queue) — command queue and concurrency
 - [Security](/gateway/security) — trust model and hardening
+- [Network](/network) — the hub for how OpenClaw connects, pairs, and secures devices across localhost, LAN, and tailnet

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -464,3 +464,4 @@ The slot is exclusive at run time - only one registered context engine is resolv
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview
 - [Session management deep dive](/reference/session-management-compaction) - the session store, transcript events, and auto-compaction internals
+- [System prompt](/concepts/system-prompt) - what OpenClaw assembles into the system prompt for every agent run, and the layers it renders from

--- a/docs/concepts/main-session.md
+++ b/docs/concepts/main-session.md
@@ -101,9 +101,11 @@ making the model carry its entire history at once:
 - Session lists show the current live conversation, not every historical
   session id behind it.
 - When the per-agent store's physical database, WAL, and session artifacts
-  exceed the disk budget (default 10 GB), OpenClaw extracts the oldest
-  unreferenced history to a verified compressed archive before removing its
-  database rows. Live, routed, and in-flight sessions are never budget victims.
+  exceed the disk budget (`session.maintenance.maxDiskBytes`, default `10gb` —
+  see [Session maintenance](/reference/session-management-compaction/maintenance)),
+  OpenClaw extracts the oldest unreferenced history to a verified compressed
+  archive before removing its database rows. Live, routed, and in-flight
+  sessions are never budget victims.
 
 ## When you want isolation instead
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -274,3 +274,4 @@ Related docs:
 - [Authentication](/gateway/authentication) - model provider auth overview
 - [Secrets](/gateway/secrets) - credential storage and SecretRef
 - [Configuration Reference](/gateway/config-secrets-env#auth-storage) - auth config keys
+- [Auth credential semantics](/auth-credential-semantics) - the canonical rules for auth profile ordering and runtime credential resolution

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -45,3 +45,4 @@ For provider examples and elapsed-time formatting, see [Date & Time](/date-time)
 - [Date & Time](/date-time) - full envelope/tool/prompt behavior and examples.
 - [Heartbeat](/gateway/heartbeat) - active hours use timezone for scheduling.
 - [Cron Jobs](/automation/cron-jobs) - cron expressions use timezone for scheduling.
+- [System prompt](/concepts/system-prompt) - the Temporal Context section that carries the user-local date and time zone into the prompt.

--- a/docs/concepts/typing-indicators.md
+++ b/docs/concepts/typing-indicators.md
@@ -73,4 +73,10 @@ Override the policy for one agent:
   <Card title="Streaming and chunking" href="/concepts/streaming" icon="bars-staggered">
     Outbound streaming behavior, chunk boundaries, and channel-specific delivery.
   </Card>
+  <Card title="Heartbeat" href="/gateway/heartbeat" icon="heart-pulse">
+    The system-owned automation that runs periodic agent turns, and the notification rules for its target chat.
+  </Card>
+  <Card title="Groups" href="/channels/groups" icon="users">
+    Group chat behavior and mention gating across group-capable channels.
+  </Card>
 </CardGroup>

--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -136,6 +136,9 @@ Or enable it in config:
 
 The output path always comes from `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH`, even
 when the flag itself is set in config; there is no config key for the path.
+See [Environment variables](/help/environment) for where OpenClaw reads
+`OPENCLAW_DIAGNOSTICS`, `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH`, and
+`OPENCLAW_DIAGNOSTICS_EVENT_LOOP` from, and in what precedence order.
 When `timeline` is enabled only from config, the earliest config-loading spans
 are missing because OpenClaw has not read config yet; subsequent startup spans
 are captured normally.

--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -241,3 +241,4 @@ file-system scan or writing a pre-OOM snapshot.
 - [Logging](/logging)
 - [OpenTelemetry export](/gateway/opentelemetry) - separate flow for streaming diagnostics to a collector
 - [Codex harness runtime](/plugins/codex-harness-runtime) - runtime boundaries, permissions, and diagnostics for the Codex harness
+- [Diagnostics flags](/diagnostics/flags) - the named flags that turn on extra logging for one subsystem without raising `logging.level` globally

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -415,3 +415,4 @@ boundary separation.
 
 - [Trusted proxy auth](/gateway/trusted-proxy-auth) — how a trusted proxy supplies the operator identity these scopes attach to
 - [Gateway protocol](/gateway/protocol) — the methods these scopes authorize
+- [Cloud Workers](/gateway/cloud-workers) — worker dispatch, whose environment and session calls are authorized against these scopes

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -347,3 +347,4 @@ launchctl bootout gui/$UID/ai.openclaw.ssh-tunnel
 - [Tailscale](/gateway/tailscale)
 - [Authentication](/gateway/authentication)
 - [Trusted proxy auth](/gateway/trusted-proxy-auth) — authenticating remote access through a reverse proxy
+- [Network](/network) — the hub for how OpenClaw connects, pairs, and secures devices across localhost, LAN, and tailnet

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -98,3 +98,4 @@ page that now holds the content.
 - [Security](/gateway/security) - security posture
 - [Configuration reference](/gateway/configuration-reference) - where each secrets and env setting is documented
 - [Ask user](/tools/ask-user) - asking the operator a non-secret question; never answer it with a credential, use the masked `secrets` tool for those
+- [Auth credential semantics](/auth-credential-semantics) - the canonical rules for auth profile ordering and runtime credential resolution

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -32,6 +32,7 @@ Understand the model:
 - [Security trust model](/gateway/security/trust-model) - One trust boundary per gateway, the boundary matrix, and the findings closed as no-action.
 - [Running the security audit](/gateway/security/running-the-audit) - What `openclaw security audit` checks and the order to fix findings in.
 - [Security audit checks](/gateway/security/audit-checks) - Reference catalog of every `checkId`, its severity, and its auto-fix support.
+- [Threat model](/security/THREAT-MODEL-ATLAS) - Adversarial threats to the OpenClaw platform and ClawHub, mapped to MITRE ATLAS.
 
 Harden a deployment:
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -171,6 +171,7 @@ Related:
 
 ## Related
 
+- [Diagnostics flags](/diagnostics/flags)
 - [Doctor](/gateway/doctor)
 - [FAQ](/help/faq)
 - [Gateway runbook](/gateway)

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -77,3 +77,4 @@ resolves. Each entry points at the page that now holds the content.
 - [Testing live](/help/testing-live)
 - [Testing updates and plugins](/help/testing-updates-plugins)
 - [CI](/ci)
+- [OpenClaw agent runtime workflow](/openclaw-agent-runtime) - the build, test, and live-validation loop for agent runtime code in `src/agents/`

--- a/docs/network.md
+++ b/docs/network.md
@@ -61,7 +61,7 @@ Local trust:
 ## Security
 
 - [Security overview](/gateway/security)
-- [Gateway config reference](/gateway/configuration)
+- [Gateway config reference](/gateway/configuration-reference)
 - [Troubleshooting](/gateway/troubleshooting)
 - [Doctor](/gateway/doctor)
 

--- a/docs/openclaw-agent-runtime.md
+++ b/docs/openclaw-agent-runtime.md
@@ -67,11 +67,10 @@ Delete those paths for a full reset. Narrower resets:
 Legacy `auth-profiles.json` files are no longer read at runtime;
 `openclaw doctor --fix` imports them into the SQLite store.
 
-## References
-
-- [Testing](/help/testing)
-- [Getting Started](/start/getting-started)
+<a id="references" />
 
 ## Related
 
 - [OpenClaw agent runtime architecture](/agent-runtime-architecture)
+- [Testing](/help/testing)
+- [Getting Started](/start/getting-started)

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -24,6 +24,12 @@ reader job. Open the page that matches your task and stay there.
 | [State schema history](/reference/database-schemas/state-schema-history)                       | Shared state database schema versions, their changes, and their first releases.                          |
 | [Integrity, troubleshooting, and recovery](/reference/database-schemas/integrity-and-recovery) | Integrity checks, common database errors, and the supported downgrade recovery path.                     |
 
+## Related
+
+- [Backups](/install/backups) — archives, per-database snapshots, scheduling, and offsite copies for the databases described here
+- [Updating](/install/updating) — updating safely, including the verified backup to take before a schema bump, and the rollback strategy
+- [Doctor](/gateway/doctor) — the repair and migration tool that fixes stale config/state and reports health problems
+
 ## Where each section moved
 
 Every section heading from the previous single-page version keeps its anchor

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -55,3 +55,6 @@ After shipping the fix:
 
 - [Security policy](https://github.com/openclaw/openclaw/blob/main/SECURITY.md) — report scope and trust model.
 - [Threat model](/security/THREAT-MODEL-ATLAS)
+- [Contributing to the threat model](/security/CONTRIBUTING-THREAT-MODEL) — how to add a threat to the living threat model; not the path for reporting a live vulnerability.
+- [Formal verification](/security/formal-verification) — machine-checked models of authorization, session isolation, and tool gating.
+- [Operator incident response](/gateway/security/operator-incident-response) — contain, rotate, audit, and collect evidence after a suspected compromise of your own Gateway.

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -217,3 +217,9 @@ Add any additional metadata hosts or reserved ranges your cloud provider or netw
 - User local WebUIs and local model servers are not covered by a general local-network bypass — allowlist them in the operator proxy policy if needed. The exception is the bundled Ollama memory embedding provider's guarded direct path, scoped to the exact host-local loopback origin from its configured `baseUrl`; LAN, tailnet, private-network, and public Ollama hosts still use the managed proxy.
 - The local debug proxy's direct upstream forwarding (for proxy requests and `CONNECT` tunnels) is disabled by default while managed proxy mode is active; enable it only for approved local diagnostics.
 - OpenClaw does not inspect, test, or certify your proxy policy. Treat proxy policy changes as security-sensitive operational changes.
+
+## Related
+
+- [Threat model](/security/THREAT-MODEL-ATLAS) — adversarial threats to the OpenClaw platform and ClawHub, mapped to MITRE ATLAS
+- [Security](/gateway/security) — the trust model, safe defaults, and hardening guidance for running OpenClaw
+- [Proxy](/cli/proxy) — `openclaw proxy`, which validates operator-managed proxy routing and runs the local debug capture proxy


### PR DESCRIPTION
Closes the remaining open `link`-kind rows in the docs audit ledger. Ten pages had a genuine one-way link, one page had a link pointing at the wrong target, and one page carried two competing link sections. Everything else in the batch was already satisfied on `main` or is not fixable in this repo — itemised below.

## ⚠️ CODEOWNERS — `@openclaw/openclaw-secops` owns 4 of the 21 files

Last-match-wins simulation over the full file list:

| File | Matching rule |
| --- | --- |
| `docs/gateway/secrets.md` | `/docs/gateway/secrets.md` |
| `docs/gateway/security/index.md` | `/docs/gateway/security/` |
| `docs/security/incident-response.md` | `/docs/security/` |
| `docs/security/network-proxy.md` | `/docs/security/` |

Each is a purely additive Related-list change: no security claim is added, removed, or restated. The other 17 files are unowned.

## Findings closed (13)

| Id | Change |
| --- | --- |
| r3-1399 | `concepts/context-engine.md`, `concepts/timezone.md` — back-link to `/concepts/system-prompt` |
| r3-1495 | `concepts/typing-indicators.md` — Cards for `/gateway/heartbeat` and `/channels/groups`, the two behaviours its Defaults section describes |
| r3-1503 | `gateway/diagnostics.md`, `gateway/troubleshooting.md` — back-link to `/diagnostics/flags`; `diagnostics/flags.md` timeline section links `/help/environment`, which documents the three `OPENCLAW_DIAGNOSTICS*` variables it names |
| r3-1524 | `gateway/operator-scopes.md` — back-link to `/gateway/cloud-workers` |
| r3-1735 | `reference/database-schemas.md` — new Related section with Backups, Updating, Doctor |
| r3-2270 | `gateway/secrets.md`, `concepts/oauth.md` — back-link to `/auth-credential-semantics` |
| r3-2274 | `concepts/agent-runtimes.md` — back-link to `/agent-runtime-architecture` |
| r3-2280 | `openclaw-agent-runtime.md` — `## References` merged into `## Related`, old `#references` id kept as an `<a id>` stub; `help/testing.md` back-links to `/openclaw-agent-runtime` |
| r3-2284 | `network.md` — "Gateway config reference" retargeted from `/gateway/configuration` to `/gateway/configuration-reference` (whose own summary is "Gateway config reference for core OpenClaw keys"); `gateway/remote.md` and `concepts/architecture.md` back-link to `/network` |
| r3-2291 | `gateway/security/index.md` and `security/network-proxy.md` — link `/security/THREAT-MODEL-ATLAS` |
| r3-2292 | `security/network-proxy.md` — new Related section (threat model, security overview, `openclaw proxy`) |
| r5-0011 | `concepts/main-session.md` — the bare "default 10 GB" now names `session.maintenance.maxDiskBytes` and links `/reference/session-management-compaction/maintenance`, where `10gb` is the documented default |
| r3-2296 | `security/incident-response.md` — back-links to the three siblings that already link to it: contributing-to-threat-model, formal verification, operator incident response |

## Refuted (1)

**r3-1149** — "add a link to `/clawhub/cli` from `publishing.md`, `cli/plugins.md`, `building-plugins.md`". `docs/clawhub/` does not exist in this repository. `docs-link-audit.mjs` says so explicitly: *"ClawHub docs are authored in openclaw/clawhub and are absent from this checkout. `/clawhub/**` routes were accepted from docs.json navigation and their fragments were not checked."* The three pages the row names live in the ClawHub repo, not here.

## Already satisfied on `main` — no change needed (20)

Verified against the current tree matching **both** `[label](/route)` and `<Card href="/route">`, and searching split children:

| Id | Evidence |
| --- | --- |
| r3-1073 | `channels/sms.md` L221 links SecretRef → `/gateway/secrets`; L406 links `gateway.trustedProxies` → `/gateway/config-gateway`; Related section present with both. No "outbound-media policy" page exists to link. |
| r3-1098 | `channels/access-groups.md:201` → `/channels/pairing` |
| r3-1509 | `gateway/secrets.md:99`, `cli/webhooks.md:150` → `/gateway/configuration-reference` |
| r3-1533 | `gateway/config-agents.md:110` → `/gateway/config-channels` |
| r3-1576 | `gateway/trusted-proxy-auth.md:636`, `gateway/configuration.md:179` → `/gateway/security/audit-checks` |
| r3-1579 | all five Related targets link back (`configuration.md:180`, `operator-scopes.md:416`, `remote.md:349`, `security/index.md:51`, `tailscale.md:104`) |
| r3-1583 | `gateway/index.md:405`, `gateway/local-models.md:296`, `tools/thinking.md:62` → `/gateway/cli-backends` |
| r3-1591 | `gateway/opentelemetry.md:83` → `/gateway/audit` |
| r3-1598 | all four link back (`sandboxing.md:96`, `sandbox-vs-tool-policy-vs-elevated.md:161`, `multi-agent-sandbox-tools.md:445`, `cli/sandbox.md:133`) |
| r3-1639 | `gateway/index.md:72` (the exact line the row names), `gateway/protocol.md:94`, `tools/index.md:220` |
| r3-1655 | `plugins/onepassword.md` Related → `[1Password](/gateway/1password)` |
| r3-1696 | `faq-first-run.md` was split; `faq-first-run/quick-start.md:52` carries an explicit `<a id="i-am-stuck" />`, L349 links `#i-am-stuck`, and `/help/faq-models` is already in Related (L88) |
| r3-1721 | `install/docker.md:324` already stubs **both** anchor forms (`bonjour-%2F-mdns` and `bonjour-/-mdns`); `gateway/configuration.md:178` → `/install/docker`. Applying the row's suggested de-encoding would have broken the link. |
| r3-1726 | The page was split (532 → 331 lines) and the self-link is gone; `install/migrating.md:151` and `gateway/doctor/config-migrations.md:30` (a split child of Doctor) both link `/install/updating` |
| r3-2236 | `gateway/security/dependency-locking.md:74`, `reference/full-release-validation.md:52` → `/reference/release-performance-sweep` |
| r3-2259 | `channels/signal.md:515`, `channels/imessage.md:125` → `/reference/rpc` |
| r5-0008 | `channels/a2a.md` Related → `[A2A plugin reference](/plugins/reference/a2a)` |
| r5-0024 | `platforms/ios.md:639`, `platforms/android.md:488` → `/gateway/stable-https-url` (the row said "iOS and Android pages"; they live under `docs/platforms/`) |
| r5-0042 | `gateway/security/audit-checks.md:165` → `/gateway/security/exposure-runbook` |
| r5-0055 | `nodes/media-understanding.md:439` → `/providers/mistral` |

Two rows counted under **closed** were also partly stale: the rpc-methods half of r3-1524 is already satisfied by `gateway/protocol/rpc-devices-nodes-and-approvals.md` linking `/gateway/cloud-workers#desktop-interactive`, and the migrating half of r3-1735 by `install/migrating.md:82`. Each still needed one edit, so each is counted once, as closed.

## Deferred (1)

**r5-0196** — "add a CLI reference page for `openclaw file-transfer` and link it from L37". The command is real (`extensions/file-transfer/src/cli.ts`), but this asks for a **new authored reference page** cross-checking flags against source, not a link fix. Out of scope for a link-repair PR; leaving the row open for a CLI-reference batch.

## Glossary

Six sources added to `docs/.i18n/glossary.zh-CN.json`, each inserted **beside its related existing term** rather than at the end of the array (so concurrent PRs touch different regions):

| Source | Target | Inserted after |
| --- | --- | --- |
| Diagnostics flags | 诊断标志 | Diagnostics export |
| Auth credential semantics | 认证凭据语义 | SecretRef credential surface |
| Network | 网络 | Network proxy |
| Proxy | 代理 | Network (new) |
| Contributing to the threat model | 参与威胁模型贡献 | Threat model |
| Formal verification | 形式化验证 | Contributing to the threat model (new) |

Every label is an existing page title or an existing link label already used elsewhere in the tree; none was coined. 1189 → 1195 entries, 0 duplicate sources.

## Validators

Baseline measured in a detached worktree at `git merge-base HEAD origin/main` = `fdc92fa`, with `node_modules` symlinked.

| Check | Result |
| --- | --- |
| `pnpm check:docs` | exit 0 |
| `pnpm format:check` (repo-wide) | exit 0, 36318 files |
| `node scripts/check-docs-mdx.mjs` | passed, 1292 files |
| `node scripts/docs-link-audit.mjs` | `checked_internal_links=13165`, `broken_links=0` |
| `node scripts/docs-link-audit.mjs --anchors` | 3 errors — identical to baseline (all `maturity/#windows-app-node`, untouched here) |
| `npx tsx scripts/format-docs.mts --check` | clean, 1280 files |
| `npx tsx scripts/check-docs-i18n-glossary.mts` | clean |
| `npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc` | 0 issues, 1279 files |
| `vitest ... src/scripts/docs-link-audit.test.ts` | **1 file / 33 tests** passed |
| `vitest ... src/docs/` | **8 files / 16 tests** passed |
| `node .audit/code-docs-anchors.mjs HEAD` | 5 dead — identical to baseline at `fdc92fa`, all documented non-defects (CHANGELOG, Go i18n test fixtures, two TS test fixtures) |

No new pages and no new directories, so `docs/docs.json` navigation and `.github/labeler.yml` need no change.

## Reconciliation

35 open `link` rows in the batch → **13 fixed** (r3-1399, r3-1495, r3-1503, r3-1524, r3-1735, r3-2270, r3-2274, r3-2280, r3-2284, r3-2291, r3-2292, r3-2296, r5-0011) + **1 refuted** (r3-1149) + **20 already satisfied** (r3-1073, r3-1098, r3-1509, r3-1533, r3-1576, r3-1579, r3-1583, r3-1591, r3-1598, r3-1639, r3-1655, r3-1696, r3-1721, r3-1726, r3-2236, r3-2259, r5-0008, r5-0024, r5-0042, r5-0055) + **1 deferred** (r5-0196) = 35.
