### PR TITLE
refactor: test provider HTTP policy through shared owners

### DIFF
--- a/extensions/deepinfra/image-generation-provider.test.ts
+++ b/extensions/deepinfra/image-generation-provider.test.ts
@@ -44,12 +44,12 @@ describe("deepinfra image generation provider", () => {
   it("sends OpenAI-compatible image generation requests and sniffs JPEG output", async () => {
     const release = vi.fn(async () => {});
     const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({
         data: [{ b64_json: jpegBytes.toString("base64"), revised_prompt: "red square" }],
       }),
       release,
-    });
+    }));
 
     const provider = buildDeepInfraImageGenerationProvider();
     const result = await provider.generateImage({
@@ -127,7 +127,7 @@ describe("deepinfra image generation provider", () => {
   });
 
   it("sends image edits as multipart OpenAI-compatible requests", async () => {
-    postMultipartRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockImplementation(async () => ({
       response: Response.json({
         data: [
           {
@@ -138,7 +138,7 @@ describe("deepinfra image generation provider", () => {
         ],
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildDeepInfraImageGenerationProvider();
     const result = await provider.generateImage({

--- a/extensions/deepinfra/video-generation-provider.test.ts
+++ b/extensions/deepinfra/video-generation-provider.test.ts
@@ -25,10 +25,10 @@ beforeAll(async () => {
 installProviderHttpMockCleanup();
 
 function mockSubmit(job: unknown, release = vi.fn(async () => {})): typeof release {
-  postJsonRequestMock.mockResolvedValue({
-    response: { json: async () => job },
+  postJsonRequestMock.mockImplementation(async () => ({
+    response: Response.json(job),
     release,
-  });
+  }));
   return release;
 }
 
@@ -49,100 +49,110 @@ describe("deepinfra video generation provider", () => {
   });
 
   it("submits an OpenAI video job, polls until succeeded, and returns the hosted output URL", async () => {
-    const release = mockSubmit({ id: "videos_abc", status: "queued" });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({ id: "videos_abc", status: "processing" }),
-    });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
-        id: "videos_abc",
-        status: "succeeded",
-        model: "Pixverse/Pixverse-T2V",
-        data: [{ url: "/generated/video.mp4" }],
-      }),
-    });
+    vi.useFakeTimers();
+    try {
+      const release = mockSubmit({ id: "videos_abc", status: "queued" });
+      fetchWithTimeoutMock.mockResolvedValueOnce(
+        Response.json({ id: "videos_abc", status: "processing" }),
+      );
+      fetchWithTimeoutMock.mockResolvedValueOnce(
+        Response.json({
+          id: "videos_abc",
+          status: "succeeded",
+          model: "Pixverse/Pixverse-T2V",
+          data: [{ url: "/generated/video.mp4" }],
+        }),
+      );
 
-    const provider = buildDeepInfraVideoGenerationProvider();
-    const result = await provider.generateVideo({
-      provider: "deepinfra",
-      model: "deepinfra/Pixverse/Pixverse-T2V",
-      prompt: "A bicycle weaving through a rainy neon street",
-      cfg: {},
-      aspectRatio: "16:9",
-      durationSeconds: 8,
-      providerOptions: {
-        seed: 42,
-        negative_prompt: "blur",
-        style: "anime",
-      },
-    });
-
-    expect(resolveProviderHttpRequestConfigMock.mock.calls).toEqual([
-      [
-        {
-          baseUrl: "https://api.deepinfra.com/v1/openai",
-          defaultBaseUrl: "https://api.deepinfra.com/v1/openai",
-          defaultHeaders: {
-            Authorization: "Bearer provider-key",
-            "Content-Type": "application/json",
-          },
-          provider: "deepinfra",
-          capability: "video",
-          transport: "http",
-          request: undefined,
-        },
-      ],
-    ]);
-
-    expect(postJsonRequestMock).toHaveBeenCalledOnce();
-    const postRequest = requireFirstPostJsonRequest(
-      postJsonRequestMock,
-      "DeepInfra video submit request",
-    );
-    const postRequestHeaders = Reflect.get(postRequest ?? {}, "headers");
-    expect(postRequestHeaders).toBeInstanceOf(Headers);
-    expect(Object.fromEntries((postRequestHeaders as Headers).entries())).toEqual({
-      authorization: "Bearer provider-key",
-      "content-type": "application/json",
-    });
-    expect(postRequest).toEqual({
-      url: "https://api.deepinfra.com/v1/openai/videos",
-      headers: postRequestHeaders,
-      body: {
-        model: "Pixverse/Pixverse-T2V",
+      const provider = buildDeepInfraVideoGenerationProvider();
+      const pending = provider.generateVideo({
+        provider: "deepinfra",
+        model: "deepinfra/Pixverse/Pixverse-T2V",
         prompt: "A bicycle weaving through a rainy neon street",
-        aspect_ratio: "16:9",
-        seconds: 8,
-        seed: 42,
-        negative_prompt: "blur",
-        style: "anime",
-      },
-      timeoutMs: 60_000,
-      fetchFn: fetch,
-      allowPrivateNetwork: false,
-      dispatcherPolicy: undefined,
-    });
+        cfg: {},
+        aspectRatio: "16:9",
+        durationSeconds: 8,
+        providerOptions: {
+          seed: 42,
+          negative_prompt: "blur",
+          style: "anime",
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
 
-    expect(pollProviderOperationJsonMock).toHaveBeenCalledOnce();
-    const pollUrls = fetchWithTimeoutMock.mock.calls.map((call) => call[0]);
-    expect(pollUrls).toEqual([
-      "https://api.deepinfra.com/v1/openai/videos/videos_abc",
-      "https://api.deepinfra.com/v1/openai/videos/videos_abc",
-    ]);
+      expect(resolveProviderHttpRequestConfigMock.mock.calls).toEqual([
+        [
+          {
+            baseUrl: "https://api.deepinfra.com/v1/openai",
+            defaultBaseUrl: "https://api.deepinfra.com/v1/openai",
+            defaultHeaders: {
+              Authorization: "Bearer provider-key",
+              "Content-Type": "application/json",
+            },
+            provider: "deepinfra",
+            capability: "video",
+            transport: "http",
+            request: undefined,
+          },
+        ],
+      ]);
 
-    expect(result.videos).toEqual([
-      {
-        url: "https://api.deepinfra.com/generated/video.mp4",
-        mimeType: "video/mp4",
-        fileName: "video-1.mp4",
-      },
-    ]);
-    expect(result.model).toBe("Pixverse/Pixverse-T2V");
-    expect(result.metadata).toEqual({
-      jobId: "videos_abc",
-      status: "succeeded",
-    });
-    expect(release).toHaveBeenCalledOnce();
+      expect(postJsonRequestMock).toHaveBeenCalledOnce();
+      const postRequest = requireFirstPostJsonRequest(
+        postJsonRequestMock,
+        "DeepInfra video submit request",
+      );
+      const postRequestHeaders = Reflect.get(postRequest ?? {}, "headers");
+      expect(postRequestHeaders).toBeInstanceOf(Headers);
+      expect(Object.fromEntries((postRequestHeaders as Headers).entries())).toEqual({
+        authorization: "Bearer provider-key",
+        "content-type": "application/json",
+      });
+      expect(postRequest).toEqual({
+        url: "https://api.deepinfra.com/v1/openai/videos",
+        headers: postRequestHeaders,
+        body: {
+          model: "Pixverse/Pixverse-T2V",
+          prompt: "A bicycle weaving through a rainy neon street",
+          aspect_ratio: "16:9",
+          seconds: 8,
+          seed: 42,
+          negative_prompt: "blur",
+          style: "anime",
+        },
+        timeoutMs: 60_000,
+        fetchFn: fetch,
+        allowPrivateNetwork: false,
+        dispatcherPolicy: undefined,
+      });
+
+      expect(pollProviderOperationJsonMock).toHaveBeenCalledOnce();
+      const pollUrls = fetchWithTimeoutMock.mock.calls.map((call) => call[0]);
+      expect(pollUrls).toEqual([
+        "https://api.deepinfra.com/v1/openai/videos/videos_abc",
+        "https://api.deepinfra.com/v1/openai/videos/videos_abc",
+      ]);
+
+      expect(result.videos).toEqual([
+        {
+          url: "https://api.deepinfra.com/generated/video.mp4",
+          mimeType: "video/mp4",
+          fileName: "video-1.mp4",
+        },
+      ]);
+      expect(result.model).toBe("Pixverse/Pixverse-T2V");
+      expect(result.metadata).toEqual({
+        jobId: "videos_abc",
+        status: "succeeded",
+      });
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("applies configured request policy to OpenAI-compatible video requests", async () => {
@@ -385,9 +395,9 @@ describe("deepinfra video generation provider", () => {
 
   it("throws the job error when the video generation fails", async () => {
     mockSubmit({ id: "videos_fail", status: "queued" });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({ id: "videos_fail", status: "failed", error: "model overloaded" }),
-    });
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({ id: "videos_fail", status: "failed", error: "model overloaded" }),
+    );
 
     const provider = buildDeepInfraVideoGenerationProvider();
     await expect(
@@ -402,14 +412,10 @@ describe("deepinfra video generation provider", () => {
 
   it("reports malformed submit JSON as a provider error", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => {
-          throw new SyntaxError("Unexpected token");
-        },
-      },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: new Response("{", { headers: { "content-type": "application/json" } }),
       release,
-    });
+    }));
 
     const provider = buildDeepInfraVideoGenerationProvider();
     await expect(

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -32,32 +32,29 @@ beforeAll(async () => {
 installProviderHttpMockCleanup();
 
 function googleTtsResponse(audio: Buffer | string = Buffer.from([1, 0, 2, 0])) {
-  return {
-    ok: true,
-    json: async () => ({
-      candidates: [
-        {
-          content: {
-            parts: [
-              {
-                inlineData: {
-                  mimeType: "audio/L16;codec=pcm;rate=24000",
-                  data: typeof audio === "string" ? audio : audio.toString("base64"),
-                },
+  return Response.json({
+    candidates: [
+      {
+        content: {
+          parts: [
+            {
+              inlineData: {
+                mimeType: "audio/L16;codec=pcm;rate=24000",
+                data: typeof audio === "string" ? audio : audio.toString("base64"),
               },
-            ],
-          },
+            },
+          ],
         },
-      ],
-    }),
-  };
+      },
+    ],
+  });
 }
 
 function installGoogleTtsRequestMock(pcm = Buffer.from([1, 0, 2, 0])) {
-  postJsonRequestMock.mockResolvedValue({
+  postJsonRequestMock.mockImplementation(async () => ({
     response: googleTtsResponse(pcm),
     release: vi.fn(async () => {}),
-  });
+  }));
   return postJsonRequestMock;
 }
 
@@ -305,10 +302,7 @@ describe("Google speech provider", () => {
     const requestSequence = vi
       .fn()
       .mockResolvedValueOnce({
-        response: {
-          ok: true,
-          json: async () => ({ candidates: [{ content: { parts: [{ text: "not audio" }] } }] }),
-        },
+        response: Response.json({ candidates: [{ content: { parts: [{ text: "not audio" }] } }] }),
         release: vi.fn(async () => {}),
       })
       .mockResolvedValueOnce({
@@ -333,11 +327,11 @@ describe("Google speech provider", () => {
   });
 
   it("rejects Gemini audio with non-canonical base64 pad bits", async () => {
-    const malformedResponse = {
+    const malformedResponse = async () => ({
       response: googleTtsResponse("ZE=="),
       release: vi.fn(async () => {}),
-    };
-    const requestSequence = vi.fn().mockResolvedValue(malformedResponse);
+    });
+    const requestSequence = vi.fn().mockImplementation(malformedResponse);
     postJsonRequestMock.mockImplementation(requestSequence);
     const provider = buildGoogleSpeechProvider();
 
@@ -360,11 +354,11 @@ describe("Google speech provider", () => {
     const pcmBase64url = pcm.toString("base64url");
     expect(pcmBase64url).toMatch(/[-_]/);
     expect(pcmBase64url).not.toMatch(/[+/]/);
-    const response = {
+    const response = async () => ({
       response: googleTtsResponse(pcmBase64url),
       release: vi.fn(async () => {}),
-    };
-    const requestSequence = vi.fn().mockResolvedValue(response);
+    });
+    const requestSequence = vi.fn().mockImplementation(response);
     postJsonRequestMock.mockImplementation(requestSequence);
     const provider = buildGoogleSpeechProvider();
 
@@ -383,11 +377,11 @@ describe("Google speech provider", () => {
   });
 
   it("rejects Gemini audio with a mixed base64 alphabet", async () => {
-    const malformedResponse = {
+    const malformedResponse = async () => ({
       response: googleTtsResponse("aGVsbG8+_"),
       release: vi.fn(async () => {}),
-    };
-    const requestSequence = vi.fn().mockResolvedValue(malformedResponse);
+    });
+    const requestSequence = vi.fn().mockImplementation(malformedResponse);
     postJsonRequestMock.mockImplementation(requestSequence);
     const provider = buildGoogleSpeechProvider();
 
@@ -715,7 +709,7 @@ describe("Google speech provider", () => {
         "Google TTS failed (429): Quota exceeded [code=RESOURCE_EXHAUSTED] [request_id=google_req_123]",
       ),
     );
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: new Response(
         JSON.stringify({
           error: {
@@ -729,7 +723,7 @@ describe("Google speech provider", () => {
         },
       ),
       release: vi.fn(async () => {}),
-    });
+    }));
     const provider = buildGoogleSpeechProvider();
 
     await expect(

--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -16,21 +16,21 @@ const {
 installProviderHttpMockCleanup();
 
 function mockGeneratedPngResponse() {
-  postJsonRequestMock.mockResolvedValue({
+  postJsonRequestMock.mockImplementation(async () => ({
     response: Response.json({
       data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
     }),
     release: vi.fn(async () => {}),
-  });
+  }));
 }
 
 function mockEditedPngResponse() {
-  postMultipartRequestMock.mockResolvedValue({
+  postMultipartRequestMock.mockImplementation(async () => ({
     response: Response.json({
       data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
     }),
     release: vi.fn(async () => {}),
-  });
+  }));
 }
 
 function mockObjectArg(mock: unknown, index = -1): Record<string, unknown> {

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -222,19 +222,20 @@ describe("openai video generation provider", () => {
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "vid_123",
           model: "sora-2",
           status: "completed",
           seconds: "4",
           size: "720x1280",
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/webm" }),
-        arrayBuffer: async () => Buffer.from("webm-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("webm-bytes"), {
+          headers: new Headers({ "content-type": "video/webm" }),
+        }),
+      );
 
     const provider = buildOpenAIVideoGenerationProvider(modelAuth);
     const result = await provider.generateVideo({
@@ -591,13 +592,13 @@ describe("openai video generation provider", () => {
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "vid_too_large",
           model: "sora-2",
           status: "completed",
         }),
-      })
+      )
       .mockResolvedValueOnce(streamedVideoResponse("too-large"));
 
     const provider = buildOpenAIVideoGenerationProvider(modelAuth);
@@ -621,17 +622,18 @@ describe("openai video generation provider", () => {
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "vid_456",
           model: "sora-2",
           status: "completed",
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildOpenAIVideoGenerationProvider(modelAuth);
     const input = Buffer.from("!png-bytes?").subarray(1, -1);
@@ -670,17 +672,18 @@ describe("openai video generation provider", () => {
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "vid_local",
           model: "sora-2",
           status: "completed",
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildOpenAIVideoGenerationProvider(modelAuth);
     await provider.generateVideo({
@@ -716,13 +719,13 @@ describe("openai video generation provider", () => {
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "vid_local",
           model: "sora-2",
           status: "completed",
         }),
-      })
+      )
       .mockResolvedValueOnce({
         headers: new Headers({ "content-type": "video/mp4" }),
         arrayBuffer: async () => Buffer.from("mp4-bytes"),
@@ -777,9 +780,8 @@ describe("openai video generation provider", () => {
     const secondRelease = vi.fn(async () => {});
     assertOkOrThrowHttpErrorMock
       .mockImplementationOnce(async () => {})
-      .mockImplementationOnce(async () => {})
       .mockImplementationOnce(async (_response, label) => {
-        throw new Error(label);
+        throw Object.assign(new Error(label), { status: _response.status });
       })
       .mockImplementationOnce(async () => {});
     postMultipartRequestMock.mockResolvedValueOnce({
@@ -790,13 +792,13 @@ describe("openai video generation provider", () => {
       }),
       release: vi.fn(async () => {}),
     });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "completed",
       }),
-    });
+    );
     fetchWithTimeoutGuardedMock
       .mockResolvedValueOnce({
         response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
@@ -834,6 +836,7 @@ describe("openai video generation provider", () => {
     expect(executeProviderOperationWithRetryMock).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "openai", stage: "download" }),
     );
+    expect(postMultipartRequestMock).toHaveBeenCalledOnce();
     expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
     expect(firstRelease).toHaveBeenCalledTimes(1);
     expect(secondRelease).toHaveBeenCalledTimes(1);
@@ -844,12 +847,11 @@ describe("openai video generation provider", () => {
     const secondRelease = vi.fn(async () => {});
     assertOkOrThrowHttpErrorMock
       .mockImplementationOnce(async () => {})
-      .mockImplementationOnce(async () => {})
       .mockImplementationOnce(async (_response, label) => {
-        throw new Error(label);
+        throw Object.assign(new Error(label), { status: _response.status });
       })
       .mockImplementationOnce(async (_response, label) => {
-        throw new Error(label);
+        throw Object.assign(new Error(label), { status: _response.status });
       });
     postMultipartRequestMock.mockResolvedValueOnce({
       response: streamedJsonResponse({
@@ -859,13 +861,13 @@ describe("openai video generation provider", () => {
       }),
       release: vi.fn(async () => {}),
     });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "completed",
       }),
-    });
+    );
     fetchWithTimeoutGuardedMock
       .mockResolvedValueOnce({
         response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
@@ -898,6 +900,7 @@ describe("openai video generation provider", () => {
       }),
     ).rejects.toThrow("OpenAI video download failed");
 
+    expect(postMultipartRequestMock).toHaveBeenCalledOnce();
     expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
     expect(firstRelease).toHaveBeenCalledTimes(1);
     expect(secondRelease).toHaveBeenCalledTimes(1);
@@ -919,10 +922,11 @@ describe("openai video generation provider", () => {
           status: "completed",
         }),
       )
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildOpenAIVideoGenerationProvider(modelAuth);
     const input = Buffer.from("!mp4-bytes?").subarray(1, -1);
@@ -983,10 +987,11 @@ describe("openai video generation provider", () => {
       .mockResolvedValueOnce(
         streamedJsonResponse({ id: "vid_edit_completed", model: "sora-2", status: "completed" }),
       )
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("completed-edit"),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("completed-edit"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const result = await buildOpenAIVideoGenerationProvider(modelAuth).generateVideo({
       provider: "openai",

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -31,9 +31,7 @@ const {
 
 let buildOpenAIVideoGenerationProvider: typeof import("./video-generation-provider.js").buildOpenAIVideoGenerationProvider;
 
-let modelAuth: Parameters<
-  typeof import("./video-generation-provider.js").buildOpenAIVideoGenerationProvider
->[0];
+let modelAuth: Parameters<typeof buildOpenAIVideoGenerationProvider>[0];
 
 beforeAll(async () => {
   modelAuth = createCapturedPluginRegistration().api.runtime.modelAuth;
@@ -106,12 +104,6 @@ function streamedVideoResponse(bytes: string): Response {
     }),
     { headers: { "content-type": "video/mp4" } },
   );
-}
-
-// Response.json keeps object fixtures on the standard Response body path so the
-// create read exercises the byte-bounded reader instead of an unbounded res.json().
-function streamedJsonResponse(payload: unknown): Response {
-  return Response.json(payload);
 }
 
 describe("openai video generation provider", () => {
@@ -213,56 +205,61 @@ describe("openai video generation provider", () => {
   });
 
   it("uses SDK-compatible multipart for text-only Sora requests", async () => {
-    postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
-        id: "vid_123",
-        model: "sora-2",
-        status: "queued",
-      }),
-      release: vi.fn(async () => {}),
-    });
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce(
-        Response.json({
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    try {
+      postMultipartRequestMock.mockResolvedValueOnce({
+        response: Response.json({
           id: "vid_123",
           model: "sora-2",
-          status: "completed",
-          seconds: "4",
-          size: "720x1280",
+          status: "queued",
         }),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("webm-bytes"), {
-          headers: new Headers({ "content-type": "video/webm" }),
-        }),
-      );
+        release: vi.fn(async () => {}),
+      });
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          Response.json({
+            id: "vid_123",
+            model: "sora-2",
+            status: "completed",
+            seconds: "4",
+            size: "720x1280",
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(Buffer.from("webm-bytes"), {
+            headers: new Headers({ "content-type": "video/webm" }),
+          }),
+        );
 
-    const provider = buildOpenAIVideoGenerationProvider(modelAuth);
-    const result = await provider.generateVideo({
-      provider: "openai",
-      model: "sora-2",
-      prompt: "A paper airplane gliding through golden hour light",
-      cfg: {},
-      durationSeconds: 4,
-    });
+      const provider = buildOpenAIVideoGenerationProvider(modelAuth);
+      const result = await provider.generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "A paper airplane gliding through golden hour light",
+        cfg: {},
+        durationSeconds: 4,
+      });
 
-    const createRequest = postMultipartRequest();
-    expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
-    const form = createRequest.body as FormData;
-    expect(form.get("prompt")).toBe("A paper airplane gliding through golden hour light");
-    expect(form.get("model")).toBe("sora-2");
-    expect(form.get("seconds")).toBe("4");
-    expect(form.get("input_reference")).toBeNull();
-    const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
-    expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_123");
-    expect(pollInit?.method).toBe("GET");
-    expect(pollTimeout).toBe(120000);
-    expect(pollFetch).toBe(fetch);
-    expect(result.videos).toHaveLength(1);
-    expect(result.videos[0]?.mimeType).toBe("video/webm");
-    expect(result.videos[0]?.fileName).toBe("video-1.webm");
-    expect(result.metadata?.videoId).toBe("vid_123");
-    expect(result.metadata?.status).toBe("completed");
+      const createRequest = postMultipartRequest();
+      expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
+      const form = createRequest.body as FormData;
+      expect(form.get("prompt")).toBe("A paper airplane gliding through golden hour light");
+      expect(form.get("model")).toBe("sora-2");
+      expect(form.get("seconds")).toBe("4");
+      expect(form.get("input_reference")).toBeNull();
+      const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
+      expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_123");
+      expect(pollInit?.method).toBe("GET");
+      expect(pollTimeout).toBe(120000);
+      expect(pollFetch).toBe(fetch);
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0]?.mimeType).toBe("video/webm");
+      expect(result.videos[0]?.fileName).toBe("video-1.webm");
+      expect(result.metadata?.videoId).toBe("vid_123");
+      expect(result.metadata?.status).toBe("completed");
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it.each(["vid_failed", undefined])(
@@ -270,7 +267,7 @@ describe("openai video generation provider", () => {
     async (videoId) => {
       const release = vi.fn(async () => {});
       postMultipartRequestMock.mockResolvedValueOnce({
-        response: streamedJsonResponse({
+        response: Response.json({
           ...(videoId ? { id: videoId } : {}),
           status: "failed",
           error: { message: "OpenAI video generation was rejected" },
@@ -297,7 +294,7 @@ describe("openai video generation provider", () => {
     const release = vi.fn(async () => {});
     const cancel = vi.fn();
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_completed",
         model: "sora-2",
         status: "completed",
@@ -356,7 +353,7 @@ describe("openai video generation provider", () => {
       const submissionRelease = vi.fn(async () => {});
       const downloadRelease = vi.fn(async () => {});
       postMultipartRequestMock.mockResolvedValueOnce({
-        response: streamedJsonResponse({
+        response: Response.json({
           id: "vid_malformed",
           model: "sora-2",
           status: "completed",
@@ -412,7 +409,7 @@ describe("openai video generation provider", () => {
         },
         async (baseUrl) => {
           postMultipartRequestMock.mockResolvedValueOnce({
-            response: streamedJsonResponse({ id: "vid_unread", status: "completed" }),
+            response: Response.json({ id: "vid_unread", status: "completed" }),
             release: vi.fn(async () => {}),
           });
           const upstreamUrl = `${baseUrl}/videos/vid_unread/content`;
@@ -485,7 +482,7 @@ describe("openai video generation provider", () => {
       const submissionRelease = vi.fn(async () => {});
       const downloadRelease = vi.fn(async () => {});
       postMultipartRequestMock.mockResolvedValueOnce({
-        response: streamedJsonResponse({ id: "vid_cloned", status: "completed" }),
+        response: Response.json({ id: "vid_cloned", status: "completed" }),
         release: submissionRelease,
       });
       if (allowPrivateNetwork) {
@@ -552,7 +549,7 @@ describe("openai video generation provider", () => {
       });
       const submissionRelease = vi.fn(async () => {});
       postMultipartRequestMock.mockResolvedValueOnce({
-        response: streamedJsonResponse({ id: "vid_cancel_failed", status: "completed" }),
+        response: Response.json({ id: "vid_cancel_failed", status: "completed" }),
         release: submissionRelease,
       });
       fetchWithTimeoutMock.mockResolvedValueOnce(
@@ -584,7 +581,7 @@ describe("openai video generation provider", () => {
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_too_large",
         model: "sora-2",
         status: "queued",
@@ -613,58 +610,63 @@ describe("openai video generation provider", () => {
   });
 
   it("uploads the SDK-compatible image reference in a multipart video request", async () => {
-    postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
-        id: "vid_456",
-        model: "sora-2",
-        status: "queued",
-      }),
-      release: vi.fn(async () => {}),
-    });
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce(
-        Response.json({
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    try {
+      postMultipartRequestMock.mockResolvedValueOnce({
+        response: Response.json({
           id: "vid_456",
           model: "sora-2",
-          status: "completed",
+          status: "queued",
         }),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("mp4-bytes"), {
-          headers: new Headers({ "content-type": "video/mp4" }),
-        }),
-      );
+        release: vi.fn(async () => {}),
+      });
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          Response.json({
+            id: "vid_456",
+            model: "sora-2",
+            status: "completed",
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(Buffer.from("mp4-bytes"), {
+            headers: new Headers({ "content-type": "video/mp4" }),
+          }),
+        );
 
-    const provider = buildOpenAIVideoGenerationProvider(modelAuth);
-    const input = Buffer.from("!png-bytes?").subarray(1, -1);
-    await provider.generateVideo({
-      provider: "openai",
-      model: "sora-2",
-      prompt: "Animate this frame",
-      cfg: {},
-      inputImages: [{ buffer: input, mimeType: "image/png" }],
-    });
-    input.fill(0);
+      const provider = buildOpenAIVideoGenerationProvider(modelAuth);
+      const input = Buffer.from("!png-bytes?").subarray(1, -1);
+      await provider.generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "Animate this frame",
+        cfg: {},
+        inputImages: [{ buffer: input, mimeType: "image/png" }],
+      });
+      input.fill(0);
 
-    const createRequest = postMultipartRequest();
-    expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
-    const form = createRequest.body as FormData;
-    const reference = form.get("input_reference");
-    expect(reference).toBeInstanceOf(File);
-    const referenceFile = reference as File;
-    expect(referenceFile.name).toBe("reference-image.png");
-    expect(referenceFile.type).toBe("image/png");
-    expect(Buffer.from(await referenceFile.arrayBuffer())).toEqual(Buffer.from("png-bytes"));
-    const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
-    expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_456");
-    expect(pollInit?.method).toBe("GET");
-    expect(pollTimeout).toBe(120000);
-    expect(pollFetch).toBe(fetch);
+      const createRequest = postMultipartRequest();
+      expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
+      const form = createRequest.body as FormData;
+      const reference = form.get("input_reference");
+      expect(reference).toBeInstanceOf(File);
+      const referenceFile = reference as File;
+      expect(referenceFile.name).toBe("reference-image.png");
+      expect(referenceFile.type).toBe("image/png");
+      expect(Buffer.from(await referenceFile.arrayBuffer())).toEqual(Buffer.from("png-bytes"));
+      const [pollUrl, pollInit, pollTimeout, pollFetch] = fetchWithTimeoutCall(0);
+      expect(pollUrl).toBe("https://api.openai.com/v1/videos/vid_456");
+      expect(pollInit?.method).toBe("GET");
+      expect(pollTimeout).toBe(120000);
+      expect(pollFetch).toBe(fetch);
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("keeps configured local baseUrl private-network blocked unless explicitly enabled", async () => {
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "queued",
@@ -711,7 +713,7 @@ describe("openai video generation provider", () => {
 
   it("honors configured request allowPrivateNetwork for local video providers", async () => {
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "queued",
@@ -785,7 +787,7 @@ describe("openai video generation provider", () => {
       })
       .mockImplementationOnce(async () => {});
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "queued",
@@ -854,7 +856,7 @@ describe("openai video generation provider", () => {
         throw Object.assign(new Error(label), { status: _response.status });
       });
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_local",
         model: "sora-2",
         status: "queued",
@@ -909,14 +911,14 @@ describe("openai video generation provider", () => {
   it("uses the video edits endpoint for video-to-video uploads", async () => {
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
-        streamedJsonResponse({
+        Response.json({
           id: "vid_789",
           model: "sora-2",
           status: "queued",
         }),
       )
       .mockResolvedValueOnce(
-        streamedJsonResponse({
+        Response.json({
           id: "vid_789",
           model: "sora-2",
           status: "completed",
@@ -959,7 +961,7 @@ describe("openai video generation provider", () => {
   it("surfaces an immediately failed OpenAI video edit without polling it", async () => {
     const release = vi.fn(async () => {});
     postMultipartRequestMock.mockResolvedValueOnce({
-      response: streamedJsonResponse({
+      response: Response.json({
         id: "vid_edit_failed",
         status: "failed",
         error: { message: "OpenAI video edit was rejected" },
@@ -985,7 +987,7 @@ describe("openai video generation provider", () => {
   it("downloads an immediately completed OpenAI video edit without polling it again", async () => {
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
-        streamedJsonResponse({ id: "vid_edit_completed", model: "sora-2", status: "completed" }),
+        Response.json({ id: "vid_edit_completed", model: "sora-2", status: "completed" }),
       )
       .mockResolvedValueOnce(
         new Response(Buffer.from("completed-edit"), {
@@ -1009,14 +1011,14 @@ describe("openai video generation provider", () => {
   it("honors configured request allowPrivateNetwork for multipart video uploads", async () => {
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
-        streamedJsonResponse({
+        Response.json({
           id: "vid_789",
           model: "sora-2",
           status: "queued",
         }),
       )
       .mockResolvedValueOnce(
-        streamedJsonResponse({
+        Response.json({
           id: "vid_789",
           model: "sora-2",
           status: "completed",

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -87,26 +87,24 @@ describe("openrouter image generation provider", () => {
 
   it("preserves chat-completion image requests for configured custom bases", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          choices: [
-            {
-              message: {
-                images: [
-                  {
-                    imageUrl: {
-                      url: `data:image/png;base64,${Buffer.from("png-one").toString("base64")}`,
-                    },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: Response.json({
+        choices: [
+          {
+            message: {
+              images: [
+                {
+                  imageUrl: {
+                    url: `data:image/png;base64,${Buffer.from("png-one").toString("base64")}`,
                   },
-                ],
-              },
+                },
+              ],
             },
-          ],
-        }),
-      },
+          },
+        ],
+      }),
       release,
-    });
+    }));
 
     const provider = buildOpenRouterImageGenerationProvider();
     const result = await provider.generateImage({
@@ -210,7 +208,7 @@ describe("openrouter image generation provider", () => {
       };
     });
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({
         choices: [
           {
@@ -221,7 +219,7 @@ describe("openrouter image generation provider", () => {
         ],
       }),
       release,
-    });
+    }));
 
     const result = await buildOpenRouterImageGenerationProvider().generateImage({
       provider: "openrouter",
@@ -262,12 +260,12 @@ describe("openrouter image generation provider", () => {
 
   it("uses a 180s default timeout when no request timeout is provided", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({
         data: [{ b64_json: Buffer.from("png-one").toString("base64") }],
       }),
       release,
-    });
+    }));
 
     const provider = buildOpenRouterImageGenerationProvider();
     await provider.generateImage({
@@ -286,12 +284,12 @@ describe("openrouter image generation provider", () => {
   });
 
   it("normalizes the official legacy base before selecting the dedicated route", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({
         data: [{ b64_json: Buffer.from("png-one").toString("base64") }],
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     await buildOpenRouterImageGenerationProvider().generateImage({
       provider: "openrouter",
@@ -313,7 +311,7 @@ describe("openrouter image generation provider", () => {
   });
 
   it("sends canonical reference images as input_references", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({
         data: [
           {
@@ -323,7 +321,7 @@ describe("openrouter image generation provider", () => {
         ],
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildOpenRouterImageGenerationProvider();
     const result = await provider.generateImage({
@@ -424,10 +422,10 @@ describe("openrouter image generation provider", () => {
   });
 
   it("wraps wrong-shape successful dedicated image responses", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: Response.json({ data: { b64_json: "bad-shape" } }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildOpenRouterImageGenerationProvider();
     await expect(
@@ -443,25 +441,23 @@ describe("openrouter image generation provider", () => {
   it("extracts image fallbacks from string content and raw b64 parts", async () => {
     const png = Buffer.from("png-inline").toString("base64");
     const raw = Buffer.from("raw-inline").toString("base64");
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          choices: [
-            {
-              message: {
-                content: `done data:image/png;base64,${png}`,
-              },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: Response.json({
+        choices: [
+          {
+            message: {
+              content: `done data:image/png;base64,${png}`,
             },
-            {
-              message: {
-                content: [{ b64_json: raw }],
-              },
+          },
+          {
+            message: {
+              content: [{ b64_json: raw }],
             },
-          ],
-        }),
-      },
+          },
+        ],
+      }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const result = await buildOpenRouterImageGenerationProvider().generateImage({
       provider: "openrouter",
@@ -477,20 +473,18 @@ describe("openrouter image generation provider", () => {
   });
 
   it("rejects invalid raw image parts in strict extraction mode", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          choices: [
-            {
-              message: {
-                content: [{ b64_json: "not-base64!" }],
-              },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: Response.json({
+        choices: [
+          {
+            message: {
+              content: [{ b64_json: "not-base64!" }],
             },
-          ],
-        }),
-      },
+          },
+        ],
+      }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     await expect(
       buildOpenRouterImageGenerationProvider().generateImage({

--- a/extensions/pixverse/video-generation-provider.test.ts
+++ b/extensions/pixverse/video-generation-provider.test.ts
@@ -59,14 +59,14 @@ function pollFetchHeaders(callIndex: number): Headers | undefined {
 }
 
 function mockPixVerseVideoSubmit(videoId = 123) {
-  postJsonRequestMock.mockResolvedValue({
+  postJsonRequestMock.mockImplementation(async () => ({
     response: streamedJsonResponse({
       ErrCode: 0,
       ErrMsg: "success",
       Resp: { video_id: videoId },
     }),
     release: vi.fn(async () => {}),
-  });
+  }));
 }
 
 function mockPixVerseVideoTask(
@@ -80,21 +80,23 @@ function mockPixVerseVideoTask(
 ) {
   const videoId = params.videoId ?? 123;
   mockPixVerseVideoSubmit(videoId);
-  fetchWithTimeoutMock.mockResolvedValueOnce({
-    json: async () => ({
-      ErrCode: 0,
-      ErrMsg: "success",
-      Resp: {
-        id: videoId,
-        status: 1,
-        url: params.videoUrl ?? "https://media.pixverse.ai/out.mp4",
-        ...(params.seed === undefined ? {} : { seed: params.seed }),
-        ...(params.outputWidth === undefined ? {} : { outputWidth: params.outputWidth }),
-        ...(params.outputHeight === undefined ? {} : { outputHeight: params.outputHeight }),
+  fetchWithTimeoutMock.mockResolvedValueOnce(
+    Response.json(
+      {
+        ErrCode: 0,
+        ErrMsg: "success",
+        Resp: {
+          id: videoId,
+          status: 1,
+          url: params.videoUrl ?? "https://media.pixverse.ai/out.mp4",
+          ...(params.seed === undefined ? {} : { seed: params.seed }),
+          ...(params.outputWidth === undefined ? {} : { outputWidth: params.outputWidth }),
+          ...(params.outputHeight === undefined ? {} : { outputHeight: params.outputHeight }),
+        },
       },
-    }),
-    headers: new Headers(),
-  });
+      { headers: new Headers() },
+    ),
+  );
 }
 
 describe("pixverse video generation provider", () => {
@@ -264,14 +266,14 @@ describe("pixverse video generation provider", () => {
   });
 
   it("uploads local image input before submitting image-to-video", async () => {
-    postMultipartRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         ErrCode: 0,
         ErrMsg: "success",
         Resp: { img_id: 456, img_url: "https://media.pixverse.ai/image.png" },
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     mockPixVerseVideoTask({ videoId: 789, videoUrl: "https://media.pixverse.ai/i2v.mp4" });
 
     const provider = buildPixVerseVideoGenerationProvider();
@@ -309,14 +311,14 @@ describe("pixverse video generation provider", () => {
   });
 
   it("uploads remote image URLs through PixVerse image upload", async () => {
-    postMultipartRequestMock.mockResolvedValue({
+    postMultipartRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         ErrCode: 0,
         ErrMsg: "success",
         Resp: { img_id: 111 },
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     mockPixVerseVideoTask({ videoId: 222, videoUrl: "https://media.pixverse.ai/remote.mp4" });
 
     const provider = buildPixVerseVideoGenerationProvider();
@@ -335,13 +337,13 @@ describe("pixverse video generation provider", () => {
   });
 
   it("rejects PixVerse API errors before polling", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         ErrCode: 400017,
         ErrMsg: "Invalid parameter",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildPixVerseVideoGenerationProvider();
     await expect(
@@ -357,14 +359,16 @@ describe("pixverse video generation provider", () => {
 
   it("reports PixVerse moderation failures from status polling", async () => {
     mockPixVerseVideoSubmit(333);
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
-        ErrCode: 0,
-        ErrMsg: "success",
-        Resp: { id: 333, status: 7 },
-      }),
-      headers: new Headers(),
-    });
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json(
+        {
+          ErrCode: 0,
+          ErrMsg: "success",
+          Resp: { id: 333, status: 7 },
+        },
+        { headers: new Headers() },
+      ),
+    );
 
     const provider = buildPixVerseVideoGenerationProvider();
     await expect(
@@ -476,37 +480,51 @@ describe("pixverse video generation provider", () => {
   });
 
   it("uses a fresh trace id for each status poll", async () => {
-    mockPixVerseVideoSubmit();
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
-          ErrCode: 0,
-          ErrMsg: "success",
-          Resp: { id: 123, status: 5 },
-        }),
-        headers: new Headers(),
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
-          ErrCode: 0,
-          ErrMsg: "success",
-          Resp: { id: 123, status: 1, url: "https://media.pixverse.ai/out.mp4" },
-        }),
-        headers: new Headers(),
+    vi.useFakeTimers();
+    try {
+      mockPixVerseVideoSubmit();
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          Response.json(
+            {
+              ErrCode: 0,
+              ErrMsg: "success",
+              Resp: { id: 123, status: 5 },
+            },
+            { headers: new Headers() },
+          ),
+        )
+        .mockResolvedValueOnce(
+          Response.json(
+            {
+              ErrCode: 0,
+              ErrMsg: "success",
+              Resp: { id: 123, status: 1, url: "https://media.pixverse.ai/out.mp4" },
+            },
+            { headers: new Headers() },
+          ),
+        );
+
+      const provider = buildPixVerseVideoGenerationProvider();
+      const pending = provider.generateVideo({
+        provider: "pixverse",
+        model: "v6",
+        prompt: "fresh trace ids",
+        cfg: {},
       });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
 
-    const provider = buildPixVerseVideoGenerationProvider();
-    await provider.generateVideo({
-      provider: "pixverse",
-      model: "v6",
-      prompt: "fresh trace ids",
-      cfg: {},
-    });
-
-    const firstHeaders = pollFetchHeaders(0);
-    const secondHeaders = pollFetchHeaders(1);
-    expect(firstHeaders?.get("Ai-trace-id")).toMatch(/^[0-9a-f-]{36}$/u);
-    expect(secondHeaders?.get("Ai-trace-id")).toMatch(/^[0-9a-f-]{36}$/u);
-    expect(secondHeaders?.get("Ai-trace-id")).not.toBe(firstHeaders?.get("Ai-trace-id"));
+      const firstHeaders = pollFetchHeaders(0);
+      const secondHeaders = pollFetchHeaders(1);
+      expect(firstHeaders?.get("Ai-trace-id")).toMatch(/^[0-9a-f-]{36}$/u);
+      expect(secondHeaders?.get("Ai-trace-id")).toMatch(/^[0-9a-f-]{36}$/u);
+      expect(secondHeaders?.get("Ai-trace-id")).not.toBe(firstHeaders?.get("Ai-trace-id"));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/qwen/video-generation-provider.test.ts
+++ b/extensions/qwen/video-generation-provider.test.ts
@@ -353,25 +353,25 @@ describe("qwen video generation provider", () => {
   });
 
   it("rejects DashScope video downloads that exceed the configured media cap", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => ({
-          request_id: "req-too-large",
-          output: { task_id: "task-too-large" },
-        }),
-      },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: Response.json({
+        request_id: "req-too-large",
+        output: { task_id: "task-too-large" },
+      }),
       release: async () => {},
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
-          output: {
-            task_status: "SUCCEEDED",
-            results: [{ video_url: "https://example.com/too-large.mp4" }],
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            output: {
+              task_status: "SUCCEEDED",
+              results: [{ video_url: "https://example.com/too-large.mp4" }],
+            },
           },
-        }),
-        headers: new Headers(),
-      })
+          { headers: new Headers() },
+        ),
+      )
       .mockResolvedValueOnce(streamedVideoResponse("too-large"));
 
     const provider = qwenVideoGenerationProvider;

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -135,12 +135,12 @@ describe("runway video generation provider", () => {
   });
 
   it("submits a text-to-video task, polls it, and downloads the output", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "task-1",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -149,10 +149,11 @@ describe("runway video generation provider", () => {
           output: ["https://example.com/out.mp4"],
         }),
       )
-      .mockResolvedValueOnce({
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-        headers: new Headers({ "content-type": "video/webm" }),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/webm" }),
+        }),
+      );
 
     const provider = buildRunwayVideoGenerationProvider();
     const result = await provider.generateVideo({
@@ -197,10 +198,10 @@ describe("runway video generation provider", () => {
     { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
     { name: "empty video", contentType: "video/mp4", body: "" },
   ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-invalid-download" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -223,10 +224,10 @@ describe("runway video generation provider", () => {
 
   it("cancels the unread response body when a generated-video MIME type is rejected", async () => {
     const canceled = vi.fn();
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-open-response" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -259,10 +260,10 @@ describe("runway video generation provider", () => {
   });
 
   it("releases a rejected download body without awaiting a debug-capture tee branch", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-captured-response" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     // The debug proxy clones every captured response, so the caller-facing body is one
     // branch of a live tee. Cancelling such a branch settles only once both branches
     // cancel, so awaiting it here would hang the download instead of surfacing the error.
@@ -313,10 +314,10 @@ describe("runway video generation provider", () => {
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-too-large" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -339,10 +340,10 @@ describe("runway video generation provider", () => {
   });
 
   it("does not round malformed duration values into create requests", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-duration" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -351,10 +352,11 @@ describe("runway video generation provider", () => {
           output: ["https://example.com/out.mp4"],
         }),
       )
-      .mockResolvedValueOnce({
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-        headers: new Headers({ "content-type": "video/mp4" }),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildRunwayVideoGenerationProvider();
     await provider.generateVideo({
@@ -371,10 +373,10 @@ describe("runway video generation provider", () => {
   });
 
   it("accepts local image buffers by converting them into data URIs", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-2" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
       .mockResolvedValueOnce(
         streamedJsonResponse({
@@ -383,10 +385,11 @@ describe("runway video generation provider", () => {
           output: ["https://example.com/out.mp4"],
         }),
       )
-      .mockResolvedValueOnce({
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-        headers: new Headers({ "content-type": "video/mp4" }),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildRunwayVideoGenerationProvider();
     await provider.generateVideo({
@@ -424,10 +427,10 @@ describe("runway video generation provider", () => {
 
   it("reports malformed create JSON with a provider-owned error", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedRawResponse("{ not json"),
       release,
-    });
+    }));
 
     const provider = buildRunwayVideoGenerationProvider();
     await expect(
@@ -442,10 +445,10 @@ describe("runway video generation provider", () => {
   });
 
   it("rejects status responses missing a task status", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-missing-status" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock.mockResolvedValueOnce(
       streamedJsonResponse({
         id: "task-missing-status",
@@ -465,10 +468,10 @@ describe("runway video generation provider", () => {
   });
 
   it("rejects malformed completed output URLs", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "task-malformed-output" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock.mockResolvedValueOnce(
       streamedJsonResponse({
         id: "task-malformed-output",

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -135,61 +135,66 @@ describe("runway video generation provider", () => {
   });
 
   it("submits a text-to-video task, polls it, and downloads the output", async () => {
-    postJsonRequestMock.mockImplementation(async () => ({
-      response: streamedJsonResponse({
-        id: "task-1",
-      }),
-      release: vi.fn(async () => {}),
-    }));
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce(
-        streamedJsonResponse({
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    try {
+      postJsonRequestMock.mockImplementation(async () => ({
+        response: streamedJsonResponse({
           id: "task-1",
-          status: "SUCCEEDED",
-          output: ["https://example.com/out.mp4"],
         }),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("mp4-bytes"), {
-          headers: new Headers({ "content-type": "video/webm" }),
-        }),
-      );
+        release: vi.fn(async () => {}),
+      }));
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          streamedJsonResponse({
+            id: "task-1",
+            status: "SUCCEEDED",
+            output: ["https://example.com/out.mp4"],
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(Buffer.from("mp4-bytes"), {
+            headers: new Headers({ "content-type": "video/webm" }),
+          }),
+        );
 
-    const provider = buildRunwayVideoGenerationProvider();
-    const result = await provider.generateVideo({
-      provider: "runway",
-      model: "gen4.5",
-      prompt: "a tiny lobster DJ under neon lights",
-      cfg: {},
-      durationSeconds: 4,
-      aspectRatio: "16:9",
-    });
+      const provider = buildRunwayVideoGenerationProvider();
+      const result = await provider.generateVideo({
+        provider: "runway",
+        model: "gen4.5",
+        prompt: "a tiny lobster DJ under neon lights",
+        cfg: {},
+        durationSeconds: 4,
+        aspectRatio: "16:9",
+      });
 
-    expect(postJsonRequestMock).toHaveBeenCalledTimes(1);
-    const createRequest = firstPostJsonRequest();
-    expect(createRequest.url).toBe("https://api.dev.runwayml.com/v1/text_to_video");
-    expect(createRequest.body).toEqual({
-      model: "gen4.5",
-      promptText: "a tiny lobster DJ under neon lights",
-      ratio: "1280:720",
-      duration: 4,
-    });
-    const pollCall = firstFetchWithTimeoutCall();
-    expect(pollCall.url).toBe("https://api.dev.runwayml.com/v1/tasks/task-1");
-    expect(pollCall.init.method).toBe("GET");
-    expect(pollCall.init.headers).toBeInstanceOf(Headers);
-    expect(pollCall.timeoutMs).toBe(120000);
-    expect(pollCall.requestFetch).toBe(fetch);
-    expect(result.videos).toHaveLength(1);
-    const video = result.videos[0];
-    if (!video) {
-      throw new Error("expected Runway generated video");
+      expect(postJsonRequestMock).toHaveBeenCalledTimes(1);
+      const createRequest = firstPostJsonRequest();
+      expect(createRequest.url).toBe("https://api.dev.runwayml.com/v1/text_to_video");
+      expect(createRequest.body).toEqual({
+        model: "gen4.5",
+        promptText: "a tiny lobster DJ under neon lights",
+        ratio: "1280:720",
+        duration: 4,
+      });
+      const pollCall = firstFetchWithTimeoutCall();
+      expect(pollCall.url).toBe("https://api.dev.runwayml.com/v1/tasks/task-1");
+      expect(pollCall.init.method).toBe("GET");
+      expect(pollCall.init.headers).toBeInstanceOf(Headers);
+      expect(pollCall.timeoutMs).toBe(120000);
+      expect(pollCall.requestFetch).toBe(fetch);
+      expect(result.videos).toHaveLength(1);
+      const video = result.videos[0];
+      if (!video) {
+        throw new Error("expected Runway generated video");
+      }
+      expect(video.fileName).toBe("video-1.webm");
+      const metadata = result.metadata as Record<string, unknown>;
+      expect(metadata.taskId).toBe("task-1");
+      expect(metadata.status).toBe("SUCCEEDED");
+      expect(metadata.endpoint).toBe("/v1/text_to_video");
+    } finally {
+      clock.mockRestore();
     }
-    expect(video.fileName).toBe("video-1.webm");
-    const metadata = result.metadata as Record<string, unknown>;
-    expect(metadata.taskId).toBe("task-1");
-    expect(metadata.status).toBe("SUCCEEDED");
-    expect(metadata.endpoint).toBe("/v1/text_to_video");
   });
 
   it.each([

--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -54,25 +54,26 @@ describe("together video generation provider", () => {
   });
 
   it("creates a video, polls completion, and downloads the output", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_123",
         status: "in_progress",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/webm" }),
-        arrayBuffer: async () => Buffer.from("webm-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("webm-bytes"), {
+          headers: new Headers({ "content-type": "video/webm" }),
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     const result = await provider.generateVideo({
@@ -105,14 +106,14 @@ describe("together video generation provider", () => {
     "surfaces an immediately failed Together submission before polling or validating id (%s)",
     async (videoId) => {
       const release = vi.fn(async () => {});
-      postJsonRequestMock.mockResolvedValue({
+      postJsonRequestMock.mockImplementation(async () => ({
         response: streamedJsonResponse({
           ...(videoId ? { id: videoId } : {}),
           status: "failed",
           error: { message: "Together video quota exhausted" },
         }),
         release,
-      });
+      }));
 
       await expect(
         buildTogetherVideoGenerationProvider().generateVideo({
@@ -130,10 +131,10 @@ describe("together video generation provider", () => {
 
   it("uses an actionable fallback when an immediately failed submission omits its error", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ status: "failed", error: null }),
       release,
-    });
+    }));
 
     await expect(
       buildTogetherVideoGenerationProvider().generateVideo({
@@ -150,17 +151,17 @@ describe("together video generation provider", () => {
 
   it("surfaces provider errors from a failed poll and releases the submission", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "video_failed_later", status: "in_progress" }),
       release,
-    });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    }));
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({
         id: "video_failed_later",
         status: "failed",
         error: { message: "Together video content policy blocked this prompt" },
       }),
-    });
+    );
 
     await expect(
       buildTogetherVideoGenerationProvider().generateVideo({
@@ -177,7 +178,7 @@ describe("together video generation provider", () => {
 
   it("downloads an immediately completed Together submission without polling it again", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_completed",
         model: "Wan-AI/Wan2.2-T2V-A14B",
@@ -185,11 +186,12 @@ describe("together video generation provider", () => {
         outputs: { video_url: "https://example.com/completed.mp4" },
       }),
       release,
-    });
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      headers: new Headers({ "content-type": "video/mp4" }),
-      arrayBuffer: async () => Buffer.from("completed-video"),
-    });
+    }));
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      new Response(Buffer.from("completed-video"), {
+        headers: new Headers({ "content-type": "video/mp4" }),
+      }),
+    );
 
     const result = await buildTogetherVideoGenerationProvider().generateVideo({
       provider: "together",
@@ -208,10 +210,10 @@ describe("together video generation provider", () => {
 
   it("rejects an immediately completed submission without a generated video URL", async () => {
     const release = vi.fn(async () => {});
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ id: "video_missing_output", status: "completed" }),
       release,
-    });
+    }));
 
     await expect(
       buildTogetherVideoGenerationProvider().generateVideo({
@@ -251,21 +253,21 @@ describe("together video generation provider", () => {
 
   it("bounds downloaded videos before materializing them", async () => {
     let canceled = false;
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_oversized",
         status: "in_progress",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_oversized",
           status: "completed",
           outputs: { video_url: "https://example.com/oversized.mp4" },
         }),
-      })
+      )
       .mockResolvedValueOnce(
         streamingResponse({
           body: "x".repeat(32),
@@ -294,21 +296,21 @@ describe("together video generation provider", () => {
     { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
     { name: "empty video", contentType: "video/mp4", body: "" },
   ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_invalid_download",
         status: "in_progress",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_invalid_download",
           status: "completed",
           outputs: { video_url: "https://example.com/invalid.mp4" },
         }),
-      })
+      )
       .mockResolvedValueOnce(new Response(body, { headers: { "content-type": contentType } }));
 
     const provider = buildTogetherVideoGenerationProvider();
@@ -323,24 +325,25 @@ describe("together video generation provider", () => {
   });
 
   it("uses the video API endpoint when the shared Together text base URL is configured", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_123",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({
@@ -364,24 +367,25 @@ describe("together video generation provider", () => {
   });
 
   it("drops out-of-range duration values before creating videos", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_123",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({
@@ -419,24 +423,25 @@ describe("together video generation provider", () => {
   });
 
   it("sends reference images for the Together image-to-video model", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({
         id: "video_123",
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           id: "video_123",
           status: "completed",
           outputs: { video_url: "https://example.com/together.mp4" },
         }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildTogetherVideoGenerationProvider();
     await provider.generateVideo({

--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -67,10 +67,10 @@ function requireFetchInitCall(index: number): {
 }
 
 function mockXaiVideoRequest(requestId: string) {
-  postJsonRequestMock.mockResolvedValue({
-    response: { json: async () => ({ request_id: requestId }) },
+  postJsonRequestMock.mockImplementation(async () => ({
+    response: Response.json({ request_id: requestId }),
     release: vi.fn(async () => {}),
-  });
+  }));
 }
 
 function mockXaiVideoTask(params: {
@@ -81,13 +81,13 @@ function mockXaiVideoTask(params: {
 }) {
   mockXaiVideoRequest(params.requestId);
   fetchWithTimeoutMock
-    .mockResolvedValueOnce({
-      json: async () => ({
+    .mockResolvedValueOnce(
+      Response.json({
         request_id: params.requestId,
         status: "done",
         video: { url: params.videoUrl },
       }),
-    })
+    )
     .mockResolvedValueOnce({
       headers: new Headers({ "content-type": params.mimeType ?? "video/mp4" }),
       arrayBuffer: async () => Buffer.from(params.videoBytes),
@@ -153,17 +153,17 @@ describe("xai video generation provider", () => {
     for (const [index, model] of models.entries()) {
       const requestId = `req_15_${index}`;
       postJsonRequestMock.mockResolvedValueOnce({
-        response: { json: async () => ({ request_id: requestId }) },
+        response: Response.json({ request_id: requestId }),
         release: vi.fn(async () => {}),
       });
       fetchWithTimeoutMock
-        .mockResolvedValueOnce({
-          json: async () => ({
+        .mockResolvedValueOnce(
+          Response.json({
             request_id: requestId,
             status: "done",
             video: { url: `https://cdn.x.ai/${requestId}.mp4` },
           }),
-        })
+        )
         .mockResolvedValueOnce({
           headers: new Headers({ "content-type": "video/mp4" }),
           arrayBuffer: async () => Buffer.from("video-bytes"),
@@ -365,13 +365,13 @@ describe("xai video generation provider", () => {
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     mockXaiVideoRequest("req_too_large");
     fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(
+        Response.json({
           request_id: "req_too_large",
           status: "done",
           video: { url: "https://cdn.x.ai/too-large.mp4" },
         }),
-      })
+      )
       .mockResolvedValueOnce(
         new Response(
           new ReadableStream({
@@ -419,10 +419,10 @@ describe("xai video generation provider", () => {
 
   it("bounds an unbounded successful xAI poll JSON body and cancels the stream", async () => {
     const oversized = oversizedJsonResponse();
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: streamedJsonResponse({ request_id: "req_poll_oversized" }),
       release: vi.fn(async () => {}),
-    });
+    }));
     fetchWithTimeoutMock.mockResolvedValueOnce(oversized.response);
 
     const provider = buildXaiVideoGenerationProvider();
@@ -439,12 +439,10 @@ describe("xai video generation provider", () => {
   });
 
   it("wraps malformed successful xAI create responses", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: {
-        json: async () => [],
-      },
+    postJsonRequestMock.mockImplementation(async () => ({
+      response: Response.json([]),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildXaiVideoGenerationProvider();
     await expect(
@@ -458,12 +456,12 @@ describe("xai video generation provider", () => {
   });
 
   it("wraps non-JSON successful xAI create responses", async () => {
-    postJsonRequestMock.mockResolvedValue({
+    postJsonRequestMock.mockImplementation(async () => ({
       response: new Response("<html>Unexpected token < in JSON</html>", {
         headers: { "content-type": "text/html" },
       }),
       release: vi.fn(async () => {}),
-    });
+    }));
 
     const provider = buildXaiVideoGenerationProvider();
     await expect(
@@ -477,52 +475,65 @@ describe("xai video generation provider", () => {
   });
 
   it("treats unknown xAI poll statuses as continue-polling and returns when terminal", async () => {
-    mockXaiVideoRequest("req_unknown_then_done");
-    fetchWithTimeoutMock
-      .mockResolvedValueOnce({
-        json: async () => ({
-          request_id: "req_unknown_then_done",
-          status: "almost_done",
-        }),
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
-          request_id: "req_unknown_then_done",
-          status: "submitted",
-        }),
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
-          request_id: "req_unknown_then_done",
-          status: "done",
-          video: { url: "https://cdn.x.ai/eventual.mp4" },
-        }),
-      })
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4"),
+    vi.useFakeTimers();
+    try {
+      mockXaiVideoRequest("req_unknown_then_done");
+      fetchWithTimeoutMock
+        .mockResolvedValueOnce(
+          Response.json({
+            request_id: "req_unknown_then_done",
+            status: "almost_done",
+          }),
+        )
+        .mockResolvedValueOnce(
+          Response.json({
+            request_id: "req_unknown_then_done",
+            status: "submitted",
+          }),
+        )
+        .mockResolvedValueOnce(
+          Response.json({
+            request_id: "req_unknown_then_done",
+            status: "done",
+            video: { url: "https://cdn.x.ai/eventual.mp4" },
+          }),
+        )
+        .mockResolvedValueOnce({
+          headers: new Headers({ "content-type": "video/mp4" }),
+          arrayBuffer: async () => Buffer.from("mp4"),
+        });
+
+      const provider = buildXaiVideoGenerationProvider();
+      const pending = provider.generateVideo({
+        provider: "xai",
+        model: "grok-imagine-video",
+        prompt: "unknown then done",
+        cfg: {},
       });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
 
-    const provider = buildXaiVideoGenerationProvider();
-    const result = await provider.generateVideo({
-      provider: "xai",
-      model: "grok-imagine-video",
-      prompt: "unknown then done",
-      cfg: {},
-    });
-
-    expect(result.metadata?.requestId).toBe("req_unknown_then_done");
-    expect(result.metadata?.status).toBe("done");
+      expect(result.metadata?.requestId).toBe("req_unknown_then_done");
+      expect(result.metadata?.status).toBe("done");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("treats `cancelled` as a terminal failure", async () => {
     mockXaiVideoRequest("req_cancelled");
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({
         request_id: "req_cancelled",
         status: "cancelled",
       }),
-    });
+    );
 
     const provider = buildXaiVideoGenerationProvider();
     await expect(
@@ -537,13 +548,13 @@ describe("xai video generation provider", () => {
 
   it("rejects completed xAI poll responses without output URLs as malformed", async () => {
     mockXaiVideoRequest("req_no_video");
-    fetchWithTimeoutMock.mockResolvedValueOnce({
-      json: async () => ({
+    fetchWithTimeoutMock.mockResolvedValueOnce(
+      Response.json({
         request_id: "req_no_video",
         status: "done",
         video: {},
       }),
-    });
+    );
 
     const provider = buildXaiVideoGenerationProvider();
     await expect(
@@ -557,46 +568,56 @@ describe("xai video generation provider", () => {
   });
 
   it("normalizes the xAI 'pending' poll status to 'processing' and keeps polling until done", async () => {
-    mockXaiVideoRequest("req_pending");
-    fetchWithTimeoutMock
-      // First poll: in-progress payload mirroring xAI's real shape
-      .mockResolvedValueOnce({
-        json: async () => ({
-          request_id: "req_pending",
-          status: "pending",
-          progress: 42,
-        }),
-      })
-      // Second poll: complete
-      .mockResolvedValueOnce({
-        json: async () => ({
-          request_id: "req_pending",
-          status: "done",
-          video: { url: "https://cdn.x.ai/video-pending.mp4" },
-          progress: 100,
-        }),
-      })
-      // Download
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+    vi.useFakeTimers();
+    try {
+      mockXaiVideoRequest("req_pending");
+      fetchWithTimeoutMock
+        // First poll: in-progress payload mirroring xAI's real shape
+        .mockResolvedValueOnce(
+          Response.json({
+            request_id: "req_pending",
+            status: "pending",
+            progress: 42,
+          }),
+        )
+        // Second poll: complete
+        .mockResolvedValueOnce(
+          Response.json({
+            request_id: "req_pending",
+            status: "done",
+            video: { url: "https://cdn.x.ai/video-pending.mp4" },
+            progress: 100,
+          }),
+        )
+        // Download
+        .mockResolvedValueOnce({
+          headers: new Headers({ "content-type": "video/mp4" }),
+          arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        });
+
+      const provider = buildXaiVideoGenerationProvider();
+      const pending = provider.generateVideo({
+        provider: "xai",
+        model: "grok-imagine-video",
+        prompt: "Pending then done",
+        cfg: {},
+        durationSeconds: 6,
+        aspectRatio: "9:16",
+        resolution: "720P",
       });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
 
-    const provider = buildXaiVideoGenerationProvider();
-    const result = await provider.generateVideo({
-      provider: "xai",
-      model: "grok-imagine-video",
-      prompt: "Pending then done",
-      cfg: {},
-      durationSeconds: 6,
-      aspectRatio: "9:16",
-      resolution: "720P",
-    });
-
-    // Two poll calls (one pending, one done) — not throwing on "pending"
-    expect((fetchWithTimeoutMock.mock.calls as unknown[]).length).toBeGreaterThanOrEqual(2);
-    expect(result.videos[0]?.mimeType).toBe("video/mp4");
-    expect(result.metadata?.requestId).toBe("req_pending");
+      // Two poll calls (one pending, one done) — not throwing on "pending"
+      expect((fetchWithTimeoutMock.mock.calls as unknown[]).length).toBeGreaterThanOrEqual(2);
+      expect(result.videos[0]?.mimeType).toBe("video/mp4");
+      expect(result.metadata?.requestId).toBe("req_pending");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("sends a single unroled image as xAI first-frame image-to-video", async () => {

--- a/src/plugin-sdk/test-helpers/dashscope-video-provider.ts
+++ b/src/plugin-sdk/test-helpers/dashscope-video-provider.ts
@@ -10,8 +10,8 @@ type ResettableMock = {
   mockReset(): unknown;
 };
 
-type ResolvableMock = {
-  mockResolvedValue(value: unknown): unknown;
+type ImplementableMock = {
+  mockImplementation(implementation: () => Promise<unknown>): unknown;
 };
 
 type ChainableResolvedValueMock = ResettableMock & {
@@ -20,7 +20,7 @@ type ChainableResolvedValueMock = ResettableMock & {
 
 export type DashscopeVideoProviderMocks = {
   resolveApiKeyForProviderMock: ClearableMock;
-  postJsonRequestMock: ResettableMock & ResolvableMock;
+  postJsonRequestMock: ResettableMock & ImplementableMock;
   fetchWithTimeoutMock: ChainableResolvedValueMock;
   assertOkOrThrowHttpErrorMock: ClearableMock;
   resolveProviderHttpRequestConfigMock: ClearableMock;
@@ -49,31 +49,29 @@ export function mockSuccessfulDashscopeVideoTask(
     taskStatus = "SUCCEEDED",
     videoUrl = "https://example.com/out.mp4",
   } = params;
-  mocks.postJsonRequestMock.mockResolvedValue({
-    response: {
-      json: async () => ({
-        request_id: requestId,
-        output: {
-          task_id: taskId,
-        },
-      }),
-    },
+  mocks.postJsonRequestMock.mockImplementation(async () => ({
+    response: Response.json({
+      request_id: requestId,
+      output: {
+        task_id: taskId,
+      },
+    }),
     release: vi.fn(async () => {}),
-  });
+  }));
   mocks.fetchWithTimeoutMock
-    .mockResolvedValueOnce({
-      json: async () => ({
+    .mockResolvedValueOnce(
+      Response.json({
         output: {
           task_status: taskStatus,
           results: [{ video_url: videoUrl }],
         },
       }),
-      headers: new Headers(),
-    })
-    .mockResolvedValueOnce({
-      arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      headers: new Headers({ "content-type": "video/mp4" }),
-    });
+    )
+    .mockResolvedValueOnce(
+      new Response(Buffer.from("mp4-bytes"), {
+        headers: { "content-type": "video/mp4" },
+      }),
+    );
 }
 
 export function expectDashscopeVideoTaskPoll(

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -3,10 +3,7 @@
  */
 import { afterEach, vi, type Mock } from "vitest";
 import type {
-  fetchProviderDownloadResponse,
-  fetchProviderOperationResponse,
   fetchWithTimeoutGuarded,
-  pollProviderOperationJson,
   postMultipartRequest,
   resolveProviderHttpRequestConfig,
   resolveProviderRequestHeaders,
@@ -18,10 +15,7 @@ type ResolveProviderHttpRequestConfigParams = Parameters<
 >[0];
 type FetchWithTimeoutGuardedParams = Parameters<typeof fetchWithTimeoutGuarded>;
 type ResolveProviderRequestHeadersParams = Parameters<typeof resolveProviderRequestHeaders>[0];
-type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJson>[0];
 type PostMultipartRequestParams = Parameters<typeof postMultipartRequest>[0];
-type FetchProviderOperationResponseParams = Parameters<typeof fetchProviderOperationResponse>[0];
-type FetchProviderDownloadResponseParams = Parameters<typeof fetchProviderDownloadResponse>[0];
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
   typeof sanitizeConfiguredModelProviderRequest
 >[0];
@@ -73,48 +67,8 @@ const providerHttpMocks = vi.hoisted(() => ({
   pollProviderOperationJsonMock: vi.fn(),
   assertOkOrThrowHttpErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
   assertOkOrThrowProviderErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
-  readProviderJsonResponseMock: vi.fn(
-    async <T>(response: Response, label: string, opts?: { maxBytes?: number }): Promise<T> => {
-      const maxBytes = opts?.maxBytes ?? 16 * 1024 * 1024;
-      if (!response.body) {
-        try {
-          return (await response.json()) as T;
-        } catch (cause) {
-          throw new Error(`${label}: malformed JSON response`, { cause });
-        }
-      }
-      const reader = response.body.getReader();
-      const chunks: Uint8Array[] = [];
-      let totalBytes = 0;
-      try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
-          totalBytes += value.byteLength;
-          if (totalBytes > maxBytes) {
-            await reader.cancel();
-            throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
-          }
-          chunks.push(value);
-        }
-      } finally {
-        reader.releaseLock();
-      }
-      const body = new Uint8Array(totalBytes);
-      let offset = 0;
-      for (const chunk of chunks) {
-        body.set(chunk, offset);
-        offset += chunk.byteLength;
-      }
-      try {
-        return JSON.parse(new TextDecoder().decode(body)) as T;
-      } catch (cause) {
-        throw new Error(`${label}: malformed JSON response`, { cause });
-      }
-    },
-  ),
+  readProviderJsonResponseMock:
+    vi.fn<<T>(response: Response, label: string, opts?: { maxBytes?: number }) => Promise<T>>(),
   sanitizeConfiguredModelProviderRequestMock: vi.fn(
     (request: SanitizeConfiguredModelProviderRequestParams) => request,
   ),
@@ -140,36 +94,6 @@ const providerHttpMocks = vi.hoisted(() => ({
 const providerHttpMockKeys = vi.hoisted(() => ({
   sanitizeConfiguredModelProviderRequest: "sanitizeConfiguredModelProviderRequest",
 }));
-
-providerHttpMocks.executeProviderOperationWithRetryMock.mockImplementation(
-  async (params: {
-    stage?: string;
-    retry?: boolean | { attempts?: number; sleep?: (ms: number) => Promise<void> };
-    operation: () => Promise<unknown>;
-  }) => {
-    const attempts =
-      typeof params.retry === "object"
-        ? Math.max(1, Math.round(params.retry.attempts ?? 1))
-        : params.retry === false || params.stage === "create"
-          ? 1
-          : 2;
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= attempts; attempt += 1) {
-      try {
-        return await params.operation();
-      } catch (error) {
-        lastError = error;
-        if (attempt >= attempts) {
-          throw error;
-        }
-        if (typeof params.retry === "object") {
-          await params.retry.sleep?.(0);
-        }
-      }
-    }
-    throw lastError;
-  },
-);
 
 providerHttpMocks.fetchWithTimeoutGuardedMock.mockImplementation(
   async (...args: FetchWithTimeoutGuardedParams) => {
@@ -207,154 +131,82 @@ providerHttpMocks.postMultipartRequestMock.mockImplementation(
   },
 );
 
-function resolveMockProviderTimeoutMs(
-  timeoutMs: FetchProviderOperationResponseParams["timeoutMs"],
-) {
-  return typeof timeoutMs === "function" ? timeoutMs() : (timeoutMs ?? 60_000);
-}
-
-function resolveMockProviderDownloadTimeoutMs(params: FetchProviderDownloadResponseParams) {
-  if (!params.deadline) {
-    return resolveMockProviderTimeoutMs(params.timeoutMs);
-  }
-  return params.deadline.deadlineAtMs === undefined
-    ? (params.deadline.timeoutMs ?? 60_000)
-    : Math.max(1, params.deadline.deadlineAtMs - Date.now());
-}
-
-providerHttpMocks.fetchProviderOperationResponseMock.mockImplementation(
-  async (params: FetchProviderOperationResponseParams) => {
-    const response = await providerHttpMocks.fetchWithTimeoutMock(
-      params.url,
-      params.init ?? {},
-      resolveMockProviderTimeoutMs(params.timeoutMs),
-      params.fetchFn,
-    );
-    if (params.requestFailedMessage) {
-      await providerHttpMocks.assertOkOrThrowHttpErrorMock(response, params.requestFailedMessage);
-    }
-    return response;
-  },
-);
-
-providerHttpMocks.fetchProviderDownloadResponseMock.mockImplementation(
-  async (params: FetchProviderDownloadResponseParams) => {
-    const response = await providerHttpMocks.fetchWithTimeoutMock(
-      params.url,
-      params.init ?? {},
-      resolveMockProviderDownloadTimeoutMs(params),
-      params.fetchFn,
-    );
-    await providerHttpMocks.assertOkOrThrowHttpErrorMock(response, params.requestFailedMessage);
-    return response;
-  },
-);
-
-providerHttpMocks.pollProviderOperationJsonMock.mockImplementation(
-  async (params: PollProviderOperationJsonParams) => {
-    for (let attempt = 0; attempt < params.maxAttempts; attempt += 1) {
-      const headers = typeof params.headers === "function" ? params.headers() : params.headers;
-      const response = await providerHttpMocks.fetchWithTimeoutMock(
-        params.url,
-        {
-          method: "GET",
-          headers,
-        },
-        params.defaultTimeoutMs,
-        params.fetchFn,
-      );
-      await providerHttpMocks.assertOkOrThrowHttpErrorMock(response, params.requestFailedMessage);
-      const payload = await response.json();
-      if (params.isComplete(payload)) {
-        return payload;
-      }
-      const failureMessage = params.getFailureMessage?.(payload);
-      if (failureMessage) {
-        throw new Error(failureMessage);
-      }
-    }
-    throw new Error(params.timeoutMessage);
-  },
-);
-
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: providerHttpMocks.resolveApiKeyForProviderMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => ({
-  assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
-  assertOkOrThrowProviderError: providerHttpMocks.assertOkOrThrowProviderErrorMock,
-  assertProviderBinaryResponseContent: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).assertProviderBinaryResponseContent,
-  createProviderOperationDeadline: ({
-    label,
-    timeoutMs,
-  }: {
-    label: string;
-    timeoutMs?: number | (() => number);
-  }) => {
-    const resolvedTimeoutMs = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
-    return {
-      label,
-      timeoutMs: resolvedTimeoutMs,
-      deadlineAtMs:
-        typeof resolvedTimeoutMs === "number" ? Date.now() + resolvedTimeoutMs : undefined,
-    };
-  },
-  createProviderOperationTimeoutResolver:
-    ({
-      deadline,
-      defaultTimeoutMs,
-    }: {
-      deadline: { deadlineAtMs?: number; label: string; timeoutMs?: number };
-      defaultTimeoutMs: number;
-    }) =>
-    () => {
-      if (typeof deadline.deadlineAtMs !== "number") {
-        return defaultTimeoutMs;
-      }
-      const remainingMs = deadline.deadlineAtMs - Date.now();
-      if (remainingMs <= 0) {
-        throw new Error(`${deadline.label} timed out after ${deadline.timeoutMs}ms`);
-      }
-      return Math.min(defaultTimeoutMs, remainingMs);
+vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/provider-http")>();
+  const timeoutTransport = await vi.importActual<typeof import("../../utils/fetch-timeout.js")>(
+    "../../utils/fetch-timeout.js",
+  );
+  const guardedTransport = await vi.importActual<typeof import("../../infra/net/fetch-guard.js")>(
+    "../../infra/net/fetch-guard.js",
+  );
+  const { resolveTransientProviderRetryOptions } =
+    await import("../../provider-runtime/operation-retry.js");
+  // Earlier SDK imports can retain the actual transport namespace; bind it at each call
+  // so both those imports and tests that restore spies use the fixture transport.
+  const installTransportMocks = () => {
+    vi.spyOn(timeoutTransport, "fetchWithTimeout").mockImplementation((...args) =>
+      providerHttpMocks.fetchWithTimeoutMock(...args),
+    );
+    vi.spyOn(guardedTransport, "fetchWithSsrFGuard").mockImplementation(async (params) => ({
+      response: await providerHttpMocks.fetchWithTimeoutMock(
+        params.url,
+        params.init ?? {},
+        params.timeoutMs,
+        params.fetchImpl,
+      ),
+      finalUrl: params.url,
+      release: async () => {},
+    }));
+  };
+  providerHttpMocks.readProviderJsonResponseMock.mockImplementation(
+    actual.readProviderJsonResponse,
+  );
+  providerHttpMocks.pollProviderOperationJsonMock.mockImplementation((params) => {
+    installTransportMocks();
+    return actual.pollProviderOperationJson(params);
+  });
+  providerHttpMocks.fetchProviderOperationResponseMock.mockImplementation((params) => {
+    installTransportMocks();
+    return actual.fetchProviderOperationResponse(params);
+  });
+  providerHttpMocks.fetchProviderDownloadResponseMock.mockImplementation((params) => {
+    installTransportMocks();
+    return actual.fetchProviderDownloadResponse(params);
+  });
+  providerHttpMocks.executeProviderOperationWithRetryMock.mockImplementation(
+    (params: Parameters<typeof actual.executeProviderOperationWithRetry>[0]) => {
+      const retry = resolveTransientProviderRetryOptions(
+        actual.providerOperationRetryConfig(params.stage, params.retry),
+      );
+      return actual.executeProviderOperationWithRetry({
+        ...params,
+        ...(retry ? { retry: { ...retry, sleep: retry.sleep ?? (async () => {}) } } : {}),
+      });
     },
-  executeProviderOperationWithRetry: providerHttpMocks.executeProviderOperationWithRetryMock,
-  fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
-  fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
-  fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
-  fetchWithTimeoutGuarded: providerHttpMocks.fetchWithTimeoutGuardedMock,
-  pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
-  postJsonRequest: providerHttpMocks.postJsonRequestMock,
-  postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
-  postTranscriptionRequest: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).postTranscriptionRequest,
-  providerOperationRetryConfig: (_stage: string) => true,
-  readProviderBinaryResponse: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).readProviderBinaryResponse,
-  readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
-  readProviderJsonObjectResponse: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).readProviderJsonObjectResponse,
-  requireTranscriptionText: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).requireTranscriptionText,
-  resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
-    defaultTimeoutMs,
-  resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
-  resolveProviderHttpRequestConfigWithOriginTrust: (
-    await importActual<typeof import("openclaw/plugin-sdk/provider-http")>()
-  ).resolveProviderHttpRequestConfigWithOriginTrust,
-  openProviderWebSocket: (await importActual<typeof import("openclaw/plugin-sdk/provider-http")>())
-    .openProviderWebSocket,
-  resolveProviderRequestHeaders: providerHttpMocks.resolveProviderRequestHeadersMock,
-  [providerHttpMockKeys.sanitizeConfiguredModelProviderRequest]:
-    providerHttpMocks.sanitizeConfiguredModelProviderRequestMock,
-  waitProviderOperationPollInterval: async () => {},
-}));
+  );
+  return {
+    ...actual,
+    assertOkOrThrowHttpError: providerHttpMocks.assertOkOrThrowHttpErrorMock,
+    assertOkOrThrowProviderError: providerHttpMocks.assertOkOrThrowProviderErrorMock,
+    executeProviderOperationWithRetry: providerHttpMocks.executeProviderOperationWithRetryMock,
+    fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
+    fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
+    fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
+    fetchWithTimeoutGuarded: providerHttpMocks.fetchWithTimeoutGuardedMock,
+    pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
+    postJsonRequest: providerHttpMocks.postJsonRequestMock,
+    postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
+    readProviderJsonResponse: providerHttpMocks.readProviderJsonResponseMock,
+    resolveProviderHttpRequestConfig: providerHttpMocks.resolveProviderHttpRequestConfigMock,
+    resolveProviderRequestHeaders: providerHttpMocks.resolveProviderRequestHeadersMock,
+    [providerHttpMockKeys.sanitizeConfiguredModelProviderRequest]:
+      providerHttpMocks.sanitizeConfiguredModelProviderRequestMock,
+  };
+});
 
 export function getProviderHttpMocks(): ProviderHttpMocks {
   return providerHttpMocks;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Provider media tests did not consistently exercise the response limits, retry rules, and polling deadlines used in production. This made regressions in shared HTTP behavior harder to catch during provider development.

## Why This Change Was Made

Run the existing provider tests through the shared JSON, retry, deadline, polling, and download-response owners, with native response fixtures and mocked network transport. Bind transport spies to the actual module namespaces at each operation so earlier SDK imports and per-test `restoreAllMocks()` calls still use the fixture transport when an operation starts; fresh response factories and explicit polling-clock advances preserve body consumption and timing behavior.

## User Impact

No user-visible runtime change. Developers get provider contract tests that exercise the shared HTTP policies, with all existing cases retained. The complete change removes 90 code lines and 97 physical lines across 13 test/support files; production LOC is unchanged.

## Evidence

- The refreshed checkout passed **397 tests in 18 suites**: all 365 provider/shared-owner cases plus 32 docs integration cases. These runs blocked unexpected external global fetches while allowing exact loopback/localhost for existing TCP checks. The rebase preserved the complete HTTP patch and all 13 changed file contents.
- Reproduced the preloaded-namespace transport bypass as a local failure under that fetch guard, then passed all 16 Runway and 17 PixVerse cases. The final full run retained the real-time Runway tee-cancellation and OpenAI socket-close checks.
- Four polling cases exercise five 5,000ms intervals and assert the request count at 4,999ms before advancing to the next poll. Three exact polling-budget cases freeze only `Date.now()` and restore it in `finally`; an advancing-clock probe reproduced all three failures before the fix and passed afterward, with clock and timer identity cleanup verified. No test cases were removed.
- The required changed-file gate and managed autoreview passed **before the rebase**, on this unchanged HTTP patch. The gate covered formatting, SDK boundaries, selected production/test type checks, lint, dead-export scans, and structural guards; review was clean through P2. After rebasing, `git diff --check` passed and all 13 source hashes still matched the reviewed patch. The 397-test integration run above is separate, fresh proof on the new base; hosted CI must independently validate the refreshed head.
- cloc 2.10 reported the same net reduction with default parsing and `--strip-str-comments`, including every fixture, timer, and transport-binding change.

Integration proof ran at `adb3c9ba909b12b92159410d9d1bb20463b9de70` on base `1670c5a1cc375f0121d4f59b17d531fa151c7434`, which includes the upstream docs fix. Shared owners and package/toolchain files are unchanged from the original review base. Hosted CI must validate the refreshed head; previous failures and their attribution remain recorded.

The facade retry adapter still supplies an instant default sleep through the existing option. These provider suites therefore do not prove default-backoff timing or cancellation during that substituted sleep; caller-supplied sleep and signals are preserved. Authentication, request-policy/header, sanitizer, and exported assertion fixtures remain mocked.
