### PR TITLE
refactor(infra): remove duplicate shell PATH test

### DIFF
--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -811,18 +811,6 @@ describe("shell env fallback", () => {
     expect(exec).toHaveBeenCalledOnce();
   });
 
-  it("returns the login-shell PATH needed by env-based executable launchers", () => {
-    const exec = vi.fn(() => framedShellEnv("PATH=/bin\0"));
-
-    const result = resolveExecutableFromUserShellPath("sh", {
-      env: { PATH: "/missing", SHELL: "/bin/sh" },
-      strategy: "fallback",
-      exec: exec as unknown as Parameters<typeof resolveExecutableFromUserShellPath>[1]["exec"],
-    });
-
-    expect(result).toEqual({ executable: "/bin/sh", pathEnv: "/bin" });
-  });
-
   it("returns null without invoking shell on win32", () => {
     const exec = vi.fn(() => framedShellEnv("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

This maintainer-requested test audit removes duplicate login-shell PATH coverage that adds maintenance work without protecting another behavior.

## Why This Change Was Made

Remove the weaker case from `src/infra/shell-env.test.ts`. The retained daemon-PATH-miss case uses the same command, shell PATH fixture, fallback strategy, and resolved result, and additionally verifies that the shell probe runs once. All other cases, imports, helpers, and production code remain unchanged.

## User Impact

No runtime change. One redundant test and 12 test lines are removed while startup, security, session, cache, and platform coverage remain.

## Evidence

- Full ordered `src/infra/shell-env.test.ts` through the normal infra-config wrapper: 32 actual passes, zero skips on Linux with Bash.
- Targeted formatting, diff check, and all 20 selected changed checks passed.
- P2 review completed scoped-clean with no findings. An initial invocation-path error stopped before reviewer launch; the corrected invocation completed.

No live-provider, installed-package, other-platform, or full-repository test run is claimed.
