### PR TITLE
refactor(models): simplify source-managed marker restoration

### DIFF
--- a/src/agents/models-config.providers.source-managed.ts
+++ b/src/agents/models-config.providers.source-managed.ts
@@ -117,7 +117,6 @@ export function enforceSourceManagedProviderSecrets(params: {
       continue;
     }
     let nextProvider = provider;
-    let providerMutated = false;
 
     const sourceApiKeyMarker = resolveSourceManagedApiKeyMarker({
       sourceProvider,
@@ -126,7 +125,6 @@ export function enforceSourceManagedProviderSecrets(params: {
     if (sourceApiKeyMarker) {
       params.secretRefManagedProviders?.add(canonicalProviderKey);
       if (nextProvider.apiKey !== sourceApiKeyMarker) {
-        providerMutated = true;
         nextProvider = {
           ...nextProvider,
           apiKey: sourceApiKeyMarker,
@@ -138,34 +136,24 @@ export function enforceSourceManagedProviderSecrets(params: {
       sourceProvider,
       sourceConfig: params.sourceConfigForSecrets,
     });
-    if (Object.keys(sourceHeaderMarkers).length > 0) {
-      const currentHeaders = isRecord(nextProvider.headers) ? nextProvider.headers : undefined;
+    const currentHeaders = isRecord(nextProvider.headers) ? nextProvider.headers : undefined;
+    if (
+      Object.entries(sourceHeaderMarkers).some(
+        ([headerName, marker]) => currentHeaders?.[headerName] !== marker,
+      )
+    ) {
       // Merge marker headers over normalized headers so auth metadata remains managed while
       // unrelated provider headers survive normalization.
-      const nextHeaders = { ...currentHeaders };
-      let headersMutated = !currentHeaders;
-      for (const [headerName, marker] of Object.entries(sourceHeaderMarkers)) {
-        if (nextHeaders[headerName] === marker) {
-          continue;
-        }
-        headersMutated = true;
-        nextHeaders[headerName] = marker;
-      }
-      if (headersMutated) {
-        providerMutated = true;
-        nextProvider = {
-          ...nextProvider,
-          headers: nextHeaders,
-        };
-      }
+      nextProvider = {
+        ...nextProvider,
+        headers: { ...currentHeaders, ...sourceHeaderMarkers },
+      };
     }
 
-    if (!providerMutated) {
+    if (nextProvider === provider) {
       continue;
     }
-    if (!nextProviders) {
-      nextProviders = { ...providers };
-    }
+    nextProviders ??= { ...providers };
     nextProviders[providerKey] = nextProvider;
   }
 


### PR DESCRIPTION
Related: #130706, #142100. Follows #143967.

## What Problem This Solves

Source-managed provider marker restoration duplicates mutation bookkeeping and header-copy loops.

## Why This Change Was Made

Use existing object identity to detect provider changes and copy headers only when an authored marker differs. Preserve canonical source ownership, managed-provider tracking, marker precedence, and header ordering. This removes 12 production lines from one file.

## User Impact

No behavior change is intended. Managed secret references and unrelated provider headers remain intact during model planning.

## Evidence

All 45 retained tests, fresh independent P2 review, and the full changed gate passed.

One exact-commit sourcePerformance build and 12 compiled public-planner scenarios passed, covering synthetic env/file/exec references, missing/matching/absent headers, canonical alias ownership, ordering, immutable inputs, and repeated/persisted no-op output. All 9,257 build products remained unchanged; zero source imports or network requests, and isolated state/processes cleaned up.

The private helper was compiler-inlined and exercised through the real public planner. Its internal return-reference identity is covered by retained tests and review, rather than claimed as a public compiled API observation. The runtime profile excludes UI and SDK declaration lanes.

Tested commit: `bd04a4c4f400ea5e3b0b8af47b2fc8d9714ddc2e`.

CI refresh: the unchanged task patch is replayed onto main `3943149f8ac269fc138ca21b5786ff2a9db3dd23`, including the navigation repair in #144037. Every changed-file postimage matches the previous reviewed head `bd04a4c4f400ea5e3b0b8af47b2fc8d9714ddc2e`. Original exact-commit runtime proof remains preserved and is not restamped; fresh CI is running for `6345173828f79b09bba78254e59cbec154ec33a1`.
