### PR TITLE
fix(ci): align release navigation regression coverage

### DIFF
--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -464,6 +464,7 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "reference/full-release-validation/profiles",
       "reference/full-release-validation/evidence",
       "reference/release-performance-sweep",
+      "gateway/security/dependency-locking",
       "reference/test",
       "reference/test/local",
       "reference/test/lanes",


### PR DESCRIPTION
Follows #143977. Related: #130706.

## What Problem This Solves

CI fails the generated locale-navigation test after the documentation reorganization moved the existing dependency-locking page into Release & CI. The generated navigation includes the route, while the test's expected list omits it.

## Why This Change Was Made

Add that one route at its intended position in the test expectation. The navigation, generator, exact ordering checks, and localized-route assertions remain unchanged. Production code is unchanged.

## User Impact

Restores the navigation regression check to match the intended documentation structure and unblocks unrelated PR checks.

## Evidence

The exact failure was reproduced on main before this one-line repair. All 11 tests in the file, independent P2 review, and the full proportional scripts gate passed. The original CI logs from #143994 and #143999 show the same missing route; their model changes cannot cause it.

Tested commit: `61f16130ab0c45345dd39d6e00cb924113a3617f`. This is a test-only correction; no product runtime build is needed.
