### PR TITLE
fix(gateway): report busctl-incompatible when busctl rejects --json

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { mockSystemAccountHome } from "../../daemon/service.test-helpers.js";
+import { BUSCTL_JSON_UNSUPPORTED_CODE } from "../../daemon/systemd-unavailable.js";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
@@ -352,6 +353,20 @@ describe("runDaemonInstall", () => {
     expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
     expect(randomTokenMock).not.toHaveBeenCalled();
     expect(service.readCommand).toHaveBeenCalledOnce();
+  });
+  it("reports busctl-incompatible when the initial read hits old busctl", async () => {
+    const unsupported: NodeJS.ErrnoException = new Error(
+      "busctl does not support --json output on this host.",
+    );
+    unsupported.code = BUSCTL_JSON_UNSUPPORTED_CODE;
+    service.readCommand.mockRejectedValueOnce(unsupported);
+    await runDaemonInstall({ json: true, force: true });
+    expect(actionState.failed[0]?.message).toContain(
+      "SERVICE_DEFINITION_UNKNOWN: [busctl-incompatible]",
+    );
+    expect(actionState.failed[0]?.message).toContain("systemd to 240 or newer");
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(randomTokenMock).not.toHaveBeenCalled();
   });
 
   it("blocks non-default install identities before inspecting host services", async () => {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -28,6 +28,7 @@ import {
 } from "../../daemon/service-types.js";
 import { resolveGatewayService, type GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd-exec.js";
+import { BUSCTL_JSON_UNSUPPORTED_CODE } from "../../daemon/systemd-unavailable.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import {
   defaultGatewayBindMode,
@@ -192,7 +193,15 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
   let existingServiceCommand: GatewayServiceCommandConfig | null;
   try {
     existingServiceCommand = await service.readCommand(process.env, { requireEffective: true });
-  } catch {
+  } catch (error) {
+    if (hasErrnoCode(error, BUSCTL_JSON_UNSUPPORTED_CODE)) {
+      try {
+        assertServiceDefinitionWritable({ kind: "unknown", reason: "busctl-incompatible" });
+      } catch (rendered) {
+        fail(rendered instanceof Error ? rendered.message : String(rendered));
+      }
+      return;
+    }
     fail("SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.");
     return;
   }

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -138,6 +138,8 @@ const SERVICE_DEFINITION_REASONS = {
     "has unverifiable system-service ownership. Restore system service-manager and filesystem inspection access from the service account, then retry; do not create a competing user service.",
   "inspection-failed":
     "cannot be safely inspected. Inspect service definition access and native service-manager availability from the service account, then retry. Do not share config or environment contents.",
+  "busctl-incompatible":
+    "cannot be inspected with this host's busctl, which rejected the JSON invocation (systemd older than 240 has no busctl --json). Upgrade systemd to 240 or newer, or manage the user unit with systemctl from the service account, then retry. Do not share config or environment contents.",
 } as const;
 
 export type ServiceDefinitionMutationArtifact = keyof typeof SERVICE_DEFINITION_ARTIFACTS;

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -292,6 +292,20 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     expect(await fs.readdir(stateDir)).toEqual([]);
     expect(await fs.readdir(path.dirname(unitPath))).toEqual([]);
   });
+  it("reports busctl-incompatible when busctl rejects --json instead of generic inspection-failed", async () => {
+    busctl.mockResolvedValue({
+      code: 1,
+      termination: "exit",
+      stdout: "",
+      stderr: "busctl: unrecognized option '--json=short' (token-secret-canary)",
+    });
+    const capability = await readSystemdDefinitionMutationCapability(env);
+    expect(capability).toMatchObject({ kind: "unknown", reason: "busctl-incompatible" });
+    expect(JSON.stringify(capability)).not.toContain("secret-canary");
+    await expect(stage()).rejects.toThrow("SERVICE_DEFINITION_UNKNOWN: [busctl-incompatible]");
+    expect(await fs.readdir(stateDir)).toEqual([]);
+    expect(await fs.readdir(path.dirname(unitPath))).toEqual([]);
+  });
 
   it.each(["unchanged", "changed", "first install"])(
     "reads root-owned type-wide defaults without write authority (%s)",

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -17,11 +17,11 @@ import {
   type ServiceDefinitionMutationCapability,
 } from "./service-types.js";
 import {
-  BUSCTL_JSON_UNSUPPORTED_CODE,
   readSystemdServiceExecStart,
   resolveSystemdEnvironmentFilePath,
   resolveSystemdUnitPath,
 } from "./systemd-service-files.js";
+import { BUSCTL_JSON_UNSUPPORTED_CODE } from "./systemd-unavailable.js";
 import { assertNoSystemSystemdOwnership, isSystemSystemdOwnershipError } from "./systemd-system.js";
 
 type Snapshot = { contents: Buffer; mode: number } | null;

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -17,6 +17,7 @@ import {
   type ServiceDefinitionMutationCapability,
 } from "./service-types.js";
 import {
+  BUSCTL_JSON_UNSUPPORTED_CODE,
   readSystemdServiceExecStart,
   resolveSystemdEnvironmentFilePath,
   resolveSystemdUnitPath,
@@ -176,7 +177,10 @@ async function inspect(
       }
     }
     return result({ kind: "writable" });
-  } catch {
+  } catch (error) {
+    if (hasErrnoCode(error, BUSCTL_JSON_UNSUPPORTED_CODE)) {
+      return result({ kind: "unknown", reason: "busctl-incompatible", artifact });
+    }
     return result({ kind: "unknown", reason: "inspection-failed", artifact });
   }
 }

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -21,8 +21,8 @@ import {
   resolveSystemdEnvironmentFilePath,
   resolveSystemdUnitPath,
 } from "./systemd-service-files.js";
-import { BUSCTL_JSON_UNSUPPORTED_CODE } from "./systemd-unavailable.js";
 import { assertNoSystemSystemdOwnership, isSystemSystemdOwnershipError } from "./systemd-system.js";
+import { BUSCTL_JSON_UNSUPPORTED_CODE } from "./systemd-unavailable.js";
 
 type Snapshot = { contents: Buffer; mode: number } | null;
 type SystemdDefinitionMutation = {

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -18,6 +18,7 @@ import type {
   GatewayServiceReadOptions,
 } from "./service-types.js";
 import { bindSystemdManagerOwner, execBusctlUser } from "./systemd-exec.js";
+import { isBusctlJsonUnsupportedDetail } from "./systemd-unavailable.js";
 import type {
   SystemdCommandSnapshotParams,
   SystemdEnvironmentFilesParams,
@@ -33,6 +34,8 @@ const SYSTEMD_GATEWAY_DOTENV_FILENAME = "gateway.systemd.env";
 const SYSTEMD_NODE_DOTENV_FILENAME = "node.systemd.env";
 const SYSTEMD_MANAGER_QUERY_TIMEOUT_MS = 5_000;
 
+/** errno-style marker: busctl rejected --json, so no JSON inspection is possible on this host. */
+export const BUSCTL_JSON_UNSUPPORTED_CODE = "BUSCTL_JSON_UNSUPPORTED";
 export function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
   const home = normalizeWindowsPathSeparators(resolveDaemonHomeDir(env));
   return path.posix.join(home, ".config", "systemd", "user", `${name}.service`);
@@ -118,6 +121,13 @@ async function readSystemdManagerCommand(
     }
     if (result.code !== 0) {
       const detail = result.stderr.trim();
+      if (result.termination === "exit" && isBusctlJsonUnsupportedDetail(detail)) {
+        const unsupported: NodeJS.ErrnoException = new Error(
+          "busctl does not support --json output on this host.",
+        );
+        unsupported.code = BUSCTL_JSON_UNSUPPORTED_CODE;
+        throw unsupported;
+      }
       if (
         result.termination === "exit" &&
         ((args.includes("LoadUnit") && detail === `Call failed: Unit ${unitName} not found.`) ||

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -18,11 +18,11 @@ import type {
   GatewayServiceReadOptions,
 } from "./service-types.js";
 import { bindSystemdManagerOwner, execBusctlUser } from "./systemd-exec.js";
-import { busctlJsonUnsupportedError, isBusctlJsonUnsupportedDetail } from "./systemd-unavailable.js";
 import type {
   SystemdCommandSnapshotParams,
   SystemdEnvironmentFilesParams,
 } from "./systemd-service-files.types.js";
+import { throwIfBusctlJsonUnsupported } from "./systemd-unavailable.js";
 import {
   parseSystemdEnvAssignments,
   parseSystemdExecStart,
@@ -119,9 +119,8 @@ async function readSystemdManagerCommand(
     }
     if (result.code !== 0) {
       const detail = result.stderr.trim();
-      if (result.termination === "exit" && isBusctlJsonUnsupportedDetail(detail)) {
-        throw busctlJsonUnsupportedError();
-      } else if (
+      throwIfBusctlJsonUnsupported(result);
+      if (
         result.termination === "exit" &&
         ((args.includes("LoadUnit") && detail === `Call failed: Unit ${unitName} not found.`) ||
           (args.includes("GetUnit") &&

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -18,7 +18,7 @@ import type {
   GatewayServiceReadOptions,
 } from "./service-types.js";
 import { bindSystemdManagerOwner, execBusctlUser } from "./systemd-exec.js";
-import { isBusctlJsonUnsupportedDetail } from "./systemd-unavailable.js";
+import { busctlJsonUnsupportedError, isBusctlJsonUnsupportedDetail } from "./systemd-unavailable.js";
 import type {
   SystemdCommandSnapshotParams,
   SystemdEnvironmentFilesParams,
@@ -34,8 +34,6 @@ const SYSTEMD_GATEWAY_DOTENV_FILENAME = "gateway.systemd.env";
 const SYSTEMD_NODE_DOTENV_FILENAME = "node.systemd.env";
 const SYSTEMD_MANAGER_QUERY_TIMEOUT_MS = 5_000;
 
-/** errno-style marker: busctl rejected --json, so no JSON inspection is possible on this host. */
-export const BUSCTL_JSON_UNSUPPORTED_CODE = "BUSCTL_JSON_UNSUPPORTED";
 export function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
   const home = normalizeWindowsPathSeparators(resolveDaemonHomeDir(env));
   return path.posix.join(home, ".config", "systemd", "user", `${name}.service`);
@@ -122,13 +120,8 @@ async function readSystemdManagerCommand(
     if (result.code !== 0) {
       const detail = result.stderr.trim();
       if (result.termination === "exit" && isBusctlJsonUnsupportedDetail(detail)) {
-        const unsupported: NodeJS.ErrnoException = new Error(
-          "busctl does not support --json output on this host.",
-        );
-        unsupported.code = BUSCTL_JSON_UNSUPPORTED_CODE;
-        throw unsupported;
-      }
-      if (
+        throw busctlJsonUnsupportedError();
+      } else if (
         result.termination === "exit" &&
         ((args.includes("LoadUnit") && detail === `Call failed: Unit ${unitName} not found.`) ||
           (args.includes("GetUnit") &&

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./systemd-lifecycle.js";
 import {
   classifySystemdUnavailableDetail,
+  isBusctlJsonUnsupportedDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
@@ -58,6 +59,19 @@ describe("classifySystemdUnavailableDetail", () => {
 
   it("returns null for unrelated details", () => {
     expect(classifySystemdUnavailableDetail("permission denied")).toBeNull();
+  });
+});
+describe("isBusctlJsonUnsupportedDetail", () => {
+  it("detects old-busctl option rejection", () => {
+    expect(isBusctlJsonUnsupportedDetail("busctl: unrecognized option '--json=short'")).toBe(true);
+  });
+
+  it("rejects unrelated failures", () => {
+    expect(isBusctlJsonUnsupportedDetail("Call failed: Unit openclaw-gateway.service not found.")).toBe(
+      false,
+    );
+    expect(isBusctlJsonUnsupportedDetail("")).toBe(false);
+    expect(isBusctlJsonUnsupportedDetail(undefined)).toBe(false);
   });
 });
 

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -67,9 +67,9 @@ describe("isBusctlJsonUnsupportedDetail", () => {
   });
 
   it("rejects unrelated failures", () => {
-    expect(isBusctlJsonUnsupportedDetail("Call failed: Unit openclaw-gateway.service not found.")).toBe(
-      false,
-    );
+    expect(
+      isBusctlJsonUnsupportedDetail("Call failed: Unit openclaw-gateway.service not found."),
+    ).toBe(false);
     expect(isBusctlJsonUnsupportedDetail("")).toBe(false);
     expect(isBusctlJsonUnsupportedDetail(undefined)).toBe(false);
   });

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -3,10 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import { hasErrnoCode } from "../infra/errno.js";
 import * as processExec from "../process/exec.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import { execFileUtf8 } from "./exec-file.js";
+import { execFileUtf8, type ExecResult } from "./exec-file.js";
 import { isLaunchctlNotLoaded } from "./launchd-exec.js";
 import {
   assertSystemdAvailable,
@@ -18,10 +19,11 @@ import {
   uninstallUserSystemdGatewayUnit,
 } from "./systemd-lifecycle.js";
 import {
+  BUSCTL_JSON_UNSUPPORTED_CODE,
   classifySystemdUnavailableDetail,
-  isBusctlJsonUnsupportedDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
+  throwIfBusctlJsonUnsupported,
 } from "./systemd-unavailable.js";
 
 describe("classifySystemdUnavailableDetail", () => {
@@ -61,17 +63,37 @@ describe("classifySystemdUnavailableDetail", () => {
     expect(classifySystemdUnavailableDetail("permission denied")).toBeNull();
   });
 });
-describe("isBusctlJsonUnsupportedDetail", () => {
-  it("detects old-busctl option rejection", () => {
-    expect(isBusctlJsonUnsupportedDetail("busctl: unrecognized option '--json=short'")).toBe(true);
+describe("throwIfBusctlJsonUnsupported", () => {
+  it("throws the branded marker for old-busctl option rejection", () => {
+    const result: ExecResult = {
+      stdout: "",
+      stderr: "busctl: unrecognized option '--json=short'",
+      code: 1,
+      termination: "exit",
+    };
+    try {
+      throwIfBusctlJsonUnsupported(result);
+      expect.unreachable();
+    } catch (error) {
+      expect(hasErrnoCode(error, BUSCTL_JSON_UNSUPPORTED_CODE)).toBe(true);
+    }
   });
 
-  it("rejects unrelated failures", () => {
-    expect(
-      isBusctlJsonUnsupportedDetail("Call failed: Unit openclaw-gateway.service not found."),
-    ).toBe(false);
-    expect(isBusctlJsonUnsupportedDetail("")).toBe(false);
-    expect(isBusctlJsonUnsupportedDetail(undefined)).toBe(false);
+  it("passes through unit absence and non-exit terminations", () => {
+    const missing: ExecResult = {
+      stdout: "",
+      stderr: "Call failed: Unit openclaw-gateway.service not found.",
+      code: 1,
+      termination: "exit",
+    };
+    expect(() => throwIfBusctlJsonUnsupported(missing)).not.toThrow();
+    const timedOut: ExecResult = {
+      stdout: "",
+      stderr: "busctl: unrecognized option '--json=short'",
+      code: 1,
+      termination: "timeout",
+    };
+    expect(() => throwIfBusctlJsonUnsupported(timedOut)).not.toThrow();
   });
 });
 

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -38,6 +38,16 @@ export function isBusctlJsonUnsupportedDetail(detail?: string): boolean {
   const normalized = normalizeDetail(detail);
   return normalized.includes("unrecognized option") && normalized.includes("--json");
 }
+/** errno-style marker: busctl rejected --json, so no JSON inspection is possible on this host. */
+export const BUSCTL_JSON_UNSUPPORTED_CODE = "BUSCTL_JSON_UNSUPPORTED";
+/** Stable domain error other modules match with hasErrnoCode; native stderr never leaves the boundary. */
+export function busctlJsonUnsupportedError(): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(
+    "busctl does not support --json output on this host.",
+  );
+  error.code = BUSCTL_JSON_UNSUPPORTED_CODE;
+  return error;
+}
 
 export function classifySystemdUnavailableDetail(detail?: string): SystemdUnavailableKind | null {
   const normalized = normalizeDetail(detail);

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -1,5 +1,5 @@
 /** Classifies systemd/systemctl unavailable errors into user-facing categories. */
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { ExecResult } from "./exec-file.js";
 
 export type SystemdUnavailableKind =
   | "missing_systemctl"
@@ -40,13 +40,18 @@ export function isBusctlJsonUnsupportedDetail(detail?: string): boolean {
 }
 /** errno-style marker: busctl rejected --json, so no JSON inspection is possible on this host. */
 export const BUSCTL_JSON_UNSUPPORTED_CODE = "BUSCTL_JSON_UNSUPPORTED";
-/** Stable domain error other modules match with hasErrnoCode; native stderr never leaves the boundary. */
-export function busctlJsonUnsupportedError(): NodeJS.ErrnoException {
-  const error: NodeJS.ErrnoException = new Error(
-    "busctl does not support --json output on this host.",
-  );
-  error.code = BUSCTL_JSON_UNSUPPORTED_CODE;
-  return error;
+/**
+ * Throws the branded marker when busctl itself rejected the --json invocation.
+ * Native stderr never leaves the boundary; callers match the marker with hasErrnoCode.
+ */
+export function throwIfBusctlJsonUnsupported(result: ExecResult): void {
+  if (result.termination === "exit" && isBusctlJsonUnsupportedDetail(result.stderr.trim())) {
+    const unsupported: NodeJS.ErrnoException = new Error(
+      "busctl does not support --json output on this host.",
+    );
+    unsupported.code = BUSCTL_JSON_UNSUPPORTED_CODE;
+    throw unsupported;
+  }
 }
 
 export function classifySystemdUnavailableDetail(detail?: string): SystemdUnavailableKind | null {

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -33,6 +33,11 @@ export function isSystemdUserBusUnavailableDetail(detail?: string): boolean {
     normalized.includes("no medium found")
   );
 }
+/** True when busctl itself rejected the invocation, e.g. systemd < 240 has no --json flag. */
+export function isBusctlJsonUnsupportedDetail(detail?: string): boolean {
+  const normalized = normalizeDetail(detail);
+  return normalized.includes("unrecognized option") && normalized.includes("--json");
+}
 
 export function classifySystemdUnavailableDetail(detail?: string): SystemdUnavailableKind | null {
   const normalized = normalizeDetail(detail);

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -1,4 +1,5 @@
 /** Classifies systemd/systemctl unavailable errors into user-facing categories. */
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ExecResult } from "./exec-file.js";
 
 export type SystemdUnavailableKind =

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -35,7 +35,7 @@ export function isSystemdUserBusUnavailableDetail(detail?: string): boolean {
   );
 }
 /** True when busctl itself rejected the invocation, e.g. systemd < 240 has no --json flag. */
-export function isBusctlJsonUnsupportedDetail(detail?: string): boolean {
+function isBusctlJsonUnsupportedDetail(detail?: string): boolean {
   const normalized = normalizeDetail(detail);
   return normalized.includes("unrecognized option") && normalized.includes("--json");
 }


### PR DESCRIPTION
Fixes #142940 (minimum remediation path from the issue).

## What Problem This Solves

On hosts with systemd older than 240, busctl has no --json flag, so every manager inspection subprocess fails at argument parsing. Install conflated that tool-invocation failure with an uninspectable definition and refused with generic SERVICE_DEFINITION_UNKNOWN, leaving systemd 239 users (RHEL 8 family, Alibaba Cloud Linux 8) with no actionable error.

## Change

- Adds throwIfBusctlJsonUnsupported guard plus BUSCTL_JSON_UNSUPPORTED marker (src/daemon/systemd-unavailable.ts). Native stderr never leaves the boundary; only the static classification maps to the reason.
- The manager query path throws the branded marker instead of generic unavailable when busctl rejects --json (src/daemon/systemd-service-files.ts).
- New busctl-incompatible service-definition reason with remediation: upgrade systemd to 240+, or manage the user unit with systemctl from the service account (src/daemon/service-types.ts).
- Definition-mutation capability maps the marker to the new reason (src/daemon/systemd-definition-mutation.ts).
- Initial install read preserves the allowlisted reason instead of the generic refusal, covering both ordinary install and --force before any write (src/cli/daemon-cli/install.ts).

No persisted data model changes: the marker and reason exist only in memory during inspection.

## Evidence

- src/daemon/systemd-definition-mutation.test.ts: busctl unrecognized-option stderr yields {kind unknown, reason busctl-incompatible}, redacts diagnostics, and stage() fails with SERVICE_DEFINITION_UNKNOWN: [busctl-incompatible].
- src/daemon/systemd-unavailable.test.ts: guard-level cases (branded throw, unit-absence passthrough, non-exit passthrough).
- src/cli/daemon-cli/install.test.ts: initial readCommand rejection with the marker fails with SERVICE_DEFINITION_UNKNOWN: [busctl-incompatible] before config reads or credential generation.
- src/daemon/systemd.test.ts (242 passed), systemd-definition-mutation (85 passed), install (42 passed) suites green locally.
- Real Linux Gateway install proof (ordinary install and --force on systemd 239 with redacted terminal output) is not available from this machine (macOS, no systemd) and is parked for a Linux host run.

## Scope note

This is the issue's sanctioned minimum: install still refuses on systemd < 240, but now with an actionable error instead of a generic one. A full legacy-output fallback (parsing pre-JSON busctl text) needs a systemd 239 fixture host and is left for a follow-up.