### PR TITLE
refactor(discord): simplify directory HTTP fixtures

### DIFF
--- a/extensions/discord/src/directory-live.test.ts
+++ b/extensions/discord/src/directory-live.test.ts
@@ -1,4 +1,3 @@
-// Discord tests cover directory live plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { DirectoryConfigParams } from "openclaw/plugin-sdk/directory-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +5,7 @@ import { DISCORD_DIRECTORY_LOOKUP_TIMEOUT_MS } from "./api.js";
 import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
 import { clearDiscordDirectoryCacheForTest } from "./directory-cache.test-support.js";
 import { listDiscordDirectoryGroupsLive, listDiscordDirectoryPeersLive } from "./directory-live.js";
+import { urlToString } from "./test-http-helpers.js";
 
 function makeParams(overrides: Partial<DirectoryConfigParams> = {}): DirectoryConfigParams {
   return {
@@ -19,17 +19,6 @@ function makeParams(overrides: Partial<DirectoryConfigParams> = {}): DirectoryCo
     accountId: "default",
     ...overrides,
   };
-}
-
-function jsonResponse(value: unknown): Response {
-  return new Response(JSON.stringify(value), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function resolveFetchUrl(input: string | URL | Request): string {
-  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 }
 
 function hangingBodyResponse(signal?: AbortSignal): Response {
@@ -96,23 +85,23 @@ describe("discord directory live lookups", () => {
 
   it("filters group channels by query and respects limit", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = resolveFetchUrl(input);
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([
+        return Response.json([
           { id: "g1", name: "Guild 1" },
           { id: "g2", name: "Guild 2" },
         ]);
       }
       if (url.endsWith("/guilds/g1/channels")) {
-        return jsonResponse([
+        return Response.json([
           { id: "c1", name: "general" },
           { id: "c2", name: "random" },
         ]);
       }
       if (url.endsWith("/guilds/g2/channels")) {
-        return jsonResponse([{ id: "c3", name: "announcements" }]);
+        return Response.json([{ id: "c3", name: "announcements" }]);
       }
-      return jsonResponse([]);
+      return Response.json([]);
     });
 
     const rows = await listDiscordDirectoryGroupsLive(makeParams({ query: "an", limit: 2 }));
@@ -137,21 +126,21 @@ describe("discord directory live lookups", () => {
 
   it("returns ranked peer results and caps member search by limit", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = resolveFetchUrl(input);
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([{ id: "g1", name: "Guild 1" }]);
+        return Response.json([{ id: "g1", name: "Guild 1" }]);
       }
       if (url.includes("/guilds/g1/members/search?")) {
         const params = new URL(url).searchParams;
         expect(params.get("query")).toBe("alice");
         expect(params.get("limit")).toBe("2");
-        return jsonResponse([
+        return Response.json([
           { user: { id: "u1", username: "alice", bot: false }, nick: "Ali" },
           { user: { id: "u2", username: "alice-bot", bot: true }, nick: null },
           { user: { id: "u3", username: "ignored", bot: false }, nick: null },
         ]);
       }
-      return jsonResponse([]);
+      return Response.json([]);
     });
 
     const rows = await listDiscordDirectoryPeersLive(makeParams({ query: "alice", limit: 2 }));
@@ -194,20 +183,20 @@ describe("discord directory live lookups", () => {
     },
   ])("$name", async ({ secondGuildMembers, limit, expectedIds }) => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = resolveFetchUrl(input);
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
-        return jsonResponse([
+        return Response.json([
           { id: "g1", name: "Guild 1" },
           { id: "g2", name: "Guild 2" },
         ]);
       }
       if (url.includes("/guilds/g1/members/search?")) {
-        return jsonResponse([{ user: { id: "101", username: "alice" }, nick: "first-alice" }]);
+        return Response.json([{ user: { id: "101", username: "alice" }, nick: "first-alice" }]);
       }
       if (url.includes("/guilds/g2/members/search?")) {
-        return jsonResponse(secondGuildMembers);
+        return Response.json(secondGuildMembers);
       }
-      return jsonResponse([]);
+      return Response.json([]);
     });
 
     const rows = await listDiscordDirectoryPeersLive(makeParams({ query: "alice", limit }));


### PR DESCRIPTION
## What Problem This Solves

Discord's live-directory tests duplicated successful JSON-response construction and fetch-input URL normalization that existing APIs already provide.

## Why This Change Was Made

Use native `Response.json` for the existing successful array payloads and the shared test URL reader. Keep the custom hanging-body fixture, cache resets, strict result assertions, and timing unchanged. The shared JSON helper keeps its different default MIME behavior for sibling tests.

## User Impact

Developer-only cleanup: 11 fewer lines of test scaffolding, with no production changes or lost directory coverage.

## Evidence

- The complete directory suite passed before and after: 7 cases with matching identities and outcomes on the same Node 26.5 runtime.
- All 14 assertion sites, 11 JSON payload arguments and 3 URL-reader inputs are retained, including the response-body timeout and cross-guild identity checks.
- Native JSON serialization, default status and MIME behavior were inspected in the exact installed runtime used for proof; this is mocked transport coverage, not a live Discord request.
- Formatting, all 19 normal changed-file checks (including extension-test types and lint), and independent source review passed.
