### PR TITLE
refactor(memory-wiki): share deferred test fixtures

### DIFF
--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -13,6 +13,7 @@ import {
   type MemoryWikiCompiledCacheSnapshot,
 } from "./src/compiled-cache.js";
 import { resolveMemoryWikiConfig } from "./src/config.js";
+import { deferred } from "./src/deferred.test-helpers.js";
 import {
   appendMemoryWikiLog,
   loadMemoryWikiValidatedVaultIdentity,
@@ -67,14 +68,6 @@ function emptyCompiledSnapshot(): MemoryWikiCompiledCacheSnapshot {
       },
     },
   };
-}
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 describe("memory-wiki plugin", () => {

--- a/extensions/memory-wiki/src/chatgpt-import.test.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.test.ts
@@ -12,6 +12,7 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { rollbackChatGptImportRun } from "./chatgpt-import.js";
 import { configureMemoryWikiCompiledCacheStore } from "./compiled-cache.js";
+import { deferred } from "./deferred.test-helpers.js";
 import {
   configureMemoryWikiImportRunStateStore,
   createMemoryWikiImportRunStateStore,
@@ -46,14 +47,6 @@ vi.mock("./compile.js", async (importOriginal) => {
 });
 
 const { configureCompiledCacheStore, createTempDir, createVault } = createMemoryWikiTestHarness();
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 function configureDurableImportRunStore(
   stateDir: string,

--- a/extensions/memory-wiki/src/deferred.test-helpers.ts
+++ b/extensions/memory-wiki/src/deferred.test-helpers.ts
@@ -1,0 +1,7 @@
+export function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import { MemoryWikiDashboardUnavailableError } from "./compiled-cache.js";
+import { deferred } from "./deferred.test-helpers.js";
 import { registerMemoryWikiGatewayMethods } from "./gateway.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
 import { listMemoryWikiImportRuns } from "./import-runs.js";
@@ -104,14 +105,6 @@ function readRespondError(respond: { mock: { calls: Array<Array<unknown>> } }): 
   expect(call?.[0]).toBe(false);
   expect(call?.[1]).toBeUndefined();
   return call?.[2];
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 const VAULT_BACKED_GATEWAY_CASES = [

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -3,19 +3,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { describe, expect, it, vi } from "vitest";
+import { deferred } from "./deferred.test-helpers.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createTempDir, createVault } = createMemoryWikiTestHarness();
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 describe("ingestMemoryWikiSource", () => {
   it("copies a local text file into sources markdown", async () => {

--- a/extensions/memory-wiki/src/mutation-coordinator.test.ts
+++ b/extensions/memory-wiki/src/mutation-coordinator.test.ts
@@ -1,18 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { deferred } from "./deferred.test-helpers.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createMemoryWikiTestHarness();
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 describe("withMemoryWikiVaultMutation", () => {
   it("serializes mutations for one vault and permits nested work", async () => {

--- a/extensions/memory-wiki/src/source-sync.test.ts
+++ b/extensions/memory-wiki/src/source-sync.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { resolveMemoryWikiConfig } from "./config.js";
+import { deferred } from "./deferred.test-helpers.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { syncMemoryWikiImportedSources } from "./source-sync.js";
 
@@ -52,14 +53,6 @@ function createConfig(
   vaultPath = path.join(os.tmpdir(), `memory-wiki-source-sync-${vaultCounter++}`),
 ) {
   return resolveMemoryWikiConfig({ vaultMode, vault: { path: vaultPath } });
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 describe("syncMemoryWikiImportedSources", () => {
@@ -165,8 +158,8 @@ describe("syncMemoryWikiImportedSources", () => {
 
   it("waits for an existing vault mutation before starting source sync", async () => {
     const config = createConfig();
-    const blockerEntered = deferred<void>();
-    const blockerGate = deferred<void>();
+    const blockerEntered = deferred();
+    const blockerGate = deferred();
     const blocker = withMemoryWikiVaultMutation(config.vault.path, async () => {
       blockerEntered.resolve(undefined);
       await blockerGate.promise;


### PR DESCRIPTION
## What Problem This Solves

Memory Wiki's test suites maintained six copies of the same deferred-promise fixture used to coordinate concurrent work.

## Why This Change Was Made

Replace those copies with one pure, private test helper that supports both void and value-bearing promises. All six suites import it directly, so source-sync tests do not load the larger shared harness or its cleanup hooks. Assertions, ordering and cleanup remain unchanged; two redundant explicit void type arguments are omitted.

## User Impact

No runtime or user-visible behavior changes. This removes 35 lines of duplicated test scaffolding without removing coverage.

## Evidence

- The same six complete suites passed before and after: 85 cases on each side, with identical case identities and outcomes.
- All 29 deferred calls and 212 assertion sites are retained, including queue ordering, service retirement, rollback recovery, background responses and source-sync coalescing.
- Formatting, the complete 20-check changed-file gate (including extension-test types and lint), and independent source review passed. The first gate caught two redundant default type arguments; the corrected candidate then passed the complete gate and all 85 cases.
