### PR TITLE
fix(agents): oversized avatar data URL is reported as renderable

### DIFF
--- a/src/agents/identity-avatar.test.ts
+++ b/src/agents/identity-avatar.test.ts
@@ -221,12 +221,15 @@ describe("resolveAgentAvatar", () => {
     }
   });
 
-  it("preserves generic and oversized data URIs at the public resolution boundary", () => {
-    const oversized = `data:image/png;base64,${"A".repeat(AVATAR_MAX_DATA_URL_CHARS)}`;
+  it("bounds image data URIs at the public resolution boundary", () => {
+    const prefix = "data:image/png;base64,";
+    const atBoundary = `${prefix}${"A".repeat(AVATAR_MAX_DATA_URL_CHARS - prefix.length)}`;
+    const oversized = `${atBoundary}A`;
     const cfg: OpenClawConfig = {
       agents: {
         list: [
           { id: "generic", identity: { avatar: "data:text/plain,avatar" } },
+          { id: "boundary", identity: { avatar: atBoundary } },
           { id: "oversized", identity: { avatar: oversized } },
         ],
       },
@@ -236,9 +239,14 @@ describe("resolveAgentAvatar", () => {
       kind: "data",
       url: "data:text/plain,avatar",
     });
-    expect(resolveAgentAvatar(cfg, "oversized")).toMatchObject({
+    expect(resolveAgentAvatar(cfg, "boundary")).toMatchObject({
       kind: "data",
-      url: oversized,
+      url: atBoundary,
+    });
+    expect(resolveAgentAvatar(cfg, "oversized")).toMatchObject({
+      kind: "none",
+      reason: "unsupported_data_url",
+      source: oversized,
     });
   });
 });

--- a/src/agents/identity-avatar.ts
+++ b/src/agents/identity-avatar.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { isAvatarImageDataUrl, isRenderableAvatarImageDataUrl } from "../shared/avatar-limits.js";
 import {
   hasAvatarUriScheme,
   isAvatarDataUrl,
@@ -97,7 +98,13 @@ export function resolveAgentAvatar(cfg: OpenClawConfig, agentId: string): AgentA
     return { kind: "remote", url: source, source };
   }
   if (isAvatarDataUrl(source)) {
-    return { kind: "data", url: source, source };
+    // Only the size bound belongs here. Generic data URIs are intentionally
+    // preserved, but an oversized image payload cannot render, so projections
+    // must not hand it to the Control UI as `data`.
+    if (isRenderableAvatarImageDataUrl(source) || !isAvatarImageDataUrl(source)) {
+      return { kind: "data", url: source, source };
+    }
+    return { kind: "none", reason: "unsupported_data_url", source };
   }
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const resolved = resolveLocalAgentAvatarPath({ raw: source, workspaceDir });

--- a/src/shared/avatar-limits.ts
+++ b/src/shared/avatar-limits.ts
@@ -17,7 +17,12 @@ export function isAvatarImageMimeType(value: string): boolean {
   return /^image\//i.test(value);
 }
 
+/** Detects an `image/*` data URL before the renderable size bound is applied. */
+export function isAvatarImageDataUrl(value: string): boolean {
+  return AVATAR_IMAGE_DATA_URL_RE.test(value);
+}
+
 /** Accepts image data URLs that fit the Gateway and Control UI payload boundary. */
 export function isRenderableAvatarImageDataUrl(value: string): boolean {
-  return value.length <= AVATAR_MAX_DATA_URL_CHARS && AVATAR_IMAGE_DATA_URL_RE.test(value);
+  return value.length <= AVATAR_MAX_DATA_URL_CHARS && isAvatarImageDataUrl(value);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who set an agent avatar through the Control UI would see the old avatar keep rendering in the agent grid, chat header, and chat bubbles, even after a Gateway restart and after clearing browser storage.

The Control UI avatar upload path stores the image as a WebP data URI. When that data URI is larger than the renderable payload boundary, the resolved agent identity still reported the avatar as a usable `data` source, so every Control UI projection treated it as drawable and then silently refused to render it. The result is an avatar that appears to save correctly but never displays, with no error surfaced to the user.

## Why This Change Was Made

`resolveAgentAvatar` accepted any `data:` URL as `kind: "data"` without applying the shared renderable size bound, while its file-based sibling (`resolveAgentAvatarUrlFromSource`) already bounded the same value at `AVATAR_MAX_DATA_URL_CHARS`. Two paths in the same subsystem disagreed about what a renderable avatar is.

This change makes the size rule consistent: an image data URL that exceeds the boundary is now reported as `kind: "none"` with `reason: "unsupported_data_url"`, so the rejection is explicit and observable instead of being folded into a renderable source. Behavior deliberately preserved:

- Generic (non-image) data URIs such as `data:text/plain,avatar` are still returned as `kind: "data"`, matching the existing public resolution contract and its test.
- At-boundary image data URLs still resolve as `kind: "data"`.
- The `AVATAR_MAX_DATA_URL_CHARS` boundary itself is unchanged; no upload, config-write, or Gateway serving behavior is touched.

Out of scope: the separate `size-drop` config-write rejection mentioned in the report, and the Control UI client-side cache. This PR only fixes the resolver reporting an unrenderable payload as renderable.

## User Impact

An oversized avatar payload is no longer reported to Control UI projections as a renderable source. Developers and operators diagnosing a missing avatar now get an explicit `unsupported_data_url` reason instead of a silently dropped value. Normal-sized avatars, remote HTTP avatars, local workspace files, and generic data URIs are unaffected.

## Evidence

### Standalone proof script against the real code path

`proof-avatar-data-url-bound.mts` (untracked, repo root) calls the exported production `resolveAgentAvatar` with crafted config values — no mocks.

Before the fix (current `upstream/main` behavior), by stashing only `src/agents/identity-avatar.ts`:

```
AVATAR_MAX_DATA_URL_CHARS = 2796230
at-boundary image data URL: kind=data url.len=2796230
oversized image data URL: kind=data url.len=2796231
generic non-image data URL: kind=data url.len=22
RESULT: normal preserved = true; oversized rejected = false; non-image rejected = false -> FAIL
```

After the fix:

```
AVATAR_MAX_DATA_URL_CHARS = 2796230
at-boundary image data URL: kind=data url.len=2796230
oversized image data URL: kind=none reason=unsupported_data_url
generic non-image data URL: kind=data url.len=22
RESULT: normal preserved = true; oversized rejected = true; non-image preserved = true -> PASS
```

The oversized payload is exactly one character past the boundary (`2796231` vs `2796230`), which isolates the size rule from every other branch.

### Focused tests

```
node scripts/run-vitest.mjs src/agents/identity-avatar.test.ts \
  src/agents/identity-avatar-file.test.ts src/shared/avatar-policy.test.ts \
  src/gateway/assistant-avatar.test.ts
```

```
Test Files  1 passed (1)   Tests  5 passed (5)
Test Files  1 passed (1)   Tests  19 passed (19)
Test Files  1 passed (1)   Tests  13 passed (13)
Test Files  1 passed (1)   Tests  8 passed (8)
```

The updated regression test asserts all three cases: generic data URI preserved, at-boundary image data URL preserved, oversized image data URL rejected with `reason: "unsupported_data_url"`. It fails against `main` and passes with this change.

### Lint and format

```
oxlint -c .oxlintrc.json src/agents/identity-avatar.ts src/shared/avatar-limits.ts src/agents/identity-avatar.test.ts
Found 0 warnings and 0 errors. Finished in 1.5s on 3 files with 230 rules.

oxfmt --check src/agents/identity-avatar.ts src/shared/avatar-limits.ts src/agents/identity-avatar.test.ts
All matched files use the correct format.
```

### What was not tested

- I did not build and run the live Control UI against a real Gateway on this host, so there is no browser before/after screenshot. The proof runs the resolver function that every Control UI projection calls, not the rendered grid.
- The macOS, iOS, and Android avatar surfaces were not exercised.
- The `size-drop` config-write rejection noted in the report is a separate path and is not addressed here.

Local environment: Windows, Node v22.22.3, TypeScript 6.0.3.

Related: #143123
