### PR TITLE
fix(test): avoid update ledger worker shutdown races

### DIFF
--- a/src/infra/update-run-ledger.process.test-support.ts
+++ b/src/infra/update-run-ledger.process.test-support.ts
@@ -35,7 +35,10 @@ process.once("message", () => {
       options,
     );
   }
-  closeOpenClawStateDatabase();
-  process.disconnect?.();
+  process.once("message", () => {
+    closeOpenClawStateDatabase();
+    process.disconnect?.();
+  });
+  process.send?.("written");
 });
 process.send?.("ready");

--- a/src/infra/update-run-ledger.test.ts
+++ b/src/infra/update-run-ledger.test.ts
@@ -737,7 +737,21 @@ describe("update run ledger", () => {
           code === 0 ? resolve() : reject(new Error(`${role} exited ${code}: ${output}`)),
         );
       });
-      return { child, ready, exited };
+      const written = ready.then(() =>
+        Promise.race([
+          new Promise<void>((resolve, reject) => {
+            child.once("message", (message) =>
+              message === "written"
+                ? resolve()
+                : reject(new Error(`Unexpected ${role} write message`)),
+            );
+          }),
+          exited.then(() => {
+            throw new Error(`${role} exited before acknowledging writes: ${output}`);
+          }),
+        ]),
+      );
+      return { child, ready, written, exited };
     });
     const deadline = setTimeout(() => {
       for (const { child } of children) {
@@ -745,11 +759,17 @@ describe("update run ledger", () => {
       }
     }, 20_000);
     try {
-      await Promise.all(children.map(({ ready }) => ready));
+      const allWritten = Promise.all(children.map(({ written }) => written));
+      await Promise.race([Promise.all(children.map(({ ready }) => ready)), allWritten]);
       for (const { child } of children) {
         child.send("start");
       }
-      await Promise.all(children.map(({ exited }) => exited));
+      await allWritten;
+      // Writes stay concurrent; handle retirement must not race another lifecycle writer.
+      for (const { child, exited } of children) {
+        child.send("close");
+        await exited;
+      }
       const persisted = getUpdateRun(run.runId, options);
       const expected = ["cli", "gateway"].flatMap((role) =>
         Array.from({ length: 16 }, (_, index) => `${role}-${index}`),
@@ -781,7 +801,7 @@ describe("update run ledger", () => {
           child.kill();
         }
       }
-      await Promise.allSettled(children.map(({ exited }) => exited));
+      await Promise.allSettled(children.flatMap(({ written, exited }) => [written, exited]));
     }
   }, 30_000);
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent CI failure in the concurrent CLI/Gateway update-ledger test when a worker exits during shared-state cleanup. The failure was observed in [CI job 102866134156](https://github.com/openclaw/openclaw/actions/runs/34475740237/job/102866134156).

## Why This Change Was Made

One worker could close its database while the other was still writing or retiring its handle, so the lifecycle coordinator correctly refused cleanup. Each worker now acknowledges completed writes before the parent requests and joins their closes sequentially. Writes still run concurrently. The readiness wait also observes write failures immediately, preserving early child errors and joining both workers during failure cleanup.

## User Impact

More reliable update-ledger CI coverage. All 32 recorded-step assertions and the final update outcome assertions remain. Production database behavior and timeouts are unchanged.

## Evidence

- After the patch-identical rebase onto the landed docs fix #144037, 79 integration cases passed: 37 update-ledger, 10 lifecycle coordinator, and 32 official-channel catalog/docs-sync cases. The existing retirement-refusal cases remain intact.
- A real-child early-exit probe reproduced an unhandled rejection before the readiness correction; afterward the same child error propagated with zero unhandled rejections and joined cleanup.
- Managed P0–P2 review of the unchanged patch: no actionable findings.
- Before the patch-identical rebase, the full changed-file gate passed, including core test typechecks, dead-export scans, and targeted lint. Both changed source files and their owner/toolchain inputs are unchanged on the new base.
