### PR TITLE
test(docs): expect dependency locking under release navigation

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -464,6 +464,7 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "reference/full-release-validation/profiles",
       "reference/full-release-validation/evidence",
       "reference/release-performance-sweep",
+      "gateway/security/dependency-locking",
       "reference/test",
       "reference/test/local",
       "reference/test/lanes",


### PR DESCRIPTION
## Problem

`test/scripts/docs-sync-publish.test.ts` pins the Release & CI route list. #143977 moved `gateway/security/dependency-locking` from Gateway & Ops into the Release process group in `docs/docs.json`, but the pinned list was not updated, so `keeps generated locale navigation aligned with English routes` fails on main and blocks every landing (for example https://github.com/openclaw/openclaw/actions/runs/34470840974/job/102850320085).

## Solution

Add the moved route to the expected release routes at its navigation position (after `reference/release-performance-sweep`).

## Impact

Main CI is green again; no navigation or docs behavior changes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 11 passed.
