### PR TITLE
refactor(mattermost): share reaction dispatch

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -454,31 +454,11 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       // The runner preserves the caller's spelling in `target` and puts the
       // directory-resolved provider destination in `to` before dispatch.
       const authorizedTarget = normalizeOptionalString(params.to);
-      if (remove) {
-        const result = await (
-          await loadMattermostChannelRuntime()
-        ).removeMattermostReaction({
-          cfg,
-          postId,
-          emojiName,
-          accountId: resolvedAccountId,
-          authorizedTarget,
-          conversationReadOrigin,
-        });
-        if (!result.ok) {
-          throw new Error(result.error);
-        }
-        return {
-          content: [
-            { type: "text" as const, text: `Removed reaction :${emojiName}: from ${postId}` },
-          ],
-          details: {},
-        };
-      }
-
-      const result = await (
-        await loadMattermostChannelRuntime()
-      ).addMattermostReaction({
+      const runtime = await loadMattermostChannelRuntime();
+      const mutateReaction = remove
+        ? runtime.removeMattermostReaction
+        : runtime.addMattermostReaction;
+      const result = await mutateReaction({
         cfg,
         postId,
         emojiName,
@@ -491,7 +471,14 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       }
 
       return {
-        content: [{ type: "text" as const, text: `Reacted with :${emojiName}: on ${postId}` }],
+        content: [
+          {
+            type: "text" as const,
+            text: remove
+              ? `Removed reaction :${emojiName}: from ${postId}`
+              : `Reacted with :${emojiName}: on ${postId}`,
+          },
+        ],
         details: {},
       };
     }

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -61,30 +61,14 @@ async function resolveBotUserId(
   return userId;
 }
 
-export async function addMattermostReaction(params: {
-  cfg: OpenClawConfig;
-  postId: string;
-  emojiName: string;
-  accountId?: string | null;
-  authorizedTarget?: string;
-  conversationReadOrigin?: ConversationReadInvocationOrigin;
-  fetchImpl?: MattermostFetch;
-}): Promise<Result> {
+export async function addMattermostReaction(params: ReactionParams): Promise<Result> {
   return runMattermostReaction(params, {
     action: "add",
     mutation: createReaction,
   });
 }
 
-export async function removeMattermostReaction(params: {
-  cfg: OpenClawConfig;
-  postId: string;
-  emojiName: string;
-  accountId?: string | null;
-  authorizedTarget?: string;
-  conversationReadOrigin?: ConversationReadInvocationOrigin;
-  fetchImpl?: MattermostFetch;
-}): Promise<Result> {
+export async function removeMattermostReaction(params: ReactionParams): Promise<Result> {
   return runMattermostReaction(params, {
     action: "remove",
     mutation: deleteReaction,


### PR DESCRIPTION
Closes #143947.

## What Problem This Solves

Maintainer-requested cleanup of duplicate Mattermost reaction dispatch. The adapter maintains two copies of the same account-bound call and result handling, while the operation module repeats a parameter type it already owns. No new user-facing defect is claimed.

## Why This Change Was Made

Select the existing add/remove export from the same lazy-loaded runtime, invoke it once with unchanged parameters, and preserve the operation-specific result text. Both exports reuse the existing private parameter type. No new wrapper, SDK surface, dependency, configuration, persistence change, or compatibility path is introduced.

## User Impact

No intended behavior change. Account and reaction gates, delegated resource binding, boolean removal, emoji normalization, bot-ID caching, HTTP requests, errors and success messages remain unchanged. Production: **+15/-44 = 29 net lines removed**; tests: **0/0**.

## Evidence

- Same four existing test files pass on original and formatted candidate: **112 cases each**.
- Independent expected-result checks and paired captures through the real adapter/client: **12 scenarios, 13 HTTP requests per side**, with identical request order, account selection, results/errors and server-side state. A rejected DELETE retains an existing reaction; disabled actions make no request; an allowed DELETE subsequently clears it. Both captures exit normally, and recorded processes, listeners and temporary homes are absent.
- This HTTP proof uses synthetic loopback servers, **not a live Mattermost deployment or host/Gateway authorization proof**. Existing delegated-resource tests are retained unchanged. The paired candidate precedes only the formatter's ternary line wrapping; the final formatted source has the separate 112-case run.
- [Configured Linux Node 24.19 changed check](https://github.com/openclaw/openclaw/actions/runs/34463583348): all **24 phases pass**, including plugin typechecks, three unused-export scans, targeted lint and guards. Native command exit 0; owned Testbox stopped. Source tree `de3cfaeb688d690dc56997c9b01f8f9124b827ed` matches the signed commit.
- Fresh independent precommit and separate exact-commit Codex reviews: no actionable P0–P2 findings. Reviewed head: `01f9186c7f0bdb56643d31434cb73a7acc99b4a3`.
- Exact-head PR CI starts after publication and remains required before landing.
