### PR TITLE
docs: Simplified Technical English pass over tools, plugins, and channels

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1600,6 +1600,22 @@
     "target": "插件入口点"
   },
   {
+    "source": "Plugin runtime helpers",
+    "target": "插件运行时辅助函数"
+  },
+  {
+    "source": "Plugin setup and config",
+    "target": "插件设置与配置"
+  },
+  {
+    "source": "Building channel plugins",
+    "target": "构建渠道插件"
+  },
+  {
+    "source": "Building provider plugins",
+    "target": "构建提供商插件"
+  },
+  {
     "source": "Plugin SDK tool policy and sandbox helpers",
     "target": "插件 SDK 工具策略与沙箱辅助方法"
   },

--- a/docs/channels/buzz.md
+++ b/docs/channels/buzz.md
@@ -42,7 +42,7 @@ Buzz uses Nostr keypairs for identity:
 
 The relay URL points to one Buzz workspace. Each room has a UUID, and OpenClaw
 treats each configured UUID as a separate group conversation. One Gateway and
-bot identity can serve many rooms; you do not need a Gateway per agent or room.
+bot identity can serve many rooms. You do not need a Gateway per agent or room.
 
 ## Before you start
 
@@ -96,12 +96,12 @@ sender-allowlist settings are preserved when setup is rerun.
 Setup resolves the selected account's `privateKey` and `authTag` SecretRefs
 without replacing the references in your configuration. If a configured secret
 is unavailable, setup reports the error without saving account changes. Make
-the secret available and rerun setup; existing accounts are not disabled.
+the secret available and rerun setup. Existing accounts are not disabled.
 Select at least one authorized room to complete setup, or go back to leave it.
 
 The automatic room-access wait is bounded. If access is not granted in time,
 setup remains open and offers authenticated Retry/Back controls. Every retry
-reuses the same relay and bot identity; the timeout does not disable Buzz or
+reuses the same relay and bot identity. The timeout does not disable Buzz or
 exit setup.
 
 ### Bot approval
@@ -129,7 +129,7 @@ configured Buzz rooms, and finally `OpenClaw`. This replaces the shortened
 public key in Buzz after its profile cache refreshes.
 
 OpenClaw also registers the same public identity in Buzz's agent directory. It
-preserves an existing agent-directory profile and channel-add policy; for a new
+preserves an existing agent-directory profile and channel-add policy. For a new
 profile it allows authorized Buzz users to add the identity. This lets Buzz
 assign the **Bot** role when the identity is invited to additional rooms
 instead of treating it as a normal member. OpenClaw still receives messages
@@ -154,8 +154,8 @@ An explicit presence rejection remains a warning, not a reconnect trigger.
 
 The local Buzz `just dev` relay does not require separate relay membership by
 default. A hosted or closed relay may require the bot public key to be added to
-the workspace community first. Adding community membership grants relay access;
-it does not add the identity to a room with the Bot role.
+the workspace community first. Adding community membership grants relay access.
+It does not add the identity to a room with the Bot role.
 
 ```bash
 buzz-admin add-member --pubkey <BOT_PUBLIC_KEY> --role member
@@ -187,7 +187,7 @@ context when those fields are present. Diff content is not interpreted as an
 OpenClaw command or textual mention.
 
 Typing uses Buzz's ephemeral kind `20002` on the active authenticated Gateway
-connection. Ordinary replies refresh it every three seconds; heartbeat-driven
+connection. Ordinary replies refresh it every three seconds. Heartbeat-driven
 replies use OpenClaw's shared typing interval, which defaults to six seconds.
 OpenClaw stops refreshing when the turn completes, is cancelled, fails, or the
 Gateway shuts down. Typing failures do not block the reply or reconnect the
@@ -222,7 +222,7 @@ The referenced public key must be a current member of the target room. Without
 an explicit identity, unknown names and duplicate profile names fail visibly
 instead of sending text that looks like a mention without notifying anyone.
 When the message contains an explicit identity, unresolved or ambiguous labels
-remain presentation text; include every intended identity explicitly. Ambiguous
+remain presentation text. Include every intended identity explicitly. Ambiguous
 errors list candidate public keys so the sender can retry with the intended
 `nostr:npub...` identity. Out-of-room public keys always fail. Mention-like text
 inside inline or fenced Markdown code is ignored, and one message can carry at
@@ -232,7 +232,7 @@ Connected Gateways resolve names from their existing in-memory directory
 snapshot and do not query the relay per message. Profiles beyond the bounded
 snapshot require an explicit `nostr:npub...` identity. A standalone mention send
 loads membership and profiles through one bounded authenticated relay session,
-publishes, and closes it; standalone messages without mention syntax keep the
+publishes, and closes it. Standalone messages without mention syntax keep the
 existing direct publish path.
 
 ### Directory and sender labels
@@ -259,8 +259,8 @@ connection and in-memory snapshot. A standalone directory command opens one
 bounded authenticated connection, loads the current snapshot, and closes it.
 Ordinary directory errors are logged without reconnecting. If a directory or
 profile subscription does not reach EOSE within 10 seconds, OpenClaw treats the
-Buzz relay session as stalled and recycles only that Buzz account connection;
-the Gateway keeps running.
+Buzz relay session as stalled and recycles only that Buzz account connection.
+The Gateway keeps running.
 
 Archived rooms are omitted from directory results and live room subscriptions.
 If a configured room is archived or restored while OpenClaw is connected, the
@@ -271,7 +271,7 @@ Each configured room uses one room-scoped relay subscription. OpenClaw reserves
 four of Buzz's 1,024 connection subscriptions for membership notifications and
 concurrent profile, membership, and metadata queries, so one account can
 configure up to 1,020 rooms. Near that limit, optional member profile
-subscriptions are reduced first; directory entries continue to work with stable
+subscriptions are reduced first. Directory entries continue to work with stable
 public keys and deterministic fallback labels.
 
 Unique current room names can resolve as outbound targets through OpenClaw's
@@ -326,26 +326,26 @@ Fresh guided setup allows normal messages from current members of the selected
 rooms. OpenClaw loads Buzz's relay-signed room roster before accepting messages,
 checks membership before queuing and again after asynchronous admission, and
 follows live relay-signed roster updates, including role changes. A removal
-invalidates queued messages immediately; cancelled admission is not committed as
+invalidates queued messages immediately. Cancelled admission is not committed as
 processed. Bounded snapshot refreshes confirm membership-change notifications.
 There is no per-message relay query or Gateway polling.
-Removing a sender does not cancel a room turn already admitted for that sender;
-losing the bot's own Bot role or stopping its connection still fences output.
+Removing a sender does not cancel a room turn already admitted for that sender.
+Losing the bot's own Bot role or stopping its connection still fences output.
 
 Startup and reconnect recover eligible messages from the last 24 hours, but
 never from before that room's first activation by this Buzz account. That
-activation floor survives restarts; sender-supplied timestamps do not advance it.
+activation floor survives restarts. Sender-supplied timestamps do not advance it.
 Replay deduplication prevents completed messages from running again.
 
 Use `groupPolicy: "allowlist"` with `groupAllowFrom` in manual configuration
 when only specific room members should be able to activate the agent.
 Each room can override `groupPolicy`, `groupAllowFrom`, or both. An omitted room
-setting inherits the account-wide value; an explicitly empty room allowlist
+setting inherits the account-wide value. An explicitly empty room allowlist
 denies every sender when its effective policy is `"allowlist"`.
 Set `requireMention: true` only when the Buzz client used by those members can
 address the bot identity.
 
-These controls decide who can start an agent run; they do not limit what the
+These controls decide who can start an agent run. They do not limit what the
 routed agent can do after a message is accepted. Treat room messages as
 untrusted input, and configure that agent's [sandbox and tool policy](/gateway/sandbox-vs-tool-policy-vs-elevated)
 for the room's trust level.
@@ -357,7 +357,7 @@ agent under the same mention and sender rules. Within each Gateway, OpenClaw
 limits repeated exchanges between each bot pair in the same relay and room:
 the default budget is 20 accepted messages in 60 seconds, followed by a
 60-second cooldown. Changing threads does not reset the budget. Restarting the
-Gateway clears this in-memory budget; separate Gateways have separate budgets.
+Gateway clears this in-memory budget. Separate Gateways have separate budgets.
 Human messages are unaffected, and suppressed bot turns are logged without
 starting an agent run.
 
@@ -380,14 +380,14 @@ longer in the current room roster are removed before context is included.
 Passive messages do not start an agent run, record a session, or send typing.
 History stays in memory for the current connection, separately for each room and
 thread, and is cleared on reconnect or restart. Each message is truncated to
-512 UTF-8 bytes; the newest complete entries fit within a 1,024-byte rendered
+512 UTF-8 bytes. The newest complete entries fit within a 1,024-byte rendered
 context budget, including labels and markers. Older entries are discarded.
 An accepted turn consumes its context without deleting messages that arrived
 while the reply was running.
 
 Membership is checked against the latest received roster when context is used.
 If the same identity leaves and rejoins before then, its previously authorized
-messages can remain in the window; leaving does not erase conversation history.
+messages can remain in the window. Leaving does not erase conversation history.
 
 ### Reply placement
 
@@ -467,16 +467,16 @@ Set `channels.buzz.responsePrefix` to prefix automatic agent replies, for
 example `"[Support]"`. Use `"auto"` for the routed agent's identity name,
 `"[{model}]"` for its selected model, or `""` to disable an inherited global
 prefix. Explicit `message` tool and CLI text sends also apply literal and
-identity prefixes; see [shared prefix behavior](/concepts/messages#prefixes-threading-and-replies)
+identity prefixes. See [shared prefix behavior](/concepts/messages#prefixes-threading-and-replies)
 for model-dependent templates. A named account can override the root prefix
 with `channels.buzz.accounts.<id>.responsePrefix`.
-CLI sends that omit `--account` use the selected default account's prefix too;
-an account-level `""` suppresses the inherited root prefix.
+CLI sends that omit `--account` use the selected default account's prefix too.
+An account-level `""` suppresses the inherited root prefix.
 
 ### Multiple bot identities
 
 One Gateway can run independent Buzz accounts, each with its own relay, bot key,
-authorization value, and selected rooms. Run `openclaw channels add --channel buzz`
+`authTag`, and selected rooms. Run `openclaw channels add --channel buzz`
 and choose a new account to configure it interactively. Adding a named account
 does not move or replace the existing root identity.
 
@@ -504,18 +504,18 @@ does not move or replace the existing root identity.
 Named accounts inherit root policy and delivery settings, but never root
 `name`, `relayUrl`, `privateKey`, `authTag`, `groups`, or `defaultTo`. Set those
 identity and room fields on each account. An explicit `accounts.default` also
-owns a complete identity and replaces the implicit root identity; it does not
+owns a complete identity and replaces the implicit root identity. It does not
 borrow root credentials or `BUZZ_*` environment variables.
 
 Set `defaultAccount` to select the account used when a command omits `--account`.
 Otherwise the implicit root/default identity is preferred, then the first
 configured account in sorted order. Account keys use lowercase letters, digits,
 hyphens, and underscores, start with a letter or digit, and are at most 64
-characters; `constructor` and `prototype` are reserved.
+characters. `constructor` and `prototype` are reserved.
 
 Use `--account ada` with message and directory commands, and add `accountId: "ada"`
 to a binding's `match` object when routing that bot to an agent. Set
-`channels.buzz.accounts.ada.enabled: false` to disable only Ada;
+`channels.buzz.accounts.ada.enabled: false` to disable only Ada.
 `channels.buzz.enabled: false` disables all Buzz accounts. Buzz does not yet
 support account disabling or deletion through `channels remove`.
 
@@ -547,11 +547,12 @@ openclaw channels add --channel buzz --name "Support bot" \
 ```
 
 Omitting `--name` or supplying a blank name preserves the existing name. This
-command saves credentials and settings; use guided setup to discover and select
+command saves credentials and settings. Use guided setup to discover and select
 rooms before starting a new bot.
 
-If a hosted workspace operator gives you an identity authorization value, set
-the selected identity's `authTag`. The implicit root identity uses
+An `authTag` is the delegated authorization value a hosted workspace operator
+issues for one identity. Set the value the operator gives you on the selected
+identity's `authTag`. The implicit root identity uses
 `channels.buzz.authTag` and can fall back to `BUZZ_AUTH_TAG`. Nested identities,
 including `accounts.default`, use `channels.buzz.accounts.<id>.authTag` and
 never borrow that environment fallback. The field accepts the same plaintext or
@@ -614,7 +615,7 @@ Use `wss://` for hosted relays. Plaintext `ws://` credential URLs are accepted
 only for loopback development relays.
 
 Never use a human owner or admin private key. Private keys and optional
-authorization values are parent-harness secrets and must not appear in logs,
+`authTag` values are parent-harness secrets and must not appear in logs,
 artifacts, screenshots, shell history, or source control.
 
 ## Rotate the bot identity
@@ -643,14 +644,14 @@ These follow-up areas are planned but are not part of the current plugin:
 
 ## Troubleshooting
 
-| Symptom                                      | What to check                                                                                                        |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| No rooms are discovered                      | Confirm this exact bot public key is in the room with the **Bot** role, then rerun the same setup command.           |
-| Authentication fails                         | Check the relay URL, bot private key, closed-relay membership, and any authorization value supplied by the operator. |
-| A message cannot be sent                     | Confirm the bot is a room member with the **Bot** role and that the UUID is configured.                              |
-| The bot receives messages but does not reply | Confirm the sender is still a room member, then check the optional sender allowlist and mention requirement.         |
-| Setup says the Gateway is not running        | Start it with `openclaw gateway`, then run `openclaw channels status --probe`.                                       |
-| Automatic room discovery expires             | Grant the Bot role, then choose Retry; the same identity remains active.                                             |
+| Symptom                                      | What to check                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| No rooms are discovered                      | Confirm this exact bot public key is in the room with the **Bot** role, then rerun the same setup command.   |
+| Authentication fails                         | Check the relay URL, bot private key, closed-relay membership, and any `authTag` supplied by the operator.   |
+| A message cannot be sent                     | Confirm the bot is a room member with the **Bot** role and that the UUID is configured.                      |
+| The bot receives messages but does not reply | Confirm the sender is still a room member, then check the optional sender allowlist and mention requirement. |
+| Setup says the Gateway is not running        | Start it with `openclaw gateway`, then run `openclaw channels status --probe`.                               |
+| Automatic room discovery expires             | Grant the Bot role, then choose Retry; the same identity remains active.                                     |
 
 ## Related
 

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -52,7 +52,7 @@ Once the gateway is running and your email is on the visibility list:
 1. Go to [Google Chat](https://chat.google.com/).
 2. Click the **+** (plus) icon next to **Direct Messages**.
 3. Search for the **App name** you configured in the Google Cloud Console.
-   - The bot does _not_ appear in the Marketplace browse list because it is a private app; search for it by name.
+   - The bot does _not_ appear in the Marketplace browse list because it is a private app. Search for it by name.
 4. Select the bot, click **Add** or **Chat**, and send a message.
 
 ## Public URL (Webhook-only)
@@ -104,7 +104,7 @@ Use Tailscale Serve for the private dashboard and Funnel for the public webhook 
    tailscale funnel status
    ```
 
-Your public webhook URL is `https://<node-name>.<tailnet>.ts.net/googlechat`; the dashboard stays tailnet-only at `https://<node-name>.<tailnet>.ts.net:8443/`. Use the public URL (without `:8443`) in the Google Chat app config.
+Your public webhook URL is `https://<node-name>.<tailnet>.ts.net/googlechat`. The dashboard stays tailnet-only at `https://<node-name>.<tailnet>.ts.net:8443/`. Use the public URL (without `:8443`) in the Google Chat app config.
 
 > Note: This configuration persists across reboots. Remove it later with `tailscale funnel reset` and `tailscale serve reset`.
 
@@ -131,23 +131,23 @@ Configure the tunnel ingress rules to route only the webhook path:
 
 1. Google Chat POSTs JSON to the gateway webhook path (POST only, JSON content type required, per-IP rate limited).
 2. OpenClaw authenticates every request before dispatch:
-   - Chat app events carry `Authorization: Bearer <token>`; the token is verified before the full body is parsed.
-   - Google Workspace Add-on events carry the token in the body (`authorizationEventObject.systemIdToken`) and are read under a stricter pre-auth budget (16 KB, 3 s) before verification.
+   - Chat app events carry `Authorization: Bearer <token>`. The token is verified before the full body is parsed.
+   - Google Workspace Add-on events carry the token in the body (`authorizationEventObject.systemIdToken`). OpenClaw reads them under a stricter pre-auth budget (16 KB, 3 s) before verification.
 3. The token is checked against `audienceType` + `audience`:
    - `audienceType: "app-url"` → audience is your HTTPS webhook URL.
    - `audienceType: "project-number"` → audience is the Cloud project number.
-   - Add-on tokens under `app-url` additionally require `appPrincipal` set to the app's numeric OAuth 2.0 client ID (21 digits, not an email); otherwise verification fails with a logged warning.
+   - Add-on tokens under `app-url` additionally require `appPrincipal` set to the app's numeric OAuth 2.0 client ID (21 digits, not an email). Otherwise verification fails with a logged warning.
 4. Messages route by space:
-   - Spaces get per-space sessions `agent:<agentId>:googlechat:group:<spaceId>`; replies go to the message thread.
-   - DMs collapse into the agent's main session by default; set `session.dmScope` for per-peer DM sessions (see [Session](/concepts/session)).
-5. DM access is pairing by default. Unknown senders receive a pairing code; approve with:
+   - Spaces get per-space sessions `agent:<agentId>:googlechat:group:<spaceId>`. Replies go to the message thread.
+   - DMs collapse into the agent's main session by default. Set `session.dmScope` for per-peer DM sessions (see [Session](/concepts/session)).
+5. DM access is pairing by default. Unknown senders receive a pairing code. Approve with:
    - `openclaw pairing approve googlechat <code>`
-6. Group spaces require @-mention by default. Mentions are detected from Chat `USER_MENTION` annotations targeting the app; set `botUser` (e.g., `users/1234567890`) if detection needs the app's user resource name.
-7. When an exec or plugin approval starts from Google Chat and a stable `users/<id>` approver is configured, OpenClaw posts a native approval card (`cardsV2`) in the originating space or thread. Card buttons carry opaque callback tokens; the manual `/approve <id> <decision>` prompt appears only when native delivery is unavailable.
+6. Group spaces require @-mention by default. Mentions are detected from Chat `USER_MENTION` annotations targeting the app. Set `botUser` (e.g., `users/1234567890`) if detection needs the app's user resource name.
+7. When an exec or plugin approval starts from Google Chat and a stable `users/<id>` approver is configured, OpenClaw posts a native approval card (`cardsV2`) in the originating space or thread. Card buttons carry opaque callback tokens. The manual `/approve <id> <decision>` prompt appears only when native delivery is unavailable.
 
 ### Inbound durability
 
-After request authentication, OpenClaw removes the add-on authorization object from storage and durably queues Google Chat `MESSAGE` events before returning `200`. A persistence failure returns `503`, allowing Google Chat to retry instead of acknowledging an event that could be lost. A durably queued `200` carries `x-openclaw-delivery-accepted: durable`; non-message action acks and error responses omit the marker, so reverse proxies can require it to distinguish durable acceptance from a generic `200`.
+After request authentication, OpenClaw removes the add-on authorization object from storage and durably queues Google Chat `MESSAGE` events before returning `200`. A persistence failure returns `503`, allowing Google Chat to retry instead of acknowledging an event that could be lost. A durably queued `200` carries `x-openclaw-delivery-accepted: durable`. Non-message action acks and error responses omit the marker, so reverse proxies can require it to distinguish durable acceptance from a generic `200`.
 
 Pending or retryable messages survive a Gateway restart, remain serialized per space, and use the Google Chat message resource name to suppress duplicate queue entries while the active or retained completion record exists. Non-message actions keep their existing detached webhook path and do not receive this durable-queue guarantee. Delivery remains at least once across the queue-to-agent boundary, so a crash during handoff can replay a turn.
 
@@ -197,15 +197,15 @@ Use these identifiers for delivery and allowlists:
 Notes:
 
 - Service account credentials: `serviceAccountFile` (path) or `serviceAccount` (inline JSON string, object, or env/file/exec/store SecretRef). Env vars `GOOGLE_CHAT_SERVICE_ACCOUNT` (inline JSON) and `GOOGLE_CHAT_SERVICE_ACCOUNT_FILE` (path) apply to the default account only. Multi-account setups use `channels.googlechat.accounts.<id>` with the same keys, including per-account `serviceAccount` SecretRefs.
-- Omitted account `dmPolicy` and `groupPolicy` inherit the channel root; explicit account policies win. The root defaults to `pairing` and `allowlist` respectively. Shared settings from `accounts.default` have lower precedence than the root; its credentials, `enabled`, and `dangerouslyAllowNameMatching` are not inherited by named accounts.
-- Default webhook path is `/googlechat` when `webhookPath` is unset; `webhookUrl` can supply the path instead.
+- Omitted account `dmPolicy` and `groupPolicy` inherit the channel root. Explicit account policies win. The root defaults to `pairing` and `allowlist` respectively. Shared settings from `accounts.default` have lower precedence than the root. Its credentials, `enabled`, and `dangerouslyAllowNameMatching` are not inherited by named accounts.
+- Default webhook path is `/googlechat` when `webhookPath` is unset. `webhookUrl` can supply the path instead.
 - Group keys must be stable space ids (`spaces/<spaceId>`). Display-name keys are deprecated and logged as such.
-- `dangerouslyAllowNameMatching` re-enables mutable email principal matching for allowlists (break-glass compatibility mode); doctor warns about email entries.
+- `dangerouslyAllowNameMatching` re-enables mutable email principal matching for allowlists (break-glass compatibility mode). Doctor warns about email entries.
 - Google Chat reaction actions are not exposed. The plugin uses service-account authentication, while Google Chat reaction endpoints require user authentication. Remove unsupported legacy reaction settings with `openclaw doctor --fix`.
 - Native approval cards use Google Chat `cardsV2` button clicks, not reaction events. Approvers come from `allowFrom` or `defaultTo` and must be stable numeric `users/<id>` values.
 - Message actions expose text `send` only. Google Chat attachment upload requires user authentication, while this plugin uses service-account authentication, so outbound file upload is not exposed.
-- `typingIndicator`: `message` (default) posts a `_<Bot> is typing..._` placeholder and edits it into the first reply; `none` disables it; `reaction` requires user OAuth and currently falls back to `message` with a logged error under service-account auth.
-- Inbound attachments (first attachment per message) are downloaded through the Chat API into the media pipeline, capped by `mediaMaxMb` (default 20). Google Drive files are not downloaded; the agent receives an unavailable-attachment notice asking for a direct file upload instead. Other unsupported attachment sources receive the same upload guidance. Messages with multiple attachments include a counted notice for the additional attachments that were not processed. Oversize attachments retain their size-limit notice.
+- `typingIndicator`: `message` (default) posts a `_<Bot> is typing..._` placeholder and edits it into the first reply. `none` disables it. `reaction` requires user OAuth and currently falls back to `message` with a logged error under service-account auth.
+- OpenClaw downloads the first inbound attachment per message through the Chat API into the media pipeline. `mediaMaxMb` caps that download (default 20). Google Drive files are not downloaded. The agent receives an unavailable-attachment notice asking for a direct file upload instead. Other unsupported attachment sources receive the same upload guidance. Messages with multiple attachments include a counted notice for the additional attachments that were not processed. Oversize attachments retain their size-limit notice.
 - Bot-authored messages are ignored by default. With `allowBots: true`, accepted bot messages use shared [bot loop protection](/channels/bot-loop-protection): configure `channels.defaults.botLoopProtection`, then override with `channels.googlechat.botLoopProtection` or `channels.googlechat.groups.<space>.botLoopProtection`.
 
 Custom emoji listing is unavailable because Google Chat's `customEmojis.list` endpoint requires user authentication with the `chat.customemojis` or `chat.customemojis.readonly` scope. This plugin authenticates exclusively as a service account with the `chat.bot` scope, which cannot access that endpoint.

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -13,10 +13,10 @@ For the usual OpenClaw iMessage deployment, run the Gateway and `imsg` on the sa
 </Note>
 
 <Warning>
-BlueBubbles support was removed. Migrate `channels.bluebubbles` configs to `channels.imessage`; OpenClaw supports iMessage through `imsg` only. Start with [BlueBubbles removal and the imsg iMessage path](/announcements/bluebubbles-imessage) for the short announcement, or [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) for the full migration table.
+BlueBubbles support was removed. Migrate `channels.bluebubbles` configs to `channels.imessage`. OpenClaw supports iMessage through `imsg` only. Start with [BlueBubbles removal and the imsg iMessage path](/announcements/bluebubbles-imessage) for the short announcement, or [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) for the full migration table.
 </Warning>
 
-Status: native external CLI integration. The Gateway spawns `imsg rpc` and speaks JSON-RPC over stdio — no separate daemon or port. Private API mode is strongly encouraged for a complete iMessage channel; replies, tapbacks, effects, polls, attachment replies, and group actions require `imsg launch` and a successful private API probe.
+Status: native external CLI integration. The Gateway spawns `imsg rpc` and speaks JSON-RPC over stdio — no separate daemon or port. Private API mode is strongly encouraged for a complete iMessage channel. Replies, tapbacks, effects, polls, attachment replies, and group actions require `imsg launch` and a successful private API probe.
 
 For the common local setup, OpenClaw setup can offer a user-confirmed Homebrew install or update for `imsg` on the signed-in Messages Mac. Manual setup and SSH-wrapper topologies remain operator-managed: install or update `imsg` in the same user context that will run the Gateway or wrapper.
 

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -45,7 +45,7 @@ https://gateway-host/line/webhook
 The Gateway answers LINE's signed webhook verification request: a `POST` with an
 empty `events` list. Signed events in LINE's `standby` mode are acknowledged without
 queueing or replying, because another channel holds chat control. Other signed
-inbound events enter the durable ingress queue before `200`; agent processing
+inbound events enter the durable ingress queue before `200`. Agent processing
 continues asynchronously.
 Failed delivery is retried from the queue, including after a Gateway restart, and
 poison events become failed queue records after bounded retries. If durable
@@ -53,7 +53,7 @@ persistence fails, the request returns
 `500` instead of acknowledging an event that could be lost.
 Delivery is at least once across the queue-to-agent boundary: a Gateway shutdown or
 crash during an active delivery can replay the turn. Message events deduplicate by
-LINE message ID; other event types use `webhookEventId`. Retained completion records
+LINE message ID. Other event types use `webhookEventId`. Retained completion records
 suppress ordinary duplicate webhooks, but handlers that perform external side effects
 should still be idempotent.
 If you need a custom path, set `channels.line.webhookPath` or
@@ -67,7 +67,7 @@ Security notes:
 ## Inbound durability
 
 The [Setup](#setup) webhook contract acknowledges an event only after it is durably
-queued. The durable `200` carries `x-openclaw-delivery-accepted: durable`; signed
+queued. The durable `200` carries `x-openclaw-delivery-accepted: durable`. Signed
 verification pings (empty event lists), standby-only batches, and error responses
 omit the marker, so
 reverse proxies can require it to distinguish durable acceptance from a generic
@@ -75,7 +75,7 @@ reverse proxies can require it to distinguish durable acceptance from a generic
 LINE-specific settings:
 
 - **Per-conversation ordering.** Events are serialized by source lane —
-  `group:<groupId>`, `room:<roomId>`, or `user:<userId>`; events without a
+  `group:<groupId>`, `room:<roomId>`, or `user:<userId>`. Events without a
   conversation source use their own event-scoped lane. Within a lane, events
   dispatch in received order, so a retrying event delays later events in the same
   chat. One chat's backlog never blocks another chat's lane, but all lanes share
@@ -97,7 +97,7 @@ LINE-specific settings:
   back to its lane through the same retry policy as any other failure: the event
   returns to pending with its attempt count incremented and `handler-timeout`
   recorded as its last error, and it keeps its place at the head of its lane. A
-  stall is not itself a dead letter — only the retry limit above ends the event,
+  stall is not itself a dead-letter — only the retry limit above ends the event,
   as `retry-limit-exceeded`. The watchdog only covers the window between claim
   and adoption: deferred progress re-arms it and adoption clears it, so a long
   agent turn is never interrupted by it. Adoption that arrives after the
@@ -117,7 +117,7 @@ LINE-specific settings:
   new event is queued rather than on a timer, records can remain past 30 days on
   an idle account, and a newly completed record can put the count above 4096 until
   the next admission. While a record exists, a redelivered webhook for the same
-  event is acknowledged without a second dispatch; once it is gone — by age or by
+  event is acknowledged without a second dispatch. Once it is gone — by age or by
   cap — a redelivery is admitted and dispatched again, so handlers with external
   side effects should not treat this window as a substitute for their own
   idempotency.
@@ -133,7 +133,7 @@ more than once (the duplicate suppression window above absorbs the repeats). See
 [Redeliver a webhook that failed to be received](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#webhook-redelivery).
 
 Dead-lettered events stay inspectable and, depending on the failure reason,
-recoverable; see [Inbound dead letters](/cli/channels#inbound-dead-letters) and
+recoverable. See [Inbound dead letters](/cli/channels#inbound-dead-letters) and
 [Troubleshooting](#troubleshooting) below.
 
 ## Configure
@@ -188,7 +188,7 @@ Token/secret files:
 ```
 
 `tokenFile` and `secretFile` must point to regular files. Symlinks are rejected.
-Inline config values win over files; env vars are the last fallback for the default account.
+Inline config values win over files. Env vars are the last fallback for the default account.
 
 Multiple accounts:
 
@@ -221,15 +221,15 @@ openclaw pairing approve line <CODE>
 Allowlists and policies:
 
 - `channels.line.dmPolicy`: `pairing | allowlist | open | disabled` (default `pairing`)
-- `channels.line.allowFrom`: allowlisted LINE user IDs for DMs; `dmPolicy: "open"` requires `["*"]`
+- `channels.line.allowFrom`: allowlisted LINE user IDs for DMs. `dmPolicy: "open"` requires `["*"]`
 - `channels.line.groupPolicy`: `allowlist | open | disabled` (default `allowlist`)
-- `channels.line.groupAllowFrom`: allowlisted LINE user IDs for groups; DM `allowFrom` entries do not admit group senders
+- `channels.line.groupAllowFrom`: allowlisted LINE user IDs for groups. DM `allowFrom` entries do not admit group senders
 - Per-group overrides: `channels.line.groups.<groupId>.allowFrom` (plus `enabled`, `requireMention`, `systemPrompt`, `skills`). With
-  `groupPolicy: "allowlist"`, set `groupAllowFrom` or the per-group `allowFrom`; an empty group allowlist blocks group messages even when DMs are open.
-- `channels.line.groups."*"` is the defaults entry for every group and room, not a fallback that a named entry replaces. A named entry overrides `"*"` field by field, so each field the named entry omits is taken from `"*"`. This matches how `requireMention` already resolves through the shared group scope tree; see [Groups](/channels/groups).
+  `groupPolicy: "allowlist"`, set `groupAllowFrom` or the per-group `allowFrom`. An empty group allowlist blocks group messages even when DMs are open.
+- `channels.line.groups."*"` is the defaults entry for every group and room, not a fallback that a named entry replaces. A named entry overrides `"*"` field by field, so each field the named entry omits is taken from `"*"`. This matches how `requireMention` already resolves through the shared group scope tree. See [Groups](/channels/groups).
 - Upgrade check: if you set `enabled` or `allowFrom` only on `channels.line.groups."*"` while also listing a named group or room, those wildcard values now apply to that named entry as well. Earlier releases returned the named entry alone, so wildcard-only fields never reached it. Before upgrading, review any `"*"` entry that sets `enabled: false` or narrows `allowFrom`, and repeat the value on a named entry that should keep its current access.
-- Quoting one of the bot's own messages counts as addressing it, so a group reply made with LINE's quote gesture reaches the agent without an explicit mention. Set `channels.defaults.implicitMentions.quotedBot: false` to stop it from bypassing the mention requirement; LINE reads that shared default and has no channel-scoped `implicitMentions` block of its own. See [Groups](/channels/groups). The bot recognizes a quote of its own message from the most recent ones it remembers sending (a few hundred per account), so quoting an older message, or one sent before the last Gateway restart, still needs a mention.
-- Static sender access groups can be referenced from `allowFrom`, `groupAllowFrom`, and per-group `allowFrom` with `accessGroup:<name>`; see [Access groups](/channels/access-groups).
+- Quoting one of the bot's own messages counts as addressing it, so a group reply made with LINE's quote gesture reaches the agent without an explicit mention. Set `channels.defaults.implicitMentions.quotedBot: false` to stop it from bypassing the mention requirement. LINE reads that shared default and has no channel-scoped `implicitMentions` block of its own. See [Groups](/channels/groups). The bot recognizes a quote of its own message from the most recent ones it remembers sending (a few hundred per account), so quoting an older message, or one sent before the last Gateway restart, still needs a mention.
+- Static sender access groups can be referenced from `allowFrom`, `groupAllowFrom`, and per-group `allowFrom` with `accessGroup:<name>`. See [Access groups](/channels/access-groups).
 - Runtime note: if `channels.line` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
 LINE IDs are case-sensitive. Valid IDs look like:
@@ -247,7 +247,7 @@ IDs. Prefixes normalize to sendable IDs, duplicates appear once, and `*` and
 `accessGroup:<name>` entries are omitted. Use `--account`, `--query`, `--limit`,
 and `--json` as described in [Directory](/cli/directory).
 
-These lists read configuration; they do not fetch a live LINE contact roster or
+These lists read configuration. They do not fetch a live LINE contact roster or
 include approvals stored through pairing.
 
 ## Group join introductions
@@ -268,9 +268,9 @@ as untrusted.
 ## Message behavior
 
 - Text is chunked at 5000 characters.
-- Markdown formatting is stripped; code blocks and tables are converted into Flex
+- Markdown formatting is stripped. Code blocks and tables are converted into Flex
   cards when possible.
-- Streaming responses are buffered; LINE receives full chunks. The loading
+- Streaming responses are buffered. LINE receives full chunks. The loading
   animation runs only in one-to-one chats — LINE's loading API accepts a user id
   and rejects group and room ids — so a group reply arrives without one. Heartbeat
   turns also show the loading animation while the reply is generated.
@@ -284,7 +284,7 @@ as untrusted.
   id is used and the message is still delivered. Multi-person rooms have no name
   API, so they keep their room id.
 - LINE describes inline emoji with metadata and alternative text. Empty `()`
-  alternatives reach the agent as `[emoji]`; meaningful alternatives such as
+  alternatives reach the agent as `[emoji]`. Meaningful alternatives such as
   `(hello)` and parentheses typed by the sender are preserved.
 
 ## Structured rich messages
@@ -295,11 +295,11 @@ block is the portable confirm-style form.
 
 A `buttons` block renders a Flex card that carries the presentation's title and
 text. A presentation whose only control is a `select` renders no card, because
-quick replies attach to the reply's own text message; its title and text blocks
+quick replies attach to the reply's own text message. Its title and text blocks
 are appended to that text instead. LINE draws at most 13 quick replies on one
 message, counted across every `select` block in the reply rather than per block.
 Each select keeps its prompt and any overflow options together in that text.
-Prompts and overflow option names remain complete; only native quick-reply button
+Prompts and overflow option names remain complete. Only native quick-reply button
 labels are shortened to LINE's 20-character limit.
 
 ```json5
@@ -381,7 +381,7 @@ non-HTTPS URLs and adds an "Image unavailable" note when it fits within LINE's
 30 KB bubble and 50 KB carousel limits. Video
 heroes keep their required alternative content: an unusable video or preview URL
 falls back to that content, and an unusable alternative image becomes a text box.
-Invalid template thumbnails are removed; carousel thumbnails are removed together
+Invalid template thumbnails are removed. Carousel thumbnails are removed together
 so every column keeps the same image layout. Text and action buttons stay intact.
 
 ## ACP support
@@ -397,12 +397,12 @@ See [ACP agents](/tools/acp-agents) for details.
 
 The LINE plugin sends images, videos, and audio through the agent message tool:
 
-- **Images**: sent as LINE image messages; the preview image defaults to the media URL.
-- **Videos**: require a preview image; set `channelData.line.previewImageUrl` to an image URL.
-- **Audio**: sent as LINE audio messages; duration defaults to 60 seconds unless `channelData.line.durationMs` is set.
+- **Images**: sent as LINE image messages. The preview image defaults to the media URL.
+- **Videos**: require a preview image. Set `channelData.line.previewImageUrl` to an image URL.
+- **Audio**: sent as LINE audio messages. Duration defaults to 60 seconds unless `channelData.line.durationMs` is set.
 
 When `mediaKind` is omitted, LINE infers it from LINE-specific options or the URL
-suffix. Native suffix inference supports JPEG/PNG, MP4, and MP3/M4A; suffixless URLs
+suffix. Native suffix inference supports JPEG/PNG, MP4, and MP3/M4A. Suffixless URLs
 retain the image fallback. Other suffixed URLs and inferred MP4 without a preview
 become text links. Explicit video still requires `previewImageUrl`.
 
@@ -422,7 +422,7 @@ link-local, and private-network targets.
   `openclaw channels status --channel line --probe --json`. For a limited allowance,
   the account’s `quota` contains `used` and `limit`. Missing quota is unknown, not unlimited.
   A healthy bot identity can coexist with an exhausted push allowance. Check the
-  account allowance or plan in LINE Official Account Manager before retrying;
+  account allowance or plan in LINE Official Account Manager before retrying.
   429 can also reflect rate limits or temporary message reservations. Ordinary
   reply-token messages do not consume this monthly allowance, unlike pushes.
   See [LINE message pricing](https://developers.line.biz/en/docs/messaging-api/pricing/).
@@ -446,7 +446,7 @@ link-local, and private-network targets.
   cause and is never cut off by it. Look at the dispatch path instead: the
   delivery preparation that runs between claim and adoption, such as inbound
   media download or a Gateway that is not accepting new work. This does not
-  dead-letter the event; `openclaw logs` shows
+  dead-letter the event. `openclaw logs` shows
   `applying retry policy (handler-timeout)` and the event waits out its backoff
   with `handler-timeout` as its last error. A stall that keeps repeating is what
   eventually exhausts the retry limit, so an event that stalls its way to a dead

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -6,7 +6,7 @@ read_when:
   - You are configuring Reef pairing, guards, or per-friend autonomy
 ---
 
-Reef is a guarded, end-to-end-encrypted side channel between OpenClaw agents owned by different people. Messages are sealed on your machine, screened by a pinned-model guard in both directions, and the relay operator can never read content. The plugin ships bundled with OpenClaw; the public relay is `https://reefwire.ai` and the relay/protocol source lives at [openclaw/reef](https://github.com/openclaw/reef).
+Reef is a guarded, end-to-end-encrypted side channel between OpenClaw agents owned by different people. Messages are sealed on your machine and screened by a pinned-model guard in both directions. The relay operator can never read content. The plugin ships bundled with OpenClaw. The public relay is `https://reefwire.ai` and the relay/protocol source lives at [openclaw/reef](https://github.com/openclaw/reef).
 
 ## Quick start
 
@@ -27,7 +27,7 @@ openclaw gateway restart
 openclaw channels status
 ```
 
-Record the safety fingerprint the wizard prints; friends compare it out of band before approving a pairing.
+Record the safety fingerprint the wizard prints. Friends compare it out of band before approving a pairing.
 
 ## Agent-driven setup
 
@@ -37,7 +37,7 @@ Agents (or scripts) can register without the wizard. With a setup session from t
 openclaw reef register --email you@example.com --handle myclaw --session <setup-session> --json
 ```
 
-Without a session, the same command sends the magic link and exits; rerun with `--token <token from the link>` to finish. Guard defaults (`openai` / `gpt-5.6-terra` / `REEF_GUARD_OPENAI_KEY`) can be overridden with `--guard-provider`, `--guard-model`, `--guard-env`, and `--guard-policy`. Friendship management is also headless:
+Without a session, the same command sends the magic link and exits. Rerun with `--token <token from the link>` to finish. Guard defaults (`openai` / `gpt-5.6-terra` / `REEF_GUARD_OPENAI_KEY`) can be overridden with `--guard-provider`, `--guard-model`, `--guard-env`, and `--guard-policy`. Friendship management is also headless:
 
 ```bash
 openclaw reef status --json
@@ -48,7 +48,7 @@ openclaw reef friend autonomy @friend extended
 openclaw reef friend remove @friend
 ```
 
-A friendship you requested is adopted automatically once the peer accepts; inbound requests still require `openclaw pairing approve reef <CODE>`.
+A friendship you requested is adopted automatically once the peer accepts. Inbound requests still require `openclaw pairing approve reef <CODE>`.
 
 ## Configuration
 
@@ -79,17 +79,17 @@ Reef lives under `channels.reef`:
 }
 ```
 
-- One handle is one claw; humans can hold many handles across machines.
-- `relayUrl` is an HTTP(S) origin such as `https://reefwire.ai`; paths, queries, URL credentials, and fragments are rejected because Reef uses an origin-wide `/v1` API.
-- Private Ed25519/X25519 keys, the encrypted replay guard, review state, delivery dedupe, audit chain, and approved peer pins live in the shared `state/openclaw.sqlite` plugin state and never leave the machine. `openclaw doctor --fix` imports and verifies retired Reef key, audit, identity-binding, setup-session, replay, review, and delivery files before archiving them.
+- One handle is one claw. Humans can hold many handles across machines.
+- `relayUrl` is an HTTP(S) origin such as `https://reefwire.ai`. Paths, queries, URL credentials, and fragments are rejected because Reef uses an origin-wide `/v1` API.
+- Private Ed25519/X25519 keys, the encrypted replay guard, review state, delivery dedupe, audit chain, and approved peer pins live in the shared `state/openclaw.sqlite` plugin state. They never leave the machine. `openclaw doctor --fix` imports and verifies retired Reef key, audit, identity-binding, setup-session, replay, review, and delivery files before archiving them.
 - Relay friendship status controls whether ciphertext may enter either mailbox. OpenClaw separately keeps each approved peer's public-key pins and autonomy tier in the same SQLite plugin state. `channels.reef` has no friendship allowlist to edit.
-- A normal OpenClaw pairing approval becomes an identity-, key-, and revocation-bound one-time handoff. Reef consumes it before accepting the relay edge or writing the verified peer pins, and the relay activates only if that exact peer key snapshot is still current. A stale approval cannot authorize changed keys or undo a local removal. Removing a friend clears local trust first, then blocks the relay edge.
+- A normal OpenClaw pairing approval becomes an identity-, key-, and revocation-bound one-time handoff. Reef consumes it before accepting the relay edge or writing the verified peer pins. The relay activates only if that exact peer key snapshot is still current. A stale approval cannot authorize changed keys or undo a local removal. Removing a friend clears local trust first, then blocks the relay edge.
 - `pinnedModel` must be an immutable model id: a dated snapshot, or one of the documented undated ids (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`). Floating aliases are rejected, and every guard response must echo the exact configured id.
-- `apiKeyEnv` names an environment variable visible to the Gateway process. The guard fails closed: a missing key or provider error fails the send immediately, and inbound messages wait un-delivered at the relay and retry until the guard is back — a provider outage never rejects a peer's message.
+- `apiKeyEnv` names an environment variable visible to the Gateway process. The guard fails closed. A missing key or provider error fails the send immediately. Inbound messages wait un-delivered at the relay and retry until the guard is back. A provider outage never rejects a peer's message.
 
 ## Adding a friend
 
-Friendship changes and review decisions from authenticated chat require the sender to match an explicit `commands.ownerAllowFrom` entry. Wildcards can admit commands, but do not grant owner authority. A configured owner can make either change in chat; friendship changes can also use `openclaw reef friend` on the Gateway host.
+Friendship changes and review decisions from authenticated chat require the sender to match an explicit `commands.ownerAllowFrom` entry. Wildcards can admit commands, but do not grant owner authority. A configured owner can make either change in chat. Friendship changes can also use `openclaw reef friend` on the Gateway host.
 
 The receiving side mints a short-lived code in an authenticated chat:
 
@@ -118,17 +118,17 @@ Change the local autonomy tier without editing config:
 /reef friend autonomy @friend notify-only
 ```
 
-The headless equivalent is `openclaw reef friend autonomy @friend notify-only`. If an active relay friendship has no matching local pin (for example, after restoring keys without the shared state database), Reef surfaces a new pairing request and stays fail-closed until you compare the fingerprint and approve it.
+The headless equivalent is `openclaw reef friend autonomy @friend notify-only`. An active relay friendship can have no matching local pin, for example after restoring keys without the shared state database. Reef then surfaces a new pairing request. It stays fail-closed until you compare the fingerprint and approve it.
 
 ## Sending and receiving
 
-Agents send through the shared `message` tool to `reef:<handle>`; humans can test the same path:
+Agents send through the shared `message` tool to `reef:<handle>`. Humans can test the same path:
 
 ```bash
 openclaw message send --channel reef --target @friend --message "hello from my claw"
 ```
 
-A send never fails silently. Local guard or relay errors fail the send immediately, replies and peer guard rejections come back through the flows below, and if the peer's claw confirms nothing for about 10 minutes the sending agent receives a delivery-delay notice, plus a follow-up once the message is finally delivered or rejected. A peer that accepts a message and simply does not reply (for example a `notify-only` friend) is a successful delivery, not an error.
+A send never fails silently. Local guard or relay errors fail the send immediately. Replies and peer guard rejections come back through the flows below. If the peer's claw confirms nothing for about 10 minutes, the sending agent receives a delivery-delay notice. A follow-up arrives once the message is finally delivered or rejected. A peer that accepts a message and simply does not reply (for example a `notify-only` friend) is a successful delivery, not an error.
 
 Inbound messages arrive as untrusted third-party data: provenance-framed, command-unauthorized, with URLs inert. Depending on the friend's autonomy tier, OpenClaw notifies you or sends a bounded guarded reply:
 
@@ -151,21 +151,21 @@ Reef runs a fail-closed classifier at both ends: outbound DLP before encryption,
 
 These review commands use the same explicit owner check described in [Adding a friend](#adding-a-friend). If no chat sender is configured as an owner, add the intended owner to `commands.ownerAllowFrom` before deciding a review.
 
-The recorded verdict owns the message until you decide: a parked inbound message waits at the relay without re-classification, an approval delivers it within about 30 seconds (after one final guard check), and a denial returns a rejection receipt to the peer. Later messages and receipts continue processing without moving the recovery cursor past the parked message. It remains eligible for retry while retained by the relay, including after a socket reconnect. Parked outbound sends stay local; after approval, resend the identical message.
+The recorded verdict owns the message until you decide. A parked inbound message waits at the relay without re-classification. An approval delivers it within about 30 seconds, after one final guard check. A denial returns a rejection receipt to the peer. Later messages and receipts continue processing without moving the recovery cursor past the parked message. It remains eligible for retry while retained by the relay, including after a socket reconnect. Parked outbound sends stay local. After approval, resend the identical message.
 
 Deterministic checks (size, UTF-8, destination pin, secret patterns) run before any model call and cannot be overridden.
 
-The model guard allows routine agent collaboration, including requests to reply, investigate, edit, test, or report. Outbound project names, code, logs, hostnames, non-secret configuration, and internal identifiers are not sensitive by themselves. Ambiguous disclosures or meta-instructions go to owner review; concrete secrets and explicit policy-override, hidden-context, or unauthorized-action attempts are denied.
+The model guard allows routine agent collaboration, including requests to reply, investigate, edit, test, or report. Outbound project names, code, logs, hostnames, non-secret configuration, and internal identifiers are not sensitive by themselves. Ambiguous disclosures or meta-instructions go to owner review. Concrete secrets and explicit policy-override, hidden-context, or unauthorized-action attempts are denied.
 
-`guard.rules` lets you define what is okay to share in your own words. `rules.outbound` shapes the DLP classifier and `rules.inbound` shapes the injection screen; each is free text up to 2,000 characters. Rules can tighten decisions ("never mention project Nightjar") and can explicitly allow named topics that would otherwise go to owner review ("medical scheduling with @doc is fine") — they can never override the deny floor (concrete secrets, credentials, keys) or the deterministic checks. Because the guard sees the sender and recipient handles, per-friend rules work as plain prose ("@alice may see anything work-related; never mention finances to @bob"). The rules text is hashed into the effective policy version recorded in the audit chain (`reef-v1+<sha256 of the rules>`), so editing rules invalidates review approvals still pending under the old policy. Restart the Gateway after changing them.
+`guard.rules` lets you define what is okay to share in your own words. `rules.outbound` shapes the DLP classifier and `rules.inbound` shapes the injection screen. Each is free text up to 2,000 characters. Rules can tighten decisions ("never mention project Nightjar") and can explicitly allow named topics that would otherwise go to owner review ("medical scheduling with @doc is fine"). They can never override the deny floor (concrete secrets, credentials, keys) or the deterministic checks. Because the guard sees the sender and recipient handles, per-friend rules work as plain prose ("@alice may see anything work-related. Never mention finances to @bob"). The rules text is hashed into the effective policy version recorded in the audit chain (`reef-v1+<sha256 of the rules>`). Editing rules therefore invalidates review approvals still pending under the old policy. Restart the Gateway after changing them.
 
-When a peer's inbound guard rejects a delivered message, Reef verifies the signed receipt against durable peer, message-ID, and body-hash state, then reserves the notice in SQLite before dispatching it through the sender's normal peer session. Reef persists the peer cooldown and removes the delivery record only after the agent turn returns. A Gateway restart from the ambiguous middle state dispatches stop-and-wait guidance with transport replies suppressed, never another resend grant. The first rejection identifies the message and allows at most one rephrased resend. Another rejection within 15 minutes dispatches stop-and-wait guidance while suppressing its channel reply; that cooldown survives Gateway restarts. Local outbound DLP denials remain terminal and never suggest rephrasing protected material. Notices never expose the private guard rationale. `requestPolicy` only controls who may request friendship and does not change message guard decisions.
+When a peer's inbound guard rejects a delivered message, Reef verifies the signed receipt against durable peer, message-ID, and body-hash state. Reef then reserves the notice in SQLite before dispatching it through the sender's normal peer session. Reef persists the peer cooldown and removes the delivery record only after the agent turn returns. A Gateway restart from the ambiguous middle state dispatches stop-and-wait guidance with transport replies suppressed, never another resend grant. The first rejection identifies the message and allows at most one rephrased resend. Another rejection within 15 minutes dispatches stop-and-wait guidance while suppressing its channel reply. That cooldown survives Gateway restarts. Local outbound DLP denials remain terminal and never suggest rephrasing protected material. Notices never expose the private guard rationale. `requestPolicy` only controls who may request friendship and does not change message guard decisions.
 
 ## Troubleshooting
 
-- `channels status` shows `running` but not `connected`: the relay WebSocket is reconnecting; check network reachability of the relay URL.
-- Inbound messages stall while sends fail with `guard_failure`: the guard provider call is failing — most commonly `apiKeyEnv` is unset in the Gateway environment or the key has no credits. Stalled inbound messages deliver automatically once the guard recovers.
-- Pairing request never appears: the recipient's channel reconciles with the relay every 30 seconds; check `openclaw pairing list reef` after that, and confirm the requester used a fresh code (codes expire after 15 minutes).
-- Pairing fails with a Reef protocol compatibility error: update OpenClaw and the Reef relay together, then approve the fresh pairing challenge again.
+- `channels status` shows `running` but not `connected`: the relay WebSocket is reconnecting. Check network reachability of the relay URL.
+- Inbound messages stall while sends fail with `guard_failure`: the guard provider call is failing. Most commonly `apiKeyEnv` is unset in the Gateway environment, or the key has no credits. Stalled inbound messages deliver automatically once the guard recovers.
+- Pairing request never appears: the recipient's channel reconciles with the relay every 30 seconds. Check `openclaw pairing list reef` after that, and confirm the requester used a fresh code (codes expire after 15 minutes).
+- Pairing fails with a Reef protocol compatibility error: update OpenClaw and the Reef relay together. Then approve the fresh pairing challenge again.
 
 See the protocol design, security model, and self-hosting guide at [reefwire.ai/docs](https://reefwire.ai/docs/).

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -5,7 +5,7 @@ read_when:
 title: "Slack"
 ---
 
-Slack support covers DMs and channels via Slack app integrations. Default transport is Socket Mode; HTTP Request URLs are also supported. Relay mode is for managed deployments where a trusted router owns Slack ingress.
+Slack support covers DMs and channels via Slack app integrations. Default transport is Socket Mode. HTTP Request URLs are also supported. Relay mode is for managed deployments where a trusted router owns Slack ingress.
 
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">
@@ -118,13 +118,13 @@ Primary reference: [Configuration reference - Slack](/gateway/config-channels#sl
 
 - mode/auth: `postAs`, `mode`, `botToken`, `appToken`, `userToken`, `signingSecret`, `webhookPath`, `accounts.*`
 - DM access: `dm.enabled`, `dmPolicy`, `allowFrom` (legacy: `dm.policy`, `dm.allowFrom`), `dm.groupEnabled`, `dm.groupChannels`
-- compatibility toggle: `dangerouslyAllowNameMatching` (break-glass; keep off unless needed)
+- compatibility toggle: `dangerouslyAllowNameMatching` (break-glass, keep off unless needed)
 - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`, `implicitMentions.*`
 - group introductions: `joinIntro`, `accounts.*.joinIntro` (default: `true`)
 - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
-- presence wakes: `presenceEvents.mode`, `presenceEvents.prompt`, `channels.*.presenceEvents.*` (`off|auto|on`; default `off`)
+- presence wakes: `presenceEvents.mode`, `presenceEvents.prompt`, `channels.*.presenceEvents.*` (`off|auto|on`, default `off`)
 - delivery: `textChunkLimit`, `streaming.chunkMode`, `mediaMaxMb`, `streaming`, `streaming.nativeTransport`, `streaming.preview.toolProgress`
-- unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control; set `unfurlLinks: true` to opt back into link previews
+- unfurls: `unfurlLinks` (default: `false`), `unfurlMedia` for `chat.postMessage` link/media preview control. Set `unfurlLinks: true` to opt back into link previews
 - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
 
 </Accordion>

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -5,7 +5,7 @@ read_when:
 title: "Zalo"
 ---
 
-Status: experimental. Direct messages and group chats are both implemented; the [Capabilities](#capabilities) table below reflects verified behavior on Zalo Bot Creator / Marketplace bots.
+Status: experimental. Direct messages and group chats are both implemented. The [Capabilities](#capabilities) table below reflects verified behavior on Zalo Bot Creator / Marketplace bots.
 
 ## Bundled plugin
 
@@ -20,7 +20,7 @@ On an older build or a custom install that excludes Zalo, install the npm packag
 
 ## Quick setup
 
-1. Create a bot token at [https://bot.zaloplatforms.com](https://bot.zaloplatforms.com) (sign in, create a bot, configure settings). The token is `numeric_id:secret`; for Marketplace bots the usable runtime token may appear in the bot's welcome message.
+1. Create a bot token at [https://bot.zaloplatforms.com](https://bot.zaloplatforms.com) (sign in, create a bot, configure settings). The token is `numeric_id:secret`. For Marketplace bots the usable runtime token may appear in the bot's welcome message.
 2. Set the token, either as env `ZALO_BOT_TOKEN=...` (default account only) or in config.
 3. Restart the gateway.
 4. Approve the pairing code on first DM contact (default DM policy is pairing).
@@ -43,20 +43,20 @@ Minimal config:
 }
 ```
 
-Multi-account: add more entries under `channels.zalo.accounts.<id>`, each with its own `botToken`/`name`. `channels.zalo.botToken` (flat, no `accounts`) is a legacy single-account shorthand; prefer `accounts.<id>.*` for new configs.
+Multi-account: add more entries under `channels.zalo.accounts.<id>`, each with its own `botToken`/`name`. `channels.zalo.botToken` (flat, no `accounts`) is a legacy single-account shorthand. Prefer `accounts.<id>.*` for new configs.
 
 ## What it is
 
-Zalo is a Vietnam-focused messaging app. Its Bot API lets the Gateway run a bot for both 1:1 conversations and group chats, with deterministic routing back to Zalo (the model never chooses channels).
+Zalo is a Vietnam-focused messaging app. Its Bot API lets the Gateway run a bot for both 1:1 conversations and group chats. Routing back to Zalo is deterministic. The model never chooses channels.
 
-This page covers **Zalo Bot Creator / Marketplace bots**. **Zalo Official Account (OA) bots** are a different product surface and may behave differently; this page does not cover them.
+This page covers **Zalo Bot Creator / Marketplace bots**. **Zalo Official Account (OA) bots** are a different product surface and may behave differently. This page does not cover them.
 
 ## How it works
 
 - Inbound messages are normalized into the shared channel envelope with media placeholders.
-- Replies always route back to the same Zalo chat; quote-reply is not used (`replyToMode` is fixed off).
-- Long-polling (`getUpdates`) by default; webhook mode available via `channels.zalo.webhookUrl`.
-- Groups require an @mention to trigger the bot; this is not configurable per channel.
+- Replies always route back to the same Zalo chat. Quote-reply is not used (`replyToMode` is fixed off).
+- Long-polling (`getUpdates`) by default. Webhook mode available via `channels.zalo.webhookUrl`.
+- Groups require an @mention to trigger the bot. This is not configurable per channel.
 
 ## Limits
 
@@ -73,7 +73,7 @@ This page covers **Zalo Bot Creator / Marketplace bots**. **Zalo Official Accoun
 ### Direct messages
 
 - `channels.zalo.dmPolicy`: `pairing` (default) | `allowlist` | `open` | `disabled`.
-- Pairing: unknown senders get a pairing code; messages are ignored until approved. Codes expire after 1 hour.
+- Pairing: unknown senders get a pairing code. Messages are ignored until approved. Codes expire after 1 hour.
   - `openclaw pairing list zalo`
   - `openclaw pairing approve zalo <CODE>`
   - Details: [Pairing](/channels/pairing)
@@ -84,9 +84,9 @@ This page covers **Zalo Bot Creator / Marketplace bots**. **Zalo Official Accoun
 Group chats are supported by the plugin (`chatTypes: ["direct", "group"]`) and gated by mention plus group policy:
 
 - `channels.zalo.groupPolicy`: `open` | `allowlist` | `disabled`.
-- `channels.zalo.groupAllowFrom` restricts which sender IDs can trigger the bot in groups; falls back to `allowFrom` when unset.
+- `channels.zalo.groupAllowFrom` restricts which sender IDs can trigger the bot in groups. Falls back to `allowFrom` when unset.
 - Default resolution: when `channels.zalo` is configured, an unset `groupPolicy` resolves to `open`. When `channels.zalo` is missing entirely, runtime fails closed to `allowlist`.
-- Reported real-world caveat: on some Marketplace-bot setups the bot could not be added to a group at all. If you hit that, verify with your bot's Zalo Bot Platform settings; it is a platform-side constraint, not an OpenClaw policy.
+- Reported real-world caveat: on some Marketplace-bot setups the bot could not be added to a group at all. If you hit that, verify with your bot's Zalo Bot Platform settings. It is a platform-side constraint, not an OpenClaw policy.
 
 ## Long-polling vs webhook
 
@@ -97,7 +97,7 @@ Group chats are supported by the plugin (`chatTypes: ["direct", "group"]`) and g
   - Zalo sends events with an `X-Bot-Api-Secret-Token` header, checked with a constant-time comparison.
   - Gateway HTTP handles webhook requests at `channels.zalo.webhookPath` (defaults to the webhook URL's path).
   - Requests must use `Content-Type: application/json` (or a `+json` media type).
-  - HTTP 200 is returned only after the raw event is durably stored; storage failures return HTTP 500. The durable `200` carries `x-openclaw-delivery-accepted: durable`, so reverse proxies can require it to distinguish OpenClaw acceptance from a generic `200` (authentication, validation, and storage-error responses omit it).
+  - OpenClaw returns HTTP 200 only after it durably stores the raw event. Storage failures return HTTP 500. The durable `200` carries `x-openclaw-delivery-accepted: durable`. Reverse proxies can require that header to distinguish OpenClaw acceptance from a generic `200`. Authentication, validation, and storage-error responses omit it.
   - getUpdates polling and webhook are mutually exclusive per Zalo API docs.
 
 ## Supported message types
@@ -105,7 +105,7 @@ Group chats are supported by the plugin (`chatTypes: ["direct", "group"]`) and g
 - Text: full support, chunked to 2000 characters.
 - Media: inbound/outbound, capped by `mediaMaxMb`.
 - Reactions, threads, polls, native commands: not supported by the plugin.
-- Streaming: the plugin declares block-streaming capability, but Zalo has no dedicated outbound queue/merge-text tuning knobs (unlike some other regional channels); verify current behavior in your environment if this matters for your use case.
+- Streaming: the plugin declares block-streaming capability. Zalo has no dedicated outbound queue/merge-text tuning knobs, unlike some other regional channels. Verify current behavior in your environment if this matters for your use case.
 
 ## Capabilities
 
@@ -142,7 +142,7 @@ openclaw message send --channel zalo --target 123456789 --message "hi"
 - Confirm the secret is 8-256 characters
 - Confirm the gateway HTTP endpoint is reachable on the configured path
 - Confirm getUpdates polling is not also running (they are mutually exclusive)
-- A burst of requests can return HTTP 429 (120 requests / 60s per path+IP); back off and retry
+- A burst of requests can return HTTP 429 (120 requests / 60s per path+IP). Back off and retry
 
 ## Configuration reference
 
@@ -167,7 +167,7 @@ Full configuration: [Configuration](/gateway/configuration)
 | `channels.zalo.accounts.<id>.responsePrefix` | Outbound response prefix override                 | -                     |
 | `channels.zalo.defaultAccount`               | Default account when multiple are configured      | `default`             |
 
-`channels.zalo.botToken`, `channels.zalo.dmPolicy`, and other flat top-level keys are the legacy single-account shorthand for the fields above; both forms are supported.
+`channels.zalo.botToken`, `channels.zalo.dmPolicy`, and other flat top-level keys are the legacy single-account shorthand for the fields above. Both forms are supported.
 
 Env option: `ZALO_BOT_TOKEN=...` resolves the default account's token only.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -26,11 +26,11 @@ using a fixed, no-shell `command/exec` reader. The reader rejects symlinks,
 enforces file and response size limits before allocation, and stages immutable
 Gateway-managed media before channel delivery without requiring a shared or
 synchronized filesystem. Codex images are materialized directly from typed
-app-server events; saved-path-only images use the same bounded remote reader.
+app-server events. Saved-path-only images use the same bounded remote reader.
 Uploads always use the Gateway's configured channel identity and request timeout.
 
 Use canonical OpenAI model refs such as `openai/gpt-5.6-sol`. Do not configure
-legacy Codex GPT refs; put OpenAI agent auth order under `auth.order.openai`.
+legacy Codex GPT refs. Put OpenAI agent auth order under `auth.order.openai`.
 Legacy Codex auth profile ids and legacy Codex auth order entries are
 repaired by `openclaw doctor --fix`.
 
@@ -53,7 +53,7 @@ dynamic tools routed through the app-server `item/tool/call` bridge. An
 ordinary OpenClaw sandbox or restricted tool policy disables native code mode
 unless you opt into the experimental sandbox exec-server path. Node-backed
 `remote-exec` on a paired device or cloud worker instead uses its
-placement-owned environment without that experimental flag. A dedicated cloud worker with a completed project preparation keeps the bound workspace and `HOME` paths, so native commands can reuse setup caches. The node exec-server still uses a separate temporary `CODEX_HOME` for each connection; ending the connection removes that Codex state and preserves the prepared project home.
+placement-owned environment without that experimental flag. A dedicated cloud worker with a completed project preparation keeps the bound workspace and `HOME` paths, so native commands can reuse setup caches. The node exec-server still uses a separate temporary `CODEX_HOME` for each connection. Ending the connection removes that Codex state and preserves the prepared project home.
 
 Eligible native-shell turns also retain `gateway_exec` and `gateway_process`
 as a distinct OpenClaw execution path. Use `gateway_exec` only when a command
@@ -68,7 +68,7 @@ terminals listed on that Codex thread before releasing the run. Other Codex
 threads and deliberately backgrounded `gateway_process` jobs are unaffected.
 If native terminal cleanup fails, the run reports an error instead of silently
 claiming cleanup succeeded. Inspect that thread's running terminals before
-starting more work. This uses Codex's terminal ownership; it does not guarantee
+starting more work. This uses Codex's terminal ownership. It does not guarantee
 cleanup of commands that deliberately detach from that ownership.
 
 With the default `tools.exec.host: "auto"` and no active OpenClaw sandbox,
@@ -76,7 +76,7 @@ Codex also receives `node_exec` when a connected node supports `system.run`.
 Offline paired devices and devices without shell support do not expose this tool.
 When a node is configured, that binding must resolve to an eligible node. Native shell
 remains on the Codex app-server host and workspace
-(Gateway-local for the default stdio deployment); `node_exec` selects the sole
+(Gateway-local for the default stdio deployment). `node_exec` selects the sole
 connected node that supports `system.run`, or requires a name or id when several
 are eligible. It keeps OpenClaw's node approval policy in force and waits for the
 remote command to finish. Remote-node background follow-up is not available. If

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -42,12 +42,12 @@ Supported actions depend on the source host and its capabilities:
 ## Before you begin
 
 - Install the official `@openclaw/codex` plugin on the Gateway. The OpenClaw
-  macOS app can install it when you enable Codex features; CLI installations can
+  macOS app can install it when you enable Codex features. CLI installations can
   run `openclaw plugins install @openclaw/codex`.
 - Install and sign in to Codex Desktop or the Codex CLI on each computer whose
   sessions you want to list.
-- Pair remote computers as OpenClaw nodes. Each computer must opt in locally;
-  enabling supervision only on the Gateway does not authorize another node.
+- Pair remote computers as OpenClaw nodes. Each computer must opt in locally.
+  Enabling supervision only on the Gateway does not authorize another node.
 - Use an owner-controlled Gateway. Session titles, working directories, and Git
   branches can reveal sensitive project information.
 
@@ -60,7 +60,7 @@ be the primary backend. Supervision becomes available when that opportunistic
 plugin activation succeeds. App Server availability is checked when
 supervision first connects. An explicit Codex plugin disable or policy block
 prevents opportunistic activation, and an existing explicit
-`supervision.enabled: false` disables agent-facing supervision tools; the
+`supervision.enabled: false` disables agent-facing supervision tools. The
 operator catalog remains registered whenever the Codex plugin is active unless
 `sessionCatalog.enabled: false` disables it. This separate switch leaves the
 Codex provider, harness, and agent-facing supervision policy unchanged while
@@ -93,8 +93,8 @@ With no explicit `appServer` connection settings, supervision uses managed
 stdio connections for the available local Codex stores. The catalog combines
 the process user's `CODEX_HOME` with existing `codex-home` stores under configured
 OpenClaw agent directories, deduplicates canonical paths, and assigns each store
-an opaque local host id. Each store gets its own App Server connection; its path
-is never exposed in the catalog. List, read, continue, archive, adoption, and
+an opaque local host id. Each store gets its own App Server connection. Its path
+is never exposed in the catalog. List, read, continue, archive, adopt, and
 terminal resume keep the selected source while retaining the explicit OpenClaw
 route agent as owner. The ordinary Codex harness remains agent-scoped by default.
 Set `appServer.homeScope: "user"` explicitly if the harness should share native
@@ -125,8 +125,8 @@ capability or command, and a stale direct invocation fails instead of exposing
 the user Codex home or spawning a different local stdio App Server.
 
 The optional `agentId` in native Mac catalog list/read requests identifies the
-Gateway's OpenClaw route owner. It cannot select an agent-specific Codex home;
-the native catalog remains user-home stdio only. Headless node catalog requests
+Gateway's OpenClaw route owner. It cannot select an agent-specific Codex home.
+The native catalog remains user-home stdio only. Headless node catalog requests
 still resolve `agentId` against that node's configured agents and use the selected
 agent's configured catalog source. This does not map agent IDs between computers.
 
@@ -142,15 +142,15 @@ Non-archived Codex sessions also appear in the main Control UI sidebar, grouped
 by host. Select one to read its persisted transcript. Each request returns at
 most 50 transcript items (20 when the caller omits `limit`), with smaller pages
 when needed for the 20 MiB transport safety ceiling. Supported stores use Codex
-`thread/items/list`; older stores and node readers retain `thread/turns/list`
-with continuation inside a turn. Scroll upward to load older pages. Loaded
+`thread/items/list`. Older stores and node readers retain `thread/turns/list`
+with paging inside a turn. Scroll upward to load older pages. Loaded
 pages render in chronological order.
 
 The Control UI shows tool results as 500-character previews and marks shortened
 output. Previewing does not rewrite the native transcript or remove generic
 `raw` data. Catalog text uses the shared 512 KiB per-item bound. The viewer never
 loads an unbounded `thread/read` history. A legacy turn response or individual
-item above the transport ceiling still fails visibly; open that session in
+item above the transport ceiling still fails visibly. Open that session in
 Codex to inspect its full output.
 
 Open the **Codex** group in the normal sessions sidebar. It lists the same sessions
@@ -158,7 +158,7 @@ grouped by host. **Load more sessions** appends the next page from each host tha
 has older rows, and those appended rows survive the sidebar's periodic refresh.
 Each host appears as soon as its own native listing settles. The visible page
 reconciles after node-connectivity changes, when it regains focus, and at most
-every 30 seconds; a changed result gets a faster follow-up pass. Sessions created
+every 30 seconds. A changed result gets a faster follow-up pass. Sessions created
 in Codex Desktop, the CLI, or another native client therefore appear without a
 full page reload. The first page follows Codex's own most-recently-updated order.
 A fresh native fork remains readable by ID but can be absent from these lists
@@ -168,7 +168,7 @@ than sending the query to App Server, because native search can also match
 transcript previews.
 
 Host availability and thread status are separate. **Offline** or **Unavailable**
-describes a host refresh; an unavailable host returns no fresh session rows and
+describes a host refresh. An unavailable host returns no fresh session rows and
 does not change a thread's native status to `offline`. Session rows use Codex
 statuses such as `idle`, `active`, `notLoaded`, or error. A failed host does not
 hide results from healthy hosts.
@@ -176,8 +176,8 @@ hide results from healthy hosts.
 The sidebar warning includes the catalog error code and the safe underlying
 Gateway error. Open **Settings > Automation > Plugins > Codex > Native Session
 Discovery** to disable discovery without disabling Codex. For
-`NODE_LIST_FAILED`, compare `openclaw nodes list` and **Settings > Devices**;
-the detailed cause identifies the pairing-store, node-registry, permission, or
+`NODE_LIST_FAILED`, compare `openclaw nodes list` and **Settings > Devices**.
+The detailed cause identifies the pairing-store, node-registry, permission, or
 Gateway lifecycle failure that needs repair.
 
 ## Start a new native Codex CLI
@@ -190,20 +190,20 @@ passed as text, never as CLI options. Local catalog sources preserve their
 selected Codex home, including opaque secondary local host IDs.
 
 Terminal creation requires `operator.admin`, `gateway.cliAgents.enabled`, the
-installed CLI, and the active catalog plugin. Terminals are enabled by default;
+installed CLI, and the active catalog plugin. Terminals are enabled by default.
 `gateway.terminal.enabled: false` blocks creation.
 It does not require an eligible OpenClaw model. A paired headless node must
-advertise and permit **`codex.terminal.start.v1`**; the existing
+advertise and permit **`codex.terminal.start.v1`**. The existing
 `codex.terminal.resume.v1` alone does not support fresh starts. The node chooses
 its own installed Codex executable and native account/configuration. The Gateway
-agent remains the authorization context; it need not exist in the node's
+agent remains the authorization context. It need not exist in the node's
 OpenClaw configuration.
 
 Local starts support the Gateway folder/worktree chooser. Node starts require
 an existing absolute directory on that node and never substitute the node's
 home if it disappears. Commands accept only cwd, an optional prompt, and terminal
 dimensions, not caller-supplied executables, argv, environment, or credentials.
-Closing the terminal cancels its node invocation; disconnects and stale pairing
+Closing the terminal cancels its node invocation. Disconnects and stale pairing
 or connection generations are handled by the same terminal relay as resume.
 See [native CLI creation](/web/control-ui/sessions-and-sidebar#start-a-native-coding-cli) for UI controls
 and prerequisites. Existing catalog viewing, resume, and Chat continuation keep
@@ -226,20 +226,20 @@ openclaw codex archive <thread-id> --confirm-no-other-runner [--agent <id>] [--h
 - `--search <text>` searches session titles case-insensitively.
 - `--host <id>` limits the response to one stable catalog host, such as
   `gateway:local`, an opaque `gateway:local:<source-id>`, or `node:<node-id>`.
-- `--limit <count>` sets 1 through 100 rows per host; the default is 50.
+- `--limit <count>` sets 1 through 100 rows per host. The default is 50.
 - `--cursor <cursor>` continues one host page and therefore requires `--host`.
 - `--json` prints the structured Gateway response.
 
 All three commands accept `--agent <id>` and inherit `--url`, `--token`, and `--timeout <ms>` from the
 Gateway client. Session listing defaults to 75,000 ms so cold paired-node
-catalogs can complete; continue and archive default to 30,000 ms. They also expose the shared
+catalogs can complete. Continue and archive default to 30,000 ms. They also expose the shared
 `--expect-final` switch, which does not change these unary supervision RPCs.
 Each shell command requests the `operator.write` Gateway scope.
 Standard `-h, --help` output is available on each subcommand.
 There is no archived or include-archived option. `sessions` can list paired
-hosts. `continue` and `archive` default to `gateway:local`; pass the listed
+hosts. `continue` and `archive` default to `gateway:local`. Pass the listed
 opaque local `--host` id to target another local Codex store. The shell
-`continue` command requests only `operator.write`; passing a node host does not
+`continue` command requests only `operator.write`. Passing a node host does not
 request the `operator.admin` scope required for paired-node continuation. Unless
 the Gateway separately grants that scope to the authenticated identity, the
 request is refused. Use the admin-authorized Control UI flow described below
@@ -270,14 +270,14 @@ The mirror keeps the newest visible tail that fits all three limits: at most 200
 user or assistant messages, 512 KiB of UTF-8 text in total, and 64 KiB per
 message. Oversized messages are truncated with a marker, and older messages are
 omitted when a cap is reached. An image or local-image input becomes the literal
-`[Image attachment]` placeholder; image data and local paths are not copied.
+`[Image attachment]` placeholder. Image data and local paths are not copied.
 
 Send the first normal Chat message to begin work. The Codex harness installs the
 real approval, elicitation, event, and delivery handlers. It uses an ephemeral
 native fork on the supervision connection to pin the source snapshot without
 supplying a model or provider override. Codex App Server selects both from its
 current native configuration and returns the actual selection. OpenClaw confirms
-the probe's subscription is released before creating the canonical branch; the
+the probe's subscription is released before creating the canonical branch. The
 probe never becomes stored history or an archive artifact. On that same
 connection, OpenClaw starts the canonical `appServer`-source full harness thread
 under its cwd and runtime policy with exactly that returned pair, injects the
@@ -307,7 +307,7 @@ ordinary session when you want a different model or fresh thread.
 
 **Fork from here** keeps the source connection and model-locked harness without
 changing the original source or parent Chat. Original imported messages and
-canonical conversation messages use different native flows; see
+canonical conversation messages use different native flows. See
 [Fork a message in a supervised Chat](/plugins/codex-supervision#fork-a-message-in-a-supervised-chat).
 
 Keep supervision enabled for this Chat. If supervision is disabled or its
@@ -316,16 +316,16 @@ closed instead of moving to an ordinary agent-home session.
 
 A new adoption snapshots the native title as a trimmed display name, capped at
 500 UTF-16 code units without splitting surrogate pairs. Native titles can be
-duplicated or blank; they do not claim unique OpenClaw labels. An explicit local
+duplicated or blank. They do not claim unique OpenClaw labels. An explicit local
 label takes priority over the stored display name. Reopening or recovering a Chat
 preserves its existing label and title snapshot, including older automatically
-assigned labels; renaming the native source does not resync either field.
+assigned labels. Renaming the native source does not resync either field.
 **Fork from here** does not inherit the native response's title as a display name
 or local label.
 
 Disabling or uninstalling the `codex` plugin does not release that ownership or
 make the Chat eligible for another model. The locked Chat remains preserved but
-unavailable; reinstall or re-enable the same plugin and restart the Gateway to
+unavailable. Reinstall or re-enable the same plugin and restart the Gateway to
 resume it. This deliberate fail-closed behavior prevents retention cleanup or a
 temporary plugin outage from silently orphaning the native binding.
 
@@ -333,7 +333,7 @@ The `codex_threads` agent tool follows the same boundary. It cannot attach a
 different fork or archive the Chat's bound native thread. List and metadata-only
 read remain available. Raw transcript reads require `allowRawTranscripts`.
 When raw access is disabled, `codex_threads` also rejects list search because
-native search includes transcript previews; the Control UI and operator CLI
+native search includes transcript previews. The Control UI and operator CLI
 still provide bounded title-only search. Rename, unarchive, detached fork, and
 archive of an unrelated unowned thread require
 `allowWriteControls`. Neither option bypasses the locked binding.
@@ -345,7 +345,7 @@ source without creating competing rollout writers.
 
 The original CLI, VS Code, Atlas, or ChatGPT source remains visible to native
 clients and the OpenClaw catalog. The canonical branch is stored as a native
-Codex thread, but its source kind is `appServer`; Codex Desktop or another
+Codex thread, but its source kind is `appServer`. Codex Desktop or another
 native client may filter that source kind, so the branch itself is not guaranteed
 to appear in every native history view.
 
@@ -388,13 +388,13 @@ API. OpenClaw keeps the complete current generic instructions in native thread
 configuration and appends one developer message that replaces earlier
 OpenClaw-supplied generic policy, including removed sections or an explicit
 empty policy. Independent native managed, guardian, security, collaboration,
-and project instructions retain their authority. This is textual supersession;
-it does not delete earlier history or change native permission enforcement.
+and project instructions retain their authority. This is textual supersession.
+It does not delete earlier history or change native permission enforcement.
 
 The refresh is session configuration recorded before the next native user turn.
 It can contain prompt-hook output for that request and remains in native history
 even if the user turn is rejected or never starts. **Fork from here** excludes
-the selected native user turn; it does not erase configuration updates recorded
+the selected native user turn. It does not erase configuration updates recorded
 before that turn. The refresh creates no user message or extra model turn.
 
 Canonical message forks require Codex 0.153.0 or newer and native model metadata.
@@ -408,7 +408,7 @@ owner. It rejects changes to the source rollout or selected model during
 initialization. Its automatic native subscription is released before readiness.
 Preparation does not run prompt hooks or provision execution environments or
 requester MCP resources. The source's actual native declarations must match the
-fresh child's declarations; creation does not reconstruct a hypothetical run's
+fresh child's declarations. Creation does not reconstruct a hypothetical run's
 tools. A child whose native policy or metadata cannot be verified is refused
 with an original-message alternative. Display copies are limited to 200 messages
 and 512 KiB of serialized message data.
@@ -426,7 +426,7 @@ Later turns require native unload evidence before applying current harness
 configuration. An unsubscribe acknowledgement alone does not establish that
 the thread unloaded. Once configuration is proven, OpenClaw refreshes the
 complete generic policy before starting the turn. Stop competing native work
-and reconnect if configuration application cannot be verified; the bound
+and reconnect if configuration application cannot be verified. The bound
 conversation is preserved. An uncertain refresh also preserves the conversation
 and retires its connection rather than replaying the operation. A failed fresh
 child with unverified cleanup remains non-ready for inspection.
@@ -434,7 +434,7 @@ child with unverified cleanup remains non-ready for inspection.
 Fresh initial materialization already supplies generic instructions and needs
 no additional policy refresh. Ordinary nonsupervised sessions keep their existing
 resume and warm-reuse behavior. Standalone cold compaction, review, and goal
-operations do not reconstruct the last run's hook-derived generic policy; the
+operations do not reconstruct the last run's hook-derived generic policy. The
 next admitted supervised run supplies current configuration and refreshes it.
 
 ## Archive a local session
@@ -452,7 +452,7 @@ supervised Chat still has a pending branch from that source. Send the Chat's
 first message to materialize its canonical branch before archiving the source.
 Archive is also blocked when OpenClaw knows that an active binding owns the
 exact target thread or any non-archived spawned descendant. OpenClaw follows the
-experimental Codex descendant query through every page; an invalid response,
+experimental Codex descendant query through every page. An invalid response,
 request failure, repeated cursor or thread, or safety-limit exhaustion rejects
 archive.
 
@@ -461,8 +461,8 @@ operation, so a turn can still start between them. App Server status is also
 not shared across independent processes. The confirmation is therefore the
 safety boundary for unknown clients and that race: quit or otherwise verify
 every other client before confirming. Restore an archived thread with Codex
-Desktop, the Codex CLI, or an owner-authorized native thread-management flow;
-it reappears after unarchive.
+Desktop, the Codex CLI, or an owner-authorized native thread-management flow.
+It reappears after unarchive.
 
 ```bash
 codex unarchive <thread-id>
@@ -477,7 +477,7 @@ Codex CLI available also expose the allowlisted `codex.terminal.resume.v1`
 command. The Gateway receives normalized
 metadata and explicitly requested bounded transcript pages, never raw App Server
 endpoints. Opening a row in the operator terminal runs `codex resume <thread-id>`
-on the owning host and relays that command's PTY; it does not expose a general
+on the owning host and relays that command's PTY. It does not expose a general
 shell or gateway-supplied argv.
 
 Chat continuation is a separate capability from the terminal relay. It requires
@@ -490,7 +490,7 @@ commands:
 
 The CLI-resume command is a dangerous node command: it needs explicit Gateway
 command allowlisting (`gateway.nodes.commands.allow`) as well as approval of
-the node's command surface; a deny rule still blocks it. The native macOS catalog
+the node's command surface. A deny rule still blocks it. The native macOS catalog
 and terminal relay alone do not provide it, although a Mac app's embedded node
 worker can advertise additional commands. Check the actual advertised and
 permitted commands, not just the host platform. Nodes exposing only list,
@@ -501,7 +501,7 @@ send a text message. Continuation freshly checks that the source is `idle` or
 `notLoaded`, creates or reopens a model-locked Chat, and binds it to the exact
 native thread on the owning node. A new Chat mirrors bounded user and assistant
 history from the newest transcript page. The catalog action itself does not
-fork or resume the native thread; the UI then forwards your draft to the bound
+fork or resume the native thread. The UI then forwards your draft to the bound
 Chat. That message and later turns run `codex exec resume` on the node with its
 native CLI configuration and return its final text. This text-prompt path does
 not create the Gateway-local branch or forward the full App Server harness
@@ -529,13 +529,13 @@ the Codex home path, Git remotes, commit SHAs, and raw App Server errors. Catalo
 access and Control UI transcript reads require the `operator.write` Gateway
 scope because fleet aggregation uses the standard `node.invoke` path, even
 though both catalog node commands are read-only. Paired-node continuation
-additionally requires `operator.admin`; subsequent bound turns enforce the
+additionally requires `operator.admin`. Subsequent bound turns enforce the
 native-execution owner/admin check.
 
 `supervision.allowRawTranscripts` and `supervision.allowWriteControls` govern
 autonomous agent and standalone MCP tools. Both default to `false`. With
 supervision enabled, `codex_threads` removes transcript previews and turns from
-list and metadata-only read results unless raw transcripts are allowed; a
+list and metadata-only read results unless raw transcripts are allowed. A
 turn-inclusive read fails closed. Every fork, rename, archive, and unarchive
 requires write controls. These options do not gate authenticated Control UI
 transcript viewing and do not bypass binding, host, status, or confirmation checks.
@@ -551,13 +551,13 @@ existing agent and standalone MCP clients:
 - `codex_session_send`
 - `codex_session_interrupt`
 
-`codex_sessions_list` is loaded-only by default; there is no `loaded_only`
+`codex_sessions_list` is loaded-only by default. There is no `loaded_only`
 parameter. Set `include_stored: true` to also read non-archived stored rows from
 Codex's state database. The optional `max_stored_sessions` cap defaults to 200
 and accepts 1 through 1,000 rows per endpoint. It does not cap loaded rows.
 Without raw-transcript permission, list results omit transcript-derived names,
 previews, and detailed endpoint errors.
-`codex_session_read` requires `allowRawTranscripts`; `include_turns: true`
+`codex_session_read` requires `allowRawTranscripts`. `include_turns: true`
 additionally asks Codex for turns.
 
 `codex_session_send` and `codex_session_interrupt` require
@@ -572,7 +572,7 @@ do not resume or start an idle source thread.
 and permission fields, and plugin allow/deny policy references into the official
 `codex` plugin without overwriting explicit canonical settings. The standalone
 compatibility MCP adapter continues to load the same five tools from that
-plugin; legacy policy environment variables apply only inside that trusted
+plugin. Legacy policy environment variables apply only inside that trusted
 adapter.
 
 For every supervision config field, see
@@ -588,7 +588,7 @@ changing activation.
 **Continue is disabled or refused:** an unmapped row is active or in an
 ineligible state, its host is offline, or another action is pending. For a
 paired-node row, also verify `operator.admin` and that all three continuation
-commands are advertised and permitted; terminal access alone is insufficient.
+commands are advertised and permitted. Terminal access alone is insufficient.
 Gateway-local stored and idle rows offer **Continue as branch** instead of
 unsafe exact-thread takeover. A row that already has a supervised Chat offers
 **Open Chat**.
@@ -600,7 +600,7 @@ rollout metadata in the selected Codex home. These checks share one request
 budget and do not scan the full catalog. Missing, unreadable, inconsistent, or
 OpenClaw-managed metadata is not accepted. Refresh the catalog, verify the session
 in its native Codex home, and retry. This error does not prove that the thread
-does not exist. Ordinary discovery keeps its existing behavior; remote sources
+does not exist. Ordinary discovery keeps its existing behavior. Remote sources
 continue to use native catalog verification.
 
 **Archive is disabled:** archive is available for stored/activity-unknown and

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -54,11 +54,11 @@ Use `openclaw plugins inspect <id>` to see a plugin's shape.
 
 ## Related
 
-- [SDK Overview](/plugins/sdk-overview) - registration API and subpath reference
-- [Runtime Helpers](/plugins/sdk-runtime) - `api.runtime` and `createPluginRuntimeStore`
-- [Setup and Config](/plugins/sdk-setup) - manifest and setup entry loading
-- [Channel Plugins](/plugins/sdk-channel-plugins) - building the `ChannelPlugin` object
-- [Provider Plugins](/plugins/sdk-provider-plugins) - provider registration and hooks
+- [Plugin SDK overview](/plugins/sdk-overview) - registration API and subpath reference
+- [Plugin runtime helpers](/plugins/sdk-runtime) - `api.runtime` and `createPluginRuntimeStore`
+- [Plugin setup and config](/plugins/sdk-setup) - manifest and setup entry loading
+- [Building channel plugins](/plugins/sdk-channel-plugins) - building the `ChannelPlugin` object
+- [Building provider plugins](/plugins/sdk-provider-plugins) - provider registration and hooks
 
 ## MCP subprocess runtime
 
@@ -71,7 +71,7 @@ const { createMcpStdioClient } = await mcpStdioRuntime.load();
 
 Use `createMcpStdioClient(params)` for a caller-owned MCP proxy subprocess fronting a stateful driver. OpenClaw owns the subprocess and its descendants, newline framing and JSON-RPC validation, initialization, request admission, deadlines, and shutdown. The client starts connecting when the factory returns. Keep this runtime out of plugin registration and paths that do not open MCP connections.
 
-Supply `command`, optional `args`, and an exact `env`; the child inherits no other environment variables. Set `clientInfo` (`name` and `version`), the required `protocolVersion`, `startupTimeoutMs`, `maxPendingRequests`, and `maxFrameBytes`. The server must return exactly the requested protocol version. OpenClaw retains a fixed 32 KiB stderr tail for unexpected-exit diagnostics. The decoder bounds pending bytes plus each incoming chunk before buffering, preserves fragmented UTF-8, skips empty lines, and requires safe integer response IDs.
+Supply `command`, optional `args`, and an exact `env`. The child inherits no other environment variables. Set `clientInfo` (`name` and `version`), the required `protocolVersion`, `startupTimeoutMs`, `maxPendingRequests`, and `maxFrameBytes`. The server must return exactly the requested protocol version. OpenClaw retains a fixed 32 KiB stderr tail for unexpected-exit diagnostics. The decoder bounds pending bytes plus each incoming chunk before buffering, preserves fragmented UTF-8, skips empty lines, and requires safe integer response IDs.
 
 The caller supplies `errors.unavailable(message, cause?)` and `errors.protocol(message, cause?)`, each returning an `Error`. The first classifies process, lifecycle, admission, deadline, and cancellation failures. The second classifies malformed frames, non-timeout JSON-RPC errors, and handshake contract violations. Plugin-specific tool-result normalization stays with the caller.
 
@@ -81,4 +81,4 @@ The returned client exposes three methods:
 - `request(method, params, { timeoutMs, signal? })` waits for startup and returns the object result. An already-aborted signal or a full pending-request limit rejects only that call. After admission, cancellation or timeout retires the entire connection and rejects pending requests with the retained fatal error. The client suppresses SDK cancellation notifications because it terminates the process instead. A non-timeout JSON-RPC error response rejects only its matching request through `errors.protocol`.
 - `stop()` closes admission, retires pending requests, and awaits startup settlement and owned-process cleanup. It rejects through `errors.unavailable` with `proxy cleanup could not be confirmed` if cleanup is uncertain. It never stops a separately started service reached through the proxy's socket.
 
-Malformed frames, incompatible initialization, write failures, and unexpected process exit also retire the whole connection. The first fatal error is retained; create a new client to reconnect. Timeout classification follows the SDK error code, so a timeout-coded server error also retires the connection.
+Malformed frames, incompatible initialization, write failures, and unexpected process exit also retire the whole connection. The first fatal error is retained. Create a new client to reconnect. Timeout classification follows the SDK error code, so a timeout-coded server error also retires the connection.

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -19,14 +19,14 @@ from a single entry point:
 
 - **`openclaw/plugin-sdk`** and **`openclaw/plugin-sdk/compat`** - re-exported
   dozens of helpers while the focused SDK was being built. Both roots are now
-  removed; import a documented subpath instead.
+  removed. Import a documented subpath instead.
 - **`openclaw/plugin-sdk/infra-runtime`** - a broad barrel mixing system
   events, heartbeat state, delivery queues, fetch/proxy helpers, file helpers,
   approval types, and unrelated utilities.
 - **`openclaw/plugin-sdk/config-runtime`** - a broad config barrel retained
   for compatibility, including deprecated direct `loadConfig` and
   `writeConfigFile` exports. Those methods were removed from the injected
-  plugin runtime, not from this retained facade.
+  plugin runtime, not from this retained barrel.
 - **`openclaw/extension-api`** - a removed bridge that gave plugins direct
   access to host-side helpers like the embedded agent runner.
 - **`api.registerEmbeddedExtensionFactory(...)`** - a removed embedded-runner-only
@@ -36,7 +36,7 @@ from a single entry point:
 
 The root SDK, compat barrel, extension bridge, and embedded extension factory
 have been removed. `infra-runtime` and `config-runtime` remain only for their
-separately recorded later windows; new plugins should use focused subpaths.
+separately recorded later windows. New plugins should use focused subpaths.
 
 <Warning>
   Plugins importing the removed root, compat, or extension surfaces no longer
@@ -50,8 +50,8 @@ applies to SDK imports, manifest fields, setup APIs, hooks, and runtime
 registration behavior.
 
 `ChatCommandDefinition.category` retains the `"docks"` value accepted by the
-2026.8.1 SDK. Command lists display these legacy definitions under **Tools**;
-the category does not enable channel docking or restore retired docking commands.
+2026.8.1 SDK. Command lists display these legacy definitions under **Tools**.
+The category does not enable channel docking or restore retired docking commands.
 New definitions should use `"tools"`.
 
 ### Why

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -45,7 +45,7 @@ Explicitly disabled or denied migration owners cannot execute their artifacts.
 The existing bundled migration compatibility rules still apply.
 
 The login caller selects only the declared auth item. Its details must contain
-the matching `provider` and `credentialKind`; a migrated result also supplies
+the matching `provider` and `credentialKind`. A migrated result also supplies
 the saved `profileId`. The owner must honor cancellation, reread the selected
 source before persistence, and reject a changed credential. Login passes
 `configPatchMode: "none"` so import preserves model defaults and restrictions.
@@ -128,14 +128,14 @@ A failed selected import stops the operation instead of silently starting a diff
     model ids like `acme-large` before runtime hooks exist. `openclaw.compat`
     and `openclaw.build` in `package.json` are required for ClawHub
     publishing (`openclaw.compat.pluginApi` and `openclaw.build.openclawVersion`
-    are the two required fields; `minGatewayVersion` falls back to
+    are the two required fields. `minGatewayVersion` falls back to
     `openclaw.install.minHostVersion` when omitted).
 
   </Step>
 
   <Step title="Register the provider">
     A minimal text provider needs an `id`, `label`, `auth`, and `catalog`.
-    `catalog` is the provider-owned runtime/config hook; it can call live
+    `catalog` is the provider-owned runtime/config hook. It can call live
     vendor APIs and returns `models.providers` entries.
 
     ```typescript index.ts
@@ -228,7 +228,7 @@ A failed selected import stops the operation instead of silently starting a diff
     `registerModelCatalogProvider` is the newer control-plane catalog surface
     for list/help/picker UI, covering `text`, `voice`, `image_generation`,
     `video_generation`, and `music_generation` rows. Keep vendor endpoint
-    calls and response mapping in the plugin; OpenClaw owns the shared row
+    calls and response mapping in the plugin. OpenClaw owns the shared row
     shape, source labels, and help rendering.
 
     That is a working provider. Users can now run
@@ -239,7 +239,7 @@ A failed selected import stops the operation instead of silently starting a diff
     import `findNormalizedProviderValue` and `resolveAuthProfileOrder` from
     `openclaw/plugin-sdk/provider-auth`. This keeps provider entrypoints from
     loading the full agent runtime just to select a credential. The deprecated
-    `agent-runtime` exports remain available for compatibility; use the narrower
+    `agent-runtime` exports remain available for compatibility. Use the narrower
     `provider-auth` route in new code. See the [removal
     timeline](/plugins/sdk-migration/removal-timeline) for the dates and gates
     that govern deprecated surfaces named on this page and its child pages.
@@ -327,7 +327,7 @@ A failed selected import stops the operation instead of silently starting a diff
     [Internals: Capability Ownership](/plugins/architecture#capability-ownership-model).
 
     Register the audio capabilities from [Provider voice
-    capabilities](/plugins/sdk-provider-plugins/voice-and-audio); register
+    capabilities](/plugins/sdk-provider-plugins/voice-and-audio). Register
     embeddings, generation, fetch, and search from [Provider media and
     search](/plugins/sdk-provider-plugins/media-and-search).
 

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -173,9 +173,9 @@ Supported field kinds are `string`, `boolean`, `integer`, `string-list`, and `ch
 
 For a boolean `useEnv` field, set `envVars` to the static environment variable names required by the plugin runtime. Non-interactive channel setup then rejects `--use-env` before writing config when any declared variable is empty. Set `envVarMode: "any"` when one variable from the list is sufficient, such as an inline credential or file-path alternative. Omitting `envVars` preserves the plugin's existing validation behavior.
 
-The released `setup`/`ChannelSetupInput` adapter stays available for existing external plugins. New plugins should expose `setupContract`; OpenClaw always prefers it when both are present.
+The released `setup`/`ChannelSetupInput` adapter stays available for existing external plugins. New plugins should expose `setupContract`. OpenClaw always prefers it when both are present.
 
-Use `afterAccountConfigWritten` (or a wizard's `afterConfigWritten`) for connection checks and other work that requires saved configuration. OpenClaw runs these callbacks after the write succeeds and passes a runtime `cfg` reread from the exact committed file, with environment references and plugin defaults resolved. The saved file can retain `${VAR}` references. Missing or invalid saved configuration prevents callback execution; callback failures are reported as post-setup warnings without undoing the saved configuration.
+Use `afterAccountConfigWritten` (or a wizard's `afterConfigWritten`) for connection checks and other work that requires saved configuration. OpenClaw runs these callbacks after the write succeeds and passes a runtime `cfg` reread from the exact committed file, with environment references and plugin defaults resolved. The saved file can retain `${VAR}` references. Missing or invalid saved configuration prevents callback execution. Callback failures are reported as post-setup warnings without undoing the saved configuration.
 
 | Field                                  | Type       | What it means                                                                 |
 | -------------------------------------- | ---------- | ----------------------------------------------------------------------------- |
@@ -253,10 +253,10 @@ Example:
 
 <AccordionGroup>
   <Accordion title="Onboarding behavior">
-    Interactive onboarding uses `openclaw.install` for install-on-demand surfaces: if your plugin exposes provider auth choices or channel setup/catalog metadata before runtime loads, onboarding can prompt for ClawHub, npm, or local install, install or enable the plugin, then continue the selected flow. ClawHub choices use `clawhubSpec` and are preferred when present; npm choices require trusted catalog metadata with a registry `npmSpec` (exact versions and `expectedIntegrity` are optional pins, enforced on install/update when set). Keep "what to show" in `openclaw.plugin.json` and "how to install it" in `package.json`.
+    Interactive onboarding uses `openclaw.install` for install-on-demand surfaces: if your plugin exposes provider auth choices or channel setup/catalog metadata before runtime loads, onboarding can prompt for ClawHub, npm, or local install, install or enable the plugin, then continue the selected flow. ClawHub choices use `clawhubSpec` and are preferred when present. Choices from npm require trusted catalog metadata with a registry `npmSpec` (exact versions and `expectedIntegrity` are optional pins, enforced on install/update when set). Keep "what to show" in `openclaw.plugin.json` and "how to install it" in `package.json`.
   </Accordion>
   <Accordion title="minHostVersion enforcement">
-    If `minHostVersion` is set, install and non-bundled manifest-registry loading both enforce it. Older hosts skip external plugins; invalid version strings are rejected. Bundled source plugins are assumed to be co-versioned with the host checkout.
+    If `minHostVersion` is set, install and non-bundled manifest-registry loading both enforce it. Older hosts skip external plugins. Invalid version strings are rejected. Bundled source plugins are assumed to be co-versioned with the host checkout.
   </Accordion>
   <Accordion title="Pinned npm installs">
     For pinned npm installs, keep the exact version in `npmSpec` and add the expected artifact integrity:
@@ -384,7 +384,7 @@ Use the broader `plugin-sdk/setup` seam when you want the full shared setup tool
 
 Use `createSetupTranslator(...)` for fixed setup wizard copy. It uses the first nonblank value from `OPENCLAW_LOCALE`, `LC_ALL`, `LC_MESSAGES`, and `LANG`, in that order, then falls back to English. Set `OPENCLAW_LOCALE=en` for an explicit English override. Keep plugin-specific setup text in plugin-owned code and use shared catalog keys only for common setup labels, status text, and official bundled plugin setup copy.
 
-The setup patch adapters stay hot-path safe on import. Their bundled single-account promotion contract-surface lookup is lazy, so importing `plugin-sdk/setup-runtime` does not eagerly load bundled contract-surface discovery before the adapter is actually used.
+The setup patch adapters do no eager work when a plugin imports them. Their bundled single-account promotion contract-surface lookup is lazy, so importing `plugin-sdk/setup-runtime` does not eagerly load bundled contract-surface discovery before the adapter is actually used.
 
 ### Channel-owned setup input fields
 
@@ -425,9 +425,9 @@ Channel-specific fields that were previously declared directly on
 `ChannelSetupInput` remain temporarily typed for external source compatibility.
 They are deprecated. A 2026-07-22 registry sweep of 426 published out-of-tree
 channel plugins removed 21 fields with no readers and retained 22 with known
-readers. Each retained field is deleted as soon as no published plugin reads it;
-no version boundary is required. New and bundled plugins must not rely on this
-tier; declare the fields they own locally.
+readers. Each retained field is deleted as soon as no published plugin reads it.
+No version boundary is required. New and bundled plugins must not rely on this
+tier. Declare the fields they own locally.
 
 ### Channel-owned single-account promotion
 
@@ -435,16 +435,16 @@ When a channel upgrades from a single-account top-level config to `channels.<id>
 
 Every channel plugin can extend or narrow that promotion through its setup adapter:
 
-- `configPromotion: "preserve-root"`: keep all root values in place, including common name, policy, and delivery fields; the plugin owns its account layout
+- `configPromotion: "preserve-root"`: keep all root values in place, including common name, policy, and delivery fields. The plugin owns its account layout
 - `singleAccountKeysToMove`: extra top-level keys that should move into the promoted account
-- `namedAccountPromotionKeys`: when named accounts already exist, only these keys move into the promoted account; shared policy/delivery keys stay at the channel root
+- `namedAccountPromotionKeys`: when named accounts already exist, only these keys move into the promoted account. Shared policy/delivery keys stay at the channel root
 - `resolveSingleAccountPromotionTarget(...)`: choose which existing account receives promoted values
 
-The presence of `singleAccountKeysToMove` marks the promotion contract complete. Declare the field even when it is an empty array to opt out of legacy key promotion; an empty array does not suppress common fields. Adapters that omit the field retain a reader-backed pre-declaration promotion tier for already-published plugins. The 2026-07-22 registry sweep removed 23 keys with no published dependents and retained six common keys plus the setup-only `rooms` key. Each retained key is deleted as soon as its published readers migrate to declarations; no version boundary is required.
+The presence of `singleAccountKeysToMove` marks the promotion contract complete. Declare the field even when it is an empty array to opt out of legacy key promotion. An empty array does not suppress common fields. Adapters that omit the field retain a reader-backed pre-declaration promotion tier for already-published plugins. The 2026-07-22 registry sweep removed 23 keys with no published dependents and retained six common keys plus the setup-only `rooms` key. Each retained key is deleted as soon as its published readers migrate to declarations. No version boundary is required.
 
 Declare `openclaw.setupFeatures.configPromotion: true` in the plugin package manifest when doctor must load these declarations from the lightweight setup entry. Doctor discovers that entry through the plugin manifest for both bundled and installed plugins, including disabled plugins. The setup-only plugin surface and the full channel plugin must expose the same declarations.
 
-For a plugin-owned root layout, also declare `openclaw.setupFeatures.configPromotion: "preserve-root"` in `package.json`. Doctor reads this static declaration for installed and bundled plugins, including disabled plugins, without executing their runtime. Omitting the declaration or using `false` does not opt out of promotion. The runtime declaration belongs on the adapter passed to `defineChannelSetupContract`, and covers shared CLI, declarative wizard, and policy-writer promotion. It does not change helpers that explicitly migrate a base name; use a selected-account writer when the root remains an implicit identity. Buzz is an example of this layout.
+For a plugin-owned root layout, also declare `openclaw.setupFeatures.configPromotion: "preserve-root"` in `package.json`. Doctor reads this static declaration for installed and bundled plugins, including disabled plugins, without executing their runtime. Omitting the declaration or using `false` does not opt out of promotion. The runtime declaration belongs on the adapter passed to `defineChannelSetupContract`, and covers shared CLI, declarative wizard, and policy-writer promotion. It does not change helpers that explicitly migrate a base name. Use a selected-account writer when the root remains an implicit identity. Buzz is an example of this layout.
 
 When calling `moveSingleAccountChannelSectionToDefaultAccount(...)` with an already resolved plugin, pass its setup adapter as `setupSurface`. Caller-supplied setup surfaces take precedence over loaded and bundled lookup, which keeps scoped or setup-only plugins independent of global registration.
 
@@ -623,17 +623,17 @@ const setupWizard: ChannelSetupWizard = {
   </Tab>
 </Tabs>
 
-**In-repo plugins:** place under the bundled plugin workspace tree; they are automatically discovered during build.
+**In-repo plugins:** place under the bundled plugin workspace tree. They are automatically discovered during build.
 
 <Info>
 For npm-sourced installs, `openclaw plugins install` installs the package into a per-plugin project under `~/.openclaw/npm/projects` with lifecycle scripts disabled (`--ignore-scripts`). Keep plugin dependency trees pure JS/TS and avoid packages that require `postinstall` builds.
 </Info>
 
 <Note>
-Gateway startup does not install plugin dependencies. npm/git/ClawHub install flows own dependency convergence; local plugins must already have their dependencies installed.
+Gateway startup does not install plugin dependencies. npm/git/ClawHub install flows own dependency convergence. Local plugins must already have their dependencies installed.
 </Note>
 
-Bundled package metadata is explicit, not inferred from built JavaScript at gateway startup. Runtime dependencies belong in the plugin package that owns them; packaged OpenClaw startup never repairs or mirrors plugin dependencies.
+Bundled package metadata is explicit, not inferred from built JavaScript at gateway startup. Runtime dependencies belong in the plugin package that owns them. Packaged OpenClaw startup never repairs or mirrors plugin dependencies.
 
 ### ClawHub publishing
 
@@ -654,5 +654,5 @@ clawhub package publish your-org/your-plugin
 - [Plugin manifest](/plugins/manifest) — full manifest schema reference
 - [SDK entry points](/plugins/sdk-entrypoints) — `definePluginEntry` and `defineChannelPluginEntry`
 - [Plugin SDK overview](/plugins/sdk-overview) — import map and registration API reference
-- [Plugin SDK subpaths](/plugins/sdk-subpaths) — the public entrypoint catalog
+- [Plugin SDK subpaths](/plugins/sdk-subpaths) — the public entry point catalog
 - [Plugin architecture internals](/plugins/architecture-internals) — load pipeline and registry model

--- a/docs/plugins/webhooks.md
+++ b/docs/plugins/webhooks.md
@@ -10,7 +10,7 @@ title: "Webhooks plugin"
 The Webhooks plugin adds authenticated HTTP routes so a trusted external
 system (Zapier, n8n, a CI job, an internal service) can create and drive
 managed OpenClaw TaskFlow records over HTTP, without writing a custom plugin.
-`create_flow` creates a tracking record; `run_task` creates or links a child task
+`create_flow` creates a tracking record. `run_task` creates or links a child task
 record. Neither operation starts an agent. The external controller owns the
 workflow and advances its state.
 
@@ -93,7 +93,7 @@ route can never act outside its bound session. To limit blast radius:
 
 Request handling order is: `POST` method, fixed-window rate limit, JSON content
 type, in-flight limit, shared-secret authentication, bounded JSON body read, then
-action validation. Earlier failures do not reach later checks.
+action validation. Earlier failures do not reach later stages.
 
 | Limit                        | Scope                                                                                                      |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
@@ -124,7 +124,7 @@ curl --include https://gateway.example.com/plugins/webhooks/zapier \
   --data '{"action":"get_flow","flowId":"<returned-flow-id>"}'
 ```
 
-HTTP `200` confirms a read or record operation, not completed agent work or
+HTTP `200` acknowledges a read or record operation, not completed agent work or
 message delivery. Use `get_task_summary` for linked task counts and
 [task inspection](/cli/tasks) for actual task status and delivery status. Keep
 those outcomes separate from the controller's flow status.
@@ -149,7 +149,7 @@ those outcomes separate from the controller's flow status.
 
 Mutating actions (`set_waiting`, `resume_flow`, `finish_flow`, `fail_flow`,
 `request_cancel`) require `flowId` and `expectedRevision` for optimistic
-concurrency; a stale revision returns `409 revision_conflict`. Read `result.current`
+concurrency. A stale revision returns `409 revision_conflict`. Read `result.current`
 or call `get_flow`, reconcile the change, then use its current revision.
 `cancel_flow` and `run_task` do not take `expectedRevision`. Action schemas reject
 unknown fields.
@@ -172,18 +172,18 @@ that a matching flow exists.
 `goal` is required. Optional fields are `controllerId`, `status` (`queued`,
 `running`, `waiting`, `blocked`), `notifyPolicy` (`done_only`, `state_changes`,
 `silent`), `currentStep`, `stateJson`, and `waitJson`. The request's `controllerId`
-overrides the route default; it is not a separate authorization boundary.
+overrides the route default. It is not a separate authorization boundary.
 
 Creation has no general idempotency key: retrying `create_flow` after an uncertain
 connection result can create a second flow. Reconcile with `list_flows` before
-repeating creation. Child success alone does not mark a managed flow finished;
-the controller must advance or finish the flow when appropriate.
+repeating creation. Child success alone does not mark a managed flow finished.
+The controller must advance or finish the flow when appropriate.
 
 ### `run_task`
 
 Required fields are `flowId`, `runtime`, and `task`. Allowed `runtime` values are
-`subagent` and `acp`; `status` defaults to `queued` and can be `running`. `startedAt`, `lastEventAt`, and
-`progressSummary` are only valid when `status` is `"running"`; sending them
+`subagent` and `acp`. `status` defaults to `queued` and can be `running`. `startedAt`, `lastEventAt`, and
+`progressSummary` are only valid when `status` is `"running"`. Sending them
 with any other status returns `400 invalid_request`.
 
 The following links an **already existing**, currently owned backing run. Use
@@ -204,9 +204,9 @@ work or grant authority.
 
 `childSessionKey` requires the exact `runId` and current backing ownership by the
 route's configured session. Foreign, stale, or replaced runs are rejected at use
-time. Omit `childSessionKey` to create an unbacked tracking record; supplying an
+time. Omit `childSessionKey` to create an unbacked tracking record. Supplying an
 invalid backing reference is rejected. Reuse by
-`runId` is scoped to the runtime, owner, child, and flow; it is not a universal
+`runId` is scoped to the runtime, owner, child, and flow. It is not a universal
 request-replay guarantee.
 
 Optional metadata includes `sourceId`, `parentTaskId`, `agentId`, `label`,
@@ -216,13 +216,13 @@ Optional metadata includes `sourceId`, `parentTaskId`, `agentId`, `label`,
 ### Waiting and completion
 
 `set_waiting` accepts `currentStep`, `stateJson`, `waitJson`, `blockedTaskId`, and
-`blockedSummary`. A nonempty blocked field selects `blocked`; otherwise the flow
+`blockedSummary`. A nonempty blocked field selects `blocked`. Otherwise the flow
 becomes `waiting`. `resume_flow` accepts `status` (`queued` default or `running`),
 `currentStep`, and `stateJson`, and clears waiting/blocked state.
 
-`finish_flow` marks the flow `succeeded` and accepts `stateJson`; `fail_flow` marks
+`finish_flow` marks the flow `succeeded` and accepts `stateJson`. `fail_flow` marks
 it `failed` and also accepts `blockedTaskId` and `blockedSummary`. Optional string
-fields accept `null` to clear them; `stateJson` and `waitJson` accept any JSON
+fields accept `null` to clear them. `stateJson` and `waitJson` accept any JSON
 value, including retained JSON `null`. Use the current `expectedRevision` for
 each transition.
 
@@ -231,7 +231,7 @@ each transition.
 `request_cancel` records cancellation intent. `cancel_flow` attempts cancellation
 of linked work. If children remain active, the response is HTTP `202` with
 `ok: true`, `code: "cancel_pending"`, and `result.cancelled: false`. Check
-`get_flow` and `get_task_summary` afterward; `202` does not mean cancellation
+`get_flow` and `get_task_summary` afterward. `202` does not mean cancellation
 finished.
 
 ## Response shape
@@ -256,7 +256,7 @@ finished.
 
 Flow and task views omit owner/requester metadata such as `ownerKey`,
 `requesterSessionKey`, and `requesterOrigin`. Task views can still include
-`childSessionKey`, `agentId`, and `runId`; treat responses as operational data.
+`childSessionKey`, `agentId`, and `runId`. Treat responses as operational data.
 `code` values include `not_found`,
 `not_managed`, `revision_conflict`, `persist_failed`, `cancel_requested`,
 `cancel_pending`, `terminal`, `invalid_request`, `request_rejected`, and
@@ -278,12 +278,12 @@ reason not covered by the named codes above.
 | `503 persist_failed`  | The record could not be persisted; investigate Gateway storage/logs before retrying.                    |
 
 Failures before action validation can be plain text, not the JSON envelope
-above. A Bearer header takes precedence over `x-openclaw-webhook-secret`;
-query-string and body tokens are not authentication methods for this plugin.
+above. A Bearer header takes precedence over `x-openclaw-webhook-secret`.
+Query-string and body tokens are not authentication methods for this plugin.
 
 ## Related
 
 - [Hooks](/automation/hooks) - internal event-driven hooks vs. this HTTP-based TaskFlow bridge
-- [Gateway webhooks (`hooks.*` config)](/automation/cron-jobs#webhooks) - separate generic Gateway HTTP endpoint feature; not the same as this plugin's routes
+- [Gateway webhooks (`hooks.*` config)](/automation/cron-jobs#webhooks) - separate generic Gateway HTTP endpoint feature. Not the same as this plugin's routes
 - [Plugin runtime SDK](/plugins/sdk-runtime)
 - [CLI webhooks](/cli/webhooks)

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -9,7 +9,7 @@ title: "Workboard plugin"
 
 The Workboard plugin adds an optional Kanban-style board to the
 [Control UI](/web/control-ui): agent-sized work cards, assignment to agents,
-and a link back to the card's task, run, and dashboard session.
+and a link back to the card's task, run, and Control UI session.
 
 Workboard is intentionally small: it tracks local operating work for one
 OpenClaw Gateway. It is not a replacement for GitHub Issues, Linear, Jira, or
@@ -27,7 +27,7 @@ Workboard is bundled but disabled by default:
    **Install** action.
 3. If the UI reports that a restart is required, restart the Gateway.
 
-The Workboard tab appears in the dashboard nav after the plugin runtime loads.
+The Workboard tab appears in the Control UI nav after the plugin runtime loads.
 While it is disabled, the tab stays hidden from navigation. Opening the
 `/workboard` route directly while the plugin is disabled or blocked by
 `plugins.allow`/`plugins.deny` shows a plugin-unavailable state instead of card
@@ -75,28 +75,26 @@ openclaw gateway restart
 | linked refs | optional task, run, session, or source URL                                                                    |
 | `execution` | optional metadata for a Codex/Claude run started from the card (engine, mode, model, session, run id, status) |
 
-Cards also carry compact metadata for attempts, comments, links, proof,
-artifacts, automation settings, attachments, worker logs, worker protocol
-state, claims, diagnostics, notifications, template id, archive state, and
-stale-session detection, plus a recent-events list (`created`, `edited`,
-`moved`, `linked`, `specified`, `decomposed`, `claimed`, `heartbeat`,
-`execution_updated`, `attempt_started`, `attempt_updated`, `comment_added`,
-`link_added`, `proof_added`, `artifact_added`, `attachment_added`,
-`diagnostic`, `notification`, `dispatch`, `orchestration`,
-`protocol_violation`, `archived`, `unarchived`, `stale`). This metadata lets an
-operator see how a card moved through the board without opening the linked
-session; it is local operating context, not a replacement for session
+Cards also carry compact metadata:
+
+| Metadata      | Values                                                                                                                                                                                                                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| card state    | attempts, comments, links, proof, artifacts, automation settings, attachments, worker logs, worker protocol state, claims, diagnostics, notifications, template id, archive state, stale-session detection                                                                                                                                                   |
+| recent events | `created`, `edited`, `moved`, `linked`, `specified`, `decomposed`, `claimed`, `heartbeat`, `execution_updated`, `attempt_started`, `attempt_updated`, `comment_added`, `link_added`, `proof_added`, `artifact_added`, `attachment_added`, `diagnostic`, `notification`, `dispatch`, `orchestration`, `protocol_violation`, `archived`, `unarchived`, `stale` |
+
+This metadata lets an operator see how a card moved through the board without
+opening the linked session. It is local operating context, not a replacement for session
 transcripts or GitHub issue history.
 
-The plugin and Control UI use one Workboard card contract. Dashboard refreshes
+The plugin and Control UI use one Workboard card contract. Control UI refreshes
 therefore preserve workspace provenance and authority, claim state, diagnostic
 actions, and notification sequence numbers instead of projecting a smaller
 UI-only copy of the card. Unknown diagnostic kinds, diagnostic severities, and
-notification kinds are ignored until both surfaces support them; they are never
+notification kinds are ignored until both surfaces support them. They are never
 rewritten into another valid state.
 
-The open dashboard updates from `plugin.workboard.changed` invalidations. Each
-event contains only a store epoch and revision; the UI then rereads canonical
+The open Workboard tab updates from `plugin.workboard.changed` invalidations. Each
+event contains only a store epoch and revision. The UI then rereads canonical
 cards through the normal `operator.read` RPC. Multiple revisions coalesce into
 one follow-up read. Workboard defers that read while a card is being dragged,
 edited, or written, then resumes after the local interaction finishes. A
@@ -130,19 +128,19 @@ Unlinked cards without an active or unresolved task association can start work d
 
 - **Run Claude** / **Run OpenAI** starts a task-tracked agent run with an
   explicit engine, sends the card prompt, and marks the card `running`. Claude
-  runs use `anthropic/claude-sonnet-4-6`; OpenAI runs use `openai/gpt-5.6-sol`.
-- **Open Claude** / **Open OpenAI** creates a linked dashboard session without
+  runs use `anthropic/claude-sonnet-4-6`. OpenAI runs use `openai/gpt-5.6-sol`.
+- **Open Claude** / **Open OpenAI** creates a linked Control UI session without
   sending the card prompt, for manual work that stays attached to the board.
-  Opening it clears any schedule and moves a `scheduled` card to `todo`;
-  other cards keep their status.
+  Opening it clears any schedule and moves a `scheduled` card to `todo`.
+  Other cards keep their status.
 
 Autonomous starts use the Gateway's task-tracked agent run path (default agent
-and model unless Claude/OpenAI is chosen explicitly); Workboard then links the
+and model unless Claude/OpenAI is chosen explicitly). Workboard then links the
 resulting task, run id, and session key back onto the card. Each linked
 execution also records an attempt summary (engine, mode, model, run id,
 timestamps, status, rolling failure count) so repeated failures stay visible.
 
-The dashboard refreshes task status from the Gateway task ledger for its
+The Control UI refreshes task status from the Gateway task ledger for its
 lifecycle display, matching tasks to cards by task id, run id, or an exact
 linked session. Card status changes are persisted by the Gateway-side Workboard
 plugin using the linked run and session lifecycle (see
@@ -175,7 +173,7 @@ plugin using the linked run and session lifecycle (see
 | `workboard_dispatch`                                                                                                                             | Nudge dependency promotion or stale-claim cleanup without launching workers; worker launch uses Gateway or slash-command dispatch.                                                        |
 
 Proof statuses are worker-reported outcomes, not independent verification. A `passed`
-entry means the worker reports that its command or check succeeded; consumers that need
+entry means the worker reports that its command or check succeeded. Consumers that need
 an independent quality gate should inspect the attached command, URL, or artifact and
 run their own verifier. `workboard_proof` returns the new record's `proofId`. When
 `workboard_complete` reports that same proof's terminal status, pass `proofId` so the
@@ -188,7 +186,7 @@ Claimed cards reject agent-tool mutations from other agents unless the caller
 holds the claim token returned by `workboard_claim`. Every card returned by an
 agent tool or Gateway RPC call redacts `metadata.claim.token` to `[redacted]`
 (the token itself is returned once, top-level, only from `workboard_claim`),
-so dashboard operators and other agents can inspect claim state without ever
+so Control UI operators and other agents can inspect claim state without ever
 seeing a usable token. Recovery goes through
 `workboard_promote`/`workboard_reassign`/`workboard_reclaim`, which do not
 require the token.
@@ -208,15 +206,18 @@ OpenClaw subagent sessions still own execution. One dispatch pass:
 Workers get bounded card context plus the claim token needed to heartbeat,
 complete, or block the card through the Workboard tools.
 
-Workspace paths follow the caller's existing filesystem authority. Gateway
-clients with `operator.write` can use configured agent workspaces;
-`operator.admin` clients can use other host checkouts. Sandboxed agent tools use
-their sandbox workspace access, while unsandboxed workspace-only tools use their
-configured workspace root. Workboard records that authority when a workspace is
+Workspace paths follow the caller's existing filesystem authority:
+
+- Gateway clients with `operator.write` can use configured agent workspaces.
+- `operator.admin` clients can use other host checkouts.
+- Sandboxed agent tools use their sandbox workspace access.
+- Unsandboxed workspace-only tools use their configured workspace root.
+
+Workboard records that authority when a workspace is
 assigned and intersects it with the current caller's authority again at dispatch,
 so a persisted card cannot widen a later caller's access. Older cards with an
 explicit host workspace but no recorded authority must have that workspace
-re-saved before a full-host dispatch; cards without a host path adopt the
+re-saved before a full-host dispatch. Cards without a host path adopt the
 current caller's authority when first dispatched.
 
 Workspace-bound dispatch accepts a directory or Git checkout only when its
@@ -234,7 +235,7 @@ worktree setup.
 
 Workspace authority does not create a second card-lifecycle permission model.
 Callers that may mutate Workboard cards can manually move them through the same
-statuses on every surface; read-only workspace access only prevents worker
+statuses on every surface. Read-only workspace access only prevents worker
 dispatch that needs writes.
 
 ### Worker selection
@@ -256,12 +257,12 @@ back to the same worker lane instead of creating unrelated sessions:
 
 If a worker cannot be started after a card is claimed, Workboard blocks the
 card, clears the claim, records the run-start failure, and appends a worker
-log line - visible in the dashboard, CLI JSON, agent tools, and card
+log line - visible in the Control UI, CLI JSON, agent tools, and card
 diagnostics.
 
 ### Entry points
 
-- Dashboard dispatch action
+- Control UI dispatch action
 - `openclaw workboard dispatch`
 - `/workboard dispatch` on a command-capable channel
 
@@ -273,12 +274,12 @@ Gateway (`OPENCLAW_GATEWAY_URL` or `gateway.mode: remote`) apply, the CLI runs
 data-only dispatch against local SQLite state - it can promote dependencies,
 clean stale claims, and block timed-out runs, but cannot start workers. Auth,
 permission, and validation failures from a reachable Gateway are not treated
-as unavailable; they surface as command errors, and so does any Gateway
+as unavailable. They surface as command errors, and so does any Gateway
 failure when an explicit `--url`/`--token` target was given.
 
 Board metadata can set `autoDecompose`, `autoDecomposePerDispatch`,
 `defaultAssignee`, and `orchestratorProfile`. OpenClaw records this intent and
-exposes it in worker context; actual specification/decomposition still runs
+exposes it in worker context. Actual specification/decomposition still runs
 through the normal Workboard tools.
 
 ## CLI and slash command
@@ -292,7 +293,7 @@ openclaw workboard dispatch [--board <id>] [--json]
 ```
 
 `list` text output hides archived cards by default (`--include-archived`
-overrides); `--json` always includes archived cards, matching the full-card
+overrides). `--json` always includes archived cards, matching the full-card
 contract used by existing scripts. `show` and `move` accept an unambiguous id
 prefix. `list`, `create`, `show`, and `move` always read/write local plugin
 state directly. Only `dispatch` calls the running Gateway, with the fallback
@@ -307,15 +308,15 @@ troubleshooting.
 the CLI. List and show are read operations for any authorized command sender.
 Create, move, and dispatch require owner status on chat surfaces, or a Gateway
 client with `operator.write`/`operator.admin`. Manual operator moves use the
-same claim-override behavior as dashboard drag-and-drop. Their worktree access
+same claim-override behavior as Control UI drag-and-drop. Their worktree access
 still follows the same workspace boundary described above.
 
 ## Session lifecycle sync
 
-Cards can link to an existing dashboard session, or one created when you
+Cards can link to an existing Control UI session, or one created when you
 start work from the card. Linked cards show the session lifecycle inline:
 running, stale, linked idle, done, or failed. You can also capture an
-existing session from its header or the Sessions tab with **Add to Workboard**; the card
+existing session from its header or the Sessions tab with **Add to Workboard**. The card
 links to that session, uses the session label or recent user prompt as title,
 and seeds notes from the recent user prompt plus the latest assistant response
 when available.
@@ -332,8 +333,8 @@ the selected chat agent.
 Opening a card loads its linked session details independently of the sidebar's
 agent filter and pagination. While details are loading or unavailable, the
 card keeps its link and shows **Session state unknown** or **Session
-unavailable**. An ambiguous provisional link shows **Session link ambiguous**;
-edit the card to select an exact session. Use **Refresh** to retry. To continue
+unavailable**. An ambiguous provisional link shows **Session link ambiguous**.
+Edit the card to select an exact session. Use **Refresh** to retry. To continue
 an existing session, select its exact link in **Edit card** and choose **Open
 session**. To start fresh, clear the link in **Edit card**. Clearing the link
 retains its task association, so **Start** remains unavailable while that task
@@ -341,7 +342,7 @@ is active or unresolved. Changing a card's assignee does not change the owner
 of its existing session.
 
 Bare `global` and `unknown` links do not identify a session owner. They show
-**Session link ambiguous** when opened; use **Edit card** to select an explicit
+**Session link ambiguous** when opened. Use **Edit card** to select an explicit
 session. Workboard does not offer these bare links for new captures or links.
 
 If an active linked session stops reporting recent activity, Workboard marks the card
@@ -351,7 +352,7 @@ Lifecycle writes are owned by the Gateway-side Workboard plugin, so they do
 not depend on an open browser tab. Agent and subagent completion hooks persist
 terminal outcomes immediately. A bounded session sweep runs once per minute to
 reconcile active, idle, missing, and stale session state. Each store mutation
-emits the normal `plugin.workboard.changed` invalidation, so an open dashboard
+emits the normal `plugin.workboard.changed` invalidation, so an open Workboard tab
 reloads the canonical card instead of writing its own lifecycle projection.
 
 While a card is in an active work state, Workboard follows the linked session:
@@ -365,17 +366,19 @@ While a card is in an active work state, Workboard follows the linked session:
 **Manual review states win.** Moving a card to `review`, `blocked`, or `done`
 stops auto-sync for that card until you move it back to `todo` or `running`.
 
-Starting a card uses normal Gateway sessions; Workboard only stores card
+Starting a card uses normal Gateway sessions. Workboard only stores card
 metadata and links. Conversation transcript, model selection, and run
 lifecycle stay owned by the regular session system. Use **Stop** on a live
 linked card to abort the active run - Workboard marks that card `blocked` so
 it stays visible for follow-up.
 
 New cards can start from Workboard templates (`bugfix`, `docs`, `release`,
-`pr_review`, `plugin`). Templates prefill title, notes, labels, and priority;
-the template id is stored as card metadata.
+`pr_review`, `plugin`). Templates prefill title, notes, labels, and priority.
+The template id is stored as card metadata.
 
-## Dashboard workflow
+<a id="dashboard-workflow" />
+
+## Control UI workflow
 
 1. Open the Workboard tab in the Control UI.
 2. Create a card with a title, notes, priority, labels, optional agent, and
@@ -400,10 +403,10 @@ first-party UI with live data — no sandbox frame or capability grant:
   control, priority, and assigned agent.
 - `workboard:board` with optional `props: { boardId }` shows the full Kanban
   board with draggable cards and status controls. Without `boardId` it shows
-  every board; with `boardId` it shows only that board.
+  every board. With `boardId` it shows only that board.
 - `workboard:mini` with optional `props: { boardId, limit }` shows per-status
   counts plus the top ready/running cards, and links to the full board page.
-  Without `boardId` it aggregates every board; with `boardId` it scopes to that
+  Without `boardId` it aggregates every board. With `boardId` it scopes to that
   board (cards created without an explicit board id live on `default`).
 
 ## Diagnostics
@@ -431,7 +434,7 @@ Gateway RPC methods live under `workboard.*`:
 
 No RPC method requires `operator.admin`. Browsers connected with read-only
 operator access can inspect the board but cannot mutate cards. An admin scope
-widens accepted Workboard host paths; it does not change the methods available.
+widens accepted Workboard host paths. It does not change the methods available.
 
 ## Storage
 
@@ -480,7 +483,7 @@ openclaw workboard list --status ready
 If the CLI reports data-only dispatch, start or restart the Gateway and
 retry - data-only dispatch updates local board state but cannot start
 subagent worker runs. Cards can also be skipped when another card for the
-same owner or agent is already running or waiting for review; complete,
+same owner or agent is already running or waiting for review. Complete,
 block, or release that active work before dispatching more for the same
 owner.
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -13,14 +13,14 @@ sidebarTitle: "ACP agents"
 
 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) sessions let
 OpenClaw run external coding harnesses (Claude Code, Cursor, Copilot, Droid,
-OpenClaw ACP, OpenCode, Gemini CLI, and other supported ACPX harnesses)
+OpenClaw ACP, OpenCode, Gemini CLI, and other supported acpx harnesses)
 through an ACP backend plugin. Each spawn is tracked as a
 [background task](/automation/tasks).
 
 <Note>
 **ACP is the external-harness path, not the default Codex path.** The native
 Codex app-server plugin owns `/codex ...` controls and the default
-`openai/gpt-*` embedded runtime for agent turns; ACP owns `/acp ...` controls
+`openai/gpt-*` embedded runtime for agent turns. ACP owns `/acp ...` controls
 and `sessions_spawn({ runtime: "acp" })` sessions.
 
 To let Codex or Claude Code connect as an external MCP client directly to

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -36,30 +36,30 @@ agent tools, but nothing listens on the loopback control port.
 - Settings: `POST /set/offline`, `POST /set/headers`, `POST /set/credentials`, `POST /set/geolocation`, `POST /set/media`, `POST /set/timezone`, `POST /set/locale`, `POST /set/device`
 
 `POST /tabs/action` is the batched form the CLI uses internally for
-`browser tab` subcommands (`{"action":"new"|"label"|"select"|"close"|"list", ...}`);
-prefer the single-purpose tab routes above when scripting directly.
+`browser tab` subcommands (`{"action":"new"|"label"|"select"|"close"|"list", ...}`).
+Prefer the single-purpose tab routes above when scripting directly.
 
 All endpoints accept `?profile=<name>`. `POST /start?headless=true` requests a
 one-shot headless launch for local managed profiles without changing persisted
-browser config; attach-only, remote CDP, and existing-session profiles reject
+browser config. Attach-only, remote CDP, and existing-session profiles reject
 that override because OpenClaw does not launch those browser processes.
 
 For tab endpoints, `targetId` is the compatibility field name. Prefer passing
-`suggestedTargetId` from `GET /tabs` or `POST /tabs/open`; labels and `tabId`
+`suggestedTargetId` from `GET /tabs` or `POST /tabs/open`. Labels and `tabId`
 handles such as `t1` are also accepted. Raw CDP target ids and unique raw
 target-id prefixes still work, but they are volatile diagnostic handles.
-Tab handles are scoped to a browser host or node and profile; keep that route
+Tab handles are scoped to a browser host or node and profile. Keep that route
 with the handle when making follow-up requests.
 
 The Control UI's `browser.request` Gateway method accepts `target: "host"` to
 pin the Gateway host or `target: "node"` with `node: "<node-id>"` to pin a browser
 node. Pass the profile in `query.profile`. Explicit routes do not fall back to
-another host; omitting them keeps the configured automatic routing. These
+another host. Omitting them keeps the configured automatic routing. These
 routing fields do not grant access or change browser policy.
 
 Browser previews require a result from the `browser` tool with a known route.
 Browser-shaped metadata from other tools does not trigger screenshots or change
-the panel's selection; those results remain ordinary tool output.
+the panel's selection. Those results remain ordinary tool output.
 
 When URL validation fails during tab listing, the tab keeps its identity and
 title but returns `url: ""` and `urlUnavailableReason`:
@@ -69,7 +69,7 @@ title but returns `url: ""` and `urlUnavailableReason`:
   because DNS lookup failed. Refresh to check again.
 
 An empty URL alone does not indicate a policy denial. Navigation-policy errors
-also carry `reason: "navigation_blocked"`; raw blocked URLs and DNS details are
+also carry `reason: "navigation_blocked"`. Raw blocked URLs and DNS details are
 not included in that metadata. Tab listings are observations, not authorization:
 every subsequent content read or action still enforces its own checks.
 
@@ -83,24 +83,24 @@ Notes:
 - This standalone loopback browser API does **not** consume trusted-proxy or
   Tailscale Serve identity headers.
 - If `gateway.auth.mode` is `none` or `trusted-proxy`, these loopback browser
-  routes do not inherit those identity-bearing modes; keep them loopback-only.
+  routes do not inherit those identity-bearing modes. Keep them loopback-only.
 
 ### Screencast stream
 
 `POST /screencast` mints a single-use token for a live view of the selected tab.
 Pass an optional `targetId`, `maxWidth`, `maxHeight`, and `quality` in the JSON
-body. Dimensions default to 1280 and are clamped to integers from 320 to 2000;
+body. Dimensions default to 1280 and are clamped to integers from 320 to 2000.
 JPEG quality defaults to 70 and is clamped from 30 to 90.
 
 The response contains `token`, `wsPath`, `expiresAtMs`, `targetId`, and `url`.
 Resolve `wsPath` against the Gateway URL and open a WebSocket there:
 `/browser/screencast?token=<token>`. The 48-character hexadecimal token expires
 after 60 seconds and can be consumed once. Invalid, expired, and reused tokens
-are rejected with HTTP 401 before upgrade. Viewers send no application messages;
-binary viewer messages close the connection.
+are rejected with HTTP 401 before upgrade. Viewers send no application messages.
+Binary viewer messages close the connection.
 
 Tickets and viewers minted through the Gateway are bound to the requesting
-Gateway connection; ending that connection revokes unused tickets and closes
+Gateway connection. Ending that connection revokes unused tickets and closes
 its viewers. Revoked (invalidated) connections are fenced immediately, before
 the Gateway socket finishes closing: their tickets cannot upgrade, and their
 viewers receive no further frames or metadata. The loopback HTTP control API
@@ -114,7 +114,7 @@ so delayed frames from the previous document cannot enter the new stream.
 A rejected navigation stops the stream.
 
 Text messages are JSON with `type` in `ready`, `meta`, or `error`. A `ready`
-message includes `targetId`, `url`, and `title`; `meta` updates `url` and `title`
+message includes `targetId`, `url`, and `title`. `meta` updates `url` and `title`
 after allowed navigation and page load. Binary messages contain:
 
 1. A four-byte unsigned big-endian JSON header length.
@@ -123,7 +123,7 @@ after allowed navigation and page load. Binary messages contain:
 
 `cssWidth` and `cssHeight` come from CDP's `deviceWidth` and `deviceHeight`
 metadata and describe the layout viewport in CSS pixels. `scrollX` and `scrollY`
-come from `scrollOffsetX` and `scrollOffsetY`; `ts` is the CDP frame timestamp.
+come from `scrollOffsetX` and `scrollOffsetY`. `ts` is the CDP frame timestamp.
 
 | Close code | Meaning                                                                                                     |
 | ---------- | ----------------------------------------------------------------------------------------------------------- |
@@ -139,7 +139,7 @@ Chrome MCP existing-session profiles and missing Playwright return HTTP 501 with
 Node-routed requests fail before proxying with `INVALID_REQUEST` and details
 `{ "code": "SCREENCAST_UNSUPPORTED", "reason": "node" }`. The Control UI falls
 back to the existing screenshot route when streaming is unavailable.
-Navigation metadata updates the tab and address bar; the displayed image keeps
+Navigation metadata updates the tab and address bar. The displayed image keeps
 its own URL and metrics until a replacement frame arrives. While Annotate or
 Inspect is active, the Control UI pins the captured image and its URL, then
 displays the latest held frame when capture mode ends.
@@ -176,7 +176,7 @@ What still works without Playwright:
 - ARIA snapshots
 - Role-style accessibility snapshots (`--interactive`, `--compact`,
   `--depth`, `--efficient`) when a per-tab CDP WebSocket is available. This is
-  a fallback for inspection and ref discovery; Playwright remains the primary
+  a fallback for inspection and ref discovery. Playwright remains the primary
   action engine.
 - Page screenshots for the managed `openclaw` browser when a per-tab CDP
   WebSocket is available
@@ -191,7 +191,7 @@ What still needs Playwright:
 - CSS-selector element screenshots (`--element`)
 - full browser PDF export
 
-Element screenshots also reject `--full-page`; the route returns `fullPage is
+Element screenshots also reject `--full-page`. The route returns `fullPage is
 not supported for element screenshots`.
 
 If you see `Playwright is not available in this gateway build`, the packaged
@@ -216,7 +216,7 @@ caches, persist `/home/node` with `OPENCLAW_HOME_VOLUME` or a bind mount. See
 
 ## How it works (internal)
 
-A small loopback control server accepts HTTP requests and connects to Chromium-based browsers via CDP. Advanced actions (click/type/snapshot/PDF) go through Playwright on top of CDP; when Playwright is missing, only non-Playwright operations are available. The agent sees one stable interface while local/remote browsers and profiles swap freely underneath.
+A small loopback control server accepts HTTP requests and connects to Chromium-based browsers via CDP. Advanced actions (click/type/snapshot/PDF) go through Playwright on top of CDP. When Playwright is missing, only non-Playwright operations are available. The agent sees one stable interface while local/remote browsers and profiles swap freely underneath.
 
 ## CLI quick reference
 
@@ -345,10 +345,10 @@ Notes:
 - The agent-facing `browser` tool exposes `action=download` (required `ref` and
   `path`) and `action=waitfordownload` (optional `path`). Both return the saved
   download URL, suggested filename, and guarded local path. Explicit download
-  interception is available for managed Playwright profiles; existing-session
+  interception is available for managed Playwright profiles. Existing-session
   profiles return an unsupported-operation error.
-- Prefer atomic chooser uploads: pass the trigger `--ref` with the upload so OpenClaw arms and clicks in one request. Paths-only `upload` remains supported when a later trigger is intentional. Use `--input-ref` or `--element` to set a file input directly. `dialog` is an arming call; run it before the click/press that triggers the dialog. If an action opens a modal, the action response includes `blockedByDialog` and `browserState.dialogs.pending`; pass that `dialogId` to respond directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
-- Cancelling a pending locator click, typing, or upload operation leaves other tabs connected. Upload waiters belong to the selected tab; a new upload on that tab replaces its previous waiter.
+- Prefer atomic chooser uploads: pass the trigger `--ref` with the upload so OpenClaw arms and clicks in one request. Paths-only `upload` remains supported when a later trigger is intentional. Use `--input-ref` or `--element` to set a file input directly. `dialog` is an arming call. Run it before the click/press that triggers the dialog. If an action opens a modal, the action response includes `blockedByDialog` and `browserState.dialogs.pending`. Pass that `dialogId` to respond directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
+- Cancelling a pending locator click, typing, or upload operation leaves other tabs connected. Upload waiters belong to the selected tab. A new upload on that tab replaces its previous waiter.
 - `click`/`type`/etc require a `ref` from `snapshot` (for example, Playwright ref `f1e12`, role ref `e12`, or actionable ARIA ref `ax12`). Copy the returned ref unchanged, including any frame prefix. CSS selectors are intentionally not supported for actions. Use `click-coords` when the visible viewport position is the only reliable target.
 - Download and trace paths are constrained to OpenClaw temp roots: `/tmp/openclaw{,/downloads}` (fallback: `${os.tmpdir()}/openclaw/...`).
 - `upload` accepts files from the OpenClaw temp uploads root and
@@ -362,20 +362,20 @@ Stable tab ids and labels survive Chromium raw-target replacement when OpenClaw
 can prove the replacement tab, such as a unique old/new pair for the same URL or
 a single old tab becoming a single new tab after form submission. Ambiguous
 duplicate-URL replacements receive fresh handles. Raw target ids are still
-volatile; prefer `suggestedTargetId` from `tabs` in scripts.
+volatile. Prefer `suggestedTargetId` from `tabs` in scripts.
 
 Snapshot flags at a glance:
 
 - `--format ai` (default with Playwright): AI snapshot with native Playwright refs, including frame-qualified refs such as `f1e12`.
-- `--format aria`: accessibility tree with `axN` refs. When Playwright is available, OpenClaw binds refs with backend DOM ids to the live page so follow-up actions can use them; otherwise treat the output as inspection-only.
+- `--format aria`: accessibility tree with `axN` refs. When Playwright is available, OpenClaw binds refs with backend DOM ids to the live page. Follow-up actions can then use them. Otherwise treat the output as inspection-only.
 - `--efficient` (or `--mode efficient`): compact role snapshot preset. Set `browser.snapshotDefaults.mode: "efficient"` to make this the default (see [Gateway configuration](/gateway/config-browser-ui-desktop#browser)).
 - `--interactive`, `--compact`, `--depth`, `--selector` force a role snapshot with `ref=e12` refs. `--frame "<iframe>"` scopes role snapshots to an iframe.
-- A selector-scoped snapshot is a point-in-time observation: if no element matches when the snapshot is requested, it returns an empty snapshot immediately instead of waiting for the snapshot timeout. Use `openclaw browser wait "<selector>"` when the page is expected to add the element later.
-- `--selector` does not change the behavior of page-wide or frame-scoped transport failures; those still use the configured snapshot timeout and diagnostics.
+- A selector-scoped snapshot is a point-in-time observation. If no element matches at request time, it returns an empty snapshot immediately. It does not wait for the snapshot timeout. Use `openclaw browser wait "<selector>"` when the page is expected to add the element later.
+- `--selector` does not change the behavior of page-wide or frame-scoped transport failures. Those still use the configured snapshot timeout and diagnostics.
 - With Playwright, `--labels` adds a screenshot with overlayed ref labels
   (prints `MEDIA:<path>`) plus an `annotations` array with each ref's bounding
   box. On `screenshot`, Playwright-backed labels work with `--full-page`,
-  `--ref`, and `--element`; on `snapshot`, the accompanying screenshot remains
+  `--ref`, and `--element`. On `snapshot`, the accompanying screenshot remains
   viewport-only. Existing-session/chrome-mcp profiles render overlay labels on
   page screenshots but do not return `annotations` or use the Playwright
   full-page/ref/element projection helper. Without Playwright or chrome-mcp,
@@ -386,7 +386,7 @@ Snapshot flags at a glance:
 
 OpenClaw supports three "snapshot" styles:
 
-- **AI snapshot (native refs)**: `openclaw browser snapshot` (default; `--format ai`)
+- **AI snapshot (native refs)**: `openclaw browser snapshot` (default, `--format ai`)
   - Output: a text snapshot with refs such as `f1e12` and matching `refs` metadata.
   - Actions: `openclaw browser click f1e12`, `openclaw browser type f1e23 "hello"` (use your snapshot's refs).
   - Internally, the ref is resolved via Playwright's `aria-ref`.
@@ -395,8 +395,8 @@ OpenClaw supports three "snapshot" styles:
   - Output: a role-based list/tree with `[ref=e12]` (and optional `[nth=1]`).
   - Actions: `openclaw browser click e12`, `openclaw browser highlight e12`.
   - Internally, the ref is resolved via `getByRole(...)` (plus `nth()` for duplicates).
-  - Names containing quotes, backslashes, or YAML punctuation remain actionable; use the ref rather than reconstructing a locator from the displayed name.
-  - A missing displayed name can mean an empty accessible name or one above Playwright's 900 UTF-16-unit limit; keep using the returned ref.
+  - Names containing quotes, backslashes, or YAML punctuation remain actionable. Use the ref rather than reconstructing a locator from the displayed name.
+  - A missing displayed name can mean an empty accessible name or one above Playwright's 900 UTF-16-unit limit. Keep using the returned ref.
   - Add `--labels` to include a screenshot with overlayed `e12` labels. On
     Playwright-backed profiles this also returns per-ref bounding-box metadata
     (`annotations[]`).
@@ -413,8 +413,8 @@ OpenClaw supports three "snapshot" styles:
 - When the driver exposes stable document identity, consecutive AI and role
   snapshots for the same profile, tab, document, and option family append
   `[new]` to ref-bearing lines absent from the previous snapshot. Navigation
-  starts a fresh unmarked baseline; existing-session snapshots omit deltas.
-  The first snapshot establishes the baseline without markers; later responses
+  starts a fresh unmarked baseline. Existing-session snapshots omit deltas.
+  The first snapshot establishes the baseline without markers. Later responses
   also expose `newElements`, and add a count footer when the value is nonzero.
   Structured `--format aria` snapshots with `axN` refs do not use delta markers.
 - Contributors: the raw-CDP fallback path has a Docker proof lane, described in
@@ -422,15 +422,15 @@ OpenClaw supports three "snapshot" styles:
 
 Ref behavior:
 
-- Refs are **not stable across navigations**; if something fails, re-run `snapshot` and use a fresh ref.
+- Refs are **not stable across navigations**. If something fails, re-run `snapshot` and use a fresh ref.
 - A batch stops after a committed main-frame navigation—including a same-URL
   reload—or after the page closes. Its `aborted` summary reports the action
-  number and skipped count; take a fresh snapshot before issuing dependent
+  number and skipped count. Take a fresh snapshot before issuing dependent
   actions, or use separate act calls when navigation is expected.
 - `/act` returns the current raw `targetId` after action-triggered replacement
   when it can prove the replacement tab. Keep using stable tab ids/labels for
   follow-up commands.
-- If the role snapshot was taken with `--frame`, role refs are scoped to that iframe until the next role snapshot.
+- A role snapshot taken with `--frame` scopes role refs to that iframe until the next role snapshot.
 - Unknown or stale `axN` refs fail fast instead of falling through to
   Playwright's `aria-ref` selector. Run a fresh snapshot on the same tab when
   that happens.
@@ -446,14 +446,14 @@ route accepts (`click`, `clickCoords`, `type`, `press`, `hover`,
 `scrollIntoView`, `drag`, `select`, `fill`, `resize`, `wait`, `evaluate`,
 `close`, `batch`) — not arbitrary `openclaw browser` subcommands. `batch` is
 not supported on `profile="user"` and other existing-session (chrome-mcp)
-profiles; send actions individually there.
+profiles. Send actions individually there.
 
 - CLI: `openclaw browser batch --actions '<json>'`, `openclaw browser batch
 --actions-file plan.json`, or `openclaw browser batch --actions-file -` to
-  read the JSON array from stdin. `--continue` sets `stopOnError=false`; the
+  read the JSON array from stdin. `--continue` sets `stopOnError=false`. The
   default is to stop on first error. `--target-id` scopes the whole batch to
-  one tab. `--actions-file` and stdin input are capped at 1,000,000 bytes;
-  split larger plans into multiple batch commands.
+  one tab. `--actions-file` and stdin input are capped at 1,000,000 bytes.
+  Split larger plans into multiple batch commands.
 - Ref lifecycle: refs come from a `snapshot` run before the batch (snapshot is
   not a nested action). A nested action that changes page state — such as a
   `click` that triggers navigation, or an `evaluate` that mutates the DOM — can
@@ -462,14 +462,14 @@ profiles; send actions individually there.
   re-snapshotting happen outside the batch (`openclaw browser navigate` /
   `snapshot`), since `open`, `navigate`, and `snapshot` are not `/act` kinds.
 - Target id conflicts: a nested action may omit `targetId` or repeat the
-  request-level `targetId`; an explicit nested `targetId` that resolves to a
+  request-level `targetId`. An explicit nested `targetId` that resolves to a
   different tab is rejected with `ACT_TARGET_ID_MISMATCH` before any action
   runs. Batched actions share the request's tab by design.
 - Error summary: the response is `{ "results": [{ "ok": true }, { "ok": false,
 "error": "<message>" }, ...] }`, one entry per action in order. When
-  `stopOnError` is the default, the array ends at the first failure; with
+  `stopOnError` is the default, the array ends at the first failure. With
   `--continue` it covers every action. Any failed entry makes the CLI exit
-  nonzero; pass `--json` to preserve the full ordered response for scripts.
+  nonzero. Pass `--json` to preserve the full ordered response for scripts.
 - Nested batches occupy one parent result. If a child action fails, that result
   reports the first child error. Each batch applies its own `stopOnError`:
   continuing inside a nested batch does not make it successful or make its
@@ -483,7 +483,7 @@ You can wait on more than just time/text:
   - `openclaw browser wait --url "**/dash"`
 - Wait for load state:
   - `openclaw browser wait --load networkidle`
-  - Supported on managed `openclaw` and raw/remote CDP profiles. Profiles using the `existing-session` driver (including the default `user` profile) reject `networkidle`; use `--url`, `--text`, a selector, or `--fn` waits there.
+  - Supported on managed `openclaw` and raw/remote CDP profiles. Profiles using the `existing-session` driver (including the default `user` profile) reject `networkidle`. Use `--url`, `--text`, a selector, or `--fn` waits there.
 - Wait for a JS predicate:
   - `openclaw browser wait --fn "window.ready===true"`
 - Wait for a selector to become visible:
@@ -547,7 +547,7 @@ These are useful for "make the site behave like X" workflows:
 
 ## Security and privacy
 
-- The openclaw browser profile may contain logged-in sessions; treat it as sensitive.
+- The openclaw browser profile may contain logged-in sessions. Treat it as sensitive.
 - `browser act kind=evaluate` / `openclaw browser evaluate` and `wait --fn`
   execute arbitrary JavaScript in the page context. Prompt injection can steer
   this. Disable it with `browser.evaluateEnabled=false` if you do not need it.
@@ -557,7 +557,7 @@ These are useful for "make the site behave like X" workflows:
   page-side function may need longer than the default evaluate timeout.
 - For logins and anti-bot notes (X/Twitter, etc.), see [Browser login + X/Twitter posting](/tools/browser-login).
 - Keep the Gateway/node host private (loopback or tailnet-only).
-- Remote CDP endpoints are powerful; tunnel and protect them.
+- Remote CDP endpoints are powerful. Tunnel and protect them.
 
 Strict-mode example (block private/internal destinations by default):
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -45,7 +45,7 @@ one per reader job. Open the page that matches your task.
 This browser is **not** your daily driver. It is a safe, isolated surface for
 agent automation and verification.
 
-On macOS, you can explicitly copy cookies from a Chrome-family system profile into a separate managed profile. The managed browser still uses its own user data directory; only the selected cookies are copied, and local storage and IndexedDB stay behind. See [Profiles](/tools/browser/existing-session#profiles-multi-browser) or the [`openclaw browser` CLI reference](/cli/browser) for import commands and limitations.
+On macOS, you can explicitly copy cookies from a Chrome-family system profile into a separate managed profile. The managed browser still uses its own user data directory. Only the selected cookies are copied, and local storage and IndexedDB stay behind. See [Profiles](/tools/browser/existing-session#profiles-multi-browser) or the [`openclaw browser` CLI reference](/cli/browser) for import commands and limitations.
 
 ## Where each section moved
 

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -27,7 +27,7 @@ a Settings link.
 - Chrome launched at least once so its user-data directory exists
 
 Windows keeps manual pairing. Current Chromium launches native hosts directly
-only when the registered host is a Windows executable; OpenClaw does not install
+only when the registered host is a Windows executable. OpenClaw does not install
 a script launcher or registry key without a proven binary framing path.
 
 ## Install
@@ -45,7 +45,7 @@ Store extension. Chrome discovers the request at browser startup. If Chrome is
 already running, fully quit and reopen it when convenient, then approve or
 enable **OpenClaw** in Chrome. OpenClaw never restarts Chrome or approves its
 permission prompt for you. The request applies to all profiles in that Chrome
-user-data directory; Chrome controls approval in each profile.
+user-data directory. Chrome controls approval in each profile.
 
 In the macOS app, **Dashboard → Settings → This Mac → Browser → Set up Chrome on
 this Mac** runs the same local setup. This always prepares Chrome on this Mac,
@@ -59,7 +59,7 @@ Store installation request. Windows requires adding the Store extension and
 [manual pairing](#advanced-manual-pairing).
 
 You can also use the Store link if Chrome does not offer the requested install.
-If you previously removed the extension, Chrome remembers that choice; explicitly
+If you previously removed the extension, Chrome remembers that choice. Explicitly
 add it again from the Store. OpenClaw does not clear Chrome's removal decision.
 
 On macOS and Linux, the origin-locked native host permits the exact official
@@ -67,7 +67,7 @@ Store identity and OpenClaw's deterministic development IDs. Once enabled, the
 extension pairs on its first native call. The installer inspects the profile's
 `Preferences` and `Secure Preferences`
 backing files and verifies the exact Store ID independently from any extension
-path. Chromium selects the backing file by settings-enforcement policy; Linux
+path. Chromium selects the backing file by settings-enforcement policy. Linux
 normally uses `Preferences`. Both files receive the same ownership, path, file
 type, permission, and size checks.
 
@@ -94,10 +94,10 @@ The installer recognizes the official Store installation only by the exact
 Foundation Store ID. That identity never makes a recorded path OpenClaw-owned.
 For unpacked development, it accepts an ID only when all of these are true:
 
-- the ID matches Chrome's 32-character extension ID format;
-- Chrome records the install location as unpacked;
+- the ID matches Chrome's 32-character extension ID format.
+- Chrome records the install location as unpacked.
 - the recorded extension path resolves exactly to the installed or bundled
-  OpenClaw extension directory;
+  OpenClaw extension directory.
 - the recorded ID equals Chromium's deterministic path ID for that exact
   canonical realpath.
 
@@ -140,7 +140,7 @@ overwritten, and older pairings keep their stored access mode.
 
 For fresh local setup, native bootstrap connects the extension through the local
 Gateway's exact `/browser/extension` route. That first authenticated connection
-wakes the lazy browser-control service and starts the profile's loopback relay;
+wakes the lazy browser-control service and starts the profile's loopback relay.
 OpenClaw and local clients such as mcporter then use that profile relay port.
 Keep `openclaw gateway run` or the managed Gateway service running. A separate
 browser request or prewarm step is not required.
@@ -155,21 +155,21 @@ remains a manual-only flow.
 A pairing on `ws://127.0.0.1:<port>/extension` can run without a local Gateway
 or browser node. On macOS and Linux, the bundled extension can ask the installed
 native host to start a standalone relay when reconnecting to that endpoint.
-Automatic local setup must be enabled. Requests are limited to once per minute;
-the extension still authenticates the relay with connection-bound v2 proofs.
+Automatic setup must be enabled. Requests are limited to once per minute.
+The extension still authenticates the relay with connection-bound v2 proofs.
 This requires both the updated native host and an extension build containing
-relay wake-up support. Store publication can lag the bundled extension; the
+relay wake-up support. Store publication can lag the bundled extension. The
 bundled unpacked development copy is the source-build validation path.
 
 Automatic wake-up requires the exact `127.0.0.1` host that the daemon serves.
-Other loopback aliases, including `localhost` and IPv6, do not trigger wake-up;
-use the canonical IPv4 endpoint when pairing for standalone operation.
+Other loopback aliases, including `localhost` and IPv6, do not trigger wake-up.
+Use the canonical IPv4 endpoint when pairing for standalone operation.
 
 Wake-up uses the port in the extension's existing canonical pairing. It does
 not switch to the first configured profile. The native host resolves current
 `browser.profiles` and permits only an extension-driver relay port, including
 automatically allocated ports and explicit `cdpPort` pins. A removed profile
-or stale port fails closed; correct the pairing to match the current profile.
+or stale port fails closed. Correct the pairing to match the current profile.
 Gateway `/browser/extension` routes and remote pairings never trigger local
 daemon wake-up. Browser-node pairings that use a direct loopback relay can use
 it even when their Gateway hint points to a remote host.
@@ -183,21 +183,21 @@ stop it while a CDP client remains connected. A later reconnect can wake it agai
 
 The standalone daemon defaults to **v2-only authentication**, independently of
 the Gateway relay's legacy default. Only an explicit
-`browser.extensionRelay.allowLegacyAuth=true` enables legacy authentication;
-an unset value, `false`, or a config-read failure never enables it. Prefer v2
+`browser.extensionRelay.allowLegacyAuth=true` enables legacy authentication.
+An unset value, `false`, or a config-read failure never enables it. Prefer v2
 clients so the persistent key is not disclosed to a process occupying the port.
 
 Gateway browser control can join a standalone relay that already owns the
 configured profile and port. It authenticates that exact owner with v2 and uses
-its existing bridge; it does not start a second listener. Stopping Gateway
+its existing bridge. It does not start a second listener. Stopping Gateway
 releases only Gateway's connections, leaving the daemon, its direct extension
 connection, and other CDP clients running. Gateway-first automatic setup through
 `/browser/extension` remains supported.
 
 Both the daemon and the Gateway must run builds that implement the owner-access
-protocol; mixing versions is unsupported. A
+protocol. Mixing versions is unsupported. A
 mismatched profile, port, key, or stricter authentication policy produces an
-error; Gateway never takes over the listener or falls back to legacy credentials.
+error. Gateway never takes over the listener or falls back to legacy credentials.
 The daemon's stricter v2-only default is compatible with Gateway's default.
 
 ### Choose tab access
@@ -206,7 +206,7 @@ The daemon's stricter v2-only default is compatible with Gateway's default.
   except tabs paused for the current browser session. Use **Pause on this tab**
   and **Allow on this tab** in the popup.
 - **Selected tabs** uses the **OpenClaw** tab group as the access-control
-  boundary. Moving a tab into the group grants access; moving it out revokes
+  boundary. Moving a tab into the group grants access. Moving it out revokes
   access.
 
 Open the extension's Settings page to change the access mode. Switching to
@@ -222,13 +222,13 @@ it before navigating. The extension allows that specific initial tab, keeps it
 in the OpenClaw group, and applies the same pause and access-mode controls.
 Existing blank tabs, manually grouped blanks, and other `about:` pages remain
 unavailable. Navigating away, replacing the tab, or restarting or reconnecting
-the extension ends the initial blank admission; returning to `about:blank`
+the extension ends the initial blank admission. Returning to `about:blank`
 does not restore it.
 
 If creation fails before the extension returns the target, it attempts to close
 the tab only while it still owns it. Tabs you paused, moved, or navigated during
 creation are left alone. A redirect, lost connection, or worker shutdown can
-leave a tab behind; close it manually if needed.
+leave a tab behind. Close it manually if needed.
 
 An explicitly commanded main-frame navigation of an authorized tab can also
 use exact `about:blank`, for example during a performance trace reset. Chrome
@@ -332,7 +332,7 @@ pairing string as a password.
 
 Without `--gateway-url`, this command retains the host-local `/extension` relay
 for standalone manual pairing. It does not wake Browser control. With native
-wake-up support installed and automatic local setup enabled, the extension can
+wake-up support installed and automatic setup enabled, the extension can
 start that relay on reconnect without a local Gateway. Otherwise, the relay
 must already be running, for example through Browser control or a browser node.
 
@@ -345,7 +345,7 @@ openclaw browser extension pair \
 ```
 
 Paste that string in **Settings → Advanced manual pairing**. This flow cannot
-use automatic bootstrap: the remote Gateway owns a different relay key, and the
+use native bootstrap: the remote Gateway owns a different relay key, and the
 local native host never fetches or copies it. Non-loopback remote URLs require
 `wss://`, and the Gateway must expose the exact `/browser/extension` WebSocket
 path without a path-rewriting proxy prefix.
@@ -362,7 +362,7 @@ Runtime binding callbacks go only to logical sessions that successfully register
 the binding name, independently of `Runtime.enable` and `Runtime.disable`.
 Removing a binding or disconnecting a client preserves other clients' registrations
 of the same name. Context-specific registrations with the same name still share
-the underlying native Runtime; use distinct names when clients need separate
+the underlying native Runtime. Use distinct names when clients need separate
 context selection.
 
 Fetch request interception has one owner per native target session. Another
@@ -373,14 +373,14 @@ streams also belong to the logical session that acquired them.
 
 Related targets (such as frames and workers) have separate logical sessions
 for each interested parent. Each parent's ordered auto-attach filter is
-preserved; the native attachment uses their union. New or broadened interests
+preserved. The native attachment uses their union. New or broadened interests
 receive existing children only after the extension accepts the command. The
 native pause-on-attach setting remains shared: the latest update wins,
 including DevTools suspend/resume. Resuming a waiting target affects all its
 logical sessions.
 
 Clients still share the underlying tabs. Navigation or page changes can
-invalidate another client's snapshot refs; this is not an isolated browser per
+invalidate another client's snapshot refs. This is not an isolated browser per
 client or complete isolation of every CDP domain and competing client policy.
 A complete tab-list request returns an error when native targets cannot yet be
 matched to Playwright pages, rather than reporting a partial list as complete.
@@ -388,7 +388,7 @@ matched to Playwright pages, rather than reporting a partial list as complete.
 If the extension connection drops, its debugger attachments retire before the
 replacement connection reattaches. An uncertain native Fetch operation also
 retires the affected attachment instead of retrying the operation against a
-replacement. Fetch cleanup is bounded; debugger teardown is not a guarantee that
+replacement. Fetch cleanup is bounded. Debugger teardown is not a guarantee that
 pending network requests are canceled. These paths do not change the access
 mode or paused tabs. Take a fresh snapshot after the target reattaches before
 using element refs. If a client no longer exposes the target, reconnect that
@@ -427,10 +427,10 @@ legacy credential on request.
 
 The extension requests only:
 
-- `debugger`: send CDP commands to allowed tabs;
-- `tabs` and `tabGroups`: discover tabs and enforce access mode;
-- `storage`: persist pairing, access mode, session pauses, and bootstrap opt-out;
-- `alarms`: wake the MV3 worker for relay/bootstrap retries;
+- `debugger`: send CDP commands to allowed tabs.
+- `tabs` and `tabGroups`: discover tabs and enforce access mode.
+- `storage`: persist pairing, access mode, session pauses, and bootstrap opt-out.
+- `alarms`: wake the MV3 worker for relay/bootstrap retries.
 - `nativeMessaging`: request a local bootstrap pairing or wake its configured relay.
 
 It does not request `activeTab`, `contextMenus`, `scripting`, or `sidePanel`.
@@ -439,7 +439,7 @@ It does not request `activeTab`, `contextMenus`, `scripting`, or `sidePanel`.
 
 The native host is `ai.openclaw.browser_bootstrap`. The extension opens a
 `chrome.runtime.connectNative` port for one request, validates the response,
-then disconnects. The host writes one response and exits; a spawned standalone
+then disconnects. The host writes one response and exits. A spawned standalone
 relay outlives this short-lived native connection.
 
 The request uses a versioned, length-prefixed JSON frame with a fresh 16-byte
@@ -457,7 +457,7 @@ The response is below Chrome's 1 MiB native-message limit. Pairing keys never
 appear in launcher arguments, manifests, status JSON, or diagnostics.
 
 The POSIX launcher and manifest use absolute canonical paths under an
-OpenClaw-owned mode-`0700` directory. Manifests are mode `0600`; the launcher is
+OpenClaw-owned mode-`0700` directory. Manifests are mode `0600`. The launcher is
 owner-executable. Symlinks, foreign ownership, unsafe modes, path traversal,
 wildcard origins, and foreign same-name registrations fail closed.
 
@@ -475,14 +475,14 @@ The unpacked development ID calculation matches Chromium's
 bytes with SHA-256 (native UTF-16LE path bytes on Windows, with only a lowercase
 drive letter uppercased), keep the first 16 digest bytes, then map hexadecimal
 digits `0` through `f` to letters `a` through `p`. The unpacked extension
-manifest has no `key`; only these development IDs depend on approved
+manifest has no `key`. Only these development IDs depend on approved
 OpenClaw-owned realpaths.
 
 The relay itself uses connection-bound HMAC proofs. The persistent per-host key
 is not sent in a URL, header, WebSocket subprotocol, or application frame during
 v2 authentication. On POSIX hosts, each key read rejects foreign-owned and
-non-regular files and tightens an owned group/other-accessible file to `0600`;
-if tightening fails, the key is refused. Windows uses its existing ACL policy.
+non-regular files and tightens an owned group/other-accessible file to `0600`.
+If tightening fails, the key is refused. Windows uses its existing ACL policy.
 
 ## Troubleshooting
 
@@ -500,12 +500,12 @@ openclaw doctor
 - **No extension ID detected:** keep Chrome running, rerun `extension install`,
   then add the official Store extension. Use **Load unpacked** only as a
   development fallback after the command says native bootstrap is ready.
-- **Extension was loaded before native setup:** restart Chrome once to clear its
+- **Extension was loaded before native bootstrap:** restart Chrome once to clear its
   cached native-host miss, then rerun the ordered install flow.
 - **Extension version mismatch:** reload the unpacked OpenClaw extension from
   `chrome://extensions`, then rerun browser doctor. Fully restart Chrome if the
   running and bundled versions still differ.
-- **Waiting for local OpenClaw:** run `extension status`; install or repair the
+- **Waiting for local OpenClaw:** run `extension status`. Install or repair the
   owned native host.
 - **Automatic setup disabled:** enable it in Settings or click **Use local
   OpenClaw**.

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -3,13 +3,13 @@ summary: "Index of the OpenClaw Code Mode documentation, one page per reader job
 title: "Code Mode"
 sidebarTitle: "Code Mode"
 read_when:
-  - You want to enable OpenClaw code mode for an agent run
+  - You want to enable OpenClaw Code Mode for an agent run
   - You need to explain why Code Mode is different from Codex Code Mode
   - You are looking for the Code Mode page that matches your task
 ---
 
 Code mode is an experimental, opt-in OpenClaw agent-runtime feature. When
-enabled, the model no longer sees every enabled tool schema; instead, it sees
+enabled, the model no longer sees every enabled tool schema. Instead, it sees
 `exec`, `wait`, and any direct-only tool whose structured result cannot cross
 the JSON-only guest bridge. The model writes a small JavaScript or TypeScript
 program that searches, describes, and calls the hidden tool catalog.
@@ -18,10 +18,10 @@ program that searches, describes, and calls the hidden tool catalog.
 OpenClaw Code Mode is off by default. To try it, open **Settings → Agents &
 Tools → Labs** and turn on **Code Mode**. The Labs switch writes the `"auto"`
 tier, which engages only for models marked as preferred Code Mode performers.
-This is the global default; agent and model overrides take precedence.
+This is the global default. Agent and model overrides take precedence.
 </Note>
 
-This page documents OpenClaw code mode, not Codex Code Mode. The two features
+This page documents OpenClaw Code Mode, not Codex Code Mode. The two features
 share a name and the same control-tool names (`exec`, `wait`), but they are
 separate implementations:
 
@@ -29,7 +29,7 @@ separate implementations:
   freeform-grammar tool: the model writes raw JavaScript source (optionally
   prefixed by a `// @exec: {...}` pragma line for execution options), executed
   in Codex's in-process V8 Code Mode runtime.
-- OpenClaw code mode runs in the generic OpenClaw agent runtime and is
+- OpenClaw Code Mode runs in the generic OpenClaw agent runtime and is
   enabled through global, agent, or model activation settings. Its `exec`
   tool takes a JSON `{ code, language }` payload, executed in a QuickJS-WASI
   worker.
@@ -38,7 +38,7 @@ Both are JavaScript execution surfaces, not shell-command surfaces. Treat them
 as independent, differently-implemented features that happen to expose
 identically-named `exec`/`wait` tools.
 
-In OpenClaw code mode, `command` is a JavaScript or TypeScript alias for
+In OpenClaw Code Mode, `command` is a JavaScript or TypeScript alias for
 `code`, not a shell command. For shell or file operations, call the appropriate
 async tool global from guest JavaScript. Recognizable shell
 commands are rejected before guest execution with actionable
@@ -46,7 +46,7 @@ commands are rejected before guest execution with actionable
 
 Source validation, TypeScript compilation, and guest execution run in a bounded
 pool of worker threads that scales with available CPU cores. Workers stay warm
-between calls; each cell gets an isolated QuickJS VM. Fast host exchanges retain
+between calls. Each cell gets an isolated QuickJS VM. Fast host exchanges retain
 that VM within the same call rather than snapshotting every await. Tool
 permissions, approvals, and session ownership remain with the Gateway. Queued
 work shares the execution deadline, and cancellation stops an active worker
@@ -73,24 +73,24 @@ job. Open the page that matches your task.
 - The `exec` description carries a bounded quick index of final callable names,
   compact input hints, and compact declared output hints when a
   trusted tool provides an output schema. It omits descriptions, full schemas,
-  MCP entries, and overflow entries; callable `catalog.search(...)` results are
+  MCP entries, and overflow entries. Callable `catalog.search(...)` results are
   the fallback. Input hints retain integer and numeric bounds as comments, such
   as `offset?: number /* integer, >= 1 */`. Other validation details remain in
-  the full schema available through `describe()`; these hints do not change
+  the full schema available through `describe()`. These hints do not change
   tool validation or output contracts.
 - Guest code calls globals directly or searches the hidden catalog for callable
   handles. A handle exposes bounded metadata and `describe()`, but never the
   exact internal catalog id. Calls use the same execution path as normal agent
   turns (policy, approvals, hooks, telemetry all still apply).
-- MCP tools are grouped under the `MCP` namespace; in code mode this is the
+- MCP tools are grouped under the `MCP` namespace. In Code Mode this is the
   only supported way to call them.
-- `wait` resumes a suspended code-mode run when nested tool calls are still
+- `wait` resumes a suspended Code Mode run when nested tool calls are still
   pending.
 
-Call `wait` only when the outer code-mode result has `status: "waiting"`, using
+Call `wait` only when the outer Code Mode result has `status: "waiting"`, using
 its top-level `runId`. A completed cell can return a background shell operation
-with its own `sessionId` inside `value`; use the enabled process-control tool
-inside a new `exec` to poll that operation. Its `sessionId` is not a code-mode
+with its own `sessionId` inside `value`. Use the enabled process-control tool
+inside a new `exec` to poll that operation. Its `sessionId` is not a Code Mode
 run ID.
 
 Code mode changes the model-facing orchestration surface only. It does not
@@ -105,10 +105,10 @@ behavior, or model selection.
 - Better orchestration: the model can use loops, joins, small transforms,
   conditional logic, and parallel nested tool calls inside one code cell.
 - Fewer model round trips: a declared output contract lets the model call and
-  transform a tool result in one `exec`; unknown outputs remain raw-first.
+  transform a tool result in one `exec`. Unknown outputs remain raw-first.
 - Provider neutral: works for OpenClaw, plugin, MCP, and client tools without
   depending on provider-native code execution.
-- Fails closed: if code mode is enabled but the QuickJS-WASI runtime is
+- Fails closed: if Code Mode is enabled but the QuickJS-WASI runtime is
   unavailable, the run fails instead of silently falling back to broad direct
   tool exposure.
 

--- a/docs/tools/custodian-skills.md
+++ b/docs/tools/custodian-skills.md
@@ -8,7 +8,7 @@ read_when:
   - Planning operational skill coverage
 ---
 
-Custodian skills are release-versioned operational playbooks shipped with OpenClaw. They live under `custodian-skills/` in the package and load at the bundled-skill precedence tier, but only for the agent resolved by `agents.defaults.systemAgent.agentId`.
+Custodian skills are release-versioned operational playbooks shipped with OpenClaw. They live under `custodian-skills/` in the package. They load at the bundled-skill precedence tier, but only for the agent resolved by `agents.defaults.systemAgent.agentId`.
 
 When that setting is absent, OpenClaw falls back to a retained legacy default owner, the sole configured agent, or legacy `main` when no explicit agent roster exists. If several agents are configured without a system agent or retained legacy owner, no agent receives the library. For every other agent, Custodian skills are absent from discovery, snapshots, slash-command catalogs, sandbox sync, and the model-facing skills prompt.
 
@@ -19,14 +19,14 @@ Normal skill controls still apply. `skills.entries.<name>.enabled: false` disabl
 Every shipped Custodian skill uses the same five sections in this order:
 
 1. **Gather** reads redacted current config and probes live state.
-2. **Mutate** uses validated non-interactive writes — `openclaw config set` / `openclaw config patch` from a trusted shell, or the in-session Custodian tool actions where policy allows — never a direct file edit.
-3. **Repair** diagnoses with `openclaw doctor --lint`; only an explicitly approved repair uses `openclaw doctor --fix --non-interactive`. The read-only `diagnose-gateway` skill recommends that separate step but never runs it.
+2. **Mutate** uses validated non-interactive writes, never a direct file edit. Those writes are `openclaw config set` / `openclaw config patch` from a trusted shell, or the in-session Custodian tool actions where policy allows.
+3. **Repair** diagnoses with `openclaw doctor --lint`. Only an explicitly approved repair uses `openclaw doctor --fix --non-interactive`. The read-only `diagnose-gateway` skill recommends that separate step but never runs it.
 4. **Prove** exercises one live end-to-end outcome.
 5. **Report** records what changed, what was observed, and what remains.
 
-All five-section playbooks keep secret values out of prompts, logs, and files. Credentials use SecretRefs or credential stores. A workflow never claims success without its Prove outcome; it reports the exact blocker when live proof is unavailable.
+All five-section playbooks keep secret values out of prompts, logs, and files. Credentials use SecretRefs or credential stores. A workflow never claims success without its Prove outcome. It reports the exact blocker when live proof is unavailable.
 
-Lint exit code `1` means findings, not a failed diagnostic command: read the report and continue the remaining checks. Ordinary `doctor`, including `--non-interactive`, can copy legacy config and migrate state without `--fix`; it is not a read-only substitute. Read-only diagnostics exclude config/service repairs and state migrations, not incidental logs or cache bookkeeping. See [Doctor](/cli/doctor#lint-mode).
+Lint exit code `1` means findings, not a failed diagnostic command: read the report and continue the remaining checks. Ordinary `doctor`, including `--non-interactive`, can copy legacy config and migrate state without `--fix`. It is not a read-only substitute. Read-only diagnostics exclude config/service repairs and state migrations, not incidental logs or cache bookkeeping. See [Doctor](/cli/doctor#lint-mode).
 
 ## First wave
 
@@ -65,7 +65,7 @@ Put local additions in the configured Custodian agent's workspace, not in the re
 <custodian-workspace>/skills/<skill-name>/SKILL.md
 ```
 
-Workspace skills already have higher precedence than the bundled tier and are scoped to that agent's workspace. Follow the same Gather → Mutate → Repair → Prove → Report contract, keep the description short, and start a new session after changing the skill. See [Creating skills](/tools/creating-skills) for the full format.
+Workspace skills already have higher precedence than the bundled tier and are scoped to that agent's workspace. Follow the same Gather → Mutate → Repair → Prove → Report contract. Keep the description short. Start a new session after changing the skill. See [Creating skills](/tools/creating-skills) for the full format.
 
 ## Related
 

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -98,7 +98,7 @@ All fields are optional unless noted.
 </ParamField>
 <ParamField path="lang" type="string">
   Language override hint for before/after mode. Unknown values and languages outside the default viewer set fall back to plain text unless the
-  Diff Viewer Language Pack plugin is installed.
+  Diffs Language Pack plugin is installed.
 </ParamField>
 <ParamField path="title" type="string">
   Viewer title override.
@@ -160,13 +160,13 @@ Built-in languages:
 
 Common aliases (`js`, `ts`, `bash`, `md`, `yml`, `c++`, `dockerfile`, `rb`, `kt`, `ps1`, etc.) normalize to those languages.
 
-Install the Diff Viewer Language Pack plugin for more languages (Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, diff, and more):
+Install the Diffs Language Pack plugin for more languages (Astro, Vue, Svelte, MDX, GraphQL, Terraform/HCL, Nix, Clojure, Elixir, Haskell, OCaml, Scala, Zig, Solidity, Verilog/VHDL, Fortran, MATLAB, LaTeX, Mermaid, Sass/Less/SCSS, Nginx, Apache, CSV, dotenv, INI, diff, and more):
 
 ```bash
 openclaw plugins install clawhub:@openclaw/diffs-language-pack
 ```
 
-Without the pack, unsupported languages still render as readable plain text. See [Diff Viewer Language Pack plugin](/plugins/reference/diffs-language-pack) and [Shiki languages](https://shiki.style/languages) for the upstream catalog.
+Without the pack, unsupported languages still render as readable plain text. See [Diffs Language Pack plugin](/plugins/reference/diffs-language-pack) and [Shiki languages](https://shiki.style/languages) for the upstream catalog.
 
 ## Output details contract
 
@@ -209,7 +209,7 @@ All successful results include `changed`: identical before/after input returns `
 
 ### Collapsed unchanged sections
 
-The viewer shows rows like `N unmodified lines`. Expand controls only appear when the rendered diff has expandable context data (typical for before/after input). Many unified patches omit context bodies in their hunks, so the row can appear without an expand control -- expected, not a bug. `expandUnchanged` only applies when expandable context exists.
+The viewer shows rows like `N unmodified lines`. Expand controls only appear when the rendered diff has expandable context data (typical for before/after input). Many unified patches omit context bodies in their hunks. The row can then appear without an expand control. That is expected, not a bug. `expandUnchanged` only applies when expandable context exists.
 
 ### Multi-file navigation
 
@@ -220,7 +220,7 @@ Patches that touch more than one file start with a changed-files summary card. T
 - added, deleted, and renamed badges
 - anchor links that jump to each file
 
-Rendered PNG/PDF files keep the per-file header counts but drop the interactive view toggles, since those are dead controls in a static file.
+Rendered PNG/PDF files keep the per-file header counts. They drop the interactive view toggles, because those are dead controls in a static file.
 
 ## Plugin defaults
 
@@ -321,7 +321,7 @@ Viewer assets:
 - `/plugins/diffs/assets/viewer-runtime.js`
 - `/plugins/diffs-language-pack/assets/viewer.js` (only when the diff uses a language pack language)
 
-The viewer document resolves these assets relative to the viewer URL, so an optional `baseUrl` path prefix carries through to asset requests too.
+The viewer document resolves these assets relative to the viewer URL. An optional `baseUrl` path prefix therefore carries through to asset requests too.
 
 URL resolution order: tool-call `baseUrl` (after strict validation) -> plugin `viewerBaseUrl` -> `gateway.publicOrigin` -> the existing bind-aware Gateway fallback.
 
@@ -386,8 +386,8 @@ Common failure text: `Diff PNG/PDF rendering requires a Chromium-compatible brow
   <Accordion title="Viewer accessibility">
     - Viewer URL resolves to `127.0.0.1` by default.
     - For remote access, set `gateway.publicOrigin`, set plugin `viewerBaseUrl`, or pass `baseUrl` per call.
-    - If `gateway.trustedProxies` includes loopback for a same-host proxy (for example Tailscale Serve), raw loopback viewer requests without forwarded client-IP headers fail closed by design.
-    - For that proxy topology, prefer `mode: "file"`/`"both"` for an attachment, or intentionally enable `security.allowRemoteViewer` plus plugin `viewerBaseUrl`/a proxy `baseUrl` for a shareable viewer link.
+    - `gateway.trustedProxies` can include loopback for a same-host proxy such as Tailscale Serve. Raw loopback viewer requests without forwarded client-IP headers then fail closed by design.
+    - For that proxy topology, prefer `mode: "file"`/`"both"` for an attachment. For a shareable viewer link, intentionally enable `security.allowRemoteViewer` plus plugin `viewerBaseUrl`/a proxy `baseUrl`.
     - Enable `security.allowRemoteViewer` only when external viewer access is intended.
 
   </Accordion>

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -14,7 +14,7 @@ sandboxed agent run commands on a real host (`gateway` or `node`). Commands
 run only when policy + allowlist + (optional) user approval all agree.
 Approvals stack **on top of** tool policy and elevated gating. Gateway
 full-session and qualifying elevated-full paths can skip host approval
-evaluation; see the [strict inline-eval exceptions](/tools/exec#inline-eval-strictinlineeval).
+evaluation. See the [strict inline-eval exceptions](/tools/exec#inline-eval-strictinlineeval).
 
 For a mode-first overview of `deny`, `allowlist`, `ask`, `auto`, `full`,
 Codex Guardian mapping, and ACPX harness permissions, see
@@ -43,7 +43,7 @@ Exec approvals are enforced locally on the execution host:
 
 The `claude-cli` backend also checks native Bash commands against the agent's
 exec allowlist when `ask: "on-miss"`. This authorizes command arguments while
-Claude Code owns execution; it does not provide OpenClaw sandboxing. See
+Claude Code owns execution. It does not provide OpenClaw sandboxing. See
 [Native Bash and the exec allowlist](/gateway/cli-backends#native-bash-and-the-exec-allowlist)
 for matching, prompting, and binding restrictions.
 
@@ -54,7 +54,7 @@ for matching, prompting, and binding restrictions.
 - Approvals reduce accidental execution risk, but are **not** a per-user auth boundary or filesystem read-only policy.
 - Once approved, a command can mutate files according to the selected host or sandbox filesystem permissions.
 - Approved node-host runs bind canonical execution context: cwd, exact argv, env binding when present, and pinned executable path when applicable.
-- Gateway approval-backed commands bind every resolved command-segment executable before review and re-check it before launch. Node hosts capture these identities during local policy evaluation and re-check before dispatch; this does not cover inner shell executables across a remote human approval wait. Protected executables use resolved real-path identity only; writable executables also use a content hash. A changed resolution during the bound window, including a new executable earlier on `PATH`, denies the run. Identity-only binding preserves otherwise eligible `allow-always` decisions. See [Interpreter/runtime commands](/tools/exec-approvals-advanced#interpreter%2Fruntime-commands).
+- Gateway approval-backed commands bind every resolved command-segment executable before review and re-check it before launch. Node hosts capture these identities during local policy evaluation and re-check before dispatch. This does not cover inner shell executables across a remote human approval wait. Protected executables use resolved real-path identity only. Writable executables also use a content hash. A changed resolution during the bound window, including a new executable earlier on `PATH`, denies the run. Identity-only binding preserves otherwise eligible `allow-always` decisions. See [Interpreter/runtime commands](/tools/exec-approvals-advanced#interpreter%2Fruntime-commands).
 - For shell scripts and direct interpreter/runtime file invocations, OpenClaw also tries to bind one concrete local file operand. If that file changes after approval but before execution, the run is denied instead of executing drifted content.
 - File binding is best-effort, not a complete model of every interpreter/runtime loader path. If exactly one concrete local file cannot be identified, OpenClaw refuses to mint an approval-backed run rather than pretend full coverage.
 
@@ -93,15 +93,15 @@ message as a fallback.
 
 For native chat approval surfaces, a node exec waits for the decision within
 the originating tool call and returns the command output there. Closing or
-cancelling that turn invalidates its pending authority; a late approval cannot
+cancelling that turn invalidates its pending authority. A late approval cannot
 restart it. A typed `SYSTEM_RUN_DENIED` result means the node rejected execution,
 not that the command may have run.
 
 ## Settings and storage
 
 Approvals live in the shared SQLite state database on the execution host. When
-`OPENCLAW_STATE_DIR` is set, the database follows that state directory;
-otherwise it uses the default OpenClaw state directory:
+`OPENCLAW_STATE_DIR` is set, the database follows that state directory.
+Otherwise it uses the default OpenClaw state directory:
 
 ```text
 $OPENCLAW_STATE_DIR/state/openclaw.sqlite#exec_approvals_config
@@ -120,7 +120,7 @@ The default approval socket follows the same root:
 
 State directories are independent trust scopes. When `OPENCLAW_STATE_DIR`
 points somewhere else, OpenClaw never imports or archives approvals from the
-default state directory; configure approvals separately for the custom state
+default state directory. Configure approvals separately for the custom state
 directory. If the active state directory still contains a legacy
 `exec-approvals.json`, stop the Gateway and run `openclaw doctor --fix` once to
 import it. Doctor also imports legacy
@@ -208,8 +208,8 @@ An incomplete pair needs an explicit choice of the intended policy before
 conversion. Pairs with `ask: "always"`, or `security: "full", ask: "on-miss"`,
 have no exact mode equivalent: retain both legacy fields and remove `mode` from
 that same object to keep their policy. Preserve other exec settings when replacing
-an object. Run `openclaw doctor --fix` for a saved file that still needs migration;
-running it again does not update a stale deployment source.
+an object. Run `openclaw doctor --fix` for a saved file that still needs migration.
+Running it again does not update a stale deployment source.
 
 ### `exec.security`
 
@@ -218,7 +218,7 @@ running it again does not update a stale deployment source.
   - `allowlist` - allow only allowlisted commands.
   - `full` - do not require an allowlist match. This does not grant elevated access.
 
-Default is `full` for gateway/node hosts; a `sandbox` host defaults to
+Default is `full` for gateway/node hosts. A `sandbox` host defaults to
 `deny` instead.
 </ParamField>
 
@@ -322,7 +322,7 @@ explicitly when a no-UI approval prompt should fall back to allow.
 
 - `tools.exec.host=auto` chooses **where** exec runs: sandbox when available, otherwise gateway.
 - YOLO chooses **how** host exec is approved: `security=full` plus `ask=off`.
-- YOLO does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy. Node preparation still reads the target policy and resolves the working directory once. If both sides allow full/off and strict inline eval is disabled, ordinary path aliases and inline scripts do not require approval binding; restrictive policy and later policy changes remain enforced.
+- YOLO does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy. Node preparation still reads the target policy and resolves the working directory once. If both sides allow full/off and strict inline eval is disabled, ordinary path aliases and inline scripts do not require approval binding. Restrictive policy and later policy changes remain enforced.
 - `auto` does not make node or gateway routing a free override from a sandboxed session. Per-call `host=node` and `host=gateway` requests are allowed from `auto` only when no sandbox runtime is active. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
 
 </Warning>
@@ -410,7 +410,7 @@ EOF
 
 ### Session and turn shortcuts
 
-- `/exec security=full ask=off <task>` requests that policy for the current message only. Include the task in the same message; a standalone directive does not affect the next message. Session permission modes and host policy can still restrict the request.
+- `/exec security=full ask=off <task>` requests that policy for the current message only. Include the task in the same message. A standalone directive does not affect the next message. Session permission modes and host policy can still restrict the request.
 - `/elevated full` is a break-glass shortcut that skips exec approvals only
   when both the requested policy and the host approvals document resolve to
   `security: "full"` and `ask: "off"`. A stricter host file, such as `ask:
@@ -465,7 +465,7 @@ anchor the pattern when you need an exact match.
 }
 ```
 
-That entry allows `python3 safe.py`; `python3 other.py` is an allowlist
+That entry allows `python3 safe.py`. `python3 other.py` is an allowlist
 miss. If a path-only entry for the same binary is also present, unmatched
 arguments can still fall back to that path-only entry. Omit the path-only
 entry when the goal is to restrict the binary to the declared arguments.
@@ -477,7 +477,7 @@ for a command segment, entries with `argPattern` do not match.
 
 Generated `allow-always` entries are bound to both the exact argv and the working
 directory where you approved them. Choosing **Always allow here** authorizes the
-same command only in that directory; running it elsewhere is an allowlist miss.
+same command only in that directory. Running it elsewhere is an allowlist miss.
 
 Older generated entries that were not directory-bound are inactive after an
 upgrade. `openclaw update` removes them during its automatic Doctor pass, or you
@@ -503,8 +503,8 @@ Each allowlist entry supports:
 For Gateway-hosted Codex runs, **Allow Always** can save a durable grant for one
 MCP tool on a server configured in `mcp.servers`. The Gateway writes the grant
 to `agents.<agentId>.mcpTools` in this same approvals document. It covers the
-exact agent, configured server name, and tool name, **with any arguments**;
-it does not grant access to other agents, servers, or tools.
+exact agent, configured server name, and tool name, **with any arguments**.
+It does not grant access to other agents, servers, or tools.
 
 Each entry has `server`, `tool`, `source: "allow-always"`, and `addedAt`
 (Unix milliseconds). `lastUsedAt` is optional. Codex apps, native plugin
@@ -514,13 +514,13 @@ match the approval to a live Gateway-owned tool call. Missing or ambiguous
 correlation retains Codex's existing native/session behavior instead.
 
 Grants apply when the server's `codex.defaultToolsApprovalMode` is `auto` or
-unspecified. Explicit `prompt` wins over a stored grant and keeps asking;
-explicit `approve` already bypasses per-call approval. See
+unspecified. Explicit `prompt` wins over a stored grant and keeps asking.
+Explicit `approve` already bypasses per-call approval. See
 [Codex tool approvals](/cli/mcp#codex-tool-approvals).
 
 The durable grant is read when OpenClaw next prepares the Codex thread
 configuration and hook registration, such as for a new session or after a
-restart. The current session continues using Codex's remembered decision;
+restart. The current session continues using Codex's remembered decision.
 OpenClaw does not reload grants for every tool call.
 
 To inspect grants, run `openclaw approvals get --gateway`. To revoke one,
@@ -534,7 +534,7 @@ openclaw approvals set --gateway --file approvals.json
 ```
 
 Omit `--gateway` from both commands to edit local approvals. Revocation takes
-effect at the next thread preparation/registration too; start a new session
+effect at the next thread preparation/registration too. Start a new session
 or restart to discard the active session's remembered approval. If Codex also
 persisted a separate approval in its native config, remove that native grant
 there as well.
@@ -547,7 +547,7 @@ and API clients that declare the `approvals` or `exec-approvals` capability.
 The TUI does not render exec approval cards, and chat channels never receive
 automation approvals, which would repeat a card on every occurrence. While a reviewer
 surface is connected, the scheduled run waits for the decision like an
-interactive run; automations are single-flight, so at most one card per job
+interactive run. Automations are single-flight, so at most one card per job
 is pending at a time. With no approval surface connected, the request is
 denied immediately and the run's error explains the policy fix. Node-host
 automation execs keep the fully headless policy (no cards) until node
@@ -582,7 +582,7 @@ change retroactively:
 
 - `tools.exec.grantExpiryDays` (unset by default) sets the default lifetime,
   in days, for **future** grants. Existing grants keep the terms they were
-  minted with; use revocation to retire them early. This is the fleet-policy
+  minted with. Use revocation to retire them early. This is the fleet-policy
   knob for managed deployments that require periodic re-approval.
 - A resolving surface may override the default per grant with the
   `grantExpiresInDays` field on `approval.resolve` /
@@ -597,7 +597,7 @@ Every standing grant is visible and revocable:
 - **Control UI**: Settings → Approvals shows the standing-grant ledger —
   automation, exact command, use count, and state (until revoked, expires in
   N days, expired, revoked) — with a Revoke action per active row.
-- **CLI**: `openclaw approvals grants list` renders the same ledger;
+- **CLI**: `openclaw approvals grants list` renders the same ledger.
   `openclaw approvals grants revoke <grant-id>` revokes one grant. Revocation
   is idempotent and takes effect at the next occurrence's spawn boundary —
   that occurrence prompts again.
@@ -619,7 +619,7 @@ allowlists.
 Skill trust belongs to the Gateway that supplied it. Switching Gateways retires
 the previous cache, including the Mac app's trusted-binary list and an approval
 check that is still in progress. A failed refresh can keep the last known trust
-from the same Gateway; it cannot import another Gateway's trust.
+from the same Gateway. It cannot import another Gateway's trust.
 
 The Mac's Exec Approvals pane refreshes its trusted binaries and agent choices
 when the selected Gateway connects. Local policy, the selected scope, and
@@ -654,7 +654,7 @@ local approvals document directly.
 Some node hosts, including the Windows companion, own a different approval
 policy format. Control UI shows these host-native policies read-only. Use the
 companion app or `openclaw approvals set --node <id|name|ip>` with the native
-policy shape to edit them; see [Approvals CLI](/cli/approvals).
+policy shape to edit them. See [Approvals CLI](/cli/approvals).
 
 CLI: `openclaw approvals` supports gateway or node editing - see
 [Approvals CLI](/cli/approvals).
@@ -668,15 +668,15 @@ approved request to the node host.
 
 The macOS approval panel keeps ordinary commands compact, with the supplied agent
 and host in one summary. It shows the working directory beneath the full,
-wrapping command; longer commands scroll. Expand **Details** to inspect the
+wrapping command. Longer commands scroll. Expand **Details** to inspect the
 executable path. Directory and executable paths remain fully selectable.
 **Copy** copies the displayed command, including visible escapes for control and
-invisible characters. The host comes from the request; a gateway or node can be
+invisible characters. The host comes from the request. A gateway or node can be
 remote from the Mac displaying the panel.
 
 Choose **Allow Once** or press **Command-Return** to approve one execution.
 Return alone does not approve. **Escape** dismisses the panel, denying the request
-when **Don't Allow** is available; otherwise it closes without a decision.
+when **Don't Allow** is available. Otherwise it closes without a decision.
 **Always Allow Here** appears only when the request's policy permits durable
 approval.
 
@@ -703,7 +703,7 @@ Control UI clients. Scope never grants authorization or changes approval policy.
 
 For example, an email approval might show `Send to 3 recipients via email
 (external): alice@example.com, bob@example.com, +1 more`. Owners supply these
-facts; channels never infer them from commands or message text. Without a
+facts. Channels never infer them from commands or message text. Without a
 declared scope, approval cards render exactly as before.
 
 ## System events and denials
@@ -739,7 +739,7 @@ id=...)` / `Exec denied (gateway id=...)`).
 
 ## Implications
 
-- **`full`** is powerful; prefer allowlists when possible.
+- **`full`** is powerful. Prefer allowlists when possible.
 - **`ask`** keeps you in the loop while still allowing fast approvals.
 - Per-agent allowlists prevent one agent's approvals from leaking into others.
 - Approvals only apply to host exec requests from **authorized senders**. Unauthorized senders cannot issue `/exec`.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -8,7 +8,7 @@ title: "Exec tool"
 
 Run shell commands in the workspace. `exec` is a mutating shell surface: commands can create, edit, or delete files wherever the selected host or sandbox filesystem permits. Disabling OpenClaw filesystem tools such as `write`, `edit`, or `apply_patch` does not make `exec` read-only.
 
-Supports foreground and background execution via `process`. If `process` is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`. Background sessions are scoped per agent; `process` only sees sessions from the same agent.
+Supports foreground and background execution via `process`. If `process` is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`. Background sessions are scoped per agent. `process` only sees sessions from the same agent.
 
 ## Parameters
 
@@ -33,7 +33,7 @@ Background the command immediately instead of waiting for `yieldMs`. The process
 </ParamField>
 
 <ParamField path="timeoutSeconds" type="number" default="tools.exec.timeoutSeconds">
-Limit the command's total lifetime, in **seconds**, overriding the configured exec timeout for this call. Expiry terminates the process even after `background` or `yieldMs` returns a session ID. `yieldMs` controls how long the tool waits before backgrounding; the `process` tool's `timeout` controls how long a poll waits, also in milliseconds.
+Limit the command's total lifetime, in **seconds**, overriding the configured exec timeout for this call. Expiry terminates the process even after `background` or `yieldMs` returns a session ID. `yieldMs` controls how long the tool waits before backgrounding. The `process` tool's `timeout` controls how long a poll waits, also in milliseconds.
 
 Applies to gateway, sandbox, and node `system.run` execution. `timeoutSeconds: 0` disables the exec process timeout for that call. For a persistent service on the gateway or in a sandbox, use `background: true` with `timeoutSeconds: 0`, then stop it with `process` action `kill` when finished. Disabling this timeout does not make the process survive its host or worker shutting down.
 </ParamField>
@@ -47,7 +47,7 @@ Where to execute. Omit `host` or use `auto` to inherit the configured exec host,
 </ParamField>
 
 <ParamField path="ask" type="'off' | 'on-miss' | 'always'">
-The baseline ask mode is derived from `tools.exec.mode` and host approvals. For channel-origin model calls, per-call `ask` is ignored when the effective host ask is `off`; otherwise it can only harden to a stricter mode.
+The baseline ask mode is derived from `tools.exec.mode` and host approvals. For channel-origin model calls, per-call `ask` is ignored when the effective host ask is `off`. Otherwise it can only harden to a stricter mode.
 </ParamField>
 
 <ParamField path="node" type="string">
@@ -60,28 +60,28 @@ Request elevated mode: escape the sandbox onto the configured host path when the
 
 Notes:
 
-- `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector; hostname-like values are rejected before the command runs.
-- Per-call `host=node` and `host=gateway` are allowed from `auto` only when no sandbox runtime is active. While a sandbox runtime is active, `auto` keeps exec in the sandbox and rejects both overrides; set `tools.exec.host=node` (or `gateway`) explicitly to run there.
-- With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`; a live sandbox means it stays in the sandbox.
+- `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector. Hostname-like values are rejected before the command runs.
+- Per-call `host=node` and `host=gateway` are allowed from `auto` only when no sandbox runtime is active. While a sandbox runtime is active, `auto` keeps exec in the sandbox and rejects both overrides. Set `tools.exec.host=node` (or `gateway`) explicitly to run there.
+- With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`. A live sandbox means it stays in the sandbox.
 - `elevated` escapes the sandbox onto the configured host path: `gateway` by default, or `node` when `tools.exec.host=node` (or the session default is `host=node`). It is only available when elevated access is enabled for the current session/provider.
 - `gateway`/`node` approvals are controlled by the host approvals file.
-- `node` requires a paired, connected node that supports `system.run` (companion app or headless node host). With no target set, exec selects the sole eligible node. If multiple eligible nodes are connected, set `exec.node`, `tools.exec.node`, or `/exec node=...` to select one; it never uses the active Canvas target. An explicit or bound target must itself be connected and executable. Completed results identify the selected node alongside command output.
-- `exec host=node` is the only shell-execution path for nodes; the legacy `nodes.run` wrapper was removed in 2026.3.31.
-- On non-Windows hosts, exec uses `SHELL` when set; if `SHELL` is `fish`, it prefers `bash` (or `sh`) from `PATH` to avoid fish-incompatible bashisms, then falls back to `SHELL` if neither exists.
-- On Windows hosts, exec prefers PowerShell 7 (`pwsh`) discovery (Program Files, ProgramW6432, then PATH), then falls back to Windows PowerShell 5.1.
-- On non-Windows gateway hosts, bash and zsh exec commands use a startup snapshot. OpenClaw captures sourceable aliases/functions and a small safe environment set from shell startup files into `$OPENCLAW_STATE_DIR/cache/shell-snapshots/`, then sources that snapshot before each exec command. Secret-looking variables are excluded; sandbox and node exec do not use this snapshot. Set `OPENCLAW_EXEC_SHELL_SNAPSHOT=0` in the Gateway process environment to disable this snapshot path.
+- `node` requires a paired, connected node that supports `system.run` (companion app or headless node host). With no target set, exec selects the sole eligible node. If multiple eligible nodes are connected, set `exec.node`, `tools.exec.node`, or `/exec node=...` to select one. It never uses the active Canvas target. An explicit or bound target must itself be connected and executable. Completed results identify the selected node alongside command output.
+- `exec host=node` is the only shell-execution path for nodes. The legacy `nodes.run` wrapper was removed in 2026.3.31.
+- On non-Windows hosts, exec uses `SHELL` when set. If `SHELL` is `fish`, it prefers `bash` (or `sh`) from `PATH` to avoid fish-incompatible bashisms, then falls back to `SHELL` if neither exists.
+- On Windows hosts, exec prefers PowerShell 7 (`pwsh`) discovery: Program Files, ProgramW6432, then PATH. It falls back to Windows PowerShell 5.1.
+- On non-Windows gateway hosts, bash and zsh exec commands use a startup snapshot. OpenClaw captures sourceable aliases/functions and a small safe environment set from shell startup files into `$OPENCLAW_STATE_DIR/cache/shell-snapshots/`, then sources that snapshot before each exec command. Secret-looking variables are excluded. Sandbox and node exec do not use this snapshot. Set `OPENCLAW_EXEC_SHELL_SNAPSHOT=0` in the Gateway process environment to disable this snapshot path.
 - Host execution (`gateway`/`node`) rejects `env.PATH` and loader overrides (`LD_*`/`DYLD_*`) to prevent binary hijacking or injected code.
-- Exact `"cat"` or empty `GIT_PAGER` and `PAGER` overrides are normalized to empty values, including on node shell-wrapper execution. This disables Git paging without passing an executable pager name through `PATH`. Other programs may interpret an empty `PAGER` differently; use their noninteractive flags when needed. Other pager commands, paths, whitespace variants, and `MANPAGER` overrides remain blocked.
+- Exact `"cat"` or empty `GIT_PAGER` and `PAGER` overrides are normalized to empty values, including on node shell-wrapper execution. This disables Git paging without passing an executable pager name through `PATH`. Other programs may interpret an empty `PAGER` differently. Use their noninteractive flags when needed. Other pager commands, paths, whitespace variants, and `MANPAGER` overrides remain blocked.
 - OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
-- With the default-off [secret egress proxy](/gateway/secrets#secret-egress-proxy), Gateway-hosted exec receives shared-store `secret` entries only as process-local sentinels. The authenticated loopback proxy substitutes plaintext at outbound HTTPS request time; the exact run token expires when the agent run closes.
+- With the default-off [secret egress proxy](/gateway/secrets#secret-egress-proxy), Gateway-hosted exec receives shared-store `secret` entries only as process-local sentinels. The authenticated loopback proxy substitutes plaintext at outbound HTTPS request time. The exact run token expires when the agent run closes.
 - Shared-store `env` entries are intentionally plaintext and reach Gateway-hosted exec from the next agent run. They do not reach sandbox, remote `node`, ACP, or Codex-native shell execution. Under the Codex harness, use `gateway_exec` for this OpenClaw-managed environment path.
-- With a [managed GitHub identity](/gateway/config-tools#tools.github), Gateway-hosted exec validates the selected profile and binds its credential privately at each process launch. An unavailable profile blocks that local execution with reconnect guidance instead of falling back to native keyring credentials. Running shells retain their launch token; later exec launches observe refreshes. Codex-native shell does not share this launch binding.
+- With a [managed GitHub identity](/gateway/config-tools#tools.github), Gateway-hosted exec validates the selected profile and binds its credential privately at each process launch. An unavailable profile blocks that local execution with reconnect guidance instead of falling back to native keyring credentials. Running shells retain their launch token. Later exec launches observe refreshes. Codex-native shell does not share this launch binding.
 - Secret egress sets `NODE_USE_ENV_PROXY=1` so supported Node.js global `fetch` clients honor the run-scoped proxy. It does not use `NODE_OPTIONS`.
 - For channel-origin runs, OpenClaw also exposes a narrow sender/chat identity JSON payload in `OPENCLAW_CHANNEL_CONTEXT` when the channel provided those ids.
 - `exec` cannot run `openclaw channels login` or `/approve` shell commands: `openclaw channels login` is an interactive channel-auth flow, and `/approve` needs to go through the approval command handler, not a shell. Run channel login in a terminal on the gateway host, or use a channel-specific login agent tool when one exists (for example `whatsapp_login`).
 - Important: sandboxing is **off by default**. If sandboxing is off, implicit `host=auto` resolves to `gateway`. Explicit `host=sandbox` still fails closed instead of silently running on the gateway host. Enable sandboxing or use `host=gateway` with approvals.
 - Script preflight checks (for common Python/Node shell-syntax mistakes) only inspect files inside the effective `workdir` boundary. If a script path resolves outside `workdir`, preflight is skipped for that file. Preflight also skips entirely when `host=gateway` and the effective policy is `security=full` with `ask=off`.
-- For long-running work that starts now, start it once and rely on automatic completion wake when it is enabled and the command emits output or fails. Use `process` for logs, status, input, or intervention; do not emulate scheduling with sleep loops, timeout loops, or repeated polling.
+- For long-running work that starts now, start it once and rely on automatic completion wake when it is enabled and the command emits output or fails. Use `process` for logs, status, input, or intervention. Do not emulate scheduling with sleep loops, timeout loops, or repeated polling.
 - Agent-started background commands appear in the Web, iOS, and Android background-task views until they finish. The task ledger is finalized before the completion heartbeat wakes the agent again.
 - For work that should happen later or on a schedule, use cron instead of `exec` sleep/delay patterns.
 
@@ -104,7 +104,7 @@ Notes:
 | `tools.exec.safeBinTrustedDirs`      | `/bin`, `/usr/bin`       | Additional explicit directories trusted for `safeBins` path checks. `PATH` entries are never auto-trusted.                                                         |
 | `tools.exec.safeBinProfiles`         | unset                    | Optional custom argv policy per safe bin (`minPositional`, `maxPositional`, `allowedValueFlags`, `deniedFlags`).                                                   |
 
-No-approval host exec is the default for gateway and node (`mode=full`) — this comes from the host-policy defaults, not from `host=auto`. If you want approvals/allowlist behavior, set `tools.exec.mode` and tighten the host approvals file; see [Exec approvals](/tools/exec-approvals#yolo-mode-no-approval). To force gateway or node routing regardless of sandbox state, set `tools.exec.host` or use `/exec host=...`.
+No-approval host exec is the default for gateway and node (`mode=full`) — this comes from the host-policy defaults, not from `host=auto`. If you want approvals/allowlist behavior, set `tools.exec.mode` and tighten the host approvals file. See [Exec approvals](/tools/exec-approvals#yolo-mode-no-approval). To force gateway or node routing regardless of sandbox state, set `tools.exec.host` or use `/exec host=...`.
 
 Example:
 
@@ -132,19 +132,19 @@ Example:
 
 Use `/exec ask=always` with a message to require human approval for that run. It does not persist to later messages. Use [session permission modes](/gateway/permission-modes) for session-wide policy.
 
-Auto-review approval is single-use. The reviewer returns `allow`, `deny`, or `ask`: `allow` runs a low- or medium-risk command once; `deny` returns a reason to the agent, which must choose a materially safer alternative or ask the user rather than work around the denial; `ask` requests human approval. Commands containing reviewer-directed text are denied back to the agent so it can rewrite the command; they do not directly escalate to human approval. Reviewer failures, timeouts, and invalid responses also ask a human. On the gateway, three consecutive reviewer denials for a session escalate the third command to human approval; a reviewer allowance or resolved human approval resets the count.
+Auto-review approval is single-use. The reviewer returns `allow`, `deny`, or `ask`: `allow` runs a low- or medium-risk command once. `deny` returns a reason to the agent, which must choose a materially safer alternative or ask the user rather than work around the denial. `ask` requests human approval. Commands containing reviewer-directed text are denied back to the agent so it can rewrite the command. They do not directly escalate to human approval. Reviewer failures, timeouts, and invalid responses also ask a human. On the gateway, three consecutive reviewer denials for a session escalate the third command to human approval. A reviewer allowance or resolved human approval resets the count.
 
-Model preparation and completion each receive the configured `tools.exec.reviewer.timeoutMs` budget. A timeout returns to human approval immediately; pending preparation and provider cleanup remain owned until they settle. Preparation that finishes after its timeout does not start a review.
+Model preparation and completion each receive the configured `tools.exec.reviewer.timeoutMs` budget. A timeout returns to human approval immediately. Pending preparation and provider cleanup remain owned until they settle. Preparation that finishes after its timeout does not start a review.
 
 For embedded agent runs, the reviewer receives a bounded, redacted excerpt of the current conversation: user requests, assistant text, tool calls, and tool results, labeled by origin. It uses this context to judge whether a command serves the user's request. The excerpt is untrusted evidence, not instructions. Conversation context is unavailable for direct node `system.run` calls and widgets.
 
 On the gateway, commands must still pass the existing mutable-file binding checks before review. Those checks continue to reject heredocs, unresolved executables, and missing script operands. The whole ordinary external dispatch chain—each original wrapper executable and the final command-segment executable—is bound at review time and re-checked before launch: protected executables use resolved real-path identity only, while writable executables also use a content hash. A changed executable resolution, including a new executable earlier on `PATH`, denies the approved run. Identity-only binding does not make an otherwise eligible human approval single-use.
 
-Reviewer-approved unpinned execution requires the complete dispatch chain to be identity-bound: the authorization plan must be complete, use direct transports, and have a recorded executable operand for every wrapper and final executable. Eligible globs and chains run as written after executable-identity, mutable-file, and working-directory revalidation. Commands rebuilt with pinned executable paths retain their existing review behavior. Node-host auto-review accepts a prepared pinned direct command, including the node's own canonical POSIX shell transport around one direct absolute executable with static arguments. Bare executable names, unquoted globs, and user-supplied wrappers still require human approval when the gateway cannot inspect the node's in-memory binding. Node executable-identity revalidation covers local policy evaluation through dispatch; it does not preserve every inner shell executable's identity across a remote human approval wait. See [Interpreter/runtime commands](/tools/exec-approvals-advanced#interpreter%2Fruntime-commands) for that boundary.
+Reviewer-approved unpinned execution requires the complete dispatch chain to be identity-bound: the authorization plan must be complete, use direct transports, and have a recorded executable operand for every wrapper and final executable. Eligible globs and chains run as written after executable-identity, mutable-file, and working-directory revalidation. Commands rebuilt with pinned executable paths retain their existing review behavior. Node-host auto-review accepts a prepared pinned direct command, including the node's own canonical POSIX shell transport around one direct absolute executable with static arguments. Bare executable names, unquoted globs, and user-supplied wrappers still require human approval when the gateway cannot inspect the node's in-memory binding. Node executable-identity revalidation covers local policy evaluation through dispatch. It does not preserve every inner shell executable's identity across a remote human approval wait. See [Interpreter/runtime commands](/tools/exec-approvals-advanced#interpreter%2Fruntime-commands) for that boundary.
 
-Shell `-c` wrappers, `env` with assignments, `xcrun`, BusyBox/Toybox applets, shell `builtin`/`command`/`exec` dispatch, and any other incomplete dispatch chain skip the reviewer with `Exec auto-review skipped: dispatch chain cannot be bound`. In auto mode, these forms take the one-shot human approval path when existing binding checks succeed; existing binding rejections still apply. Plain commands and transparent `env` without assignments remain eligible when their complete chains are bound. There are no persisted data model changes: binding stays in memory for the approval lifetime.
+Shell `-c` wrappers, `env` with assignments, `xcrun`, BusyBox/Toybox applets, shell `builtin`/`command`/`exec` dispatch, and any other incomplete dispatch chain skip the reviewer with `Exec auto-review skipped: dispatch chain cannot be bound`. In auto mode, these forms take the one-shot human approval path when existing binding checks succeed. Existing binding rejections still apply. Plain commands and transparent `env` without assignments remain eligible when their complete chains are bound. There are no persisted data model changes: binding stays in memory for the approval lifetime.
 
-POSIX login or interactive shell wrappers in the requested command never receive auto-review. When binding succeeds, as with `bash -lc 'printf ok'`, they require human approval because their implicit startup files are outside operand binding. Existing binding rejections still take precedence; interactive forms rejected as code-loading options remain denied. This applies to wrappers in the requested command; the gateway's ordinary shell startup snapshot is unchanged.
+POSIX login or interactive shell wrappers in the requested command never receive auto-review. When binding succeeds, as with `bash -lc 'printf ok'`, they require human approval because their implicit startup files are outside operand binding. Existing binding rejections still take precedence. Interactive forms rejected as code-loading options remain denied. This applies to wrappers in the requested command. The gateway's ordinary shell startup snapshot is unchanged.
 
 Explicit `ask=always`, security-audit suppression changes, and commands above the review candidate limit go directly to human approval.
 
@@ -152,7 +152,7 @@ Codex app-server command approvals that are not already decided by explicit runt
 
 ### Inline eval (`strictInlineEval`)
 
-`tools.exec.strictInlineEval` is a separate opt-in setting and defaults to `false`. When ordinary host approval evaluation runs, enabling it requires reviewer or explicit approval for recognized inline interpreter-eval forms, even when exec and host policies allow `full`/`off`. Examples include `python -c`, `node -e`, `ruby -e`, `perl -e`, `php -r`, `lua -e`, `osascript -e`, and similar forms across other supported interpreters and command carriers (`awk`, `find -exec`, `make`, `sed`, `xargs`, and more). In `mode=auto`, the normal exec approval path may let the native auto reviewer allow a low- or medium-risk one-off command; direct node-host `system.run` calls still require an explicit approval because they cannot hand the command to a human approval route. A reviewer denial returns to the agent with a reason; `ask` goes to a human. `allow-always` can still persist benign interpreter/script invocations, but inline-eval forms do not become durable allow rules.
+`tools.exec.strictInlineEval` is a separate opt-in setting and defaults to `false`. When ordinary host approval evaluation runs, enabling it requires reviewer or explicit approval for recognized inline interpreter-eval forms, even when exec and host policies allow `full`/`off`. Examples include `python -c`, `node -e`, `ruby -e`, `perl -e`, `php -r`, `lua -e`, `osascript -e`, and similar forms across other supported interpreters and command carriers (`awk`, `find -exec`, `make`, `sed`, `xargs`, and more). In `mode=auto`, the normal exec approval path may let the native auto reviewer allow a low- or medium-risk one-off command. Direct node-host `system.run` calls still require an explicit approval because they cannot hand the command to a human approval route. A reviewer denial returns to the agent with a reason. `ask` goes to a human. `allow-always` can still persist benign interpreter/script invocations, but inline-eval forms do not become durable allow rules.
 
 Configured `tools.exec.mode: "full"` alone does not skip this check. Gateway execution skips the host approval path in either of these cases:
 
@@ -169,7 +169,7 @@ For ordinary configured full/off execution without prompts for these forms, leav
   - macOS: `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`
   - Linux: `/usr/local/bin`, `/usr/bin`, `/bin`
   - To prevent user shell configuration (like `~/.zshenv` or `/etc/zshenv`) from overriding priority paths during startup, `tools.exec.pathPrepend` entries are securely prepended to the final `PATH` inside the shell command right before execution.
-- `host=sandbox`: runs `sh -lc` (login shell) inside the container, so `/etc/profile` may reset `PATH`. OpenClaw prepends `env.PATH` after profile sourcing via an internal env var (no shell interpolation); `tools.exec.pathPrepend` applies here too.
+- `host=sandbox`: runs `sh -lc` (login shell) inside the container, so `/etc/profile` may reset `PATH`. OpenClaw prepends `env.PATH` after profile sourcing via an internal env var (no shell interpolation). `tools.exec.pathPrepend` applies here too.
 - `host=node`: only non-blocked env overrides you pass are sent to the node. `env.PATH` overrides are rejected for host execution and ignored by node hosts. If you need additional PATH entries on a node, configure the node host service environment (systemd/launchd) or install tools in standard locations.
 
 Per-agent node binding (use the keyed agent ID in config):
@@ -179,7 +179,7 @@ openclaw config get agents.entries
 openclaw config set 'agents.entries.main.tools.exec.node' "node-id-or-name"
 ```
 
-Control UI: the **Devices** page includes a small "Exec node binding" panel for the same settings. If a saved target cannot be resolved or no longer advertises execution support, its binding stays selected and is marked **Unavailable**. Supported names, addresses, and ID prefixes resolve without rewriting the saved reference.
+Control UI: the **Devices** page includes a small "Exec node binding" panel for the same settings. A saved target can become unresolvable or stop advertising execution support. Its binding then stays selected and is marked **Unavailable**. Supported names, addresses, and ID prefixes resolve without rewriting the saved reference.
 
 ### Python environments (`uv`)
 
@@ -195,7 +195,7 @@ For repeated agent work, record the project convention in the workspace's `AGENT
 
 ## Session overrides (`/exec`)
 
-Send `/exec host=... node=...` on its own to set **per-session** placement defaults. `security` and `ask` apply to the **current message only**; include them with the task you want to run. Send `/exec` with no arguments to show the resolved defaults.
+Send `/exec host=... node=...` on its own to set **per-session** placement defaults. `security` and `ask` apply to the **current message only**. Include them with the task you want to run. Send `/exec` with no arguments to show the resolved defaults.
 
 Example:
 
@@ -204,13 +204,13 @@ Example:
 /exec security=allowlist ask=always inspect the build output
 ```
 
-`/exec` is only honored for **authorized senders** through channel allowlists/pairing and access groups. Access-group enforcement is always on. It does not write config. Authorized external channel senders may persist placement defaults; internal gateway/webchat clients need `operator.admin` to do so. Turn-scoped `security` and `ask` do not require that persistence permission.
+`/exec` is only honored for **authorized senders** through channel allowlists/pairing and access groups. Access-group enforcement is always on. It does not write config. Authorized external channel senders may persist placement defaults. Internal gateway/webchat clients need `operator.admin` to do so. Turn-scoped `security` and `ask` do not require that persistence permission.
 
 A standalone `/exec security=deny` acknowledges the run-only setting but starts no agent run and does not affect the next message. Use [session permission modes](/gateway/permission-modes) to keep a policy across messages.
 
 The `execSecurity` and `execAsk` fields in `sessions.patch` and `sessions.patchMany` are retired. They remain in the protocol v4 wire schema, but requests containing either field (including `null`) are rejected with `INVALID_REQUEST` and replacement guidance. Set `permissionMode` (`read-only`, `guarded`, `workspace`, or `full`) for session-wide policy, or use `/exec` with a message for a single run.
 
-When a session has a permission mode, per-turn `/exec` overrides can only tighten its security and approval policy. For example, `/exec security=deny` blocks exec for that turn even in a full-access session; an override requesting looser security or fewer approvals leaves the session mode's limits unchanged. Full-access sessions bypass host approval-file floors only while effective security remains `full`. Tightening `ask` alone still applies the requested approval level without restoring those floors.
+When a session has a permission mode, per-turn `/exec` overrides can only tighten its security and approval policy. For example, `/exec security=deny` blocks exec for that turn even in a full-access session. An override requesting looser security or fewer approvals leaves the session mode's limits unchanged. Full-access sessions bypass host approval-file floors only while effective security remains `full`. Tightening `ask` alone still applies the requested approval level without restoring those floors.
 
 To hard-disable exec, deny it via tool policy (`tools.deny: ["exec"]` or per-agent). Outside the full-access session exception above, host approval-file floors still apply.
 
@@ -218,7 +218,7 @@ To hard-disable exec, deny it via tool policy (`tools.deny: ["exec"]` or per-age
 
 Sandboxed agents can require per-request approval before `exec` runs on the gateway or node host. See [Exec approvals](/tools/exec-approvals) for the policy, allowlist, and UI flow.
 
-When a human approval can be delivered, ordinary Gateway and node exec calls wait within the current tool call and return the command result after approval. Flows that explicitly request asynchronous follow-up return immediately with `status: "approval-pending"` and an approval id. An `approval-pending` result means the command has not started, so foreground fallback warnings appear only if the approved command actually runs inline. Approved asynchronous runs emit command progress and completion system events (`Exec running` / `Exec finished`). Denied or timed-out approvals are terminal for the host command; see [System events and denials](/tools/exec-approvals#system-events-and-denials) for notification behavior.
+When a human approval can be delivered, ordinary Gateway and node exec calls wait within the current tool call and return the command result after approval. Flows that explicitly request asynchronous follow-up return immediately with `status: "approval-pending"` and an approval id. An `approval-pending` result means the command has not started, so foreground fallback warnings appear only if the approved command actually runs inline. Approved asynchronous runs emit command progress and completion system events (`Exec running` / `Exec finished`). Denied or timed-out approvals are terminal for the host command. See [System events and denials](/tools/exec-approvals#system-events-and-denials) for notification behavior.
 
 On channels with native approval cards/buttons, the agent should rely on that native UI first and only include a manual `/approve` command when the tool result explicitly says chat approvals are unavailable or manual approval is the only path.
 
@@ -268,7 +268,7 @@ Send keys (tmux-style):
 {"tool":"process","action":"send-keys","sessionId":"<id>","keys":["Up","Up","Enter"]}
 ```
 
-For text, use `literal`; for exact input bytes, use `hex`. A mixed request sends literal UTF-8 text, hex bytes, then named keys, in that order:
+For text, use `literal`. For exact input bytes, use `hex`. A mixed request sends literal UTF-8 text, hex bytes, then named keys, in that order:
 
 ```json
 {
@@ -295,7 +295,7 @@ Paste (bracketed by default):
 
 ## apply_patch
 
-`apply_patch` is a subtool of `exec` for structured multi-file edits. It is enabled by default and available to any model provider; `allowModels` can restrict it. Use config only when you want to disable it or restrict it to specific models:
+`apply_patch` is a subtool of `exec` for structured multi-file edits. It is enabled by default and available to any model provider. `allowModels` can restrict it. Use config only when you want to disable it or restrict it to specific models:
 
 ```json5
 {
@@ -309,12 +309,12 @@ Paste (bracketed by default):
 
 Notes:
 
-- Tool policy still applies; `allow: ["write"]` implicitly allows `apply_patch`.
-- `deny: ["write"]` does not deny `apply_patch`; deny `apply_patch` explicitly or use `deny: ["group:fs"]` when patch writes should also be blocked.
+- Tool policy still applies. `allow: ["write"]` implicitly allows `apply_patch`.
+- `deny: ["write"]` does not deny `apply_patch`. Deny `apply_patch` explicitly or use `deny: ["group:fs"]` when patch writes should also be blocked.
 - Config lives under `tools.exec.applyPatch`.
-- `tools.exec.applyPatch.enabled` defaults to `true`; set it to `false` to disable the tool.
+- `tools.exec.applyPatch.enabled` defaults to `true`. Set it to `false` to disable the tool.
 - `tools.exec.applyPatch.workspaceOnly` defaults to `true` (workspace-contained). Set it to `false` only if you intentionally want `apply_patch` to write/delete outside the workspace directory.
-- `tools.exec.applyPatch.allowModels` is an optional allowlist of model ids (raw, like `gpt-5.4`, or full, like `openai/gpt-5.4`). When set, only matching models get the tool; when unset, all models get it.
+- `tools.exec.applyPatch.allowModels` is an optional allowlist of model ids (raw, like `gpt-5.4`, or full, like `openai/gpt-5.4`). When set, only matching models get the tool. When unset, all models get it.
 
 ## Related
 

--- a/docs/tools/goal.md
+++ b/docs/tools/goal.md
@@ -37,7 +37,7 @@ a separate sandbox policy session.
 ```
 
 `start` is optional: `/goal get CI green for PR 87469` also creates a goal,
-since any text after `/goal` that is not a known action word is treated as a
+OpenClaw treats any text after `/goal` that is not a known action word as a
 new objective.
 
 ## What goals are for
@@ -90,21 +90,20 @@ Commands: /goal edit <objective>, /goal pause, /goal complete, /goal clear
 Only one goal can exist on a session at a time. Starting a second goal fails
 with `Goal error: goal already exists` until the current one is cleared.
 
-`/goal start` does not take a token-budget flag; a budget can only be set
-through the model-facing `create_goal` tool.
+`/goal start` does not take a token-budget flag. Only the model-facing `create_goal` tool can set a budget.
 
 ## Statuses
 
 - `active`: the session is pursuing the goal.
-- `paused`: the operator paused the goal; `/goal resume` makes it active
+- `paused`: the operator paused the goal. `/goal resume` makes it active
   again.
-- `blocked`: the agent or operator reported a real blocker; `/goal resume`
+- `blocked`: the agent or operator reported a real blocker. `/goal resume`
   makes it active again when new information or state is available.
-- `budget_limited`: the configured token budget was reached; `/goal resume`
+- `budget_limited`: the configured token budget was reached. `/goal resume`
   restarts pursuit from the same objective with a fresh budget window.
-- `usage_limited`: reserved for a future usage-limit stop state; `/goal
+- `usage_limited`: reserved for a future usage-limit stop state. `/goal
 resume` restarts pursuit the same way.
-- `complete`: the goal was achieved. Complete goals are terminal; use `/goal
+- `complete`: the goal was achieved. Complete goals are terminal. Use `/goal
 clear` before starting another goal.
 
 `/new` and `/reset` clear the current session goal, since they intentionally
@@ -120,7 +119,7 @@ next fresh snapshot and uses that as the baseline, so tokens spent before the
 goal existed are not charged to it.
 
 When usage reaches the budget, the goal moves to `budget_limited`. This does
-not delete the goal or erase the objective; it tells the operator and the
+not delete the goal or erase the objective. It tells the operator and the
 agent that the goal is no longer actively being pursued until it is resumed or
 cleared. Resuming starts a new budget window at the current fresh token
 count.
@@ -148,7 +147,7 @@ target.
 actually achieved. It should mark a goal `blocked` only after the same
 blocking condition recurs for at least three consecutive goal turns, not for
 ordinary difficulty or missing polish. Updating goal status does not send a
-chat reply; the agent must still provide the user's requested final response.
+chat reply. The agent must still provide the user's requested final response.
 
 ## Goal context on every turn
 
@@ -172,7 +171,7 @@ commands in Goal mode. Cancel leaves the objective as a normal chat draft.
 Starting a Goal saves the Goal, its user turn, and the run admission together
 before acknowledging Send. A failed admission leaves the draft intact and
 does not create a Goal. Start and Resume require an idle local session with
-recoverable history; they are not queued or steered into another run. The UI
+recoverable history. They are not queued or steered into another run. The UI
 reports unsupported or busy sessions rather than creating an inactive Goal.
 
 The web Control UI shows the goal as a compact pill above the chat composer:
@@ -182,20 +181,20 @@ objective, and a live elapsed timer.
 The pill carries inline controls:
 
 - **Pencil** opens an Edit Goal composer with the current objective. Saving
-  changes only the objective; cancelling restores the previous chat draft.
+  changes only the objective. Cancelling restores the previous chat draft.
 - **Pause / resume** updates the current Goal. Resume also starts a continuation
   through normal chat admission. Its internal input stays in model history
-  without appearing as a human chat message; the assistant reply remains visible.
+  without appearing as a human chat message. The assistant reply remains visible.
 - **Trash** clears the current Goal.
 - **Chevron** expands the pill to show the full objective, the latest status
   note, token usage, and elapsed time.
 
 Edit, Pause, and Clear do not send slash commands or add chat turns. Controls
 target the displayed Goal ID, so a stale button cannot change a replacement
-Goal. If a request is interrupted, retry it unchanged; a successful replay
+Goal. If a request is interrupted, retry it unchanged. A successful replay
 refreshes the current state instead of restoring an old Goal snapshot.
 
-The action buttons are unavailable without a connection; the expand chevron
+The action buttons are unavailable without a connection. The expand chevron
 keeps working. Concurrent Goal actions are rejected while an operation is
 pending. These controls require
 a Gateway advertising the structured Goal capability. Text `/goal` commands
@@ -206,29 +205,29 @@ remain available for CLI and other command-capable surfaces.
 Goal start uses `chat.send` with the ordinary `message` as the objective and
 `intent: { kind: "session-goal-start", version: 1, issuedAtMs }`. It keeps the
 normal `idempotencyKey`, attachment, and reply fields. Per-request runtime or
-delivery-route overrides are rejected; Goal work uses the session settings and
+delivery-route overrides are rejected. Goal work uses the session settings and
 local delivery so recovery keeps the same contract. Objectives
 must contain non-whitespace text and are limited to 16,000 characters.
 
 `sessions.goal.update` accepts `edit` with `objective`, or `pause`, `resume`,
 `block`, and `complete` with an optional `note` of at most 2,000 characters.
 `sessions.goal.clear` removes the Goal. Both methods require `sessionKey`,
-`goalId`, `operationId`, and `issuedAtMs`; `agentId` and `sessionId` can pin the
+`goalId`, `operationId`, and `issuedAtMs`. `agentId` and `sessionId` can pin the
 target. They require normal session participation and `operator.write` scope.
 
 Keep the original operation ID, timestamp, target, and payload for retries.
-Receipts remain valid for 24 hours from `issuedAtMs`; timestamps more than
+Receipts remain valid for 24 hours from `issuedAtMs`. Timestamps more than
 five minutes ahead of the Gateway clock are rejected. Reusing an ID with a
 different request is rejected. Expired requests cannot recreate a cleared
-Goal. The per-session limit is 4,096 unexpired receipts; hitting it rejects
+Goal. The per-session limit is 4,096 unexpired receipts. Hitting it rejects
 new operations until receipts expire rather than evicting valid retry state.
 
 Results include `operationId`, `action`, `sessionId`, `goalId`, and `status`
 (`started`, `updated`, or `cleared`), plus the resulting `goal` when present
 and `runId` for start/resume. A replay adds `replayed: true`: this is the
 original operation result, not the current Goal state. Refresh the session
-after replay. Receipts prevent duplicate Goal mutations and input turns;
-they do not promise exactly-once external tool or provider effects.
+after replay. Receipts prevent duplicate Goal mutations and input turns.
+They do not promise exactly-once external tool or provider effects.
 
 ## TUI
 
@@ -250,7 +249,7 @@ note, token budget, and available commands.
 ## Channel behavior
 
 `/goal` works in command-capable OpenClaw sessions, including the TUI and
-chat surfaces that permit text commands. Goal state is attached to the
+chat surfaces that permit text commands. Goal state attaches to the
 session key, not the transport, so two surfaces sharing a session key see the
 same goal.
 

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -30,7 +30,7 @@ or sign in with OpenAI ChatGPT/Codex OAuth.
 <Steps>
   <Step title="Configure auth">
     Set an API key for at least one provider (for example `OPENAI_API_KEY`,
-    `GEMINI_API_KEY`, `OPENROUTER_API_KEY`) or sign in with OpenAI Codex OAuth.
+    `GEMINI_API_KEY`, `OPENROUTER_API_KEY`) or sign in with OpenAI ChatGPT/Codex OAuth.
   </Step>
   <Step title="Pick a default model (optional)">
     ```json5
@@ -75,19 +75,19 @@ internal image endpoints remain blocked by default.
 
 ## Common routes
 
-| Goal                                                 | Model ref                                                                                           | Auth                                   |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| OpenAI image generation with API billing             | `openai/gpt-image-2`                                                                                | `OPENAI_API_KEY`                       |
-| OpenAI GPT Image 2.5                                 | `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst`                                     | Explicit OpenAI API-key route          |
-| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                                                                                | OpenAI ChatGPT/Codex OAuth             |
-| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                                                                              | `OPENAI_API_KEY` or OpenAI Codex OAuth |
-| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`                                                        | `DEEPINFRA_API_KEY`                    |
-| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                                                                  | `FAL_KEY`                              |
-| fal GPT Image 2.5                                    | `fal/openai/gpt-image-2.5/flare/text-to-image` or `fal/openai/gpt-image-2.5/sunburst/text-to-image` | `FAL_KEY`                              |
-| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview`                                                  | `OPENROUTER_API_KEY`                   |
-| LiteLLM image generation                             | `litellm/gpt-image-2`                                                                               | `LITELLM_API_KEY`                      |
-| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`                                                               | `AZURE_OPENAI_API_KEY` or Entra ID     |
-| Google Gemini image generation                       | `google/gemini-3.1-flash-image`                                                                     | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
+| Goal                                             | Model ref                                                                                           | Auth                                           |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| OpenAI image generation with API billing         | `openai/gpt-image-2`                                                                                | `OPENAI_API_KEY`                               |
+| OpenAI GPT Image 2.5                             | `openai/gpt-image-2.5-flare` or `openai/gpt-image-2.5-sunburst`                                     | Explicit OpenAI API-key route                  |
+| OpenAI image generation with ChatGPT/Codex OAuth | `openai/gpt-image-2`                                                                                | OpenAI ChatGPT/Codex OAuth                     |
+| OpenAI transparent-background PNG/WebP           | `openai/gpt-image-1.5`                                                                              | `OPENAI_API_KEY` or OpenAI ChatGPT/Codex OAuth |
+| DeepInfra image generation                       | `deepinfra/black-forest-labs/FLUX-1-schnell`                                                        | `DEEPINFRA_API_KEY`                            |
+| fal Krea 2 expressive/style-directed generation  | `fal/krea/v2/medium/text-to-image`                                                                  | `FAL_KEY`                                      |
+| fal GPT Image 2.5                                | `fal/openai/gpt-image-2.5/flare/text-to-image` or `fal/openai/gpt-image-2.5/sunburst/text-to-image` | `FAL_KEY`                                      |
+| OpenRouter image generation                      | `openrouter/google/gemini-3.1-flash-image-preview`                                                  | `OPENROUTER_API_KEY`                           |
+| LiteLLM image generation                         | `litellm/gpt-image-2`                                                                               | `LITELLM_API_KEY`                              |
+| Microsoft Foundry MAI image generation           | `microsoft-foundry/<deployment-name>`                                                               | `AZURE_OPENAI_API_KEY` or Entra ID             |
+| Google Gemini image generation                   | `google/gemini-3.1-flash-image`                                                                     | `GEMINI_API_KEY` or `GOOGLE_API_KEY`           |
 
 The same tool handles text-to-image and reference-image editing. Use `image`
 for one reference or `images` for multiple. For Krea 2 models on fal, those
@@ -160,7 +160,7 @@ current session:
 </ParamField>
 <ParamField path="images" type="string[]">
   Multiple reference images for edit mode or style-reference models (up to 16
-  through the shared tool; provider-specific limits still apply).
+  through the shared tool. Provider-specific limits still apply).
 </ParamField>
 <ParamField path="size" type="string">
   Size hint: `1024x1024`, `1536x1024`, `1024x1536`, `2048x2048`, `3840x2160`.
@@ -202,7 +202,7 @@ nearby geometry option instead of the exact requested one, OpenClaw remaps to
 the closest supported size, aspect ratio, or resolution before submission.
 Unsupported output hints are dropped for providers that do not declare
 support and reported in the tool result. Tool results report the applied
-settings; `details.normalization` captures any requested-to-applied
+settings. `details.normalization` captures any requested-to-applied
 translation.
 </Note>
 
@@ -239,7 +239,7 @@ For `image_generate`, OpenClaw tries providers in this order:
 3. **`agents.defaults.mediaModels.image.fallbacks`** in order.
 4. **Auto-detection** - only when neither a primary nor fallback model is
    configured, using configured provider defaults:
-   - current default provider first;
+   - current default provider first.
    - remaining registered image-generation providers in provider-id order.
 
 If a provider fails (auth error, rate limit, etc.), the next configured
@@ -253,7 +253,7 @@ from each attempt.
   </Accordion>
   <Accordion title="Auto-detection uses configured providers">
     Auto-detection considers provider defaults whose readiness or auth checks pass.
-    Explicit image model configuration limits fallback to the configured list;
+    Explicit image model configuration limits fallback to the configured list.
     OpenClaw does not append auto-detected providers.
   </Accordion>
   <Accordion title="Timeouts">
@@ -261,7 +261,7 @@ from each attempt.
     backends. A per-call `timeoutMs` tool parameter overrides the configured
     default, and configured defaults override plugin-authored provider
     defaults. Google and OpenRouter hosted image providers use 180 second
-    defaults; Microsoft Foundry MAI, xAI, and Azure OpenAI image generation use
+    defaults. Microsoft Foundry MAI, xAI, and Azure OpenAI image generation use
     600 seconds. Codex dynamic-tool calls use a 120 second `image_generate`
     bridge default and honor the same timeout budget when configured, bounded
     by OpenClaw's 600000 ms dynamic-tool bridge maximum.
@@ -284,7 +284,7 @@ inputs. Pass a reference image path or URL:
 ```
 
 OpenAI, OpenRouter, and Google support up to 5 reference images via the
-`images` parameter; xAI supports up to 3. fal supports 1 reference image for
+`images` parameter. xAI supports up to 3. fal supports 1 reference image for
 Flux image-to-image, up to 16 for GPT Image 2.5 edits, up to 10 for older GPT Image edits, up to 10 style references
 for Krea 2, and up to 14 for Nano Banana 2 edits. Microsoft Foundry, MiniMax,
 and ComfyUI support 1.
@@ -332,14 +332,14 @@ and ComfyUI support 1.
 
     The `openai/gpt-image-1.5`, `openai/gpt-image-1`, and
     `openai/gpt-image-1-mini` models can still be selected explicitly. Use
-    `gpt-image-1.5` for transparent-background PNG/WebP output; the current
+    `gpt-image-1.5` for transparent-background PNG/WebP output. The current
     `gpt-image-2` API rejects `background: "transparent"`.
 
     `gpt-image-2` supports both text-to-image generation and
     reference-image editing through the same `image_generate` tool.
     OpenClaw forwards `prompt`, `count`, `size`, `quality`, `outputFormat`,
     and reference images to OpenAI. OpenAI does **not** receive
-    `aspectRatio` or `resolution` directly; when possible OpenClaw maps
+    `aspectRatio` or `resolution` directly. When possible OpenClaw maps
     those into a supported `size`, otherwise the tool reports them as
     ignored overrides.
 
@@ -367,8 +367,8 @@ and ComfyUI support 1.
     }
     ```
 
-    `openai.background` accepts `transparent`, `opaque`, or `auto`;
-    transparent outputs require `outputFormat` `png` or `webp` and a
+    `openai.background` accepts `transparent`, `opaque`, or `auto`.
+    Transparent outputs require `outputFormat` `png` or `webp` and a
     transparency-capable OpenAI image model. OpenClaw routes default
     `gpt-image-2` transparent-background requests to `gpt-image-1.5`.
     `openai.outputCompression` applies to JPEG/WebP outputs and is ignored
@@ -411,7 +411,7 @@ and ComfyUI support 1.
     - Edit endpoint: `/mai/v1/images/edits`
     - Auth: `AZURE_OPENAI_API_KEY` / provider API key, or Entra ID through `az login`
     - Output: one PNG image
-    - Size: default `1024x1024`; width and height must each be at least 768 px,
+    - Size: default `1024x1024`. Width and height must each be at least 768 px,
       and total pixels must be at most 1,048,576
     - Edits: one PNG or JPEG reference image, supported only by
       `MAI-Image-2.5-Flash` and `MAI-Image-2.5` deployments
@@ -482,7 +482,7 @@ and ComfyUI support 1.
     ```
 
     Krea 2 returns one image per request. Prefer `aspectRatio` for
-    Krea; OpenClaw maps `size` to the closest supported Krea aspect ratio and
+    Krea. OpenClaw maps `size` to the closest supported Krea aspect ratio and
     rejects `resolution` for Krea rather than dropping it. Use `fal.creativity`
     when you want a native Krea creativity level:
 
@@ -590,7 +590,7 @@ openclaw infer image generate \
 </Tabs>
 
 The same `--output-format`, `--background`, and `--quality` flags are available
-on `openclaw infer image edit`; `--openai-background` remains as an
+on `openclaw infer image edit`. `--openai-background` remains as an
 OpenAI-specific alias. Use `--openai-moderation low|auto` with both OpenAI image
 generation and reference-image edits. The direct OpenAI Images API and the
 ChatGPT/Codex OAuth Responses backend both support the moderation hint.

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -25,10 +25,10 @@ action. Behavior varies by channel.
 - Set `remove: true` to remove one specific emoji (requires non-empty
   `emoji`).
 - `clearAll: true` is a Feishu/Lark-only flag that removes every reaction the
-  bot placed on the message; it is paired with an empty `emoji`.
+  bot placed on the message. It is paired with an empty `emoji`.
 - `emoji-list` is a separate `message` tool action, not a `react` parameter. It
   reports the emoji a channel will accept. What it returns and which
-  per-channel action toggle enables it both vary by channel; see the channel
+  per-channel action toggle enables it both vary by channel. See the channel
   pages under [Channels](/channels).
 - On channels with status reactions, `trackToolCalls: true` on a reaction lets
   the runtime reuse that reacted message for the same turn's status lifecycle.
@@ -46,7 +46,7 @@ action. Behavior varies by channel.
 
   <Accordion title="Nextcloud Talk">
     - Adding reactions only: `emoji` is required and must be non-empty.
-    - Reaction removal is not wired to a delete call yet; `remove: true` is rejected with an explicit error instead of silently no-oping.
+    - Reaction removal is not wired to a delete call yet. `remove: true` is rejected with an explicit error instead of silently no-oping.
     - Requires the Talk bot registered with the `reaction` feature (see [Nextcloud Talk channel docs](/channels/nextcloud-talk)).
 
   </Accordion>
@@ -61,7 +61,7 @@ action. Behavior varies by channel.
   <Accordion title="WhatsApp">
     - Empty `emoji` removes the bot reaction.
     - `remove: true` maps to empty emoji internally (still requires `emoji` in the tool call).
-    - WhatsApp has one bot reaction slot per message; sending a new reaction replaces it rather than stacking multiple emoji.
+    - WhatsApp has one bot reaction slot per message. Sending a new reaction replaces it rather than stacking multiple emoji.
 
   </Accordion>
 
@@ -80,13 +80,13 @@ action. Behavior varies by channel.
   </Accordion>
 
   <Accordion title="Signal">
-    - Inbound reaction notifications are controlled by `channels.signal.reactionNotifications`: `"off"` disables them, `"own"` (default) emits events when users react to bot messages, `"all"` emits events for all reactions, and `"allowlist"` emits events only for senders in `channels.signal.reactionAllowlist`.
+    - `channels.signal.reactionNotifications` controls inbound reaction notifications. `"off"` disables them. `"own"` (default) emits events when users react to bot messages. `"all"` emits events for all reactions. `"allowlist"` emits events only for senders in `channels.signal.reactionAllowlist`.
 
   </Accordion>
 
   <Accordion title="iMessage">
-    - Outbound reactions are iMessage tapbacks (`love`, `like`, `dislike`, `laugh`, `emphasize`, and `question`); `emoji` must map to one of these kinds to add a reaction.
-    - `remove: true` without a recognized tapback kind removes all tapback kinds; with a recognized kind it removes just that one.
+    - Outbound reactions are iMessage tapbacks (`love`, `like`, `dislike`, `laugh`, `emphasize`, and `question`). `emoji` must map to one of these kinds to add a reaction.
+    - `remove: true` without a recognized tapback kind removes all tapback kinds. With a recognized kind it removes just that one.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/tools/secrets.md
+++ b/docs/tools/secrets.md
@@ -18,7 +18,7 @@ conversation. Subagent and ACP worker sessions do not receive it.
 
 It is enabled by default and governed by the normal tool policy — there is no
 dedicated config key. To remove it, deny it like any other tool (for example
-`tools.deny: ["secrets"]` in `openclaw.json`); allowlists and tool profiles
+`tools.deny: ["secrets"]` in `openclaw.json`). Allowlists and tool profiles
 apply to it the same way.
 
 The tool description tells the agent to list metadata first,
@@ -34,8 +34,8 @@ reason. For egress use, it proposes the exact destination hosts too.
   on the prompt, and the tool blocks until you answer, skip, or it times out
   (15 minutes by default, with `timeoutSeconds` clamped to 30–3600 seconds).
   This is a maximum human wait, subject to earlier cancellation or the overall
-  run timeout; the question does not extend an explicit run budget.
-  The request is bound to the requesting agent run; if
+  run timeout. The request does not extend an explicit run budget.
+  The request is bound to the requesting agent run. If
   that authority closes before you answer, the pending prompt is cancelled and
   the write is refused.
 - `list` — entry metadata: name, kind, allowed hosts, and last update. Secret
@@ -55,17 +55,17 @@ The web Control UI docks the prompt above the composer with a masked input.
 The prompt always shows who is asking (agent and session), the entry name, the
 agent's stated reason, and an editable list of allowed hosts, so you have the
 final say on where the credential may be used. If the name already exists, the
-prompt says so and shows when and by whom the entry was last updated;
-submitting replaces the stored value. The Gateway preserves submitted values
+prompt says so and shows when and by whom the entry was last updated.
+Submitting replaces the stored value. The Gateway preserves submitted values
 exactly, including leading or trailing whitespace. Web, TUI, and Apple request fields
-are single-line; use the CLI's `--value-file` input for multiline credentials.
+are single-line. Use the CLI's `--value-file` input for multiline credentials.
 
 The Gateway-connected TUI also accepts requests through a masked input: typed
 characters appear as bullets and are never added to the chat log or input
 history. The prompt shows the entry name, reason, and proposed allowed hosts.
-The host list is read-only in the TUI; submitting accepts the displayed list.
+The host list is read-only in the TUI. Submitting accepts the displayed list.
 Use the Control UI if you need to edit it before submitting. **Skip** declines
-the request; Esc leaves it pending, and `/question` reopens it. Never enter a
+the request. Esc leaves it pending, and `/question` reopens it. Never enter a
 credential in the ordinary composer.
 
 Local mode (`openclaw chat` or `openclaw tui --local`) cannot fulfill store-bound
@@ -75,12 +75,12 @@ question prompt supports masked input, but that alone does not provide the
 Gateway's secret-store write and runtime refresh flow.
 
 If the agent omits a host proposal, a replacement request starts with the entry's
-current hosts; a new entry starts with an empty list. An explicitly empty proposal
+current hosts. A new entry starts with an empty list. An explicitly empty proposal
 stays empty. Submitting saves the displayed list or your edits, even if another
 write changes the entry while the prompt is pending. Clearing the list disables
 egress substitution while keeping the credential usable through config SecretRefs.
 
-Once the store write commits, the question is answered and cannot be submitted
+Once the store write commits, the request is answered and cannot be submitted
 again. A later runtime refresh failure does not undo that write: resolve the
 reported provider error and run `openclaw secrets reload`, rather than resubmitting.
 
@@ -88,7 +88,7 @@ The same tool result reports `status: "stored"`, the SecretRef, and `currentPoli
 from one follow-up metadata read. This is the entry's current host list, which you
 can edit, not Gateway configuration or an immutable approval receipt: another
 write may have changed it. `available` includes the
-complete allowed-host list; an empty list means no egress. If the serialized list
+complete allowed-host list. An empty list means no egress. If the serialized list
 exceeds 512 characters, `omitted` reports only `allowedHostCount`. `missing`,
 `kind_changed`, and `unavailable` mean the entry disappeared, became an `env`
 entry, or has no complete validated host policy. None undo the saved result or invite
@@ -101,7 +101,7 @@ configuration changes.
 Allowed hosts govern Gateway egress substitution, not config SecretRefs. Leave
 only the exact hosts that should receive the credential. An empty list prevents
 egress substitution but still allows supported config fields to resolve the
-stored credential. Egress also requires the proxy to be enabled; never work
+stored credential. Egress also requires the proxy to be enabled. Never work
 around a missing proxy or destination permission by putting plaintext in commands,
 arguments, URLs, logs, or chat.
 </Warning>
@@ -132,7 +132,7 @@ because answering provides a value rather than reading one.
 In Gateway-backed sessions, a missing credential for an unrelated provider does
 not block a turn on a healthy provider. The agent can use that healthy model to
 request the missing entry. Selecting the unavailable provider still fails until
-its SecretRef resolves; OpenClaw does not silently substitute an environment or
+its SecretRef resolves. OpenClaw does not silently substitute an environment or
 auth-profile credential.
 
 A stored entry is a regular shared-store entry (see
@@ -140,27 +140,27 @@ A stored entry is a regular shared-store entry (see
 
 - Use the returned full `ref` wherever a SecretRef is accepted (provider API
   keys, channel tokens). With the default store alias, it is
-  `{ "source": "store", "provider": "default", "id": "STRIPE_API_KEY" }`;
+  `{ "source": "store", "provider": "default", "id": "STRIPE_API_KEY" }`.
   `secrets.defaults.store` selects a different provider alias. Writes trigger
   refresh of affected config and auth-profile references. A successful refresh
   also replaces prepared model state, so later catalog reads use the new
   credential for providers already in the agent's model scope.
-- `env` entries are readable values; the operator sets them, not the credential
+- `env` entries are readable values. The operator sets them, not the credential
   request flow.
 - `secret` entries reach Gateway-host subprocess traffic through automatically
   injected opaque environment sentinels only when the egress proxy is enabled
-  (`secrets.egressProxy.enabled`). The variable uses the stored entry name; read
+  (`secrets.egressProxy.enabled`). The variable uses the stored entry name. Read
   it from the command process's inherited environment. Do not supply a secret
   template, override that variable, or print it. Substitution requires the
   destination to match the entry's allowed hosts. With the proxy disabled,
-  protected entries are not injected; use a supported config SecretRef instead.
+  protected entries are not injected. Use a supported config SecretRef instead.
   Native harness shell, sandbox, and node execution do not receive these protected
   values. The provider troubleshooting switch `OPENCLAW_SECRET_SENTINELS=off` does
   not disable protected-store sealing.
 
 Gateway-host exec captures one store snapshot on its first execution in a run.
 A credential stored before that point can be included. Afterward, additions,
-replacements, deletions, and host edits do not refresh that run's snapshot; start
+replacements, deletions, and host edits do not refresh that run's snapshot. Start
 a new run to observe them. A successful credential request does not promise that
 an already-running exec tool can use the new value.
 
@@ -170,4 +170,4 @@ upstream transport cannot be recalled.
 
 ## Related
 
-- [Ask user](/tools/ask-user) — structured questions for non-credential decisions; a credential is never a valid answer to one
+- [Ask user](/tools/ask-user) — structured questions for non-credential decisions. A credential is never a valid answer to one

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -48,19 +48,19 @@ two future model or tool round trips. Deep turns the user interrupted qualify
 too: the wrong path and its correction are exactly the evidence worth keeping.
 The reviewer is told when a turn was interrupted and captures only procedures
 that visibly worked before the stop. Turns that ended in a provider or prompt
-error never schedule a review; that failure is transient environment noise, and
+error never schedule a review. That failure is transient environment noise, and
 a review on the same model would likely hit it again.
 
 Experience review starts only when all of these conditions hold:
 
 - the foreground turn completed or was interrupted, but did not end in a
-  provider or prompt error;
-- the current turn used at least 10 model iterations;
+  provider or prompt error.
+- the current turn used at least 10 model iterations.
 - the run was an eligible foreground conversation, not cron, heartbeat, memory,
-  overflow, hook, subagent, or review work;
+  overflow, hook, subagent, or review work.
 - the runtime reported the resolved provider, model, and actual availability of
-  `skill_workshop`;
-- the system has been quiet for 30 seconds; and
+  `skill_workshop`.
+- the system has been quiet for 30 seconds.
 - no agent or reply run is still active.
 
 A later foreground completion in the same session restarts the quiet period.
@@ -75,14 +75,14 @@ asynchronously after the quiet period. The reviewer connects earlier requirement
 and corrections with observed results across that retained conversation, even
 when the latest turn is routine. Later messages are excluded. If the saved
 turn was rewritten or removed, the review records a failure instead of using
-different evidence. The review runs under a private detached session identity;
-its messages never enter the foreground transcript or session record. Reviews
+different evidence. The review runs under a private detached session identity.
+Its messages never enter the foreground transcript or session record. Reviews
 retain the foreground session's sandbox policy.
 
 In `auto` mode, the reviewer uses ordinary directory, file, patch, and shell
 tools under the source session's permissions. It can inspect complete skills and
 supporting files, correct several connected files, and verify the result. Its
-file tools are rooted at the Workshop directory; shell commands retain the
+file tools are rooted at the Workshop directory. Shell commands retain the
 operator's existing approval policy. An enabled sandbox must provide writable
 access to that directory. The run uses the normal configured agent timeout.
 
@@ -90,8 +90,8 @@ The reviewer shares the weekly collection's maintenance instructions: audit
 before editing, give a procedure one home, preserve distinct tasks, and verify
 the resulting files. New learning should replace a misleading rule or strengthen
 an existing one rather than append another copy. A covered lesson needs no edit.
-The runtime receipt identifies skills actually used in the foreground turn;
-ordinary directory reads discover the current collection without a separate
+The runtime receipt identifies skills actually used in the foreground turn.
+Ordinary directory reads discover the current collection without a separate
 clipped inventory.
 
 In `propose` mode, only `skill_workshop` executes. The reviewer can inspect and
@@ -100,28 +100,28 @@ read/hash/size validation remains in effect. The draft stays pending even if the
 operator enables automatic learning during that review.
 
 Each review gets one attempt. A failure is recorded instead of retried. Automatic
-maintenance records `completed` when the agent run succeeds; that status is not
+maintenance records `completed` when the agent run succeeds. That status is not
 a claim that a file changed. Completed file edits survive later failure or
 cancellation, and future sessions receive a refreshed skill snapshot. Source
 session deletion, replacement, or a permission-mode change fences retained tools.
 
 Good candidates include:
 
-- a reliable recovery after repeated tool or model failures;
+- a reliable recovery after repeated tool or model failures.
 - a durable user correction or standing instruction ("from now on," "always,"
   "never," "stop doing X"), embedded as a procedure step in the skill governing
-  that work;
-- a non-obvious ordering constraint that prevented a recurring error;
-- a stable multi-step workflow that required repeated discovery; or
+  that work.
+- a non-obvious ordering constraint that prevented a recurring error.
+- a stable multi-step workflow that required repeated discovery.
 - a reusable preflight that would avoid several future calls.
 
 The reviewer should abstain for:
 
-- routine successful work or a one-time request;
-- personal facts and simple preferences;
-- transient environment or service failures;
-- generic advice without concrete supporting evidence;
-- unsupported negative claims; or
+- routine successful work or a one-time request.
+- personal facts and simple preferences.
+- transient environment or service failures.
+- generic advice without concrete supporting evidence.
+- unsupported negative claims.
 - secrets and credential material.
 
 ## Mode policy
@@ -187,7 +187,7 @@ openclaw skills workshop reject <proposal-id> --reason "Not reusable"
 
 Proposal captures remain visible in `openclaw skills workshop list`. Direct
 maintenance changes appear in the installed Workshop skills, not as proposal
-records. Weekly review results remain in automation history; retained legacy
+records. Weekly review results remain in automation history. Retained legacy
 backups keep their [restore path](/tools/skill-workshop#changes-and-recovery).
 
 Residual risk remains: an agent can make an incorrect edit. Inspect installed
@@ -197,7 +197,7 @@ skills in Workshop, or choose `propose` when every capture needs human review.
 
 Delayed experience review requires the runtime to report its resolved model and
 actual `skill_workshop` availability. The embedded runner and Codex app-server
-harness report those facts; Codex also reports its exact model-iteration count.
+harness report those facts. Codex also reports its exact model-iteration count.
 Other CLI-backed runtimes fail closed until they provide the same runtime facts.
 `/learn` does not depend on delayed review and continues to work on those
 runtimes.
@@ -223,13 +223,13 @@ the additional run.
 
 Weekly [collection review](/tools/skill-workshop#collection-review) uses the
 agent's configured model and normal cron scheduling. Skill bodies remain review
-material, not active instructions. Completed edits persist; there is no
+material, not active instructions. Completed edits persist. There is no
 collection-wide transaction or automatic rollback.
 
 **Learn from past conversations** in Workshop opens a normal agent session with
 the learning instructions. The agent uses its configured model, permitted tools,
-existing skills, and accessible conversation history. It chooses what to read;
-there is no separate scan threshold, transcript bundle, or batch cursor.
+existing skills, and accessible conversation history. It chooses what to read.
+There is no separate scan threshold, transcript bundle, or batch cursor.
 
 The session follows the current Workshop mode: `auto` permits direct skill
 improvements, while `propose` leaves suggestions for approval. You can watch,
@@ -301,14 +301,14 @@ Check the following:
 4. The runtime reported the resolved model and actual `skill_workshop`
    availability.
 5. Tool policy permits Workshop. Automatic maintenance also needs normal file
-   access; an enabled sandbox must expose its Workshop directory as writable.
+   access. An enabled sandbox must expose its Workshop directory as writable.
 6. The Gateway stayed running and idle through the 30-second quiet period.
 
 An eligible experience review can still abstain. No proposal is the expected
 result when the evidence does not clear the reusable-procedure bar.
 Use `openclaw skills curator status` to inspect experience review outcomes and
-live skill usage. Current weekly collection results are in automation run history;
-Curator retains only the earlier collection records. Curator does not archive or
+live skill usage. Current weekly collection results are in automation run history.
+That CLI retains only the earlier collection records. It does not archive or
 expire skills by age. The `curator pin`, `unpin`, and `restore` commands return an
 error explaining that weekly collection review manages the skill collection.
 
@@ -327,7 +327,7 @@ openclaw skills workshop inspect <proposal-id>
 ```
 
 A normal write failure leaves it pending for manual review. A critical scanner
-result moves it to quarantine. Fix the cause and apply manually; do not build a
+result moves it to quarantine. Fix the cause and apply manually. Do not build a
 retry loop around automatic capture.
 
 ### Too many low-value captures appear

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -10,34 +10,34 @@ read_when:
   - You need the show_widget input, security, or retention contract
 ---
 
-`show_widget` is a core tool that shows a self-contained HTML widget on the user's current surface. OpenClaw renders it inline in the Control UI and in iOS, Android, macOS, and Linux Quick Chat transcripts; the Linux dashboard uses the browser Control UI. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
+`show_widget` is a core tool that shows a self-contained HTML widget on the user's current surface. OpenClaw renders it inline in the Control UI and in iOS, Android, macOS, and Linux Quick Chat transcripts. The Linux dashboard uses the browser Control UI. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
 
 For a pinned data report, provide a structured `report` with `pin: true`. Reports render directly in the Control UI dashboard using its native typography and layout, without a document frame. Use HTML for arbitrary interactive content or an inline preview. See [Native dashboard reports](#native-dashboard-reports).
 
 ## How widgets work
 
-For HTML widgets, OpenClaw core validates `widget_code` by parsing every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`, then wraps it once in the canonical HTML document. Core rejects the call with the line and column of the first syntax error, so a widget with a broken script is never hosted. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI reads the document over its authenticated Gateway connection and renders it through the dedicated-origin, double-iframe sandbox used by dashboard widgets and MCP Apps. The widget frame does not need its own login session. iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
+For HTML widgets, OpenClaw core validates `widget_code` by parsing every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`, then wraps it once in the canonical HTML document. Core rejects the call with the line and column of the first syntax error, so a widget with a broken script is never hosted. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI reads the document over its authenticated Gateway connection and renders it through the dedicated-origin, double-iframe sandbox used by dashboard widgets and MCP Apps. The widget frame does not need its own login session. iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload. Quick Chat keeps the widget for its active reply.
 
-Channel plugins can register a contextual presenter behind the same core tool. In a configured Discord session, core hands the composed document to the Discord presenter, which stores it and posts the Activity button in the current channel. The model still makes one `show_widget` call; there is no transport-specific widget tool or content kind.
+Channel plugins can register a contextual presenter behind the same core tool. In a configured Discord session, core hands the composed document to the Discord presenter, which stores it and posts the Activity button in the current channel. The model still makes one `show_widget` call. There is no transport-specific widget tool or content kind.
 
-In Control UI sessions, a Canvas widget can also be pinned to the session dashboard. Set `pin: true` in the tool call, or use **Pin to dashboard** on an existing transcript widget. Pinning gives the dashboard copy its own identity and capability grants; the inline preview never inherits those grants. The browser never resolves a widget data binding inside the untrusted frame.
+In Control UI sessions, a Canvas widget can also be pinned to the session dashboard. Set `pin: true` in the tool call, or use **Pin to dashboard** on an existing transcript widget. Pinning gives the dashboard copy its own identity and capability grants. The inline preview never inherits those grants. The browser never resolves a widget data binding inside the untrusted frame.
 
 For browser embedding, the wrapper document injects six small host bridges around the widget code:
 
-- A size reporter posts the rendered content height to the embedding chat, which clamps it and fits the iframe (48 to 8000 pixels).
-- A host bridge defines a global `sendPrompt(text)` helper plus the structured `openclaw.prompt`, `openclaw.state`, `openclaw.data`, and `openclaw.cron` APIs; `sendPrompt(text)` is the fire-and-forget form of `openclaw.prompt.send`. Inline chat prompts retain their private message channel; dashboard APIs use a view-ticket-bound request channel. See [Interactive widgets](#interactive-widgets) and [Dashboard capabilities](#dashboard-capabilities).
-- An error reporter captures uncaught script and event-handler exceptions and unhandled promise rejections. It sends at most three distinct messages per document load, with messages capped at 500 UTF-16 units, source basenames at 200, and optional integer line and column numbers. The Control UI shows a notice and forwards one report per document and chat session per page load to the Gateway as a session wake event, with an additional shared limit of 10 reports per key per 60 seconds (up to 100 tracked keys). Reports are forwarded to the agent only for widgets rendered within ten minutes of their message; older restored history shows the notice without waking the agent. If the session already has an active run, the event stays queued and the immediate wake retries until the session lane is free, so the model sees it on its next available turn. The wake turn runs without the originating client capabilities, so `show_widget` can be unavailable there; the report asks the model to reply with the corrected code and show it on the next turn. Native apps do not report runtime errors yet.
-- A theme bridge listens for the Control UI's current design tokens and applies them as CSS variables, on load and again on every theme change.
+- A size reporter posts the rendered content height to the embedding chat. The chat clamps that height and fits the iframe (48 to 8000 pixels).
+- A host bridge defines a global `sendPrompt(text)` helper plus the structured `openclaw.prompt`, `openclaw.state`, `openclaw.data`, and `openclaw.cron` APIs. `sendPrompt(text)` is the fire-and-forget form of `openclaw.prompt.send`. Inline chat prompts retain their private message channel. Dashboard APIs use a view-ticket-bound request channel. See [Interactive widgets](#interactive-widgets) and [Dashboard capabilities](#dashboard-capabilities).
+- An error reporter captures uncaught script and event-handler exceptions and unhandled promise rejections. It sends at most three distinct messages per document load, with messages capped at 500 UTF-16 units, source basenames at 200, and optional integer line and column numbers. The Control UI shows a notice and forwards one report per document and chat session per page load to the Gateway as a session wake event, with an additional shared limit of 10 reports per key per 60 seconds (up to 100 tracked keys). Reports are forwarded to the agent only for widgets rendered within ten minutes of their message. Older restored history shows the notice without waking the agent. If the session already has an active run, the event stays queued and the immediate wake retries until the session lane is free, so the model sees it on its next available turn. The wake turn runs without the originating client capabilities, so `show_widget` can be unavailable there. The report asks the model to reply with the corrected code and show it on the next turn. Native apps do not report runtime errors yet.
+- A theme bridge listens for the Control UI's current design tokens and applies them as CSS variables. It does this on load and again on every theme change.
 - A snapshot bridge renders the current widget document as a PNG when the embedding chat requests an export.
 - A chat-host bridge hides embedded scrollbar chrome when the widget runs inline while preserving scrolling behavior.
 
-Everything else stays inside the frame: the document runs in an opaque origin with a strict Content Security Policy, so widget scripts cannot reach the Control UI, the Gateway, or the network.
+Everything else stays inside the frame. The document runs in an opaque origin with a strict Content Security Policy. Widget scripts cannot reach the Control UI, the Gateway, or the network.
 
 OpenClaw exposes `show_widget` only when the originating Gateway client declares the `inline-widgets` capability or exactly one registered current-channel presenter synchronously matches trusted run context. The Control UI and supported native apps declare the inline capability automatically. Linux Quick Chat stays text-only for Gateway connections that require a custom TLS leaf pin because its platform WebView cannot bind that pin. Discord matches only when Activities are configured for the current account and a concrete channel is available. Other channel runs without an inline client or matching presenter do not receive the tool.
 
 An agent-turn automation bound to a persistent session and carrying a server-authored scheduled tool policy may explicitly allow `show_widget` without an inline client. That scheduled surface is pinned-only: every call requires `pin: true`, writes to the bound session dashboard, and cannot set `presentation.target`. Detached cron-run sessions, ordinary capless channel runs, and scheduled jobs without an explicit tool cap remain excluded. The originating-client capability remains mandatory for inline presentation.
 
-When the Gateway automatically resumes an interrupted Control UI turn after a restart, the recovered turn can also create or update pinned dashboard widgets without a connected browser. Recovery uses the same pinned-only surface: set `pin: true` and omit `presentation.target`. Inline previews still require a new turn from a client that declares `inline-widgets`; the resumed turn does not inherit a browser connection or device presentation rights.
+When the Gateway automatically resumes an interrupted Control UI turn after a restart, the recovered turn can also create or update pinned dashboard widgets without a connected browser. Recovery uses the same pinned-only surface: set `pin: true` and omit `presentation.target`. Inline previews still require a new turn from a client that declares `inline-widgets`. The resumed turn does not inherit a browser connection or device presentation rights.
 
 Capability transport covers embedded, Codex app-server, and CLI-backed model backends. Grant-authenticated MCP callers without `inline-widgets` remain fail closed unless their trusted run context matches a presenter. Authenticated direct HTTP `tools/invoke` requests cannot request inline rendering, but a request carrying eligible current-channel context can use the matching presenter. Authentication never bypasses presenter or route eligibility.
 
@@ -76,16 +76,16 @@ Bare headings, paragraphs, links, buttons, inputs, selects, textareas, tables, a
 - `.row` for a wrapping horizontal layout
 - `button.primary` for the primary action
 
-The Control UI posts an `openclaw:widget-theme` message with the active theme values when a widget loads and whenever the theme changes. Widgets therefore track every theme family, including Claw, Knot, Dash, and custom themes, without reloading. Outside the Control UI, including native apps and direct opens, widgets use the baked light or dark palette selected by `prefers-color-scheme`.
+The Control UI posts an `openclaw:widget-theme` message with the active theme values when a widget loads. It posts again whenever the theme changes. Widgets therefore track every theme family, including Claw, Knot, Dash, and custom themes, without reloading. Outside the Control UI, including native apps and direct opens, widgets use the baked light or dark palette selected by `prefers-color-scheme`.
 
 Author widgets with four rules:
 
 1. Use the design variables for every color and background. Do not hardcode color values.
 2. Keep the page background transparent so the widget belongs to its host surface.
 3. Reserve `--accent-fill` for at most one primary action.
-4. Fit the iframe width at every viewport. Avoid fixed page or card widths; use fluid sizing and wrap or stack multi-column layouts when narrow. Use horizontal scrolling only when exact geometry must remain.
+4. Fit the iframe width at every viewport. Avoid fixed page or card widths. Use fluid sizing and wrap or stack multi-column layouts when narrow. Use horizontal scrolling only when exact geometry must remain.
 
-**Export:** In web chat, open the widget card menu to copy the rendered widget to the clipboard or download it as a PNG. Older widget documents without the snapshot bridge fall back to an HTML file download.
+**Export:** In web chat, open the widget card menu. From there, copy the rendered widget to the clipboard or download it as a PNG. Older widget documents without the snapshot bridge fall back to an HTML file download.
 
 ## Use the tool
 
@@ -96,25 +96,25 @@ The core tool requires `title` and one content input: `widget_code` for HTML or 
 </ParamField>
 
 <ParamField path="widget_code" type="string">
-  Required for HTML, SVG, or registered source; omit when providing `report`. For HTML, core parses every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`. The call is rejected with the line and column of the first syntax error, so a widget with a broken script is never hosted. For inline-widget clients, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. The Discord presenter accepts HTML source up to 48 KiB. A Discord-only route does not advertise or accept registered non-HTML content kinds.
+  Required for HTML, SVG, or registered source. Omit when providing `report`. For HTML, core parses every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`. The call is rejected with the line and column of the first syntax error, so a widget with a broken script is never hosted. For inline-widget clients, input beginning with `<svg` after trimming is rendered in SVG mode. Maximum length is 262,144 characters. The Discord presenter accepts HTML source up to 48 KiB. A Discord-only route does not advertise or accept registered non-HTML content kinds.
 </ParamField>
 
 <ParamField path="report" type="object">
-  Structured native report with a `blocks` array. Requires `pin: true`; omit `widget_code`, `kind`, and `capabilities`. Device presentation is unavailable. Maximum 8KB of UTF-8 JSON. See [Native dashboard reports](#native-dashboard-reports).
+  Structured native report with a `blocks` array. Requires `pin: true`. Omit `widget_code`, `kind`, and `capabilities`. Device presentation is unavailable. Maximum 8KB of UTF-8 JSON. See [Native dashboard reports](#native-dashboard-reports).
 </ParamField>
 
 Discord also accepts optional `button_label` text for the Activity launch button. The Canvas schema intentionally omits this Discord-only field.
 
 The core `show_widget` tool also accepts these optional dashboard placement fields, including when Discord is the presentation destination:
 
-- `kind`: `html` by default, plus active registered source kinds when available. Applies to `widget_code`; omit with `report`.
+- `kind`: `html` by default, plus active registered source kinds when available. Applies to `widget_code`. Omit with `report`.
 - `pin`: also place an HTML or registered widget on the session dashboard. Required for reports and on the pinned-only scheduled surface.
-- `name`: stable widget name; defaults to a slug of `title`.
+- `name`: stable widget name. Defaults to a slug of `title`.
 - `tab`: destination tab slug.
 - `size`: one of `sm`, `md`, `lg`, `xl`, or `full`.
 - `presentation.frame`: pinned dashboard frame: `card`, `full-bleed`, or `frameless`.
 - `after`: sibling widget name after which to place the widget.
-- `capabilities`: access requested by a pinned widget. `netOrigins` contains exact HTTPS origins; `tools` contains `prompt`, an allowlisted read binding, or an exact `cron.trigger:<jobId>` action.
+- `capabilities`: access requested by a pinned widget. `netOrigins` contains exact HTTPS origins. `tools` contains `prompt`, an allowlisted read binding, or an exact `cron.trigger:<jobId>` action.
 
 An inline result includes a Canvas preview handle, so the Control UI and supported native apps render the widget directly from the tool call and restore it after history reload. A successful current-channel presentation returns a generic message receipt describing what became visible. Pinned results retain the board widget name so the Control UI does not offer a duplicate pin after transcript reload.
 
@@ -124,7 +124,7 @@ Pinned results also report `capabilityState`: `none`, `pending`, `rejected`, or
 `rejected`, review the requested access and session permission policy with the
 operator before retrying. The inline preview does not inherit dashboard grants.
 
-If current-channel presentation fails, core falls back inline only when the originating client actually supports inline widgets. Otherwise the tool fails visibly. When `pin: true` succeeded before presentation failed, the result is explicitly partial and names the durable board widget; presentation failure never rolls back that unrelated board state.
+If current-channel presentation fails, core falls back inline only when the originating client actually supports inline widgets. Otherwise the tool fails visibly. When `pin: true` succeeded before presentation failed, the result is explicitly partial and names the durable board widget. Presentation failure never rolls back that unrelated board state.
 
 ## Native dashboard reports
 
@@ -155,7 +155,7 @@ Use a report for a pinned summary made of text, metrics, tables, simple charts, 
 }
 ```
 
-The result names the pinned board widget; it creates no inline preview, native device panel, or Discord Activity. Do not combine `report` with `widget_code`, `kind`, `capabilities`, or device presentation. The report field does not change the registered source-kind namespace.
+The result names the pinned board widget. It creates no inline preview, native device panel, or Discord Activity. Do not combine `report` with `widget_code`, `kind`, `capabilities`, or device presentation. The report field does not change the registered source-kind namespace.
 
 Each block has a required `type`:
 
@@ -167,7 +167,7 @@ Each block has a required `type`:
 | `chart`   | `points`: 1–40 objects with `label` and finite numeric `value`; optional `style` (`bar`, the default, or `line`) and `title`.                               |
 | `links`   | `items`: 1–20 objects with `label`, HTTP(S) `url`, and optional `detail`. Optional `title`.                                                                 |
 
-A report contains 1–24 blocks and at most 8KB of encoded JSON. Titles have 1–120 characters, labels 1–160, details at most 240, and URLs at most 2,048. Chart values stay between `-Number.MAX_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER`. Unknown fields are rejected. Reports accept no HTML, CSS, scripts, media, executable actions, network reads, or Gateway RPCs; links are ordinary navigation.
+A report contains 1–24 blocks and at most 8KB of encoded JSON. Titles have 1–120 characters, labels 1–160, details at most 240, and URLs at most 2,048. Chart values stay between `-Number.MAX_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER`. Unknown fields are rejected. Reports accept no HTML, CSS, scripts, media, executable actions, network reads, or Gateway RPCs. Links are ordinary navigation.
 
 Reuse the same `name` and `pin: true` with a new `report` object to replace a report's data. The `dashboard` tool can also create or update it with `action: "widget_put"`, `pluginKind: "session:report"`, and `props: report`. To convert an existing HTML widget, first remove it with `dashboard` action `widget_remove`, then create the report. A same-name update cannot change the widget's content owner.
 
@@ -175,11 +175,11 @@ Reuse the same `name` and `pin: true` with a new `report` object to replace a re
 
 When a widget presenter plugin is active, `presentation.target` also offers `node_panel`. OpenClaw creates the same hosted widget document, selects a connected widget-panel-capable Mac, and opens its native panel at that document. The tool result names the selected Mac.
 
-If no eligible Mac is connected or the node command fails, the widget still appears inline in chat and the result explains how to recover. Pair a Mac running OpenClaw or open the macOS app, then retry. Widgets shown in a native panel are render-only; widget actions are disabled there.
+If no eligible Mac is connected or the node command fails, the widget still appears inline in chat and the result explains how to recover. Pair a Mac running OpenClaw or open the macOS app, then retry. Widgets shown in a native panel are render-only. Widget actions are disabled there.
 
 ## Interactive widgets
 
-In the Control UI, widget scripts can drive the conversation. The wrapper document defines a global `sendPrompt(text)` function; calling it submits `text` to the chat as if the user had typed and sent the message. Wire it to buttons or other controls to build interactive flows such as pickers, quizzes, or drill-down dashboards. Native apps render interactive widget code but do not expose this chat prompt bridge.
+In the Control UI, widget scripts can drive the conversation. The wrapper document defines a global `sendPrompt(text)` function. Calling it submits `text` to the chat as if the user had typed and sent the message. Wire it to buttons or other controls to build interactive flows such as pickers, quizzes, or drill-down dashboards. Native apps render interactive widget code but do not expose this chat prompt bridge.
 
 ```html
 <button onclick="sendPrompt('Show the failing tests in detail')">Failing tests</button>
@@ -189,27 +189,27 @@ Every prompt is validated on both sides of the frame boundary:
 
 - `sendPrompt` requires [transient user activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation) inside the widget: it only works in the few seconds after the user clicks or presses a key in the widget, so wire it to buttons and other click targets — calling it automatically on load does nothing. The bridge keeps the sending endpoint private to itself and fails closed in browsers that do not expose user activation, so widget code cannot bypass the check.
 - Prompt authority belongs to the original widget document only. The trusted bridge offers its channel endpoint to the chat before widget code can run or navigate the frame, the chat adopts only that first offer, and the channel dies with the document on navigation. Externally allowed embed URLs are never adopted.
-- The widget frame must be visible in the chat transcript and hold focus — an additional host-observed signal that the user is actually interacting with this widget.
+- The widget frame must be visible in the chat transcript and hold focus. That is an additional host-observed signal that the user is actually interacting with this widget.
 - The text must be non-empty after trimming and at most 4,000 characters.
 - Prompts starting with `/` are rejected, so widget code cannot trigger chat commands such as `/approve` or `/stop`.
-- Each widget document may send at most 10 prompts per rolling minute; excess prompts are dropped silently.
+- Each widget document may send at most 10 prompts per rolling minute. Excess prompts are dropped silently.
 
 Accepted prompts appear in the transcript as regular user messages and start a normal agent turn in the session that owns the widget. There is no feedback channel into the widget: a dropped prompt fails silently, and the widget cannot read the agent's reply.
 
 ## Dashboard capabilities
 
-Pinned HTML and registered-source widgets expose one ticket-bound host API. An explicit [session permission mode](/gateway/permission-modes) determines how declared capabilities are approved: **Full access** grants them immediately; **Workspace** uses an AI reviewer and rejects anything it does not allow; **Guarded** shows an **Allow** / **Reject** card; **Read only** rejects them. Without an explicit session mode, the equivalent configured exec approval policy applies.
+Pinned HTML and registered-source widgets expose one ticket-bound host API. An explicit [session permission mode](/gateway/permission-modes) determines how declared capabilities are approved: **Full access** grants them immediately. **Workspace** uses an AI reviewer and rejects anything it does not allow. **Guarded** shows an **Allow** / **Reject** card. **Read only** rejects them. Without an explicit session mode, the equivalent configured exec approval policy applies.
 
 - `openclaw.host.controlUiBaseUrl` exposes the Control UI origin plus its configured base path after the dashboard host initializes. It is `null` before initialization and outside the dashboard, so read it in the link's click handler rather than when the widget script first runs.
-- `openclaw.prompt.send(text)` requires transient user activation and posts a visible composer message. Declaring and receiving the `prompt` tool grant skips the extra per-click confirmation; validation, focus checks, and rate limits still apply.
+- `openclaw.prompt.send(text)` requires transient user activation and posts a visible composer message. Declaring and receiving the `prompt` tool grant skips the extra per-click confirmation. Validation, focus checks, and rate limits still apply.
 - `openclaw.state.emit(payload)` adds a session notice. Payloads are capped at 8 KiB, and identical client emissions within five seconds are coalesced.
 - `openclaw.data.read(bindingId, params?)` resolves only at the Gateway. Core bindings are `sessions.list`, `usage.status`, `usage.cost`, `cron.list`, `cron.status`, `agents.list`, `health`, and the repository-scoped `github.actions.runs` binding below.
 - `openclaw.action.run(actionId, params?)` invokes an operator-granted plugin dashboard action verb through its write-scoped Gateway method.
 - `openclaw.cron.trigger(jobId)` runs an existing job now only when the exact `cron.trigger:<jobId>` capability was granted.
 
-User-clicked links to `http` or `https` destinations are forwarded to the Control UI host, which opens a new tab with `noopener` and `noreferrer`. Forwarding covers a primary click on a `target="_blank"` link and a middle-button click on any link, matching how links behave elsewhere in the Control UI; a widget's own `preventDefault` still cancels the click. The widget sandbox never grants popup permission, and script-initiated `window.open` does not work.
+OpenClaw forwards user-clicked links to `http` or `https` destinations to the Control UI host. The host opens a new tab with `noopener` and `noreferrer`. Forwarding covers a primary click on a `target="_blank"` link and a middle-button click on any link, matching how links behave elsewhere in the Control UI. A widget's own `preventDefault` still cancels the click. The widget sandbox never grants popup permission, and script-initiated `window.open` does not work.
 
-Network access is separate from host tools. Put exact HTTPS origins in `capabilities.netOrigins`; once the session policy grants them, only those origins enter the widget's `connect-src`. Wildcards, credentials, paths, query strings, and undeclared origins remain blocked. A literal port is allowed only when it is part of the declared origin.
+Network access is separate from host tools. Put exact HTTPS origins in `capabilities.netOrigins`. Once the session policy grants them, only those origins enter the widget's `connect-src`. Wildcards, credentials, paths, query strings, and undeclared origins remain blocked. A literal port is allowed only when it is part of the declared origin.
 
 The tool schema describes currently active plugin read bindings and action
 verbs, including action parameter schemas when provided. This discovery text is
@@ -235,14 +235,14 @@ input, replacing `owner/repo` in both places:
 The read runs in the pinned dashboard after approval, not the inline preview.
 No `netOrigins` declaration or token is needed. Repository names are
 case-insensitive and grants use lowercase spelling. A grant for one repository
-cannot read another; granting only `https://api.github.com` network access does
+cannot read another. Granting only `https://api.github.com` network access does
 not authorize this binding.
 
 Direct browser fetches to `api.github.com` do not inherit the agent's login and
 share GitHub's anonymous IP quota. Existing widgets using `fetch` should replace
 that call with the binding and replace their GitHub `netOrigins` declaration with
 the repository-scoped tool grant. Check the effective account in **Agent settings
-→ Tools → GitHub account**; administrators can also reach it from **Settings →
+→ Tools → GitHub account**. Administrators can also reach it from **Settings →
 Profile → GitHub connections**.
 
 For refreshable widgets, keep the last successful data and a separate error
@@ -255,14 +255,14 @@ including metadata from private repositories accessible to the selected agent
 identity.** The host selects the agent override, then the configured System
 identity, then native GitHub authentication. It never uses the Control UI
 preview credential or a human's publication-only **My GitHub** connection.
-A configured but unavailable identity fails closed with reconnect guidance;
-it does not retry anonymously or fall through to another account.
+A configured but unavailable identity fails closed with reconnect guidance.
+It does not retry anonymously or fall through to another account.
 
 Before saving an HTML or registered widget declaring this binding, the Gateway
 verifies the selected identity. An unavailable identity or retired caller fails
 without replacing an existing widget, creating a pending grant, or broadcasting
 a change. Reconnect the agent's GitHub identity in Settings and retry. Pinning
-does not query Actions or verify repository permission; those checks happen on
+does not query Actions or verify repository permission. Those checks happen on
 read. Ordinary widgets and MCP App tool names do not trigger this identity check.
 
 | Parameter             | Contract                                                                                                                                                                               |
@@ -285,7 +285,7 @@ at 30 entries. Successful reads are cached for about 30 seconds within the
 current Gateway, board identity, credential, repository, and filter scope.
 
 Rate limits, access denial, unavailable identity, and upstream failure return
-sanitized guidance. Redirects are refused; for a renamed repository, verify its
+sanitized guidance. Redirects are refused. For a renamed repository, verify its
 new name and update both the read and grant. Each caller revalidates its widget,
 Gateway, and identity before receiving data, including shared reads and cache
 hits. Removing one widget does not fail another authorized widget's shared read.

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -17,7 +17,7 @@ metadata) that becomes a live skill only when applied.
 Automatic background learning and weekly collection review instead maintain the
 Workshop directory with normal agent file tools. These direct edits do not create
 proposals or automatic rollback snapshots. Choose `propose` mode when each new
-capture needs review before publication.
+skill change needs review before publication.
 
 By default, Skill Workshop writes only under the active agent's
 `<state-dir>/agents/<agentId>/agent/workshop-skills`. When `agents.entries.<id>.agentDir` is
@@ -25,12 +25,12 @@ configured, it writes under `<agentDir>/workshop-skills` instead. Operators edit
 bundled, plugin, ClawHub, extra-root, managed, personal-agent, project, and
 workspace skills through their owning tools or files. The same authoring tool
 also supports [personal library skills](/tools/skills#personal-skills-on-a-shared-gateway)
-when the Gateway supplies an authorized library target; those operations publish
+when the Gateway supplies an authorized library target. Those operations publish
 managed revisions rather than Workshop proposals.
 
 Workshop storage is installation-managed and separate from the session
 workspace and managed skill library. `OPENCLAW_STATE_DIR` selects the state
-directory; `~/.openclaw` is the default.
+directory. `~/.openclaw` is the default.
 
 This page is an index. Skill Workshop is documented on eight pages, one per
 reader job. Open the page that matches your task.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -26,7 +26,7 @@ command handling is enabled for the surface.
   <Card title="Directives" icon="sliders">
     `/think`, `/fast`, `/verbose`, `/trace`, `/reasoning`, `/elevated`,
     `/exec`, `/model`, `/queue` — stripped from the message before the model
-    sees it. Most persist session settings when sent alone; `/exec` security
+    sees it. Most persist session settings when sent alone. `/exec` security
     and approval options apply only to their message.
   </Card>
   <Card title="Inline shortcuts" icon="bolt">
@@ -47,7 +47,7 @@ command handling is enabled for the surface.
       persist to the session and reply with an acknowledgement.
       `/exec security=... ask=...` is the exception: these options apply only
       to the current message and never change later turns. Include them with
-      the task; use [session permission modes](/gateway/permission-modes) for
+      the task. Use [session permission modes](/gateway/permission-modes) for
       session-wide policy. `/exec host=... node=...` still persists placement.
     - In **normal chat** messages with other text, they act as inline hints and
       do **not** persist session settings.
@@ -55,7 +55,7 @@ command handling is enabled for the surface.
       configured `/<alias>` persists the session selection. Owner/admin `-a`
       and `-g` scopes also request an update for the selected default.
     - Directives only apply for **authorized senders**. If `commands.allowFrom`
-      is set, it is the only allowlist used; otherwise authorization comes from
+      is set, it is the only allowlist used. Otherwise authorization comes from
       channel allowlists, pairing, and always-on access-group enforcement. Unauthorized
       senders see directives treated as plain text.
   </Accordion>
@@ -94,15 +94,15 @@ command handling is enabled for the surface.
 </ParamField>
 
 <ParamField path="commands.native" type='boolean | "auto"' default='"auto"'>
-  Registers native commands. Auto: on for Discord/Telegram; off for Slack;
-  ignored for providers without native support. Override per-channel with
+  Registers native commands. Auto: on for Discord/Telegram. Off for Slack.
+  Ignored for providers without native support. Override per-channel with
   `channels.<provider>.commands.native`. On Discord, `false` skips slash-command
-  registration; previously registered commands may stay visible until removed.
+  registration. Previously registered commands may stay visible until removed.
 </ParamField>
 
 <ParamField path="commands.nativeSkills" type='boolean | "auto"' default='"auto"'>
   Registers skill commands natively when supported. Auto: on for
-  Discord/Telegram; off for Slack. Override with
+  Discord/Telegram. Off for Slack. Override with
   `channels.<provider>.commands.nativeSkills`.
 </ParamField>
 
@@ -139,11 +139,11 @@ command handling is enabled for the surface.
 <ParamField path="commands.ownerAllowFrom" type="string[]">
   Explicit owner allowlist for owner-only command surfaces. Separate from
   `commands.allowFrom` and DM pairing access. CLI pairing approval records the
-  first owner; Control UI pairing has an explicit owner checkbox. Authorized
+  first owner. Control UI pairing has an explicit owner checkbox. Authorized
   non-owners receive a refusal with the exact configuration command for their
   sender ID when using an owner-only command such as `/restart` or `/update`.
   Use `channel:id` (for example, `discord:123456789012345678`). If an upgrade
-  leaves a legacy `channel:user:id` owner entry, run `openclaw doctor --fix`;
+  leaves a legacy `channel:user:id` owner entry, run `openclaw doctor --fix`.
   Doctor rewrites recognized channel entries and reports their list positions.
 </ParamField>
 
@@ -154,13 +154,13 @@ Channel plugins can enforce owner-only command access through their
 <ParamField path="commands.allowFrom" type="object">
   Per-provider allowlist for command authorization. When configured, it is the
   **only** authorization source for commands and directives. Use `"*"` for a
-  global default; provider-specific keys override it. Discord sender entries
+  global default. Provider-specific keys override it. Discord sender entries
   accept bare user IDs or `user:<id>` and `discord:<id>` aliases.
 </ParamField>
 
 When `commands.allowFrom` is not configured, command authorization follows
 the channel's allowlists and pairing state. Access-group entries referenced by
-channel allowlists are resolved automatically; there is no command-level
+channel allowlists are resolved automatically. There is no command-level
 access-group toggle.
 
 Session commands `/new` and `/reset` (including `/reset soft`) remain available
@@ -172,7 +172,7 @@ Reset access does not grant other command or owner-only authority. Internal
 Gateway callers with explicit scopes still need `operator.admin` to reset.
 When both the request and reply stay in WebChat, rejected `/new` and `/reset`
 commands show a permission denial. A denied command does not perform the
-requested reset or run its follow-up text; normal idle/daily rollover still
+requested reset or run its follow-up text. Normal idle/daily rollover still
 applies. Ask your Gateway administrator to reset the session, or send your
 message without the command.
 
@@ -217,7 +217,7 @@ plugins, and installed skills.
     HTML conversation cards omit messages marked hidden. The sidebar's **All**
     filter includes these records with a **[hidden]** label for debugging.
     Message counts describe the raw archive. The HTML file and its JSONL download
-    still contain hidden records; hiding a message does not redact the export.
+    still contain hidden records. Hiding a message does not redact the export.
 
     <Note>
       Control UI intercepts typed `/new` to create and switch to a fresh
@@ -240,7 +240,7 @@ plugins, and installed skills.
     | `/reasoning [on\|off\|stream]` | Toggle reasoning visibility. Alias: `/reason` |
     | `/elevated [on\|off\|ask\|full]` | Toggle elevated mode. Alias: `/elev` |
     | `/exec host=<auto\|sandbox\|gateway\|node> security=<deny\|allowlist\|full> ask=<off\|on-miss\|always> node=<id>` | Show resolved exec defaults; persist host/node placement, apply security/ask to this message only. See [Session permission modes](/gateway/permission-modes) |
-    | `/login [codex\|openai]` | Pair a Codex or OpenAI login from a private chat or Web UI session. Owner/admin only |
+    | `/login [codex\|openai]` | Pair a Codex or OpenAI login from a private chat or Control UI session. Owner/admin only |
     | `/model [name\|default\|list\|status] [-s\|--session\|-a\|--agent\|-g\|--global]` | Show or select a model. `-s` changes only this session; owner/admin `-a` and `-g` also update configured defaults |
     | `/models [provider] [page] [limit=<n>\|all]` | List configured/auth-available providers or models |
     | `/queue <mode>` | Manage active-run queue behavior. See [Queue](/concepts/queue) and [Queue steering](/concepts/queue-steering) |
@@ -249,16 +249,16 @@ plugins, and installed skills.
     <AccordionGroup>
       <Accordion title="verbose / trace / fast / reasoning safety">
         - `/verbose` is for debugging — keep it **off** in normal use.
-        - `/trace` reveals only plugin-owned trace/debug lines; normal verbose chatter stays off.
-        - `/fast auto|on|off` persists a session override; use the Sessions UI `inherit` option to clear it.
-        - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`; direct Anthropic requests map it to `service_tier=auto` or `standard_only`.
+        - `/trace` reveals only plugin-owned trace/debug lines. Normal verbose chatter stays off.
+        - `/fast auto|on|off` persists a session override. Use the Sessions UI `inherit` option to clear it.
+        - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`. Direct Anthropic requests map it to `service_tier=auto` or `standard_only`.
         - `/reasoning`, `/verbose`, and `/trace` are risky in group settings — they may reveal internal reasoning or plugin diagnostics. Keep them off in group chats.
 
       </Accordion>
       <Accordion title="Model switching details">
         - Prefer choosing the model when creating a session. Changing it in an established session is an advanced operation because model context limits, prompt/tool behavior, and prompt-cache behavior can differ. See [Choose a model for a session](/concepts/models#choose-a-model-for-a-session).
 
-        **Scope in one line:** `-s` changes only this session, `-a` also updates the agent default, and `-g` also updates the shared global default. Without a flag, `agents.defaults.modelSelectionScope` applies when set; omission changes only this session.
+        **Scope in one line:** `-s` changes only this session, `-a` also updates the agent default, and `-g` also updates the shared global default. Without a flag, `agents.defaults.modelSelectionScope` applies when set. Omission changes only this session.
 
         Configured `/<alias>` shorthands accept the same trailing scope and `--runtime` options as `/model <alias>`.
 
@@ -299,7 +299,7 @@ plugins, and installed skills.
 
 `/dashboard` is reserved as a built-in command. If an existing user skill is
 named `dashboard`, skill discovery exposes its generated slash alias as
-`/dashboard_2`; `$dashboard` and `/skill dashboard` continue to select that
+`/dashboard_2`. `$dashboard` and `/skill dashboard` continue to select that
 user skill directly.
 
   <Accordion title="Skills, allowlists, approvals">
@@ -356,7 +356,7 @@ user skill directly.
 | [`/voice`](/nodes/talk#choose-a-talk-voice-from-chat) `status\|list\|set <voiceId>` | Manage Talk voice config. Discord native name: `/talkvoice`                                                                                                                                    |
 | `/codex <action> ...`                                                               | Bind, steer, and inspect the Codex app-server harness (status, threads, resume, model, fast, permissions, compact, review, mcp, skills, and more). See [Codex harness](/plugins/codex-harness) |
 
-LINE-only: `/card ...` (rich card presets; see [LINE](/channels/line))
+LINE-only: `/card ...` (rich card presets, see [LINE](/channels/line))
 
 QQBot-only: `/bot-ping`, `/bot-version`, `/bot-help`, `/bot-upgrade`, `/bot-logs`
 
@@ -368,7 +368,7 @@ User-invocable skills are exposed as slash commands:
 - Skills may register as direct commands using their declared skill name.
 - Native skill-command registration is controlled by `commands.nativeSkills` and
   `channels.<provider>.commands.nativeSkills`.
-- Names are sanitized to `a-z0-9_` (max 32 chars); collisions get numeric suffixes.
+- Names are sanitized to `a-z0-9_` (max 32 chars). Collisions get numeric suffixes.
 
 <AccordionGroup>
   <Accordion title="Skill command dispatch">
@@ -402,11 +402,11 @@ use the Control UI Tools panel or config surfaces.
 
 ## `/loop`: recurring conversation work
 
-`/loop` is owner-only because it uses the cron control-plane tool. `/loop 5m check deploy status` asks the agent to create a fixed-cadence cron job in the current conversation. Without an interval, `/loop watch for new issues` creates a self-paced loop that checks more often while active and backs off toward 1 hour while quiet. `/loop status` lists the conversation's loop jobs; `/loop stop [name]` removes them.
+`/loop` is owner-only because it uses the cron control-plane tool. `/loop 5m check deploy status` asks the agent to create a fixed-cadence cron job in the current conversation. Without an interval, `/loop watch for new issues` creates a self-paced loop that checks more often while active and backs off toward 1 hour while quiet. `/loop status` lists the conversation's loop jobs. `/loop stop [name]` removes them.
 
 ## `/model`: model selection
 
-Use `-s` to change only the current session, `-a` to also update the agent default, or `-g` to also update the shared global default. The long forms are `--session`, `--agent`, and `--global`; an explicit scope overrides `agents.defaults.modelSelectionScope`.
+Use `-s` to change only the current session, `-a` to also update the agent default, or `-g` to also update the shared global default. The long forms are `--session`, `--agent`, and `--global`. An explicit scope overrides `agents.defaults.modelSelectionScope`.
 
 Without a flag or that optional setting, `/model <model>` changes only the current session, including for owners/admins. Set `agents.defaults.modelSelectionScope` to `"agent"` or `"global"` only when you want unqualified selections to update that default. The setting does not grant permission to write configured defaults. See [Model selection scope](/gateway/config-agents/models#agentsdefaultsmodelselectionscope).
 
@@ -430,7 +430,7 @@ Numeric selections such as `/model 3` are not supported.
 On Discord, the bare native `/model` and `/models` commands open an interactive
 picker. Choose a provider and model from the dropdowns, then select **Submit**.
 Discord follows the direct command behavior, including `modelSelectionScope`.
-Telegram model browsing uses callback buttons; selections always remain session-only.
+Telegram model browsing uses callback buttons. Selections always remain session-only.
 The picker respects `agents.defaults.modelPolicy.allow`,
 including `provider/*` entries. Without an explicit allowlist, model entries and
 aliases do not restrict selection.
@@ -522,9 +522,9 @@ Gateways automatically because plugin source modules changed. Trusted ClawHub
 and official-catalog installs do not need a provenance acknowledgement. Arbitrary npm,
 git, archive, `npm-pack:`, and local path sources show a provenance warning and
 require a trailing `--force` after you review the source. This flag acknowledges
-the source and permits replacement of an existing install; it does not bypass
+the source and permits replacement of an existing install. It does not bypass
 `security.installPolicy` or installer security checks. ClawHub Review outcomes
-are printed informationally; blocked releases remain non-installable.
+are printed informationally. Blocked releases remain non-installable.
 Marketplace, linked, and pinned installs remain shell-only.
 
 `/plugins inspect <child>` (also `show` or `get`) and `/plugins inspect all` include the shared package install metadata for multi-entry plugins. Inspection returns `install: null` when package ownership is missing or ambiguous, and preserves its runtime capability report. It releases its inspection registration resources before returning a reply, while the running Gateway's active registrations remain available. Cleanup failures propagate as command failures.
@@ -583,7 +583,7 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - **Native Discord commands:** `agent:<agentId>:discord:slash:<userId>`
     - **Native Slack commands:** `agent:<agentId>:slack:slash:<userId>` (prefix configurable via `channels.slack.slashCommand.sessionPrefix`)
     - **Native Telegram commands:** `telegram:slash:<userId>` (targets the chat session via `CommandTargetSessionKey`)
-    - **`/login codex`** sends device pairing codes only through private chat or Web UI response paths. Telegram group/topic invocations ask the owner to DM the bot instead.
+    - **`/login codex`** sends device pairing codes only through private chat or Control UI response paths. Telegram group/topic invocations ask the owner to DM the bot instead.
     - **`/stop`** targets the active chat session to abort the current run.
 
   </Accordion>
@@ -599,12 +599,12 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - In Control UI, every non-skill slash command can be selected in the middle of a draft. The command runs separately, only the command invocation is removed, and the surrounding draft remains unsent.
     - In Control UI (WebChat), selecting a skill from slash completion inserts the existing `$skill-name` reference into the message (for example, `Please use $weather to check Sydney`).
     - Inline command dispatch follows the same connection, permission, and confirmation checks as sending that command by itself. Typing slash-like prose without selecting or submitting the completion does not execute it.
-    - On external channels, unauthorized text command-only messages are silently ignored; inline `/...` tokens are treated as plain text. Native `/compact` returns an authorization refusal when a channel-admitted sender cannot use the command. Reset denials show a permission reply only when the request and reply stay in WebChat.
+    - On external channels, unauthorized text command-only messages are silently ignored. Inline `/...` tokens are treated as plain text. Native `/compact` returns an authorization refusal when a channel-admitted sender cannot use the command. Reset denials show a permission reply only when the request and reply stay in WebChat.
 
   </Accordion>
   <Accordion title="Argument notes">
     - Commands accept an optional `:` between the command and args (`/think: high`, `/send: on`).
-    - `/new <model>` accepts a model alias, `provider/model`, or a provider name (fuzzy match); if no match, the text is treated as the message body.
+    - `/new <model>` accepts a model alias, `provider/model`, or a provider name (fuzzy match). If no match, the text is treated as the message body.
     - `/allowlist add|remove` requires `commands.config: true` and honors channel `configWrites`.
 
   </Accordion>

--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -23,8 +23,8 @@ bounded concurrency, and progress reporting to that program.
 Use ordinary `sessions_spawn` announcing runs for one or a few children. Reserve
 Swarm for large parallel fan-out: several similar children (about five or more),
 typically driven by Code Mode `agents.run` with control flow such as `Promise.all`.
-Collectors (`collect: true`) send no completion notification and cannot be steered;
-their results must be explicitly collected. Use `outputSchema` for structured
+Collector children (`collect: true`) send no completion notification and cannot be steered.
+Their results must be explicitly collected. Use `outputSchema` for structured
 results and `groupId` to group a batch.
 
 ## Enable Swarm
@@ -32,7 +32,7 @@ results and `groupId` to group a batch.
 Swarm needs no enablement setting. Omitted `tools.swarm`, an empty object, or
 an object that sets only limits all leave Swarm enabled. Code Mode remains
 separately opt-in, and normal tool policy still applies. Existing Codex sessions
-can retain an older tool catalog; see the
+can retain an older tool catalog. See the
 [fresh-session guidance](/tools/swarm#use-swarm-from-other-harnesses) below.
 
 To opt out, turn off **Settings → Agents & Tools → Labs → Swarm** in the
@@ -52,7 +52,7 @@ shorthand in `openclaw.json`:
 limits. To re-enable Swarm, remove the explicit opt-out, set `swarm: true` or
 `swarm: { enabled: true }`, or turn the Labs switch back on.
 
-To tune the limits, use object form. These are the defaults; you only need to
+To tune the limits, use object form. These are the defaults. You only need to
 include values you want to change:
 
 ```json5
@@ -86,7 +86,7 @@ Numeric values must be positive integers. OpenClaw bounds
 You can override Swarm for one configured agent with
 `agents.entries.*.tools.swarm`. Per-agent values merge over the top-level
 setting. An agent's `false` or `{ enabled: false }` disables Swarm for that
-agent; `true` or `{ enabled: true }` enables it even if globally disabled.
+agent. `true` or `{ enabled: true }` enables it even if globally disabled.
 A limits-only per-agent object inherits global enablement, so it does not
 re-enable a global `false`.
 
@@ -111,7 +111,7 @@ sandbox policy can remove the native tool. If the Swarm API is absent, check
 [Code Mode activation](/tools/code-mode/configuration#activation) and
 [Sub-agents](/tools/subagents).
 
-Code Mode waits for collector results internally; its `agents.run()` API does
+Code Mode waits for collector results internally. Its `agents.run()` API does
 not require the standalone `agents_wait` tool to be allowed. The
 [low-level tool flow](/tools/swarm#use-swarm-from-other-harnesses) needs both
 `sessions_spawn` and `agents_wait` allowed. Enabling Swarm never grants tools
@@ -148,7 +148,7 @@ JSON Schema, it resolves to the value submitted through the child's
 `structured_output` tool. A failed, killed, timed-out, or schema-invalid child
 rejects the promise with an error whose `name` is `"SwarmAgentError"` and whose
 `runId`, `status`, and `message` identify the failed child and outcome. There is
-no global `SwarmAgentError` constructor; inspect the caught error's fields.
+no global `SwarmAgentError` constructor. Inspect the caught error's fields.
 Spawn or bridge failures can reject with other errors. Read the exact generated
 declarations and short orchestration idioms from `API.read("agents.d.ts")`
 inside Code Mode.
@@ -156,8 +156,8 @@ inside Code Mode.
 Use `label` for a recognizable child name in the dashboard and sidebar. Use
 `phase` in the options to publish a phase immediately before that child
 starts, or call `phase()` when several children belong to the same stage.
-`log()` publishes a short progress note. Progress calls are fire-and-forget;
-they do not delay the script if the UI is unavailable.
+`log()` publishes a short progress note. Progress calls are fire-and-forget.
+They do not delay the script if the UI is unavailable.
 
 ### Fan out in parallel with structured results
 
@@ -219,7 +219,7 @@ try {
 
 `Promise.allSettled` preserves partial results while waiting for every child.
 `Promise.all` rejects on the first failure and does not collect the remaining
-outcomes for you. Keep completed work and report failed lanes; do not respawn
+outcomes for you. Keep completed work and report failed lanes. Do not respawn
 the batch automatically. A later provider failure can still prevent a final
 model reply, so retain the collected results for recovery.
 
@@ -230,13 +230,13 @@ Code Mode separately bounds concurrent guest bridge calls with
 `tools.codeMode.maxPendingToolCalls` (default `16`, maximum `128`). Swarm
 launches, progress notes, and result waits queue automatically when those slots
 are full. Queued requests retain their original arguments across snapshot
-resumes; stopping the run discards requests that have not been admitted.
+resumes. Stopping the run discards requests that have not been admitted.
 `maxConcurrent` still limits running children, and group child limits still
 apply. Ordinary tool calls and timers share this guest queue but have their own
 128-request waiting quota, separate from the in-flight bridge cap. Swarm launches,
 notes, and result waits do not consume that quota and retain their existing group,
 VM memory, and snapshot limits. Exceeding the ordinary quota fails the synchronous
-frontier before any new calls from it are dispatched; await smaller ordinary
+frontier before any new calls from it are dispatched. Await smaller ordinary
 batches instead. See [Code Mode](/tools/code-mode/internals#nested-tool-execution)
 for queue, cancellation, and resource-limit semantics.
 
@@ -299,7 +299,7 @@ completion path. They write a durable collector result for the parent to
 await instead of announcing or steering a reply back into the parent session.
 The accepted spawn receipt describes this path: collect the result with
 `agents_wait`, or await `agents.run()` in OpenClaw Code Mode. Do not use
-`sessions_yield` to wait for collectors; they do not send completion notifications.
+`sessions_yield` to wait for collector children. They do not send completion notifications.
 
 The target agent resolves in this order:
 
@@ -307,9 +307,9 @@ The target agent resolves in this order:
 2. `tools.swarm.defaultAgentId`.
 3. The requesting agent.
 
-A dedicated, lean worker agent is useful when swarm children need a smaller
+A dedicated, lean worker agent is useful when collector children need a smaller
 tool surface, cheaper model, or tighter sandbox policy. OpenClaw does not ship
-a built-in `worker` agent id; configure one before naming it as the default.
+a built-in `worker` agent id. Configure one before naming it as the default.
 Harden that worker with `tools.swarm: false` in its per-agent configuration so
 it can be spawned but cannot start swarms from its own top-level sessions:
 
@@ -341,7 +341,7 @@ result exposes those fields for explicit recovery logic.
 
 ### Keep collector groups flat
 
-Swarm children can delegate recursively, but the usual orchestration idiom is
+Collector children can delegate recursively, but the usual orchestration idiom is
 to return work to the parent instead of expanding the collector tree:
 
 ```javascript
@@ -356,7 +356,7 @@ const plan = await agents.run("Plan this job as independent tasks.", {
 return await Promise.all(plan.tasks.map((task) => agents.run(task)));
 ```
 
-Nested collectors are discouraged for Swarm. Group caps, budgets, and
+Nested collector children are discouraged for Swarm. Group caps, budgets, and
 observability all assume flat collector groups. Set
 `agents.defaults.subagents.maxSpawnDepth: 1` when a workflow must enforce that
 shape.
@@ -364,7 +364,7 @@ shape.
 Every child has one admission owner. Announce and interactive children use
 `agents.defaults.subagents.maxChildrenPerAgent` (default `5`) and do not count
 collector children. Collector children use only `maxChildrenPerGroup` and
-`maxTotalPerGroup`; they do not consume the per-session child budget. The spawn
+`maxTotalPerGroup`. They do not consume the per-session child budget. The spawn
 depth guard still applies to both modes.
 
 After admission, children above `maxConcurrent` queue FIFO within their swarm
@@ -383,28 +383,28 @@ visible status markers. Click or tap **Child details**, or activate it with the
 keyboard, to expand available child names, status icons, and run durations. The
 view shows up to four active groups plus the latest completed group, with an
 explicit count when more groups are active. Each card displays at most 64 markers
-and 64 child details; its counts include every accepted group member.
+and 64 child details. Its counts include every accepted group member.
 
 The latest completed group's counts remain visible after the children finish,
 including when the parent fails before writing its final response. Groups whose
-children all succeed use a compact completion row; activate the row to expand
+children all succeed use a compact completion row. Activate the row to expand
 child details and the final-response reminder. Running, queued, and failed groups
 keep their visible status markers and counts. These are
 child outcomes, not confirmation that the parent produced a synthesis. Counts
 come from retained collector records, so reloading the page or cleaning up a
 child session does not reduce the reported total. They expire with the existing
-collector retention policy; this is not a permanent execution archive.
+collector retention policy. This is not a permanent execution archive.
 
 Native Android, iOS, and macOS chat surfaces still show active-only phase-grouped
 grids, capped at 256 markers per phase with an overflow count. Accessible labels
 identify each child's status. All clients present killed and timed-out children
 as failed. Native groups leave the widget when none of their children are queued
-or running; the native widget disappears when no active groups remain.
+or running. The native widget disappears when no active groups remain.
 
 The session sidebar keeps the normal parent/child tree. Expand the parent row to
 inspect a collector child or open its transcript without losing the swarm hierarchy.
 
-Delete-mode collectors can clean up their child sessions immediately after
+Delete-mode collector children can clean up their child sessions immediately after
 completion while retaining their waitable results. Those collector records remain
 available until the group is archived after every member reaches its retention
 deadline. Retained child sessions are archived as a batch at that point.
@@ -415,7 +415,7 @@ Use **Stop** in the parent chat to cancel a running swarm. A Stop targeting a
 specific parent run also cancels its associated collector children and their
 nested descendants. Collector mode changes result delivery, not cancellation
 scope. Successful cancellation prevents selected queued children from starting
-as running siblings stop; it does not cancel work from unrelated parent turns.
+as running siblings stop. It does not cancel work from unrelated parent turns.
 
 If Stop reports incomplete descendant cancellation, inspect the remaining work
 on the [Tasks page](/automation/tasks#control-ui) and retry cancellation for
@@ -432,7 +432,7 @@ session-wide Stop scopes.
 You can use Swarm without OpenClaw Code Mode. Its core tools are
 harness-independent: start collector children with
 `sessions_spawn({ collect: true })` and drain them with bounded `agents_wait`
-calls. Both tools must be allowed by the effective tool policy; default-on
+calls. Both tools must be allowed by the effective tool policy. Default-on
 Swarm does not add them to a restrictive tool profile or allowlist.
 
 Codex Code Mode automatically exposes eligible dynamic OpenClaw tools under
@@ -453,8 +453,8 @@ The new session still needs a tool policy that permits both collector tools.
 With the currently supported Codex runtime, dynamic OpenClaw tool results reach
 Code Mode as JSON text. Parse each result before reading fields. Codex also
 serializes dynamic tool calls, so `Promise.all` does not submit several
-`sessions_spawn` calls concurrently. Launch collectors in a bounded loop;
-already-accepted children can still run while later launches are submitted.
+`sessions_spawn` calls concurrently. Launch collector children in a bounded loop.
+Already-accepted children can still run while later launches are submitted.
 
 ```javascript
 function parseToolResult(value) {
@@ -522,7 +522,7 @@ return { completed, failures };
 
 Drain the pending set before synthesizing the successful results and reporting
 failures. A rejected launch or failed child must not discard results from other
-accepted children. Keep the returned run IDs for recovery; do not repeat
+accepted children. Keep the returned run IDs for recovery. Do not repeat
 successful launches or automatically rerun failed work.
 
 Each `agents_wait` call accepts 1–1000 run ids. It returns:
@@ -566,14 +566,14 @@ or its authorized parent chain can wait on a collector.
 
 This is bounded long polling, not a busy status loop. Keep passing only the
 remaining run ids until `pending` is empty. Collector mode supports native
-OpenClaw sub-agents; it does not support ACP runtime, thread binding, visible
+OpenClaw sub-agents. It does not support ACP runtime, thread binding, visible
 sessions, or persistent session mode.
 
 <a id="limits-and-roadmap" />
 
 ## Limits
 
-Swarm runs one-shot collector children; there is no stateful multi-turn worker
+Swarm runs one-shot collector children. There is no stateful multi-turn worker
 API. Children run on the local Gateway's sub-agent lane, and spawns have no
 cloud-placement option. Saved workflow definitions and a graph DSL are not part
 of Swarm's current direction.

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -9,12 +9,12 @@ read_when:
 ---
 
 OpenClaw converts outbound replies into native voice messages on Feishu, Matrix,
-Telegram, and WhatsApp; audio attachments everywhere else; and PCM/Ulaw streams
-for telephony and Talk.
+Telegram, and WhatsApp. Every other channel receives an audio attachment.
+Telephony and Talk receive PCM or Ulaw streams.
 
 TTS is the speech-output half of [Talk](/nodes/talk)'s `stt-tts` mode (`talk.speak` calls this
 same synthesis path). Provider-native `realtime` Talk sessions synthesize
-speech inside the realtime provider instead; `transcription` sessions never
+speech inside the realtime provider instead. `transcription` sessions never
 synthesize an assistant voice reply.
 
 This page is an index. Text-to-speech is documented on seven pages, one per
@@ -63,7 +63,7 @@ resolves. Each entry points at the page that now holds the content.
 The previous single-page version also minted an anchor for every step, tab,
 accordion, and field. Those anchors are preserved here so that any deep link
 into the old page still resolves. Nine accordion anchors lost a `-1` suffix
-when the tab that shared their slug moved to a different page; the stub below
+when the tab that shared their slug moved to a different page. The stub below
 keeps the old id and points at the new one.
 
 **Quickstart**


### PR DESCRIPTION
## Simplified Technical English: `docs/tools/`, `docs/plugins/`, `docs/channels/`

Third STE batch. Works the 38 open `ste` findings whose `file` is under those three directories (37 distinct pages).

### Density, measured both ways on one identical 37-file list

`ste-lint.py` scores per file, so raw totals move for reasons unrelated to the edits. Both numbers use the same file list, before and after.

| Cap | Per-file before → after | Concatenated before → after |
| --- | --- | --- |
| `--max-words 20` (instruction) | **1.251 → 0.309** hard/100w (805 → 199) | **1.111 → 0.197** (735 → 130) |
| `--max-words 25` (descriptive, linter default) | **1.091 → 0.205** hard/100w (702 → 132) | **0.954 → 0.094** (631 → 62) |

Word count is stable across the change (64,362 → 64,346). The per-file/concatenated gap is synonym-rotation collapsing, as in batch two.

Rule mix, per file at the 20-word cap:

| Rule | Before | After |
| --- | --- | --- |
| `semicolon` | 530 | **0** |
| `long-sentence` | 187 | 112 |
| `synonym-rotation` | 88 | 87 |

Every one of the 37 files is now under the audit's 1.5/100w threshold at both caps. Worst remaining at the 25-word cap: `custodian-skills.md` 0.56, `show-widget.md` 0.53, `browser.md` 0.49. Worst at the 20-word cap: `show-widget.md` 0.92, `exec.md` 0.89.

### The "rate rows don't batch" premise did not hold

66% of hard violations were semicolons (530 of 805), and they took one fix. A guarded rewriter mirrored `ste-lint.py`'s own skip rules (fences, frontmatter, table rows, MDX imports) and additionally refused to touch a semicolon inside inline code, a link target, an HTML/JSX tag, a bare URL, or an HTML entity. 526 were split; 4 were deferred to hand review. The whole diff was then read line by line, which caught four classes of problem the rewriter got wrong:

- **`tts.md` — a serial-semicolon list, not two clauses.** "…Feishu, Matrix, Telegram, and WhatsApp; audio attachments everywhere else; and PCM/Ulaw streams for telephony and Talk." An automatic split produced a sentence fragment. Rewritten by hand into three sentences.
- **Four parenthetical semicolons** (`(break-glass; keep off unless needed)`, `` (`off|auto|on`; default `off`) ``, `` (default; `--format ai`) ``, `(rich card presets; see [LINE](…))`). A period inside a parenthetical reads badly; these became commas.
- **Brand casing at a new sentence start.** `xAI` and `npm` are lowercase product names. Auto-capitalisation produced "XAI" and "Npm"; `xAI` was restored (the same passage already starts a sentence with `fal`) and the npm sentence was recast as "Choices from npm require…".
- **Three list items ending `; and` / `; or`.** The bulleted lists already carry the conjunction in their lead-in ("all of these conditions hold", "The reviewer should abstain for"), so the trailing conjunctions were dropped rather than turned into sentences.

Nothing in the sweep altered a string the software emits: every flagged semicolon was outside inline code and outside fenced blocks by construction, and line counts are byte-for-byte preserved across all 34 files.

### Anchors

One heading renamed: `docs/plugins/workboard.md` `## Dashboard workflow` → `## Control UI workflow`, with `<a id="dashboard-workflow" />` preserving the old id. Enumerated with `parseDocsDocument` across all 34 changed pages, before at the merge-base and after:

```
docs/plugins/workboard.md
  dropped: []
  added:   ["control-ui-workflow"]
```

**Zero anchors dropped repo-wide.** Every `<a id>` stub left by an earlier split was treated as untouchable, and several findings were refuted rather than "fixed" because their only surviving evidence was inside one.

### Findings: 25 closed, 8 refuted, 5 partial — 38 rows

**Closed (25)**
`r3-1054` `r3-1076` `r3-1087` `r3-1090` `r3-1094` `r3-1968` `r3-1972` `r3-1974` `r3-1977` `r3-2048` `r3-2339` `r3-2344` `r3-2374` `r3-2378` `r3-2401` `r3-2408` `r3-2414` `r3-2424` `r3-2427` `r3-2438` `r3-2445` `r3-2456` `r3-2480` `r3-2500` `r5-0052`

**Refuted (8)**
`r3-1030` `r3-1899` `r3-1923` `r3-1950` `r3-1960` `r3-2353` `r3-2362` `r3-2382`

**Partial (5)**
`r3-1082` `r3-1912` `r3-1963` `r3-2509` `r5-0193`

25 + 8 + 5 = 38. Every row appears in exactly one bucket.

<details><summary>Per-id detail, closed (25)</summary>

| Id | Page | What changed |
| --- | --- | --- |
| `r3-1054` | `channels/imessage.md` | Rate 1.6 → **0.65**/100w at the 20-word cap, 0.22 at 25. The "procedure sections" the row names moved into 8 child pages when the page was split; the parent is a 923-word index. |
| `r3-1076` | `channels/buzz.md` | One prose name for the credential: `authTag` now defined once ("the delegated authorization value a hosted workspace operator issues for one identity") and used at L479, L553, L617 and the troubleshooting table, replacing "authorization value" / "identity authorization value". "Owner attestation" was **kept** — it is the artifact the credential produces, not another name for it. |
| `r3-1087` | `channels/zalo.md` | Rate 2.3 → **0.25**. Semicolons split; the two passive bullets the row names in *How it works* rewritten with a named actor ("OpenClaw returns HTTP 200 only after it durably stores the raw event"). |
| `r3-1090` | `channels/reef.md` | Rate 2.1 → **0.22** (25-word cap), 0.44 at the 20-word cap. 12 sentences split, concentrated in *Guards and owner review* and *Troubleshooting* as the row asks. |
| `r3-1094` | `channels/googlechat.md` | Rate 1.8 → **0.39** (25-word cap). *Config highlights* bullets now carry one fact per sentence. |
| `r3-1968` | `plugins/sdk-setup.md` | "entrypoint" → "entry point"; the undefined "hot-path safe on import" replaced with what the next sentence already explains ("do no eager work when a plugin imports them"). |
| `r3-1972` | `plugins/sdk-entrypoints.md` | Five Related labels realigned to their targets' real `title:` frontmatter (SDK Overview → Plugin SDK overview, and four more). Prose already used "entry point" consistently. |
| `r3-1974` | `plugins/workboard.md` | The 24-name recent-events enumeration and the card-metadata list moved out of one prose sentence into a two-row table matching the page's own `Card fields` idiom. The four workspace-authority rules (L211) became a bulleted list. |
| `r3-1977` | `plugins/workboard.md` | 13 sites disambiguated: "Control UI" for the app, "Workboard tab" for the open view, "session dashboards" kept for the widget host. `openclaw dashboard` (CLI) and the `dashboard` tool name left verbatim. |
| `r3-2048` | `plugins/webhooks.md` | Rate under threshold; "later checks" → "later stages" and "confirms" → "acknowledges" so "validate/validation" is the only validation verb. |
| `r3-2339` | `tools/code-mode.md` | Nine sites: `code mode` and `code-mode` → **Code Mode**. "Codex Code Mode" preserved as the distinct product; `<a id>` stub labels untouched. |
| `r3-2344` | `tools/acp-agents.md` | Sole `ACPX` → `acpx`. The over-25-word sentences the row names are already gone: 0 hard violations on the page. |
| `r3-2374` | `tools/slash-commands.md` | "Web UI" → "Control UI" (L243, L586). "WebChat" kept where it names the channel, and L600 already defines the relationship as "Control UI (WebChat)". |
| `r3-2378` | `tools/skill-workshop.md` | "capture" → "skill change". "cleanup" and "curation" already occur **0** times; "proposal" and "collection review" were already the single terms. |
| `r3-2401` | `tools/image-generation.md` | One name for the route: "OpenAI ChatGPT/Codex OAuth" at L33, L82 and L83. "`openai` OAuth profile" kept — it names the configured profile, not the route. |
| `r3-2408` | `tools/browser-control.md` | Rate 1.7 → **0.17**. Semicolons replaced; three remaining over-cap sentences split. |
| `r3-2414` | `tools/exec.md` | Rate 2.1 → **0.44** (25-word cap), 0.89 at the 20-word cap. 37 semicolons plus two sentence splits. |
| `r3-2424` | `tools/show-widget.md` | Rate 2.1 → **0.53** (25-word cap), 0.92 at the 20-word cap. 33 semicolons plus seven splits in the reference sections. |
| `r3-2427` | `tools/chrome-extension.md` | Four names reduced to two real ones — see Judgment calls. |
| `r3-2438` | `tools/self-learning.md` | "Curator retains… Curator does not…" → "That CLI retains… It does not…", so `openclaw skills curator status` is named once as the CLI surface and "collection review" names the process. "collection cleanup" already occurred 0 times. |
| `r3-2445` | `tools/swarm.md` | Seven sites: "collectors" and "Swarm children" → "collector children", including the defining first use at L26. |
| `r3-2456` | `tools/goal.md` | Rate 1.53 → **0.28**. The three passive sentences the row names by line rewritten with actors ("OpenClaw treats any text…", "Only the model-facing `create_goal` tool can set a budget", "Goal state attaches to the session key"). |
| `r3-2480` | `tools/secrets.md` | "question" → "request" where it meant the credential-request object (L37, L83). "prompt" already meant only the UI card. |
| `r3-2500` | `tools/custodian-skills.md` | Rate 1.50 → **0.56** (both caps). The row's L23 and L29 were semicolon splits; L22 (*Mutate*, 33 words) now leads with the constraint, and the three-imperative sentence at L68 became three sentences. |
| `r5-0052` | `tools/diffs.md` | 18 → **4** hard (20-word cap); rate 0.26. Every semicolon replaced; five prose sentences split. The two language-name enumerations (L159, L163) left — see Judgment calls. |

</details>

<details><summary>Per-id detail, partial (5)</summary>

| Id | Done | Not done, and why |
| --- | --- | --- |
| `r3-1082` | The one prose spelling variant fixed: "dead letter" → "dead-letter" (L100). | The `Gateway`/`gateway` half is refuted (see table below). "Inbound dead letters" at L136 is a **link label that must keep matching its target heading** `## Inbound dead letters` in `docs/cli/channels.md:83`. `dead-letters` at L431/436 is the verbatim CLI subcommand. |
| `r3-1912` | "retained facade" → "retained barrel", so one wide re-export module has one name. | The row asks for "compatibility subpath". The page uses **subpath** for the new focused imports and **barrel** for the old wide ones; collapsing them would destroy a real distinction. "compatibility adapter" (L48) is the deprecation mechanism, not a surface. "Removed compatibility surfaces" (L111) is an `<a id>` stub label. |
| `r3-1963` | "continuation" now names one thing: the pagination sense at L146 became "paging inside a turn". Mixed part of speech in the L97 verb list fixed ("adoption" → "adopt"). | The row's premise is refuted (see table below). |
| `r3-2509` | Rate 1.8 → **0.19**. The remaining long sentence split into five, which also removed its passive. | The "one term for the actor" half is refuted: "agent" and "bot" are different actors. |
| `r5-0193` | The naming half, fixed on the editable side: `tools/diffs.md` L101/163/169 now say "Diffs Language Pack plugin", matching the generated page's title. | The length half asks to restructure a 26-name enumeration inside a **generated** page. See Judgment calls. |

</details>

### Why the refutations

All eight are the same cause batch two found: **the page named was split into a child directory after the audit ran**, so the cited terms occur zero times on it.

| Id | Page | Evidence |
| --- | --- | --- |
| `r3-1030` | `channels/slack.md` | Split (11 children). "MPIM" and "multi-person direct message": **0 occurrences**. "Group DMs (MPDMs)" survives only inside two preserved `<a id>` stubs (L54, L81) — renaming breaks published anchors. "HTTP mode": 0; the page says "HTTP Request URLs" throughout. |
| `r3-1899` | `plugins/codex-harness.md` | Split (9 children); row cites line 1078, file is 313 lines. `app-server` ×33, `appServer` ×1 — and that one is the verbatim config key `appServer.*` in a link description. No rotation. |
| `r3-1923` | `plugins/sdk-provider-plugins.md` | Split (5 children). Grep for "the host / the core / OpenClaw core / the Gateway": **0 matches**. Linter reports 0 hard violations on the file. |
| `r3-1950` | `plugins/sdk-agent-harness.md` | Split (8 children). "embedded runtime", "built-in executor/harness/runtime", "native harness", "in-process": **0 matches**. |
| `r3-1960` | `plugins/voice-call.md` | Split (5 children). "classic": 0. "non-realtime": 0. Only "carrier webhooks" (L91) survives — one name, not three. |
| `r3-2353` | `tools/browser.md` | Split (9 children). The parent already does what the fix asks: "existing-session attach" (L27) with "Chrome DevTools MCP" as the mechanism (L15). The other names live only in `<a id>` stubs (L81–83). |
| `r3-2362` | `tools/tts.md` | Split (7 children). "voice note": **0**. "PTT"/"push-to-talk": **0**. The suggested keeper term appears nowhere on the page; adopting it would coin vocabulary. |
| `r3-2382` | `tools/exec-approvals.md` | Not split — **already satisfied on `main`**. "host approvals document" is used at L29/72/304/350/387/415/505/652 with no competitor; L102–113 already states SQLite stores it. The other "names" are `exec-approvals.json` (a legacy filename being migrated away from) and `approvals.json` (a scratch file in a shell example). |
| `r3-1082` (partial) | `channels/line.md` | Refuted half: the page has **10** `Gateway` and **2** lowercase `gateway`, and both lowercase ones are non-prose — a hostname inside a ```text fence (L42) and the `/gateway/security` route in a link (L462). |
| `r3-1963` (partial) | `plugins/codex-supervision.md` | Refuted half: **Continue as branch**, **adoption** and **continuation** are three different things, not one. L260 branches from a local session without resuming the source; L483–500 binds a Chat to an exact native thread on a paired node; L317 snapshots a native title into the catalog. The fix's own rule is what the page already does. |

### Judgment calls

- **`r5-0193` — fixed on the editable side.** That page is generated: `scripts/generate-plugin-inventory-doc.mts:686-696` writes `docs/plugins/reference/<id>.md`, and the file carries "Generated file. Do not edit by hand." The naming half of the row is real — the generated title is "Diffs Language Pack plugin" while `tools/diffs.md` said "Diff Viewer Language Pack plugin" at L101/163/169 — so `diffs.md` was aligned to the generated name instead. The length half asks to split an enumeration of 26 language names inside the page's hand-editable block; grouping them would add a categorisation the source does not state, so it is left, per "sentences whose length is entirely enumeration".
- **`r3-2427` picked a different keeper than the row suggested.** The row proposed "automatic local setup". `automatic setup` is the verbatim UI control ("**Use automatic setup**", "**Disconnect and disable automatic setup**") and `native bootstrap` is the mechanism (native host `ai.openclaw.browser_bootstrap`, and a heading). Those two are load-bearing; "automatic local setup" (2 uses), "native setup" (1) and "automatic bootstrap" (1) were the redundant ones, so they were folded into the two real names.
- **`r3-2509` — the actor half refuted.** "agent" (the caller) and "bot" (the channel account that owns the reaction) are not the same actor; rewriting "the bot's reactions" to "the agent's reactions" would be wrong on every per-channel bullet. Rate half closed: 1.8 → 0.38.
- **`r3-2480` kept "question prompt".** L74 names the separate `/question` surface, not the credential request; "question" was replaced with "request" only where it meant the credential-request object (L37, L83).
- **`custodian-skills.md` L13 left long on purpose.** "…falls back to a retained legacy default owner, the sole configured agent, or legacy `main` when no explicit agent roster exists" — whether the trailing qualifier scopes the whole list or only the last item is genuinely ambiguous in the source. Any split picks a reading. Kept, and flagged.
- **The linter's 87 remaining `synonym-rotation` hits were left.** None of them is what a ledger row names — every term row here is about domain vocabulary, which `SYNONYM_GROUPS` does not cover. The residue is generic verb pairs the regex cannot resolve: CLI subcommand names (`validate`, `remove`, `start`), noun/verb pairs in one sentence, and different-referent uses (`check the action's fields` for a reader vs `validate provider payloads` for a service).
- **112 `long-sentence` hits remain at the 20-word instruction cap** (45 at the 25-word descriptive cap that governs reference prose). They are concentrated in `exec.md` and `show-widget.md` security prose, where splitting further risks detaching a scope qualifier from its condition. Policy: "Stop when the sentence is unambiguous, not when it is shortest."

### Validators

All run on the staged tree, in a worktree with `node_modules` symlinked from the base clone.

| Check | Result |
| --- | --- |
| `pnpm check:docs` (the CI job's own aggregate) | **exit 0** |
| ↳ `format-docs.mts --check` | clean, 1280 files |
| ↳ `markdownlint-cli2` (config's own glob) | Linting: **1279 files**, 0 issues |
| ↳ `lint:templates` | 12 files, 0 issues |
| ↳ `check-docs-mdx.mjs` | passed, 1293 files |
| ↳ `check-docs-i18n-glossary.mts` | passed |
| ↳ `docs:check-links`, `docs:check-config-examples` | passed |
| `docs-link-audit.mjs --anchors` | 13,472 links, **3 broken** — the pre-existing `#windows-app-node` trio in `maturity/`, untouched by this PR |
| `vitest … docs-link-audit.test.ts` | **1 file / 33 tests** passed |
| `vitest … src/docs/` | **8 files / 16 tests** passed |
| `pnpm plugins:inventory:check` | exit 0 (generated tree unchanged) |
| `parseDocsDocument` anchor diff, 34 pages | 0 dropped, 1 added |

Baseline for the anchor audit was taken at `git merge-base HEAD origin/main` (`60c11c46bfa`), not at `origin/main`.

### Glossary

`check-docs-i18n-glossary.mts` hard-failed on 4 renamed Related link labels in `sdk-entrypoints.md`. Added, using the exact target page titles — no coined vocabulary:

- `Plugin runtime helpers`, `Plugin setup and config`, `Building channel plugins`, `Building provider plugins`

Inserted **beside the existing `Plugin entry points` / `Plugin SDK overview` entries** (index ~399), not appended, so this does not collide on the end-of-array line with every other concurrent PR. Result verified as a superset with **0 duplicate sources** (1198 → 1202).

### CODEOWNERS

Simulated last-match-wins over the full file list before editing. **No file in this PR is owned.** `.github/CODEOWNERS` has no catch-all rule and no entry matching `docs/tools/**`, `docs/plugins/**`, `docs/channels/**`, or `docs/.i18n/**`; its docs entries are confined to `docs/security/`, `docs/gateway/`, `docs/cli/`, and two `docs/reference/` files.

Two standing exclusions were checked and honoured: `docs/plugins/sdk-subpaths.md` (contract test reads it whole) is **not** in this PR, and `docs/plugins/reference/**` plus `docs/plugins/plugin-inventory.md` are generated — confirmed by grepping `scripts/` for each path rather than inferring from the directory.

### Premises in the brief that did not hold

- **"Rate rows don't batch" — confirmed wrong, again.** Two thirds of all hard violations across 37 files were semicolons with a single mechanical fix.
- **The refutation rate was lower than batch two's.** 8 split-page refutations here versus 8 for 8 there, because this batch mixed split index pages with pages that were never split.
- **One row's suggested fix would have made the page worse.** `r3-2362` prescribes a keeper term ("voice note") that occurs zero times on the page.
