### PR TITLE
feat(sessions): explain slow artifact cleanup preparation

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -361,6 +361,25 @@ SQL statement, measure CPU time or lock contention, or establish that a nearby
 RPC caused the delay. Older records may lack `operation`; do not infer it from
 adjacent log messages.
 
+For `session.lifecycle.artifacts-prepare`, the same warning includes a bounded
+`artifactPreparation` object. `admissionMode` distinguishes an existing cached
+handle from asynchronous acquisition; `admissionMs` stops when the planner
+receives that handle. Asynchronous acquisition may include shared admission and
+integrity-check waits, so it is not a CPU measurement.
+
+The remaining millisecond fields separate node inventory and selection
+(`nodeInventoryMs`), references and entry deletion plans (`referencePlanningMs`),
+orphan selection and plans (`orphanPlanningMs`), and transcript marker iteration
+(`markerScanMs`). Orphan planning excludes marker time. Counts report existing
+node/window rows before agent or prefix filtering, referenced IDs, selected entries, entered marker queries,
+consumed marker rows, and deletion plans. They are observed result counts, not
+SQLite internal row visits. No identifiers, marker text, transcript contents, or
+byte counts are added. `completed: false` marks partial observations when
+preparation failed; absent fields were not completed. These fields do not change
+the warning threshold or prove that a nearby request caused the work. Rounding
+and work outside the measured subphases can leave a difference from
+`writerExecutionMs`; do not assign that remainder to a specific phase.
+
 ### Slow reply preparation
 
 When a reply spends a long time preparing, inspect the normal Gateway logs:

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -15,7 +15,7 @@ import {
   replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
-import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
+import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-artifacts.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { runByteLimitedArchiveCleanupFixture } from "./test-helpers.js";

--- a/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as logging from "../../logging/logger.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -14,7 +15,7 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
-import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
+import { readArtifactPreparationLogs } from "./session-accessor.sqlite-diagnostics.test-support.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
@@ -51,9 +52,13 @@ describe("SQLite lifecycle cleanup reclamation", () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     archiveMaterializationHook.afterMaterialize = undefined;
+    await logging.flushLogger();
+    logging.resetLogger();
     closeOpenClawAgentDatabasesForTest();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("does not start a worker when startup cleanup has nothing to reclaim", async () => {
@@ -85,57 +90,116 @@ describe("SQLite lifecycle cleanup reclamation", () => {
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(entry);
   });
 
-  it("rejects cleanup planning when a native scan fails after an orphan marker", async () => {
-    const sessionKey = "agent:main:marker-scan-history";
-    const sessionId = "marker-scan-history";
-    const events = [
-      { type: "metadata", runId: "cleanup-race-marker" },
-      { type: "metadata", runId: "failing-tail" },
-    ];
-    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
-    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
-    await replaceSessionEntry(
-      { sessionKey, storePath },
-      { sessionId: "marker-scan-current", updatedAt: Date.now() },
-    );
-    const database = openDatabase(storePath);
-    const failure = new Error("late native transcript read failure");
-    const observed: unknown[] = [];
-    database.db.function("cleanup_marker_event", (eventJson) => {
-      observed.push(eventJson);
-      if (eventJson === JSON.stringify(events[1])) {
-        throw failure;
-      }
-      return eventJson;
-    });
-    // A connection-local view fails during native stepping without changing the saved schema.
-    database.db.exec(`CREATE TEMP VIEW transcript_events AS
-      SELECT session_id, seq, cleanup_marker_event(event_json) AS event_json, created_at
-      FROM main.transcript_events`);
-    let caught: unknown;
-    try {
-      planSessionLifecycleArtifactCleanup(database, {
-        archiveRemovedEntryTranscripts: false,
-        archiveDirectory: path.dirname(storePath),
-        sessionKeySegmentPrefix: "unrelated-prefix-",
-        transcriptContentMarker: "cleanup-race-marker",
-        orphanTranscriptMinAgeMs: 0,
-        nowMs: Date.now(),
+  it.each([false, true])(
+    "reports warm marker phases without changing native failure=%s",
+    async (fail) => {
+      const sessionKey = "agent:main:marker-scan-history";
+      const sessionId = "marker-scan-history";
+      const events = [
+        { type: "metadata", runId: fail ? "cleanup-race-marker" : "ordinary-row" },
+        { type: "metadata", runId: "failing-tail" },
+      ];
+      await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+      await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
+      await replaceSessionEntry(
+        { sessionKey, storePath },
+        { sessionId: "marker-scan-current", updatedAt: Date.now() },
+      );
+      const before = structuredClone(loadSessionEntry({ sessionKey, storePath }));
+      const database = openDatabase(storePath);
+      const failure = new Error("late native transcript read failure");
+      const observed: unknown[] = [];
+      let clock = 0;
+      let advanceClock = true;
+      vi.spyOn(performance, "now").mockImplementation(() => clock);
+      database.db.function("cleanup_marker_event", (eventJson) => {
+        observed.push(eventJson);
+        if (advanceClock) {
+          clock += 600;
+        }
+        if (fail && eventJson === JSON.stringify(events[1])) {
+          throw failure;
+        }
+        return eventJson;
       });
-    } catch (error) {
-      caught = error;
-    } finally {
-      database.db.exec("DROP VIEW temp.transcript_events");
-    }
-    expect(caught).toBe(failure);
-    expect(observed).toContain(JSON.stringify(events[0]));
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
-      sessionId: "marker-scan-current",
-    });
-    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
-      events,
-    );
-  });
+      database.db.function("cleanup_event_age", (createdAt) => {
+        if (advanceClock) {
+          clock += 20;
+        }
+        return createdAt;
+      });
+      // Native age and payload reads advance the clock, not the number of timer calls.
+      database.db.exec(`CREATE TEMP VIEW transcript_events AS
+        SELECT session_id, seq, cleanup_marker_event(event_json) AS event_json,
+          cleanup_event_age(created_at) AS created_at
+        FROM main.transcript_events`);
+      const logPath = path.join(tempDirs.make("cleanup-diagnostics-log-"), "writer.log");
+      vi.stubEnv("OPENCLAW_TEST_FILE_LOG", "1");
+      logging.setLoggerOverride({ level: "warn", file: logPath });
+      const cleanup = () =>
+        cleanupSessionLifecycleArtifactsCore({
+          storePath,
+          archiveRemovedEntryTranscripts: false,
+          sessionKeySegmentPrefix: "unrelated-prefix-",
+          transcriptContentMarker: "cleanup-race-marker",
+          orphanTranscriptMinAgeMs: 0,
+          nowMs: Date.now(),
+        });
+      let workersStarted = 0;
+      const onWorker = () => {
+        workersStarted += 1;
+      };
+      channel("worker_threads").subscribe(onWorker);
+      try {
+        if (fail) {
+          await expect(cleanup()).rejects.toBe(failure);
+        } else {
+          await expect(cleanup()).resolves.toEqual({
+            removedEntries: 0,
+            archivedTranscriptArtifacts: 0,
+          });
+        }
+        const records = await readArtifactPreparationLogs(logPath);
+        expect(records).toHaveLength(1);
+        expect(records[0]?.message).toBe(
+          fail ? "SQLite session write failed" : "slow SQLite session write",
+        );
+        expect(records[0]?.details.artifactPreparation).toEqual({
+          admissionMode: "cached",
+          admissionMs: 0,
+          nodeInventoryMs: 0,
+          referencePlanningMs: 0,
+          orphanPlanningMs: 40,
+          markerScanMs: 1200,
+          nodeRows: 1,
+          windowRows: 2,
+          referenceIds: 1,
+          selectedEntries: 0,
+          markerWindows: 1,
+          markerRows: fail ? 1 : 2,
+          ...(fail ? {} : { deletePlans: 0 }),
+          completed: !fail,
+        });
+        expect(observed).toEqual(events.map((event) => JSON.stringify(event)));
+        if (!fail) {
+          advanceClock = false;
+          await expect(cleanup()).resolves.toEqual({
+            removedEntries: 0,
+            archivedTranscriptArtifacts: 0,
+          });
+          expect(await readArtifactPreparationLogs(logPath)).toEqual(records);
+        }
+      } finally {
+        channel("worker_threads").unsubscribe(onWorker);
+        database.db.exec("DROP VIEW temp.transcript_events");
+      }
+      expect(workersStarted).toBe(0);
+      expect(loadSessionEntry({ sessionKey, storePath })).toEqual(before);
+      await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
+        events,
+      );
+    },
+  );
 
   it("reclaims orphan-only history and republishes pending archives on an empty pass", async () => {
     const now = Date.now();

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -22,6 +22,32 @@ export type SqliteSessionReclamationDiagnostics = {
   workerThreadId?: number;
 };
 
+export type SqliteSessionDatabaseAdmissionDiagnostics = {
+  admissionMode?: "cached" | "async";
+  admissionMs?: number;
+};
+
+/** One cleanup attempt owns these numeric observations; no row or transcript is retained. */
+export type SqliteSessionArtifactPreparationDiagnostics =
+  SqliteSessionDatabaseAdmissionDiagnostics & {
+    nodeInventoryMs?: number;
+    referencePlanningMs?: number;
+    orphanPlanningMs?: number;
+    markerScanMs?: number;
+    nodeRows?: number;
+    windowRows?: number;
+    referenceIds?: number;
+    selectedEntries?: number;
+    markerWindows?: number;
+    markerRows?: number;
+    deletePlans?: number;
+    completed?: boolean;
+  };
+
+export type SqliteSessionWriteDiagnostics = SqliteSessionReclamationDiagnostics & {
+  artifactPreparation?: SqliteSessionArtifactPreparationDiagnostics;
+};
+
 export type SessionTranscriptInstance = SessionEntrySummary & {
   agentId: string;
   /** Stable transcript identity, including rotated history for one logical session key. */

--- a/src/config/sessions/session-accessor.sqlite-diagnostics.test-support.ts
+++ b/src/config/sessions/session-accessor.sqlite-diagnostics.test-support.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { flushLogger } from "../../logging/logger.js";
+
+export async function readArtifactPreparationLogs(logPath: string) {
+  await flushLogger();
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .flatMap((line) => {
+      const record: unknown = JSON.parse(line);
+      if (!isRecord(record)) {
+        throw new Error("expected structured writer log");
+      }
+      const message = record["1"];
+      const details = record["2"];
+      if (
+        (message === "slow SQLite session write" || message === "SQLite session write failed") &&
+        isRecord(details) &&
+        details.operation === "session.lifecycle.artifacts-prepare"
+      ) {
+        return [{ message, details }];
+      }
+      return [];
+    });
+}

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-admission.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-admission.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as sqlite from "../../infra/node-sqlite.js";
 import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import * as logging from "../../logging/logger.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesAsync,
@@ -22,6 +24,7 @@ import {
   replaceSessionEntrySync,
   resetSessionEntryLifecycle,
 } from "./session-accessor.js";
+import { readArtifactPreparationLogs } from "./session-accessor.sqlite-diagnostics.test-support.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 
 const archiveHook = vi.hoisted(() => ({ afterMaterialize: undefined as (() => void) | undefined }));
@@ -57,6 +60,8 @@ afterEach(async () => {
   }
   await Promise.allSettled(pending.splice(0));
   archiveHook.afterMaterialize = undefined;
+  await logging.flushLogger();
+  logging.resetLogger();
   await closeOpenClawAgentDatabasesAsync();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
@@ -178,6 +183,51 @@ it.each(["delete", "artifact cleanup"] as const)(
     expect(loadSessionEntryReadOnly(f.scope)).toBeUndefined();
   },
 );
+
+it("reports actual cold artifact admission before the no-op planner", async () => {
+  const f = fixture();
+  const admission = observeColdAdmission(f.databaseOptions.path);
+  const logPath = path.join(path.dirname(f.scope.storePath), "admission.log");
+  vi.stubEnv("OPENCLAW_TEST_FILE_LOG", "1");
+  logging.setLoggerOverride({ level: "warn", file: logPath });
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const work = own(
+    cleanupSessionLifecycleArtifactsCore({
+      storePath: f.scope.storePath,
+      sessionKeySegmentPrefix: "unrelated-prefix-",
+      transcriptContentMarker: "unused-marker",
+      archiveRemovedEntryTranscripts: false,
+      orphanTranscriptMinAgeMs: 0,
+    }),
+  );
+  await admission.entered.promise;
+  // The real integrity child remains owned; only its admission-wait interval advances.
+  clock = 1250;
+  admission.release.resolve();
+  await expect(work).resolves.toEqual({ removedEntries: 0, archivedTranscriptArtifacts: 0 });
+  expect(admission.parentChecks()).toBe(0);
+  const records = await readArtifactPreparationLogs(logPath);
+  expect(records).toHaveLength(1);
+  expect(records[0]?.message).toBe("slow SQLite session write");
+  expect(records[0]?.details.artifactPreparation).toEqual({
+    admissionMode: "async",
+    admissionMs: 1250,
+    nodeInventoryMs: 0,
+    referencePlanningMs: 0,
+    orphanPlanningMs: 0,
+    markerScanMs: 0,
+    nodeRows: 1,
+    windowRows: 1,
+    referenceIds: 1,
+    selectedEntries: 0,
+    markerWindows: 0,
+    markerRows: 0,
+    deletePlans: 0,
+    completed: true,
+  });
+  expect(loadSessionEntryReadOnly(f.scope)).toMatchObject({ sessionId: "retained" });
+});
 
 it("rejects retired authority before evaluating a stale deletion target", async () => {
   const f = fixture();

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-artifacts.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-artifacts.ts
@@ -1,0 +1,339 @@
+import { performance } from "node:perf_hooks";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type { SessionStateDeletePlan } from "./session-accessor.sqlite-archive.js";
+import type { SqliteSessionArtifactPreparationDiagnostics } from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryStore } from "./session-accessor.sqlite-entry-store.js";
+import {
+  collectProjectedReferencedSessionIds,
+  planSessionStateDeleteIfUnreferenced,
+} from "./session-accessor.sqlite-lifecycle-state.js";
+import type { LifecycleArtifactCleanupPlan } from "./session-accessor.sqlite-lifecycle-types.js";
+import { collectSessionStateIdsForEntry } from "./session-accessor.sqlite-references.js";
+import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function sessionKeyBelongsToAgent(sessionKey: string, agentId: string | undefined): boolean {
+  if (agentId === undefined) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  return parsed !== null && normalizeAgentId(parsed.agentId) === normalizeAgentId(agentId);
+}
+
+function readSessionTranscriptUpdatedAt(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): number | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("created_at").as("updated_at"))
+      .where("session_id", "=", sessionId),
+  );
+  if (row?.updated_at === null || row?.updated_at === undefined) {
+    return undefined;
+  }
+  return sqliteNumber(row.updated_at);
+}
+
+function sqliteTranscriptStateIsReclaimable(params: {
+  database: OpenClawAgentDatabase;
+  sessionUpdatedAt?: number;
+  sessionId: string;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  const transcriptUpdatedAt = readSessionTranscriptUpdatedAt(params.database, params.sessionId);
+  const updatedAt =
+    params.sessionUpdatedAt === undefined
+      ? transcriptUpdatedAt
+      : Math.max(params.sessionUpdatedAt, transcriptUpdatedAt ?? params.sessionUpdatedAt);
+  return updatedAt === undefined || params.nowMs - updatedAt >= params.orphanTranscriptMinAgeMs;
+}
+
+function sqliteTranscriptStateHasMarker(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  transcriptContentMarker: string;
+  diagnostics?: SqliteSessionArtifactPreparationDiagnostics;
+}): boolean {
+  const startedAt = params.diagnostics ? performance.now() : 0;
+  if (params.diagnostics) {
+    params.diagnostics.markerWindows = (params.diagnostics.markerWindows ?? 0) + 1;
+  }
+  try {
+    const db = getSessionKysely(params.database.db);
+    const rows = iterateSqliteQuerySync(
+      params.database.db,
+      db
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", params.sessionId)
+        .orderBy("seq", "asc"),
+    );
+    // Consume every row so late SQLite errors still abort cleanup planning.
+    let hasMarker = false;
+    for (const row of rows) {
+      if (params.diagnostics) {
+        params.diagnostics.markerRows = (params.diagnostics.markerRows ?? 0) + 1;
+      }
+      hasMarker ||= row.event_json.includes(params.transcriptContentMarker);
+    }
+    return hasMarker;
+  } finally {
+    if (params.diagnostics) {
+      params.diagnostics.markerScanMs =
+        (params.diagnostics.markerScanMs ?? 0) + performance.now() - startedAt;
+    }
+  }
+}
+
+// Plans orphan cleanup without file writes or row deletion; finalization
+// handles archive durability before removing rows.
+function planSqliteOrphanLifecycleTranscriptStateDeletes(params: {
+  agentId?: string;
+  archiveRemovedEntryTranscripts: boolean;
+  archiveDirectory: string;
+  database: OpenClawAgentDatabase;
+  excludedSessionIds?: ReadonlySet<string>;
+  pluginOwnerId?: string;
+  referencedSessionIds: ReadonlySet<string>;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+  diagnostics?: SqliteSessionArtifactPreparationDiagnostics;
+}): SessionStateDeletePlan[] {
+  const db = getSessionKysely(params.database.db);
+  const rows = executeSqliteQuerySync(
+    params.database.db,
+    db
+      .selectFrom("session_windows")
+      .select(["session_id", "session_key", "plugin_owner_id"])
+      .orderBy("session_id", "asc"),
+  ).rows;
+
+  if (params.diagnostics) {
+    params.diagnostics.windowRows = rows.length;
+  }
+  const deletePlans: SessionStateDeletePlan[] = [];
+  // Orphan transcript state is represented by a historical window that is no
+  // longer the node's current id. The marker scopes cleanup to this lifecycle.
+  for (const row of rows) {
+    if (
+      !sessionKeyBelongsToAgent(row.session_key, params.agentId) ||
+      params.referencedSessionIds.has(row.session_id) ||
+      params.excludedSessionIds?.has(row.session_id) ||
+      (params.pluginOwnerId && row.plugin_owner_id && row.plugin_owner_id !== params.pluginOwnerId)
+    ) {
+      continue;
+    }
+    if (
+      !sqliteTranscriptStateIsReclaimable({
+        database: params.database,
+        sessionId: row.session_id,
+        nowMs: params.nowMs,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+      }) ||
+      !sqliteTranscriptStateHasMarker({
+        database: params.database,
+        sessionId: row.session_id,
+        transcriptContentMarker: params.transcriptContentMarker,
+        diagnostics: params.diagnostics,
+      })
+    ) {
+      continue;
+    }
+    const plan = planSessionStateDeleteIfUnreferenced({
+      archiveTranscript: params.archiveRemovedEntryTranscripts,
+      archiveDirectory: params.archiveDirectory,
+      database: params.database,
+      reason: "deleted",
+      referencedSessionIds: params.referencedSessionIds,
+      sessionId: row.session_id,
+    });
+    if (plan) {
+      deletePlans.push(plan);
+    }
+  }
+  return deletePlans;
+}
+
+export function planSessionLifecycleArtifactCleanup(
+  database: OpenClawAgentDatabase,
+  params: {
+    agentId?: string;
+    archiveRemovedEntryTranscripts: boolean;
+    archiveDirectory: string;
+    pluginOwnerId?: string;
+    sessionKeySegmentPrefix: string;
+    transcriptContentMarker: string;
+    orphanTranscriptMinAgeMs: number;
+    nowMs: number;
+    diagnostics?: SqliteSessionArtifactPreparationDiagnostics;
+  },
+): LifecycleArtifactCleanupPlan {
+  const diagnostics = params.diagnostics;
+  type Phase = "nodeInventoryMs" | "referencePlanningMs" | "orphanPlanningMs";
+  let phase: Phase = "nodeInventoryMs";
+  let phaseStartedAt = diagnostics ? performance.now() : 0;
+  if (diagnostics) {
+    diagnostics.markerScanMs = 0;
+    diagnostics.markerRows = 0;
+    diagnostics.markerWindows = 0;
+    diagnostics.completed = false;
+  }
+  const recordPhase = (next?: Phase) => {
+    if (diagnostics) {
+      const finishedAt = performance.now();
+      diagnostics[phase] = (diagnostics[phase] ?? 0) + finishedAt - phaseStartedAt;
+      phaseStartedAt = finishedAt;
+    }
+    if (next) {
+      phase = next;
+    }
+  };
+  try {
+    const db = getSessionKysely(database.db);
+    const rows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .select(["entry_json", "session_key", "current_session_id", "updated_at"])
+        .orderBy("session_key", "asc"),
+    ).rows;
+
+    if (diagnostics) {
+      diagnostics.nodeRows = rows.length;
+    }
+    const removedSessionIds = new Set<string>();
+    const entries: LifecycleArtifactCleanupPlan["entries"] = [];
+    const projectedStore = readSessionEntryStore(database);
+    const foreignOwnedSessionIds = params.pluginOwnerId
+      ? new Set(
+          executeSqliteQuerySync(
+            database.db,
+            db
+              .selectFrom("session_windows")
+              .select("session_id")
+              .where("plugin_owner_id", "is not", null)
+              .where("plugin_owner_id", "!=", params.pluginOwnerId),
+          ).rows.map((row) => row.session_id),
+        )
+      : undefined;
+    for (const row of rows) {
+      if (
+        !sessionKeyBelongsToAgent(row.session_key, params.agentId) ||
+        !sessionKeySegmentStartsWith(row.session_key, params.sessionKeySegmentPrefix)
+      ) {
+        continue;
+      }
+      const entry = projectedStore[row.session_key];
+      const sessionIds = uniqueStrings([
+        row.current_session_id,
+        ...(entry ? collectSessionStateIdsForEntry(entry) : []),
+      ]);
+      // Window ownership survives placeholder nodes and ownerless row projections; preserve
+      // the entire node when any referenced generation belongs to another plugin.
+      if (
+        (params.pluginOwnerId &&
+          entry?.pluginOwnerId &&
+          entry.pluginOwnerId !== params.pluginOwnerId) ||
+        sessionIds.some((sessionId) => foreignOwnedSessionIds?.has(sessionId))
+      ) {
+        continue;
+      }
+      if (
+        !sqliteTranscriptStateIsReclaimable({
+          database,
+          // Admission updates the node even when a run has no event yet or reuses old events.
+          sessionUpdatedAt: sqliteNumber(row.updated_at),
+          sessionId: row.current_session_id,
+          nowMs: params.nowMs,
+          orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        })
+      ) {
+        continue;
+      }
+      for (const sessionId of sessionIds) {
+        removedSessionIds.add(sessionId);
+      }
+      entries.push({
+        expectedEntry: entry ? cloneSessionEntry(entry) : undefined,
+        sessionKey: row.session_key,
+      });
+      delete projectedStore[row.session_key];
+    }
+
+    if (diagnostics) {
+      diagnostics.selectedEntries = entries.length;
+    }
+    recordPhase("referencePlanningMs");
+    const referencedSessionIds = collectProjectedReferencedSessionIds({
+      database,
+      excludedSessionKeys: entries.map((entry) => entry.sessionKey),
+      projectedStore,
+    });
+    if (diagnostics) {
+      diagnostics.referenceIds = referencedSessionIds.size;
+    }
+    const deletePlans: SessionStateDeletePlan[] = [];
+    for (const sessionId of removedSessionIds) {
+      const plan = planSessionStateDeleteIfUnreferenced({
+        archiveTranscript: params.archiveRemovedEntryTranscripts,
+        archiveDirectory: params.archiveDirectory,
+        database,
+        referencedSessionIds,
+        sessionId,
+      });
+      if (plan) {
+        deletePlans.push(plan);
+      }
+    }
+    recordPhase("orphanPlanningMs");
+    deletePlans.push(
+      ...planSqliteOrphanLifecycleTranscriptStateDeletes({
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts,
+        archiveDirectory: params.archiveDirectory,
+        database,
+        excludedSessionIds: removedSessionIds,
+        ...(params.pluginOwnerId ? { pluginOwnerId: params.pluginOwnerId } : {}),
+        referencedSessionIds,
+        transcriptContentMarker: params.transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs: params.nowMs,
+        diagnostics,
+      }),
+    );
+    if (diagnostics) {
+      diagnostics.deletePlans = deletePlans.length;
+      diagnostics.completed = true;
+    }
+    return { deletePlans, entries };
+  } finally {
+    recordPhase();
+    if (diagnostics?.orphanPlanningMs !== undefined) {
+      // Marker reads have their own timer; keep the emitted planning phases disjoint.
+      diagnostics.orphanPlanningMs -= diagnostics.markerScanMs ?? 0;
+    }
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -2,12 +2,9 @@ import { toUSVString } from "node:util";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
   sqliteStringSet,
 } from "../../infra/kysely-sync.js";
-import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   isIncognitoOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
@@ -35,7 +32,6 @@ import {
   readSessionEntryStore,
 } from "./session-accessor.sqlite-entry-store.js";
 import type {
-  LifecycleArtifactCleanupPlan,
   ProjectedLifecycleMutation,
   SessionEntryRemovalPlan,
 } from "./session-accessor.sqlite-lifecycle-types.js";
@@ -93,79 +89,6 @@ export function shouldRemoveSessionEntry(
     return false;
   }
   return removal.expectedUpdatedAt === undefined || entry.updatedAt === removal.expectedUpdatedAt;
-}
-
-function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
-  const firstSeparator = sessionKey.indexOf(":");
-  if (firstSeparator < 0) {
-    return sessionKey.startsWith(prefix);
-  }
-  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
-  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
-  return sessionSegment.startsWith(prefix);
-}
-
-function sessionKeyBelongsToAgent(sessionKey: string, agentId: string | undefined): boolean {
-  if (agentId === undefined) {
-    return true;
-  }
-  const parsed = parseAgentSessionKey(sessionKey);
-  return parsed !== null && normalizeAgentId(parsed.agentId) === normalizeAgentId(agentId);
-}
-
-function readSessionTranscriptUpdatedAt(
-  database: OpenClawAgentDatabase,
-  sessionId: string,
-): number | undefined {
-  const db = getSessionKysely(database.db);
-  const row = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("transcript_events")
-      .select((eb) => eb.fn.max<number | bigint>("created_at").as("updated_at"))
-      .where("session_id", "=", sessionId),
-  );
-  if (row?.updated_at === null || row?.updated_at === undefined) {
-    return undefined;
-  }
-  return sqliteNumber(row.updated_at);
-}
-
-function sqliteTranscriptStateIsReclaimable(params: {
-  database: OpenClawAgentDatabase;
-  sessionUpdatedAt?: number;
-  sessionId: string;
-  nowMs: number;
-  orphanTranscriptMinAgeMs: number;
-}): boolean {
-  const transcriptUpdatedAt = readSessionTranscriptUpdatedAt(params.database, params.sessionId);
-  const updatedAt =
-    params.sessionUpdatedAt === undefined
-      ? transcriptUpdatedAt
-      : Math.max(params.sessionUpdatedAt, transcriptUpdatedAt ?? params.sessionUpdatedAt);
-  return updatedAt === undefined || params.nowMs - updatedAt >= params.orphanTranscriptMinAgeMs;
-}
-
-function sqliteTranscriptStateHasMarker(params: {
-  database: OpenClawAgentDatabase;
-  sessionId: string;
-  transcriptContentMarker: string;
-}): boolean {
-  const db = getSessionKysely(params.database.db);
-  const rows = iterateSqliteQuerySync(
-    params.database.db,
-    db
-      .selectFrom("transcript_events")
-      .select("event_json")
-      .where("session_id", "=", params.sessionId)
-      .orderBy("seq", "asc"),
-  );
-  // Consume every row so late SQLite errors still abort cleanup planning.
-  let hasMarker = false;
-  for (const row of rows) {
-    hasMarker ||= row.event_json.includes(params.transcriptContentMarker);
-  }
-  return hasMarker;
 }
 
 /** Session ids protected by live node state. */
@@ -536,187 +459,6 @@ function deleteSqliteSessionStateRows(database: OpenClawAgentDatabase, sessionId
     db.deleteFrom("session_windows").where("session_id", "=", sessionId),
   );
   return Number(deleted.numAffectedRows ?? 0n) > 0;
-}
-
-// Plans orphan cleanup without file writes or row deletion; finalization
-// handles archive durability before removing rows.
-function planSqliteOrphanLifecycleTranscriptStateDeletes(params: {
-  agentId?: string;
-  archiveRemovedEntryTranscripts: boolean;
-  archiveDirectory: string;
-  database: OpenClawAgentDatabase;
-  excludedSessionIds?: ReadonlySet<string>;
-  pluginOwnerId?: string;
-  referencedSessionIds: ReadonlySet<string>;
-  transcriptContentMarker: string;
-  orphanTranscriptMinAgeMs: number;
-  nowMs: number;
-}): SessionStateDeletePlan[] {
-  const db = getSessionKysely(params.database.db);
-  const rows = executeSqliteQuerySync(
-    params.database.db,
-    db
-      .selectFrom("session_windows")
-      .select(["session_id", "session_key", "plugin_owner_id"])
-      .orderBy("session_id", "asc"),
-  ).rows;
-
-  const deletePlans: SessionStateDeletePlan[] = [];
-  // Orphan transcript state is represented by a historical window that is no
-  // longer the node's current id. The marker scopes cleanup to this lifecycle.
-  for (const row of rows) {
-    if (
-      !sessionKeyBelongsToAgent(row.session_key, params.agentId) ||
-      params.referencedSessionIds.has(row.session_id) ||
-      params.excludedSessionIds?.has(row.session_id) ||
-      (params.pluginOwnerId && row.plugin_owner_id && row.plugin_owner_id !== params.pluginOwnerId)
-    ) {
-      continue;
-    }
-    if (
-      !sqliteTranscriptStateIsReclaimable({
-        database: params.database,
-        sessionId: row.session_id,
-        nowMs: params.nowMs,
-        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
-      }) ||
-      !sqliteTranscriptStateHasMarker({
-        database: params.database,
-        sessionId: row.session_id,
-        transcriptContentMarker: params.transcriptContentMarker,
-      })
-    ) {
-      continue;
-    }
-    const plan = planSessionStateDeleteIfUnreferenced({
-      archiveTranscript: params.archiveRemovedEntryTranscripts,
-      archiveDirectory: params.archiveDirectory,
-      database: params.database,
-      reason: "deleted",
-      referencedSessionIds: params.referencedSessionIds,
-      sessionId: row.session_id,
-    });
-    if (plan) {
-      deletePlans.push(plan);
-    }
-  }
-  return deletePlans;
-}
-
-export function planSessionLifecycleArtifactCleanup(
-  database: OpenClawAgentDatabase,
-  params: {
-    agentId?: string;
-    archiveRemovedEntryTranscripts: boolean;
-    archiveDirectory: string;
-    pluginOwnerId?: string;
-    sessionKeySegmentPrefix: string;
-    transcriptContentMarker: string;
-    orphanTranscriptMinAgeMs: number;
-    nowMs: number;
-  },
-): LifecycleArtifactCleanupPlan {
-  const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .select(["entry_json", "session_key", "current_session_id", "updated_at"])
-      .orderBy("session_key", "asc"),
-  ).rows;
-
-  const removedSessionIds = new Set<string>();
-  const entries: LifecycleArtifactCleanupPlan["entries"] = [];
-  const projectedStore = readSessionEntryStore(database);
-  const foreignOwnedSessionIds = params.pluginOwnerId
-    ? new Set(
-        executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("session_windows")
-            .select("session_id")
-            .where("plugin_owner_id", "is not", null)
-            .where("plugin_owner_id", "!=", params.pluginOwnerId),
-        ).rows.map((row) => row.session_id),
-      )
-    : undefined;
-  for (const row of rows) {
-    if (
-      !sessionKeyBelongsToAgent(row.session_key, params.agentId) ||
-      !sessionKeySegmentStartsWith(row.session_key, params.sessionKeySegmentPrefix)
-    ) {
-      continue;
-    }
-    const entry = projectedStore[row.session_key];
-    const sessionIds = uniqueStrings([
-      row.current_session_id,
-      ...(entry ? collectSessionStateIdsForEntry(entry) : []),
-    ]);
-    // Window ownership survives placeholder nodes and ownerless row projections; preserve
-    // the entire node when any referenced generation belongs to another plugin.
-    if (
-      (params.pluginOwnerId &&
-        entry?.pluginOwnerId &&
-        entry.pluginOwnerId !== params.pluginOwnerId) ||
-      sessionIds.some((sessionId) => foreignOwnedSessionIds?.has(sessionId))
-    ) {
-      continue;
-    }
-    if (
-      !sqliteTranscriptStateIsReclaimable({
-        database,
-        // Admission updates the node even when a run has no event yet or reuses old events.
-        sessionUpdatedAt: sqliteNumber(row.updated_at),
-        sessionId: row.current_session_id,
-        nowMs: params.nowMs,
-        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
-      })
-    ) {
-      continue;
-    }
-    for (const sessionId of sessionIds) {
-      removedSessionIds.add(sessionId);
-    }
-    entries.push({
-      expectedEntry: entry ? cloneSessionEntry(entry) : undefined,
-      sessionKey: row.session_key,
-    });
-    delete projectedStore[row.session_key];
-  }
-
-  const referencedSessionIds = collectProjectedReferencedSessionIds({
-    database,
-    excludedSessionKeys: entries.map((entry) => entry.sessionKey),
-    projectedStore,
-  });
-  const deletePlans: SessionStateDeletePlan[] = [];
-  for (const sessionId of removedSessionIds) {
-    const plan = planSessionStateDeleteIfUnreferenced({
-      archiveTranscript: params.archiveRemovedEntryTranscripts,
-      archiveDirectory: params.archiveDirectory,
-      database,
-      referencedSessionIds,
-      sessionId,
-    });
-    if (plan) {
-      deletePlans.push(plan);
-    }
-  }
-  deletePlans.push(
-    ...planSqliteOrphanLifecycleTranscriptStateDeletes({
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts,
-      archiveDirectory: params.archiveDirectory,
-      database,
-      excludedSessionIds: removedSessionIds,
-      ...(params.pluginOwnerId ? { pluginOwnerId: params.pluginOwnerId } : {}),
-      referencedSessionIds,
-      transcriptContentMarker: params.transcriptContentMarker,
-      orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
-      nowMs: params.nowMs,
-    }),
-  );
-  return { deletePlans, entries };
 }
 
 export function deletePlannedLifecycleArtifactEntries(

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -27,6 +27,7 @@ import type {
   ResetSessionEntryLifecycleResult,
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
+  SqliteSessionArtifactPreparationDiagnostics,
   SqliteSessionReclamationDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
 import {
@@ -44,8 +45,8 @@ import {
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitArchivedTranscriptUpdates } from "./session-accessor.sqlite-events.js";
+import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-artifacts.js";
 import {
-  planSessionLifecycleArtifactCleanup,
   planSessionStateDeleteIfUnreferenced,
   readSessionGenerationIdsForKeys,
   planSessionStateAfterEntryRemoval,
@@ -141,22 +142,29 @@ export async function cleanupSessionLifecycleArtifactsCore(
   if (!withOpenClawAgentDatabaseReadOnly(() => true, databaseOptions).found) {
     return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
   }
+  const artifactPreparation: SqliteSessionArtifactPreparationDiagnostics = {};
   const cleanupPlan = await runExclusiveSqliteSessionWrite(
     resolved,
     async () =>
-      withSqliteSessionDatabase(databaseOptions, (database) =>
-        planSessionLifecycleArtifactCleanup(database, {
-          ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
-          archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          ...(pluginOwnerId ? { pluginOwnerId } : {}),
-          sessionKeySegmentPrefix,
-          transcriptContentMarker,
-          orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
-          nowMs: params.nowMs ?? Date.now(),
-        }),
+      withSqliteSessionDatabase(
+        databaseOptions,
+        (database) =>
+          planSessionLifecycleArtifactCleanup(database, {
+            ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
+            archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
+            archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+            ...(pluginOwnerId ? { pluginOwnerId } : {}),
+            sessionKeySegmentPrefix,
+            transcriptContentMarker,
+            orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+            nowMs: params.nowMs ?? Date.now(),
+            diagnostics: artifactPreparation,
+          }),
+        undefined,
+        artifactPreparation,
       ),
     "session.lifecycle.artifacts-prepare",
+    { artifactPreparation },
   );
   if (cleanupPlan.entries.length === 0 && cleanupPlan.deletePlans.length === 0) {
     // Startup probes need no reclamation Worker, but previously committed archives

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -8,18 +8,25 @@ import { afterEach, expect, test, vi } from "vitest";
 import * as logging from "../../logging/logger.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
+import type {
+  SqliteSessionArtifactPreparationDiagnostics,
+  SqliteSessionReclamationDiagnostics,
+  SqliteSessionWriteDiagnostics,
+} from "./session-accessor.sqlite-contract.js";
 import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import { drainSessionStoreWriterQueuesForTest } from "./store-writer-state.js";
 
 afterEach(() => vi.restoreAllMocks());
 
-async function readFailedWriterLog(failure: unknown) {
+async function readFailedWriterLog(failure: unknown, diagnostics?: SqliteSessionWriteDiagnostics) {
   return await withOpenClawTestState(
     { scenario: "minimal", env: { OPENCLAW_TEST_FILE_LOG: "1" } },
     async (state) => {
       const logPath = state.path("sqlite-write.log");
       logging.setLoggerOverride({ level: "warn", file: logPath });
+      const operation = diagnostics?.artifactPreparation
+        ? "session.lifecycle.artifacts-prepare"
+        : "session.transcript.batch";
       try {
         await expect(
           runExclusiveSqliteSessionWrite(
@@ -27,7 +34,8 @@ async function readFailedWriterLog(failure: unknown) {
             async () => {
               throw failure;
             },
-            "session.transcript.batch",
+            operation,
+            diagnostics,
           ),
         ).rejects.toBe(failure);
         await logging.flushLogger();
@@ -37,8 +45,8 @@ async function readFailedWriterLog(failure: unknown) {
         const details = record["2"];
         assert.ok(isRecord(details));
         expect(record["1"]).toBe("SQLite session write failed");
-        expect(details.operation).toBe("session.transcript.batch");
-        return { content, error: details.error };
+        expect(details.operation).toBe(operation);
+        return { content, error: details.error, details };
       } finally {
         await logging.flushLogger();
         logging.resetLogger();
@@ -97,6 +105,48 @@ test("failed writer error summaries are bounded without splitting a surrogate pa
   const prefix = "x".repeat(2_047);
   const record = await readFailedWriterLog(new Error(`${prefix}🦞 trailing details`));
   expect(record.error).toBe(prefix);
+});
+
+test("artifact preparation file logs retain numeric phases without payload fields", async () => {
+  const artifactPreparation: SqliteSessionArtifactPreparationDiagnostics = {
+    admissionMode: "async",
+    admissionMs: 1200.4,
+    nodeInventoryMs: 20.6,
+    referencePlanningMs: 4.2,
+    orphanPlanningMs: 5.1,
+    markerScanMs: 19.6,
+    nodeRows: 8,
+    windowRows: 12,
+    referenceIds: 8,
+    selectedEntries: 0,
+    markerWindows: 2,
+    markerRows: 5,
+    completed: false,
+  };
+  Object.assign(artifactPreparation, {
+    sessionId: "synthetic-private-session",
+    marker: "synthetic-private-marker",
+  });
+  const record = await readFailedWriterLog(new Error("synthetic planning failure"), {
+    artifactPreparation,
+  });
+  expect(record.details.artifactPreparation).toEqual({
+    admissionMode: "async",
+    admissionMs: 1200,
+    nodeInventoryMs: 21,
+    referencePlanningMs: 4,
+    orphanPlanningMs: 5,
+    markerScanMs: 20,
+    nodeRows: 8,
+    windowRows: 12,
+    referenceIds: 8,
+    selectedEntries: 0,
+    markerWindows: 2,
+    markerRows: 5,
+    completed: false,
+  });
+  expect(record.content).not.toContain("synthetic-private-session");
+  expect(record.content).not.toContain("synthetic-private-marker");
 });
 
 test.each([false, true])(

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -31,7 +31,9 @@ import type {
   SessionAccessScope,
   SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
-  SqliteSessionReclamationDiagnostics,
+  SqliteSessionArtifactPreparationDiagnostics,
+  SqliteSessionDatabaseAdmissionDiagnostics,
+  SqliteSessionWriteDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
 import type { SqliteSessionWriteOperation } from "./session-accessor.sqlite-write-operation.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
@@ -128,20 +130,68 @@ export function withSqliteSessionDatabase<T>(
   options: OpenClawAgentDatabaseOptions,
   operation: (database: OpenClawAgentDatabase) => T,
   assertCurrent?: () => void,
+  diagnostics?: SqliteSessionDatabaseAdmissionDiagnostics,
 ): T | Promise<T> {
   assertCurrent?.();
-  if (getOpenClawAgentDatabaseIfOpen(options)) {
-    return operation(openOpenClawAgentDatabase(options));
+  const startedAt = diagnostics ? performance.now() : 0;
+  const finishAdmission = diagnostics
+    ? () => {
+        if (diagnostics.admissionMs === undefined) {
+          diagnostics.admissionMs = performance.now() - startedAt;
+        }
+      }
+    : undefined;
+  const admittedOperation = finishAdmission
+    ? (database: OpenClawAgentDatabase) => {
+        finishAdmission();
+        return operation(database);
+      }
+    : operation;
+  try {
+    if (getOpenClawAgentDatabaseIfOpen(options)) {
+      if (diagnostics) {
+        diagnostics.admissionMode = "cached";
+      }
+      return admittedOperation(openOpenClawAgentDatabase(options));
+    }
+    if (diagnostics) {
+      diagnostics.admissionMode = "async";
+    }
+    // The caller keeps its FIFO section while the existing owner joins the integrity child.
+    const result = withOpenClawAgentDatabaseAsync(options, admittedOperation, assertCurrent);
+    return finishAdmission ? result.finally(finishAdmission) : result;
+  } catch (error) {
+    finishAdmission?.();
+    throw error;
   }
-  // The caller keeps its FIFO section while the existing owner joins the integrity child.
-  return withOpenClawAgentDatabaseAsync(options, operation, assertCurrent);
+}
+
+function artifactPreparationLogFields(diagnostics: SqliteSessionArtifactPreparationDiagnostics) {
+  const milliseconds = (value: number | undefined) =>
+    value === undefined ? undefined : Math.round(value);
+  return {
+    admissionMode: diagnostics.admissionMode,
+    admissionMs: milliseconds(diagnostics.admissionMs),
+    nodeInventoryMs: milliseconds(diagnostics.nodeInventoryMs),
+    referencePlanningMs: milliseconds(diagnostics.referencePlanningMs),
+    orphanPlanningMs: milliseconds(diagnostics.orphanPlanningMs),
+    markerScanMs: milliseconds(diagnostics.markerScanMs),
+    nodeRows: diagnostics.nodeRows,
+    windowRows: diagnostics.windowRows,
+    referenceIds: diagnostics.referenceIds,
+    selectedEntries: diagnostics.selectedEntries,
+    markerWindows: diagnostics.markerWindows,
+    markerRows: diagnostics.markerRows,
+    deletePlans: diagnostics.deletePlans,
+    completed: diagnostics.completed === true,
+  };
 }
 
 export async function runExclusiveSqliteSessionWrite<T>(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   fn: () => Promise<T>,
   operation: SqliteSessionWriteOperation,
-  reclamation?: SqliteSessionReclamationDiagnostics,
+  diagnostics?: SqliteSessionWriteDiagnostics,
 ): Promise<T> {
   const databaseOptions = toDatabaseOptions(scope);
   const storePath = resolveOpenClawAgentSqlitePath(databaseOptions);
@@ -152,9 +202,12 @@ export async function runExclusiveSqliteSessionWrite<T>(
     threadId,
     isMainThread,
     operation,
-    ...(reclamation?.kind ? { reclamationKind: reclamation.kind } : {}),
-    ...(reclamation?.workerThreadId !== undefined
-      ? { workerThreadId: reclamation.workerThreadId }
+    ...(diagnostics?.kind ? { reclamationKind: diagnostics.kind } : {}),
+    ...(diagnostics?.workerThreadId !== undefined
+      ? { workerThreadId: diagnostics.workerThreadId }
+      : {}),
+    ...(diagnostics?.artifactPreparation
+      ? { artifactPreparation: artifactPreparationLogFields(diagnostics.artifactPreparation) }
       : {}),
     elapsedMs: Math.round(completedAt - startedAt),
     ...(timing.startedAt !== undefined && timing.finishedAt !== undefined


### PR DESCRIPTION
Closes #143939
Related: #143226, #143434

## What Problem This Solves

Resolves a problem where operators investigating slow lifecycle artifact cleanup see only the complete writer interval, without knowing whether time was spent admitting the database, inventorying sessions, building references, planning orphan cleanup, or scanning transcript markers.

## Why This Change Was Made

The existing preparation owner records its actual cached/asynchronous admission path, disjoint phase timings and counts from the rows and collections it already consumes. The existing slow/failed writer warning projects these bounded numeric fields under `artifactPreparation`, including partial observations when preparation fails. The artifact planner and its private helpers move into one focused module to preserve the existing file-size limit.

SQL, cleanup selection and ordering, complete marker consumption, error/result identity, database authority, warning thresholds and Worker lifetime remain unchanged. The fields contain no session identifiers or transcript/marker contents. There is no additional query, byte scan, configuration, schema or retention change.

## User Impact

Existing slow or failed artifact-cleanup warnings now explain which preparation phases ran and how much work they observed. Short successful calls remain quiet. Documentation describes partial records, disjoint phase timing and the unassigned remainder against the complete writer interval.

## Evidence

- **39 focused tests pass** across writer logging, warm/cold admission, cleanup/reclamation and cleanup races. Real producer-to-file-log tests cover warm success, the original late native error, consumed-row prefixes, partial status, quiet follow-up calls, exact no-op/state preservation and no cleanup Worker. Cold proof retains a real joined integrity child and verifies admission timing independently of planning.
- The complete changed-file gate and fresh independent P2 review pass, including typechecks, lint, dead exports, schema/storage guards and runtime import-cycle checks. Independent source review confirms the extracted function bodies are unchanged.
- **Fresh Linux public-SDK proof passes** on identical candidate source: full build, one ordinary `cleanupSessionLifecycleArtifacts` call through the built package export, and persistence readback from a second process. Cleanup returns exactly zero removed entries and zero archived artifacts; the current entry and old history remain unchanged. The private-local transcript package export is used only to seed the synthetic fixture. Runtime: Linux x64, Node 24.19.0, SQLite 3.53.3. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34464709621), native exit 0; all process owners joined and the lease is confirmed completed. No model turn or Gateway scenario was used.
- **Twelve source-pinned macOS comparison processes pass**, with separate trace runs and B/C/C/B timing at 1,102 ordinary nodes and 256 marker-absent history rows. SQL/method/row/returned-byte traces match exactly. Comparing the mean of two process medians, the observed differences are +0.070 ms for nodes and -0.056 ms for history. Every first call, warm repeat and outlier is retained, including a 13.284-ms baseline history repeat. Each process has seven correlated warm repeats; this is descriptive small-fixture overhead evidence, not a scalability, statistical-significance or production-latency claim.

The Linux run proves the ordinary built SDK flow; local controlled tests prove slow/failure diagnostic emission. Neither reproduces a production stall or identifies its cause.
