### PR TITLE
refactor(config): derive agent defaults from schema

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -1,11 +1,9 @@
 // Defines agent default configuration types shared by runtime schemas.
-import type { FastMode } from "@openclaw/normalization-core/string-coerce";
-import type { SilentReplyPolicyShape } from "../shared/silent-reply-policy.js";
+import type { z } from "zod";
 import type {
-  AgentModelConfig,
-  AgentToolModelConfig,
   AgentRuntimePolicyConfig,
   AgentSandboxConfig,
+  AgentToolModelConfig,
 } from "./types.agents-shared.js";
 import type {
   BlockStreamingChunkConfig,
@@ -13,6 +11,9 @@ import type {
   HumanDelayConfig,
   TypingMode,
 } from "./types.base.js";
+import type { AgentDefaultsBaseSchema } from "./zod-schema.agent-defaults-base.js";
+
+type SchemaAgentDefaultsConfig = z.input<typeof AgentDefaultsBaseSchema>;
 
 /** Workspace bootstrap-file injection policy for agent system prompts. */
 export type AgentContextInjection = "always" | "continuation-skip" | "never";
@@ -108,7 +109,7 @@ export type AgentContextLimitsConfig = {
   postCompactionMaxChars?: number;
 };
 
-export type AgentDefaultsConfig = {
+export type AgentDefaultsConfig = SchemaAgentDefaultsConfig & {
   /** @deprecated Doctor-only legacy input. */
   imageGenerationModel?: AgentToolModelConfig;
   /** @deprecated Doctor-only legacy input. */
@@ -125,250 +126,37 @@ export type AgentDefaultsConfig = {
   timeFormat?: "auto" | "12" | "24";
   /** @deprecated Doctor-only legacy input. */
   promptOverlays?: { gpt5?: { personality?: "friendly" | "on" | "off" } };
-  /** Global default provider params applied to all models before per-model and per-agent overrides. */
-  params?: Record<string, unknown>;
-  /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
-  model?: AgentModelConfig;
-  /** Model-selection scope; defaults to the current session. */
-  modelSelectionScope?: ModelSelectionScope;
-  /** Optional lower-cost model for short internal tasks such as generated session titles. */
-  utilityModel?: string;
   /**
    * @deprecated Legacy raw config accepted only by doctor/migration repair.
    * Normal schema parsing rejects this key; use per-model agentRuntime instead.
    */
   agentRuntime?: AgentRuntimePolicyConfig;
-  /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
-  imageModel?: AgentToolModelConfig;
-  /** Media-generation model preferences by output modality. */
-  mediaModels?: {
-    image?: AgentToolModelConfig;
-    video?: AgentToolModelConfig;
-    music?: AgentToolModelConfig;
-  };
-  /** Optional voice model and fallbacks (provider/model) for TTS/STT/realtime voice providers. */
-  voiceModel?: AgentToolModelConfig;
-  /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
-  pdfModel?: AgentToolModelConfig;
-  /** Maximum PDF file size in megabytes (default: 10). */
-  pdfMaxMb?: number;
-  /** Maximum number of PDF pages to process (default: 20). */
-  pdfMaxPages?: number;
-  /** Model catalog with optional aliases (full provider/model keys). */
-  models?: Record<string, AgentModelEntryConfig>;
-  /** Explicit model override policy. Empty or omitted allow permits any model. */
-  modelPolicy?: AgentModelPolicyConfig;
-  /** Agent bootstrap and memory directory; also the working directory when cwd is unset. */
-  workspace?: string;
-  /** Working directory for agent reply runs, separate from workspace bootstrap and memory files. */
-  cwd?: string;
-  /** Optional default allowlist of skills for agents that do not set agents.entries.*.skills. */
-  skills?: string[];
-  /** Silent-reply policy by conversation type. */
-  silentReply?: SilentReplyPolicyShape;
-  /** Optional repository root for system prompt runtime line (overrides auto-detect). */
-  repoRoot?: string;
-  /** Provider-independent prompt overlays applied by model family. */
-  /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
-  skipBootstrap?: boolean;
-  /**
-   * List of optional bootstrap filenames to skip writing to the workspace root.
-   * Applies to: SOUL.md, USER.md, IDENTITY.md ("HEARTBEAT.md" is accepted but a no-op).
-   * Required workspace setup such as AGENTS.md still runs.
-   * Example: ["SOUL.md", "USER.md", "IDENTITY.md"]
-   */
-  skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
-  /**
-   * Controls when workspace bootstrap files (AGENTS.md, SOUL.md, etc.) are
-   * injected into the system prompt:
-   * - always: inject on every turn (default)
-   * - continuation-skip: skip injection on safe continuation turns once the
-   *   transcript already contains a completed assistant turn
-   */
-  contextInjection?: AgentContextInjection;
-  /** Max chars for injected bootstrap files before truncation (default: 20000). */
-  bootstrapMaxChars?: number;
-  /** Max total chars across all injected bootstrap files (default: 150000). */
-  bootstrapTotalMaxChars?: number;
-  /** Experimental agent-default flags. Keep off unless you are intentionally testing a preview surface. */
-  experimental?: {
-    /**
-     * Drop heavyweight non-essential default tools for weaker or smaller local
-     * model backends. Experimental preview only.
-     */
-    localModelLean?: boolean;
-  };
-  /**
-   * Agent-visible bootstrap truncation warning mode:
-   * - off: do not inject warning text
-   * - once: inject once per unique truncation signature
-   * - always: inject on every run with truncation (default)
-   */
-  /**
-   * Optional IANA timezone for model-visible timestamps, prompt context, system events,
-   * and heartbeat active hours. Defaults to the host timezone.
-   */
-  userTimezone?: string;
-  /** Runtime-owned first-turn startup context for bare /new and /reset. */
-  startupContext?: AgentStartupContextConfig;
-  /** Focused context-budget overrides for high-volume injected/read surfaces. */
   contextLimits?: AgentContextLimitsConfig;
-  /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
-  contextPruning?: AgentContextPruningConfig;
-  /** Compaction tuning and pre-compaction memory flush behavior. */
-  compaction?: AgentCompactionConfig;
-  /** Embedded OpenClaw runner hardening and compatibility controls. */
-  embeddedAgent?: {
-    /**
-     * How embedded OpenClaw should trust workspace-local `.openclaw/settings.json`.
-     * - sanitize (default): apply project settings except shellPath/shellCommandPrefix
-     * - ignore: ignore project settings entirely
-     * - trusted: trust project settings as-is
-     */
-    projectSettingsPolicy?: "trusted" | "sanitize" | "ignore";
-    /**
-     * Embedded OpenClaw execution contract:
-     * - default: keep the standard runner behavior
-     * - strict-agentic: enable structured plan tracking and non-visible turn recovery on supported GPT-5 runs
-     */
-    executionContract?: EmbeddedAgentExecutionContract;
-  };
-  /** Default thinking level when no /think directive is present. */
-  thinkingDefault?: AgentThinkingLevel;
-  /** Default fast-mode policy inherited by agent entries that omit it. */
-  fastModeDefault?: FastMode;
-  /** Default verbose level when no /verbose directive is present. */
-  verboseDefault?: "off" | "on" | "full";
-  /**
-   * Detail mode for user-visible tool progress in /verbose and editable progress drafts.
-   * - explain: compact human summary (default)
-   * - raw: include raw command/detail when available
-   */
-  toolProgressDetail?: "explain" | "raw";
-  /** Default reasoning level when no /reasoning directive is present. */
-  reasoningDefault?: "off" | "on" | "stream";
-  /** Default elevated level when no /elevated directive is present. */
-  elevatedDefault?: "off" | "on" | "ask" | "full";
-  /** Default block streaming level when no override is present. */
-  blockStreamingDefault?: "off" | "on";
-  /**
-   * Block streaming boundary:
-   * - "text_end": end of each assistant text content block (before tool calls)
-   * - "message_end": end of the whole assistant message (may include tool blocks)
-   */
-  blockStreamingBreak?: "text_end" | "message_end";
-  /** Soft block chunking for streamed replies (min/max chars, prefer paragraph/newline). */
   blockStreamingChunk?: BlockStreamingChunkConfig;
-  /**
-   * Block reply coalescing (merge streamed chunks before send).
-   * idleMs: wait time before flushing when idle.
-   */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
-  /** Human-like delay between block replies. */
   humanDelay?: HumanDelayConfig;
-  timeoutSeconds?: number;
-  /** Max inbound media size in MB for agent-visible attachments (text note or future image attach). */
-  mediaMaxMb?: number;
-  /**
-   * Max image side length (pixels) when sanitizing base64 image payloads in transcripts/tool results.
-   * Default: 1200.
-   */
-  imageMaxDimensionPx?: number;
-  /**
-   * Image compression/detail preference for image-tool media loading.
-   * Default: auto, which adapts to provider/model limits and image count.
-   */
-  imageQuality?: AgentImageQualityPreference;
-  typingIntervalSeconds?: number;
-  /** Typing indicator start mode (never|instant|thinking|message). */
   typingMode?: TypingMode;
-  /** Periodic background heartbeat runs. */
   heartbeat?: {
-    /** Agent that owns ambient heartbeat runs when no per-agent heartbeat is configured. */
     agentId?: string;
-    /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
     every?: string;
-    /** Optional active-hours window (local time); heartbeats run only inside this window. */
     activeHours?: {
-      /** Start time (24h, HH:MM). Inclusive. */
       start?: string;
-      /** End time (24h, HH:MM). Exclusive. Use "24:00" for end-of-day. */
       end?: string;
-      /** Timezone for the window ("user", "local", or IANA TZ id). Default: "user". */
       timezone?: string;
     };
-    /** Heartbeat model override (provider/model). */
     model?: string;
-    /** Session key for heartbeat runs ("main" or explicit session key). */
     session?: string;
-    /** Delivery target. Default "owner" uses explicit ownerAllowFrom/allowFrom; "last" may follow groups. */
     target?: string;
-    /** Direct/DM delivery policy. Default: "allow". */
     directPolicy?: "allow" | "block";
-    /** Explicit channel destination; ignored for target "owner" or an unset target. */
     to?: string;
-    /** Optional account id for multi-account channels. */
     accountId?: string;
-    /** Override the heartbeat prompt body. The default treats scratch as monitor prose and directs recurring work to cron jobs. */
     prompt?: string;
-    /** Run timeout in seconds for heartbeat agent turns. Unset uses global timeout or heartbeat cadence capped at 600 seconds. */
     timeoutSeconds?: number;
-    /**
-     * If true, run heartbeat turns with lightweight bootstrap context.
-     * Lightweight mode skips workspace bootstrap files; monitor scratch is
-     * injected by the heartbeat runner either way.
-     */
     lightContext?: boolean;
-    /**
-     * If true, run heartbeat turns in an isolated session with no prior
-     * conversation history. Dramatically reduces per-heartbeat token cost by
-     * avoiding the full session transcript.
-     */
     isolatedSession?: boolean;
   };
-  /** Owner for ambient system-agent/Custodian inference and unscoped operator-read fallbacks. */
-  systemAgent?: {
-    agentId?: string;
-  };
-  /** Upgrade-only owner for the inherited credential store until H2-2 relocates credentials. */
-  authInheritance?: {
-    agentId?: string;
-  };
-  /** Upgrade-only owner for retired main-agent rows and legacy fixed session stores. */
-  sessionStore?: {
-    agentId?: string;
-  };
-  /** Max concurrent agent runs across all conversations. Default: min(16, max(8, available CPU parallelism)). */
-  maxConcurrent?: number;
-  /** Sub-agent defaults (spawned via sessions_spawn). */
-  subagents?: {
-    /** Prompt-only guidance for how strongly the main agent should delegate work. Default: "suggest". */
-    delegationMode?: SubagentDelegationMode;
-    /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any configured target. */
-    allowAgents?: string[];
-    /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 8. */
-    maxConcurrent?: number;
-    /** Maximum depth for sessions_spawn chains. Default behavior: 5. */
-    maxSpawnDepth?: number;
-    /** Maximum active children a single requester session may spawn. Default behavior: 5. */
-    maxChildrenPerAgent?: number;
-    /** Auto-archive sub-agent sessions after N minutes (default: 60, set 0 to disable). */
-    archiveAfterMinutes?: number;
-    /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
-    model?: AgentModelConfig;
-    /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
-    thinking?: string;
-    /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
-    runTimeoutSeconds?: number;
-    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
-    announceTimeoutMs?: number;
-    /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
-    requireAgentId?: boolean;
-  };
-  /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
 };
-
 export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionPostIndexSyncMode = "off" | "async" | "await";
 export type AgentCompactionIdentifierPolicy = "strict" | "off";

--- a/src/config/zod-schema.agent-defaults-base.ts
+++ b/src/config/zod-schema.agent-defaults-base.ts
@@ -1,0 +1,236 @@
+// Defines Zod schema fragments for agent default configuration.
+import { z } from "zod";
+import { isValidNonNegativeByteSizeString } from "./byte-size.js";
+import { AgentModelMapSchema, AgentModelPolicySchema } from "./zod-schema.agent-entry-base.js";
+import { AgentModelSchema, AgentToolModelSchema } from "./zod-schema.agent-model.js";
+
+const SilentReplyPolicySchema = z.union([z.literal("allow"), z.literal("disallow")]);
+
+const NonNegativeByteSizeSchema = z.union([
+  z.number().int().nonnegative(),
+  z.string().refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
+]);
+
+const OptionalBootstrapFileNameSchema = z.enum([
+  "SOUL.md",
+  "USER.md",
+  "HEARTBEAT.md",
+  "IDENTITY.md",
+]);
+
+const AgentThinkingLevelSchema = z.enum([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "adaptive",
+  "max",
+  "ultra",
+]);
+
+const EmbeddedAgentConfigSchema = z
+  .object({
+    projectSettingsPolicy: z
+      .union([z.literal("trusted"), z.literal("sanitize"), z.literal("ignore")])
+      .optional(),
+    executionContract: z.union([z.literal("default"), z.literal("strict-agentic")]).optional(),
+  })
+  .strict();
+
+export const SilentReplyPolicyConfigSchema = z
+  .object({
+    group: SilentReplyPolicySchema.optional(),
+    internal: SilentReplyPolicySchema.optional(),
+  })
+  .strict();
+
+export const AgentDefaultsBaseSchema = z
+  .object({
+    /** Global default provider params applied to all models before per-model and per-agent overrides. */
+    params: z.record(z.string(), z.unknown()).optional(),
+    model: AgentModelSchema.optional(),
+    modelSelectionScope: z.enum(["session", "agent", "global"]).optional(),
+    utilityModel: z.string().optional(),
+    imageModel: AgentToolModelSchema.optional(),
+    mediaModels: z
+      .object({
+        image: AgentToolModelSchema.optional(),
+        video: AgentToolModelSchema.optional(),
+        music: AgentToolModelSchema.optional(),
+      })
+      .strict()
+      .optional(),
+    voiceModel: AgentToolModelSchema.optional(),
+    pdfModel: AgentToolModelSchema.optional(),
+    pdfMaxMb: z.number().positive().optional(),
+    pdfMaxPages: z.number().int().positive().optional(),
+    models: AgentModelMapSchema.optional(),
+    modelPolicy: AgentModelPolicySchema.optional(),
+    workspace: z.string().optional(),
+    cwd: z.string().optional(),
+    skills: z.array(z.string()).optional(),
+    silentReply: SilentReplyPolicyConfigSchema.optional(),
+    repoRoot: z.string().optional(),
+    skipBootstrap: z.boolean().optional(),
+    skipOptionalBootstrapFiles: z.array(OptionalBootstrapFileNameSchema).optional(),
+    contextInjection: z
+      .union([z.literal("always"), z.literal("continuation-skip"), z.literal("never")])
+      .optional(),
+    bootstrapMaxChars: z.number().int().positive().optional(),
+    bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    experimental: z
+      .object({
+        localModelLean: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    userTimezone: z.string().optional(),
+    startupContext: z
+      .object({
+        enabled: z.boolean().optional(),
+        applyOn: z.array(z.union([z.literal("new"), z.literal("reset")])).optional(),
+        dailyMemoryDays: z.number().int().min(1).max(14).optional(),
+        maxFileBytes: z
+          .number()
+          .int()
+          .min(1)
+          .max(64 * 1024)
+          .optional(),
+        maxFileChars: z.number().int().min(1).max(10_000).optional(),
+        maxTotalChars: z.number().int().min(1).max(50_000).optional(),
+      })
+      .strict()
+      .optional(),
+    contextPruning: z
+      .object({
+        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+        ttl: z.string().optional(),
+        tools: z
+          .object({
+            allow: z.array(z.string()).optional(),
+            deny: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+        hardClear: z
+          .object({
+            enabled: z.boolean().optional(),
+            placeholder: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    compaction: z
+      .object({
+        enabled: z.boolean().optional(),
+        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        provider: z.string().optional(),
+        thinkingLevel: z.union([AgentThinkingLevelSchema, z.literal("inherit")]).optional(),
+        keepRecentTokens: z.number().int().positive().optional(),
+        identifierPolicy: z.union([z.literal("strict"), z.literal("off")]).optional(),
+        recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+        qualityGuard: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxRetries: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
+        midTurnPrecheck: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+        postIndexSync: z.enum(["off", "async", "await"]).optional(),
+        postCompactionSections: z.array(z.string()).optional(),
+        model: z.string().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+        memoryFlush: z
+          .object({
+            enabled: z.boolean().optional(),
+            model: z.string().optional(),
+            softThresholdTokens: z.number().int().nonnegative().optional(),
+            forceFlushTranscriptBytes: NonNegativeByteSizeSchema.optional(),
+          })
+          .strict()
+          .optional(),
+        maxActiveTranscriptBytes: NonNegativeByteSizeSchema.optional(),
+        notifyUser: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    embeddedAgent: EmbeddedAgentConfigSchema.optional(),
+    thinkingDefault: AgentThinkingLevelSchema.optional(),
+    fastModeDefault: z.union([z.boolean(), z.literal("auto")]).optional(),
+    verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    toolProgressDetail: z.union([z.literal("explain"), z.literal("raw")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
+    elevatedDefault: z
+      .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
+      .optional(),
+    blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
+    // 0 = unlimited run budget; stream liveness watchdogs still apply.
+    timeoutSeconds: z.number().int().nonnegative().optional(),
+    mediaMaxMb: z.number().positive().optional(),
+    imageMaxDimensionPx: z.number().int().positive().optional(),
+    imageQuality: z.enum(["auto", "efficient", "balanced", "high"]).optional(),
+    typingIntervalSeconds: z.number().int().positive().optional(),
+    systemAgent: z
+      .object({
+        agentId: z.string().trim().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+    authInheritance: z
+      .object({
+        agentId: z.string().trim().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+    sessionStore: z
+      .object({
+        agentId: z.string().trim().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+    maxConcurrent: z.number().int().positive().optional(),
+    subagents: z
+      .object({
+        delegationMode: z.enum(["suggest", "prefer"]).optional(),
+        allowAgents: z.array(z.string()).optional(),
+        maxConcurrent: z.number().int().positive().optional(),
+        maxSpawnDepth: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe(
+            "Maximum nesting depth for sub-agent spawning. Default: 5; 1 makes direct children leaves.",
+          ),
+        maxChildrenPerAgent: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .optional()
+          .describe(
+            "Maximum number of active children a single agent session can spawn (default: 5).",
+          ),
+        archiveAfterMinutes: z.number().int().min(0).optional(),
+        model: AgentModelSchema.optional(),
+        thinking: z.string().optional(),
+        runTimeoutSeconds: z.number().int().min(0).optional(),
+        announceTimeoutMs: z.number().int().positive().optional(),
+        requireAgentId: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -1,14 +1,10 @@
-// Defines Zod schema fragments for agent default configuration.
+// Composes dependency-heavy runtime validators onto the leaf agent-defaults schema.
 import { z } from "zod";
-import { isValidNonNegativeByteSizeString } from "./byte-size.js";
+import { AgentDefaultsBaseSchema } from "./zod-schema.agent-defaults-base.js";
 import {
-  HeartbeatSchema,
-  AgentSandboxSchema,
   AgentContextLimitsSchema,
-  AgentModelMapSchema,
-  AgentModelPolicySchema,
-  AgentModelSchema,
-  AgentToolModelSchema,
+  AgentSandboxSchema,
+  HeartbeatSchema,
 } from "./zod-schema.agent-runtime.js";
 import {
   BlockStreamingChunkSchema,
@@ -17,243 +13,18 @@ import {
   TypingModeSchema,
 } from "./zod-schema.core.js";
 
-const SilentReplyPolicySchema = z.union([z.literal("allow"), z.literal("disallow")]);
+export { SilentReplyPolicyConfigSchema } from "./zod-schema.agent-defaults-base.js";
 
-const NonNegativeByteSizeSchema = z.union([
-  z.number().int().nonnegative(),
-  z.string().refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
-]);
-
-const OptionalBootstrapFileNameSchema = z.enum([
-  "SOUL.md",
-  "USER.md",
-  "HEARTBEAT.md",
-  "IDENTITY.md",
-]);
-
-const AgentThinkingLevelSchema = z.enum([
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "adaptive",
-  "max",
-  "ultra",
-]);
-
-const EmbeddedAgentConfigSchema = z
-  .object({
-    projectSettingsPolicy: z
-      .union([z.literal("trusted"), z.literal("sanitize"), z.literal("ignore")])
-      .optional(),
-    executionContract: z.union([z.literal("default"), z.literal("strict-agentic")]).optional(),
-  })
-  .strict();
-
-export const SilentReplyPolicyConfigSchema = z
-  .object({
-    group: SilentReplyPolicySchema.optional(),
-    internal: SilentReplyPolicySchema.optional(),
-  })
-  .strict();
-
-export const AgentDefaultsSchema = z
-  .object({
-    /** Global default provider params applied to all models before per-model and per-agent overrides. */
-    params: z.record(z.string(), z.unknown()).optional(),
-    model: AgentModelSchema.optional(),
-    modelSelectionScope: z.enum(["session", "agent", "global"]).optional(),
-    utilityModel: z.string().optional(),
-    imageModel: AgentToolModelSchema.optional(),
-    mediaModels: z
-      .object({
-        image: AgentToolModelSchema.optional(),
-        video: AgentToolModelSchema.optional(),
-        music: AgentToolModelSchema.optional(),
-      })
-      .strict()
-      .optional(),
-    voiceModel: AgentToolModelSchema.optional(),
-    pdfModel: AgentToolModelSchema.optional(),
-    pdfMaxMb: z.number().positive().optional(),
-    pdfMaxPages: z.number().int().positive().optional(),
-    models: AgentModelMapSchema.optional(),
-    modelPolicy: AgentModelPolicySchema.optional(),
-    workspace: z.string().optional(),
-    cwd: z.string().optional(),
-    skills: z.array(z.string()).optional(),
-    silentReply: SilentReplyPolicyConfigSchema.optional(),
-    repoRoot: z.string().optional(),
-    skipBootstrap: z.boolean().optional(),
-    skipOptionalBootstrapFiles: z.array(OptionalBootstrapFileNameSchema).optional(),
-    contextInjection: z
-      .union([z.literal("always"), z.literal("continuation-skip"), z.literal("never")])
-      .optional(),
-    bootstrapMaxChars: z.number().int().positive().optional(),
-    bootstrapTotalMaxChars: z.number().int().positive().optional(),
-    experimental: z
-      .object({
-        localModelLean: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    userTimezone: z.string().optional(),
-    startupContext: z
-      .object({
-        enabled: z.boolean().optional(),
-        applyOn: z.array(z.union([z.literal("new"), z.literal("reset")])).optional(),
-        dailyMemoryDays: z.number().int().min(1).max(14).optional(),
-        maxFileBytes: z
-          .number()
-          .int()
-          .min(1)
-          .max(64 * 1024)
-          .optional(),
-        maxFileChars: z.number().int().min(1).max(10_000).optional(),
-        maxTotalChars: z.number().int().min(1).max(50_000).optional(),
-      })
-      .strict()
-      .optional(),
-    contextLimits: AgentContextLimitsSchema,
-    contextPruning: z
-      .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
-        ttl: z.string().optional(),
-        tools: z
-          .object({
-            allow: z.array(z.string()).optional(),
-            deny: z.array(z.string()).optional(),
-          })
-          .strict()
-          .optional(),
-        hardClear: z
-          .object({
-            enabled: z.boolean().optional(),
-            placeholder: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
-    compaction: z
-      .object({
-        enabled: z.boolean().optional(),
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
-        provider: z.string().optional(),
-        thinkingLevel: z.union([AgentThinkingLevelSchema, z.literal("inherit")]).optional(),
-        keepRecentTokens: z.number().int().positive().optional(),
-        identifierPolicy: z.union([z.literal("strict"), z.literal("off")]).optional(),
-        recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
-        qualityGuard: z
-          .object({
-            enabled: z.boolean().optional(),
-            maxRetries: z.number().int().nonnegative().optional(),
-          })
-          .strict()
-          .optional(),
-        midTurnPrecheck: z
-          .object({
-            enabled: z.boolean().optional(),
-          })
-          .strict()
-          .optional(),
-        postIndexSync: z.enum(["off", "async", "await"]).optional(),
-        postCompactionSections: z.array(z.string()).optional(),
-        model: z.string().optional(),
-        timeoutSeconds: z.number().int().positive().optional(),
-        memoryFlush: z
-          .object({
-            enabled: z.boolean().optional(),
-            model: z.string().optional(),
-            softThresholdTokens: z.number().int().nonnegative().optional(),
-            forceFlushTranscriptBytes: NonNegativeByteSizeSchema.optional(),
-          })
-          .strict()
-          .optional(),
-        maxActiveTranscriptBytes: NonNegativeByteSizeSchema.optional(),
-        notifyUser: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    embeddedAgent: EmbeddedAgentConfigSchema.optional(),
-    thinkingDefault: AgentThinkingLevelSchema.optional(),
-    fastModeDefault: z.union([z.boolean(), z.literal("auto")]).optional(),
-    verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
-    toolProgressDetail: z.union([z.literal("explain"), z.literal("raw")]).optional(),
-    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
-    elevatedDefault: z
-      .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
-      .optional(),
-    blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
-    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
-    blockStreamingChunk: BlockStreamingChunkSchema.optional(),
-    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    humanDelay: HumanDelaySchema.optional(),
-    // 0 = unlimited run budget; stream liveness watchdogs still apply.
-    timeoutSeconds: z.number().int().nonnegative().optional(),
-    mediaMaxMb: z.number().positive().optional(),
-    imageMaxDimensionPx: z.number().int().positive().optional(),
-    imageQuality: z.enum(["auto", "efficient", "balanced", "high"]).optional(),
-    typingIntervalSeconds: z.number().int().positive().optional(),
-    typingMode: TypingModeSchema.optional(),
-    heartbeat: HeartbeatSchema.unwrap()
-      .safeExtend({ agentId: z.string().trim().min(1).optional() })
-      .optional(),
-    systemAgent: z
-      .object({
-        agentId: z.string().trim().min(1).optional(),
-      })
-      .strict()
-      .optional(),
-    authInheritance: z
-      .object({
-        agentId: z.string().trim().min(1).optional(),
-      })
-      .strict()
-      .optional(),
-    sessionStore: z
-      .object({
-        agentId: z.string().trim().min(1).optional(),
-      })
-      .strict()
-      .optional(),
-    maxConcurrent: z.number().int().positive().optional(),
-    subagents: z
-      .object({
-        delegationMode: z.enum(["suggest", "prefer"]).optional(),
-        allowAgents: z.array(z.string()).optional(),
-        maxConcurrent: z.number().int().positive().optional(),
-        maxSpawnDepth: z
-          .number()
-          .int()
-          .min(1)
-          .max(5)
-          .optional()
-          .describe(
-            "Maximum nesting depth for sub-agent spawning. Default: 5; 1 makes direct children leaves.",
-          ),
-        maxChildrenPerAgent: z
-          .number()
-          .int()
-          .min(1)
-          .max(20)
-          .optional()
-          .describe(
-            "Maximum number of active children a single agent session can spawn (default: 5).",
-          ),
-        archiveAfterMinutes: z.number().int().min(0).optional(),
-        model: AgentModelSchema.optional(),
-        thinking: z.string().optional(),
-        runTimeoutSeconds: z.number().int().min(0).optional(),
-        announceTimeoutMs: z.number().int().positive().optional(),
-        requireAgentId: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    sandbox: AgentSandboxSchema,
-  })
+export const AgentDefaultsSchema = AgentDefaultsBaseSchema.safeExtend({
+  contextLimits: AgentContextLimitsSchema,
+  blockStreamingChunk: BlockStreamingChunkSchema.optional(),
+  blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+  humanDelay: HumanDelaySchema.optional(),
+  typingMode: TypingModeSchema.optional(),
+  heartbeat: HeartbeatSchema.unwrap()
+    .safeExtend({ agentId: z.string().trim().min(1).optional() })
+    .optional(),
+  sandbox: AgentSandboxSchema,
+})
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -13,7 +13,7 @@ import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { MANAGED_GITHUB_PROFILE_ID_PATTERN } from "./github-identity-profile-id.js";
 import { LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS } from "./web-search-legacy-provider-keys.js";
 import { AgentEntryBaseSchema } from "./zod-schema.agent-entry-base.js";
-import { AgentModelSchema, AgentToolModelSchema } from "./zod-schema.agent-model.js";
+import { AgentModelSchema } from "./zod-schema.agent-model.js";
 import {
   GroupChatSchema,
   HumanDelaySchema,
@@ -31,8 +31,6 @@ import {
   SandboxPruneSchema,
 } from "./zod-schema.sandbox.js";
 import { sensitive } from "./zod-schema.sensitive.js";
-
-export { AgentModelMapSchema, AgentModelPolicySchema } from "./zod-schema.agent-entry-base.js";
 
 const AgentTtsConfigSchema = TtsConfigSchema.unwrap()
   .extend({ prefsPath: z.string().optional() })
@@ -701,8 +699,6 @@ export const MemorySearchSchema = z
   })
   .strict()
   .optional();
-export { AgentModelSchema, AgentToolModelSchema };
-
 export const AgentEntrySchema = AgentEntryBaseSchema.extend({
   memory: z
     .object({


### PR DESCRIPTION
## Summary

- extract a dependency-safe `AgentDefaultsBaseSchema`
- derive the released agent-defaults authoring contract from that schema
- retain explicit overlays for Doctor-only legacy inputs and dependency-heavy runtime validators
- remove obsolete runtime-schema re-exports

Production diff: **+259 / -468 = -209 LOC**.

## Compatibility

This is a type-ownership refactor. Runtime parsing, defaults, persistence, and migration behavior are unchanged. The explicit overlays preserve all nine Doctor-only legacy inputs plus the existing heartbeat, sandbox, tools, and context-limit authoring contracts.

## Proof

- 520 focused config and Doctor tests
- core production and all test-type shards
- Plugin SDK declaration generation
- runtime and Madge cycle checks
- full `pnpm check:changed`
- fresh P0-P2 review

