### PR TITLE
perf(workers): speed up remote workspace captures with many files

### DIFF
--- a/src/gateway/worker-environments/workspace-sync-hashing.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-hashing.test.ts
@@ -1,0 +1,204 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import { parseRemoteWorkspaceManifestEnvelope } from "./workspace-hash-memo.js";
+import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function manifestWorkspace() {
+  const root = await fs.realpath(tempDirs.make("openclaw-manifest-hashing-"));
+  const home = path.join(root, "home");
+  const workspace = path.join(root, "workspace");
+  await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
+  return { root, home, workspace };
+}
+
+it("hashes concurrently within four readers and preserves manifest and memo ordering", async () => {
+  const { root, home, workspace } = await manifestWorkspace();
+  const auditPath = path.join(root, "handles.json");
+  const entries = await Promise.all(
+    Array.from({ length: 8 }, async (_, index) => {
+      const name = `${index}.bin`;
+      const content = Buffer.alloc(1024, index);
+      const file = path.join(workspace, name);
+      await fs.writeFile(file, content, { mode: 0o600 });
+      return {
+        path: name,
+        type: "file",
+        mode: 0o644,
+        size: content.length,
+        sha256: createHash("sha256").update(content).digest("hex"),
+      };
+    }),
+  );
+  const prelude = String.raw`{
+    const io = require("node:fs");
+    const open = io.promises.open.bind(io.promises);
+    const handles = [];
+    let active = 0, maximum = 0, activeAtResult;
+    io.promises.open = async (...args) => {
+      active++;
+      maximum = Math.max(maximum, active);
+      const handle = await open(...args);
+      handles.push(handle);
+      const close = handle.close.bind(handle);
+      let closed = false;
+      handle.close = async () => {
+        await close();
+        if (!closed) { closed = true; active--; }
+      };
+      return handle;
+    };
+    const write = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (...args) => { activeAtResult = active; return write(...args); };
+    process.once("exit", () => io.writeFileSync(${JSON.stringify(auditPath)}, JSON.stringify({
+      maximum, activeAtResult, closed: handles.map((handle) => handle.fd === -1),
+    })));
+  }
+  `;
+  let memo: Array<[string, string]> = [];
+  let manifestRef: string | undefined;
+  for (const cached of [false, true]) {
+    const result = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        prelude + REMOTE_WORKSPACE_MANIFEST_JS,
+        workspace,
+        "",
+        "all",
+        "memo-v1",
+      ],
+      { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: home }, input: JSON.stringify(memo) },
+    );
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const response = parseRemoteWorkspaceManifestEnvelope(result.stdout);
+    expect(response.metrics).toMatchObject({
+      contentHashCount: cached ? 0 : entries.length,
+      memoHitCount: cached ? entries.length : 0,
+      memoTruncatedCount: 0,
+    });
+    const raw = await fs.readFile(
+      path.join(home, ".openclaw-worker", "manifests", `${response.manifestRef.slice(7)}.json`),
+      "utf8",
+    );
+    expect(JSON.parse(raw)).toEqual({ version: 1, baseCommit: null, entries });
+    expect(response.manifestRef).toBe(`sha256:${createHash("sha256").update(raw).digest("hex")}`);
+    if (cached) {
+      expect(response.manifestRef).toBe(manifestRef);
+      expect(response.memo).toEqual(memo);
+    }
+    memo = response.memo;
+    manifestRef = response.manifestRef;
+    const audit = JSON.parse(await fs.readFile(auditPath, "utf8")) as { maximum: number };
+    expect(audit).toMatchObject({ activeAtResult: 0, closed: Array(entries.length).fill(true) });
+    expect(audit.maximum).toBeGreaterThan(1);
+    expect(audit.maximum).toBeLessThanOrEqual(4);
+  }
+});
+
+it.each(["pending-open", "active-reader"] as const)(
+  "preserves the first failure and joins a %s before reporting it",
+  async (mode) => {
+    const { root, home, workspace } = await manifestWorkspace();
+    const first = path.join(workspace, "a.bin");
+    const second = path.join(workspace, "b.bin");
+    const auditPath = path.join(root, "failure.json");
+    await Promise.all([fs.writeFile(first, "first"), fs.writeFile(second, Buffer.alloc(64))]);
+    // Real opens and streams are held at their I/O boundaries, without a timing race.
+    const prelude = String.raw`{
+      const io = require("node:fs");
+      const first = ${JSON.stringify(first)}, second = ${JSON.stringify(second)};
+      const mode = ${JSON.stringify(mode)};
+      const handles = [], started = new Set();
+      let releaseOpen, releaseRead;
+      const openGate = new Promise((resolve) => { releaseOpen = resolve; });
+      const readGate = new Promise((resolve) => { releaseRead = resolve; });
+      let pending = 0, readStarted = false, secondStats = 0, atFailure;
+      let reading;
+      const open = io.promises.open.bind(io.promises);
+      io.promises.open = async (...args) => {
+        const file = args[0];
+        started.add(file);
+        pending++;
+        if (file === second && mode === "pending-open") await openGate;
+        const handle = await open(...args);
+        pending--;
+        handles.push(handle);
+        const stat = handle.stat.bind(handle), close = handle.close.bind(handle);
+        handle.stat = async (...options) => {
+          if (file === first) {
+            if (mode === "active-reader" && started.has(second)) await readGate;
+            throw new Error("first manifest failure");
+          }
+          secondStats++;
+          return stat(...options);
+        };
+        handle.close = async () => {
+          await close();
+          if (file === first) {
+            await new Promise((resolve) => setImmediate(resolve));
+            releaseOpen();
+            throw new Error("secondary close failure");
+          }
+        };
+        if (file === second && mode === "active-reader") {
+          const createReadStream = handle.createReadStream.bind(handle);
+          handle.createReadStream = (options) => {
+            const stream = createReadStream({ ...options, highWaterMark: 2 });
+            reading = stream;
+            const iterate = stream[Symbol.asyncIterator].bind(stream);
+            const aborted = new Promise((resolve) => {
+              if (options.signal?.aborted) resolve();
+              else options.signal?.addEventListener("abort", resolve, { once: true });
+            });
+            stream[Symbol.asyncIterator] = async function* () {
+              for await (const chunk of iterate()) {
+                readStarted = true;
+                releaseRead();
+                await aborted;
+                yield chunk;
+              }
+            };
+            return stream;
+          };
+        }
+        return handle;
+      };
+      const write = process.stderr.write.bind(process.stderr);
+      process.stderr.write = (...args) => {
+        atFailure = { pending, closed: handles.every((handle) => handle.fd === -1) };
+        return write(...args);
+      };
+      process.once("exit", () => io.writeFileSync(${JSON.stringify(auditPath)}, JSON.stringify({
+        atFailure, opened: handles.length, pending, readStarted, secondStats,
+        streamDestroyed: reading?.destroyed, closed: handles.every((handle) => handle.fd === -1),
+      })));
+    }
+    `;
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", prelude + REMOTE_WORKSPACE_MANIFEST_JS, workspace],
+      { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: home } },
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("first manifest failure");
+    expect(result.stderr).not.toContain("secondary close failure");
+    const audit = JSON.parse(await fs.readFile(auditPath, "utf8"));
+    expect(audit).toMatchObject({
+      opened: 2,
+      pending: 0,
+      closed: true,
+      readStarted: mode === "active-reader",
+      atFailure: { pending: 0, closed: true },
+    });
+    expect(audit).toMatchObject(
+      mode === "pending-open" ? { secondStats: 0 } : { streamDestroyed: true },
+    );
+    expect(await fs.readdir(path.join(home, ".openclaw-worker", "manifests"))).toEqual([]);
+  },
+);

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -357,53 +357,79 @@ async function hashFiles(entries) {
     (bytes, entry) => bytes + (entry.type === "symlink" ? Buffer.byteLength(entry.target) : 0),
     0,
   );
-  for (const entry of entries) {
-    if (entry.type !== "file") {
-      continue;
+  let next = 0;
+  let failure;
+  const controller = new AbortController();
+  const stop = (error) => {
+    if (!failure) {
+      failure = { error };
+      controller.abort(error);
     }
-    const absolute = path.join(root, entry.path);
-    const handle = await fs.promises.open(
-      absolute,
-      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
-    );
-    try {
-      const before = await handle.stat({ bigint: true });
-      if (!before.isFile()) fail("worker workspace file changed while it was being read");
-      const size = Number(before.size);
-      openedBytes += size;
-      if (openedBytes > MAX_WORKSPACE_INVENTORY_TOTAL_BYTES) {
-        fail("worker workspace manifest exceeds its eligible byte limit");
+  };
+  async function worker() {
+    while (!failure && next < entries.length) {
+      const entry = entries[next++];
+      if (entry.type !== "file") {
+        continue;
       }
-      const identity = workspaceStatIdentity("worker", before);
-      let sha256 = hashMemo.get(identity);
-      if (sha256) {
-        metrics.memoHitCount += 1;
-      } else {
-        const hashStartedAt = performance.now();
-        const hash = crypto.createHash("sha256");
-        const stream = handle.createReadStream({ autoClose: false });
-        let bytesRead = 0;
-        for await (const chunk of stream) {
-          bytesRead += chunk.length;
-          if (bytesRead > size) fail("worker workspace file changed while it was being read");
-          hash.update(chunk);
+      const absolute = path.join(root, entry.path);
+      let handle;
+      try {
+        handle = await fs.promises.open(
+          absolute,
+          fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+        );
+        controller.signal.throwIfAborted();
+        const before = await handle.stat({ bigint: true });
+        controller.signal.throwIfAborted();
+        if (!before.isFile()) fail("worker workspace file changed while it was being read");
+        const openedSize = Number(before.size);
+        openedBytes += openedSize;
+        if (openedBytes > MAX_WORKSPACE_INVENTORY_TOTAL_BYTES) {
+          fail("worker workspace manifest exceeds its eligible byte limit");
         }
-        sha256 = hash.digest("hex");
-        metrics.contentHashCount += 1;
-        metrics.contentHashDurationMs += performance.now() - hashStartedAt;
+        const identity = workspaceStatIdentity("worker", before);
+        let sha256 = hashMemo.get(identity);
+        if (sha256) {
+          metrics.memoHitCount += 1;
+        } else {
+          const hashStartedAt = performance.now();
+          const hash = crypto.createHash("sha256");
+          const stream = handle.createReadStream({ autoClose: false, signal: controller.signal });
+          let bytes = 0;
+          for await (const chunk of stream) {
+            bytes += chunk.length;
+            if (bytes > openedSize) fail("worker workspace file changed while it was being read");
+            hash.update(chunk);
+          }
+          sha256 = hash.digest("hex");
+          metrics.contentHashCount += 1;
+          // Concurrent samples overlap; their sum is hashing effort, not wall time.
+          metrics.contentHashDurationMs += performance.now() - hashStartedAt;
+        }
+        const after = await handle.stat({ bigint: true });
+        if (workspaceStatIdentity("worker", after) !== identity) {
+          fail("worker workspace file changed while it was being read");
+        }
+        entry.mode = Number(after.mode & 0o777n);
+        entry.size = Number(after.size);
+        entry.sha256 = sha256;
+        usedHashMemo.set(identity, sha256);
+      } catch (error) {
+        stop(error);
+      } finally {
+        try {
+          await handle?.close();
+        } catch (error) {
+          stop(error);
+        }
       }
-      const after = await handle.stat({ bigint: true });
-      if (workspaceStatIdentity("worker", after) !== identity) {
-        fail("worker workspace file changed while it was being read");
-      }
-      entry.mode = Number(after.mode & 0o777n);
-      entry.size = Number(after.size);
-      entry.sha256 = sha256;
-      usedHashMemo.set(identity, sha256);
-    } finally {
-      await handle.close();
     }
   }
+  // The standalone child cannot import the shared pool. Stop admission on the
+  // first failure and join every reader before publishing or returning it.
+  await Promise.all(Array.from({ length: Math.min(4, entries.length) }, worker));
+  if (failure) throw failure.error;
 }
 function ensurePrivateDirectory(directory) {
   try {


### PR DESCRIPTION
Related: #134931.

## What Problem This Solves

Remote workspace captures spend unnecessary time opening and hashing many small files, including captures that can reuse remembered hashes. If a read fails and closing its handle also fails, the close error can hide the original cause.

## Why This Change Was Made

Use up to four concurrent readers within the existing opened-byte budget and file-growth checks. The first failure stops new admission, aborts active reads, and is reported only after pending opens and handle cleanup settle. Manifest ordering, memo selection, and publication remain unchanged.

## User Impact

Many-file workspace captures can finish sooner without a new setting. Local measurements saved 77–105 ms for 2,048 small files; a workload dominated by one large file was effectively unchanged. These are capture timings, not whole-session startup measurements.

## Evidence

- Three new real-file cases demonstrate red-to-green failures and cover bounded overlapping readers, deterministic cold-hash/memo-hit output, pending-open settlement, active-reader cancellation, first-error preservation, closed handles, and no publication after failure.
- All 17 focused owner/sibling cases passed. The full changed-file gate passed without skips, and a fresh independent P2 review found no actionable issue.
- Local macOS benchmark: five alternating pairs per case/mode, 60 measured runs. For 2,048 × 4 KiB files, median total capture time fell from 277.4 to 172.8 ms with an empty hash memo, and from 192.2 to 115.2 ms on memo hits. Every manifest, file hash and memo matched independently. OS caches were uncontrolled; an empty memo is not a cold disk cache.
- Fresh AWS/Linux proof passed on this exact commit: 42 actual generated-script captures on one m7a.large VM with Node24.20.0, including 36 measured runs (three alternating pairs per workload/memo mode) and six warm-ups. An independent oracle checked every file hash, mode, size, manifest, stat-derived memo and hit/hash count. The IMDSv2 no-role check passed. The VM was confirmed released with complete cleanup; all eight host commands and remote child processes settled, scratch was removed, and root independently verified process absence plus all137,476 dependency entries and40,682 tracked source files unchanged.
- For 2,048 × 4 KiB files on that VM, median producer capture time fell from326.7 to252.0ms with an empty memo and from177.5 to120.3ms on memo hits. Observed child completion fell from370.2 to319.4ms and242.7 to193.5ms respectively. Medium and64MiB-dominated observed completion was effectively unchanged. Producer capture uses its own totalDurationMs; child completion additionally includes Node startup and supervisor polling. OS caches were uncontrolled, and one VM/three pairs does not establish a general speedup.
- The original CI merge failed on unrelated documentation navigation. Existing repair #144037 is now merged; [fresh merge CI](https://github.com/openclaw/openclaw/actions/runs/34481024459) passed with its actual preflight checkout verified against repaired main and this exact hashing commit unchanged. An earlier refresh retained GitHub’s stale merge SHA and was canceled after its preflight exposed the mismatch. The old failed/canceled runs remain recorded.

This is a two-file extraction from the original combined work. It adds 26 net production lines and three regression cases; no configuration, schema, wire-format, or workspace acceptance change is included. Overlapping per-file hash durations measure effort; total capture duration remains the wall-time measure. No changelog edit is needed before release generation.
