### PR TITLE
fix(models): preserve selected IDs during rematerialization

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -439,6 +439,7 @@ async function materializeBtwRuntimeModel(
       ...(params.forceResolve !== undefined ? { forceResolve: params.forceResolve } : {}),
       resolveModel: ({ config, authProfileId, authProfileMode }) =>
         resolveModelAsync(params.provider, params.modelId, agentDir, config, {
+          modelIdSource: "selected",
           authStorage: params.authStorage,
           modelRegistry: params.modelRegistry,
           skipAgentDiscovery: true,

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -377,6 +377,7 @@ export function shouldCompareProviderRuntimeResolvedModel(params: {
 export function normalizeProviderModelRef(params: {
   provider: string;
   modelId: string;
+  modelIdSource?: "input" | "selected";
   cfg?: OpenClawConfig;
   workspaceDir?: string;
 }): {
@@ -392,10 +393,13 @@ export function normalizeProviderModelRef(params: {
   });
   return {
     provider: manifestAlias.provider,
-    model: normalizeStaticProviderModelId(
-      normalizeProviderId(manifestAlias.provider),
-      params.modelId,
-    ),
+    model:
+      params.modelIdSource === "selected"
+        ? params.modelId
+        : normalizeStaticProviderModelId(
+            normalizeProviderId(manifestAlias.provider),
+            params.modelId,
+          ),
     manifestAlias,
   };
 }

--- a/src/agents/embedded-agent-runner/model.selected-materialization.test.ts
+++ b/src/agents/embedded-agent-runner/model.selected-materialization.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.types.js";
+import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
+import { makeProviderModelFixture } from "../test-helpers/provider-model-fixture.js";
+import { createEmptyAgentDiscoveryStores, resolveModelAsync } from "./model.js";
+
+const provider = "selected-model-test";
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: provider,
+      providers: [provider],
+      modelIdNormalization: {
+        providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
+      },
+    },
+  ],
+});
+
+function createResolutionOptions() {
+  const stores = createEmptyAgentDiscoveryStores();
+  stores.modelRegistry.registerProvider(provider, {
+    api: "openai-completions",
+    baseUrl: "https://selected-model.example/v1",
+    models: ["middle", "final"].map((id) =>
+      Object.assign(
+        makeProviderModelFixture({
+          provider,
+          id,
+          api: "openai-completions",
+          baseUrl: "https://selected-model.example/v1",
+        }),
+        { contextWindow: 16_000, maxTokens: 4_096 },
+      ),
+    ),
+  });
+  return { ...stores, skipAgentDiscovery: true, skipProviderRuntimeHooks: true };
+}
+
+describe("selected model materialization", () => {
+  it("keeps raw input alias resolution", async () => {
+    await withPluginRuntimeGenerationScope({ metadataSnapshot }, async () => {
+      const options = createResolutionOptions();
+      for (const [input, expected] of [
+        ["entry", "middle"],
+        ["middle", "final"],
+      ] as const) {
+        const result = await resolveModelAsync(provider, input, undefined, {}, options);
+        expect(result.model?.id).toBe(expected);
+      }
+    });
+  });
+
+  it.each(["direct", "credential", "route"] as const)(
+    "preserves the selected executable ID during %s materialization",
+    async (mode) => {
+      await withPluginRuntimeGenerationScope({ metadataSnapshot }, async () => {
+        const options = createResolutionOptions();
+        const selected = await resolveModelAsync(provider, "entry", undefined, {}, options);
+        expect(selected.model?.id).toBe("middle");
+        const resolveModel = () =>
+          resolveModelAsync(
+            provider,
+            "middle",
+            undefined,
+            {},
+            {
+              ...options,
+              modelIdSource: "selected",
+            },
+          );
+        const model =
+          mode === "direct"
+            ? (await resolveModel()).model
+            : await materializePreparedRuntimeModel({
+                plan: {
+                  providerForAuth: provider,
+                  authProfileProviderForAuth: provider,
+                  selectedAuthMode: "api-key",
+                  ...(mode === "route"
+                    ? {
+                        modelRoute: {
+                          provider,
+                          modelId: "middle",
+                          api: "openai-completions" as const,
+                          baseUrl: "https://selected-model.example/v1",
+                          authRequirement: "api-key" as const,
+                          requestTransportOverrides: "none" as const,
+                        },
+                      }
+                    : {}),
+                },
+                provider,
+                modelId: "middle",
+                model: selected.model,
+                metadataSnapshot,
+                forceResolve: true,
+                resolveModel,
+              });
+        expect(model?.id).toBe("middle");
+      });
+    },
+  );
+
+  it.each([
+    { name: "literal row", rowProvider: provider, wireId: "middle", expected: 1100 },
+    {
+      name: "provider spelling",
+      rowProvider: provider.toUpperCase(),
+      wireId: "middle",
+      expected: 1100,
+    },
+    { name: "logical reference", rowProvider: provider, wireId: "wire-middle", expected: 1100 },
+    { name: "equivalent fallback", rowProvider: undefined, wireId: "middle", expected: 2200 },
+  ])(
+    "uses the captured $name for selected model media metadata",
+    async ({ rowProvider, wireId, expected }) => {
+      const options = createResolutionOptions();
+      const row = (providerId: string, modelId: string, id: string, maxSidePx: number) => ({
+        provider: providerId,
+        modelId,
+        model: {
+          ...makeProviderModelFixture({
+            provider: providerId,
+            id,
+            api: "openai-completions",
+            baseUrl: "https://selected-model.example/v1",
+          }),
+          mediaInput: { image: { maxSidePx } },
+        },
+      });
+      const config = {};
+      const preparedModelRuntime = {
+        catalogOwner: undefined,
+        agentDir: "/tmp/selected-model-test",
+        activeProjectKeys: [],
+        allowGatewaySubagentBinding: false,
+        config,
+        observationConfig: config,
+        isCurrent: () => true,
+        authModes: {},
+        metadataSnapshot,
+        modelCatalog: { entries: [], routeVariants: [] },
+        configuredRuntimeModels: [
+          row("other-provider", "middle", "middle", 4400),
+          row(provider, "final", "final", 2200),
+          ...(rowProvider ? [row(rowProvider, "middle", wireId, 1100)] : []),
+        ],
+        inlineProviderModels: [],
+        createStores: () => options,
+      } satisfies PreparedModelRuntimeSnapshot;
+      const result = await resolveModelAsync(provider, "middle", undefined, config, {
+        ...options,
+        modelIdSource: "selected",
+        allowBundledStaticCatalogFallback: true,
+        preparedModelRuntime,
+      });
+      expect(result.model).toMatchObject({
+        id: "middle",
+        mediaInput: { image: { maxSidePx: expected } },
+      });
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -57,6 +57,8 @@ type CommonModelResolutionOptions = {
 };
 
 type AsyncModelResolutionOptions = CommonModelResolutionOptions & {
+  /** Selected executable IDs must not pass through input aliases again. */
+  modelIdSource?: "input" | "selected";
   allowBundledStaticCatalogFallback?: boolean;
   preferBundledStaticCatalogTransport?: boolean;
   agentRuntimeId?: string;
@@ -146,7 +148,13 @@ export async function resolveModelAsync(
   const resolve = async () => {
     const workspaceDir =
       options?.workspaceDir ?? preparedModelRuntime?.workspaceDir ?? derivedWorkspaceDir;
-    const normalizedRef = normalizeProviderModelRef({ provider, modelId, cfg, workspaceDir });
+    const normalizedRef = normalizeProviderModelRef({
+      provider,
+      modelId,
+      cfg,
+      workspaceDir,
+      modelIdSource: options?.modelIdSource,
+    });
     let { authStorage, modelRegistry } = options ?? {};
     if (!authStorage || !modelRegistry) {
       const stores = preparedModelRuntime?.createStores() ?? createEmptyAgentDiscoveryStores();
@@ -162,6 +170,11 @@ export async function resolveModelAsync(
       if (!staticCatalogResolved) {
         staticCatalogResolved = true;
         staticCatalogModel =
+          preparedModelRuntime?.configuredRuntimeModels?.find(
+            ({ modelId: candidateId, provider: rowProvider }) =>
+              candidateId === normalizedRef.model &&
+              normalizeProviderId(rowProvider) === normalizeProviderId(normalizedRef.provider),
+          )?.model ??
           preparedModelRuntime?.configuredRuntimeModels?.find(
             ({ modelId: candidateId, provider: rowProvider }) =>
               staticModelIdMatches({

--- a/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-plan.auth-pin.test.ts
@@ -136,6 +136,86 @@ describe("embedded run auth plan provider pin", () => {
     });
   });
 
+  it("does not materialize a raw alias as a different executable model", async () => {
+    const provider = "raw-auth-model";
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          [provider]: {
+            api: "openai-completions",
+            baseUrl: "https://raw-auth-model.example/v1",
+            apiKey: "synthetic-fixture",
+            models: [],
+          },
+        },
+      },
+    };
+    const stores = modelRuntime.createEmptyAgentDiscoveryStores();
+    stores.modelRegistry.registerProvider(provider, {
+      api: "openai-completions",
+      baseUrl: "https://raw-auth-model.example/v1",
+      models: [
+        {
+          id: "middle",
+          name: "middle",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 16_000,
+          maxTokens: 1_024,
+        },
+      ],
+    });
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: provider,
+          providers: [provider],
+          modelIdNormalization: { providers: { [provider]: { aliases: { entry: "middle" } } } },
+        },
+      ],
+    });
+    await withPluginRuntimeGenerationScope({ metadataSnapshot }, async () => {
+      const resolution = await modelRuntime.resolveModelAsync(
+        provider,
+        "entry",
+        agentDir,
+        config,
+        stores,
+      );
+      expect(resolution.model?.id).toBe("middle");
+      const model = resolution.model!;
+      const prepared = await prepareEmbeddedRunAuthPlan({
+        runParams: {
+          sessionId: "raw-model-session",
+          runId: "raw-model-run",
+          workspaceDir: state.workspaceDir,
+          prompt: "Auth preparation only",
+          timeoutMs: 5_000,
+          config,
+        },
+        provider,
+        modelId: "entry",
+        model,
+        agentDir,
+        workspaceDir: state.workspaceDir,
+        nativeModelOwned: false,
+        ...stores,
+        getAgentHarness: () => openClawHarness,
+        setAgentHarness: () => {},
+        getRuntimeModel: () => model,
+        getEffectiveModel: () => model,
+        applyResolvedRuntimeModel: () => {},
+        selectHarnessForPreparedAttempts: () => openClawHarness,
+      });
+      await expect(
+        prepared.materializeAuthPlanUncached(prepared.activePreparedAuthPlan, true),
+      ).rejects.toThrow(
+        "Unable to rematerialize raw-auth-model/entry for its resolved auth profile.",
+      );
+    });
+  });
+
   it.each([
     { pin: true, authMode: "api-key", authRequirement: "api-key", kind: "direct" },
     { pin: false, authMode: "oauth", authRequirement: "subscription", kind: "profile" },

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -629,6 +629,7 @@ async function runIsolatedCompletionOwned(
                 metadataSnapshot: lease.snapshot.metadataSnapshot,
                 resolveModel: ({ config: modelConfig, authProfileId, authProfileMode }) =>
                   resolveModelAsync(runtimeModel.provider, runtimeModel.id, agentDir, modelConfig, {
+                    modelIdSource: "selected",
                     preparedModelRuntime: lease.snapshot,
                     workspaceDir,
                     authProfileId,

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -340,6 +340,7 @@ async function prepareSimpleCompletionModelCore(
           model: initialModel,
           resolveModel: ({ config, authProfileId, authProfileMode }) =>
             modelResolver(initialModel.provider, initialModel.id, params.agentDir, config, {
+              modelIdSource: "selected",
               ...(params.agentId ? { agentId: params.agentId } : {}),
               skipAgentDiscovery: true,
               allowBundledStaticCatalogFallback: true,

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -157,6 +157,7 @@ async function prepareResolvedImageRuntime(
       params.agentDir,
       params.cfg,
       {
+        modelIdSource: "selected",
         authStorage,
         modelRegistry,
         skipAgentDiscovery: true,


### PR DESCRIPTION
Related: #130706, #142100. Follows #143792.

## What Problem This Solves

Refreshing model metadata can reinterpret an already selected model ID as another input alias. With `entry → middle → final`, refreshing `middle` can select `final`. Captured metadata can also choose an equivalent row instead of the exact logical model, supplying the wrong image limit.

## Why This Change Was Made

Give the existing async resolver an explicit input/selected distinction. Four verified callers preserve the IDs returned by model resolution: simple completion, isolated completion, BTW, and image credential refresh. Captured metadata prefers the exact logical row before the existing static-equivalent fallback. This adds 21 production lines.

## User Impact

These completion and refresh paths keep the selected executable ID and image limits. Auth-plan and compaction callbacks still accept mixed logical inputs and retain their existing input-normalization behavior. A real auth-boundary regression prevents a raw alias from being fabricated as an executable model. Existing validation can still reject a raw logical ID that differs from the resolved ID; the canonical producer-to-auth handoff belongs to #143961.

## Evidence

The original resolver regressions and the new real auth regression failed before their respective repairs. The narrowed cohort passed 55 model/auth/compaction tests; four auth tests were repeated after correcting the new registry fixture's declared input shape. Fresh P2 review covers current neighboring row/registry changes. The full changed gate passed after that test-only type correction.

One sourcePerformance build at exact commit `4e923e0129bec3d316a7de2b6269418ef56157f1` and six real compiled loopback HTTP requests passed, covering raw aliases, selected IDs, exact 1,100-pixel limits, and credential/route rematerialization. Compiled raw-logical-ID rejection also passed. The private auth callback's direct proof is source-level (six real setup/auth cases), not represented as a compiled export.

All 9,549 root and canonical workspace outputs remained unchanged; zero checkout source imports, and the isolated listener/state were cleaned up. This is synthetic loopback proof, not an upstream-provider request; the runtime profile omits UI and declarations. The original build and failed CI remain preserved. This PR does not establish a fix for #130324.

CI refresh: the unchanged task patch is replayed onto main `3943149f8ac269fc138ca21b5786ff2a9db3dd23`, including the navigation repair in #144037. Every changed-file postimage matches the previous reviewed head `4e923e0129bec3d316a7de2b6269418ef56157f1`. Original exact-commit runtime proof remains preserved and is not restamped; fresh CI is running for `b55528b79eea857e6f908e72f8daaa4fe99bda03`.
