### PR TITLE
fix(agents): preserve selected tool inventory models

### DIFF
--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { makeOpenClawConfigFixture } from "./embedded-agent-runner/model.test-harness.js";
+import {
+  makeModel,
+  makeOpenClawConfigFixture,
+} from "./embedded-agent-runner/model.test-harness.js";
 
 const runtimeMocks = vi.hoisted(() => {
   const createLease = (owner: string) => {
@@ -140,44 +143,72 @@ describe("acquireEffectiveToolInventoryRuntimeModelContext", () => {
     expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
   });
 
-  it("uses configured model context without acquiring a runtime lease", async () => {
-    const { acquireEffectiveToolInventoryRuntimeModelContext } =
-      await import("./tools-effective-inventory.js");
-    const cfg = makeOpenClawConfigFixture({
-      models: {
-        providers: {
-          custom: {
-            api: "anthropic-messages",
-            models: [
-              {
-                id: "configured",
-                name: "Configured",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 8192,
-                maxTokens: 1024,
-              },
-            ],
+  it.each([
+    ["prefixed sibling", "custom", "configured", "configured", "custom/configured"],
+    ["case-distinct sibling", "custom", "configured", "configured", "Configured"],
+    ["prefixed fallback", "custom", "configured", "custom/configured", undefined],
+    ["case-insensitive fallback", "custom", "configured", "Configured", undefined],
+    ["static alias", "xai", "grok-4.3-latest", "grok-4.3", undefined],
+  ] as const)(
+    "uses configured model context without acquiring a runtime lease (%s)",
+    async (_case, provider, modelId, rowId, siblingId) => {
+      const { acquireEffectiveToolInventoryRuntimeModelContext, resolveConfiguredModelCompat } =
+        await import("./tools-effective-inventory.js");
+      const configuredModel = {
+        ...makeModel(rowId),
+        name: "Configured",
+        contextWindow: 8192,
+        maxTokens: 1024,
+        compat: { supportsTools: true },
+      };
+      const cfg = makeOpenClawConfigFixture({
+        models: {
+          providers: {
+            [provider]: {
+              api: "anthropic-messages",
+              models: [
+                ...(siblingId
+                  ? [
+                      {
+                        ...configuredModel,
+                        id: siblingId,
+                        name: "Sibling",
+                        api: "openai-completions" as const,
+                        compat: { supportsTools: false },
+                      },
+                    ]
+                  : []),
+                configuredModel,
+              ],
+            },
           },
         },
-      },
-    });
+      });
 
-    const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
-      cfg,
-      modelProvider: "custom",
-      modelId: "configured",
-    });
-    expect(acquired.run((context) => context)).toMatchObject({
-      modelApi: "anthropic-messages",
-      runtimeModel: { id: "configured", provider: "custom" },
-    });
-    acquired.release();
-    expect(runtimeMocks.acquire).not.toHaveBeenCalled();
-    expect(runtimeMocks.resolveModelAsync).not.toHaveBeenCalled();
-    expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
-  });
+      const acquired = await acquireEffectiveToolInventoryRuntimeModelContext({
+        cfg,
+        modelProvider: provider,
+        modelId,
+      });
+      expect(acquired.run((context) => context)).toMatchObject({
+        modelApi: "anthropic-messages",
+        runtimeModel: {
+          id: modelId,
+          name: "Configured",
+          provider,
+          compat: { supportsTools: true },
+        },
+      });
+      expect(resolveConfiguredModelCompat({ cfg, modelProvider: provider, modelId })).toEqual({
+        supportsTools: true,
+      });
+      expect(configuredModel.id).toBe(rowId);
+      acquired.release();
+      expect(runtimeMocks.acquire).not.toHaveBeenCalled();
+      expect(runtimeMocks.resolveModelAsync).not.toHaveBeenCalled();
+      expect(runtimeMocks.requestLease.release).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses bundled model context without acquiring a runtime lease", async () => {
     runtimeMocks.staticCatalogModel.mockReturnValue({

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/config.js";
+import { findConfiguredProviderModel } from "../config/model-provider-config.js";
 import { extractModelCompat } from "../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtime.js";
@@ -171,17 +172,9 @@ function resolveStaticToolInventoryRuntimeModelContext(params: {
   const agentId = params.agentId?.trim() || resolveSessionAgentId({ config: params.cfg });
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
   const providerConfig = findNormalizedProviderValue(params.cfg.models?.providers, provider);
-  const configuredModels = Array.isArray(providerConfig?.models) ? providerConfig.models : [];
-  const normalizedModelId = normalizeStaticProviderModelId(provider, modelId);
-  const normalizedModelKey = normalizeLowercaseStringOrEmpty(normalizedModelId);
-  const providerPrefixedModelKey = normalizeLowercaseStringOrEmpty(
-    `${provider}/${normalizedModelId}`,
+  const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId, (id) =>
+    normalizeLowercaseStringOrEmpty(normalizeStaticProviderModelId(provider, id)),
   );
-  const configuredModel = configuredModels.find((model) => {
-    const id = normalizeStaticProviderModelId(provider, model.id);
-    const key = normalizeLowercaseStringOrEmpty(id);
-    return key === normalizedModelKey || key === providerPrefixedModelKey;
-  });
   const bundledStaticModel = resolveBundledStaticCatalogModel({
     provider,
     modelId,
@@ -202,7 +195,7 @@ function resolveStaticToolInventoryRuntimeModelContext(params: {
       runtimeModel: {
         ...bundledStaticModel,
         ...configuredModel,
-        id: configuredModel.id,
+        id: modelId,
         name: configuredModel.name ?? bundledStaticModel?.name ?? configuredModel.id,
         provider,
         api: configuredApi,
@@ -320,20 +313,9 @@ export function resolveConfiguredModelCompat(params: {
     return undefined;
   }
   const providerConfig = findNormalizedProviderValue(params.cfg.models?.providers, provider);
-  const models = Array.isArray(providerConfig?.models) ? providerConfig.models : [];
-  if (models.length === 0) {
-    return undefined;
-  }
-  const normalizedModelId = normalizeStaticProviderModelId(provider, modelId);
-  const normalizedModelKey = normalizeLowercaseStringOrEmpty(normalizedModelId);
-  const providerPrefixedModelKey = normalizeLowercaseStringOrEmpty(
-    `${provider}/${normalizedModelId}`,
+  const match = findConfiguredProviderModel(providerConfig, provider, modelId, (id) =>
+    normalizeLowercaseStringOrEmpty(normalizeStaticProviderModelId(provider, id)),
   );
-  const match = models.find((model) => {
-    const id = normalizeStaticProviderModelId(provider, model.id);
-    const key = normalizeLowercaseStringOrEmpty(id);
-    return key === normalizedModelKey || key === providerPrefixedModelKey;
-  });
   return extractModelCompat(match);
 }
 


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Tool inventory can borrow capabilities from a prefixed or case-distinct sibling row and replace the selected model ID with that configured spelling.

## Why This Change Was Made

Use the shared configured-row owner for static runtime metadata and compatibility. Preserve the selected model ID while retaining provider API/base-URL inheritance and prepared-runtime ownership. This removes 18 production lines.

## User Impact

Tool availability and compatibility follow the intended configured model, including exact rows alongside legacy spellings.

## Evidence

Five baseline failures and six controls established the defect. All 77 focused tests, independent P2 review, and the full changed-file gate passed.

One exact-commit gatewayWatch build and 11 compiled inventory cases passed with all 15 canonical workspace output roots checked. Static donor metadata uses a synthetic manifest through the existing bundled-test override; dynamic scope remains covered by the focused tests. A deliberately denied source import confirmed the guard, and there were no unexpected source imports or network requests. Outputs stayed unchanged and processes/state were cleaned up. This is compiled boundary proof, not a live Gateway or external-provider request.

Tested commit: `eaf3498f3ef8fa745f292b6da6ebd889113f416f`.

CI refresh: the unchanged task patch is replayed onto main `3943149f8ac269fc138ca21b5786ff2a9db3dd23`, including the navigation repair in #144037. Every changed-file postimage matches the previous reviewed head `652b6b6258faff91e6fef1f8e817bcfb37a20777`. Original exact-commit runtime proof remains preserved and is not restamped; fresh CI is running for `8f4f3390ff3489908c48a1b4b125b588649a4022`.
