### PR TITLE
fix(imessage): restore remote attachments for external installs

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -2,9 +2,14 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.js";
 import * as globals from "../../globals.js";
 import * as mediaRoots from "../../media/channel-inbound-roots.js";
 import * as mediaReference from "../../media/media-reference.js";
+import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata.test-support.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import * as execSpawn from "../../process/exec-spawn.js";
 import * as processExec from "../../process/exec.js";
 import { isPidAlive } from "../../shared/pid-alive.js";
@@ -71,6 +76,108 @@ function remoteStageParams(state: OpenClawTestState, abortSignal?: AbortSignal) 
   };
 }
 
+const INSTALLED_REMOTE_PATH = "/installed/attachments/report.txt";
+const INSTALLED_OWNER_PLUGIN_ID = "imessage";
+
+/**
+ * Builds a staging request whose only channel media contract is an official
+ * plugin installed outside the bundled tree.
+ */
+async function installedOwnerStageParams(params: {
+  state: OpenClawTestState;
+  plugins?: OpenClawConfig["plugins"];
+  artifactBody?: string;
+}) {
+  const pluginDir = params.state.path("installed-plugins", INSTALLED_OWNER_PLUGIN_ID);
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.writeFile(path.join(pluginDir, "package.json"), '{"type":"commonjs"}\n');
+  await fs.writeFile(
+    path.join(pluginDir, "media-contract-api.js"),
+    params.artifactBody ??
+      'module.exports.resolveRemoteInboundAttachmentRoots = () => ["/installed/attachments"];\n',
+  );
+  const cfg: OpenClawConfig = {
+    channels: { imessage: { enabled: true } },
+    ...(params.plugins ? { plugins: params.plugins } : {}),
+    agents: {
+      ownership: "explicit",
+      entries: { main: {} },
+      defaults: {
+        skipBootstrap: true,
+        sandbox: {
+          mode: "all",
+          scope: "agent",
+          workspaceRoot: params.state.path("sandbox"),
+          workspaceAccess: "none",
+        },
+      },
+    },
+  };
+  const ctx: RuntimeMsgContext = {
+    Body: "synthetic attachment",
+    Provider: INSTALLED_OWNER_PLUGIN_ID,
+    MediaRemoteHost: "user@gateway-host",
+    media: [
+      {
+        path: INSTALLED_REMOTE_PATH,
+        url: INSTALLED_REMOTE_PATH,
+        contentType: "text/plain",
+      },
+    ],
+  };
+  return {
+    ctx,
+    sessionCtx: structuredClone(ctx),
+    cfg,
+    agentId: "main",
+    sessionKey: "agent:main:installed-owner-fixture",
+    workspaceDir: params.state.workspaceDir,
+    pluginDir,
+  };
+}
+
+/**
+ * Runs a scenario against an empty bundled plugin tree so the installed owner is
+ * the only place a channel media contract can come from.
+ */
+async function withEmptyBundledPlugins(
+  state: OpenClawTestState,
+  run: () => Promise<void>,
+): Promise<void> {
+  const bundledPluginsDir = state.path("bundled-plugins");
+  await fs.mkdir(bundledPluginsDir, { recursive: true });
+  await withEnvAsync(
+    {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+    },
+    run,
+  );
+}
+
+/** Publishes the installed official owner that the staging path reads from. */
+function publishInstalledOwnerSnapshot(cfg: OpenClawConfig, pluginDir: string): void {
+  const snapshot = createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: INSTALLED_OWNER_PLUGIN_ID,
+        origin: "global",
+        channels: [INSTALLED_OWNER_PLUGIN_ID],
+        trustedOfficialInstall: true,
+        rootDir: pluginDir,
+      },
+    ],
+  });
+  snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg, process.env);
+  setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
+}
+
+function releaseInstalledOwnerSnapshot(): void {
+  setCurrentPluginMetadataSnapshot(undefined);
+  clearPluginMetadataLifecycleCaches();
+}
+
 afterEach(() => vi.restoreAllMocks());
 
 describe("stageSandboxMedia SCP", () => {
@@ -113,6 +220,127 @@ describe("stageSandboxMedia SCP", () => {
         "synthetic attachment bytes",
       );
       await expect(fs.stat(path.dirname(download))).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("stages a remote attachment whose roots resolve from a trusted installed channel plugin", async () => {
+    await withOpenClawTestState({ label: "scp-installed-owner" }, async (state) => {
+      const params = await installedOwnerStageParams({ state });
+      await withEmptyBundledPlugins(state, async () => {
+        publishInstalledOwnerSnapshot(params.cfg, params.pluginDir);
+        try {
+          let download = "";
+          const runScp = vi
+            .spyOn(processExec, "runCommandWithTimeout")
+            .mockImplementation(async (argv) => {
+              download = argv.at(-1)!;
+              await fs.writeFile(download, "installed channel bytes");
+              return SUCCESS;
+            });
+
+          const result = await stageSandboxMedia(params);
+
+          expect(runScp).toHaveBeenCalledExactlyOnceWith(
+            [
+              "scp",
+              "-o",
+              "BatchMode=yes",
+              "-o",
+              "StrictHostKeyChecking=yes",
+              "--",
+              `user@gateway-host:${INSTALLED_REMOTE_PATH}`,
+              download,
+            ],
+            expect.objectContaining({
+              maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
+            }),
+          );
+          expect(result.staged.size).toBe(1);
+          const fact = params.ctx.media?.[0];
+          expect(fact).toMatchObject({ staged: true, contentType: "text/plain" });
+          expect(await fs.readFile(path.join(fact!.workspaceDir!, fact!.path!), "utf8")).toBe(
+            "installed channel bytes",
+          );
+        } finally {
+          releaseInstalledOwnerSnapshot();
+        }
+      });
+    });
+  });
+
+  it("skips a denied installed owner before its media contract executes", async () => {
+    await withOpenClawTestState({ label: "scp-installed-owner-denied" }, async (state) => {
+      const canary = path.join(
+        state.path("installed-plugins", INSTALLED_OWNER_PLUGIN_ID),
+        "artifact-executed-canary",
+      );
+      const params = await installedOwnerStageParams({
+        state,
+        plugins: { deny: [INSTALLED_OWNER_PLUGIN_ID] },
+        artifactBody: [
+          `require("node:fs").writeFileSync(${JSON.stringify(canary)}, "executed");`,
+          'module.exports.resolveRemoteInboundAttachmentRoots = () => ["/installed/attachments"];',
+          "",
+        ].join("\n"),
+      });
+      await withEmptyBundledPlugins(state, async () => {
+        publishInstalledOwnerSnapshot(params.cfg, params.pluginDir);
+        try {
+          const log = vi.spyOn(globals, "logVerbose").mockImplementation(() => {});
+          const runScp = vi
+            .spyOn(processExec, "runCommandWithTimeout")
+            .mockResolvedValue({ ...SUCCESS, code: 1, stderr: "unexpected transfer" });
+
+          const result = await stageSandboxMedia(params);
+
+          expect(result.staged.size).toBe(0);
+          expect(runScp).not.toHaveBeenCalled();
+          expect(existsSync(canary)).toBe(false);
+          expect(log).toHaveBeenCalledWith(
+            `Blocking remote media staging from disallowed attachment path: ${INSTALLED_REMOTE_PATH}`,
+          );
+          expect(params.ctx.media?.[0]).not.toMatchObject({ staged: true });
+        } finally {
+          releaseInstalledOwnerSnapshot();
+        }
+      });
+    });
+  });
+
+  it("stops staging after an earlier transfer once the installed owner is denied", async () => {
+    await withOpenClawTestState({ label: "scp-installed-owner-reload" }, async (state) => {
+      const enabled = await installedOwnerStageParams({ state });
+      await withEmptyBundledPlugins(state, async () => {
+        publishInstalledOwnerSnapshot(enabled.cfg, enabled.pluginDir);
+        try {
+          const runScp = vi
+            .spyOn(processExec, "runCommandWithTimeout")
+            .mockImplementation(async (argv) => {
+              await fs.writeFile(argv.at(-1)!, "first transfer");
+              return SUCCESS;
+            });
+
+          expect((await stageSandboxMedia(enabled)).staged.size).toBe(1);
+          expect(runScp).toHaveBeenCalledTimes(1);
+
+          releaseInstalledOwnerSnapshot();
+          const denied = await installedOwnerStageParams({
+            state,
+            plugins: { deny: [INSTALLED_OWNER_PLUGIN_ID] },
+          });
+          publishInstalledOwnerSnapshot(denied.cfg, denied.pluginDir);
+          const log = vi.spyOn(globals, "logVerbose").mockImplementation(() => {});
+
+          expect((await stageSandboxMedia(denied)).staged.size).toBe(0);
+          expect(runScp).toHaveBeenCalledTimes(1);
+          expect(log).toHaveBeenCalledWith(
+            `Blocking remote media staging from disallowed attachment path: ${INSTALLED_REMOTE_PATH}`,
+          );
+          expect(denied.ctx.media?.[0]).not.toMatchObject({ staged: true });
+        } finally {
+          releaseInstalledOwnerSnapshot();
+        }
+      });
     });
   });
 

--- a/src/media/channel-inbound-roots.fast-path.test.ts
+++ b/src/media/channel-inbound-roots.fast-path.test.ts
@@ -5,9 +5,17 @@ import type { OpenClawConfig } from "../config/types.js";
 
 const publicSurfaceLoaderMocks = vi.hoisted(() => ({
   loadBundledPluginPublicArtifactModuleSync: vi.fn(),
+  loadPluginPublicArtifactModuleSync: vi.fn(),
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => publicSurfaceLoaderMocks);
+
+// Installed-plugin discovery is out of scope for the bundled fast path; keep these
+// tests independent of the host plugin metadata graph.
+vi.mock("../plugins/plugin-metadata-snapshot.runtime.js", () => ({
+  getCurrentPluginMetadataSnapshotRuntime: () => undefined,
+  resolvePluginMetadataSnapshotRuntime: () => undefined,
+}));
 
 import {
   resolveChannelInboundAttachmentRoots,
@@ -38,6 +46,7 @@ function createContext(provider: string, accountId = "work"): MsgContext {
 
 beforeEach(() => {
   publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockReset();
+  publicSurfaceLoaderMocks.loadPluginPublicArtifactModuleSync.mockReset();
 });
 
 describe("channel inbound roots fast path", () => {

--- a/src/media/channel-inbound-roots.installed-plugin.test.ts
+++ b/src/media/channel-inbound-roots.installed-plugin.test.ts
@@ -1,0 +1,184 @@
+// Channel inbound root installed-plugin tests cover external channel media contracts.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { withEnv } from "../test-utils/env.js";
+import {
+  resolveChannelInboundAttachmentRootsForChannel,
+  resolveChannelRemoteInboundAttachmentRoots,
+} from "./channel-inbound-roots.js";
+
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  setCurrentPluginMetadataSnapshot(undefined);
+  clearPluginMetadataLifecycleCaches();
+  tempDirs.cleanup();
+});
+
+function createContext(provider: string, accountId = "work"): MsgContext {
+  return {
+    Body: "hi",
+    From: "imessage:work:demo",
+    To: "+2000",
+    ChatType: "direct",
+    Provider: provider,
+    AccountId: accountId,
+  };
+}
+
+/** Writes an installed channel plugin whose media contract artifact exists on disk. */
+function writeInstalledChannelPlugin(params: {
+  pluginRoot: string;
+  pluginId: string;
+  marker: string;
+}): string {
+  const pluginDir = path.join(params.pluginRoot, params.pluginId);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "package.json"), '{"type":"commonjs"}\n');
+  fs.writeFileSync(
+    path.join(pluginDir, "media-contract-api.js"),
+    [
+      `module.exports.resolveInboundAttachmentRoots = () => [${JSON.stringify(params.marker)} + "/local"];`,
+      `module.exports.resolveRemoteInboundAttachmentRoots = () => [${JSON.stringify(params.marker)} + "/remote"];`,
+      "",
+    ].join("\n"),
+  );
+  return pluginDir;
+}
+
+describe("channel media contract resolution for installed plugins", () => {
+  it("resolves local and remote media roots from a trusted installed channel plugin", () => {
+    const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
+    const pluginRoot = tempDirs.make("openclaw-media-installed-");
+    const pluginDir = writeInstalledChannelPlugin({
+      pluginRoot,
+      pluginId: "imessage",
+      marker: "/installed",
+    });
+    const cfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
+
+    withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      () => {
+        const snapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "imessage",
+              origin: "global",
+              channels: ["imessage"],
+              trustedOfficialInstall: true,
+              rootDir: pluginDir,
+            },
+          ],
+        });
+        snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg);
+        setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
+
+        expect(
+          resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
+        ).toEqual(["/installed/remote"]);
+        expect(
+          resolveChannelInboundAttachmentRootsForChannel({
+            cfg,
+            channelId: "imessage",
+            accountId: "work",
+          }),
+        ).toEqual(["/installed/local"]);
+      },
+    );
+  });
+
+  it("ignores installed channel-adjacent plugins that are not trusted official installs", () => {
+    const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
+    const pluginRoot = tempDirs.make("openclaw-media-installed-");
+    const pluginDir = writeInstalledChannelPlugin({
+      pluginRoot,
+      pluginId: "imessage",
+      marker: "/untrusted",
+    });
+    const cfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
+
+    withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      () => {
+        const snapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "imessage",
+              origin: "global",
+              channels: ["imessage"],
+              rootDir: pluginDir,
+            },
+          ],
+        });
+        snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg);
+        setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
+
+        expect(
+          resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
+        ).toBeUndefined();
+      },
+    );
+  });
+
+  it("keeps bundled channel media contracts ahead of installed plugin owners", () => {
+    const pluginRoot = tempDirs.make("openclaw-media-installed-");
+    const pluginDir = writeInstalledChannelPlugin({
+      pluginRoot,
+      pluginId: "imessage",
+      marker: "/installed",
+    });
+    const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
+    const bundledChannelDir = path.join(bundledPluginsDir, "imessage");
+    fs.mkdirSync(bundledChannelDir, { recursive: true });
+    fs.writeFileSync(path.join(bundledChannelDir, "package.json"), '{"type":"commonjs"}\n');
+    fs.writeFileSync(
+      path.join(bundledChannelDir, "media-contract-api.js"),
+      'module.exports.resolveRemoteInboundAttachmentRoots = () => ["/bundled/remote"];\n',
+    );
+    const cfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
+
+    withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      () => {
+        const snapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "imessage",
+              origin: "global",
+              channels: ["imessage"],
+              trustedOfficialInstall: true,
+              rootDir: pluginDir,
+            },
+          ],
+        });
+        snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg);
+        setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
+
+        expect(
+          resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
+        ).toEqual(["/bundled/remote"]);
+      },
+    );
+  });
+});

--- a/src/media/channel-inbound-roots.installed-plugin.test.ts
+++ b/src/media/channel-inbound-roots.installed-plugin.test.ts
@@ -54,9 +54,43 @@ function writeInstalledChannelPlugin(params: {
   return pluginDir;
 }
 
+/** Runs one installed-plugin scenario against an empty bundled plugin root. */
+function withInstalledChannelPlugin(
+  params: {
+    cfg: OpenClawConfig;
+    pluginDir: string;
+    trustedOfficialInstall?: boolean;
+  },
+  run: () => void,
+): void {
+  const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
+  withEnv(
+    {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+    },
+    () => {
+      const snapshot = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "imessage",
+            origin: "global",
+            channels: ["imessage"],
+            ...(params.trustedOfficialInstall === false ? {} : { trustedOfficialInstall: true }),
+            rootDir: params.pluginDir,
+          },
+        ],
+      });
+      snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(params.cfg);
+      setCurrentPluginMetadataSnapshot(snapshot, { config: params.cfg });
+      run();
+    },
+  );
+}
+
 describe("channel media contract resolution for installed plugins", () => {
   it("resolves local and remote media roots from a trusted installed channel plugin", () => {
-    const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
     const pluginRoot = tempDirs.make("openclaw-media-installed-");
     const pluginDir = writeInstalledChannelPlugin({
       pluginRoot,
@@ -65,43 +99,21 @@ describe("channel media contract resolution for installed plugins", () => {
     });
     const cfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
 
-    withEnv(
-      {
-        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
-        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      () => {
-        const snapshot = createPluginMetadataSnapshotFixture({
-          plugins: [
-            {
-              id: "imessage",
-              origin: "global",
-              channels: ["imessage"],
-              trustedOfficialInstall: true,
-              rootDir: pluginDir,
-            },
-          ],
-        });
-        snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg);
-        setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
-
-        expect(
-          resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
-        ).toEqual(["/installed/remote"]);
-        expect(
-          resolveChannelInboundAttachmentRootsForChannel({
-            cfg,
-            channelId: "imessage",
-            accountId: "work",
-          }),
-        ).toEqual(["/installed/local"]);
-      },
-    );
+    withInstalledChannelPlugin({ cfg, pluginDir }, () => {
+      expect(
+        resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
+      ).toEqual(["/installed/remote"]);
+      expect(
+        resolveChannelInboundAttachmentRootsForChannel({
+          cfg,
+          channelId: "imessage",
+          accountId: "work",
+        }),
+      ).toEqual(["/installed/local"]);
+    });
   });
 
   it("ignores installed channel-adjacent plugins that are not trusted official installs", () => {
-    const bundledPluginsDir = tempDirs.make("openclaw-media-bundled-");
     const pluginRoot = tempDirs.make("openclaw-media-installed-");
     const pluginDir = writeInstalledChannelPlugin({
       pluginRoot,
@@ -110,32 +122,46 @@ describe("channel media contract resolution for installed plugins", () => {
     });
     const cfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
 
-    withEnv(
-      {
-        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
-        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      () => {
-        const snapshot = createPluginMetadataSnapshotFixture({
-          plugins: [
-            {
-              id: "imessage",
-              origin: "global",
-              channels: ["imessage"],
-              rootDir: pluginDir,
-            },
-          ],
-        });
-        snapshot.policyHash = resolveInstalledPluginIndexPolicyHash(cfg);
-        setCurrentPluginMetadataSnapshot(snapshot, { config: cfg });
+    withInstalledChannelPlugin({ cfg, pluginDir, trustedOfficialInstall: false }, () => {
+      expect(
+        resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
+      ).toBeUndefined();
+    });
+  });
 
+  it.each([
+    ["denylisted", { plugins: { deny: ["imessage"] } }],
+    ["explicitly disabled", { plugins: { entries: { imessage: { enabled: false } } } }],
+    ["outside a restrictive allowlist", { plugins: { allow: ["localchat"] } }],
+    ["with plugins globally disabled", { plugins: { enabled: false } }],
+  ] as const)(
+    "revokes attachment-root authority for an installed owner that is %s",
+    (_label, pluginConfig) => {
+      const pluginRoot = tempDirs.make("openclaw-media-installed-");
+      const pluginDir = writeInstalledChannelPlugin({
+        pluginRoot,
+        pluginId: "imessage",
+        marker: "/disabled",
+      });
+      const cfg = {
+        channels: { imessage: { enabled: true } },
+        ...pluginConfig,
+      } as OpenClawConfig;
+
+      withInstalledChannelPlugin({ cfg, pluginDir }, () => {
         expect(
           resolveChannelRemoteInboundAttachmentRoots({ cfg, ctx: createContext("imessage") }),
         ).toBeUndefined();
-      },
-    );
-  });
+        expect(
+          resolveChannelInboundAttachmentRootsForChannel({
+            cfg,
+            channelId: "imessage",
+            accountId: "work",
+          }),
+        ).toBeUndefined();
+      });
+    },
+  );
 
   it("keeps bundled channel media contracts ahead of installed plugin owners", () => {
     const pluginRoot = tempDirs.make("openclaw-media-installed-");

--- a/src/media/channel-inbound-roots.installed-plugin.test.ts
+++ b/src/media/channel-inbound-roots.installed-plugin.test.ts
@@ -163,6 +163,46 @@ describe("channel media contract resolution for installed plugins", () => {
     },
   );
 
+  it("revokes attachment-root authority after an earlier successful resolution", () => {
+    const pluginRoot = tempDirs.make("openclaw-media-installed-");
+    const pluginDir = writeInstalledChannelPlugin({
+      pluginRoot,
+      pluginId: "imessage",
+      marker: "/policy-reload",
+    });
+    const enabledCfg = { channels: { imessage: { enabled: true } } } as OpenClawConfig;
+
+    withInstalledChannelPlugin({ cfg: enabledCfg, pluginDir }, () => {
+      expect(
+        resolveChannelRemoteInboundAttachmentRoots({
+          cfg: enabledCfg,
+          ctx: createContext("imessage"),
+        }),
+      ).toEqual(["/policy-reload/remote"]);
+
+      clearPluginMetadataLifecycleCaches();
+      const deniedCfg = {
+        channels: { imessage: { enabled: true } },
+        plugins: { deny: ["imessage"] },
+      } as OpenClawConfig;
+      withInstalledChannelPlugin({ cfg: deniedCfg, pluginDir }, () => {
+        expect(
+          resolveChannelRemoteInboundAttachmentRoots({
+            cfg: deniedCfg,
+            ctx: createContext("imessage"),
+          }),
+        ).toBeUndefined();
+        expect(
+          resolveChannelInboundAttachmentRootsForChannel({
+            cfg: deniedCfg,
+            channelId: "imessage",
+            accountId: "work",
+          }),
+        ).toBeUndefined();
+      });
+    });
+  });
+
   it("keeps bundled channel media contracts ahead of installed plugin owners", () => {
     const pluginRoot = tempDirs.make("openclaw-media-installed-");
     const pluginDir = writeInstalledChannelPlugin({

--- a/src/media/channel-inbound-roots.ts
+++ b/src/media/channel-inbound-roots.ts
@@ -2,7 +2,20 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { loadBundledPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
+import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+// Metadata reads stay behind the registration bridge so media root resolution
+// never pulls the control-plane/kysely graph into light call paths.
+import {
+  getCurrentPluginMetadataSnapshotRuntime,
+  resolvePluginMetadataSnapshotRuntime,
+} from "../plugins/plugin-metadata-snapshot.runtime.js";
+import {
+  loadBundledPluginPublicArtifactModuleSync,
+  loadPluginPublicArtifactModuleSync,
+} from "../plugins/public-surface-loader.js";
+
+const CHANNEL_MEDIA_CONTRACT_ARTIFACT = "media-contract-api.js";
 
 type ChannelMediaContractApi = {
   resolveInboundAttachmentRoots?: (params: {
@@ -16,7 +29,14 @@ type ChannelMediaContractApi = {
 };
 type ChannelMediaRootResolver = keyof ChannelMediaContractApi;
 
-function loadChannelMediaContractApi(
+function acceptsResolver(
+  loaded: ChannelMediaContractApi,
+  resolver: ChannelMediaRootResolver,
+): boolean {
+  return typeof loaded[resolver] === "function";
+}
+
+function loadBundledChannelMediaContractApi(
   channelId: string,
   resolver: ChannelMediaRootResolver,
 ): ChannelMediaContractApi | undefined {
@@ -24,12 +44,9 @@ function loadChannelMediaContractApi(
     // Media-root resolution must stay a narrow artifact load, not full channel bootstrap.
     const loaded = loadBundledPluginPublicArtifactModuleSync<ChannelMediaContractApi>({
       dirName: channelId,
-      artifactBasename: "media-contract-api.js",
+      artifactBasename: CHANNEL_MEDIA_CONTRACT_ARTIFACT,
     });
-    if (typeof loaded[resolver] === "function") {
-      return loaded;
-    }
-    return undefined;
+    return acceptsResolver(loaded, resolver) ? loaded : undefined;
   } catch (error) {
     if (
       !(
@@ -44,15 +61,119 @@ function loadChannelMediaContractApi(
   return undefined;
 }
 
-function findChannelMediaContractApi(
-  channelId: string | null | undefined,
-  resolver: ChannelMediaRootResolver,
-) {
-  const normalized = normalizeOptionalLowercaseString(channelId);
+function declaresChannel(plugin: PluginManifestRecord, channelId: string): boolean {
+  return plugin.channels.some(
+    (ownedChannelId) => normalizeOptionalLowercaseString(ownedChannelId) === channelId,
+  );
+}
+
+type ChannelMediaContractOwner = Pick<PluginManifestRecord, "id" | "rootDir">;
+
+/**
+ * Lists installed official channel plugins that may own a channel's media contract.
+ *
+ * Bundled owners are resolved from the bundled plugin surface; workspace and
+ * community installs never gain attachment-root authority, so only
+ * host-verified official npm installs qualify.
+ */
+export function listTrustedInstalledChannelMediaContractOwners(params: {
+  channelId: string;
+  plugins: readonly PluginManifestRecord[];
+}): ChannelMediaContractOwner[] {
+  const channelId = normalizeOptionalLowercaseString(params.channelId);
+  if (!channelId) {
+    return [];
+  }
+  return params.plugins
+    .filter(
+      (plugin) =>
+        plugin.origin === "global" &&
+        plugin.trustedOfficialInstall === true &&
+        declaresChannel(plugin, channelId),
+    )
+    .map((plugin) => ({ id: plugin.id, rootDir: plugin.rootDir }))
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+function resolveInstalledChannelMediaContractOwners(params: {
+  channelId: string;
+  cfg: OpenClawConfig;
+}): ChannelMediaContractOwner[] {
+  try {
+    const snapshot =
+      getCurrentPluginMetadataSnapshotRuntime({
+        config: params.cfg,
+        allowScopedSnapshot: true,
+        allowWorkspaceScopedSnapshot: true,
+      }) ?? resolvePluginMetadataSnapshotRuntime({ config: params.cfg });
+    if (!snapshot) {
+      return [];
+    }
+    return listTrustedInstalledChannelMediaContractOwners({
+      channelId: params.channelId,
+      plugins: snapshot.manifestRegistry.plugins,
+    });
+  } catch {
+    // Discovery must never turn a missing channel artifact into a hard failure.
+    return [];
+  }
+}
+
+function loadInstalledChannelMediaContractApi(params: {
+  channelId: string;
+  cfg: OpenClawConfig;
+  resolver: ChannelMediaRootResolver;
+}): ChannelMediaContractApi | undefined {
+  for (const owner of resolveInstalledChannelMediaContractOwners({
+    channelId: params.channelId,
+    cfg: params.cfg,
+  })) {
+    try {
+      const loaded = loadPluginPublicArtifactModuleSync<ChannelMediaContractApi>({
+        pluginRoot: owner.rootDir,
+        artifactBasename: CHANNEL_MEDIA_CONTRACT_ARTIFACT,
+        origin: "global",
+      });
+      if (acceptsResolver(loaded, params.resolver)) {
+        return loaded;
+      }
+    } catch (error) {
+      if (error instanceof MissingPublicSurfaceError) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  return undefined;
+}
+
+function loadChannelMediaContractApi(params: {
+  channelId: string;
+  cfg: OpenClawConfig;
+  resolver: ChannelMediaRootResolver;
+}): ChannelMediaContractApi | undefined {
+  return (
+    loadBundledChannelMediaContractApi(params.channelId, params.resolver) ??
+    // External official channel packages ship outside the core bundle, so the
+    // installed plugin root is the only place their media contract can live.
+    loadInstalledChannelMediaContractApi(params)
+  );
+}
+
+function findChannelMediaContractApi(params: {
+  channelId: string | null | undefined;
+  cfg: OpenClawConfig;
+  resolver: ChannelMediaRootResolver;
+}) {
+  const normalized = normalizeOptionalLowercaseString(params.channelId);
   if (!normalized) {
     return undefined;
   }
-  return loadChannelMediaContractApi(normalized, resolver);
+  return loadChannelMediaContractApi({
+    channelId: normalized,
+    cfg: params.cfg,
+    resolver: params.resolver,
+  });
 }
 
 /** Resolves local inbound attachment roots from the channel named in a message context. */
@@ -73,10 +194,11 @@ export function resolveChannelInboundAttachmentRootsForChannel(params: {
   channelId?: string | null;
   accountId?: string | null;
 }): readonly string[] | undefined {
-  const contractApi = findChannelMediaContractApi(
-    params.channelId,
-    "resolveInboundAttachmentRoots",
-  );
+  const contractApi = findChannelMediaContractApi({
+    channelId: params.channelId,
+    cfg: params.cfg,
+    resolver: "resolveInboundAttachmentRoots",
+  });
   if (contractApi?.resolveInboundAttachmentRoots) {
     return contractApi.resolveInboundAttachmentRoots({
       cfg: params.cfg,
@@ -91,10 +213,11 @@ export function resolveChannelRemoteInboundAttachmentRoots(params: {
   cfg: OpenClawConfig;
   ctx: MsgContext;
 }): readonly string[] | undefined {
-  const contractApi = findChannelMediaContractApi(
-    params.ctx.Surface ?? params.ctx.Provider,
-    "resolveRemoteInboundAttachmentRoots",
-  );
+  const contractApi = findChannelMediaContractApi({
+    channelId: params.ctx.Surface ?? params.ctx.Provider,
+    cfg: params.cfg,
+    resolver: "resolveRemoteInboundAttachmentRoots",
+  });
   if (contractApi?.resolveRemoteInboundAttachmentRoots) {
     return contractApi.resolveRemoteInboundAttachmentRoots({
       cfg: params.cfg,

--- a/src/media/channel-inbound-roots.ts
+++ b/src/media/channel-inbound-roots.ts
@@ -75,9 +75,10 @@ type ChannelMediaContractOwner = Pick<PluginManifestRecord, "id" | "rootDir">;
  * community installs never gain attachment-root authority, so only
  * host-verified official npm installs qualify. Current operator policy still
  * wins over install provenance: denylisted, explicitly disabled, and
- * out-of-allowlist plugins lose attachment-root authority.
+ * out-of-allowlist plugins lose attachment-root authority before their artifact
+ * executes or supplies file-access roots.
  */
-export function listTrustedInstalledChannelMediaContractOwners(params: {
+function listTrustedInstalledChannelMediaContractOwners(params: {
   channelId: string;
   cfg: OpenClawConfig;
   plugins: readonly PluginManifestRecord[];

--- a/src/media/channel-inbound-roots.ts
+++ b/src/media/channel-inbound-roots.ts
@@ -3,13 +3,12 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { resolveManifestOwnerBasePolicyBlock } from "../plugins/manifest-owner-policy.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 // Metadata reads stay behind the registration bridge so media root resolution
 // never pulls the control-plane/kysely graph into light call paths.
-import {
-  getCurrentPluginMetadataSnapshotRuntime,
-  resolvePluginMetadataSnapshotRuntime,
-} from "../plugins/plugin-metadata-snapshot.runtime.js";
+import { getCurrentPluginMetadataSnapshotRuntime } from "../plugins/plugin-metadata-snapshot.runtime.js";
 import {
   loadBundledPluginPublicArtifactModuleSync,
   loadPluginPublicArtifactModuleSync,
@@ -74,22 +73,27 @@ type ChannelMediaContractOwner = Pick<PluginManifestRecord, "id" | "rootDir">;
  *
  * Bundled owners are resolved from the bundled plugin surface; workspace and
  * community installs never gain attachment-root authority, so only
- * host-verified official npm installs qualify.
+ * host-verified official npm installs qualify. Current operator policy still
+ * wins over install provenance: denylisted, explicitly disabled, and
+ * out-of-allowlist plugins lose attachment-root authority.
  */
 export function listTrustedInstalledChannelMediaContractOwners(params: {
   channelId: string;
+  cfg: OpenClawConfig;
   plugins: readonly PluginManifestRecord[];
 }): ChannelMediaContractOwner[] {
   const channelId = normalizeOptionalLowercaseString(params.channelId);
   if (!channelId) {
     return [];
   }
+  const normalizedConfig = normalizePluginsConfig(params.cfg.plugins);
   return params.plugins
     .filter(
       (plugin) =>
         plugin.origin === "global" &&
         plugin.trustedOfficialInstall === true &&
-        declaresChannel(plugin, channelId),
+        declaresChannel(plugin, channelId) &&
+        resolveManifestOwnerBasePolicyBlock({ plugin, normalizedConfig }) === null,
     )
     .map((plugin) => ({ id: plugin.id, rootDir: plugin.rootDir }))
     .toSorted((left, right) => left.id.localeCompare(right.id));
@@ -100,21 +104,23 @@ function resolveInstalledChannelMediaContractOwners(params: {
   cfg: OpenClawConfig;
 }): ChannelMediaContractOwner[] {
   try {
-    const snapshot =
-      getCurrentPluginMetadataSnapshotRuntime({
-        config: params.cfg,
-        allowScopedSnapshot: true,
-        allowWorkspaceScopedSnapshot: true,
-      }) ?? resolvePluginMetadataSnapshotRuntime({ config: params.cfg });
+    // Read the current plugin metadata generation only. Attachment-root
+    // resolution must never start plugin discovery or index work of its own.
+    const snapshot = getCurrentPluginMetadataSnapshotRuntime({
+      config: params.cfg,
+      allowScopedSnapshot: true,
+      allowWorkspaceScopedSnapshot: true,
+    });
     if (!snapshot) {
       return [];
     }
     return listTrustedInstalledChannelMediaContractOwners({
       channelId: params.channelId,
+      cfg: params.cfg,
       plugins: snapshot.manifestRegistry.plugins,
     });
   } catch {
-    // Discovery must never turn a missing channel artifact into a hard failure.
+    // Snapshot reads must never turn a missing channel artifact into a hard failure.
     return [];
   }
 }


### PR DESCRIPTION
Closes #144025

## What Problem This Solves

Fixes an issue where users of the official external iMessage plugin had remote attachments skipped even when the files were inside configured allowed roots. Core only looked for a bundled media contract, which is absent from the published external-only installation.

## Why This Change Was Made

The existing media-root resolver now falls back to a globally installed, verified official channel owner that passes the canonical plugin policy. It loads that owner's validated `media-contract-api.js` and keeps bundled contracts first. Attachment roots remain plugin-owned, and the existing SCP staging path is unchanged.

## User Impact

Allowed remote attachments can reach local staging with the official external iMessage plugin. Operator deny/allow policies and plugin disablement remain authoritative.

## Evidence

- Packaged baseline `decc0d9e05fb`: the real Gateway admitted an inbound from a protocol-compatible `imsg` fixture, rejected the configured allowed attachment before SCP, and completed `/status` without staging it.
- Packaged candidate `cd14f8f190b6`: the same public installation and ingress path loaded the real external media contract, made one strict loopback SSH/SCP transfer, and staged all 68 bytes with an identical digest.
- Both runs used the public plugin installer and public runtime inspection for `@openclaw/imessage@2026.9.3`; inspection confirmed a loaded global official install, with no bundled iMessage copy.
- Complete app-server protocol captures show metadata/account reads only, with no model turn requested.
- All 31 focused resolver, lifecycle, staging and cancellation tests passed. Formatting, targeted lint, line-count and assertion-safety checks passed.
- Live controls verified selected-account and default roots, root revocation after reload, outside/unsafe-path refusal, bad host-key refusal and recovery, and rejection of a 51 MiB file after download without staged publication. Temporary staging directories were gone before Gateway shutdown.
- Per-plugin disablement, denylisting and global disablement stopped the watch; restoring each policy allowed one successful transfer. Existing activation rules retain explicitly configured plugins in the effective allowlist; the separate excluded-owner predicate is covered by focused tests.
- Independent public acceptance completed 34 steps and 16 fresh inbounds: nine permitted attachments each staged once with all 68 bytes intact; seven refusal cases staged nothing. Every inbound received its matching completed outcome and fixture reply. Configuration and host-key records were restored.
- A separate packaged control with both real bundled and official external copies opened the bundled media contract before a successful strict SCP transfer.
- Installing the unchanged registry archive through the local-archive route retained untrusted provenance and stopped at trusted channel-state admission before a watch opened. Workspace inspection likewise retained untrusted provenance, but Gateway startup stopped during official-plugin installation repair under the restricted test network; this does not prove the later media guard. Origin exclusion remains covered by source and focused tests.

The channel transport used a synthetic fixture on Linux. A real Messages Mac, live recipient delivery, and HEIC decoding were not exercised.
