### PR TITLE
fix(ci): retain QA profile diagnostics on failure

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -914,6 +914,7 @@ jobs:
         working-directory: selected
 
       - name: Download QA profile shard evidence
+        id: download_shards
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: qa-profile-evidence-shard-*-${{ needs.validate_selected_ref.outputs.selected_revision }}
@@ -960,19 +961,8 @@ jobs:
             shardCount: Number(process.env.SHARD_COUNT),
           });
           NODE
-          jq -s \
-            --arg profile "$QA_PROFILE" \
-            --argjson exitCode "$qa_exit_code" \
-            '{
-              target: .[0].target,
-              profile: $profile,
-              run: .[0].run,
-              shards: map(.shard + {exitCode, timedOut, timeoutOutcome, completedAt}),
-              exitCode: $exitCode,
-              timedOut: false,
-              timeoutOutcome: "none",
-              completedAt: (map(.completedAt) | max)
-            }' "${status_paths[@]}" > "$OUTPUT_DIR/qa-profile-run-status.json"
+          # Preserve the former status assembly's admission checks; projection is advisory below.
+          jq -s --argjson exitCode "$qa_exit_code" 'map(.shard + {})' "${status_paths[@]}" >/dev/null
           echo "output_dir=${OUTPUT_DIR}" >> "$GITHUB_OUTPUT"
           echo "qa_exit_code=${qa_exit_code}" >> "$GITHUB_OUTPUT"
 
@@ -1041,6 +1031,46 @@ jobs:
           echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
           echo "trusted_reason=${TRUSTED_REASON}" >> "$GITHUB_OUTPUT"
           echo "qa_evidence_path=qa-evidence.json" >> "$GITHUB_OUTPUT"
+
+      # Diagnostics use the frozen harness even when candidate aggregation cannot start.
+      # They never produce a manifest or participate in qualification outputs.
+      - name: Collect QA profile diagnostics
+        id: collect_diagnostics
+        if: always()
+        continue-on-error: true
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          INPUT_DIR: ${{ github.workspace }}/selected/.artifacts/qa-profile-shards
+          OUTPUT_DIR: ${{ github.workspace }}/selected/.artifacts/qa-e2e/profile-${{ needs.plan_qa_profile.outputs.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
+          PLAN_MATRIX_JSON: ${{ needs.plan_qa_profile.outputs.matrix }}
+          QA_PROFILE: ${{ needs.plan_qa_profile.outputs.profile }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_revision }}
+          PROTOCOL_BASE_SHA: ${{ needs.validate_selected_ref.outputs.protocol_base_revision }}
+          QA_EXIT_CODE: ${{ steps.aggregate.outputs.qa_exit_code }}
+          SHARD_JOB_OUTCOME: ${{ needs.run_qa_profile_shard.result }}
+          DOWNLOAD_OUTCOME: ${{ steps.download_shards.outcome }}
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+          FINALIZE_OUTCOME: ${{ steps.evidence.outcome }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"
+          node scripts/qa/qa-profile-run-status.mjs
+
+      - name: Upload QA profile diagnostics
+        id: upload_diagnostics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: qa-profile-diagnostics-${{ needs.plan_qa_profile.outputs.profile }}-${{ needs.validate_selected_ref.outputs.selected_revision }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/selected/.artifacts/qa-e2e/profile-${{ needs.plan_qa_profile.outputs.profile }}-${{ github.run_id }}-${{ github.run_attempt }}/qa-profile-run-status.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Warn if QA profile diagnostics were not retained
+        if: always() && (steps.collect_diagnostics.outcome == 'failure' || steps.upload_diagnostics.outcome == 'failure')
+        run: echo "::warning::QA profile diagnostics collection or upload failed; inspect the original shard artifacts and job logs."
 
       - name: Upload QA profile evidence
         if: always() && steps.evidence.outcome == 'success'

--- a/scripts/qa/qa-profile-run-status.mjs
+++ b/scripts/qa/qa-profile-run-status.mjs
@@ -1,0 +1,308 @@
+// The trusted workflow owns this diagnostic projection; it never attests QA evidence.
+import fs from "node:fs";
+import path from "node:path";
+
+const MAX_SHARDS = 32;
+const MAX_ARTIFACTS = 128;
+const MAX_STATUS_BYTES = 64 * 1024;
+const MAX_MATRIX_BYTES = 256 * 1024;
+const outcomes = new Set(["success", "failure", "cancelled", "skipped"]);
+const timeoutOutcomes = new Set(["none", "term", "kill"]);
+const compareText = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
+// This CLI must run before candidate dependencies are available.
+const record = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const exitCode = (value) => (Number.isInteger(value) && value >= 0 && value <= 255 ? value : null);
+const timestamp = (value) =>
+  typeof value === "string" &&
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) &&
+  Number.isFinite(Date.parse(value))
+    ? value
+    : null;
+const ids = (value) =>
+  Array.isArray(value) &&
+  value.length <= 2048 &&
+  value.every((id) => typeof id === "string" && /^[a-zA-Z0-9_.-]{1,160}$/u.test(id))
+    ? value
+    : null;
+function sameIds(actual, expected) {
+  if (!ids(actual) || actual.length !== expected.length) {
+    return false;
+  }
+  const sorted = expected.toSorted(compareText);
+  return actual.toSorted(compareText).every((id, index) => id === sorted[index]);
+}
+
+function canonicalPath(filePath) {
+  let ancestor = path.resolve(filePath);
+  const suffix = [];
+  while (!fs.existsSync(ancestor)) {
+    suffix.unshift(path.basename(ancestor));
+    ancestor = path.dirname(ancestor);
+  }
+  return path.join(fs.realpathSync(ancestor), ...suffix);
+}
+
+function collect() {
+  const env = process.env;
+  if (
+    !/^[a-z0-9]+(?:[.-][a-z0-9]+)*$/u.test(env.QA_PROFILE ?? "") ||
+    (env.QA_PROFILE?.length ?? 0) > 160 ||
+    !/^[0-9a-f]{40}$/u.test(env.TARGET_SHA ?? "") ||
+    !/^[0-9a-f]{40}$/u.test(env.PROTOCOL_BASE_SHA ?? "") ||
+    !/^[1-9][0-9]{0,19}$/u.test(env.GITHUB_RUN_ID ?? "") ||
+    !/^[1-9][0-9]{0,5}$/u.test(env.GITHUB_RUN_ATTEMPT ?? "") ||
+    !env.INPUT_DIR ||
+    !env.OUTPUT_DIR
+  ) {
+    throw new Error("Invalid workflow identity");
+  }
+  const inputRoot = canonicalPath(env.INPUT_DIR);
+  const outputRoot = canonicalPath(env.OUTPUT_DIR);
+  const relativeOutput = path.relative(inputRoot, outputRoot);
+  if (
+    !relativeOutput ||
+    (!relativeOutput.startsWith(`..${path.sep}`) &&
+      relativeOutput !== ".." &&
+      !path.isAbsolute(relativeOutput))
+  ) {
+    throw new Error("Diagnostic output must not modify downloaded inputs");
+  }
+  const matrixText = env.PLAN_MATRIX_JSON ?? "";
+  if (Buffer.byteLength(matrixText) > MAX_MATRIX_BYTES) {
+    throw new Error("Profile matrix exceeds diagnostic limit");
+  }
+  const matrix = JSON.parse(matrixText);
+  if (
+    !record(matrix) ||
+    !Array.isArray(matrix.include) ||
+    matrix.include.length < 1 ||
+    matrix.include.length > MAX_SHARDS ||
+    matrix.include.some(
+      (shard) =>
+        !record(shard) ||
+        typeof shard.id !== "string" ||
+        !/^shard-[0-9]{2}$/u.test(shard.id) ||
+        !ids(shard.categoryIds) ||
+        !ids(shard.scenarioIds),
+    ) ||
+    new Set(matrix.include.map((shard) => shard.id)).size !== matrix.include.length
+  ) {
+    throw new Error("Invalid profile matrix");
+  }
+  const planned = new Map(matrix.include.map((shard) => [shard.id, shard]));
+  const diagnostics = [];
+  const add = (source, reason) => diagnostics.push({ source, reason });
+  const statusCounts = new Map();
+  const evidenceIds = new Set();
+  const shards = [];
+  let statusFiles = 0;
+  let evidenceFiles = 0;
+  let entries = [];
+  try {
+    if (!fs.lstatSync(env.INPUT_DIR).isDirectory()) {
+      throw new Error("Invalid input directory");
+    }
+    const directory = fs.opendirSync(env.INPUT_DIR);
+    try {
+      for (let entry; (entry = directory.readSync()) !== null;) {
+        entries.push(entry);
+        if (entries.length > MAX_ARTIFACTS) {
+          // Never publish an enumeration-order-dependent partial inventory.
+          entries = [];
+          add(null, "artifact-limit");
+          break;
+        }
+      }
+    } finally {
+      directory.closeSync();
+    }
+  } catch {
+    add(null, "input-unavailable");
+  }
+  entries.sort((left, right) => compareText(left.name, right.name));
+  for (const [index, entry] of entries.entries()) {
+    // Artifact names and payload prose are untrusted; publish only an ordinal and known IDs.
+    const source = `artifact-${String(index + 1).padStart(3, "0")}`;
+    if (!entry.isDirectory()) {
+      add(source, "invalid-artifact-directory");
+      continue;
+    }
+    const artifactMatch = /^qa-profile-evidence-shard-(shard-[0-9]{2})-([0-9a-f]{40})$/u.exec(
+      entry.name,
+    );
+    const artifactId = artifactMatch?.[1] ?? null;
+    if (!artifactMatch || !planned.has(artifactId)) {
+      add(source, "unexpected-artifact");
+    }
+    if (artifactMatch && artifactMatch[2] !== env.TARGET_SHA) {
+      add(source, "artifact-sha-mismatch");
+    }
+    const directory = path.join(env.INPUT_DIR, entry.name);
+    try {
+      if (fs.lstatSync(path.join(directory, "qa-evidence.json")).isFile()) {
+        evidenceFiles += 1;
+        if (planned.has(artifactId)) {
+          evidenceIds.add(artifactId);
+        }
+      } else {
+        add(source, "invalid-evidence-file");
+      }
+    } catch {
+      add(source, "missing-evidence-file");
+    }
+    let status;
+    let fd;
+    try {
+      const statusPath = path.join(directory, "qa-profile-run-status.json");
+      if (!fs.lstatSync(statusPath).isFile()) {
+        throw new Error("Invalid status file");
+      }
+      fd = fs.openSync(statusPath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+      const buffer = Buffer.alloc(MAX_STATUS_BYTES + 1);
+      const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+      statusFiles += 1;
+      if (bytes > MAX_STATUS_BYTES) {
+        add(source, "status-size-limit");
+        continue;
+      }
+      status = JSON.parse(buffer.subarray(0, bytes).toString("utf8"));
+      if (!record(status) || !record(status.shard)) {
+        throw new Error("Invalid status");
+      }
+    } catch {
+      add(source, "missing-or-malformed-status");
+      continue;
+    } finally {
+      if (fd !== undefined) {
+        fs.closeSync(fd);
+      }
+    }
+    const id =
+      typeof status.shard.id === "string" && /^shard-[0-9]{2}$/u.test(status.shard.id)
+        ? status.shard.id
+        : null;
+    const expected = planned.get(id);
+    if (!expected) {
+      add(source, "unexpected-shard");
+    }
+    if (id !== artifactId) {
+      add(source, "artifact-shard-mismatch");
+    }
+    if (expected) {
+      statusCounts.set(id, (statusCounts.get(id) ?? 0) + 1);
+    }
+    for (const [matches, reason] of [
+      [status.profile === env.QA_PROFILE, "profile-mismatch"],
+      [status.target?.sha === env.TARGET_SHA, "target-sha-mismatch"],
+      [status.target?.protocolBaseSha === env.PROTOCOL_BASE_SHA, "protocol-sha-mismatch"],
+      [status.run?.id === env.GITHUB_RUN_ID, "run-id-mismatch"],
+      [status.run?.attempt === Number(env.GITHUB_RUN_ATTEMPT), "run-attempt-mismatch"],
+    ]) {
+      if (!matches) {
+        add(source, reason);
+      }
+    }
+    const categoryIds = expected && sameIds(status.shard.categoryIds, expected.categoryIds);
+    const scenarioIds = expected && sameIds(status.shard.scenarioIds, expected.scenarioIds);
+    if (!categoryIds) {
+      add(source, "category-membership-mismatch");
+    }
+    if (!scenarioIds) {
+      add(source, "scenario-membership-mismatch");
+    }
+    const code = exitCode(status.exitCode);
+    const timedOut = typeof status.timedOut === "boolean" ? status.timedOut : null;
+    const timeoutOutcome = timeoutOutcomes.has(status.timeoutOutcome)
+      ? status.timeoutOutcome
+      : null;
+    if (code === null || timedOut === null || timeoutOutcome === null) {
+      add(source, "invalid-outcome");
+    }
+    if (timedOut !== null && timeoutOutcome !== null && timedOut !== (timeoutOutcome !== "none")) {
+      add(source, "timeout-outcome-mismatch");
+    }
+    const completedAt = timestamp(status.completedAt);
+    if (!completedAt) {
+      add(source, "invalid-completion-time");
+    }
+    shards.push({
+      id,
+      source,
+      exitCode: code,
+      timedOut,
+      timeoutOutcome,
+      completedAt,
+    });
+  }
+  const expectedIds = [...planned.keys()].toSorted(compareText);
+  const knownTimeouts =
+    shards.length === expectedIds.length &&
+    expectedIds.every((id) => statusCounts.get(id) === 1) &&
+    shards.every((shard) => shard.timedOut !== null);
+  const timedOut = shards.some((shard) => shard.timedOut === true)
+    ? true
+    : knownTimeouts
+      ? false
+      : null;
+  const result = {
+    target: { sha: env.TARGET_SHA, protocolBaseSha: env.PROTOCOL_BASE_SHA },
+    profile: env.QA_PROFILE,
+    run: { id: env.GITHUB_RUN_ID, attempt: Number(env.GITHUB_RUN_ATTEMPT) },
+    shards,
+    // Only the existing aggregate step owns this exit code. Missing output stays unknown.
+    exitCode: /^(0|[1-9][0-9]{0,2})$/u.test(env.QA_EXIT_CODE ?? "")
+      ? exitCode(Number(env.QA_EXIT_CODE))
+      : null,
+    timedOut,
+    timeoutOutcome: shards.some((shard) => shard.timeoutOutcome === "kill")
+      ? "kill"
+      : shards.some((shard) => shard.timeoutOutcome === "term")
+        ? "term"
+        : timedOut === false
+          ? "none"
+          : null,
+    completedAt:
+      shards
+        .map((shard) => shard.completedAt)
+        .filter(Boolean)
+        .toSorted(compareText)
+        .at(-1) ?? null,
+    diagnostics: {
+      stages: Object.fromEntries(
+        ["SHARD_JOB_OUTCOME", "DOWNLOAD_OUTCOME", "AGGREGATE_OUTCOME", "FINALIZE_OUTCOME"].map(
+          (key) => [key, outcomes.has(env[key]) ? env[key] : "unknown"],
+        ),
+      ),
+      expectedShards: expectedIds,
+      statusFiles,
+      evidenceFiles,
+      missingStatuses: expectedIds.filter((id) => !statusCounts.has(id)),
+      missingEvidence: expectedIds.filter((id) => !evidenceIds.has(id)),
+      duplicateStatuses: expectedIds.filter((id) => statusCounts.get(id) > 1),
+      issues: diagnostics,
+    },
+  };
+  fs.mkdirSync(env.OUTPUT_DIR, { recursive: true });
+  const fd = fs.openSync(
+    path.join(env.OUTPUT_DIR, "qa-profile-run-status.json"),
+    fs.constants.O_WRONLY |
+      fs.constants.O_CREAT |
+      fs.constants.O_TRUNC |
+      (fs.constants.O_NOFOLLOW ?? 0),
+    0o644,
+  );
+  try {
+    fs.writeFileSync(fd, `${JSON.stringify(result, null, 2)}\n`);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+try {
+  collect();
+} catch {
+  // Raw parser/filesystem errors can contain downloaded names or payloads.
+  console.error("::warning::QA profile diagnostics could not be retained.");
+  console.error("[qa-profile-run-status] FAILED (exit 1)");
+  process.exitCode = 1;
+}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -16581,6 +16581,9 @@ fi
     expect(aggregateStep.run).toContain("Timed-out QA shard cannot contribute partial evidence");
     expect(aggregateStep.run).toContain("-mindepth 2 -maxdepth 2");
     expect(aggregateStep.run).toContain("aggregateQaProfileEvidenceShards");
+    expect(aggregateStep.run).toContain(
+      `jq -s --argjson exitCode "$qa_exit_code" 'map(.shard + {})' "\${status_paths[@]}" >/dev/null`,
+    );
     expect(aggregateStep.run).toContain("if jq -e '.timedOut == true'");
     expect(aggregateStep.env?.OUTPUT_DIR).toContain(
       "${{ github.workspace }}/selected/.artifacts/qa-e2e/",
@@ -16589,6 +16592,48 @@ fi
       (step: WorkflowStep) => step.name === "Upload QA profile evidence",
     );
     expect(aggregateUploadStep.with?.path).toBe("${{ steps.aggregate.outputs.output_dir }}");
+
+    const diagnosticStep = qaAggregateJob.steps.find(
+      (step: WorkflowStep) => step.name === "Collect QA profile diagnostics",
+    );
+    expect(diagnosticStep.if).toBe("always()");
+    expect(diagnosticStep["continue-on-error"]).toBe(true);
+    expect(diagnosticStep).not.toHaveProperty("working-directory");
+    expect(diagnosticStep.run).toContain('test "$(git rev-parse HEAD)" = "$EXPECTED_WORKFLOW_SHA"');
+    expect(diagnosticStep.run).toContain("node scripts/qa/qa-profile-run-status.mjs");
+    expect(diagnosticStep.env.EXPECTED_WORKFLOW_SHA).toBe(
+      "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+    );
+    expect(diagnosticStep.env.PLAN_MATRIX_JSON).toBe("${{ needs.plan_qa_profile.outputs.matrix }}");
+    expect(diagnosticStep.env.QA_EXIT_CODE).toBe("${{ steps.aggregate.outputs.qa_exit_code }}");
+    expect(diagnosticStep.env.FINALIZE_OUTCOME).toBe("${{ steps.evidence.outcome }}");
+    const diagnosticUpload = qaAggregateJob.steps.find(
+      (step: WorkflowStep) => step.name === "Upload QA profile diagnostics",
+    );
+    expect(diagnosticUpload.if).toBe("always()");
+    expect(diagnosticUpload["continue-on-error"]).toBe(true);
+    expect(diagnosticUpload.with.name).toBe(
+      "qa-profile-diagnostics-${{ needs.plan_qa_profile.outputs.profile }}-${{ needs.validate_selected_ref.outputs.selected_revision }}-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+    expect(diagnosticUpload.with.name).not.toMatch(/^qa-profile-evidence-/u);
+    expect(diagnosticUpload.with.path).toBe(
+      `${diagnosticStep.env.OUTPUT_DIR}/qa-profile-run-status.json`,
+    );
+    expect(diagnosticUpload.with["if-no-files-found"]).toBe("warn");
+    const finalizerIndex = qaAggregateJob.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Finalize QA profile evidence",
+    );
+    expect(qaAggregateJob.steps.indexOf(diagnosticStep)).toBeGreaterThan(finalizerIndex);
+    expect(qaAggregateJob.steps.indexOf(diagnosticUpload)).toBeLessThan(
+      qaAggregateJob.steps.indexOf(aggregateUploadStep),
+    );
+    expect(JSON.stringify(qaAggregateJob.outputs)).not.toContain("diagnostics");
+    const diagnosticWarning = qaAggregateJob.steps.find(
+      (step: WorkflowStep) => step.name === "Warn if QA profile diagnostics were not retained",
+    );
+    expect(diagnosticWarning.if).toBe(
+      "always() && (steps.collect_diagnostics.outcome == 'failure' || steps.upload_diagnostics.outcome == 'failure')",
+    );
 
     const failProfileStep = qaAggregateJob.steps.find(
       (step: WorkflowStep) => step.name === "Fail if QA profile failed",

--- a/test/scripts/qa-profile-run-status.test.ts
+++ b/test/scripts/qa-profile-run-status.test.ts
@@ -1,0 +1,372 @@
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const collectorPath = path.join(repoRoot, "scripts/qa/qa-profile-run-status.mjs");
+const workflow = parse(
+  readFileSync(path.join(repoRoot, ".github/workflows/qa-profile-evidence.yml"), "utf8"),
+);
+const aggregateScript = workflow.jobs.aggregate_qa_profile.steps.find(
+  (step: { name: string }) => step.name === "Aggregate validated shard evidence",
+).run as string;
+const finalGateScript = workflow.jobs.aggregate_qa_profile.steps.find(
+  (step: { name: string }) => step.name === "Fail if QA profile failed",
+).run as string;
+const targetSha = "a".repeat(40);
+const protocolSha = "b".repeat(40);
+const plan = {
+  include: [
+    { id: "shard-01", categoryIds: ["fixture.one"], scenarioIds: ["scenario-one"] },
+    { id: "shard-02", categoryIds: ["fixture.two"], scenarioIds: ["scenario-two"] },
+  ],
+};
+
+function fixture() {
+  const root = tempDirs.make("openclaw-qa-profile-status-");
+  const selected = path.join(root, "selected");
+  mkdirSync(selected);
+  const input = path.join(selected, ".artifacts/qa-profile-shards");
+  const output = path.join(selected, ".artifacts/qa-e2e/profile-all-42-1");
+  const env = {
+    PATH: process.env.PATH ?? "",
+    INPUT_DIR: input,
+    OUTPUT_DIR: output,
+    PLAN_MATRIX_JSON: JSON.stringify(plan),
+    QA_PROFILE: "all",
+    TARGET_SHA: targetSha,
+    PROTOCOL_BASE_SHA: protocolSha,
+    GITHUB_RUN_ID: "42",
+    GITHUB_RUN_ATTEMPT: "1",
+    SHARD_COUNT: "2",
+    GITHUB_OUTPUT: path.join(root, "github-output"),
+    QA_EXIT_CODE: "",
+    SHARD_JOB_OUTCOME: "failure",
+    DOWNLOAD_OUTCOME: "success",
+    AGGREGATE_OUTCOME: "failure",
+    FINALIZE_OUTCOME: "skipped",
+  };
+  const status = (index = 0) => ({
+    target: { sha: targetSha, protocolBaseSha: protocolSha },
+    profile: "all",
+    shard: plan.include[index],
+    run: { id: "42", attempt: 1 },
+    exitCode: 0,
+    timedOut: false,
+    timeoutOutcome: "none",
+    completedAt: "2026-09-10T00:00:00.000Z",
+  });
+  const writeShard = (index = 0, payload: unknown = status(index), artifactSha = targetSha) => {
+    const directory = path.join(
+      input,
+      `qa-profile-evidence-shard-${plan.include[index]!.id}-${artifactSha}`,
+    );
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, "qa-evidence.json"), '{"fixture":"unchanged"}\n');
+    const statusPath = path.join(directory, "qa-profile-run-status.json");
+    writeFileSync(
+      statusPath,
+      typeof payload === "string" ? payload : `${JSON.stringify(payload)}\n`,
+    );
+    return statusPath;
+  };
+  const collect = (overrides: Partial<typeof env> = {}) => {
+    const run = spawnSync(process.execPath, [collectorPath], {
+      cwd: root,
+      env: { ...env, ...overrides },
+      encoding: "utf8",
+    });
+    expect(run.status, run.stderr).toBe(0);
+    const text = readFileSync(path.join(output, "qa-profile-run-status.json"), "utf8");
+    return { text, result: JSON.parse(text) };
+  };
+  return { root, selected, input, output, env, status, writeShard, collect };
+}
+
+describe("QA profile failure diagnostics", () => {
+  it.skipIf(process.platform === "win32").each(["missing", "timeout"])(
+    "retains status after the actual aggregate shell rejects %s evidence",
+    (failure) => {
+      const f = fixture();
+      const first = f.writeShard();
+      const original = readFileSync(first);
+      if (failure === "timeout") {
+        f.writeShard(1, { ...f.status(1), exitCode: 124, timedOut: true, timeoutOutcome: "term" });
+      }
+      const aggregate = spawnSync("bash", ["-c", aggregateScript], {
+        cwd: f.selected,
+        env: f.env,
+        encoding: "utf8",
+      });
+      expect(aggregate.status).toBe(1);
+      expect(aggregate.stderr).toContain(
+        failure === "missing"
+          ? "Expected 2 completed status and evidence files"
+          : "Timed-out QA shard",
+      );
+      const { result } = f.collect();
+      expect(result.exitCode).toBeNull();
+      expect(result.diagnostics.stages.AGGREGATE_OUTCOME).toBe("failure");
+      expect(result.diagnostics.missingStatuses).toEqual(failure === "missing" ? ["shard-02"] : []);
+      expect(result.timedOut).toBe(failure === "timeout" ? true : null);
+      expect(readFileSync(first)).toEqual(original);
+      expect(readdirSync(f.output)).toEqual(["qa-profile-run-status.json"]);
+    },
+  );
+
+  it("retains unknown outcomes when no download directory exists", () => {
+    const { result } = fixture().collect({
+      DOWNLOAD_OUTCOME: "failure",
+      AGGREGATE_OUTCOME: "skipped",
+    });
+    expect(result).toMatchObject({
+      exitCode: null,
+      timedOut: null,
+      timeoutOutcome: null,
+      shards: [],
+    });
+    expect(result.diagnostics).toMatchObject({
+      missingStatuses: ["shard-01", "shard-02"],
+      missingEvidence: ["shard-01", "shard-02"],
+      issues: [{ source: null, reason: "input-unavailable" }],
+    });
+  });
+
+  it("retains other shard diagnostics when an ID cannot be coerced to a string", () => {
+    const f = fixture();
+    f.writeShard(0, { ...f.status(), shard: { ...plan.include[0], id: { toString: null } } });
+    f.writeShard(1);
+    const { result } = f.collect();
+    expect(result.shards.map((shard: { id: string | null }) => shard.id)).toEqual([
+      null,
+      "shard-02",
+    ]);
+    expect(result.diagnostics.missingStatuses).toEqual(["shard-01"]);
+    expect(result.diagnostics.issues).toContainEqual({
+      source: "artifact-001",
+      reason: "unexpected-shard",
+    });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses to execute diagnostics from an unfrozen harness",
+    () => {
+      const f = fixture();
+      const script = workflow.jobs.aggregate_qa_profile.steps.find(
+        (step: { name: string }) => step.name === "Collect QA profile diagnostics",
+      ).run;
+      const head = spawnSync("git", ["rev-parse", "HEAD"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).stdout.trim();
+      for (const expected of ["", "not-a-sha", "f".repeat(40), head]) {
+        const run = spawnSync("bash", ["-c", script], {
+          cwd: repoRoot,
+          env: { ...f.env, EXPECTED_WORKFLOW_SHA: expected },
+          encoding: "utf8",
+        });
+        expect(run.status, run.stderr).toBe(expected === head ? 0 : 1);
+        expect(existsSync(path.join(f.output, "qa-profile-run-status.json"))).toBe(
+          expected === head,
+        );
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each([null, {}, [], "invalid", 1, true])(
+    "preserves the previous jq admission for shard shape %#",
+    (shard) => {
+      const f = fixture();
+      const statusPath = f.writeShard(0, { ...f.status(), shard });
+      const admission = aggregateScript
+        .split("\n")
+        .find((line) => line.includes("map(.shard + {})"));
+      expect(admission).toBeDefined();
+      for (const code of ["0", "1", "oops"]) {
+        const env = { ...f.env, qa_exit_code: code, STATUS_PATH: statusPath };
+        const prior = spawnSync(
+          "jq",
+          [
+            "-s",
+            "--argjson",
+            "exitCode",
+            code,
+            "map(.shard + {exitCode, timedOut, timeoutOutcome, completedAt})",
+            statusPath,
+          ],
+          { env, encoding: "utf8" },
+        );
+        const current = spawnSync("bash", ["-c", `status_paths=("$STATUS_PATH")\n${admission}`], {
+          env,
+          encoding: "utf8",
+        });
+        expect(current.status).toBe(prior.status);
+        expect(current.status === 0).toBe(
+          code !== "oops" &&
+            (shard === null || (!Array.isArray(shard) && typeof shard === "object")),
+        );
+      }
+    },
+  );
+
+  it.each([
+    [0, false, "none"],
+    [1, false, "none"],
+    [124, false, "none"],
+    [137, false, "none"],
+    [124, true, "term"],
+    [137, true, "kill"],
+  ])(
+    "preserves exit %i and supervised timeout %s/%s independently",
+    (code, timedOut, timeoutOutcome) => {
+      const f = fixture();
+      f.writeShard(0, { ...f.status(), exitCode: code, timedOut, timeoutOutcome });
+      f.writeShard(1);
+      const { result } = f.collect({
+        QA_EXIT_CODE: String(code),
+        AGGREGATE_OUTCOME: "success",
+        FINALIZE_OUTCOME: "success",
+      });
+      expect(result).toMatchObject({ exitCode: code, timedOut, timeoutOutcome });
+      expect(result.shards[0]).toMatchObject({ exitCode: code, timedOut, timeoutOutcome });
+      expect(result.diagnostics.issues).toEqual([]);
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each(["0", "1", "124", "137"])(
+    "does not change the existing allow_failures decision for exit %s",
+    (code) => {
+      for (const allowFailures of ["false", "true"]) {
+        const f = fixture();
+        f.writeShard();
+        f.writeShard(1);
+        f.collect({ QA_EXIT_CODE: code });
+        const gate = spawnSync("bash", ["-c", finalGateScript], {
+          env: { ...f.env, QA_EXIT_CODE: code, ALLOW_FAILURES: allowFailures },
+          encoding: "utf8",
+        });
+        expect(gate.status).toBe(allowFailures === "true" ? 0 : Number(code));
+      }
+    },
+  );
+
+  it.each(["{", "null", "[]", "x".repeat(65 * 1024)])(
+    "bounds malformed status input %#",
+    (payload) => {
+      const f = fixture();
+      const source = f.writeShard(0, payload);
+      const original = readFileSync(source);
+      const { result } = f.collect();
+      expect(result.shards).toEqual([]);
+      expect(result.diagnostics.issues[0].reason).toBe(
+        payload.length > 64 * 1024 ? "status-size-limit" : "missing-or-malformed-status",
+      );
+      expect(readFileSync(source)).toEqual(original);
+    },
+  );
+
+  it("reports duplicate, unexpected, identity and membership diagnostics without leaking payloads", () => {
+    const f = fixture();
+    const privateText = "private-payload-sentinel:/operator/home?token=secret";
+    f.writeShard();
+    f.writeShard(0, f.status(), "c".repeat(40));
+    f.writeShard(1, {
+      ...f.status(1),
+      profile: privateText,
+      target: { sha: "d".repeat(40), protocolBaseSha: "e".repeat(40), ref: privateText },
+      run: { id: "43", attempt: 2 },
+      shard: { id: "shard-99", categoryIds: [privateText], scenarioIds: [{ toString: null }] },
+      stderr: privateText,
+      exitCode: privateText,
+      timedOut: privateText,
+      timeoutOutcome: privateText,
+      completedAt: privateText,
+    });
+    const { text, result } = f.collect();
+    expect(text).not.toContain(privateText);
+    expect(text).not.toContain(f.root);
+    expect(result.target).toEqual({ sha: targetSha, protocolBaseSha: protocolSha });
+    expect(result.diagnostics.duplicateStatuses).toEqual(["shard-01"]);
+    expect(result.diagnostics.missingStatuses).toEqual(["shard-02"]);
+    expect(result.diagnostics.issues.map((issue: { reason: string }) => issue.reason)).toEqual(
+      expect.arrayContaining([
+        "artifact-sha-mismatch",
+        "unexpected-shard",
+        "artifact-shard-mismatch",
+        "profile-mismatch",
+        "target-sha-mismatch",
+        "protocol-sha-mismatch",
+        "run-id-mismatch",
+        "run-attempt-mismatch",
+        "category-membership-mismatch",
+        "scenario-membership-mismatch",
+        "invalid-outcome",
+        "invalid-completion-time",
+      ]),
+    );
+  });
+
+  it("records missing evidence and finalizer failure without rewriting the aggregate exit", () => {
+    const f = fixture();
+    const directory = path.join(f.input, `qa-profile-evidence-shard-shard-01-${targetSha}`);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, "qa-profile-run-status.json"), JSON.stringify(f.status()));
+    const { result } = f.collect({
+      QA_EXIT_CODE: "0",
+      AGGREGATE_OUTCOME: "success",
+      FINALIZE_OUTCOME: "failure",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.diagnostics.stages.FINALIZE_OUTCOME).toBe("failure");
+    expect(result.diagnostics.missingEvidence).toEqual(["shard-01", "shard-02"]);
+    expect(result).not.toHaveProperty("qaPassed");
+  });
+
+  it("bounds the artifact inventory and produces deterministic output", () => {
+    const f = fixture();
+    for (let index = 0; index < 129; index += 1) {
+      mkdirSync(path.join(f.input, String(index)), { recursive: true });
+    }
+    const first = f.collect();
+    const second = f.collect();
+    expect(first.text).toBe(second.text);
+    expect(first.result.shards).toEqual([]);
+    expect(first.result.diagnostics.issues).toEqual([{ source: null, reason: "artifact-limit" }]);
+    expect(Buffer.byteLength(first.text)).toBeLessThan(2048);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "cannot be consumed as qualified maturity evidence",
+    () => {
+      const f = fixture();
+      f.collect();
+      const consumerDirectory = path.join(f.root, ".artifacts/maturity-evidence");
+      mkdirSync(consumerDirectory, { recursive: true });
+      copyFileSync(
+        path.join(f.output, "qa-profile-run-status.json"),
+        path.join(consumerDirectory, "qa-profile-run-status.json"),
+      );
+      const consumer = parse(
+        readFileSync(path.join(repoRoot, ".github/workflows/maturity-scorecard.yml"), "utf8"),
+      );
+      const script = consumer.jobs.publish.steps.find(
+        (step: { name: string }) => step.name === "Require one QA evidence file",
+      ).run;
+      const run = spawnSync("bash", ["-c", script], { cwd: f.root, env: f.env, encoding: "utf8" });
+      expect(run.status).toBe(1);
+      expect(run.stderr).toContain("Expected exactly one aggregate QA evidence manifest, found 0");
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

QA profile aggregation rejects missing or timed-out shards before writing aggregate status, leaving operators without the diagnostics needed to investigate the failure.

## Why This Change Was Made

A dependency-free collector runs from the frozen trusted harness after aggregation and finalization, including their failure paths. It publishes bounded, sanitized diagnostics in a separate artifact and reports collection/upload failures as warnings. Existing aggregate admission, plan attestation, finalization, qualification uploads and `allow_failures` decisions remain authoritative.

The collector now handles both layouts produced by the pinned `actions/download-artifact`: one matching artifact extracted directly at the input root, or multiple artifacts in named directories. A flat root is one artifact, including its suite reports and execution folders. Both layouts use the same bounded parser; flat shard identity comes from the validated status and planned shard IDs, without inventing artifact-name provenance.

## User Impact

Operators retain surviving shard exit, timeout and completion details while absent planned shards remain missing. Diagnostics cover malformed, duplicate, unexpected and identity-mismatched input without exposing downloaded names or free-form payload text. Unknown aggregate exits remain unknown.

The separate `qa-profile-diagnostics-<profile>-<sha>-<run>-<attempt>` artifact contains only `qa-profile-run-status.json`; it cannot qualify a run.

## Evidence

Current signed repair: `0d08f82fb020f57d42ef156c2b16f1da8a1dcda5` (parent `1c1b362288758358241894d12e2fa2b3b1613cc8`).

The parent contains the flat-layout repair. This child only uses `Set.has` for fixed diagnostic filename membership; the exact patch passed targeted lint and all 37 collector tests, and fresh exact-head autoreview found no actionable P0-P2 findings.

- Actual regression before repair: a directly extracted surviving shard produced an empty shard list. Strengthened fixtures also exposed nested payload files being misclassified as artifacts, inflating the evidence count and adding spurious issues.
- `node scripts/run-vitest.mjs test/scripts/qa-profile-run-status.test.ts`: **37 passed** on the final committed content. Coverage includes one survivor of two planned shards, a single planned shard, normal report/execution payloads, unplanned IDs, symlinks, malformed/oversized inputs, input-byte preservation, named-directory behavior and rejection of diagnostics-only qualification.
- Targeted formatting, collector syntax and `git diff --check` passed. Independent source review and fresh exact-commit autoreview found no actionable P0-P2 findings. Normal signing hooks passed and committed blobs match the tested content.
- The flat-layout correction adds 8 net production lines (+16/-8), supporting the dependency extraction contract through the existing parser; tests changed +127/-19.
- Historical evidence at **831712** remains retained: 39 focused tests, 22 controlled workflow-shell cases, remote targeted checks and successful exact-head hosted CI/native preparation. It does **not** establish new-head CI or cover the subsequently discovered flat-layout defect.

New-head hosted checks and ClawSweeper review are separate landing gates. No live QA profile or full release qualification is claimed.

## Follow-up: single-artifact qualification discovery

`.github/workflows/qa-profile-evidence.yml:933-934` still searches only depth two for qualification inputs. This behavior predates this PR and remains unchanged. Handle the flat download layout in a separate qualification-owner change with its own aggregate, attestation and finalizer coverage; this diagnostic repair does not relax those gates.

<!-- Punchcard-Session: clear-meadow-meadow-4g -->
