### PR TITLE
refactor(config): derive hook types from schemas

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -1,105 +1,30 @@
 // Defines hook configuration matching and command types.
 import type { InstallRecordBase } from "./types.installs.js";
-export type HookMappingMatch = {
-  path?: string;
-  source?: string;
-};
+import type {
+  HookMappingConfigInput,
+  HooksGmailConfigInput,
+  InternalHooksConfigInput,
+} from "./zod-schema.hooks.js";
 
-export type HookMappingTransform = {
-  module: string;
-  export?: string;
-};
-
-export type HookSessionMode = "isolated" | "persistent";
-
-export type HookMappingConfig = {
-  id?: string;
-  match?: HookMappingMatch;
-  action?: "wake" | "agent";
-  wakeMode?: "now" | "next-heartbeat";
-  name?: string;
-  /** Route this hook to a specific agent (unknown ids fall back to the default agent). */
-  agentId?: string;
-  sessionKey?: string;
-  /** Reuse the resolved session key across runs instead of creating a fresh run session. */
-  sessionMode?: HookSessionMode;
-  messageTemplate?: string;
-  textTemplate?: string;
-  /**
-   * Fan the mapping out over a top-level payload array: one action per element,
-   * with templates/transforms seeing a payload whose array holds only that
-   * element. Example: the gmail preset uses `forEach: "messages"` so batched
-   * pushes dispatch one isolated run per email.
-   */
-  forEach?: string;
-  deliver?: boolean;
-  /** DANGEROUS: Disable external content safety wrapping for this hook. */
-  allowUnsafeExternalContent?: boolean;
-  /**
-   * "last" or any runtime channel id (including plugin channels).
-   * Validation against configured/registered channels happens in gateway hooks runtime.
-   */
+export type HookMappingConfig = Omit<HookMappingConfigInput, "channel"> & {
+  /** Preserve channel-id autocomplete while allowing runtime plugin channels. */
   channel?: "last" | (string & {});
-  to?: string;
-  /** Override model for this hook (provider/model or alias). */
-  model?: string;
-  thinking?: string;
-  timeoutSeconds?: number;
-  transform?: HookMappingTransform;
 };
 
-export type HooksGmailTailscaleMode = "off" | "serve" | "funnel";
-
-export type HooksGmailConfig = {
-  account?: string;
-  label?: string;
-  topic?: string;
-  subscription?: string;
-  pushToken?: string;
-  hookUrl?: string;
-  includeBody?: boolean;
-  maxBytes?: number;
-  renewEveryMinutes?: number;
-  /** DANGEROUS: Disable external content safety wrapping for Gmail hooks. */
-  allowUnsafeExternalContent?: boolean;
-  serve?: {
-    bind?: string;
-    port?: number;
-    path?: string;
-  };
-  tailscale?: {
-    mode?: HooksGmailTailscaleMode;
-    path?: string;
-    /** Optional tailscale serve/funnel target (port, host:port, or full URL). */
-    target?: string;
-  };
-  /** Optional model override for Gmail hook processing (provider/model or alias). */
-  model?: string;
-  /** Optional thinking level override for Gmail hook processing. */
-  thinking?: "off" | "minimal" | "low" | "medium" | "high";
-};
-
-export type HookConfig = {
-  enabled?: boolean;
-  env?: Record<string, string>;
-  [key: string]: unknown;
-};
+export type HookMappingMatch = NonNullable<HookMappingConfigInput["match"]>;
+export type HookMappingTransform = NonNullable<HookMappingConfigInput["transform"]>;
+export type HookSessionMode = NonNullable<HookMappingConfigInput["sessionMode"]>;
+export type HooksGmailConfig = HooksGmailConfigInput;
+export type HooksGmailTailscaleMode = NonNullable<
+  NonNullable<HooksGmailConfigInput["tailscale"]>["mode"]
+>;
+export type HookConfig = NonNullable<NonNullable<InternalHooksConfigInput["entries"]>[string]>;
 
 export type HookInstallRecord = InstallRecordBase & {
   hooks?: string[];
 };
 
-export type InternalHooksConfig = {
-  /** Enable hooks system */
-  enabled?: boolean;
-  /** Per-hook configuration overrides */
-  entries?: Record<string, HookConfig>;
-  /** Load configuration */
-  load?: {
-    /** Additional hook directories to scan */
-    extraDirs?: string[];
-  };
-};
+export type InternalHooksConfig = InternalHooksConfigInput;
 
 export type HooksConfig = {
   enabled?: boolean;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -73,6 +73,8 @@ export const HookMappingSchema = z
   .strict()
   .optional();
 
+export type HookMappingConfigInput = NonNullable<z.input<typeof HookMappingSchema>>;
+
 const HookConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -96,6 +98,8 @@ export const InternalHooksSchema = z
   })
   .strict()
   .optional();
+
+export type InternalHooksConfigInput = NonNullable<z.input<typeof InternalHooksSchema>>;
 
 export const HooksGmailSchema = z
   .object({
@@ -138,3 +142,5 @@ export const HooksGmailSchema = z
   })
   .strict()
   .optional();
+
+export type HooksGmailConfigInput = NonNullable<z.input<typeof HooksGmailSchema>>;


### PR DESCRIPTION
## Summary

- derive hook mapping, Gmail, and internal-hook authoring types from their canonical Zod input schemas
- retain the released plugin-channel autocomplete overlay
- remove the parallel handwritten contract hierarchy

Production diff: **+23 / -92 = -69 LOC**.

## Compatibility

Runtime parsing and persisted config bytes are unchanged. Schema input types preserve pre-parse optionality, internal hook entries remain open to hook-owned keys, and the explicit channel overlay continues to accept arbitrary registered plugin channel ids.

## Proof

- 130 focused hook, Gmail, gateway, and runtime-config tests
- core production and all test-type shards
- Plugin SDK declaration generation
- runtime and Madge cycle checks
- full `pnpm check:changed`
- fresh P0-P2 review

