### PR TITLE
refactor(whatsapp): remove duplicate listener-state tests

### DIFF
--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -33,20 +33,6 @@ beforeEach(() => {
 });
 
 describe("active WhatsApp listener view", () => {
-  it("reads controller-backed state", () => {
-    const listener = makeListener();
-    runtimeContextMocks.getChannelRuntimeContext.mockImplementation(
-      ({ accountId }: { accountId?: string }) =>
-        accountId === "work"
-          ? {
-              getActiveListener: () => listener,
-            }
-          : null,
-    );
-
-    expect(getActiveWebListener("work")).toBe(listener);
-  });
-
   it("resolves the configured default account when accountId is omitted", () => {
     const listener = makeListener();
     runtimeContextMocks.getChannelRuntimeContext.mockImplementation(

--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -84,19 +84,6 @@ describe("createWebChannelStatusController", () => {
     expect(last.lifecycle).toBe("recovering");
   });
 
-  it("produces snapshots that enable stale-socket health detection", () => {
-    const patches: Record<string, unknown>[] = [];
-    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
-
-    controller.noteConnected(1000);
-
-    const last = patches.at(-1)!;
-    // The gateway health policy checks `connected === true && lastTransportActivityAt != null`
-    // to decide whether to run stale-socket detection. Both must be present.
-    expect(last.connected).toBe(true);
-    expect(last.lastTransportActivityAt).toBe(1000);
-  });
-
   it("clears watchdog recovery history once the socket is healthy again", () => {
     const patches: Record<string, unknown>[] = [];
     const controller = createWebChannelStatusController((s) => patches.push({ ...s }));


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Two WhatsApp tests repeat assertions already covered by stronger retained cases. This maintainer-requested cleanup removes that duplicate coverage without removing a distinct behavioral contract.

## Why This Change Was Made

The retained listener test checks the identical explicit `work` account lookup and additionally verifies `resolveWebAccountId`. The retained `noteConnected(1000)` test checks the same connected state and activity timestamp plus the ready lifecycle. Independent Gateway health-policy tests continue to cover stale-socket behavior.

## User Impact

No runtime behavior changes. Removes two redundant cases and 27 test lines; production code, imports, helpers, configuration, and all retained assertions are unchanged.

## Evidence

- Both complete WhatsApp files: 18 passed, zero skips.
- Complete Gateway health-policy file: 54 passed, zero skips.
- All 19 selected changed checks passed without retries.
- Targeted formatting and diff checks passed.
- Fresh P2 review: scoped-clean, no findings.

No live WhatsApp or Gateway execution, packaging, or local full-repository test run is claimed.
