### PR TITLE
fix(sessions): preserve resolved model override identities

### DIFF
--- a/src/agents/model-selection-persisted.ts
+++ b/src/agents/model-selection-persisted.ts
@@ -1,6 +1,7 @@
 // Persisted model metadata normalization without loading the broader selection runtime.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_PROVIDER } from "./defaults.js";
+import type { ModelFallbackRouteResolution } from "./model-fallback.types.js";
 import type { ModelRef } from "./model-ref-shared.js";
 import { parseModelRef } from "./model-selection-normalize.js";
 
@@ -12,6 +13,7 @@ export function resolvePersistedOverrideModelRef(params: {
   defaultProvider?: unknown;
   overrideProvider?: unknown;
   overrideModel?: unknown;
+  routeResolution?: ModelFallbackRouteResolution;
   allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
@@ -20,6 +22,10 @@ export function resolvePersistedOverrideModelRef(params: {
   const overrideModel = normalizeOptionalString(params.overrideModel);
   if (!overrideModel) {
     return null;
+  }
+  if (params.routeResolution === "resolved") {
+    // The producer already selected this identity; parsing aliases again can select another model.
+    return { provider: overrideProvider ?? defaultProvider, model: overrideModel };
   }
   const encodedOverride = overrideProvider ? `${overrideProvider}/${overrideModel}` : overrideModel;
   return (
@@ -36,10 +42,11 @@ export function resolvePersistedOverrideModelRef(params: {
 export function normalizeStoredOverrideModel(params: {
   providerOverride?: unknown;
   modelOverride?: unknown;
+  routeResolution?: ModelFallbackRouteResolution;
 }): { providerOverride?: string; modelOverride?: string } {
   const providerOverride = normalizeOptionalString(params.providerOverride);
   const modelOverride = normalizeOptionalString(params.modelOverride);
-  if (!providerOverride || !modelOverride) {
+  if (!providerOverride || !modelOverride || params.routeResolution === "resolved") {
     return {
       providerOverride,
       modelOverride,

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
 import { findModelInCatalog } from "./model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import type { ModelFallbackRouteResolution } from "./model-fallback.types.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   type ModelManifestNormalizationContext,
@@ -136,6 +137,7 @@ export function resolvePersistedSelectedModelRef(params: {
   runtimeModel?: unknown;
   overrideProvider?: unknown;
   overrideModel?: unknown;
+  overrideRouteResolution?: ModelFallbackRouteResolution;
   allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef | null {
@@ -143,6 +145,7 @@ export function resolvePersistedSelectedModelRef(params: {
     defaultProvider: params.defaultProvider,
     overrideProvider: params.overrideProvider,
     overrideModel: params.overrideModel,
+    routeResolution: params.overrideRouteResolution,
     allowManifestNormalization: params.allowManifestNormalization,
     allowPluginNormalization: params.allowPluginNormalization,
   });

--- a/src/agents/session-model-ref.ts
+++ b/src/agents/session-model-ref.ts
@@ -1,5 +1,6 @@
 // Resolves persisted session model metadata without loading Gateway projections.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveSessionModelOverrideRouteResolution } from "../config/sessions/model-override-provenance.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
@@ -21,6 +22,8 @@ type SessionModelEntry =
       | "modelOverride"
       | "providerOverride"
       | "modelOverrideRouteResolution"
+      | "modelOverrideFallbackOriginProvider"
+      | "modelOverrideFallbackOriginModel"
     >;
 
 export function resolveSessionModelRef(
@@ -29,22 +32,19 @@ export function resolveSessionModelRef(
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
+  const overrideRouteResolution = resolveSessionModelOverrideRouteResolution(entry);
   const normalizedOverride = normalizeStoredOverrideModel({
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
+    routeResolution: overrideRouteResolution,
   });
   if (normalizedOverride.providerOverride && normalizedOverride.modelOverride) {
-    // Resolved overrides were canonicalized by their producer. Re-running plugin hooks here
-    // can cold-load provider runtime and transform the same persisted identity twice.
-    const allowPluginNormalization =
-      entry?.modelOverrideRouteResolution === "resolved"
-        ? false
-        : options?.allowPluginNormalization;
     return resolvePersistedSelectedModelRef({
       defaultProvider: normalizedOverride.providerOverride,
       overrideProvider: normalizedOverride.providerOverride,
       overrideModel: normalizedOverride.modelOverride,
-      allowPluginNormalization,
+      overrideRouteResolution,
+      allowPluginNormalization: options?.allowPluginNormalization,
     })!;
   }
   const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
@@ -72,6 +72,7 @@ export function resolveSessionModelRef(
     runtimeModel: agentId ? undefined : runtimeModel,
     overrideProvider: normalizedOverride.providerOverride,
     overrideModel: normalizedOverride.modelOverride,
+    overrideRouteResolution,
     allowPluginNormalization: options?.allowPluginNormalization,
   });
   return persisted ?? resolved;

--- a/src/gateway/session-utils-model.identity.test.ts
+++ b/src/gateway/session-utils-model.identity.test.ts
@@ -1,18 +1,125 @@
 import { afterEach, expect, test } from "vitest";
+import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import { resolveDirectStoredModelOverride } from "../sessions/stored-model-overrides.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { listSessionFixture } from "./session-list.test-support.js";
 import { getSessionDefaults, projectSessionPatchResult } from "./session-utils-model.js";
+import {
+  buildSessionListRowMetadataContext,
+  resolveSessionSelectedModelRef,
+} from "./session-utils-projection.js";
 import { buildGatewaySessionRow } from "./session-utils-row.js";
 
 afterEach(() => {
   resetConfigRuntimeState();
   resetPluginRuntimeStateForTest();
 });
+
+const identityConfig: OpenClawConfig = {
+  plugins: { enabled: false },
+  agents: { entries: { main: {} }, defaults: { model: "custom/default" } },
+};
+const identityMetadata = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "custom",
+      providers: ["custom"],
+      modelIdNormalization: {
+        providers: { custom: { aliases: { latest: "middle", middle: "final" } } },
+      },
+    },
+  ],
+});
+
+function writtenModelOverride(model: string): SessionEntry {
+  const entry: SessionEntry = { sessionId: "written-model", updatedAt: 1 };
+  applyModelOverrideToSessionEntry({ entry, selection: { provider: "custom", model } });
+  return structuredClone(entry);
+}
+
+async function withIdentityScope(run: () => void): Promise<void> {
+  await withStateDirEnv("session-override-identity-", async () =>
+    withPluginRuntimeGenerationScope({ metadataSnapshot: identityMetadata }, run),
+  );
+}
+
+test.each(["custom/model", "middle"])(
+  "preserves writer-resolved model %s across readers",
+  async (model) => {
+    await withIdentityScope(() => {
+      const entry = writtenModelOverride(model);
+      const original = structuredClone(entry);
+      expect(entry.modelOverrideRouteResolution).toBe("resolved");
+      expect
+        .soft(
+          resolveDirectStoredModelOverride({
+            sessionEntry: entry,
+            defaultProvider: "custom",
+            allowPluginNormalization: false,
+          }),
+        )
+        .toMatchObject({ provider: "custom", model, routeResolution: "resolved" });
+      expect
+        .soft(
+          resolveSessionModelRef(identityConfig, entry, "main", {
+            allowPluginNormalization: false,
+          }),
+        )
+        .toEqual({ provider: "custom", model });
+      expect
+        .soft(
+          resolveSessionSelectedModelRef({
+            cfg: identityConfig,
+            agentId: "main",
+            source: { entry, loadSessionEntry: () => undefined },
+            allowPluginNormalization: false,
+          }),
+        )
+        .toEqual({ provider: "custom", model, storedOverrideSource: "session" });
+      expect(entry).toEqual(original);
+    });
+  },
+);
+
+test.each([false, true])(
+  "separates cached raw and resolved selections (resolved first=%s)",
+  async (resolvedFirst) => {
+    await withIdentityScope(() => {
+      const resolved = { entry: writtenModelOverride("middle"), model: "middle" };
+      const raw = {
+        entry: {
+          sessionId: "raw-model",
+          updatedAt: 1,
+          providerOverride: "custom",
+          modelOverride: "latest",
+        },
+        model: "final",
+      };
+      const rowContext = buildSessionListRowMetadataContext({ now: 1 });
+      for (const { entry, model } of resolvedFirst ? [resolved, raw] : [raw, resolved]) {
+        expect
+          .soft(
+            resolveSessionSelectedModelRef({
+              cfg: identityConfig,
+              agentId: "main",
+              source: { entry, loadSessionEntry: () => undefined },
+              rowContext,
+              allowPluginNormalization: false,
+            }),
+          )
+          .toEqual({ provider: "custom", model, storedOverrideSource: "session" });
+      }
+    });
+  },
+);
 
 test.each([
   { provider: "demo-cli", model: "shared-model", expectedProvider: "demo-provider" },

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -1,7 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { readSessionRuntimeOwnership } from "../agents/harness/session-runtime-ownership.js";
-import { normalizeStoredOverrideModel } from "../agents/model-selection.js";
 import {
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
@@ -82,10 +81,6 @@ export function resolveSessionSelectedModelRef(params: {
           : {}),
       }
     : undefined;
-  const override = normalizeStoredOverrideModel({
-    providerOverride: selectedEntry?.providerOverride,
-    modelOverride: selectedEntry?.modelOverride,
-  });
   if (!params.rowContext) {
     return {
       ...resolveSessionModelRef(params.cfg, selectedEntry, params.agentId, {
@@ -96,8 +91,9 @@ export function resolveSessionSelectedModelRef(params: {
   }
   const key = [
     normalizeAgentId(params.agentId),
-    override.providerOverride ?? "",
-    override.modelOverride ?? "",
+    selectedEntry?.providerOverride ?? "",
+    selectedEntry?.modelOverride ?? "",
+    storedOverride?.routeResolution ?? "",
   ].join("\0");
   const cached = params.rowContext.selectedModelByOverrideRef.get(key);
   if (cached) {

--- a/src/sessions/stored-model-overrides.ts
+++ b/src/sessions/stored-model-overrides.ts
@@ -29,19 +29,18 @@ function resolveStoredOverrideFromEntry(params: {
   if (params.entry?.modelOverrideSource === "default") {
     return null;
   }
+  const routeResolution = resolveSessionModelOverrideRouteResolution(params.entry);
   const normalized = normalizeStoredOverrideModel({
     providerOverride: params.entry?.providerOverride,
     modelOverride: params.entry?.modelOverride,
+    routeResolution,
   });
-  const routeResolution = resolveSessionModelOverrideRouteResolution(params.entry);
   const ref = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
     overrideProvider: normalized.providerOverride,
     overrideModel: normalized.modelOverride,
-    // Resolved overrides are already canonical. Re-running provider normalization
-    // can rewrite their persisted identity while projecting a detail row.
-    allowPluginNormalization:
-      routeResolution === "resolved" ? false : params.allowPluginNormalization,
+    routeResolution,
+    allowPluginNormalization: params.allowPluginNormalization,
   });
   return ref
     ? {


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

The session model-override writer records an exact selected model ID and marks it resolved. Readers then strip a provider prefix and parse aliases again before checking that provenance, turning a stored `custom/model` into `model` or advancing a selected alias target. Gateway row caches also conflate raw and resolved overrides, making the result depend on row order.

## Why This Change Was Made

Pass existing route provenance through the persisted model readers and preserve IDs already selected by the writer. Reuse the existing provenance owner, including legacy automatic-fallback provenance. Key the in-memory Gateway projection cache by the original override fields and resolution state. This changes five production files by six net lines and adds no persistent field or schema.

## User Impact

Resolved session overrides retain the selected model through direct reads, agent-scoped selection, and Gateway row projection. Raw legacy parsing, default resets, parent inheritance, and automatic-fallback exclusion retain their existing behavior. Reply-selection integration remains a separate small cut.

## Evidence

Four intended writer-to-reader/cache regressions failed against unchanged production. Applying only the reader repair left both cache-order cases failing, proving the cache distinction is necessary. The complete repair passed 192 tests across five suites, fresh managed P2 review, and the full changed-file gate.

At exact commit `c6bf573fbcf0b5ed7485a3718f99d43e2a222caf`, one canonical `sourcePerformance` build and all eight compiled behavior cases passed. The real writer, direct/session readers, and exported Gateway row builder preserved resolved prefix and alias-like IDs, legacy provenance, raw controls, both cache orders with repeat hits, and runtime-versus-agent selection. All 12,179 inventoried build files remained unchanged; source and other-checkout import denial controls passed; owned processes and state were cleaned up.

This is synthetic compiled component-boundary proof, without external-provider or live Gateway traffic. The runtime build excludes UI and SDK declarations. Initial artifact discovery found the projection helper was internal, so the probe used its real exported row-builder caller; no production seam or rebuild was added.
