### PR TITLE
fix(agents): preserve selected models through fallback and auth refresh

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1719,7 +1719,6 @@ src/agents/embedded-agent-runner/prompt-cache-observability.ts	2
 src/agents/embedded-agent-runner/replay-history.ts	53
 src/agents/embedded-agent-runner/result-fallback-classifier.ts	2
 src/agents/embedded-agent-runner/run-entry.ts	3
-src/agents/embedded-agent-runner/run-orchestrator.ts	1
 src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts	4
 src/agents/embedded-agent-runner/run/abortable.ts	2
 src/agents/embedded-agent-runner/run/attempt-async-tasks.ts	1

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1341,6 +1341,7 @@ export function runAgentAttempt(params: {
     provider: embeddedAgentProvider,
     model: params.modelOverride,
     modelRoutingProvenance: params.modelRoutingProvenance,
+    requestedRouteResolution: "resolved",
     modelHasVision: params.modelHasVision,
     modelThinkingCapability: params.modelThinkingCapability,
     modelFallbacksOverride: params.modelFallbacksOverride,

--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -59,6 +59,7 @@ const installRunEmbeddedMocks = () => {
     resolveModelAsync: async (provider: string, modelId: string) => {
       const subscriptionModel = modelId === "chatgpt-mock";
       return {
+        logicalRef: { provider, model: modelId },
         model: {
           id: modelId,
           name: modelId,

--- a/src/agents/embedded-agent-runner/compact.delegate.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate.test.ts
@@ -127,7 +127,13 @@ async function createFixture(operation: "summary" | "endpoint", globalAlias = fa
   authStorage.setRuntimeApiKey(model.provider, "test-api-key");
   const modelRegistry = sessions.ModelRegistry.inMemory(authStorage);
   modelRegistry.registerProvider(model.provider, { api: model.api, streamSimple: stream });
-  resolveModelMock.mockReturnValue({ model, error: null, authStorage, modelRegistry });
+  resolveModelMock.mockImplementation((provider = model.provider, modelId = model.id) => ({
+    logicalRef: { provider, model: modelId },
+    model,
+    error: null,
+    authStorage,
+    modelRegistry,
+  }));
   vi.mocked(streamResolution.resolveEmbeddedAgentStream).mockReturnValue({
     streamFn: stream,
     strategy: "session-custom",

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -24,6 +24,7 @@ import type { attemptServerEndpointCompaction } from "./server-endpoint-compacti
 import type { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
 type MockResolvedModel = {
+  logicalRef: { provider: string; model: string };
   model: {
     provider: string;
     api: string;
@@ -66,6 +67,7 @@ export const resolveContextEngineMock = vi.fn(async () => ({
 export const resolveModelMock: Mock<
   (provider?: string, modelId?: string, agentDir?: string, cfg?: unknown) => MockResolvedModel
 > = vi.fn((provider?: string, modelId?: string, _agentDir?: string, _cfg?: unknown) => ({
+  logicalRef: { provider: provider ?? "openai", model: modelId ?? "fake" },
   model: {
     provider: provider ?? "openai",
     api: "openai-responses",
@@ -627,6 +629,7 @@ export function resetCompactHooksHarnessMocks(workspaceDir: string): void {
 
   resolveModelMock.mockReset();
   resolveModelMock.mockImplementation((provider?: string, modelId?: string) => ({
+    logicalRef: { provider: provider ?? "openai", model: modelId ?? "fake" },
     model: {
       provider: provider ?? "openai",
       api: "openai-responses",

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -237,6 +237,7 @@ function mockResolvedModel(params?: {
           | undefined
       )?.models?.providers?.[provider];
       return {
+        logicalRef: { provider, model: modelId },
         model: {
           provider,
           api: providerConfig?.api ?? "openai-responses",
@@ -1844,12 +1845,13 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
     });
-    resolveModelMock.mockReturnValueOnce({
+    resolveModelMock.mockImplementationOnce((provider = "openai", modelId = "fake") => ({
+      logicalRef: { provider, model: modelId },
       model: { provider: "openai", api: "openai-responses", id: "fake", input: [] },
       error: null,
       authStorage: { setRuntimeApiKey: vi.fn() },
       modelRegistry: {},
-    });
+    }));
     createOpenClawCodingToolsMock.mockReturnValueOnce([
       {
         name: "healthy_lookup",
@@ -3438,6 +3440,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         const api = providerConfig?.api ?? defaultApi;
         const subscription = api === "openai-chatgpt-responses";
         return {
+          logicalRef: { provider, model: modelId },
           model: {
             provider,
             id: modelId,
@@ -3930,7 +3933,8 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       dispose,
     } as never);
     resolveModelAsyncMock
-      .mockResolvedValueOnce({
+      .mockImplementationOnce(async (provider, modelId) => ({
+        logicalRef: { provider, model: modelId },
         model: {
           provider: "openai",
           id: "fake",
@@ -3941,7 +3945,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         error: null,
         authStorage,
         modelRegistry: {},
-      })
+      }))
       .mockRejectedValueOnce(new Error("route materialization failed"));
 
     await expect(
@@ -3979,10 +3983,11 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     const releaseModelResolution = createDeferred();
     const authStorage = { setRuntimeApiKey: vi.fn() };
     let hostActive = true;
-    resolveModelAsyncMock.mockImplementationOnce(async () => {
+    resolveModelAsyncMock.mockImplementationOnce(async (provider, modelId) => {
       modelResolutionStarted.resolve(undefined);
       await releaseModelResolution.promise;
       return {
+        logicalRef: { provider, model: modelId },
         model: {
           provider: "openai",
           id: "fake",

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -59,6 +59,7 @@ const resolveModelAsyncMock = vi.fn(
       return {
         ...stores,
         model: { ...staticCatalogModel, provider, id: modelId, name: modelId },
+        logicalRef: { provider, model: modelId },
       };
     }
     return {
@@ -256,7 +257,7 @@ describe("embedded model resolution consistency", () => {
         modelIdNormalization: {
           providers: {
             "custom-provider": {
-              aliases: { "legacy-model": "modern-model" },
+              aliases: { "legacy-model": "modern-model", "modern-model": "unexpected-second-pass" },
             },
           },
         },
@@ -268,7 +269,7 @@ describe("embedded model resolution consistency", () => {
         agentId: "worker",
         provider: initial.provider,
         model: initial.modelId,
-        requestedRouteResolution: "resolved",
+        requestedRouteResolution: "raw",
         fallbacksOverride: [],
         manifestPlugins,
       }),
@@ -277,7 +278,7 @@ describe("embedded model resolution consistency", () => {
         provider: "custom-provider",
         model: "modern-model",
         routeOrigin: "requested",
-        routeResolution: "resolved",
+        routeResolution: "raw",
       },
     ]);
     expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledWith({

--- a/src/agents/embedded-agent-runner/model-resolution.ts
+++ b/src/agents/embedded-agent-runner/model-resolution.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
+import type { ModelFallbackRouteResolution } from "../model-fallback.types.js";
 import {
   prepareModelRuntimeSnapshot,
   type PreparedModelRuntimeSnapshot,
@@ -13,6 +14,7 @@ export async function resolveTieredModel(params: {
   provider: string;
   fallbackProvider?: string;
   modelId: string;
+  requestedRouteResolution?: ModelFallbackRouteResolution;
   agentDir: string;
   config?: OpenClawConfig;
   workspaceDir: string;
@@ -26,6 +28,13 @@ export async function resolveTieredModel(params: {
       ? [params.provider, params.fallbackProvider]
       : [params.provider];
   const resolveCandidates = async (options: Parameters<typeof resolveModelAsync>[4]) => {
+    const modelOptions: Parameters<typeof resolveModelAsync>[4] = {
+      ...options,
+      workspaceDir: params.workspaceDir,
+      authProfileId: params.authProfileId,
+      authProfileMode: params.authProfileMode,
+      modelIdSource: params.requestedRouteResolution === "resolved" ? "selected" : "input",
+    };
     let firstFailure: { provider: string; resolution: ModelResolution } | undefined;
     for (const provider of providers) {
       const resolution = await resolveModelAsync(
@@ -33,10 +42,10 @@ export async function resolveTieredModel(params: {
         params.modelId,
         params.agentDir,
         params.config,
-        options,
+        modelOptions,
       );
       if (resolution.model) {
-        return { provider, resolution };
+        return { provider: resolution.logicalRef.provider, resolution };
       }
       firstFailure ??= { provider, resolution };
     }
@@ -47,9 +56,6 @@ export async function resolveTieredModel(params: {
     allowBundledStaticCatalogFallback: params.staticCatalogOwnsTransport,
     preferBundledStaticCatalogTransport: params.staticCatalogOwnsTransport,
     preparedModelRuntime: params.preparedModelRuntime,
-    workspaceDir: params.workspaceDir,
-    authProfileId: params.authProfileId,
-    authProfileMode: params.authProfileMode,
   });
   if (firstTier.resolution.model || params.staticCatalogOwnsTransport) {
     return firstTier;
@@ -66,9 +72,6 @@ export async function resolveTieredModel(params: {
   // the route metadata needed to explain a provider-declared retirement.
   return await resolveCandidates({
     ...preparedModelRuntime.createStores(),
-    workspaceDir: params.workspaceDir,
-    authProfileId: params.authProfileId,
-    authProfileMode: params.authProfileMode,
     allowBundledStaticCatalogFallback: true,
     preparedModelRuntime,
   });

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -6,7 +6,7 @@ import { resolveDefaultAgentDir } from "../agent-scope.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
 import { resolveLegacyInheritedAuthDir } from "../legacy-inherited-auth-dir.js";
 import { resolveModelWorkspaceDir } from "../model-discovery-context.js";
-import { modelKey } from "../model-ref-shared.js";
+import { modelKey, type ModelRef } from "../model-ref-shared.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { buildSuppressedBuiltInModelError } from "../model-suppression.js";
 import {
@@ -100,18 +100,21 @@ function resolvePreparedAgentSnapshot(
   return getPreparedModelRuntimeSnapshot({ ...base, workspaceDir: derivedWorkspaceDir });
 }
 
+type ModelResolution = {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+} & (
+  | { model: Model; logicalRef: Readonly<ModelRef>; error?: undefined }
+  | { model?: undefined; error: string }
+);
+
 export async function resolveModelAsync(
   provider: string,
   modelId: string,
   agentDir?: string,
   cfg?: OpenClawConfig,
   options?: AsyncModelResolutionOptions,
-): Promise<{
-  model?: Model;
-  error?: string;
-  authStorage: AuthStorage;
-  modelRegistry: ModelRegistry;
-}> {
+): Promise<ModelResolution> {
   const resolvedAgentDir = agentDir ?? resolveDefaultAgentDir(cfg ?? {});
   const derivedWorkspaceDir = resolveModelWorkspaceDir(
     cfg,
@@ -155,6 +158,7 @@ export async function resolveModelAsync(
       workspaceDir,
       modelIdSource: options?.modelIdSource,
     });
+    const logicalRef = { provider: normalizedRef.provider, model: normalizedRef.model };
     let { authStorage, modelRegistry } = options ?? {};
     if (!authStorage || !modelRegistry) {
       const stores = preparedModelRuntime?.createStores() ?? createEmptyAgentDiscoveryStores();
@@ -244,7 +248,7 @@ export async function resolveModelAsync(
         getStaticCatalogModel: getManifestStaticCatalogModel,
       });
       if (suppressedRuntimeModel) {
-        return { model: suppressedRuntimeModel, authStorage, modelRegistry };
+        return { model: suppressedRuntimeModel, logicalRef, authStorage, modelRegistry };
       }
       return {
         error:
@@ -387,7 +391,7 @@ export async function resolveModelAsync(
       }
     }
     if (model) {
-      return { model, authStorage, modelRegistry };
+      return { model, logicalRef, authStorage, modelRegistry };
     }
     return {
       error: buildUnknownModelError({

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -83,7 +83,6 @@ import type {
   RunEmbeddedAgentParamsWithSessionFile,
 } from "./run/internal-params.js";
 import { createEmbeddedRunLaneController } from "./run/lane-controller.js";
-import type { RunEmbeddedAgentParams } from "./run/params.js";
 import { bindRunToPreparedModelRuntime } from "./run/prepared-runtime-context.js";
 import { createEmbeddedRunProgressController } from "./run/progress-controller.js";
 import { createRecoveryMessageActionTurnCapability } from "./run/recovery-message-action-capability.js";
@@ -95,9 +94,8 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 const EMPTY_EMBEDDED_AGENT_CONFIG: OpenClawConfig = Object.freeze({});
 
 export function runEmbeddedAgent(
-  paramsInput: RunEmbeddedAgentParams,
+  internalParamsInput: RunEmbeddedAgentInternalParams,
 ): Promise<EmbeddedAgentRunResult> {
-  const internalParamsInput = paramsInput as RunEmbeddedAgentInternalParams;
   const requestedProvider = normalizeOptionalString(internalParamsInput.provider);
   const requestedModel = normalizeOptionalString(internalParamsInput.model);
   const needsConfiguredDefault =
@@ -291,7 +289,7 @@ async function runEmbeddedAgentInternal(
         manifestPlugins: pluginMetadataSnapshot,
         provider: requestedRuntimeSelection.provider,
         model: requestedRuntimeSelection.modelId,
-        requestedRouteResolution: "resolved",
+        requestedRouteResolution: params.requestedRouteResolution,
         fallbacksOverride: runtimePluginFallbacksOverride,
       }).map((candidate, index) =>
         requestedHarnessRuntime &&

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -128,6 +128,7 @@ type MockAgentDiscoveryStores = {
 
 type MockResolveModelResult = MockAgentDiscoveryStores & {
   model: MockResolvedModel;
+  logicalRef: { provider: string; model: string };
   error: null;
 };
 
@@ -237,6 +238,7 @@ function createMockResolvedModel(
   )?.models?.providers?.[provider];
   const usesOpenAITransport = provider === "openai" || provider === "codex";
   return {
+    logicalRef: { provider, model: modelId },
     model: {
       id: modelId,
       provider,

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -32,6 +32,7 @@ import {
 import { buildTestCtx } from "../../auto-reply/reply/test-ctx.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../../auto-reply/types.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { FailoverReason } from "../failover/signal.js";
@@ -608,6 +609,87 @@ describe("prepared harness source delivery", () => {
         "Your replies are automatically sent to this conversation",
       );
     }
+  });
+
+  it.each([
+    { name: "configured input", selection: {} },
+    { name: "unmarked raw pair", selection: { provider: "openai", model: "legacy-model" } },
+    {
+      name: "marked raw pair",
+      selection: { provider: "openai", model: "legacy-model", requestedRouteResolution: "raw" },
+    },
+    {
+      name: "resolved pair",
+      selection: { provider: "openai", model: "gpt-5.4", requestedRouteResolution: "resolved" },
+    },
+  ] as const)("prepares $name with one manifest normalization pass", async ({ selection }) => {
+    const { runEmbeddedAgent } = await loadSourceDeliveryHarness();
+    mockedGlobalHookRunner.hasHooks.mockReturnValue(false);
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "primary" }]);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ assistantTexts: ["primary"] }),
+    );
+    useOpenAIPlatformAuthFixture();
+    const metadataSnapshot = {
+      ...createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "openai",
+            providers: ["openai"],
+            modelIdNormalization: {
+              providers: {
+                openai: {
+                  aliases: { "legacy-model": "gpt-5.4", "gpt-5.4": "unexpected-second-pass" },
+                },
+              },
+            },
+          },
+        ],
+      }),
+      workspaceDir: state.workspaceDir,
+    };
+    const config = { agents: { defaults: { model: { primary: "openai/legacy-model" } } } };
+    const pluginRegistry = createEmptyPluginRegistry();
+    const baseLease = await mockedAcquireAgentRunPreparedModelRuntime({
+      config,
+      agentId: "worker",
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+    });
+    mockedAcquireAgentRunPreparedModelRuntime.mockClear();
+    mockedAcquireAgentRunPreparedModelRuntime.mockResolvedValueOnce({
+      ...baseLease,
+      snapshot: {
+        ...baseLease.snapshot,
+        metadataSnapshot,
+        pluginRegistry,
+      },
+    });
+
+    await runEmbeddedAgent({
+      agentId: "worker",
+      sessionId: "manifest-model-preparation",
+      workspaceDir: state.workspaceDir,
+      prompt: "hello",
+      runId: "manifest-model-preparation",
+      timeoutMs: 30_000,
+      modelFallbacksOverride: [],
+      config,
+      pluginGeneration: {
+        pluginMetadataSnapshot: metadataSnapshot,
+        pluginRegistry,
+        configuredCatalogEntries: [],
+        inlineProviderModels: [],
+      },
+      ...selection,
+    });
+
+    expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.4", agentId: "worker" }],
+      }),
+      expect.any(Object),
+    );
   });
 
   it("prepares a Codex primary without pinning a plugin-owned fallback", async () => {

--- a/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
@@ -102,7 +102,11 @@ describe("embedded run auth plan provider pin", () => {
       },
     };
     const stores = modelRuntime.createEmptyAgentDiscoveryStores();
-    vi.spyOn(modelRuntime, "resolveModelAsync").mockResolvedValue({ ...stores, model });
+    vi.spyOn(modelRuntime, "resolveModelAsync").mockResolvedValue({
+      ...stores,
+      model,
+      logicalRef: { provider: model.provider, model: model.id },
+    });
     const prepared = await withPluginRuntimeGenerationScope(
       { metadataSnapshot: createPluginMetadataSnapshotFixture() },
       () =>
@@ -136,86 +140,6 @@ describe("embedded run auth plan provider pin", () => {
     });
   });
 
-  it("does not materialize a raw alias as a different executable model", async () => {
-    const provider = "raw-auth-model";
-    const config: OpenClawConfig = {
-      models: {
-        providers: {
-          [provider]: {
-            api: "openai-completions",
-            baseUrl: "https://raw-auth-model.example/v1",
-            apiKey: "synthetic-fixture",
-            models: [],
-          },
-        },
-      },
-    };
-    const stores = modelRuntime.createEmptyAgentDiscoveryStores();
-    stores.modelRegistry.registerProvider(provider, {
-      api: "openai-completions",
-      baseUrl: "https://raw-auth-model.example/v1",
-      models: [
-        {
-          id: "middle",
-          name: "middle",
-          reasoning: false,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 16_000,
-          maxTokens: 1_024,
-        },
-      ],
-    });
-    const metadataSnapshot = createPluginMetadataSnapshotFixture({
-      plugins: [
-        {
-          id: provider,
-          providers: [provider],
-          modelIdNormalization: { providers: { [provider]: { aliases: { entry: "middle" } } } },
-        },
-      ],
-    });
-    await withPluginRuntimeGenerationScope({ metadataSnapshot }, async () => {
-      const resolution = await modelRuntime.resolveModelAsync(
-        provider,
-        "entry",
-        agentDir,
-        config,
-        stores,
-      );
-      expect(resolution.model?.id).toBe("middle");
-      const model = resolution.model!;
-      const prepared = await prepareEmbeddedRunAuthPlan({
-        runParams: {
-          sessionId: "raw-model-session",
-          runId: "raw-model-run",
-          workspaceDir: state.workspaceDir,
-          prompt: "Auth preparation only",
-          timeoutMs: 5_000,
-          config,
-        },
-        provider,
-        modelId: "entry",
-        model,
-        agentDir,
-        workspaceDir: state.workspaceDir,
-        nativeModelOwned: false,
-        ...stores,
-        getAgentHarness: () => openClawHarness,
-        setAgentHarness: () => {},
-        getRuntimeModel: () => model,
-        getEffectiveModel: () => model,
-        applyResolvedRuntimeModel: () => {},
-        selectHarnessForPreparedAttempts: () => openClawHarness,
-      });
-      await expect(
-        prepared.materializeAuthPlanUncached(prepared.activePreparedAuthPlan, true),
-      ).rejects.toThrow(
-        "Unable to rematerialize raw-auth-model/entry for its resolved auth profile.",
-      );
-    });
-  });
-
   it.each([
     { pin: true, authMode: "api-key", authRequirement: "api-key", kind: "direct" },
     { pin: false, authMode: "oauth", authRequirement: "subscription", kind: "profile" },
@@ -235,6 +159,7 @@ describe("embedded run auth plan provider pin", () => {
       vi.spyOn(modelRuntime, "resolveModelAsync").mockImplementation(
         async (_provider, _modelId, _agentDir, cfg) => ({
           ...stores,
+          logicalRef: { provider: _provider, model: _modelId },
           model:
             cfg?.models?.providers?.openai?.api === "openai-responses"
               ? platformModel

--- a/src/agents/embedded-agent-runner/run/auth-plan.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.ts
@@ -49,6 +49,7 @@ function loadEmbeddedRunAuthProfileStore(params: {
 export async function prepareEmbeddedRunAuthPlan(params: {
   runParams: RunEmbeddedAgentParams;
   provider: string;
+  /** Selected logical ID returned by the model resolver. */
   modelId: string;
   model: RuntimeModel;
   agentDir: string;
@@ -225,6 +226,7 @@ export async function prepareEmbeddedRunAuthPlan(params: {
       generationRouteModelMemo: params.preparedModelRuntime?.routeModelResolutionMemo,
       resolveModel: ({ config, authProfileId, authProfileMode }) =>
         resolveModelAsync(params.provider, params.modelId, params.agentDir, config, {
+          modelIdSource: "selected",
           authStorage: params.authStorage,
           modelRegistry: params.modelRegistry,
           skipAgentDiscovery: true,

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -1,6 +1,7 @@
 import type { SessionTranscriptRuntimeTarget } from "../../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../../../config/sessions/types.js";
 import type { AgentExecutionAuthBinding } from "../../execution-auth-binding.js";
+import type { ModelFallbackRouteResolution } from "../../model-fallback.types.js";
 import type { PreparedModelRuntimePluginGeneration } from "../../prepared-model-runtime.types.js";
 import type { CompactionRequestBudget } from "../../sessions/compaction/request-budget.js";
 import type { SystemAgentToolOptions } from "../../tools/system-agent-tool.js";
@@ -33,6 +34,8 @@ export type CompactionAccountingFact = Readonly<
 >;
 
 export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
+  /** Candidate producers have already resolved the model against their captured metadata. */
+  requestedRouteResolution?: ModelFallbackRouteResolution;
   onCompactionRequestBudget?: (budget: CompactionRequestBudget | undefined) => void;
   onCompactionAccounting?: (fact: CompactionAccountingFact | undefined) => void;
   /** Attempt-local context observer, installed by the host loop before dispatch. */

--- a/src/agents/embedded-agent-runner/run/model-setup.selected-model.test.ts
+++ b/src/agents/embedded-agent-runner/run/model-setup.selected-model.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { Model } from "../../../llm/types.js";
+import { createPluginMetadataSnapshotFixture } from "../../../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { withPluginRuntimeGenerationScope } from "../../../plugins/runtime/generation-scope.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { writePersistedAuthProfileStoreRaw } from "../../auth-profiles/sqlite.js";
+import { resolveModelCandidateChain } from "../../model-fallback-candidates.js";
+import type { PreparedModelRuntimeSnapshot } from "../../prepared-model-runtime.js";
+import { createEmptyAgentDiscoveryStores } from "../model.js";
+import { prepareEmbeddedRunAuthPlan } from "./auth-plan.js";
+import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
+import { resolveEmbeddedRunModelSetup } from "./model-setup.js";
+import { resolveInitialEmbeddedRunModel } from "./runtime-resolution.js";
+
+const provider = "first-selected";
+const otherProvider = "hook-selected";
+const cases = [
+  { name: "configured default", input: {}, planned: "middle", expected: "middle" },
+  {
+    name: "unmarked raw entry",
+    input: { provider, model: "entry" },
+    planned: "middle",
+    expected: "middle",
+  },
+  {
+    name: "marked raw entry",
+    input: { provider, model: "entry", requestedRouteResolution: "raw" },
+    planned: "middle",
+    expected: "middle",
+  },
+  {
+    name: "raw middle alias",
+    input: { provider, model: "middle" },
+    planned: "final",
+    expected: "final",
+  },
+  {
+    name: "selected middle",
+    input: { provider, model: "middle", requestedRouteResolution: "resolved" },
+    planned: "middle",
+    expected: "middle",
+  },
+  {
+    name: "selected model hook redirect",
+    input: { provider, model: "middle", requestedRouteResolution: "resolved" },
+    hook: { modelOverride: "entry" },
+    planned: "middle",
+    expected: "middle",
+  },
+  {
+    name: "selected provider hook redirect",
+    input: { provider, model: "middle", requestedRouteResolution: "resolved" },
+    hook: { providerOverride: otherProvider },
+    planned: "middle",
+    expected: "other-final",
+  },
+  {
+    name: "locked selection ignores hook",
+    input: {
+      provider,
+      model: "middle",
+      requestedRouteResolution: "resolved",
+      modelSelectionLocked: true,
+    },
+    hook: { modelOverride: "entry" },
+    planned: "middle",
+    expected: "middle",
+  },
+  {
+    name: "raw plain control",
+    input: { provider, model: "plain" },
+    planned: "plain",
+    expected: "plain",
+  },
+  {
+    name: "selected plain control",
+    input: { provider, model: "plain", requestedRouteResolution: "resolved" },
+    planned: "plain",
+    expected: "plain",
+  },
+] as const;
+
+describe.each(["registry", "prepared static"] as const)("initial model setup using %s", (tier) => {
+  it.each(cases)("preserves $name through materialization", async (scenario) => {
+    await withOpenClawTestState(
+      { label: "initial-model-selection", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+      async (state) => {
+        const config: OpenClawConfig = {
+          agents: { defaults: { workspace: state.workspaceDir, model: `${provider}/entry` } },
+        };
+        writePersistedAuthProfileStoreRaw(
+          {
+            version: 1,
+            profiles: Object.fromEntries(
+              [provider, otherProvider].map((id) => [
+                `${id}:fixture`,
+                { type: "api_key" as const, provider: id, key: "synthetic-fixture" },
+              ]),
+            ),
+          },
+          state.agentDir(),
+        );
+        const metadataSnapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: provider,
+              providers: [provider, otherProvider],
+              modelIdNormalization: {
+                providers: {
+                  [provider]: { aliases: { entry: "middle", middle: "final" } },
+                  [otherProvider]: { aliases: { middle: "other-final" } },
+                },
+              },
+            },
+          ],
+        });
+        const createModel = (modelProvider: string, id: string) =>
+          ({
+            provider: modelProvider,
+            id,
+            name: id,
+            api: "openai-completions",
+            baseUrl: "https://initial-model.example/v1",
+            input: ["text"],
+            reasoning: false,
+            contextWindow: 32000,
+            maxTokens: 256,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          }) satisfies Model;
+        const models = ["middle", "final", "plain"].map((id) => createModel(provider, id));
+        const otherModels = [createModel(otherProvider, "other-final")];
+        const stores = createEmptyAgentDiscoveryStores();
+        if (tier === "registry") {
+          stores.modelRegistry.registerProvider(provider, {
+            api: "openai-completions",
+            baseUrl: "https://initial-model.example/v1",
+            models,
+          });
+          stores.modelRegistry.registerProvider(otherProvider, {
+            api: "openai-completions",
+            baseUrl: "https://initial-model.example/v1",
+            models: otherModels,
+          });
+        }
+        const snapshot: PreparedModelRuntimeSnapshot = {
+          catalogOwner: undefined,
+          agentId: "main",
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          activeProjectKeys: [],
+          config,
+          observationConfig: config,
+          isCurrent: () => true,
+          authModes: {},
+          metadataSnapshot,
+          pluginRegistry: createEmptyPluginRegistry(),
+          allowGatewaySubagentBinding: false,
+          modelCatalog: { entries: [], routeVariants: [] },
+          inlineProviderModels: [],
+          configuredRuntimeModels:
+            tier === "prepared static"
+              ? [...models, ...otherModels].map((model) => ({
+                  provider: model.provider,
+                  modelId: model.id,
+                  model,
+                }))
+              : [],
+          createStores: () => stores,
+        };
+        await withPluginRuntimeGenerationScope(snapshot, async () => {
+          const runParams: RunEmbeddedAgentInternalParams = {
+            config,
+            agentId: "main",
+            sessionId: "initial-model-selection",
+            runId: "initial-model-selection",
+            workspaceDir: state.workspaceDir,
+            prompt: "Synthetic model selection",
+            timeoutMs: 1000,
+            agentHarnessId: "openclaw",
+            ...scenario.input,
+          };
+          const initial = resolveInitialEmbeddedRunModel({
+            ...runParams,
+            config: runParams.config,
+          });
+          const planned = resolveModelCandidateChain({
+            cfg: config,
+            agentId: "main",
+            provider: initial.provider,
+            model: initial.modelId,
+            requestedRouteResolution: runParams.requestedRouteResolution,
+            fallbacksOverride: [],
+            manifestPlugins: metadataSnapshot,
+          });
+          expect(planned[0]?.model).toBe(scenario.planned);
+          const hook = "hook" in scenario ? scenario.hook : undefined;
+          const setup = await resolveEmbeddedRunModelSetup({
+            runParams,
+            ...initial,
+            agentDir: snapshot.agentDir,
+            workspaceDir: state.workspaceDir,
+            globalLane: "test",
+            hookRunner: hook
+              ? { hasHooks: () => true, runBeforeModelResolve: async () => hook }
+              : undefined,
+            hookContext: { sessionId: runParams.sessionId, workspaceDir: state.workspaceDir },
+            onHooksResolved: () => {},
+            preparedModelRuntime: snapshot,
+          });
+          const requestedModelId =
+            hook && "modelOverride" in hook && runParams.modelSelectionLocked !== true
+              ? hook.modelOverride
+              : initial.modelId;
+          expect(setup.requestedModelId).toBe(requestedModelId);
+          expect(setup.model.id).toBe(scenario.expected);
+          let currentModel = setup.model;
+          let harness = setup.agentHarness;
+          const auth = await prepareEmbeddedRunAuthPlan({
+            runParams,
+            provider: setup.provider,
+            modelId: setup.modelId,
+            model: setup.model,
+            agentDir: snapshot.agentDir,
+            workspaceDir: state.workspaceDir,
+            nativeModelOwned: false,
+            authStorage: setup.authStorage,
+            modelRegistry: setup.modelRegistry,
+            preparedModelRuntime: snapshot,
+            getAgentHarness: () => harness,
+            setAgentHarness: (next) => {
+              harness = next;
+            },
+            getRuntimeModel: () => currentModel,
+            getEffectiveModel: () => currentModel,
+            applyResolvedRuntimeModel: (next) => {
+              currentModel = next;
+            },
+            selectHarnessForPreparedAttempts: () => harness,
+          });
+          const rematerialized = await auth.materializeAuthPlanUncached(
+            auth.activePreparedAuthPlan,
+            true,
+          );
+          expect(setup.modelId).toBe(scenario.expected);
+          expect(rematerialized?.id).toBe(scenario.expected);
+        });
+      },
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/model-setup.ts
+++ b/src/agents/embedded-agent-runner/run/model-setup.ts
@@ -14,7 +14,7 @@ import { resolveSelectedOpenAIRuntimeProvider } from "../../openai-routing.js";
 import type { PreparedModelRuntimeSnapshot } from "../../prepared-model-runtime.js";
 import { resolveTieredModel } from "../model-resolution.js";
 import { createEmptyAgentDiscoveryStores } from "../model.js";
-import type { RunEmbeddedAgentParams } from "./params.js";
+import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
 import { resolveRequestStreamTransportOverrides } from "./runtime-resolution.js";
 import type { assertAgentHarnessRunAdmission } from "./session-bootstrap.js";
 import {
@@ -29,7 +29,7 @@ export type PreparedNativeSessionRuntime = {
 } & ({ auth: "native" } | { auth: "host"; modelRef: ModelRef });
 
 function prepareNativeSessionRuntime(
-  runParams: RunEmbeddedAgentParams,
+  runParams: RunEmbeddedAgentInternalParams,
   harness: AgentHarness,
   admission: ReturnType<typeof assertAgentHarnessRunAdmission>,
 ): PreparedNativeSessionRuntime | undefined {
@@ -100,7 +100,7 @@ function prepareNativeSessionRuntime(
 }
 
 export async function resolveEmbeddedRunModelSetup(params: {
-  runParams: RunEmbeddedAgentParams;
+  runParams: RunEmbeddedAgentInternalParams;
   sessionAdmission?: ReturnType<typeof assertAgentHarnessRunAdmission>;
   provider: string;
   modelId: string;
@@ -216,6 +216,9 @@ export async function resolveEmbeddedRunModelSetup(params: {
       ...(selectedRuntimeProvider !== provider ? { fallbackProvider: provider } : {}),
       modelId,
       agentDir: params.agentDir,
+      requestedRouteResolution: modelSelectionChangedByHook
+        ? "raw"
+        : runParams.requestedRouteResolution,
       config: runParams.config,
       workspaceDir: params.workspaceDir,
       authProfileId: runParams.authProfileId,
@@ -224,20 +227,13 @@ export async function resolveEmbeddedRunModelSetup(params: {
     });
     resolvedModelProvider = tieredResolution.provider;
     modelResolution = tieredResolution.resolution;
-  }
-  if (!modelResolution) {
-    throw new FailoverError(`Unknown model: ${provider}/${modelId}`, {
-      reason: "model_not_found",
-      provider,
-      model: modelId,
-      sessionId: runParams.sessionId,
-      lane: params.globalLane,
-    });
+    if (modelResolution.model) {
+      modelId = modelResolution.logicalRef.model;
+    }
   }
   provider = resolvedModelProvider;
-  const { model, error, authStorage, modelRegistry } = modelResolution;
-  if (!model) {
-    throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+  if (!modelResolution.model) {
+    throw new FailoverError(modelResolution.error ?? `Unknown model: ${provider}/${modelId}`, {
       reason: "model_not_found",
       provider,
       model: modelId,
@@ -245,6 +241,7 @@ export async function resolveEmbeddedRunModelSetup(params: {
       lane: params.globalLane,
     });
   }
+  const { model, authStorage, modelRegistry } = modelResolution;
 
   return {
     provider,

--- a/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
@@ -320,6 +320,7 @@ describe("runEmbeddedAgent usage reporting", () => {
 
   it("reports the resolved model provider when OpenClaw marks the assistant message as the native runtime", async () => {
     mockedResolveModelAsync.mockResolvedValueOnce({
+      logicalRef: { provider: "openrouter", model: "openai/gpt-5.4" },
       model: {
         id: "openai/gpt-5.4",
         provider: "openrouter",

--- a/src/agents/model-fallback-candidates.generation.test.ts
+++ b/src/agents/model-fallback-candidates.generation.test.ts
@@ -35,7 +35,8 @@ describe("fallback candidates across provider generations", () => {
             id: provider,
             label: "Fallback generation",
             auth: [],
-            normalizeModelId: ({ modelId }) => (modelId === "latest" ? model : undefined),
+            normalizeModelId: ({ modelId }) =>
+              modelId === "latest" ? model : modelId === model ? "renormalized-model" : undefined,
           },
         });
         return { metadataSnapshot, pluginRegistry };

--- a/src/agents/model-fallback-candidates.generation.test.ts
+++ b/src/agents/model-fallback-candidates.generation.test.ts
@@ -8,23 +8,49 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 
 describe("fallback candidates across provider generations", () => {
   afterEach(() => resetPluginRuntimeStateForTest());
 
-  it.each(["generation", "request"] as const)(
-    "uses the %s registry with identical metadata and config",
-    (scope) => {
+  it.each(
+    (["generation", "request"] as const).flatMap((scope) =>
+      (["configured-fallback", "configured-primary"] as const).flatMap((origin) =>
+        [false, true].map((manifestAlias) => ({ scope, origin, manifestAlias })),
+      ),
+    ),
+  )(
+    "uses the $scope registry for $origin with manifest alias=$manifestAlias",
+    ({ scope, origin, manifestAlias }) => {
       const provider = `fallback-${scope}`;
+      const requestedModel = origin === "configured-primary" ? "other" : "primary";
+      const runtimeInput = manifestAlias ? "release" : "latest";
       const cfg: OpenClawConfig = {
         agents: {
           defaults: {
-            model: { primary: `${provider}/primary`, fallbacks: [`${provider}/latest`] },
+            model: {
+              primary: `${provider}/${origin === "configured-primary" ? "latest" : "primary"}`,
+              fallbacks: origin === "configured-primary" ? [] : [`${provider}/latest`],
+            },
           },
         },
       };
       const metadataSnapshot = createPluginMetadataSnapshotFixture({
-        plugins: [{ id: provider, providers: [provider] }],
+        plugins: [
+          {
+            id: provider,
+            providers: [provider],
+            ...(manifestAlias
+              ? {
+                  modelIdNormalization: {
+                    providers: {
+                      [provider]: { aliases: { latest: "release", release: "manifest-reapplied" } },
+                    },
+                  },
+                }
+              : {}),
+          },
+        ],
       });
       const createGeneration = (model: string) => {
         const pluginRegistry = createEmptyPluginRegistry();
@@ -36,7 +62,11 @@ describe("fallback candidates across provider generations", () => {
             label: "Fallback generation",
             auth: [],
             normalizeModelId: ({ modelId }) =>
-              modelId === "latest" ? model : modelId === model ? "renormalized-model" : undefined,
+              modelId === runtimeInput
+                ? model
+                : modelId === model
+                  ? "renormalized-model"
+                  : undefined,
           },
         });
         return { metadataSnapshot, pluginRegistry };
@@ -46,23 +76,25 @@ describe("fallback candidates across provider generations", () => {
       const empty = { metadataSnapshot, pluginRegistry: createEmptyPluginRegistry() };
       const active = createGeneration("model-active");
       setActivePluginRegistry(active.pluginRegistry, "fallback-generation-fixture");
-      const resolve = () => resolveModelCandidateChain({ cfg, provider, model: "primary" });
+      const resolve = () => resolveModelCandidateChain({ cfg, provider, model: requestedModel });
       const expected = (model: string) => [
-        { provider, model: "primary", routeOrigin: "requested", routeResolution: "raw" },
-        { provider, model, routeOrigin: "configured-fallback", routeResolution: "resolved" },
+        { provider, model: requestedModel, routeOrigin: "requested", routeResolution: "raw" },
+        { provider, model, routeOrigin: origin, routeResolution: "resolved" },
       ];
       for (const [generation, model] of [
         [a, "model-a"],
         [b, "model-b"],
-        [empty, "latest"],
+        [empty, runtimeInput],
         [a, "model-a"],
         [a, "model-a"],
       ] as const) {
         const candidates =
           scope === "generation"
             ? withPluginRuntimeGenerationScope(generation, resolve)
-            : withPluginMetadataSnapshotScope(metadataSnapshot, () =>
-                withPluginRuntimeRegistryScope(generation.pluginRegistry, resolve),
+            : withPluginMetadataSnapshotScope(
+                metadataSnapshot,
+                () => withPluginRuntimeRegistryScope(generation.pluginRegistry, resolve),
+                { compatibleConfigs: [cfg] },
               );
         expect(candidates).toEqual(expected(model));
         for (const candidate of candidates) {
@@ -71,11 +103,125 @@ describe("fallback candidates across provider generations", () => {
           candidate.routeResolution = "resolved";
         }
       }
-      expect(withPluginMetadataSnapshotScope(metadataSnapshot, resolve)).toEqual(
-        expected("model-active"),
-      );
+      expect(
+        withPluginMetadataSnapshotScope(metadataSnapshot, resolve, { compatibleConfigs: [cfg] }),
+      ).toEqual(expected("model-active"));
     },
   );
+
+  it.each([
+    "planning-disabled",
+    "plugins-disabled-without-config",
+    "plugins-disabled-with-config",
+    "configured-row",
+    "fallbacks-overridden",
+  ] as const)("preserves appended-primary normalization guard: %s", (guard) => {
+    const provider = "guarded-primary";
+    const hasProviderConfig =
+      guard === "plugins-disabled-with-config" || guard === "configured-row";
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: !guard.startsWith("plugins-disabled") },
+      agents: { defaults: { model: { primary: `${provider}/latest`, fallbacks: [] } } },
+      models: hasProviderConfig
+        ? {
+            providers: {
+              [provider]: {
+                api: "openai-completions",
+                baseUrl: "http://127.0.0.1:9/v1",
+                models:
+                  guard === "configured-row"
+                    ? [
+                        makeProviderModelFixture({
+                          id: "latest",
+                          provider,
+                          api: "openai-completions",
+                          baseUrl: "http://127.0.0.1:9/v1",
+                        }),
+                      ]
+                    : [],
+              },
+            },
+          }
+        : undefined,
+    };
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: provider, providers: [provider] }],
+    });
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.providers.push({
+      pluginId: provider,
+      source: "/tmp/guarded-primary/index.js",
+      provider: {
+        id: provider,
+        label: "Guarded primary",
+        auth: [],
+        normalizeModelId: () => {
+          throw new Error("guarded primary entered runtime normalization");
+        },
+      },
+    });
+    const candidates = withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
+      resolveModelCandidateChain({
+        cfg,
+        provider,
+        model: "other",
+        requestedRouteResolution: "resolved",
+        allowPluginNormalization: guard !== "planning-disabled",
+        ...(guard === "fallbacks-overridden" ? { fallbacksOverride: [] } : {}),
+      }),
+    );
+    expect(candidates).toEqual([
+      { provider, model: "other", routeOrigin: "requested", routeResolution: "resolved" },
+      ...(guard === "fallbacks-overridden"
+        ? []
+        : [
+            {
+              provider,
+              model: "latest",
+              routeOrigin: "configured-primary",
+              routeResolution: "resolved",
+            },
+          ]),
+    ]);
+  });
+
+  it("deduplicates the runtime-refined primary against an already resolved request", () => {
+    const provider = "deduplicated-primary";
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: `${provider}/latest`, fallbacks: [] } } },
+    };
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: provider, providers: [provider] }],
+    });
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.providers.push({
+      pluginId: provider,
+      source: "/tmp/deduplicated-primary/index.js",
+      provider: {
+        id: provider,
+        label: "Deduplicated primary",
+        auth: [],
+        normalizeModelId: ({ modelId }) =>
+          modelId === "latest"
+            ? "selected"
+            : modelId === "selected"
+              ? "renormalized-model"
+              : undefined,
+      },
+    });
+    expect(
+      withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
+        resolveModelCandidateChain({
+          cfg,
+          provider,
+          model: "selected",
+          requestedRouteResolution: "resolved",
+        }),
+      ),
+    ).toEqual([
+      { provider, model: "selected", routeOrigin: "requested", routeResolution: "resolved" },
+    ]);
+  });
 
   it("keeps narrowed manifest policies separate when the runtime registry is shared", () => {
     const provider = "fallback-manifest";

--- a/src/agents/model-fallback-candidates.test.ts
+++ b/src/agents/model-fallback-candidates.test.ts
@@ -1,9 +1,152 @@
 import { describe, expect, it } from "vitest";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
-import { resolveImageFallbackCandidates } from "./model-fallback-candidates.js";
+import {
+  resolveImageFallbackCandidates,
+  resolveModelCandidateChain,
+} from "./model-fallback-candidates.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
+
+const customProvider: ModelProviderConfig = {
+  api: "openai-completions",
+  baseUrl: "http://127.0.0.1:9/v1",
+  models: ["model", "custom/model"].map((id) =>
+    makeProviderModelFixture({
+      id,
+      provider: "custom",
+      api: "openai-completions",
+      baseUrl: "http://127.0.0.1:9/v1",
+    }),
+  ),
+};
+
+describe("resolveModelCandidateChain", () => {
+  it.each([
+    { origin: "requested", primary: "custom/model", model: "custom/model", first: "custom/model" },
+    { origin: "configured-fallback", primary: "custom/model", model: "model", first: "model" },
+    {
+      origin: "configured-primary",
+      primary: "custom/custom/model",
+      model: "model",
+      first: "model",
+    },
+  ] as const)(
+    "preserves literal model namespaces from $origin",
+    ({ origin, primary, model, first }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary,
+              fallbacks:
+                origin === "configured-primary"
+                  ? []
+                  : ["custom/custom/model", "custom/model", "custom/custom/model"],
+            },
+          },
+        },
+        models: {
+          providers: {
+            custom: customProvider,
+          },
+        },
+      };
+
+      expect(
+        resolveModelCandidateChain({
+          cfg,
+          provider: " Custom ",
+          model,
+          requestedRouteResolution: "resolved",
+          manifestPlugins: [],
+        }),
+      ).toEqual([
+        { provider: "custom", model: first, routeOrigin: "requested", routeResolution: "resolved" },
+        {
+          provider: "custom",
+          model: first === "model" ? "custom/model" : "model",
+          routeOrigin: origin === "configured-primary" ? origin : "configured-fallback",
+          routeResolution: "resolved",
+        },
+      ]);
+    },
+  );
+
+  it.each(["raw", "resolved", "configured-fallback", "configured-primary"] as const)(
+    "does not reapply manifest aliases after resolving the %s route",
+    (origin) => {
+      const primary = origin === "configured-primary" ? "latest" : "unrelated";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: `candidate/${primary}`,
+              fallbacks: origin === "configured-fallback" ? ["candidate/latest"] : [],
+            },
+          },
+        },
+      };
+      const candidates = resolveModelCandidateChain({
+        cfg,
+        provider: "candidate",
+        model: origin === "raw" ? "latest" : origin === "resolved" ? "release" : "unrelated",
+        requestedRouteResolution: origin === "raw" ? "raw" : "resolved",
+        manifestPlugins: [
+          {
+            modelIdNormalization: {
+              providers: { candidate: { aliases: { latest: "release", release: "stable" } } },
+            },
+          },
+        ],
+      });
+
+      expect(candidates).toContainEqual({
+        provider: "candidate",
+        model: "release",
+        routeOrigin: origin === "raw" || origin === "resolved" ? "requested" : origin,
+        routeResolution: origin === "raw" ? "raw" : "resolved",
+      });
+      expect(candidates.some(({ model }) => model === "stable")).toBe(false);
+    },
+  );
+});
 
 describe("resolveImageFallbackCandidates", () => {
+  it("keeps distinct literal model namespaces while removing duplicate routes", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "custom/model",
+            fallbacks: ["custom/custom/model", "custom/model", "custom/custom/model"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: customProvider,
+        },
+      },
+    };
+    expect(
+      resolveImageFallbackCandidates({ cfg, defaultProvider: "custom", manifestPlugins: [] }),
+    ).toEqual([
+      {
+        provider: "custom",
+        model: "model",
+        routeOrigin: "configured-primary",
+        routeResolution: "resolved",
+      },
+      {
+        provider: "custom",
+        model: "custom/model",
+        routeOrigin: "configured-fallback",
+        routeResolution: "resolved",
+      },
+    ]);
+  });
+
   it("records unresolved configured entries without changing the resolved chain", async () => {
     const warnLogs = createWarnLogCapture("openclaw-image-fallback-candidates-test");
     const cfg = {

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -33,6 +33,7 @@ import {
   type ModelManifestNormalizationContext,
   modelKey,
   normalizeModelRef,
+  normalizeProviderId,
 } from "./model-ref-shared.js";
 import {
   buildModelAliasIndex,
@@ -72,7 +73,7 @@ function createModelCandidateCollector() {
     if (!candidate.provider || !candidate.model) {
       return;
     }
-    const key = modelKey(candidate.provider, candidate.model);
+    const key = JSON.stringify([candidate.provider, candidate.model]);
     if (seen.has(key)) {
       return;
     }
@@ -278,20 +279,22 @@ function resolveFallbackCandidatesUncached(
   const defaultModel = primary?.model ?? DEFAULT_MODEL;
   const providerRaw = normalizeOptionalString(params.provider) || defaultProvider;
   const modelRaw = normalizeOptionalString(params.model) || defaultModel;
-  const normalizeCandidateRef = (provider: string, model: string) =>
-    normalizeModelRef(provider, model, {
-      allowPluginNormalization:
-        params.allowPluginNormalization !== false &&
-        allowsPluginModelNormalization({
-          cfg: params.cfg,
-          provider,
-          model,
-        }),
-      manifestPlugins: params.manifestPlugins,
-    });
   const allowPluginModelAliases =
     params.allowPluginNormalization !== false && params.cfg?.plugins?.enabled !== false;
-  const normalizedPrimary = normalizeCandidateRef(providerRaw, modelRaw);
+  const requestedRouteResolution = params.requestedRouteResolution ?? "raw";
+  const normalizedPrimary =
+    requestedRouteResolution === "resolved"
+      ? { provider: normalizeProviderId(providerRaw), model: modelRaw }
+      : normalizeModelRef(providerRaw, modelRaw, {
+          allowPluginNormalization:
+            params.allowPluginNormalization !== false &&
+            allowsPluginModelNormalization({
+              cfg: params.cfg,
+              provider: providerRaw,
+              model: modelRaw,
+            }),
+          manifestPlugins: params.manifestPlugins,
+        });
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     agentId: params.agentId,
@@ -300,7 +303,6 @@ function resolveFallbackCandidatesUncached(
     manifestPlugins: params.manifestPlugins,
   });
   const { candidates, addCandidate } = createModelCandidateCollector();
-  const requestedRouteResolution = params.requestedRouteResolution ?? "raw";
   let requestedCandidate = normalizedPrimary;
   const exactRequestedRouteConfigured =
     hasExactConfiguredProviderModel({
@@ -329,11 +331,7 @@ function resolveFallbackCandidatesUncached(
         manifestPlugins: params.manifestPlugins,
       }) ?? normalizedPrimary;
   }
-  addCandidate(
-    normalizeCandidateRef(requestedCandidate.provider, requestedCandidate.model),
-    "requested",
-    requestedRouteResolution,
-  );
+  addCandidate(requestedCandidate, "requested", requestedRouteResolution);
 
   const modelFallbacks =
     params.fallbacksOverride !== undefined
@@ -356,19 +354,11 @@ function resolveFallbackCandidatesUncached(
     }
     // Fallbacks are explicit user intent; do not silently filter them by the
     // model allowlist.
-    addCandidate(
-      normalizeCandidateRef(resolved.ref.provider, resolved.ref.model),
-      "configured-fallback",
-      "resolved",
-    );
+    addCandidate(resolved.ref, "configured-fallback", "resolved");
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {
-    addCandidate(
-      normalizeCandidateRef(primary.provider, primary.model),
-      "configured-primary",
-      "resolved",
-    );
+    addCandidate(primary, "configured-primary", "resolved");
   }
   return candidates;
 }

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -42,6 +42,7 @@ import {
   resolveModelAliasFromPair,
   resolveModelRefFromString,
 } from "./model-selection-resolve.js";
+import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 
 const MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES = 256;
 const fallbackCandidateCache = new Map<string, ModelFallbackCandidate[]>();
@@ -358,7 +359,19 @@ function resolveFallbackCandidatesUncached(
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {
-    addCandidate(primary, "configured-primary", "resolved");
+    // Primary resolution owns static normalization; refine only through its runtime hook.
+    let model = primary.model;
+    if (
+      allowPluginModelAliases &&
+      allowsPluginModelNormalization({ cfg: params.cfg, ...primary })
+    ) {
+      model =
+        normalizeProviderModelIdWithRuntime({
+          provider: primary.provider,
+          context: { provider: primary.provider, modelId: model },
+        }) ?? model;
+    }
+    addCandidate({ ...primary, model }, "configured-primary", "resolved");
   }
   return candidates;
 }

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -2,9 +2,9 @@ import { createApiRegistry } from "@openclaw/ai";
 import { beforeEach, expect, it, vi } from "vitest";
 import type { Model } from "../llm/types.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
-import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+import type { SimpleCompletionModelResolver } from "./simple-completion-scope.js";
 
 const mocks = vi.hoisted(() => ({
   acquireRuntimeLease: vi.fn(),
@@ -61,7 +61,7 @@ import {
   acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
-function createOllamaModelResolver(): typeof resolveModelAsync {
+function createOllamaModelResolver(): SimpleCompletionModelResolver {
   return vi.fn(async (provider, modelId, _agentDir, _cfg, options) => ({
     model: {
       provider,
@@ -115,7 +115,7 @@ beforeEach(() => {
 it("keeps route rematerialization and runtime auth on the supplied generation", async () => {
   const observedModelGenerations: string[] = [];
   const observedRuntimeAuthGenerations: string[] = [];
-  const modelResolver: typeof resolveModelAsync = vi.fn(
+  const modelResolver: SimpleCompletionModelResolver = vi.fn(
     async (provider, modelId, _agentDir, cfg, options) => {
       if (!options?.authStorage || !options.modelRegistry) {
         throw new Error("prepared stores were not bound");

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -14,7 +14,6 @@ import {
 } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { createSyncSuiteTempRootTracker } from "../plugins/test-helpers/fs-fixtures.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
@@ -29,6 +28,7 @@ import {
   acquireSimpleCompletionModel,
   acquireSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
+import type { SimpleCompletionModelResolver } from "./simple-completion-scope.js";
 
 const tempRoots = createSyncSuiteTempRootTracker("openclaw-simple-completion-plugin-scope");
 
@@ -163,7 +163,7 @@ module.exports = {
       },
     } satisfies OpenClawConfig;
     let preparedRuntime: PreparedModelRuntimeSnapshot | undefined;
-    const modelResolver: typeof resolveModelAsync = vi.fn(
+    const modelResolver: SimpleCompletionModelResolver = vi.fn(
       async (provider, modelId, _agentDir, _cfg, options) => {
         preparedRuntime = options?.preparedModelRuntime;
         return {

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -9,13 +9,13 @@ import {
   mintSecretSentinel,
   resolveSecretSentinel,
 } from "../secrets/sentinel.js";
-import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import {
   fingerprintAuthProfileCredential,
   fingerprintResolvedProviderAuth,
 } from "./execution-auth-binding.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+import type { SimpleCompletionModelResolver } from "./simple-completion-scope.js";
 import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 
 // Hoisted mocks keep Vitest module replacement stable while the implementation
@@ -201,22 +201,24 @@ function createOpenAIRouteModelResolver(params: {
   api: "openai-responses" | "openai-chatgpt-responses";
   baseUrl: string;
 }) {
-  return vi.fn<typeof resolveModelAsync>(async (provider, modelId, _agentDir, cfg, options) => {
-    if (!options?.authStorage || !options.modelRegistry) {
-      throw new Error("Prepared model stores were not bound");
-    }
-    const configured = cfg?.models?.providers?.openai;
-    return {
-      model: makeProviderModelFixture({
-        provider,
-        id: modelId,
-        api: configured?.api ?? params.api,
-        baseUrl: configured?.baseUrl ?? params.baseUrl,
-      }),
-      authStorage: options.authStorage,
-      modelRegistry: options.modelRegistry,
-    };
-  });
+  return vi.fn<SimpleCompletionModelResolver>(
+    async (provider, modelId, _agentDir, cfg, options) => {
+      if (!options?.authStorage || !options.modelRegistry) {
+        throw new Error("Prepared model stores were not bound");
+      }
+      const configured = cfg?.models?.providers?.openai;
+      return {
+        model: makeProviderModelFixture({
+          provider,
+          id: modelId,
+          api: configured?.api ?? params.api,
+          baseUrl: configured?.baseUrl ?? params.baseUrl,
+        }),
+        authStorage: options.authStorage,
+        modelRegistry: options.modelRegistry,
+      };
+    },
+  );
 }
 
 describe("prepareSimpleCompletionModel", () => {
@@ -234,7 +236,7 @@ describe("prepareSimpleCompletionModel", () => {
       modelId: "claude-opus-4-6",
       agentDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/runtime-workspace",
-      modelResolver: hoisted.resolveModelAsyncMock as typeof resolveModelAsync,
+      modelResolver: hoisted.resolveModelAsyncMock as SimpleCompletionModelResolver,
     });
 
     expectPreparedModelResult(result);

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -25,7 +25,6 @@ import {
 } from "./agent-scope.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
-import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import {
   fingerprintAuthProfileCredential,
   fingerprintResolvedProviderAuth,
@@ -65,6 +64,7 @@ import { getModelRegistryRuntime } from "./sessions/model-registry-runtime.js";
 import {
   createPreparedSimpleCompletionResolverContext,
   type PreparedSimpleCompletionResolverContext,
+  type SimpleCompletionModelResolver,
 } from "./simple-completion-scope.js";
 import type {
   AgentSimpleCompletionSelection,
@@ -171,7 +171,7 @@ export type PrepareSimpleCompletionModelParams = {
   allowBundledStaticCatalogFallback?: boolean;
   skipAgentDiscovery?: boolean;
   bindAuthOwner?: boolean;
-  modelResolver?: typeof resolveModelAsync;
+  modelResolver?: SimpleCompletionModelResolver;
   /** Internal caller-owned generation. Public plugin callers use the agent helper below. */
   preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   workspaceDir?: string;
@@ -453,7 +453,7 @@ async function acquirePreparedSimpleCompletionRuntime(
     cfg: OpenClawConfig | undefined;
     agentId?: string;
     agentDir?: string;
-    modelResolver?: typeof resolveModelAsync;
+    modelResolver?: SimpleCompletionModelResolver;
     workspaceDir?: string;
     agentRuntimeId?: string;
     pluginMetadataSnapshot?: PluginMetadataSnapshot;

--- a/src/agents/simple-completion-scope.ts
+++ b/src/agents/simple-completion-scope.ts
@@ -1,7 +1,10 @@
 import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 
-type SimpleCompletionModelResolver = typeof resolveModelAsync;
+/** Shipped SDK resolver callbacks do not supply core-owned logical reference facts. */
+export type SimpleCompletionModelResolver = (
+  ...args: Parameters<typeof resolveModelAsync>
+) => Promise<Omit<Awaited<ReturnType<typeof resolveModelAsync>>, "logicalRef">>;
 
 export type PreparedSimpleCompletionResolverContext = Readonly<{
   modelResolver: SimpleCompletionModelResolver;

--- a/src/agents/simple-completion.types.ts
+++ b/src/agents/simple-completion.types.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
-import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import type { ResolvedProviderAuth } from "./model-auth.js";
+import type { SimpleCompletionModelResolver } from "./simple-completion-scope.js";
 
 export type PreparedSimpleCompletionModel =
   | {
@@ -45,5 +45,5 @@ export type PrepareSimpleCompletionModelForAgentParams = {
   useAsyncModelResolution?: boolean;
   skipAgentDiscovery?: boolean;
   bindAuthOwner?: boolean;
-  modelResolver?: typeof resolveModelAsync;
+  modelResolver?: SimpleCompletionModelResolver;
 };

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-fixtures.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-fixtures.ts
@@ -148,6 +148,7 @@ export function createResolvedEmbeddedRunnerModel(
   options?: { baseUrl?: string },
 ) {
   return {
+    logicalRef: { provider, model: modelId },
     model: {
       id: modelId,
       name: modelId,

--- a/src/agents/tools/image-tool.custom-provider-auth.regression.test.ts
+++ b/src/agents/tools/image-tool.custom-provider-auth.regression.test.ts
@@ -126,7 +126,8 @@ describe("image custom provider auth regression", () => {
       resolveAutoMediaKeyProviders: () => [],
       resolveDefaultMediaModel: () => undefined,
       resolveRegisteredMediaUnderstandingProvider: () => undefined,
-      resolveModelAsync: async () => ({
+      resolveModelAsync: async (provider, model) => ({
+        logicalRef: { provider, model },
         model: {} as never,
         authStorage: {} as never,
         modelRegistry: {} as never,

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -633,6 +633,7 @@ const resolveConfiguredImageModelForTest: NonNullable<
     (candidate) => candidate.id === model || candidate.id === `${provider}/${model}`,
   );
   return {
+    logicalRef: { provider, model },
     model: {
       ...configuredModel,
       id: model,
@@ -3404,6 +3405,7 @@ describe("image compression policy", () => {
   it("keeps runtime Anthropic media limits for dated model variants", async () => {
     testing.setProviderDepsForTest({
       resolveModelAsync: async (_provider, model) => ({
+        logicalRef: { provider: _provider, model },
         model: {
           mediaInput: {
             image: model.includes("opus")
@@ -3440,6 +3442,7 @@ describe("image compression policy", () => {
   it("merges partial configured Anthropic media policy with runtime side limits", async () => {
     testing.setProviderDepsForTest({
       resolveModelAsync: async (_provider, _model, _agentDir, _cfg, options) => ({
+        logicalRef: { provider: _provider, model: _model },
         model: {
           mediaInput: {
             image: options?.skipProviderRuntimeHooks

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -171,6 +171,7 @@ export async function buildEmbeddedRunBaseParams(params: {
     provider: params.provider,
     model: params.model,
     modelHasVision: await resolveRunModelHasVision(params),
+    requestedRouteResolution: "resolved" as const,
     modelSelectionLocked: params.run.modelSelectionLocked,
     modelFallbackAvailability,
     modelFallbacksOverride,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -254,6 +254,7 @@ describe("agent-runner-utils", () => {
 
     expect(resolved.runBaseParams.runId).toBe("run-1");
     expect(resolved.runBaseParams.promptCacheKey).toBe("stable-session-cache-key");
+    expect(resolved.runBaseParams.requestedRouteResolution).toBe("resolved");
   });
 
   it("uses the queued conversation policy snapshot", async () => {

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -899,6 +899,7 @@ async function probeTarget(params: {
         prompt: PROBE_PROMPT,
         provider: model.provider,
         model: model.model,
+        requestedRouteResolution: "resolved",
         modelFallbacksOverride: [],
         authProfileId: isolatedProfileId ?? target.profileId,
         authProfileIdSource: isolatedProfileId || target.profileId ? "user" : undefined,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -788,6 +788,7 @@ function createCronPromptExecutor(
           provider: providerOverride,
           model: modelOverride,
           agentHarnessRuntimeOverride: sessionRuntimeOverride,
+          requestedRouteResolution: "resolved",
           modelFallbacksOverride: cronFallbacksOverride,
           authProfileId: params.liveSelection.authProfileId,
           authProfileIdSource: params.liveSelection.authProfileId

--- a/src/gateway/session-companion-ask.ts
+++ b/src/gateway/session-companion-ask.ts
@@ -203,6 +203,7 @@ async function defaultRun(params: SessionCompanionRunParams): Promise<string> {
       provider: selection.runtimeProvider ?? selection.provider,
       model: selection.modelId,
       modelFallbacksOverride: [],
+      requestedRouteResolution: "resolved",
       agentHarnessRuntimeOverride: "openclaw",
       authProfileId: selection.profileId,
       authProfileIdSource: selection.profileId ? "user" : undefined,

--- a/src/skills/workshop/review-run.ts
+++ b/src/skills/workshop/review-run.ts
@@ -38,6 +38,7 @@ export async function runSkillWorkshopReview(
       // Review prompts and cloned prefixes are sized for this exact model.
       modelSelectionLocked: true,
       modelFallbacksOverride: [],
+      requestedRouteResolution: "resolved",
       disableTrajectory: true,
       skillWorkshopProposalOnly: params.skillWorkshopProposalOnly ?? true,
       cleanupBundleMcpOnRunEnd: true,


### PR DESCRIPTION
Related: #130706, #142100, #134496. Builds on #143994.

## What Problem This Solves

Selected model IDs could be parsed again as authored input during fallback planning or credential refresh. A chain such as `entry → middle → final` could advance an already selected model, while display-key deduplication could discard distinct provider/model pairs.

## Why This Change Was Made

Resolve authored input at its owner, return the logical reference from successful model resolution, and carry that reference through embedded setup and auth refresh. Canonical internal producers mark completed selections; actual plugin-hook redirects return to raw resolution. Executable wire IDs remain separate from logical model IDs.

The appended configured primary still needs its permitted runtime-only normalization. Apply that refinement once through the existing captured registry helper, without repeating manifest normalization. Keep disabled-plugin and exact configured-route guards. Existing official-plugin resolver callbacks retain their shipped shape without supplying core-owned logical-reference facts.

This repair adds 19 production lines overall. The candidate-marker cleanup, initial completion/media selection, compaction, and fallback display remain separate cuts. Configuration, persistence, and fallback policy are unchanged.

## User Impact

Fallback execution and credential rotation retain the intended model. Runtime-only aliases in an appended configured primary continue working, and distinct literal candidates remain available.

## Evidence

At `72ec42297ef10cef59520ec2f85d86241f2d4de8`:

- 294 focused tests passed, together with the full changed gate and fresh complete-PR P2 review.
- The previous `41ebecf` head reproduced five intended failures. Two runtime-only appended-primary controls passed on the original working `5f161b6` source. The corrected fifteen-case generation suite passes with the same configuration-bound fixture, including manifest/runtime chains, A/B and empty generations, disabled normalization, exact rows, and deduplication.
- One normal full build passed, including SDK declarations. Nine compiled public-runner scenarios made 24 actual loopback HTTP requests through synthetic credential rejection/rotation, configured fallback, both appended-primary variants, hook redirects, and locked-selection controls. Two additional compiled contracts use the real Arcee plugin and materializer.
- All 11,931 built files remained unchanged. No checkout TypeScript was imported, all owned runtime processes exited, and source stayed clean.

The earlier 31-case auth-rotation E2E passed at `41ebecf`; it is retained as evidence for that revision, not claimed as a rerun on the new head. Current auth regression coverage comes from focused owner tests and the compiled HTTP scenarios. An initial request-scope fixture lacked its normal config-compatibility binding; that failed attempt is preserved, and baseline/control/candidate were rerun with the same corrected fixture.

The HTTP proof uses isolated loopback endpoints and synthetic credentials. Arcee proof is offline. Neither is an authenticated hosted-provider test or a fresh npm installation test. Exact-head CI remains required before landing.
