### PR TITLE
fix: keep inbound media fixtures on one filesystem

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -1683,11 +1683,12 @@ describe("loadWebMedia", () => {
     async (swapOpen, expectedCode) => {
       const id = `signal-hardlink-race-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`;
       const filePath = path.join(stateDir, "media", "inbound", id);
-      const outsidePath = path.join(fixtureRoot, `${id}.outside`);
+      const outsidePath = path.join(stateDir, `${id}.outside`);
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       await fs.writeFile(filePath, "inside");
       await fs.writeFile(outsidePath, "outside-secret");
       let matchingOpens = 0;
+      let linkCreated = false;
       __setFsSafeTestHooksForTest({
         afterPreOpenLstat: async (openedPath) => {
           if (path.basename(openedPath) !== id) {
@@ -1699,6 +1700,7 @@ describe("loadWebMedia", () => {
           }
           await fs.rm(filePath);
           await fs.link(outsidePath, filePath);
+          linkCreated = true;
         },
       });
 
@@ -1708,6 +1710,7 @@ describe("loadWebMedia", () => {
           expectedCode,
         );
         expect(matchingOpens).toBe(swapOpen);
+        expect(linkCreated).toBe(true);
       } finally {
         await fs.rm(filePath, { force: true });
         await fs.rm(outsidePath, { force: true });


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers can push updates.

</details>

## What Problem This Solves

Resolves a problem where the inbound-media fixture fails with EXDEV when the preferred OpenClaw temp root and isolated test state are on different filesystems. An earlier rejection case can also accept a translated fixture-setup failure without completing the intended setup.

## Why This Change Was Made

Place the synthetic outside payload under the owned test state directory, still outside the inbound directory, and assert that the existing link setup completed. Both existing cases, guard hooks, expected error codes, open-count assertions, and cleanup remain intact; no production code changes.

## User Impact

No user-visible behavior change. This is test fixture portability maintenance, with three added net test lines and stronger protection against a setup failure being mistaken for the expected rejection.

## Evidence

- Original Linux full-run evidence at source 918c3d reported EXDEV. Its preserved filesystem receipt showed the preferred temp root and isolated test temp directory on different devices; this supports a fixture setup diagnosis rather than a demonstrated production guard regression.
- Harmless local create/link/stat/unlink proof confirmed the proposed directory layout shares a device and inode, with two links and complete cleanup. No guarded-open hook was invoked by that proof.
- Corrected private-dependency validation on Node26.8.1/macOS at pinned source 918c3d: the same three ordinary inbound-media cases passed before and after; all 116 case/status rows matched, with 113 cases filtered out. Both filesystem-swap cases were deliberately excluded from execution. This is not Linux Node24 or current-main runtime proof.
- Static whole-file inverse verification preserves every original assertion and both table rows outside the four reviewed edits. Full mapped static gate passed; independent P2 review found no actionable findings.
- Initial dependency setup exposed inherited workspace symlinks; those task-owned links were replaced, the affected generated dependency entries were restored, and the corrected install/proof preserved the external root's 545-entry and lock fingerprints exactly. Earlier results are retained as historical outcomes rather than claimed isolated proof.

No runtime improvement or complete-suite pass is claimed by this patch.
