### PR TITLE
refactor(config): derive memory search types from schema

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -534,7 +534,6 @@ src/config/sessions/session-accessor.conformance.test.ts
 src/config/sessions/session-accessor.test.ts
 src/config/sessions/transcript.test.ts
 src/config/sessions/transcript.ts
-src/config/zod-schema.agent-runtime.ts
 src/config/zod-schema.core.ts
 src/context-engine/context-engine.test.ts
 src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -1,9 +1,8 @@
-import type { MemoryExtraPath } from "../memory-host-sdk/host/types.js";
 /**
  * Memory config types shared by core context-engine paths and memory host/plugin runtimes.
  * Builtin memory stays core-owned.
  */
-import type { SecretInput } from "./types.secrets.js";
+import type { MemorySearchConfigInput } from "./zod-schema.memory-search.js";
 
 export type { MemoryExtraPath } from "../memory-host-sdk/host/types.js";
 
@@ -17,86 +16,12 @@ export type MemoryConfig = {
   search?: MemorySearchConfig;
 };
 
-export type MemorySearchConfig = {
-  /** Enable vector memory search (default: true). */
-  enabled?: boolean;
-  /** Use relevant context from this agent's other private conversations. */
-  rememberAcrossConversations?: boolean;
-  /** Sources to index and search (default: ["memory"]). */
-  sources?: Array<"memory" | "sessions">;
-  /** Extra paths to include in memory search, optionally filtered by a glob. */
-  extraPaths?: MemoryExtraPath[];
-  /** Optional multimodal file indexing for selected extra paths. */
-  multimodal?: {
-    /** Enable image/audio embeddings from extraPaths. */
-    enabled?: boolean;
-    /** Which non-text file types to index. */
-    modalities?: Array<"image" | "audio" | "all">;
-    /** Max bytes allowed per multimodal file before it is skipped. */
-    maxFileBytes?: number;
-  };
-  /** Experimental session transcript indexing. */
-  experimental?: {
-    sessionMemory?: boolean;
-  };
-  /** Memory embedding provider adapter id. */
-  provider?: string;
-  remote?: {
-    baseUrl?: string;
-    apiKey?: SecretInput;
-    headers?: Record<string, string>;
-    batch?: {
-      /** Enable batch API for embedding indexing (OpenAI/Gemini; default: true). */
-      enabled?: boolean;
-    };
-  };
-  /** Fallback memory embedding provider adapter id when embeddings fail. */
-  fallback?: string;
-  /** Embedding model id (remote) or alias (local). */
-  model?: string;
-  /** Optional provider-specific embedding input_type for query and document requests. */
-  inputType?: string;
-  /** Optional provider-specific embedding input_type for query-time memory search. */
-  queryInputType?: string;
-  /** Optional provider-specific embedding input_type for document/index embeddings. */
-  documentInputType?: string;
-  /**
-   * Provider-specific output vector dimensions. Gemini supports 128 to 3072.
-   * Google recommends 768, 1536, or 3072 dimensions.
-   */
-  outputDimensionality?: number;
-  /** Local embedding settings for the managed llama.cpp server. */
-  local?: {
-    /** GGUF model path or hf: URI. */
-    modelPath?: string;
-  };
-  /** Index storage configuration. */
-  store?: {
-    fts?: {
-      /** FTS5 tokenizer (default: "unicode61"). Use "trigram" for CJK text support. */
-      tokenizer?: "unicode61" | "trigram";
-    };
-    vector?: {
-      /** Enable the sqlite-vec semantic index (default: true). */
-      enabled?: boolean;
-      /** Optional override path to sqlite-vec extension (.dylib/.so/.dll). */
-      extensionPath?: string;
-    };
+export type MemorySearchConfig = Omit<MemorySearchConfigInput, "store"> & {
+  /** Preserve legacy embedding-cache authoring accepted by Doctor migrations. */
+  store?: NonNullable<MemorySearchConfigInput["store"]> & {
     cache?: {
-      /** Enable embedding cache (default: true). */
       enabled?: boolean;
-      /** Optional max cache entries per provider/model. */
       maxEntries?: number;
     };
-  };
-  /** Query behavior. */
-  query?: {
-    maxResults?: number;
-    minScore?: number;
-  };
-  /** Index cache behavior. */
-  cache?: {
-    /** Cache chunk embeddings in SQLite (default: true). */
-    enabled?: boolean;
   };
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -25,6 +25,7 @@ import {
   TypingModeSchema,
   TtsConfigSchema,
 } from "./zod-schema.core.js";
+import { MemorySearchSchema } from "./zod-schema.memory-search.js";
 import {
   SandboxBrowserSchema,
   SandboxDockerSchema,
@@ -614,91 +615,6 @@ const AgentToolsSchema = z
   })
   .optional();
 
-export const MemorySearchSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    rememberAcrossConversations: z.boolean().optional(),
-    sources: z.array(z.union([z.literal("memory"), z.literal("sessions")])).optional(),
-    extraPaths: z
-      .array(
-        z.union([
-          z.string(),
-          z.object({ path: z.string(), pattern: z.string().optional() }).strict(),
-        ]),
-      )
-      .optional(),
-    multimodal: z
-      .object({
-        enabled: z.boolean().optional(),
-        modalities: z
-          .array(z.union([z.literal("image"), z.literal("audio"), z.literal("all")]))
-          .optional(),
-        maxFileBytes: z.number().int().positive().optional(),
-      })
-      .strict()
-      .optional(),
-    experimental: z.object({ sessionMemory: z.boolean().optional() }).strict().optional(),
-    provider: z.string().optional(),
-    remote: z
-      .object({
-        baseUrl: z.string().optional(),
-        apiKey: SecretInputSchema.optional().register(sensitive),
-        headers: z.record(z.string(), z.string()).optional(),
-        batch: z
-          .object({
-            enabled: z.boolean().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
-    fallback: z.string().optional(),
-    model: z.string().optional(),
-    inputType: z.string().min(1).optional(),
-    queryInputType: z.string().min(1).optional(),
-    documentInputType: z.string().min(1).optional(),
-    outputDimensionality: z.number().int().positive().optional(),
-    local: z
-      .object({
-        modelPath: z.string().optional(),
-      })
-      .strict()
-      .optional(),
-    store: z
-      .object({
-        fts: z
-          .object({
-            tokenizer: z.union([z.literal("unicode61"), z.literal("trigram")]).optional(),
-          })
-          .strict()
-          .optional(),
-        vector: z
-          .object({
-            enabled: z.boolean().optional(),
-            extensionPath: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
-    query: z
-      .object({
-        maxResults: z.number().int().positive().optional(),
-        minScore: z.number().min(0).max(1).optional(),
-      })
-      .strict()
-      .optional(),
-    cache: z
-      .object({
-        enabled: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .optional();
 export const AgentEntrySchema = AgentEntryBaseSchema.extend({
   memory: z
     .object({
@@ -790,4 +706,3 @@ export const ToolsSchema = z
     );
   })
   .optional();
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -5,20 +5,17 @@ import { z } from "zod";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import type { OpenRouterRouting, VercelGatewayRouting } from "../llm/types.js";
 import { normalizeExactAllowedHost } from "../secrets/exact-hostname.js";
-import {
-  formatExecSecretRefIdValidationMessage,
-  isValidExecSecretRefId,
-  isValidFileSecretRefId,
-  SECRET_PROVIDER_ALIAS_PATTERN,
-} from "../secrets/ref-contract.js";
+import { SECRET_PROVIDER_ALIAS_PATTERN } from "../secrets/ref-contract.js";
 import { isBuiltInModelProviderOverlayId } from "./model-provider-config.js";
 import type { ModelCompatConfig } from "./types.models.js";
 import { MODEL_APIS, MODEL_THINKING_FORMATS } from "./types.models.js";
 import { ENV_SECRET_REF_ID_RE } from "./types.secrets.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
+import { SecretInputSchema } from "./zod-schema.secret-input.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 export { isBuiltInModelProviderOverlayId } from "./model-provider-config.js";
+export { SecretInputSchema, SecretRefSchema } from "./zod-schema.secret-input.js";
 
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
@@ -32,84 +29,6 @@ function isAbsolutePath(value: string): boolean {
     WINDOWS_UNC_PATH_PATTERN.test(value)
   );
 }
-
-const EnvSecretRefSchema = z
-  .object({
-    source: z.literal("env"),
-    provider: z
-      .string()
-      .regex(
-        SECRET_PROVIDER_ALIAS_PATTERN,
-        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
-      ),
-    id: z
-      .string()
-      .regex(
-        ENV_SECRET_REF_ID_RE,
-        'Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
-      ),
-  })
-  .strict();
-
-const FileSecretRefSchema = z
-  .object({
-    source: z.literal("file"),
-    provider: z
-      .string()
-      .regex(
-        SECRET_PROVIDER_ALIAS_PATTERN,
-        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
-      ),
-    id: z
-      .string()
-      .refine(
-        isValidFileSecretRefId,
-        'File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.',
-      ),
-  })
-  .strict();
-
-const ExecSecretRefSchema = z
-  .object({
-    source: z.literal("exec"),
-    provider: z
-      .string()
-      .regex(
-        SECRET_PROVIDER_ALIAS_PATTERN,
-        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
-      ),
-    id: z.string().refine(isValidExecSecretRefId, formatExecSecretRefIdValidationMessage()),
-  })
-  .strict();
-
-const StoreSecretRefSchema = z
-  .object({
-    source: z.literal("store"),
-    provider: z
-      .string()
-      .regex(
-        SECRET_PROVIDER_ALIAS_PATTERN,
-        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
-      ),
-    id: z
-      .string()
-      .regex(
-        ENV_SECRET_REF_ID_RE,
-        'Store secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
-      ),
-  })
-  .strict();
-
-/** Config-level secret reference schema shared by model/provider/plugin credential fields. */
-export const SecretRefSchema = z.discriminatedUnion("source", [
-  EnvSecretRefSchema,
-  FileSecretRefSchema,
-  ExecSecretRefSchema,
-  StoreSecretRefSchema,
-]);
-
-/** Accepts either legacy inline secret strings or structured secret references. */
-export const SecretInputSchema = z.union([z.string(), SecretRefSchema]);
 
 /** Canonical operator-configurable SSRF policy shared by network-capable surfaces. */
 export const SsrFPolicyConfigSchema = z

--- a/src/config/zod-schema.memory-search.ts
+++ b/src/config/zod-schema.memory-search.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { SecretInputSchema } from "./zod-schema.secret-input.js";
+import { sensitive } from "./zod-schema.sensitive.js";
+
+export const MemorySearchSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    rememberAcrossConversations: z.boolean().optional(),
+    sources: z.array(z.union([z.literal("memory"), z.literal("sessions")])).optional(),
+    extraPaths: z
+      .array(
+        z.union([
+          z.string(),
+          z.object({ path: z.string(), pattern: z.string().optional() }).strict(),
+        ]),
+      )
+      .optional(),
+    multimodal: z
+      .object({
+        enabled: z.boolean().optional(),
+        modalities: z
+          .array(z.union([z.literal("image"), z.literal("audio"), z.literal("all")]))
+          .optional(),
+        maxFileBytes: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    experimental: z.object({ sessionMemory: z.boolean().optional() }).strict().optional(),
+    provider: z.string().optional(),
+    remote: z
+      .object({
+        baseUrl: z.string().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        headers: z.record(z.string(), z.string()).optional(),
+        batch: z
+          .object({
+            enabled: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    fallback: z.string().optional(),
+    model: z.string().optional(),
+    inputType: z.string().min(1).optional(),
+    queryInputType: z.string().min(1).optional(),
+    documentInputType: z.string().min(1).optional(),
+    outputDimensionality: z.number().int().positive().optional(),
+    local: z
+      .object({
+        modelPath: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    store: z
+      .object({
+        fts: z
+          .object({
+            tokenizer: z.union([z.literal("unicode61"), z.literal("trigram")]).optional(),
+          })
+          .strict()
+          .optional(),
+        vector: z
+          .object({
+            enabled: z.boolean().optional(),
+            extensionPath: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    query: z
+      .object({
+        maxResults: z.number().int().positive().optional(),
+        minScore: z.number().min(0).max(1).optional(),
+      })
+      .strict()
+      .optional(),
+    cache: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
+export type MemorySearchConfigInput = NonNullable<z.input<typeof MemorySearchSchema>>;

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import { findEdgeAuthIssue } from "../shared/gateway-edge-auth-headers.js";
 import type { ConfigSchemaShape } from "./schema.field-metadata.js";
 import type { GatewayRemoteConfig } from "./types.gateway.js";
-import { MemorySearchSchema } from "./zod-schema.agent-runtime.js";
 import { SecretInputSchema } from "./zod-schema.core.js";
 import { McpServerSchema } from "./zod-schema.mcp-server.js";
+import { MemorySearchSchema } from "./zod-schema.memory-search.js";
 import { NodeHostAgentRunsSchema, NodeHostWorkerRunsSchema } from "./zod-schema.node-host.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 

--- a/src/config/zod-schema.secret-input.ts
+++ b/src/config/zod-schema.secret-input.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import {
+  formatExecSecretRefIdValidationMessage,
+  isValidExecSecretRefId,
+  isValidFileSecretRefId,
+  SECRET_PROVIDER_ALIAS_PATTERN,
+} from "../secrets/ref-contract.js";
+import { ENV_SECRET_REF_ID_RE } from "./types.secrets.js";
+
+const EnvSecretRefSchema = z
+  .object({
+    source: z.literal("env"),
+    provider: z
+      .string()
+      .regex(
+        SECRET_PROVIDER_ALIAS_PATTERN,
+        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
+      ),
+    id: z
+      .string()
+      .regex(
+        ENV_SECRET_REF_ID_RE,
+        'Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
+      ),
+  })
+  .strict();
+
+const FileSecretRefSchema = z
+  .object({
+    source: z.literal("file"),
+    provider: z
+      .string()
+      .regex(
+        SECRET_PROVIDER_ALIAS_PATTERN,
+        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
+      ),
+    id: z
+      .string()
+      .refine(
+        isValidFileSecretRefId,
+        'File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.',
+      ),
+  })
+  .strict();
+
+const ExecSecretRefSchema = z
+  .object({
+    source: z.literal("exec"),
+    provider: z
+      .string()
+      .regex(
+        SECRET_PROVIDER_ALIAS_PATTERN,
+        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
+      ),
+    id: z.string().refine(isValidExecSecretRefId, formatExecSecretRefIdValidationMessage()),
+  })
+  .strict();
+
+const StoreSecretRefSchema = z
+  .object({
+    source: z.literal("store"),
+    provider: z
+      .string()
+      .regex(
+        SECRET_PROVIDER_ALIAS_PATTERN,
+        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
+      ),
+    id: z
+      .string()
+      .regex(
+        ENV_SECRET_REF_ID_RE,
+        'Store secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
+      ),
+  })
+  .strict();
+
+/** Config-level secret reference schema shared by model/provider/plugin credential fields. */
+export const SecretRefSchema = z.discriminatedUnion("source", [
+  EnvSecretRefSchema,
+  FileSecretRefSchema,
+  ExecSecretRefSchema,
+  StoreSecretRefSchema,
+]);
+
+/** Accepts either legacy inline secret strings or structured secret references. */
+export const SecretInputSchema = z.union([z.string(), SecretRefSchema]);


### PR DESCRIPTION
## Summary

- extract dependency-safe memory-search and secret-input schema leaves
- preserve the existing core secret-schema exports
- derive the memory-search authoring contract from the canonical schema
- remove the now-obsolete max-lines suppression and baseline entry

Production diff: **+186 / -250 = -64 LOC**.

## Compatibility

Secret reference validation moved unchanged and remains re-exported from the existing core module. Runtime parsing, persistence, normalization, and migrations are unchanged. The explicit `store.cache` overlay preserves the legacy Doctor migration input that is intentionally outside the current runtime schema.

## Proof

- focused memory, config, Doctor, migration, and secret-schema test projects
- core production and all test-type shards
- Plugin SDK declaration generation
- runtime and Madge cycle checks
- full `pnpm check:changed`
- fresh P0-P2 review

