### PR TITLE
fix(docs): align locale navigation with split release tabs

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -520,7 +520,7 @@
       ]
     },
     {
-      "tab": "发布与 CI",
+      "tab": "发布",
       "groups": [
         {
           "group": "发布说明",
@@ -531,16 +531,21 @@
           ]
         },
         {
-          "group": "成熟度",
-          "pages": ["zh-CN/maturity/scorecard", "zh-CN/maturity/taxonomy"]
-        },
-        {
           "group": "发布流程",
           "pages": [
             "zh-CN/reference/RELEASING",
             "zh-CN/reference/full-release-validation",
             "zh-CN/reference/release-performance-sweep"
           ]
+        }
+      ]
+    },
+    {
+      "tab": "贡献",
+      "groups": [
+        {
+          "group": "成熟度",
+          "pages": ["zh-CN/maturity/scorecard", "zh-CN/maturity/taxonomy"]
         },
         {
           "group": "测试与 CI",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3323,7 +3323,6 @@
                       "help/testing-live/media-providers"
                     ]
                   },
-                  "channels/qa-channel",
                   "concepts/mantis",
                   "concepts/mantis-slack-desktop-runbook"
                 ]

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -424,18 +424,21 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
     expect(simplifiedChinese).toBeDefined();
     expect(german).toBeDefined();
     expect(english!.tabs.slice(-4).map((tab) => tab.tab)).toEqual([
-      "Gateway & Ops",
       "Reference",
-      "Release & CI",
+      "Releases",
+      "Contributing",
       "Help",
     ]);
 
-    const releaseTab = english!.tabs.find((tab) => tab.tab === "Release & CI");
+    const releaseTab = english!.tabs.find((tab) => tab.tab === "Releases");
+    const contributingTab = english!.tabs.find((tab) => tab.tab === "Contributing");
     const releaseNotes = collectPages(releaseTab?.groups?.[0]);
     expect(releaseTab?.groups?.map((group) => group.group)).toEqual([
       "Release notes",
-      "Maturity",
       "Release process",
+    ]);
+    expect(contributingTab?.groups?.map((group) => group.group)).toEqual([
+      "Maturity",
       "Testing and CI",
     ]);
     // Releases may have a version page or subpages, so read the published routes from the
@@ -452,8 +455,6 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
     expect("releases/2026.8.1/memory/nested").not.toMatch(releaseRoutePattern);
     const releaseRoutes = [
       ...releaseNotes,
-      "maturity/scorecard",
-      "maturity/taxonomy",
       "reference/RELEASING",
       "reference/full-release-validation",
       "reference/full-release-validation/dispatch",
@@ -465,46 +466,21 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       "reference/full-release-validation/evidence",
       "reference/release-performance-sweep",
       "gateway/security/dependency-locking",
-      "reference/test",
-      "reference/test/local",
-      "reference/test/lanes",
-      "reference/test/docker",
-      "reference/test/performance",
-      "reference/test/runner-internals",
-      "reference/test/remote-proof",
-      "ci",
-      "ci/pipeline",
-      "ci/watching-runs",
-      "ci/checkout",
-      "ci/scope-and-routing",
-      "ci/scope-and-routing/selection",
-      "ci/scope-and-routing/node-test-lanes",
-      "ci/scope-and-routing/job-budgets",
-      "ci/scope-and-routing/manual-dispatches",
-      "ci/runners",
-      "ci/capacity",
-      "ci/release-validation",
-      "ci/release-validation/full-release-validation",
-      "ci/release-validation/live-and-e2e-shards",
-      "ci/release-validation/package-acceptance",
-      "ci/release-validation/install-smoke-and-docker-e2e",
-      "ci/release-validation/plugin-prerelease",
-      "ci/scheduled-workflows",
-      "ci/local-proof",
-      "help/scripts",
-      "concepts/qa-e2e-automation",
-      "concepts/qa-e2e-automation/command-surface",
-      "concepts/qa-e2e-automation/operator-flow",
-      "concepts/qa-e2e-automation/scenario-coverage",
-      "concepts/qa-e2e-automation/channel-qa-reference",
-      "concepts/qa-e2e-automation/slack-qa",
-      "concepts/qa-e2e-automation/whatsapp-and-credentials",
-      "concepts/qa-e2e-automation/extending-the-stack",
-      "concepts/qa-e2e-automation/qa-reporting",
-      "concepts/personal-agent-benchmark-pack",
     ];
     expect(collectPages(releaseTab)).toEqual(releaseRoutes);
     expect(new Set(releaseRoutes)).toHaveLength(releaseRoutes.length);
+    const contributingRoutes = collectPages(contributingTab);
+    expect(contributingRoutes).toEqual(
+      expect.arrayContaining([
+        "maturity/scorecard",
+        "maturity/taxonomy",
+        "reference/test",
+        "ci",
+        "help/testing",
+        "concepts/mantis",
+      ]),
+    );
+    expect(new Set(contributingRoutes)).toHaveLength(contributingRoutes.length);
 
     const englishWithoutClawHub = {
       ...english,
@@ -516,14 +492,10 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
     expect(collectPages(simplifiedChinese).toSorted()).toEqual(expectedZhPages);
     expect(simplifiedChinese!.tabs[0]?.tab).toBe("快速开始");
     expect(simplifiedChinese!.tabs[0]?.groups?.[0]?.group).toBe("首页");
-    const simplifiedChineseReleaseTab = simplifiedChinese!.tabs.find(
-      (tab) => tab.tab === "发布与 CI",
-    );
+    const simplifiedChineseReleaseTab = simplifiedChinese!.tabs.find((tab) => tab.tab === "发布");
     expect(simplifiedChineseReleaseTab?.groups?.map((group) => group.group)).toEqual([
       "发布说明",
-      "成熟度",
       "发布流程",
-      "测试与 CI",
     ]);
     expect(collectPages(simplifiedChineseReleaseTab?.groups?.[0])).toEqual(
       releaseNotes.map((page) => `zh-CN/${page}`),
@@ -532,6 +504,16 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       releaseRoutes.map((page) => `zh-CN/${page}`),
     );
     expect(new Set(collectPages(simplifiedChineseReleaseTab))).toHaveLength(releaseRoutes.length);
+    const simplifiedChineseContributingTab = simplifiedChinese!.tabs.find(
+      (tab) => tab.tab === "贡献",
+    );
+    expect(simplifiedChineseContributingTab?.groups?.map((group) => group.group)).toEqual([
+      "成熟度",
+      "测试与 CI",
+    ]);
+    expect(collectPages(simplifiedChineseContributingTab)).toEqual(
+      contributingRoutes.map((page) => `zh-CN/${page}`),
+    );
 
     expect(collectPages(german)).toHaveLength(collectPages(englishWithoutClawHub).length);
     expect(german!.tabs[0]?.tab).toBe("Loslegen");
@@ -545,8 +527,14 @@ fs.writeFileSync('package-lock.json', JSON.stringify(lock));
       const localizedReleaseTab = locale.tabs.find((tab) =>
         collectPages(tab).includes(`${localeDir}/releases/index`),
       );
+      const localizedContributingTab = locale.tabs.find((tab) =>
+        collectPages(tab).includes(`${localeDir}/maturity/scorecard`),
+      );
       expect(collectPages(localizedReleaseTab)).toEqual(localizedRoutes);
       expect(new Set(collectPages(localizedReleaseTab))).toHaveLength(localizedRoutes.length);
+      expect(collectPages(localizedContributingTab)).toEqual(
+        contributingRoutes.map((page) => `${localeDir}/${page}`),
+      );
     }
   });
 });


### PR DESCRIPTION
Related: #144021. Restores the documentation checks blocking #144017 and other PRs.

## What Problem This Solves

The English navigation was split into Releases and Contributing, but the Simplified Chinese overlay and publisher test still expected the combined tab. The reorganization also exposed the private QA channel in navigation despite its explicit hidden-docs setting.

## Why This Change Was Made

Split the Chinese labels to match the English layout, and validate the release and contributor route sets independently. Remove only the accidental QA navigation entry, preserving its page and existing links and keeping the catalog exposure guard intact.

## User Impact

Chinese navigation uses the matching release/contributor labels, and the documentation regression checks cover the current layout. Internal QA transport docs stay outside advertised navigation.

## Evidence

Author validation:

- docs-sync-publish and official-channel-catalog tooling suites: 32/32
- pnpm check:test-types
- pnpm lint
- pnpm format:check
- git diff --check

Maintainer verification: a fresh independent P2 review found no actionable issue. A direct JSON comparison confirmed all 294 Chinese route occurrences are preserved; the sole English navigation removal is `channels/qa-channel`, whose unchanged manifest declares `channel.exposure.docs: false`. The page and inbound links are unchanged.

Current head: `0d90f952ad90403eb1886499164b8a9c49573abc`. Its [replacement CI run](https://github.com/openclaw/openclaw/actions/runs/34477767029) passed. The actual tested merge tree and the formerly failing locale-navigation test were independently verified; the prior head's catalog failure is preserved in the review evidence. No checks or allowlists were weakened.
