### PR TITLE
fix(auto-reply): suppress a text-only final already delivered as a caption (#144006)

### DIFF
--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -151,7 +151,14 @@ Claude CLI reuse (`claude -p`) is a sanctioned OpenClaw integration path. Anthro
 ### Google Vertex and Gemini CLI runtime
 
 - `google-vertex`: managed Google Cloud access through gcloud Application
-  Default Credentials.
+  Default Credentials. Set `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and
+  `GOOGLE_CLOUD_LOCATION` in the Gateway service environment; without a project
+  the run fails with `Vertex AI requires a project ID`. The ADC path requires
+  the literal credential value `gcp-vertex-credentials` — store it with
+  `openclaw models auth paste-api-key --provider google-vertex`. Any other
+  value, including a token from `gcloud auth print-access-token`, is sent as
+  `x-goog-api-key` and rejected by Vertex with `401 UNAUTHENTICATED`. See
+  [Google (Gemini)](/providers/google).
 - `google-gemini-cli`: optional local runtime for an explicitly configured
   canonical `google/*` model.
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -11,7 +11,7 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 - Provider: `google`
 - Auth: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 - API: Google Gemini API
-- Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials
+- Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials; the stored credential must be the literal value `gcp-vertex-credentials`
 - Optional runtime: `agentRuntime.id: "google-gemini-cli"` runs an explicitly configured model through the local Gemini CLI
 
 ## Getting started
@@ -140,6 +140,60 @@ the Gateway already runs inside a managed Google Cloud environment.
     `google-gemini-cli/*` refs remain legacy compatibility aliases. New configs
     should use `google/*` model refs plus the explicit runtime selection above.
 
+  </Tab>
+
+  <Tab title="Vertex AI (ADC)">
+    **Recommended for:** Gateways running inside Google Cloud with an attached
+    service account or workload identity.
+
+    `google-vertex` authenticates through Google Cloud Application Default
+    Credentials (ADC) and refreshes the access token itself, so no credential
+    rotation is needed. The stored provider credential is a marker, not a
+    secret.
+
+    <Steps>
+      <Step title="Provide Application Default Credentials">
+        On GCE, Cloud Run, and GKE the metadata server supplies ADC. Elsewhere,
+        run:
+
+        ```bash
+        gcloud auth application-default login
+        ```
+
+        Or point `GOOGLE_APPLICATION_CREDENTIALS` at a service-account key file.
+      </Step>
+      <Step title="Set the project and location">
+        `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) and `GOOGLE_CLOUD_LOCATION`
+        must be set in the Gateway service environment:
+
+        ```bash
+        export GOOGLE_CLOUD_PROJECT="my-project"
+        export GOOGLE_CLOUD_LOCATION="us-central1"
+        ```
+
+        Without a project the run fails with `Vertex AI requires a project ID.
+        Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.`
+      </Step>
+      <Step title="Store the ADC credential marker">
+        Store the literal value `gcp-vertex-credentials` as the provider
+        credential:
+
+        ```bash
+        openclaw models auth paste-api-key --provider google-vertex
+        # paste exactly: gcp-vertex-credentials
+        ```
+
+        OpenClaw treats that value as a marker and resolves ADC headers instead
+        of sending the value as an API key. Any other value, including a valid
+        token from `gcloud auth print-access-token`, is sent as
+        `x-goog-api-key` and rejected by Vertex with `401 UNAUTHENTICATED`.
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
   </Tab>
 </Tabs>
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -194,6 +194,7 @@ the Gateway already runs inside a managed Google Cloud environment.
         ```
       </Step>
     </Steps>
+
   </Tab>
 </Tabs>
 

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1473,6 +1473,63 @@ describe("buildReplyPayloads media filter integration", () => {
     }
   });
 
+  // Issue #144006: a block that carries explicit-TTS audio delivers its text as
+  // the channel caption. The later text-only final repeats that exact text, so a
+  // media-less final must consult the same recorded sent-text evidence as a
+  // media-bearing one.
+  it.each<DirectBlockDedupeCase>([
+    {
+      name: "suppresses a text-only final already delivered as a captioned voice block",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer." }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+    },
+    {
+      name: "suppresses a text-only final already delivered as a captioned voice block while streaming",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer." }],
+      params: { blockStreamingEnabled: true, blockReplyPipeline: null, replyToMode: "off" },
+    },
+    {
+      name: "keeps a text-only final whose text was never delivered",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Supplementary closing line." }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+      expected: { text: "Supplementary closing line." },
+    },
+    {
+      name: "keeps an error final whose text matches a delivered voice block",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer.", isError: true }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+      expected: { text: "Spoken answer.", isError: true },
+    },
+  ])("$name", async ({ keyPayloads, payloads, directlySentBlockPayloads, params, expected }) => {
+    const { replyPayloads } = await buildTestReplyPayloads({
+      directlySentBlockKeys: new Set(keyPayloads.map(createBlockReplyContentKey)),
+      ...(directlySentBlockPayloads ? { directlySentBlockPayloads } : {}),
+      payloads,
+      ...params,
+    });
+
+    expect(replyPayloads).toHaveLength(expected ? 1 : 0);
+    if (expected) {
+      expectFields(replyPayloads[0], expected);
+    }
+  });
+
   it("preserves final text when internal whitespace changed", async () => {
     const directlySentBlockPayloads = [
       setReplyPayloadMetadata({ text: "constx=1" }, { assistantMessageIndex: 1 }),

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -15,6 +15,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  isReplyPayloadTerminalContent,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -373,9 +374,12 @@ export async function buildReplyPayloads(params: {
         { ...payload, text: undefined, mediaUrl: undefined, mediaUrls: undefined },
         { trimText: true },
       );
+      // A media-bearing block delivers its text as the channel caption, so the
+      // same recorded sent-text evidence covers a matching text-only final.
       const wasSent = hasRichContent
         ? params.blockReplyPipeline?.hasSentExactPayload?.(payload)
-        : params.blockReplyPipeline?.hasSentPayload(payload);
+        : params.blockReplyPipeline?.hasSentPayload(payload) ||
+          (isReplyPayloadTerminalContent(payload) && hasDirectlySentText(payload));
       if (wasSent) {
         return null;
       }
@@ -404,7 +408,7 @@ export async function buildReplyPayloads(params: {
   };
   const preserveDirectlyUnsentPayload = (payload: ReplyPayload): ReplyPayload | null => {
     const reply = resolveSendableOutboundReplyParts(payload);
-    if (!reply.hasMedia || !reply.trimmedText) {
+    if (reply.hasMedia && !reply.trimmedText) {
       return payload;
     }
     return preserveUnsentMediaAfterBlockSend(payload);


### PR DESCRIPTION
Closes #144006.

## What Problem This Solves

With an explicit `tts` tool call on Telegram (`tts.auto: off`), the reporter sees the reply text twice: once as the voice note's caption and once as a standalone `sendMessage`.

An explicit `tts` tool result queues audio media (`src/agents/tools/tts-tool.ts:80-94` → `queuePendingToolMedia`, `src/agents/embedded-agent-subscribe.handlers.tools.results.ts:436-475`). The next non-reasoning assistant reply absorbs that media (`consumePendingToolMediaIntoReply`, `src/agents/embedded-agent-subscribe.handlers.messages.replies.ts:89-147`), so the block that goes to the channel carries **text + audio**, and a channel that renders media text as a caption (Telegram sets `captionedFinalText: true`, `extensions/telegram/src/setup-plugin.ts:40-42`) delivers that reply text once as the caption.

The same turn later produces a text-only final payload. `buildReplyPayloads` (`src/auto-reply/reply/agent-runner-payloads.ts`) is supposed to drop finals whose content a block already delivered, but only **media-bearing** finals consulted the recorded direct-send evidence:

- `preserveUnsentMediaAfterBlockSend` handled media-less payloads with `blockReplyPipeline.hasSentPayload` only, never `hasDirectlySentText`.
- `preserveDirectlyUnsentPayload` returned media-less payloads untouched (`if (!reply.hasMedia || !reply.trimmedText) return payload`), so the branches that drop already-sent payloads never reached the text comparison.

Because `createBlockReplyContentKey` includes the media list, a text-only final can never match the content key of the media-bearing block, so the exact-key path cannot cover it either. The result is the reported second bubble.

The fix makes media-less finals consult the same recorded delivery evidence as media-bearing ones, gated on terminal content so reasoning, commentary, status, error and fallback payloads keep their existing behavior. Text that was never delivered still ships; the audio is untouched.

## Evidence

`src/auto-reply/reply/agent-runner-payloads.test.ts` gains a table modelled on the reported shape: a block that delivered `Spoken answer.` as a captioned voice block, followed by a text-only final with identical text.

Failing first (before the fix), same file:

```
FAIL  src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > suppresses a text-only final already delivered as a captioned voice block
FAIL  src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > suppresses a text-only final already delivered as a captioned voice block while streaming
AssertionError: expected [ { text: 'Spoken answer.', …(6) } ] to have a length of +0 but got 1
 Tests  2 failed | 89 passed (91)
```

Passing after the fix, same file:

```
Test Files  1 passed (1)
      Tests  91 passed (91)
```

Command used for both runs:

```
PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner-payloads.test.ts
```

The same table keeps a final whose text was never delivered and keeps an error final. Neighbouring dedupe and pipeline suites stay green (`reply-delivery`, `reply-payloads-transport-dedupe`, `block-reply-pipeline`: 69 passed), and the whole `src/auto-reply/reply` project ran at `5651 passed, 1 failed` where the single failure is `stage-sandbox-media.scp.test.ts` timing out at 120s — that test spawns a real `scp` process tree, never imports this module, and is unrelated to this change.

`node_modules/.bin/oxlint` on both changed files reports nothing.

## Not Verified

Which runtime entry produced the reporter's turn (streaming on/off, whether the captioning block came through the block pipeline or a direct send) is **not** confirmed by a live Telegram reproduction — that needs Telegram credentials and is out of scope here. The fix closes the shared defect that lets already-delivered caption text be sent again as a text-only final; the dedupe branch it exercises is exactly the one that let a media-less final survive.
