### PR TITLE
fix(gateway): preserve conversation in terminal CLI history

### DIFF
--- a/src/chat/tool-content.ts
+++ b/src/chat/tool-content.ts
@@ -1,4 +1,5 @@
 // Normalizes tool result content for chat transcript rendering.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 const TOOL_USE_ID_FIELDS = [
@@ -53,4 +54,63 @@ export function resolveToolUseId(block: ToolContentBlock): string | undefined {
     }
   }
   return undefined;
+}
+
+export function readToolErrorFlag(value: Record<string, unknown>): boolean | undefined {
+  const raw = value.isError ?? value.is_error;
+  return typeof raw === "boolean" ? raw : undefined;
+}
+
+const TOOL_NOT_FOUND_PATTERN = /^tool not found\.?$/i;
+const MAX_ERROR_DETECT_CHARS = 20_000;
+const TOOL_ERROR_STATUSES = new Set(["error", "failed", "timeout"]);
+
+function hasToolErrorStatus(value: unknown): boolean {
+  return typeof value === "string" && TOOL_ERROR_STATUSES.has(value.trim().toLowerCase());
+}
+
+export function isToolErrorOutput(outputText: string | undefined): boolean {
+  if (!outputText) {
+    return false;
+  }
+  const trimmed = outputText.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (TOOL_NOT_FOUND_PATTERN.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.length > MAX_ERROR_DETECT_CHARS) {
+    return false;
+  }
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return false;
+  }
+  if (!isRecord(parsed)) {
+    return false;
+  }
+  const obj = parsed;
+  const explicitErrorFlag = readToolErrorFlag(obj);
+  if (explicitErrorFlag !== undefined) {
+    return explicitErrorFlag;
+  }
+  if ("error" in obj) {
+    const value = obj.error;
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (value && typeof value === "object") {
+      return true;
+    }
+  }
+  return hasToolErrorStatus(obj.status);
 }

--- a/src/gateway/server-methods/chat-history-budget.ts
+++ b/src/gateway/server-methods/chat-history-budget.ts
@@ -1,6 +1,23 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  isToolCallContentType,
+  isToolErrorOutput,
+  isToolResultContentType,
+  readToolErrorFlag,
+} from "../../chat/tool-content.js";
 import { readTranscriptDisplayPosition } from "../../chat/transcript-display-position.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { logLargePayload } from "../../logging/diagnostic-payload.js";
+import {
+  extractChatHistoryBlockText,
+  extractChatToolResultCanvasPreview,
+} from "../chat-display-projection.canvas.js";
+import {
+  hasTranscriptMediaFacts,
+  isAssistantInternalReasoningContentType,
+  isAssistantTextContentType,
+} from "../chat-display-projection.helpers.js";
 
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
@@ -26,6 +43,105 @@ export function createChatHistoryByteCounter() {
       messages.reduce<number>((bytes, message) => bytes + messageBytes(message), 0) +
       Math.max(0, messages.length - 1),
   };
+}
+
+function hasHistoryToolPresentation(
+  message: Record<string, unknown>,
+  inheritedError?: boolean,
+): boolean {
+  return Boolean(
+    asOptionalRecord(message.details) ||
+    (readToolErrorFlag(message) ?? inheritedError) === true ||
+    extractChatToolResultCanvasPreview(message),
+  );
+}
+
+function isPlainHistoryToolResult(
+  message: Record<string, unknown>,
+  inheritedError?: boolean,
+): boolean {
+  if (
+    hasHistoryToolPresentation(message, inheritedError) ||
+    (readToolErrorFlag(message) ??
+      inheritedError ??
+      isToolErrorOutput(extractChatHistoryBlockText(message)))
+  ) {
+    return false;
+  }
+  const content = message.content ?? message.text;
+  return (
+    content === undefined ||
+    typeof content === "string" ||
+    (Array.isArray(content) &&
+      content.every((block) => {
+        const entry = asOptionalRecord(block);
+        return isAssistantTextContentType(entry?.type) && typeof entry?.text === "string";
+      }))
+  );
+}
+
+function isChatHistoryActivity(message: unknown): boolean {
+  const entry = asOptionalRecord(message);
+  if (!entry || hasTranscriptMediaFacts(entry) || hasHistoryToolPresentation(entry)) {
+    return false;
+  }
+  const metadata = asOptionalRecord(entry["__openclaw"]);
+  if (
+    metadata?.kind !== undefined ||
+    metadata?.turnBoundary === true ||
+    metadata?.replyToId !== undefined ||
+    metadata?.replyToPreview !== undefined ||
+    entry.openclawDelivery !== undefined ||
+    entry.stopReason === "error"
+  ) {
+    return false;
+  }
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role === "toolresult" || role === "tool_result" || role === "tool" || role === "function") {
+    return isPlainHistoryToolResult(entry);
+  }
+  if (
+    (role !== "assistant" && role !== "user") ||
+    (typeof entry.text === "string" && entry.text.trim()) ||
+    !Array.isArray(entry.content) ||
+    entry.content.length === 0
+  ) {
+    return false;
+  }
+  // Tool rows can also carry canvas previews, media, or other visible outcomes.
+  // Only known activity without such presentation is eligible for trimming.
+  return entry.content.every((block) => {
+    const content = asOptionalRecord(block);
+    if (!content) {
+      return false;
+    }
+    return isToolResultContentType(content.type)
+      ? isPlainHistoryToolResult(content, readToolErrorFlag(entry))
+      : !hasHistoryToolPresentation(content, readToolErrorFlag(entry)) &&
+          (isToolCallContentType(content.type) ||
+            isAssistantInternalReasoningContentType(content.type));
+  });
+}
+
+export function trimChatHistoryActivity(params: {
+  messages: unknown[];
+  maxBytes: number;
+  byteCounter: ReturnType<typeof createChatHistoryByteCounter>;
+}): unknown[] {
+  const { messages, maxBytes, byteCounter } = params;
+  let bytes = byteCounter.messagesBytes(messages);
+  if (bytes <= maxBytes) {
+    return messages;
+  }
+  let remaining = messages.length;
+  return messages.filter((message) => {
+    if (bytes <= maxBytes || !isChatHistoryActivity(message)) {
+      return true;
+    }
+    bytes -= byteCounter.messageBytes(message) + (remaining > 1 ? 1 : 0);
+    remaining -= 1;
+    return false;
+  });
 }
 
 function buildChatHistoryUnavailableSentinel(): Record<string, unknown> {

--- a/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
@@ -3,13 +3,20 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { composeTranscriptDisplay } from "../../chat/transcript-display-position.js";
 import {
   appendTranscriptMessage,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  augmentChatHistoryWithCanvasBlocks,
+  projectChatDisplayMessages,
+} from "../chat-display-projection.js";
+import * as cliSessionHistory from "../cli-session-history.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
 import { readChatHistoryMessageId } from "../session-history-tail.js";
 import { chatHistoryHandlers } from "./chat-history-handler.js";
 
@@ -107,7 +114,255 @@ function expectMissingAnchor(page: HistoryPage) {
   }
 }
 
+async function withImportedSnapshot(
+  method: "chat.history" | "chat.startup",
+  messages: Record<string, unknown>[],
+  run: (read: (params: HistoryRequest) => Promise<HistoryPage>) => Promise<void>,
+) {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const scope = {
+      agentId: "main",
+      sessionKey: "agent:main:cli-history-budget",
+      sessionId: randomUUID(),
+    };
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+      providerOverride: "claude-cli",
+      cliSessionBindings: { "claude-cli": { sessionId: randomUUID() } },
+    });
+    const snapshot = vi
+      .spyOn(cliSessionHistory, "readChatHistoryCliSessionImportSnapshot")
+      .mockResolvedValue(messages);
+    const handler = expectDefined(chatHistoryHandlers[method], "history handler");
+    const context = createDirectChatContext();
+    try {
+      await run(async (params) => {
+        let result: HistoryPage | undefined;
+        await handler({
+          params: { sessionKey: scope.sessionKey, ...params },
+          context,
+          req: { type: "req", id: randomUUID(), method },
+          client: null,
+          isWebchatConnect: () => false,
+          respond: (ok, payload, error) => {
+            expect(error).toBeUndefined();
+            expect(ok).toBe(true);
+            result = payload as HistoryPage;
+          },
+        });
+        return expectDefined(result, "history response");
+      });
+    } finally {
+      snapshot.mockRestore();
+    }
+  });
+}
+
+function importedMessage(
+  id: string,
+  timestamp: number,
+  content: unknown,
+  fields: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    role: "assistant",
+    content,
+    timestamp,
+    __openclaw: { id, importedFrom: "claude-cli", externalId: id },
+    ...fields,
+  };
+}
+
+function toolHistory(count: number, startTimestamp: number) {
+  return Array.from({ length: count }, (_, index) =>
+    importedMessage(`tool-${index}`, startTimestamp + index, [
+      { type: "toolcall", id: `call-${index}`, name: "Read", arguments: { file: "source.ts" } },
+      { type: "tool_result", tool_use_id: `call-${index}`, content: "x".repeat(7_500) },
+    ]),
+  );
+}
+
+function projectImportedSnapshot(messages: Record<string, unknown>[]) {
+  return composeTranscriptDisplay(
+    augmentChatHistoryWithCanvasBlocks(
+      projectChatDisplayMessages(messages, { includeCommentaryFallbacks: true }),
+    ),
+  );
+}
+
 describe("CLI-imported history anchors", () => {
+  it.each(["chat.history", "chat.startup"] as const)(
+    "%s keeps conversation and structured outcomes before trimming terminal tool history",
+    async (method) => {
+      const conversation = [
+        importedMessage("old-question", 1, "Old question", { role: "user" }),
+        importedMessage("old-answer", 2, "Old answer"),
+        importedMessage("attachment", 3, [
+          {
+            type: "attachment",
+            attachment: {
+              kind: "document",
+              label: "report.pdf",
+              url: "https://example.com/report.pdf",
+            },
+          },
+        ]),
+        importedMessage("image", 4, [{ type: "image", url: "https://example.com/image.png" }]),
+        importedMessage("canvas", 5, [
+          {
+            type: "canvas",
+            preview: {
+              kind: "canvas",
+              surface: "assistant_message",
+              render: "url",
+              viewId: "chart",
+              url: "/chart",
+            },
+          },
+        ]),
+        importedMessage("media", 6, [], {
+          __openclaw: {
+            id: "media",
+            importedFrom: "claude-cli",
+            externalId: "media",
+            media: [{ path: "media://inbound/recording", contentType: "audio/ogg" }],
+          },
+        }),
+        importedMessage("unknown-outcome", 7, [{ type: "plugin_outcome", value: "Report ready" }]),
+        importedMessage("canvas-tool-outcome", 8, [
+          { type: "toolcall", id: "canvas-call", name: "canvas", arguments: {} },
+          {
+            type: "tool_result",
+            tool_use_id: "canvas-call",
+            content: JSON.stringify({
+              kind: "canvas",
+              view: { id: "tool-chart", url: "/chart" },
+              presentation: { target: "assistant_message" },
+            }),
+          },
+        ]),
+        importedMessage("failed-tool-outcome", 9, [
+          {
+            type: "tool_result",
+            name: "sessions_spawn",
+            content: JSON.stringify({ status: "error", error: "Inventory unavailable" }),
+          },
+        ]),
+      ];
+      const successfulTool = importedMessage("successful-error-shaped-tool", 10, [
+        {
+          type: "tool_result",
+          name: "Read",
+          is_error: false,
+          content: JSON.stringify({ status: "error", error: "Example output" }),
+        },
+      ]);
+      const tools = toolHistory(900, 11);
+      const newest = importedMessage("new-answer", 1_000, "New answer");
+      const messages = [...conversation, successfulTool, ...tools, newest];
+      const original = JSON.stringify(messages);
+      const projected = projectImportedSnapshot(messages);
+      expect(Buffer.byteLength(JSON.stringify(projected))).toBeGreaterThan(
+        getMaxChatHistoryMessagesBytes(),
+      );
+
+      await withImportedSnapshot(method, messages, async (read) => {
+        const page = await read({ limit: 2, maxBytes: 1024 });
+        const ids = page.messages.map(readChatHistoryMessageId);
+        expect(ids).not.toContain("successful-error-shaped-tool");
+        expect(ids.slice(0, conversation.length)).toEqual(
+          conversation.map(readChatHistoryMessageId),
+        );
+        expect(page.messages.slice(0, conversation.length)).toEqual(
+          projected.slice(0, conversation.length),
+        );
+        expect(page.messages.at(-1)).toEqual(projected.at(-1));
+        const retainedToolIds = ids.filter((id) => id?.startsWith("tool-"));
+        expect(retainedToolIds.length).toBeGreaterThan(0);
+        expect(retainedToolIds.length).toBeLessThan(tools.length);
+        expect(retainedToolIds).toEqual(
+          tools.slice(-retainedToolIds.length).map(readChatHistoryMessageId),
+        );
+        expect(Buffer.byteLength(JSON.stringify(page.messages))).toBeLessThanOrEqual(
+          getMaxChatHistoryMessagesBytes(),
+        );
+        expect(page).toMatchObject({ hasMore: false, totalMessages: messages.length });
+        expect(page).not.toHaveProperty("nextOffset");
+        expect(page).not.toHaveProperty("completeSnapshot");
+        expect((await read({ offset: 9999, limit: 2 })).messages).toEqual(page.messages);
+      });
+      expect(JSON.stringify(messages)).toBe(original);
+    },
+  );
+
+  it("retains an expendable requested anchor and its contiguous sequence group", async () => {
+    const tools = toolHistory(900, 10);
+    const anchorGroup = tools.slice(0, 3);
+    for (const [index, message] of anchorGroup.entries()) {
+      message["__openclaw"] = { id: `anchor-${index}`, seq: 1, importedFrom: "claude-cli" };
+    }
+    const messages = [
+      importedMessage("question", 1, "Keep the question", { role: "user" }),
+      ...anchorGroup,
+      ...tools.slice(3),
+      importedMessage("answer", 1_000, "Keep the answer"),
+    ];
+    const projected = projectImportedSnapshot(messages);
+    expect(Buffer.byteLength(JSON.stringify(projected))).toBeGreaterThan(
+      getMaxChatHistoryMessagesBytes(),
+    );
+    await withImportedSnapshot("chat.history", messages, async (read) => {
+      const page = await read({ messageId: "anchor-1", limit: 1 });
+      const ids = page.messages.map(readChatHistoryMessageId);
+      expect(ids).toContain("question");
+      const anchorIndex = ids.indexOf("anchor-0");
+      expect(anchorIndex).toBeGreaterThanOrEqual(0);
+      expect(page.messages.slice(anchorIndex, anchorIndex + 3)).toEqual(projected.slice(1, 4));
+      expect(page).not.toHaveProperty("completeSnapshot");
+      expect(Buffer.byteLength(JSON.stringify(page.messages))).toBeLessThanOrEqual(
+        getMaxChatHistoryMessagesBytes(),
+      );
+      expectMissingAnchor(await read({ messageId: "missing", limit: 1 }));
+    });
+  });
+
+  it("preserves normalized under-budget imported messages byte-for-byte", async () => {
+    const messages = [
+      importedMessage("question", 1, "Question: 海 🦀", { role: "user" }),
+      ...toolHistory(2, 2),
+      importedMessage("thinking", 4, [
+        {
+          type: "thinking",
+          thinking: "Compare the two results",
+          thinkingSignature: "private-replay-signature",
+        },
+      ]),
+      importedMessage("answer", 5, "Answer"),
+    ];
+    const original = JSON.stringify(messages);
+    const projected = projectImportedSnapshot(messages);
+    const expected = JSON.stringify(projected);
+    expect(expected).not.toContain("private-replay-signature");
+    expect(projected.map(readChatHistoryMessageId)).toEqual([
+      "question",
+      "tool-0",
+      "tool-1",
+      "answer",
+    ]);
+    await withImportedSnapshot("chat.history", messages, async (read) => {
+      const page = await read({ limit: 1, maxBytes: 1024 });
+      expect(JSON.stringify(page.messages)).toBe(expected);
+      expect(page).toMatchObject({
+        completeSnapshot: true,
+        hasMore: false,
+        totalMessages: messages.length,
+      });
+      expect(page).not.toHaveProperty("nextOffset");
+    });
+    expect(JSON.stringify(messages)).toBe(original);
+  });
+
   it("retains metadata-only imports on anchored history reads", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const scope = {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -57,6 +57,7 @@ import {
   createChatHistoryByteCounter,
   replaceOversizedChatHistoryMessages,
   reportOmittedChatHistory,
+  trimChatHistoryActivity,
 } from "./chat-history-budget.js";
 import { readChatHistoryDelta } from "./chat-history-delta.js";
 import {
@@ -355,25 +356,34 @@ async function handleChatHistoryRequest({
     : maxHistoryBytes;
   // A smaller page budget must not replace otherwise readable messages. The
   // tail cap keeps one whole message; the server's single-message cap still applies.
-  const perMessageHardCap = Math.min(
-    CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
-    getMaxChatHistoryMessagesBytes(),
-  );
   const byteCounter = createChatHistoryByteCounter();
   const replaced = replaceOversizedChatHistoryMessages({
     byteCounter,
     messages: normalized,
-    maxSingleMessageBytes: perMessageHardCap,
+    maxSingleMessageBytes: Math.min(
+      CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+      getMaxChatHistoryMessagesBytes(),
+    ),
   });
+  // Terminal imports have no older-page cursor. Anchored reads retain their
+  // existing neighborhood selector instead of changing which groups surround the anchor.
+  const prioritized =
+    historyPage.completeCliImport && !messageId
+      ? trimChatHistoryActivity({
+          messages: replaced.messages,
+          maxBytes: responseHistoryBytes,
+          byteCounter,
+        })
+      : replaced.messages;
   const capped = messageId
     ? capChatHistoryAroundMessage({
-        messages: replaced.messages,
+        messages: prioritized,
         messageId,
         // A nonempty JSON array costs one framing byte plus each message and its separator.
         maxCost: responseHistoryBytes - 1,
         messageCost: (message) => byteCounter.messageBytes(message) + 1,
       })
-    : capArrayByJsonBytes(replaced.messages, responseHistoryBytes, byteCounter.messageBytes).items;
+    : capArrayByJsonBytes(prioritized, responseHistoryBytes, byteCounter.messageBytes).items;
   const historyBudgetPreserved =
     replaced.replacedCount === 0 &&
     capped.length === normalized.length &&
@@ -396,7 +406,6 @@ async function handleChatHistoryRequest({
     pagination !== undefined && candidateNextOffset !== undefined
       ? pagination.exhausted !== true && candidateNextOffset < pagination.totalMessages
       : undefined;
-  const nextOffset = hasMore ? candidateNextOffset : undefined;
   reportOmittedChatHistory({
     originalMessages: normalized,
     finalMessages: capped,
@@ -653,7 +662,7 @@ async function handleChatHistoryRequest({
     ...(inputReceipts ? { inputReceipts, inputConsumptions } : {}),
     ...(historyPage.deltaCursor ? { deltaCursor: historyPage.deltaCursor } : {}),
     ...(historyPage.responseOffset !== undefined ? { offset: historyPage.responseOffset } : {}),
-    ...(hasMore ? { nextOffset } : {}),
+    ...(hasMore ? { nextOffset: candidateNextOffset } : {}),
     ...(hasMore !== undefined ? { hasMore } : {}),
     ...(pagination !== undefined ? { totalMessages: pagination.totalMessages } : {}),
     ...(historyPage.completeCliImport && !hasMore && historyBudgetPreserved

--- a/src/gateway/server-methods/chat-history-request-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-request-budget.test.ts
@@ -22,7 +22,17 @@ describe("chat history request byte budgets", () => {
         await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
         const messages = Array.from({ length: 12 }, (_, index) => ({
           role: index % 2 === 0 ? "user" : "assistant",
-          content: [{ type: "text", text: `record-${index}: ${"x".repeat(3_000)}` }],
+          content:
+            index % 4 === 1
+              ? [
+                  { type: "toolcall", id: `call-${index}`, name: "Read", arguments: {} },
+                  {
+                    type: "tool_result",
+                    tool_use_id: `call-${index}`,
+                    content: `record-${index}: ${"x".repeat(3_000)}`,
+                  },
+                ]
+              : [{ type: "text", text: `record-${index}: ${"x".repeat(3_000)}` }],
         }));
         for (const message of messages) {
           await appendTranscriptMessage(scope, { message });

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -12,6 +12,8 @@ import {
 } from "../../../../src/chat/canvas-render.js";
 import {
   isToolCallContentType,
+  isToolErrorOutput,
+  readToolErrorFlag,
   isToolResultContentType,
   resolveToolUseId,
 } from "../../../../src/chat/tool-content.js";
@@ -96,11 +98,6 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
-function readToolErrorFlag(value: Record<string, unknown>): boolean | undefined {
-  const raw = value.isError ?? value.is_error;
-  return typeof raw === "boolean" ? raw : undefined;
-}
-
 function readToolExitCode(...values: unknown[]): number | undefined {
   for (const value of values) {
     const record = readRecord(value);
@@ -110,60 +107,6 @@ function readToolExitCode(...values: unknown[]): number | undefined {
     }
   }
   return undefined;
-}
-
-const TOOL_NOT_FOUND_PATTERN = /^tool not found\.?$/i;
-const MAX_ERROR_DETECT_CHARS = 20_000;
-const TOOL_ERROR_STATUSES = new Set(["error", "failed", "timeout"]);
-
-function hasToolErrorStatus(value: unknown): boolean {
-  return typeof value === "string" && TOOL_ERROR_STATUSES.has(value.trim().toLowerCase());
-}
-
-function isToolErrorOutput(outputText: string | undefined): boolean {
-  if (!outputText) {
-    return false;
-  }
-  const trimmed = outputText.trim();
-  if (!trimmed) {
-    return false;
-  }
-  if (TOOL_NOT_FOUND_PATTERN.test(trimmed)) {
-    return true;
-  }
-  if (trimmed.length > MAX_ERROR_DETECT_CHARS) {
-    return false;
-  }
-  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
-    return false;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    return false;
-  }
-  if (!isRecord(parsed)) {
-    return false;
-  }
-  const obj = parsed;
-  const explicitErrorFlag = readToolErrorFlag(obj);
-  if (explicitErrorFlag !== undefined) {
-    return explicitErrorFlag;
-  }
-  if ("error" in obj) {
-    const value = obj.error;
-    if (typeof value === "string") {
-      return value.trim().length > 0;
-    }
-    if (typeof value === "boolean") {
-      return value;
-    }
-    if (value && typeof value === "object") {
-      return true;
-    }
-  }
-  return hasToolErrorStatus(obj.status);
 }
 
 export function isToolCardError(card: ToolCard): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users lose older conversation, attachments, and canvas output when a tool-heavy imported CLI session exceeds the history response limit. The snapshot is terminal, so changing the page offset cannot recover the omitted conversation. This affects both session startup and Copy → Conversation as Markdown in the Control UI.

## Why This Change Was Made

After the existing per-message limit, unanchored terminal imports now discard the oldest ordinary tool activity before conversation and visible outcomes. The Gateway shares the UI's existing tool-failure recognition so failed results remain visible. The existing final byte cap stays authoritative, including when outcomes alone exceed it.

Requested message anchors retain their existing neighborhood selection. The repair preserves stored transcripts, under-budget responses, local-history paging, and import behavior. This scoped revision carries forward @von8794's history repair and excludes the unrelated model-fallback diagnostics from the original branch.

## User Impact

Users can read older conversation and media outcomes in large imported sessions. Ordinary activity remains available when it fits. Responses that discard content still omit the complete-snapshot marker.

## Evidence

Tested baseline: `a1f920995f2b1c5642602d79c90c9bd9817f944d`. Tested candidate: `96fa7e14cc28a2e3c2446d956de5ced41279c354`.

Independent validation drove eight successful public turns through an isolated CLI protocol process, compiled Gateway, and matching served Control UI. It compared the same stored session before and after the repair; no paid provider was used.

| Observation | Baseline | Candidate |
| --- | --- | --- |
| Normalized input | 1,048 rows / 10,844,850 bytes | Same input |
| Returned history | 602 rows / 6,286,044 bytes | 624 rows / 6,288,088 bytes |
| Conversation and meaningful outcomes | Older conversation/media/canvas omitted | All 44 outcome rows retained unchanged |
| Ordinary offsets 0, 2, 100, 1,000, 9,999 | Same truncated terminal response | Same repaired terminal response |

The candidate removes exactly the oldest 424 ordinary Read rows. All surviving rows retain their content, identity, timestamps, metadata, and order within the unchanged 6,291,456-byte cap. Real UI startup and Copy → Conversation as Markdown match public history. The restored canvas visibly loads, and the persisted input image loads through the served media route.

Under-budget history (71,461 bytes), Unicode history (1,388 bytes), existing/missing anchors, identity paging, and unbound local paging match baseline bytes. Native and stored transcript snapshots remain unchanged during reads. All 13,829 deployed runtime file records match the hosted artifact.

Native validation passed 49 Gateway tests in seven files, 11 UI outcome tests, commit hooks, formatting, and 230 syntax rules. Handler tests cover structured attachment/media/canvas outcomes, serialized tool failures, explicit-success precedence, anchored groups, and under-budget equality. These boundary tests are distinct from the public scenarios; individual document downloads and outcome-only overflow were not exercised by the public validator.

The [candidate artifact build](https://github.com/openclaw/openclaw/actions/runs/34536669457) produced the exact tested runtime. Its later Doctor shutdown verifier and locale fallback-baseline check failed on source-proven unrelated paths; their failures remain recorded. This is not a claim of fully green CI. Final PR checks and independent exact-head review remain required.
