### PR TITLE
fix(agents): retain embedded generated-media provenance

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -21,6 +21,7 @@ export function createBaseToolHandlerState() {
     pendingMessagingTargets: new Map<string, unknown>(),
     pendingMessagingMediaUrls: new Map<string, string[]>(),
     pendingToolMediaUrls: [] as string[],
+    hostOwnedToolMediaUrls: [] as string[],
     pendingToolAudioAsVoice: false,
     pendingToolTrustedLocalMedia: false,
     deterministicApprovalPromptPending: false,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -123,6 +123,7 @@ function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSourceReplyPayloads: () => [] as MessagingToolSourceReplyPayload[],
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
+    getHostOwnedToolMediaUrls: () => [] as string[],
     hasToolMediaBlockReply: () => false,
     getVisibleBlockReplyCount: () => 0,
     getSuccessfulCronAdds: () => 0,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -524,6 +524,7 @@ import {
   buildRuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
+import { resolveEmbeddedHostOwnedToolMediaUrls } from "./tool-media-payloads.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PreflightRecoveryBudgetSnapshot = Pick<
@@ -3801,6 +3802,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSourceReplyPayloads,
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
+        getHostOwnedToolMediaUrls,
         hasToolMediaBlockReply,
         getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
@@ -5747,6 +5749,11 @@ export async function runEmbeddedAttempt(
         successfulCronAdds: getSuccessfulCronAdds(),
       });
       const pendingToolMediaReply = getPendingToolMediaReply();
+      const messagingToolSentMediaUrlsNow = getMessagingToolSentMediaUrls();
+      const hostOwnedToolMediaUrls = resolveEmbeddedHostOwnedToolMediaUrls({
+        hostOwnedToolMediaUrls: getHostOwnedToolMediaUrls(),
+        messagingToolSentMediaUrls: messagingToolSentMediaUrlsNow,
+      });
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
@@ -5963,6 +5970,7 @@ export async function runEmbeddedAttempt(
         messagingToolSourceReplyPayloads,
         heartbeatToolResponse,
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
+        hostOwnedToolMediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
         toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
         hasToolMediaBlockReply: hasToolMediaBlockReplyNow,

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -5,7 +5,30 @@ import {
   getReplyPayloadMetadata,
   setReplyPayloadMetadata,
 } from "../../../auto-reply/reply-payload.js";
-import { mergeAttemptToolMediaPayloads } from "./tool-media-payloads.js";
+import {
+  mergeAttemptToolMediaPayloads,
+  resolveEmbeddedHostOwnedToolMediaUrls,
+} from "./tool-media-payloads.js";
+
+describe("resolveEmbeddedHostOwnedToolMediaUrls", () => {
+  it("keeps validated tool media that the message tool did not already deliver", () => {
+    expect(
+      resolveEmbeddedHostOwnedToolMediaUrls({
+        hostOwnedToolMediaUrls: ["/tmp/already-sent.png", "/tmp/generated.png"],
+        messagingToolSentMediaUrls: ["/tmp/already-sent.png"],
+      }),
+    ).toEqual(["/tmp/generated.png"]);
+  });
+
+  it("does not classify message-tool media as host-owned", () => {
+    expect(
+      resolveEmbeddedHostOwnedToolMediaUrls({
+        hostOwnedToolMediaUrls: ["/tmp/already-sent.png"],
+        messagingToolSentMediaUrls: ["/tmp/already-sent.png"],
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe("mergeAttemptToolMediaPayloads", () => {
   it("attaches tool media to the first visible reply", () => {

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -12,6 +12,23 @@ import type { EmbeddedAgentRunResult } from "../types.js";
 /** Channel payload shape produced by embedded runs after auto-reply normalization. */
 type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number];
 
+export function resolveEmbeddedHostOwnedToolMediaUrls(params: {
+  hostOwnedToolMediaUrls?: string[];
+  messagingToolSentMediaUrls?: string[];
+}): string[] | undefined {
+  const messagingMedia = new Set(
+    params.messagingToolSentMediaUrls?.map((url) => url.trim()).filter(Boolean) ?? [],
+  );
+  const hostOwnedMedia = Array.from(
+    new Set(
+      params.hostOwnedToolMediaUrls
+        ?.map((url) => url.trim())
+        .filter((url) => url.length > 0 && !messagingMedia.has(url)) ?? [],
+    ),
+  );
+  return hostOwnedMedia.length > 0 ? hostOwnedMedia : undefined;
+}
+
 /**
  * Merges media emitted by tools into the channel payloads produced by the
  * assistant turn. The first successful, non-reasoning reply owns the media so

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -81,6 +81,7 @@ function createTestContext(): {
       pendingMessagingTexts: new Map<string, string>(),
       pendingMessagingMediaUrls: new Map<string, string[]>(),
       pendingToolMediaUrls: [],
+      hostOwnedToolMediaUrls: [],
       pendingToolAudioAsVoice: false,
       pendingToolTrustedLocalMedia: false,
       deterministicApprovalPromptPending: false,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -694,7 +694,12 @@ function hasMessagingRichContent(record: Record<string, unknown>): boolean {
 
 function queuePendingToolMedia(
   ctx: ToolHandlerContext,
-  mediaReply: { mediaUrls: string[]; audioAsVoice?: boolean; trustedLocalMedia?: boolean },
+  mediaReply: {
+    mediaUrls: string[];
+    audioAsVoice?: boolean;
+    hostOwned?: boolean;
+    trustedLocalMedia?: boolean;
+  },
 ) {
   const seen = new Set(ctx.state.pendingToolMediaUrls);
   for (const mediaUrl of mediaReply.mediaUrls) {
@@ -703,6 +708,15 @@ function queuePendingToolMedia(
     }
     seen.add(mediaUrl);
     ctx.state.pendingToolMediaUrls.push(mediaUrl);
+  }
+  if (mediaReply.hostOwned) {
+    const hostOwnedMedia = new Set(ctx.state.hostOwnedToolMediaUrls);
+    for (const mediaUrl of mediaReply.mediaUrls) {
+      if (!hostOwnedMedia.has(mediaUrl)) {
+        hostOwnedMedia.add(mediaUrl);
+        ctx.state.hostOwnedToolMediaUrls.push(mediaUrl);
+      }
+    }
   }
   if (mediaReply.audioAsVoice) {
     ctx.state.pendingToolAudioAsVoice = true;
@@ -913,6 +927,9 @@ async function emitToolResultOutput(params: {
   }
   queuePendingToolMedia(ctx, {
     mediaUrls,
+    ...(rawToolName === "image_generate" && ctx.builtinToolNames?.has(rawToolName)
+      ? { hostOwned: true }
+      : {}),
     ...(mediaReply.audioAsVoice ? { audioAsVoice: true } : {}),
     ...(mediaReply.trustedLocalMedia ? { trustedLocalMedia: true } : {}),
   });

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -170,6 +170,7 @@ export type EmbeddedAgentSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   pendingToolMediaUrls: string[];
+  hostOwnedToolMediaUrls: string[];
   pendingToolAudioAsVoice: boolean;
   pendingToolTrustedLocalMedia: boolean;
   hasToolMediaBlockReply: boolean;
@@ -314,6 +315,7 @@ type ToolHandlerState = Pick<
   | "pendingMessagingTexts"
   | "pendingMessagingMediaUrls"
   | "pendingToolMediaUrls"
+  | "hostOwnedToolMediaUrls"
   | "pendingToolAudioAsVoice"
   | "pendingToolTrustedLocalMedia"
   | "deterministicApprovalPromptPending"

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -412,7 +412,7 @@ describe("subscribeEmbeddedAgentSession", () => {
   it("delivers generated image media once in markdown verbose output", async () => {
     const onToolResult = vi.fn();
     const onBlockReply = vi.fn();
-    const { emit } = createSubscribedHarness({
+    const { emit, subscription } = createSubscribedHarness({
       runId: "run",
       onToolResult,
       onBlockReply,
@@ -466,6 +466,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       text: "Here is the image.",
       mediaUrls: ["/tmp/generated.png"],
     });
+    expect(subscription.getHostOwnedToolMediaUrls()).toEqual(["/tmp/generated.png"]);
   });
 
   it("does not duplicate generated image media when the assistant reply has MEDIA lines", async () => {
@@ -768,6 +769,31 @@ describe("subscribeEmbeddedAgentSession", () => {
       mediaUrls: ["/tmp/reply.opus"],
       audioAsVoice: true,
     });
+    expect(subscription.getHostOwnedToolMediaUrls()).toEqual([]);
+  });
+
+  it("tracks built-in generated image media as host-owned", () => {
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      builtinToolNames: new Set(["image_generate"]),
+    });
+
+    emit({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        details: {
+          media: {
+            mediaUrl: "/tmp/generated.png",
+          },
+        },
+      },
+    });
+    emit({ type: "agent_end" });
+
+    expect(subscription.getHostOwnedToolMediaUrls()).toEqual(["/tmp/generated.png"]);
   });
 
   it("counts orphaned tool media emitted through block replies", async () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -235,6 +235,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
     pendingToolMediaUrls: initialPendingToolMediaUrls,
+    hostOwnedToolMediaUrls: [],
     pendingToolAudioAsVoice: false,
     pendingToolTrustedLocalMedia: false,
     hasToolMediaBlockReply: false,
@@ -1243,6 +1244,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.heartbeatToolResponse = undefined;
     state.pendingMessagingMediaUrls.clear();
     state.pendingToolMediaUrls = [];
+    state.hostOwnedToolMediaUrls = [];
     state.pendingToolAudioAsVoice = false;
     state.pendingToolTrustedLocalMedia = false;
     state.visibleBlockReplyCount = 0;
@@ -1433,6 +1435,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),
+    getHostOwnedToolMediaUrls: () => state.hostOwnedToolMediaUrls.slice(),
     hasToolMediaBlockReply: () => state.hasToolMediaBlockReply,
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,


### PR DESCRIPTION
## Summary
- preserve exact built-in image_generate provenance through the embedded Pi runner
- deliver host-owned generated media on message-tool-only routes without promoting ordinary tool media
- suppress media already sent through the message tool

## Validation
- 244 focused tests passed
- full test typecheck passed
- repository lint passed
- formatting and diff checks passed

Backports the embedded-runner half of the generated-image delivery contract for the frozen 2026.7.33 candidate.