### PR TITLE
refactor(config): derive MCP server types from schema

### DIFF
--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -1,71 +1,12 @@
 // Defines MCP server and tool approval configuration types.
-export type McpCodexToolApprovalMode = "auto" | "prompt" | "approve";
+import type { McpServerConfigInput } from "./zod-schema.mcp-server.js";
 
-export type McpServerCodexConfig = {
-  /** OpenClaw agent ids that should receive this server in Codex app-server threads. */
-  agents?: string[];
-  /** Codex MCP tool approval mode emitted as default_tools_approval_mode. */
-  defaultToolsApprovalMode?: McpCodexToolApprovalMode;
-};
-
-export type McpServerToolFilterConfig = {
-  /**
-   * Exact MCP tool names or simple "*" globs to expose from this server.
-   *
-   * When omitted, all server tools remain eligible unless excluded.
-   */
-  include?: string[];
-  /** Exact MCP tool names or simple "*" globs to hide from this server. */
-  exclude?: string[];
-};
-
-export type McpServerConfig = {
-  /** Set false to keep the saved definition while excluding it from runtime/probe sessions. */
-  enabled?: boolean;
-  /** Stdio transport: command to spawn. */
-  command?: string;
-  /** Stdio transport: arguments for the command. */
-  args?: string[];
-  /** Environment variables passed to the server process (stdio only). */
-  env?: Record<string, string | number | boolean>;
-  /** Working directory for stdio server. */
-  cwd?: string;
-  /** HTTP transport: URL of the remote MCP server (http or https). */
-  url?: string;
-  /** Transport type — "stdio" for command-bearing servers, "sse" or "streamable-http" for remote URLs. */
-  transport?: "stdio" | "sse" | "streamable-http";
-  /** HTTP transport: extra HTTP headers sent with every request. */
-  headers?: Record<string, string | number | boolean>;
-  /** Optional connection timeout in milliseconds. */
-  connectionTimeoutMs?: number;
-  /** Optional per-request timeout in milliseconds. */
-  requestTimeoutMs?: number;
-  /** Whether this server can safely handle concurrent tool calls. */
-  supportsParallelToolCalls?: boolean;
-  /** HTTP OAuth mode. Tokens are stored in OpenClaw state, not in config. */
-  auth?: "oauth";
-  /** Optional OAuth client metadata overrides for HTTP MCP servers. */
-  oauth?: {
-    /** Credential ownership for this server. Defaults to shared operator credentials. */
-    identity?: "shared" | "per-requester";
-    /** Refresh-capable auth profile used to inject the current bearer token. */
-    authProfileId?: string;
-    scope?: string;
-    redirectUrl?: string;
-    clientMetadataUrl?: string;
-  };
-  /** HTTP TLS verification, disabled only for explicitly trusted private endpoints. */
-  sslVerify?: boolean;
-  /** HTTP mutual TLS client certificate path. */
-  clientCert?: string;
-  /** HTTP mutual TLS client key path. */
-  clientKey?: string;
-  /** Optional per-server OpenClaw MCP tool selection. */
-  toolFilter?: McpServerToolFilterConfig;
-  /** Codex-specific projection controls for Codex app-server/runtime config. */
-  codex?: McpServerCodexConfig;
-  [key: string]: unknown;
-};
+export type McpServerConfig = McpServerConfigInput;
+export type McpServerCodexConfig = NonNullable<McpServerConfigInput["codex"]>;
+export type McpCodexToolApprovalMode = NonNullable<
+  McpServerCodexConfig["defaultToolsApprovalMode"]
+>;
+export type McpServerToolFilterConfig = NonNullable<McpServerConfigInput["toolFilter"]>;
 
 export type McpConfig = {
   /** Session runtime idle TTL in milliseconds; unset or zero keeps the runtime alive. */

--- a/src/config/zod-schema.mcp-server.ts
+++ b/src/config/zod-schema.mcp-server.ts
@@ -1,0 +1,160 @@
+import { isHttpsUrl, isHttpUrl } from "@openclaw/net-policy/url-protocol";
+import { z } from "zod";
+import { sensitive } from "./zod-schema.sensitive.js";
+
+const HttpUrlSchema = z.string().url().refine(isHttpUrl, "Expected http:// or https:// URL");
+
+const McpOAuthClientMetadataUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const url = new URL(value);
+    return isHttpsUrl(url) && url.pathname !== "/";
+  }, "Expected https:// URL with a non-root pathname");
+
+export const McpServerSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    command: z.string().optional(),
+    args: z.array(z.string()).optional(),
+    env: z
+      .record(
+        z.string(),
+        z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
+      )
+      .optional(),
+    cwd: z.string().optional(),
+    url: HttpUrlSchema.optional(),
+    transport: z
+      .union([z.literal("stdio"), z.literal("sse"), z.literal("streamable-http")])
+      .optional(),
+    headers: z
+      .record(
+        z.string(),
+        z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
+      )
+      .optional(),
+    connectionTimeoutMs: z.number().finite().positive().optional(),
+    requestTimeoutMs: z.number().finite().positive().optional(),
+    supportsParallelToolCalls: z.boolean().optional(),
+    auth: z.literal("oauth").optional(),
+    oauth: z
+      .strictObject({
+        identity: z.enum(["shared", "per-requester"]).optional(),
+        authProfileId: z.string().trim().min(1).optional(),
+        scope: z.string().trim().min(1).optional(),
+        redirectUrl: HttpUrlSchema.optional(),
+        clientMetadataUrl: McpOAuthClientMetadataUrlSchema.optional(),
+      })
+      .optional(),
+    sslVerify: z.boolean().optional(),
+    clientCert: z.string().optional(),
+    clientKey: z.string().optional(),
+    toolFilter: z
+      .strictObject({
+        include: z.array(z.string().trim().min(1)).min(1).optional(),
+        exclude: z.array(z.string().trim().min(1)).min(1).optional(),
+      })
+      .optional(),
+    codex: z
+      .strictObject({
+        agents: z
+          .array(
+            z
+              .string()
+              .trim()
+              .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i),
+          )
+          .min(1)
+          .optional(),
+        defaultToolsApprovalMode: z.enum(["auto", "prompt", "approve"]).optional(),
+      })
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    // This schema is .catchall(z.unknown()) (open-world server options), so
+    // unknown keys survive into this refine; retired aliases are rejected here.
+    for (const key of [
+      "connectTimeout",
+      "connect_timeout",
+      "timeout",
+      "workingDirectory",
+      "supports_parallel_tool_calls",
+      "ssl_verify",
+      "client_cert",
+      "client_key",
+    ] as const) {
+      if (Object.hasOwn(data, key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unrecognized key: "${key}"`,
+        });
+      }
+    }
+    const codex = data.codex;
+    if (codex && Object.hasOwn(codex, "default_tools_approval_mode")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["codex", "default_tools_approval_mode"],
+        message: 'Unrecognized key: "default_tools_approval_mode"',
+      });
+    }
+    if (Object.hasOwn(data, "disabled")) {
+      const disabled = Reflect.get(data, "disabled") as unknown;
+      const replacement =
+        typeof disabled === "boolean"
+          ? `"enabled: ${!disabled}" instead, then run "openclaw doctor --fix" to migrate existing config`
+          : 'the canonical "enabled" boolean instead';
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `unsupported key "disabled"; use ${replacement}`,
+        path: ["disabled"],
+      });
+    }
+    if (data.oauth?.identity === "per-requester") {
+      if (data.auth !== "oauth") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'oauth.identity "per-requester" requires auth: "oauth"',
+          path: ["oauth", "identity"],
+        });
+      }
+      if (data.oauth.authProfileId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'oauth.authProfileId cannot be used with oauth.identity "per-requester"',
+          path: ["oauth", "authProfileId"],
+        });
+      }
+      if (!data.url) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'oauth.identity "per-requester" requires an HTTP server URL',
+          path: ["oauth", "identity"],
+        });
+      }
+      // Command precedence would resolve stdio and strand the server: partitioned
+      // out of the static runtime with no requester sign-in path.
+      if (data.command !== undefined || data.transport === "stdio") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'oauth.identity "per-requester" cannot be combined with a command or "stdio" transport',
+          path: ["oauth", "identity"],
+        });
+      }
+    }
+    if (
+      data.transport === "stdio" &&
+      (typeof data.command !== "string" || data.command.trim().length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '"stdio" transport requires a non-empty command',
+        path: ["transport"],
+      });
+    }
+  })
+  .catchall(z.unknown());
+
+export type McpServerConfigInput = z.input<typeof McpServerSchema>;

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -1,4 +1,3 @@
-import { isHttpsUrl, isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import { findEdgeAuthIssue } from "../shared/gateway-edge-auth-headers.js";
@@ -6,6 +5,7 @@ import type { ConfigSchemaShape } from "./schema.field-metadata.js";
 import type { GatewayRemoteConfig } from "./types.gateway.js";
 import { MemorySearchSchema } from "./zod-schema.agent-runtime.js";
 import { SecretInputSchema } from "./zod-schema.core.js";
+import { McpServerSchema } from "./zod-schema.mcp-server.js";
 import { NodeHostAgentRunsSchema, NodeHostWorkerRunsSchema } from "./zod-schema.node-host.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
@@ -117,16 +117,6 @@ export const MemorySchema = z
     search: MemorySearchSchema,
   })
   .optional();
-
-const HttpUrlSchema = z.string().url().refine(isHttpUrl, "Expected http:// or https:// URL");
-
-const McpOAuthClientMetadataUrlSchema = z
-  .string()
-  .url()
-  .refine((value) => {
-    const url = new URL(value);
-    return isHttpsUrl(url) && url.pathname !== "/";
-  }, "Expected https:// URL with a non-root pathname");
 
 export const ResponsesEndpointUrlFetchShape = {
   allowUrl: z.boolean().optional(),
@@ -251,152 +241,6 @@ export const TalkSchema = z
       });
     }
   });
-
-const McpServerSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    command: z.string().optional(),
-    args: z.array(z.string()).optional(),
-    env: z
-      .record(
-        z.string(),
-        z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
-      )
-      .optional(),
-    cwd: z.string().optional(),
-    url: HttpUrlSchema.optional(),
-    transport: z
-      .union([z.literal("stdio"), z.literal("sse"), z.literal("streamable-http")])
-      .optional(),
-    headers: z
-      .record(
-        z.string(),
-        z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
-      )
-      .optional(),
-    connectionTimeoutMs: z.number().finite().positive().optional(),
-    requestTimeoutMs: z.number().finite().positive().optional(),
-    supportsParallelToolCalls: z.boolean().optional(),
-    auth: z.literal("oauth").optional(),
-    oauth: z
-      .strictObject({
-        identity: z.enum(["shared", "per-requester"]).optional(),
-        authProfileId: z.string().trim().min(1).optional(),
-        scope: z.string().trim().min(1).optional(),
-        redirectUrl: HttpUrlSchema.optional(),
-        clientMetadataUrl: McpOAuthClientMetadataUrlSchema.optional(),
-      })
-      .optional(),
-    sslVerify: z.boolean().optional(),
-    clientCert: z.string().optional(),
-    clientKey: z.string().optional(),
-    toolFilter: z
-      .strictObject({
-        include: z.array(z.string().trim().min(1)).min(1).optional(),
-        exclude: z.array(z.string().trim().min(1)).min(1).optional(),
-      })
-      .optional(),
-    codex: z
-      .strictObject({
-        agents: z
-          .array(
-            z
-              .string()
-              .trim()
-              .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i),
-          )
-          .min(1)
-          .optional(),
-        defaultToolsApprovalMode: z.enum(["auto", "prompt", "approve"]).optional(),
-      })
-      .optional(),
-  })
-  .superRefine((data, ctx) => {
-    // This schema is .catchall(z.unknown()) (open-world server options), so
-    // unknown keys survive into this refine; retired aliases are rejected here.
-    for (const key of [
-      "connectTimeout",
-      "connect_timeout",
-      "timeout",
-      "workingDirectory",
-      "supports_parallel_tool_calls",
-      "ssl_verify",
-      "client_cert",
-      "client_key",
-    ] as const) {
-      if (Object.hasOwn(data, key)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Unrecognized key: "${key}"`,
-        });
-      }
-    }
-    const codex = data.codex;
-    if (codex && Object.hasOwn(codex, "default_tools_approval_mode")) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["codex", "default_tools_approval_mode"],
-        message: 'Unrecognized key: "default_tools_approval_mode"',
-      });
-    }
-    if (Object.hasOwn(data, "disabled")) {
-      const disabled = Reflect.get(data, "disabled") as unknown;
-      const replacement =
-        typeof disabled === "boolean"
-          ? `"enabled: ${!disabled}" instead, then run "openclaw doctor --fix" to migrate existing config`
-          : 'the canonical "enabled" boolean instead';
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `unsupported key "disabled"; use ${replacement}`,
-        path: ["disabled"],
-      });
-    }
-    if (data.oauth?.identity === "per-requester") {
-      if (data.auth !== "oauth") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'oauth.identity "per-requester" requires auth: "oauth"',
-          path: ["oauth", "identity"],
-        });
-      }
-      if (data.oauth.authProfileId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'oauth.authProfileId cannot be used with oauth.identity "per-requester"',
-          path: ["oauth", "authProfileId"],
-        });
-      }
-      if (!data.url) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'oauth.identity "per-requester" requires an HTTP server URL',
-          path: ["oauth", "identity"],
-        });
-      }
-      // Command precedence would resolve stdio and strand the server: partitioned
-      // out of the static runtime with no requester sign-in path.
-      if (data.command !== undefined || data.transport === "stdio") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'oauth.identity "per-requester" cannot be combined with a command or "stdio" transport',
-          path: ["oauth", "identity"],
-        });
-      }
-    }
-    // transport "stdio" requires a non-empty command — URL-only servers must use "sse" or "streamable-http"
-    if (
-      data.transport === "stdio" &&
-      (typeof data.command !== "string" || data.command.trim().length === 0)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: '"stdio" transport requires a non-empty command',
-        path: ["transport"],
-      });
-    }
-  })
-  .catchall(z.unknown());
 
 const RESERVED_MCP_SERVER_NAME = "__proto__";
 const RESERVED_MCP_SERVER_NAME_ERROR = 'MCP server name "__proto__" is reserved; rename the server';


### PR DESCRIPTION
## Summary

- extract the MCP server validator into a dependency-safe schema leaf
- derive the released server, Codex, tool-filter, and approval-mode authoring contracts from its input
- remove the parallel handwritten MCP server hierarchy

Production diff: **+168 / -223 = -55 LOC**.

## Compatibility

All transport, OAuth, URL, retired-key, and stdio refinements moved unchanged. Zod's catchall input preserves the released open-world `[key: string]: unknown` server contract, and the existing named public aliases remain exported. Runtime config persistence and normalization are unchanged.

## Proof

- 164 focused schema, config, transport, OAuth, Codex, and node-host tests
- core production and all test-type shards
- Plugin SDK declaration generation
- runtime and Madge cycle checks
- full `pnpm check:changed`
- fresh P0-P2 review

