### PR TITLE
fix(maturity): bind evidence to semantic taxonomy identity

### DIFF
--- a/extensions/qa-lab/src/cli-scenario-selection.test.ts
+++ b/extensions/qa-lab/src/cli-scenario-selection.test.ts
@@ -17,7 +17,10 @@ vi.mock("./cli.runtime.js", () => ({
 
 import { registerQaLabCli } from "./cli.js";
 import { resolveQaRunProfileMembership } from "./profile-planning.js";
-import type { QaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
+import {
+  qaMaturityTaxonomyIdentity,
+  type QaScorecardTaxonomyReport,
+} from "./scorecard-taxonomy.js";
 import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 
@@ -60,7 +63,16 @@ describe.each(["suite", "profile"] as const)("%s scenario selection", (lane) => 
           const scorecardReport = {
             taxonomyPath: "taxonomy.yaml",
             title: "Selection fixture",
-            taxonomy: { sourcePath: "taxonomy.yaml" },
+            taxonomy: {
+              sourcePath: "taxonomy.yaml",
+              identity: qaMaturityTaxonomyIdentity({
+                version: 1,
+                title: "Selection fixture",
+                profiles: [],
+                levels: [],
+                surfaces: [],
+              }),
+            },
             profileCount: 1,
             profiles: [
               {

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { isCrablineServerChannel, OPENCLAW_CRABLINE_DEFAULT_CHANNEL } from "@openclaw/crabline";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaScenarioById, type QaScenarioPack } from "./scenario-catalog.js";
+import * as taxonomyModule from "./scorecard-taxonomy.js";
 
 const {
   runQaManualLane,
@@ -905,160 +906,177 @@ describe("qa cli runtime", () => {
     expect(runQaSuite).not.toHaveBeenCalled();
   });
 
-  it("dispatches a taxonomy-backed profile category through the suite runner", async () => {
-    const previousProfile = process.env.OPENCLAW_QA_PROFILE;
-    process.env.OPENCLAW_QA_PROFILE = "release";
-    try {
-      runQaSuite.mockImplementationOnce(async (params) => {
-        expect(process.env.OPENCLAW_QA_PROFILE).toBe("smoke-ci");
-        await fs.writeFile(
-          suiteEvidencePath,
-          JSON.stringify(
-            makeQaEvidence([
-              {
-                test: {
-                  kind: "qa-scenario",
-                  id: "telegram-commands-command",
-                  title: "Telegram commands list reply",
-                  source: {
-                    path: "qa/scenarios/channels/telegram-commands-command.yaml",
-                  },
-                },
-                coverage: [
-                  {
-                    id: "telegram.built-in-commands",
-                    role: "primary",
-                  },
-                ],
-                execution: {
-                  runner: "host",
-                  environment: {
-                    ref: null,
-                    os: process.platform,
-                    nodeVersion: process.version,
-                  },
-                  provider: {
-                    id: "openai",
-                    live: false,
-                    model: {
-                      name: "gpt-5.6-luna",
-                      ref: "mock-openai/gpt-5.6-luna",
+  it.each(["full", "slim"] as const)(
+    "captures taxonomy before the filtered %s profile suite runs",
+    async (evidenceMode) => {
+      const report = taxonomyModule.readQaScorecardTaxonomyReport(readQaScenarioPack().scenarios);
+      const capturedIdentity = { ...report.taxonomy!.identity };
+      const readReport = vi
+        .spyOn(taxonomyModule, "readQaScorecardTaxonomyReport")
+        .mockReturnValue(report);
+      const previousProfile = process.env.OPENCLAW_QA_PROFILE;
+      process.env.OPENCLAW_QA_PROFILE = "release";
+      try {
+        runQaSuite.mockImplementationOnce(async (params) => {
+          expect(process.env.OPENCLAW_QA_PROFILE).toBe("smoke-ci");
+          report.taxonomy!.identity.sha256 = "0".repeat(64);
+          report.profiles.find((entry) => entry.id === "smoke-ci")!.evidenceMode =
+            evidenceMode === "full" ? "slim" : "full";
+          await fs.writeFile(
+            suiteEvidencePath,
+            JSON.stringify(
+              makeQaEvidence([
+                {
+                  test: {
+                    kind: "qa-scenario",
+                    id: "telegram-commands-command",
+                    title: "Telegram commands list reply",
+                    source: {
+                      path: "qa/scenarios/channels/telegram-commands-command.yaml",
                     },
-                    fixture: "mock-openai",
                   },
-                  channel: {
-                    id: "qa-channel",
-                    live: false,
+                  coverage: [
+                    {
+                      id: "telegram.built-in-commands",
+                      role: "primary",
+                    },
+                  ],
+                  execution: {
+                    runner: "host",
+                    environment: {
+                      ref: null,
+                      os: process.platform,
+                      nodeVersion: process.version,
+                    },
+                    provider: {
+                      id: "openai",
+                      live: false,
+                      model: {
+                        name: "gpt-5.6-luna",
+                        ref: "mock-openai/gpt-5.6-luna",
+                      },
+                      fixture: "mock-openai",
+                    },
+                    channel: {
+                      id: "qa-channel",
+                      live: false,
+                    },
+                    packageSource: {
+                      kind: "source-checkout",
+                    },
+                    artifacts: [],
                   },
-                  packageSource: {
-                    kind: "source-checkout",
+                  result: {
+                    status: "pass",
                   },
-                  artifacts: [],
                 },
-                result: {
-                  status: "pass",
-                },
-              },
-            ]),
-          ),
-          "utf8",
-        );
-        return flowSuiteRuntimeResult({
-          observedCells: expandQaScenarioExecutionCells({
-            scenarios: [readQaScenarioById("telegram-commands-command")],
-            channelDriver: params?.channelDriver ?? "qa-channel",
-            channel: params?.channelId ?? params?.channelDriverSelection?.channel,
-            defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
-            supportsChannel: isCrablineServerChannel,
-            expandChannels: true,
-          }),
-          reportPath: suiteReportPath,
-          summaryPath: suiteSummaryPath,
+              ]),
+            ),
+            "utf8",
+          );
+          return flowSuiteRuntimeResult({
+            observedCells: expandQaScenarioExecutionCells({
+              scenarios: [readQaScenarioById("telegram-commands-command")],
+              channelDriver: params?.channelDriver ?? "qa-channel",
+              channel: params?.channelId ?? params?.channelDriverSelection?.channel,
+              defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+              supportsChannel: isCrablineServerChannel,
+              expandChannels: true,
+            }),
+            reportPath: suiteReportPath,
+            summaryPath: suiteSummaryPath,
+          });
         });
-      });
 
-      await runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        outputDir: ".artifacts/qa-e2e/smoke-ci",
-        profile: "smoke-ci",
-        surface: "telegram",
-        category: "telegram.native-controls-and-approvals",
-        scenarioIds: ["telegram-commands-command"],
-        transportId: "qa-channel",
-        fastMode: true,
-        concurrency: 2,
-        allowFailures: true,
-      });
+        await runQaProfileCommand({
+          repoRoot: "/tmp/openclaw-repo",
+          outputDir: ".artifacts/qa-e2e/smoke-ci",
+          profile: "smoke-ci",
+          evidenceMode,
+          surface: "telegram",
+          category: "telegram.native-controls-and-approvals",
+          scenarioIds: ["telegram-commands-command"],
+          transportId: "qa-channel",
+          fastMode: true,
+          concurrency: 2,
+          allowFailures: true,
+        });
 
-      const suiteArgs = mockFirstObjectArg(runQaSuite);
-      expectFields(suiteArgs, {
-        repoRoot: path.resolve("/tmp/openclaw-repo"),
-        outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa-e2e/smoke-ci"),
-        transportId: "qa-channel",
-        channelDriver: "crabline",
-        providerMode: "mock-openai",
-        fastMode: true,
-        concurrency: 2,
-      });
-      expect(suiteArgs.channelDriverSelection).toMatchObject({
-        channel: "telegram",
-        channelDriver: "crabline",
-      });
-      expect(suiteArgs.scenarioIds).toEqual(["telegram-commands-command"]);
-      expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
-      const evidence = JSON.parse(await fs.readFile(suiteEvidencePath, "utf8")) as {
-        evidenceMode?: unknown;
-        entries?: unknown[];
-        profile?: unknown;
-        profilePlan?: {
-          counts?: Record<string, unknown>;
-          expectedCells?: unknown[];
-          observedCells?: unknown[];
-        };
-        scorecard?: {
-          run?: { evidenceEntryCount?: unknown };
-          coverageIds?: { fulfilled?: unknown };
-          categoryReports?: Array<{
-            id?: unknown;
+        const suiteArgs = mockFirstObjectArg(runQaSuite);
+        expectFields(suiteArgs, {
+          repoRoot: path.resolve("/tmp/openclaw-repo"),
+          outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa-e2e/smoke-ci"),
+          transportId: "qa-channel",
+          channelDriver: "crabline",
+          providerMode: "mock-openai",
+          fastMode: true,
+          concurrency: 2,
+        });
+        expect(suiteArgs.channelDriverSelection).toMatchObject({
+          channel: "telegram",
+          channelDriver: "crabline",
+        });
+        expect(suiteArgs.scenarioIds).toEqual(["telegram-commands-command"]);
+        expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
+        const evidence = JSON.parse(await fs.readFile(suiteEvidencePath, "utf8")) as {
+          evidenceMode?: unknown;
+          entries?: unknown[];
+          profile?: unknown;
+          profilePlan?: {
+            taxonomyIdentity?: unknown;
+            counts?: Record<string, unknown>;
+            expectedCells?: unknown[];
+            observedCells?: unknown[];
+          };
+          scorecard?: {
+            run?: { evidenceEntryCount?: unknown };
             coverageIds?: { fulfilled?: unknown };
-            missingCoverageIds?: unknown;
-          }>;
+            categoryReports?: Array<{
+              id?: unknown;
+              coverageIds?: { fulfilled?: unknown };
+              missingCoverageIds?: unknown;
+            }>;
+          };
         };
-      };
-      expect(evidence.profile).toBe("smoke-ci");
-      expect(evidence.profilePlan?.counts).toMatchObject({
-        membership: 1,
-        selected: 1,
-        excluded: 0,
-        expectedCells: 1,
-        observedCells: 1,
-        missingCells: 0,
-      });
-      expect(evidence.profilePlan?.observedCells).toEqual(evidence.profilePlan?.expectedCells);
-      expect(evidence.evidenceMode).toBe("slim");
-      expect(evidence.scorecard).toMatchObject({
-        run: {
-          evidenceEntryCount: 1,
-        },
-      });
-      expect(evidence.scorecard).not.toHaveProperty("kind");
-      expect(evidence.scorecard).not.toHaveProperty("taxonomy");
-      expect(evidence.scorecard).not.toHaveProperty("profile");
-      expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
-        id: "telegram.native-controls-and-approvals",
-      });
-      expect(evidence.entries?.[0]).not.toHaveProperty("execution");
-      expect(JSON.stringify(evidence.scorecard)).not.toContain("telegram-commands-command");
-      expectWriteContains(stdoutWrite, "QA run profile: smoke-ci; categories: 1; scenarios:");
-      expectWriteContains(stdoutWrite, `QA profile scorecard: ${suiteEvidencePath}`);
-    } finally {
-      if (previousProfile === undefined) {
-        delete process.env.OPENCLAW_QA_PROFILE;
-      } else {
-        process.env.OPENCLAW_QA_PROFILE = previousProfile;
+        expect(evidence.profile).toBe("smoke-ci");
+        expect(evidence.profilePlan?.counts).toMatchObject({
+          membership: 1,
+          selected: 1,
+          excluded: 0,
+          expectedCells: 1,
+          observedCells: 1,
+          missingCells: 0,
+        });
+        expect(evidence.profilePlan?.observedCells).toEqual(evidence.profilePlan?.expectedCells);
+        expect(evidence.evidenceMode).toBe(evidenceMode);
+        expect(evidence.profilePlan?.taxonomyIdentity).toEqual(capturedIdentity);
+        expect(evidence.scorecard).toMatchObject({
+          run: {
+            evidenceEntryCount: 1,
+          },
+        });
+        expect(evidence.scorecard).not.toHaveProperty("kind");
+        expect(evidence.scorecard).not.toHaveProperty("taxonomy");
+        expect(evidence.scorecard).not.toHaveProperty("profile");
+        expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
+          id: "telegram.native-controls-and-approvals",
+        });
+        expect(Object.hasOwn(evidence.entries?.[0] as object, "execution")).toBe(
+          evidenceMode === "full",
+        );
+        expect(JSON.stringify(evidence.scorecard)).not.toContain("telegram-commands-command");
+        expectWriteContains(stdoutWrite, "QA run profile: smoke-ci; categories: 1; scenarios:");
+        expectWriteContains(stdoutWrite, `QA profile scorecard: ${suiteEvidencePath}`);
+      } finally {
+        readReport.mockRestore();
+        if (previousProfile === undefined) {
+          delete process.env.OPENCLAW_QA_PROFILE;
+        } else {
+          process.env.OPENCLAW_QA_PROFILE = previousProfile;
+        }
       }
-    }
-  });
+    },
+  );
 
   it("passes non-Crabline profile channel drivers as declarative suite metadata", async () => {
     await runQaProfileCommand({

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -688,6 +688,12 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   if (!profileReport) {
     throw new Error(`taxonomy.yaml does not define QA run profile ${profile}.`);
   }
+  if (!scorecardReport.taxonomy) {
+    throw new Error("QA profile evidence requires a taxonomy identity.");
+  }
+  // Capture before the suite runs so later taxonomy reads cannot rebind its evidence.
+  const taxonomyIdentity = { ...scorecardReport.taxonomy.identity };
+  const evidenceMode = opts.evidenceMode ?? profileReport.evidenceMode;
   const membership = resolveQaRunProfileMembership(
     {
       profile,
@@ -775,7 +781,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     const suiteResult = await runQaSuiteCommand({
       repoRoot,
       outputDir: opts.outputDir,
-      evidenceMode: opts.evidenceMode,
+      evidenceMode,
       transportId: opts.transportId,
       providerMode,
       primaryModel: opts.primaryModel,
@@ -799,6 +805,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   }
   const profilePlan = qaProfileEvidencePlan.build({
     profile,
+    taxonomyIdentity,
     membershipScenarios: taxonomyScenarios,
     selectedScenarios: scenarios,
     excludedScenarios: executionSelection.excludedScenarios,
@@ -807,7 +814,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   });
   await attachQaProfileScorecardEvidenceToFile({
     evidencePath,
-    evidenceMode: opts.evidenceMode,
+    evidenceMode,
     profile,
     profilePlan,
     filters: {

--- a/extensions/qa-lab/src/profile-evidence-plan.test.ts
+++ b/extensions/qa-lab/src/profile-evidence-plan.test.ts
@@ -1,8 +1,10 @@
 // QA Lab tests cover canonical profile scheduling evidence.
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { qaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import { readQaScenarioById } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
+import { qaMaturityTaxonomyIdentity, readQaMaturityTaxonomySource } from "./scorecard-taxonomy.js";
 
 describe("QA profile evidence plan", () => {
   const portable = readQaScenarioById("thread-isolation");
@@ -12,6 +14,9 @@ describe("QA profile evidence plan", () => {
   function buildPlan(observedCells: QaScenarioExecutionCell[]) {
     return qaProfileEvidencePlan.build({
       profile: "all",
+      taxonomyIdentity: qaMaturityTaxonomyIdentity(
+        readQaMaturityTaxonomySource(path.resolve(import.meta.dirname, "../../../taxonomy.yaml")),
+      ),
       membershipScenarios: [excluded, native, portable],
       selectedScenarios: [portable, native],
       excludedScenarios: [{ scenario: excluded, reasons: ["providerMode=mock-openai"] }],
@@ -73,6 +78,55 @@ describe("QA profile evidence plan", () => {
         expectedCells: complete.expectedCells.toReversed(),
       }).success,
     ).toBe(false);
+  });
+
+  it("includes semantic identity in attestation", () => {
+    const plan = buildPlan([]);
+    expect(
+      qaProfileEvidencePlan.attest({
+        ...plan,
+        taxonomyIdentity: { version: 1, sha256: "0".repeat(64) },
+      }).sha256,
+    ).not.toBe(qaProfileEvidencePlan.attest(plan).sha256);
+    expect(() =>
+      qaProfileEvidencePlan.build({
+        profile: "all",
+        membershipScenarios: [],
+        selectedScenarios: [],
+        excludedScenarios: [],
+        expectedCells: [],
+        observedCells: [],
+        // @ts-expect-error new producers must supply identity even though historical parsing accepts absence.
+        taxonomyIdentity: undefined,
+      }),
+    ).toThrow();
+  });
+
+  it("preserves historical plan bytes and its fixed attestation digest", () => {
+    const cell = { scenarioId: "historical-scenario", executionKind: "flow", channel: "telegram" };
+    const historical = {
+      profile: "all",
+      membership: ["historical-scenario"],
+      selected: ["historical-scenario"],
+      excluded: [],
+      expectedCells: [cell],
+      observedCells: [cell],
+      missingCells: [],
+      counts: {
+        membership: 1,
+        selected: 1,
+        excluded: 0,
+        expectedCells: 1,
+        observedCells: 1,
+        missingCells: 0,
+      },
+    };
+    const attestation = qaProfileEvidencePlan.attest(historical, true);
+    expect(JSON.stringify(attestation.plan)).toBe(JSON.stringify(historical));
+    expect(attestation.plan).not.toHaveProperty("taxonomyIdentity");
+    expect(attestation.sha256).toBe(
+      "6c09166ba9ba6719862d917a29795165a90997cdc5658cd4c65e3a10d89e0fa1",
+    );
   });
 
   it("normalizes object key order before workflow hashing", () => {

--- a/extensions/qa-lab/src/profile-evidence-plan.test.ts
+++ b/extensions/qa-lab/src/profile-evidence-plan.test.ts
@@ -1,10 +1,14 @@
 // QA Lab tests cover canonical profile scheduling evidence.
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { qaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import { readQaScenarioById } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
-import { qaMaturityTaxonomyIdentity, readQaMaturityTaxonomySource } from "./scorecard-taxonomy.js";
+import {
+  qaMaturityTaxonomyIdentity,
+  readQaMaturityTaxonomySource,
+  type QaMaturityTaxonomyIdentity,
+} from "./scorecard-taxonomy.js";
 
 describe("QA profile evidence plan", () => {
   const portable = readQaScenarioById("thread-isolation");
@@ -81,6 +85,9 @@ describe("QA profile evidence plan", () => {
   });
 
   it("includes semantic identity in attestation", () => {
+    expectTypeOf<
+      Parameters<typeof qaProfileEvidencePlan.build>[0]["taxonomyIdentity"]
+    >().toEqualTypeOf<QaMaturityTaxonomyIdentity>();
     const plan = buildPlan([]);
     expect(
       qaProfileEvidencePlan.attest({
@@ -89,16 +96,17 @@ describe("QA profile evidence plan", () => {
       }).sha256,
     ).not.toBe(qaProfileEvidencePlan.attest(plan).sha256);
     expect(() =>
-      qaProfileEvidencePlan.build({
-        profile: "all",
-        membershipScenarios: [],
-        selectedScenarios: [],
-        excludedScenarios: [],
-        expectedCells: [],
-        observedCells: [],
-        // @ts-expect-error new producers must supply identity even though historical parsing accepts absence.
-        taxonomyIdentity: undefined,
-      }),
+      Reflect.apply(qaProfileEvidencePlan.build, undefined, [
+        {
+          profile: "all",
+          membershipScenarios: [],
+          selectedScenarios: [],
+          excludedScenarios: [],
+          expectedCells: [],
+          observedCells: [],
+          taxonomyIdentity: undefined,
+        },
+      ]),
     ).toThrow();
   });
 

--- a/extensions/qa-lab/src/profile-evidence-plan.ts
+++ b/extensions/qa-lab/src/profile-evidence-plan.ts
@@ -3,6 +3,10 @@ import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScenarioExecutionCell } from "./scenario-lane.js";
+import {
+  qaMaturityTaxonomyIdentitySchema,
+  type QaMaturityTaxonomyIdentity,
+} from "./scorecard-taxonomy.js";
 
 const idSchema = z.string().trim().min(1);
 const cellSchema = z.strictObject({
@@ -33,6 +37,8 @@ const planShape = z.strictObject({
   observedCells: z.array(cellSchema),
   missingCells: z.array(cellSchema),
   counts: z.record(z.enum(listNames), z.number().int().nonnegative()),
+  // Historical plans retain their original serialized bytes and attestation digest.
+  taxonomyIdentity: qaMaturityTaxonomyIdentitySchema.optional(),
 });
 
 type PlanShape = z.infer<typeof planShape>;
@@ -122,6 +128,7 @@ function canonicalCells(cells: readonly QaScenarioExecutionCell[]) {
 
 function build(params: {
   profile: string;
+  taxonomyIdentity: QaMaturityTaxonomyIdentity;
   membershipScenarios: readonly QaSeedScenarioWithSource[];
   selectedScenarios: readonly QaSeedScenarioWithSource[];
   excludedScenarios: readonly {
@@ -148,6 +155,7 @@ function build(params: {
     profile: params.profile,
     ...lists,
     counts: Object.fromEntries(listNames.map((name) => [name, lists[name].length])),
+    taxonomyIdentity: qaMaturityTaxonomyIdentitySchema.parse(params.taxonomyIdentity),
   });
 }
 

--- a/extensions/qa-lab/src/profile-evidence-sharding.test.ts
+++ b/extensions/qa-lab/src/profile-evidence-sharding.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./profile-evidence-sharding.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
 import type { QaScenarioExecutionCell } from "./scenario-lane.js";
+import * as taxonomyModule from "./scorecard-taxonomy.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const { exclusiveLiveChannels, liveAdapterFactories } = vi.hoisted(() => {
@@ -102,6 +103,8 @@ async function writeShardEvidenceSet(params: {
       params.incompleteFirstShard && index === 0 ? expectedCells.slice(1) : expectedCells;
     const profilePlan = qaProfileEvidencePlan.build({
       profile: "all",
+      taxonomyIdentity: taxonomyModule.readQaScorecardTaxonomyReport([...scenarioById.values()])
+        .taxonomy!.identity,
       membershipScenarios: scenarios,
       selectedScenarios: scenarios,
       excludedScenarios: [],
@@ -223,12 +226,26 @@ describe("QA profile evidence sharding", () => {
       unreferencedPayloadRelativePath,
     } = await writeShardEvidenceSet({ outputDir });
     const outputPath = path.join(outputDir, "aggregate", "qa-evidence.json");
-    const aggregate = await aggregateQaProfileEvidenceShards({
-      evidencePaths,
-      generatedAt: "2026-08-16T00:00:01.000Z",
-      outputPath,
-      profile: "all",
-    });
+    const report = taxonomyModule.readQaScorecardTaxonomyReport(readQaScenarioPack().scenarios);
+    const readReport = vi
+      .spyOn(taxonomyModule, "readQaScorecardTaxonomyReport")
+      .mockReturnValueOnce(report)
+      .mockImplementation(() => {
+        throw new Error("taxonomy must be captured once");
+      });
+    let aggregate;
+    try {
+      aggregate = await aggregateQaProfileEvidenceShards({
+        evidencePaths,
+        generatedAt: "2026-08-16T00:00:01.000Z",
+        outputPath,
+        profile: "all",
+      });
+      expect(readReport).toHaveBeenCalledTimes(1);
+    } finally {
+      readReport.mockRestore();
+    }
+    expect(aggregate.profilePlan?.taxonomyIdentity).toEqual(report.taxonomy!.identity);
 
     expect(aggregate.profilePlan?.selected).toHaveLength(
       shardPlan.shards.flatMap((shard) => shard.scenarioIds).length,
@@ -255,6 +272,34 @@ describe("QA profile evidence sharding", () => {
       ),
     ).toBe(unreferencedPayloadContent);
   });
+
+  it.each(["missing", "mismatch", "mixed"] as const)(
+    "rejects %s taxonomy identity before any aggregate writes",
+    async (kind) => {
+      const outputDir = tempDirs.make("qa-profile-shards-identity-");
+      const { evidencePaths } = await writeShardEvidenceSet({ outputDir });
+      const alteredPaths = kind === "mixed" ? [evidencePaths.at(-1)!] : evidencePaths;
+      for (const file of alteredPaths) {
+        const summary = validateQaEvidenceSummaryJson(JSON.parse(await fs.readFile(file, "utf8")));
+        if (kind === "missing") {
+          delete summary.profilePlan!.taxonomyIdentity;
+        } else {
+          summary.profilePlan!.taxonomyIdentity = { version: 1, sha256: "0".repeat(64) };
+        }
+        await fs.writeFile(file, JSON.stringify(summary));
+      }
+      const outputPath = path.join(outputDir, "aggregate", "qa-evidence.json");
+      await expect(
+        aggregateQaProfileEvidenceShards({
+          evidencePaths,
+          generatedAt: "2026-08-16T00:00:01.000Z",
+          outputPath,
+          profile: "all",
+        }),
+      ).rejects.toThrow("semantic taxonomy identity");
+      await expect(fs.stat(path.dirname(outputPath))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 
   it("preserves an incomplete child as incomplete aggregate evidence", async () => {
     const outputDir = tempDirs.make("qa-profile-shards-incomplete-");

--- a/extensions/qa-lab/src/profile-evidence-sharding.ts
+++ b/extensions/qa-lab/src/profile-evidence-sharding.ts
@@ -86,7 +86,15 @@ function resolveQaProfileEvidenceSelection(profile: string) {
   if (executionSelection.selectedScenarios.length === 0) {
     throw new Error(`QA profile ${profile} does not select any executable scenarios.`);
   }
-  return { executionSelection, liveAdapterFactories, membership };
+  if (!scorecardReport.taxonomy) {
+    throw new Error("QA profile evidence requires a taxonomy identity.");
+  }
+  return {
+    executionSelection,
+    liveAdapterFactories,
+    membership,
+    taxonomyIdentity: scorecardReport.taxonomy.identity,
+  };
 }
 
 function estimateQaProfileScenarioCost(scenario: QaSeedScenarioWithSource) {
@@ -199,11 +207,17 @@ export function createQaProfileEvidenceShardPlan(
   profile: string,
   shardCount = DEFAULT_QA_PROFILE_SHARD_COUNT,
 ): QaProfileEvidenceShardPlan {
+  return buildQaProfileEvidenceShardPlan(shardCount, resolveQaProfileEvidenceSelection(profile));
+}
+
+function buildQaProfileEvidenceShardPlan(
+  shardCount: number,
+  selection: ReturnType<typeof resolveQaProfileEvidenceSelection>,
+): QaProfileEvidenceShardPlan {
   if (!Number.isInteger(shardCount) || shardCount < 1 || shardCount > MAX_QA_PROFILE_SHARD_COUNT) {
     throw new Error(`QA profile shard count must be between 1 and ${MAX_QA_PROFILE_SHARD_COUNT}.`);
   }
-  const { executionSelection, liveAdapterFactories, membership } =
-    resolveQaProfileEvidenceSelection(profile);
+  const { executionSelection, liveAdapterFactories, membership } = selection;
   const categoryIdsByScenarioRef = new Map<string, string[]>();
   for (const category of membership.categories) {
     for (const scenarioRef of category.scenarioRefs) {
@@ -361,7 +375,12 @@ export async function aggregateQaProfileEvidenceShards(params: {
   const outputPath = path.resolve(params.outputPath);
   const aggregateRoot = path.dirname(outputPath);
   const canonicalAggregateRoot = await canonicalPathFromExistingAncestor(aggregateRoot);
-  const shardPlan = createQaProfileEvidenceShardPlan(params.profile, params.shardCount);
+  const selection = resolveQaProfileEvidenceSelection(params.profile);
+  const { executionSelection, membership, taxonomyIdentity } = selection;
+  const shardPlan = buildQaProfileEvidenceShardPlan(
+    params.shardCount ?? DEFAULT_QA_PROFILE_SHARD_COUNT,
+    selection,
+  );
   if (params.evidencePaths.length !== shardPlan.shards.length) {
     throw new Error(
       `QA profile ${params.profile} requires ${shardPlan.shards.length} shard evidence files, received ${params.evidencePaths.length}.`,
@@ -390,6 +409,15 @@ export async function aggregateQaProfileEvidenceShards(params: {
       );
     }
     const childPlan = qaProfileEvidencePlan.attest(summary.profilePlan).plan;
+    if (
+      !childPlan.taxonomyIdentity ||
+      childPlan.taxonomyIdentity.version !== taxonomyIdentity.version ||
+      childPlan.taxonomyIdentity.sha256 !== taxonomyIdentity.sha256
+    ) {
+      throw new Error(
+        `QA shard evidence ${evidencePath} has a missing or mismatched semantic taxonomy identity.`,
+      );
+    }
     const shard = expectedShardBySignature.get(shardSignature(childPlan.selected));
     if (!shard || seenShardIds.has(shard.id)) {
       throw new Error(`QA shard evidence ${evidencePath} does not match one unique planned shard.`);
@@ -435,18 +463,9 @@ export async function aggregateQaProfileEvidenceShards(params: {
     observedCells.push(...childPlan.observedCells);
   }
 
-  await fs.mkdir(path.join(aggregateRoot, "shards"), { recursive: true });
-  for (const payload of payloads) {
-    await fs.cp(payload.source, payload.destination, {
-      recursive: true,
-      errorOnExist: true,
-      force: false,
-    });
-  }
-
-  const { executionSelection, membership } = resolveQaProfileEvidenceSelection(params.profile);
   const profilePlan = qaProfileEvidencePlan.build({
     profile: membership.profile.id,
+    taxonomyIdentity,
     membershipScenarios: membership.selectedScenarios,
     selectedScenarios: executionSelection.selectedScenarios,
     excludedScenarios: executionSelection.excludedScenarios,
@@ -457,6 +476,15 @@ export async function aggregateQaProfileEvidenceShards(params: {
     evidenceSummaries: summaries,
     generatedAt: params.generatedAt,
   });
+  await fs.mkdir(path.join(aggregateRoot, "shards"), { recursive: true });
+  for (const payload of payloads) {
+    await fs.cp(payload.source, payload.destination, {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+  }
+
   await fs.writeFile(outputPath, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
   await attachQaProfileScorecardEvidenceToFile({
     evidencePath: outputPath,

--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -8,9 +8,12 @@ import {
   type QaEvidenceSummaryJson,
   type QaEvidenceSummaryEntry,
 } from "./evidence-summary.js";
-import type { QaProfileEvidencePlan } from "./profile-evidence-plan.js";
+import { qaProfileEvidencePlan, type QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
-import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
+import {
+  qaMaturityTaxonomyIdentity,
+  type QaScorecardCategoryCoverageReport,
+} from "./scorecard-taxonomy.js";
 
 function evidenceEntry(
   coverage: QaEvidenceSummaryEntry["coverage"],
@@ -60,6 +63,8 @@ function categoryInventory(coverageIds: string[]): QaScorecardCategoryCoverageRe
 
 async function buildQaProfileScorecardEvidence(params: {
   evidence: QaEvidenceSummaryJson;
+  profilePlan?: QaProfileEvidencePlan;
+  evidenceMode?: "full" | "slim";
   filters: { surface?: string; category?: string };
   categories: readonly QaScorecardCategoryCoverageReport[];
 }) {
@@ -70,23 +75,26 @@ async function buildQaProfileScorecardEvidence(params: {
     const scorecard = await attachQaProfileScorecardEvidenceToFile({
       evidencePath,
       profile: "release",
-      profilePlan: {
-        profile: "release",
-        membership: [],
-        selected: [],
-        excluded: [],
-        expectedCells: [],
-        observedCells: [],
-        missingCells: [],
-        counts: {
-          membership: 0,
-          selected: 0,
-          excluded: 0,
-          expectedCells: 0,
-          observedCells: 0,
-          missingCells: 0,
-        },
-      } satisfies QaProfileEvidencePlan,
+      evidenceMode: params.evidenceMode,
+      profilePlan:
+        params.profilePlan ??
+        ({
+          profile: "release",
+          membership: [],
+          selected: [],
+          excluded: [],
+          expectedCells: [],
+          observedCells: [],
+          missingCells: [],
+          counts: {
+            membership: 0,
+            selected: 0,
+            excluded: 0,
+            expectedCells: 0,
+            observedCells: 0,
+            missingCells: 0,
+          },
+        } satisfies QaProfileEvidencePlan),
       filters: params.filters,
       categories: params.categories,
     });
@@ -101,6 +109,38 @@ async function buildQaProfileScorecardEvidence(params: {
 }
 
 describe("profile scorecard evidence", () => {
+  it.each(["full", "slim"] as const)(
+    "preserves captured identity in %s evidence without duplicating it in the scorecard",
+    async (evidenceMode) => {
+      const profilePlan = qaProfileEvidencePlan.build({
+        profile: "release",
+        taxonomyIdentity: qaMaturityTaxonomyIdentity({
+          version: 1,
+          title: "Evidence fixture",
+          profiles: [],
+          levels: [],
+          surfaces: [],
+        }),
+        membershipScenarios: [],
+        selectedScenarios: [],
+        excludedScenarios: [],
+        expectedCells: [],
+        observedCells: [],
+      });
+      const { writtenEvidence, scorecard } = await buildQaProfileScorecardEvidence({
+        evidence: evidenceSummary([evidenceEntry([{ id: "coverage.one", role: "primary" }])]),
+        evidenceMode,
+        profilePlan,
+        filters: {},
+        categories: [categoryInventory(["coverage.one"])],
+      });
+      expect(writtenEvidence.evidenceMode).toBe(evidenceMode);
+      expect(writtenEvidence.profilePlan).toEqual(profilePlan);
+      expect(scorecard).not.toHaveProperty("taxonomyIdentity");
+      expect(scorecard.coverageIds.fulfilled).toBe(1);
+    },
+  );
+
   it("scores atomic feature coverage by its one exact coverage ID", async () => {
     const category: QaScorecardCategoryCoverageReport = {
       id: "surface.category",

--- a/extensions/qa-lab/src/scorecard-taxonomy.test.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import YAML, { YAMLParseError } from "yaml";
 import {
   readQaMaturityTaxonomySource,
+  qaMaturityTaxonomyIdentity,
+  type QaMaturityTaxonomy,
   readQaScorecardProfileOptions,
   readValidatedQaMaturityScoreSources,
 } from "./scorecard-taxonomy.js";
@@ -117,6 +119,186 @@ describe("QA maturity YAML readers", () => {
 
       expect(() => readQaMaturityTaxonomySource(taxonomyPath)).toThrow(YAMLParseError);
       expect(() => readQaScorecardProfileOptions("fixture", dir)).toThrow(YAMLParseError);
+    });
+  });
+});
+
+describe("semantic taxonomy identity", () => {
+  const source = path.resolve(import.meta.dirname, "../../../taxonomy.yaml");
+  const read = () => readQaMaturityTaxonomySource(source);
+  const category = (taxonomy: QaMaturityTaxonomy) =>
+    taxonomy.surfaces
+      .find(
+        (surface) =>
+          !surface.archived && surface.categories.some((entry) => entry.features.length > 1),
+      )!
+      .categories.find((entry) => entry.features.length > 1)!;
+  const proofSurface = (taxonomy: QaMaturityTaxonomy) =>
+    taxonomy.surfaces.find((surface) => surface.additional_validation?.length)!;
+
+  it.each<[string, (taxonomy: QaMaturityTaxonomy) => void]>([
+    [
+      "feature addition",
+      (taxonomy) =>
+        category(taxonomy).features.push({
+          name: "New capability",
+          coverageIds: ["tools.new-capability"],
+        }),
+    ],
+    [
+      "same-count feature replacement",
+      (taxonomy) => {
+        category(taxonomy).features[0]!.coverageIds = ["tools.replacement"];
+      },
+    ],
+    [
+      "feature move",
+      (taxonomy) => {
+        const from = category(taxonomy);
+        const to = taxonomy.surfaces
+          .flatMap((surface) => surface.categories)
+          .find((entry) => entry !== from)!;
+        to.features.push(from.features.pop()!);
+      },
+    ],
+    [
+      "feature meaning",
+      (taxonomy) => {
+        category(taxonomy).features[0]!.description = "Changed capability meaning";
+      },
+    ],
+    [
+      "internal whitespace",
+      (taxonomy) => {
+        category(taxonomy).features[0]!.name += "  meaning";
+      },
+    ],
+    [
+      "category meaning",
+      (taxonomy) => {
+        category(taxonomy).category_note += ".updated";
+      },
+    ],
+    [
+      "documentation reference",
+      (taxonomy) => {
+        category(taxonomy).docs.push("/help/new-proof");
+      },
+    ],
+    [
+      "surface meaning",
+      (taxonomy) => {
+        taxonomy.surfaces[0]!.family = "changed";
+      },
+    ],
+    [
+      "archive",
+      (taxonomy) => {
+        taxonomy.surfaces[0]!.archived = true;
+      },
+    ],
+    [
+      "profile selector",
+      (taxonomy) => {
+        taxonomy.profiles[0]!.coverageIds.push("tools.new-selector");
+      },
+    ],
+    [
+      "profile driver",
+      (taxonomy) => {
+        taxonomy.profiles[0]!.channelDriver =
+          taxonomy.profiles[0]!.channelDriver === "live" ? "qa-channel" : "live";
+      },
+    ],
+    [
+      "profile evidence mode",
+      (taxonomy) => {
+        taxonomy.profiles[0]!.evidenceMode =
+          taxonomy.profiles[0]!.evidenceMode === "slim" ? "full" : "slim";
+      },
+    ],
+    [
+      "completeness reference",
+      (taxonomy) => {
+        proofSurface(taxonomy).completeness_instructions += ".updated";
+      },
+    ],
+    [
+      "proof command",
+      (taxonomy) => {
+        proofSurface(taxonomy).additional_validation![0]!.command += " --changed";
+      },
+    ],
+    [
+      "proof purpose",
+      (taxonomy) => {
+        proofSurface(taxonomy).additional_validation![0]!.purpose += " changed";
+      },
+    ],
+  ])("changes when %s changes", (_name, mutate) => {
+    const taxonomy = read();
+    const before = qaMaturityTaxonomyIdentity(taxonomy);
+    mutate(taxonomy);
+    expect(qaMaturityTaxonomyIdentity(taxonomy)).not.toEqual(before);
+  });
+
+  it("ignores ordering, duplicate set references, and maturity decisions", () => {
+    const taxonomy = read();
+    const before = qaMaturityTaxonomyIdentity(taxonomy);
+    taxonomy.profiles.reverse();
+    taxonomy.surfaces.reverse();
+    taxonomy.snapshot = { date: "2099-01-01", source_ref: "new revision" };
+    taxonomy.title = "Editorial title";
+    taxonomy.process_version = 99;
+    taxonomy.levels.reverse();
+    for (const profile of taxonomy.profiles) {
+      profile.categoryIds.reverse();
+      profile.coverageIds.reverse();
+    }
+    for (const surface of taxonomy.surfaces) {
+      surface.categories.reverse();
+      surface.additional_validation?.reverse();
+      surface.level = "stable";
+      surface.rationale = "New editorial decision";
+      surface.last_score_run = { completed_at: "2099-01-01" };
+      for (const entry of surface.categories) {
+        entry.features.reverse();
+        entry.docs = [...entry.docs.toReversed(), ...entry.docs];
+        entry.human_lts_override = !entry.human_lts_override;
+        entry.search_anchors.push("new search hint");
+      }
+    }
+    expect(qaMaturityTaxonomyIdentity(taxonomy)).toEqual(before);
+  });
+
+  it("normalizes YAML formatting and equivalent parsed defaults", async () => {
+    await withTempDir("qa-taxonomy-identity-", async (dir) => {
+      const file = path.join(dir, "taxonomy.yaml");
+      fs.writeFileSync(
+        file,
+        "version: 1\ntitle: Example\nprofiles: [{id: all, description: All}]\n",
+      );
+      const before = qaMaturityTaxonomyIdentity(readQaMaturityTaxonomySource(file));
+      fs.writeFileSync(
+        file,
+        YAML.stringify({
+          title: " Example ",
+          version: 1,
+          surfaces: [],
+          profiles: [
+            {
+              description: " All ",
+              id: "all",
+              evidenceMode: "full",
+              channelDriver: "qa-channel",
+              includeAllCategories: false,
+              categoryIds: [],
+              coverageIds: [],
+            },
+          ],
+        }),
+      );
+      expect(qaMaturityTaxonomyIdentity(readQaMaturityTaxonomySource(file))).toEqual(before);
     });
   });
 });

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -1,4 +1,5 @@
 // Qa Lab plugin module validates taxonomy-backed QA scorecard evidence.
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
@@ -178,6 +179,16 @@ const qaMaturitySurfaceSchema = z.object({
   rationale: z.string().trim().min(1).optional(),
   completeness_instructions: z.string().trim().min(1).optional(),
   last_score_run: qaMaturityScoreLastRunSchema.optional(),
+  additional_validation: z
+    .array(
+      z.object({
+        id: qaScorecardIdSchema,
+        name: z.string().trim().min(1),
+        command: z.string().trim().min(1),
+        purpose: z.string().trim().min(1),
+      }),
+    )
+    .optional(),
   categories: z.array(qaMaturityCategorySchema).default([]),
 });
 
@@ -455,6 +466,7 @@ export type QaScorecardTaxonomyReport = {
   title: string | null;
   taxonomy: {
     sourcePath: string;
+    identity: QaMaturityTaxonomyIdentity;
   } | null;
   profileCount: number;
   profiles: QaScorecardProfileReport[];
@@ -635,6 +647,63 @@ function uniqueSorted(values: Iterable<string>) {
 
 function percent(part: number, total: number) {
   return total === 0 ? 0 : Number(((part / total) * 100).toFixed(1));
+}
+
+export const qaMaturityTaxonomyIdentitySchema = z.strictObject({
+  version: z.literal(1),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+});
+
+export type QaMaturityTaxonomyIdentity = z.infer<typeof qaMaturityTaxonomyIdentitySchema>;
+
+export function qaMaturityTaxonomyIdentity(
+  taxonomy: QaMaturityTaxonomy,
+): QaMaturityTaxonomyIdentity {
+  const byId = <T extends { id: string }>(values: readonly T[]) =>
+    values.toSorted((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+  const refs = (values: readonly string[]) => [...new Set(values)].toSorted();
+  // Evidence binds to capability meaning and proof obligations, not maturity decisions
+  // or YAML layout. Explicit projection keeps unrelated metadata out of the identity.
+  const semantics = {
+    profiles: byId(taxonomy.profiles).map((profile) => ({
+      id: profile.id,
+      description: profile.description,
+      includeAllCategories: profile.includeAllCategories,
+      categoryIds: refs(profile.categoryIds),
+      coverageIds: refs(profile.coverageIds),
+      channelDriver: profile.channelDriver,
+      evidenceMode: profile.evidenceMode ?? "full",
+    })),
+    surfaces: byId(activeQaMaturityTaxonomySurfaces(taxonomy)).map((surface) => ({
+      id: surface.id,
+      name: surface.name,
+      family: surface.family,
+      completenessInstructions: surface.completeness_instructions ?? null,
+      additionalValidation: byId(surface.additional_validation ?? []).map((validation) => ({
+        id: validation.id,
+        name: validation.name,
+        command: validation.command,
+        purpose: validation.purpose,
+      })),
+      categories: byId(surface.categories).map((category) => ({
+        id: category.id,
+        name: category.name,
+        note: category.category_note,
+        docs: refs(category.docs),
+        features: byId(
+          category.features.map((feature) => ({
+            id: feature.coverageIds[0]!,
+            name: feature.name,
+            description: feature.description ?? null,
+          })),
+        ),
+      })),
+    })),
+  };
+  return {
+    version: 1,
+    sha256: createHash("sha256").update(JSON.stringify(semantics)).digest("hex"),
+  };
 }
 
 export function activeQaMaturityTaxonomySurfaces(taxonomy: QaMaturityTaxonomy) {
@@ -1248,6 +1317,7 @@ function buildQaScorecardTaxonomyReport(params: {
     taxonomy: params.taxonomy
       ? {
           sourcePath: QA_MATURITY_TAXONOMY_PATH,
+          identity: qaMaturityTaxonomyIdentity(params.taxonomy),
         }
       : null,
     profileCount: params.taxonomy?.profiles.length ?? 0,

--- a/extensions/qa-lab/test-api.ts
+++ b/extensions/qa-lab/test-api.ts
@@ -1,0 +1,6 @@
+// QA Lab test API exposes evidence fixtures without loading runtime entrypoints.
+export { qaProfileEvidencePlan } from "./src/profile-evidence-plan.js";
+export {
+  qaMaturityTaxonomyIdentity,
+  readQaMaturityTaxonomySource,
+} from "./src/scorecard-taxonomy.js";

--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -15,6 +15,7 @@ import {
   qaMaturityCoverageCategoryKey,
   qaMaturityScoreObjectForScore,
   qaMaturityTaxonomyLevelMap,
+  qaMaturityTaxonomyIdentity,
   readQaMaturityTaxonomySource,
   readValidatedQaMaturityScoreSources,
   type QaMaturityCoverageScores,
@@ -54,6 +55,7 @@ type EvidenceSummary = {
   statuses: StatusCounts;
   blockingResults: string[];
   scorecard?: QaEvidenceScorecardJson;
+  taxonomyStatus: "current" | "unknown" | "mismatch";
 };
 
 type StatusCounts = Record<QaEvidenceStatus, number>;
@@ -780,7 +782,11 @@ function followUpText(missingCoverageIds: readonly string[]): string {
   return `${missingCoverageIds.length} capability ${missingCoverageIds.length === 1 ? "gap" : "gaps"}`;
 }
 
-function readEvidenceSummaries(evidenceDir?: string): EvidenceSummary[] {
+function readEvidenceSummaries(
+  taxonomy: QaMaturityTaxonomy,
+  evidenceDir?: string,
+): EvidenceSummary[] {
+  const identity = qaMaturityTaxonomyIdentity(taxonomy);
   return collectQaEvidenceFiles(evidenceDir).map((filePath) => {
     const payload = validateQaEvidenceSummaryJson(JSON.parse(fs.readFileSync(filePath, "utf8")));
     return {
@@ -792,6 +798,12 @@ function readEvidenceSummaries(evidenceDir?: string): EvidenceSummary[] {
       statuses: countStatuses(payload.entries),
       blockingResults: blockingResultLabels(payload.entries),
       scorecard: payload.scorecard,
+      taxonomyStatus: !payload.profilePlan?.taxonomyIdentity
+        ? "unknown"
+        : payload.profilePlan.taxonomyIdentity.version === identity.version &&
+            payload.profilePlan.taxonomyIdentity.sha256 === identity.sha256
+          ? "current"
+          : "mismatch",
     };
   });
 }
@@ -836,14 +848,24 @@ function deriveCoverageScores(
   taxonomy: QaMaturityTaxonomy,
   evidenceSummaries: EvidenceSummary[],
 ): DerivedCoverageScores {
-  const warnings: string[] = [];
-  const coverageSummary = latestCoverageScorecard(evidenceSummaries);
+  const warnings = evidenceSummaries.flatMap((item) =>
+    !item.scorecard || item.taxonomyStatus === "current"
+      ? []
+      : [
+          `${item.path}: semantic taxonomy identity is ${item.taxonomyStatus === "unknown" ? "missing" : "mismatched"}; historical evidence cannot supply current coverage`,
+        ],
+  );
+  const current = evidenceSummaries.filter((item) => item.taxonomyStatus === "current");
+  const coverageSummary = latestCoverageScorecard(current);
   if (!coverageSummary) {
+    if (latestCoverageScorecard(evidenceSummaries)) {
+      return { categories: new Map(), surfaces: new Map(), rollups: {}, warnings };
+    }
     throw new Error(
       "maturity scorecard rendering requires all or release profile qa-evidence.json with a scorecard field; pass --evidence-dir with QA evidence artifacts",
     );
   }
-  const selectedProfileScorecardSummaries = evidenceSummaries.filter(
+  const selectedProfileScorecardSummaries = current.filter(
     (item) => item.profile === coverageSummary.profile && item.scorecard,
   );
   if (selectedProfileScorecardSummaries.length > 1) {
@@ -990,6 +1012,7 @@ function renderEvidenceSection(
       '  <div className="maturity-evidence-card">',
       `    <span className="maturity-evidence-title">${markdownEscape(checkSetTitle(item.profile))}</span>`,
       `    <span>${markdownEscape(item.generatedAt)}</span>`,
+      `    <span>${item.taxonomyStatus === "current" ? "Current taxonomy evidence" : `Historical evidence: taxonomy identity ${item.taxonomyStatus}`}</span>`,
       `    <span>${item.entryCount} checks - ${markdownEscape(resultCountsText(item.statuses))}</span>`,
       `    <span>${markdownEscape(countText(scorecard?.categories))} areas - ${markdownEscape(countText(scorecard?.features))} features - ${markdownEscape(countText(scorecard?.coverageIds))} coverage IDs</span>`,
       "  </div>",
@@ -997,9 +1020,31 @@ function renderEvidenceSection(
   }
   lines.push("</div>", "");
 
-  const categoryRows = scorecardSummaries.flatMap((item) =>
-    (item.scorecard?.categoryReports ?? []).map((category) => ({ item, category })),
-  );
+  const historical = scorecardSummaries.filter((item) => item.taxonomyStatus !== "current");
+  if (historical.length > 0) {
+    lines.push(
+      "### Historical category evidence",
+      "",
+      "These recorded categories describe the original run and do not contribute to current coverage.",
+      "",
+      "| Profile | Recorded category | ID | Outcome | Features | Coverage IDs |",
+      "| --- | --- | --- | --- | --- | --- |",
+    );
+    for (const item of historical) {
+      for (const category of item.scorecard?.categoryReports ?? []) {
+        lines.push(
+          `| ${markdownEscape(item.profile)} | ${markdownEscape(category.name)} | ${markdownEscape(category.id)} | ${markdownEscape(category.status)} | ${markdownEscape(countText(category.features))} | ${markdownEscape(countText(category.coverageIds))} |`,
+        );
+      }
+    }
+    lines.push("");
+  }
+
+  const categoryRows = scorecardSummaries
+    .filter((item) => item.taxonomyStatus === "current")
+    .flatMap((item) =>
+      (item.scorecard?.categoryReports ?? []).map((category) => ({ item, category })),
+    );
   if (categoryRows.length > 0) {
     const grouped = new Map<string, Array<(typeof categoryRows)[number]>>();
     for (const row of categoryRows) {
@@ -1323,7 +1368,7 @@ function main(): void {
 
   validateTaxonomyDocsReferences(taxonomy, docsRouteIndex);
 
-  const evidenceSummaries = readEvidenceSummaries(args.evidenceDir);
+  const evidenceSummaries = readEvidenceSummaries(taxonomy, args.evidenceDir);
   if (!args.allowFailures) {
     rejectBlockingEvidence(evidenceSummaries);
   }

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -4,6 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { qaProfileEvidencePlan } from "../../extensions/qa-lab/src/profile-evidence-plan.js";
+import {
+  qaMaturityTaxonomyIdentity,
+  readQaMaturityTaxonomySource,
+} from "../../extensions/qa-lab/src/scorecard-taxonomy.js";
 import { parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -16,7 +21,7 @@ type TaxonomyFixture = {
 
 type TaxonomySurfaceFixture = {
   id?: string;
-  status?: string;
+  archived?: boolean;
   categories?: TaxonomyCategoryFixture[];
 };
 
@@ -58,6 +63,10 @@ function writeQaEvidence(params: {
   dir: string;
   entries: Array<{ id: string; status: "pass" | "fail" | "blocked" | "skipped" }>;
   scorecard?: unknown;
+  historical?: boolean;
+  taxonomyPath?: string;
+  profile?: string;
+  generatedAt?: string;
 }) {
   const scorecard = params.scorecard ?? {
     filters: { surface: null, category: null },
@@ -91,9 +100,24 @@ function writeQaEvidence(params: {
       {
         kind: "openclaw.qa.evidence-summary",
         schemaVersion: 2,
-        generatedAt: "2026-06-23T00:00:00.000Z",
+        generatedAt: params.generatedAt ?? "2026-06-23T00:00:00.000Z",
         evidenceMode: "full",
-        profile: "all",
+        profile: params.profile ?? "all",
+        profilePlan: params.historical
+          ? undefined
+          : qaProfileEvidencePlan.build({
+              profile: params.profile ?? "all",
+              taxonomyIdentity: qaMaturityTaxonomyIdentity(
+                readQaMaturityTaxonomySource(
+                  params.taxonomyPath ?? path.join(repoRoot, "taxonomy.yaml"),
+                ),
+              ),
+              membershipScenarios: [],
+              selectedScenarios: [],
+              excludedScenarios: [],
+              expectedCells: [],
+              observedCells: [],
+            }),
         entries: params.entries.map((entry) => ({
           test: {
             kind: "qa-scenario",
@@ -118,9 +142,7 @@ function allProfileScorecardFixture(
   taxonomyPath = path.join(repoRoot, "taxonomy.yaml"),
 ) {
   const taxonomy = parseYaml(fs.readFileSync(taxonomyPath, "utf8")) as TaxonomyFixture;
-  const activeSurfaces = (taxonomy.surfaces ?? []).filter(
-    (surface) => surface.status !== "retired",
-  );
+  const activeSurfaces = (taxonomy.surfaces ?? []).filter((surface) => !surface.archived);
   const categoryReports = activeSurfaces.flatMap((surface) =>
     (surface.categories ?? []).map((category) => {
       const coverageIds = [
@@ -406,6 +428,224 @@ describe("maturity docs renderer CLI", () => {
     expect(result.stderr).toContain("failing-scenario (fail)");
     expect(result.stderr).toContain("blocked-scenario (blocked)");
   });
+
+  it.each(["missing", "mismatch"] as const)(
+    "rejects %s historical identity before mutating strict output",
+    (identityState) => {
+      const outputDir = tempDirs.make("openclaw-maturity-identity-output-");
+      const evidenceDir = tempDirs.make("openclaw-maturity-identity-evidence-");
+      const staticAssetsDir = path.join(outputDir, "assets");
+      fs.mkdirSync(staticAssetsDir);
+      fs.writeFileSync(path.join(staticAssetsDir, "taxonomy.yaml"), "preserved\n");
+      writeQaEvidence({
+        dir: evidenceDir,
+        entries: [{ id: "historical-pass", status: "pass" }],
+        historical: identityState === "missing",
+        scorecard: allProfileScorecardFixture(),
+      });
+
+      if (identityState === "mismatch") {
+        const file = path.join(evidenceDir, "qa-evidence.json");
+        const evidence = JSON.parse(fs.readFileSync(file, "utf8"));
+        evidence.profilePlan.taxonomyIdentity.sha256 = "0".repeat(64);
+        fs.writeFileSync(file, JSON.stringify(evidence));
+      }
+
+      const result = runCli(
+        "--output-dir",
+        outputDir,
+        "--evidence-dir",
+        evidenceDir,
+        "--static-assets-dir",
+        staticAssetsDir,
+        "--strict-inputs",
+        "--allow-failures",
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        `semantic taxonomy identity is ${identityState === "missing" ? "missing" : "mismatched"}`,
+      );
+      expect(fs.readFileSync(path.join(staticAssetsDir, "taxonomy.yaml"), "utf8")).toBe(
+        "preserved\n",
+      );
+      expect(fs.existsSync(path.join(outputDir, "maturity"))).toBe(false);
+    },
+  );
+
+  it("keeps historical outcomes but leaves current coverage unscored", () => {
+    const outputDir = tempDirs.make("openclaw-maturity-identity-output-");
+    const evidenceDir = tempDirs.make("openclaw-maturity-identity-evidence-");
+    writeQaEvidence({
+      dir: evidenceDir,
+      entries: [{ id: "historical-pass", status: "pass" }],
+      historical: true,
+      scorecard: allProfileScorecardFixture(),
+    });
+
+    const scoresPath = path.join(outputDir, "scores.yaml");
+    const scores = parseYaml(
+      fs.readFileSync(path.join(repoRoot, "qa/maturity-scores.yaml"), "utf8"),
+    );
+    const coverage = { score: 100, label: "Clawesome" };
+    scores.rollups.surface_average.coverage = { ...coverage };
+    scores.rollups.category_average.coverage = { ...coverage };
+    for (const surface of scores.surfaces) {
+      surface.scores.coverage = { ...coverage };
+      for (const category of surface.categories) category.coverage = { ...coverage };
+    }
+    fs.writeFileSync(scoresPath, stringifyYaml(scores));
+    const result = runCli(
+      "--output-dir",
+      outputDir,
+      "--evidence-dir",
+      evidenceDir,
+      "--scores",
+      scoresPath,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("semantic taxonomy identity is missing");
+    const scorecard = fs.readFileSync(path.join(outputDir, "maturity", "scorecard.md"), "utf8");
+    expect(scorecard).toContain("Coverage Unscored");
+    expect(scorecard).toContain("Historical evidence: taxonomy identity unknown");
+    expect(scorecard).toContain("1 passed");
+    expect(scorecard).toContain(
+      `<span className="maturity-summary-value">${expectedMaturityScorePercent()}%</span>`,
+    );
+    expect(scorecard).not.toContain("Readiness by area");
+    expect(scorecard).toContain("Historical category evidence");
+    const historicalCategory = allProfileScorecardFixture().categoryReports[0]!;
+    expect(scorecard).toContain(historicalCategory.name);
+    expect(scorecard).toContain(historicalCategory.id);
+    expect(scorecard).toContain(
+      `| missing | 0 of ${historicalCategory.features.total} (0%) | 0 of ${historicalCategory.coverageIds.total} (0%) |`,
+    );
+  });
+
+  it("marks same-category historical evidence mismatched after capability meaning changes", () => {
+    const outputDir = tempDirs.make("openclaw-maturity-identity-output-");
+    const evidenceDir = tempDirs.make("openclaw-maturity-identity-evidence-");
+    writeQaEvidence({
+      dir: evidenceDir,
+      entries: [{ id: "previous-pass", status: "pass" }],
+      scorecard: allProfileScorecardFixture(),
+    });
+    const taxonomy = readQaMaturityTaxonomySource(path.join(repoRoot, "taxonomy.yaml"));
+    taxonomy.surfaces
+      .flatMap((surface) => surface.categories)
+      .find((category) => category.features.length > 0)!.features[0]!.description =
+      "A changed capability contract";
+    const taxonomyPath = path.join(outputDir, "taxonomy.yaml");
+    fs.writeFileSync(taxonomyPath, stringifyYaml(taxonomy));
+    const result = runCli(
+      "--output-dir",
+      outputDir,
+      "--evidence-dir",
+      evidenceDir,
+      "--taxonomy",
+      taxonomyPath,
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("semantic taxonomy identity is mismatched");
+    const scorecard = fs.readFileSync(path.join(outputDir, "maturity", "scorecard.md"), "utf8");
+    expect(scorecard).toContain("Coverage Unscored");
+    expect(scorecard).toContain("Historical evidence: taxonomy identity mismatch");
+    expect(scorecard).toContain("1 passed");
+    expect(scorecard).not.toContain("Readiness by area");
+    expect(scorecard).toContain("Historical category evidence");
+    const historicalCategory = allProfileScorecardFixture().categoryReports[0]!;
+    expect(scorecard).toContain(historicalCategory.name);
+    expect(scorecard).toContain(historicalCategory.id);
+    expect(scorecard).toContain(
+      `| missing | 0 of ${historicalCategory.features.total} (0%) | 0 of ${historicalCategory.coverageIds.total} (0%) |`,
+    );
+  });
+
+  it("selects matching release coverage before newer mismatched all evidence", () => {
+    const outputDir = tempDirs.make("openclaw-maturity-identity-output-");
+    const evidenceDir = tempDirs.make("openclaw-maturity-identity-evidence-");
+    writeQaEvidence({
+      dir: path.join(evidenceDir, "release"),
+      profile: "release",
+      entries: [{ id: "current-pass", status: "pass" }],
+      scorecard: allProfileScorecardFixture(),
+    });
+    writeQaEvidence({
+      dir: path.join(evidenceDir, "all"),
+      generatedAt: "2099-01-01T00:00:00.000Z",
+      entries: [{ id: "old-pass", status: "pass" }],
+      scorecard: allProfileScorecardFixture(),
+    });
+    const file = path.join(evidenceDir, "all", "qa-evidence.json");
+    const stale = JSON.parse(fs.readFileSync(file, "utf8"));
+    stale.profilePlan.taxonomyIdentity.sha256 = "0".repeat(64);
+    for (const category of stale.scorecard.categoryReports)
+      category.coverageIds.fulfillmentPercent = 100;
+    fs.writeFileSync(file, JSON.stringify(stale));
+    const result = runCli("--output-dir", outputDir, "--evidence-dir", evidenceDir);
+    expect(result.status).toBe(0);
+    const scorecard = fs.readFileSync(path.join(outputDir, "maturity", "scorecard.md"), "utf8");
+    expect(scorecard).toContain("Coverage Experimental - 0%");
+    expect(scorecard).toContain("Historical evidence: taxonomy identity mismatch");
+    expect(scorecard).toContain("Readiness by area");
+  });
+
+  it.each([
+    { status: "pass", allowFailures: false, exitCode: 0 },
+    { status: "fail", allowFailures: false, exitCode: 1 },
+    { status: "blocked", allowFailures: false, exitCode: 1 },
+    { status: "fail", allowFailures: true, exitCode: 0 },
+    { status: "blocked", allowFailures: true, exitCode: 0 },
+  ] as const)(
+    "keeps raw $status diagnostics separate from scorecard identity (allowFailures=$allowFailures)",
+    ({ status, allowFailures, exitCode }) => {
+      const outputDir = tempDirs.make("openclaw-maturity-raw-output-");
+      const evidenceDir = tempDirs.make("openclaw-maturity-raw-evidence-");
+      writeQaEvidence({
+        dir: evidenceDir,
+        entries: [{ id: "current-pass", status: "pass" }],
+        scorecard: allProfileScorecardFixture(),
+      });
+      const rawDir = path.join(evidenceDir, "native");
+      writeQaEvidence({
+        dir: rawDir,
+        profile: "native",
+        historical: true,
+        entries: [{ id: `native-${status}`, status }],
+      });
+      const rawPath = path.join(rawDir, "qa-evidence.json");
+      const raw = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+      delete raw.scorecard;
+      fs.writeFileSync(rawPath, JSON.stringify(raw));
+      const staticAssetsDir = path.join(outputDir, "assets");
+      fs.mkdirSync(staticAssetsDir);
+      fs.writeFileSync(path.join(staticAssetsDir, "taxonomy.yaml"), "preserved\n");
+      const result = runCli(
+        "--output-dir",
+        outputDir,
+        "--evidence-dir",
+        evidenceDir,
+        "--static-assets-dir",
+        staticAssetsDir,
+        "--strict-inputs",
+        ...(allowFailures ? ["--allow-failures"] : []),
+      );
+      expect(result.status).toBe(exitCode);
+      expect(result.stderr).not.toContain("semantic taxonomy identity");
+      if (exitCode === 1) {
+        expect(result.stderr).toContain(`native-${status} (${status})`);
+        expect(fs.existsSync(path.join(outputDir, "maturity"))).toBe(false);
+        expect(fs.readFileSync(path.join(staticAssetsDir, "taxonomy.yaml"), "utf8")).toBe(
+          "preserved\n",
+        );
+      } else {
+        expect(result.stderr).toBe("");
+        const scorecard = fs.readFileSync(path.join(outputDir, "maturity", "scorecard.md"), "utf8");
+        expect(scorecard).toContain("Coverage Experimental - 0%");
+      }
+    },
+  );
 
   it("allows incomplete evidence without awarding Coverage to non-passing checks", () => {
     const outputDir = tempDirs.make("openclaw-maturity-docs-output-");

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -492,7 +492,9 @@ describe("maturity docs renderer CLI", () => {
     scores.rollups.category_average.coverage = { ...coverage };
     for (const surface of scores.surfaces) {
       surface.scores.coverage = { ...coverage };
-      for (const category of surface.categories) category.coverage = { ...coverage };
+      for (const category of surface.categories) {
+        category.coverage = { ...coverage };
+      }
     }
     fs.writeFileSync(scoresPath, stringifyYaml(scores));
     const result = runCli(
@@ -580,8 +582,9 @@ describe("maturity docs renderer CLI", () => {
     const file = path.join(evidenceDir, "all", "qa-evidence.json");
     const stale = JSON.parse(fs.readFileSync(file, "utf8"));
     stale.profilePlan.taxonomyIdentity.sha256 = "0".repeat(64);
-    for (const category of stale.scorecard.categoryReports)
+    for (const category of stale.scorecard.categoryReports) {
       category.coverageIds.fulfillmentPercent = 100;
+    }
     fs.writeFileSync(file, JSON.stringify(stale));
     const result = runCli("--output-dir", outputDir, "--evidence-dir", evidenceDir);
     expect(result.status).toBe(0);

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -4,11 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { qaProfileEvidencePlan } from "../../extensions/qa-lab/src/profile-evidence-plan.js";
 import {
   qaMaturityTaxonomyIdentity,
+  qaProfileEvidencePlan,
   readQaMaturityTaxonomySource,
-} from "../../extensions/qa-lab/src/scorecard-taxonomy.js";
+} from "../../extensions/qa-lab/test-api.js";
 import { parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maturity reports credited old evidence as current coverage after taxonomy meaning changed while category IDs and counts stayed the same.

## Why This Change Was Made

The taxonomy owner computes one versioned semantic identity and captures it before profile execution. The existing profile plan carries that identity through shards and aggregation; aggregation rejects missing or mismatched identities before writing output. Historical plans keep their original digest when identity is absent.

The change adds net 158 production lines for this ownership and evidence-validity contract, net 602 test lines, and six lines in a private test-support barrel. The landing follow-up uses that permitted QA Lab test surface and checks the required identity type directly, preserving the invalid-input runtime assertion without adding a suppression allowance.

## User Impact

Only matching evidence supplies current numeric coverage. Historical evidence remains inspectable with its original counts and outcomes: missing identity is historical unknown, mismatch is historical mismatch, and historical-only current coverage is Unscored. Strict input checks reject unqualified scorecard evidence before writing, while raw diagnostics retain existing failure handling. Manual quality, confidence, maturity and LTS decisions remain independent.

Older identity-free summaries remain readable and keep their original plan bytes and attestation digest. Newly populated plans require updated readers: older strict readers reject the added identity field. This is not a forward-compatibility claim.

The accepted operating transition is a coordinated upgrade of the producer, aggregator and renderer to the same revision, followed by evidence regeneration for current coverage. Retain older artifacts for historical inspection; do not combine old readers with newly populated plans, or use identity-free artifacts as current strict-input evidence. The existing maturity workflow passes one selected revision to the evidence workflow and checks the same revision for artifact validation and rendering. This addresses the ClawSweeper reader-transition decision without claiming a mixed-version rollout.

## Evidence

- [Normal CI](https://github.com/openclaw/openclaw/actions/runs/34514896088), attempt 1, passed for head `95b76419144b48f24826c7769f59fd9a298c28c8`: 83 successful jobs, 16 skipped, zero failed. The aggregate `openclaw/ci-gate` passed. Actual execution used integration commit `55bebc2a1050aeb717f11120ff97ba88e4195914`, with parents `e0b7f1d46e9050fbd13a040c8a1bce4d243a0e63` and the PR head.
- Actual execution passed all 266 focused P07 cases across eight files, all 10 plugin test-boundary cases, all four suppression-inventory cases, and all 11 docs-sync cases including the previously failing locale assertion. Plugin, script and root test typechecking passed; the new required-identity type assertion is covered by the plugin test compiler lane. Build artifacts and required checks passed.
- The previously stalled tooling workload was traced by file membership across the new shard layout: all 66 files were selected and emitted results, with 2,228 passing cases, zero failures and 119 explicit platform skips. Both formerly sequential workloads are covered, including the previously unreached second group. The earlier no-output watchdog failure remains a real failed run with no established root cause; the new run completed without changing its timeout or assertions.
- Compatibility assertions passed for the fixed historical plan digest `6c09166ba9ba6719862d917a29795165a90997cdc5658cd4c65e3a10d89e0fa1`, identity capture before execution, full/slim retention, matching aggregate success, and absent/mismatched/mixed shard rejection before writes. All 17 real renderer CLI cases passed: matching current coverage, historical unknown/mismatch with Unscored current coverage, preserved historical counts/outcomes, and strict rejection before output writes.
- Independent source/commit review and immutable structured autoreview passed across all 13 changed paths. Retained earlier proof also covers six doctor guard cases and exact-head source-manifest checks; those are historical receipts, not additional executions in this CI run.

## Review Disposition And Limits

ClawSweeper revision 6 reviewed the exact PR head with no code findings and an affirmative best-fix judgment. Its blocked/needs-human badge is distinct from this maintainer disposition. Both pre-merge items are addressed: the coordinated same-revision producer/aggregator/renderer upgrade and evidence regeneration are accepted, and the executed artifact/renderer compatibility cases above provide the required contract proof. Older artifacts remain historical; older strict readers cannot consume new identity-bearing plans. Mixed-version operation is unsupported.

This proves the source/artifact transition, not a standalone mixed-version deployment or a complete QA evidence workflow rollout. The earlier environment-count ancestry comparison was skipped because the remote comparison ancestry was unavailable; the patch adds no environment surface.

Related: https://github.com/openclaw/openclaw/issues/141950

Punchcard-Session: calm-river-harbor-jg
