### PR TITLE
docs(feishu): document channels.feishu.historyLimit

### DIFF
--- a/docs/channels/feishu/access-control.md
+++ b/docs/channels/feishu/access-control.md
@@ -48,6 +48,12 @@ openclaw pairing approve feishu <CODE>
 Mentions of other people stay readable in the text sent to the agent,
 including when consecutive messages are combined.
 
+**Group history** (`channels.feishu.historyLimit`):
+
+- Maximum number of prior group messages retained as context for a group chat. Set `0` to disable history retention.
+- Falls back to `messages.groupChat.historyLimit` when unset; the default is `50`.
+- Per-account override: `channels.feishu.accounts.<id>.historyLimit`.
+
 ## Group configuration examples
 
 ### Allow all groups, no @mention required

--- a/docs/channels/feishu/configuration-reference.md
+++ b/docs/channels/feishu/configuration-reference.md
@@ -41,6 +41,7 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.groups.<chat_id>.enabled`               | Enable/disable a specific group                                                      | `true`                               |
 | `channels.feishu.groups.<chat_id>.allowFrom`             | Per-group sender allowlist (overrides `groupSenderAllowFrom`)                        | -                                    |
 | `channels.feishu.groupSessionScope`                      | Group session mapping (`group`, `group_sender`, `group_topic`, `group_topic_sender`) | `group`                              |
+| `channels.feishu.historyLimit`                           | Max group messages to load as context (`0` disables)                                 | `50`                                 |
 | `channels.feishu.replyToMode`                            | Reply-reference mode (`off`, `first`, `all`, `batched`)                              | `all`                                |
 | `channels.feishu.replyInThread`                          | Bot replies create/continue topic threads (`disabled`, `enabled`)                    | `disabled`                           |
 | `channels.feishu.reactionNotifications`                  | Inbound reaction events (`off`, `own`, `all`)                                        | `own`                                |


### PR DESCRIPTION
## What Problem This Solves

The Feishu channel reference omitted the `channels.feishu.historyLimit` option, even though the field is defined in the Feishu config schema and consumed at runtime when recording group-chat history context. Users configuring via the docs could not discover this capability.

- Problem: `docs/channels/feishu/configuration-reference.md` had no row for `historyLimit`, and `docs/channels/feishu/access-control.md` had no mention in its Group chats section. The field has existed in the schema since before the Feishu page was split by reader job (#143085).
- Solution: Add a configuration-reference row and a short Group history subsection, matching the sibling channel wording.
- What changed: `docs/channels/feishu/configuration-reference.md` (+1 row) and `docs/channels/feishu/access-control.md` (+6 lines).
- What did NOT change: No code or behavior changes. Documentation only.

## Why This Change Was Made

`channels.feishu.historyLimit` is defined in `extensions/feishu/src/config-schema.ts:254` as `z.number().int().min(0).optional()`, part of `FeishuSharedConfigShape` (so it applies both at the top level and per account via `...FeishuSharedConfigShape` in `FeishuAccountConfigSchema`). At runtime, `extensions/feishu/src/bot.ts:510` resolves it as `feishuCfg?.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT` and passes the result as `limit` to `createChannelHistoryWindow(...).record({...})` at `bot.ts:657` (and the active replay path at `bot.ts:1166,1181`). `DEFAULT_GROUP_HISTORY_LIMIT` is `50` (`src/auto-reply/reply/history.ts:6`). The implementation and command contract are unchanged; this is a documentation discoverability fix.

The sibling `dmHistoryLimit` field is also present in the schema but is **not** documented here: grep of `extensions/feishu/src/` (excluding schema and tests) shows no runtime consumer, so documenting it would describe behavior that does not exist. It is left out intentionally per the dead-field gate.

## User Impact

Users can now discover the `historyLimit` group-history context cap (`0` disables; default `50`; falls back to `messages.groupChat.historyLimit`) from the Feishu configuration reference and access-control pages, matching the existing wording in the Signal (`docs/channels/signal.md:312`) and Nextcloud Talk (`docs/channels/nextcloud-talk.md:156`) docs. No runtime behavior changes.

## Evidence

**Schema source** (`extensions/feishu/src/config-schema.ts:254`)
```typescript
historyLimit: z.number().int().min(0).optional(),
```
Part of `FeishuSharedConfigShape`, spread into both `FeishuConfigSchemaBase` (top level) and `FeishuAccountConfigSchema` (per-account), so `channels.feishu.historyLimit` and `channels.feishu.accounts.<id>.historyLimit` are both valid.

**Runtime default** (`src/auto-reply/reply/history.ts:6`)
```typescript
export const DEFAULT_GROUP_HISTORY_LIMIT = 50;
```

**Runtime consumer** (`extensions/feishu/src/bot.ts:508-510,657`)
```typescript
const historyLimit = Math.max(
  0,
  feishuCfg?.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
);
// ...
createChannelHistoryWindow({ historyMap: chatHistories }).record({
  historyKey: groupHistoryKey,
  limit: historyLimit,
  entry: { /* sender, body, timestamp, messageId */ },
});
```

**Sibling docs** — already documented for Signal (`docs/channels/signal.md:312`): "Group history context uses `channels.signal.historyLimit` ... falling back to `messages.groupChat.historyLimit`. Set `0` to disable (default 50)." and Nextcloud Talk (`docs/channels/nextcloud-talk.md:156`).

**Dead-field gate (not documented)** — `dmHistoryLimit` is defined at `config-schema.ts:255` but has no runtime consumer in `extensions/feishu/src/` (excluding schema and tests). It is intentionally omitted from this change.

**Documentation checks**
- `oxfmt --check docs/channels/feishu/access-control.md docs/channels/feishu/configuration-reference.md` — All matched files use the correct format (2 files).
- `node scripts/docs-list.js` — both Feishu subpages indexed normally, no `[unterminated]`/error.
- `git diff --check` — no whitespace issues.
- `node scripts/check-docs-mdx.mjs` — not run in worktree (missing `node_modules`; `scripts/lib/tsx-cli-shim.mjs` throws "Repository dependencies are missing... Run pnpm install"). Same environment limitation as prior docs PRs; MDX check runs in CI on the exact head.

**Autoreview**: not yet run; will trigger `$autoreview --mode uncommitted` before PR creation per CLAUDE.md pre-land gate.

**Proof boundary**: this is a documentation discoverability fix; the Feishu implementation is unchanged. No runtime behavior proof applies.

Public documentation: https://docs.openclaw.ai/channels/feishu/configuration-reference

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes — verified 5-layer evidence (Schema → Type → Default → Consumer → Sibling docs), confirmed the dead-field gate excludes `dmHistoryLimit`, and confirmed the gap still exists on the latest `origin/main` before writing.
