### PR TITLE
docs(update): clarify automatic legacy status expiry

### DIFF
--- a/docs/cli/update/status-and-history.md
+++ b/docs/cli/update/status-and-history.md
@@ -50,14 +50,20 @@ includes `activeRun` when a run is active and `lastRun` when history exists.
 If history cannot be read or classified, status still shows update availability
 and runtime findings. Human output explains that run status is unavailable;
 JSON includes `runStatusError` and omits the run fields. This does not mean
-there are no active or past runs, and status does not repair the underlying state.
+there are no active or past runs, and status does not repair unreadable history.
+
+Status can reconcile an untouched, identityless legacy admission after more than
+24 hours if it remains at its initial `requested/in_progress` step and has no
+retained recovery descriptor. The row stays in history as `failed` with reason
+`legacy-driver-expired`, and status shows a retry advisory. Other history remains
+read-only.
 
 When the active row has been inactive for more than 30 minutes and its recorded
 driver is verifiably dead, status also reports `abandonedRun` with its `runId`
-and reconciliation `rule`. Status remains read-only: the stored row stays in
-`activeRun` until the Gateway or explicit repair commits the outcome.
-Identityless rows are never reconciled automatically, even when their only
-step is `requested/in_progress`. For stale identityless rows, JSON includes
+and reconciliation `rule`. For these rows, status remains read-only: the stored
+row stays in `activeRun` until the Gateway or explicit repair commits the outcome.
+Identityless rows outside the legacy-expiry shape are not reconciled automatically.
+For those stale identityless rows, JSON includes
 `staleRun` with `runId` and `guidance`; human status and Doctor preflight report
 "no activity since &lt;time&gt;; if no update is running, run `openclaw update repair`
 or start a new `openclaw update`".
@@ -127,8 +133,8 @@ remain protected, and automatic reconciliation stays disabled for that run.
 Heartbeat write errors warn once per driver run and do not interrupt a running
 build, install, or finalization phase.
 
-Historical rows without a driver identity require explicit `update repair` or
-a new operator-started `openclaw update`.
+Historical identityless rows outside the legacy-expiry shape require explicit
+`update repair` or a new operator-started `openclaw update`.
 An old `requested` row alone does not prove that its updater exited: the 2026.9.2
 updater can still be waiting on package-manager or registry preflight before it
 records its first staging step. Stop an unrecorded old updater before explicitly

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -202,6 +202,12 @@ from a chat shell; use the update action so restart and notification stay coordi
 
 ## Stale update history
 
+Untouched, identityless legacy admissions older than 24 hours can
+[expire automatically](/cli/update/status-and-history#run-history-and-reports)
+during Gateway startup or a status check. The row is retained as `failed` with
+reason `legacy-driver-expired` and retry advice; no explicit repair is needed
+for that shape.
+
 If update status stays in progress while the Gateway is healthy, check that no
 update is still running. On the updated installation, run:
 
@@ -214,8 +220,9 @@ For an inactive legacy row older than 30 minutes, repair verifies that the
 running Gateway matches the installed version and build, then clears the stale
 run without maintenance or a service restart. A new explicit `openclaw update`
 can also supersede a single stale identityless row. Recent rows and recorded
-live drivers are protected. Identityless rows are never cleared automatically;
-the Control UI's configuration-write suspension clears after reconciliation.
+live drivers are protected. Identityless rows outside the legacy-expiry shape
+require explicit recovery; the Control UI's configuration-write suspension clears
+after reconciliation.
 
 OpenClaw 2026.9.2 does not reject a new CLI update because an older running row
 exists: its [admission path](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-run.ts#L77)


### PR DESCRIPTION
## What Problem This Solves

The update status and installation guides still said status is always read-only and identityless update records always need manual repair. Current code already expires a narrow class of untouched legacy admissions after 24 hours, so those blanket statements gave operators conflicting guidance.

## Why This Change Was Made

Describe the existing exception and link the installation guide to its detailed conditions: an untouched identityless admission at its initial requested step, older than 24 hours, with no retained recovery descriptor. Preserve manual recovery guidance for other stale records.

## User Impact

Operators can distinguish records that can expire automatically from those requiring explicit recovery. This changes documentation only; update behavior and storage policy remain unchanged.

## Evidence

The 10-stage docs-only changed gate, canonical formatting, changed-page MDX, glossary and whitespace checks passed. Independent review found no actionable findings through P2. The canonical publishing parser resolves the new link.

The whole-doc anchor audit still reports three pre-existing `windows-app-node` references in generated maturity pages. Their source and parser are unchanged from the base, and the same parser confirms the baseline failures. External ClawHub fragments remain unverified without that source checkout. No runtime tests were needed for this wording correction.
