### PR TITLE
refactor(tui): compact command handler test cases

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2393,37 +2393,34 @@ describe("tui command handlers", () => {
   );
 
   it.each([
-    { command: "/model openai/gpt-5.6-luna", hook: "refresh" },
-    { command: "/think high", hook: "refresh" },
-    { command: "/verbose full", hook: "history" },
-    { command: "/usage reset", hook: "refresh" },
-  ])(
-    "hides a stale $command failure after its post-patch $hook rejects",
-    async ({ command, hook }) => {
-      const followup = createDeferred();
-      const harness = createHarness({
-        currentAgentId: "research",
-        currentSessionKey: "agent:research:private",
-        currentSessionId: "private-session",
-        ...(hook === "history"
-          ? { loadHistory: vi.fn(() => followup.promise) as LoadHistoryMock }
-          : { refreshSessionInfo: vi.fn(() => followup.promise) }),
-      });
-      const pending = harness.handleCommand(command);
-      const followupCall = hook === "history" ? harness.loadHistory : harness.refreshSessionInfo;
-      await vi.waitFor(() => expect(followupCall).toHaveBeenCalledTimes(1));
-      harness.addSystem.mockClear();
-      harness.state.currentAgentId = "ops";
-      harness.state.currentSessionKey = "agent:ops:public";
-      harness.state.currentSessionId = "public-session";
+    ["/model openai/gpt-5.6-luna", "refresh"],
+    ["/think high", "refresh"],
+    ["/verbose full", "history"],
+    ["/usage reset", "refresh"],
+  ])("hides a stale %s failure after its post-patch %s rejects", async (command, hook) => {
+    const followup = createDeferred();
+    const harness = createHarness({
+      currentAgentId: "research",
+      currentSessionKey: "agent:research:private",
+      currentSessionId: "private-session",
+      ...(hook === "history"
+        ? { loadHistory: vi.fn(() => followup.promise) as LoadHistoryMock }
+        : { refreshSessionInfo: vi.fn(() => followup.promise) }),
+    });
+    const pending = harness.handleCommand(command);
+    const followupCall = hook === "history" ? harness.loadHistory : harness.refreshSessionInfo;
+    await vi.waitFor(() => expect(followupCall).toHaveBeenCalledTimes(1));
+    harness.addSystem.mockClear();
+    harness.state.currentAgentId = "ops";
+    harness.state.currentSessionKey = "agent:ops:public";
+    harness.state.currentSessionId = "public-session";
 
-      followup.reject(new Error("private provider account rejected research tenant"));
-      await pending;
+    followup.reject(new Error("private provider account rejected research tenant"));
+    await pending;
 
-      expect(harness.addSystem).not.toHaveBeenCalled();
-      expect(harness.state.currentAgentId).toBe("ops");
-    },
-  );
+    expect(harness.addSystem).not.toHaveBeenCalled();
+    expect(harness.state.currentAgentId).toBe("ops");
+  });
 
   it.each(["/model openai/gpt-5.6-luna", "/usage reset"])(
     "ignores a stale global-agent %s result",
@@ -2464,50 +2461,47 @@ describe("tui command handlers", () => {
   );
 
   it.each([
-    { command: "/think high", rejected: false },
-    { command: "/verbose full", rejected: false },
-    { command: "/usage reset", rejected: false },
-    { command: "/model openai/gpt-5.6-luna", rejected: true },
-  ])(
-    "ignores a stale $command patch after the same session is reset",
-    async ({ command, rejected }) => {
-      const deferred = createDeferred<{
-        ok: true;
-        path: string;
-        key: string;
-        entry: Record<string, unknown>;
-      }>();
-      const harness = createHarness({
-        currentSessionId: "session-before-reset",
-        sessionGeneration: 4,
-        sessionInfo: { responseUsage: "tokens", effectiveResponseUsage: "tokens" },
-        patchSession: vi.fn(() => deferred.promise),
+    ["/think high", false],
+    ["/verbose full", false],
+    ["/usage reset", false],
+    ["/model openai/gpt-5.6-luna", true],
+  ])("ignores a stale %s patch after the same session is reset", async (command, rejected) => {
+    const deferred = createDeferred<{
+      ok: true;
+      path: string;
+      key: string;
+      entry: Record<string, unknown>;
+    }>();
+    const harness = createHarness({
+      currentSessionId: "session-before-reset",
+      sessionGeneration: 4,
+      sessionInfo: { responseUsage: "tokens", effectiveResponseUsage: "tokens" },
+      patchSession: vi.fn(() => deferred.promise),
+    });
+
+    const pending = harness.handleCommand(command);
+    harness.state.currentSessionId = "session-after-reset";
+    harness.state.sessionGeneration = 5;
+    if (rejected) {
+      deferred.reject(new Error("stale session setting"));
+    } else {
+      deferred.resolve({
+        ok: true,
+        path: "/sessions/patch",
+        key: "agent:main:main",
+        entry: { model: "stale-model" },
       });
+    }
+    await pending;
 
-      const pending = harness.handleCommand(command);
-      harness.state.currentSessionId = "session-after-reset";
-      harness.state.sessionGeneration = 5;
-      if (rejected) {
-        deferred.reject(new Error("stale session setting"));
-      } else {
-        deferred.resolve({
-          ok: true,
-          path: "/sessions/patch",
-          key: "agent:main:main",
-          entry: { model: "stale-model" },
-        });
-      }
-      await pending;
-
-      expect(harness.state.sessionInfo.responseUsage).toBe("tokens");
-      expect(harness.state.sessionInfo.effectiveResponseUsage).toBe("tokens");
-      expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
-      expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
-      expect(harness.loadHistory).not.toHaveBeenCalled();
-      expect(harness.clearTools).not.toHaveBeenCalled();
-      expect(harness.addSystem).not.toHaveBeenCalled();
-    },
-  );
+    expect(harness.state.sessionInfo.responseUsage).toBe("tokens");
+    expect(harness.state.sessionInfo.effectiveResponseUsage).toBe("tokens");
+    expect(harness.applySessionInfoFromPatch).not.toHaveBeenCalled();
+    expect(harness.refreshSessionInfo).not.toHaveBeenCalled();
+    expect(harness.loadHistory).not.toHaveBeenCalled();
+    expect(harness.clearTools).not.toHaveBeenCalled();
+    expect(harness.addSystem).not.toHaveBeenCalled();
+  });
 
   it("applies a model patch after its selected session becomes canonical", async () => {
     const deferred = createDeferred<{
@@ -2626,28 +2620,25 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    { mode: "gateway", local: false, command: "/think default", field: "thinkingLevel" },
-    { mode: "gateway", local: false, command: "/fast default", field: "fastMode" },
-    { mode: "embedded", local: true, command: "/think default", field: "thinkingLevel" },
-    { mode: "embedded", local: true, command: "/fast default", field: "fastMode" },
-    { mode: "gateway", local: false, command: "/think inherit", field: "thinkingLevel" },
-    { mode: "embedded", local: true, command: "/fast reset", field: "fastMode" },
-  ])(
-    "clears the $field session override for $command in $mode mode",
-    async ({ local, command, field }) => {
-      const { handleCommand, patchSession, refreshSessionInfo } = createHarness({
-        opts: { local },
-      });
+    ["thinkingLevel", "/think default", "gateway", false],
+    ["fastMode", "/fast default", "gateway", false],
+    ["thinkingLevel", "/think default", "embedded", true],
+    ["fastMode", "/fast default", "embedded", true],
+    ["thinkingLevel", "/think inherit", "gateway", false],
+    ["fastMode", "/fast reset", "embedded", true],
+  ])("clears the %s session override for %s in %s mode", async (field, command, _mode, local) => {
+    const { handleCommand, patchSession, refreshSessionInfo } = createHarness({
+      opts: { local },
+    });
 
-      await handleCommand(command);
+    await handleCommand(command);
 
-      expect(patchSession).toHaveBeenCalledWith({
-        key: "agent:main:main",
-        [field]: null,
-      });
-      expect(refreshSessionInfo).toHaveBeenCalledOnce();
-    },
-  );
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      [field]: null,
+    });
+    expect(refreshSessionInfo).toHaveBeenCalledOnce();
+  });
 
   it("does not treat non-default model names as session reset aliases", async () => {
     const { handleCommand, patchSession } = createHarness();
@@ -2717,57 +2708,39 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    {
-      name: "provider-specific binary on",
-      local: false,
-      levels: [
+    [
+      "provider-specific binary on",
+      false,
+      [
         { id: "off", label: "off" },
         { id: "high", label: "on" },
       ],
-      input: "on",
-      expected: "high",
-    },
-    {
-      name: "case-insensitive binary on in embedded mode",
-      local: true,
-      levels: [{ id: "high", label: "on" }],
-      input: "ON",
-      expected: "high",
-    },
-    {
-      name: "always-on high profile",
-      local: false,
-      levels: [{ id: "high", label: "always on" }],
-      input: "always on",
-      expected: "high",
-    },
-    {
-      name: "always-on off profile",
-      local: false,
-      levels: [{ id: "off", label: "always on" }],
-      input: "always on",
-      expected: "off",
-    },
-    {
-      name: "Moonshot binary on",
-      local: false,
-      levels: [{ id: "low", label: "on" }],
-      input: "on",
-      expected: "low",
-    },
-    {
-      name: "canonical id ahead of another option's label",
-      local: false,
-      levels: [
+      "on",
+      "high",
+    ],
+    [
+      "case-insensitive binary on in embedded mode",
+      true,
+      [{ id: "high", label: "on" }],
+      "ON",
+      "high",
+    ],
+    ["always-on high profile", false, [{ id: "high", label: "always on" }], "always on", "high"],
+    ["always-on off profile", false, [{ id: "off", label: "always on" }], "always on", "off"],
+    ["Moonshot binary on", false, [{ id: "low", label: "on" }], "on", "low"],
+    [
+      "canonical id ahead of another option's label",
+      false,
+      [
         { id: "low", label: "high" },
         { id: "high", label: "turbo" },
       ],
-      input: "high",
-      expected: "high",
-    },
+      "high",
+      "high",
+    ],
   ])(
-    "resolves $name to its canonical thinking level",
-    async ({ local, levels, input, expected }) => {
+    "resolves %s to its canonical thinking level",
+    async (_name, local, levels, input, expected) => {
       const { handleCommand, patchSession, addSystem } = createHarness({
         opts: { local },
         sessionInfo: { thinkingLevels: levels },
@@ -3316,13 +3289,13 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    { reason: "missing-auth", guidance: "Run openclaw models auth login or choose another model." },
-    { reason: "auth-failed", guidance: "Run openclaw models auth login or choose another model." },
-    { reason: "cooldown", guidance: "Wait and retry, or choose another model." },
-    { reason: undefined, guidance: "Run openclaw models auth login or choose another model." },
+    ["missing-auth", "Run openclaw models auth login or choose another model."],
+    ["auth-failed", "Run openclaw models auth login or choose another model."],
+    ["cooldown", "Wait and retry, or choose another model."],
+    [undefined, "Run openclaw models auth login or choose another model."],
   ])(
-    "keeps unavailable model availability $reason visible without applying it",
-    async ({ reason, guidance }) => {
+    "keeps unavailable model availability %s visible without applying it",
+    async (reason, guidance) => {
       const harness = createHarness({
         listModels: vi.fn().mockResolvedValue([
           {
@@ -3415,33 +3388,24 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    { local: false, command: "/model default" },
-    { local: true, command: "/model default" },
-    { local: false, command: "/model DEFAULT" },
-    {
-      local: false,
-      command: "/model openai/gpt-5.6-luna --runtime codex continue with this model",
-    },
-    {
-      local: false,
-      command: "/model openai/gpt-5.6-luna --runtime openclaw continue with this model",
-    },
-  ])(
-    "forwards $command through the server directive path (local: $local)",
-    async ({ command, local }) => {
-      const sendChat = vi.fn().mockResolvedValue({ status: "ok" });
-      const patchSession = vi.fn();
-      const { handleCommand } = createHarness({ sendChat, patchSession, opts: { local } });
+    ["/model default", false],
+    ["/model default", true],
+    ["/model DEFAULT", false],
+    ["/model openai/gpt-5.6-luna --runtime codex continue with this model", false],
+    ["/model openai/gpt-5.6-luna --runtime openclaw continue with this model", false],
+  ])("forwards %s through the server directive path (local: %s)", async (command, local) => {
+    const sendChat = vi.fn().mockResolvedValue({ status: "ok" });
+    const patchSession = vi.fn();
+    const { handleCommand } = createHarness({ sendChat, patchSession, opts: { local } });
 
-      await handleCommand(command);
+    await handleCommand(command);
 
-      expectSendChatFields(sendChat, {
-        message: command,
-        sessionKey: "agent:main:main",
-      });
-      expect(patchSession).not.toHaveBeenCalled();
-    },
-  );
+    expectSendChatFields(sendChat, {
+      message: command,
+      sessionKey: "agent:main:main",
+    });
+    expect(patchSession).not.toHaveBeenCalled();
+  });
 
   it("shows resolved canonical model ref after /model alias, not raw alias string", async () => {
     // When the user types `/model gpt4` (a bare alias), the gateway resolves it
@@ -3791,42 +3755,12 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    {
-      name: "session result",
-      sessionKey: "agent:main:first",
-      agentId: "main",
-      fails: false,
-      replace: false,
-    },
-    {
-      name: "global-agent result",
-      sessionKey: "global",
-      agentId: "main",
-      fails: false,
-      replace: false,
-    },
-    {
-      name: "session failure",
-      sessionKey: "agent:main:first",
-      agentId: "main",
-      fails: true,
-      replace: false,
-    },
-    {
-      name: "replacement-session result",
-      sessionKey: "agent:main:first",
-      agentId: "main",
-      fails: false,
-      replace: true,
-    },
-    {
-      name: "replacement-session failure",
-      sessionKey: "agent:main:first",
-      agentId: "main",
-      fails: true,
-      replace: true,
-    },
-  ])("suppresses a stale usage-cost $name", async ({ sessionKey, agentId, fails, replace }) => {
+    ["session result", "agent:main:first", "main", false, false],
+    ["global-agent result", "global", "main", false, false],
+    ["session failure", "agent:main:first", "main", true, false],
+    ["replacement-session result", "agent:main:first", "main", false, true],
+    ["replacement-session failure", "agent:main:first", "main", true, true],
+  ])("suppresses a stale usage-cost %s", async (_name, sessionKey, agentId, fails, replace) => {
     const deferred = createDeferred<{ text: string }>();
     const runUsageCostCommand = vi.fn(() => deferred.promise);
     const harness = createHarness({


### PR DESCRIPTION
## What Problem This Solves

The TUI command-handler suite repeats object property labels across table-driven cases, making the test data longer and harder to scan than the behavior it covers.

## Why This Change Was Made

Convert homogeneous Vitest object tables to positional tuples while preserving every case, value, title, and assertion. Production code is unchanged.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, easier-to-review command-handler suite.

## Evidence

- 236 focused tests pass
- `pnpm check:changed` passes on the exact head
- P3 autoreview: scoped clean (0.99)
- Net change: 66 LOC removed

