### PR TITLE
docs(gateway,concepts,install,help): fix information-architecture findings

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -95,12 +95,6 @@ automatic compaction requires the complete replacement to fit the estimated targ
 Early required preflight runs before those request facts are available and still
 uses history-based sizing; it does not guarantee this preferred headroom.
 
-### Provider checkpoints
-
-When an embedded Responses provider returns a compacted window, OpenClaw preserves the complete returned context alongside the checkpoint. Recent-turn history limits do not discard an eligible checkpoint, and the retained context still counts toward the model's prompt budget. The saved checkpoint is limited to 16 MiB; oversized or incompatible endpoint output uses the normal client-side compaction path instead of being truncated.
-
-If an older version or transcript redaction removes the complete window needed for replay, OpenClaw asks you to run `/compact`. That command rebuilds context from the saved conversation through client-side compaction. It does not guess the missing provider context or delete the transcript.
-
 ## Configuration
 
 Configure compaction under `agents.defaults.compaction` in your `openclaw.json`. The most common knobs are listed below; for the full reference, see [Session management deep dive](/reference/session-management-compaction).
@@ -164,16 +158,6 @@ The byte guard applies to the active SQLite transcript history. Legacy JSONL
 checkpoint artifacts are not the active compaction target.
 </Warning>
 
-### Successor transcripts
-
-A context engine may return an explicit compacted successor session identity within the same agent, session key, and store. OpenClaw publishes the accepted successor before maintenance, hooks, or retries use it, while retaining the current writer's ownership. Cancelling afterward does not roll that completed transition back. The built-in SQLite compactor keeps the current session identity and does not create a second runtime transcript.
-
-A [worker placement](/gateway/cloud-workers) cannot transfer ownership to a different session identity during compaction. Custom engines must keep the current identity while the placement owns the session, or the operator must move the session back to the Gateway before retrying. A rejected transition leaves the original session and worker claim intact.
-
-OpenClaw no longer writes separate `.checkpoint.*.jsonl` copies for new
-compactions. Existing legacy checkpoint files can still be used while referenced
-and are pruned by normal session cleanup.
-
 ### Compaction notices
 
 By default, compaction runs silently. Set `notifyUser` to show brief status messages when compaction starts and completes, and to surface a degraded notice when a pre-compaction memory flush is exhausted but the reply still continues:
@@ -211,6 +195,24 @@ Before compaction, OpenClaw can run a **silent memory flush** turn to store dura
 Memory flush is optional maintenance: a failure, including exhausted retries, does not reset the session or discard conversation history. If compaction is unnecessary or succeeds, OpenClaw continues the reply; with `notifyUser` enabled, exhausted flush retries also produce a degraded notice. If required compaction fails, OpenClaw reports that failure and keeps the conversation intact instead of starting over automatically.
 
 The memory-flush model override is exact and does not inherit the active session fallback chain. See [Memory](/concepts/memory) for details and config.
+
+## Provider and engine behavior
+
+### Provider checkpoints
+
+When an embedded Responses provider returns a compacted window, OpenClaw preserves the complete returned context alongside the checkpoint. Recent-turn history limits do not discard an eligible checkpoint, and the retained context still counts toward the model's prompt budget. The saved checkpoint is limited to 16 MiB; oversized or incompatible endpoint output uses the normal client-side compaction path instead of being truncated.
+
+If an older version or transcript redaction removes the complete window needed for replay, OpenClaw asks you to run `/compact`. That command rebuilds context from the saved conversation through client-side compaction. It does not guess the missing provider context or delete the transcript.
+
+### Successor transcripts
+
+A context engine may return an explicit compacted successor session identity within the same agent, session key, and store. OpenClaw publishes the accepted successor before maintenance, hooks, or retries use it, while retaining the current writer's ownership. Cancelling afterward does not roll that completed transition back. The built-in SQLite compactor keeps the current session identity and does not create a second runtime transcript.
+
+A [worker placement](/gateway/cloud-workers) cannot transfer ownership to a different session identity during compaction. Custom engines must keep the current identity while the placement owns the session, or the operator must move the session back to the Gateway before retrying. A rejected transition leaves the original session and worker claim intact.
+
+OpenClaw no longer writes separate `.checkpoint.*.jsonl` copies for new
+compactions. Existing legacy checkpoint files can still be used while referenced
+and are pruned by normal session cleanup.
 
 ## Pluggable compaction providers
 

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -33,6 +33,23 @@ partial-result warning. Session transcript hits require fresh visibility checks
 and are excluded from timeout recovery. A partial response does not put the
 entire memory corpus into the timeout cooldown.
 
+## When to use
+
+The builtin engine is the right choice for most users:
+
+- Works out of the box with no extra dependencies.
+- Handles keyword and vector search well.
+- Supports all embedding providers.
+- Hybrid search combines the best of both retrieval approaches.
+
+The builtin engine can index directories outside the workspace with
+`memory.search.extraPaths`. It uses bounded lexical query expansion to improve
+conversational recall, but it does not provide a learned or model-based relevance
+reranking stage. Its MMR pass is deterministic and local.
+
+Consider [Honcho](/concepts/memory-honcho) if you want cross-session memory
+with automatic user modeling.
+
 ## Getting started
 
 By default, the builtin engine uses OpenAI embeddings. If `OPENAI_API_KEY` or
@@ -209,23 +226,6 @@ relevance reranker. To replace QMD's in-process, zero-key GGUF embeddings,
 install the [llama.cpp provider](/plugins/llama-cpp) and set
 `memory.search.provider: "local"`; without an embedding provider, builtin uses
 BM25 keyword search only.
-
-## When to use
-
-The builtin engine is the right choice for most users:
-
-- Works out of the box with no extra dependencies.
-- Handles keyword and vector search well.
-- Supports all embedding providers.
-- Hybrid search combines the best of both retrieval approaches.
-
-The builtin engine can index directories outside the workspace with
-`memory.search.extraPaths`. It uses bounded lexical query expansion to improve
-conversational recall, but it does not provide a learned or model-based relevance
-reranking stage. Its MMR pass is deterministic and local.
-
-Consider [Honcho](/concepts/memory-honcho) if you want cross-session memory
-with automatic user modeling.
 
 ## Troubleshooting
 

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -75,40 +75,6 @@ fallbacks without pinning that primary. In **Settings → Agents → Overview**,
 fallback chips preserves primary inheritance. Removing every chip saves an empty
 chain instead of restoring the shared fallbacks.
 
-Outside group and channel conversations, OpenClaw sends a visible notice when a turn moves onto fallback. It sends another notice when a later turn succeeds on the selected primary. Group and channel conversations keep the same fallback state and lifecycle events without posting these notices. Persisted notice state prevents repeated notices when consecutive turns use the same selected/active pair, while model selection itself remains unchanged.
-
-## Auth failure skip cache
-
-By default, every new turn keeps the existing fallback retry behavior. OpenClaw retries each configured fallback candidate again. This includes non-primary candidates that recently failed with `auth` or `auth_permanent`.
-
-Opt in to suppress repeat auth failures with:
-
-```bash
-OPENCLAW_FALLBACK_SKIP_TTL_MS=60000
-```
-
-When enabled, OpenClaw records an in-memory, session-scoped skip marker for a non-primary fallback candidate after an auth-class failure. The key includes the session, provider, model, and selected automatic or explicit profile ID. Switching profiles does not inherit another profile's failure marker. Primary candidates are never skipped, so an explicit user model selection still surfaces the real auth error. The cache is process-local and clears on Gateway restart.
-
-The value is a TTL in milliseconds. `0` or unset disables the cache. Positive values are clamped between 1 second and 10 minutes.
-
-## User-visible fallback notices
-
-Outside group and channel conversations, OpenClaw sends a status notice in the same reply surface when a session moves onto an auto-selected fallback:
-
-```text
-↪️ Model Fallback: <fallback> (selected <primary>; <reason>)
-```
-
-When a later probe succeeds and the session returns to the selected primary, OpenClaw sends:
-
-```text
-↪️ Model Fallback cleared: <primary> (was <fallback>)
-```
-
-These notices are operational messages, not assistant content. They deliver once per state change outside group and channel conversations, including side-effect-only turns when feasible, but repeated turn-local fallback transitions do not repeat them. Group and channel conversations suppress the visible notices while retaining the same fallback state and lifecycle events. Delivery bypasses normal source-reply suppression, does not consume the first assistant reply slot for threaded channels, and is excluded from text-to-speech.
-
-When a fallback answers, the Control UI shows the successful answer once and removes empty failed-attempt placeholders from that same run. The raw transcript retains the failed attempts for troubleshooting. Failed turns and attempts that produced partial visible output remain visible.
-
 ## Auth storage (keys + OAuth)
 
 OpenClaw uses **auth profiles** for both API keys and OAuth tokens.
@@ -253,6 +219,20 @@ State is stored in the per-agent SQLite auth state under `usageStats`:
 }
 ```
 
+## Auth failure skip cache
+
+By default, every new turn keeps the existing fallback retry behavior. OpenClaw retries each configured fallback candidate again. This includes non-primary candidates that recently failed with `auth` or `auth_permanent`.
+
+Opt in to suppress repeat auth failures with:
+
+```bash
+OPENCLAW_FALLBACK_SKIP_TTL_MS=60000
+```
+
+When enabled, OpenClaw records an in-memory, session-scoped skip marker for a non-primary fallback candidate after an auth-class failure. The key includes the session, provider, model, and selected automatic or explicit profile ID. Switching profiles does not inherit another profile's failure marker. Primary candidates are never skipped, so an explicit user model selection still surfaces the real auth error. The cache is process-local and clears on Gateway restart.
+
+The value is a TTL in milliseconds. `0` or unset disables the cache. Positive values are clamped between 1 second and 10 minutes.
+
 ## Billing disables
 
 Billing/credit failures (for example "insufficient credits" / "credit balance too low") are treated as failover-worthy. OpenClaw marks the credential as **disabled** for ten minutes initially and rotates to the next eligible profile/provider.
@@ -376,6 +356,26 @@ Live model switching follows these rules:
 - A live switch can select a model outside the active fallback chain. OpenClaw then returns the original switch to the agent, reply, or isolated-cron retry owner. The selected model can complete the same turn.
 
 The active run carries its chosen candidate directly. Live reconciliation changes that candidate only for an explicit pending user switch, so no temporary fallback override or rollback is needed.
+
+## User-visible fallback notices
+
+Outside group and channel conversations, OpenClaw sends a status notice in the same reply surface when a session moves onto an auto-selected fallback:
+
+```text
+↪️ Model Fallback: <fallback> (selected <primary>; <reason>)
+```
+
+When a later probe succeeds and the session returns to the selected primary, OpenClaw sends:
+
+```text
+↪️ Model Fallback cleared: <primary> (was <fallback>)
+```
+
+These notices are operational messages, not assistant content. They deliver once per state change outside group and channel conversations, including side-effect-only turns when feasible, but repeated turn-local fallback transitions do not repeat them. Group and channel conversations suppress the visible notices while retaining the same fallback state and lifecycle events. Delivery bypasses normal source-reply suppression, does not consume the first assistant reply slot for threaded channels, and is excluded from text-to-speech.
+
+Persisted notice state prevents repeated notices when consecutive turns use the same selected/active pair, while model selection itself remains unchanged.
+
+When a fallback answers, the Control UI shows the successful answer once and removes empty failed-attempt placeholders from that same run. The raw transcript retains the failed attempts for troubleshooting. Failed turns and attempts that produced partial visible output remain visible.
 
 ## Observability and failure summaries
 

--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -65,6 +65,8 @@ Each person can sign in to a model account for their Gateway profile. New sessio
 
 There are two sign-ins: the Gateway identifies **you**, then the provider authorizes **your model account**. CLI and web UI use the same personal account store on the selected Gateway. A shared server does not turn personal sign-in into shared credentials. System/agent credentials are a separate scope, managed through `models auth` on the machine running that OpenClaw installation.
 
+### Account concepts
+
 There are four separate pieces:
 
 | Piece            | What it means                                                                                         |
@@ -73,6 +75,8 @@ There are four separate pieces:
 | New-chat default | The saved account your new chats prefer for that provider. Changing it does not repin existing chats. |
 | Chat selection   | The account already selected for one chat. Other people and forks keep that selection.                |
 | Sign-in attempt  | A temporary, cancellable operation. No account is saved until sign-in succeeds.                       |
+
+### Adding an account
 
 Open **Settings → Profile → Connected accounts**, select **Add account**, then choose a provider and sign-in method. Adding an account needs an identified connection with `operator.write`.
 
@@ -88,19 +92,27 @@ The page lists saved accounts with friendly labels and marks the new-chat defaul
 
 The page reports the exact sign-in operation as pending, connected, cancelled, expired, or failed. **Cancel** asks the Gateway to retire that operation, including an exchange already in flight. Disconnecting, losing permission, or restarting the Gateway prevents an unfinished sign-in from starting another provider request or saving credentials. Start a new sign-in after reconnecting. Refreshing profile identity does not interrupt account controls.
 
+### Choosing an account for a chat
+
 Open the model menu in **New session** or an existing chat. Use **Account for this chat** to choose one of your saved accounts for the selected provider. The account picker remains available when **Automatic** has no eligible models. In New session, choosing an account previews eligible models before your first message. The selection applies to the session you create and can also be used for [draft-title preparation](/web/control-ui/sessions-and-sidebar#new-session-names) before you press Start. It does not change your new-chat default or saved model preference. Changing accounts discards the old title suggestion. In an existing chat, it changes that chat's selection.
 
 The account control shows a person a person-level label for someone else's personal account, not its private email, provider account label, or account id. The label describes the selection, not a billing receipt: configured shared failover accounts can still be used.
 
 Chat status and model listings identify a selected personal credential as **personal account**, without exposing its private label, email, or account id.
 
+### CLI and Custodian
+
 The CLI uses the same Gateway operations through [`openclaw models accounts`](/cli/models#personal-model-accounts). Run `openclaw models accounts login` to choose a provider and method, or supply `login <provider> --method <id>` directly. Use `list` to inspect saved accounts. Each command shows the selected Gateway, verified person, and Personal scope. It targets that person, not `--agent` or the operating-system username.
 
 Ask OpenClaw (Custodian) requires administrator access and a working configured inference route. Ask it to manage your personal model accounts, or enter `model accounts`. In the Control UI it opens **Settings → Profile → Connected accounts**. In a terminal it gives the CLI commands. If Custodian is unavailable, open **Connected accounts** or use the CLI directly. The handoff makes no change by itself. Complete sign-in in the protected controls or hidden terminal prompt, never in the conversation. Delegated agent requests cannot open or complete the human sign-in flow.
 
+### Where credentials are stored
+
 Credentials and the selected link are saved together in private, identity-scoped records in the shared state database (`state/openclaw.sqlite` under the Gateway state directory). There is no second account database or JSON sidecar. Pending sign-in operations live only in Gateway memory. Credentials are not added to the shared or agent-local auth stores, copied into global runtime snapshots, or included in automatic account rotation. Reconnecting replaces only a credential owned by that person. For ChatGPT, matching a workspace alone is not enough: the provider must also identify the same user. An administrator-linked shared account is never overwritten by a personal reconnect.
 
 Administrators can still create shared profiles through the CLI (`openclaw models auth login --provider openai --profile-id openai:alice`, see [OAuth](/concepts/oauth)) and link them with `users.linkAuthProfile`. Attaching an existing shared credential is an admin decision. `users.unlinkAuthProfile` remains self-or-admin, and `users.listAuthLinks` returns link metadata without secrets. A personal credential cannot be linked to another person's profile.
+
+### Pin and default rules
 
 When a linked person creates a session, OpenClaw captures their default as that session's auth selection. The selection has the same strength as a `/model ...@profile` pin. This happens before an initial message is dispatched, including when creation and the first message are separate requests. Sessions first created by turn admission capture the default at that admission. The pin is **session-sticky**: other people steering into that session use its selected account, and forks inherit it. An explicit `/model ...@profile -s` pin outranks the link. A fresh personal selection must belong to the authenticated human making it. Knowing another person's account id is not permission to select it. Agent- and channel-originated turns do not create personal links. For runtimes using OpenClaw's auth fallback planner, the ordered shared profiles for the same provider remain failover candidates if the pinned account fails. This matches the behavior of an explicit pin. Claude CLI requires its selected account and does not substitute shared profiles or its native login when that account cannot be used.
 

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -142,7 +142,9 @@ runtime accepts steering and otherwise becomes a followup; `followup` and
 before starting the newest message. The explicit `/steer <message>` command is
 not a local-mode command.
 
-## Scope and guarantees
+<a id="scope-and-guarantees" />
+
+## Input durability
 
 Ordinary Control UI input sent to an existing session is stored in the per-agent database
 before the Gateway acknowledges it. In `collect` mode, appending the combined
@@ -159,6 +161,8 @@ attempt is abandoned before agent-turn adoption. Abandonment releases that
 attempt's inbound and queue dedupe entries before ingress retries it. Messages
 already adopted or consumed keep duplicate suppression, so transport redelivery
 does not repeat their effects.
+
+## Lanes and scope
 
 - Applies to auto-reply agent runs across all inbound channels that use the gateway reply pipeline (WhatsApp web, Telegram, Slack, Discord, Signal, iMessage, webchat, etc.).
 - Default lane (`main`) is process-wide for inbound turns; set `agents.defaults.maxConcurrent` to allow multiple sessions in parallel.

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -232,16 +232,14 @@ tool clamp stays limited to its spawn subtree. Incognito sessions remain hidden
 from every cross-session tool. Ambient group watches still add activity notices
 and prompt hints; they do not grant access.
 
-## Further reading
-
-- [Session Management](/concepts/session): routing, lifecycle, maintenance
-- [Sub-agents](/tools/subagents): child-session lifecycle and delivery
-- [ACP Agents](/tools/acp-agents): external harness spawning
-- [Multi-agent](/concepts/multi-agent): multi-agent architecture
-- [Gateway Configuration](/gateway/configuration): session tool config knobs
+<a id="further-reading" />
 
 ## Related
 
-- [Session management](/concepts/session)
+- [Session Management](/concepts/session): routing, lifecycle, maintenance
 - [Session pruning](/concepts/session-pruning)
+- [Sub-agents](/tools/subagents): child-session lifecycle and delivery
+- [ACP Agents](/tools/acp-agents): external harness spawning
+- [Multi-agent](/concepts/multi-agent): multi-agent architecture
 - [Goal](/tools/goal) — durable per-session objectives, read and updated through the dedicated `get_goal`, `create_goal`, and `update_goal` tools
+- [Gateway Configuration](/gateway/configuration): session tool config knobs

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -330,7 +330,9 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 | `/status` in chat          | Context usage, model, and toggles               |
 | `/context list`            | What is in the system prompt                    |
 
-## Further reading
+<a id="further-reading" />
+
+## Related
 
 - [Session search](/concepts/session-search) - full-text recall across past transcripts
 - [Session Pruning](/concepts/session-pruning) - trimming tool results
@@ -339,13 +341,8 @@ Preview any maintenance run with `openclaw sessions cleanup --dry-run`.
 - [Session Management Deep Dive](/reference/session-management-compaction) -
   store schema, transcripts, send policy, origin metadata, and advanced config
 - [Multi-Agent](/concepts/multi-agent) - routing and session isolation across agents
-- [Background Tasks](/automation/tasks) - how detached work creates task records with session references
-- [Channel routing](/channels/channel-routing) - how inbound messages are routed to sessions
-
-## Related
-
-- [Session pruning](/concepts/session-pruning)
-- [Session tools](/concepts/session-tool)
+- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - per-agent sandbox and tool restrictions, including session visibility
 - [Transcript hygiene](/reference/transcript-hygiene) - in-memory, provider-specific transcript sanitization applied before a run
 - [Command queue](/concepts/queue)
-- [Multi-agent sandbox and tools](/tools/multi-agent-sandbox-tools) - per-agent sandbox and tool restrictions, including session visibility
+- [Background Tasks](/automation/tasks) - how detached work creates task records with session references
+- [Channel routing](/channels/channel-routing) - how inbound messages are routed to sessions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1393,7 +1393,8 @@
                   "install/node",
                   "install/node-compatibility",
                   "install/bun",
-                  "install/bun-compatibility"
+                  "install/bun-compatibility",
+                  "install/nix"
                 ]
               },
               {
@@ -1425,7 +1426,6 @@
               {
                 "group": "Containers",
                 "pages": [
-                  "install/ansible",
                   "install/docker",
                   {
                     "group": "Docker",
@@ -1436,7 +1436,6 @@
                       "install/docker/sandbox-and-troubleshooting"
                     ]
                   },
-                  "install/nix",
                   "install/podman"
                 ]
               },
@@ -1471,6 +1470,7 @@
                   {
                     "group": "Self-hosted and local",
                     "pages": [
+                      "install/ansible",
                       "install/docker-vm-runtime",
                       "install/kubernetes",
                       "install/macos-vm",
@@ -1746,6 +1746,7 @@
                 "pages": [
                   "concepts/messages",
                   "concepts/streaming",
+                  "concepts/typing-indicators",
                   "concepts/progress-drafts",
                   "concepts/retry",
                   "concepts/queue",
@@ -1935,6 +1936,7 @@
                 "group": "Automation",
                 "pages": [
                   "automation/index",
+                  "gateway/heartbeat",
                   "automation/cron-jobs",
                   {
                     "group": "Automations",
@@ -2472,7 +2474,6 @@
                     "group": "Health and diagnostics",
                     "pages": [
                       "gateway/health",
-                      "gateway/heartbeat",
                       "gateway/doctor",
                       {
                         "group": "Doctor",
@@ -2562,7 +2563,6 @@
                       "gateway/security/rate-limiting",
                       "gateway/security/operator-incident-response",
                       "gateway/security/secure-file-operations",
-                      "gateway/security/dependency-locking",
                       "gateway/operator-scopes",
                       "gateway/sandboxing",
                       {
@@ -2589,6 +2589,8 @@
                   {
                     "group": "Protocols and APIs",
                     "pages": [
+                      "gateway/clients",
+                      "gateway/external-apps",
                       "gateway/protocol",
                       {
                         "group": "Gateway protocol",
@@ -2608,11 +2610,15 @@
                           "gateway/protocol/auth"
                         ]
                       },
-                      "gateway/clients",
                       "gateway/embedding",
                       "gateway/openai-http-api",
                       "gateway/openresponses-http-api",
-                      "gateway/tools-invoke-http-api",
+                      "gateway/tools-invoke-http-api"
+                    ]
+                  },
+                  {
+                    "group": "Models and local providers",
+                    "pages": [
                       "gateway/cli-backends",
                       "gateway/local-models",
                       "gateway/local-model-services"
@@ -2624,7 +2630,6 @@
                       "network",
                       "gateway/pairing",
                       "gateway/discovery",
-                      "gateway/portals",
                       "gateway/bonjour"
                     ]
                   }
@@ -2721,6 +2726,7 @@
                       "web/control-ui/development"
                     ]
                   },
+                  "gateway/portals",
                   "web/notifications",
                   "web/urls",
                   "web/dashboard",
@@ -2930,7 +2936,6 @@
                 "group": "RPC and API",
                 "pages": [
                   "reference/rpc",
-                  "gateway/external-apps",
                   "reference/device-models"
                 ]
               },
@@ -3123,6 +3128,7 @@
                   "reference/openclaw-ai",
                   "reference/prompt-caching",
                   "reference/api-usage-costs",
+                  "concepts/usage-tracking",
                   "reference/transcript-hygiene",
                   "reference/database-schemas",
                   {
@@ -3150,17 +3156,15 @@
                       "reference/session-management-compaction/housekeeping"
                     ]
                   },
-                  "date-time"
+                  "date-time",
+                  "concepts/timezone"
                 ]
               },
               {
                 "group": "Concept internals",
                 "pages": [
                   "concepts/typebox",
-                  "concepts/markdown-formatting",
-                  "concepts/typing-indicators",
-                  "concepts/usage-tracking",
-                  "concepts/timezone"
+                  "concepts/markdown-formatting"
                 ]
               },
               {
@@ -3217,7 +3221,8 @@
                       "reference/full-release-validation/evidence"
                     ]
                   },
-                  "reference/release-performance-sweep"
+                  "reference/release-performance-sweep",
+                  "gateway/security/dependency-locking"
                 ]
               },
               {

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -6,7 +6,7 @@ read_when:
 title: "Gateway logging"
 ---
 
-# Logging
+<a id="logging" />
 
 For a user-facing overview (CLI + Control UI + config), see [/logging](/logging).
 

--- a/docs/gateway/multi-tenant-hosting.md
+++ b/docs/gateway/multi-tenant-hosting.md
@@ -7,7 +7,7 @@ read_when:
 title: "Multi-tenant hosting"
 ---
 
-# Multi-tenant hosting
+<a id="multi-tenant-hosting" />
 
 OpenClaw's default security model is one trusted operator boundary per Gateway, not hostile multi-tenant isolation inside one shared Gateway. Hosting users or organizations that do not share a trust boundary therefore means running a separate complete OpenClaw instance for each tenant.
 

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -11,89 +11,6 @@ doc-schema-version: 1
 
 Debugging helpers for streaming output, gateway iteration, and startup profiling.
 
-## Runtime debug overrides
-
-`/debug` sets **runtime-only** config overrides (memory, not disk). Disabled by default; enable with `commands.debug: true`.
-
-```text
-/debug show
-/debug set channels.whatsapp.responsePrefix="[openclaw]"
-/debug unset channels.whatsapp.responsePrefix
-/debug reset
-```
-
-`/debug reset` clears all overrides and returns to the on-disk config.
-
-## Session trace output
-
-`/trace` shows plugin-owned trace/debug lines for one session without enabling full verbose mode. Use it for plugin diagnostics such as Active Memory debug summaries; use `/verbose` for normal status/tool output.
-
-```text
-/trace
-/trace on
-/trace off
-```
-
-## Plugin lifecycle trace
-
-Set `OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1` for a phase-by-phase breakdown of plugin metadata, discovery, registry, runtime mirror, config mutation, and refresh work. Writes to stderr, so JSON command output stays parseable.
-Plugin load failures include their stack trace while this trace is enabled.
-
-```bash
-OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 openclaw plugins install tokenjuice --force
-```
-
-```text
-[plugins:lifecycle] phase="config read" ms=6.83 status=ok command="install"
-[plugins:lifecycle] phase="slot selection" ms=94.31 status=ok command="install" pluginId="tokenjuice"
-[plugins:lifecycle] phase="registry refresh" ms=51.56 status=ok command="install" reason="source-changed"
-```
-
-Use this before reaching for a CPU profiler. From a source checkout, measure the built runtime with `node dist/entry.js ...` after `pnpm build`; `pnpm openclaw ...` also measures source-runner overhead.
-
-For synchronous module-load timings, use the shared diagnostics surface instead of a separate plugin-only environment switch:
-
-```bash
-OPENCLAW_DIAGNOSTICS=plugin.load-profile openclaw plugins list
-```
-
-## CLI startup and command profiling
-
-Checked-in startup benchmarks:
-
-```bash
-pnpm test:startup:bench:smoke
-pnpm tsx scripts/bench-cli-startup.ts --preset real --case status --runs 3
-pnpm tsx scripts/bench-cli-startup.ts --preset real --cpu-prof-dir .artifacts/cli-cpu
-```
-
-For one-off profiling through the normal source runner, set `OPENCLAW_RUN_NODE_CPU_PROF_DIR`:
-
-```bash
-OPENCLAW_RUN_NODE_CPU_PROF_DIR=.artifacts/cli-cpu pnpm openclaw status
-```
-
-The source runner adds Node CPU profile flags and writes a `.cpuprofile` for the command. Use this before adding temporary instrumentation to command code.
-
-For startup stalls that look like synchronous filesystem or module-loader work, add Node's sync I/O trace flag through the source runner:
-
-```bash
-OPENCLAW_TRACE_SYNC_IO=1 pnpm openclaw gateway --force
-```
-
-`pnpm gateway:watch` leaves this flag disabled by default for the watched Gateway child; set `OPENCLAW_TRACE_SYNC_IO=1` when you want sync I/O trace output in watch mode too.
-
-## Node and tsx startup errors
-
-If a source-run command fails with `TypeError: __name is not a function`, capture
-`node --version`, `pnpm list tsx --depth 0`, the exact command, and the full stack.
-Confirm that Node is a [supported version](/install/node).
-
-From a trusted source checkout, run `pnpm build` before comparing the failure with
-the built runtime through `pnpm openclaw <command>`. The repository's typecheck
-does not emit build output. Keep the failing command and version evidence in a
-bug report rather than applying a workaround from an old investigation.
-
 ## Gateway watch mode
 
 ```bash
@@ -284,11 +201,71 @@ OPENCLAW_RAW_STREAM_PATH=~/.openclaw/logs/raw-stream.jsonl
 
 Default file: `~/.openclaw/logs/raw-stream.jsonl`
 
-## Safety notes
+### Safety notes
 
 - Raw stream logs can include full prompts, tool output, and user data.
 - Keep logs local and delete them after debugging.
 - If you share logs, scrub secrets and PII first.
+
+## CLI startup and command profiling
+
+Checked-in startup benchmarks:
+
+```bash
+pnpm test:startup:bench:smoke
+pnpm tsx scripts/bench-cli-startup.ts --preset real --case status --runs 3
+pnpm tsx scripts/bench-cli-startup.ts --preset real --cpu-prof-dir .artifacts/cli-cpu
+```
+
+For one-off profiling through the normal source runner, set `OPENCLAW_RUN_NODE_CPU_PROF_DIR`:
+
+```bash
+OPENCLAW_RUN_NODE_CPU_PROF_DIR=.artifacts/cli-cpu pnpm openclaw status
+```
+
+The source runner adds Node CPU profile flags and writes a `.cpuprofile` for the command. Use this before adding temporary instrumentation to command code.
+
+For startup stalls that look like synchronous filesystem or module-loader work, add Node's sync I/O trace flag through the source runner:
+
+```bash
+OPENCLAW_TRACE_SYNC_IO=1 pnpm openclaw gateway --force
+```
+
+`pnpm gateway:watch` leaves this flag disabled by default for the watched Gateway child; set `OPENCLAW_TRACE_SYNC_IO=1` when you want sync I/O trace output in watch mode too.
+
+## Plugin lifecycle trace
+
+Set `OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1` for a phase-by-phase breakdown of plugin metadata, discovery, registry, runtime mirror, config mutation, and refresh work. Writes to stderr, so JSON command output stays parseable.
+Plugin load failures include their stack trace while this trace is enabled.
+
+```bash
+OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 openclaw plugins install tokenjuice --force
+```
+
+```text
+[plugins:lifecycle] phase="config read" ms=6.83 status=ok command="install"
+[plugins:lifecycle] phase="slot selection" ms=94.31 status=ok command="install" pluginId="tokenjuice"
+[plugins:lifecycle] phase="registry refresh" ms=51.56 status=ok command="install" reason="source-changed"
+```
+
+Use this before reaching for a CPU profiler. From a source checkout, measure the built runtime with `node dist/entry.js ...` after `pnpm build`; `pnpm openclaw ...` also measures source-runner overhead.
+
+For synchronous module-load timings, use the shared diagnostics surface instead of a separate plugin-only environment switch:
+
+```bash
+OPENCLAW_DIAGNOSTICS=plugin.load-profile openclaw plugins list
+```
+
+## Node and tsx startup errors
+
+If a source-run command fails with `TypeError: __name is not a function`, capture
+`node --version`, `pnpm list tsx --depth 0`, the exact command, and the full stack.
+Confirm that Node is a [supported version](/install/node).
+
+From a trusted source checkout, run `pnpm build` before comparing the failure with
+the built runtime through `pnpm openclaw <command>`. The repository's typecheck
+does not emit build output. Keep the failing command and version evidence in a
+bug report rather than applying a workaround from an old investigation.
 
 ## Debugging in VSCode
 
@@ -319,6 +296,29 @@ Set breakpoints in `src/` TypeScript files; the debugger maps them to compiled J
 - **Debug Gateway** can start/stop without affecting `/dist`, but you manage the build cycle in a separate terminal.
 - Edit `launch.json` `args` to debug other CLI subcommands.
 - To use the built CLI for other tasks (for example `dashboard --no-open` if your debug session spawns a new auth token), run it from another terminal: `node ./openclaw.mjs` or an alias like `alias openclaw-build="node $(pwd)/openclaw.mjs"`.
+
+## Runtime debug overrides
+
+`/debug` sets **runtime-only** config overrides (memory, not disk). Disabled by default; enable with `commands.debug: true`.
+
+```text
+/debug show
+/debug set channels.whatsapp.responsePrefix="[openclaw]"
+/debug unset channels.whatsapp.responsePrefix
+/debug reset
+```
+
+`/debug reset` clears all overrides and returns to the on-disk config.
+
+## Session trace output
+
+`/trace` shows plugin-owned trace/debug lines for one session without enabling full verbose mode. Use it for plugin diagnostics such as Active Memory debug summaries; use `/verbose` for normal status/tool output.
+
+```text
+/trace
+/trace on
+/trace off
+```
 
 ## Related
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -39,6 +39,28 @@ The variables below are the supported environment contract for operators. Undocu
 | `OPENCLAW_INCLUDE_ROOTS`  | Allow `$include` to resolve from additional roots.                                                   |
 | `OPENCLAW_SQLITE_LIBRARY` | Override the SQLite library for [Bun on macOS](/install/bun-compatibility#sqlite-library-selection). |
 
+#### `OPENCLAW_HOME`
+
+When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.homedir()`) for internal OpenClaw path defaults. This includes the default state directory, config path, agent directories, credentials, installer onboarding workspace, and the default dev checkout used by `openclaw update --channel dev`.
+
+`OPENCLAW_HOME` does not grant ownership of the OS account's native Gateway service. Gateway service-management commands treat a relocated home as isolated state; use the OS account home and a named profile when a separate native service identity is required.
+
+**Precedence:** `OPENCLAW_HOME` > `$HOME` > `USERPROFILE` > Termux `PREFIX` home fallback on Android > `os.homedir()`
+
+**Example** (macOS LaunchDaemon):
+
+```xml
+<key>EnvironmentVariables</key>
+<dict>
+  <key>OPENCLAW_HOME</key>
+  <string>/Users/user</string>
+</dict>
+```
+
+`OPENCLAW_HOME` can also be set to a tilde path (e.g. `~/svc`), which gets expanded using the same OS home fallback chain before use.
+
+Explicit path variables such as `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_GIT_DIR` still take precedence. OS-account tasks such as shell startup file detection, package-manager setup, and host `~` expansion may still use the real system home.
+
 ### Gateway and authentication
 
 | Variable                    | Purpose                                                         |
@@ -274,28 +296,6 @@ unavailable instead of triggering a network request.
 | `OPENCLAW_DEBUG_MODEL_PAYLOAD`   | Model payload diagnostics: `summary`, `tools`, or `full-redacted`. `full-redacted` is capped and redacted but may include prompt/message text.                                               |
 | `OPENCLAW_DEBUG_SSE`             | Streaming diagnostics: `events` for first/done timing, `peek` to include the first five redacted SSE events.                                                                                 |
 | `OPENCLAW_DEBUG_CODE_MODE`       | Code-mode model-surface diagnostics, including provider-tool hiding and compact control/direct enforcement.                                                                                  |
-
-### `OPENCLAW_HOME`
-
-When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.homedir()`) for internal OpenClaw path defaults. This includes the default state directory, config path, agent directories, credentials, installer onboarding workspace, and the default dev checkout used by `openclaw update --channel dev`.
-
-`OPENCLAW_HOME` does not grant ownership of the OS account's native Gateway service. Gateway service-management commands treat a relocated home as isolated state; use the OS account home and a named profile when a separate native service identity is required.
-
-**Precedence:** `OPENCLAW_HOME` > `$HOME` > `USERPROFILE` > Termux `PREFIX` home fallback on Android > `os.homedir()`
-
-**Example** (macOS LaunchDaemon):
-
-```xml
-<key>EnvironmentVariables</key>
-<dict>
-  <key>OPENCLAW_HOME</key>
-  <string>/Users/user</string>
-</dict>
-```
-
-`OPENCLAW_HOME` can also be set to a tilde path (e.g. `~/svc`), which gets expanded using the same OS home fallback chain before use.
-
-Explicit path variables such as `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_GIT_DIR` still take precedence. OS-account tasks such as shell startup file detection, package-manager setup, and host `~` expansion may still use the real system home.
 
 ## nvm users: web_fetch TLS failures
 

--- a/docs/help/testing-updates-plugins.md
+++ b/docs/help/testing-updates-plugins.md
@@ -15,6 +15,17 @@ install, load, update, and uninstall plugins from every supported source.
 For the broader test runner map, see [Testing](/help/testing). For live provider
 keys and network-touching suites, see [Testing live](/help/testing-live).
 
+## On this page
+
+- [What we protect](#what-we-protect) - the guarantees these lanes exist to defend.
+- [Local proof during development](#local-proof-during-development) - the commands to run while you iterate.
+- [Docker lanes](#docker-lanes) - lane reference: what each lane runs and when.
+- [Package Acceptance](#package-acceptance) - lane reference: the acceptance matrix and its gates.
+- [Release default](#release-default) - which lanes a release candidate must clear.
+- [Legacy compatibility](#legacy-compatibility) - older package and plugin states still covered.
+- [Adding coverage](#adding-coverage) - where a new regression belongs.
+- [Failure triage](#failure-triage) - what to do when a lane goes red.
+
 ## What we protect
 
 - A package tarball is complete, has a valid `dist/postinstall-inventory.json`,

--- a/docs/install/backups.md
+++ b/docs/install/backups.md
@@ -7,7 +7,7 @@ read_when:
 title: "Backups"
 ---
 
-# Backups
+<a id="backups" />
 
 OpenClaw keeps its authoritative state in SQLite: one global control-plane
 database under the state directory (usually `~/.openclaw`), plus one database

--- a/docs/install/upstash.md
+++ b/docs/install/upstash.md
@@ -96,6 +96,13 @@ ssh -F /dev/null -o ControlMaster=no -o ServerAliveInterval=15 -o ServerAliveCou
 This bypasses stale local `~/.ssh/config` settings and keeps the tunnel active
 through idle network periods.
 
+## Next steps
+
+- Set up messaging channels: [Channels](/channels)
+- Configure the Gateway: [Gateway configuration](/gateway/configuration)
+- Keep OpenClaw up to date: [Updating](/install/updating)
+- Compare hosting options: [Linux server](/vps)
+
 ## Related
 
 - [Remote access](/gateway/remote)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -26,7 +26,9 @@ tuning that applies everywhere.
   <Card title="Northflank" href="/install/northflank">One-click, browser setup</Card>
   <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
   <Card title="Railway" href="/install/railway">One-click, browser setup</Card>
+  <Card title="Render" href="/install/render">Managed web service</Card>
   <Card title="Raspberry Pi" href="/install/raspberry-pi">ARM self-hosted</Card>
+  <Card title="Upstash Box" href="/install/upstash">SSH-managed sandbox box</Card>
 </CardGroup>
 
 **AWS (EC2 / Lightsail / free tier)** also works well.


### PR DESCRIPTION
Structure-only pass over the 50 open `ia` (information-architecture) audit rows filed against `docs/gateway/`, `docs/concepts/`, `docs/install/` and `docs/help/`.

**No page splits, no file moves, no URL changes, no new pages.** Everything here is either an on-page structural edit or a `docs.json` navigation move.

## CODEOWNERS

Last-match-wins simulated over the full changed-file list **before** editing: **zero owned files**. `docs/gateway/security/dependency-locking.md` is the only `secops`-owned page any row touched, and its row (`r3-1679`) is satisfied by a `docs.json` nav move alone — the "leave a one-line link in the security index" half was already present at `docs/gateway/security/index.md:47`, so that file is untouched. `docs/docs.json`, `docs/vps.md` and every `docs/{gateway,concepts,install,help}` file changed here match no CODEOWNERS rule.

## Anchor proof

All 15 changed pages enumerated with the repo's own `parseDocsDocument`, before and after:

| Page | before | after | lost | added |
| --- | --- | --- | --- | --- |
| `docs/concepts/multi-user.md` | 16 | 22 | 0 | 6 |
| `docs/concepts/model-failover.md` | 37 | 37 | 0 | 0 |
| `docs/concepts/session-tool.md` | 11 | 11 | 0 | 0 |
| `docs/concepts/session.md` | 13 | 13 | 0 | 0 |
| `docs/concepts/compaction.md` | 16 | 17 | 0 | 1 |
| `docs/concepts/memory-builtin.md` | 11 | 11 | 0 | 0 |
| `docs/concepts/queue.md` | 14 | 16 | 0 | 2 |
| `docs/gateway/logging.md` | 15 | 15 | 0 | 0 |
| `docs/gateway/multi-tenant-hosting.md` | 8 | 8 | 0 | 0 |
| `docs/install/backups.md` | 13 | 13 | 0 | 0 |
| `docs/help/environment.md` | 25 | 25 | 0 | 0 |
| `docs/help/debugging.md` | 14 | 14 | 0 | 0 |
| `docs/help/testing-updates-plugins.md` | 9 | 10 | 0 | 1 |
| `docs/install/upstash.md` | 9 | 10 | 0 | 1 |
| `docs/vps.md` | 9 | 9 | 0 | 0 |

**Zero ids lost, zero collisions, 11 added.** The after-set is a strict superset on every page.

Measured, not assumed:
- **Level changes do not change the slug.** `## Safety notes` → `### Safety notes` (debugging) and `### OPENCLAW_HOME` → `#### OPENCLAW_HOME` (environment) both kept `safety-notes` and `openclaw_home`.
- **Whole-H2-block reordering does not change ids.** `model-failover.md` and `debugging.md` were reordered block-wise; both came back with an identical 37- and 14-id set.
- **Three authored stubs added**, all for the removed body H1s: `<a id="logging" />`, `<a id="multi-tenant-hosting" />`, `<a id="backups" />`. Each page's own id set confirms no duplicate authored/canonical id. Precedent commit `204971f2a94` ("docs: remove duplicate body H1s ... across 10 pages") removed the same shape of H1 without stubs; I kept the ids anyway, since a grep cannot see external bookmarks. Happy to drop the three stubs if you prefer the earlier convention.
- **`<a id="further-reading" />`** kept on `session.md` and `session-tool.md` where the merged section's heading is now `## Related`.
- **`<a id="scope-and-guarantees" />`** kept on `queue.md` where that heading became two.

## Validators

- `pnpm check:docs` — **exit 0** (format-docs 1280 files clean, markdownlint `Linting: 1279 files`, mdx, i18n glossary, links, config examples).
- `node scripts/docs-link-audit.mjs --anchors` — **3 broken**, all the known pre-existing `maturity/#windows-app-node` ones (`maturity/scorecard.md:90,144`, `maturity/taxonomy.md:165`). No `maturity/` file is touched by this PR.
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — **1 file / 33 tests passed**.
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files / 16 tests passed**.
- `node .audit/code-docs-anchors.mjs HEAD` — **5 dead**, the documented non-defects (CHANGELOG, `localized_links_test.go` x2, `docs-link-audit.test.ts`, `gateway-chat.connection.test.ts`). Unchanged.
- `.github/labeler.yml`: no gap created — this PR adds no files, so every changed path keeps the glob that already matched it.

## Word count

Flat apart from headings, with three deliberate exceptions:
- `model-failover.md` **-45**: the duplicated fallback-notice paragraph under "Selection source policy" was folded into the canonical notices section (its one unique sentence, about persisted notice state, was carried over verbatim). That deduplication *is* the finding.
- `session.md` **-6** / `session-tool.md` **-3**: the merged Related lists dropped entries that appeared in both lists.
- `testing-updates-plugins.md` **+96**, `upstash.md` **+28**, `vps.md` **+11**, `multi-user.md` **+28**: added headings, an "On this page" index, a "Next steps" list, and two provider cards.

No rule chain or precedence list was reordered internally. `model-failover.md` and `debugging.md` moved whole H2 blocks only; every list inside them is byte-identical.

## Stale rows

Nine rows describe pages that were split into child directories after the audit ran; their cited line numbers point past the end of the page that exists today. Details per id in the review notes below.
