### PR TITLE
fix(models): resolve authored catalog aliases once

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -399,6 +399,12 @@ requests. Use a current auth profile or authored request configuration instead.
 The session SDK preserves authored `models.json` keys and headers while merging
 generated model metadata below authored rows.
 
+Provider aliases in `models.providers.*.models` resolve once before discovery.
+If an alias and its exact destination are both configured, the destination row
+owns the model fields; omitted fields are not copied from the alias row.
+Catalog IDs from `models.json` and plugin discovery stay literal during refresh,
+apart from built-in corrections for retired Google and Together model names.
+
 <AccordionGroup>
   <Accordion title="Merge mode precedence">
     For matching provider IDs:

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -166,7 +166,7 @@ describe("models-config merge helpers", () => {
       mergeProviderModels(implicit, explicit, {
         providerId: "ollama",
         sourceModelFields: new Map([
-          ["ollama/qwen3-vl:latest", { inputOmitted: true, cost: undefined }],
+          [JSON.stringify(["ollama", "qwen3-vl:latest"]), { inputOmitted: true, cost: undefined }],
         ]),
       }).models?.[0]?.input,
     ).toEqual(["text", "image"]);

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -13,11 +13,6 @@ import type {
 } from "../config/types.models.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
-import {
-  modelKey,
-  createConfiguredProviderCatalogModelIdNormalizer,
-  type ModelManifestNormalizationContext,
-} from "./model-ref-shared.js";
 
 export function normalizeProviderMapKeys<T>(
   providers: Record<string, T> | null | undefined,
@@ -53,6 +48,7 @@ export type ExistingProviderConfig = ProviderConfig & {
   api?: string;
 };
 
+/** Authored fields keyed by exact provider/model tuples, independent of display ref syntax. */
 export type SourceModelFields = ReadonlyMap<
   string,
   { inputOmitted: boolean; cost: ProviderConfig["models"][number]["cost"] | undefined }
@@ -76,7 +72,6 @@ type ProviderModelMergeOptions = {
   providerId: string;
   modelIdMatching?: "exact";
   sourceModelFields?: SourceModelFields;
-  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
   preserveConfiguredModelMembership?: boolean;
 };
 
@@ -132,7 +127,6 @@ export function mergeProviderModels(
       .filter(([id]) => Boolean(id)),
   );
   const seen = new Set<string>();
-  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
 
   const mergedModels = explicitModels.map((explicitModel) => {
     const id = getModelId(explicitModel);
@@ -145,7 +139,7 @@ export function mergeProviderModels(
       return explicitModel;
     }
     const sourceFields = options?.sourceModelFields?.get(
-      modelKey(normalizeProviderId(options.providerId), normalizeModelId(options.providerId, id)),
+      JSON.stringify([normalizeProviderId(options.providerId), id]),
     );
     // Materialized defaults are not authored pins. Reuse raw source cost in both
     // merge passes so the final pass cannot restore an older catalog schedule.
@@ -249,7 +243,6 @@ export function mergeProviders(params: {
   implicit?: Record<string, ProviderConfig> | null;
   explicit?: Record<string, ProviderConfig> | null;
   sourceModelFields?: SourceModelFields;
-  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }): Record<string, ProviderConfig> {
   const out = normalizeProviderMapKeys(params.implicit);
   for (const [providerKey, explicit] of Object.entries(normalizeProviderMapKeys(params.explicit))) {
@@ -258,7 +251,6 @@ export function mergeProviders(params: {
       ? mergeProviderModels(implicit, explicit, {
           providerId: providerKey,
           sourceModelFields: params.sourceModelFields,
-          manifestPlugins: params.manifestPlugins,
         })
       : explicit;
   }

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -9,6 +9,7 @@ import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.
 import type { ProviderPlugin } from "../plugins/types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { planOpenClawModelsJsonSource } from "./models-config.js";
+import { planOpenClawModelsJson } from "./models-config.plan.js";
 import { planModelsJsonForTest } from "./models-config.plan.test-support.js";
 import * as modelsConfigProviders from "./models-config.providers.js";
 import { createPreparedModelCatalogWorkerInput } from "./prepared-model-catalog-worker.js";
@@ -45,6 +46,22 @@ describe("models config input presence", () => {
     {
       name: "keeps independent input when the active secrets source has no row",
       sourceModels: [],
+      expected: ["text"],
+    },
+    {
+      name: "preserves explicit input when a later duplicate omits it",
+      sourceModels: [
+        { id: "vision-model", name: "vision-model", input: ["text"] },
+        { id: "vision-model", name: "vision-model" },
+      ],
+      expected: ["text"],
+    },
+    {
+      name: "inherits explicit input from an exact duplicate before discovery",
+      sourceModels: [
+        { id: "vision-model", name: "vision-model" },
+        { id: "vision-model", name: "vision-model", input: ["text"] },
+      ],
       expected: ["text"],
     },
   ] as const)("$name in the final generated models.json", async ({ sourceModels, expected }) => {
@@ -95,6 +112,147 @@ describe("models config input presence", () => {
     };
     expect(generated.providers["model-input-fixture"]?.models?.[0]?.input).toEqual(expected);
   });
+
+  it.each(["merge", "replace"] as const)(
+    "keeps one-step identities and exact source fields through repeated %s planning",
+    async (mode) => {
+      const providerId = "custom";
+      const rates = { input: 11, output: 22, cacheRead: 3, cacheWrite: 4 };
+      const scopedRates = { input: 33, output: 44, cacheRead: 5, cacheWrite: 6 };
+      const sourceModel = (
+        id: string,
+        fields: {
+          input?: Array<"text" | "image">;
+          cost?: Partial<ModelDefinitionConfig["cost"]>;
+        } = {},
+      ) => {
+        const { input: _input, cost: _cost, ...row } = model(id);
+        return { ...row, ...fields };
+      };
+      const cfg = {
+        models: {
+          mode,
+          providers: {
+            [providerId]: {
+              baseUrl: "https://catalog-fields.example/v1",
+              api: "openai-completions",
+              apiKey: "CATALOG_FIXTURE_KEY",
+              models: [
+                sourceModel("latest", { cost: { input: 7 } }),
+                sourceModel("bare", { input: ["text"], cost: { input: 2 } }),
+                sourceModel("custom/bare", { cost: { output: 8 } }),
+                sourceModel("alias-exact", {
+                  input: ["text"],
+                  cost: { input: 99, output: 99, cacheRead: 99, cacheWrite: 99 },
+                }),
+                sourceModel("exact"),
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const original = structuredClone(cfg);
+      const discovered = {
+        baseUrl: "https://catalog-fields.example/v1",
+        api: "openai-completions" as const,
+        apiKey: "CATALOG_FIXTURE_KEY",
+        models: ["middle", "bare", "custom/bare", "exact", "discovered-only"].map((id) =>
+          Object.assign(model(id, ["text", "image"]), {
+            cost: id === "custom/bare" ? scopedRates : rates,
+          }),
+        ),
+      };
+      const plugin: ProviderPlugin = {
+        id: providerId,
+        pluginId: providerId,
+        label: "Catalog fields fixture",
+        auth: [],
+        staticCatalog: { run: async () => ({ provider: discovered }) },
+      };
+      const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: providerId,
+            providers: [providerId],
+            modelIdNormalization: {
+              providers: {
+                [providerId]: {
+                  aliases: { latest: "middle", middle: "final", "alias-exact": "exact" },
+                },
+              },
+            },
+          },
+        ],
+      });
+      const merged = mode === "merge";
+      const emptyRates = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+      const inheritedInput = merged ? ["text", "image"] : undefined;
+      const expected = [
+        {
+          id: "middle",
+          input: inheritedInput,
+          cost: { ...(merged ? rates : emptyRates), input: 7 },
+        },
+        { id: "bare", input: ["text"], cost: { ...(merged ? rates : emptyRates), input: 2 } },
+        {
+          id: "custom/bare",
+          input: inheritedInput,
+          cost: { ...(merged ? scopedRates : emptyRates), output: 8 },
+        },
+        { id: "exact", input: inheritedInput, cost: merged ? rates : undefined },
+      ];
+      await withOpenClawTestState({ label: "catalog-authored-fields" }, async (state) => {
+        let existingRaw = "";
+        let existingParsed: unknown = {};
+        let pluginCatalogs: Array<{ pluginId: string; contents: string }> = [];
+        for (let pass = 0; pass < 2; pass++) {
+          const plan = await planOpenClawModelsJson({
+            context: {
+              cfg,
+              discoveryAuthConfig: cfg,
+              sourceConfigForSecrets: cfg,
+              agentDir: state.agentDir(),
+              env: state.env,
+              envFingerprint: state.env,
+              pluginMetadataSnapshot,
+              preparedStaticProviderCatalog: {
+                providers: [plugin],
+                entries: [{ provider: plugin, result: { provider: discovered } }],
+              },
+              providerDiscoveryEntriesOnly: true,
+              providerDiscoveryProviderIds: [providerId],
+            },
+            existingRaw,
+            existingParsed,
+            pluginCatalogs,
+          });
+          expect(plan.action).toBe("write");
+          if (plan.action !== "write") {
+            throw new Error(`Expected catalog write plan, got ${plan.action}`);
+          }
+          const contents = plan.pluginCatalogWrites?.["plugins/custom/catalog.json"];
+          expect(contents).toBeDefined();
+          if (!contents) {
+            throw new Error("Expected the plugin-owned catalog");
+          }
+          const generated = JSON.parse(contents) as {
+            providers: Record<string, { models: ModelDefinitionConfig[] }>;
+          };
+          expect(
+            generated.providers[providerId]?.models.map(({ id, input, cost }) => ({
+              id,
+              input,
+              cost,
+            })),
+          ).toEqual(expected);
+          expect(cfg).toStrictEqual(original);
+          existingRaw = plan.contents;
+          existingParsed = JSON.parse(plan.contents);
+          pluginCatalogs = [{ pluginId: providerId, contents }];
+        }
+      });
+    },
+  );
 
   const liveCost = {
     input: 11,

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -3,18 +3,12 @@
  * this module to merge implicit provider discovery, explicit config, and
  * preserved secrets before touching models.json.
  */
-import { mergeModelCost } from "../config/model-cost.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import {
-  modelKey,
-  createConfiguredProviderCatalogModelIdNormalizer,
-  type ModelManifestNormalizationContext,
-} from "./model-ref-shared.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -24,6 +18,7 @@ import {
 } from "./models-config.merge.js";
 import {
   enforceSourceManagedProviderSecrets,
+  materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,
   normalizeProviders,
   resolveImplicitProviders,
@@ -115,25 +110,18 @@ function buildPluginCatalogWrites(
 
 function buildSourceModelFields(
   sourceProviders: Record<string, ProviderConfig> | undefined,
-  manifestPlugins: ModelManifestNormalizationContext["manifestPlugins"],
 ): SourceModelFields {
-  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
-  const fields = new Map<
-    string,
-    { inputOmitted: boolean; cost: ReturnType<typeof mergeModelCost> }
-  >();
-  for (const [providerId, provider] of Object.entries(normalizeProviderMapKeys(sourceProviders))) {
-    for (const model of provider.models ?? []) {
-      const key = modelKey(providerId, normalizeModelId(providerId, model.id));
-      const existing = fields.get(key);
-      fields.set(key, {
-        inputOmitted: existing?.inputOmitted || !Object.hasOwn(model, "input"),
-        // Duplicate source rows keep the same first-authored priority as publication.
-        cost: mergeModelCost(model.cost, existing?.cost),
-      });
-    }
-  }
-  return fields;
+  return new Map(
+    Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
+      (provider.models ?? []).map(
+        (model) =>
+          [
+            JSON.stringify([providerId, model.id.trim()]),
+            { inputOmitted: !Object.hasOwn(model, "input"), cost: model.cost },
+          ] as const,
+      ),
+    ),
+  );
 }
 
 /** Resolves providers for models.json. */
@@ -143,12 +131,15 @@ async function resolveProvidersForModelsJson(params: {
 }): Promise<Record<string, ProviderConfig>> {
   const { context } = params;
   const { agentDir, env } = context;
-  const explicitProviders = stripBlankProviderBaseUrls(context.cfg.models?.providers ?? {});
+  const explicitProviders = stripBlankProviderBaseUrls(
+    materializeConfiguredProviderCatalogModels(context.cfg.models?.providers, {
+      manifestPlugins: context.pluginMetadataSnapshot,
+    }) ?? {},
+  );
   const cfg = context.cfg.models?.providers
     ? { ...context.cfg, models: { ...context.cfg.models, providers: explicitProviders } }
     : context.cfg;
-  const manifestPlugins = context.pluginMetadataSnapshot;
-  const sourceModelFields = buildSourceModelFields(context.cfg.models?.providers, manifestPlugins);
+  const sourceModelFields = buildSourceModelFields(explicitProviders);
   // When models.mode is "replace" the user opts out of provider discovery, so
   // skip the (potentially slow) implicit-provider resolver entirely and return
   // only the explicit providers. See openclaw#66957.
@@ -189,7 +180,6 @@ async function resolveProvidersForModelsJson(params: {
     implicit: implicitProviders,
     explicit: explicitProviders,
     sourceModelFields,
-    manifestPlugins,
   });
 }
 
@@ -309,7 +299,6 @@ export async function planOpenClawModelsJson(params: {
 
   const mode = cfg.models?.mode ?? "merge";
   const secretRefManagedProviders = new Set<string>();
-  const manifestPlugins = context.pluginMetadataSnapshot;
   const providerPolicyManifestRegistry =
     context.pluginMetadataSnapshot?.pluginIds === undefined
       ? context.pluginMetadataSnapshot?.manifestRegistry
@@ -322,7 +311,6 @@ export async function planOpenClawModelsJson(params: {
       secretDefaults: cfg.secrets?.defaults,
       sourceConfigForSecrets: context.sourceConfigForSecrets,
       secretRefManagedProviders,
-      manifestPlugins,
       ...(providerPolicyManifestRegistry
         ? { manifestRegistry: providerPolicyManifestRegistry }
         : {}),
@@ -339,9 +327,7 @@ export async function planOpenClawModelsJson(params: {
     secretRefManagedProviders,
   });
   const normalizedMergedProviders =
-    normalizeProviderCatalogModelsForConfig(mergedProviders, {
-      manifestPlugins,
-    }) ?? mergedProviders;
+    normalizeProviderCatalogModelsForConfig(mergedProviders) ?? mergedProviders;
   const secretEnforcedProviders =
     enforceSourceManagedProviderSecrets({
       providers: normalizedMergedProviders,
@@ -362,9 +348,7 @@ export async function planOpenClawModelsJson(params: {
     secretRefManagedProviders,
   });
   const normalizedRootProviders =
-    normalizeProviderCatalogModelsForConfig(rootProviders, {
-      manifestPlugins,
-    }) ?? rootProviders;
+    normalizeProviderCatalogModelsForConfig(rootProviders) ?? rootProviders;
   const rootWithManagedSecrets =
     enforceSourceManagedProviderSecrets({
       providers: normalizedRootProviders,

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -964,7 +964,10 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       env: { ...state.env, AWS_PROFILE: "default" },
       explicitProviders: { "amazon-bedrock": explicitProvider },
       sourceModelFields: new Map([
-        ["amazon-bedrock/vision-model", { inputOmitted: true, cost: undefined }],
+        [
+          JSON.stringify(["amazon-bedrock", "vision-model"]),
+          { inputOmitted: true, cost: undefined },
+        ],
       ]),
     });
 

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -10,7 +10,6 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { ManifestModelIdNormalizationSource } from "../plugins/manifest-model-id-normalization.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
@@ -127,7 +126,6 @@ function mergeImplicitProviderConfig(params: {
   implicit: ProviderConfig;
   dynamicProviderModels?: boolean;
   sourceModelFields?: SourceModelFields;
-  manifestPlugins?: ManifestModelIdNormalizationSource;
 }): ProviderConfig {
   const { providerId, existing, implicit } = params;
   if (!existing) {
@@ -140,7 +138,6 @@ function mergeImplicitProviderConfig(params: {
   return mergeProviderModels(implicit, existing, {
     providerId,
     sourceModelFields: params.sourceModelFields,
-    manifestPlugins: params.manifestPlugins,
     preserveConfiguredModelMembership:
       !params.dynamicProviderModels && Array.isArray(existing.models) && existing.models.length > 0,
   });
@@ -365,7 +362,6 @@ async function resolvePluginImplicitProviders(
           providerId,
         }),
         sourceModelFields: ctx.sourceModelFields,
-        manifestPlugins: ctx.pluginMetadataSnapshot,
       });
       discovered[providerId] = resolveImplicitProviderAuthMarker({
         ctx,

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -7,9 +7,12 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createConfigIoContext } from "../config/io.context.js";
 import { readConfigFileSnapshotFromContext } from "../config/io.snapshot.js";
 import { ModelsConfigSchema } from "../config/zod-schema.core.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
+  materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,
   normalizeProviders,
 } from "./models-config.providers.normalize.js";
@@ -117,63 +120,156 @@ describe("normalizeProviders", () => {
     }
   });
 
-  it("normalizes retired Google Gemini model ids before emitting provider config", async () => {
-    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
-    try {
-      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
-        google: {
-          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-          api: "google-generative-ai",
-          apiKey: "GOOGLE_API_KEY", // pragma: allowlist secret
-          models: [
-            createModel({
-              id: "gemini-3-pro-preview",
-              name: "Gemini 3 Pro",
-            }),
-          ],
-        },
-        "google-gemini-cli": {
-          baseUrl: "openclaw://google-gemini-cli",
-          models: [
-            createModel({
-              id: "gemini-3-pro-preview",
-              name: "Gemini CLI 3 Pro",
-            }),
-          ],
-        },
-        openrouter: {
-          baseUrl: "https://openrouter.ai/api/v1",
-          api: "openai-completions",
-          apiKey: "OPENROUTER_API_KEY", // pragma: allowlist secret
-          models: [
-            createModel({
-              id: "google/gemini-3-pro-preview",
-              name: "Gemini 3 Pro via OpenRouter",
-            }),
-          ],
-        },
-      };
+  it.each([
+    ["google", "gemini-3-pro-preview", "gemini-3.1-pro-preview"],
+    ["google-gemini-cli", "gemini-3-pro-preview", "gemini-3.1-pro-preview"],
+    ["openrouter", "google/gemini-3-pro-preview", "google/gemini-3.1-pro-preview"],
+    ["custom", "proxy/google/gemini-3-pro-preview", "proxy/google/gemini-3.1-pro-preview"],
+    ["together", "moonshotai/Kimi-K2.5", "moonshotai/Kimi-K2.6"],
+  ])("publishes the named %s retirement %s as %s", (provider, id, expected) => {
+    const providers = {
+      [provider]: { baseUrl: "https://models.example/v1", models: [createModel({ id })] },
+    };
+    const normalized = normalizeProviderCatalogModelsForConfig(providers);
+    expect(normalized?.[provider]?.models).toEqual([createModel({ id: expected })]);
+  });
 
-      const normalized = normalizeProviders({ providers, agentDir });
+  const manifestPlugins = createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "catalog-identity-fixture",
+        providers: ["custom"],
+        modelIdNormalization: {
+          providers: {
+            custom: {
+              aliases: {
+                latest: "middle",
+                middle: "final",
+                "alias-a": "target",
+                "alias-b": "target",
+              },
+            },
+          },
+        },
+      },
+    ],
+  });
+  const exactSparseRow = { id: "target", name: "Exact" };
+  const populatedAlias = createModel({ id: "alias-a", input: ["text", "image"] });
 
-      expect(normalized?.google?.models?.map((model) => model.id)).toEqual([
-        "gemini-3.1-pro-preview",
-      ]);
-      expect(normalized?.["google-gemini-cli"]?.models?.map((model) => model.id)).toEqual([
-        "gemini-3.1-pro-preview",
-      ]);
-      expect(normalized?.openrouter?.models?.map((model) => model.id)).toEqual([
-        "google/gemini-3.1-pro-preview",
-      ]);
-    } finally {
-      await fs.rm(agentDir, { recursive: true, force: true });
-    }
+  it.each([
+    {
+      name: "one alias step",
+      models: [{ id: "latest", name: "Authored" }],
+      expected: [{ id: "middle", name: "Authored" }],
+    },
+    {
+      name: "alias-chain membership without raw lookup keys",
+      models: ["latest", "middle", "final"].map((id) => ({ id, name: id })),
+      expected: [
+        { id: "middle", name: "middle" },
+        { id: "final", name: "final" },
+      ],
+    },
+    {
+      name: "reversed alias-chain membership",
+      models: ["final", "middle", "latest"].map((id) => ({ id, name: id })),
+      expected: [
+        { id: "final", name: "final" },
+        { id: "middle", name: "middle" },
+      ],
+    },
+    {
+      name: "exact omissions before an alias",
+      models: [exactSparseRow, populatedAlias],
+      expected: [exactSparseRow],
+    },
+    {
+      name: "exact omissions after an alias",
+      models: [populatedAlias, exactSparseRow],
+      expected: [exactSparseRow],
+    },
+    {
+      name: "first-equivalent omissions without an exact row",
+      models: [{ id: "alias-b", name: "First" }, populatedAlias],
+      expected: [{ id: "target", name: "First" }],
+    },
+    {
+      name: "same-spelling partial costs and input omissions",
+      models: [
+        { id: "latest", name: "First", cost: { input: 7 } },
+        { id: "latest", name: "Second", input: ["image"], cost: { input: 9, output: 8 } },
+        { id: "latest", name: "Third", input: ["text"], cost: { cacheRead: 0.5 } },
+      ],
+      expected: [
+        {
+          id: "middle",
+          name: "First",
+          input: ["image"],
+          cost: { input: 7, output: 8, cacheRead: 0.5 },
+        },
+      ],
+    },
+    {
+      name: "invalid row positions between normalized members",
+      models: [
+        { id: "latest", name: "Alias" },
+        { id: "", name: "Blank" },
+        { id: " \t ", name: "Whitespace" },
+        { id: 23, name: "Non-string" },
+        { id: "middle", name: "Exact" },
+      ],
+      expected: [
+        { id: "middle", name: "Exact" },
+        { id: "", name: "Blank" },
+        { id: " \t ", name: "Whitespace" },
+        { id: 23, name: "Non-string" },
+        { id: "final", name: "Exact" },
+      ],
+    },
+  ])("materializes $name before discovery", ({ models, expected }) => {
+    // Raw authored rows intentionally omit fields that discovery will supply.
+    const providers = {
+      custom: { baseUrl: "https://models.example/v1", models },
+    } as unknown as NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>;
+    const original = structuredClone(providers);
+    const materialized = materializeConfiguredProviderCatalogModels(providers, { manifestPlugins });
+    expect(materialized?.custom?.models).toStrictEqual(expected);
+    expect(providers).toStrictEqual(original);
+  });
+
+  it("preserves emitted aliases, case, whitespace, and self-provider namespaces during publication", () => {
+    const ids: Array<[string, string[]]> = [
+      ["custom", ["latest", "middle", "Model", "model", "custom/Model", " model "]],
+      ["anthropic", ["sonnet", "anthropic/sonnet"]],
+      ["google", [" unrelated-model "]],
+      ["huggingface", ["huggingface/vendor/model"]],
+      ["openrouter", ["auto"]],
+      ["nvidia", ["Model"]],
+      ["together", [" unrelated-model "]],
+    ];
+    const providers = Object.fromEntries(
+      ids.map(([provider, models]) => [
+        provider,
+        { baseUrl: "https://models.example/v1", models: models.map((id) => createModel({ id })) },
+      ]),
+    );
+    const published = withPluginMetadataSnapshotScope(manifestPlugins, () =>
+      normalizeProviderCatalogModelsForConfig(providers),
+    );
+    expect(published).toBe(providers);
+    expect(
+      Object.entries(published ?? {}).map(([provider, value]) => [
+        provider,
+        value.models.map((model) => model.id),
+      ]),
+    ).toEqual(ids);
   });
 
   it("deduplicates model rows and keeps repeated publication stable with secret ownership", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
     try {
-      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+      const providers = {
         google: {
           baseUrl: "https://generativelanguage.googleapis.com/v1beta",
           api: "google-generative-ai",
@@ -195,13 +291,15 @@ describe("normalizeProviders", () => {
           ],
         },
         custom: { baseUrl: "https://models.example/v1", models: [] },
-      };
+      } satisfies NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>;
 
       const normalized = normalizeProviders({ providers, agentDir, env: {} });
+      expect(normalized?.google?.models).toBe(providers.google.models);
+      const published = normalizeProviderCatalogModelsForConfig(normalized);
 
-      expect(normalized?.google?.models).toHaveLength(1);
+      expect(published?.google?.models).toHaveLength(1);
       // The first normalized row wins so explicit config details are not replaced by discovery.
-      const model = normalized?.google?.models?.[0];
+      const model = published?.google?.models?.[0];
       expect(model?.id).toBe("gemini-3.1-pro-preview");
       expect(model?.name).toBe("Pinned Gemini");
       expect(model?.contextWindow).toBe(12345);
@@ -209,8 +307,7 @@ describe("normalizeProviders", () => {
       expect(model?.reasoning).toBe(false);
       expect(model?.cost).toEqual({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 });
 
-      const published = normalizeProviderCatalogModelsForConfig(normalized);
-      expect(published).toBe(normalized);
+      expect(normalizeProviderCatalogModelsForConfig(published)).toBe(published);
       const secretRefManagedProviders = new Set<string>();
       const repeated = normalizeProviders({
         providers: published,

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -1,8 +1,10 @@
 /**
- * Normalizes configured provider model rows for runtime/discovery use.
+ * Materializes authored model rows and finalizes emitted provider catalogs.
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeConfiguredProviderCatalogModelRef } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { mergeModelCost } from "../config/model-cost.js";
+import { normalizeProviderCatalogModelIdForConfig } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
@@ -69,20 +71,23 @@ function mergeNormalizedProviderModel(
 function normalizeProviderModelsForConfig(
   providerKey: string,
   provider: ProviderConfig,
-  options: ModelManifestNormalizationContext = {},
-  completeCatalogCosts = false,
 ): ProviderConfig {
   if (!Array.isArray(provider.models) || provider.models.length === 0) {
     return provider;
   }
 
-  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
+  const providerId = normalizeProviderId(providerKey);
   let mutated = false;
   const nextModels: ProviderModelConfig[] = [];
   const seenById = new Map<string, number>();
   for (const model of provider.models) {
     const rawId = getProviderModelId(model);
-    const normalizedId = rawId ? normalizeModelId(providerKey, rawId) : rawId;
+    const normalizedId = rawId
+      ? normalizeProviderCatalogModelIdForConfig(
+          providerId,
+          normalizeConfiguredProviderCatalogModelRef(rawId),
+        )
+      : rawId;
     const normalizedModel =
       normalizedId && normalizedId !== rawId ? { ...model, id: normalizedId } : model;
     if (normalizedModel !== model) {
@@ -104,22 +109,20 @@ function normalizeProviderModelsForConfig(
     nextModels.push(normalizedModel);
   }
 
-  if (completeCatalogCosts) {
-    for (const [index, model] of nextModels.entries()) {
-      const normalized = normalizeModelCostForCatalog(model);
-      if (normalized !== model) {
-        nextModels[index] = normalized;
-        mutated = true;
-      }
+  for (const [index, model] of nextModels.entries()) {
+    const normalized = normalizeModelCostForCatalog(model);
+    if (normalized !== model) {
+      nextModels[index] = normalized;
+      mutated = true;
     }
   }
 
   return mutated ? { ...provider, models: nextModels } : provider;
 }
 
-export function normalizeProviderCatalogModelsForConfig(
+function normalizeProviderModelMap(
   providers: ModelsConfig["providers"],
-  options: ModelManifestNormalizationContext = {},
+  normalize: (providerKey: string, provider: ProviderConfig) => ProviderConfig,
 ): ModelsConfig["providers"] {
   if (!providers) {
     return providers;
@@ -128,14 +131,68 @@ export function normalizeProviderCatalogModelsForConfig(
   let mutated = false;
   const next: Record<string, ProviderConfig> = {};
   for (const [providerKey, provider] of Object.entries(providers)) {
-    // Complete the publication schema after duplicate rows merge, or synthetic
-    // zeroes can mask explicit cache prices supplied by a later row.
-    const normalized = normalizeProviderModelsForConfig(providerKey, provider, options, true);
+    const normalized = normalize(providerKey, provider);
     mutated ||= normalized !== provider;
     next[providerKey] = normalized;
   }
 
   return mutated ? next : providers;
+}
+
+/** Resolves authored aliases once, before discovery consumes configured model membership. */
+export function materializeConfiguredProviderCatalogModels(
+  providers: ModelsConfig["providers"],
+  options: ModelManifestNormalizationContext = {},
+): ModelsConfig["providers"] {
+  const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
+  return normalizeProviderModelMap(providers, (providerKey, provider) => {
+    if (!Array.isArray(provider.models) || provider.models.length === 0) {
+      return provider;
+    }
+    const exactRows = new Map<string, ProviderModelConfig>();
+    for (const model of provider.models) {
+      const id = getProviderModelId(model)?.trim();
+      if (id) {
+        const existing = exactRows.get(id);
+        exactRows.set(id, existing ? mergeNormalizedProviderModel(existing, model) : model);
+      }
+    }
+    const normalizedIds = new Map<string, string>();
+    const selectedRows = new Map<string, ProviderModelConfig>();
+    for (const [id, model] of exactRows) {
+      const normalized = normalizeModelId(providerKey, id) || id;
+      normalizedIds.set(id, normalized);
+      // Exact destinations retain their omissions; other aliases do not donate fields.
+      if (!selectedRows.has(normalized)) {
+        selectedRows.set(normalized, exactRows.get(normalized) ?? model);
+      }
+    }
+    const seen = new Set<string>();
+    const models = provider.models.flatMap((model) => {
+      const rawId = getProviderModelId(model);
+      if (!rawId) {
+        return [model];
+      }
+      const id = normalizedIds.get(rawId.trim())!;
+      if (seen.has(id)) {
+        return [];
+      }
+      seen.add(id);
+      const selected = selectedRows.get(id)!;
+      return [selected.id === id ? selected : { ...selected, id }];
+    });
+    return models.length === provider.models.length &&
+      models.every((model, index) => model === provider.models[index])
+      ? provider
+      : { ...provider, models };
+  });
+}
+
+/** Finalizes emitted rows without applying authored aliases to their identities. */
+export function normalizeProviderCatalogModelsForConfig(
+  providers: ModelsConfig["providers"],
+): ModelsConfig["providers"] {
+  return normalizeProviderModelMap(providers, normalizeProviderModelsForConfig);
 }
 
 export function normalizeProviders(params: {
@@ -145,7 +202,6 @@ export function normalizeProviders(params: {
   secretDefaults?: SecretDefaults;
   sourceConfigForSecrets?: OpenClawConfig;
   secretRefManagedProviders?: Set<string>;
-  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): ModelsConfig["providers"] {
   const { providers } = params;
@@ -252,9 +308,6 @@ export function normalizeProviders(params: {
       params.manifestRegistry,
     );
 
-    normalizedProvider = normalizeProviderModelsForConfig(normalizedKey, normalizedProvider, {
-      manifestPlugins: params.manifestPlugins,
-    });
     mutated ||= normalizedProvider !== provider;
 
     const existing = next[normalizedKey];

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -5,6 +5,7 @@
  */
 export { resolveImplicitProviders } from "./models-config.providers.implicit.js";
 export {
+  materializeConfiguredProviderCatalogModels,
   normalizeProviderCatalogModelsForConfig,
   normalizeProviders,
 } from "./models-config.providers.normalize.js";

--- a/src/agents/models-config.root-authorship.test.ts
+++ b/src/agents/models-config.root-authorship.test.ts
@@ -19,6 +19,7 @@ vi.mock("../plugins/provider-discovery.js", async (importOriginal) => ({
 
 import { planOpenClawModelsJsonSource } from "./models-config.js";
 import {
+  loadPersistedPluginModelCatalogsReadOnly,
   PLUGIN_MODEL_CATALOG_GENERATED_BY,
   replacePersistedPluginModelCatalogs,
 } from "./plugin-model-catalog.js";
@@ -39,75 +40,115 @@ const native: ModelProviderConfig = {
   ],
 };
 const metadata = createPluginMetadataSnapshotFixture({
-  plugins: [{ id: "catalog-owner", providers: ["fixture"] }],
+  plugins: [
+    {
+      id: "catalog-owner",
+      providers: ["fixture", "cached-fixture"],
+      modelIdNormalization: {
+        providers: {
+          fixture: { aliases: { latest: "middle", middle: "final" } },
+          "cached-fixture": { aliases: { latest: "middle", middle: "final" } },
+        },
+      },
+    },
+  ],
 });
-const provider: ProviderPlugin = {
-  id: "fixture",
-  pluginId: "catalog-owner",
-  label: "Fixture",
-  auth: [],
-  staticCatalog: { order: "simple", run: async () => ({ provider: native }) },
-};
 
 describe("manual root catalog authorship", () => {
   let state: OpenClawTestState;
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "manual-root-catalog" });
-    resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
   });
   afterEach(async () => {
     await state.cleanup();
     vi.clearAllMocks();
   });
 
-  it("keeps manual root models separate from a refreshed generated provider", async () => {
-    const manual: ModelProviderConfig = {
-      ...native,
-      baseUrl: "https://manual.example/v1",
-      apiKey: "manual-root-key",
-      headers: { "X-Manual": "preserve" },
-      models: [
-        {
-          ...native.models[0]!,
-          id: "manual-model",
-          name: "Manual root model",
-          contextWindow: 24576,
-        },
-      ],
-    };
-    const root = {
-      providers: { fixture: manual, "auth-only": { apiKey: "auth-only-key", models: [] } },
-    };
-    const rootPath = path.join(state.agentDir(), "models.json");
-    const original = JSON.stringify(root);
-    await fs.mkdir(state.agentDir(), { recursive: true });
-    await fs.writeFile(rootPath, original);
-    replacePersistedPluginModelCatalogs({
-      agentDir: state.agentDir(),
-      pluginCatalogWrites: {
-        "plugins/catalog-owner/catalog.json": JSON.stringify({
-          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
-          providers: { fixture: native },
-        }),
-      },
-    });
+  it.each([
+    ["latest", "middle"],
+    ["middle", "latest"],
+  ])(
+    "keeps manual, implicit, and generated ids literal across replanning (%s first)",
+    async (first, second) => {
+      const modelIds = [first, second];
+      const models = modelIds.map((id) => ({ ...native.models[0]!, id, name: id }));
+      const discovered = { ...native, models: [...native.models, ...models] };
+      const provider: ProviderPlugin = {
+        id: "fixture",
+        pluginId: "catalog-owner",
+        label: "Fixture",
+        auth: [],
+        staticCatalog: { order: "simple", run: async () => ({ provider: discovered }) },
+      };
+      resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
+      const manual: ModelProviderConfig = {
+        ...native,
+        baseUrl: "https://manual.example/v1",
+        apiKey: "manual-root-key",
+        headers: { "X-Manual": "preserve" },
+        models: [
+          {
+            ...native.models[0]!,
+            id: "manual-model",
+            name: "Manual root model",
+            contextWindow: 24576,
+          },
+          ...models,
+        ],
+      };
+      const cached = { ...native, models };
+      const root = {
+        providers: { fixture: manual, "auth-only": { apiKey: "auth-only-key", models: [] } },
+      };
+      const rootPath = path.join(state.agentDir(), "models.json");
+      let rootContents = JSON.stringify(root);
+      let pluginContents = JSON.stringify({
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: { fixture: native, "cached-fixture": cached },
+      });
+      await fs.mkdir(state.agentDir(), { recursive: true });
 
-    const planned = await planOpenClawModelsJsonSource({}, state.agentDir(), {
-      env: state.env,
-      pluginMetadataSnapshot: metadata,
-      providerDiscoveryProviderIds: ["fixture"],
-      providerDiscoveryEntriesOnly: true,
-    });
+      for (let pass = 0; pass < 3; pass++) {
+        // Each pass starts from the prior planned generation, installed only by this fixture.
+        await fs.writeFile(rootPath, rootContents);
+        replacePersistedPluginModelCatalogs({
+          agentDir: state.agentDir(),
+          pluginCatalogWrites: { "plugins/catalog-owner/catalog.json": pluginContents },
+        });
+        const persistedCatalogs = loadPersistedPluginModelCatalogsReadOnly(state.agentDir());
+        const planned = await planOpenClawModelsJsonSource({}, state.agentDir(), {
+          env: state.env,
+          pluginMetadataSnapshot: metadata,
+          providerDiscoveryProviderIds: ["fixture"],
+          providerDiscoveryEntriesOnly: true,
+        });
 
-    assert(planned.modelsJsonContents, "The plan must retain the manual root catalog");
-    expect(JSON.parse(planned.modelsJsonContents)).toMatchObject(root);
-    const generated = planned.pluginCatalogs.find(({ pluginId }) => pluginId === "catalog-owner");
-    assert(generated, "The refreshed plugin catalog must remain independently generated");
-    expect(
-      JSON.parse(generated.contents).providers.fixture.models.map(
-        (model: { id: string }) => model.id,
-      ),
-    ).toEqual(["native-model"]);
-    expect(await fs.readFile(rootPath, "utf8")).toBe(original);
-  });
+        assert(planned.modelsJsonContents, "The plan must retain the manual root catalog");
+        const plannedRoot = JSON.parse(planned.modelsJsonContents);
+        expect(plannedRoot).toEqual(root);
+        expect(
+          plannedRoot.providers.fixture.models.map((model: { id: string }) => model.id),
+        ).toEqual(["manual-model", ...modelIds]);
+        expect(planned.pluginCatalogs).toHaveLength(1);
+        const generated = planned.pluginCatalogs.find(
+          ({ pluginId }) => pluginId === "catalog-owner",
+        );
+        assert(generated, "The refreshed plugin catalog must remain independently generated");
+        const generatedProviders = JSON.parse(generated.contents).providers;
+        expect(generatedProviders.fixture.models.map((model: { id: string }) => model.id)).toEqual([
+          "native-model",
+          ...modelIds,
+        ]);
+        expect(
+          generatedProviders["cached-fixture"].models.map((model: { id: string }) => model.id),
+        ).toEqual(modelIds);
+        expect(await fs.readFile(rootPath, "utf8")).toBe(rootContents);
+        expect(loadPersistedPluginModelCatalogsReadOnly(state.agentDir())).toEqual(
+          persistedCatalogs,
+        );
+        rootContents = planned.modelsJsonContents;
+        pluginContents = generated.contents;
+      }
+    },
+  );
 });

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -57,6 +57,8 @@ vi.mock("./models-config.providers.js", async () => {
     }: {
       providers: Record<string, ModelsProviderConfig>;
     }) => providers,
+    materializeConfiguredProviderCatalogModels: (providers: Record<string, ModelsProviderConfig>) =>
+      providers,
     normalizeProviders: ({ providers }: { providers: Record<string, ModelsProviderConfig> }) =>
       providers,
     normalizeProviderCatalogModelsForConfig: (providers: Record<string, ModelsProviderConfig>) =>

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -29,6 +29,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 }));
 
 vi.mock("./models-config.providers.js", () => ({
+  materializeConfiguredProviderCatalogModels: (providers: unknown) => providers,
   enforceSourceManagedProviderSecrets: ({ providers }: { providers: unknown }) => providers,
   normalizeProviderCatalogModelsForConfig: (providers: unknown) => providers,
   normalizeProviders: ({ providers }: { providers: unknown }) => providers,

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -518,7 +518,6 @@ export class ModelRegistry {
           ? mergeProviderModels(existing, provider, {
               providerId,
               modelIdMatching: "exact",
-              manifestPlugins: this.pluginMetadataSnapshot,
             })
           : provider;
       }

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -265,25 +265,30 @@ describe("applyModelDefaults", () => {
     });
   });
 
-  it("normalizes retired Gemini primary and fallback refs", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          model: {
-            primary: "google/gemini-3-pro-preview",
-            fallbacks: ["google/gemini-3-pro-preview", "openai/gpt-5.5"],
+  it.each(["google", "google-vertex", "google-gemini-cli", "myproxy/google"])(
+    "normalizes retired Gemini primary and fallback refs under %s",
+    (provider) => {
+      const retired = `${provider}/gemini-3-pro-preview`;
+      const replacement = `${provider}/gemini-3.1-pro-preview`;
+      const cfg = {
+        agents: {
+          defaults: {
+            model: {
+              primary: retired,
+              fallbacks: [retired, "openai/gpt-5.5"],
+            },
           },
         },
-      },
-    } satisfies OpenClawConfig;
+      } satisfies OpenClawConfig;
 
-    const next = applyModelDefaults(cfg);
+      const next = applyModelDefaults(cfg);
 
-    expect(next.agents?.defaults?.model).toEqual({
-      primary: "google/gemini-3.1-pro-preview",
-      fallbacks: ["google/gemini-3.1-pro-preview", "openai/gpt-5.5"],
-    });
-  });
+      expect(next.agents?.defaults?.model).toEqual({
+        primary: replacement,
+        fallbacks: [replacement, "openai/gpt-5.5"],
+      });
+    },
+  );
 
   it("normalizes the retired Together default primary and fallback refs", () => {
     const cfg = {

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -59,6 +59,14 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
 
 const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vertex"]);
 
+/** Applies existing Google/Together model fixes while preserving literal catalog namespaces. */
+export function normalizeProviderCatalogModelIdForConfig(provider: string, model: string): string {
+  if (GOOGLE_PROVIDER_IDS.has(provider) || model.startsWith("google/")) {
+    return normalizeGooglePreviewModelId(model);
+  }
+  return provider === "together" ? normalizeTogetherModelId(model) : model;
+}
+
 /** Canonicalizes provider/model refs before they are persisted to config. */
 export function normalizeAgentModelRefForConfig(model: string): string {
   const trimmed = model.trim();
@@ -68,12 +76,7 @@ export function normalizeAgentModelRefForConfig(model: string): string {
   }
 
   const { provider, modelId: modelSuffix } = parsed;
-  const normalizedModel =
-    GOOGLE_PROVIDER_IDS.has(provider) || modelSuffix.startsWith("google/")
-      ? normalizeGooglePreviewModelId(modelSuffix)
-      : provider === "together"
-        ? normalizeTogetherModelId(modelSuffix)
-        : modelSuffix;
+  const normalizedModel = normalizeProviderCatalogModelIdForConfig(provider, modelSuffix);
   return modelKey(provider, normalizedModel);
 }
 


### PR DESCRIPTION
Related: #130706, #142100. Follows the planner cleanup #143851.

## What Problem This Solves

Provider catalog planning can apply an authored alias more than once: `entry → middle → final` can publish the wrong model and miss the intended discovery donor. Later publication can also reinterpret already-emitted manual/plugin IDs. Source cost and input-presence records use display keys that can attach one row's fields to another model.

## Why This Change Was Made

Resolve authored rows once before discovery. Merge same-spelling partial costs, select an exact destination before equivalent rows, and retain omitted fields for the real catalog donor. Carry source cost/input-presence facts with exact provider/model tuple keys. Later catalog publication preserves emitted IDs and applies only the existing Google/Together retirement corrections.

Provider/auth normalization, secret-marker enforcement, root authorship, replace-mode membership, and the generic registry merge contracts remain in their existing owners. Remove their obsolete alias-normalization plumbing and document the catalog behavior. This adds 28 production lines; the separately landed planner cleanup #143851 removed 47.

## User Impact

Configured aliases select the intended executable model, explicit input/cost metadata stays attached to its row, and repeated refreshes preserve manual and generated catalog IDs. No setting, dependency, schema, or stored-state design is added.

## Evidence

Six intended regressions failed against unchanged main, covering duplicate input ownership, repeated alias resolution in merge/replace modes, and manual catalog drift in both row orders. The fixed focused cohort passed 206 tests across 11 files, including normalization, merging, source metadata, root authorship, discovery, environment handling, retirement corrections, and ModelRegistry. Two mechanical test-fixture type/lint corrections subsequently passed 51 focused tests and targeted lint. Fresh P2 review and the complete changed-file gate passed; production remained unchanged through those fixture corrections.

At exact commit `c481d1644dbf8b2d86cd52c8ebed2f4b349681e9`, one canonical `sourcePerformance` build and all 12 compiled public writer/registry scenarios passed. They repeat merge/replace planning and verify exact omissions, duplicate input, namespace-separated costs, and literal manual/generated IDs, including spaced IDs. All 9,253 captured root/workspace build files were unchanged, no checkout TypeScript or HTTP was used, both synthetic state roots were removed, and all processes joined. This runtime build excludes UI and SDK declarations.

The first compiled attempt stopped with an incomplete hand-built metadata fixture. The retained failure was corrected by constructing metadata through the emitted canonical producer; no product changes, rebuild, or restamping occurred. Review also caught an unnecessary trim of emitted IDs, which was reproduced and removed before the final source review.
