### PR TITLE
refactor(test): focus agent UI assertions on behavior

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -464,8 +464,6 @@ describe("agents tools panel (browser)", () => {
 
     expect(group).toBeInstanceOf(HTMLDetailsElement);
     expect(tool).toBeInstanceOf(HTMLDetailsElement);
-    expect(group ? [...group.classList] : []).toEqual(["agent-tools-group"]);
-    expect(tool ? [...tool.classList] : []).toEqual(["agent-tool-card"]);
 
     if (!group || !tool) {
       throw new Error("expected agent tool group and card");
@@ -630,8 +628,6 @@ describe("agents tools panel (browser)", () => {
 
     expect(group).toBeInstanceOf(HTMLDetailsElement);
     expect(tool).toBeInstanceOf(HTMLDetailsElement);
-    expect(group ? [...group.classList] : []).toEqual(["agent-tools-group"]);
-    expect(tool ? [...tool.classList] : []).toEqual(["agent-tool-card"]);
     expect(chip?.getAttribute("href")).toBe("#agent-tool-read");
 
     if (!group || !tool || !chip) {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -1004,27 +1004,16 @@ describe("renderAgentFiles", () => {
     const previewExpandButton = expandButton!;
     previewExpandButton.click();
 
-    expect([...previewPanel.classList]).toEqual(["md-preview-dialog__panel", "fullscreen"]);
-    expect([...previewExpandButton.classList]).toEqual([
-      "btn",
-      "btn--sm",
-      "md-preview-icon-btn",
-      "md-preview-expand-btn",
-      "is-fullscreen",
-    ]);
+    expect(previewPanel.classList.contains("fullscreen")).toBe(true);
+    expect(previewExpandButton.classList.contains("is-fullscreen")).toBe(true);
     expect(previewExpandButton.getAttribute("aria-pressed")).toBe("true");
     expect(previewExpandButton.getAttribute("aria-label")).toBe("Collapse preview");
     expect(previewExpandButton.closest("openclaw-tooltip")?.content).toBe("Collapse preview");
 
     container.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click();
 
-    expect([...previewPanel.classList]).toEqual(["md-preview-dialog__panel"]);
-    expect([...previewExpandButton.classList]).toEqual([
-      "btn",
-      "btn--sm",
-      "md-preview-icon-btn",
-      "md-preview-expand-btn",
-    ]);
+    expect(previewPanel.classList.contains("fullscreen")).toBe(false);
+    expect(previewExpandButton.classList.contains("is-fullscreen")).toBe(false);
     expect(previewExpandButton.getAttribute("aria-pressed")).toBe("false");
     expect(previewExpandButton.getAttribute("aria-label")).toBe("Expand preview");
     expect(previewExpandButton.closest("openclaw-tooltip")?.content).toBe("Expand preview");


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Agent UI tests reject harmless additional or reordered CSS classes even when the controls behave correctly.

## Why This Change Was Made

Remove exact singleton-class checks from tool-panel interactions and narrow preview checks to the fullscreen state flags. Keep native control types, collapse/open state, focus, scrolling, URL behavior, accessible labels, pressed state, tooltip reset, and icon-state coverage. All cases and fixtures remain unchanged.

## User Impact

No product UI change. The tests continue protecting behavior without requiring an exact styling class list. This removes 15 net test lines and does not remove any test invocation.

## Evidence

Complete before/after runs passed with identical ordered case identities and statuses: 23 unit tests and 27 headless Chromium tests, with zero failures or skips. Browser and unit projects ran separately because the report merger does not support combining inline/browser configurations; the initial reporting failure is retained.

The mapped changed gate and independent review validate the final source. No runtime speedup is claimed.
