### PR TITLE
fix(agents): use the selected configured context limit

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1677,9 +1677,7 @@ src/agents/config.ts	1
 src/agents/content-blocks.ts	1
 src/agents/context-cache-projection.ts	1
 src/agents/context-cache.ts	1
-src/agents/context-resolution.ts	1
 src/agents/context-runtime-state.ts	4
-src/agents/context-window-guard.ts	1
 src/agents/context.ts	2
 src/agents/cron-creator-authority-context.ts	1
 src/agents/custom-api-registry.ts	2

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -3,8 +3,16 @@ import {
   resolveClaudeSonnet5ModelIdentity,
   supportsClaude1MContext,
 } from "@openclaw/llm-core";
-import { stripSelfProviderModelPrefix } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  normalizeConfiguredProviderCatalogModelId,
+  stripSelfProviderModelPrefix,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  findConfiguredProviderModel,
+  resolveMergedModelProviderConfig,
+} from "../config/model-provider-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   lookupCachedContextTokens,
@@ -13,7 +21,6 @@ import {
   providerContextTokenCacheKey,
 } from "./context-cache.js";
 import { resolveModelExtraParamSources } from "./model-extra-params.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 type ConfigModelEntry = { id?: string; contextWindow?: number; contextTokens?: number };
 type ProviderConfigEntry = {
@@ -64,31 +71,19 @@ function resolveProviderModelRef(params: {
   return provider && model ? { provider, model } : undefined;
 }
 
-function resolveConfiguredProviderModel(
+/** Preserve shipped self-prefixed context refs after exact configured-row selection. */
+export function resolveConfiguredProviderModel(
   cfg: OpenClawConfig | null | undefined,
   provider: string,
   model: string,
 ): ConfigModelEntry | undefined {
-  const providers = (cfg?.models as ModelsConfig | undefined)?.providers;
-  const requestedProvider = provider.trim();
-  const normalizedProvider = normalizeProviderId(provider);
-  const providerEntries = Object.entries(providers ?? {});
-  const providerConfig =
-    providerEntries.find(([providerId]) => providerId.trim() === requestedProvider)?.[1] ??
-    providerEntries.find(
-      ([providerId]) => normalizeProviderId(providerId) === normalizedProvider,
-    )?.[1];
-  const bareModel = stripSelfProviderModelPrefix(normalizedProvider, model);
+  const providerConfig = resolveMergedModelProviderConfig(cfg ?? undefined, provider);
+  const bareModel = stripSelfProviderModelPrefix(provider, model);
   const spellings = bareModel === model ? [model] : [model, bareModel];
   for (const spelling of spellings) {
-    const match = providerConfig?.models?.find((entry) => {
-      const entryId = entry.id?.trim();
-      return (
-        entryId === spelling ||
-        (entryId !== undefined &&
-          stripSelfProviderModelPrefix(normalizedProvider, entryId) === spelling)
-      );
-    });
+    const match = findConfiguredProviderModel(providerConfig, provider, spelling, (id) =>
+      normalizeConfiguredProviderCatalogModelId(provider, id),
+    );
     if (match) {
       return match;
     }

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -113,6 +113,36 @@ describe("context-window-guard", () => {
     });
   });
 
+  it.each([false, true])("uses the exact row's context window (exact first=%s)", (exactFirst) => {
+    const models = openRouterModelConfig({
+      contextWindow: 128_000,
+    }).models.providers.openrouter.models.flatMap((model) => [
+      { ...model, id: "custom/model", contextWindow: 2_000 },
+      { ...model, id: "model", contextWindow: 128_000 },
+    ]);
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.invalid",
+            models: exactFirst ? models.toReversed() : models,
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "custom",
+      modelId: "model",
+      modelContextWindow: 128_000,
+      defaultTokens: 200_000,
+    });
+
+    expect(info).toEqual({ source: "modelsConfig", tokens: 128_000 });
+    expect(evaluateContextWindowGuard({ info }).shouldBlock).toBe(false);
+  });
+
   it("matches bare provider model config ids against provider-scoped runtime model ids", () => {
     const cfg = openRouterModelConfig({ contextWindow: 1_000_000, contextTokens: 936_000 });
 

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -4,8 +4,8 @@
  * Configured model values can cap provider metadata, and local endpoints get
  * more actionable remediation text.
  */
-import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveConfiguredProviderModel } from "./context-resolution.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 
 export const CONTEXT_WINDOW_HARD_MIN_TOKENS = 4_000;
@@ -29,27 +29,6 @@ function normalizePositiveInt(value: unknown): number | null {
   return int > 0 ? int : null;
 }
 
-function modelIdMatchesProviderScope(params: {
-  configuredId?: string;
-  provider: string;
-  modelId: string;
-}): boolean {
-  const configuredId = params.configuredId?.trim();
-  if (!configuredId) {
-    return false;
-  }
-  if (configuredId === params.modelId) {
-    return true;
-  }
-  const providerPrefix = params.provider ? `${params.provider}/` : "";
-  if (!providerPrefix) {
-    return false;
-  }
-  const stripProvider = (id: string) =>
-    id.startsWith(providerPrefix) ? id.slice(providerPrefix.length) : id;
-  return stripProvider(configuredId) === stripProvider(params.modelId);
-}
-
 /** Resolve the effective context window and source for one provider/model. */
 export function resolveContextWindowInfo(params: {
   cfg: OpenClawConfig | undefined;
@@ -59,24 +38,9 @@ export function resolveContextWindowInfo(params: {
   modelContextWindow?: number;
   defaultTokens: number;
 }): ContextWindowInfo {
-  const fromModelsConfig = (() => {
-    const providers = params.cfg?.models?.providers as
-      | Record<
-          string,
-          { models?: Array<{ id?: string; contextTokens?: number; contextWindow?: number }> }
-        >
-      | undefined;
-    const providerEntry = findNormalizedProviderValue(providers, params.provider);
-    const models = Array.isArray(providerEntry?.models) ? providerEntry.models : [];
-    const match = models.find((model) =>
-      modelIdMatchesProviderScope({
-        configuredId: model?.id,
-        provider: params.provider,
-        modelId: params.modelId,
-      }),
-    );
-    return normalizePositiveInt(match?.contextTokens) ?? normalizePositiveInt(match?.contextWindow);
-  })();
+  const match = resolveConfiguredProviderModel(params.cfg, params.provider, params.modelId);
+  const fromModelsConfig =
+    normalizePositiveInt(match?.contextTokens) ?? normalizePositiveInt(match?.contextWindow);
   const fromModel =
     normalizePositiveInt(params.modelContextTokens) ??
     normalizePositiveInt(params.modelContextWindow);

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -666,6 +666,24 @@ describe("lookupContextTokens", () => {
       expected: 900_000,
     },
     {
+      name: "prefers the exact bare row over an earlier self-prefixed row",
+      model: "kilo-auto/balanced",
+      configuredModels: [
+        createConfiguredModel("kilocode/kilo-auto/balanced", 2_000),
+        createConfiguredModel("kilo-auto/balanced", 128_000),
+      ],
+      expected: 128_000,
+    },
+    {
+      name: "keeps the exact bare row ahead of a later self-prefixed row",
+      model: "kilo-auto/balanced",
+      configuredModels: [
+        createConfiguredModel("kilo-auto/balanced", 128_000),
+        createConfiguredModel("kilocode/kilo-auto/balanced", 2_000),
+      ],
+      expected: 128_000,
+    },
+    {
       name: "does not strip another provider's prefix",
       model: "openrouter/anthropic/claude-sonnet-5",
       configuredModels: [createConfiguredModel("anthropic/claude-sonnet-5", 900_000)],


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

A prefixed or equivalent model row appearing earlier in configuration can supply the context limit for a different selected model. Context lookup and the context-window guard also implement separate matching rules.

## Why This Change Was Made

Share the existing exact configured-row owner between context lookup and the window guard. Exact selected rows take priority while shipped self-prefix and OpenRouter compatibility remain supported. This removes 41 production lines and two obsolete assertion allowances.

## User Impact

The selected model receives its own configured context cap, so an unrelated sibling cannot cause premature context warnings or change its limit.

## Evidence

129 focused tests, a 20-case fixture retest, independent P2 review, and the full changed-file gate passed. Earlier gate failures required only an exact shrink-only assertion-baseline update and a fresh-array test-fixture correction.

One exact-commit sourcePerformance build and 16 compiled context/guard scenarios passed. All 9,258 captured root/workspace output files remained unchanged; no checkout source imports or network requests occurred, and isolated state/processes were cleaned up. This is compiled boundary proof, without a live Gateway or external provider. The runtime build excludes UI and declarations.

Tested commit: `08383a80d9e55bc299e92e6db022e2e98f8b3eab`.

CI refresh: the unchanged task patch is replayed onto main `3943149f8ac269fc138ca21b5786ff2a9db3dd23`, including the navigation repair in #144037. Every changed-file postimage matches the previous reviewed head `c3c72733b6b5902e97c47a657feb886c9151ff51`. Original exact-commit runtime proof remains preserved and is not restamped; fresh CI is running for `aca25caeeb842394b10c83e2551e69052c9ed8bc`.
