### PR TITLE
docs: fix 20 concrete gateway/provider defects from the ux audit

### DIFF
--- a/docs/gateway/1password.md
+++ b/docs/gateway/1password.md
@@ -25,7 +25,10 @@ OpenClaw pairs with **1Password** in four independent ways:
 
 ## Resolve config secrets with the plugin
 
-Enable the bundled plugin and create its service-account token file:
+Enable the bundled plugin and create its service-account token file. Export the
+service account's token as `OP_SERVICE_ACCOUNT_TOKEN` in the shell you run this
+in first — the block writes that value to disk and then clears it from the
+environment, so without it you get an empty token file:
 
 ```bash
 openclaw plugins enable onepassword

--- a/docs/gateway/bonjour.md
+++ b/docs/gateway/bonjour.md
@@ -118,7 +118,7 @@ The gateway writes a rolling log file (printed on startup as `gateway log file: 
 
 OpenClaw starts each Bonjour service once and leaves probing, retry, name-conflict resolution, and interface-change republishing to the mDNS responder. This avoids overlapping publish attempts during normal network churn. Repeated internal self-probe messages are suppressed so they cannot flood the gateway log.
 
-When multiple OpenClaw gateways advertise from the same host, Bonjour may append suffixes such as `(2)` or `(3)` to keep service instance names unique. Those suffixes are normal conflict resolution and do not indicate duplicate OCM supervision.
+When multiple OpenClaw gateways advertise from the same host, Bonjour may append suffixes such as `(2)` or `(3)` to keep service instance names unique. Those suffixes are normal conflict resolution.
 
 Bonjour uses the system hostname for the advertised `.local` host when it's a valid DNS label. If the system hostname contains spaces, underscores, or another invalid DNS-label character, OpenClaw falls back to `openclaw.local`. Set `OPENCLAW_MDNS_HOSTNAME=<name>` before starting the gateway when you need an explicit host label.
 

--- a/docs/gateway/doctor/config-migrations.md
+++ b/docs/gateway/doctor/config-migrations.md
@@ -66,7 +66,8 @@ beyond the grace period.
       `routing.transcribeAudio`, top-level `agent.*`, or top-level `identity`
       from the pre-multi-agent config shape) no longer have a migration path;
       config using them now fails validation instead of being rewritten. Fix
-      those keys by hand against the current config reference before doctor
+      those keys by hand against the current
+      [configuration reference](/gateway/configuration-reference) before doctor
       can proceed.
     </Note>
 

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -60,6 +60,11 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
   </Step>
   <Step title="Restart the Gateway">
     The HTTP route is registered at plugin startup, so reload after enabling.
+
+    ```bash
+    openclaw gateway restart
+    ```
+
   </Step>
   <Step title="Scrape the protected route">
     Send the same gateway auth your operator clients use:

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -142,7 +142,7 @@ Most setups only need the API key. To pin the provider explicitly:
 ```
 
 <Note>
-If the Gateway runs as a daemon (launchd, systemd, Docker), make sure `BASETEN_API_KEY` is available to that process. A key exported only in an interactive shell is not visible to an already-running managed service.
+If the Gateway runs as a daemon (launchd, systemd, Docker), make sure `BASETEN_API_KEY` is available to that process (for example, in `~/.openclaw/.env` or via `env.shellEnv`). A key exported only in an interactive shell is not visible to an already-running managed service.
 </Note>
 
 ## Related

--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -72,8 +72,9 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
 ```
 
 `--mode` defaults to `local`, so this is the same run as the **Direct flag**
-command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
-onboarding against a remote Gateway.
+command above. Run it on the Gateway host: remote-client onboarding
+(`--mode remote`) only configures the local client connection and does not set
+up provider credentials on the server.
 
 ## Discovery and pricing
 

--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -71,6 +71,10 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
   --cerebras-api-key "$CEREBRAS_API_KEY"
 ```
 
+`--mode` defaults to `local`, so this is the same run as the **Direct flag**
+command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
+onboarding against a remote Gateway.
+
 ## Discovery and pricing
 
 When Cerebras auth is configured and the inference base URL is the canonical

--- a/docs/providers/fal.md
+++ b/docs/providers/fal.md
@@ -20,6 +20,9 @@ generation.
 ## Getting started
 
 <Steps>
+  <Step title="Get an API key">
+    Create a key at [fal.ai/dashboard/keys](https://fal.ai/dashboard/keys).
+  </Step>
   <Step title="Set the API key">
     ```bash
     openclaw onboard --auth-choice fal-api-key

--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -74,6 +74,10 @@ openclaw onboard --non-interactive \
   --accept-risk
 ```
 
+`--mode` defaults to `local`, so this is the same run as the **Direct flag**
+command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
+onboarding against a remote Gateway.
+
 ## Built-in catalog
 
 Setup saves connection settings and aliases without copying generated catalog rows into your config.

--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -75,8 +75,9 @@ openclaw onboard --non-interactive \
 ```
 
 `--mode` defaults to `local`, so this is the same run as the **Direct flag**
-command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
-onboarding against a remote Gateway.
+command above. Run it on the Gateway host: remote-client onboarding
+(`--mode remote`) only configures the local client connection and does not set
+up provider credentials on the server.
 
 ## Built-in catalog
 

--- a/docs/providers/gmi.md
+++ b/docs/providers/gmi.md
@@ -44,7 +44,15 @@ Then run:
 openclaw onboard --auth-choice gmi-api-key
 ```
 
-Non-interactive setups can pass `--gmi-api-key <key>`, or set:
+For scripted or CI installs, pass everything on the command line:
+
+```bash
+openclaw onboard --non-interactive --accept-risk --skip-health \
+  --auth-choice gmi-api-key \
+  --gmi-api-key "$GMI_API_KEY"
+```
+
+Or set the key in the environment instead:
 
 ```bash
 export GMI_API_KEY="<your-gmi-api-key>" # pragma: allowlist secret

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -36,8 +36,8 @@ openclaw gateway restart
   </Step>
   <Step title="Set the API key">
     ```bash
-export GROQ_API_KEY=gsk_...
-```
+    export GROQ_API_KEY=gsk_...
+    ```
   </Step>
   <Step title="Set a default model">
     ```json5

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -30,8 +30,13 @@ spend limits, and backend failover without changing OpenClaw config.
   <Tab title="Manual setup">
     <Steps>
       <Step title="Start LiteLLM Proxy">
+        LiteLLM calls the upstream provider on your behalf, so export that
+        provider's key before starting it — `ANTHROPIC_API_KEY` for the model
+        below. See [Model routing](#advanced) for multi-backend setups.
+
         ```bash
         pip install 'litellm[proxy]'
+        export ANTHROPIC_API_KEY=sk-ant-...
         litellm --model claude-opus-4-6
         ```
       </Step>
@@ -42,6 +47,7 @@ spend limits, and backend failover without changing OpenClaw config.
         ```
       </Step>
     </Steps>
+
   </Tab>
 </Tabs>
 

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -73,8 +73,9 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
 ```
 
 `--mode` defaults to `local`, so this is the same run as the **Direct flag**
-command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
-onboarding against a remote Gateway.
+command above. Run it on the Gateway host: remote-client onboarding
+(`--mode remote`) only configures the local client connection and does not set
+up provider credentials on the server.
 
 ## Built-in catalog
 

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -72,6 +72,10 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
   --meta-api-key "$MODEL_API_KEY"
 ```
 
+`--mode` defaults to `local`, so this is the same run as the **Direct flag**
+command above. Pass `--mode remote --remote-url wss://<host>:18789` instead when
+onboarding against a remote Gateway.
+
 ## Built-in catalog
 
 Prices and data-use terms come from Meta's

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -205,7 +205,9 @@ longer work. Migrate existing Qwen configurations to an active model.
     model idle watchdog before they emit a first response chunk. For custom
     NVIDIA provider entries, raise the provider timeout instead of the whole
     agent runtime timeout; `timeoutSeconds` covers provider HTTP requests and
-    raises the idle/stream watchdog ceiling for that provider:
+    raises the idle/stream watchdog ceiling for that provider. The provider id
+    below (`custom-integrate-api-nvidia-com`) is a name you choose, not a
+    reserved value; any id works as long as your model refs use the same prefix:
 
     ```json5
     {

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -77,7 +77,8 @@ Step Plan (`stepfun-plan`):
       </Step>
       <Step title="Non-interactive alternative">
         ```bash
-        openclaw onboard --auth-choice stepfun-standard-api-key-intl \
+        openclaw onboard --non-interactive --accept-risk --skip-health \
+          --auth-choice stepfun-standard-api-key-intl \
           --stepfun-api-key "$STEPFUN_API_KEY"
         ```
       </Step>
@@ -116,7 +117,8 @@ Step Plan (`stepfun-plan`):
       </Step>
       <Step title="Non-interactive alternative">
         ```bash
-        openclaw onboard --auth-choice stepfun-plan-api-key-intl \
+        openclaw onboard --non-interactive --accept-risk --skip-health \
+          --auth-choice stepfun-plan-api-key-intl \
           --stepfun-api-key "$STEPFUN_API_KEY"
         ```
       </Step>

--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -36,10 +36,13 @@ plugin and uses the Anthropic Messages API.
     ```
   </Step>
   <Step title="Verify the default model">
-    Onboarding sets the default model to:
-    ```text
-    synthetic/hf:MiniMaxAI/MiniMax-M3
+    Onboarding sets the default model to `synthetic/hf:MiniMaxAI/MiniMax-M3`.
+    Confirm it is registered:
+
+    ```bash
+    openclaw models list --provider synthetic
     ```
+
   </Step>
 </Steps>
 

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -93,9 +93,10 @@ openclaw onboard --non-interactive \
 
 <Note>
 `--accept-risk` is required alongside `--non-interactive`. `--mode` defaults to
-`local`, so these are the same runs as the **direct flag** commands above; pass
-`--mode remote --remote-url wss://<host>:18789` instead when onboarding against
-a remote Gateway.
+`local`, so these are the same runs as the **direct flag** commands above. Run
+them on the Gateway host: remote-client onboarding (`--mode remote`) only
+configures the local client connection and does not set up provider credentials
+on the server.
 </Note>
 
 ## Built-in catalog

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -92,7 +92,10 @@ openclaw onboard --non-interactive \
 ```
 
 <Note>
-`--accept-risk` is required alongside `--non-interactive`.
+`--accept-risk` is required alongside `--non-interactive`. `--mode` defaults to
+`local`, so these are the same runs as the **direct flag** commands above; pass
+`--mode remote --remote-url wss://<host>:18789` instead when onboarding against
+a remote Gateway.
 </Note>
 
 ## Built-in catalog

--- a/docs/providers/vercel-ai-gateway.md
+++ b/docs/providers/vercel-ai-gateway.md
@@ -32,6 +32,7 @@ refs such as `vercel-ai-gateway/openai/gpt-5.5` and
   <Step title="Install the plugin">
     ```bash
     openclaw plugins install @openclaw/vercel-ai-gateway-provider
+    openclaw gateway restart
     ```
   </Step>
   <Step title="Set the API key">

--- a/docs/providers/vllm.md
+++ b/docs/providers/vllm.md
@@ -20,7 +20,13 @@ vLLM serves open-source (and some custom) models through an **OpenAI-compatible*
 
 <Steps>
   <Step title="Start vLLM with an OpenAI-compatible server">
-    Your base URL must expose `/v1` endpoints (`/v1/models`, `/v1/chat/completions`). vLLM commonly runs on:
+    Your base URL must expose `/v1` endpoints (`/v1/models`, `/v1/chat/completions`). Start the server with the model you want to serve:
+
+    ```bash
+    vllm serve <model-id>
+    ```
+
+    See the [vLLM online serving docs](https://docs.vllm.ai/en/latest/serving/online_serving/) for flags. vLLM commonly runs on:
 
     ```text
     http://127.0.0.1:8000/v1

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -129,7 +129,7 @@ message.
     provider: "xiaomi",
     providers: {
       xiaomi: {
-        apiKey: "xiaomi_api_key",
+        apiKey: "${XIAOMI_API_KEY}",
         model: "mimo-v2.5-tts",
         speakerVoice: "mimo_default",
         format: "mp3",

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -7,7 +7,8 @@ title: "Z.AI"
 ---
 
 Z.AI is the API platform for **GLM** models. It provides REST APIs for GLM and
-uses API keys for authentication. Create your API key in the Z.AI console.
+uses API keys for authentication. Create your API key in the
+[Z.AI console](https://z.ai/manage-apikey/apikey-list).
 OpenClaw uses the `zai` provider with a Z.AI API key.
 
 | Property | Value                                        |


### PR DESCRIPTION
## What this is

The `ux` slice of the docs audit for `docs/gateway/` and `docs/providers/` — 183 open rows. `ux` is the largest and softest audit category, so this PR deliberately does **not** attempt all of them. It takes the subset that names something objectively checkable and leaves the rest as an explicit, itemised queue, matching the shape of the two prior `ux` batches (`docs/tools/`: 16 fixed / 9 refuted / 101 untouched; `docs/cli` + `docs/concepts`: 15 fixed / 24 refuted / 160 untouched).

**20 fixed, 23 refuted with evidence, 2 deferred, 138 not attempted — 183 total.** Every id is listed below and the counts reconcile. 20 files changed, no heading renamed, no anchor dropped.

## Fixed (20)

Each is a defect a reader would act on wrongly, not a style preference.

**Missing prerequisite — the block cannot be pasted as written**

| id | page | defect |
| --- | --- | --- |
| `r3-1654` | `gateway/1password.md` | The token-file block reads `"$OP_SERVICE_ACCOUNT_TOKEN"` and then `unset`s it, but nothing on the page says to set it. A reader pasting the block writes an **empty** token file — and the very next paragraph says setup needs an "accepted non-empty token file". Added the export prerequisite. |
| `r3-2201` | `providers/litellm.md` | Manual setup step 1 runs `litellm --model claude-opus-4-6`, which needs `ANTHROPIC_API_KEY` in the environment. The only mention of that is inside a **collapsed** "Model routing" accordion 110 lines below. Added the export to the step. |

**A step with no action**

| id | page | defect |
| --- | --- | --- |
| `r3-1618` | `gateway/prometheus.md` | Step titled "Restart the Gateway" said only "reload after enabling" — no command. Added `openclaw gateway restart`. |
| `r3-2132` | `providers/vllm.md` | Step 1, "Start vLLM with an OpenAI-compatible server", gave only a URL. Added `vllm serve <model-id>` and the upstream serving-docs link. |
| `r3-2205` | `providers/synthetic.md` | Step titled "Verify the default model" only restated what onboarding sets. Added `openclaw models list --provider synthetic`, the idiom already used on eight sibling provider pages. |
| `r5-0059` | `providers/gmi.md` | "Non-interactive setups can pass `--gmi-api-key <key>`" — one flag, no command. Added the full block in the sibling-page shape. |
| `r3-1530` | `gateway/doctor/config-migrations.md` | "Fix those keys by hand against the current config reference" — no link. Linked `/gateway/configuration-reference`. (Row said `doctor.md:268`; the content is now in the split child.) |

**Self-contradiction / silently divergent commands**

| id | page | defect |
| --- | --- | --- |
| `r3-2167` | `providers/stepfun.md` | Both steps titled **"Non-interactive alternative"** omit `--non-interactive` — and `--accept-risk`, which `docs/cli/onboard.md:275` says is *required* alongside it. As written they run the interactive wizard, contradicting their own title. |
| `r3-2153` `r3-2151` `r3-2155` `r3-2188` | `cerebras`, `fireworks`, `meta`, `tencent` | Each page shows two non-interactive onboarding commands that differ only by `--mode local`, with nothing saying which to use. `docs/cli/onboard.md:275`: "`--mode` defaults to `local`." Stated that once per page, and directed provider setup to the Gateway host — see the ClawSweeper round below. |
| `r3-2190` | `providers/vercel-ai-gateway.md` | Install step omits `openclaw gateway restart`. `docs/plugins/manage-plugins.md` is explicit that the Gateway keeps the plugin inventory it discovered at startup and that added plugins require a restart — so the very next step (`openclaw onboard --auth-choice ai-gateway-api-key`) runs against a Gateway that has not loaded the provider. 30 of 36 provider install blocks already pair the two. |
| `r3-2136` | `providers/xiaomi.md` | TTS example used `apiKey: "xiaomi_api_key"` — lowercase, neither a marked placeholder nor the env var. The page's own property table says `XIAOMI_API_KEY`, and the canonical `docs/tools/tts/configuration.md:279` uses `"${XIAOMI_API_KEY}"` for this exact provider. Aligned to the canonical form. |

**Concrete missing element**

| id | page | defect |
| --- | --- | --- |
| `r3-2142` | `providers/fal.md` | The page requires `FAL_KEY` and contains **zero** external links — nothing says where the key comes from. Added a "Get an API key" step. (Second half of the row, "add a verify step", not done — no verified media-catalog verify command; see Not attempted.) |
| `r3-2139` | `providers/zai.md` | "Create your API key in the Z.AI console" with no link; the page links docs.z.ai and z.ai/subscribe but never the console. Linked it. |
| `r3-2150` | `providers/baseten.md` | The daemon-env note states the problem ("make sure `BASETEN_API_KEY` is available to that process") and stops. Eight sibling pages give the fix — "for example, in `~/.openclaw/.env` or via `env.shellEnv`". Added it. |
| `r3-2145` | `providers/nvidia.md` | `"custom-integrate-api-nvidia-com"` appears nowhere else in the repo; it reads as a reserved id. Said it is a name the reader chooses. |
| `r3-1641` | `gateway/bonjour.md` | "do not indicate duplicate **OCM** supervision" — `OCM` is defined nowhere in `docs/` (it appears only in release notes and `docs/ci/`, undefined there too). Took the row's second option and dropped the clause; the preceding sentence carries the whole reassurance. |

**Renders wrong**

| id | page | defect |
| --- | --- | --- |
| `r3-2194` | `providers/groq.md` | The step-2 code fence sat at column 0 inside a `<Step>` indented at 4, breaking out of its container. Every other Step fence on the page is indented. |

## Refuted with evidence (23)

**Two rows whose suggested fix was itself the breaking change** — the pattern the program brief warns about:

- `r3-2115` (`moonshot.md`) — "Two H3 headings share the text 'Config example' and produce the same anchor." They do not. `parseDocsDocument` on the current file yields `config-example`, `config-example-1` and **`config-example-2`**: ids are deduplicated. Renaming as proposed would break the published `#config-example-1`.
- `r3-2080` (`openai.md`) — same claim, same answer: `route-summary-1`, `route-summary-2`, `config-example-1`, `config-example-2` all exist as distinct ids in `docs/providers/openai/setup.md`.

**A class-level refutation, like the standing `MD025` one:** `config/markdownlint-cli2.jsonc` sets `"MD040": false`, so an untagged code fence is a deliberate repo-wide choice, not a defect. That refutes `r3-2203` (`azure-speech.md`) and the language-tag half of `r3-2081` (`openai.md`).

**Already satisfied in the current tree** (the audit predates the splits):

- `r3-2086` (`ollama.md:116`) — "one credential code block exports the same variable twice, so a copied block ends with the placeholder value". After the `docs/providers/ollama/` split the two exports are already in separate fences on separate pages (`ollama/recipes.md:78`, `ollama/model-discovery.md:108`). The row's own suggested fix is done.

**Premise does not hold against the current page:**

- `r3-2118` (`github-copilot.md`) — "The Copilot Proxy tab does not say how to configure the model list it needs." It does, inside the tab: "Configure the base URL and model ids with: `openclaw models auth login --provider copilot-proxy --set-default`".
- `r3-2207` (`kilocode.md`) — "The page title and the directory label use different names." There is no separate directory label: `docs.json:2289` carries only the route `providers/kilocode`, and the nav label comes from the page's own `title: "Kilo Gateway"`. `kilocode` is the provider id and route slug, both stated explicitly at line 13.
- `r3-2103` (`minimax.md`) — "The fallback example targets M2.7 although M3 is the documented default." The accordion is titled "Fallback example" and its own first line says "fail over to MiniMax M2.7"; a fallback naming an older model is the point of the example. The `-cn` ids the row asks to define are defined at line 386.
- `r3-2181` (`opencode.md`) — "The steps assume an API key that the page names only after the steps." The key is named at line 16, *before* the steps, and the "Getting an API key" accordion links `opencode.ai/auth`. Reordering it into the funnel is a flow preference.
- `r3-2114` (`moonshot.md`) — "No step tells the reader where to create a Moonshot API key." The page carries a `<Card href="https://platform.moonshot.ai">` labelled "Moonshot API key management and documentation", and the onboarding step prompts for the key. Per the program brief, a `<Card href>` counts as the link being present.

**Stylistic — I could not state what a reader would get wrong (13):** `r3-1653`, `r3-1589`, `r3-1588`, `r3-1640`, `r3-1615`, `r3-1611`, `r3-1522`, `r3-1619`, `r3-2156`, `r3-2166`, `r3-2168`, `r3-2143`, `r3-2154`. These ask for a numbered list instead of prose, a definition list instead of a table, an added section index, or a reordering of content that is complete and correct as it stands. `r3-1589` is additionally covered by the standing `MD025` refutation.

## Deferred (2)

- `r3-2083` (`ollama` — `apiKey: "OLLAMA_API_KEY"` unexplained). The row asks me to state that a bare env-var name in `apiKey` is read from that variable. That rule is documented **nowhere** in `docs/`, and the only source evidence I found (`src/agents/sessions/model-registry.ts:939`) concerns auth-*status* labelling, not key resolution. Five docs pages use the bare form and many more use `${...}`; this needs a source-verified statement and a repo-wide convention decision, not a one-page prose fix. Writing it without that proof would be inventing the fix.
- `r3-2192` (`groq` — the daemon-env note repeated on eight shard pages with drift). The row asks for a shared snippet. No snippet mechanism is in use for these pages; doing it as eight hand edits is exactly the churn this batch is meant to avoid, and doing it properly is its own PR.

## Not attempted (138)

**On CODEOWNERS-owned pages (15).** `r3-1673`, `r3-1672` (`authentication.md`); `r3-1651` (`sandbox-vs-tool-policy-vs-elevated.md`); `r3-1571`, `r3-1573`, `r3-1570` (`sandboxing.md`); `r3-1547`, `r3-1550`, `r3-1552`, `r3-1555`, `r3-1548` (`secrets.md`); `r3-1574`, `r3-1575`, `r3-1678`, `r3-1657` (`security/**`). Checked against `.github/CODEOWNERS` lines 53-60 **before** editing anything. All 15 are page-structure or prose-density rows; none names an accuracy defect, so skipping them costs nothing — the same result a prior batch reported for its 8 owned rows. `r3-1672` (troubleshooting sends the reader to a `setup-token` path the page never shows) is the one worth a follow-up, and it belongs in a secops-routed PR.

**Version-scope rows (7).** `r3-1656`, `r3-1649`, `r3-1644`, `r3-1634`, `r3-1627`, `r3-2092`, `r3-1613`. Each asks to attach a release or checked-on date to a "currently" / "beta" / "previously" hedge. Each needs its own release archaeology, and this is the class where an earlier round produced roughly twenty wrong deferrals off a truncated history. They want a dedicated batch.

**Page-split / large-restructure rows (10).** `r3-1596`, `r3-1642`, `r3-1636`, `r3-1643`, `r3-1670`, `r3-1516`, `r3-2119`, `r3-1506`, `r3-1662`, `r3-1544`. Splitting is governed by `.audit/split-brief.md` and is not `ux` work.

**Remaining rows left open (106).** Prose-density, reordering, table-to-list, intro-paragraph, accordion-promotion and cross-page-deduplication rows for which I could not state what a reader would get wrong, or which need a canonicality decision across page owners plus new glossary sources before any link can be added. Left open rather than churned across directories other people are editing:

<details><summary>106 ids</summary>

`r3-1511` `r3-1515` `r3-1517` `r3-1526` `r3-1529` `r3-1536` `r3-1538` `r3-1556` `r3-1558` `r3-1559` `r3-1560` `r3-1564` `r3-1565` `r3-1569` `r3-1577` `r3-1578` `r3-1580` `r3-1581` `r3-1586` `r3-1590` `r3-1592` `r3-1597` `r3-1601` `r3-1602` `r3-1603` `r3-1605` `r3-1608` `r3-1610` `r3-1614` `r3-1621` `r3-1622` `r3-1624` `r3-1625` `r3-1628` `r3-1630` `r3-1635` `r3-1637` `r3-1638` `r3-1645` `r3-1646` `r3-1647` `r3-1652` `r3-1664` `r3-1665` `r3-1666` `r3-1667` `r3-1669` `r3-1675` `r3-1681` `r3-2084` `r3-2085` `r3-2087` `r3-2088` `r3-2089` `r3-2090` `r3-2091` `r3-2093` `r3-2094` `r3-2096` `r3-2099` `r3-2101` `r3-2104` `r3-2106` `r3-2108` `r3-2109` `r3-2112` `r3-2113` `r3-2122` `r3-2123` `r3-2125` `r3-2126` `r3-2128` `r3-2129` `r3-2133` `r3-2134` `r3-2135` `r3-2137` `r3-2138` `r3-2141` `r3-2144` `r3-2147` `r3-2157` `r3-2158` `r3-2161` `r3-2162` `r3-2164` `r3-2172` `r3-2174` `r3-2175` `r3-2176` `r3-2178` `r3-2179` `r3-2182` `r3-2185` `r3-2197` `r3-2198` `r3-2199` `r3-2206` `r3-2208` `r5-0075` `r5-0232` `r5-0239` `r5-0247` `r5-0248` `r5-0251` `r5-0252`

</details>

## ClawSweeper round

Revision 1 was correctly blocked with one P2: my first version of the `--mode local` note offered `--mode remote --remote-url …` as an alternative. That is wrong. `runNonInteractiveSetup` returns through `runNonInteractiveRemoteSetup` (`src/commands/onboard-non-interactive/remote.ts`), which writes `gateway.remote` connection settings and never consumes the provider credential — and `docs/start/wizard-cli-reference.md:434` already says remote-client onboarding does not set up provider credentials on the server. A reader following my sentence would have finished onboarding with the provider unconfigured. I verified the source path myself rather than taking the finding on trust.

Commit `4933ec2b` replaces the remote alternative on all four pages with the Gateway-host instruction and keeps the `--mode local` equivalence, which was the point of the rows. Revision 2 verdict: **ready for maintainer review, 0 findings, 0 blockers** (🐚 platinum hermit 4/6). Auto-merge is **not** enabled and the PR is **not** merged.

## Validators

Run on the staged tree in a worktree with `node_modules` symlinked in. Base: `60c11c46bfae` (`git merge-base HEAD origin/main`).

- `pnpm check:docs` — **exit 0**. Docs formatting clean (1280 files); markdownlint `Linting: 1279 files`, 0 issues; MDX, i18n glossary, links and config-example fences all clean.
- `pnpm format:check` (repo-wide `oxfmt`, 36340 files) — **exit 0**.
- `node scripts/docs-link-audit.mjs --anchors` — 13474 internal links checked, **3** broken: the three known pre-existing `/maturity/taxonomy#windows-app-node` errors, unchanged. Baseline re-measured on this tree, not quoted from the brief.
- `npx vitest --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — **1 file / 33 tests passed**.
- `npx vitest --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files / 16 tests passed** (file count checked against the expected eight, per the false-green warning).
- `.audit/docs-test-pins.py` over all 20 changed paths: the only test hits are `extensions/{baseten,groq,meta,nvidia}/index.test.ts`, and each pins the **route** (`docsPath: "/providers/<id>"`), not page content. No route changed.

## Anchors

Enumerated with `parseDocsDocument` on all 20 changed files at the merge-base and at `HEAD`. **No heading was renamed and no id was lost.**

- One id added: `get-an-api-key` on `providers/fal.md` (the new step).
- Two ids on `gateway/prometheus.md` shifted: `403-openclawverbatim388end` → `403-openclawverbatim391end`, and `openclawverbatim394end-is-climbing` → `openclawverbatim397end-is-climbing`. These are not published anchors — they are the parser's placeholder tokens for inline code inside `<Accordion title>` attributes, and their index moves whenever a code fence is added earlier in the file. Nothing in the repo links to them, and the two real inbound `prometheus#` anchors (`#event-loop-observation-windows`, `#garbage-collection-duration`, from `gateway/opentelemetry/model-calls-and-metrics.md`) are untouched and still resolve.

## CODEOWNERS

**No owned file is touched.** `.github/CODEOWNERS` (lines 53-60) covers `/docs/gateway/authentication.md`, `sandbox-vs-tool-policy-vs-elevated.md`, `sandboxing.md`, `sandboxing/`, `secrets.md`, `secrets/`, `secrets-plan-contract.md` and `security/`, all `@openclaw/openclaw-secops`. The intended file list was simulated against those globs before any edit, and the 15 findings landing on them are itemised under Not attempted.

## Other notes

- `docs/.i18n/glossary.zh-CN.json` is **not** touched. The one new `/`-route link (`/gateway/configuration-reference`) sits in a `<Note>` paragraph rather than a list item, so `check-docs-i18n-glossary.mts` does not gate it — confirmed by the passing run, not assumed.
- No new directory is created, so `.github/labeler.yml` needs no change.
- No generated page is edited: `scripts/` greps clean for all 20 paths.
- **Adjacent finding, not fixed here.** Five further provider pages omit `openclaw gateway restart` after `openclaw plugins install`: `fireworks`, `fish-audio`, `github-copilot`, `venice`, `zai`. Only `vercel-ai-gateway` carries an audit row for it, so only that one is fixed — flagging the rest rather than silently widening the diff.
- **A premise in my brief that did not hold.** The brief said "several `docs/providers/` pages were split into child directories". Only two have — `ollama` and `openai`. Twelve `docs/gateway/` pages have. The `providers/` line numbers were otherwise close to accurate; the `gateway/` ones were not.
