### PR TITLE
fix(telegram): stabilize the replacement-session retry test

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -3168,7 +3168,7 @@ describe("TelegramPollingSession", () => {
 
   it("retries a lone active spooled handler in a replacement session (#84158)", async () => {
     // Core drain releases a hanging claim so a replacement session retries it.
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.useFakeTimers();
     const firstAbort = new AbortController();
     const secondAbort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));


### PR DESCRIPTION
Related: #84158

## What Problem This Solves

Fixes a flaky Telegram replacement-session retry test on slower CI hosts. The test expected update 42 to remain pending after its watchdog released the claim, but its still-running first session could retry and finish the update before the assertion observed it.

## Why This Change Was Made

The test now uses manual fake timers, preserving every existing explicit clock advance, assertion, handler, and replacement-session operation. Host scheduling delays can no longer advance the fake retry deadline independently of the test.

## User Impact

The replacement-session retry check is deterministic under delayed observation. Telegram runtime behavior is unchanged.

## Evidence

- [Observed CI failure](https://github.com/openclaw/openclaw/actions/runs/34476148274/job/102869286191): the pending-update assertion expected `[42]` and observed `[]`.
- Ordinary unchanged focused and full-file runs passed locally. A controlled reproduction added the same temporary 150 ms real pause before the assertion: automatic fake time advanced 140 ms, the handler ran a second time, and pending changed from `[42]` to `[]`, failing the original assertion. With manual fake timers, fake time and the pending state remained unchanged and the identical schedule passed.
- All diagnostic code and pauses were removed from the final one-line change. The clean full file passes all 76 tests; required changed checks and independent P2 review pass.
