### PR TITLE
refactor(terminal): verify closed output through writes

### DIFF
--- a/packages/terminal-core/src/stream-writer.test.ts
+++ b/packages/terminal-core/src/stream-writer.test.ts
@@ -2,49 +2,41 @@ import { describe, expect, it, vi } from "vitest";
 import { createSafeStreamWriter } from "./stream-writer.js";
 
 describe("createSafeStreamWriter", () => {
-  it("signals broken pipes and closes the writer", () => {
-    let brokenPipeCount = 0;
-    const writer = createSafeStreamWriter({
-      onBrokenPipe: () => {
-        brokenPipeCount += 1;
-      },
+  it.each([
+    { code: "EPIPE", method: "writeLine", beforeWriteFails: false },
+    { code: "EIO", method: "write", beforeWriteFails: true },
+  ] as const)("keeps the writer closed after $code", ({ code, method, beforeWriteFails }) => {
+    const failure = Object.assign(new Error(code), { code });
+    const beforeWrite = vi.fn(() => {
+      if (beforeWriteFails) {
+        throw failure;
+      }
     });
-    const stream = {
-      write: () => {
-        const err = new Error("EPIPE") as NodeJS.ErrnoException;
-        err.code = "EPIPE";
-        throw err;
-      },
-    } as unknown as NodeJS.WriteStream;
-
-    expect(writer.writeLine(stream, "hello")).toBe(false);
-    expect(writer.isClosed()).toBe(true);
-    expect(brokenPipeCount).toBe(1);
-
-    brokenPipeCount = 0;
-    expect(writer.writeLine(stream, "again")).toBe(false);
-    expect(brokenPipeCount).toBe(0);
-  });
-
-  it("treats broken pipes from beforeWrite as closed", () => {
-    let brokenPipeCount = 0;
-    const writer = createSafeStreamWriter({
-      onBrokenPipe: () => {
-        brokenPipeCount += 1;
-      },
-      beforeWrite: () => {
-        const err = new Error("EIO") as NodeJS.ErrnoException;
-        err.code = "EIO";
-        throw err;
-      },
+    const onBrokenPipe = vi.fn();
+    const writer = createSafeStreamWriter({ beforeWrite, onBrokenPipe });
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => {
+      if (!beforeWriteFails) {
+        throw failure;
+      }
+      return true;
     });
-    const stream = {
-      write: () => true,
-    } as unknown as NodeJS.WriteStream;
+    try {
+      expect(writer[method](process.stdout, "hello")).toBe(false);
+      expect(onBrokenPipe).toHaveBeenCalledTimes(1);
+      expect(onBrokenPipe.mock.calls[0]?.[0]).toBe(failure);
+      expect(onBrokenPipe.mock.calls[0]?.[1]).toBe(
+        beforeWriteFails ? process.stderr : process.stdout,
+      );
 
-    expect(writer.write(stream, "hi")).toBe(false);
-    expect(writer.isClosed()).toBe(true);
-    expect(brokenPipeCount).toBe(1);
+      beforeWrite.mockReturnValue(undefined);
+      write.mockReturnValue(true);
+      expect(writer[method](process.stdout, "again")).toBe(false);
+      expect(beforeWrite).toHaveBeenCalledTimes(1);
+      expect(write).toHaveBeenCalledTimes(beforeWriteFails ? 0 : 1);
+      expect(onBrokenPipe).toHaveBeenCalledTimes(1);
+    } finally {
+      write.mockRestore();
+    }
   });
 
   it("notifies once when a reentrant write closes before the outer write", () => {
@@ -72,7 +64,8 @@ describe("createSafeStreamWriter", () => {
       expect(writer.write(process.stdout, "outer")).toBe(false);
       expect(nestedResult).toBe(false);
       expect(callbackResult).toBe(false);
-      expect(writer.isClosed()).toBe(true);
+      write.mockReturnValue(true);
+      expect(writer.write(process.stdout, "ignored")).toBe(false);
       expect(notifications).toBe(1);
       expect(write.mock.calls.map(([text]) => text)).toEqual(["nested", "outer"]);
     } finally {
@@ -99,7 +92,6 @@ describe("createSafeStreamWriter", () => {
         thrown = error;
       }
       expect(thrown).toBe(callbackError);
-      expect(writer.isClosed()).toBe(true);
       expect(writer.write(process.stdout, "ignored")).toBe(false);
       expect(write).toHaveBeenCalledTimes(1);
     } finally {

--- a/packages/terminal-core/src/stream-writer.ts
+++ b/packages/terminal-core/src/stream-writer.ts
@@ -10,7 +10,6 @@ export type SafeStreamWriterOptions = {
 export type SafeStreamWriter = {
   write: (stream: NodeJS.WriteStream, text: string) => boolean;
   writeLine: (stream: NodeJS.WriteStream, text: string) => boolean;
-  isClosed: () => boolean;
 };
 
 /** Detect broken pipe style stream errors. */
@@ -57,6 +56,5 @@ export function createSafeStreamWriter(options: SafeStreamWriterOptions = {}): S
   return {
     write,
     writeLine,
-    isClosed: () => closed,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The internal terminal writer exposed a state getter only for tests, while the before-write error test did not check whether later writes stayed suppressed. Two tests also used incomplete objects cast as Node streams.

## Why This Change Was Made

Remove the getter and verify closure through actual write behavior. The EPIPE and before-write EIO cases share a table; after the first failure, their mocks become harmless while call history remains intact. A later write must still be rejected without another hook, stream write or notification. Real stdout spies replace the two fake-stream casts, with restoration in `finally`.

The reentrant and throwing-callback cases retain their error identity, notification ordering and stream-call checks. No supported public SDK getter contract or known production consumer was found. The helper has shipped through internal package aliases, so this does not establish zero external use.

## User Impact

No intended user-visible behavior change. The internal writer exposes only the operations used by Logs, and its four retained tests protect observable closure. Removes two production lines and eight test lines.

## Evidence

All four stronger cases passed against unchanged production. The same test bytes then passed after getter removal alongside all 35 Logs CLI cases: 39 distinct cases, no skips. All 28 canonical changed-file checks, formatting, whitespace and independent review passed.

No live Gateway or external plugin execution was used for this internal cleanup.
