### PR TITLE
fix(trajectory): preserve paginated read evidence

### DIFF
--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -1,5 +1,9 @@
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
-import { extractBalancedJsonFragments, stableStringify } from "@openclaw/normalization-core";
+import {
+  expectDefined,
+  extractBalancedJsonFragments,
+  stableStringify,
+} from "@openclaw/normalization-core";
 import { parseRetryAfterHeadersSeconds } from "../internal/retry-after.js";
 
 const NON_CREDENTIAL_FIELD_NAMES = new Set([
@@ -34,19 +38,58 @@ const LOOSE_CREDENTIAL_PAIR_RE =
 const MEDIA_DATA_URL_RE =
   /data:(?:audio|image|video)\/[a-z0-9.+-]+(?:;[^,;\s]+)*;base64,[ \t]*(?:\r?\n[ \t]*)?[a-z0-9+/_=-]+(?:[ \t]*\r?\n[ \t]*[a-z0-9+/_=-]+)*/giu;
 const MAX_DIAGNOSTIC_JSON_LENGTH = 16 * 1024;
-// Complete count-and-prose notices are not arrays; numeric grammar stays with JSON.parse.
-const NUMERIC_BRACKET_PROSE_RE =
-  /\[\s*\d+\s+(?!(?:true|false|null)(?![\w-]))[A-Za-z][^"'\\[\]{},:]*\]/gu;
+const BRACKET_PROSE_PATTERN = String.raw`(\[+)([A-Za-z][A-Za-z0-9 _.-]*|\s*\d+\s+(?!(?:true|false|null)(?![\w-]))[A-Za-z][A-Za-z0-9 _.=-]*)(\]+)`;
+const BRACKET_PROSE_RE = new RegExp(`^${BRACKET_PROSE_PATTERN}$`, "u");
+const BRACKET_PROSE_PART_RE = new RegExp(String.raw`(?<!\[)${BRACKET_PROSE_PATTERN}`, "gu");
+const JSON_LITERAL_PROSE_START_RE = /^(?:true|false|null)\b(?!-)/u;
+const PROSE_ASSIGNMENT_RE =
+  /(?<![A-Za-z0-9_.-])([A-Za-z0-9_.-]+)\s*(?:=\s*)+(?=([^=;&\s\]'"},]+))/gu;
 const PRIVATE_KEY_HEADER_RE = /-----BEGIN [A-Z ]*PRIVATE KEY/iu;
-const JSON_ARRAY_START_RE = /\[\s*(?:[{"\d\]-]|(?:true|false|null)(?![\w-]))/u;
+const JSON_ARRAY_START_RE = /\[\s*(?:[{"\d\]-]|true\b|false\b|null\b)/u;
 const MALFORMED_JSON_RE =
   /\{|(?:"[^"]+"|\b(?:b64_json|data|(?:input|output)?(?:audio|image|video)[\w-]*))\s*:/iu;
 
 function looksLikeDiagnosticJson(value: string): boolean {
-  const arrayText = value.replace(NUMERIC_BRACKET_PROSE_RE, (fragment) =>
-    PRIVATE_KEY_HEADER_RE.test(fragment) ? fragment : "[text]",
+  return JSON_ARRAY_START_RE.test(value) || MALFORMED_JSON_RE.test(value);
+}
+
+function isPlainBracketProse(value: string): boolean {
+  const match = BRACKET_PROSE_RE.exec(value);
+  return (
+    match !== null &&
+    expectDefined(match[1], "opening brackets").length ===
+      expectDefined(match[3], "closing brackets").length &&
+    !JSON_LITERAL_PROSE_START_RE.test(expectDefined(match[2], "bracket prose"))
   );
-  return JSON_ARRAY_START_RE.test(arrayText) || MALFORMED_JSON_RE.test(value);
+}
+
+function hasSensitiveProseContent(value: string): boolean {
+  if (PRIVATE_KEY_HEADER_RE.test(value)) {
+    return true;
+  }
+  let mediaContext = false;
+  let contextualPayload = false;
+  for (const match of value.matchAll(PROSE_ASSIGNMENT_RE)) {
+    const assigned = expectDefined(match[2], "diagnostic assignment value");
+    const valueEnd = match.index + match[0].length + assigned.length;
+    if (assigned === "<redacted>" && value[valueEnd] !== "=") {
+      continue;
+    }
+    const key = expectDefined(match[1], "diagnostic assignment field");
+    const normalized = normalizeDiagnosticFieldName(key);
+    if (
+      isCredentialFieldName(normalized) ||
+      extractDiagnosticMediaField(key, normalized, undefined, false)
+    ) {
+      return true;
+    }
+    mediaContext ||= isDiagnosticMediaPayload({ [key]: { value: assigned } });
+    contextualPayload ||= Boolean(extractDiagnosticMediaField(key, normalized, undefined, true));
+    if (mediaContext && contextualPayload) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function normalizeDiagnosticFieldName(value: string): string {
@@ -247,7 +290,16 @@ export function redactDiagnosticText(value: string): string {
   if (!looksLikeDiagnosticJson(text)) {
     return text;
   }
+  const allowProse = !hasSensitiveProseContent(text);
   if (text.length > MAX_DIAGNOSTIC_JSON_LENGTH) {
+    // Prove the whole bracket surface is prose before bypassing the structured-data bound.
+    const remaining =
+      allowProse && !MALFORMED_JSON_RE.test(text)
+        ? text.replace(BRACKET_PROSE_PART_RE, (part) => (isPlainBracketProse(part) ? "" : part))
+        : text;
+    if (allowProse && !/[[\]{}]/u.test(remaining) && !MALFORMED_JSON_RE.test(text)) {
+      return text;
+    }
     return "[Oversized diagnostic JSON redacted]";
   }
   let cursor = 0;
@@ -257,16 +309,19 @@ export function redactDiagnosticText(value: string): string {
     const plainText = text.slice(cursor, fragment.startIndex);
     unstructured += plainText;
     redacted += plainText;
+    // Only the complete outer fragment can establish a prose exemption.
+    if (allowProse && isPlainBracketProse(fragment.json)) {
+      redacted += fragment.json;
+      cursor = fragment.endIndex + 1;
+      continue;
+    }
     try {
       const state = { changed: false, nodesRemaining: 64 };
       const parsed = JSON.parse(fragment.json);
       const projected = projectDiagnosticValue(parsed, {}, new WeakSet(), false, state);
       redacted += state.changed ? stableStringify(projected) : fragment.json;
     } catch {
-      if (looksLikeDiagnosticJson(fragment.json)) {
-        return "[Malformed diagnostic JSON redacted]";
-      }
-      redacted += fragment.json;
+      return "[Malformed diagnostic JSON redacted]";
     }
     cursor = fragment.endIndex + 1;
   }

--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -35,7 +35,8 @@ const MEDIA_DATA_URL_RE =
   /data:(?:audio|image|video)\/[a-z0-9.+-]+(?:;[^,;\s]+)*;base64,[ \t]*(?:\r?\n[ \t]*)?[a-z0-9+/_=-]+(?:[ \t]*\r?\n[ \t]*[a-z0-9+/_=-]+)*/giu;
 const MAX_DIAGNOSTIC_JSON_LENGTH = 16 * 1024;
 const PLAIN_BRACKET_TAG_RE = /^\[[A-Za-z0-9][A-Za-z0-9 _.-]*\]$/u;
-const JSON_ARRAY_START_RE = /\[\s*(?:[{"\d\]-]|true\b|false\b|null\b)/u;
+const JSON_ARRAY_START_RE =
+  /\[\s*(?:[[{"\]]|(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)(?![\d.eE+-])(?=\s*(?:,|\]|[[{"-]|\d|true\b|false\b|null\b)))/u;
 const MALFORMED_JSON_RE =
   /\{|(?:"[^"]+"|\b(?:b64_json|data|(?:input|output)?(?:audio|image|video)[\w-]*))\s*:/iu;
 

--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -36,7 +36,7 @@ const MEDIA_DATA_URL_RE =
 const MAX_DIAGNOSTIC_JSON_LENGTH = 16 * 1024;
 const PLAIN_BRACKET_TAG_RE = /^\[[A-Za-z0-9][A-Za-z0-9 _.-]*\]$/u;
 const JSON_ARRAY_START_RE =
-  /\[\s*(?:[[{"\]]|(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)(?![\d.eE+-])(?=\s*(?:,|\]|[[{"-]|\d|true\b|false\b|null\b)))/u;
+  /\[\s*(?:[{"\]]|(?:true|false|null)(?![\w-])(?=\s*(?:,|\]|[[{"-]|\d|true\b|false\b|null\b))|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?(?![\d.eE+-])(?=\s*(?:,|\]|[[{"-]|\d|true\b|false\b|null\b)))/u;
 const MALFORMED_JSON_RE =
   /\{|(?:"[^"]+"|\b(?:b64_json|data|(?:input|output)?(?:audio|image|video)[\w-]*))\s*:/iu;
 

--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -4,6 +4,53 @@ import { configureProviderErrorRedactor, projectProviderError } from "./provider
 
 describe("projectProviderError", () => {
   it.each([
+    ["", "[2 ordinary lines remain] token=<redacted>"],
+    ["=short-secret", "[Malformed diagnostic JSON redacted]"],
+  ])("requires a complete redaction marker before preserving prose (%s)", (suffix, expected) => {
+    expect(
+      projectProviderError(`[2 ordinary lines remain] token=<redacted>${suffix}`).errorMessage,
+    ).toBe(expected);
+  });
+
+  it.each([
+    '[true-story,"sk-synthetic-secret-value"]',
+    '[false-positive,"sk-synthetic-secret-value"]',
+    '[null-value,"sk-synthetic-secret-value"]',
+    "[1 note token=short-secret]",
+    "[1 note token=1234]",
+    "[1 note b64_json=QUJDRA==]",
+    "[1 note image=QUJDRA==]",
+    "[1 note type=image data=QUJDRA==]",
+    "[1 note data=QUJDRA== type=image]",
+    "[1 note status=token=short-secret]",
+    "[1 note status=b64_json=QUJDRA==]",
+    "[1 note token==short-secret]",
+    "[1 note b64_json==QUJDRA==]",
+    "[1 note type==image data=QUJDRA==]",
+    "[1 note token= =short-secret]",
+    '[[2 ordinary lines remain],"sk-synthetic-secret-value"]',
+    '[ [2 ordinary lines remain],"sk-synthetic-secret-value"]',
+    '[note [2 ordinary lines remain],"sk-synthetic-secret-value"]',
+  ])("keeps structured admission around prose: %s", (error) => {
+    expect(projectProviderError(error).errorMessage).toBe("[Malformed diagnostic JSON redacted]");
+  });
+
+  it("preserves an ordinary comparison alongside numeric prose", () => {
+    const value = "count == 3\n[2 ordinary lines remain]";
+    expect(projectProviderError(value).errorMessage).toBe(value);
+  });
+
+  it.each([
+    '[note "-----BEGIN PRIVATE KEY-----\\nQUJDRA==\\n-----END PRIVATE KEY-----"] {"ok":true}',
+    '[note "sk-synthetic-secret-value"] {"ok":true}',
+    '[note "\\u002d\\u002d\\u002d\\u002d\\u002dBEGIN PRIVATE KEY-----QUJDRA=="] {"ok":true}',
+    '[note -----BEGIN PRIVATE KEY-----\nQUJDRA==\n-----END PRIVATE KEY-----] {"ok":true}',
+    '[note token=short-secret] {"ok":true}',
+  ])("fails closed for nonnumeric structured fragments: %s", (error) => {
+    expect(projectProviderError(error).errorMessage).toBe("[Malformed diagnostic JSON redacted]");
+  });
+
+  it.each([
     "\nQUJDRA==\n-----END PRIVATE KEY-----",
     "QUJDRA==-----END PRIVATE KEY-----",
     "QUJDRA==",

--- a/src/agents/payload-redaction.test.ts
+++ b/src/agents/payload-redaction.test.ts
@@ -230,6 +230,11 @@ describe("sanitizeDiagnosticPayload", () => {
     "[2 more lines in file. Use offset=3 to continue.]",
     "[12 more lines in file. Use offset=34 to continue.]",
     "[0 records matched the query.]",
+    "[[reply_to_current]] Hello",
+    "[[audio_as_voice]] Voice note",
+    "[false-positive]",
+    "[true-story]",
+    "[null-value]",
   ])("preserves plain bracketed diagnostic text", (value) => {
     expect(sanitizeDiagnosticPayload(value)).toBe(value);
   });

--- a/src/agents/payload-redaction.test.ts
+++ b/src/agents/payload-redaction.test.ts
@@ -224,12 +224,15 @@ describe("sanitizeDiagnosticPayload", () => {
     expect(sanitizeDiagnosticPayload(value)).toBe(value);
   });
 
-  it.each(["[GoogleGenerativeAI Error]: provider unavailable", "[429] rate limited: retry later"])(
-    "preserves plain bracketed diagnostic text",
-    (value) => {
-      expect(sanitizeDiagnosticPayload(value)).toBe(value);
-    },
-  );
+  it.each([
+    "[GoogleGenerativeAI Error]: provider unavailable",
+    "[429] rate limited: retry later",
+    "[2 more lines in file. Use offset=3 to continue.]",
+    "[12 more lines in file. Use offset=34 to continue.]",
+    "[0 records matched the query.]",
+  ])("preserves plain bracketed diagnostic text", (value) => {
+    expect(sanitizeDiagnosticPayload(value)).toBe(value);
+  });
 
   it("fails closed for malformed JSON diagnostic strings", () => {
     const sanitized = sanitizeDiagnosticPayload('{"type":"video","data":"QUJDRA=="');
@@ -237,6 +240,13 @@ describe("sanitizeDiagnosticPayload", () => {
     expect(sanitized).not.toContain(MEDIA_DATA);
     expect(sanitized).toBe("[Malformed diagnostic JSON redacted]");
   });
+
+  it.each(["[0,1", "[true false]", '[null{"type":"video","data":"QUJDRA=="}]'])(
+    "fails closed for malformed JSON arrays",
+    (value) => {
+      expect(sanitizeDiagnosticPayload(value)).toBe("[Malformed diagnostic JSON redacted]");
+    },
+  );
 
   it("fails closed for hostile diagnostic properties", () => {
     const value = { type: "video", data: MEDIA_DATA };

--- a/src/agents/payload-redaction.test.ts
+++ b/src/agents/payload-redaction.test.ts
@@ -224,6 +224,48 @@ describe("sanitizeDiagnosticPayload", () => {
     expect(sanitizeDiagnosticPayload(value)).toBe(value);
   });
 
+  it("preserves a long plain page and its pagination notice", () => {
+    const value = `${"read evidence\n".repeat(1500)}[[continue]]\n[2 more lines in file. Use offset=3 to continue.]`;
+    expect(sanitizeDiagnosticPayload(value)).toBe(value);
+  });
+
+  it.each([
+    ["", "[2 ordinary lines remain] token=<redacted>"],
+    ["=short-secret", "[Malformed diagnostic JSON redacted]"],
+  ])("requires a complete redaction marker before preserving prose (%s)", (suffix, expected) => {
+    expect(sanitizeDiagnosticPayload(`[2 ordinary lines remain] token=<redacted>${suffix}`)).toBe(
+      expected,
+    );
+  });
+
+  it.each([
+    '[true-story,"sk-synthetic-secret-value"]',
+    '[false-positive,"sk-synthetic-secret-value"]',
+    '[null-value,"sk-synthetic-secret-value"]',
+    "[1 note token=short-secret]",
+    "[1 note token=1234]",
+    "[1 note b64_json=QUJDRA==]",
+    "[1 note image=QUJDRA==]",
+    "[1 note type=image data=QUJDRA==]",
+    "[1 note data=QUJDRA== type=image]",
+    "[1 note status=token=short-secret]",
+    "[1 note status=b64_json=QUJDRA==]",
+    "[1 note token==short-secret]",
+    "[1 note b64_json==QUJDRA==]",
+    "[1 note type==image data=QUJDRA==]",
+    "[1 note token= =short-secret]",
+    '[[2 ordinary lines remain],"sk-synthetic-secret-value"]',
+    '[ [2 ordinary lines remain],"sk-synthetic-secret-value"]',
+    '[note [2 ordinary lines remain],"sk-synthetic-secret-value"]',
+  ])("keeps structured admission around prose: %s", (value) => {
+    expect(sanitizeDiagnosticPayload(value)).toBe("[Malformed diagnostic JSON redacted]");
+  });
+
+  it("preserves an ordinary comparison alongside numeric prose", () => {
+    const value = "count == 3\n[2 ordinary lines remain]";
+    expect(sanitizeDiagnosticPayload(value)).toBe(value);
+  });
+
   it.each([
     "[GoogleGenerativeAI Error]: provider unavailable",
     "[429] rate limited: retry later",
@@ -249,6 +291,16 @@ describe("sanitizeDiagnosticPayload", () => {
 
     expect(sanitized).not.toContain(MEDIA_DATA);
     expect(sanitized).toBe("[Malformed diagnostic JSON redacted]");
+  });
+
+  it.each([
+    '[note "-----BEGIN PRIVATE KEY-----\\nQUJDRA==\\n-----END PRIVATE KEY-----"] {"ok":true}',
+    '[note "sk-synthetic-secret-value"] {"ok":true}',
+    '[note "\\u002d\\u002d\\u002d\\u002d\\u002dBEGIN PRIVATE KEY-----QUJDRA=="] {"ok":true}',
+    '[note -----BEGIN PRIVATE KEY-----\nQUJDRA==\n-----END PRIVATE KEY-----] {"ok":true}',
+    '[note token=short-secret] {"ok":true}',
+  ])("fails closed for nonnumeric structured fragments: %s", (value) => {
+    expect(sanitizeDiagnosticPayload(value)).toBe("[Malformed diagnostic JSON redacted]");
   });
 
   it.each([

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -187,7 +187,7 @@ function writeToolCallOnlySessionFile(sessionFile: string): void {
   );
 }
 
-function writeToolCallSessionFile(sessionFile: string): void {
+function writeToolCallSessionFile(sessionFile: string, toolResultText = "README contents"): void {
   const header = {
     type: "session",
     version: 3,
@@ -226,7 +226,7 @@ function writeToolCallSessionFile(sessionFile: string): void {
       id: "entry-tool-result",
       parentId: "entry-tool-call",
       timestamp: "2026-04-01T05:46:42.000Z",
-      message: toolResultMessage([{ type: "text", text: "README contents" }]),
+      message: toolResultMessage([{ type: "text", text: toolResultText }]),
     },
     {
       type: "message",
@@ -801,6 +801,35 @@ describe("exportTrajectoryBundle", () => {
     );
 
     expect(artifacts).toBeUndefined();
+  });
+
+  it("preserves paginated read evidence in exported trajectory events", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    const paginationNotice = "[12 more lines in file. Use offset=34 to continue.]";
+    writeToolCallSessionFile(sessionFile, `Project: Orion\nOwner: Vega\n\n${paginationNotice}`);
+
+    await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+    });
+
+    const exportedEvents = fs
+      .readFileSync(path.join(outputDir, "events.jsonl"), "utf8")
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line) as TrajectoryEvent);
+    const toolResult = exportedEvents.find((event) => event.type === "tool.result");
+
+    expect(toolResult?.data).toMatchObject({
+      message: {
+        isError: false,
+        content: [{ type: "text", text: `Project: Orion\nOwner: Vega\n\n${paginationNotice}` }],
+      },
+    });
   });
 
   it("preserves numeric transcript timestamps", async () => {

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { Message, Usage } from "openclaw/plugin-sdk/llm";
 import { afterAll, describe, expect, it } from "vitest";
+import { createReadTool } from "../agents/sessions/tools/read.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
   replaceSessionEntry,
@@ -806,9 +807,21 @@ describe("exportTrajectoryBundle", () => {
   it("preserves paginated read evidence in exported trajectory events", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");
+    const sourceFile = path.join(tmpDir, "evidence.txt");
     const outputDir = path.join(tmpDir, "bundle");
-    const paginationNotice = "[12 more lines in file. Use offset=34 to continue.]";
-    writeToolCallSessionFile(sessionFile, `Project: Orion\nOwner: Vega\n\n${paginationNotice}`);
+    fs.writeFileSync(
+      sourceFile,
+      `${Array.from({ length: 15 }, (_, index) => `evidence-line-${index + 1}`).join("\n")}\n`,
+      "utf8",
+    );
+    const readResult = await createReadTool(tmpDir).execute("call_1", {
+      path: "evidence.txt",
+      offset: 1,
+      limit: 3,
+    });
+    const resultText = readResult.content.find((part) => part.type === "text")?.text;
+    expect(resultText).toContain("[12 more lines in file. Use offset=4 to continue.]");
+    writeToolCallSessionFile(sessionFile, resultText ?? "");
 
     await exportTrajectoryBundle({
       outputDir,
@@ -827,7 +840,7 @@ describe("exportTrajectoryBundle", () => {
     expect(toolResult?.data).toMatchObject({
       message: {
         isError: false,
-        content: [{ type: "text", text: `Project: Orion\nOwner: Vega\n\n${paginationNotice}` }],
+        content: [{ type: "text", text: resultText }],
       },
     });
   });

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -823,7 +823,7 @@ describe("exportTrajectoryBundle", () => {
       });
       const resultText = readResult.content.find((part) => part.type === "text")?.text;
       expect(resultText).toContain("[12 more lines in file. Use offset=4 to continue.]");
-      writeToolCallSessionFile(sessionFile, expectDefined(resultText));
+      writeToolCallSessionFile(sessionFile, expectDefined(resultText, "read result text"));
 
       await exportTrajectoryBundle({
         outputDir,


### PR DESCRIPTION
Closes #143830

## What Problem This Solves

Fixes an issue where users exporting an agent trajectory after a paginated `read` would lose successful read text. The export replaced the text and continuation notice with `[Malformed diagnostic JSON redacted]`, including pages containing harmless JSON.

## Why This Change Was Made

The shared sanitizer preserves complete plain-bracket fragments while retaining broad JSON detection and bounded parsing. It checks the complete outer fragment, so an inner notice or a partial tag cannot hide malformed sensitive content. Prose exemptions use the existing credential and media rules, including typed media context.

## User Impact

Exported trajectories retain successful read evidence and continuation instructions. Ordinary directives, complete reads, and final pages remain readable. Read errors stay errors, and credentials and media stay redacted.

## Evidence

- Pinned main `da7e3b6` reproduced the lost text through a real isolated Gateway agent turn, the shipped `read` tool, session persistence, and public `openclaw sessions export-trajectory`.
- Final build `eddbec63` preserved the complete 77-byte paginated result in both runtime and transcript exports, with `isError: false`.
- Fresh source-blind acceptance passed all 23 additional public controls, including the 21,053-byte paginated transcript, safe JSON/directives, error identity, and the new malformed-fragment/assignment cases. Runtime capture retains its existing long-text limit; the complete transcript export remains byte-equal.
- Focused source-mode tests: 3 files, 337 passed. Formatting, syntax lint, file-size and assertion-safety checks passed. Fresh independent source review found no remaining actionable issue.
- Regression probes cover mixed JSON/prose, malformed numeric and nonnumeric fragments, nested notices, short credentials, typed media, chained assignments, incomplete private keys, and the structured-data size bound. The earlier test-type error was corrected at its caller; no typecheck exception is used.

Captured public-route text:

```text
Read / final export:
Project: Orion
Owner: Vega

[2 more lines in file. Use offset=3 to continue.]

Baseline export:
[Malformed diagnostic JSON redacted]
```

The existing projection may replace detailed read errors and credential-bearing JSON strings with the redaction marker. Baseline-owner checks preserve that limitation rather than claiming harmless fields survive every sensitive projection.

The local endpoint generated deterministic traffic; it did not supply independent model reasoning. Both original commits by @linhongyu510 are retained, together with the subsequent review corrections and failure history.
