### PR TITLE
docs: fix information-architecture findings in plugins and channels docs

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -2092,6 +2092,14 @@
     "target": "渠道路由"
   },
   {
+    "source": "Bot loop protection",
+    "target": "机器人循环保护"
+  },
+  {
+    "source": "Access groups",
+    "target": "访问组"
+  },
+  {
     "source": "Channels Overview",
     "target": "渠道概览"
   },

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -85,6 +85,8 @@ openclaw gateway
 Named accounts must use a configured token or token file; the shared env
 variable is intentionally limited to the default account.
 
+## Configuration
+
 ### JSON5 reference
 
 The equivalent config shape is:
@@ -157,6 +159,8 @@ uses the loopback endpoint for REST requests, setup verification, and the
 realtime WebSocket, while discussion `embedUrl` and `openUrl` links continue to
 use the public `baseUrl`. If `apiBaseUrl` is omitted, all traffic uses
 `baseUrl`, preserving existing behavior.
+
+### Plugin allowlist behavior
 
 If `plugins.allow` is a non-empty restrictive list, explicitly selecting
 ClickClack in channel setup or running `openclaw plugins enable clickclack`
@@ -568,3 +572,10 @@ OpenClaw only needs current `bot:write` for normal agent chat and command-menu s
 - No inbound replies: confirm the token has realtime read access. The bot always ignores its own messages; other bot messages are denied by default, and when `allowBots` is enabled the sender bot ID must also be listed explicitly in `allowFrom`.
 - Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.
 - No command menu: confirm `commandMenu` is not `false`, the ClickClack server supports `PUT /api/bots/self/commands`, and the token has `commands:write`.
+
+## Related
+
+- [Pairing](/channels/pairing)
+- [Groups](/channels/groups)
+- [Bot loop protection](/channels/bot-loop-protection)
+- [Access groups](/channels/access-groups)

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -601,17 +601,13 @@ The agent system prompt includes a group intro on the first turn of a new group 
 - List chats: `imsg chats --limit 20`.
 - Group replies always go back to the same `chat_id`.
 
-## WhatsApp system prompts
-
-See [WhatsApp](/channels/whatsapp#system-prompts) for the canonical WhatsApp system prompt rules, including group and direct prompt resolution, wildcard behavior, and account override semantics.
-
-## WhatsApp specifics
-
-See [Group messages](/channels/group-messages) for WhatsApp-only behavior (history injection, mention handling details).
-
 ## Related
+
+<a id="whatsapp-system-prompts" />
+<a id="whatsapp-specifics" />
 
 - [Broadcast groups](/channels/broadcast-groups)
 - [Channel routing](/channels/channel-routing)
-- [Group messages](/channels/group-messages)
+- [Group messages](/channels/group-messages) — WhatsApp-only behavior (history injection, mention handling details)
 - [Pairing](/channels/pairing)
+- [WhatsApp](/channels/whatsapp#system-prompts) — canonical WhatsApp system prompt rules, including group and direct prompt resolution, wildcard behavior, and account override semantics

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -7,7 +7,9 @@ title: "WhatsApp"
 
 Status: production-ready via WhatsApp Web (Baileys). The gateway owns the linked session(s); there is no separate Twilio WhatsApp channel.
 
-## Install
+## Setup
+
+### Install
 
 `openclaw onboard` and `openclaw channels add --channel whatsapp` prompt to install the plugin the first time you select it; `openclaw channels login --channel whatsapp` offers the same install flow if the plugin is missing. Dev checkouts use the local plugin path; stable/beta installs `@openclaw/whatsapp` from npm first, then falls back to its declared ClawHub package only when the npm target is unavailable. The WhatsApp runtime ships outside the core OpenClaw npm package, so its runtime dependencies stay with the external plugin. Manual install:
 
@@ -29,7 +31,7 @@ Use `npm:@openclaw/whatsapp` or `clawhub:@openclaw/whatsapp` to force a source; 
   </Card>
 </CardGroup>
 
-## Quick setup
+### Quick setup
 
 <Steps>
   <Step title="Configure access policy">
@@ -101,7 +103,7 @@ openclaw pairing approve whatsapp <CODE>
 A separate WhatsApp number is recommended (setup and metadata are optimized for it), but personal-number/self-chat setups are fully supported.
 </Note>
 
-## Deployment patterns
+### Deployment patterns
 
 <AccordionGroup>
   <Accordion title="Dedicated number (recommended)">
@@ -253,7 +255,9 @@ Inbound WhatsApp messages can carry personal content, phone numbers, group ident
 
 Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHooks.messageReceived`. Only enable this for plugins you trust with inbound WhatsApp content and identifiers.
 
-## Access control and activation
+## Access control
+
+### Access control and activation
 
 <Tabs>
   <Tab title="DM policy">
@@ -314,7 +318,7 @@ Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHoo
   </Tab>
 </Tabs>
 
-## Configured ACP bindings
+### Configured ACP bindings
 
 WhatsApp supports persistent ACP bindings via top-level `bindings[]`:
 
@@ -345,7 +349,7 @@ WhatsApp supports persistent ACP bindings via top-level `bindings[]`:
 
 Direct chats match E.164 numbers; groups match WhatsApp group JIDs. Group allowlists, sender policy, and mention/activation gating run before OpenClaw ensures the bound ACP session exists. A matched binding owns the route — broadcast groups do not fan that turn out to ordinary WhatsApp sessions.
 
-## Personal-number and self-chat behavior
+### Personal-number and self-chat behavior
 
 `channels.whatsapp.selfChatMode` controls same-number DM admission and self-chat safeguards. Set it at the channel level or override it per account with `channels.whatsapp.accounts.<id>.selfChatMode`.
 
@@ -358,7 +362,9 @@ Self-chat safeguards are enabled by `true` and disabled by `false`. When the set
 
 A liveness probe sent to your own number can therefore become agent input with `selfChatMode` unset or `true`. Set `selfChatMode: false` if you want to exclude those self-originated DMs.
 
-## Message normalization and context
+## Messaging and delivery
+
+### Message normalization and context
 
 <AccordionGroup>
   <Accordion title="Inbound envelope and reply context">
@@ -406,7 +412,7 @@ A liveness probe sent to your own number can therefore become agent input with `
   </Accordion>
 </AccordionGroup>
 
-## Delivery, chunking, and media
+### Delivery, chunking, and media
 
 <AccordionGroup>
   <Accordion title="Text chunking">
@@ -438,7 +444,7 @@ A liveness probe sent to your own number can therefore become agent input with `
   </Accordion>
 </AccordionGroup>
 
-## Reply quoting
+### Reply quoting
 
 `channels.whatsapp.replyToMode` controls native reply quoting (outbound replies visibly quote the inbound message):
 
@@ -457,7 +463,9 @@ Per-account override: `channels.whatsapp.accounts.<id>.replyToMode`.
 { channels: { whatsapp: { replyToMode: "first" } } }
 ```
 
-## Reaction level
+## Reactions and typing
+
+### Reaction level
 
 `channels.whatsapp.reactionLevel` controls how broadly the agent uses emoji reactions:
 
@@ -474,7 +482,7 @@ Per-account override: `channels.whatsapp.accounts.<id>.reactionLevel`.
 { channels: { whatsapp: { reactionLevel: "ack" } } }
 ```
 
-## Acknowledgment reactions
+### Acknowledgment reactions
 
 `messages.ackReaction` sends an immediate reaction on inbound receipt, gated by the active WhatsApp account's `reactionLevel` (suppressed when `"off"`). `messages.ackReactionScope` selects direct messages, groups, or both:
 
@@ -489,7 +497,7 @@ Per-account override: `channels.whatsapp.accounts.<id>.reactionLevel`.
 
 Notes: the reaction is sent immediately after inbound is accepted (pre-reply); omit `messages.ackReaction` or set it to `""` for no acknowledgment. Failures are logged but do not block reply delivery. The default scope is `"group-mentions"`; use `"all"` for direct messages and all eligible groups. In a group whose activation is `always`, `"group-mentions"` acks every message rather than only mention-triggered turns, because activation stands in for the mention check.
 
-## Lifecycle status reactions
+### Lifecycle status reactions
 
 Set `messages.statusReactions.enabled: true` to let WhatsApp replace the ack reaction during a turn instead of leaving a static receipt emoji, cycling through states such as queued, thinking, tool activity, compaction, done, and error:
 
@@ -505,7 +513,7 @@ Set `messages.statusReactions.enabled: true` to let WhatsApp replace the ack rea
 
 Notes: `messages.ackReactionScope` still controls eligibility for direct messages and groups; the queued state uses the same effective emoji as plain acknowledgment reactions. WhatsApp has one bot reaction slot per message, so lifecycle updates replace the current reaction in place and restore the acknowledgment after the final done/error state.
 
-## Active-turn typing
+### Active-turn typing
 
 For admitted automatic turns where typing is allowed, WhatsApp sends a
 `composing` presence update when agent execution begins and refreshes it while

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1651,8 +1651,8 @@
                   "channels/pairing",
                   "channels/access-groups",
                   "channels/bot-loop-protection",
-                  "channels/group-messages",
                   "channels/groups",
+                  "channels/group-messages",
                   "channels/ambient-room-events",
                   "channels/broadcast-groups",
                   "channels/channel-routing",
@@ -2974,8 +2974,7 @@
                 "pages": [
                   "plugins/plugin-inventory",
                   "plugins/reference",
-                  "plugins/dependency-resolution",
-                  "plugins/install-overrides"
+                  "plugins/dependency-resolution"
                 ]
               },
               {
@@ -3086,6 +3085,7 @@
                     ]
                   },
                   "plugins/compatibility",
+                  "plugins/install-overrides",
                   "plugins/sdk-channel-outbound",
                   "plugins/sdk-channel-inbound",
                   "plugins/sdk-channel-ingress",

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -6,7 +6,7 @@ read_when:
   - Working on the plugin load pipeline or registry
   - Implementing provider runtime hooks or channel plugins
 title: "Plugin internals"
-sidebarTitle: "Internals"
+sidebarTitle: "Architecture"
 ---
 
 This is the **deep architecture reference** for the OpenClaw plugin system. For practical guides, start with one of the focused pages below.

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -107,7 +107,33 @@ Claude `hooks/hooks.json` remains in the declared capabilities, but does not app
 as a supported hook. A bundle containing both layouts keeps its OpenClaw hook packs.
 Inspection does not execute handlers or prove that the running Gateway loaded them.
 
-#### MCP for embedded OpenClaw
+#### Embedded OpenClaw settings
+
+Claude `settings.json` is imported as default embedded OpenClaw settings when
+the bundle is enabled. OpenClaw sanitizes shell override keys before applying
+them:
+
+- `shellPath`
+- `shellCommandPrefix`
+
+#### Embedded OpenClaw LSP
+
+- Enabled Claude bundles can contribute LSP server config.
+- OpenClaw loads `.lsp.json` plus any manifest-declared `lspServers` paths.
+- Bundle LSP config is merged into the effective embedded OpenClaw LSP
+  defaults.
+- Only supported stdio-backed LSP servers are runnable; unsupported
+  transports still show up in `openclaw plugins inspect <id>`.
+
+### Detected but not executed
+
+These are recognized and shown in diagnostics, but OpenClaw does not run them:
+
+- Claude `hooks/hooks.json` automation
+- Cursor `.cursor/agents`, `.cursor/hooks.json`, `.cursor/rules`
+- Codex `.app.json` metadata beyond capability reporting
+
+## MCP for embedded OpenClaw
 
 - Enabled bundles can contribute MCP server config.
 - OpenClaw merges bundle MCP config into the effective embedded OpenClaw
@@ -121,7 +147,7 @@ Inspection does not execute handlers or prove that the running Gateway loaded th
 - Bundle MCP tool catalogs are sorted deterministically before registration, so
   upstream `listTools()` order changes do not thrash prompt-cache tool blocks.
 
-##### Transports
+### Transports
 
 MCP servers can use stdio or HTTP transport.
 
@@ -172,7 +198,7 @@ MCP servers can use stdio or HTTP transport.
   both stdio and HTTP transports. Request timeout defaults to 60 seconds and
   can be overridden with `requestTimeoutMs`.
 
-##### Tool naming
+### Tool naming
 
 OpenClaw registers bundle MCP tools with provider-safe names in the form
 `serverName__toolName`. For example, a server keyed `"vigil-harbor"` exposing a
@@ -190,32 +216,6 @@ OpenClaw registers bundle MCP tools with provider-safe names in the form
 - Profile filtering treats every tool from one bundle MCP server as
   plugin-owned by `bundle-mcp`, so profile allow/deny lists can reference
   either individual exposed tool names or the `bundle-mcp` plugin key.
-
-#### Embedded OpenClaw settings
-
-Claude `settings.json` is imported as default embedded OpenClaw settings when
-the bundle is enabled. OpenClaw sanitizes shell override keys before applying
-them:
-
-- `shellPath`
-- `shellCommandPrefix`
-
-#### Embedded OpenClaw LSP
-
-- Enabled Claude bundles can contribute LSP server config.
-- OpenClaw loads `.lsp.json` plus any manifest-declared `lspServers` paths.
-- Bundle LSP config is merged into the effective embedded OpenClaw LSP
-  defaults.
-- Only supported stdio-backed LSP servers are runnable; unsupported
-  transports still show up in `openclaw plugins inspect <id>`.
-
-### Detected but not executed
-
-These are recognized and shown in diagnostics, but OpenClaw does not run them:
-
-- Claude `hooks/hooks.json` automation
-- Cursor `.cursor/agents`, `.cursor/hooks.json`, `.cursor/rules`
-- Codex `.app.json` metadata beyond capability reporting
 
 ## Bundle formats
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -38,16 +38,16 @@ All Codex harness settings live under `plugins.entries.codex.config`.
 
 Top-level fields:
 
-| Field                      | Default                  | Meaning                                                                                                                                        |
-| -------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                    |
-| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings. The ordinary harness defaults to agent-scoped state.                        |
-| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                       |
-| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                    |
-| `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
-| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                               |
-| `sessionCatalog`           | enabled                  | Native Codex session discovery for the sidebar. Set `enabled: false` to disable it, or set `homes` to include additional local Codex stores.   |
-| `supervision`              | disabled                 | Agent-facing native-session transcript and write-control policy. See [Codex supervision](/plugins/codex-supervision).                          |
+| Field                      | Default                  | Meaning                                                                                                                                                                                                                                 |
+| -------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`. See [Codex model discovery](/plugins/codex-harness-reference/model-discovery).                                                                                              |
+| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings. The ordinary harness defaults to agent-scoped state. See [Codex app-server transport](/plugins/codex-harness-reference/app-server-transport).                        |
+| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context. See [Codex dynamic tools](/plugins/codex-harness-reference/dynamic-tools).                                                                     |
+| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns. See [Codex dynamic tools](/plugins/codex-harness-reference/dynamic-tools).                                                                                  |
+| `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins).                                                                                          |
+| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                                                                                                                        |
+| `sessionCatalog`           | enabled                  | Native Codex session discovery for the sidebar. Set `enabled: false` to disable it, or set `homes` to include additional local Codex stores. See [Codex session catalog and supervision](/plugins/codex-harness-reference/supervision). |
+| `supervision`              | disabled                 | Agent-facing native-session transcript and write-control policy. See [Codex supervision](/plugins/codex-supervision).                                                                                                                   |
 
 ## Where each section moved
 

--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -47,6 +47,8 @@ cd ~/.openclaw/npm/projects/<encoded-package>
 npm install --omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 ```
 
+### npm-pack tarball installs
+
 `openclaw plugins install npm-pack:<path.tgz>` uses the same per-plugin npm
 project root for a local npm-pack tarball: OpenClaw reads the tarball's npm
 metadata, adds it to the managed project as a copied `file:` dependency, runs
@@ -67,6 +69,8 @@ published package path that records official trust. Privileged helper access
 and trusted-official scope handling should be validated on that trusted
 install path, not inferred from a local tarball install.
 
+### Missing runtime imports
+
 If a plugin fails at runtime with a missing import, fix the package manifest
 instead of repairing the managed project by hand. Runtime imports belong in
 the plugin package `dependencies` or `optionalDependencies`; `devDependencies`
@@ -75,10 +79,14 @@ are not installed for managed runtime projects. A local `npm install` inside
 diagnostic, but it is not package-acceptance proof because the next install or
 update recreates the project from package metadata.
 
+### Hoisted transitive dependencies
+
 npm may hoist transitive dependencies to the per-plugin project's
 `node_modules` beside the plugin package. OpenClaw scans the managed project
 root before trusting the install, and removes that project on uninstall, so
 hoisted runtime dependencies stay inside that plugin's cleanup boundary.
+
+### Lockfile policy
 
 OpenClaw-owned npm plugin packages never ship npm lockfiles. The repository
 uses `pnpm-lock.yaml` as its committed product dependency review boundary, then
@@ -95,6 +103,8 @@ policy, and rejects generated versions absent from `pnpm-lock.yaml`. Nothing
 is written into the checkout. Third-party plugin packages may still contain
 lockfiles according to their own packaging policy; OpenClaw's installer leaves
 that npm behavior to the installed npm version.
+
+### Verify a package tarball
 
 Before treating a local package as release-candidate proof, inspect the
 tarball that will be installed:
@@ -117,6 +127,8 @@ tmpdir=$(mktemp -d)
 )
 rm -rf "$tmpdir"
 ```
+
+### Bundled runtime dependencies
 
 OpenClaw-owned npm plugin packages can also publish with explicit
 `bundledDependencies`. The npm publish path overlays the runtime dependency
@@ -145,6 +157,8 @@ instead of embedding every platform binary in the plugin tarball. The root
 bundle its full dependency tree. See
 [dependency locking](/gateway/security/dependency-locking).
 
+### Host peer dependency
+
 Plugins that import `openclaw/plugin-sdk/*` declare `openclaw` as a peer
 dependency. OpenClaw does not let npm install a separate registry copy of the
 host package into a managed project, because a stale host package can affect
@@ -152,6 +166,8 @@ npm's peer resolution inside that plugin. Managed npm installs skip npm peer
 resolution/materialization, and OpenClaw reasserts plugin-local
 `node_modules/openclaw` links for installed packages that declare the host
 peer, after install or update.
+
+### git installs
 
 git installs clone or refresh the repository, then run:
 

--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -156,13 +156,9 @@ openclaw googlemeet test-listen <meet-url> --transport chrome-node
 
 It joins in transcribe mode, waits for fresh caption/transcript movement, and returns `listenVerified`, `listenTimedOut`, manual-action fields, and current caption health.
 
-### Realtime session health
+<a id="notes" />
 
-During talk-back sessions, `google_meet` status reports Chrome/audio bridge health: `inCall`, `manualAction`, `providerConnected`, `realtimeReady`, `audioInputActive`, `audioOutputActive`, last input/output timestamps, byte counters, and bridge-closed state. Managed Chrome sessions only speak the intro/test phrase after health reports `inCall: true`; otherwise `speechReady: false` and the speech attempt is blocked rather than silently no-opping.
-
-Local Chrome joins through the signed-in OpenClaw browser profile and routes its microphone and speaker through the native backend selected by `chrome.audioBackend`. The default shared loopback device is enough for a first smoke test but can echo; use separate virtual devices or a Loopback-style graph for clean duplex audio.
-
-## Notes
+## Audio bridge architecture
 
 Google Meet's official media API is receive-oriented, so speaking into a call still needs a participant path. This plugin keeps that boundary visible: Chrome handles browser participation and local audio routing; Twilio handles phone dial-in participation.
 
@@ -176,6 +172,12 @@ With the command-pair Chrome bridge, `chrome.bargeInInputCommand` can listen to 
 For clean duplex audio, route Meet output and Meet microphone through separate virtual devices or a Loopback-style virtual device graph; the default shared loopback device can echo other participants back into the call.
 
 `googlemeet speak` triggers the active talk-back audio bridge for a Chrome session; `googlemeet leave` stops it (and, for Twilio sessions delegated through Voice Call, hangs up the underlying call). Use `googlemeet end-active-conference` to also close the active Google Meet conference for an API-managed space.
+
+### Realtime session health
+
+During talk-back sessions, `google_meet` status reports Chrome/audio bridge health: `inCall`, `manualAction`, `providerConnected`, `realtimeReady`, `audioInputActive`, `audioOutputActive`, last input/output timestamps, byte counters, and bridge-closed state. Managed Chrome sessions only speak the intro/test phrase after health reports `inCall: true`; otherwise `speechReady: false` and the speech attempt is blocked rather than silently no-opping.
+
+Local Chrome joins through the signed-in OpenClaw browser profile and routes its microphone and speaker through the native backend selected by `chrome.audioBackend`. The default shared loopback device is enough for a first smoke test but can echo; use separate virtual devices or a Loopback-style graph for clean duplex audio.
 
 ## Where each section moved
 

--- a/docs/plugins/manifest/setup-and-auth.md
+++ b/docs/plugins/manifest/setup-and-auth.md
@@ -161,6 +161,15 @@ Because setup lookup can execute plugin-owned `setup-api` code, normalized `setu
 
 When setup runtime executes, setup registry diagnostics report providers or CLI backends that `setup-api` registers without matching manifest declarations. CLI backend descriptors also report a missing runtime registration because setup lookup needs the registered backend configuration. Provider descriptors may remain metadata-only even when the same setup module contributes migrations, CLI backends, probes, or selected provider runtimes.
 
+### setup fields
+
+| Field              | Required | Type       | What it means                                                                                                                                  |
+| ------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `providers`        | No       | `object[]` | Provider setup descriptors exposed during setup and onboarding.                                                                                |
+| `cliBackends`      | No       | `string[]` | Setup-time backend ids used for descriptor-first setup lookup. Keep normalized ids globally unique.                                            |
+| `configMigrations` | No       | `string[]` | Config migration ids owned by this plugin's setup surface.                                                                                     |
+| `requiresRuntime`  | No       | `boolean`  | Whether setup still needs `setup-api` execution after descriptor lookup. Explicit `false` disables it; omission preserves the legacy fallback. |
+
 ### setup.providers reference
 
 | Field          | Required | Type       | What it means                                                                                    |
@@ -183,15 +192,6 @@ Supported evidence entries:
 | `requiresAllEnv`   | No       | `string[]` | Every listed env var must be non-empty before the evidence is valid.                                           |
 | `credentialMarker` | Yes      | `string`   | Non-secret marker returned when the evidence is present.                                                       |
 | `source`           | No       | `string`   | User-facing source label for auth/status output.                                                               |
-
-### setup fields
-
-| Field              | Required | Type       | What it means                                                                                                                                  |
-| ------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `providers`        | No       | `object[]` | Provider setup descriptors exposed during setup and onboarding.                                                                                |
-| `cliBackends`      | No       | `string[]` | Setup-time backend ids used for descriptor-first setup lookup. Keep normalized ids globally unique.                                            |
-| `configMigrations` | No       | `string[]` | Config migration ids owned by this plugin's setup surface.                                                                                     |
-| `requiresRuntime`  | No       | `boolean`  | Whether setup still needs `setup-api` execution after descriptor lookup. Explicit `false` disables it; omission preserves the legacy fallback. |
 
 ## uiHints reference
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -55,13 +55,6 @@ Backend plugin APIs and ordinary plugin loading do not require that setting.
 The `register(api)` callback receives an `OpenClawPluginApi` object with these
 methods:
 
-Plugins that provide an external team-chat surface for a session can register
-the single process-wide provider exported by
-`openclaw/plugin-sdk/session-discussion`. Its `info({ sessionKey })` method
-reports whether a discussion is unavailable, ready to open, or already open;
-`open({ sessionKey })` creates or resolves the discussion and returns its embed
-and external URLs. Registering another provider replaces the current provider.
-
 Each group of registration methods has its own page:
 
 | Group                                                                                       | What it registers                                                     |
@@ -73,6 +66,13 @@ Each group of registration methods has its own page:
 | [CLI and discovery](/plugins/sdk-overview/cli-and-discovery#gateway-discovery-registration) | Gateway discovery advertisers, CLI registrars, CLI backends           |
 | [Exclusive slots](/plugins/sdk-overview/memory-and-context#exclusive-slots)                 | Context engine and memory capability, one active at a time            |
 | [Events and lifecycle](/plugins/sdk-overview/events-and-hooks#events-and-lifecycle)         | Typed lifecycle hooks and conversation binding callbacks              |
+
+Plugins that provide an external team-chat surface for a session can register
+the single process-wide provider exported by
+`openclaw/plugin-sdk/session-discussion`. Its `info({ sessionKey })` method
+reports whether a discussion is unavailable, ready to open, or already open;
+`open({ sessionKey })` creates or resolves the discussion and returns its embed
+and external URLs. Registering another provider replaces the current provider.
 
 ### API object fields
 

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -14,6 +14,15 @@ Reference for plugin packaging (`package.json` metadata), manifests (`openclaw.p
 **Looking for a walkthrough?** The how-to guides cover packaging in context: [Channel plugins](/plugins/sdk-channel-plugins#step-1-package-and-manifest) and [Provider plugins](/plugins/sdk-provider-plugins#step-1-package-and-manifest).
 </Tip>
 
+On this page:
+
+- [Package metadata](#package-metadata)
+- [Plugin manifest](#plugin-manifest)
+- [Setup entry](#setup-entry)
+- [Config schema](#config-schema)
+- [Setup wizards](#setup-wizards)
+- [Publishing and installing](#publishing-and-installing)
+
 ## Package metadata
 
 Your `package.json` needs an `openclaw` field that tells the plugin system what your plugin provides:
@@ -324,19 +333,6 @@ Even plugins with no config must ship a schema. An empty schema is valid:
 
 See [Plugin manifest](/plugins/manifest) for the full schema reference.
 
-## ClawHub publishing
-
-Skills and plugin packages use separate ClawHub publish commands. For plugin packages, use the package-specific command:
-
-```bash
-clawhub package publish your-org/your-plugin --dry-run
-clawhub package publish your-org/your-plugin
-```
-
-<Note>
-`clawhub skill publish <path>` is a different command for publishing a skill folder, not a plugin package. See [Publishing on ClawHub](/clawhub/publishing).
-</Note>
-
 ## Setup entry
 
 `setup-entry.ts` is a lightweight alternative to `index.ts` that OpenClaw loads when it only needs setup surfaces (onboarding, config repair, disabled channel inspection):
@@ -638,6 +634,19 @@ Gateway startup does not install plugin dependencies. npm/git/ClawHub install fl
 </Note>
 
 Bundled package metadata is explicit, not inferred from built JavaScript at gateway startup. Runtime dependencies belong in the plugin package that owns them; packaged OpenClaw startup never repairs or mirrors plugin dependencies.
+
+### ClawHub publishing
+
+Skills and plugin packages use separate ClawHub publish commands. For plugin packages, use the package-specific command:
+
+```bash
+clawhub package publish your-org/your-plugin --dry-run
+clawhub package publish your-org/your-plugin
+```
+
+<Note>
+`clawhub skill publish <path>` is a different command for publishing a skill folder, not a plugin package. See [Publishing on ClawHub](/clawhub/publishing).
+</Note>
 
 ## Related
 


### PR DESCRIPTION
Structural-only pass over the open `ia` (information-architecture) audit rows for `docs/plugins/` and `docs/channels/` — 45 rows in the work list. No prose was rewritten; the only content additions are headings, one Related section, and one section index.

## Anchor proof

`parseDocsDocument` id sets enumerated before and after over all 11 changed pages:

| Page | before | after | lost | added |
| --- | --- | --- | --- | --- |
| `docs/channels/clickclack.md` | 22 | 25 | 0 | `configuration`, `plugin-allowlist-behavior`, `related` |
| `docs/channels/groups.md` | 38 | 38 | 0 | — |
| `docs/channels/whatsapp.md` | 57 | 61 | 0 | `access-control`, `messaging-and-delivery`, `reactions-and-typing`, `setup` |
| `docs/plugins/architecture.md` | 44 | 44 | 0 | — |
| `docs/plugins/bundles.md` | 29 | 29 | 0 | — |
| `docs/plugins/codex-harness-reference.md` | 24 | 24 | 0 | — |
| `docs/plugins/dependency-resolution.md` | 7 | 15 | 0 | 8 new H3 ids under `install-roots` |
| `docs/plugins/google-meet.md` | 47 | 48 | 0 | `audio-bridge-architecture` |
| `docs/plugins/manifest/setup-and-auth.md` | 7 | 7 | 0 | — |
| `docs/plugins/sdk-overview.md` | 26 | 26 | 0 | — |
| `docs/plugins/sdk-setup.md` | 44 | 44 | 0 | — |

**0 ids lost, 0 collisions, 16 ids added.** Two renames/removals are covered by authored `<a id>` stubs, and neither page still publishes those ids itself:

- `docs/channels/groups.md` — `#whatsapp-system-prompts`, `#whatsapp-specifics` (redirect-only H2 stubs removed; links carried into `## Related`).
- `docs/plugins/google-meet.md` — `#notes` (H2 renamed to "Audio bridge architecture").

Level changes were measured, not assumed: 13 H2→H3 demotions on `whatsapp.md` and one H4→H2 + two H5→H3 promotions on `bundles.md` all preserved their slugs.

## Validators

- `pnpm check:docs` — pass (exit 0)
- `node scripts/check-docs-mdx.mjs` — pass, 1292 files
- `node scripts/docs-link-audit.mjs` — 0 broken, 13148 links checked (base 13140)
- `node scripts/docs-link-audit.mjs --anchors` — 3 broken, 13430 checked. Baseline measured in a detached worktree at the merge-base `fdc92faed36`: **the same 3** `maturity/#windows-app-node` errors, 13416 checked. No regression.
- `npx tsx scripts/format-docs.mts --check` — clean, 1280 files
- `npx tsx scripts/check-docs-i18n-glossary.mts` — pass
- `npx markdownlint-cli2 --config config/markdownlint-cli2.jsonc` — 0 issues, **1279 files linted**
- `pnpm format:check` — clean (36318 files); `pnpm lint:templates` — 0 issues, 12 files
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — **1 file / 33 tests** passed
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files / 16 tests** passed
- `node .audit/code-docs-anchors.mjs HEAD` — 151 anchored refs outside `docs/`, 5 dead: the documented non-defects (`CHANGELOG.md`, two `localized_links_test.go`, `docs-link-audit.test.ts` fixture, `gateway-chat.connection.test.ts`). None in the pages touched here.

Glossary: two sources appended next to the existing `Channel routing` entry (not at the end of the array) for the new `## Related` list items on ClickClack — `Bot loop protection` and `Access groups`. Both are existing page titles; no vocabulary was coined.

CODEOWNERS: last-match-wins simulation over the 13-file list matches no secops- or release-manager-owned path. No new page directories, so no `.github/labeler.yml` gap is created.

## Findings closed (14)

| id | page | what changed |
| --- | --- | --- |
| r3-1062 | `channels/whatsapp.md` | 24 flat H2s grouped under 4 parent H2s (Setup, Access control, Messaging and delivery, Reactions and typing) by demoting contiguous siblings to H3. No section reordered. |
| r3-1067 | `channels/clickclack.md` | added `## Related` linking pairing, groups, bot loop protection, access groups |
| r3-1068 | `channels/clickclack.md` | added `## Configuration` so the three reference H3s stop nesting under Quick setup; the orphaned plugin-allowlist paragraph got its own H3 |
| r3-1069 | `channels/groups.md` | **partial** — the two redirect-only stubs deleted and their links moved into Related, with anchor stubs. `## iMessage specifics` kept: it is not a redirect, it carries three unique routing facts, and deleting it would drop content. |
| r3-1130 | `docs.json` | `channels/groups` now precedes the WhatsApp-specific `channels/group-messages` |
| r3-1915 | `plugins/google-meet.md` | **partial** — `## Notes` renamed to `## Audio bridge architecture` (+`#notes` stub) and `### Realtime session health` moved under it, out of Quick start. The "Install notes" rename is stale (no such heading), and "move under Tool" is unreachable: the Tool section now lives on `google-meet/tool-and-modes`. |
| r3-1930 | `plugins/sdk-overview.md` | **partial** — the session-discussion paragraph moved below the registration table it interrupted. The duplicate `registerNodeHostCommand` row is no longer on this page: it is now on `sdk-overview/infrastructure.md:38` and `sdk-overview/tools-and-commands.md:33`, so deduplicating it is a different page's call. |
| r3-1938 | `plugins/codex-harness-reference.md` | the five unlinked config-surface rows (`discovery`, `appServer`, `codexDynamicToolsLoading`, `codexDynamicToolsExclude`, `sessionCatalog`) now link to the child pages that document them, matching the three rows that already did |
| r3-1965 | `plugins/sdk-setup.md` | `## ClawHub publishing` folded into `## Publishing and installing` as an H3; short section index added after the intro |
| r3-1983 | `plugins/architecture.md` | `sidebarTitle: "Internals"` → `"Architecture"`, so it no longer collides with the adjacent `architecture-internals` page and its "Plugin architecture internals" group |
| r3-2044 | `plugins/bundles.md` | "MCP for embedded OpenClaw" promoted H4→H2 and its children H5→H3; the block moved to after "Detected but not executed" so "Embedded OpenClaw settings"/"LSP" stay under "Supported now". Max depth is now H4. |
| r3-2052 | `plugins/dependency-resolution.md` | eight H3s added inside "Install roots" (npm-pack tarball installs, missing runtime imports, hoisted transitive dependencies, lockfile policy, verify a package tarball, bundled runtime dependencies, host peer dependency, git installs) |
| r3-2074 | `docs.json` | `plugins/install-overrides` moved from "Plugin reference" to "Plugin maintainer reference" — the page opens by saying it is for maintainers and exists for E2E and package validation only |
| r5-0121 | `plugins/manifest/setup-and-auth.md` | **partial** — the `setup` object table moved before its child `setup.providers` table. The "Notes hides ten field rules" half is stale: there is no Notes block, component, or heading on the page. |

## Findings refuted (12)

| id | evidence |
| --- | --- |
| r3-1052 | `channels/imessage.md` is now a 131-line split index with four H2s. There is no "Quick setup"/"Setup" pair and no line 218. |
| r3-1056 | `channels/feishu.md` is now a 100-line split index with three H2s; "Inbound durability" is not on it. |
| r3-1120 | The migration procedure is already delegated — the section links `[Doctor](/cli/doctor#session-sqlite-migration)` for the sequence. What remains is storage layout that the page's own session-key model depends on. |
| r3-1134 | `channels/bot-loop-protection` **is** in the Channels → Configuration nav group. |
| r3-1898 | The page is 313 lines, not 1,500, and `## Where each section moved` (`:213`) is a linked index of all nine child pages. |
| r3-1920 | `docs/plugins/reference/google-meet.md` is already titled "Google Meet plugin reference". No shared title. |
| r3-1978 | The 22 siblings were regrouped after the audit ran — `plugins/workboard` now sits in "Plugin guides → Automation and integrations". `docs/plugins/reference/workboard.md` is titled "Workboard plugin reference", not a same-title stub. |
| r3-2019 | **The suggested fix is the breaking change.** `createChannelIngressMonitor` is exported from `openclaw/plugin-sdk/channel-outbound` (`src/plugin-sdk/channel-outbound.ts:37`). Moving the section to the inbound page would document an API that page's subpath does not export. The page's routing rule is about receive/context/dispatch *orchestration*, not ingress durability helpers. |
| r5-0087 | `channels/slack.md` is now a 153-line split index with a single `## Related` at `:132`. There is no line 2234 and no back-to-back related-links pair. |
| r5-0092 | Same page, same reason — no line 1354 or 1978. |
| r5-0093 | Same page, same reason — no line 1328 and no DM-policy Note. |
| r5-0094 | Same page, same reason — no line 1331 and no multi-account precedence list. |

(Four of these — r5-0087/0092/0093/0094 — share one cause: the Slack page was split into `channels/slack/*` after the audit ran. Any residual duplication now lives in the children and should be re-audited against those files.)

## Findings deferred (19)

**Split-plan rows** — each fix says "split into … as described in the split plan"; that is the split lane's work, with its own brief, child pages, glossary sources and `docs.json` regrouping: r3-1985 (`message-presentation.md`, 764 lines), r3-1988 (`codex-native-plugins.md`, 613), r3-1996 (`cli-backend-plugins.md`, 558), r3-2001 (`memory-wiki.md`, 587), r3-2004 (`sdk-testing.md`, 396), r3-2007 (`codex-computer-use.md`, 424), r3-2029, r3-2034, r3-2043, r3-2047, r3-2054, r3-2015 (all require a new concept/sub-page to exist first).

**Cross-page content moves** — these change two pages' anchor sets at once and pick a destination the row does not pin down:

- r3-0945 — half stale, half deferred. The "which channel first" guidance and one `openclaw channels add` example are already above the catalog (`channels/index.md:18-31`, catalog at `:33`), so that half needs no change. What remains is moving `## Group join introductions` (45 lines) from the channels hub to `channels/groups.md`, which is a cross-page move.
- r3-1124 — `## Plugin diagnostics` documents `openclaw/plugin-sdk/access-groups`, a topic-specific helper. `/plugins/sdk-runtime` is now a split family of eight children with no access-groups child, so the destination is a maintainer's call.
- r3-2038 — line anchors have drifted (L310-338 is now mid-"Registering tools"), and the named destination, "a contributor page", does not exist.
- r3-2051 — moving the tarball-verification steps to building-plugins would separate them from the `npm-pack:` context they depend on; this PR instead made them findable in place as `### Verify a package tarball` (r3-2052).

**Other**

- r3-1139 (`channels/location.md`) — the premise is only half right. The page documents runtime behavior operators see (`ctx` fields, `message` tool payloads, a per-channel support matrix) and its `read_when` names an operator use case. The row's alternative, "rewrite it for operators", is a rewrite, not a restructure.
- r3-1944 (`plugins/sdk-subpaths.md`) — under a standing refusal: a contract test reads the page whole and asserts 21 literal entrypoint strings. The fix also requires splitting the page.
- r5-0188 (`plugins/reference/anthropic-vertex.md`) — the page is generated (`pnpm plugins:inventory:gen`). Putting a generated plugin-reference page into the `providers/*` nav group, or creating a new providers page, is a taxonomy decision for a maintainer. The narrower alternative is a Related link from `docs/providers/anthropic.md`, which belongs in a link-kind PR with its glossary source.

## Counts

45 rows in the work list: **14 closed** (4 of them partial, each itemised above), **12 refuted**, **19 deferred**. 14 + 12 + 19 = 45.

No generated page was hand-edited: `docs/plugins/reference/**` and `docs/plugins/plugin-inventory.md` are untouched, and `scripts/` was grepped for every page path before editing.
