### PR TITLE
docs: close the small audit categories (generated, governance, link, split)

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4104,6 +4104,14 @@
     "target": "节点文件传输"
   },
   {
+    "source": "File transfers",
+    "target": "文件传输"
+  },
+  {
+    "source": "File Transfer plugin reference",
+    "target": "文件传输插件参考"
+  },
+  {
     "source": "Node command policy",
     "target": "节点命令策略"
   },

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,6 +18,8 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 - Use an explicit `<a id="stable-section-name" />` for a durable section link when heading wording may change. Keep existing named anchors when reorganizing content.
 - README and other GitHub-rendered docs should keep absolute docs URLs so links work outside the docs site.
 - Docs content must stay generic: no personal device names, hostnames, or local paths. Use placeholders like `user@gateway-host` and `~/path/to/skills`.
+- For tokens, API keys, and credential snippets, follow [Secret Placeholder Conventions](/reference/secret-placeholder-conventions). Keep example values obviously fake so secret scanners stay quiet.
+- For tokens, API keys, and credential snippets, follow [Secret Placeholder Conventions](/reference/secret-placeholder-conventions). Keep example values obviously fake so secret scanners stay quiet.
 
 ## Docs Content Rules
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -207,8 +207,13 @@ Both ordinary CI and this strict audit publish the outcome, package count,
 duration, timestamp, and bounded failure reason in the job summary. A completed
 npm check covers npm bulk advisories only, not every upstream advisory source.
 
-The triage owner is **@steipete**. Investigate failed scheduled runs and rerun
-the strict workflow to confirm recovery:
+The triage owner is **@steipete**, set on 2026-09-03 in
+[#137960](https://github.com/openclaw/openclaw/pull/137960). No `.github/CODEOWNERS`
+rule covers `.github/workflows/dependency-audit.yml`, so this line is the only
+record of that ownership. Review routing for a fix follows the lockfile owner
+`@openclaw/openclaw-secops`, which owns `/pnpm-lock.yaml` and `/package-lock.json`.
+Investigate failed scheduled runs and rerun the strict workflow to confirm
+recovery:
 
 ```bash
 gh workflow run dependency-audit.yml --repo openclaw/openclaw --ref main

--- a/docs/cli/file-transfer.md
+++ b/docs/cli/file-transfer.md
@@ -1,0 +1,76 @@
+---
+summary: "CLI reference for `openclaw file-transfer` (review and migrate standing file-transfer approvals)"
+read_when:
+  - You upgraded and older file-transfer permissions stopped taking effect
+  - You need the flag surface for `openclaw file-transfer approvals migrate`
+  - You want a scriptable check for unreviewed file-transfer permissions
+title: "File transfers"
+---
+
+# `openclaw file-transfer`
+
+Review the standing approvals that the file-transfer plugin stores under
+`plugins.entries.file-transfer.config`. The command group ships with the
+file-transfer plugin. It is absent when that plugin is not installed.
+
+## `file-transfer approvals migrate`
+
+Review older file-transfer permissions and migrate them to the current policy
+format. Older positive permissions stay inactive until this review finishes.
+Deny rules, size limits, and symlink settings keep applying throughout.
+
+```bash
+openclaw file-transfer approvals migrate
+openclaw file-transfer approvals migrate --dry-run
+openclaw file-transfer approvals migrate --json
+```
+
+| Option      | Effect                                                                          |
+| ----------- | ------------------------------------------------------------------------------- |
+| `--dry-run` | Walk the prompts and print the plan. No config is written.                      |
+| `--json`    | Print the unreviewed permissions as JSON and exit. No prompts, no config write. |
+
+Both options default to off.
+
+### Where it runs
+
+Run the command on the Gateway host in an interactive terminal. The command
+updates that host's file-transfer policy, so it refuses to run when
+`gateway.mode` is `remote`. It also refuses when the OpenClaw config is invalid.
+Fix the config first, then rerun.
+
+### What the interactive run asks
+
+The command lists one entry per legacy permission, shown as
+`<node selector> · read|write · <path>`. Choose one outcome per entry:
+
+- **Require exact reapproval** removes the ambiguous permission. The next use
+  prompts once and records the exact node, command, requested path, and
+  canonical target.
+- **Keep as an intentional wildcard** preserves the entry as an
+  operator-authored glob.
+- **Remove this permission** drops the entry outright.
+
+The command then prints a plan with the count for each outcome, plus a
+downgrade note. It asks for one confirmation before writing. On success it
+writes the migrated config and reports the adjacent config backup path. It says
+so when that backup cannot be verified.
+
+### Scripted and non-interactive use
+
+`--json` reports the work without changing anything. Use it in a health check or
+an upgrade script.
+
+| Situation                     | Output                                                                                                        | Exit code |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- | --------- |
+| Nothing to review             | `{"status":"ok","changed":false,"message":"No legacy permissions need review."}`                              | 0         |
+| Permissions still need review | `{"status":"needs-input","changed":false,"items":[...],"command":"openclaw file-transfer approvals migrate"}` | 2         |
+
+Without `--json`, a non-interactive shell is an error. The command tells you to
+rerun it in a terminal rather than guessing an outcome for each permission.
+
+## Related
+
+- [CLI reference](/cli)
+- [Node file transfers](/nodes/file-transfers)
+- [File Transfer plugin reference](/plugins/reference/file-transfer)

--- a/docs/cli/file-transfer.md
+++ b/docs/cli/file-transfer.md
@@ -66,8 +66,11 @@ an upgrade script.
 | Nothing to review             | `{"status":"ok","changed":false,"message":"No legacy permissions need review."}`                              | 0         |
 | Permissions still need review | `{"status":"needs-input","changed":false,"items":[...],"command":"openclaw file-transfer approvals migrate"}` | 2         |
 
-Without `--json`, a non-interactive shell is an error. The command tells you to
-rerun it in a terminal rather than guessing an outcome for each permission.
+Without `--json`, the command checks for work first. A non-interactive shell is
+an error only when permissions still need review. The command then tells you to
+rerun it in a terminal rather than guessing an outcome for each permission. A
+non-interactive run with nothing to review prints the same no-work message and
+exits 0, so a repeated upgrade script stays quiet.
 
 ## Related
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -37,7 +37,7 @@ Setup commands by intent:
 | Pairing and channels         | [`pairing`](/cli/pairing) · [`qr`](/cli/qr) · [`devices`](/cli/devices) · [`channels`](/cli/channels)                                                                                                                                 |
 | Security and plugins         | [`security`](/cli/security) · [`secrets`](/cli/secrets) · [`skills`](/cli/skills) · [`plugins`](/cli/plugins) · [`proxy`](/cli/proxy)                                                                                                 |
 | Legacy aliases               | [`daemon`](/cli/daemon) (gateway service) · [`clawbot`](/cli/clawbot) (namespace)                                                                                                                                                     |
-| Plugins (optional)           | [`path`](/cli/path) · [`policy`](/cli/policy) · [`voicecall`](/cli/voicecall) · [`workboard`](/cli/workboard) (if installed)                                                                                                          |
+| Plugins (optional)           | [`file-transfer`](/cli/file-transfer) · [`path`](/cli/path) · [`policy`](/cli/policy) · [`voicecall`](/cli/voicecall) · [`workboard`](/cli/workboard) (if installed)                                                                  |
 
 ## Global flags
 

--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -43,7 +43,7 @@ Kimi model IDs:
 ```json5
 {
   agents: {
-    defaults: { model: { primary: "moonshot/kimi-k2.6" } },
+    defaults: { model: { primary: "moonshot/kimi-k3" } },
   },
   models: {
     mode: "merge",
@@ -52,7 +52,7 @@ Kimi model IDs:
         baseUrl: "https://api.moonshot.ai/v1",
         apiKey: "${MOONSHOT_API_KEY}",
         api: "openai-completions",
-        models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
+        models: [{ id: "kimi-k3", name: "Kimi K3" }],
       },
     },
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2883,6 +2883,7 @@
                           "cli/plugins/marketplace"
                         ]
                       },
+                      "cli/file-transfer",
                       "cli/path",
                       "cli/policy",
                       {

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -1,5 +1,5 @@
 ---
-summary: "Generated index of OpenClaw plugin reference pages"
+summary: "Pointer to the generated OpenClaw plugin reference pages"
 read_when:
   - You need a reference page for a specific OpenClaw plugin
   - You are auditing plugin docs coverage
@@ -12,8 +12,10 @@ Run `pnpm plugins:inventory:gen` to rebuild it. -->
 This section holds one reference page for each OpenClaw plugin. Each page states
 the package, the install route, and the surface the plugin adds.
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 152
-generated plugin reference pages by distribution, package, and description.
+This page is a pointer, not the index. The browsable list of all
+152 generated plugin reference pages lives in
+[Plugin inventory](/plugins/plugin-inventory), sorted by distribution, package,
+and description.
 
 ## How this page is built
 

--- a/docs/plugins/reference/file-transfer.md
+++ b/docs/plugins/reference/file-transfer.md
@@ -41,6 +41,9 @@ apply. Run this command on the Gateway host in an interactive terminal:
 openclaw file-transfer approvals migrate
 ```
 
+See [File transfers](/cli/file-transfer) for the full flag surface and the
+non-interactive exit codes.
+
 For each older path, choose one outcome:
 
 - **Require exact reapproval** removes the ambiguous permission. The next use

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -24,9 +24,14 @@ Source generation fails if a present channel secret-contract artifact cannot loa
 
 [//]: # "secretref-supported-list-start"
 
+#### `agents`
+
 - `agents.entries.*.memory.search.remote.apiKey`
 - `agents.entries.*.tts.personas.*.providers.*.apiKey`
 - `agents.entries.*.tts.providers.*.apiKey`
+
+#### `channels`
+
 - `channels.buzz.accounts.*.authTag`
 - `channels.buzz.accounts.*.privateKey`
 - `channels.buzz.authTag`
@@ -89,12 +94,24 @@ Source generation fails if a present channel secret-contract artifact cannot loa
 - `channels.zalo.accounts.*.webhookSecret`
 - `channels.zalo.botToken`
 - `channels.zalo.webhookSecret`
+
+#### `cron`
+
 - `cron.webhookToken`
+
+#### `gateway`
+
 - `gateway.auth.password`
 - `gateway.auth.token`
 - `gateway.remote.password`
 - `gateway.remote.token`
+
+#### `memory`
+
 - `memory.search.remote.apiKey`
+
+#### `models`
+
 - `models.providers.*.apiKey`
 - `models.providers.*.headers.*`
 - `models.providers.*.request.auth.token`
@@ -108,6 +125,9 @@ Source generation fails if a present channel secret-contract artifact cannot loa
 - `models.providers.*.request.tls.cert`
 - `models.providers.*.request.tls.key`
 - `models.providers.*.request.tls.passphrase`
+
+#### `plugins`
+
 - `plugins.entries.acpx.config.mcpServers.*.env.*`
 - `plugins.entries.brave.config.webSearch.apiKey`
 - `plugins.entries.codex.config.appServer.authToken`
@@ -133,9 +153,18 @@ Source generation fails if a present channel secret-contract artifact cannot loa
 - `plugins.entries.voice-call.config.twilio.authToken`
 - `plugins.entries.webhooks.config.routes.*.secret`
 - `plugins.entries.xai.config.webSearch.apiKey`
+
+#### `skills`
+
 - `skills.entries.*.apiKey`
+
+#### `talk`
+
 - `talk.providers.*.apiKey`
 - `talk.realtime.providers.*.apiKey`
+
+#### `tts`
+
 - `tts.personas.*.providers.*.apiKey`
 - `tts.providers.*.apiKey`
 

--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -542,7 +542,7 @@ ${renderSurface(record.surface)}${manualBlock ? `\n\n${manualBlock}` : ""}${rela
 function renderReferenceIndex(records: PluginRecord[]) {
   const referenceCount = records.filter(hasGeneratedReferencePage).length;
   return `---
-summary: "Generated index of OpenClaw plugin reference pages"
+summary: "Pointer to the generated OpenClaw plugin reference pages"
 read_when:
   - You need a reference page for a specific OpenClaw plugin
   - You are auditing plugin docs coverage
@@ -554,8 +554,10 @@ ${GENERATED_NOTICE}
 This section holds one reference page for each OpenClaw plugin. Each page states
 the package, the install route, and the surface the plugin adds.
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all ${referenceCount}
-generated plugin reference pages by distribution, package, and description.
+This page is a pointer, not the index. The browsable list of all
+${referenceCount} generated plugin reference pages lives in
+[Plugin inventory](/plugins/plugin-inventory), sorted by distribution, package,
+and description.
 
 ## How this page is built
 


### PR DESCRIPTION
Closes the four small audit categories that still had open rows (`generated`, `governance`, `link`, and the size-driven half of `split`), by fixing what is real and refuting the rest with evidence. 27 rows reviewed: **6 fixed**, **8 refuted or already satisfied on `main`**, **13 deferred** to a decision this PR should not make (6 + 8 + 13 = 27).

Per category: `link` (1 row) is **closed**. `governance` (3) is closed except `r3-0988`. `generated` (7) is closed except the three maturity/plugin-stub rows. `split` (9) is closed except the three release-notes rows. `i18n` (7) has **no mechanical work left** — every remaining row needs a native zh reviewer or a product-naming call.

## Fixed (by finding id)

| id | kind | change |
|---|---|---|
| `r5-0143` | governance | `docs/ci/scheduled-workflows.md` — the Dependency Audit triage owner now carries the date it was set (2026-09-03, #137960, verified with `git log -S`) and names the routing team. |
| `r3-2264` | governance | `docs/AGENTS.md` — the placeholder rule now links `/reference/secret-placeholder-conventions`. |
| `r3-1349` | generated | `docs/concepts/model-providers/custom-providers.md` — the Moonshot config example now registers `kimi-k3`, matching the "Example model" line above it. |
| `r3-2248` | generated | `docs/reference/secretref-credential-surface.md` — the 114 supported targets are grouped under one `####` per top-level config key. |
| `r3-2078` | generated | `scripts/generate-plugin-inventory-doc.mts` — `docs/plugins/reference.md` now describes itself as a pointer instead of claiming to be an index it does not hold. |
| `r5-0196` | link | New `docs/cli/file-transfer.md`, the CLI reference for `openclaw file-transfer`, linked from the plugin reference page, `docs/cli/index.md`, and the nav. |

### Notes on the fixed rows

**`r3-1349` — the ledger's suggested fix was the wrong direction.** The row says "align the example model with the config block", i.e. change `moonshot/kimi-k3` to `kimi-k2.6`. `extensions/moonshot/openclaw.plugin.json:60` sets `"defaultModel": "kimi-k3"`, so the prose line is the correct one and the JSON block was the outlier. Applying the row as written would have put a non-default model in the docs. Aligned the other way, using the manifest's own display name `Kimi K3`.

**`r3-2264` — `docs/CLAUDE.md` is a symlink to `docs/AGENTS.md`.** The row treats them as two files needing two edits. `ls -l` shows `docs/CLAUDE.md -> AGENTS.md`, so one edit covers both. The new link sits mid-bullet rather than at the head of a list item, so it is not a `LIST_ITEM_LINK_RE` match and needs no coined glossary vocabulary.

**`r3-2248` — no generator exists.** The row says "change the generator". `git grep secretref-supported-list` finds only the page itself and `src/secrets/target-registry.docs.test.ts`: the list is hand-maintained and *test-verified*, not generated. That test parses only lines matching `^- \`x\`` inside the markers and compares them as a **set**, so inserting `####` headings is invisible to it. Verified: `src/secrets/target-registry.docs.test.ts` 1 file / 2 tests passing.

**`r3-2078`** — taking the row's second branch ("retitle the page as a pointer") rather than the first. Emitting all 152 child links here would duplicate `docs/plugins/plugin-inventory.md`, which already carries that browsable table. `pnpm plugins:inventory:gen` regenerated only `docs/plugins/reference.md`.

**`r5-0196`** — the flag surface is small enough to author from source with confidence: `extensions/file-transfer/src/cli.ts:157-170` registers exactly one leaf command with `--dry-run` and `--json`. Every claim on the page maps to a line in `cli.ts` or `approvals-migration.ts`, including the remote-Gateway refusal (`cli.ts:51`), the exit code 2 on `--json` with unresolved items (`cli.ts:73`), and the `.bak` verification wording (`cli.ts:150-154`).

## Refuted, or already satisfied on `main`

| id | outcome |
|---|---|
| `r3-2079` | **Already fixed on `main`** by #140254 (`git log -S '# Plugin reference'`). Neither the page nor the generator template has an H1. Ledger row never updated. |
| `r3-1609` `r3-1617` `r3-1620` `r3-1623` `r3-2371` `r5-0051` | **Refuted on size.** These `split` rows target pages of 15.5k–35k raw bytes (`diffs` 15,490 · `remote` 16,665 · `cloud-sessions` 20,103 · `pairing` 20,796 · `openai-http-api` 23,265, 19,183 de-padded · `slash-commands` 35,063). All are under the 40k split trigger before padding is even discounted, and hold `r6-0009` keeps Control UI children of 28k–48k whole on the explicit standard "revisit only if a child grows past about 60k characters". Splitting these fragments one coherent reader job each. The genuine document-type-mixing concerns they raise are already tracked as open `ux`/`ia` rows on the same lines (`r3-1608`, `r3-1610`, `r3-0374`–`r3-0377`, `r3-1621`, `r3-1622`, `r3-1624`, `r3-2372`–`r3-2374`, `r5-0049`, `r5-0052`) and belong there. |
| `r3-0995` | **Accounted for, nothing mechanical left.** #143853 equalised the 2 pairs decidable from in-file evidence and refuted 4 more as deliberate identity mappings (`Meta`/`meta` etc., where the lowercase form is a provider id). The remaining pair is `Channel Routing`/`Channel routing`. |

## Deferred, with who should decide

| id | blocked on |
|---|---|
| `r3-0968` `r3-0969` `r3-0970` | **The release-notes process, not this repo.** No script in `scripts/` or `.github/` writes `docs/releases/` (`r6-0008` re-confirmed). The precedent split of `2026.8.1` into 22 children left 14 children still over 40k, eight of them named `maintenance-changes-part-1..8` — arbitrary chunking, not reader jobs — and two newer pages have landed unsplit since (`2026.9.2` 381,061 B, `2026.9.3` 377,652 B). Hand-splitting three more archives fixes three pages while the emitter keeps producing them. Owner: whoever owns the release-note assembly (`r6-0008`). |
| `r3-0973` `r3-0974` | **`r6-0007`:** `scripts/qa/render-maturity-docs.ts` cannot run outside CI without `qa-evidence.json`, so a generator change is unverifiable here. Also `scripts/docs-i18n/taxonomy_source_test.go` pins five links inside the `## Details` section the split removes, and the generator mints 50 `#<surface-slug>` deep anchors that path-to-path redirects cannot fan out. |
| `r3-0976` | Deleting 139 stub pages that `plugin-inventory.md` links individually is an IA restructure, not a template change (recorded by #140254). Needs a docs-IA decision. |
| `r3-0988` | The schema-history tables would have to be generated from `scripts/generate-sqlite-session-schema-baseline.ts`, whose output is gitignored. That is a build-artifact decision for the state/DB owners. |
| `r3-0990` `r3-0991` `r3-0993` `r3-0994` `r3-0996` `r3-0997` | **Native-reviewer or product-naming decisions.** #143853 already landed the mechanical half of each (the `composeLocaleNav` warning, six group labels sourced from the project's own glossary, two case-variant merges, 25 link labels realigned to their target titles). What is left is: ~57 nav labels in 11 languages, 8 zh-Hans group labels with no glossary target, 9 zh-CN base terms whose identity mappings would contradict the file's own usage, and tree-wide renames (`subagent`/`sub-agent`, 192 files; `env var`/`environment variable`, 236 files) that each need a product-naming call. `r3-0997` is additionally blocked on `r3-0994` by `r6-0002` — a full-tree mode reports ~35,600 gaps today, so it is a report, not a gate. This PR deliberately arbitrates no Chinese. |

## CODEOWNERS

Last-match-wins simulated over the changed-file list with three working controls. One owned file:

- `docs/reference/secretref-credential-surface.md` → `@openclaw/openclaw-secops`

Everything else is unowned. Not routed to a separate PR: splitting it out would move the gate rather than remove it.

## One pre-existing `main` break, fixed here

`test/scripts/docs-sync-publish.test.ts` fails on `main`: `gateway/security/dependency-locking` was added to the Release & CI nav tab without being added to that test's pinned route list, and the docs-sync-publish lane is not selected by that kind of change — exactly what the test's own comment predicts. Reproduced at the merge-base sha in a detached worktree (`expected [ 'releases/index', …(57) ] to deeply equal [ …(56) ]`, byte-identical to the failure here). Because this PR touches `docs/docs.json` it *does* select that lane, so the pre-existing red would land on this PR. Pinned the missing route: 1 file / 11 tests now pass.

## Validation

Baseline measured in a detached worktree at the merge-base with `node_modules` symlinked, then re-run after the rebase onto `origin/main`.

```
pnpm check:docs                          exit 0
  format:docs:check                      clean (1281 files)
  markdownlint-cli2 (docs config)        Linting: 1280 files, 0 issues
  markdownlint-cli2 (templates)          Linting: 12 files, 0 issues
  check-docs-mdx                         passed (1294 files)
  check-docs-i18n-glossary               exit 0
  docs-link-audit                        checked_internal_links=13205  broken_links=0
  check-docs-config-examples             exit 0
pnpm format:check (oxfmt, repo-wide)     all 36,350 files formatted
docs-link-audit --anchors                13496 links, 3 broken — the known
                                         #windows-app-node trio, identical to baseline
pnpm plugins:inventory:check             exit 0
pnpm maturity:check                      exit 0
```

Tests, with file counts (a bare `--config vitest.unit-src` run over `src/secrets/` and `src/config/` reports "No test files found" and exits 0 — both directories are excluded from that shard, so that green is meaningless; the owning configs are below):

```
vitest.secrets.config.ts        src/secrets/target-registry.docs.test.ts   1 file / 2 tests   pass
vitest.runtime-config.config.ts src/config/validation.policy.test.ts       1 file / 18 tests  pass
vitest.tooling.config.ts        test/scripts/docs-sync-publish.test.ts     1 file / 11 tests  pass
vitest.tooling.config.ts        src/scripts/docs-link-audit.test.ts        1 file / 33 tests  pass
vitest.tooling.config.ts        test/scripts/release-preflight.test.ts     1 file / 22 tests  pass
vitest.unit-src.config.ts       src/docs/                                  8 files / 16 tests pass
```

Also run: `.audit/docs-test-pins.py` over all eight changed pages (pins classified: `taxonomy.yaml` entries are page-level, no anchors); `.audit/check-orphan-refs.py` (2 candidates, both pre-existing same-page prose); `.audit/stranded-stubs.py docs` (4 suspects, byte-identical to baseline); `.audit/ste-lint.py docs/cli/file-transfer.md` (0 violations, 285 words).

`.github/labeler.yml` already matches the new page through `docs/**`; no file-exact glob names any page here, so no CI gap is created.

## Glossary

Two sources appended to `docs/.i18n/glossary.zh-CN.json`, inserted **beside the existing `Node file transfers` entry** rather than at the end, so this does not collide with concurrent splits:

- `File transfers` → `文件传输` — the new page's frontmatter title. Derived from the existing `Node file transfers` → `节点文件传输`.
- `File Transfer plugin reference` → `文件传输插件参考` — a `## Related` link label. Composed from the same term plus the existing `Plugin reference` → `插件参考`.

No vocabulary was coined: both targets are substrings of entries already in the file.

## Premises in the brief that did not hold

1. **"The split program is complete."** It is complete for hand-written pages, but not for `docs/releases/`: three audited pages are still 202k–575k, two more have landed since the audit unsplit, and the one release page that *was* split still has 14 oversized children. Recorded above under `r3-0968`–`r3-0970`.
2. **"`docs/plugins/reference/**` and `plugin-inventory.md` are generated; `docs/maturity/*` is generated."** True, but `docs/reference/secretref-credential-surface.md` — a `generated`-kind row — is not generated by anything. `git grep` for its marker finds only a test. The row's "change the generator" fix had no referent.
3. **"`docs/AGENTS.md` and `docs/CLAUDE.md`"** are one file and a symlink, not two files.

Not enabling auto-merge and not merging.
