### PR TITLE
fix(auto-reply): stop narrating tagging status in room-event replies

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -334,7 +334,7 @@ function createGatewayDrainingError(): Error {
 }
 
 const ROOM_EVENT_MESSAGE_TOOL_DIRECTIVE =
-  "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.";
+  "Treat this message as observed room activity, not a request. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. Do not mention or reference your tagging or mention status when you do respond. To respond visibly, use message(action=send); your final text here stays private either way.";
 
 function createInboundBody<T extends string>(body: T) {
   return { Body: body, RawBody: body, CommandBody: body };
@@ -4242,11 +4242,11 @@ describe("runPreparedReply media-only handling", () => {
       expect(heartbeatRun.sourceReplyDeliveryMode).toBe(stableMode);
       expect(roomEventRun.extraSystemPrompt).toBe(expectedPrompt);
       expect(requireRunReplyAgentCall(0).followupRun.currentInboundContext?.text).toContain(
-        "You were not explicitly tagged or mentioned in this room event",
+        "Do not mention or reference your tagging or mention status",
       );
       expect(roomEventRun.extraSystemPromptStatic).toBe(expectedPrompt);
       expect(roomEventRun.extraSystemPromptStatic).not.toContain(
-        "You were not explicitly tagged or mentioned in this room event",
+        "Do not mention or reference your tagging or mention status",
       );
       expect(primaryRun.extraSystemPromptStatic).toBe(roomEventRun.extraSystemPromptStatic);
       expect(heartbeatRun.extraSystemPromptStatic).toBe(roomEventRun.extraSystemPromptStatic);

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -177,7 +177,7 @@ describe("buildReplyPromptEnvelope", () => {
           "#35674 Other: I wish I could enjoy 5.5",
           "#35675 User ->#35674: Are you fr fr",
         ].join("\n"),
-        "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.",
+        "Treat this message as observed room activity, not a request. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. Do not mention or reference your tagging or mention status when you do respond. To respond visibly, use message(action=send); your final text here stays private either way.",
         "Thread note",
         "System event",
       ].join("\n\n"),
@@ -196,7 +196,7 @@ describe("buildReplyPromptEnvelope", () => {
           JSON.stringify({ message_id: "35676", inbound_event_kind: "room_event" }, null, 2),
           "```",
         ].join("\n"),
-        "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.",
+        "Treat this message as observed room activity, not a request. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. Do not mention or reference your tagging or mention status when you do respond. To respond visibly, use message(action=send); your final text here stays private either way.",
         "Thread note",
         "System event",
       ].join("\n\n"),
@@ -269,13 +269,18 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.currentInboundContext?.text).toContain("Alice: old context");
     expect(envelope.queuedBody).toBe("#2002 Bob: current note");
     expect(envelope.currentInboundContext?.text).toContain(
-      "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking.",
+      "Treat this message as observed room activity, not a request. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. Do not mention or reference your tagging or mention status when you do respond.",
     );
     expect(envelope.currentInboundContext?.text).not.toContain("message(action=send)");
     expect(envelope.currentInboundContext?.text).not.toContain(
       "your final text here stays private",
     );
     expect(envelope.queuedBody).not.toContain("[Chat history]");
+    // Stating tagging status seeds unwanted meta-commentary ("you didn't tag
+    // me, but...") when the model does choose to respond.
+    expect(envelope.currentInboundContext?.text).not.toContain(
+      "You were not explicitly tagged or mentioned",
+    );
   });
 
   it("keeps completed audio transcripts in room-event bodies", () => {

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -16,7 +16,7 @@ import { appendChannelPromptContext } from "./channel-prompt-context.js";
 
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
 const ROOM_EVENT_PARTICIPATION_RULE =
-  "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking.";
+  "Treat this message as observed room activity, not a request. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. Do not mention or reference your tagging or mention status when you do respond.";
 const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [
   "Conversation context (chronological, selected for current message):",
   "Chat history since last reply:",


### PR DESCRIPTION
Closes #143843

## What Problem This Solves

In `room_event` inbound mode (e.g. `unmentionedInbound: "room_event"` with
`requireMention: false`, common in support/help-routing channels), the model is
expected to auto-engage on ambient room activity without being tagged. The
per-turn participation rule injected into the prompt states, verbatim: "You
were not explicitly tagged or mentioned in this room event." When the model
does decide to reply, it picks up that fact and narrates it back to the user
— producing meta-commentary like "You didn't tag me, but..." or "I wasn't
explicitly mentioned, but since I'm a thread participant...". This is
confusing and unwanted in normal room conversation, and it defeats the intent
of the wording (added in #130901 to reduce over-participation), which was to
keep the model selective, not to make it announce its own admission logic.

## Why This Change Was Made

ClawSweeper's own review of the issue explicitly rejected a wholesale revert
of #130901 ("the stricter wording addresses documented over-participation")
and instead asked for "narrow wording adjustment... to avoid engagement
narration while preserving default silence, selective participation, and
explicit message-tool delivery." This PR does exactly that: it removes the raw
tagging-status statement (redundant — `room_event` already means "not an
explicit mention" by construction) and replaces it with an explicit
instruction not to reference tagging/mention status in the reply. The
"default: stay silent" / "only respond if useful" / "a previous mention or
reply is not an invitation to keep talking" selectivity language is preserved
byte-for-byte, so the behavior #130901 was protecting against is unaffected.

## User Impact

Users in `room_event`-enabled group chats/support channels no longer see the
model explain its own tagging/mention status when it chooses to speak, while
the model still defaults to silence and stays selective about when to
respond.

## Evidence

Focused unit tests in `src/auto-reply/reply/prompt-prelude.test.ts` assert the
exact model-facing prompt text built for `room_event` turns. Added a
regression assertion that the tagging-status sentence is absent from the
built prompt, and updated the existing byte-for-byte prompt assertions (here
and in `src/auto-reply/reply/get-reply-run.media-only.test.ts`) to the new
wording.

Proved the regression test actually catches the bug: reverted just the source
file to the pre-fix wording (`git checkout HEAD~1 -- src/auto-reply/reply/prompt-prelude.ts`)
and reran the suite — it failed exactly as expected:

```
 × buildReplyPromptEnvelope > projects room events as context instead of user requests
   → expected '[OpenClaw room event]\n\nRoom context…' to be '[OpenClaw room event]\n\nRoom context…'
   - Treat this message as observed room activity, not a request. Default: stay silent. ... Do not mention or reference your tagging or mention status when you do respond. To respond visibly, use message(action=send); ...
   + Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. ...

 × buildReplyPromptEnvelope > uses the raw current body for room-event current event text
   → expected '[OpenClaw room event]\n\nRoom context…' to contain 'Treat this message as observed room a…'

 Test Files  1 failed (1)
      Tests  2 failed | 14 passed (16)
```

Restored the fix and reran both affected suites — all pass:

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/prompt-prelude.test.ts
 Test Files  1 passed (1)
      Tests  16 passed (16)

$ node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts
 Test Files  1 passed (1)
      Tests  178 passed (178)
```

Also ran, scoped to the changed files (repo-wide `pnpm lint`/`pnpm changed:lanes`
compare against a stale fork `origin/main` in this sandboxed checkout and are
not usable here; used the underlying tools directly instead):

```
$ node scripts/run-oxlint.mjs src/auto-reply/reply/prompt-prelude.ts src/auto-reply/reply/prompt-prelude.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts
[plugin-sdk boundary dts] fresh; skipping
$ echo $?
0

$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
$ echo $?
0

$ node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/auto-reply/reply/prompt-prelude.test.ts","src/auto-reply/reply/get-reply-run.media-only.test.ts"]'
[check:changed] core test graphs: messaging
$ echo $?
0

$ node_modules/.bin/oxfmt --check src/auto-reply/reply/prompt-prelude.ts src/auto-reply/reply/prompt-prelude.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts
All matched files use the correct format.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
