### PR TITLE
fix(ui): keep terminal sessions when restore is interrupted

### DIFF
--- a/ui/src/components/terminal/terminal-panel-restore.test.ts
+++ b/ui/src/components/terminal/terminal-panel-restore.test.ts
@@ -1,0 +1,369 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import type { TerminalGatewayClient } from "./terminal-connection.ts";
+import type { TerminalPanelSessionController } from "./terminal-panel-session-controller.ts";
+import {
+  createTerminalController,
+  defineTestTerminalPanelElement,
+  terminalOpenResult,
+  type CreateGhosttyTerminalMock,
+} from "./terminal-panel.test-support.ts";
+import type { OpenClawTerminalPanel } from "./terminal-panel.ts";
+import type { TerminalTaskQueue } from "./terminal-task-queue.ts";
+
+vi.mock("../../app/sw-refresh.runtime.ts", () => ({
+  refreshControlUiServiceWorker: vi.fn(async () => false),
+}));
+
+const STORAGE_KEY = "openclaw.terminal.sessions.v1";
+const createTerminal: CreateGhosttyTerminalMock = vi.fn();
+const PANEL_TAG = defineTestTerminalPanelElement(createTerminal);
+const mounted: Array<{
+  panel: OpenClawTerminalPanel;
+  sessions: TerminalPanelSessionController;
+}> = [];
+
+function attachResult(sessionId: string) {
+  return { ...terminalOpenResult(sessionId), buffer: "ready", seq: 5 };
+}
+
+type PendingAttach = ReturnType<typeof createDeferred<ReturnType<typeof attachResult>>> & {
+  sessionId: string;
+};
+const pendingAttaches: PendingAttach[] = [];
+
+function createGateway(sessionIds = ["session-a", "session-b"]) {
+  const attaches: PendingAttach[] = [];
+  const requests: Array<{ method: string; params: unknown }> = [];
+  const listeners = new Set<Parameters<TerminalGatewayClient["addEventListener"]>[0]>();
+  const list = vi.fn(async () => ({
+    sessions: sessionIds.map((sessionId) => ({
+      ...terminalOpenResult(sessionId),
+      attached: false,
+      createdAtMs: 1,
+    })),
+  }));
+  const client: TerminalGatewayClient = {
+    forceReconnect: vi.fn(),
+    request: <T>(method: string, params?: unknown) => {
+      requests.push({ method, params });
+      if (method === "terminal.list") {
+        return list() as Promise<T>;
+      }
+      if (method === "terminal.attach") {
+        const { sessionId } = params as { sessionId: string };
+        const reply = { ...createDeferred<ReturnType<typeof attachResult>>(), sessionId };
+        attaches.push(reply);
+        pendingAttaches.push(reply);
+        return reply.promise as Promise<T>;
+      }
+      return Promise.resolve(
+        method === "terminal.open" ? terminalOpenResult("replacement") : {},
+      ) as Promise<T>;
+    },
+    addEventListener: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  return {
+    client,
+    list,
+    attaches,
+    requests,
+    emit: (event: Parameters<Parameters<TerminalGatewayClient["addEventListener"]>[0]>[0]) => {
+      for (const listener of listeners) {
+        listener(event);
+      }
+    },
+  };
+}
+
+function mountPanel(client: TerminalGatewayClient) {
+  const panel = document.createElement(PANEL_TAG) as OpenClawTerminalPanel;
+  panel.client = client;
+  panel.available = true;
+  const sessions = (panel as unknown as { terminalSessions: TerminalPanelSessionController })
+    .terminalSessions;
+  const mountedPanel = { panel, sessions };
+  mounted.push(mountedPanel);
+  document.body.append(panel);
+  if (!panel.terminalPanelOpen) {
+    panel.toggle();
+  }
+  return mountedPanel;
+}
+
+function savedIds(): string[] {
+  return JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "[]") as string[];
+}
+
+async function waitForAttach(gateway: ReturnType<typeof createGateway>, index: number) {
+  await waitForFast(() => expect(gateway.attaches).toHaveLength(index + 1));
+  return gateway.attaches[index]!;
+}
+
+async function startInterruptedRestore() {
+  const gateway = createGateway();
+  const { panel, sessions } = mountPanel(gateway.client);
+  const first = await waitForAttach(gateway, 0);
+  first.resolve(attachResult(first.sessionId));
+  const second = await waitForAttach(gateway, 1);
+  await panel.updateComplete;
+  expect(sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual(["session-a", ""]);
+  return { gateway, panel, sessions, second };
+}
+
+function recordSessionWrites(sessions: TerminalPanelSessionController) {
+  const writes: Array<{
+    ids: string[];
+    tabs: Array<{ sessionId: string; status: string }>;
+  }> = [];
+  const setItem = sessionStorage.setItem.bind(sessionStorage);
+  vi.spyOn(sessionStorage, "setItem").mockImplementation((key, value) => {
+    if (key === STORAGE_KEY) {
+      writes.push({
+        ids: JSON.parse(value) as string[],
+        tabs: sessions.tabs.map((tab) => ({
+          sessionId: tab.gatewaySessionId,
+          status: tab.status,
+        })),
+      });
+    }
+    setItem(key, value);
+  });
+  return writes;
+}
+
+describe("terminal persisted restore", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-a", "session-b"]));
+    createTerminal.mockImplementation(async () => createTerminalController());
+    await i18n.setLocale("en");
+  });
+
+  afterEach(async () => {
+    for (const { sessions } of mounted) {
+      sessions.cancelPendingActions();
+    }
+    document.body.replaceChildren();
+    for (const reply of pendingAttaches) {
+      reply.resolve(attachResult(reply.sessionId));
+    }
+    // Join the existing boot queues after disposal, including replies released by cleanup.
+    await Promise.all(
+      mounted.map(({ sessions }) =>
+        (sessions as unknown as { bootQueue: TerminalTaskQueue }).bootQueue.enqueue(async () => {}),
+      ),
+    );
+    mounted.length = 0;
+    pendingAttaches.length = 0;
+    createTerminal.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    await i18n.setLocale("en");
+  });
+
+  it("keeps both ids during replay and a second attach, then restores both after interruption", async () => {
+    const gateway = createGateway();
+    const { panel, sessions } = mountPanel(gateway.client);
+    const writes = recordSessionWrites(sessions);
+    const first = await waitForAttach(gateway, 0);
+    first.resolve(attachResult(first.sessionId));
+    const second = await waitForAttach(gateway, 1);
+
+    expect(writes).toContainEqual({
+      ids: ["session-a", "session-b"],
+      tabs: [{ sessionId: "", status: "live" }],
+    });
+    expect(
+      writes.every(({ ids }) => JSON.stringify(ids) === JSON.stringify(["session-a", "session-b"])),
+    ).toBe(true);
+    expect(savedIds()).toEqual(["session-a", "session-b"]);
+    expect(sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual(["session-a", ""]);
+
+    const writeCount = writes.length;
+    panel.remove();
+    expect(writes).toHaveLength(writeCount);
+    expect(savedIds()).toEqual(["session-a", "session-b"]);
+    second.resolve(attachResult(second.sessionId));
+
+    const replacement = mountPanel(gateway.client);
+    const restoredFirst = await waitForAttach(gateway, 2);
+    expect(writes).toHaveLength(writeCount);
+    restoredFirst.resolve(attachResult(restoredFirst.sessionId));
+    const restoredSecond = await waitForAttach(gateway, 3);
+    expect(savedIds()).toEqual(["session-a", "session-b"]);
+    restoredSecond.resolve(attachResult(restoredSecond.sessionId));
+    await waitForFast(() => expect(replacement.sessions.booting).toBe(false));
+
+    expect(replacement.sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+    expect(savedIds()).toEqual(["session-a", "session-b"]);
+    expect(gateway.requests.some(({ method }) => method === "terminal.open")).toBe(false);
+    expect(gateway.requests.some(({ method }) => method === "terminal.close")).toBe(false);
+  });
+
+  it.each([
+    { closeIndex: 0, closed: "session-a", remaining: "session-b" },
+    { closeIndex: 1, closed: "session-b", remaining: "session-a" },
+  ])(
+    "retires a deliberate close of $closed while the second attach is pending",
+    async ({ closeIndex, closed, remaining }) => {
+      const { gateway, panel, sessions, second } = await startInterruptedRestore();
+      const close =
+        panel.renderRoot.querySelectorAll<HTMLButtonElement>(".tabstrip-tab__close")[closeIndex];
+      expect(close).toBeDefined();
+      close!.click();
+      expect(savedIds()).toEqual([remaining]);
+      if (closeIndex === 1) {
+        expect(gateway.requests.some(({ method }) => method === "terminal.close")).toBe(false);
+      }
+
+      second.resolve(attachResult(second.sessionId));
+      await waitForFast(() => expect(sessions.booting).toBe(false));
+      expect(gateway.requests).toContainEqual({
+        method: "terminal.close",
+        params: { sessionId: closed },
+      });
+      expect(sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual([remaining]);
+      expect(savedIds()).toEqual([remaining]);
+    },
+  );
+
+  it("retires an exit delivered before adoption without resurrecting its id on attach completion", async () => {
+    const { gateway, sessions, second } = await startInterruptedRestore();
+    const writes = recordSessionWrites(sessions);
+    gateway.emit({
+      event: "terminal.exit",
+      payload: { sessionId: "session-b", exitCode: 0, reason: "exited" },
+    });
+    second.resolve(attachResult(second.sessionId));
+    await waitForFast(() => expect(sessions.booting).toBe(false));
+
+    expect(writes).toContainEqual({
+      ids: ["session-a"],
+      tabs: [
+        { sessionId: "session-a", status: "live" },
+        { sessionId: "", status: "exited" },
+      ],
+    });
+    expect(sessions.tabs[1]).toMatchObject({ gatewaySessionId: "session-b", status: "exited" });
+    expect(savedIds()).toEqual(["session-a"]);
+    expect(gateway.requests).not.toContainEqual({
+      method: "terminal.resize",
+      params: { sessionId: "session-b", cols: 100, rows: 30 },
+    });
+  });
+
+  it("removes an adopted session that exits while another restore is pending", async () => {
+    const { gateway, sessions, second } = await startInterruptedRestore();
+    gateway.emit({
+      event: "terminal.exit",
+      payload: { sessionId: "session-a", exitCode: 0, reason: "exited" },
+    });
+    expect(savedIds()).toEqual(["session-b"]);
+    second.resolve(attachResult(second.sessionId));
+    await waitForFast(() => expect(sessions.booting).toBe(false));
+    expect(savedIds()).toEqual(["session-b"]);
+  });
+
+  it.each(
+    ["same-client reconnect", "replacement client", "replacement host"].flatMap((transition) =>
+      ["resolve", "reject"].map((completion) => ({ transition, completion })),
+    ),
+  )(
+    "keeps the restore set across $transition and a stale attach $completion",
+    async ({ transition, completion }) => {
+      const { gateway, panel, sessions, second } = await startInterruptedRestore();
+      const currentGateway = transition === "same-client reconnect" ? gateway : createGateway();
+      let current = { panel, sessions };
+      const writes = recordSessionWrites(sessions);
+      if (transition === "replacement host") {
+        panel.remove();
+        current = mountPanel(currentGateway.client);
+      } else {
+        if (transition === "same-client reconnect") {
+          panel.client = null;
+          panel.available = false;
+          await panel.updateComplete;
+          await waitForFast(() => expect(sessions.tabs).toHaveLength(0));
+        }
+        panel.client = currentGateway.client;
+        panel.available = true;
+        await panel.updateComplete;
+      }
+      await waitForFast(() => expect(sessions.tabs).toHaveLength(0));
+      expect(writes).toHaveLength(0);
+      expect(savedIds()).toEqual(["session-a", "session-b"]);
+
+      if (completion === "resolve") {
+        second.resolve(attachResult(second.sessionId));
+      } else {
+        second.reject(new Error("old connection closed"));
+      }
+      const firstIndex = currentGateway === gateway ? 2 : 0;
+      const restoredFirst = await waitForAttach(currentGateway, firstIndex);
+      expect(writes).toHaveLength(0);
+      restoredFirst.resolve(attachResult(restoredFirst.sessionId));
+      const restoredSecond = await waitForAttach(currentGateway, firstIndex + 1);
+      expect(savedIds()).toEqual(["session-a", "session-b"]);
+      restoredSecond.resolve(attachResult(restoredSecond.sessionId));
+      await waitForFast(() => expect(current.sessions.booting).toBe(false));
+      expect(savedIds()).toEqual(["session-a", "session-b"]);
+      expect(gateway.requests.some(({ method }) => method === "terminal.close")).toBe(false);
+    },
+  );
+
+  it("prunes a completed transient failure but retains a later unresolved session", async () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-a", "session-b", "session-c"]));
+    const gateway = createGateway(["session-a", "session-b", "session-c"]);
+    const { sessions } = mountPanel(gateway.client);
+    const first = await waitForAttach(gateway, 0);
+    first.resolve(attachResult(first.sessionId));
+    const second = await waitForAttach(gateway, 1);
+    second.reject(new Error("gateway temporarily unavailable"));
+    const third = await waitForAttach(gateway, 2);
+    expect(gateway.list).toHaveBeenCalledTimes(2);
+    expect(savedIds()).toEqual(["session-a", "session-c"]);
+    third.resolve(attachResult(third.sessionId));
+    await waitForFast(() => expect(sessions.booting).toBe(false));
+    expect(savedIds()).toEqual(["session-a", "session-c"]);
+    expect(sessions.tabs.every((tab) => tab.status === "live")).toBe(true);
+  });
+
+  it("prunes a failed list before opening the existing fresh-session fallback", async () => {
+    const gateway = createGateway();
+    gateway.list.mockRejectedValueOnce(new Error("gateway temporarily unavailable"));
+    const { sessions } = mountPanel(gateway.client);
+    await waitForFast(() => expect(savedIds()).toEqual(["replacement"]));
+    expect(gateway.attaches).toHaveLength(0);
+    expect(sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual(["replacement"]);
+    expect(sessions.booting).toBe(false);
+  });
+
+  it("restores duplicate stored ids once and persists their original order", async () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-b", "session-a", "session-b"]));
+    const gateway = createGateway();
+    const { sessions } = mountPanel(gateway.client);
+    const first = await waitForAttach(gateway, 0);
+    expect(first.sessionId).toBe("session-b");
+    first.resolve(attachResult(first.sessionId));
+    const second = await waitForAttach(gateway, 1);
+    expect(second.sessionId).toBe("session-a");
+    expect(savedIds()).toEqual(["session-b", "session-a"]);
+    second.resolve(attachResult(second.sessionId));
+    await waitForFast(() => expect(sessions.booting).toBe(false));
+    expect(gateway.attaches).toHaveLength(2);
+    expect(savedIds()).toEqual(["session-b", "session-a"]);
+  });
+});

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -276,9 +276,6 @@ export class TerminalPanelSessionController
         this.persistSessions();
       }
     } catch {
-      if (!this.isTerminalOperationCurrent(operation, restore)) {
-        return;
-      }
       // terminal.list failed (older gateway, surface flapping): fall through
       // to a fresh session below.
     } finally {
@@ -714,10 +711,8 @@ export class TerminalPanelSessionController
         .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
         .map((tab) => tab.gatewaySessionId),
     );
-    if (restore) {
-      for (const sessionId of restore.pending.keys()) {
-        ids.add(sessionId);
-      }
+    for (const sessionId of restore?.pending.keys() ?? []) {
+      ids.add(sessionId);
     }
     persistTerminalSessionIds([...ids]);
   }

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -25,10 +25,15 @@ import { TerminalOpenRetry, terminalIntentQueue } from "./terminal-pending-actio
 import type { TerminalIntentHost } from "./terminal-pending-actions.ts";
 import {
   loadPersistedTerminalSessionIds,
-  persistLiveTerminalSessions,
+  persistTerminalSessionIds,
 } from "./terminal-session-storage.ts";
 import { TerminalTabReadinessController } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
+
+type TerminalRestoreBatch = {
+  operation: TerminalOperation;
+  pending: Map<string, TerminalPanelSessionTab | undefined>;
+};
 
 /** Owns gateway PTY sessions and the Ghostty controllers bound to them. */
 export class TerminalPanelSessionController
@@ -47,6 +52,7 @@ export class TerminalPanelSessionController
   private lifecycleAbortController = new AbortController();
   private lifecycleSyncToken = 0;
   private tabSequence = 0;
+  private pendingRestore: TerminalRestoreBatch | null = null;
   readonly openRetry = new TerminalOpenRetry();
   private readonly bootQueue = new TerminalTaskQueue();
   private readonly intentHost: TerminalIntentHost;
@@ -75,13 +81,13 @@ export class TerminalPanelSessionController
       onReady: () => {
         this.openRetry.clear();
         this.updateControllerState("tabs", [...this.tabs]);
-        persistLiveTerminalSessions(this.tabs);
+        this.persistSessions();
       },
       onTimeout: (tab) => {
         this.host.terminalPanelErrorText = t("terminal.connectionTimedOut");
         void this.connection?.close(tab.gatewaySessionId);
         this.dropFailedTab(tab);
-        persistLiveTerminalSessions(this.tabs);
+        this.persistSessions();
       },
     });
   }
@@ -236,46 +242,53 @@ export class TerminalPanelSessionController
     if (persisted.length === 0) {
       return;
     }
+    // Readiness can persist an adopted tab while later attaches are still pending.
+    // Retain those ids until this generation resolves or deliberately removes them.
+    const restore: TerminalRestoreBatch = {
+      operation,
+      pending: new Map(persisted.map((sessionId) => [sessionId, undefined])),
+    };
+    this.pendingRestore = restore;
     this.updateControllerState("booting", true);
     try {
       const connection = this.connectionFor(operation);
       const listed = await connection.list();
-      if (!this.isTerminalOperationCurrent(operation)) {
+      if (!this.isTerminalOperationCurrent(operation, restore)) {
         return;
       }
       const known = new Map(listed.map((session) => [session.sessionId, session]));
-      for (const sessionId of persisted) {
+      for (const sessionId of restore.pending.keys()) {
         const session = known.get(sessionId);
         if (!session) {
-          await this.restoreExitedSession(sessionId, operation);
+          await this.restoreExitedSession(sessionId, restore);
         } else {
           await this.attachSession(
             sessionId,
             operation,
             session.owner?.startsWith("agent:") === true,
-            true,
+            restore,
           );
         }
-        if (!this.isTerminalOperationCurrent(operation)) {
+        if (!this.isTerminalOperationCurrent(operation, restore)) {
           return;
         }
+        restore.pending.delete(sessionId);
+        this.persistSessions();
       }
     } catch {
-      if (!this.isTerminalOperationCurrent(operation)) {
+      if (!this.isTerminalOperationCurrent(operation, restore)) {
         return;
       }
       // terminal.list failed (older gateway, surface flapping): fall through
       // to a fresh session below.
     } finally {
-      if (this.isTerminalOperationCurrent(operation)) {
+      if (this.isTerminalOperationCurrent(operation, restore)) {
+        this.pendingRestore = null;
         this.updateControllerState("booting", false);
+        // Completed failures keep the existing pruning policy, including list failure.
+        this.persistSessions();
       }
     }
-    if (!this.isTerminalOperationCurrent(operation)) {
-      return;
-    }
-    // Prune ids the gateway no longer knows (reaped or externally closed).
-    persistLiveTerminalSessions(this.tabs);
   }
 
   private async ensureInitialSession(agentId: string | null): Promise<boolean> {
@@ -338,7 +351,10 @@ export class TerminalPanelSessionController
   /** Boots a tab with a libterminal controller, ready for an open or attach RPC. */
   private async bootTab(
     operation: TerminalOperation,
-    options: { awaitFirstOutput?: boolean } = {},
+    options: {
+      awaitFirstOutput?: boolean;
+      restore?: { batch: TerminalRestoreBatch; sessionId: string };
+    } = {},
   ) {
     const boot = await bootTerminalPanelSession({
       panel: this.host,
@@ -346,14 +362,17 @@ export class TerminalPanelSessionController
       sequence: ++this.tabSequence,
       signal: operation.signal,
       awaitFirstOutput: options.awaitFirstOutput === true,
-      isCurrent: () => this.isTerminalOperationCurrent(operation),
+      isCurrent: () => this.isTerminalOperationCurrent(operation, options.restore?.batch),
       onReady: (tab) => this.readiness.markReady(tab),
       onExit: (tab, info) => this.handleExit(tab.id, info),
     });
-    if (!this.isTerminalOperationCurrent(operation)) {
+    if (!this.isTerminalOperationCurrent(operation, options.restore?.batch)) {
       disposeTerminalController(boot.tab.controller, boot.tab.host);
       throw new Error("terminal operation cancelled");
     }
+    // Replay and close can precede adoption; associate the placeholder privately,
+    // without making an unadopted gatewaySessionId usable by input or resize.
+    options.restore?.batch.pending.set(options.restore.sessionId, boot.tab);
     this.updateControllerState("tabs", [...this.tabs, boot.tab]);
     this.updateControllerState("activeId", boot.tab.id);
     return boot;
@@ -365,6 +384,7 @@ export class TerminalPanelSessionController
     result: TerminalOpenResult,
     agentOwned = false,
   ): void {
+    this.retireRestoredTab(tab);
     tab.gatewaySessionId = result.sessionId;
     tab.shellName = result.title ?? shellBasename(result.shell);
     tab.shell = result.shell;
@@ -389,7 +409,7 @@ export class TerminalPanelSessionController
       }
     }
     this.updateControllerState("tabs", [...this.tabs]);
-    persistLiveTerminalSessions(this.tabs);
+    this.persistSessions();
   }
 
   /** Removes a tab whose open/attach never produced a server session. */
@@ -521,16 +541,18 @@ export class TerminalPanelSessionController
     sessionId: string,
     operation: TerminalOperation,
     agentOwned = false,
-    confirmGoneOnFailure = false,
+    restore?: TerminalRestoreBatch,
   ): Promise<boolean> {
     let createdTab: TerminalPanelSessionTab | undefined;
     let createdConnection: TerminalConnection | undefined;
     try {
-      const boot = await this.bootTab(operation);
+      const boot = await this.bootTab(operation, {
+        restore: restore && { batch: restore, sessionId },
+      });
       createdTab = boot.tab;
       createdConnection = boot.connection;
       const result = await boot.connection.attach(sessionId, boot.sink);
-      if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+      if (!this.isTerminalOperationCurrent(operation, restore) || boot.tab.cancelled) {
         // A user close is deliberate; lifecycle cancellation leaves the existing
         // server session available for the next reconnect to reattach.
         if (boot.tab.cancelled === "close") {
@@ -545,10 +567,16 @@ export class TerminalPanelSessionController
       this.adoptSession(boot.tab, result, agentOwned);
       return true;
     } catch (error) {
+      if (!this.isTerminalOperationCurrent(operation, restore)) {
+        return false;
+      }
       const sessionGone =
-        confirmGoneOnFailure && createdConnection
-          ? await this.confirmRestoredSessionGone(createdConnection, sessionId, operation)
+        restore && createdConnection
+          ? await this.confirmRestoredSessionGone(createdConnection, sessionId, restore)
           : false;
+      if (!this.isTerminalOperationCurrent(operation, restore)) {
+        return false;
+      }
       if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
         if (sessionGone) {
           this.markRestoredSessionExited(createdTab, sessionId);
@@ -556,7 +584,7 @@ export class TerminalPanelSessionController
           this.dropFailedTab(createdTab);
         }
       }
-      if (!confirmGoneOnFailure && this.isTerminalOperationCurrent(operation)) {
+      if (!restore) {
         this.host.terminalPanelErrorText = `${t("terminal.attachFailed")}: ${formatUiError(error)}`;
       }
       return false;
@@ -566,12 +594,12 @@ export class TerminalPanelSessionController
   private async confirmRestoredSessionGone(
     connection: TerminalConnection,
     sessionId: string,
-    operation: TerminalOperation,
+    restore: TerminalRestoreBatch,
   ): Promise<boolean> {
     try {
       const sessions = await connection.list();
       return (
-        this.isTerminalOperationCurrent(operation) &&
+        this.isTerminalOperationCurrent(restore.operation, restore) &&
         !sessions.some((session) => session.sessionId === sessionId)
       );
     } catch {
@@ -584,10 +612,12 @@ export class TerminalPanelSessionController
   /** Keeps a dead persisted session visible without replaying bytes from a missing PTY. */
   private async restoreExitedSession(
     sessionId: string,
-    operation: TerminalOperation,
+    restore: TerminalRestoreBatch,
   ): Promise<void> {
-    const boot = await this.bootTab(operation);
-    if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+    const boot = await this.bootTab(restore.operation, {
+      restore: { batch: restore, sessionId },
+    });
+    if (!this.isTerminalOperationCurrent(restore.operation, restore) || boot.tab.cancelled) {
       if (this.tabs.includes(boot.tab)) {
         boot.tab.cancelled = "lifecycle";
         this.dropFailedTab(boot.tab);
@@ -610,6 +640,7 @@ export class TerminalPanelSessionController
     if (!tab) {
       return;
     }
+    this.retireRestoredTab(tab);
     this.readiness.stop(tab);
     tab.status = "exited";
     tab.exitReason = info.reason;
@@ -621,7 +652,7 @@ export class TerminalPanelSessionController
     // The connection drops its own sink on exit delivery, so no release() here —
     // the session id may not be recorded yet when an early exit is replayed.
     this.updateControllerState("tabs", [...this.tabs]);
-    persistLiveTerminalSessions(this.tabs);
+    this.persistSessions();
   }
 
   closeTab(tabId: string): void {
@@ -629,6 +660,7 @@ export class TerminalPanelSessionController
     if (!tab) {
       return;
     }
+    this.retireRestoredTab(tab);
     this.host.terminalPanelUploadController.cancelForTab(tab);
     if (tab.gatewaySessionId && tab.status !== "exited") {
       void this.connection?.close(tab.gatewaySessionId);
@@ -645,7 +677,7 @@ export class TerminalPanelSessionController
     if (this.activeId === tabId) {
       this.updateControllerState("activeId", this.tabs.at(-1)?.id ?? null);
     }
-    persistLiveTerminalSessions(this.tabs);
+    this.persistSessions();
     // Fullscreen documents (mobile WebViews) have no toggle to reopen a closed
     // panel, so closing the last tab keeps the panel with an empty tab strip
     // (the "+" button stays reachable) instead of leaving a dead blank page.
@@ -658,6 +690,36 @@ export class TerminalPanelSessionController
     this.updateControllerState("activeId", tabId);
     const tab = this.tabs.find((entry) => entry.id === tabId);
     void focusTerminalSession(tab, this.host.updateComplete);
+  }
+
+  private retireRestoredTab(tab: TerminalPanelSessionTab): void {
+    const restore = this.pendingRestore;
+    if (restore && this.isTerminalOperationCurrent(restore.operation, restore)) {
+      for (const [sessionId, pendingTab] of restore.pending) {
+        if (pendingTab === tab) {
+          restore.pending.delete(sessionId);
+          break;
+        }
+      }
+    }
+  }
+
+  private persistSessions(): void {
+    const restore = this.pendingRestore;
+    if (restore && !this.isTerminalOperationCurrent(restore.operation, restore)) {
+      return;
+    }
+    const ids = new Set(
+      this.tabs
+        .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
+        .map((tab) => tab.gatewaySessionId),
+    );
+    if (restore) {
+      for (const sessionId of restore.pending.keys()) {
+        ids.add(sessionId);
+      }
+    }
+    persistTerminalSessionIds([...ids]);
   }
 
   private captureTerminalOperation(): TerminalOperation | null {
@@ -678,13 +740,17 @@ export class TerminalPanelSessionController
     };
   }
 
-  private isTerminalOperationCurrent(operation: TerminalOperation): boolean {
+  private isTerminalOperationCurrent(
+    operation: TerminalOperation,
+    restore?: TerminalRestoreBatch,
+  ): boolean {
     return (
       this.host.isConnected &&
       this.host.available &&
       this.host.client === operation.client &&
       this.activeClient === operation.client &&
       this.lifecycleGeneration === operation.generation &&
+      (!restore || this.pendingRestore === restore) &&
       !operation.signal.aborted
     );
   }
@@ -704,6 +770,7 @@ export class TerminalPanelSessionController
 
   private disposeAllTabs(): void {
     this.lifecycleGeneration += 1;
+    this.pendingRestore = null;
     terminalIntentQueue.resetLifecycle(this.intentHost);
     this.lifecycleAbortController.abort();
     this.lifecycleAbortController = new AbortController();

--- a/ui/src/components/terminal/terminal-session-storage.ts
+++ b/ui/src/components/terminal/terminal-session-storage.ts
@@ -5,7 +5,6 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   TerminalPanelAction,
   TerminalPanelCatalogReference,
-  TerminalPanelSessionTab,
 } from "./terminal-panel-session-types.ts";
 
 const TERMINAL_SESSIONS_KEY = "openclaw.terminal.sessions.v1";
@@ -72,20 +71,12 @@ export function loadPersistedTerminalSessionIds(): string[] {
   }
 }
 
-function persistTerminalSessionIds(ids: readonly string[]): void {
+export function persistTerminalSessionIds(ids: readonly string[]): void {
   try {
     globalThis.sessionStorage?.setItem(TERMINAL_SESSIONS_KEY, JSON.stringify(ids));
   } catch {
     // Storage may be unavailable (private mode); reattach just won't work.
   }
-}
-
-export function persistLiveTerminalSessions(tabs: readonly TerminalPanelSessionTab[]): void {
-  persistTerminalSessionIds(
-    tabs
-      .filter((tab) => tab.status === "live" && tab.gatewaySessionId)
-      .map((tab) => tab.gatewaySessionId),
-  );
 }
 
 export function loadPersistedTerminalActions(): TerminalPanelAction[] {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reloading the Control UI while multiple terminals were restoring could silently lose later terminal tabs. Those terminal sessions remained alive on the Gateway, but disappeared from the browser's saved session list.

## Why This Change Was Made

The terminal session controller now owns persistence for both adopted sessions and its current batch of unresolved restores. A completed restore, explicit close, or delivered exit retires the matching pending ID; disposal and stale completions cannot overwrite a newer generation.

This replaces the storage helper's live-tab-only projection. The additional 53 net production lines represent the generation-bound restore lifecycle; action journal, Gateway protocol, PTY behavior, authentication, and configuration are unchanged. Regression tests add 369 lines separately.

Storage compatibility is unchanged: the same `openclaw.terminal.sessions.v1` sessionStorage key contains the same JSON array of session-ID strings. Existing saved IDs use the normal restore path; no migration, schema, new key, or format conversion is needed. Both the focused tests and the real browser proof below restore the original stored IDs, not replacement sessions. The data-model compatibility concern is addressed by that unchanged serialized contract and existing-ID restore evidence; the new bookkeeping is private to the controller's current lifecycle generation.

## User Impact

Reloading or reconnecting during a multi-terminal restore keeps the original terminals available. Deliberately closed or exited terminals are not resurrected, and completed transient attach failures retain the existing pruning behavior.

## Evidence

- Baseline `5815dd0379c5295039b8d9efe02275dcfe922438`: 17,781 Node-hosted UI tests passed with one skipped test through the Bun package-script launcher. This proves script compatibility, not Bun-hosted Vitest execution.
- Before, on that baseline: real Chromium sessions against both Bun and Node Gateways reproduced the loss. With only the second attach held, the first adoption saved `[A]`; another reload showed one tab while terminal B remained alive on the Gateway.
- Regression RED, on candidate `76ace2cd6a9f9fbae25d8540bfc59528c1c8d5d7` with the exact baseline production files overlaid: the 14 new tests produced 11 persistence assertion failures and three passes, with normal exit 1. The failures include the original replay ordering. Both overlaid files were then restored and verified clean.
- Regression GREEN: all 124 Node-hosted tests across nine terminal suites passed on `76ace2cd`, including all 14 new tests. The same 124 tests passed freshly on current head `eec37926a80e8d5e655e093eed0cb99c60b73200`. Coverage includes replay-before-adoption, explicit close, delivered exit, reconnect, host/client replacement, stale completion, transient failure, and duplicate IDs.
- Accepted real after-proof on `76ace2cd`: actual Bun 1.4.2 and Node 24.19.0 Gateways with Chromium 144 retained `[A, B]` during the held attach and restored the same two live, attached sessions after reload. Both runs recorded zero replacement opens and zero UI errors. Served entry and terminal assets matched that build and differed from the before-proof assets.
- That `76ace2cd` real Bun browser run also passed chat/history, second-session navigation, restart/reconnect, terminal output and changed canvas pixels, the intentional Node PTY helper, and 390x844 mobile chat/navigation. All observed proof children joined, four ports closed, and no terminal sessions remained. Eight screenshot hashes and dimensions were verified. The provider was a local mock; no authenticated external-provider claim is made.
- Current head `eec37926`: targeted lint, UI typechecking, all 124 focused tests, private-QA build, and canonical UI build passed. Fresh full-branch autoreview found no actionable findings. This commit only simplifies the two linted expressions, without weakening either lint rule.
- Current-head real after-proof passed with actual Bun 1.4.2 and Node 24.19.0 Gateways and Chromium 144. Both retained the original `[A, B]` while only B's attach was held, then restored those same two live, attached sessions after reload, with zero replacement opens, replayed held requests, or UI errors. Served entry and terminal assets matched the current build and differed from the before-proof assets. The Bun flow also passed chat/history, two-session navigation, reload, Gateway restart/reconnect, 390x844 mobile navigation/chat, terminal output and changed canvas pixels, and close/exit of the intentional Node PTY helper. Four stages exited 0 and joined; 254 process observations, four closed ports, zero remaining terminals, and eight inspected screenshots were retained. These isolated Gateways used a local mock provider, not authenticated external inference.
- Current-head worker qualification passed one Node-hosted and one genuinely Bun-hosted Vitest case. Each verified its real executable, fork worker, connected IPC, parent bootstrap, and exact compiled worker generation. The temporary probe was removed after both processes joined. Subsequent matched Node/Bun runs passed 17 selected runtime cases each: five SQLite cancellation cases, ten supervisor/output-lifecycle cases, and two existing Node-owned PTY handoff cases. Filter exclusions were recorded; the deliberately Node-only helper-disconnect test was not claimed as Bun support.
- Current-head direct Vite dev proof passed under both Node 24.19.0 and Bun 1.4.2 against isolated actual Bun Gateways. Each normal-auth browser flow sent one marker, received a final response, verified one history entry, and retained it after reload. Five outer stages exited 0 and joined; 187 process observations and six closed ports were recorded. Both 1280x900 screenshots were inspected. Node Vite logged a non-fatal EPIPE before context close, and both screenshots showed a shared "Server updated" advisory; those observations remain unresolved rather than being described as clean logs.
- An earlier current-head browser attempt was **interrupted before Gateway startup by the diagnostic harness's process-observation failure**. The supervisor terminated the active fixture during `update repair` / `finalize:doctor`; that exit-1 message did not establish a natural doctor failure. Its cleanup-pending (125) receipt remains preserved, and that exact lease was stopped and confirmed completed. The temporary observer correction was independently qualified on Linux, including a real owned zombie and synthetic live-thread/identity negatives, before the successful current-head retry. An earlier worker probe also failed a diagnostic facade-path assumption before Bun ran; its failed receipt remains distinct from the corrected pair.
- Predecessor static proof on `76ace2cd`: the three-file changed-check run passed core-test and UI typechecking, formatting, guards, i18n, and dead-export scans before the two lint findings now corrected on `eec37926`. Those predecessor results are not relabeled as current-head results.
- Exact-head [CI run 34481954459, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34481954459) passed: 88 successful jobs, 13 skipped, no failed or pending jobs. Its actual tested merge was `7fc214a0c0a1d81e81f0682cc9de925dca9104e9`, with this unchanged PR head as its second parent and the separately repaired main branch as its first. UI unit shards, Control UI performance, browser suites, and real-Gateway UI checks passed. Earlier draft-skipped, stale-input, and failed overall attempts are not used as passing aggregate CI evidence.
- The seven additional recovery/mobile E2E files and their 21 Node-hosted cases were individually verified in [CI run 34477096168, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34477096168), at actual merge `a533c48375e1fc4e1f3991d739bd634d844e2ed1` with the same `eec37926` PR head. That run's aggregate failed unrelated docs checks; its verified individual UI jobs remain valid case-level evidence. The 21-case per-file breakdown was not separately reverified in run 34481954459 and is not a Bun-hosted test claim.
- Remaining diagnostic limitation: direct Node Vite build passed in 10.221s, but that earlier invocation's subsequent prebuilt inspector rejected a changed synthetic carrier stamp. A later canonical same-carrier preparation passed, then direct Bun Vite build reached transformation and hit the diagnostic's fixed 180s deadline with joined cleanup. The product owner allows 600s; this result does not establish its root cause, an unsupported path, or a regression introduced by this terminal repair. No timeout, loader, runtime guard, or product behavior was changed to make it pass.

Sanitized tab-strip captures from the baseline before-proof and accepted `76ace2cd` after-proof; raw terminal captures remain private:

Before, after the interrupted restore and second reload:

![One terminal tab remains after the interrupted restore](https://github.com/user-attachments/assets/b0bdc644-4a71-4965-89f3-a12e5d6711eb)

After, with the same two original terminals restored:

![Both original terminal tabs remain after reload](https://github.com/user-attachments/assets/e1440862-eb0f-414f-bb2f-42de12969bd2)

The original `76ace2cd` regression command passed, but its surrounding diagnostic controller exited 1 because it expected a compact reporter summary rather than Vitest's verbose case rows. The retained output independently verified all 124 passing cases; that failed controller receipt remains unchanged. The later `eec37926` test run separately passed its result-count checks.

Nonblocking review follow-up: assess visibility of buffered pre-adoption exits without changing replay/stale-detach ordering. That existing transport delivery policy is unchanged; this repair retires IDs when the controller receives the exit.

Separate diagnostic follow-ups: investigate direct Bun Vite build completion within the existing 600s product bound; identify the Node Vite proxy EPIPE observed before context close; explain the shared dev "Server updated" advisory. None is established as a regression from this terminal patch. The scoped terminal repair is verified; the broader Bun campaign is not described as universally clean.
