### PR TITLE
fix(qa): bind coverage IDs to producer assertions

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.coverage.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.coverage.test.ts
@@ -1,0 +1,307 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateQaEvidenceSummaryJson } from "./evidence-summary.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
+import { runQaTestFileScenarios } from "./test-file-scenario-runner.js";
+import {
+  buildScriptProducerEvidence,
+  createScenarioRunnerTestHarness,
+  makeTestFileScenario,
+  writeScriptProducerEvidence,
+  QA_TEST_RUNNER_DEFAULTS,
+} from "./test-file-scenario-runner.test-support.js";
+
+const harness = createScenarioRunnerTestHarness();
+
+afterEach(async () => {
+  await harness.cleanup();
+});
+
+describe("producer coverage claims", () => {
+  it.each(["full", "slim"] as const)(
+    "caps producer coverage without promoting or inventing claims in %s mode",
+    async (evidenceMode) => {
+      const repoRoot = await harness.makeTempRepo("qa-script-coverage-claims-");
+      const outputDir = path.join(repoRoot, "out");
+      const claims = [
+        [],
+        [{ id: "qa.coverage", role: "primary" }],
+        [{ id: "qa.coverage", role: "secondary" }],
+        [{ id: "qa.reporting", role: "primary" }],
+        [{ id: "qa.reporting", role: "secondary" }],
+        [{ id: "ui.control", role: "primary" }],
+        [{ id: "qa.coverage", role: "diagnostic" }],
+        [{ id: "qa.reporting", role: "diagnostic" }],
+      ];
+      const producerEntries = claims.flatMap(
+        (coverage, index) =>
+          buildScriptProducerEvidence({
+            coverage,
+            producerId: `claim-${index}`,
+            status: "pass",
+            artifacts: [{ kind: "log", path: "producer.log" }],
+          }).entries,
+      );
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        ...QA_TEST_RUNNER_DEFAULTS,
+        evidenceMode,
+        scenarios: [makeTestFileScenario("script", "scripts/evidence-producer.ts")],
+        runCommand: async () => {
+          await writeScriptProducerEvidence({
+            outputDir,
+            coverage: [],
+            producerId: "failed-diagnostic",
+            failureReason: "boundary failed without a coverage claim",
+            status: "fail",
+            additionalEntries: producerEntries,
+          });
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      });
+
+      expect(result.results[0]?.status).toBe("fail");
+      expect(result.evidence.entries.map((entry) => entry.coverage)).toEqual([
+        [],
+        [],
+        [{ id: "qa.coverage", role: "primary" }],
+        [{ id: "qa.coverage", role: "secondary" }],
+        [{ id: "qa.reporting", role: "secondary" }],
+        [{ id: "qa.reporting", role: "secondary" }],
+        [],
+        [{ id: "qa.coverage", role: "diagnostic" }],
+        [{ id: "qa.reporting", role: "diagnostic" }],
+      ]);
+      expect(result.evidence.entries[0]?.result).toMatchObject({
+        status: "fail",
+        failure: { reason: "boundary failed without a coverage claim" },
+      });
+      for (const [index, original] of producerEntries.entries()) {
+        const imported = result.evidence.entries[index + 1];
+        expect(imported?.test).toEqual(original.test);
+        expect(imported?.result).toEqual(original.result);
+        if (evidenceMode === "slim") {
+          expect(imported?.execution).toBeUndefined();
+        } else {
+          expect(imported?.execution).toEqual({
+            ...original.execution,
+            artifacts: [
+              {
+                ...original.execution?.artifacts[0],
+                path: "out/scenario-script/run-1/producer.log",
+              },
+            ],
+          });
+        }
+      }
+    },
+  );
+});
+
+describe.skipIf(process.platform === "win32")("onboarding assertion attribution", () => {
+  it.each(["full", "slim"] as const)(
+    "fulfills only the passing boundary through producer, importer, scorecard and renderer in %s mode",
+    async (evidenceMode) => {
+      const repoRoot = process.cwd();
+      const tempRoot = await harness.makeTempDir("qa-onboarding-attribution-");
+      const outputDir = path.join(tempRoot, "evidence");
+      const binDir = path.join(tempRoot, "bin");
+      await fs.mkdir(binDir);
+      // Exercise the real producer and marker parser without invoking Docker.
+      // The child reports exactly one completed boundary before failing.
+      await fs.writeFile(
+        path.join(binDir, "bash"),
+        [
+          "#!/bin/sh",
+          '[ "$1" = "scripts/e2e/onboard-docker.sh" ] || exit 91',
+          '[ "$OPENCLAW_ONBOARD_E2E_CASES" = "guided-skip-ui,local-auth-refs,local-password,remote-non-interactive,reset,skills" ] || exit 92',
+          "echo 'QA_ASSERT cli.guided-onboarding pass'",
+          "exit 7",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      const scenario = readQaScenarioById("cli-onboarding");
+      const coverageIds = [
+        "cli.gateway-auth-storage",
+        "cli.guided-onboarding",
+        "cli.remote-onboarding",
+        "cli.targeted-reconfiguration",
+      ];
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        ...QA_TEST_RUNNER_DEFAULTS,
+        evidenceMode,
+        scenarios: [scenario],
+        env: { PATH: `${binDir}${path.delimiter}${process.env.PATH}` },
+      });
+      expect(result.results[0]).toMatchObject({
+        status: "fail",
+        failureMessage: `${path.basename(process.execPath)} exited with 7`,
+        includeFallbackEvidence: true,
+      });
+      expect(result.evidence.entries.map((entry) => [entry.test.id, entry.result.status])).toEqual([
+        ["cli-gateway-auth-storage", "fail"],
+        ["cli-guided-onboarding", "pass"],
+        ["cli-remote-onboarding", "fail"],
+        ["cli-targeted-reconfiguration", "fail"],
+        ["cli-onboarding", "fail"],
+      ]);
+      const features = coverageIds.map((id) => ({ name: id, coverageIds: [id] }));
+      const scorecard = await attachQaProfileScorecardEvidenceToFile({
+        evidencePath: result.evidencePath,
+        evidenceMode,
+        profile: "all",
+        profilePlan: {
+          profile: "all",
+          membership: [],
+          selected: [],
+          excluded: [],
+          expectedCells: [],
+          observedCells: [],
+          missingCells: [],
+          counts: {
+            membership: 0,
+            selected: 0,
+            excluded: 0,
+            expectedCells: 0,
+            observedCells: 0,
+            missingCells: 0,
+          },
+        },
+        filters: {},
+        categories: [
+          {
+            id: "cli.onboarding-and-auth-setup",
+            taxonomySurfaceId: "cli",
+            taxonomyCategoryName: "Onboarding",
+            inventoryStatus: "complete",
+            profiles: ["all"],
+            features,
+            coverageIds,
+            inventoriedCoverageIds: coverageIds,
+            inventoryRefs: [],
+            scenarioRefs: [],
+            missingCoverageIds: [],
+            missingInventoryRefs: [],
+          },
+        ],
+      });
+      expect(scorecard.coverageIds).toEqual({
+        total: 4,
+        fulfilled: 1,
+        missing: 3,
+        fulfillmentPercent: 25,
+      });
+      const producer = result.results[0]?.producerEvidence;
+      expect(producer?.entries.map((entry) => entry.coverage)).toEqual(
+        coverageIds.map((id) => [{ id, role: "primary" }]),
+      );
+      for (const [index, original] of (producer?.entries ?? []).entries()) {
+        const imported = result.evidence.entries[index];
+        expect(imported?.test).toEqual(original.test);
+        expect(imported?.result).toEqual(original.result);
+        expect(imported?.coverage).toEqual(original.coverage);
+        expect(imported?.execution).toEqual(
+          evidenceMode === "slim" ? undefined : original.execution,
+        );
+      }
+      for (const index of [0, 2, 3]) {
+        expect(result.evidence.entries[index]?.result.failure?.reason).toContain(
+          "missing executable assertion marker(s):",
+        );
+      }
+      const written = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(result.evidencePath, "utf8")),
+      );
+      expect(written.entries).toEqual(result.evidence.entries);
+      expect(written.evidenceMode).toBe(evidenceMode);
+
+      const taxonomyPath = path.join(tempRoot, "taxonomy.json");
+      const scoresPath = path.join(tempRoot, "scores.json");
+      const surface = { id: "cli", name: "CLI", family: "core", level: "experimental" };
+      const scores = {
+        quality: { score: 0, label: "Experimental" },
+        completeness: { score: 0, label: "Experimental" },
+      };
+      await fs.writeFile(
+        taxonomyPath,
+        JSON.stringify({
+          version: 1,
+          title: "Onboarding attribution fixture",
+          levels: [{ id: "experimental", code: "M1", label: "Experimental" }],
+          surfaces: [
+            {
+              ...surface,
+              categories: [
+                {
+                  id: "onboarding-and-auth-setup",
+                  name: "Onboarding",
+                  features,
+                  category_note: "Four independently asserted onboarding boundaries",
+                  docs: [],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      await fs.writeFile(
+        scoresPath,
+        JSON.stringify({
+          version: 1,
+          process_version: 1,
+          counts: { active_surfaces: 1, category_scores: 1 },
+          rollups: { surface_average: scores, category_average: scores },
+          surfaces: [
+            {
+              ...surface,
+              scores,
+              categories: [
+                {
+                  name: "Onboarding",
+                  ...scores,
+                  lts: { supported: false, human_override: false },
+                },
+              ],
+              lts: { supported_categories: 0, total_categories: 1, status: "none" },
+            },
+          ],
+        }),
+      );
+      const renderArgs = [
+        "--import",
+        "tsx",
+        "scripts/qa/render-maturity-docs.ts",
+        "--taxonomy",
+        taxonomyPath,
+        "--scores",
+        scoresPath,
+        "--evidence-dir",
+        outputDir,
+        "--output-dir",
+        path.join(tempRoot, "rendered"),
+      ];
+      const rejected = spawnSync(process.execPath, renderArgs, { cwd: repoRoot, encoding: "utf8" });
+      expect(rejected.status, rejected.stderr).toBe(1);
+      expect(rejected.stderr).toContain("maturity docs require passing QA evidence");
+      expect(rejected.stderr).toContain("cli-onboarding (fail)");
+      const rendered = spawnSync(process.execPath, [...renderArgs, "--allow-failures"], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      expect(rendered.status, rendered.stderr).toBe(0);
+      const markdown = await fs.readFile(
+        path.join(tempRoot, "rendered/maturity/scorecard.md"),
+        "utf8",
+      );
+      expect(markdown).toContain("25%");
+      expect(markdown).toContain("1 passed, 4 failed");
+    },
+    60_000,
+  );
+});

--- a/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
@@ -195,10 +195,7 @@ describe("qa test file scenario runner", () => {
     expect(evidence.entries).toHaveLength(1);
     expect(evidence.entries[0]).toMatchObject({
       test: { kind: "script-producer-check", id: "script-producer.web-ui.smoke" },
-      coverage: [
-        { id: "qa.coverage", role: "primary" },
-        { id: "qa.reporting", role: "secondary" },
-      ],
+      coverage: [],
       execution: {
         runner: "evidence-producer-script",
         artifacts: [
@@ -285,10 +282,7 @@ describe("qa test file scenario runner", () => {
     expect(evidence.entries).toHaveLength(2);
     expect(evidence.entries[0]).toMatchObject({
       test: { kind: "script-producer-check", id: "script-producer.web-ui.smoke" },
-      coverage: [
-        { id: "qa.coverage", role: "primary" },
-        { id: "qa.reporting", role: "secondary" },
-      ],
+      coverage: [],
       result: {
         status: "fail",
         failure: { reason: "Script producer check failed." },
@@ -409,10 +403,7 @@ describe("qa test file scenario runner", () => {
       expect(
         result.evidence.entries.find((entry) => entry.test.id === "scenario-script"),
       ).toMatchObject({
-        coverage: [
-          { id: "qa.coverage", role: "primary" },
-          { id: "qa.reporting", role: "secondary" },
-        ],
+        coverage: [],
         execution: {
           artifacts: [{ kind: "log", path: expect.stringContaining("producer.log") }],
           runner: "evidence-producer-script",

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -240,18 +240,22 @@ function buildScenarioEvidenceTarget(scenario: QaTestFileScenario) {
   };
 }
 
-function coverageForScenario(scenario: QaTestFileScenario) {
-  return [
-    ...(scenario.coverage?.primary ?? []).map((id) => ({ id, role: "primary" as const })),
-    ...(scenario.coverage?.secondary ?? []).map((id) => ({ id, role: "secondary" as const })),
-  ];
-}
-
 function withScenarioCoverage(
   entry: QaEvidenceSummaryJson["entries"][number],
   scenario: QaTestFileScenario,
 ) {
-  return { ...entry, coverage: coverageForScenario(scenario) };
+  const primary = new Set(scenario.coverage?.primary ?? []);
+  const secondary = new Set(scenario.coverage?.secondary ?? []);
+  return {
+    ...entry,
+    coverage: entry.coverage
+      .filter(({ id }) => primary.has(id) || secondary.has(id))
+      .map((coverage) =>
+        coverage.role === "primary" && !primary.has(coverage.id)
+          ? { id: coverage.id, role: "secondary" }
+          : coverage,
+      ),
+  };
 }
 
 async function runScenarioCommandSteps(params: {
@@ -508,8 +512,8 @@ function buildTestFileEvidence(params: {
   env?: NodeJS.ProcessEnv;
 }) {
   const producerEntries = params.results.flatMap((result) =>
-    // Producer artifacts own execution facts; the scenario catalog remains the
-    // sole owner of which semantic features those facts cover.
+    // Producers bind assertions to coverage; the catalog caps their ownership.
+    // Filling absent claims would let one passing assertion fulfill failed siblings.
     (result.producerEvidence?.entries ?? []).map((entry) =>
       withScenarioCoverage(entry, result.scenario),
     ),

--- a/scripts/e2e/qa-cli-onboarding.mjs
+++ b/scripts/e2e/qa-cli-onboarding.mjs
@@ -1,7 +1,11 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { buildScriptEvidenceSummary, QA_EVIDENCE_FILENAME } from "../../extensions/qa-lab/api.js";
+import {
+  buildScriptEvidenceSummary,
+  QA_EVIDENCE_FILENAME,
+  readQaScenarioById,
+} from "../../extensions/qa-lab/api.js";
 import { createQaScriptEvidenceWriter } from "../../test/e2e/qa-lab/runtime/script-evidence.js";
 
 const args = process.argv.slice(2);
@@ -14,6 +18,7 @@ if (artifactBaseIndex === -1 || !artifactBase || artifactBase.startsWith("-")) {
 const boundaries = [
   {
     id: "cli-gateway-auth-storage",
+    coverageId: "cli.gateway-auth-storage",
     title: "CLI Gateway auth storage",
     markers: [
       "QA_ASSERT cli.gateway-auth-storage.token-ref pass",
@@ -22,16 +27,19 @@ const boundaries = [
   },
   {
     id: "cli-guided-onboarding",
+    coverageId: "cli.guided-onboarding",
     title: "CLI guided onboarding",
     marker: "QA_ASSERT cli.guided-onboarding pass",
   },
   {
     id: "cli-remote-onboarding",
+    coverageId: "cli.remote-onboarding",
     title: "CLI remote onboarding",
     marker: "QA_ASSERT cli.remote-onboarding pass",
   },
   {
     id: "cli-targeted-reconfiguration",
+    coverageId: "cli.targeted-reconfiguration",
     title: "CLI targeted reconfiguration",
     markers: [
       "QA_ASSERT cli.targeted-reconfiguration.reset pass",
@@ -39,6 +47,12 @@ const boundaries = [
     ],
   },
 ];
+const primaryCoverageIds = new Set(readQaScenarioById("cli-onboarding").coverage?.primary ?? []);
+for (const boundary of boundaries) {
+  if (!primaryCoverageIds.has(boundary.coverageId)) {
+    throw new Error(`Onboarding boundary is not catalog-owned: ${boundary.coverageId}`);
+  }
+}
 const writer = createQaScriptEvidenceWriter({
   artifactBase,
   logFileName: "cli-onboarding.log",
@@ -118,6 +132,7 @@ const evidence = buildScriptEvidenceSummary({
   targets: boundaries.map((boundary) => ({
     id: boundary.id,
     title: boundary.title,
+    primaryCoverageIds: [boundary.coverageId],
     sourcePath: "scripts/e2e/qa-cli-onboarding.mjs",
   })),
   results,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators reviewing QA onboarding coverage would see all four capabilities fulfilled when only one onboarding boundary passed and the producer exited with a failure.

## Why This Change Was Made

The onboarding producer now records an explicit, catalog-validated coverage ID for each boundary, and the importer intersects existing claims with catalog ownership while capping their roles. The net 19 production lines establish those ownership checks; empty diagnostics, secondary and nonstandard roles, execution metadata, and terminal-failure precedence remain intact.

## User Impact

A run with one passing and three failing onboarding boundaries reports 1/4 coverage (25%), preserves all four boundary results, and retains the terminal failure. Full and slim evidence retain partial coverage and failures in diagnostic rendering; default rendering still rejects failed evidence.

## Evidence

- Before the fix: all four new regression cases failed against the original production files. Both full and slim onboarding cases incorrectly fulfilled 4/4 capabilities instead of 1/4.
- The end-to-end attribution test runs the actual onboarding producer with controlled child markers and a nonzero exit, imports its fresh artifact, then checks the real scorecard and renderer. This boundary test does not require Docker.
- Final-source proof: 32 tests in the two focused files and 51 sibling tests covering native runners, Docker batch evidence, the shared atomic writer, and scorecards passed. Six unchanged doctor-contract tests passed in the preceding gate stage: 89 unique passing tests across eight files and separate stages.
- All 29 selected changed-surface gates passed collectively. After correcting one lint finding, the affected tests, production/test type checks, formatting, and targeted lint were refreshed; the previously unrun gate suffix also passed.
- Verified commit: `45e9a302af30df33784cac8f2355f44021f8e4e8`. Proof ran on Linux x64 with Node 24.19.0 and pnpm 12.3.4 after a frozen-lock dependency install. The complete materialized source was verified before and after each stage; final manifest SHA-256: `bdcc64f18622a5be41730c7eb2025608907c493fe2ae5f6aef93f08498be3276`. Independent source/proof review and structured review found no actionable issues.
- This qualifies standalone assertion attribution. Separate combined-stack proof with the semantic identity change in https://github.com/openclaw/openclaw/pull/143976 remains outstanding and requires later integration of its owner-supplied fixture identity. Full-suite, packaging, and live-provider qualification were not run.

Punchcard-Session: silver-brook-timber-ry
