### PR TITLE
docs: scope version-locked claims in tools and plugins pages

### DIFF
--- a/docs/plugins/architecture-internals/load-pipeline.md
+++ b/docs/plugins/architecture-internals/load-pipeline.md
@@ -61,14 +61,18 @@ actual behavior such as hooks, tools, commands, or provider flows.
 Optional manifest `activation` and `setup` blocks stay on the control plane.
 They are metadata-only descriptors for activation planning and setup discovery;
 they do not replace runtime registration, `register(...)`, or `setupEntry`.
-Live activation consumers use manifest command, channel, and provider hints to
-narrow plugin loading before broader registry materialization:
+Live activation consumers use manifest activation metadata to narrow plugin
+loading before broader registry materialization:
 
 - CLI loading narrows to plugins that own the requested primary command
 - channel setup/plugin resolution narrows to plugins that own the requested
   channel id
 - explicit provider setup/runtime resolution narrows to plugins that own the
   requested provider id
+- agent-runtime planning narrows to plugins that declare the selected embedded
+  harness runtime id in `activation.onAgentHarnesses`
+- startup plugin selection adds plugins whose `activation.onConfigPaths`
+  entries are present and enabled in config
 - Gateway startup planning uses `activation.onStartup` for explicit startup
   imports; plugins without startup metadata load only through narrower
   activation triggers

--- a/docs/plugins/architecture-internals/provider-hooks.md
+++ b/docs/plugins/architecture-internals/provider-hooks.md
@@ -289,4 +289,5 @@ Compatibility:
 - rename `discovery` to `catalog`. A provider plugin that still registers
   `discovery` publishes no catalog rows
 - `augmentModelCatalog` is deprecated; bundled providers should publish
-  supplemental rows through `registerModelCatalogProvider`
+  supplemental rows through `registerModelCatalogProvider`. Its removal gate is
+  2026-10-01

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -110,7 +110,7 @@ accepts them.
 
 Uploading the same `beamId` updates the existing catalog row when its `updatedAt` is newer. Equal-timestamp uploads may refresh the same state or mark a live row completed, but cannot regress a completed row to live. Older uploads and equal-timestamp completion regressions still return the normal `200` success response, but OpenClaw ignores them. Only accepted updates refresh retention and uploader attribution.
 
-`sourceModel` is optional. Current automatic mirrors include the latest model reported by the source catalog. Older clients and snapshots remain valid without it.
+`sourceModel` is optional. Automatic mirrors include the latest model reported by the source catalog. Older clients and snapshots remain valid without it.
 
 ## Continue on the Team Gateway
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -179,8 +179,10 @@ transcript, and compaction boundaries also differ. See
 
 ## Upcoming deprecations
 
-A few hook-adjacent surfaces are deprecated but still supported. Migrate
-before the next major release:
+A few hook-adjacent surfaces are deprecated but still supported. Removal
+eligibility is tracked per surface in the plugin compatibility registry, as a
+`removeAfter` date or an explicit removal gate, not at a major-version
+boundary. Migrate now:
 
 - **Plaintext channel envelopes** in `inbound_claim` and `message_received`
   handlers. Prefer typed fields instead of parsing flat envelope text:

--- a/docs/plugins/manifest/surfaces.md
+++ b/docs/plugins/manifest/surfaces.md
@@ -17,7 +17,7 @@ field is required. Use a square PNG that remains recognizable at 16 px; 512×512
 Missing, unreadable, or invalid icons are ignored and do not invalidate the plugin.
 
 OpenClaw adopts this fixed package path as its icon convention, matching the path proposed in
-an open Agent Plugins spec proposal ([agent-plugins-spec#66](https://github.com/agentplugins/agent-plugins-spec/pull/66)). OpenClaw itself implements Agent Plugins 1.0.0. Other Agent Plugins
+Agent Plugins spec proposal [agent-plugins-spec#66](https://github.com/agentplugins/agent-plugins-spec/pull/66). OpenClaw itself implements Agent Plugins 1.0.0. Other Agent Plugins
 consumers may not discover it unless that proposal is adopted. The fixed path keeps packages
 portable and inspectable, avoids manifest path indirection and precedence rules, and lets OpenClaw
 render the icon without a runtime network request. Top-level plugin-branding icon URLs are not

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -256,7 +256,7 @@ registered. Use the finalizable live-preview helpers from
 
 ## Migration
 
-`runtime.channel.turn.*` runtime aliases were removed. Use:
+`runtime.channel.turn.*` runtime aliases were removed in 2026.5.27. Use:
 
 - `runtime.channel.inbound.run(...)` for raw inbound events.
 - `runtime.channel.inbound.dispatchReply(...)` for assembled reply contexts.
@@ -264,6 +264,11 @@ registered. Use the finalizable live-preview helpers from
 - `runtime.channel.inbound.runPreparedReply(...)`, deprecated, only for
   channel-owned prepared dispatch paths that already assemble their own
   dispatch closure.
+
+`runPreparedReply` is carried by the `plugin-runtime-api-compat-aliases`
+compatibility record, whose earliest removal review date is 2026-10-01. That
+date is a review date and not a scheduled removal: the alias stays until every
+enumerated surface is proven to have no bundled or published reader.
 
 New plugin code should not introduce `turn`-named channel APIs. Keep model or
 agent turn vocabulary inside agent/provider code; channel plugins use inbound,

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -325,9 +325,10 @@ raw callback string. Actor and source-message checks remain channel-owned.
     so their handlers, command catalogs, and routes use the new generation.
     Manually stopped accounts stay stopped. Ordinary channel config changes
     still restart only the affected channel or accounts.
-    `retainNativeCatalog(provider)` is deprecated and will be removed in the
-    next breaking SDK release; existing calls only assert that the captured
-    registry generation is still active.
+    `retainNativeCatalog(provider)` has been deprecated since 2026.9.2 and
+    will be removed in the next breaking SDK release; it is retained for
+    callers written against 2026.9.1, and existing calls only assert that the
+    captured registry generation is still active.
     Call `prepareDispatch(rawArgs)` only on that winner and execute the returned
     dispatch with `dispatch.execute(context)`. Carry an explicit
     `{ kind: "non-plugin" }` decision for retained built-in and skill winners.

--- a/docs/plugins/sdk-overview/tools-and-commands.md
+++ b/docs/plugins/sdk-overview/tools-and-commands.md
@@ -68,10 +68,15 @@ Guidance entries may be legacy strings, which apply to every prompt surface, or
 structured entries:
 
 ```ts
-agentPromptGuidance: [
-  "Global command hint.",
-  { text: "Only show this in the main OpenClaw prompt.", surfaces: ["openclaw_main"] },
-];
+api.registerCommand({
+  name: "demo_cmd",
+  description: "Demo command",
+  agentPromptGuidance: [
+    "Global command hint.",
+    { text: "Only show this in the main OpenClaw prompt.", surfaces: ["openclaw_main"] },
+  ],
+  handler: async () => ({ text: "ok" }),
+});
 ```
 
 Structured `surfaces` may include `openclaw_main`, `codex_app_server`,

--- a/docs/plugins/sdk-provider-plugins/media-and-search.md
+++ b/docs/plugins/sdk-provider-plugins/media-and-search.md
@@ -18,6 +18,7 @@ plugins](/plugins/sdk-provider-plugins) guide.
 <Tabs>
   <Tab title="Embeddings">
     ```typescript
+    // fetchAcmeEmbedding is your plugin's own vendor API call, not an SDK export.
     api.registerEmbeddingProvider({
       id: "acme-ai",
       defaultModel: "acme-embed",

--- a/docs/plugins/sdk-provider-plugins/runtime-hooks.md
+++ b/docs/plugins/sdk-provider-plugins/runtime-hooks.md
@@ -82,7 +82,10 @@ families](/plugins/sdk-provider-plugins/hook-families) for the shared builders.
 
     The older `resolveWebSocketSessionPolicy` hook remains supported but is
     deprecated. Move its fields under `resolveTransportTurnState.websocket`;
-    fields from the new hook take precedence during migration.
+    fields from the new hook take precedence during migration. The hook carries
+    a TypeScript `@deprecated` annotation only: it has no compatibility-registry
+    record and therefore no published removal date. See the [removal
+    timeline](/plugins/sdk-migration/removal-timeline) for the surfaces that do.
 
   </Tab>
   <Tab title="Usage and billing">
@@ -94,6 +97,7 @@ families](/plugins/sdk-provider-plugins/hook-families) for the shared builders.
       return auth ? { token: auth.token } : null;
     },
     fetchUsageSnapshot: async (ctx) => {
+      // fetchAcmeUsage is your plugin's own vendor API call, not an SDK export.
       return await fetchAcmeUsage(ctx.token, ctx.timeoutMs);
     },
     ```

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -91,6 +91,8 @@ Use `createPluginRuntimeStore` to store the runtime reference for use outside th
     ```typescript
     import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
 
+    // `myPlugin` is your own `ChannelPlugin` object and `store` is the store
+    // created in the previous step; neither is an SDK export.
     export default defineChannelPluginEntry({
       id: "my-plugin",
       name: "My Plugin",

--- a/docs/plugins/sdk-runtime/gateway-and-nodes.md
+++ b/docs/plugins/sdk-runtime/gateway-and-nodes.md
@@ -229,6 +229,7 @@ api.registerService({
   start(ctx) {
     unsubscribeSessionsChanged = ctx.gatewayEvents?.onSessionsChanged((event) => {
       // event: { sessionKey, agentId?, label?, displayName?, reason?, phase? }
+      // refreshSession is your plugin's own handler, not an SDK export.
       refreshSession(event.sessionKey);
     });
   },
@@ -253,6 +254,8 @@ that intentionally starts required work in the background must report later fail
 through its generation-bound health reporter:
 
 ```typescript
+// startIndexWorker and stopIndexWorker are your plugin's own background-work
+// helpers, not SDK exports.
 api.registerService({
   id: "index-worker",
   start(ctx) {

--- a/docs/plugins/sdk-runtime/media.md
+++ b/docs/plugins/sdk-runtime/media.md
@@ -78,6 +78,7 @@ Speech, media understanding, generation, web search, and the low-level media uti
 
     // Structured image extraction through a specific provider/model.
     // Include at least one image; text inputs are supplemental context.
+    // receiptImageBuffer is your own image bytes, not an SDK-provided value.
     const evidence = await api.runtime.mediaUnderstanding.extractStructuredWithModel({
       provider: "codex",
       model: "gpt-5.6-sol",

--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -138,7 +138,7 @@ The runtime config snapshot, durable plugin-scoped storage, system utilities, ev
 
     `openChannelIngressQueue<TPayload>(...)` opens a persisted ingress queue scoped to the calling plugin, for buffering inbound events that need at-least-once processing across restarts. When stale-claim recovery uses `shouldRecover`, also provide `shouldRecoverCorrupt` if corrupt claimed payloads should be quarantined: its payload-independent claim identity lets the plugin preserve live owner and lane policy before the queue tombstones the row.
 
-    Plugin-state leases were removed. Use short SQLite transactions for atomic database work and plugin-scoped keyed stores (`openKeyedStore` or `openSyncKeyedStore`) for bounded durable state.
+    Plugin-state leases were removed in 2026.8.1. Use short SQLite transactions for atomic database work and plugin-scoped keyed stores (`openKeyedStore` or `openSyncKeyedStore`) for bounded durable state.
 
     `openChannelIngressDrain(...)` opens the core channel-agnostic worker over that queue (or creates a queue when none is supplied). The drain owns stale-claim recovery, per-lane claim serialization, complete-at-adoption or complete-on-dispatch-return, retry/dead-letter disposition, optional pre-adoption supersede, and claim→adoption stall timeout. Wire claim ownership into reply generation with `turnAdoptionLifecycle` (via `bindIngressLifecycleToReplyOptions` from `plugin-sdk/channel-outbound`). Channel plugins keep accept-side enqueue, lane derivation, non-retryable classification, and any supersede authorization policy.
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -479,11 +479,12 @@ Generated `allow-always` entries are bound to both the exact argv and the workin
 directory where you approved them. Choosing **Always allow here** authorizes the
 same command only in that directory; running it elsewhere is an allowlist miss.
 
-Older generated entries that were not directory-bound are inactive after an
-upgrade. `openclaw update` removes them during its automatic Doctor pass, or you
-can run `openclaw doctor --fix` yourself. Rerun an affected workflow and choose
-**Always allow here** to create the replacement. Manual allowlist rules are not
-changed. For a manual path-only rule, omit both `source` and `argPattern`.
+Generated entries saved before 2026.8.1 are not directory-bound and are inactive
+after upgrading. `openclaw update` removes them during its automatic Doctor pass,
+or you can run `openclaw doctor --fix` yourself. Rerun an affected workflow and
+choose **Always allow here** to create the replacement. Manual allowlist rules
+are not changed. For a manual path-only rule, omit both `source` and
+`argPattern`.
 
 Each allowlist entry supports:
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -208,7 +208,7 @@ Example:
 
 A standalone `/exec security=deny` acknowledges the run-only setting but starts no agent run and does not affect the next message. Use [session permission modes](/gateway/permission-modes) to keep a policy across messages.
 
-The `execSecurity` and `execAsk` fields in `sessions.patch` and `sessions.patchMany` are retired. They remain in the protocol v4 wire schema, but requests containing either field (including `null`) are rejected with `INVALID_REQUEST` and replacement guidance. Set `permissionMode` (`read-only`, `guarded`, `workspace`, or `full`) for session-wide policy, or use `/exec` with a message for a single run.
+The `execSecurity` and `execAsk` fields in `sessions.patch` and `sessions.patchMany` were retired in 2026.8.1. They remain in the protocol v4 wire schema, but requests containing either field (including `null`) are rejected with `INVALID_REQUEST` and replacement guidance. Set `permissionMode` (`read-only`, `guarded`, `workspace`, or `full`) for session-wide policy, or use `/exec` with a message for a single run.
 
 When a session has a permission mode, per-turn `/exec` overrides can only tighten its security and approval policy. For example, `/exec security=deny` blocks exec for that turn even in a full-access session; an override requesting looser security or fewer approvals leaves the session mode's limits unchanged. Full-access sessions bypass host approval-file floors only while effective security remains `full`. Tightening `ask` alone still applies the requested approval level without restoring those floors.
 


### PR DESCRIPTION
## What

Closes the open `accuracy`-kind audit findings for `docs/tools/` and `docs/plugins/` — **53 rows**. 16 files changed, +50 / -21, prose and code-sample comments only. No page splits, no headings renamed, no anchors changed, no `docs.json` or glossary edits.

**14 fixed, 4 refuted, 35 already satisfied on `main`** (14 + 4 + 35 = 53).

Two earlier accuracy passes landed after the audit snapshot and had already covered most of the batch: `c83277b9703` (#143179, 2026-09-09) and `d84f5e8cbd5` (#143857, 2026-09-10). Every row below was re-verified against current source before it was edited, refuted, or closed.

## Fixed here (14)

| id | page | change | evidence |
| --- | --- | --- | --- |
| `r3-2383` | `docs/tools/exec-approvals.md` | "Older generated entries" → "Generated entries saved before 2026.8.1" | `1c37c8cdc71` (2026-08-25), PR #129636 listed in `docs/releases/2026.8.1/security-and-privacy.md:116`; behavior live in `src/infra/exec-approvals-generated-migration.ts` |
| `r3-2415` | `docs/tools/exec.md` | `execSecurity`/`execAsk` "are retired" → "were retired in 2026.8.1" | `a151c1e0d35` (2026-08-29), PR #132740 in `docs/releases/2026.8.1/security-and-privacy.md:237`; rejection live at `src/gateway/sessions-patch.ts:198` |
| `r3-2036` | `docs/plugins/sdk-channel-inbound.md` | `runtime.channel.turn.*` "were removed" → "removed in 2026.5.27"; added the `runPreparedReply` compatibility-record paragraph | `6c3740255f3` (2026-05-27), earliest stable tag `v2026.5.27`, `CHANGELOG.md:28054`; aliases absent from `src/` today; record at `src/plugins/compat/deprecation-marking.ts:325-360` |
| `r3-1937` | `docs/plugins/sdk-channel-plugins.md` | `retainNativeCatalog` deprecation scoped to 2026.9.2 | its own annotation at `src/plugins/plugin-command-runtime.ts:97` ("retained for v2026.9.1 callers"); `cbaa21e6e32` (#138112), earliest stable tag `v2026.9.2` |
| `r3-1905` | `docs/plugins/sdk-runtime/state-and-system.md` | plugin-state leases "were removed" → "removed in 2026.8.1" | `9809375fdac` (2026-08-09), PR #121140 in `docs/releases/2026.8.1/maintenance-changes-part-6.md:157` |
| `r3-1902` | `docs/plugins/sdk-runtime.md`, `sdk-runtime/gateway-and-nodes.md`, `sdk-runtime/media.md` | marked `myPlugin`/`store`, `refreshSession`, `startIndexWorker`/`stopIndexWorker`, `receiptImageBuffer` as caller-owned, not SDK exports | `src/plugin-sdk/core.ts:553` |
| `r3-1921` | `docs/plugins/sdk-provider-plugins/media-and-search.md`, `.../runtime-hooks.md` | carried the parent page's "Acme AI is a fictional vendor / `fetchAcme*` are placeholders" note into the two child samples that call `fetchAcme*` | the split left children without the parent's disclaimer |
| `r3-1924` | `docs/plugins/sdk-provider-plugins/runtime-hooks.md` | `resolveWebSocketSessionPolicy`: stated that it carries a TypeScript `@deprecated` only, with no compatibility-registry record and therefore no published removal date | no match in `src/plugins/compat/`; annotation at `src/plugins/provider-plugin.types.ts:344` |
| `r3-1931` | `docs/plugins/sdk-overview/tools-and-commands.md` | bare `agentPromptGuidance: [...]` fragment (invalid at object scope) wrapped in a complete `api.registerCommand({...})` | required fields `name`/`description`/`handler` at `src/plugins/plugin-command.types.ts:170,186,216`; `agentPromptGuidance` at `:195`; API at `plugin-api.types.ts:329`; return shape matches the sibling example in `docs/plugins/hooks/tool-policy.md:172` |
| `r3-1928` | `docs/plugins/architecture-internals/provider-hooks.md` | added the 2026-10-01 removal gate to the `augmentModelCatalog` deprecation | `plugin-provider-manifest-compat-aliases` record, `deprecation-marking.ts:375-394`, `DEFAULT_REMOVE_AFTER = "2026-10-01"` |
| `r3-1909` | `docs/plugins/hooks.md` | "Migrate before the next major release" → the per-surface `removeAfter` / removal-gate contract | `src/plugins/compat/types.ts:21-22`; `docs/plugins/sdk-migration/compatibility-policy.md:231` states "OpenClaw does not ship major releases" |
| `r5-0116` | `docs/plugins/manifest/surfaces.md` | dropped the undated "open" from the spec-proposal reference | the PR's state is external and unverifiable from this repo; the following clause already handles adoption. (The spec-version half was already fixed on `main`.) |
| `r5-0118` | `docs/plugins/architecture-internals/load-pipeline.md` | completed the activation consumer list with the `activation.onAgentHarnesses` and `activation.onConfigPaths` consumers, and fixed the lead-in that contradicted its own list | `src/plugins/activation-planner.ts:186` (`listAgentHarnessTriggerReasons`); `src/plugins/gateway-startup-plugin-config.ts:294-332` (`hasConfiguredActivationPath`, `addConfiguredActivationPathPluginIds`) |
| `r3-2056` | `docs/plugins/beam.md` | "Current automatic mirrors" → "Automatic mirrors" | claim verified still true at `extensions/beam/src/mirror.ts:379` and `mirror.test.ts:427`. (The named-links half was already scoped to 2026.8.2 on `main`; independently confirmed via `61edeb8a6fe` / #125755.) |

Note on `r5-0118`: the row's **suggested** fix — delete the consumer list on `manifest/capabilities.md` and link to `architecture-internals` — was refuted. The two lists genuinely differ and `capabilities.md` is the more complete one, so deleting it would have lost information. The real defect was that the internals list was incomplete, so that is what was fixed.

## Refuted, with evidence (4)

- **`r3-2370`** — `docs/tools/slash-commands.md` says "three sources" and lists **three** bullets, and the code genuinely has three: `buildSkillCommandDefinitions` at `src/auto-reply/commands-registry-list.ts:9`, the `skillCommands` param at `:33`, the spread at `:39`. The row's alternative ("change three to two") would have introduced a new error.
- **`r3-1933`** — `sdk-overview/tools-and-commands.md:79` and `sdk-overview/host-hooks.md:249` already carry precise scope ("deprecated it on 2026-07-25 with a `removeAfter` date of 2026-10-01"), matching `MARKING_DATE` and `DEFAULT_REMOVE_AFTER` in `deprecation-marking.ts` for the `plugin-runtime-api-compat-aliases` record. The compatibility registry is **date**-keyed, not version-keyed; replacing verified dates with invented release numbers would be a regression.
- **`r3-2053`** — the two "older versions" sentences trace to `ed8f50f240a` (2026-05-01) and `7ed73f5383a` (2026-05-02), under a prerelease scheme predating the current release series, with no matching `CHANGELOG.md` entry. Both already pair the legacy statement with the present contract in the same paragraph, and the page opener states the governing contract outright. No version guessed. (The deprecated-selector half was already scoped to 2026.9.2 on `main`.)
- **`r3-1957`** — the second "not yet" at `docs/plugins/codex-harness-runtime/sandbox-streaming.md:43` paraphrases the shipped user-facing error string verbatim: `extensions/codex/src/app-server/side-question.ts:228` emits "…`/btw` is not yet bound to the active placement.", asserted in `side-question.test.ts:1221`. Rewording the doc away from the product's own words would break error-message matching during troubleshooting. (The Windows half was already restated as a present limit on `main`.)

## Already satisfied on `main`, no change needed (35)

`r3-1900`, `r3-1917`, `r3-1919`, `r3-1926`, `r3-1961`, `r3-1987`, `r3-1994`, `r3-1998`, `r3-2003`, `r3-2041`, `r3-2045`, `r3-2060`, `r3-2061`, `r3-2356`, `r3-2360`, `r3-2368`, `r3-2379`, `r3-2394`, `r3-2402`, `r3-2409`, `r3-2425`, `r3-2428`, `r3-2430`, `r3-2434`, `r3-2439`, `r3-2443`, `r3-2444`, `r3-2497`, `r3-2520`, `r3-2522`, `r5-0029`, `r5-0036`, `r5-0039`, `r5-0049`, `r5-0115`

Four of these are worth calling out because a naive pass would have edited them:

- **`r3-1994`** — `docs/plugins/plugin-inventory.md` is **generated** by `scripts/generate-plugin-inventory-doc.mts` (`docs/AGENTS.md` line 28). The "launch cutover" sentence was already removed from **both** the generator (`:760`) and the generated page (`:47`), so no hand-edit and no regeneration. `pnpm plugins:inventory:check` exits 0.
- **`r5-0029`** — the onboard CLI reference is `docs/cli/onboard.md` (hand-authored, not generated) and lines 340-350 already carry `--auth-choice llama-cpp-existing-server`, `--auth-choice llama-cpp`, `--llama-server-api-key`, and the `LLAMA_SERVER_API_KEY` fallback — every name matching `extensions/llama-cpp/openclaw.plugin.json`.
- **`r3-1961`** — the two "Current runtime behavior:" strings were paragraph **lead-ins, not headings**, so there was never a `#current-runtime-behavior` anchor; an `<a id>` stub would have invented one. Already reworded to "Runtime behavior:" on `main`.
- **`r3-2356`** — the TTS precedence direction on `docs/tools/tts/configuration.md:477` ("Later layers win") was re-verified against `resolveEffectiveTtsConfig` in `src/tts/tts-config.ts:106-120` plus `src/infra/deep-merge.ts:21-53` and the assertion in `src/tts/tts-config.test.ts:147`. It is correct as written.

## Guardrail coverage — unchanged

`src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts` hard-codes `PUBLIC_CONTRACT_REFERENCE_FILES` (2 entries), `TYPED_PUBLIC_CONTRACT_REFERENCE_FILES` (9 entries) and `SDK_SUBPATH_DOC_FILE` (1). **None of those 12 files is touched by this PR**, and no content was moved out of any of them, so the guardrail's coverage is identical before and after: 2 + 9 + 1. `docs/plugins/sdk-subpaths.md` is untouched, per its standing refusal. The test passes: 1 file / 19 tests under `vitest.contracts-plugin`.

## CODEOWNERS

A last-match-wins simulation over all 16 changed files finds **no** matching rule — `.github/CODEOWNERS` has no `docs/tools/**` or `docs/plugins/**` entry (its docs entries cover only `docs/security/`, `docs/gateway/`, `docs/cli/`, `docs/reference/`). No ownership gate on this PR.

## Validators

Baseline measured in a detached worktree at the merge-base `60c11c46bfa`, `node_modules` symlinked in.

| check | baseline | this branch |
| --- | --- | --- |
| `pnpm check:docs` | exit 0 | exit 0 |
| `pnpm format:check` (`oxfmt`, repo-wide, 36340 files) | exit 0 | exit 0 |
| `format-docs.mts --check` | clean, 1280 files | clean, 1280 files |
| `check-docs-mdx.mjs` | pass, 1292 files | pass, 1293 files |
| `docs-link-audit.mjs` | `broken_links=0` | `broken_links=0` |
| `docs-link-audit.mjs --anchors` | `broken_links=3`, exit 1 | `broken_links=3`, exit 1 — the same three pre-existing `maturity/#windows-app-node` errors |
| `markdownlint-cli2` (config's own globs) | `Linting: 1279 files`, 0 issues | `Linting: 1279 files`, 0 issues |
| `vitest.tooling` `src/scripts/docs-link-audit.test.ts` | 1 file / 33 tests pass | 1 file / 33 tests pass |
| `vitest.full-core-unit-src` `src/docs/` | 8 files, **1 failed** (`ERR_MODULE_NOT_FOUND`, `packages/markdown-core/src/reasoning-tags.ts`), 15 tests | **8 files / 16 tests pass** |
| `vitest.contracts-plugin` SDK package guardrails | — | 1 file / 19 tests pass |
| `pnpm plugins:inventory:check` | — | exit 0 |

The single baseline red is the known workspace-package resolution artifact of a symlinked `node_modules` in the measurement worktree (`node_modules/@openclaw/*` resolving through the base clone). It does not reproduce on this branch.

No new `.github/labeler.yml` gap: nothing was split, so every changed path keeps whatever glob already matched it.
