### PR TITLE
fix(models): preserve literal rows in model policy catalogs

### DIFF
--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -14,11 +14,12 @@ import { openAIModelCatalogRoutePolicy } from "./openai-model-routes.js";
 
 describe("resolveLogicalVisibleModelCatalog", () => {
   it.each(["all", "configured", "default"] as const)(
-    "keeps case-distinct configured identities in the %s view",
+    "keeps case-distinct and literal provider-prefixed identities in the %s view",
     async (view) => {
       const catalog: ModelCatalogEntry[] = [
         { provider: "fixture", id: "MixedCase", name: "Large", contextWindow: 64_000 },
         { provider: "fixture", id: "mixedcase", name: "Small", contextWindow: 16_000 },
+        { provider: "fixture", id: "fixture/MixedCase", name: "Namespaced", contextWindow: 32_000 },
       ];
       const result = await resolveLogicalVisibleModelCatalog({
         cfg: { agents: { defaults: { modelPolicy: { allow: ["fixture/*"] } } } },
@@ -34,7 +35,7 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       });
 
       expect(result).toEqual(expect.arrayContaining(catalog));
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
     },
   );
 

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1058,24 +1058,19 @@ function buildAllowedModelSetFromPrepared(
       manifestPlugins: params.manifestPlugins,
     })?.ref;
   };
-  const catalogKeys = new Set<string>();
-  for (const entry of catalog) {
-    catalogKeys.add(modelKey(entry.provider, entry.id));
-  }
+  const allowAll = (): AllowedModelSet => {
+    const allowedKeys = new Set(catalog.map((entry) => modelKey(entry.provider, entry.id)));
+    if (defaultKey) {
+      allowedKeys.add(defaultKey);
+    }
+    return { allowAny: true, allowedCatalog: catalog, allowedKeys };
+  };
 
   if (allowAny) {
-    if (defaultKey) {
-      catalogKeys.add(defaultKey);
-    }
-    return {
-      allowAny: true,
-      allowedCatalog: catalog,
-      allowedKeys: catalogKeys,
-    };
+    return allowAll();
   }
 
   const allowedKeys = new Set<string>();
-  const allowedRefKeys = new Set<string>();
   const catalogIdentities = new Set(catalog.map(resolveModelCatalogIdentityKey));
   const allowedCatalogIdentities = new Set<string>();
   const allowedCaseInsensitiveIdentities = new Set<string>();
@@ -1086,14 +1081,10 @@ function buildAllowedModelSetFromPrepared(
     allowedKeys.add(wildcardKey);
   }
   const addAllowedCatalogRef = (ref: ModelRef) => {
-    const key = modelKey(ref.provider, ref.model);
-    if (!allowedRefKeys.has(key)) {
-      allowedRefKeys.add(key);
-      allowedCatalogIdentities.add(
-        resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model }),
-      );
-      allowedCaseInsensitiveIdentities.add(caseInsensitiveIdentity(ref.provider, ref.model));
-    }
+    allowedCatalogIdentities.add(
+      resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model }),
+    );
+    allowedCaseInsensitiveIdentities.add(caseInsensitiveIdentity(ref.provider, ref.model));
   };
   for (const entry of expandModelCatalogWildcards(catalog, wildcardModelKeys)) {
     allowedKeys.add(modelKey(entry.provider, entry.id));
@@ -1107,18 +1098,19 @@ function buildAllowedModelSetFromPrepared(
     const key = modelKey(parsed.provider, parsed.model);
     allowedKeys.add(key);
     addAllowedCatalogRef(parsed);
+    const syntheticKey = modelCatalogEntryKey({ provider: parsed.provider, id: parsed.model });
 
     if (
       !catalogIdentities.has(
         resolveModelCatalogIdentityKey({ provider: parsed.provider, id: parsed.model }),
       ) &&
       !findModelCatalogEntry(catalog, { provider: parsed.provider, modelId: parsed.model }) &&
-      !syntheticCatalogEntries.has(key)
+      !syntheticCatalogEntries.has(syntheticKey)
     ) {
       // Config can allow a model before it appears in live provider catalogs.
       // Synthetic entries keep UI/model switchers aligned with that allowlist.
       const alias = metadata.aliasByKey.get(key);
-      syntheticCatalogEntries.set(key, {
+      syntheticCatalogEntries.set(syntheticKey, {
         id: parsed.model,
         name: parsed.model,
         provider: parsed.provider,
@@ -1152,14 +1144,7 @@ function buildAllowedModelSetFromPrepared(
   ];
 
   if (allowedCatalog.length === 0 && allowedKeys.size === 0 && wildcardModelKeys.size === 0) {
-    if (defaultKey) {
-      catalogKeys.add(defaultKey);
-    }
-    return {
-      allowAny: true,
-      allowedCatalog: catalog,
-      allowedKeys: catalogKeys,
-    };
+    return allowAll();
   }
 
   return {
@@ -1631,17 +1616,7 @@ export function dedupeModelCatalogEntries(
 ): ModelCatalogEntry[] {
   // Preserve the first occurrence after precedence merging while removing
   // provider/id duplicates from configured and auth-backed catalogs.
-  const seen = new Set<string>();
-  const next: ModelCatalogEntry[] = [];
-  for (const entry of entries) {
-    const key = modelKey(entry.provider, entry.id);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    next.push(entry);
-  }
-  return next;
+  return dedupeByKey(entries, modelCatalogEntryKey);
 }
 
 export function createModelVisibilityPolicyWithFallbacks(

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1113,6 +1113,145 @@ describe("model-selection", () => {
   });
 
   describe("buildAllowedModelSet", () => {
+    it.each([
+      ["absent", false],
+      ["absent", true],
+      ["forward", false],
+      ["forward", true],
+      ["reversed", false],
+      ["reversed", true],
+      ["first-only", false],
+      ["first-only", true],
+      ["nested-only", false],
+      ["nested-only", true],
+    ] as const)(
+      "keeps literal provider-prefixed models visible (%s catalog; reversed policy=%s)",
+      (catalogOrder, reversePolicy) => {
+        const rows = [
+          { provider: "custom", id: "model", name: "model" },
+          { provider: "custom", id: "custom/model", name: "custom/model" },
+        ];
+        const allow = rows.map((entry) => `custom/${entry.id}`);
+        if (reversePolicy) {
+          allow.reverse();
+        }
+        const catalogRows =
+          catalogOrder === "reversed" || catalogOrder === "nested-only" ? rows.toReversed() : rows;
+        const availableRows = catalogOrder.endsWith("-only")
+          ? catalogRows.slice(0, 1)
+          : catalogRows;
+        const policy = createModelVisibilityPolicy({
+          cfg: {
+            agents: {
+              defaults: { modelPolicy: { allow } },
+            },
+            models: {
+              providers: {
+                custom: {
+                  api: "openai-completions",
+                  baseUrl: "https://custom.example/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          catalog: [
+            ...(catalogOrder === "absent" ? [] : availableRows),
+            { provider: "other", id: "model", name: "Excluded" },
+          ],
+          defaultProvider: "custom",
+        });
+
+        expect(policy.allowAny).toBe(false);
+        expect([...policy.allowedKeys]).toEqual(["custom/model"]);
+        expect(policy.visibleCatalog({ catalog: [], defaultVisibleCatalog: [] })).toEqual(
+          catalogOrder === "absent" && reversePolicy ? rows.toReversed() : catalogRows,
+        );
+      },
+    );
+
+    it.each([
+      ["case-insensitive", "Model", "model", false],
+      ["case-insensitive", "model", "Model", false],
+      ["literal slash", "team/Reader", "Reader", true],
+      ["literal slash", "Reader", "team/Reader", true],
+    ] as const)(
+      "preserves %s matching when only %s is catalogued",
+      (_kind, id, missing, expectSynthetic) => {
+        const catalog = [{ provider: "custom", id, name: id }];
+        const policy = createModelVisibilityPolicy({
+          cfg: {
+            agents: {
+              defaults: { modelPolicy: { allow: [`custom/${id}`, `custom/${missing}`] } },
+            },
+            models: {
+              providers: {
+                custom: {
+                  api: "openai-completions",
+                  baseUrl: "https://custom.example/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          catalog,
+          defaultProvider: "custom",
+        });
+
+        expect(policy.visibleCatalog({ catalog: [], defaultVisibleCatalog: [] })).toEqual([
+          ...catalog,
+          ...(expectSynthetic ? [{ provider: "custom", id: missing, name: missing }] : []),
+        ]);
+      },
+    );
+
+    it.each([false, true])(
+      "preserves literal Arcee refs while matching equivalent catalog rows (catalog supplied=%s)",
+      (supplied) => {
+        const direct = {
+          provider: "arcee",
+          id: "trinity-large-thinking",
+          name: "trinity-large-thinking",
+        };
+        const wire = {
+          provider: "arcee",
+          id: "arcee-ai/trinity-large-thinking",
+          name: "arcee-ai/trinity-large-thinking",
+        };
+        const catalog = supplied ? [wire] : [];
+        const policy = createModelVisibilityPolicy({
+          cfg: {
+            agents: {
+              defaults: {
+                modelPolicy: {
+                  allow: [
+                    "arcee/*",
+                    "arcee/trinity-large-thinking",
+                    "arcee/arcee-ai/trinity-large-thinking",
+                  ],
+                },
+              },
+            },
+            models: {
+              providers: {
+                arcee: {
+                  api: "openai-completions",
+                  baseUrl: "https://arcee.example/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          catalog,
+          defaultProvider: "arcee",
+        });
+
+        expect(policy.visibleCatalog({ catalog, defaultVisibleCatalog: catalog })).toEqual(
+          supplied ? [wire] : [direct, wire],
+        );
+      },
+    );
+
     it("retains every configured row in a large allowlist without admitting other rows", () => {
       const catalog = Array.from({ length: 400 }, (_, index) => ({
         provider: "custom",
@@ -1533,7 +1672,7 @@ describe("model-selection", () => {
       ]);
     });
 
-    it("keeps exact same-provider entries visible beside wildcard catalog rows", () => {
+    it("keeps literal wildcard rows and exact entries with the first duplicate's metadata", () => {
       const cfg: OpenClawConfig = {
         agents: {
           defaults: {
@@ -1545,10 +1684,12 @@ describe("model-selection", () => {
           },
         },
       } as unknown as OpenClawConfig;
+      const nested = { provider: "vllm", id: "vllm/qwen-local", name: "Namespaced Qwen" };
+      const catalog = [{ provider: "vllm", id: "qwen-local", name: "Qwen Local" }, nested];
 
       const policy = createModelVisibilityPolicy({
         cfg,
-        catalog: [{ provider: "vllm", id: "qwen-local", name: "Qwen Local" }],
+        catalog,
         defaultProvider: "anthropic",
         defaultModel: "claude-sonnet-4-6",
       });
@@ -1556,12 +1697,9 @@ describe("model-selection", () => {
       expect(
         policy.visibleCatalog({
           catalog: [],
-          defaultVisibleCatalog: [{ provider: "vllm", id: "qwen-local", name: "Qwen Local" }],
+          defaultVisibleCatalog: [...catalog, { ...nested, name: "Duplicate row" }],
         }),
-      ).toEqual([
-        { provider: "vllm", id: "qwen-local", name: "Qwen Local" },
-        { provider: "vllm", id: "manual", name: "manual" },
-      ]);
+      ).toEqual([...catalog, { provider: "vllm", id: "manual", name: "manual" }]);
     });
 
     it("does not re-add a default outside mixed wildcard and exact filters", () => {


### PR DESCRIPTION
Related: #130706, #142100. Follows #143872.

## What Problem This Solves

Model-policy catalog construction can drop distinct literal provider/model rows when their display keys coincide. An explicit allowlist or wildcard can therefore lose a catalog row even though the selection policy already permits it. Synthetic rows can also collide during deduplication.

## Why This Change Was Made

Use the existing literal catalog-row key for private deduplication and synthetic entries, and retain all logical identities before filtering. Reuse the shared deduplication helper and one lazy allow-all result builder. Public display/authorization keys, provider equivalence, aliases, and unique case-insensitive lookup keep their existing contracts. The change removes 25 production lines from one owner.

## User Impact

Model browsers and selection catalogs retain distinct allowed rows, including provider-prefixed and slash-containing model IDs. Genuine missing rows remain visible as sparse synthetic entries without copying another row's capabilities.

## Evidence

Eleven intended missing-row regressions failed before the repair. The final focused cohort passed 225 tests across four suites, including partial catalogs, both policy orders, case-insensitive compatibility controls, and Arcee wire/direct identities. Fresh managed P2 review and the full changed-file gate passed. The replay onto main containing #143872 is byte-identical with unchanged reviewed owner/dependency and gate-tooling context; a further 189 selection/visibility tests passed on that main replay.

At exact commit `4eba0cd1084fab2510d1a63c7147dd4b2d13828b`, one canonical `sourcePerformance` build and all 22 compiled catalog/policy scenarios passed. The probe made no network requests and imported no checkout source. All 9,255 captured build files remained unchanged; the process and isolated state were cleaned up. This is synthetic compiled boundary proof, not an external-provider or live Gateway test. The runtime profile excludes UI and SDK declarations.

The first compiled probe stopped before scenarios because its copied build inventory omitted workspace package outputs. Those outputs were admitted only after verifying their canonical build ownership, current source, and generation within the same build interval. The original failure is retained; no product files, stamps, or source-import guard were changed.
