### PR TITLE
fix(daemon): clear self-referencing OPENCLAW_WRAPPER on macOS gateway install

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -6,11 +6,13 @@ import { Writable } from "node:stream";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeStateDirDotEnv } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { resolveLaunchAgentLabel } from "../daemon/launchd-label.js";
 import {
   buildLaunchAgentPlist,
   readLaunchAgentProgramArgumentsFromFile,
 } from "../daemon/launchd-plist.js";
 import { decodeLaunchAgentPlistFixture } from "../daemon/launchd-plist.test-support.js";
+import { resolveLaunchAgentEnvWrapperPath } from "../daemon/launchd-service-files.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
 
@@ -603,6 +605,46 @@ describe("buildGatewayInstallPlan", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "Ignoring OPENCLAW_WRAPPER because it points to the Windows task script",
+      ),
+    );
+  });
+
+  it("clears a macOS wrapper env that points at the generated LaunchAgent env wrapper", async () => {
+    const env = isolatedPlanEnv();
+    const selfWrapperPath = resolveLaunchAgentEnvWrapperPath(env, resolveLaunchAgentLabel(env));
+    const warn = vi.fn();
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({
+        OPENCLAW_WRAPPER: selfWrapperPath,
+      }),
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+      warn,
+    });
+
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledOnce();
+    expect(
+      firstMockArg(mocks.resolveGatewayProgramArguments, "resolveGatewayProgramArguments")
+        .wrapperPath,
+    ).toBeUndefined();
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimePath: "/opt/node" }),
+    );
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledOnce();
+    expect(
+      firstMockArg(mocks.buildServiceEnvironment, "buildServiceEnvironment").env?.OPENCLAW_WRAPPER,
+    ).toBeUndefined();
+    expect(plan.environment.OPENCLAW_WRAPPER).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Ignoring OPENCLAW_WRAPPER because it points to the generated LaunchAgent environment wrapper",
       ),
     );
   });

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -9,6 +9,8 @@ import { collectDurableServiceEnvVarSources } from "../config/state-dir-dotenv.j
 import type { OpenClawConfig } from "../config/types.js";
 import { coerceSecretRef, resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
+import { resolveLaunchAgentLabel } from "../daemon/launchd-label.js";
+import { resolveLaunchAgentEnvWrapperPath } from "../daemon/launchd-service-files.js";
 import { resolveGatewayStateDir, resolveGatewayTaskScriptPath } from "../daemon/paths.js";
 import {
   OPENCLAW_WRAPPER_ENV_KEY,
@@ -835,7 +837,21 @@ export async function buildGatewayInstallPlan(params: {
       `Ignoring ${OPENCLAW_WRAPPER_ENV_KEY} because it points to the Windows task script; using the OpenClaw gateway entrypoint directly to avoid a recursive gateway.cmd wrapper.`,
     );
   }
-  const wrapperPath = wrapperPointsAtWindowsTaskScript
+  const generatedLaunchAgentWrapperPath =
+    platform === "darwin"
+      ? resolveLaunchAgentEnvWrapperPath(params.env, resolveLaunchAgentLabel(params.env))
+      : undefined;
+  const wrapperPointsAtGeneratedLaunchAgentWrapper =
+    Boolean(wrapperInput?.trim()) &&
+    isSameServicePath(wrapperInput, generatedLaunchAgentWrapperPath, platform);
+  if (wrapperPointsAtGeneratedLaunchAgentWrapper) {
+    params.warn?.(
+      `Ignoring ${OPENCLAW_WRAPPER_ENV_KEY} because it points to the generated LaunchAgent environment wrapper; using the OpenClaw gateway entrypoint directly to avoid a self-referencing wrapper.`,
+    );
+  }
+  const wrapperPointsAtGeneratedScript =
+    wrapperPointsAtWindowsTaskScript || wrapperPointsAtGeneratedLaunchAgentWrapper;
+  const wrapperPath = wrapperPointsAtGeneratedScript
     ? undefined
     : await resolveOpenClawWrapperPath(wrapperInput);
   const { devMode, runtimePath } = await resolveDaemonInstallRuntimeInputs({
@@ -847,7 +863,7 @@ export async function buildGatewayInstallPlan(params: {
   });
   const serviceInputEnv: Record<string, string | undefined> = wrapperPath
     ? { ...params.env, [OPENCLAW_WRAPPER_ENV_KEY]: wrapperPath }
-    : wrapperPointsAtWindowsTaskScript
+    : wrapperPointsAtGeneratedScript
       ? omitEnvKey(params.env, OPENCLAW_WRAPPER_ENV_KEY)
       : params.env;
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({


### PR DESCRIPTION
Closes #144001

## What Problem This Solves
macOS Gateway reinstall fails when `OPENCLAW_WRAPPER` points to OpenClaw's generated environment launcher.

## User Impact
Reinstall restores the runtime and Gateway entrypoint instead of nesting the launcher. Genuine custom wrappers still work.

## Why This Change Was Made
The shared install planner rejects generated launchers before selecting runtime arguments and environment. This setting has one writer. Production code shrinks by eight lines.

## Evidence
On isolated macOS services, `gateway install --force --runtime node --wrapper "$launcher"` produced duplicate arguments, exit 2 and no health before the fix; afterward, health returned 200. Persisted-input and repeat reinstall, fresh install, a genuine custom wrapper, authentication and environment retention passed.

The unmodified published 2026.9.3 updater completed with a normal runtime definition plus the invalid persisted wrapper value. The installed candidate answered health and authenticated status. An already-recursive definition is unidentifiable to that old updater; direct candidate reinstall is the proven recovery. No package was published.

The installer patch is unchanged from these native observations at `cebb120f`.

## Compatibility
Windows generated-script rejection is unchanged. No new configuration or migration.

## Consumers
Install, startup repair, Doctor and setup share the planner.

## Invalidation
Existing service owners regenerate arguments and environment.

## Tests
Registered-command cases fail on the original main implementation. After integrating main, 657 installer/update tests and 600 current catalog/release/inventory tests pass. Full build, type-aware preflight, formatting, both line limits, unused-file/export and architecture checks pass.

Earlier CI run 35153572691 failed; the exact formatting repair from #150330 is included. New hosted checks must complete.
