### PR TITLE
fix(models): normalize configured aliases once

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -28,7 +28,6 @@ import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   createConfiguredProviderCatalogModelIdNormalizer,
   normalizeConfiguredProviderCatalogModelId,
-  normalizeStaticProviderModelId,
   type ModelManifestNormalizationContext,
   type ModelRef,
   modelKey,
@@ -548,17 +547,10 @@ function normalizeExactConfiguredProviderRef(
   const provider = normalizeLowercaseStringOrEmpty(configuredProvider);
   return {
     provider,
-    model: normalizeConfiguredProviderCatalogModelId(
-      provider,
-      normalizeStaticProviderModelId(provider, modelRaw.trim(), {
-        allowManifestNormalization: params.allowManifestNormalization,
-        manifestPlugins: params.manifestPlugins,
-      }),
-      {
-        allowManifestNormalization: params.allowManifestNormalization,
-        manifestPlugins: params.manifestPlugins,
-      },
-    ),
+    model: normalizeConfiguredProviderCatalogModelId(provider, modelRaw.trim(), {
+      allowManifestNormalization: params.allowManifestNormalization,
+      manifestPlugins: params.manifestPlugins,
+    }),
   };
 }
 

--- a/src/agents/simple-completion-runtime.selection.test.ts
+++ b/src/agents/simple-completion-runtime.selection.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resolveSimpleCompletionSelectionForAgent as resolveSimpleCompletionSelectionForAgentBase } from "./simple-completion-runtime.js";
 
 function resolveSimpleCompletionSelectionForAgent(
@@ -22,6 +24,48 @@ function requireSelection(selection: ReturnType<typeof resolveSimpleCompletionSe
 }
 
 describe("resolveSimpleCompletionSelectionForAgent", () => {
+  it.each([false, true])("normalizes configured aliases once (explicit=%s)", (explicit) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        entries: { main: {} },
+        defaults: { model: { primary: "fixture/entry" } },
+      },
+      models: {
+        providers: {
+          fixture: {
+            api: "openai-completions",
+            baseUrl: "https://fixture.invalid/v1",
+            models: ["middle", "final"].map((id): ModelDefinitionConfig => ({
+              id,
+              name: id,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 256,
+            })),
+          },
+        },
+      },
+    };
+    const selection = requireSelection(
+      resolveSimpleCompletionSelectionForAgent({
+        cfg,
+        agentId: "main",
+        ...(explicit ? { modelRef: "fixture/entry" } : {}),
+        manifestPlugins: [
+          createPluginManifestRecordFixture({
+            id: "fixture",
+            modelIdNormalization: {
+              providers: { fixture: { aliases: { entry: "middle", middle: "final" } } },
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(selection).toMatchObject({ provider: "fixture", modelId: "middle" });
+  });
+
   it("preserves multi-segment model ids (openrouter provider models)", () => {
     const cfg = {
       agents: {

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -795,7 +795,7 @@ describe("plugin metadata snapshot", () => {
           expect(normalizeStaticProviderModelId("missing", "latest")).toBe("latest");
           expect(resolveDefaultModelForAgent({ cfg })).toEqual({
             provider: "demo",
-            model: "final-model",
+            model: "middle-model",
           });
           expect(buildConfiguredModelCatalog({ cfg })).toMatchObject([
             { provider: "demo", id: "middle-model" },


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Selection through an explicitly configured provider applied static/manifest normalization twice. With `entry → middle → final`, both the configured default and an explicit model reference could skip the intended `middle` target before execution starts.

## Why This Change Was Made

Use the existing configured-model normalizer once and remove the redundant inner call and unused import. This removes eight production lines while preserving its input options and provider behavior. The prepared-policy snapshot test now expects the same one-step target, retaining all four repetitions and the no-enumeration checks.

## User Impact

Explicit and default model selection stop at the intended alias target. Provider-local namespaces, case, OpenRouter, NVIDIA, and existing Google retirement behavior remain covered.

## Evidence

The original two public-selection cases failed before the production fix. The retained production validation passed 185 focused tests, P2 review, and the full changed-file gate.

The stale snapshot expectation was reproduced on parent `9fa89b66509a933942517b9e59afe6d97551d6a4`. At the corrected commit `e1b2e4eec5d1481d10b3e58bd9680bb4ce00922c`, all 44 tests across the snapshot and public-selection suites passed, along with fresh P2 review and the normal changed check scoped to the edited test. Only one expected value changed; production postimages and the earlier selection regression file are byte-identical to `9fa89b66509a933942517b9e59afe6d97551d6a4`.

The historical runtime proof remains bound to `cd4c8650b23d9891333fb0c7ac4e6980da7a775e`: one canonical `sourcePerformance` build and ten compiled explicit/default/compatibility cases passed without network requests or source imports. The 9,256-file root/workspace inventory and symlinks remained unchanged. That proof is retained without rebuilding or restamping for this test-only correction; subsequent main-only replay changes were assessed separately. The profile excludes UI and SDK declarations.

## CI Readiness

The existing [CI run for `9fa89b66509`](https://github.com/openclaw/openclaw/actions/runs/34481605102) failed `checks-node-compact-small-16` and its aggregate gate. Two Gateway authentication/catalog cases and one route-model-reuse case timed out while polling HTTP readiness. Those failures are tracked separately from this snapshot assertion correction; baseline/candidate Linux attribution remains in progress. The updated PR head still requires green exact-head CI before landing.
