### PR TITLE
fix(models): select authored rows before applying defaults

### DIFF
--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -3,8 +3,12 @@
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeConfiguredProviderCatalogModelRef } from "@openclaw/model-catalog-core/provider-model-id-normalization";
-import { mergeModelCost } from "../config/model-cost.js";
 import { normalizeProviderCatalogModelIdForConfig } from "../config/model-input.js";
+import {
+  getProviderModelId,
+  materializeConfiguredProviderModelRows,
+  mergeNormalizedProviderModel,
+} from "../config/model-provider-rows.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
@@ -34,10 +38,6 @@ type ProviderModelConfig = NonNullable<
   NonNullable<ModelsConfig["providers"]>[string]["models"]
 >[number];
 
-function getProviderModelId(model: ProviderModelConfig): string | undefined {
-  return typeof model.id === "string" && model.id.trim() ? model.id : undefined;
-}
-
 function normalizeModelCostForCatalog(model: ProviderModelConfig): ProviderModelConfig {
   const cost = model.cost;
   if (
@@ -58,14 +58,6 @@ function normalizeModelCostForCatalog(model: ProviderModelConfig): ProviderModel
       cacheWrite: cost.cacheWrite ?? 0,
     },
   };
-}
-
-function mergeNormalizedProviderModel(
-  existing: ProviderModelConfig,
-  incoming: ProviderModelConfig,
-): ProviderModelConfig {
-  const cost = mergeModelCost(incoming.cost, existing.cost);
-  return { ...incoming, ...existing, ...(cost ? { cost } : {}) };
 }
 
 function normalizeProviderModelsForConfig(
@@ -145,47 +137,9 @@ export function materializeConfiguredProviderCatalogModels(
   options: ModelManifestNormalizationContext = {},
 ): ModelsConfig["providers"] {
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer(options);
-  return normalizeProviderModelMap(providers, (providerKey, provider) => {
-    if (!Array.isArray(provider.models) || provider.models.length === 0) {
-      return provider;
-    }
-    const exactRows = new Map<string, ProviderModelConfig>();
-    for (const model of provider.models) {
-      const id = getProviderModelId(model)?.trim();
-      if (id) {
-        const existing = exactRows.get(id);
-        exactRows.set(id, existing ? mergeNormalizedProviderModel(existing, model) : model);
-      }
-    }
-    const normalizedIds = new Map<string, string>();
-    const selectedRows = new Map<string, ProviderModelConfig>();
-    for (const [id, model] of exactRows) {
-      const normalized = normalizeModelId(providerKey, id) || id;
-      normalizedIds.set(id, normalized);
-      // Exact destinations retain their omissions; other aliases do not donate fields.
-      if (!selectedRows.has(normalized)) {
-        selectedRows.set(normalized, exactRows.get(normalized) ?? model);
-      }
-    }
-    const seen = new Set<string>();
-    const models = provider.models.flatMap((model) => {
-      const rawId = getProviderModelId(model);
-      if (!rawId) {
-        return [model];
-      }
-      const id = normalizedIds.get(rawId.trim())!;
-      if (seen.has(id)) {
-        return [];
-      }
-      seen.add(id);
-      const selected = selectedRows.get(id)!;
-      return [selected.id === id ? selected : { ...selected, id }];
-    });
-    return models.length === provider.models.length &&
-      models.every((model, index) => model === provider.models[index])
-      ? provider
-      : { ...provider, models };
-  });
+  return normalizeProviderModelMap(providers, (providerKey, provider) =>
+    materializeConfiguredProviderModelRows(provider, (id) => normalizeModelId(providerKey, id)),
+  );
 }
 
 /** Finalizes emitted rows without applying authored aliases to their identities. */

--- a/src/agents/prepared-model-runtime.inline-defaults.test.ts
+++ b/src/agents/prepared-model-runtime.inline-defaults.test.ts
@@ -1,0 +1,165 @@
+import { assert, describe, expect, it } from "vitest";
+import { applyModelDefaults } from "../config/defaults.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import { validateConfigObjectRaw } from "../config/validation-core.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
+import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
+import { prepareConfiguredRuntimeModels } from "./prepared-model-runtime.configured.js";
+
+type AuthoredModelRow = Pick<ModelDefinitionConfig, "id" | "name"> &
+  Partial<Omit<ModelDefinitionConfig, "id" | "name" | "cost">> & {
+    cost?: Partial<ModelDefinitionConfig["cost"]>;
+  };
+
+type ProducerCase = {
+  name: string;
+  rows: AuthoredModelRow[];
+  expected: Pick<ModelDefinitionConfig, "name" | "reasoning" | "input" | "contextWindow" | "cost">;
+};
+
+const metadata = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "row-selection-fixture",
+      providers: ["row-selection-fixture"],
+      modelIdNormalization: {
+        providers: { "row-selection-fixture": { aliases: { legacy: "selected" } } },
+      },
+    },
+  ],
+});
+const alias: AuthoredModelRow = {
+  id: "legacy",
+  name: "Alias",
+  contextWindow: 16_000,
+  reasoning: true,
+  input: ["text", "image"],
+};
+const exact = { id: "selected", name: "Exact", contextWindow: 96_000 };
+const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+describe("prepared inline row defaults", () => {
+  it.each<ProducerCase>([
+    {
+      name: "sparse exact after alias",
+      rows: [alias, exact],
+      expected: {
+        name: "Exact",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 96_000,
+        cost: defaultCost,
+      },
+    },
+    {
+      name: "sparse exact before alias",
+      rows: [exact, alias],
+      expected: {
+        name: "Exact",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 96_000,
+        cost: defaultCost,
+      },
+    },
+    {
+      name: "explicit false exact",
+      rows: [alias, { ...exact, reasoning: false, input: ["text"] }],
+      expected: {
+        name: "Exact",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 96_000,
+        cost: defaultCost,
+      },
+    },
+    {
+      name: "explicit true exact",
+      rows: [
+        { ...alias, reasoning: false, input: ["text"] },
+        { ...exact, reasoning: true, input: ["text", "image"] },
+      ],
+      expected: {
+        name: "Exact",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 96_000,
+        cost: defaultCost,
+      },
+    },
+    {
+      name: "same-spelling cost and capability omissions",
+      rows: [
+        { ...exact, cost: { input: 7 } },
+        {
+          ...exact,
+          name: "Later duplicate",
+          contextWindow: 128_000,
+          reasoning: true,
+          input: ["image"],
+          cost: { input: 9, output: 8, cacheRead: 0.5 },
+        },
+      ],
+      expected: {
+        name: "Exact",
+        reasoning: true,
+        input: ["image"],
+        contextWindow: 96_000,
+        cost: { input: 7, output: 8, cacheRead: 0.5, cacheWrite: 0 },
+      },
+    },
+    {
+      name: "one raw row",
+      rows: [exact],
+      expected: {
+        name: "Exact",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 96_000,
+        cost: defaultCost,
+      },
+    },
+  ])("selects $name before capabilities become runtime defaults", ({ rows, expected }) => {
+    const parsed = validateConfigObjectRaw({
+      models: {
+        providers: {
+          "row-selection-fixture": {
+            api: "openai-completions",
+            baseUrl: "https://fixture.invalid/v1",
+            models: rows,
+          },
+        },
+      },
+    });
+    assert(parsed.ok);
+    const source = structuredClone(parsed.config);
+    const config = applyModelDefaults(parsed.config, {
+      manifestRegistry: metadata.manifestRegistry,
+    });
+    const inline = buildInlineProviderModels(config.models?.providers ?? {}, {
+      providerMetadataOwners: metadata.owners,
+    });
+    const configured = prepareConfiguredRuntimeModels({
+      config,
+      inlineProviderModels: inline,
+      configuredModelRefs: [{ provider: "row-selection-fixture", modelId: "selected" }],
+      metadataSnapshot: metadata,
+      providerStaticModels: [],
+      resolveStaticCatalogModel: () => undefined,
+      matchesStaticModelId: createStaticModelIdMatcher({ manifestPlugins: metadata }),
+    });
+    const expectedModel = {
+      id: "selected",
+      ...expected,
+      api: "openai-completions",
+      baseUrl: "https://fixture.invalid/v1",
+    };
+    expect(config.models?.providers?.["row-selection-fixture"]?.models).toMatchObject([
+      { id: "selected", ...expected },
+    ]);
+    expect(inline).toMatchObject([expectedModel]);
+    expect(configured.map(({ model }) => model)).toMatchObject([expectedModel]);
+    expect(parsed.config).toEqual(source);
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -19,6 +19,7 @@ import {
   normalizeAgentModelMapForConfig,
   normalizeAgentModelSelectionForConfig,
 } from "./model-input.js";
+import { materializeConfiguredProviderModelRows } from "./model-provider-rows.js";
 import {
   applyProviderConfigDefaultsForConfig,
   normalizeProviderConfigForConfigDefaults,
@@ -225,11 +226,19 @@ export function applyModelDefaults(
     );
     const nextProviders = { ...providerConfig };
     for (const [providerId, provider] of Object.entries(providerConfig)) {
-      const normalizedProvider = normalizeProviderConfigForConfigDefaults({
-        provider: providerId,
-        providerConfig: provider,
-        manifestRegistry,
-      });
+      const normalizedProvider = materializeConfiguredProviderModelRows(
+        normalizeProviderConfigForConfigDefaults({
+          provider: providerId,
+          providerConfig: provider,
+          manifestRegistry,
+        }),
+        (modelId) =>
+          normalizeConfiguredProviderCatalogModelId(
+            providerId,
+            modelId,
+            modelIdNormalizationPolicies,
+          ),
+      );
       const models = normalizedProvider.models;
       if (!Array.isArray(models) || models.length === 0) {
         if (normalizedProvider !== provider) {
@@ -247,11 +256,7 @@ export function applyModelDefaults(
       let providerMutated = false;
       const nextModels = models.map((model) => {
         const raw = model as ModelDefinitionLike;
-        const id = normalizeConfiguredProviderCatalogModelId(
-          providerId,
-          raw.id,
-          modelIdNormalizationPolicies,
-        );
+        const id = raw.id;
 
         // Config entries are overrides, not full definitions: authored fields
         // win, the owning catalog row fills omitted fields, and only then do
@@ -305,7 +310,6 @@ export function applyModelDefaults(
             ? catalogModel.compat
             : undefined;
         const modelMutated =
-          id !== raw.id ||
           raw.reasoning !== reasoning ||
           raw.input === undefined ||
           costMutated ||
@@ -323,7 +327,6 @@ export function applyModelDefaults(
           {},
           raw,
           {
-            id,
             reasoning,
             input,
             cost,

--- a/src/config/model-provider-rows.ts
+++ b/src/config/model-provider-rows.ts
@@ -1,0 +1,59 @@
+import { mergeModelCost } from "./model-cost.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "./types.models.js";
+
+export function getProviderModelId(model: ModelDefinitionConfig): string | undefined {
+  return typeof model.id === "string" && model.id.trim() ? model.id : undefined;
+}
+
+export function mergeNormalizedProviderModel(
+  existing: ModelDefinitionConfig,
+  incoming: ModelDefinitionConfig,
+): ModelDefinitionConfig {
+  const cost = mergeModelCost(incoming.cost, existing.cost);
+  return { ...incoming, ...existing, ...(cost ? { cost } : {}) };
+}
+
+/** Selects authored model rows before defaults erase field omissions. */
+export function materializeConfiguredProviderModelRows<
+  T extends Pick<ModelProviderConfig, "models">,
+>(provider: T, normalizeModelId: (id: string) => string): T {
+  if (!Array.isArray(provider.models) || provider.models.length === 0) {
+    return provider;
+  }
+  const exactRows = new Map<string, ModelDefinitionConfig>();
+  for (const model of provider.models) {
+    const id = getProviderModelId(model)?.trim();
+    if (id) {
+      const existing = exactRows.get(id);
+      exactRows.set(id, existing ? mergeNormalizedProviderModel(existing, model) : model);
+    }
+  }
+  const normalizedIds = new Map<string, string>();
+  const selectedRows = new Map<string, ModelDefinitionConfig>();
+  for (const [id, model] of exactRows) {
+    const normalized = normalizeModelId(id) || id;
+    normalizedIds.set(id, normalized);
+    // Exact destinations retain their omissions; other aliases do not donate fields.
+    if (!selectedRows.has(normalized)) {
+      selectedRows.set(normalized, exactRows.get(normalized) ?? model);
+    }
+  }
+  const seen = new Set<string>();
+  const models = provider.models.flatMap((model) => {
+    const rawId = getProviderModelId(model);
+    if (!rawId) {
+      return [model];
+    }
+    const id = normalizedIds.get(rawId.trim())!;
+    if (seen.has(id)) {
+      return [];
+    }
+    seen.add(id);
+    const selected = selectedRows.get(id)!;
+    return [selected.id === id ? selected : { ...selected, id }];
+  });
+  return models.length === provider.models.length &&
+    models.every((model, index) => model === provider.models[index])
+    ? provider
+    : { ...provider, models };
+}


### PR DESCRIPTION
Related: #130706, #142100. Follows #143967.

## What Problem This Solves

Config defaults can collapse an alias into an exact destination after filling its omitted capabilities, allowing the alias row to contaminate the selected row. Later planning cannot recover which fields were authored.

## Why This Change Was Made

Reuse the planner's existing row-selection algorithm in the config owner, before capability defaults. Remove the later repeated ID normalization and let the planner delegate to the shared pure helper. Exact destinations retain their omissions and same-spelling duplicate costs retain their existing merge semantics. This adds 16 production lines; sparse capability inheritance and runtime pricing remain separate follow-ups.

## User Impact

The intended authored model row determines which fields are explicit before defaults or prepared runtime metadata are added.

## Evidence

Five baseline failures and one control established the producer defect. The fresh-main replay passed 132 focused tests, six final fixture rechecks, independent P2 review with unchanged production context, and the full changed gate. A test-table type correction produced byte-identical JavaScript and unchanged assertions.

One normal full build at the tested commit and 18 compiled cases passed: six config/defaults-to-inline/runtime cases and 12 planner/registry controls. All 11,929 root/workspace output files remained unchanged; the proof loaded no checkout TypeScript and made no HTTP or catalog rediscovery calls. All owned processes joined. This is compiled producer/planner proof, not an upstream-provider request.

Tested commit: `0ffd387049b04c07dda65f61f68684548105ca36`.

CI refresh: the unchanged authored-row patch is replayed onto main `eb9f4ff537c01eed0596bf0949f40be0d5b16e9f`, including the separate session-fixture cleanup in #144087 identified during the TaskFlow CI investigation. Every changed-file postimage and the stable task patch match `5b6b4ffc04f538feb334186e54aac03eab375fa6`. Original exact-commit runtime proof is preserved without restamping; fresh CI is required for `eb90eba9303c5eae8e7d1972bbb21a600077934a`. #144087 documents the historical causal limit.
