### PR TITLE
refactor(auto-reply): remove duplicate routed-hook test

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -625,37 +625,6 @@ describe("routeReply", () => {
     });
   });
 
-  it("suppresses routed delivery when reply payload hooks cancel", async () => {
-    mocks.deliverOutboundPayloads.mockImplementationOnce(
-      async ({
-        onPayloadDeliveryOutcome,
-      }: {
-        onPayloadDeliveryOutcome?: (outcome: unknown) => void;
-      }) => {
-        onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "suppressed",
-          reason: "cancelled_by_reply_payload_sending_hook",
-        });
-        return [];
-      },
-    );
-
-    const res = await routeTestReply({
-      payload: { text: "hello" },
-      channel: "telegram",
-      to: "chat-1",
-    });
-
-    expect(res).toEqual({
-      ok: true,
-      delivered: false,
-      suppressed: true,
-      reason: "cancelled_by_reply_payload_sending_hook",
-    });
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
-  });
-
   it("suppresses routed delivery when reply payload hooks empty the payload", async () => {
     mocks.deliverOutboundPayloads.mockImplementationOnce(
       async ({


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Maintainer-requested test cleanup removes a routed-reply cancellation case that duplicates stronger existing coverage.

## Why This Change Was Made

The retained durable-delivery suppression case uses the same mock callback, route inputs, result assertions, and delivery call-count assertion, and also verifies the reply-hook context. The distinct empty-payload suppression case remains unchanged.

## User Impact

No runtime behavior changes. This removes one redundant test case and 31 test lines; all other cases, helpers, imports, and production code remain unchanged.

## Evidence

- Full ordered `route-reply.test.ts` under its owning configuration: 43 actual passes, zero skips.
- All 20 selected changed checks passed, with no retries.
- Fresh P2 review: scoped-clean, no findings.

Proof uses mocked outbound delivery and the real routing path. No live channel or Gateway execution, packaging check, local full-repository test run, or persistent-store integration proof is claimed.
