### PR TITLE
refactor(terminal): remove unused stream writer reset

### DIFF
--- a/packages/terminal-core/src/stream-writer.test.ts
+++ b/packages/terminal-core/src/stream-writer.test.ts
@@ -80,38 +80,6 @@ describe("createSafeStreamWriter", () => {
     }
   });
 
-  it("keeps a callback reset effective through a reentrant successful write", () => {
-    const failure = Object.assign(new Error("closed pipe"), { code: "EPIPE" });
-    let notifications = 0;
-    let recoveredResult: boolean | undefined;
-    const writer = createSafeStreamWriter({
-      onBrokenPipe: () => {
-        notifications += 1;
-        if (notifications === 1) {
-          writer.reset();
-          recoveredResult = writer.write(process.stdout, "recovered");
-        }
-      },
-    });
-    const write = vi.spyOn(process.stdout, "write").mockImplementation((text) => {
-      if (text === "recovered") {
-        return true;
-      }
-      throw failure;
-    });
-    try {
-      expect(writer.write(process.stdout, "first")).toBe(false);
-      expect(recoveredResult).toBe(true);
-      expect(writer.isClosed()).toBe(false);
-      expect(writer.write(process.stdout, "retry")).toBe(false);
-      expect(writer.isClosed()).toBe(true);
-      expect(notifications).toBe(2);
-      expect(write.mock.calls.map(([text]) => text)).toEqual(["first", "recovered", "retry"]);
-    } finally {
-      write.mockRestore();
-    }
-  });
-
   it("keeps the output closed when the notification callback throws", () => {
     const failure = Object.assign(new Error("closed pipe"), { code: "EPIPE" });
     const callbackError = new Error("notification failed");

--- a/packages/terminal-core/src/stream-writer.ts
+++ b/packages/terminal-core/src/stream-writer.ts
@@ -10,7 +10,6 @@ export type SafeStreamWriterOptions = {
 export type SafeStreamWriter = {
   write: (stream: NodeJS.WriteStream, text: string) => boolean;
   writeLine: (stream: NodeJS.WriteStream, text: string) => boolean;
-  reset: () => void;
   isClosed: () => boolean;
 };
 
@@ -58,9 +57,6 @@ export function createSafeStreamWriter(options: SafeStreamWriterOptions = {}): S
   return {
     write,
     writeLine,
-    reset: () => {
-      closed = false;
-    },
     isClosed: () => closed,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of an unused reopening path in the internal terminal writer. Its only current caller was a test for reopening itself.

## Why This Change Was Made

Remove `reset` from the writer implementation and type, together with that test. Logs keeps its writer private and stops output when it closes. The other writer methods and callbacks retain their existing behavior.

The helper has shipped through internal package aliases, but no documented public SDK contract or known production consumer of `reset` was found. Those internal import paths remain available; this audit cannot rule out untracked external use.

## User Impact

No intended user-visible change. Removes four production lines and 32 test lines while preserving coverage of the used writer behavior.

## Evidence

All 39 existing writer and Logs CLI cases passed, including EPIPE/EIO closure, reentrant notification, throwing callbacks, output formatting, and pending-probe cancellation. All 28 canonical changed-file checks passed. Independent review found no actionable findings through P2.

No live Gateway or external plugin execution was used for this internal cleanup.
