### PR TITLE
test(config): simplify explicit environment fixtures

### DIFF
--- a/src/config/config.nix-integration-u3-u5-u9.test.ts
+++ b/src/config/config.nix-integration-u3-u5-u9.test.ts
@@ -12,11 +12,7 @@ import { withTempHome } from "./test-helpers.js";
 
 vi.unmock("../version.js");
 
-function envWith(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
-  // Hermetic env: don't inherit process.env because other tests may mutate it.
-  return { ...overrides };
-}
-
+// Hermetic env: don't inherit process.env because other tests may mutate it.
 describe("Nix integration (U3, U5, U9)", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -24,66 +20,63 @@ describe("Nix integration (U3, U5, U9)", () => {
 
   describe("U3: isNixMode env var detection", () => {
     it("isNixMode is false when OPENCLAW_NIX_MODE is not set", () => {
-      expect(resolveIsNixMode(envWith({ OPENCLAW_NIX_MODE: undefined }))).toBe(false);
+      expect(resolveIsNixMode({ OPENCLAW_NIX_MODE: undefined })).toBe(false);
     });
 
     it("isNixMode is false when OPENCLAW_NIX_MODE is empty", () => {
-      expect(resolveIsNixMode(envWith({ OPENCLAW_NIX_MODE: "" }))).toBe(false);
+      expect(resolveIsNixMode({ OPENCLAW_NIX_MODE: "" })).toBe(false);
     });
 
     it("isNixMode is false when OPENCLAW_NIX_MODE is not '1'", () => {
-      expect(resolveIsNixMode(envWith({ OPENCLAW_NIX_MODE: "true" }))).toBe(false);
+      expect(resolveIsNixMode({ OPENCLAW_NIX_MODE: "true" })).toBe(false);
     });
 
     it("isNixMode is true when OPENCLAW_NIX_MODE=1", () => {
-      expect(resolveIsNixMode(envWith({ OPENCLAW_NIX_MODE: "1" }))).toBe(true);
+      expect(resolveIsNixMode({ OPENCLAW_NIX_MODE: "1" })).toBe(true);
     });
   });
 
   describe("U5: CONFIG_PATH and STATE_DIR env var overrides", () => {
     it("STATE_DIR defaults to ~/.openclaw when env not set", () => {
-      expect(resolveStateDir(envWith({ OPENCLAW_STATE_DIR: undefined }))).toMatch(/\.openclaw$/);
+      expect(resolveStateDir({ OPENCLAW_STATE_DIR: undefined })).toMatch(/\.openclaw$/);
     });
 
     it("STATE_DIR respects OPENCLAW_STATE_DIR override", () => {
-      expect(resolveStateDir(envWith({ OPENCLAW_STATE_DIR: "/custom/state/dir" }))).toBe(
+      expect(resolveStateDir({ OPENCLAW_STATE_DIR: "/custom/state/dir" })).toBe(
         path.resolve("/custom/state/dir"),
       );
     });
 
     it("STATE_DIR respects OPENCLAW_HOME when state override is unset", () => {
       const customHome = path.join(path.sep, "custom", "home");
-      expect(
-        resolveStateDir(envWith({ OPENCLAW_HOME: customHome, OPENCLAW_STATE_DIR: undefined })),
-      ).toBe(path.join(path.resolve(customHome), ".openclaw"));
+      expect(resolveStateDir({ OPENCLAW_HOME: customHome, OPENCLAW_STATE_DIR: undefined })).toBe(
+        path.join(path.resolve(customHome), ".openclaw"),
+      );
     });
 
     it("CONFIG_PATH defaults to OPENCLAW_HOME/.openclaw/openclaw.json", () => {
       const customHome = path.join(path.sep, "custom", "home");
       expect(
-        resolveConfigPathCandidate(
-          envWith({
-            OPENCLAW_HOME: customHome,
-            OPENCLAW_CONFIG_PATH: undefined,
-            OPENCLAW_STATE_DIR: undefined,
-          }),
-        ),
+        resolveConfigPathCandidate({
+          OPENCLAW_HOME: customHome,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        }),
       ).toBe(path.join(path.resolve(customHome), ".openclaw", "openclaw.json"));
     });
 
     it("CONFIG_PATH defaults to ~/.openclaw/openclaw.json when env not set", () => {
       expect(
-        resolveConfigPathCandidate(
-          envWith({ OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined }),
-        ),
+        resolveConfigPathCandidate({
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        }),
       ).toMatch(/\.openclaw[\\/]openclaw\.json$/);
     });
 
     it("CONFIG_PATH respects OPENCLAW_CONFIG_PATH override", () => {
       expect(
-        resolveConfigPathCandidate(
-          envWith({ OPENCLAW_CONFIG_PATH: "/nix/store/abc/openclaw.json" }),
-        ),
+        resolveConfigPathCandidate({ OPENCLAW_CONFIG_PATH: "/nix/store/abc/openclaw.json" }),
       ).toBe(path.resolve("/nix/store/abc/openclaw.json"));
     });
 
@@ -91,7 +84,7 @@ describe("Nix integration (U3, U5, U9)", () => {
       await withTempHome(async (home) => {
         expect(
           resolveConfigPathCandidate(
-            envWith({ OPENCLAW_HOME: home, OPENCLAW_CONFIG_PATH: "~/.openclaw/custom.json" }),
+            { OPENCLAW_HOME: home, OPENCLAW_CONFIG_PATH: "~/.openclaw/custom.json" },
             () => home,
           ),
         ).toBe(path.join(home, ".openclaw", "custom.json"));
@@ -101,7 +94,7 @@ describe("Nix integration (U3, U5, U9)", () => {
     it("CONFIG_PATH uses STATE_DIR when only state dir is overridden", () => {
       expect(
         resolveConfigPathCandidate(
-          envWith({ OPENCLAW_STATE_DIR: "/custom/state", OPENCLAW_TEST_FAST: "1" }),
+          { OPENCLAW_STATE_DIR: "/custom/state", OPENCLAW_TEST_FAST: "1" },
           () => path.join(path.sep, "tmp", "openclaw-config-home"),
         ),
       ).toBe(path.join(path.resolve("/custom/state"), "openclaw.json"));
@@ -110,26 +103,20 @@ describe("Nix integration (U3, U5, U9)", () => {
 
   describe("U6: gateway port resolution", () => {
     it("uses default when env and config are unset", () => {
-      expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: undefined }))).toBe(
+      expect(resolveGatewayPort({}, { OPENCLAW_GATEWAY_PORT: undefined })).toBe(
         DEFAULT_GATEWAY_PORT,
       );
     });
 
     it("prefers OPENCLAW_GATEWAY_PORT over config", () => {
       expect(
-        resolveGatewayPort(
-          { gateway: { port: 19002 } },
-          envWith({ OPENCLAW_GATEWAY_PORT: "19001" }),
-        ),
+        resolveGatewayPort({ gateway: { port: 19002 } }, { OPENCLAW_GATEWAY_PORT: "19001" }),
       ).toBe(19001);
     });
 
     it("falls back to config when env is invalid", () => {
       expect(
-        resolveGatewayPort(
-          { gateway: { port: 19003 } },
-          envWith({ OPENCLAW_GATEWAY_PORT: "nope" }),
-        ),
+        resolveGatewayPort({ gateway: { port: 19003 } }, { OPENCLAW_GATEWAY_PORT: "nope" }),
       ).toBe(19003);
     });
   });

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -26,10 +26,6 @@ import {
   STATE_DIR,
 } from "./paths.js";
 
-function envWith(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
-  return { ...overrides };
-}
-
 describe("default state directory", () => {
   it("matches filesystem aliases of the default state directory", async () => {
     await withTestDir({ prefix: "openclaw-default-state-" }, async (root) => {
@@ -314,7 +310,7 @@ describe("oauth paths", () => {
     const env = {
       OPENCLAW_OAUTH_DIR: "/custom/oauth",
       OPENCLAW_STATE_DIR: "/custom/state",
-    } as NodeJS.ProcessEnv;
+    };
 
     expect(resolveOAuthDir(env, "/custom/state")).toBe(path.resolve("/custom/oauth"));
     expect(resolveLegacyOAuthPath(env)).toBe(
@@ -325,7 +321,7 @@ describe("oauth paths", () => {
   it("derives oauth path from OPENCLAW_STATE_DIR when unset", () => {
     const env = {
       OPENCLAW_STATE_DIR: "/custom/state",
-    } as NodeJS.ProcessEnv;
+    };
 
     expect(resolveOAuthDir(env, "/custom/state")).toBe(path.join("/custom/state", "credentials"));
     expect(resolveLegacyOAuthPath(env)).toBe(
@@ -339,12 +335,12 @@ describe("gateway port resolution", () => {
     expect(
       resolveGatewayPort(
         { gateway: { port: 19002 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "19001", OPENCLAW_PROFILE: "work" }),
+        { OPENCLAW_GATEWAY_PORT: "19001", OPENCLAW_PROFILE: "work" },
       ),
     ).toBe(19001);
-    expect(
-      resolveGatewayPort({ gateway: { port: 19002 } }, envWith({ OPENCLAW_PROFILE: "work" })),
-    ).toBe(19002);
+    expect(resolveGatewayPort({ gateway: { port: 19002 } }, { OPENCLAW_PROFILE: "work" })).toBe(
+      19002,
+    );
   });
 
   it.each([
@@ -352,7 +348,7 @@ describe("gateway port resolution", () => {
     { profile: "p1402", expected: 55636 },
     { profile: "p2380", expected: 55636 },
   ])("derives the byte-exact profile port for $profile", ({ profile, expected }) => {
-    const port = resolveGatewayPort({}, envWith({ OPENCLAW_PROFILE: profile }));
+    const port = resolveGatewayPort({}, { OPENCLAW_PROFILE: profile });
     expect(port).toBe(expected);
     expect(port).toBeGreaterThanOrEqual(20000);
     expect(port).toBeLessThan(60000);
@@ -361,9 +357,7 @@ describe("gateway port resolution", () => {
   it.each([undefined, "default", "Default", "../escape"])(
     "keeps the default port for profile %j",
     (profile) => {
-      expect(resolveGatewayPort({}, envWith({ OPENCLAW_PROFILE: profile }))).toBe(
-        DEFAULT_GATEWAY_PORT,
-      );
+      expect(resolveGatewayPort({}, { OPENCLAW_PROFILE: profile })).toBe(DEFAULT_GATEWAY_PORT);
     },
   );
 
@@ -371,17 +365,14 @@ describe("gateway port resolution", () => {
     expect(
       resolveGatewayPort(
         { gateway: { port: 19002 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" }),
+        { OPENCLAW_GATEWAY_PORT: "127.0.0.1:18789" },
       ),
     ).toBe(18789);
   });
 
   it("accepts Compose-style IPv6 host publish values from env", () => {
     expect(
-      resolveGatewayPort(
-        { gateway: { port: 19002 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "[::1]:28789" }),
-      ),
+      resolveGatewayPort({ gateway: { port: 19002 } }, { OPENCLAW_GATEWAY_PORT: "[::1]:28789" }),
     ).toBe(28789);
   });
 
@@ -389,7 +380,7 @@ describe("gateway port resolution", () => {
     expect(
       resolveGatewayPort(
         { gateway: { port: 19002 } },
-        envWith({ CLAWDBOT_GATEWAY_PORT: "127.0.0.1:18789" }),
+        { CLAWDBOT_GATEWAY_PORT: "127.0.0.1:18789" },
       ),
     ).toBe(19002);
   });
@@ -398,40 +389,37 @@ describe("gateway port resolution", () => {
     expect(
       resolveGatewayPort(
         { gateway: { port: 19003 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }),
+        { OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" },
       ),
     ).toBe(19003);
   });
 
   it("falls back to config when env ports exceed TCP bounds", () => {
     expect(
-      resolveGatewayPort({ gateway: { port: 19003 } }, envWith({ OPENCLAW_GATEWAY_PORT: "65536" })),
+      resolveGatewayPort({ gateway: { port: 19003 } }, { OPENCLAW_GATEWAY_PORT: "65536" }),
     ).toBe(19003);
     expect(
       resolveGatewayPort(
         { gateway: { port: 19004 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:65536" }),
+        { OPENCLAW_GATEWAY_PORT: "127.0.0.1:65536" },
       ),
     ).toBe(19004);
     expect(
-      resolveGatewayPort(
-        { gateway: { port: 19005 } },
-        envWith({ OPENCLAW_GATEWAY_PORT: "[::1]:65536" }),
-      ),
+      resolveGatewayPort({ gateway: { port: 19005 } }, { OPENCLAW_GATEWAY_PORT: "[::1]:65536" }),
     ).toBe(19005);
   });
 
   it("falls back when malformed IPv6 inputs do not provide an explicit port", () => {
-    expect(
-      resolveGatewayPort({ gateway: { port: 19003 } }, envWith({ OPENCLAW_GATEWAY_PORT: "::1" })),
-    ).toBe(19003);
-    expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "2001:db8::1" }))).toBe(
+    expect(resolveGatewayPort({ gateway: { port: 19003 } }, { OPENCLAW_GATEWAY_PORT: "::1" })).toBe(
+      19003,
+    );
+    expect(resolveGatewayPort({}, { OPENCLAW_GATEWAY_PORT: "2001:db8::1" })).toBe(
       DEFAULT_GATEWAY_PORT,
     );
   });
 
   it("falls back to the default port when env is invalid and config is unset", () => {
-    expect(resolveGatewayPort({}, envWith({ OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" }))).toBe(
+    expect(resolveGatewayPort({}, { OPENCLAW_GATEWAY_PORT: "127.0.0.1:not-a-port" })).toBe(
       DEFAULT_GATEWAY_PORT,
     );
   });
@@ -453,7 +441,7 @@ describe("state + config path candidates", () => {
   it("uses OPENCLAW_STATE_DIR when set", () => {
     const env = {
       OPENCLAW_STATE_DIR: "/new/state",
-    } as NodeJS.ProcessEnv;
+    };
 
     expect(resolveStateDir(env, () => "/home/test")).toBe(path.resolve("/new/state"));
   });
@@ -462,7 +450,7 @@ describe("state + config path candidates", () => {
     const env = {
       OPENCLAW_STATE_DIR: ".",
       OPENCLAW_HOME: "/srv/openclaw-home",
-    } as NodeJS.ProcessEnv;
+    };
 
     normalizeStateDirEnv(env);
 
@@ -473,7 +461,7 @@ describe("state + config path candidates", () => {
     const env = {
       OPENCLAW_STATE_DIR: "relative-state",
       OPENCLAW_HOME: "/srv/openclaw-home",
-    } as NodeJS.ProcessEnv;
+    };
 
     normalizeStateDirEnv(env);
     const normalized = env.OPENCLAW_STATE_DIR;
@@ -516,7 +504,7 @@ describe("state + config path candidates", () => {
   it("uses OPENCLAW_HOME for default state/config locations", () => {
     const env = {
       OPENCLAW_HOME: "/srv/openclaw-home",
-    } as NodeJS.ProcessEnv;
+    };
     expectOpenClawHomeDefaults(env);
   });
 
@@ -524,14 +512,14 @@ describe("state + config path candidates", () => {
     const env = {
       OPENCLAW_HOME: "/srv/openclaw-home",
       HOME: "/home/other",
-    } as NodeJS.ProcessEnv;
+    };
     expectOpenClawHomeDefaults(env);
   });
 
   it("orders default config candidates in a stable order", () => {
     const home = "/home/test";
     const resolvedHome = path.resolve(home);
-    const candidates = resolveDefaultConfigCandidates({} as NodeJS.ProcessEnv, () => home);
+    const candidates = resolveDefaultConfigCandidates({}, () => home);
     const expected = [
       path.join(resolvedHome, ".openclaw", "openclaw.json"),
       path.join(resolvedHome, ".openclaw", "clawdbot.json"),
@@ -545,7 +533,7 @@ describe("state + config path candidates", () => {
     await withTestDir({ prefix: "openclaw-state-" }, async (root) => {
       const newDir = path.join(root, ".openclaw");
       await fs.mkdir(newDir, { recursive: true });
-      const resolved = resolveStateDir({} as NodeJS.ProcessEnv, () => root);
+      const resolved = resolveStateDir({}, () => root);
       expect(resolved).toBe(newDir);
     });
   });
@@ -554,7 +542,7 @@ describe("state + config path candidates", () => {
     await withTestDir({ prefix: "openclaw-state-legacy-" }, async (root) => {
       const legacyDir = path.join(root, ".clawdbot");
       await fs.mkdir(legacyDir, { recursive: true });
-      const resolved = resolveStateDir({} as NodeJS.ProcessEnv, () => root);
+      const resolved = resolveStateDir({}, () => root);
       expect(resolved).toBe(legacyDir);
     });
   });
@@ -566,7 +554,7 @@ describe("state + config path candidates", () => {
       const legacyPath = path.join(legacyDir, "openclaw.json");
       await fs.writeFile(legacyPath, "{}", "utf-8");
 
-      const resolved = resolveConfigPathCandidate({} as NodeJS.ProcessEnv, () => root);
+      const resolved = resolveConfigPathCandidate({}, () => root);
       expect(resolved).toBe(legacyPath);
     });
   });
@@ -595,7 +583,7 @@ describe("state + config path candidates", () => {
       await fs.writeFile(legacyConfig, "{}", "utf-8");
 
       const overrideDir = path.join(root, "override");
-      const env = { OPENCLAW_STATE_DIR: overrideDir } as NodeJS.ProcessEnv;
+      const env = { OPENCLAW_STATE_DIR: overrideDir };
       const resolved = resolveConfigPath(env, overrideDir, () => root);
       expect(resolved).toBe(path.join(overrideDir, "openclaw.json"));
     });
@@ -606,32 +594,28 @@ describe("resolveIncludeRoots", () => {
   const HOME = path.parse(process.cwd()).root + "fakehome";
 
   it("returns an empty list when OPENCLAW_INCLUDE_ROOTS is unset or blank", () => {
-    expect(resolveIncludeRoots(envWith({}), () => HOME)).toStrictEqual([]);
-    expect(resolveIncludeRoots(envWith({ OPENCLAW_INCLUDE_ROOTS: "" }), () => HOME)).toStrictEqual(
-      [],
-    );
-    expect(
-      resolveIncludeRoots(envWith({ OPENCLAW_INCLUDE_ROOTS: "   " }), () => HOME),
-    ).toStrictEqual([]);
+    expect(resolveIncludeRoots({}, () => HOME)).toStrictEqual([]);
+    expect(resolveIncludeRoots({ OPENCLAW_INCLUDE_ROOTS: "" }, () => HOME)).toStrictEqual([]);
+    expect(resolveIncludeRoots({ OPENCLAW_INCLUDE_ROOTS: "   " }, () => HOME)).toStrictEqual([]);
   });
 
   it("splits on the platform path delimiter and resolves each entry to an absolute path", () => {
     const a = path.resolve(path.parse(process.cwd()).root, "shared", "a");
     const b = path.resolve(path.parse(process.cwd()).root, "shared", "b");
-    const env = envWith({ OPENCLAW_INCLUDE_ROOTS: [a, b].join(path.delimiter) });
+    const env = { OPENCLAW_INCLUDE_ROOTS: [a, b].join(path.delimiter) };
     expect(resolveIncludeRoots(env, () => HOME)).toEqual([a, b]);
   });
 
   it("expands a leading tilde in each entry using the resolved home dir", () => {
-    const env = envWith({ OPENCLAW_INCLUDE_ROOTS: "~/share/openclaw" });
+    const env = { OPENCLAW_INCLUDE_ROOTS: "~/share/openclaw" };
     expect(resolveIncludeRoots(env, () => HOME)).toEqual([path.join(HOME, "share", "openclaw")]);
   });
 
   it("drops empty entries and preserves de-duplicated order for repeated roots", () => {
     const a = path.resolve(path.parse(process.cwd()).root, "shared", "a");
-    const env = envWith({
+    const env = {
       OPENCLAW_INCLUDE_ROOTS: ["", a, "  ", a].join(path.delimiter),
-    });
+    };
     expect(resolveIncludeRoots(env, () => HOME)).toEqual([a]);
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Configuration-path and Nix integration tests wrap explicit environment fixtures in redundant copying helpers and type assertions, making their isolated inputs harder to read.

## Why This Change Was Made

Use the same 35 fresh object literals directly, remove two private copying helpers and 12 redundant casts, and retain every existing assertion. Nix fixtures remain hermetic: they do not inherit `process.env`.

## User Impact

No production behavior, configuration or public API changes. The two test files add 62 lines and remove 91, a net reduction of 29 lines that includes formatter reflow.

## Evidence

The original and final versions each passed all 70 cases, with matching identities, statuses and order within each suite. All 87 assertion sites remain. Independent review is clean through P2, and all 20 normal local changed checks passed with source unchanged and observed processes closed.

This proof covers synthetic environment fixtures and local filesystem behavior; it does not claim a native Nix installation or Windows run.
