### PR TITLE
fix(ui): show failed file opens in Review

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5547,6 +5547,7 @@ export const en: TranslationMap & {
       editFile: "Edit file",
       searchInFile: "Search in file",
       showInFiles: "Show in Files",
+      unavailable: "Unable to open",
       previousMatch: "Previous match",
       nextMatch: "Next match",
       overwrite: "Overwrite",

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -630,6 +630,45 @@ describe("chat pane embedded panels", () => {
     expect(state.sidebarContent).toBeNull();
   });
 
+  it("shows why a file could not open instead of falling back to the session diff", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionKey: "agent:main:review",
+      branch: "feature/review",
+      baseRef: "main",
+      additions: 1,
+      deletions: 1,
+      files: [{ path: "example.txt", status: "modified", additions: 1, deletions: 1 }],
+    });
+    const state = {
+      client: { request },
+      connected: true,
+      connectionEpoch: 1,
+      hello: { features: { methods: ["sessions.diff"] } },
+      sessionKey: "agent:main:review",
+      sidebarContent: { kind: "unavailable", message: "Failed to load docs/chat.md" },
+      sidebarLayout: { columns: [] },
+    } as unknown as ChatPageHost;
+    const mount = document.body.appendChild(document.createElement("div"));
+    const definitions = sidebarPanelDefinitions({
+      state,
+      renderDetail: (content) =>
+        html`<openclaw-chat-detail-panel
+          .content=${content}
+          embedded
+        ></openclaw-chat-detail-panel>`,
+      workspace: html`<div>Files</div>`,
+    } as Parameters<typeof sidebarPanelDefinitions>[0]);
+    await renderPanelFixture(mount, openSlot({ columns: [] }, "detail"), definitions);
+
+    const notice = mount.querySelector(".review-unavailable");
+    expect(notice?.getAttribute("role")).toBe("alert");
+    expect(notice?.classList.contains("danger")).toBe(true);
+    expect(notice?.querySelector("strong")?.textContent).toBe("Unable to open");
+    expect(notice?.querySelector("span")?.textContent).toBe("Failed to load docs/chat.md");
+    expect(mount.querySelector("openclaw-session-diff")).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("enumerates a structural loading variant for every side-panel tab", async () => {
     const expected = {
       browser: "browser",

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -218,9 +218,14 @@ export function sidebarPanelDefinitions(
       icons.diff,
       detailContent?.kind === "loading"
         ? renderPanelLoadingSkeleton("review", t("common.loading"))
-        : detailContent && params
-          ? params.renderDetail(detailContent)
-          : null,
+        : detailContent?.kind === "unavailable"
+          ? html`<div class="callout danger review-unavailable" role="alert">
+              <strong>${t("chat.detailPanel.unavailable")}</strong>
+              <span>${detailContent.message}</span>
+            </div>`
+          : detailContent && params
+            ? params.renderDetail(detailContent)
+            : null,
     ),
     definePanel("terminal", "terminal", icons.terminal, terminal),
     definePanel("browser", "browser", icons.globe, browser),

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -295,7 +295,10 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       cancelChatStreamRenderFrame(state);
       cancelChatScroll(state);
       invalidateImageLightbox(state);
-      if (state.sidebarContent?.kind === "loading") {
+      if (
+        state.sidebarContent?.kind === "loading" ||
+        state.sidebarContent?.kind === "unavailable"
+      ) {
         state.sidebarContent = null;
       }
       clearSessionWorkspaceTimers(state);

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -390,7 +390,7 @@ export function createPageState(
     const normalized = normalizeSidebarLayout(layout);
     // Every close route commits here; tab switches retain the pending selection.
     if (
-      state.sidebarContent?.kind === "loading" &&
+      (state.sidebarContent?.kind === "loading" || state.sidebarContent?.kind === "unavailable") &&
       !normalized.columns.some((column) => column.panels.some((panel) => panel.slot === "detail"))
     ) {
       state.sidebarContent = null;

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -18,7 +18,7 @@ function recordSidebarContent(this: SessionWorkspaceHost, content: SidebarSelect
 function loadedSidebarContent(state: SessionWorkspaceHost): Promise<SidebarContent> {
   return vi.waitFor(() => {
     const content = state.sidebarContent;
-    if (!content || content.kind === "loading") {
+    if (!content || content.kind === "loading" || content.kind === "unavailable") {
       throw new Error("Sidebar content is not loaded");
     }
     return content;

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -520,7 +520,7 @@ describe("session workspace artifacts", () => {
       expect(createSessionWorkspaceProps(state).error).toMatch(/InvalidCharacterError|invalid/i),
     );
     expect(handleOpenSidebar).toHaveBeenCalledOnce();
-    expect(state.sidebarContent).toBeNull();
+    expect(state.sidebarContent).toMatchObject({ kind: "unavailable" });
   });
 });
 
@@ -765,7 +765,10 @@ describe("openSessionWorkspaceFile", () => {
       ),
     );
     expect(handleOpenSidebar).toHaveBeenCalledOnce();
-    expect(state.sidebarContent).toBeNull();
+    expect(state.sidebarContent).toEqual({
+      kind: "unavailable",
+      message: "Failed to load screenshots/result.png",
+    });
   });
 
   it("does not render base64 content as text when the preview discriminator disagrees", async () => {
@@ -799,7 +802,36 @@ describe("openSessionWorkspaceFile", () => {
       expect(createSessionWorkspaceProps(state).error).toBe("Failed to load notes.txt"),
     );
     expect(handleOpenSidebar).toHaveBeenCalledOnce();
-    expect(state.sidebarContent).toBeNull();
+    expect(state.sidebarContent).toEqual({
+      kind: "unavailable",
+      message: "Failed to load notes.txt",
+    });
+  });
+
+  it("keeps a rejected file open as an unavailable Review selection", async () => {
+    const handleOpenSidebar = vi.fn(recordSidebarContent);
+    const state = {
+      client: {},
+      connected: true,
+      handleOpenSidebar,
+      hello: gatewayHello([]),
+      sessionKey: "agent:main:current",
+      sidebarContent: null,
+      sessions: {
+        getFile: vi.fn().mockRejectedValue(new Error("session file not found")),
+      },
+    } as unknown as SessionWorkspaceHost;
+
+    openSessionWorkspaceFile(state, { path: "/outside/workspace/chat.md" });
+
+    await vi.waitFor(() =>
+      expect(state.sidebarContent).toEqual({
+        kind: "unavailable",
+        message: "session file not found",
+      }),
+    );
+    expect(createSessionWorkspaceProps(state).error).toBe("session file not found");
+    expect(handleOpenSidebar).toHaveBeenCalledOnce();
   });
 
   it("opens unsupported session files as metadata without treating bytes as text", async () => {

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -176,15 +176,22 @@ function openWorkspaceItem<T>(
   openSessionCheckoutSidebar(state, request);
   const isCurrent = () =>
     state.sidebarContent === request && isCurrentSessionWorkspace(state, workspace);
+  const fail = (message: string) => {
+    if (!isCurrent()) {
+      return;
+    }
+    workspace.error = message;
+    const unavailable = { kind: "unavailable" as const, message };
+    trackSessionCheckoutSidebar(unavailable);
+    state.sidebarContent = unavailable;
+  };
   void (async () => {
     workspace.error = null;
     try {
       const result = await load();
       const content = result == null ? null : render(result);
       if (!content) {
-        if (isCurrent()) {
-          workspace.error = missingMessage;
-        }
+        fail(missingMessage);
         return;
       }
       if (isCurrent()) {
@@ -192,9 +199,7 @@ function openWorkspaceItem<T>(
         state.sidebarContent = content;
       }
     } catch (error) {
-      if (isCurrent()) {
-        workspace.error = formatUiError(error);
-      }
+      fail(formatUiError(error));
     } finally {
       if (state.sidebarContent === request) {
         state.sidebarContent = null;

--- a/ui/src/pages/chat/components/chat-sidebar-content-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content-types.ts
@@ -136,4 +136,9 @@ export type SidebarContent =
   | SessionDiffSidebarContent
   | { kind: "task"; taskId: string };
 
-export type SidebarSelection = SidebarContent | { kind: "loading" };
+export type SidebarSelection =
+  | SidebarContent
+  | { kind: "loading" }
+  // A failed open keeps owning the Review tab; an empty selection falls back to
+  // the session diff, which reads as if the click had opened something else.
+  | { kind: "unavailable"; message: string };

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1718,6 +1718,14 @@ openclaw-session-discussion {
 }
 
 /* Mobile: Full-screen modal */
+/* Review selection that failed to open (path outside the workspace, missing file). */
+.review-unavailable {
+  display: grid;
+  gap: 4px;
+  font-size: var(--control-ui-text-sm);
+  overflow-wrap: anywhere;
+}
+
 /* ── Session diff panel (sessions.diff sidebar content) ── */
 
 .session-diff {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1719,6 +1719,10 @@ openclaw-session-discussion {
 
 .review-unavailable {
   display: grid;
+  flex: 1;
+  align-self: flex-start;
+  min-width: 0;
+  margin: 16px;
   gap: 4px;
   font-size: var(--control-ui-text-sm);
   overflow-wrap: anywhere;


### PR DESCRIPTION
Fixes #143971.

## Problem

Clicking a missing file, directory, or out-of-workspace file link in chat silently showed unrelated session changes in Review. The Gateway had rejected the file read, but clearing Review's pending selection caused the panel to load the session diff.

## Change

Keep a failed file or artifact open as an unavailable Review selection and show “Unable to open” with the Gateway error. Retain the existing request and session guards so stale failures cannot replace newer selections or reopen a closed panel. Use a compact error callout across the panel width.

Gateway access checks, successful text/image/binary previews, Files errors, and editor permissions remain unchanged. The original contributor commits are preserved. Thanks to @Marvinthebored and @Peetiegonzalez for the original repair and tests.

## Validation

- Real baseline chat reply → file link → Gateway file read → unrelated session diff, with visible tracked changes.
- Rebuilt candidate: missing, outside-workspace, and directory links show the actual error without requesting a diff; valid UTF-8 and unsupported-binary previews work.
- Both new regressions fail on baseline for the intended reasons; 186 focused UI tests pass.
- Formatting, translation verification, CSS lint, source ratchets, and the normal commit hook pass.
- Fresh independent browser acceptance covers delayed failures after selecting another file, the real Files artifact, an actual background task, and Diff; closing Review and switching sessions also retain the newer intent.
- The final error layout was inspected at two viewport sizes. Files errors/retry and editor controls were checked. HTML-shaped error text and denied-editor scopes have focused unit coverage.
- The bounded native type-aware lint attempt exceeded its memory limit. Hosted CI owns that remaining gate; no failed check is counted as passed.

Some cold-start browser control attempts stopped before a file read reached the Gateway. Their timing cause remains unassigned; successful acceptance cases retain the actual request, response, and visible result.

All browser fixtures use synthetic data and a deterministic provider through the normal agent path.

## Before and after

Before: the rejected file link displays unrelated session changes.

![Missing file opens the unrelated session diff](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-143958/public-media/20260910-124456-022596973/review-file-before.png?X-Amz-Expires=604800&X-Amz-Date=20260910T124457Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260910%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=dfc2d23bfe48c53b3615c3034448a9c2b665339c2af124877fcc2717c961667d)

After: Review retains the failed selection and shows the error.

![Review shows Unable to open and the Gateway error](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-143958/public-media/20260910-124456-022596973/review-file-after.png?X-Amz-Expires=604800&X-Amz-Date=20260910T124457Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260910%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=aaff5807c75c2fef0fc8d3ff331afb86d67b5ae9048873f34b660e32cc1601b4)

Valid file links still open the code preview.

![Valid file retains its code preview](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-143958/public-media/20260910-124456-022596973/review-file-valid.png?X-Amz-Expires=604800&X-Amz-Date=20260910T124457Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260910%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=d939596a4abbaa20b4449c48900c4342d93f551481a63c86317fb792db408e24)

The hosted image links expire on September 17, 2026. Their downloads were verified against the captured image hashes.
