### PR TITLE
docs(vertex): document the gcp-vertex-credentials ADC credential marker

### DIFF
--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -151,7 +151,14 @@ Claude CLI reuse (`claude -p`) is a sanctioned OpenClaw integration path. Anthro
 ### Google Vertex and Gemini CLI runtime
 
 - `google-vertex`: managed Google Cloud access through gcloud Application
-  Default Credentials.
+  Default Credentials. Set `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and
+  `GOOGLE_CLOUD_LOCATION` in the Gateway service environment; without a project
+  the run fails with `Vertex AI requires a project ID`. The ADC path requires
+  the literal credential value `gcp-vertex-credentials` — store it with
+  `openclaw models auth paste-api-key --provider google-vertex`. Any other
+  value, including a token from `gcloud auth print-access-token`, is sent as
+  `x-goog-api-key` and rejected by Vertex with `401 UNAUTHENTICATED`. See
+  [Google (Gemini)](/providers/google).
 - `google-gemini-cli`: optional local runtime for an explicitly configured
   canonical `google/*` model.
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -11,7 +11,7 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 - Provider: `google`
 - Auth: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - API: Google Gemini API
-- Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials
+- Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials; the stored credential must be the literal value `gcp-vertex-credentials`
 - Optional runtime: `agentRuntime.id: "google-gemini-cli"` runs an explicitly configured model through the local Gemini CLI
 
 ## Getting started
@@ -140,6 +140,60 @@ the Gateway already runs inside a managed Google Cloud environment.
     `google-gemini-cli/*` refs remain legacy compatibility aliases. New configs
     should use `google/*` model refs plus the explicit runtime selection above.
 
+  </Tab>
+
+  <Tab title="Vertex AI (ADC)">
+    **Recommended for:** Gateways running inside Google Cloud with an attached
+    service account or workload identity.
+
+    `google-vertex` authenticates through Google Cloud Application Default
+    Credentials (ADC) and refreshes the access token itself, so no credential
+    rotation is needed. The stored provider credential is a marker, not a
+    secret.
+
+    <Steps>
+      <Step title="Provide Application Default Credentials">
+        On GCE, Cloud Run, and GKE the metadata server supplies ADC. Elsewhere,
+        run:
+
+        ```bash
+        gcloud auth application-default login
+        ```
+
+        Or point `GOOGLE_APPLICATION_CREDENTIALS` at a service-account key file.
+      </Step>
+      <Step title="Set the project and location">
+        `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and `GOOGLE_CLOUD_LOCATION`
+        must be set in the Gateway service environment:
+
+        ```bash
+        export GOOGLE_CLOUD_PROJECT="my-project"
+        export GOOGLE_CLOUD_LOCATION="us-central1"
+        ```
+
+        Without a project the run fails with `Vertex AI requires a project ID.
+        Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.`
+      </Step>
+      <Step title="Store the ADC credential marker">
+        Store the literal value `gcp-vertex-credentials` as the provider
+        credential:
+
+        ```bash
+        openclaw models auth paste-api-key --provider google-vertex
+        # paste exactly: gcp-vertex-credentials
+        ```
+
+        OpenClaw treats that value as a marker and resolves ADC headers instead
+        of sending the value as an API key. Any other value, including a valid
+        token from `gcloud auth print-access-token`, is sent as
+        `x-goog-api-key` and rejected by Vertex with `401 UNAUTHENTICATED`.
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
   </Tab>
 </Tabs>
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -194,6 +194,7 @@ the Gateway already runs inside a managed Google Cloud environment.
         ```
       </Step>
     </Steps>
+
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
Closes #143764

## What Problem This Solves

Fixes an issue where operators setting up `google-vertex` through Google Cloud
Application Default Credentials would follow the docs, store whatever credential
value they had on hand (for example `gcloud auth print-access-token`), and get a
`401 UNAUTHENTICATED` from Vertex with nothing in the docs pointing at the cause.
The ADC path accepts ADC-resolved credentials only when the stored provider
credential is the literal sentinel `gcp-vertex-credentials`; any other value is
sent as `x-goog-api-key` and rejected.

## Why This Change Was Made

Both pages referenced by the issue, `/providers/google` and
`/concepts/model-providers/official-provider-plugins`, described `google-vertex`
as using gcloud Application Default Credentials without saying what to store as
the credential. The pages now state the sentinel value, the environment
variables the ADC path requires, and the failure modes, so the ADC path is
followable end to end. No behavior changes; docs only.

## Scope

- `docs/providers/google.md`: new `Vertex AI (ADC)` tab covering the ADC source,
  `GOOGLE_CLOUD_PROJECT`/`GCLOUD_PROJECT` plus `GOOGLE_CLOUD_LOCATION`, storing
  the literal `gcp-vertex-credentials` value, and the verification command. One
  provider-list bullet now names the required credential.
- `docs/concepts/model-providers/official-provider-plugins.md`: the Google Vertex
  entry states the same credential marker, env requirements, and failure modes.

Values are taken from `extensions/google/openclaw.plugin.json`
(`setup.providers[google-vertex].authEvidence`: `credentialMarker:
gcp-vertex-credentials`, `requiresAnyEnv: [GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT]`,
`requiresAllEnv: [GOOGLE_CLOUD_LOCATION]`) and `extensions/google/transport-stream.ts:233`
(`Vertex AI requires a project ID`). No source files changed.

## User Impact

Operators following the google-vertex ADC setup now have a working recipe
instead of a 401, including the exact credential string to paste and the two
environment variables the Gateway process needs.

## Evidence

Docs checks, scoped to the two changed pages:

`bunx markdownlint-cli2 --config config/markdownlint-cli2.jsonc <the two files>`

```
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Summary: 0 issues in 0 files
EXIT=0
```

MDX compile plus Mintlify component indentation, run with the same
`@mdx-js/mdx` `compile` call and the repo's `checkMintlifyAccordionIndentation`
helper as `scripts/check-docs-mdx.mts`:

```
OK docs/providers/google.md
OK docs/concepts/model-providers/official-provider-plugins.md
errors=0
EXIT=0
```
