### PR TITLE
fix(models): preserve session selections and enforce exact allowlists

### DIFF
--- a/src/agents/agent-command.live-model-switch.test-helpers.ts
+++ b/src/agents/agent-command.live-model-switch.test-helpers.ts
@@ -195,7 +195,6 @@ export function createTestModelVisibilityPolicy(params: ModelSelectionParams) {
     providerWildcards: new Set<string>(),
     hasConfiguredEntries: !allowed.allowAny,
     hasProviderWildcards: wildcardModelKeys.size > 0,
-    allowsKey,
     allows: ({ provider, model }: { provider: string; model: string }) =>
       allowsKey(`${provider}/${model}`),
     allowsByWildcard: ({ provider, model }: { provider: string; model: string }) =>

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -218,9 +218,7 @@ export async function resolveEmbeddedModelSelection(params: {
         overrideModel,
         params.modelManifestContext,
       );
-      if (
-        !visibilityPolicy.allowsKey(modelKey(normalizedOverride.provider, normalizedOverride.model))
-      ) {
+      if (!visibilityPolicy.allows(normalizedOverride)) {
         const { updated } = applyModelOverrideToSessionEntry({
           entry,
           selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -347,10 +345,7 @@ export async function resolveEmbeddedModelSelection(params: {
       storedAlias?.model ?? storedModelOverride,
       params.modelManifestContext,
     );
-    if (
-      isModelSelectionLocked(sessionEntry) ||
-      visibilityPolicy.allowsKey(modelKey(normalizedStored.provider, normalizedStored.model))
-    ) {
+    if (isModelSelectionLocked(sessionEntry) || visibilityPolicy.allows(normalizedStored)) {
       provider = normalizedStored.provider;
       model = normalizedStored.model;
       requestedRouteResolution =
@@ -404,7 +399,7 @@ export async function resolveEmbeddedModelSelection(params: {
     if (!explicitRef) {
       throw new Error("Invalid model override.");
     }
-    if (!visibilityPolicy.allowsKey(modelKey(explicitRef.provider, explicitRef.model))) {
+    if (!visibilityPolicy.allows(explicitRef)) {
       const rejectedKey = `${sanitizeForLog(explicitRef.provider)}/${sanitizeForLog(explicitRef.model)}`;
       const policyPath = visibilityPolicy.allowConfigPath ?? "modelPolicy.allow";
       const repairPath = visibilityPolicy.allowRepairConfigPath;

--- a/src/agents/command/model-selection.turn-model-differential.test.ts
+++ b/src/agents/command/model-selection.turn-model-differential.test.ts
@@ -97,7 +97,7 @@ vi.mock("../model-visibility-policy.js", () => ({
     allowAny: true,
     allowedCatalog: [],
     selectionAliasIndex: { byAlias: new Map(), byKey: new Map() },
-    allowsKey: () => true,
+    allows: () => true,
     resolveSelection: (ref: { provider: string; model: string }) => ref,
   }),
 }));

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -31,7 +31,7 @@ import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.j
 import { prepareInternalSessionEffectsSession } from "../internal-session-effects.js";
 import { LiveSessionModelSwitchError } from "../live-model-switch.js";
 import { prepareModelRunCapabilities } from "../model-catalog-lookup.js";
-import { modelKey, resolveThinkingDefault } from "../model-selection.js";
+import { resolveThinkingDefault } from "../model-selection.js";
 import { resolveConfiguredThinkingDefault } from "../model-thinking-default.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
 import {
@@ -604,7 +604,7 @@ export async function runEmbeddedAgentAttempt(params: RunEmbeddedAgentAttemptPar
           err.model,
           modelManifestContext,
         );
-        if (!visibilityPolicy.allowsKey(modelKey(switchRef.provider, switchRef.model))) {
+        if (!visibilityPolicy.allows(switchRef)) {
           log.info(
             `Live session model switch in subagent run ${runId}: ` +
               `rejected ${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)} (not in allowlist)`,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -958,6 +958,7 @@ type AllowedModelSet = {
   allowAny: boolean;
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
+  allows: (ref: ModelRef) => boolean;
 };
 
 /** Build explicit model override authorization without widening it for automatic fallbacks. */
@@ -1063,7 +1064,7 @@ function buildAllowedModelSetFromPrepared(
     if (defaultKey) {
       allowedKeys.add(defaultKey);
     }
-    return { allowAny: true, allowedCatalog: catalog, allowedKeys };
+    return { allowAny: true, allowedCatalog: catalog, allowedKeys, allows: () => true };
   };
 
   if (allowAny) {
@@ -1073,6 +1074,7 @@ function buildAllowedModelSetFromPrepared(
   const allowedKeys = new Set<string>();
   const catalogIdentities = new Set(catalog.map(resolveModelCatalogIdentityKey));
   const allowedCatalogIdentities = new Set<string>();
+  const exactAllowedIdentities = new Set<string>();
   const allowedCaseInsensitiveIdentities = new Set<string>();
   const caseInsensitiveIdentity = (provider: string, model: string) =>
     JSON.stringify([normalizeProviderId(provider), normalizeLowercaseStringOrEmpty(model)]);
@@ -1081,10 +1083,10 @@ function buildAllowedModelSetFromPrepared(
     allowedKeys.add(wildcardKey);
   }
   const addAllowedCatalogRef = (ref: ModelRef) => {
-    allowedCatalogIdentities.add(
-      resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model }),
-    );
+    const identity = resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model });
+    allowedCatalogIdentities.add(identity);
     allowedCaseInsensitiveIdentities.add(caseInsensitiveIdentity(ref.provider, ref.model));
+    return identity;
   };
   for (const entry of expandModelCatalogWildcards(catalog, wildcardModelKeys)) {
     allowedKeys.add(modelKey(entry.provider, entry.id));
@@ -1097,7 +1099,7 @@ function buildAllowedModelSetFromPrepared(
     }
     const key = modelKey(parsed.provider, parsed.model);
     allowedKeys.add(key);
-    addAllowedCatalogRef(parsed);
+    exactAllowedIdentities.add(addAllowedCatalogRef(parsed));
     const syntheticKey = modelCatalogEntryKey({ provider: parsed.provider, id: parsed.model });
 
     if (
@@ -1130,7 +1132,10 @@ function buildAllowedModelSetFromPrepared(
   ) {
     allowedKeys.add(defaultKey);
     if (defaultRef) {
-      addAllowedCatalogRef(defaultRef);
+      const identity = addAllowedCatalogRef(defaultRef);
+      if (wildcardModelKeys.size === 0) {
+        exactAllowedIdentities.add(identity);
+      }
     }
   }
 
@@ -1151,6 +1156,15 @@ function buildAllowedModelSetFromPrepared(
     allowAny: false,
     allowedCatalog,
     allowedKeys,
+    allows: (ref) => {
+      const provider = normalizeProviderId(ref.provider);
+      return (
+        exactAllowedIdentities.has(resolveModelCatalogIdentityKey({ provider, id: ref.model })) ||
+        // Wildcard catalog expansion uses display keys; it cannot authorize resolved tuples.
+        (visibility.providerWildcards.has(provider) &&
+          isModelKeyAllowedBySet(wildcardModelKeys, `${provider}/${ref.model}`))
+      );
+    },
   };
 }
 
@@ -1703,7 +1717,7 @@ export function createModelVisibilityPolicyWithFallbacks(
     allowConfigPath: visibility.configPath,
     allowRepairConfigPath: visibility.repairConfigPath,
     allowsKey,
-    allows: (ref) => allowsKey(modelKey(ref.provider, ref.model)),
+    allows: allowed.allows,
     allowsByWildcard: (ref) =>
       isModelKeyAllowedBySet(wildcardModelKeys, modelKey(ref.provider, ref.model)),
     resolveSelection: (ref) =>

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1086,7 +1086,7 @@ function buildAllowedModelSetFromPrepared(
     const identity = resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model });
     allowedCatalogIdentities.add(identity);
     allowedCaseInsensitiveIdentities.add(caseInsensitiveIdentity(ref.provider, ref.model));
-    return identity;
+    return modelCatalogEntryKey({ provider: ref.provider, id: ref.model });
   };
   for (const entry of expandModelCatalogWildcards(catalog, wildcardModelKeys)) {
     allowedKeys.add(modelKey(entry.provider, entry.id));
@@ -1159,7 +1159,7 @@ function buildAllowedModelSetFromPrepared(
     allows: (ref) => {
       const provider = normalizeProviderId(ref.provider);
       return (
-        exactAllowedIdentities.has(resolveModelCatalogIdentityKey({ provider, id: ref.model })) ||
+        exactAllowedIdentities.has(modelCatalogEntryKey({ provider, id: ref.model })) ||
         // Wildcard catalog expansion uses display keys; it cannot authorize resolved tuples.
         (visibility.providerWildcards.has(provider) &&
           isModelKeyAllowedBySet(wildcardModelKeys, `${provider}/${ref.model}`))
@@ -1203,7 +1203,7 @@ export function getModelRefStatus(
       }),
     ),
     allowAny: allowed.allowAny,
-    allowed: allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key),
+    allowed: allowed.allows(params.ref),
   };
 }
 
@@ -1566,37 +1566,31 @@ function resolveAllowedModelSelection(
     cfg?: OpenClawConfig;
     provider: string;
     model: string;
-    allowAny: boolean;
-    allowedKeys: ReadonlySet<string>;
+    allows: (ref: ModelRef) => boolean;
     allowedCatalog: readonly ModelCatalogEntry[];
     allowManifestNormalization?: boolean;
     allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelRef | null {
-  const normalizeSelectionRef = (provider: string, model: string) =>
+  const current =
     resolveExactConfiguredProviderRef({
       cfg: params.cfg,
-      raw: `${provider}/${model}`,
+      raw: `${params.provider}/${params.model}`,
       allowManifestNormalization: params.allowManifestNormalization,
       manifestPlugins: params.manifestPlugins,
     }) ??
-    normalizeModelRef(provider, model, {
+    normalizeModelRef(params.provider, params.model, {
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
     });
-  const current = normalizeSelectionRef(params.provider, params.model);
-  if (
-    params.allowAny ||
-    isModelKeyAllowedBySet(params.allowedKeys, modelKey(current.provider, current.model))
-  ) {
+  if (params.allows(current)) {
     return current;
   }
-  const fallback = params.allowedCatalog[0];
-  if (!fallback) {
-    return null;
-  }
-  return normalizeSelectionRef(fallback.provider, fallback.id);
+  const fallback = params.allowedCatalog.find((entry) =>
+    params.allows({ provider: entry.provider, model: entry.id }),
+  );
+  return fallback ? { provider: fallback.provider, model: fallback.id } : null;
 }
 
 export type ModelVisibilityPolicy = {
@@ -1614,7 +1608,6 @@ export type ModelVisibilityPolicy = {
   hasProviderWildcards: boolean;
   allowConfigPath?: string | null;
   allowRepairConfigPath: string;
-  allowsKey: (key: string) => boolean;
   allows: (ref: { provider: string; model: string }) => boolean;
   allowsByWildcard: (ref: { provider: string; model: string }) => boolean;
   resolveSelection: (ref: { provider: string; model: string }) => ModelRef | null;
@@ -1699,8 +1692,6 @@ export function createModelVisibilityPolicyWithFallbacks(
     // retention, but are not user-selectable overrides unless policy also allows them.
     addConfiguredRef(fallback, true, selectionAliasIndex);
   }
-  const allowsKey = (key: string): boolean =>
-    allowed.allowAny || isModelKeyAllowedBySet(allowed.allowedKeys, key);
   const policy: ModelVisibilityPolicy = {
     allowAny: allowed.allowAny,
     configuredCatalog,
@@ -1716,17 +1707,20 @@ export function createModelVisibilityPolicyWithFallbacks(
     hasProviderWildcards: wildcardModelKeys.size > 0,
     allowConfigPath: visibility.configPath,
     allowRepairConfigPath: visibility.repairConfigPath,
-    allowsKey,
     allows: allowed.allows,
-    allowsByWildcard: (ref) =>
-      isModelKeyAllowedBySet(wildcardModelKeys, modelKey(ref.provider, ref.model)),
+    allowsByWildcard: (ref) => {
+      const provider = normalizeProviderId(ref.provider);
+      return (
+        visibility.providerWildcards.has(provider) &&
+        isModelKeyAllowedBySet(wildcardModelKeys, `${provider}/${ref.model}`)
+      );
+    },
     resolveSelection: (ref) =>
       resolveAllowedModelSelection({
         provider: ref.provider,
         model: ref.model,
         cfg: params.cfg,
-        allowAny: allowed.allowAny,
-        allowedKeys: allowed.allowedKeys,
+        allows: allowed.allows,
         allowedCatalog: allowed.allowedCatalog,
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -160,6 +160,25 @@ describe("model-selection plugin runtime normalization", () => {
     }
   });
 
+  it("normalizes an unrestricted reply default before selecting it", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(normalizeLegacyFixtureModel);
+    const cfg = { agents: { defaults: { modelPolicy: { allow: [] } } } };
+    const state = await createModelSelectionStateForTest({
+      cfg,
+      agentCfg: cfg.agents.defaults,
+      defaultProvider: "custom-provider",
+      defaultModel: "custom-legacy-model",
+      provider: "custom-provider",
+      model: "custom-legacy-model",
+      hasModelDirective: false,
+    });
+
+    expect({ provider: state.provider, model: state.model }).toEqual({
+      provider: "custom-provider",
+      model: "custom-modern-model",
+    });
+  });
+
   it("keeps plugin-normalized stored overrides allowed in auto-reply runtime selection", async () => {
     // Stored session overrides are runtime inputs, so provider-owned
     // normalization keeps old persisted ids usable without resetting them.

--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -1,6 +1,7 @@
 // Explicit model policy tests keep catalog metadata separate from override restrictions.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import { getModelRefStatus } from "./model-selection-resolve.js";
 import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 
 function createPolicy(cfg: OpenClawConfig, agentId?: string) {
@@ -189,20 +190,40 @@ describe("explicit model visibility policy", () => {
     expect(policy.allows({ provider: "anthropic", model: "claude-sonnet-4-6" })).toBe(false);
   });
 
-  it("does not authorize a default from a colliding provider wildcard", () => {
+  it.each([
+    ["custom/team", "Reader", "custom/*"],
+    ["custom", "custom/team/Reader", "custom/team/*"],
+  ])("keeps %s/%s outside the literal wildcard %s", (provider, model, allow) => {
+    const cfg = { agents: { defaults: { modelPolicy: { allow: [allow] } } } };
+    const allowed = { provider: "custom", model: "team/Reader" };
+    const candidate = { provider, model };
     const policy = createModelVisibilityPolicy({
-      cfg: { agents: { defaults: { modelPolicy: { allow: ["custom/*"] } } } },
+      cfg,
       catalog: [
-        { provider: "custom", id: "team/Reader", name: "Allowed model" },
-        { provider: "custom/team", id: "Reader", name: "Other provider default" },
+        { provider: allowed.provider, id: allowed.model, name: "Allowed model" },
+        { provider, id: model, name: "Other literal default" },
       ],
-      defaultProvider: "custom/team",
-      defaultModel: "Reader",
+      defaultProvider: provider,
+      defaultModel: model,
     });
 
     expect(policy.allowAny).toBe(false);
-    expect(policy.allows({ provider: "custom", model: "team/Reader" })).toBe(true);
-    expect(policy.allows({ provider: "custom/team", model: "Reader" })).toBe(false);
+    expect(policy.allows(allowed)).toBe(true);
+    expect(policy.allowsByWildcard(allowed)).toBe(true);
+    expect(policy.allows(candidate)).toBe(false);
+    expect.soft(policy.allowsByWildcard(candidate)).toBe(false);
+    expect.soft(policy.resolveSelection(candidate)).toEqual(allowed);
+    expect
+      .soft(
+        getModelRefStatus({
+          cfg,
+          catalog: policy.allowedCatalog,
+          ref: candidate,
+          defaultProvider: provider,
+          defaultModel: model,
+        }).allowed,
+      )
+      .toBe(false);
   });
 
   it("matches nested prefix wildcards on canonical model-key segment boundaries", () => {
@@ -214,18 +235,22 @@ describe("explicit model visibility policy", () => {
       },
     });
 
-    expect(policy.allowsKey("clawrouter/anthropic/claude-haiku-4-5")).toBe(true);
+    expect(policy.allows({ provider: "clawrouter", model: "anthropic/claude-haiku-4-5" })).toBe(
+      true,
+    );
     expect(
       policy.allowsByWildcard({
         provider: "clawrouter",
         model: "anthropic/claude-haiku-4-5",
       }),
     ).toBe(true);
-    expect(policy.allowsKey("clawrouter/anthropicX/claude-haiku-4-5")).toBe(false);
-    expect(policy.allowsKey("clawrouter/google/gemini-3.5-flash")).toBe(false);
-    expect(policy.allowsKey("openai/gpt-5.5")).toBe(true);
+    expect(policy.allows({ provider: "clawrouter", model: "anthropicX/claude-haiku-4-5" })).toBe(
+      false,
+    );
+    expect(policy.allows({ provider: "clawrouter", model: "google/gemini-3.5-flash" })).toBe(false);
+    expect(policy.allows({ provider: "openai", model: "gpt-5.5" })).toBe(true);
     expect(policy.allowsByWildcard({ provider: "openai", model: "gpt-5.5" })).toBe(false);
-    expect(policy.allowsKey("openai/gpt-5.6-sol")).toBe(false);
+    expect(policy.allows({ provider: "openai", model: "gpt-5.6-sol" })).toBe(false);
     expect(policy.allowedCatalog.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
       "clawrouter/anthropic/claude-haiku-4-5",
       "openai/gpt-5.5",
@@ -243,10 +268,12 @@ describe("explicit model visibility policy", () => {
 
     // The padded nested wildcard must keep its namespace rather than widening to
     // every clawrouter model.
-    expect(policy.allowsKey("clawrouter/anthropic/claude-haiku-4-5")).toBe(true);
-    expect(policy.allowsKey("clawrouter/google/gemini-3.5-flash")).toBe(false);
-    expect(policy.allowsKey("openai/gpt-5.5")).toBe(true);
-    expect(policy.allowsKey("openai/gpt-5.6-sol")).toBe(false);
+    expect(policy.allows({ provider: "clawrouter", model: "anthropic/claude-haiku-4-5" })).toBe(
+      true,
+    );
+    expect(policy.allows({ provider: "clawrouter", model: "google/gemini-3.5-flash" })).toBe(false);
+    expect(policy.allows({ provider: "openai", model: "gpt-5.5" })).toBe(true);
+    expect(policy.allows({ provider: "openai", model: "gpt-5.6-sol" })).toBe(false);
     expect(policy.allowedCatalog.map((entry) => `${entry.provider}/${entry.id}`)).toEqual([
       "clawrouter/anthropic/claude-haiku-4-5",
       "openai/gpt-5.5",
@@ -262,9 +289,11 @@ describe("explicit model visibility policy", () => {
       },
     });
 
-    expect(policy.allowsKey("clawrouter/anthropic/claude-haiku-4-5")).toBe(true);
-    expect(policy.allowsKey("clawrouter/google/gemini-3.5-flash")).toBe(true);
-    expect(policy.allowsKey("openai/gpt-5.6-sol")).toBe(false);
+    expect(policy.allows({ provider: "clawrouter", model: "anthropic/claude-haiku-4-5" })).toBe(
+      true,
+    );
+    expect(policy.allows({ provider: "clawrouter", model: "google/gemini-3.5-flash" })).toBe(true);
+    expect(policy.allows({ provider: "openai", model: "gpt-5.6-sol" })).toBe(false);
   });
 
   it("resolves conflicting policy aliases in each agent's model map", () => {

--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -189,6 +189,22 @@ describe("explicit model visibility policy", () => {
     expect(policy.allows({ provider: "anthropic", model: "claude-sonnet-4-6" })).toBe(false);
   });
 
+  it("does not authorize a default from a colliding provider wildcard", () => {
+    const policy = createModelVisibilityPolicy({
+      cfg: { agents: { defaults: { modelPolicy: { allow: ["custom/*"] } } } },
+      catalog: [
+        { provider: "custom", id: "team/Reader", name: "Allowed model" },
+        { provider: "custom/team", id: "Reader", name: "Other provider default" },
+      ],
+      defaultProvider: "custom/team",
+      defaultModel: "Reader",
+    });
+
+    expect(policy.allowAny).toBe(false);
+    expect(policy.allows({ provider: "custom", model: "team/Reader" })).toBe(true);
+    expect(policy.allows({ provider: "custom/team", model: "Reader" })).toBe(false);
+  });
+
   it("matches nested prefix wildcards on canonical model-key segment boundaries", () => {
     const policy = createPolicy({
       agents: {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -2729,6 +2729,41 @@ describe("session_status tool", () => {
     expect(saved.liveModelSwitchPending).toBe(true);
   });
 
+  it("rejects a colliding provider-wildcard model change without writing the session", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+        providerOverride: "custom/team",
+        modelOverride: "Reader",
+        modelOverrideSource: "user",
+      },
+    });
+    mockConfig = {
+      ...createMockConfig(),
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {},
+          modelPolicy: { allow: ["custom/*"] },
+        },
+      },
+    };
+
+    await expect(
+      getSessionStatusTool().execute("literal-denied", { model: "Reader" }),
+    ).rejects.toThrow('Model "custom/team/Reader" is not allowed.');
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+
+    await getSessionStatusTool().execute("literal-allowed", { model: "custom/team/Reader" });
+    const saved = latestMockCallArg(updateSessionStoreMock, 1) as Record<string, SessionEntry>;
+    expect(saved.main).toMatchObject({
+      providerOverride: "custom",
+      modelOverride: "team/Reader",
+      modelOverrideSource: "user",
+    });
+  });
+
   it("resolves a model alias configured only on the target agent", async () => {
     resetSessionStore({
       main: { sessionId: "s1", updatedAt: 10 },

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -553,7 +553,7 @@ async function resolveModelOverride(params: {
     throw new Error(`Unrecognized model "${raw}".`);
   }
   const key = modelKey(resolved.ref.provider, resolved.ref.model);
-  if (!policy.allowsKey(key)) {
+  if (!policy.allows(resolved.ref)) {
     throw new Error(`Model "${key}" is not allowed.`);
   }
   const isDefault =

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1143,7 +1143,9 @@ describe("/model chat UX", () => {
       allowedModelCatalog: policy.allowedCatalog,
     });
 
-    expect(policy.allowsKey("openrouter/meta-llama/llama-3.3-70b-instruct:free")).toBe(true);
+    expect(
+      policy.allows({ provider: "openrouter", model: "meta-llama/llama-3.3-70b-instruct:free" }),
+    ).toBe(true);
     expect(reply?.text).toContain("openrouter/meta-llama/llama-3.3-70b-instruct:free");
     expect(reply?.text).not.toContain("anthropic/openrouter:free");
   });

--- a/src/auto-reply/reply/model-selection-directive.test.ts
+++ b/src/auto-reply/reply/model-selection-directive.test.ts
@@ -86,6 +86,45 @@ describe("resolveModelDirectiveSelection", () => {
     },
   );
 
+  it.each(["custom/custom/model", "chosen", "cho"])(
+    "keeps literal configured-model permission for %s",
+    (raw) => {
+      for (const allow of ["custom/model", "custom/custom/model"]) {
+        const { result } = resolveDirective({
+          cfg: {
+            agents: {
+              defaults: {
+                models: { "custom/custom/model": { alias: "chosen" } },
+                modelPolicy: { allow: [allow] },
+              },
+            },
+            models: {
+              providers: {
+                custom: {
+                  api: "openai-responses",
+                  baseUrl: "https://custom.example/v1",
+                  models: [],
+                },
+              },
+            },
+          },
+          raw,
+        });
+
+        if (allow === "custom/custom/model") {
+          expect
+            .soft(result.selection)
+            .toMatchObject({ provider: "custom", model: "custom/model" });
+        } else if (raw === "cho") {
+          expect.soft(result.selection).toBeUndefined();
+          expect.soft(result.error).toBeTruthy();
+        } else {
+          expect.soft(result.selection).toMatchObject({ provider: "custom", model: "model" });
+        }
+      }
+    },
+  );
+
   it.each([undefined, {}, { allow: [] }, { allow: ["openai/*"] }])(
     "permits an explicit uncataloged model with policy %j",
     async (modelPolicy) => {

--- a/src/auto-reply/reply/model-selection-directive.ts
+++ b/src/auto-reply/reply/model-selection-directive.ts
@@ -222,7 +222,7 @@ export function resolveModelDirectiveSelection(params: {
       }
       const provider = normalizeProviderId(key.slice(0, slash));
       const model = key.slice(slash + 1);
-      if (model.endsWith("*") || !policy.allowsKey(key)) {
+      if (model.endsWith("*") || !policy.allows({ provider, model })) {
         continue;
       }
       if (providerFilter && provider !== providerFilter) {
@@ -244,8 +244,7 @@ export function resolveModelDirectiveSelection(params: {
         });
       }
       for (const match of aliasMatches) {
-        const key = modelKey(match.provider, match.model);
-        if (!policy.allowsKey(key)) {
+        if (!policy.allows(match)) {
           continue;
         }
         if (!candidates.some((c) => c.provider === match.provider && c.model === match.model)) {
@@ -331,7 +330,7 @@ export function resolveModelDirectiveSelection(params: {
       ...(resolved.alias ? { alias: resolved.alias } : {}),
     },
   };
-  const permitted = policy.allowsKey(resolvedKey);
+  const permitted = policy.allows(resolved.ref);
   // Preserve catalog hints for bare fragments, while explicit routes and aliases
   // depend only on policy, never on finite picker membership.
   if (

--- a/src/auto-reply/reply/model-selection.resolved-pin.test.ts
+++ b/src/auto-reply/reply/model-selection.resolved-pin.test.ts
@@ -34,8 +34,14 @@ type SelectionCase = {
   name: string;
   pin: string;
   expected: string;
+  provider?: string;
+  allow?: string[];
+  readerModel?: string;
   raw?: boolean;
   disallowed?: boolean;
+  inherited?: boolean;
+  locked?: boolean;
+  configuredProvider?: boolean;
   heartbeat?: boolean;
   oneTurn?: boolean;
   cli?: boolean;
@@ -51,17 +57,112 @@ test.each<SelectionCase>([
   { name: "one-turn override", pin: "middle", expected: "once", oneTurn: true },
   { name: "bound CLI provider", pin: "cli-model", expected: "cli-model", cli: true },
   { name: "missing auth pin", pin: "plain-model", expected: "plain-model", missingAuthPin: true },
+  {
+    name: "resolved prefix rejected by a colliding exact allowlist",
+    pin: "custom/model",
+    expected: "default",
+    allow: ["custom/default", "custom/model"],
+    disallowed: true,
+  },
+  {
+    name: "inherited resolved prefix rejected by a colliding exact allowlist",
+    pin: "custom/model",
+    expected: "default",
+    allow: ["custom/default", "custom/model"],
+    disallowed: true,
+    inherited: true,
+  },
+  {
+    name: "raw prefix allowed as the plain model",
+    pin: "custom/model",
+    expected: "model",
+    readerModel: "model",
+    allow: ["custom/default", "custom/model"],
+    raw: true,
+  },
+  {
+    name: "locked resolved prefix outside the exact allowlist",
+    pin: "custom/model",
+    expected: "custom/model",
+    allow: ["custom/default", "custom/model"],
+    locked: true,
+  },
+  {
+    name: "resolved prefix allowed by the provider wildcard",
+    pin: "custom/model",
+    expected: "custom/model",
+    allow: ["custom/*"],
+  },
+  {
+    name: "inherited resolved prefix allowed by its namespace wildcard",
+    pin: "custom/model",
+    expected: "custom/model",
+    allow: ["custom/default", "custom/custom/*"],
+    inherited: true,
+  },
+  {
+    name: "namespace wildcard rejects a different model prefix",
+    pin: "customness/model",
+    expected: "default",
+    allow: ["custom/default", "custom/custom/*"],
+    disallowed: true,
+  },
+  {
+    name: "exact model namespace does not authorize another provider",
+    provider: "custom/team",
+    pin: "Reader",
+    expected: "default",
+    allow: ["custom/default", "custom/team/Reader"],
+    disallowed: true,
+  },
+  {
+    name: "provider wildcard does not authorize another provider",
+    provider: "custom/team",
+    pin: "Reader",
+    expected: "default",
+    allow: ["custom/*"],
+    disallowed: true,
+  },
+  {
+    name: "resolved prefix allowed by its exact configured ref",
+    pin: "custom/model",
+    expected: "custom/model",
+    allow: ["custom/default", "custom/custom/model"],
+    configuredProvider: true,
+  },
+  {
+    name: "exact configured prefix does not authorize the plain model",
+    pin: "model",
+    expected: "default",
+    allow: ["custom/default", "custom/custom/model"],
+    configuredProvider: true,
+    disallowed: true,
+  },
 ])("selects $name through the reply owner", async (fixture) => {
   await withStateDirEnv("reply-resolved-pin-", async () => {
+    const allow = fixture.allow ?? (fixture.disallowed ? ["custom/default"] : undefined);
     const cfg: OpenClawConfig = {
       plugins: { enabled: false },
       agents: {
         entries: { main: {} },
         defaults: {
           model: "custom/default",
-          ...(fixture.disallowed ? { modelPolicy: { allow: ["custom/default"] } } : {}),
+          ...(allow ? { modelPolicy: { allow } } : {}),
         },
       },
+      ...(fixture.configuredProvider
+        ? {
+            models: {
+              providers: {
+                custom: {
+                  api: "openai-responses",
+                  baseUrl: "https://custom.example/v1",
+                  models: [],
+                },
+              },
+            },
+          }
+        : {}),
     };
     const registry = createEmptyPluginRegistry();
     registry.cliBackends.push({
@@ -83,29 +184,44 @@ test.each<SelectionCase>([
         }),
       ).toBe("custom");
     }
-    const provider = fixture.cli ? "demo-cli" : "custom";
-    const entry: SessionEntry = { sessionId: "resolved-pin", updatedAt: 1 };
+    const provider = fixture.provider ?? (fixture.cli ? "demo-cli" : "custom");
+    const pinnedEntry: SessionEntry = { sessionId: "resolved-pin", updatedAt: 1 };
     applyModelOverrideToSessionEntry({
-      entry,
+      entry: pinnedEntry,
       selection: { provider, model: fixture.pin },
       ...(fixture.missingAuthPin ? { profileOverride: "missing-test-profile" } : {}),
     });
     if (fixture.raw) {
-      delete entry.modelOverrideRouteResolution;
+      delete pinnedEntry.modelOverrideRouteResolution;
     }
     if (fixture.cli) {
-      entry.cliSessionBindings = { "demo-cli": { sessionId: "fixture-session" } };
+      pinnedEntry.cliSessionBindings = { "demo-cli": { sessionId: "fixture-session" } };
+    }
+    const entry: SessionEntry = fixture.inherited
+      ? { sessionId: "child", updatedAt: 1 }
+      : pinnedEntry;
+    if (fixture.locked) {
+      entry.modelSelectionLocked = true;
     }
     const sessionKey = "agent:main:resolved-pin";
+    const parentSessionKey = "agent:main:parent-pin";
+    const sessionStore = {
+      [sessionKey]: entry,
+      ...(fixture.inherited ? { [parentSessionKey]: pinnedEntry } : {}),
+    };
     const entries = [
       "default",
+      "model",
       "custom/model",
+      "customness/model",
+      "team/Reader",
       "middle",
       "final",
       "denied",
       "cli-model",
       "plain-model",
     ].map((id) => ({ provider: "custom", id, name: id }));
+    entries.push({ provider: "custom/team", id: "Reader", name: "Other provider" });
     const preparedModelCatalog: ModelCatalogSnapshot = {
       entries,
       routeVariants: entries,
@@ -116,10 +232,13 @@ test.each<SelectionCase>([
       async () => {
         // A failure here belongs to the reader dependency, before this owner's live-turn path.
         expect(
-          resolveDirectStoredModelOverride({ sessionEntry: entry, defaultProvider: "custom" }),
+          resolveDirectStoredModelOverride({
+            sessionEntry: pinnedEntry,
+            defaultProvider: "custom",
+          }),
         ).toMatchObject({
           provider,
-          model: fixture.raw ? "middle" : fixture.pin,
+          model: fixture.readerModel ?? (fixture.raw ? "middle" : fixture.pin),
           routeResolution: fixture.raw ? "raw" : "resolved",
         });
         const selection = await createModelSelectionState({
@@ -127,8 +246,9 @@ test.each<SelectionCase>([
           agentId: "main",
           agentCfg: cfg.agents?.defaults,
           sessionEntry: entry,
-          sessionStore: { [sessionKey]: entry },
+          sessionStore,
           sessionKey,
+          parentSessionKey: fixture.inherited ? parentSessionKey : undefined,
           defaultProvider: "custom",
           defaultModel: "default",
           provider: "custom",
@@ -142,13 +262,16 @@ test.each<SelectionCase>([
         expect(selection).toMatchObject({
           provider: "custom",
           model: fixture.expected,
-          resetModelOverride: fixture.disallowed === true,
+          resetModelOverride: fixture.disallowed === true && !fixture.inherited,
         });
-        if (fixture.disallowed) {
+        if (fixture.disallowed && !fixture.inherited) {
           expect(selection.resetModelOverrideReason).toBe("disallowed");
           expect(entry.modelOverride).toBeUndefined();
         } else {
-          expect(entry.modelOverride).toBe(fixture.pin);
+          expect(pinnedEntry.modelOverride).toBe(fixture.pin);
+        }
+        if (fixture.inherited) {
+          expect(entry.modelOverride).toBeUndefined();
         }
         if (fixture.missingAuthPin) {
           expect(entry.authProfileOverride).toBeUndefined();

--- a/src/auto-reply/reply/model-selection.resolved-pin.test.ts
+++ b/src/auto-reply/reply/model-selection.resolved-pin.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { resolveCliRuntimeCanonicalProvider } from "../../agents/cli-backends.js";
+import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { resolveDirectStoredModelOverride } from "../../sessions/stored-model-overrides.js";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import { createModelSelectionState } from "./model-selection.js";
+
+vi.mock("../../agents/auth-profiles.runtime.js", () => ({
+  ensureAuthProfileStore: () => ({ version: 1, profiles: {} }),
+}));
+
+afterEach(() => resetPluginRuntimeStateForTest());
+
+const metadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "fixture",
+      providers: ["custom", "demo-cli"],
+      modelIdNormalization: {
+        providers: { custom: { aliases: { latest: "middle", middle: "final" } } },
+      },
+    },
+  ],
+});
+
+type SelectionCase = {
+  name: string;
+  pin: string;
+  expected: string;
+  raw?: boolean;
+  disallowed?: boolean;
+  heartbeat?: boolean;
+  oneTurn?: boolean;
+  cli?: boolean;
+  missingAuthPin?: boolean;
+};
+
+test.each<SelectionCase>([
+  { name: "resolved provider-prefixed model", pin: "custom/model", expected: "custom/model" },
+  { name: "resolved alias-like model", pin: "middle", expected: "middle" },
+  { name: "legacy raw model", pin: "latest", expected: "final", raw: true },
+  { name: "disallowed pin", pin: "denied", expected: "default", disallowed: true },
+  { name: "explicit heartbeat override", pin: "middle", expected: "heartbeat", heartbeat: true },
+  { name: "one-turn override", pin: "middle", expected: "once", oneTurn: true },
+  { name: "bound CLI provider", pin: "cli-model", expected: "cli-model", cli: true },
+  { name: "missing auth pin", pin: "plain-model", expected: "plain-model", missingAuthPin: true },
+])("selects $name through the reply owner", async (fixture) => {
+  await withStateDirEnv("reply-resolved-pin-", async () => {
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: false },
+      agents: {
+        entries: { main: {} },
+        defaults: {
+          model: "custom/default",
+          ...(fixture.disallowed ? { modelPolicy: { allow: ["custom/default"] } } : {}),
+        },
+      },
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.cliBackends.push({
+      pluginId: "fixture",
+      source: "fixture",
+      backend: {
+        id: "demo-cli",
+        modelProvider: "custom",
+        config: { command: "false", input: "arg", output: "text" },
+      },
+    });
+    setActivePluginRegistry(registry);
+    if (fixture.cli) {
+      expect(
+        resolveCliRuntimeCanonicalProvider({
+          runtime: "demo-cli",
+          config: cfg,
+          includeSetupRegistry: true,
+        }),
+      ).toBe("custom");
+    }
+    const provider = fixture.cli ? "demo-cli" : "custom";
+    const entry: SessionEntry = { sessionId: "resolved-pin", updatedAt: 1 };
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider, model: fixture.pin },
+      ...(fixture.missingAuthPin ? { profileOverride: "missing-test-profile" } : {}),
+    });
+    if (fixture.raw) {
+      delete entry.modelOverrideRouteResolution;
+    }
+    if (fixture.cli) {
+      entry.cliSessionBindings = { "demo-cli": { sessionId: "fixture-session" } };
+    }
+    const sessionKey = "agent:main:resolved-pin";
+    const entries = [
+      "default",
+      "custom/model",
+      "middle",
+      "final",
+      "denied",
+      "cli-model",
+      "plain-model",
+    ].map((id) => ({ provider: "custom", id, name: id }));
+    const preparedModelCatalog: ModelCatalogSnapshot = {
+      entries,
+      routeVariants: entries,
+      authoritative: true,
+    };
+    await withPluginRuntimeGenerationScope(
+      { metadataSnapshot, pluginRegistry: registry },
+      async () => {
+        // A failure here belongs to the reader dependency, before this owner's live-turn path.
+        expect(
+          resolveDirectStoredModelOverride({ sessionEntry: entry, defaultProvider: "custom" }),
+        ).toMatchObject({
+          provider,
+          model: fixture.raw ? "middle" : fixture.pin,
+          routeResolution: fixture.raw ? "raw" : "resolved",
+        });
+        const selection = await createModelSelectionState({
+          cfg,
+          agentId: "main",
+          agentCfg: cfg.agents?.defaults,
+          sessionEntry: entry,
+          sessionStore: { [sessionKey]: entry },
+          sessionKey,
+          defaultProvider: "custom",
+          defaultModel: "default",
+          provider: "custom",
+          model: fixture.oneTurn ? "once" : fixture.heartbeat ? "heartbeat" : "default",
+          hasModelDirective: false,
+          hasOneTurnModelOverride: fixture.oneTurn,
+          isHeartbeat: fixture.heartbeat,
+          hasResolvedHeartbeatModelOverride: fixture.heartbeat,
+          preparedModelCatalog,
+        });
+        expect(selection).toMatchObject({
+          provider: "custom",
+          model: fixture.expected,
+          resetModelOverride: fixture.disallowed === true,
+        });
+        if (fixture.disallowed) {
+          expect(selection.resetModelOverrideReason).toBe("disallowed");
+          expect(entry.modelOverride).toBeUndefined();
+        } else {
+          expect(entry.modelOverride).toBe(fixture.pin);
+        }
+        if (fixture.missingAuthPin) {
+          expect(entry.authProfileOverride).toBeUndefined();
+        }
+      },
+    );
+  });
+});

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -761,40 +761,46 @@ describe("createModelSelectionState catalog loading", () => {
     ).toBe(272_000);
   });
 
-  it("uses the first visible provider wildcard model when the configured primary is filtered out", async () => {
-    vi.mocked(loadModelCatalogLocal).mockClear();
-    vi.mocked(loadModelCatalogLocal).mockResolvedValueOnce([
-      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
-      { provider: "openai", id: "gpt-5.5-codex", name: "GPT-5.5 Codex" },
-      { provider: "vllm", id: "qwen3-local", name: "Qwen3 Local" },
-    ]);
-    const cfg = {
-      agents: {
-        defaults: {
-          model: { primary: "anthropic/claude-opus-4-5" },
-          models: {
-            "openai/*": {},
-            "vllm/*": {},
+  it.each([
+    ["anthropic", "claude-opus-4-5", "openai/*", "gpt-5.5-codex", 1],
+    ["openai/team", "claude-opus-4-5", "openai/*", "gpt-5.5-codex", 1],
+    ["openai", "openai/team/Reader", "openai/team/*", "team/Reader", 1],
+    ["openai", "team/Reader", "openai/team/*", "team/Reader", 0],
+  ] as const)(
+    "selects %s/%s with wildcard %s",
+    async (defaultProvider, defaultModel, allow, selectedModel, catalogLoads) => {
+      vi.mocked(loadModelCatalogLocal).mockClear();
+      if (catalogLoads) {
+        vi.mocked(loadModelCatalogLocal).mockResolvedValueOnce([
+          { provider: defaultProvider, id: defaultModel, name: "Configured primary" },
+          { provider: "openai", id: selectedModel, name: "Allowed model" },
+          { provider: "vllm", id: "qwen3-local", name: "Qwen3 Local" },
+        ]);
+      }
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: `${defaultProvider}/${defaultModel}` },
+            models: { [allow]: {}, "vllm/*": {} },
           },
         },
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    const state = await createModelSelectionState({
-      cfg,
-      agentCfg: cfg.agents?.defaults,
-      defaultProvider: "anthropic",
-      defaultModel: "claude-opus-4-5",
-      provider: "anthropic",
-      model: "claude-opus-4-5",
-      hasModelDirective: false,
-    });
+      const state = await createModelSelectionState({
+        cfg,
+        agentCfg: cfg.agents?.defaults,
+        defaultProvider,
+        defaultModel,
+        provider: defaultProvider,
+        model: defaultModel,
+        hasModelDirective: false,
+      });
 
-    expect(state.provider).toBe("openai");
-    expect(state.model).toBe("gpt-5.5-codex");
-    expect(state.allowedModelKeys.has("anthropic/claude-opus-4-5")).toBe(false);
-    expect(loadModelCatalogLocal).toHaveBeenCalledOnce();
-  });
+      expect(state.provider).toBe("openai");
+      expect(state.model).toBe(selectedModel);
+      expect(loadModelCatalogLocal).toHaveBeenCalledTimes(catalogLoads);
+    },
+  );
 
   it("does not reject wildcard-only policy before an explicit model directive is resolved", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -331,7 +331,7 @@ export async function createModelSelectionState(params: {
       runtimeModelNormalization,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    const overrideAllowed = visibilityPolicy.allowsKey(key);
+    const overrideAllowed = visibilityPolicy.allows(normalizedOverride);
     // A degraded catalog cannot prove a pin is disallowed. Preserve it while the turn falls back
     // to primary, then re-evaluate after discovery recovers; config-proven stale pins still reset.
     const shouldResetOverride =
@@ -443,8 +443,7 @@ export async function createModelSelectionState(params: {
       sessionEntry,
       runtimeModelNormalization,
     );
-    const key = modelKey(normalizedStoredOverride.provider, normalizedStoredOverride.model);
-    if (modelSelectionLocked || visibilityPolicy.allowsKey(key)) {
+    if (modelSelectionLocked || visibilityPolicy.allows(normalizedStoredOverride)) {
       provider = normalizedStoredOverride.provider;
       model = normalizedStoredOverride.model;
       requestedRouteResolution =

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -50,7 +50,7 @@ import {
 } from "./model-runtime-normalization.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
-  normalizeStoredRuntimeModelRef,
+  resolveStoredRuntimeModelRef,
 } from "./stored-model-override.js";
 export {
   resolveModelDirectiveSelection,
@@ -174,6 +174,7 @@ export async function createModelSelectionState(params: {
   let provider = params.provider;
   let model = params.model;
   let requestedRouteResolution: ModelFallbackRouteResolution = "resolved";
+  let resolvedStoredOverrideSelected = false;
   const primaryProvider = params.primaryProvider ?? defaultProvider;
   const primaryModel = params.primaryModel ?? defaultModel;
   const hasOneTurnModelOverride = params.hasOneTurnModelOverride === true;
@@ -320,9 +321,11 @@ export async function createModelSelectionState(params: {
     directStoredModelOverride &&
     !hasOneTurnModelOverride
   ) {
-    const normalizedOverride = normalizeStoredRuntimeModelRef(
-      directStoredModelOverride.provider ?? defaultProvider,
-      directStoredModelOverride.model,
+    const normalizedOverride = resolveStoredRuntimeModelRef(
+      {
+        ...directStoredModelOverride,
+        provider: directStoredModelOverride.provider ?? defaultProvider,
+      },
       cfg,
       sessionEntry,
       runtimeModelNormalization,
@@ -430,9 +433,12 @@ export async function createModelSelectionState(params: {
             ...runtimeModelNormalization,
           })
         : null;
-    const normalizedStoredOverride = normalizeStoredRuntimeModelRef(
-      storedAlias?.provider ?? storedProvider,
-      storedAlias?.model ?? storedOverride.model,
+    const normalizedStoredOverride = resolveStoredRuntimeModelRef(
+      {
+        ...storedOverride,
+        provider: storedAlias?.provider ?? storedProvider,
+        model: storedAlias?.model ?? storedOverride.model,
+      },
       cfg,
       sessionEntry,
       runtimeModelNormalization,
@@ -443,11 +449,15 @@ export async function createModelSelectionState(params: {
       model = normalizedStoredOverride.model;
       requestedRouteResolution =
         storedAlias || storedRouteCataloged ? "resolved" : storedOverride.routeResolution;
+      resolvedStoredOverrideSelected = storedOverride.routeResolution === "resolved";
     }
   }
 
   const skipResolveSelection =
-    params.hasModelDirective || hasOneTurnModelOverride || modelSelectionLocked;
+    params.hasModelDirective ||
+    hasOneTurnModelOverride ||
+    modelSelectionLocked ||
+    resolvedStoredOverrideSelected;
   if (!skipResolveSelection) {
     const unresolvedSelectionKey = modelKey(provider, model);
     const allowedInitialSelection = visibilityPolicy.resolveSelection({

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -13,15 +13,17 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { StoredModelOverride } from "../../sessions/stored-model-overrides.js";
 import type { RuntimeModelNormalization } from "./model-runtime-normalization.js";
 
-/** Normalizes a stored model ref, resolving runtime aliases only for CLI-bound sessions. */
-export function normalizeStoredRuntimeModelRef(
-  provider: string,
-  model: string,
+/** Preserves selected model IDs while resolving provider aliases for CLI-bound sessions. */
+export function resolveStoredRuntimeModelRef(
+  ref: StoredModelOverride & { provider: string },
   cfg?: OpenClawConfig,
   sessionEntry?: SessionEntry,
   normalization: RuntimeModelNormalization = RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 ) {
-  const normalized = normalizeModelRef(provider, model, normalization);
+  const normalized =
+    ref.routeResolution === "resolved"
+      ? { provider: ref.provider, model: ref.model }
+      : normalizeModelRef(ref.provider, ref.model, normalization);
   const hasCliSessionBinding =
     sessionEntry?.cliSessionBindings?.[normalized.provider] !== undefined;
   const canonicalProvider =

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -209,7 +209,6 @@ vi.mock("../agents/model-selection.js", () => {
           hasProviderWildcards: wildcardModelKeys.size > 0,
           allowConfigPath: policy.configPath,
           allowRepairConfigPath: "agents.defaults.modelPolicy.allow",
-          allowsKey,
           allows: ({ provider, model }: ModelRef) => allowsKey(modelKey(provider, model)),
           allowsByWildcard: ({ provider, model }: ModelRef) =>
             isModelKeyAllowedBySet(wildcardModelKeys, modelKey(provider, model)),

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -151,8 +151,8 @@ describe("explicit model allow policy migration", () => {
           agentId,
         });
         expect(policy.allowAny).toBe(false);
-        expect(policy.allowsKey(`${agentId}/bare`)).toBe(true);
-        expect(policy.allowsKey("unrelated/denied")).toBe(false);
+        expect(policy.allows({ provider: agentId, model: "bare" })).toBe(true);
+        expect(policy.allows({ provider: "unrelated", model: "denied" })).toBe(false);
       }
     },
   );

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { startGatewayConfigReloader } from "../gateway/config-reload.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import * as tmpDirOwner from "../infra/tmp-openclaw-dir.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -143,6 +144,9 @@ describe("config io write", () => {
 
   beforeAll(async () => {
     await suiteRootTracker.setup();
+    vi.spyOn(tmpDirOwner, "resolvePreferredOpenClawTmpDir").mockReturnValue(
+      await suiteRootTracker.make("coordinator"),
+    );
 
     // Default: return an empty plugin list so existing tests that don't need
     // plugin-owned channel schemas keep working unchanged.
@@ -161,6 +165,7 @@ describe("config io write", () => {
   afterAll(async () => {
     closeOpenClawStateDatabaseForTest();
     resetConfigRuntimeState();
+    vi.mocked(tmpDirOwner.resolvePreferredOpenClawTmpDir).mockRestore();
     await suiteRootTracker.cleanup();
   });
 
@@ -410,7 +415,9 @@ describe("config io write", () => {
             });
           const beforePolicy = policyFor(before.config);
           expect(beforePolicy.allowAny).toBe(modelPolicy !== undefined);
-          expect(beforePolicy.allowsKey("demo/denied")).toBe(modelPolicy !== undefined);
+          expect(beforePolicy.allows({ provider: "demo", model: "denied" })).toBe(
+            modelPolicy !== undefined,
+          );
 
           await io.writeConfigFile({
             ...before.config,
@@ -427,7 +434,9 @@ describe("config io write", () => {
           expect([...afterPolicy.allowedKeys].toSorted()).toEqual(
             [...beforePolicy.allowedKeys].toSorted(),
           );
-          expect(afterPolicy.allowsKey("demo/denied")).toBe(beforePolicy.allowsKey("demo/denied"));
+          expect(afterPolicy.allows({ provider: "demo", model: "denied" })).toBe(
+            beforePolicy.allows({ provider: "demo", model: "denied" }),
+          );
           expect(after.sourceConfig.agents?.defaults?.models).toEqual(models);
           expect(after.sourceConfig.browser?.enabled).toBe(false);
           if (includeAt) {

--- a/src/gateway/http-utils.model-override.test.ts
+++ b/src/gateway/http-utils.model-override.test.ts
@@ -45,6 +45,55 @@ describe("resolveOpenAiCompatModelOverride", () => {
       .mockResolvedValue([{ id: "gpt-5.4", name: "GPT 5.4", provider: "openai" }]);
   });
 
+  it("keeps provider-wildcard grants separate from a colliding default provider", async () => {
+    loadConfigMock.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        list: [{ id: "main" }],
+        defaults: { model: { primary: "Reader" }, modelPolicy: { allow: ["custom/*"] } },
+      },
+      models: {
+        providers: {
+          "custom/team": {
+            api: "openai-completions",
+            baseUrl: "https://fixture.invalid/v1",
+            models: [
+              {
+                id: "Reader",
+                name: "Reader",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+    loadGatewayModelCatalogMock.mockResolvedValue([
+      { provider: "custom", id: "team/Reader", name: "Allowed model" },
+      { provider: "custom/team", id: "Reader", name: "Other provider default" },
+    ]);
+
+    await expect(
+      resolveOpenAiCompatModelOverride({
+        req: createReq({ "x-openclaw-model": "Reader" }),
+        agentId: "main",
+        model: "openclaw",
+      }),
+    ).resolves.toEqual({
+      errorMessage: "Model 'custom/team/Reader' is not allowed for agent 'main'.",
+    });
+    await expect(
+      resolveOpenAiCompatModelOverride({
+        req: createReq({ "x-openclaw-model": "custom/team/Reader" }),
+        agentId: "main",
+        model: "openclaw",
+      }),
+    ).resolves.toEqual({ modelOverride: "custom/team/Reader" });
+  });
+
   it("rejects CLI model overrides outside the configured allowlist", async () => {
     await expect(
       resolveOpenAiCompatModelOverride({

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -208,7 +208,7 @@ export async function resolveOpenAiCompatModelOverride(params: {
     ...modelManifestContext,
   });
   const normalized = modelKey(parsed.provider, parsed.model);
-  if (!policy.allowsKey(normalized)) {
+  if (!policy.allows(parsed)) {
     return {
       errorMessage: `Model '${normalized}' is not allowed for agent '${params.agentId}'.`,
     };

--- a/src/plugins/provider-model-routes.installed.test.ts
+++ b/src/plugins/provider-model-routes.installed.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveModelProviderAuthConfig } from "../agents/model-auth-provider-route.js";
 import { resolveConfiguredModelCatalogOverrides } from "../agents/model-catalog-route.js";
+import { getModelRefStatus, resolveModelRefFromString } from "../agents/model-selection.js";
+import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withEnv } from "../test-utils/env.js";
 import { withPluginMetadataSnapshotScope } from "./current-plugin-metadata-snapshot.js";
@@ -87,6 +89,121 @@ describe("installed Arcee catalog identity", () => {
       expect(
         createProviderModelCatalogIdNormalizer("arcee")("arcee-ai/trinity-large-thinking"),
       ).toBe("trinity-large-thinking");
+    });
+  });
+
+  it("keeps catalog-equivalent Arcee ids distinct in exact model policy", () => {
+    installed(true, (_root, metadataSnapshot) => {
+      const logical = { provider: "arcee", model: "trinity-large-thinking" };
+      const wire = { provider: "arcee", model: "arcee-ai/trinity-large-thinking" };
+      expect(createProviderModelCatalogIdNormalizer("arcee")(wire.model)).toBe(logical.model);
+      for (const ref of [logical, wire]) {
+        expect(
+          resolveModelRefFromString({
+            cfg: {},
+            raw: `${ref.provider}/${ref.model}`,
+            defaultProvider: "arcee",
+            manifestPlugins: metadataSnapshot,
+            allowManifestNormalization: true,
+            allowPluginNormalization: false,
+          })?.ref,
+        ).toEqual(ref);
+      }
+
+      for (const { allow, expected } of [
+        { allow: `arcee/${logical.model}`, expected: [true, false] },
+        { allow: `arcee/${wire.model}`, expected: [false, true] },
+        { allow: "arcee/*", expected: [true, true] },
+      ]) {
+        const params = {
+          cfg: { agents: { defaults: { modelPolicy: { allow: [allow] } } } },
+          catalog: [logical, wire].map(({ provider, model }) => ({
+            provider,
+            id: model,
+            name: model,
+          })),
+          defaultProvider: "arcee",
+          manifestPlugins: metadataSnapshot,
+          allowManifestNormalization: true,
+          allowPluginNormalization: false,
+        };
+        const policy = createModelVisibilityPolicy(params);
+        expect.soft([policy.allows(logical), policy.allows(wire)], allow).toEqual(expected);
+        expect
+          .soft(
+            [logical, wire].map((ref) => getModelRefStatus({ ...params, ref }).allowed),
+            allow,
+          )
+          .toEqual(expected);
+      }
+    });
+  });
+
+  it.each([false, true])(
+    "only selects an authorized Arcee fallback (later row: %s)",
+    (laterRow) => {
+      installed(true, (_root, manifestPlugins) => {
+        const logical = { provider: "arcee", model: "trinity-large-thinking" };
+        const wire = { provider: "arcee", id: "arcee-ai/trinity-large-thinking", name: "Wire" };
+        const later = { provider: "arcee", id: "safe-model", name: "Allowed fallback" };
+        const policy = createModelVisibilityPolicy({
+          cfg: {
+            agents: {
+              defaults: {
+                modelPolicy: {
+                  allow: laterRow
+                    ? ["arcee/trinity-large-thinking", "arcee/safe-model"]
+                    : ["arcee/trinity-large-thinking"],
+                },
+              },
+            },
+          },
+          catalog: laterRow ? [wire, later] : [wire],
+          defaultProvider: "arcee",
+          manifestPlugins,
+        });
+
+        expect(policy.allowedCatalog[0]).toEqual(wire);
+        expect(policy.resolveSelection(logical)).toEqual(logical);
+        expect(policy.resolveSelection({ provider: "arcee", model: "denied-model" })).toEqual(
+          laterRow ? { provider: "arcee", model: "safe-model" } : null,
+        );
+      });
+    },
+  );
+
+  it("keeps captured exact grants stable when the current catalog policy changes", () => {
+    installed(true, () => {
+      const logical = { provider: "arcee", model: "trinity-large-thinking" };
+      const wire = { provider: "arcee", model: "arcee-ai/trinity-large-thinking" };
+      const empty = createPluginMetadataSnapshotFixture();
+      const captured = withPluginMetadataSnapshotScope(empty, () => {
+        expect(createProviderModelCatalogIdNormalizer("arcee")(wire.model)).toBe(wire.model);
+        return [
+          { allowed: logical, denied: wire },
+          { allowed: wire, denied: logical },
+        ].map(({ allowed, denied }) => {
+          const policy = createModelVisibilityPolicy({
+            cfg: {
+              agents: { defaults: { modelPolicy: { allow: [`arcee/${allowed.model}`] } } },
+            },
+            catalog: [],
+            defaultProvider: "arcee",
+            manifestPlugins: empty,
+            allowManifestNormalization: true,
+            allowPluginNormalization: false,
+          });
+          expect(policy.allows(allowed)).toBe(true);
+          expect(policy.allows(denied)).toBe(false);
+          return { policy, allowed, denied };
+        });
+      });
+
+      expect(createProviderModelCatalogIdNormalizer("arcee")(wire.model)).toBe(logical.model);
+      for (const { policy, allowed, denied } of captured) {
+        expect.soft(policy.allows(allowed)).toBe(true);
+        expect.soft(policy.allows(denied)).toBe(false);
+      }
     });
   });
 


### PR DESCRIPTION
Related: #130706, #142100. Follows #143975.

## What Problem This Solves

A resolved session model could be normalized again before a reply. Model-policy checks could also authorize a different provider/model tuple through a flattened display key or provider-owned catalog equivalence. For example, `custom/*` must not grant the distinct provider `custom/team`, and an exact logical Arcee grant must not grant its wire spelling merely because both rows describe the same catalog model.

## Why This Change Was Made

Preserve writer-resolved session IDs and route typed selection, status, fallback, command, live-switch, HTTP, tool, and directive admission through the existing policy predicate for provider/model pairs. Exact grants use literal identities; wildcard checks keep the provider boundary and unchanged model bytes. Remove the obsolete string admission method. Catalog visibility remains separate from selection authority, and fallback rows must independently pass admission.

Existing raw/default normalization, model locks, CLI mapping, heartbeat/turn precedence, and permitted fuzzy fallback behavior remain intact. Config-write tests now use their existing owned temporary root for coordinator state, preserving real SQLite and fail-closed checks while avoiding unrelated shared leases.

## User Impact

Replies keep the authorized model selected for the session. Exact and wildcard grants cannot select a different tuple through display-key or catalog-equivalence collisions. When no authorized fallback exists, the existing caller error explains that no allowed model is available.

Compatibility decision: selections admitted only through a display-key collision or catalog-equivalent spelling intentionally stop qualifying. Operators who want that distinct provider/model pair must add its explicit entry to the existing model allowlist. The repair keeps normal raw-input resolution and authorized fuzzy fallback; it does not expand selection authority to preserve collision-dependent behavior. Deployment prevalence of those accidental grants is unknown.

## Evidence

- Eleven additional owner/caller regression cases fail on the frozen literal-only predecessor, covering policy/status, Arcee fallback, reply discovery, HTTP, session status, and raw/alias/partial-alias directives. Earlier resolved-selection and exact-Arcee admission baselines remain preserved separately.
- **1,033 focused tests across 18 files passed**, including the affected consumers, legacy migration/write behavior, browse, picker, reset, and worker-inference paths.
- The normal complete-PR changed gate passed across all 22 paths. Fresh staged P2 review found no actionable P0–P2 findings.
- One canonical full build of `77e043dfcefc55b86df2c23b6ef64216e3890b35` passed, including UI, SDK declarations, and SDK export checks.
- **37 compiled cases passed**: 21 reply/policy cases including the original 20 plus a real runtime-normalization hook; 12 actual-Arcee/status/fallback/wildcard/directive cases; and four HTTP/session-tool cases. The latter use real loopback HTTP requests through the emitted Gateway header helper and the real emitted tool factory with an owned SQLite session store.
- Four intentional source/cross-checkout imports were rejected; actual source imports were zero. All 11,932 files across 17 build-output roots remained unchanged. The prior 9,014-file build and frozen predecessor source/index also remained unchanged.

The compiled HTTP fixture exercises the Gateway header-validation helper, not a full Gateway startup or provider inference. No real credentials, external provider calls, CLI backend execution, or operator Gateway connections were used. Exact-head CI and native prepare must pass before landing.

Complete PR delta: **+13 net production lines, +601 test lines**. This admission follow-up removes 12 production lines relative to `9a9d2535`.
