### PR TITLE
docs: fix 17 concrete plugin/channel defects from the ux audit

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -1,5 +1,5 @@
 ---
-summary: "Routing rules per channel (WhatsApp, Telegram, Discord, Slack) and shared context"
+summary: "How OpenClaw picks an agent and session for each inbound message, and how replies route back"
 read_when:
   - Changing channel routing or inbox behavior
 title: "Channel routing"

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -61,7 +61,7 @@ starts. Full walkthrough: [Telegram](/channels/telegram). Command reference:
 - [Twitch](/channels/twitch) - Twitch chat bot: install, credentials, access control, token refresh (official plugin).
 - [WebChat](/web/webchat) - Native and Control UI WebChat usage over the Gateway WebSocket (included in core).
 - [WeChat](/channels/wechat) - WeChat channel setup through the external openclaw-weixin plugin (external plugin).
-- [WeCom](/channels/wecom) - Install the official WeCom plugin and find its versioned setup documentation (external plugin).
+- [WeCom](/channels/wecom) - Install the external WeCom plugin and find its versioned setup documentation (external plugin).
 - [WhatsApp](/channels/whatsapp) - WhatsApp channel support, access controls, delivery behavior, and operations (official plugin).
 - [Yuanbao](/channels/yuanbao) - Yuanbao bot overview, features, and configuration (external plugin).
 - [Zalo](/channels/zalo) - Zalo bot support status, capabilities, and configuration (official plugin).

--- a/docs/channels/matrix-push-rules.md
+++ b/docs/channels/matrix-push-rules.md
@@ -51,6 +51,14 @@ curl -sS -X POST \
   }'
 ```
 
+    Replace `https://matrix.example.org` with your homeserver base URL and
+    `@alice:example.org` with the recipient's MXID. Export the `access_token`
+    from the response as `USER_ACCESS_TOKEN`; the remaining steps read it:
+
+```bash
+export USER_ACCESS_TOKEN="<access_token from the login response>"
+```
+
   </Step>
 
   <Step title="Verify pushers exist">

--- a/docs/channels/matrix/setup.md
+++ b/docs/channels/matrix/setup.md
@@ -23,8 +23,8 @@ openclaw plugins install @openclaw/matrix
 ## Setup
 
 1. Create a Matrix account on your homeserver.
-2. Configure `channels.matrix` with `homeserver` + `accessToken`, or `homeserver` + `userId` + `password`.
-3. Restart the gateway.
+2. Configure `channels.matrix` with `homeserver` + `accessToken`, or `homeserver` + `userId` + `password`. Create the access token in your Matrix client or homeserver admin UI; password auth mints and caches one for you on first login.
+3. Restart the gateway: `openclaw gateway restart`.
 4. Start a DM with the bot, or invite it to a room. Fresh invites only land when [`autoJoin`](#auto-join) allows them.
 
 ### Interactive setup

--- a/docs/channels/tlon.md
+++ b/docs/channels/tlon.md
@@ -55,6 +55,9 @@ Or edit config directly:
 }
 ```
 
+The login code is your ship's web login code: run `+code` in the ship's dojo to print the current
+one. It rotates, so re-read it whenever authentication starts failing.
+
 Restart the gateway after editing config directly. Then DM the bot or @ mention it in a group
 channel.
 
@@ -332,7 +335,7 @@ Full configuration: [Configuration](/gateway/configuration)
 ## Related
 
 - [Channels Overview](/channels) — all supported channels
-- [Pairing](/channels/pairing) — DM authentication and pairing flow
+- [Pairing](/channels/pairing) — DM authentication for channels that declare it; Tlon is not one of them and uses the `dmAllowlist` plus `ownerShip` approval flow above instead
 - [Groups](/channels/groups) — group chat behavior and mention gating
 - [Channel routing](/channels/channel-routing) — session routing for messages
 - [Security](/gateway/security) — access model and hardening

--- a/docs/channels/wechat.md
+++ b/docs/channels/wechat.md
@@ -125,7 +125,7 @@ openclaw gateway restart
 ## Sidecar process
 
 The WeChat plugin can run helper work beside the Gateway while it monitors the
-Tencent iLink API. In issue #68451, that helper path exposed a bug in OpenClaw's
+Tencent iLink API. In [issue #68451](https://github.com/openclaw/openclaw/issues/68451), that helper path exposed a bug in OpenClaw's
 generic stale-Gateway cleanup: a child process could try to clean up the parent
 Gateway process, causing restart loops under process managers such as systemd.
 

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -1,5 +1,5 @@
 ---
-summary: "Install the official WeCom plugin and find its versioned setup documentation"
+summary: "Install the external WeCom plugin and find its versioned setup documentation"
 read_when:
   - You want to connect OpenClaw to WeCom
   - You need the supported WeCom plugin and its setup documentation

--- a/docs/channels/yuanbao.md
+++ b/docs/channels/yuanbao.md
@@ -35,7 +35,7 @@ Requires OpenClaw 2026.4.10 or above. Check with `openclaw --version`; upgrade w
 openclaw channels login --channel yuanbao
 ```
 
-Follow the prompts to enter your App ID and App Secret.
+Follow the prompts to enter your App Key (`appKey`) and App Secret (`appSecret`).
 
 ## Access control
 

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -14,7 +14,7 @@ Zalo ships as a bundled plugin in current OpenClaw releases, so packaged builds 
 On an older build or a custom install that excludes Zalo, install the npm package directly:
 
 - Install: `openclaw plugins install @openclaw/zalo`
-- Pinned version: `openclaw plugins install @openclaw/zalo@2026.6.11`
+- Pinned version: `openclaw plugins install @openclaw/zalo@<version>` (pin only for reproducible installs)
 - From a local checkout: `openclaw plugins install ./path/to/local/zalo-plugin`
 - Details: [Plugins](/tools/plugin)
 

--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -194,29 +194,17 @@ Shared-token WebSocket clients without a trusted device identity cannot self-dec
 
 ## Troubleshooting
 
-`404 Not Found`
+**`404 Not Found`** The plugin is disabled, the Gateway has not reloaded it since enablement, or the request is going to a different Gateway process.
 
-: The plugin is disabled, the Gateway has not reloaded it since enablement, or the request is going to a different Gateway process.
+**`401 Unauthorized`** The request did not satisfy Gateway HTTP auth. Check the bearer token or the trusted-proxy identity headers.
 
-`401 Unauthorized`
+**`405 Method Not Allowed`** The request used something other than `POST`.
 
-: The request did not satisfy Gateway HTTP auth. Check the bearer token or the trusted-proxy identity headers.
+**`413 Payload Too Large`** The request body exceeded the 1 MB limit.
 
-`405 Method Not Allowed`
+**`400 INVALID_REQUEST`** The request body is not valid JSON, the `method` field is missing, the method is not in the plugin allowlist, or a suspension resume ID does not match the active lease.
 
-: The request used something other than `POST`.
-
-`413 Payload Too Large`
-
-: The request body exceeded the 1 MB limit.
-
-`400 INVALID_REQUEST`
-
-: The request body is not valid JSON, the `method` field is missing, the method is not in the plugin allowlist, or a suspension resume ID does not match the active lease.
-
-`503 UNAVAILABLE`
-
-: The Gateway method is starting, rate-limited, suspended, or waiting on a competing suspension/resume operation. Inspect `error.details` when present and honor `error.retryAfterMs` before retrying.
+**`503 UNAVAILABLE`** The Gateway method is starting, rate-limited, suspended, or waiting on a competing suspension/resume operation. Inspect `error.details` when present and honor `error.retryAfterMs` before retrying.
 
 ## Related
 

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -190,29 +190,17 @@ When browsing Claude sessions on paired nodes, update those nodes alongside the 
 
 ## Troubleshooting
 
-`404 Not Found`
+**`404 Not Found`** The Beam plugin is disabled, the Gateway has not reloaded it since enablement, or the request is reaching another Gateway.
 
-: The Beam plugin is disabled, the Gateway has not reloaded it since enablement, or the request is reaching another Gateway.
+**`401 Unauthorized`** The request did not satisfy Gateway HTTP auth. Check the bearer credential or trusted-proxy/Access session.
 
-`401 Unauthorized`
+**`405 Method Not Allowed`** The receiver accepts only `POST`.
 
-: The request did not satisfy Gateway HTTP auth. Check the bearer credential or trusted-proxy/Access session.
+**`413 Payload Too Large`** The serialized request exceeded 56 KiB. The official skill drops older sanitized messages until the snapshot fits.
 
-`405 Method Not Allowed`
+**`429 Too Many Requests`** The authenticated client exceeded the bounded request or concurrency limit. Retry after the current minute window.
 
-: The receiver accepts only `POST`.
-
-`413 Payload Too Large`
-
-: The serialized request exceeded 56 KiB. The official skill drops older sanitized messages until the snapshot fits.
-
-`429 Too Many Requests`
-
-: The authenticated client exceeded the bounded request or concurrency limit. Retry after the current minute window.
-
-`beam mirror upload blocked ... receiver returned redirect`
-
-: The configured mirror endpoint returned a redirect. Beam does not follow redirects and suppresses repeated attempts for the current service instance; set `mirror.endpoint` to the final receiver URL. A Gateway restart probes the configured endpoint once again.
+**`beam mirror upload blocked ... receiver returned redirect`** The configured mirror endpoint returned a redirect. Beam does not follow redirects and suppresses repeated attempts for the current service instance; set `mirror.endpoint` to the final receiver URL. A Gateway restart probes the configured endpoint once again.
 
 ## Related
 

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -219,9 +219,12 @@ local proof.
   </Step>
 
   <Step title="Publish">
-    Validate the package before publishing:
+    Publishing uses the separate `clawhub` CLI. Install and sign in first, then
+    validate the package before publishing:
 
     ```bash
+    npm i -g clawhub
+    clawhub login
     clawhub package publish your-org/your-plugin --dry-run
     clawhub package publish your-org/your-plugin
     ```
@@ -379,7 +382,7 @@ Oxlint is not type-aware, so it cannot enforce these annotations.
 <Check>Entry point uses `defineChannelPluginEntry` or `definePluginEntry`</Check>
 <Check>All imports use focused `plugin-sdk/<subpath>` paths</Check>
 <Check>Internal imports use local modules, not SDK self-imports</Check>
-<Check>Tests pass (`pnpm test <bundled-plugin-root>/my-plugin/`)</Check>
+<Check>Tests pass (`pnpm test extensions/my-plugin/`)</Check>
 <Check>`pnpm check` passes (in-repo plugins)</Check>
 
 ## Test against beta releases

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -49,6 +49,10 @@ for the OpenAI account and admin model.
 
 ## Quickstart
 
+The source Codex home is the Codex CLI state directory you are migrating from:
+`~/.codex` by default, or `CODEX_HOME` when that variable is set. See
+[`openclaw migrate`](/cli/migrate) to point at a different one with `--from`.
+
 Preview migration from the source Codex home:
 
 ```bash

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -392,22 +392,22 @@ Put config under `plugins.entries.memory-wiki.config`:
 
 Key toggles:
 
-| Key                                        | Values / default                               | Notes                                                                         |
-| ------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------- |
-| `vaultMode`                                | `isolated` (default), `bridge`, `unsafe-local` | chooses input and integration behavior                                        |
-| `vault.scope`                              | `global` (default), `agent`                    | one shared vault or one child vault per agent                                 |
-| `vault.path`                               | global default `<state-dir>/wiki/main`         | exact vault globally; agent-scope parent defaults to `<state-dir>/wiki`       |
-| `vault.renderMode`                         | `native` (default), `obsidian`                 |                                                                               |
-| `bridge.readMemoryArtifacts`               | default `true`                                 | import active memory plugin public artifacts                                  |
-| `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                                             |
-| `unsafeLocal.allowPrivateMemoryCoreAccess` | default `false`                                | required to run `unsafe-local` imports                                        |
-| `unsafeLocal.paths`                        | default `[]`                                   | explicit local paths to import in `unsafe-local` mode                         |
-| `ingest.autoCompile`                       | default `true`                                 | rebuild compiled output after imported sources change                         |
-| `search.backend`                           | `shared` (default), `local`                    |                                                                               |
-| `search.corpus`                            | `wiki` (default), `memory`, `all`              |                                                                               |
-| `context.includeCompiledDigestPrompt`      | default `false`                                | append the selected agent's compact digest snapshot to memory prompt sections |
-| `render.createBacklinks`                   | default `true`                                 | generate deterministic related blocks                                         |
-| `render.createDashboards`                  | default `true`                                 | generate dashboard pages                                                      |
+| Key                                        | Values / default                               | Notes                                                                                      |
+| ------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `vaultMode`                                | `isolated` (default), `bridge`, `unsafe-local` | chooses input and integration behavior                                                     |
+| `vault.scope`                              | `global` (default), `agent`                    | one shared vault or one child vault per agent                                              |
+| `vault.path`                               | global default `<state-dir>/wiki/main`         | exact vault globally; agent-scope parent defaults to `<state-dir>/wiki`                    |
+| `vault.renderMode`                         | `native` (default), `obsidian`                 | `obsidian` writes Obsidian-friendly pages instead of native output                         |
+| `bridge.readMemoryArtifacts`               | default `true`                                 | import active memory plugin public artifacts                                               |
+| `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                                                          |
+| `unsafeLocal.allowPrivateMemoryCoreAccess` | default `false`                                | required to run `unsafe-local` imports                                                     |
+| `unsafeLocal.paths`                        | default `[]`                                   | explicit local paths to import in `unsafe-local` mode                                      |
+| `ingest.autoCompile`                       | default `true`                                 | rebuild compiled output after imported sources change                                      |
+| `search.backend`                           | `shared` (default), `local`                    | `shared` uses the shared memory search flow when available; `local` searches the wiki only |
+| `search.corpus`                            | `wiki` (default), `memory`, `all`              | which corpus wiki search covers                                                            |
+| `context.includeCompiledDigestPrompt`      | default `false`                                | append the selected agent's compact digest snapshot to memory prompt sections              |
+| `render.createBacklinks`                   | default `true`                                 | generate deterministic related blocks                                                      |
+| `render.createDashboards`                  | default `true`                                 | generate dashboard pages                                                                   |
 
 The state directory is `~/.openclaw` by default. When `OPENCLAW_STATE_DIR` is
 set, default wiki vaults use that directory instead. Explicit `vault.path`

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -74,12 +74,18 @@ Normalize plugin-owned attachment records with `toInboundMediaFacts(...)`, then
 pass the resulting ordered array through the context's `media` field:
 
 ```ts
+// saved, nativeUrl, messageId, and caption are plugin-supplied values from the
+// platform event you just normalized.
 const media = toInboundMediaFacts([
   { path: saved.path, url: nativeUrl, contentType: saved.contentType, messageId },
 ]);
 
-const ctx = finalizeInboundContext({ Body: caption, media });
+const ctx = runtime.channel.reply.finalizeInboundContext({ Body: caption, media });
 ```
+
+`toInboundMediaFacts` is exported from this subpath. `finalizeInboundContext` is
+not: it is reached through the injected plugin runtime as
+`runtime.channel.reply.finalizeInboundContext`.
 
 Array position is attachment identity. Per-fact `transcribed`, `messageId`, and
 `workspaceDir` replace the legacy parallel index/workspace fields. The

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -125,8 +125,14 @@ export const demoMessageAdapter = defineChannelMessageAdapter({
 ```
 
 Only declare capabilities the native transport actually preserves. Cover
-each declared send, receipt, live-preview, and receive-ack capability with
-the contract helpers exported from this subpath.
+each declared capability with the matching contract helper exported from this
+subpath:
+
+- send: `verifyChannelMessageAdapterCapabilityProofs(...)`
+- durable final delivery: `verifyDurableFinalCapabilityProofs(...)`
+- live preview: `verifyChannelMessageLiveCapabilityAdapterProofs(...)` and
+  `verifyChannelMessageLiveFinalizerProofs(...)`
+- receive ack: `verifyChannelMessageReceiveAckPolicyAdapterProofs(...)`
 
 ## Outbound echo suppression
 


### PR DESCRIPTION
## What this is

The `ux`-kind audit queue for `docs/plugins/` and `docs/channels/` held 167 open rows when I pulled it and **164** by the time I reconciled (three closed under me while I worked). This PR is scored against the current 164. This PR works the subset that turned out to be **accuracy, prerequisite, and link defects mis-filed as `ux`** — 17 findings — and leaves the presentation-only rows alone rather than churning directories other people are editing.

**No heading text changed anywhere in this diff**, so no anchor ids move and no stubs are needed (verified: `git diff -U0 | grep -E '^[+-]#{1,6} '` is empty).

## Findings closed (17)

**Impossible sequence / missing prerequisite**

- **r5-0009** — `docs/channels/matrix-push-rules.md`: step 2 mints an access token but never says to export it, while steps 3-5 all read `$USER_ACCESS_TOKEN`. Added the `export` line and named the step-2 placeholders.
- **r3-1046** — `docs/channels/matrix/setup.md`: step 3 said "Restart the gateway" with no command (`openclaw gateway restart` is used everywhere else in docs), and step 2 asked for an `accessToken` the page never explains how to obtain. Both stated now.
- **r3-1102** — `docs/channels/tlon.md`: Setup asks for a ship login code the page never sources. Added: run `+code` in the ship's dojo; the code rotates.
- **r3-2039** — `docs/plugins/building-plugins.md`: the Publish step runs `clawhub package publish` without introducing the `clawhub` CLI. `docs/tools/creating-skills.md`, `docs/plugins/manage-plugins.md` and `docs/cli/skills.md` all document `npm i -g clawhub`; added the install + `clawhub login` lines to match.
- **r3-1989** — `docs/plugins/codex-native-plugins.md`: "source Codex home" is used in the Quickstart and only defined via a Related link. Added a one-line gloss (`~/.codex`, or `CODEX_HOME`) sourced from `docs/cli/migrate.md:137`.

**Accuracy defects**

- **r3-2035** — `docs/plugins/sdk-channel-inbound.md`: the media example calls a bare `finalizeInboundContext(...)` in a page whose import block is `buildChannelInboundEventContext`, `runChannelInboundEvent`, `dispatchChannelInboundReply`. `finalizeInboundContext` is **not exported from `src/plugin-sdk/channel-inbound.ts`** at all — it lives in `src/auto-reply/reply/inbound-context.ts` and reaches plugins only as `runtime.channel.reply.finalizeInboundContext` (`src/plugins/runtime/runtime-channel.ts:125`). Corrected the call and said which of the two helpers this subpath actually exports. The example's undeclared identifiers are now marked as plugin-supplied.
- **r3-2018** — `docs/plugins/sdk-channel-outbound.md`: "Cover each declared send, receipt, live-preview, and receive-ack capability with the contract helpers exported from this subpath" named none of them. Named all five, from `src/plugin-sdk/channel-outbound.ts` (re-exported from `channels/message/contracts.js`), mapped to the capability each one proves.
- **r3-1103** — `docs/channels/tlon.md`: the Related list labelled `/channels/pairing` "DM authentication and pairing flow". Tlon does **not** implement pairing — it is absent from `docs/channels/pairing.md:77`'s supported-channel list and `grep -ri pairing extensions/tlon/` returns nothing. Relabelled to point at Tlon's own `dmAllowlist` + `ownerShip` flow. Link label `Pairing` is unchanged, so no glossary entry is needed.
- **r3-1111** — `docs/channels/yuanbao.md`: the interactive-setup sentence called the credential "App ID"; every other mention on the page (`--token` docs, both config blocks, the reference table) calls it `appKey` / App Key.
- **r3-1141** — `docs/channels/wecom.md`: the frontmatter `summary` called the plugin "official" while the body says "external ... maintained by the Tencent WeCom team" and the catalog entry says "(external plugin)". `docs/channels/index.md` is generated from that summary between markers, so the generated line moved with it — `pnpm channels:catalog:check` passes, confirming the hand-edit is byte-identical to what the generator produces.
- **r3-1121** — `docs/channels/channel-routing.md`: the summary promised "Routing rules per channel (WhatsApp, Telegram, Discord, Slack)". The page has no per-channel sections; its headings are Key terms, Outbound target prefixes, Session key shapes, Main DM route pinning, Routing rules (how an agent is chosen), Broadcast groups, Config overview, Session storage, WebChat behavior, Reply context. Rewritten to what the page contains.

**Rendering defects**

- **r3-2055** / **r3-2067** — `docs/plugins/beam.md`, `docs/plugins/admin-http-rpc.md`: both Troubleshooting sections used markdown definition-list syntax (`term` / blank / `: definition`). This site is Mintlify (`docs/docs.json` `$schema`), which does not render deflists, so each definition publishes as a literal paragraph beginning with a colon. These two pages were the **only** users of the pattern in `docs/` (12 lines total; now 0). Converted to the bold-label form already used in `docs/plugins/plugin-permission-requests.md:236-251`.

**Missing / stale concrete elements**

- **r3-2002** — `docs/plugins/memory-wiki.md`: three of fourteen rows in the key-toggles table had empty Notes cells (`vault.renderMode`, `search.backend`, `search.corpus`). Filled from the page's own prose (L546 and the "Search and retrieval" section) rather than invented.
- **r3-2040** — `docs/plugins/building-plugins.md`: the same bundled-plugin test command appears as `pnpm test extensions/my-plugin/` in the Quickstart and `pnpm test <bundled-plugin-root>/my-plugin/` in the checklist. Requirements already state that bundled plugins are discovered from `extensions/*`, so the checklist now uses that form.
- **r3-1131** — `docs/channels/wechat.md`: bare "In issue #68451" with no link. Linked using the `[issue #N](…/issues/N)` form used throughout `docs/releases/`.
- **r3-1089** — `docs/channels/zalo.md`: a literal `@openclaw/zalo@2026.6.11` as the pinned-version example goes stale. Replaced with `@<version>` plus the "pin only for reproducible installs" qualifier that `docs/channels/tlon.md` already uses.

## Findings refuted (11) — evidence, not opinion

- **r3-1119** (`channel-routing.md`) — "the body H1 duplicates the frontmatter title with a different name". The body H1 differs from the title (`Channels & routing` vs `Channel routing`), but MD025 is off by policy and no reader is misled by a page whose H1 is a longer form of its nav title.
- **r3-1093** (`reef.md`) — "unindented code fences break the numbered quick-start list between items 2 and 3". CommonMark ordered lists carry a `start` attribute, so the fence splits the list into two lists that still render `1. 2.` then `3.`. Nothing renders wrong; indenting is a style preference.
- **r3-1118** (`nextcloud-talk.md`) — "the read_when hint targets contributors while the page is operator setup". `Working on <X> channel features` is the house convention across `discord.md`, `googlechat.md`, `msteams.md`, `nextcloud-talk.md` and `tlon.md`. Changing one page makes the set inconsistent; this is a repo-wide convention question, not a page defect.
- **r3-1112** (`broadcast-groups.md`) — "the overview names an internal QA lane a reader cannot use". The sentence is true and states what the fanout behavior is verified against. A reader gets nothing wrong from it.
- **r3-1116** (`ambient-room-events.md`) — "names one model generation as latest-generation". The sentence already states the property that matters ("tool-reliable") and gives the model only as an example, so it does not mislead when a newer generation ships.
- **r3-2075** (`install-overrides.md`) — "examples carry a fixed release version". The version appears inside an example tarball filename (`/tmp/openclaw-codex-2026.5.8.tgz`) and an example npm spec. A concrete filename is what makes the example readable; it is not a version claim about the product.
- **r3-2071** (`oc-path.md`) — "usage examples appear before the step that enables the plugin". The intro states two paragraphs earlier that the plugin is opt-in and "leaves it dormant until you enable it", and says the page covers how to enable it. The reader is warned before the examples.
- **r5-0085**, **r5-0086** (`slack.md`), **r5-0253** (`groups.md`) — "defaults sit only inside an Accordion". The values are published; Accordions are the site's progressive-disclosure component and are used this way throughout. No default is missing, and promoting them is a layout preference.
- **r3-1975** (`workboard.md`) — "Run Codex and Run Claude may need harness plugins the page does not name". The controls have been renamed since the audit snapshot: the page now documents **Run Claude / Run OpenAI**. Whether either requires a harness plugin needs a runtime claim I could not establish from source, so I am not asserting one.

## Already refuted in the ledger before I reached them (3)

I reached these independently and agree with the standing refutation; no action taken.

- **r3-2057** (`onepassword.md`), **r3-2066** (`vault.md`) — body H1 beside a frontmatter title. `config/markdownlint-cli2.jsonc` sets `"MD025": false`.
- **r3-2069** (`geolocation.md`) — untagged fence. The same config sets `"MD040": false`.

## Not attempted (136) — with reasons

- **`docs/plugins/sdk-subpaths.md` (r3-1942, r3-1945, r3-1946)** — under a standing refusal.
- **Generated pages (r3-1993, r3-1995, r5-0198, r5-0207)** — `docs/plugins/plugin-inventory.md` is written by `scripts/generate-plugin-inventory-doc.mts`, and `docs/plugins/reference/**` is generated. Any fix belongs in the generator, not the page.
- **The remaining 129 rows** are the classes the brief rules out: "add an intro paragraph naming the reader" (r3-1027, r3-1037, r3-1038, r3-1051, r3-1061, r3-1064, r3-1897, r3-2020, r3-2032, r3-2049, r3-2063, r3-1138 …), "this table wraps / replace it with a list" (r3-1028, r3-1032, r3-1044, r3-1072, r3-1901, r3-1908, r3-1914, r3-1958, r3-1969, r3-1986, r3-2013, r3-2030, r3-2059, r3-2073, r3-1107, r3-1109, r3-1929 …), "this paragraph is dense / split it into a list" (r3-1058, r3-1063, r3-1075, r3-1100, r3-1114, r3-1128, r3-1132, r3-1907, r3-1913, r3-1916, r3-2014, r3-2024, r3-1104 …), "add a section index / funnel" (r3-1953, r3-2028, r3-2033, r3-2050, r3-2064, r3-1984 …), "reorder for flow / move this section" (r3-1071, r3-1086, r3-1092, r3-1097, r3-1099, r3-1101, r3-1110, r3-1964, r3-1973, r3-2000, r3-2065, r3-2070, r3-1095, r3-1123 …), and cross-page de-duplication (r3-1035, r3-1036, r3-1040, r3-1041, r3-1049, r3-1050, r3-1055, r3-1060, r3-1066, r3-1074, r3-1078, r3-1080, r3-1085, r3-1088, r3-1105, r3-1108, r3-1113, r3-1117, r3-1122, r3-1892, r3-1896, r3-1906, r3-1949, r3-1982, r3-1990, r3-1999, r3-2023, r3-2042, r3-2062, r3-2068, r3-2076, r3-2037, r5-0120 …). For none of these can I state what a reader would get wrong without the change.
- **Back-link rows (r3-1129, r3-1133, r3-1936, r3-1940, r3-1967, r3-1971, r3-1976, r3-2072, r3-1091, r3-1125, r3-1135, r3-1981)** were left for a link-focused pass: each needs a `href="…"`-and-`(…)` presence check plus a zh-CN glossary source per new list-item link label, which is a different shape of change from this PR.
- **Version-scope rows (r3-1077, r3-1081, r3-1083, r3-1115, r3-1127, r3-2006, r3-2008, r3-2016, r3-2021, r3-2025, r3-1894, r3-1951, r3-1954, r3-1059 …)** need `git log -S` archaeology per row to name a release. That is now possible on this clone but is its own batch.

- **Accordion-promotion rows (r3-1922, r3-1966, r3-1980)** are the same class as the r5-0085/r5-0086/r5-0253 refutations above; I did not re-argue them individually.
- **Term-glossing rows (r3-1979 `architecture.md`, r3-2027 `sdk-channel-ingress.md`)** are close to the r3-1989 fix I did make, but each needs a definition sourced per term rather than one; they are a sensible follow-up batch.
- **r3-1106 (`troubleshooting.md`)** proposes deleting one H3 under every channel H2. Every one of those H3s publishes an anchor; the fix as written would drop ~20 ids and needs `<a id>` stubs, which is a different-shaped change from this PR.
- **r3-1126 (`nostr.md`)** and **r3-1140 (`wecom.md`)** — the wecom row asks the page to inline config that the page deliberately delegates to the external plugin's versioned package docs (it says so explicitly, and the plugin can change independently of OpenClaw). The nostr row needs a decision about the house local-install form across three pages, not a one-page edit.

## CODEOWNERS

Simulated last-match-wins over the 16 changed files against `.github/CODEOWNERS`: **no file matches any rule**. No secops- or release-managers-owned paths in this diff.

## Validators

Run on the staged tree in the worktree (`node_modules` symlinked from the base clone):

- `pnpm check:docs` — **exit 0**. Covers `format:docs:check` (1280 files clean), `lint:docs` (markdownlint: `Linting: 1279 files`), `lint:templates`, `docs:check-mdx`, `docs:check-i18n-glossary`, `docs:check-links`, `docs:check-config-examples` (4922 fences seen / 1224 validated).
- `node scripts/docs-link-audit.mjs --anchors` — `checked_internal_links=13488`, `broken_links=3`: the three pre-existing `maturity/#windows-app-node` errors, unchanged from base.
- `npx vitest run --config test/vitest/vitest.full-core-unit-src.config.ts src/docs/` — **8 files / 16 tests passed**.
- `npx vitest run --config test/vitest/vitest.unit-src.config.ts src/docs/channel-config-examples.test.ts` — **1 file / 3 tests passed** (this config, not the tooling one, which matches nothing here).
- `npx vitest run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts` — **1 file / 33 tests passed**.
- `pnpm format:check` (repo-wide oxfmt) — **exit 0**, 36349 files.
- `pnpm channels:catalog:check` — **exit 0** (gates the generated `docs/channels/index.md` block).

No new files, no untracked files left in the worktree, no `docs/docs.json` or `docs/.i18n/glossary.zh-CN.json` change (no heading moved and no new list-item link label was introduced, so no glossary source is required).

## Premises in my brief that did not hold

- The brief listed `docs/plugins/reference/**` and `plugin-inventory.md` as the generated set. **`docs/channels/index.md` is generated too** — `scripts/write-official-channel-catalog.mts` rewrites a marked block from each channel page's `summary` frontmatter, and `pnpm channels:catalog:check` gates it. Any PR editing a channel page's `summary` must regenerate or hand-match that block.
- The brief sized this at **~167 rows**; the ledger reads **164** open `ux` rows for these two directories now. `r3-2057`, `r3-2066` and `r3-2069` were refuted by a concurrent agent while I worked — I had reached the same conclusion independently. Re-reconcile counts at the end of a batch, not the start.
- The suggested fix on **r3-1093** was itself the wrong call — indenting the fences would have been churn, not a repair, because the list numbering already renders correctly.
