### PR TITLE
improve: reduce SQLite snapshot process startup cost

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3061,7 +3061,6 @@ src/infra/sqlite-readonly-location.ts	3
 src/infra/sqlite-schema-contract.ts	9
 src/infra/sqlite-snapshot.ts	2
 src/infra/sqlite-strict.ts	7
-src/infra/sqlite-transaction.ts	2
 src/infra/sqlite-user-version.ts	1
 src/infra/sqlite-wal.ts	5
 src/infra/startup-migration-checkpoint.ts	1

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -68,7 +68,7 @@ export const vitestWorkerBuildEntries = {
   // The retention fixture executes the real nested QuickJS worker.
   "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
   // The real ulimit fixture must import its parent before imposing a file-size limit.
-  "infra/sqlite-readonly-location": "src/infra/sqlite-readonly-location.ts",
+  "infra/sqlite-snapshot-source": "src/infra/sqlite-snapshot-source.ts",
   // Keep provider preparation in the same compiled graph as payload rendering;
   // a source-injected plugin would miss duplicated registry scope state.
   "plugins/provider-hook-runtime": "src/plugins/provider-hook-runtime.ts",

--- a/src/agents/auth-profiles/shared-store-bootstrap.ts
+++ b/src/agents/auth-profiles/shared-store-bootstrap.ts
@@ -4,7 +4,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { hasErrnoCode } from "../../infra/errno.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
-import { prepareSqliteReadOnlyLocationSync } from "../../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocationSync } from "../../infra/sqlite-snapshot-source.js";
 import { writeConfigMachineState } from "../../state/config-machine-state-write.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -9,7 +9,7 @@ import { isDeepStrictEqual } from "node:util";
 import { projectModelProviderConfig } from "../../config/model-provider-config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../../infra/sqlite-error-diagnostics.js";
 import { isUserModelAuthProfileId } from "../../state/user-model-account-id.js";
 import { readUserModelAuthProfile } from "../../state/user-model-accounts.js";
 import { isRecord } from "../../utils.js";

--- a/src/cli/update-cli/update-command-result-diagnostics.test.ts
+++ b/src/cli/update-cli/update-command-result-diagnostics.test.ts
@@ -3,7 +3,7 @@ import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
-import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../../infra/sqlite-error-diagnostics.js";
 import { formatUpdateFinalizationError } from "./update-command-result.js";
 
 const dirs = useAutoCleanupTempDirTracker(afterEach);

--- a/src/cli/update-cli/update-command-result.ts
+++ b/src/cli/update-cli/update-command-result.ts
@@ -9,7 +9,7 @@ import {
 import { collectNestedErrorCandidates } from "../../infra/error-graph-internal.js";
 import { formatErrorMessage, formatUncaughtError } from "../../infra/errors.js";
 import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
-import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../../infra/sqlite-error-diagnostics.js";
 import type { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
 import {
   markControlPlaneUpdateRestartSentinelFailure,

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import { createRequire, registerHooks } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { SQLITE_READONLY_CHILD_ARG } from "../infra/runtime-process-entrypoints.js";
 
 const require = createRequire(import.meta.url);
 const root = process.env.HOME!;
@@ -111,7 +112,8 @@ const stubs = new Map<string, string>([
   // place that URL in a shared chunk. Workers still execute their real compiled code.
   [
     sourceUrl("../infra/runtime-process-entrypoints.ts"),
-    `export const runtimeProcessEntrypoints = ${runtimeProcessEntrypointsJson};`,
+    `export const runtimeProcessEntrypoints = ${runtimeProcessEntrypointsJson};
+export const SQLITE_READONLY_CHILD_ARG = ${JSON.stringify(SQLITE_READONLY_CHILD_ARG)};`,
   ],
   [sourceUrl("../commands/doctor.ts"), doctorSource],
   [sourceUrl("../config/config.ts"), snapshotSource],

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -37,8 +37,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
     readConfigFileSnapshot: mocks.readConfigFileSnapshot,
   };
 });
-vi.mock("../infra/sqlite-readonly-location.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../infra/sqlite-readonly-location.js")>();
+vi.mock("../infra/sqlite-snapshot-source.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/sqlite-snapshot-source.js")>();
   mocks.actualPrepareSqliteReadOnlyLocationSync.mockImplementation(
     actual.prepareSqliteReadOnlyLocationSync,
   );

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -27,7 +27,7 @@ import {
   type HealthCheckContext,
   type HealthFinding,
 } from "../flows/health-checks.js";
-import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-snapshot-source.js";
 import {
   resolvePluginInstallRoots,
   withPluginInstallRoots,

--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -2,7 +2,7 @@ import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import {

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
@@ -2,8 +2,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
 import { setSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
+import { isSqliteLockError } from "../../infra/sqlite-error-diagnostics.js";
 import {
-  isSqliteLockError,
   runSqliteImmediateTransactionSync,
   withSqliteWriteAdmissionService,
 } from "../../infra/sqlite-transaction.js";

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -7,7 +7,7 @@ import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-snapshot-source.js";
 import { isArtifactPreservingStateRead } from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {

--- a/src/flows/doctor-health.migration-refusal.test.ts
+++ b/src/flows/doctor-health.migration-refusal.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as doctorMaintenance from "../commands/doctor-maintenance.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { SQLITE_READONLY_CHILD_ARG } from "../infra/sqlite-readonly-worker.js";
+import { SQLITE_READONLY_CHILD_ARG } from "../infra/runtime-process-entrypoints.js";
 import * as coordinators from "../infra/state-database-coordinator.js";
 import { DoctorStateMigrationRefusalError } from "../infra/state-migrations.messages.js";
 import {

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -36,8 +36,8 @@ const readonlyPreparation = vi.hoisted(() => ({
   turns: [] as Promise<void>[],
 }));
 
-vi.mock("../infra/sqlite-readonly-location.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../infra/sqlite-readonly-location.js")>();
+vi.mock("../infra/sqlite-snapshot-source.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/sqlite-snapshot-source.js")>();
   const observe = (pathname: string) => {
     let progressed = false;
     readonlyPreparation.turns.push(

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -1,7 +1,7 @@
 import { onSessionIdentityMutation } from "../../config/sessions/session-accessor.js";
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { withTimeout } from "../../infra/fs-safe.js";
-import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../../infra/sqlite-error-diagnostics.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { WorkerExecutionMode, WorkerProfile } from "../../plugins/types.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -1,6 +1,8 @@
 // Runtime launchers and the package build share these subprocess locations.
 const currentModuleUrl = import.meta.url;
 
+export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
+
 export const runtimeProcessEntrypoints = {
   stateMigrationSnapshot: {
     currentModuleUrl,

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { applyPrivateModeSync } from "./private-mode.js";
-import { isSqliteLockError } from "./sqlite-transaction.js";
+import { isSqliteLockError } from "./sqlite-error-diagnostics.js";
 
 export class SqliteCoordinatorError extends Error {
   constructor(

--- a/src/infra/sqlite-error-diagnostics.ts
+++ b/src/infra/sqlite-error-diagnostics.ts
@@ -1,5 +1,5 @@
 import { extractErrorCode } from "@openclaw/normalization-core/error-coercion";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { asOptionalObjectRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 
 const STORAGE_ERRORS = [
   ["SQLITE_BUSY", "database is locked", 5],
@@ -55,4 +55,44 @@ export function formatSqliteErrorCodeSuffix(error: unknown): string {
     current = current.cause;
   }
   return details.size > 0 ? ` (${[...details].join(", ")})` : "";
+}
+
+// Native snapshot coordination needs classification without loading transaction logging.
+const SQLITE_LOCK_ERROR_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED"]);
+// Node reports SQLite failures with a generic string code and the extended
+// SQLite result in `errcode`; the low byte identifies BUSY or LOCKED.
+const SQLITE_BUSY_RESULT_CODE = 5;
+const SQLITE_LOCKED_RESULT_CODE = 6;
+const SQLITE_CORRUPT_RESULT_CODE = 11;
+const SQLITE_NOTADB_RESULT_CODE = 26;
+const SQLITE_PRIMARY_RESULT_CODE_MASK = 0xff;
+
+export function sqliteErrorCode(error: unknown): string | undefined {
+  const code = asOptionalObjectRecord(error)?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export function sqliteExtendedResultCode(error: unknown): number | undefined {
+  const errcode = asOptionalObjectRecord(error)?.errcode;
+  return typeof errcode === "number" && Number.isInteger(errcode) ? errcode : undefined;
+}
+
+export function sqlitePrimaryResultCode(error: unknown): number | undefined {
+  const errcode = sqliteExtendedResultCode(error);
+  return errcode === undefined ? undefined : errcode & SQLITE_PRIMARY_RESULT_CODE_MASK;
+}
+
+export function isSqliteLockError(error: unknown): boolean {
+  const code = sqliteErrorCode(error);
+  if (code !== undefined && SQLITE_LOCK_ERROR_CODES.has(code)) {
+    return true;
+  }
+  const primaryCode = sqlitePrimaryResultCode(error);
+  return primaryCode === SQLITE_BUSY_RESULT_CODE || primaryCode === SQLITE_LOCKED_RESULT_CODE;
+}
+
+/** Report proven file damage (corrupt page or non-database header), not transient failure. */
+export function isSqliteCorruptionError(error: unknown): boolean {
+  const primaryCode = sqlitePrimaryResultCode(error);
+  return primaryCode === SQLITE_CORRUPT_RESULT_CODE || primaryCode === SQLITE_NOTADB_RESULT_CODE;
 }

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -2,12 +2,12 @@ import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { isSqliteCorruptionError } from "./sqlite-error-diagnostics.js";
 import {
   readStableSqliteFileGeneration,
   sameSqliteFileGeneration,
   type SqliteFileGeneration,
 } from "./sqlite-file-generation.js";
-import { isSqliteCorruptionError } from "./sqlite-transaction.js";
 
 type SqliteIntegrityChecks = {
   integrityCheck: "ok";

--- a/src/infra/sqlite-readonly-location.cancellation.test.ts
+++ b/src/infra/sqlite-readonly-location.cancellation.test.ts
@@ -5,12 +5,12 @@ import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import { SQLITE_READONLY_CHILD_ARG } from "./runtime-process-entrypoints.js";
 import * as workerUrls from "./runtime-worker-url.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
-} from "./sqlite-readonly-location.js";
-import { SQLITE_READONLY_CHILD_ARG } from "./sqlite-readonly-worker.js";
+} from "./sqlite-snapshot-source.js";
 
 const processMocks = vi.hoisted(() => ({
   execFile: vi.fn<typeof import("node:child_process").execFile>(),

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -11,11 +11,13 @@ import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-wor
 import { startSqliteConcurrentWriter } from "./sqlite-concurrent-writer.test-support.js";
 import { readMainDatabasePosixLocks } from "./sqlite-posix-locks.test-support.js";
 import {
-  prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationInProcess,
-  prepareSqliteReadOnlyLocationSync,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
+import {
+  prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocationSync,
+} from "./sqlite-snapshot-source.js";
 
 const writers: Array<ReturnType<typeof startSqliteConcurrentWriter>> = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
@@ -492,7 +494,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       database.close();
       const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
       const extension = workerUrl.pathname.endsWith(".ts") ? ".ts" : ".js";
-      const moduleUrl = new URL(`./sqlite-readonly-location${extension}`, workerUrl).href;
+      const moduleUrl = new URL(`./sqlite-snapshot-source${extension}`, workerUrl).href;
       const script = `
         const { prepareSqliteReadOnlyLocation } = await import(${JSON.stringify(moduleUrl)});
         try {

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -13,12 +13,7 @@ import {
   createPrivateSqliteTempDirectorySync,
   resolvePrivateSqliteSnapshotStagingRoot,
 } from "./sqlite-private-directory.js";
-import { runSqliteReadOnlyWorker, runSqliteReadOnlyWorkerSync } from "./sqlite-readonly-worker.js";
 import { withSqliteSourceHandle, withSqliteSourceHandleAsync } from "./sqlite-source-handle.js";
-import {
-  hasStateDatabaseSourceExclusion,
-  prepareStateDatabaseMutationSnapshot,
-} from "./state-database-coordinator.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;
 const COPY_BUFFER_BYTES = 1024 * 1024;
@@ -26,7 +21,7 @@ const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
-const SQLITE_SNAPSHOT_STAGING_PREFIX = `openclaw-sqlite-readonly-${process.pid}-`;
+export const SQLITE_SNAPSHOT_STAGING_PREFIX = `openclaw-sqlite-readonly-${process.pid}-`;
 const pendingTempDirectoryCleanup = new Set<string>();
 let cleanupExitHandlerInstalled = false;
 
@@ -44,7 +39,7 @@ type SourceSidecars = {
 
 type SourceJournalMode = "empty" | "rollback" | "unknown" | "wal";
 
-type PreparedSqliteReadOnlyLocation = {
+export type PreparedSqliteReadOnlyLocation = {
   cleanup: () => boolean;
   location: string;
 };
@@ -299,7 +294,7 @@ function rollbackJournalReferencesSuperJournal(journalPath: string): boolean {
   }
 }
 
-function removeTempDirectory(tempDir: string): boolean {
+export function removeTempDirectory(tempDir: string): boolean {
   try {
     fs.rmSync(tempDir, { force: true, maxRetries: 3, recursive: true, retryDelay: 20 });
     pendingTempDirectoryCleanup.delete(tempDir);
@@ -322,7 +317,7 @@ function removeTempDirectory(tempDir: string): boolean {
   }
 }
 
-function adoptPreparedLocation(
+export function adoptPreparedLocation(
   location: string,
   ownedRoot?: string,
   requireCleanup = false,
@@ -432,7 +427,7 @@ function createStableReadOnlyCopyInTempDirectory(
   }
 }
 
-async function createSqliteSnapshotStagingDirectory(
+export async function createSqliteSnapshotStagingDirectory(
   stagingRoot = resolvePrivateSqliteSnapshotStagingRoot(),
 ): Promise<string> {
   try {
@@ -616,82 +611,6 @@ function prepareReadOnlySourceSyncInProcess(
   throw new Error(`SQLite source did not stabilize for read-only inspection: ${canonicalPath}`, {
     cause: lastChange,
   });
-}
-
-export async function prepareSqliteReadOnlyLocation(
-  pathname: string,
-  options: { preserveSourceArtifacts?: boolean; signal?: AbortSignal } = {},
-): Promise<PreparedSqliteReadOnlyLocation> {
-  let stagingRoot: string | undefined;
-  try {
-    options.signal?.throwIfAborted();
-    const ownedSnapshot = prepareStateDatabaseMutationSnapshot(pathname);
-    if (ownedSnapshot) {
-      const prepared = await ownedSnapshot;
-      try {
-        options.signal?.throwIfAborted();
-        return prepared;
-      } catch (error) {
-        prepared.cleanup();
-        throw error;
-      }
-    }
-    if (hasStateDatabaseSourceExclusion(pathname)) {
-      const prepared = options.preserveSourceArtifacts
-        ? prepareSqliteReadOnlyLocationSyncInProcess(pathname)
-        : await prepareSqliteReadOnlyLocationInProcess(pathname);
-      try {
-        options.signal?.throwIfAborted();
-        return prepared;
-      } catch (error) {
-        prepared.cleanup();
-        throw error;
-      }
-    }
-    // A stopped worker may never publish its random snapshot path. Allocate its
-    // private parent first so cancellation can join the child and remove all copies.
-    stagingRoot = await createSqliteSnapshotStagingDirectory();
-    options.signal?.throwIfAborted();
-    const location = await runSqliteReadOnlyWorker(pathname, {
-      mode: options.preserveSourceArtifacts ? "sync" : "async",
-      signal: options.signal,
-      stagingRoot,
-    });
-    options.signal?.throwIfAborted();
-    // Cancellable maintenance must retain its fence on cleanup failure; ordinary
-    // read-only handles report false so their owner can retry close.
-    return adoptPreparedLocation(location, stagingRoot, options.signal !== undefined);
-  } catch (error) {
-    if (stagingRoot && !removeTempDirectory(stagingRoot)) {
-      throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
-        cause: error,
-      });
-    }
-    options.signal?.throwIfAborted();
-    throw error;
-  }
-}
-
-export function prepareSqliteReadOnlyLocationSync(
-  pathname: string,
-): PreparedSqliteReadOnlyLocation {
-  if (hasStateDatabaseSourceExclusion(pathname)) {
-    return prepareSqliteReadOnlyLocationSyncInProcess(pathname);
-  }
-  const stagingRoot = createPrivateSqliteTempDirectorySync(
-    resolvePrivateSqliteSnapshotStagingRoot(),
-    SQLITE_SNAPSHOT_STAGING_PREFIX,
-  );
-  try {
-    return adoptPreparedLocation(runSqliteReadOnlyWorkerSync(pathname, stagingRoot), stagingRoot);
-  } catch (error) {
-    if (!removeTempDirectory(stagingRoot)) {
-      throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
-        cause: error,
-      });
-    }
-    throw error;
-  }
 }
 
 export function prepareSqliteReadOnlyLocationInProcess(pathname: string, stagingRoot?: string) {

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,10 +1,10 @@
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import { SQLITE_READONLY_CHILD_ARG } from "./runtime-process-entrypoints.js";
 import { formatSqliteErrorCodeSuffix } from "./sqlite-error-diagnostics.js";
 import {
   prepareSqliteReadOnlyLocationInProcess,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
-import { SQLITE_READONLY_CHILD_ARG } from "./sqlite-readonly-worker.js";
 
 // The sync strategy raw-copies without attaching SQLite to the source, so sync
 // callers stay byte-neutral on the live family; the async strategy holds a read

--- a/src/infra/sqlite-readonly-worker.ts
+++ b/src/infra/sqlite-readonly-worker.ts
@@ -6,10 +6,12 @@ import { formatByteSize } from "@openclaw/normalization-core";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hasErrnoCode } from "./errno.js";
-import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import {
+  runtimeProcessEntrypoints,
+  SQLITE_READONLY_CHILD_ARG,
+} from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 
-export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
 const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
 const SQLITE_INSPECTION_TIMEOUT_MS = 30_000;
 const SQLITE_INSPECTION_TIMEOUT_MAX_MS = 30 * 60_000;

--- a/src/infra/sqlite-snapshot-source.ts
+++ b/src/infra/sqlite-snapshot-source.ts
@@ -1,9 +1,101 @@
 // Keep source lifetime pinned while the snapshot owner consumes live or private bytes.
 import fs, { type BigIntStats } from "node:fs";
-import { prepareSqliteReadOnlyLocation } from "./sqlite-readonly-location.js";
+import {
+  createPrivateSqliteTempDirectorySync,
+  resolvePrivateSqliteSnapshotStagingRoot,
+} from "./sqlite-private-directory.js";
+import {
+  adoptPreparedLocation,
+  createSqliteSnapshotStagingDirectory,
+  prepareSqliteReadOnlyLocationInProcess,
+  prepareSqliteReadOnlyLocationSyncInProcess,
+  removeTempDirectory,
+  SQLITE_SNAPSHOT_STAGING_PREFIX,
+  type PreparedSqliteReadOnlyLocation,
+} from "./sqlite-readonly-location.js";
+import { runSqliteReadOnlyWorker, runSqliteReadOnlyWorkerSync } from "./sqlite-readonly-worker.js";
 import { withSqliteSourceHandleAsync } from "./sqlite-source-handle.js";
+import {
+  hasStateDatabaseSourceExclusion,
+  prepareStateDatabaseMutationSnapshot,
+} from "./state-database-coordinator.js";
 
-type PreparedSqliteReadOnlyLocation = Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>>;
+// Keep parent launch orchestration out of the native snapshot child's import graph.
+export async function prepareSqliteReadOnlyLocation(
+  pathname: string,
+  options: { preserveSourceArtifacts?: boolean; signal?: AbortSignal } = {},
+): Promise<PreparedSqliteReadOnlyLocation> {
+  let stagingRoot: string | undefined;
+  try {
+    options.signal?.throwIfAborted();
+    const ownedSnapshot = prepareStateDatabaseMutationSnapshot(pathname);
+    if (ownedSnapshot) {
+      const prepared = await ownedSnapshot;
+      try {
+        options.signal?.throwIfAborted();
+        return prepared;
+      } catch (error) {
+        prepared.cleanup();
+        throw error;
+      }
+    }
+    if (hasStateDatabaseSourceExclusion(pathname)) {
+      const prepared = options.preserveSourceArtifacts
+        ? prepareSqliteReadOnlyLocationSyncInProcess(pathname)
+        : await prepareSqliteReadOnlyLocationInProcess(pathname);
+      try {
+        options.signal?.throwIfAborted();
+        return prepared;
+      } catch (error) {
+        prepared.cleanup();
+        throw error;
+      }
+    }
+    // A stopped worker may never publish its random snapshot path. Allocate its
+    // private parent first so cancellation can join the child and remove all copies.
+    stagingRoot = await createSqliteSnapshotStagingDirectory();
+    options.signal?.throwIfAborted();
+    const location = await runSqliteReadOnlyWorker(pathname, {
+      mode: options.preserveSourceArtifacts ? "sync" : "async",
+      signal: options.signal,
+      stagingRoot,
+    });
+    options.signal?.throwIfAborted();
+    // Cancellable maintenance must retain its fence on cleanup failure; ordinary
+    // read-only handles report false so their owner can retry close.
+    return adoptPreparedLocation(location, stagingRoot, options.signal !== undefined);
+  } catch (error) {
+    if (stagingRoot && !removeTempDirectory(stagingRoot)) {
+      throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
+        cause: error,
+      });
+    }
+    options.signal?.throwIfAborted();
+    throw error;
+  }
+}
+
+export function prepareSqliteReadOnlyLocationSync(
+  pathname: string,
+): PreparedSqliteReadOnlyLocation {
+  if (hasStateDatabaseSourceExclusion(pathname)) {
+    return prepareSqliteReadOnlyLocationSyncInProcess(pathname);
+  }
+  const stagingRoot = createPrivateSqliteTempDirectorySync(
+    resolvePrivateSqliteSnapshotStagingRoot(),
+    SQLITE_SNAPSHOT_STAGING_PREFIX,
+  );
+  try {
+    return adoptPreparedLocation(runSqliteReadOnlyWorkerSync(pathname, stagingRoot), stagingRoot);
+  } catch (error) {
+    if (!removeTempDirectory(stagingRoot)) {
+      throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
 
 async function prepareSqliteSnapshotSource(
   pathname: string,

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -13,16 +13,14 @@ import {
   runWithSqliteBusyTimeout,
   shouldReportSqliteLockFailure,
 } from "./sqlite-busy-timeout.js";
+import {
+  isSqliteLockError,
+  sqliteErrorCode,
+  sqliteExtendedResultCode,
+  sqlitePrimaryResultCode,
+} from "./sqlite-error-diagnostics.js";
 import { discardSqliteTransactionState } from "./sqlite-post-commit.js";
 
-const SQLITE_LOCK_ERROR_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED"]);
-// Node reports SQLite failures with a generic string code and the extended
-// SQLite result in `errcode`; the low byte identifies BUSY or LOCKED.
-const SQLITE_BUSY_RESULT_CODE = 5;
-const SQLITE_LOCKED_RESULT_CODE = 6;
-const SQLITE_CORRUPT_RESULT_CODE = 11;
-const SQLITE_NOTADB_RESULT_CODE = 26;
-const SQLITE_PRIMARY_RESULT_CODE_MASK = 0xff;
 const DEFAULT_SLOW_BUSY_WAIT_MS = 1_000;
 const DEFAULT_SLOW_TRANSACTION_HOLD_MS = 1_000;
 
@@ -121,37 +119,6 @@ function assertSyncTransactionResult(value: unknown): void {
       "SQLite write transactions must be synchronous; Promise returns are not supported.",
     );
   }
-}
-
-function sqliteErrorCode(error: unknown): string | undefined {
-  const code = error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
-  return typeof code === "string" ? code : undefined;
-}
-
-function sqliteExtendedResultCode(error: unknown): number | undefined {
-  const errcode =
-    error && typeof error === "object" ? (error as { errcode?: unknown }).errcode : undefined;
-  return typeof errcode === "number" && Number.isInteger(errcode) ? errcode : undefined;
-}
-
-function sqlitePrimaryResultCode(error: unknown): number | undefined {
-  const errcode = sqliteExtendedResultCode(error);
-  return errcode === undefined ? undefined : errcode & SQLITE_PRIMARY_RESULT_CODE_MASK;
-}
-
-export function isSqliteLockError(error: unknown): boolean {
-  const code = sqliteErrorCode(error);
-  if (code !== undefined && SQLITE_LOCK_ERROR_CODES.has(code)) {
-    return true;
-  }
-  const primaryCode = sqlitePrimaryResultCode(error);
-  return primaryCode === SQLITE_BUSY_RESULT_CODE || primaryCode === SQLITE_LOCKED_RESULT_CODE;
-}
-
-/** Report proven file damage (corrupt page or non-database header), not transient failure. */
-export function isSqliteCorruptionError(error: unknown): boolean {
-  const primaryCode = sqlitePrimaryResultCode(error);
-  return primaryCode === SQLITE_CORRUPT_RESULT_CODE || primaryCode === SQLITE_NOTADB_RESULT_CODE;
 }
 
 function slowBusyWaitThresholdMs(options: SqliteTransactionOptions | undefined): number {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -11,7 +11,8 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hasErrnoCode } from "./errno.js";
 import { normalizeSqliteNonNegativeInteger } from "./sqlite-busy-timeout.js";
 import { createSqliteLifecycleAggregateError } from "./sqlite-coordinator.js";
-import { isSqliteLockError, runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
+import { isSqliteLockError } from "./sqlite-error-diagnostics.js";
+import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
 // WAL maintenance configures SQLite write-ahead logging and schedules bounded
 // checkpoints so state databases do not accumulate unbounded WAL files.

--- a/src/plugin-sdk/sqlite-runtime.ts
+++ b/src/plugin-sdk/sqlite-runtime.ts
@@ -23,7 +23,7 @@ export { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 export {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
-} from "../infra/sqlite-readonly-location.js";
+} from "../infra/sqlite-snapshot-source.js";
 export {
   runSqliteImmediateTransaction,
   runSqliteImmediateTransactionSync,

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -13,12 +13,10 @@ import {
   sqliteStringSet,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { isSqliteCorruptionError } from "../infra/sqlite-error-diagnostics.js";
 import { isTerminalSqliteIntegrityError } from "../infra/sqlite-integrity.js";
 import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "../infra/sqlite-number.js";
-import {
-  isSqliteCorruptionError,
-  runSqliteImmediateTransactionSync,
-} from "../infra/sqlite-transaction.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import {
   hasOpenClawStateTablesBeyondStartupCheckpoint,

--- a/src/state/openclaw-database-preflight.artifacts.test.ts
+++ b/src/state/openclaw-database-preflight.artifacts.test.ts
@@ -13,7 +13,7 @@ import {
 import { resolveConfiguredAgentDatabaseCandidatePaths } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readMainDatabasePosixLocks } from "../infra/sqlite-posix-locks.test-support.js";
-import * as snapshots from "../infra/sqlite-readonly-location.js";
+import * as snapshots from "../infra/sqlite-snapshot-source.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import {
   registerOpenClawAgentDatabase,

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -13,11 +13,11 @@ import {
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
 import { hasNodeErrorCode } from "../infra/path-guards.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import {
   collectSqliteSchemaIssues,
   type SqliteSchemaIssue,
 } from "../infra/sqlite-schema-contract.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import {
   describeRunningOpenClawBuild,
   readSqliteUserVersion,

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -8,6 +8,7 @@ import {
   createSqliteLifecycleAggregateError,
   runWithSqliteCoordinator,
 } from "../infra/sqlite-coordinator.js";
+import { isSqliteCorruptionError } from "../infra/sqlite-error-diagnostics.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import {
   confirmSqliteFileIntegrity,
@@ -18,7 +19,6 @@ import {
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "../infra/sqlite-readonly-location.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
-import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { registerSqliteCacheExitClose } from "../infra/sqlite-wal.js";
 import {

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { hasNodeErrorCode } from "../infra/path-guards.js";
-import * as sqliteReadOnly from "../infra/sqlite-readonly-location.js";
+import * as sqliteReadOnly from "../infra/sqlite-snapshot-source.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withTempDir } from "../test-utils/temp-dir.js";

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -7,7 +7,7 @@ import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
-} from "../infra/sqlite-readonly-location.js";
+} from "../infra/sqlite-snapshot-source.js";
 import { withSqliteSourceHandle } from "../infra/sqlite-source-handle.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";

--- a/src/state/openclaw-state-db-source-exclusion.test.ts
+++ b/src/state/openclaw-state-db-source-exclusion.test.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { withSqliteSourceHandleAsync } from "../infra/sqlite-source-handle.js";
 import { acquireStateDatabaseHandleExclusion } from "../infra/state-database-coordinator.js";
 import { createDeferredCore } from "../shared/deferred.js";

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
+import { isSqliteCorruptionError } from "../infra/sqlite-error-diagnostics.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -16,8 +16,8 @@ import {
   verifyAndRepairCanonicalSqliteIndexes,
 } from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import { assertSqliteSchemaTablesPresent } from "../infra/sqlite-schema-contract.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
 import type { SqliteTransactionOptions } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";

--- a/src/state/openclaw-state-lease-binding.test.ts
+++ b/src/state/openclaw-state-lease-binding.test.ts
@@ -1,7 +1,7 @@
 import { AsyncResource } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";

--- a/src/state/openclaw-state-lease-exclusion.nested.test.ts
+++ b/src/state/openclaw-state-lease-exclusion.nested.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";

--- a/src/state/openclaw-state-lease-exclusion.test.ts
+++ b/src/state/openclaw-state-lease-exclusion.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { Worker } from "node:worker_threads";
 import { describe, expect, it } from "vitest";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withAgentDatabaseMaintenanceLease } from "./openclaw-agent-db.js";

--- a/src/state/openclaw-state-lease-heartbeat.worker.ts
+++ b/src/state/openclaw-state-lease-heartbeat.worker.ts
@@ -1,10 +1,8 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { runWithSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
 import { runWithSqliteCoordinator } from "../infra/sqlite-coordinator.js";
-import {
-  isSqliteLockError,
-  runSqliteImmediateTransactionSync,
-} from "../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../infra/sqlite-error-diagnostics.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import {
   acquireStateDatabaseCoordinator,
   StateDatabaseCoordinatorContentionError,

--- a/src/state/openclaw-state-lease.ts
+++ b/src/state/openclaw-state-lease.ts
@@ -4,7 +4,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
-import { isSqliteLockError } from "../infra/sqlite-transaction.js";
+import { isSqliteLockError } from "../infra/sqlite-error-diagnostics.js";
 import { StateDatabaseCoordinatorContentionError } from "../infra/state-database-coordinator.js";
 import { loggingState } from "../logging/state.js";
 import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "./openclaw-state-db-readonly.js";

--- a/src/state/openclaw-state-mutation-snapshot.test.ts
+++ b/src/state/openclaw-state-mutation-snapshot.test.ts
@@ -2,7 +2,7 @@ import { AsyncResource } from "node:async_hooks";
 import { spawnSync } from "node:child_process";
 import { DatabaseSync } from "node:sqlite";
 import { expect, it } from "vitest";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-snapshot-source.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { closeTrackedStateDatabase, openTrackedStateDatabase } from "./openclaw-state-db-handle.js";
 import {

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -14,7 +14,7 @@ import {
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { requireNodeSqlite, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
-import * as sqliteReadonlyLocation from "../infra/sqlite-readonly-location.js";
+import * as sqliteReadonlyLocation from "../infra/sqlite-snapshot-source.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -9,12 +9,12 @@ import {
   createSqliteLifecycleAggregateError,
   runWithSqliteCoordinator,
 } from "../infra/sqlite-coordinator.js";
+import { isSqliteLockError } from "../infra/sqlite-error-diagnostics.js";
 import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
-} from "../infra/sqlite-readonly-location.js";
-import { isSqliteLockError } from "../infra/sqlite-transaction.js";
+} from "../infra/sqlite-snapshot-source.js";
 import {
   acquireStateDatabaseCoordinator,
   StateDatabaseCoordinatorContentionError,

--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -179,7 +179,7 @@ export function workerProbe(
     "configured-value.ts",
     'export const value: string = "configured";',
   );
-  const parent = path.join(root, "src/infra/sqlite-readonly-location.ts");
+  const parent = path.join(root, "src/infra/sqlite-snapshot-source.ts");
   const test = writeFixture(
     directory,
     "child.test.ts",
@@ -199,7 +199,7 @@ export function workerProbe(
     import { tuiPtyRuntimeEntrypoints } from ${JSON.stringify(path.join(root, "src/tui/tui-pty-runtime-test-support.ts"))};
     import { cliCompactionBackendEntrypoints } from ${JSON.stringify(path.join(root, "src/agents/command/cli-compaction-runtime.test-support.ts"))};
     import { resolveRuntimeWorkerUrl } from ${JSON.stringify(path.join(root, "src/infra/runtime-worker-url.ts"))};
-    import { prepareSqliteReadOnlyLocation } from ${JSON.stringify(path.join(root, "src/infra/sqlite-readonly-location.ts"))};
+    import { prepareSqliteReadOnlyLocation } from ${JSON.stringify(path.join(root, "src/infra/sqlite-snapshot-source.ts"))};
     import { runSqliteTranscriptArchivePublishWorker } from ${JSON.stringify(path.join(root, "src/config/sessions/session-accessor.sqlite-archive.ts"))};
     const tuiUrls = Object.values(tuiPtyRuntimeEntrypoints).map(entry => resolveRuntimeWorkerUrl(entry).href);
     const setupUrls = cliCompactionBackendEntrypoints.map(entry => resolveRuntimeWorkerUrl(entry).href);

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -1296,7 +1296,7 @@ export default class {
              assert.equal(getFsSafeNativeConfig().mode,'auto');
              await import(pathToFileURL(process.argv[1]));
              assert.equal(getFsSafeNativeConfig().mode,'off');`,
-            path.join(initialDirectory, "dist/infra/sqlite-readonly-location.js"),
+            path.join(initialDirectory, "dist/infra/sqlite-snapshot-source.js"),
           ],
           fixture,
           {


### PR DESCRIPTION
## What Problem This Solves

SQLite snapshot processes repeatedly load parent-side launch and logging code that they do not use. In the measured update CLI suite, 5,226 synchronous snapshot processes accounted for about 85% of elapsed time, making their cold imports a significant test and command cost.

## Why This Change Was Made

Move the existing public snapshot-routing functions into the existing snapshot-source orchestration module. Keep copying, recovery, staging, adoption and the single cleanup registry in their current low-level owner. The child argument stays unchanged and moves to the shared process-entrypoint module; the pure SQLite error predicates move out of transaction logging into the existing diagnostics module.

All callers follow the owning modules. The plugin SDK façade keeps the same export names and types, and the test-only compiled library entry follows its implementation. The actual worker entry, arguments, budgets, copy algorithms, cancellation, process isolation, source preservation and ownership checks are unchanged. Two moved field reads use the existing equivalent object coercer, retiring two assertions without adding baseline allowance.

## User Impact

The measured native snapshot child starts faster without changing update, Doctor, database or plugin behavior. No flags, caches, worker pools, schema or persistence changes are introduced. Most of the 47-file diff updates imports; production is +19 net lines for the internal owner boundary, tests/support +4, and assertion baseline -1 row. No test case, assertion or timeout is removed or weakened.

## Evidence

- Real managed compiled-child A/B/A: median **110.752 / 87.944 / 114.255 ms** across three native children per leg. The original ledger case passes in every leg. The verified static dependency closure is **67 / 47 / 67 modules**, **462,705 / 307,340 / 462,705 bytes**.
- Whole wrapper time is **8.15 / 6.77 / 6.63 seconds**, including ordinary build, inspection and cleanup; this does **not** establish a whole-wrapper or full-CI speedup. Reported whole-command maximum RSS is 2,296,840,192 / 2,306,850,816 / 2,299,084,800 bytes; no memory reduction is claimed.
- Same Node 24.19.0, pnpm 12.3.4, frozen dependencies, original test source and source-only root layout. The temporary observer forwarded native arguments/options/results unchanged, stayed outside the child graph, and captured files after the child timer. It was removed before correctness checks. Every recorded process exited, generated worker directories were removed by their normal owner, and source/dependency seals matched.
- **339 focused tests passed**: snapshot copy/cancellation/worker behavior, actual SQLite transaction/coordinator and read-only callers, Doctor/Gateway/state ownership, the two source/build artifact cases, and all 16 real subprocess repair/finalize output cases. The Linux-specific live-WAL POSIX lock case passed in CI (194 ms); current-main fresh/expired/retained history rows also passed. The remaining 32 artifact cases were deliberately filtered; no other broad success is implied.

Full `pnpm build` passed in 240.97 seconds, the correctly scoped `pnpm check:changed --base a265abfecad458603578d72395a8dde6f5d3eadc` passed, and the built iMessage entrypoint profile passed (98.44 MB peak RSS; no comparative memory claim). The initial CI run exposed an omitted export in the subprocess fixture’s prepared-entrypoint substitute; it now forwards the canonical child marker while preserving prepared worker locations. The existing JSON case failed before that fix, then all 16 process cases passed. A separate documentation expectation failure was repaired upstream in #144037. Independent review has no accepted actionable P0–P2 findings; the fixture follow-up is scoped-clean through P2. Fresh full CI must pass before landing. This is not a live installed-package update or a claim that the eight-minute CI objective is complete.
