### PR TITLE
fix(gateway): avoid duplicate user turns after Claude CLI resume

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -247,9 +247,11 @@ register a small wrapper backend plugin.
 - Helper runs with a caller-owned in-memory transcript use that history for hooks, bounded session notes, and fresh-session reseeding, including meaningful history before compaction. Empty memory stays empty even when the run carries another session's storage identity. Context-engine maintenance rewrites that same memory before the helper returns, even when the engine requests background maintenance. Durable transcripts retain their background maintenance path. An explicitly owned native CLI binding can still resume. Resumed turns send the current prompt and bounded session notes without replaying the conversation history.
 
 When prompt content changes, a compatible CLI session can resume with an OpenClaw
-context note before the current user prompt. Chat history ignores that exact note
-when matching imported Claude user turns to local turns, so the same turn appears
-once. Stored transcript text and unmatched imported turns remain intact.
+context note before the current user prompt. Chat history first matches imported
+Claude user turns against the full local text, including any literal quote of the
+note. If that does not match, it ignores one exact context note for comparison, so
+the same turn appears once. Stored transcript text and unmatched imported turns
+remain intact.
 
 ### History account boundaries
 

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -89,7 +89,11 @@ import {
   resolveCliAuthEpoch,
 } from "../cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
-import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
+import {
+  buildCliSessionDriftNote,
+  hashCliSessionText,
+  resolveCliSessionReuse,
+} from "../cli-session.js";
 import {
   claudeCliSessionTranscriptHasContent,
   claudeCliSessionTranscriptHasOrphanedToolUse,
@@ -271,7 +275,7 @@ function prependCliSessionDriftUserContext(
   if (reusableCliSession.mode !== "reuse-with-drift") {
     return context;
   }
-  const note = `OpenClaw resumed this CLI session after prompt content changed. Follow the current turn's instructions; changed=${reusableCliSession.drift.reasons.join(",")}.`;
+  const note = buildCliSessionDriftNote(reusableCliSession.drift.reasons);
   if (!context) {
     return { text: note };
   }

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -183,6 +183,26 @@ export type CliSessionReuseResult =
     }
   | { mode: "invalidate"; invalidatedReason: CliSessionInvalidatedReason };
 
+const CLI_SESSION_DRIFT_NOTE_PREFIX =
+  "OpenClaw resumed this CLI session after prompt content changed.";
+
+/** User-turn note telling a resumed CLI session that its prompt content drifted. */
+export function buildCliSessionDriftNote(reasons: readonly CliSessionContentDriftReason[]): string {
+  return `${CLI_SESSION_DRIFT_NOTE_PREFIX} Follow the current turn's instructions; changed=${reasons.join(",")}.`;
+}
+
+/**
+ * Claude records the drift note as ordinary user text. Strip it so an imported
+ * row still compares equal to the local turn it duplicates.
+ */
+export function stripCliSessionDriftNote(text: string): string {
+  if (!text.startsWith(CLI_SESSION_DRIFT_NOTE_PREFIX)) {
+    return text;
+  }
+  const separator = text.indexOf("\n\n");
+  return separator === -1 ? "" : text.slice(separator + 2);
+}
+
 /** Decide whether a stored CLI session can be reused for the current auth/prompt/cwd/MCP state. */
 export function resolveCliSessionReuse(params: {
   binding?: CliSessionBinding;

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -127,9 +127,9 @@ function extractComparableText(
   const stripResult = isClaudeImport
     ? stripTrailingCliImageMentions(joined)
     : { text: joined, stripped: false };
-  const normalizeText = (text: string) => {
+  const normalizeText = (value: string) => {
     const visible = stripInlineDirectiveTagsForDisplay(
-      role === "user" ? stripInboundMetadata(text) : text,
+      role === "user" ? stripInboundMetadata(value) : value,
     ).text;
     return visible.replace(/\s+/g, " ").trim();
   };
@@ -359,9 +359,10 @@ function findFirstTimestampCandidateInRange(
 
 function findMinimumOrderCursor(
   entries: ComparableHistoryMessage[],
-  cursor: number,
+  startCursor: number,
   minimumOrder: number,
 ): number {
+  let cursor = startCursor;
   let end = entries.length;
   while (cursor < end) {
     const middle = Math.floor((cursor + end) / 2);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -26,6 +26,7 @@ type ComparableHistoryMessage = {
   cliImageTurnKey?: string;
   role?: string;
   text?: string;
+  driftNoteText?: string;
   timestamp?: number;
 };
 
@@ -89,6 +90,7 @@ function extractComparableText(
   hasCliImageMentions: boolean;
   cliImageTurnKey?: string;
   text?: string;
+  driftNoteText?: string;
 } {
   if (!message || typeof message !== "object") {
     return { hasCliImageMentions: false };
@@ -121,13 +123,22 @@ function extractComparableText(
   if (!joined) {
     return { hasCliImageMentions: false };
   }
-  const stripResult = isClaudeCliImportedUserMessage(message, role)
-    ? stripTrailingCliImageMentions(stripCliSessionDriftNote(rawText).trim())
+  const isClaudeImport = isClaudeCliImportedUserMessage(message, role);
+  const stripResult = isClaudeImport
+    ? stripTrailingCliImageMentions(joined)
     : { text: joined, stripped: false };
-  const visible = stripInlineDirectiveTagsForDisplay(
-    role === "user" ? stripInboundMetadata(stripResult.text) : stripResult.text,
-  ).text;
-  const normalized = visible.replace(/\s+/g, " ").trim();
+  const normalizeText = (text: string) => {
+    const visible = stripInlineDirectiveTagsForDisplay(
+      role === "user" ? stripInboundMetadata(text) : text,
+    ).text;
+    return visible.replace(/\s+/g, " ").trim();
+  };
+  const normalized = normalizeText(stripResult.text);
+  const withoutDriftNote = isClaudeImport ? stripCliSessionDriftNote(rawText) : rawText;
+  const driftNoteText =
+    withoutDriftNote !== rawText
+      ? normalizeText(stripTrailingCliImageMentions(withoutDriftNote.trim()).text)
+      : undefined;
   const meta = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
   const storedImageTurnKey = normalizeOptionalString(meta?.cliImageTurnKey);
   return {
@@ -136,6 +147,7 @@ function extractComparableText(
       ? { cliImageTurnKey: storedImageTurnKey ?? readCliImageTurnContext(joined) }
       : {}),
     ...(normalized ? { text: normalized } : {}),
+    ...(driftNoteText ? { driftNoteText } : {}),
   };
 }
 
@@ -158,6 +170,7 @@ function prepareComparableMessage(
     ...(comparableText.cliImageTurnKey ? { cliImageTurnKey: comparableText.cliImageTurnKey } : {}),
     role,
     text: comparableText.text,
+    driftNoteText: comparableText.driftNoteText,
     timestamp: asFiniteNumber(record.timestamp),
   };
 }
@@ -344,6 +357,24 @@ function findFirstTimestampCandidateInRange(
   return best;
 }
 
+function findMinimumOrderCursor(
+  entries: ComparableHistoryMessage[],
+  cursor: number,
+  minimumOrder: number,
+): number {
+  let end = entries.length;
+  while (cursor < end) {
+    const middle = Math.floor((cursor + end) / 2);
+    const candidate = entries[middle];
+    if (candidate && candidate.order < minimumOrder) {
+      cursor = middle + 1;
+    } else {
+      end = middle;
+    }
+  }
+  return cursor;
+}
+
 function findTimestampMatch(
   summary: TimestampSummary | undefined,
   timestamp: number | undefined,
@@ -353,51 +384,56 @@ function findTimestampMatch(
   if (!summary) {
     return undefined;
   }
-  while (
-    summary.missingTimestampCursor < summary.missingTimestamps.length &&
-    (summary.missingTimestamps[summary.missingTimestampCursor]?.order ?? Number.POSITIVE_INFINITY) <
-      minimumOrder
-  ) {
+  while (summary.missingTimestampCursor < summary.missingTimestamps.length) {
+    const candidate = summary.missingTimestamps[summary.missingTimestampCursor];
+    if (!candidate || !consumed.has(candidate)) {
+      break;
+    }
     summary.missingTimestampCursor += 1;
   }
-  while (
-    summary.timestampedOrderCursor < summary.timestampedByOrder.length &&
-    (summary.timestampedByOrder[summary.timestampedOrderCursor]?.order ??
-      Number.POSITIVE_INFINITY) < minimumOrder
-  ) {
-    const skipped = summary.timestampedByOrder[summary.timestampedOrderCursor];
-    if (skipped) {
-      summary.timestampRoot = removeTimestampCandidate(summary.timestampRoot, skipped);
+  while (summary.timestampedOrderCursor < summary.timestampedByOrder.length) {
+    const candidate = summary.timestampedByOrder[summary.timestampedOrderCursor];
+    if (!candidate || !consumed.has(candidate)) {
+      break;
     }
     summary.timestampedOrderCursor += 1;
   }
+  // An alternate text view can impose a higher floor than this index owns.
+  // Keep order-only skips local until a match commits that floor for this text.
   if (timestamp === undefined) {
-    while (summary.missingTimestampCursor < summary.missingTimestamps.length) {
-      const candidate = summary.missingTimestamps[summary.missingTimestampCursor];
-      if (candidate && !consumed.has(candidate)) {
+    let missingCursor = findMinimumOrderCursor(
+      summary.missingTimestamps,
+      summary.missingTimestampCursor,
+      minimumOrder,
+    );
+    let timestampedCursor = findMinimumOrderCursor(
+      summary.timestampedByOrder,
+      summary.timestampedOrderCursor,
+      minimumOrder,
+    );
+    while (missingCursor < summary.missingTimestamps.length) {
+      const candidate = summary.missingTimestamps[missingCursor];
+      if (candidate && candidate.order >= minimumOrder && !consumed.has(candidate)) {
         break;
       }
-      summary.missingTimestampCursor += 1;
+      missingCursor += 1;
     }
-    while (summary.timestampedOrderCursor < summary.timestampedByOrder.length) {
-      const candidate = summary.timestampedByOrder[summary.timestampedOrderCursor];
-      if (candidate && !consumed.has(candidate)) {
+    while (timestampedCursor < summary.timestampedByOrder.length) {
+      const candidate = summary.timestampedByOrder[timestampedCursor];
+      if (candidate && candidate.order >= minimumOrder && !consumed.has(candidate)) {
         break;
       }
-      summary.timestampedOrderCursor += 1;
+      timestampedCursor += 1;
     }
-    const missing = summary.missingTimestamps[summary.missingTimestampCursor];
-    const timestamped = summary.timestampedByOrder[summary.timestampedOrderCursor];
+    const missing = summary.missingTimestamps[missingCursor];
+    const timestamped = summary.timestampedByOrder[timestampedCursor];
     const candidate =
       missing && (!timestamped || missing.order < timestamped.order) ? missing : timestamped;
     if (!candidate) {
       return undefined;
     }
-    if (candidate === missing) {
-      summary.missingTimestampCursor += 1;
-    } else {
-      summary.timestampedOrderCursor += 1;
-    }
+    summary.missingTimestampCursor = missingCursor + (candidate === missing ? 1 : 0);
+    summary.timestampedOrderCursor = timestampedCursor + (candidate === timestamped ? 1 : 0);
     return candidate;
   }
   let timestamped = findFirstTimestampCandidateInRange(
@@ -429,13 +465,18 @@ function findTimestampMatch(
     }
     return timestamped;
   }
-  while (summary.missingTimestampCursor < summary.missingTimestamps.length) {
-    const candidate = summary.missingTimestamps[summary.missingTimestampCursor];
-    if (candidate && !consumed.has(candidate)) {
-      summary.missingTimestampCursor += 1;
+  let missingCursor = findMinimumOrderCursor(
+    summary.missingTimestamps,
+    summary.missingTimestampCursor,
+    minimumOrder,
+  );
+  while (missingCursor < summary.missingTimestamps.length) {
+    const candidate = summary.missingTimestamps[missingCursor];
+    if (candidate && candidate.order >= minimumOrder && !consumed.has(candidate)) {
+      summary.missingTimestampCursor = missingCursor + 1;
       return candidate;
     }
-    summary.missingTimestampCursor += 1;
+    missingCursor += 1;
   }
   return undefined;
 }
@@ -535,13 +576,24 @@ export function mergeImportedChatHistoryMessages(params: {
   const consumedLocalCandidates = new Set<ComparableHistoryMessage>();
   const advanceRoleTextMinimumOrder = (
     entry: ComparableHistoryMessage,
-    matchedOrder = entry.order,
+    matched: ComparableHistoryMessage,
   ) => {
-    if (!entry.role || !entry.text) {
+    if (!entry.role) {
       return;
     }
-    const key = JSON.stringify([entry.role, entry.text]);
-    roleTextMinimumOrder.set(key, Math.max(roleTextMinimumOrder.get(key) ?? 0, matchedOrder + 1));
+    // A literal match must not consume order for an unrelated unprefixed turn.
+    // Other matches also advance the note-free view, including edited identities.
+    const matchedText = matched.text === entry.text ? entry.text : entry.driftNoteText;
+    for (const text of [entry.text, matchedText]) {
+      if (!text) {
+        continue;
+      }
+      const key = JSON.stringify([entry.role, text]);
+      roleTextMinimumOrder.set(
+        key,
+        Math.max(roleTextMinimumOrder.get(key) ?? 0, matched.order + 1),
+      );
+    }
   };
   const indexEntry = (entry: ComparableHistoryMessage) => {
     if (entry.externalIdentityKey) {
@@ -584,7 +636,7 @@ export function mergeImportedChatHistoryMessages(params: {
       const exactIdentityMatch = exactExternalIdentityIndex.get(externalIdentityKey);
       if (exactIdentityMatch) {
         consumedLocalCandidates.add(exactIdentityMatch);
-        advanceRoleTextMinimumOrder(imported, exactIdentityMatch.order);
+        advanceRoleTextMinimumOrder(imported, exactIdentityMatch);
         continue;
       }
     }
@@ -614,27 +666,37 @@ export function mergeImportedChatHistoryMessages(params: {
         changed = true;
       }
       consumedLocalCandidates.add(imageDuplicate);
-      advanceRoleTextMinimumOrder(imported, imageDuplicate.order);
+      advanceRoleTextMinimumOrder(imported, imageDuplicate);
       continue;
     }
-    const roleTextKey =
-      imported.role && imported.text ? JSON.stringify([imported.role, imported.text]) : undefined;
-    const minimumOrder = roleTextKey ? (roleTextMinimumOrder.get(roleTextKey) ?? 0) : 0;
-    const duplicate = imported.hasCliImageMentions
-      ? undefined
-      : imported.externalIdentityKey
-        ? findRoleTextCandidate(
-            identitylessRoleTextIndex,
-            imported,
-            consumedLocalCandidates,
-            minimumOrder,
-          )
-        : findRoleTextCandidate(
-            allMessageRoleTextIndex,
-            imported,
-            consumedLocalCandidates,
-            minimumOrder,
-          );
+    let duplicate: ComparableHistoryMessage | undefined;
+    if (!imported.hasCliImageMentions) {
+      const index = imported.externalIdentityKey
+        ? identitylessRoleTextIndex
+        : allMessageRoleTextIndex;
+      const importedMinimumOrder =
+        roleTextMinimumOrder.get(JSON.stringify([imported.role, imported.text])) ?? 0;
+      // A user can quote the complete note. Prefer that literal local turn
+      // before comparing the text after an OpenClaw-generated note.
+      for (const text of [imported.text, imported.driftNoteText]) {
+        if (!imported.role || !text) {
+          continue;
+        }
+        const minimumOrder = Math.max(
+          importedMinimumOrder,
+          roleTextMinimumOrder.get(JSON.stringify([imported.role, text])) ?? 0,
+        );
+        duplicate = findRoleTextCandidate(
+          index,
+          { ...imported, text },
+          consumedLocalCandidates,
+          minimumOrder,
+        );
+        if (duplicate) {
+          break;
+        }
+      }
+    }
     if (duplicate) {
       const projected = projectImportedIdentity(duplicate.message, imported.message);
       if (projected !== duplicate.message) {
@@ -646,7 +708,7 @@ export function mergeImportedChatHistoryMessages(params: {
         changed = true;
       }
       consumedLocalCandidates.add(duplicate);
-      advanceRoleTextMinimumOrder(imported, duplicate.order);
+      advanceRoleTextMinimumOrder(imported, duplicate);
       continue;
     }
     merged.push(imported);

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -10,6 +10,7 @@ import {
   hashCliImageTurnEntryId,
   readCliImageTurnContext,
 } from "../agents/cli-image-turn-correlation.js";
+import { stripCliSessionDriftNote } from "../agents/cli-session.js";
 import { isOpenClawCliImageCachePath } from "../agents/embedded-agent-runner/run/images.media-refs.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { isImageMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
@@ -120,7 +121,7 @@ function extractComparableText(
     return { hasCliImageMentions: false };
   }
   const stripResult = isClaudeCliImportedUserMessage(message, role)
-    ? stripTrailingCliImageMentions(joined)
+    ? stripTrailingCliImageMentions(stripCliSessionDriftNote(joined))
     : { text: joined, stripped: false };
   const visible = stripInlineDirectiveTagsForDisplay(
     role === "user" ? stripInboundMetadata(stripResult.text) : stripResult.text,

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -720,6 +720,35 @@ describe("cli session history", () => {
     },
   );
 
+  it("dedupes a drift-note user import against the local turn it repeats", () => {
+    const timestamp = Date.parse("2026-09-10T10:57:09.764Z");
+    const localMessage = {
+      role: "user",
+      content: "test ping...",
+      timestamp,
+      __openclaw: { id: "local-test-ping", senderIsOwner: true },
+    };
+    const importedMessage = {
+      role: "user",
+      content:
+        "OpenClaw resumed this CLI session after prompt content changed. Follow the current turn's instructions; changed=system-prompt,prompt-tools.\n\ntest ping...",
+      timestamp: timestamp + 1_531,
+      __openclaw: {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "469988d1-1f29-4ffd-a4b4-26a349e765df",
+      },
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [importedMessage],
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(readRecord(merged[0]).content).toBe("test ping...");
+  });
+
   it("retains mention-only imports near unrelated local image turns", () => {
     const timestamp = Date.parse("2026-03-26T16:29:54.500Z");
     const importedMessage = {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -824,22 +824,170 @@ describe("cli session history", () => {
     expect(merged).toEqual([localMessage, importedMessage]);
   });
 
-  it.each([CLAUDE_RESUME_DRIFT_NOTES[0], `${CLAUDE_RESUME_DRIFT_NOTES[0]}\nhello`])(
-    "matches literal note text without a blank separator: %s",
-    (content) => {
-      const localMessage = { role: "user", content, timestamp: 1_000 };
-      const importedMeta = {
+  it.each([
+    CLAUDE_RESUME_DRIFT_NOTES[0],
+    `${CLAUDE_RESUME_DRIFT_NOTES[0]}\nhello`,
+    ...CLAUDE_RESUME_DRIFT_NOTES.map((note) => `${note}\n\nhello`),
+  ])("matches literal note text: %s", (content) => {
+    const localMessage = { role: "user", content, timestamp: 1_000 };
+    const importedMeta = {
+      importedFrom: "claude-cli",
+      cliSessionId: "session-1",
+      externalId: "literal-note",
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages: [localMessage],
+      importedMessages: [{ ...localMessage, timestamp: 1_001, __openclaw: importedMeta }],
+    });
+
+    expect(merged).toEqual([{ ...localMessage, __openclaw: importedMeta }]);
+  });
+
+  it("prefers a literal note match and preserves the distinct unprefixed turn", () => {
+    const literal = `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nhello`;
+    const localMessages = [
+      { role: "user", content: "hello", timestamp: 1_000 },
+      { role: "user", content: literal, timestamp: 1_001 },
+    ];
+    const importedMeta = {
+      importedFrom: "claude-cli",
+      cliSessionId: "session-1",
+      externalId: "literal-note",
+    };
+
+    const merged = mergeImportedChatHistoryMessages({
+      localMessages,
+      importedMessages: [
+        { role: "user", content: literal, timestamp: 1_002, __openclaw: importedMeta },
+      ],
+    });
+
+    expect(merged).toEqual([localMessages[0], { ...localMessages[1], __openclaw: importedMeta }]);
+  });
+
+  it.each(["text", "external identity"])(
+    "keeps an ordinary unprefixed import eligible after a literal %s match",
+    (matchKind) => {
+      const literal = `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nhello`;
+      const literalMeta = {
         importedFrom: "claude-cli",
         cliSessionId: "session-1",
         externalId: "literal-note",
       };
+      const plainMeta = { ...literalMeta, externalId: "plain-user" };
+      const localMessages = [
+        { role: "user", content: "hello", timestamp: 1_000 },
+        {
+          role: "user",
+          content: literal,
+          timestamp: 1_001,
+          ...(matchKind === "external identity" ? { __openclaw: literalMeta } : {}),
+        },
+      ];
 
       const merged = mergeImportedChatHistoryMessages({
-        localMessages: [localMessage],
-        importedMessages: [{ ...localMessage, timestamp: 1_001, __openclaw: importedMeta }],
+        localMessages,
+        importedMessages: [
+          { role: "user", content: literal, timestamp: 1_002, __openclaw: literalMeta },
+          { role: "user", content: "hello", timestamp: 1_003, __openclaw: plainMeta },
+        ],
       });
 
-      expect(merged).toEqual([{ ...localMessage, __openclaw: importedMeta }]);
+      expect(merged).toEqual([
+        { ...localMessages[0], __openclaw: plainMeta },
+        { ...localMessages[1], __openclaw: literalMeta },
+      ]);
+    },
+  );
+
+  it.each([
+    {
+      label: "literal then stripped",
+      firstLocalIsLiteral: false,
+      firstImportTime: 1_002,
+      secondImportTime: 1_003,
+    },
+    {
+      label: "stripped then literal",
+      firstLocalIsLiteral: true,
+      firstImportTime: 600_001,
+      secondImportTime: 1_002,
+    },
+  ])(
+    "keeps repeated native text order when matching $label",
+    ({ firstLocalIsLiteral, firstImportTime, secondImportTime }) => {
+      const literal = `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nhello`;
+      const localMessages = [
+        { role: "user", content: firstLocalIsLiteral ? literal : "hello", timestamp: 1_000 },
+        {
+          role: "user",
+          content: firstLocalIsLiteral ? "hello" : literal,
+          timestamp: firstImportTime,
+        },
+      ];
+      const firstMeta = {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "first-import",
+      };
+      const laterImport = {
+        role: "user",
+        content: literal,
+        timestamp: secondImportTime,
+        __openclaw: { ...firstMeta, externalId: "later-import" },
+      };
+
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages,
+        importedMessages: [
+          { role: "user", content: literal, timestamp: firstImportTime, __openclaw: firstMeta },
+          laterImport,
+        ],
+      });
+
+      expect(merged).toHaveLength(3);
+      expect(merged).toContainEqual(localMessages[0]);
+      expect(merged).toContainEqual({ ...localMessages[1], __openclaw: firstMeta });
+      expect(merged).toContainEqual(laterImport);
+    },
+  );
+
+  it.each([1_000, undefined])(
+    "keeps ordinary matches after an unsuccessful stripped lookup (timestamp=%s)",
+    (timestamp) => {
+      const literal = `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nhello`;
+      const localMessages = [
+        { role: "user", content: "hello", timestamp },
+        { role: "user", content: literal, timestamp: 1_001 },
+      ];
+      const literalMeta = {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "literal-user",
+      };
+      const plainMeta = { ...literalMeta, externalId: "plain-user" };
+      const repeatedImport = {
+        role: "user",
+        content: literal,
+        timestamp: 1_003,
+        __openclaw: { ...literalMeta, externalId: "repeated-user" },
+      };
+
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages,
+        importedMessages: [
+          { role: "user", content: literal, timestamp: 1_002, __openclaw: literalMeta },
+          repeatedImport,
+          { role: "user", content: "hello", timestamp: 1_004, __openclaw: plainMeta },
+        ],
+      });
+
+      expect(merged).toEqual([
+        { ...localMessages[0], __openclaw: plainMeta },
+        { ...localMessages[1], __openclaw: literalMeta },
+        repeatedImport,
+      ]);
     },
   );
 
@@ -1947,6 +2095,92 @@ describe("cli session history", () => {
     expect(merged[1]).toBe(exactLocal);
     expect(readRecord(readRecord(merged[2])["__openclaw"]).externalId).toBe("later-id");
   });
+
+  it.each([CLAUDE_RESUME_DRIFT_NOTES[0], CLAUDE_RESUME_DRIFT_NOTES[1]])(
+    "keeps drift-note order after an edited exact identity: %s",
+    (laterNote) => {
+      const earlierLocal = { role: "user", content: "Original ask", timestamp: 1_000 };
+      const exactMeta = {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "exact-user",
+      };
+      const exactLocal = {
+        role: "user",
+        content: "Edited ask",
+        timestamp: 1_001,
+        __openclaw: exactMeta,
+      };
+      const laterImport = {
+        role: "user",
+        content: `${laterNote}\n\nOriginal ask`,
+        timestamp: 1_003,
+        __openclaw: { ...exactMeta, externalId: "later-user" },
+      };
+
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages: [earlierLocal, exactLocal],
+        importedMessages: [
+          {
+            role: "user",
+            content: `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nOriginal ask`,
+            timestamp: 1_002,
+            __openclaw: exactMeta,
+          },
+          laterImport,
+        ],
+      });
+
+      expect(merged).toEqual([earlierLocal, exactLocal, laterImport]);
+    },
+  );
+
+  it.each([CLAUDE_RESUME_DRIFT_NOTES[0], CLAUDE_RESUME_DRIFT_NOTES[1]])(
+    "keeps drift-note order after an exact image turn: %s",
+    (laterNote) => {
+      const earlierLocal = { role: "user", content: "Same caption", timestamp: 1_000 };
+      const localEntryId = "local-image-order";
+      const imageLocal = {
+        role: "user",
+        content: "Same caption",
+        timestamp: 1_001,
+        __openclaw: {
+          id: localEntryId,
+          media: [{ kind: "image", contentType: "image/png", path: "/media/inbound/order.png" }],
+        },
+      };
+      const imageMeta = {
+        importedFrom: "claude-cli",
+        cliSessionId: "session-1",
+        externalId: "image-user",
+      };
+      const laterImport = {
+        role: "user",
+        content: `${laterNote}\n\nSame caption`,
+        timestamp: 1_003,
+        __openclaw: { ...imageMeta, externalId: "later-user" },
+      };
+
+      const merged = mergeImportedChatHistoryMessages({
+        localMessages: [earlierLocal, imageLocal],
+        importedMessages: [
+          {
+            role: "user",
+            content: `${CLAUDE_RESUME_DRIFT_NOTES[0]}\n\nSame caption\n\n${formatCliImageTurnContext(hashCliImageTurnEntryId(localEntryId))}\n\n@/tmp/openclaw/openclaw-cli-images/${"a".repeat(64)}.png`,
+            timestamp: 1_002,
+            __openclaw: imageMeta,
+          },
+          laterImport,
+        ],
+      });
+
+      expect(merged).toEqual([
+        earlierLocal,
+        { ...imageLocal, __openclaw: { ...imageLocal.__openclaw, ...imageMeta } },
+        laterImport,
+      ]);
+    },
+  );
 
   it("does not surface a secret present only in imported history after merge", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -767,7 +767,7 @@ describe("cli session history", () => {
       expect(merged).toEqual([
         {
           ...localMessage,
-          __openclaw: { ...localMessage.__openclaw, ...importedMessage.__openclaw },
+          __openclaw: { ...localMessage["__openclaw"], ...importedMessage["__openclaw"] },
         },
       ]);
       expect({ localMessage, importedMessage }).toEqual(before);
@@ -2176,7 +2176,7 @@ describe("cli session history", () => {
 
       expect(merged).toEqual([
         earlierLocal,
-        { ...imageLocal, __openclaw: { ...imageLocal.__openclaw, ...imageMeta } },
+        { ...imageLocal, __openclaw: { ...imageLocal["__openclaw"], ...imageMeta } },
         laterImport,
       ]);
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reloading a Claude CLI conversation see the current user turn twice after the session resumes with changed prompt content.

## Why This Change Was Made

The runner and history importer share the complete context-note format. History first matches the full user text, then tries comparison without one exact generated note. Literal quotes keep their normal match. The existing merge retains identity, timestamp, image and ordering rules, and failed comparison attempts preserve candidates for later turns.

## User Impact

A resumed user turn appears once. Literal note text, distinct native messages, images and unmatched imports remain intact. Stored transcripts, session reuse, authentication and configuration are unchanged.

## Evidence

- Real Gateway and served Control UI used the unmodified official Claude Code 2.1.267 client. The client handled stdio, resumed its own native session, and wrote its own project history. A local Anthropic Messages API supplied synthetic assistant responses; it did not write transcripts. All proof processes shared a private network with no external route, so no vendor credentials or paid inference were used.
- Two real public chat turns, with normal bootstrap completion between them, selected actual system-prompt drift in the same native session. Baseline history returned five rows and the reloaded UI showed the second user turn twice. The candidate returned four rows and showed that turn once.
- Independent official-client acceptance passed all 14 real turns and eight copied-history controls. Literal notes, images, mixed turns, distinct native identities, timestamps, roles, sender metadata and reply directives were preserved. Eighteen browser captures were inspected. The submitted image bytes also match the image block sent by the actual client.
- The runtime proof executed `d2475ee4b0ca468123a634ae676f47ab05228b42`. The final follow-up only renames internal bindings and changes test property-access syntax for lint. Independent source review confirmed that these edits preserve the exercised behavior; the original build identity stays attached to the proof.
- 135 focused history/handler tests passed on the final corrected source. The unchanged CLI session/preparation paths retain 214 passing sibling tests. Regression cases failed on the baseline, original parser and rejected intermediate candidates for their intended reasons.
- Focused non-type guards, formatting, docs checks and the normal native hook passed. Full typechecks and type-aware lint are assigned to hosted CI on the final head.

The API responses are synthetic. This proves the supported client's persistence and the real Gateway/history/UI path, without claiming vendor inference or model image understanding.

AI-assisted.
