### PR TITLE
fix: drain worker transcript fixtures before removing state

### DIFF
--- a/src/gateway/worker-environments/transcript-commit.test.ts
+++ b/src/gateway/worker-environments/transcript-commit.test.ts
@@ -18,6 +18,7 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { waitForSessionTranscriptIndexReconcilesInStateDir } from "../../config/sessions/session-transcript-reconcile.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { closeOpenClawAgentDatabasesAsync } from "../../state/openclaw-agent-db.js";
@@ -212,6 +213,7 @@ describe("worker transcript commit application", () => {
     unsubscribe?.();
     clearRuntimeConfigSnapshot();
     try {
+      await waitForSessionTranscriptIndexReconcilesInStateDir(root);
       await closeOpenClawAgentDatabasesAsync(root);
       closeOpenClawStateDatabaseByPath(stateDatabasePath);
       await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where worker transcript tests could remove their temporary state directory while a deferred transcript-index reconcile still owned work. The full Linux run reported a SQLite WAL identity fatal under this fixture after all 14 cases had passed.

## Why This Change Was Made

Drain the existing root-scoped transcript-index reconcile owner before the existing asynchronous agent-database close, exact shared-state database close, and directory removal. This retains the existing cleanup and all 14 cases, assertions, and execution order; no production behavior or timeout changes.

## User Impact

No product behavior changes. Test teardown waits for the producer that can reopen fixture state, preserving SQLite safety checks and failed-cleanup evidence.

## Evidence

Local proof is bound to commit 918c3d212590478ca9cc11669f3b5ccd3ca2936f; the owning test is unchanged on current main before this patch.

- Safe instrumented original run: all 14 cases passed; three reconciles remained pending after the original database closes and reopened three shared-state handle generations during the safety drain. All 17 generations were closed before unlink. This was an instrumented lifecycle observation, not an unmodified green baseline or an induced fatal.
- Candidate observation: all 14 cases passed; no pending reconciles or open handles before unlink, with no extra safety closes.
- Real-worker completion fence: original database close returned while the reconcile was held; the added drain completed only after releasing the worker acknowledgement, lease release, and worker exit. All work was joined in cleanup.
- Normal owning suite plus session-state cleanup sibling: 16 passed, with the original 14 case identities and order retained.
- Required changed-file gate passed with physically owned dependencies; fresh independent review found no actionable issues.

These focused results establish the fixture lifetime repair. They do not claim a successful full Linux rerun or a runtime improvement. Current integration remains subject to exact-head CI and native merge verification.
