### PR TITLE
refactor(auto-reply): remove duplicate inbound-audio test

### DIFF
--- a/src/auto-reply/reply/inbound-media.test.ts
+++ b/src/auto-reply/reply/inbound-media.test.ts
@@ -39,10 +39,6 @@ describe("hasInboundAudio", () => {
     ).toBe(true);
   });
 
-  it("accepts the structured audio kind when a MIME subtype is unavailable", () => {
-    expect(hasInboundAudio({ media: [{ kind: "audio" }] })).toBe(true);
-  });
-
   it("does not infer audio from placeholder or transcript text", () => {
     expect(hasInboundAudio({ Body: "<media:audio>" })).toBe(false);
     expect(hasInboundAudio({ Body: "[Audio]\nTranscript:\nhello" })).toBe(false);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The maintainer-requested test audit found a redundant inbound-audio case. Its structured audio-kind input and assertion are already covered by a retained test.

## Why This Change Was Made

Remove the duplicate case while retaining `detects native audio facts without legacy projections`, which checks the identical audio-kind input and also covers structured MIME information. All other cases and assertions remain unchanged.

## User Impact

No runtime behavior changes. This removes one redundant test case and four test lines, with no production changes.

## Evidence

- Full `inbound-media.test.ts`: 10 tests passed, zero skipped.
- All 20 selected changed checks passed.
- Fresh P2 review: scoped-clean, no findings.
- Targeted formatting and diff checks passed.

No live media or channel execution, packaging proof, or local full-repository test run is claimed.
