### PR TITLE
refactor(auto-reply): reuse deferred test fixtures

### DIFF
--- a/src/auto-reply/reply/followup-turn-execution.lifecycle.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
 import {
@@ -24,10 +25,7 @@ beforeEach(resetFollowupTurnTestState);
 describe("executeFollowupTurn lifecycle", () => {
   it("drains detached progress before the caller can project a final", async () => {
     const order: string[] = [];
-    let releaseProgress!: () => void;
-    const progressBarrier = new Promise<void>((resolve) => {
-      releaseProgress = resolve;
-    });
+    const { promise: progressBarrier, resolve: releaseProgress } = createDeferred();
     state.execute.mockImplementation(async (params: AgentTurnParams) => {
       void params.opts?.onItemEvent?.({ progressText: "working" });
       return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
@@ -113,10 +111,7 @@ describe("executeFollowupTurn lifecycle", () => {
 
   it("drains detached progress before propagating execution failure", async () => {
     const order: string[] = [];
-    let releaseProgress!: () => void;
-    const progressBarrier = new Promise<void>((resolve) => {
-      releaseProgress = resolve;
-    });
+    const { promise: progressBarrier, resolve: releaseProgress } = createDeferred();
     const failure = new Error("execution failed");
     state.execute.mockImplementation(async (params: AgentTurnParams) => {
       void params.opts?.onItemEvent?.({ progressText: "working" });
@@ -190,10 +185,7 @@ describe("executeFollowupTurn lifecycle", () => {
 
   it("waits for every pending task before propagating a drain failure", async () => {
     const failure = new Error("tool task failed");
-    let releaseSlowTask!: () => void;
-    const slowBarrier = new Promise<void>((resolve) => {
-      releaseSlowTask = resolve;
-    });
+    const { promise: slowBarrier, resolve: releaseSlowTask } = createDeferred();
     const order: string[] = [];
     state.execute.mockImplementation(async (params: AgentTurnParams) => {
       const failedTask = Promise.reject(failure).finally(() => {

--- a/src/auto-reply/reply/pending-tool-task-drain.test.ts
+++ b/src/auto-reply/reply/pending-tool-task-drain.test.ts
@@ -1,19 +1,7 @@
 // Tests pending tool task drain ordering, settlement, and failure handling.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
-
-function deferredTask() {
-  let resolve: (() => void) | undefined;
-  let reject: ((error: Error) => void) | undefined;
-  const promise = new Promise<void>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  if (!resolve || !reject) {
-    throw new Error("Expected deferred task callbacks to be initialized");
-  }
-  return { promise, resolve, reject };
-}
 
 async function flushPromises() {
   await Promise.resolve();
@@ -32,8 +20,8 @@ describe("drainPendingToolTasks", () => {
   });
 
   it("waits for all pending tasks to settle", async () => {
-    const first = deferredTask();
-    const second = deferredTask();
+    const first = createDeferred();
+    const second = createDeferred();
     const tasks = new Set([first.promise, second.promise]);
 
     const drain = drainPendingToolTasks({ tasks, idleTimeoutMs: 1_000 });
@@ -48,8 +36,8 @@ describe("drainPendingToolTasks", () => {
 
   it("resets the idle timeout after each completed task", async () => {
     vi.useFakeTimers();
-    const first = deferredTask();
-    const second = deferredTask();
+    const first = createDeferred();
+    const second = createDeferred();
     const onTimeout = vi.fn();
     const tasks = new Set([first.promise, second.promise]);
 
@@ -67,8 +55,8 @@ describe("drainPendingToolTasks", () => {
   });
 
   it("drains tasks added after the initial snapshot", async () => {
-    const first = deferredTask();
-    const second = deferredTask();
+    const first = createDeferred();
+    const second = createDeferred();
     const tasks = new Set([first.promise]);
 
     const drain = drainPendingToolTasks({ tasks, idleTimeoutMs: 1_000 });
@@ -83,7 +71,7 @@ describe("drainPendingToolTasks", () => {
 
   it("returns timeout when no pending task settles before the idle window", async () => {
     vi.useFakeTimers();
-    const stuck = deferredTask();
+    const stuck = createDeferred();
     const onTimeout = vi.fn();
     const tasks = new Set([stuck.promise]);
 
@@ -98,8 +86,8 @@ describe("drainPendingToolTasks", () => {
   });
 
   it("treats rejected tasks as drained progress", async () => {
-    const failed = deferredTask();
-    const later = deferredTask();
+    const failed = createDeferred();
+    const later = createDeferred();
     const tasks = new Set([failed.promise, later.promise]);
 
     const drain = drainPendingToolTasks({ tasks, idleTimeoutMs: 1_000 });


### PR DESCRIPTION
## What Problem This Solves

The pending-tool drain and queued follow-up lifecycle tests maintained their own deferred-promise setup alongside an existing shared test helper.

## Why This Change Was Made

Use the existing shared helper for all nine local factory calls and three adjacent lifecycle barriers. The barriers keep their original promise and resolver names; assertions, await ordering, timers and cleanup stay unchanged. The shared helper and production code are unchanged.

## User Impact

Developer-only cleanup: 20 fewer lines of test scaffolding with the same drain and follow-up coverage.

## Evidence

- Both complete suites passed before and after: 12 cases each, with matching case identities and outcomes on the same Node runtime.
- All 28 assertion sites remain, including live task-set growth, idle timeout reset, rejected-task progress, final-projection ordering and failure propagation.
- Formatting, all 20 normal changed-file checks (including the messaging test graph and lint), and independent source review passed.
