### PR TITLE
refactor(models): reuse logical catalog deduplication

### DIFF
--- a/src/agents/model-catalog-view.ts
+++ b/src/agents/model-catalog-view.ts
@@ -1,5 +1,6 @@
 /** Keeps public and private runtime projections on the same captured catalog. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import type { ModelAuthAvailabilityEvaluation } from "./model-auth-availability.js";
 import {
   projectModelCatalogEntryForRoute,
@@ -27,15 +28,8 @@ export function createModelCatalogView(params: {
   }
   const variantsOf = (entry: Pick<ModelCatalogEntry, "provider" | "id">) =>
     variantsByKey.get(resolveModelCatalogIdentityKey(entry));
-  const logicalEntries = new Map<string, ModelCatalogEntry>();
-  for (const entry of params.catalog) {
-    const key = resolveModelCatalogIdentityKey(entry);
-    if (!logicalEntries.has(key)) {
-      logicalEntries.set(key, entry);
-    }
-  }
   return {
-    logicalEntries: [...logicalEntries.values()],
+    logicalEntries: dedupeByKey(params.catalog, resolveModelCatalogIdentityKey),
     variantsOf,
     project(entry: ModelCatalogEntry, evaluation: ModelAuthAvailabilityEvaluation) {
       const projection: ModelCatalogRouteProjection =


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Prepared catalog views duplicate the existing first-wins deduplication loop.

## Why This Change Was Made

Use the shared dedupe helper while retaining logical identity keys, row references, original ordering, and physical route variants. This removes six production lines from one file.

## User Impact

No behavior change is intended. Catalog projection and caching retain the same logical rows and variants.

## Evidence

All 22 retained tests, independent P2 review, and the full changed-file gate passed.

One exact-commit sourcePerformance build and seven compiled scenarios through the real Gateway catalog projector passed: first-wins references/order, variants including repeated references, cached projections, empty catalogs, and Arcee equivalence. The compiler inlined the private view, so the proof uses its existing public consumer without adding a test seam. All 9,256 build artifacts remained unchanged; zero source imports/network attempts and verified process/state cleanup. This is synthetic compiled projection proof, not a running Gateway or external-provider request. The runtime build excludes UI and declarations.

Tested commit: `c88fc81646aa8d13cb0560d3b2cca91821758338`.

CI refresh: the unchanged task patch is replayed onto main `3943149f8ac269fc138ca21b5786ff2a9db3dd23`, including the navigation repair in #144037. Every changed-file postimage matches the previous reviewed head `458e60f06f7ffcc7e8908c067c5a47e4cf27f9aa`. Original exact-commit runtime proof remains preserved and is not restamped; fresh CI is running for `d5c08297dc6e94efde5e9078814e35d45f59f564`.
