### PR TITLE
fix(update): keep progress consistent without redundant ledger reads

### DIFF
--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -81,6 +81,100 @@ describe("update progress", () => {
     expect(lines.join("\n")).toContain("Build type error");
   });
 
+  it("does not leave a phase observer after initial observation fails", () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    vi.mocked(getUpdateRun).mockImplementationOnce(() => {
+      throw new Error("initial ledger read failed");
+    });
+    try {
+      expect(() => createUpdateProgress(true, context)).toThrow("initial ledger read failed");
+      run.phase = "verifying";
+      run.steps = [
+        { step: "requested", status: "completed" },
+        { step: "verifying", status: "in_progress" },
+      ];
+      printResult(result, { run: context });
+      const lines = log.mock.calls.flat();
+      expect(lines.join("\n")).toContain("OpenClaw update in progress: verifying.");
+      expect(lines.filter((line) => typeof line === "string" && line.startsWith("Phase:"))).toEqual(
+        [],
+      );
+    } finally {
+      // Replace and dispose a leaked observer when this regression runs on old code.
+      vi.mocked(getUpdateRun).mockImplementation(() => run);
+      presentation = createUpdateProgress(true, context);
+      presentation.dispose();
+      presentation = undefined;
+    }
+  });
+
+  it("keeps unbound step presentation independent of ledger records", () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    presentation = createUpdateProgress(true);
+    run.phase = "validating";
+    run.steps.push({ step: "validating", status: "in_progress" });
+    vi.mocked(getUpdateRun).mockImplementation(() => {
+      throw new Error("unbound presentation must not read the ledger");
+    });
+    try {
+      presentation.progress.onStepStart?.(step, run);
+      presentation.progress.onStepComplete?.(
+        { ...step, durationMs: 1200, exitCode: 1, stdoutTail: "Build type error" },
+        run,
+      );
+      expect(log).toHaveBeenCalledWith("build...");
+      expect(log.mock.calls.flat().join("\n")).toContain("Build type error");
+      expect(
+        log.mock.calls
+          .flat()
+          .filter((line) => typeof line === "string" && line.startsWith("Phase:")),
+      ).toEqual([]);
+    } finally {
+      vi.mocked(getUpdateRun).mockImplementation(() => run);
+    }
+  });
+
+  it.each([true, false])(
+    "renders the report and phases from one snapshot (present: %s)",
+    (present) => {
+      const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+      presentation = createUpdateProgress(true, context);
+      const captured: UpdateRunRecord = {
+        ...run,
+        phase: "verifying",
+        steps: [
+          { step: "requested", status: "completed" },
+          { step: "verifying", status: "in_progress" },
+        ],
+      };
+      const later: UpdateRunRecord = {
+        ...captured,
+        phase: "repairing",
+        steps: [
+          { step: "requested", status: "completed" },
+          { step: "verifying", status: "completed" },
+          { step: "repairing", status: "in_progress" },
+        ],
+      };
+      vi.mocked(getUpdateRun)
+        .mockReturnValueOnce(present ? captured : undefined)
+        .mockReturnValue(later);
+      try {
+        printResult(result, { run: context });
+        const lines = log.mock.calls.flat();
+        expect(
+          lines.filter((line) => typeof line === "string" && line.startsWith("Phase:")),
+        ).toEqual(present ? ["Phase: requested", "Phase: verifying"] : ["Phase: requested"]);
+        expect(lines.join("\n")).toContain(
+          present ? "OpenClaw update in progress: verifying." : "OpenClaw updated.",
+        );
+        expect(log).not.toHaveBeenCalledWith("Phase: repairing");
+      } finally {
+        vi.mocked(getUpdateRun).mockImplementation(() => run);
+      }
+    },
+  );
+
   it("prints the exact repair command from a recoverable step", () => {
     const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
     presentation = createUpdateProgress(true, context);

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -4,7 +4,7 @@ import { UPDATE_RUN_PHASES } from "../../../packages/gateway-protocol/src/update
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import { getUpdateRun } from "../../infra/update-run-ledger.js";
-import type { UpdateRunPhase } from "../../infra/update-run-record.js";
+import type { UpdateRunPhase, UpdateRunRecord } from "../../infra/update-run-record.js";
 import {
   renderUpdateRunReport,
   updateRunReportInputFromResult,
@@ -20,16 +20,29 @@ import type { UpdateCommandOptions } from "./shared.js";
 
 // One command owns each observer. The final report flushes it before printing so
 // a fast final transition cannot appear after the report or leave a spinner active.
-const activeUpdateProgress = new Map<string, () => void>();
+const activeUpdateProgress = new Map<string, (record: UpdateRunRecord | undefined) => void>();
 const UPDATE_PROGRESS_POLL_MS = 250;
 
 function isAdvisoryStep(step: { advisory?: UpdateStepAdvisory }): boolean {
   return step.advisory !== undefined;
 }
 
+// These CLI-only callbacks can render the row just committed by their ledger owner.
+export type UpdateDisplayProgress = {
+  onHeartbeat?: UpdateStepProgress["onHeartbeat"];
+  onStepStart?: (
+    step: Parameters<NonNullable<UpdateStepProgress["onStepStart"]>>[0],
+    record?: UpdateRunRecord,
+  ) => void;
+  onStepComplete?: (
+    step: Parameters<NonNullable<UpdateStepProgress["onStepComplete"]>>[0],
+    record?: UpdateRunRecord,
+  ) => void;
+};
+
 /** Runner-facing progress callbacks plus terminal spinner cleanup. */
 type ProgressController = {
-  progress: UpdateStepProgress;
+  progress: UpdateDisplayProgress;
   stop: () => void;
   suspend: () => void;
   resume: () => void;
@@ -60,15 +73,14 @@ export function createUpdateProgress(
       timer = undefined;
     }
   };
-  const refresh = () => {
-    // Candidate migrations can advance the ledger beyond this process's reader.
-    // Step callbacks and final cleanup must respect the same fence as the timer.
-    if (observation !== "active") {
-      return undefined;
-    }
-    const record = run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
-    if (!record) {
-      return undefined;
+  // Candidate migrations can advance the ledger beyond this process's reader.
+  // Step callbacks and final cleanup must respect the same fence as the timer.
+  const read = () =>
+    observation === "active" && run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
+  const renderRecord = (record: UpdateRunRecord | undefined) => {
+    // Doctor's unbound spinner does not observe ledger phases, even after a write.
+    if (observation !== "active" || !run || !record) {
+      return;
     }
     currentPhase = record.phase;
     // A child process can cross several phases between reads. Replay the recorded
@@ -86,15 +98,15 @@ export function createUpdateProgress(
     if (record.status !== "running") {
       clearTimer();
     }
-    return record;
   };
-  const flush = () => {
-    refresh();
+  const flush = (record: UpdateRunRecord | undefined) => {
+    renderRecord(record);
     stop();
   };
   const poll = () => {
     timer = undefined;
-    const record = refresh();
+    const record = read();
+    renderRecord(record);
     if (record?.status === "running") {
       // The CLI owns this poll only for its active operation; fresh-process
       // finalization and gateway verification write the same ledger row.
@@ -103,12 +115,13 @@ export function createUpdateProgress(
     }
   };
   if (run) {
-    activeUpdateProgress.set(run.runId, flush);
+    // Initial observation can throw; publish only once the caller can own cleanup.
     poll();
+    activeUpdateProgress.set(run.runId, flush);
   }
-  const progress: UpdateStepProgress = {
-    onStepStart: (step) => {
-      flush();
+  const progress: UpdateDisplayProgress = {
+    onStepStart: (step, record) => {
+      flush(record ?? read());
       const label = currentPhase ? `${currentPhase} — ${step.name}` : step.name;
       if (process.stdout.isTTY) {
         currentSpinner = spinner({ indicator: "timer" });
@@ -117,8 +130,8 @@ export function createUpdateProgress(
         defaultRuntime.log(`${label}...`);
       }
     },
-    onStepComplete: (step) => {
-      flush();
+    onStepComplete: (step, record) => {
+      flush(record ?? read());
       printStep(step);
     },
   };
@@ -142,7 +155,7 @@ export function createUpdateProgress(
     },
     dispose: () => {
       try {
-        flush();
+        flush(read());
       } finally {
         observation = "disposed";
         clearTimer();
@@ -221,7 +234,7 @@ export function printResult(
     return;
   }
   if (result.runId) {
-    activeUpdateProgress.get(result.runId)?.();
+    activeUpdateProgress.get(result.runId)?.(run);
   }
   const report = renderUpdateRunReport(run ?? updateRunReportInputFromResult(result), reportHints);
   defaultRuntime.log("");

--- a/src/cli/update-cli/update-command-run.test.ts
+++ b/src/cli/update-cli/update-command-run.test.ts
@@ -14,16 +14,20 @@ import {
 } from "../../daemon/systemd-service-files.js";
 import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
 import { createRetainedUpdateRecovery } from "../../infra/update-retained-recovery.test-support.js";
+import * as updateRunLedger from "../../infra/update-run-ledger.js";
 import { createUpdateRun, finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
 import {
   loadUpdateRecovery,
   UpdateRecoveryRequiredError,
 } from "../../infra/update-run-recovery.js";
 import { renderUpdateRunReport } from "../../infra/update-run-report.js";
+import { defaultRuntime } from "../../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createUpdateProgress } from "./progress.js";
 import {
   admitUpdateCommandRun,
   completeUpdateCommandRun,
+  createUpdateRunProgress,
   failUpdateCommandRun,
   withUpdatePreviewSignals,
 } from "./update-command-run.js";
@@ -79,6 +83,89 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+});
+
+it("presents committed steps without reopening the ledger for display", () => {
+  const env = { OPENCLAW_STATE_DIR: dirs.make("update-progress-committed-") };
+  const run = { runId: createUpdateRun({ trigger: "cli" }, { env }).runId, env };
+  const tty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+  let presentation: ReturnType<typeof createUpdateProgress> | undefined;
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+  try {
+    presentation = createUpdateProgress(true, run);
+    const progress = createUpdateRunProgress(run, presentation.progress);
+    updateRunLedger.recordUpdateRunPhase(run.runId, "validating", {}, { env });
+    const reread = vi.spyOn(updateRunLedger, "getUpdateRun").mockImplementation(() => {
+      throw new Error("step presentation must use its committed row");
+    });
+    try {
+      for (const [index, name] of ["fetch", "build", "doctor"].entries()) {
+        const step = { name, command: `run ${name}`, index, total: 3 };
+        progress.onStepStart?.(step);
+        progress.onStepComplete?.({
+          ...step,
+          durationMs: 1,
+          exitCode: name === "fetch" ? 0 : 1,
+          ...(name === "build" ? { stdoutTail: "Build type error" } : {}),
+          ...(name === "doctor"
+            ? {
+                advisory: {
+                  kind: "package-post-install-doctor" as const,
+                  message: "Skipped optional cache cleanup",
+                },
+                warnings: ["Skipped optional cache cleanup", "Skipped legacy cache cleanup"],
+              }
+            : {}),
+        });
+      }
+      expect(log).toHaveBeenCalledWith("validating — fetch...");
+      expect(log).toHaveBeenCalledWith("validating — build...");
+      expect(log.mock.calls.flat().join("\n")).toContain("Build type error");
+      expect(log.mock.calls.flat().join("\n")).toContain("Skipped optional cache cleanup");
+      expect(
+        log.mock.calls
+          .flat()
+          .filter((line) => typeof line === "string" && line.startsWith("Phase:")),
+      ).toEqual(["Phase: requested", "Phase: validating"]);
+    } finally {
+      reread.mockRestore();
+    }
+    const recorded = getUpdateRun(run.runId, { env });
+    expect(
+      recorded?.steps
+        .filter((step) => step.step === "fetch" || step.step === "build")
+        .map(({ step, status, detail }) => ({ step, status, detail })),
+    ).toEqual([
+      { step: "fetch", status: "completed", detail: undefined },
+      { step: "build", status: "failed", detail: "Exit code: 1; Build type error" },
+    ]);
+    expect(recorded?.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ step: "doctor", status: "completed" }),
+        expect.objectContaining({
+          step: "warning:doctor",
+          status: "completed",
+          detail: "Skipped optional cache cleanup",
+        }),
+        expect.objectContaining({
+          step: "warning:doctor:2",
+          status: "completed",
+          detail: "Skipped legacy cache cleanup",
+        }),
+      ]),
+    );
+  } finally {
+    try {
+      presentation?.dispose();
+    } finally {
+      if (tty) {
+        Object.defineProperty(process.stdout, "isTTY", tty);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
+  }
 });
 
 it.each([false, true])(

--- a/src/cli/update-cli/update-command-run.ts
+++ b/src/cli/update-cli/update-command-run.ts
@@ -54,6 +54,7 @@ import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-stat
 import { VERSION } from "../../version.js";
 import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { registerSignalExitBarrier, waitForSignalExitBarriers } from "../signal-exit-barrier.js";
+import type { UpdateDisplayProgress } from "./progress.js";
 import { parseUpdateTimeoutMs, resolveUpdateRoot, type UpdateCommandOptions } from "./shared.js";
 import { suppressDeprecations } from "./suppress-deprecations.js";
 import {
@@ -250,7 +251,7 @@ export function failUpdateCommandRun(
 
 export function createUpdateRunProgress(
   run: NonNullable<UpdateCommandOptions["run"]>,
-  progress: UpdateStepProgress,
+  progress: UpdateDisplayProgress,
 ): UpdateStepProgress & {
   deferLedgerWrites: () => void;
   flushLedgerWrites: () => void;
@@ -262,9 +263,9 @@ export function createUpdateRunProgress(
   const record = (step: UpdateRunStep) => {
     if (deferred) {
       pendingSteps.push(step);
-    } else {
-      recordUpdateRunStep(run.runId, step, { env: run.env });
+      return undefined;
     }
+    return recordUpdateRunStep(run.runId, step, { env: run.env });
   };
   return {
     pendingSteps,
@@ -285,15 +286,21 @@ export function createUpdateRunProgress(
       }
     },
     onStepStart(step) {
-      record({ step: step.name, status: "in_progress", startedAtMs: Date.now() });
-      progress.onStepStart?.(step);
+      const committed = record({ step: step.name, status: "in_progress", startedAtMs: Date.now() });
+      progress.onStepStart?.(step, committed);
     },
     onStepComplete(step) {
       const endedAtMs = Date.now();
+      // A completed step may persist warnings; display its final committed row.
+      let committed: UpdateRunRecord | undefined;
       for (const entry of updateRunStepsFromResultStep(step)) {
-        record({ ...entry, startedAtMs: Math.max(0, endedAtMs - step.durationMs), endedAtMs });
+        committed = record({
+          ...entry,
+          startedAtMs: Math.max(0, endedAtMs - step.durationMs),
+          endedAtMs,
+        });
       }
-      progress.onStepComplete?.(step);
+      progress.onStepComplete?.(step, committed);
     },
   };
 }

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -71,8 +71,11 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
         allowGatewayActivation: false,
       }),
     );
-    expect(progress.onStepStart).toHaveBeenCalledWith(step);
-    expect(progress.onStepComplete).toHaveBeenCalledWith({ ...step, durationMs: 1, exitCode: 0 });
+    expect(progress.onStepStart).toHaveBeenCalledWith(step, undefined);
+    expect(progress.onStepComplete).toHaveBeenCalledWith(
+      { ...step, durationMs: 1, exitCode: 0 },
+      undefined,
+    );
     expect(mocks.createUpdateProgress).toHaveBeenCalledWith(true);
     expect(stop).toHaveBeenCalledTimes(1);
     expect(mocks.maybeRestartServiceAfterFailedMutableUpdate).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI update progress would reopen the run ledger immediately after each committed step and could announce a newer phase beside an older final report. In the measured 481-case update CLI suite, synchronous SQLite snapshot processes consumed about 85% of elapsed time.

## Why This Change Was Made

Preserve all step and warning-row writes, then pass the existing step writer's final committed record directly to the private CLI display callback, and use one observation for the final phase flush and report. No record is cached for later use. Initial observation, polling, resume, disposal, and deferred-step fallback still read through the existing guarded owner. Shared runner callbacks, ledger writes, database schema, integrity checks, admission, and operational authority are unchanged.

Publish the progress observer only after its initial observation succeeds, so a failed construction cannot leave an observer whose disposer was never returned. Doctor's unbound step display, JSON output and suspended presentation keep their existing behavior.

## User Impact

Update progress avoids redundant synchronous database snapshots and keeps phase output consistent with the final report. No new flags or configuration are needed. Production changes are +20 lines for the private callback type and read/render ownership split; tests add 184 lines. No existing tests, assertions, deadlines or shards are removed or weakened.

## Evidence

- Four regression failures on current main prove the mixed-observation, committed-step reread and observer-publication defects. All 83 focused progress, real-ledger command-run and Doctor tests pass on the final candidate.
- Before integrating main’s new per-step warning rows, full CLI runs passed the same 481 cases in the original order. The candidate reduced synchronous snapshot launches from 5,226 to 4,843 (383 fewer), with all 5,598 ledger writes retained. Whole-run time was 809.82 seconds before and 846.34 seconds after: this pair does **not** establish a full-suite speedup.
- The same nine existing package-spec cases passed an A/B/A comparison in 61.986 / 27.704 / 38.469 seconds. Callback-heavy cases benefit, but baseline variability prevents a precise general CI speedup claim. This comparison also predates the warning-row integration; the final integration is covered by the 83-case run. Same test source, dependencies, Node 24.19.0, pnpm 12.3.4 and source-only root layout; no diagnostic instrumentation or altered cache flags in this comparison.
- Focused command: `node scripts/run-vitest.mjs src/cli/update-cli/progress.test.ts src/cli/update-cli/update-command-run.test.ts src/commands/doctor-update.test.ts`.
- Timing command: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t 'resolves package install specs from tags and env overrides' --reporter=verbose`.

These are local CLI and real isolated ledger tests, with external update/service actions mocked by the existing harness; they do not claim a live installed-package update or an eight-minute full CI result. Independent review is clean through P2; `pnpm check:changed` passes, including core/test type checks, formatting, lint, dead exports, import cycles and storage guards. Exact-head CI will be verified before landing.
