### PR TITLE
test(gateway): reuse deferred terminal fixtures

### DIFF
--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -5,6 +5,7 @@ import {
   ErrorCodes,
   type TerminalUploadResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
@@ -44,14 +45,6 @@ const sessionMocks = vi.hoisted(() => ({
     }),
   ),
 }));
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 vi.mock("../node-command-policy.js", () => ({
   resolveNodeCommandAllowlist: policyMocks.resolveNodeCommandAllowlist,
@@ -487,7 +480,7 @@ describe("terminal gateway policy", () => {
   });
 
   it("does not create a terminal after the owning connection closes during catalog lookup", async () => {
-    const plan = deferred<{ kind: "local"; argv: string[] }>();
+    const plan = createDeferred<{ kind: "local"; argv: string[] }>();
     const openTerminal = vi.fn(() => plan.promise);
     installCatalog({
       id: "codex",
@@ -520,7 +513,7 @@ describe("terminal gateway policy", () => {
   });
 
   it("closes a terminal whose owning connection disappears during PTY creation", async () => {
-    const created = deferred<{
+    const created = createDeferred<{
       ok: true;
       sessionId: string;
       agentId: string;
@@ -556,7 +549,7 @@ describe("terminal gateway policy", () => {
   it("times out one terminal open with request-scoped cancellation", async () => {
     vi.useFakeTimers();
     try {
-      const created = deferred<{
+      const created = createDeferred<{
         ok: true;
         sessionId: string;
         agentId: string;
@@ -597,7 +590,7 @@ describe("terminal gateway policy", () => {
   });
 
   it("does not create a terminal when disabled during catalog lookup", async () => {
-    const plan = deferred<{ kind: "local"; argv: string[] }>();
+    const plan = createDeferred<{ kind: "local"; argv: string[] }>();
     const openTerminal = vi.fn(() => plan.promise);
     installCatalog({
       id: "codex",
@@ -630,7 +623,7 @@ describe("terminal gateway policy", () => {
   });
 
   it("uses the refreshed launch plan after catalog lookup", async () => {
-    const plan = deferred<{ kind: "local"; argv: string[] }>();
+    const plan = createDeferred<{ kind: "local"; argv: string[] }>();
     const openTerminal = vi.fn(() => plan.promise);
     installCatalog({
       id: "codex",
@@ -806,7 +799,7 @@ describe("terminal gateway policy", () => {
     "rejects a changed node admission: %s",
     async (change) => {
       const command = "anthropic.claude.terminal.resume.v1";
-      const policy = deferred<null>();
+      const policy = createDeferred<null>();
       policyMocks.applyPluginNodeInvokePolicy.mockImplementationOnce(() => policy.promise);
       installCatalog({
         id: "claude",

--- a/src/gateway/terminal/node-relay.test.ts
+++ b/src/gateway/terminal/node-relay.test.ts
@@ -1,20 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
-import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { type NodeInvokeResult, NodeRegistry } from "../node-registry.js";
 import { createNodeRelayBackend } from "./node-relay.js";
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
-
 describe("createNodeRelayBackend", () => {
   it("waits for pairing validation and dispatch instead of the final node exit", async () => {
-    const pairingState = deferred<{ identity: string; generation: string }>();
+    const pairingState = createDeferred<{ identity: string; generation: string }>();
     const frames: string[] = [];
     const resolveCurrentPairingState = vi.fn(async () => await pairingState.promise);
     const registry = new NodeRegistry({
@@ -78,7 +70,7 @@ describe("createNodeRelayBackend", () => {
     "codex.terminal.start.v1",
     "anthropic.claude.terminal.start.v1",
   ])("%s relays progress, input, resize, cancellation, and exit", async (command) => {
-    const invokeResult = deferred<NodeInvokeResult>();
+    const invokeResult = createDeferred<NodeInvokeResult>();
     let onProgress: ((chunk: string) => void) | undefined;
     let signal: AbortSignal | undefined;
     const sendInvokeInput = vi.fn();

--- a/src/gateway/terminal/session-manager.open-cancellation.test.ts
+++ b/src/gateway/terminal/session-manager.open-cancellation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { TerminalSessionManager } from "./session-manager.js";
 import {
   baseOpenRequest as baseRequest,
@@ -6,17 +7,9 @@ import {
   makeFakePty,
 } from "./session-manager.test-helpers.js";
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
-
 describe("TerminalSessionManager open cancellation", () => {
   it("kills a backend that finishes after its open request is cancelled", async () => {
-    const spawned = deferred<FakeTerminalPty>();
+    const spawned = createDeferred<FakeTerminalPty>();
     const controller = new AbortController();
     const first = makeFakePty();
     const second = makeFakePty();
@@ -48,8 +41,8 @@ describe("TerminalSessionManager open cancellation", () => {
   });
 
   it("bounds cancelled backend operations until they settle", async () => {
-    const firstSpawn = deferred<FakeTerminalPty>();
-    const secondSpawn = deferred<FakeTerminalPty>();
+    const firstSpawn = createDeferred<FakeTerminalPty>();
+    const secondSpawn = createDeferred<FakeTerminalPty>();
     const firstController = new AbortController();
     const secondController = new AbortController();
     let spawnCount = 0;

--- a/src/gateway/terminal/session-manager.task-lifecycle.test.ts
+++ b/src/gateway/terminal/session-manager.task-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { TerminalSessionManager } from "./session-manager.js";
 import {
   agentTerminalOwner,
@@ -12,10 +13,8 @@ const TERMINAL_EVENT_EXIT = "terminal.exit";
 
 describe("TerminalSessionManager task lifecycle", () => {
   it("aborts a matching pending task open and kills its late backend", async () => {
-    let resolveSpawn!: (pty: ReturnType<typeof makeFakePty>) => void;
-    const spawn = new Promise<ReturnType<typeof makeFakePty>>((resolve) => {
-      resolveSpawn = resolve;
-    });
+    const { promise: spawn, resolve: resolveSpawn } =
+      createDeferred<ReturnType<typeof makeFakePty>>();
     const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: () => spawn });
     const opening = manager.open(
       baseOpenRequest({
@@ -117,10 +116,8 @@ describe("TerminalSessionManager task lifecycle", () => {
   it("drains one agent incarnation while admitting its same-key replacement", async () => {
     const oldPty = makeFakePty();
     const pendingPty = makeFakePty();
-    let resolvePending!: (pty: ReturnType<typeof makeFakePty>) => void;
-    const pendingBackend = new Promise<ReturnType<typeof makeFakePty>>((resolve) => {
-      resolvePending = resolve;
-    });
+    const { promise: pendingBackend, resolve: resolvePending } =
+      createDeferred<ReturnType<typeof makeFakePty>>();
     const replacementPtys = [makeFakePty(), makeFakePty()];
     let spawnIndex = 0;
     const manager = new TerminalSessionManager({

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { TerminalBackend } from "./backend.js";
 import { composeTerminalIntroBanner } from "./intro-banner.js";
 import { TerminalSessionManager } from "./session-manager.js";
@@ -374,10 +375,7 @@ describe("TerminalSessionManager", () => {
     const emit = vi.fn();
     const livePty = makeFakePty();
     const pendingPty = makeFakePty();
-    let releasePending: (() => void) | undefined;
-    const pendingGate = new Promise<void>((resolve) => {
-      releasePending = resolve;
-    });
+    const { promise: pendingGate, resolve: releasePending } = createDeferred();
     const manager = new TerminalSessionManager({
       emit,
       spawn: async (request) => {
@@ -470,10 +468,7 @@ describe("TerminalSessionManager", () => {
   ])("kills a pending open when its connection $label and disconnects", async ({ request }) => {
     const emit = vi.fn();
     const fake = makeFakePty();
-    let release: (() => void) | undefined;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: gate, resolve: release } = createDeferred();
     const manager = new TerminalSessionManager({
       emit,
       spawn: async () => {
@@ -497,10 +492,7 @@ describe("TerminalSessionManager", () => {
 
   it("enforces the cap against concurrent opens racing on the async spawn", async () => {
     // Spawn resolves on a later tick so both opens await it before either registers.
-    let release: (() => void) | undefined;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const { promise: gate, resolve: release } = createDeferred();
     const manager = new TerminalSessionManager({
       emit: vi.fn(),
       spawn: async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Terminal lifecycle tests repeat Promise and callback plumbing that makes their coordination steps harder to read.

## Why This Change Was Made

Reuse the existing shared deferred fixture for eager barriers and remove three private factory copies. Keep callback-created eviction barriers in place because their creation records spawn readiness, and preserve every ordering, cancellation, authority and cleanup assertion.

## User Impact

No production behavior or public API changes. Five test files add 23 lines and remove 56, a net reduction of 33 lines. No tests are removed.

## Evidence

The original and candidate versions each passed all 115 cases with no skips, using the same seven-suite scope, including eviction and dispatch-authority siblings. Case identities, statuses and order within each suite match, and source remained unchanged during both runs.

The required local changed-file gate passed. Independent final review passed with no actionable findings. This is fixture-level proof, not a live backend, product behavior or native terminal platform claim.

### Reproducible after-change fixture evidence

The following complete command was run against the original source at `af50bd6c76843dde8f6c1c2eb1fd507f9f86eee1` and against the exact five-file afterimage committed as `68e466ba50dde091916e0a5ca16f4169dc2b523f`:

```sh
node scripts/run-vitest.mjs \
  src/gateway/terminal/node-relay.test.ts \
  src/gateway/terminal/session-manager.open-cancellation.test.ts \
  src/gateway/server-methods/terminal.test.ts \
  src/gateway/terminal/session-manager.task-lifecycle.test.ts \
  src/gateway/terminal/session-manager.test.ts \
  src/gateway/terminal/session-manager.eviction.test.ts \
  src/gateway/server-methods/terminal.dispatch-authority.test.ts
```

Both native runs exited 0 on the same Node 26.5.0 executable, with this result:

```text
 Test Files  7 passed (7)
      Tests  115 passed (115)
```

Native JSON reports have identical case names and outcomes, zero failures and zero skips. The after-change run preserves late-backend disposal after cancellation, the physical spawn cap, task closure and exact session-incarnation draining. The unchanged eviction suite still waits for callback-created resolver readiness, and the unchanged dispatch-authority suite retains its four-command by six-state table. Every source and context hash remained unchanged throughout each run, and the runners joined their children before returning.

The normal five-file `check-changed` gate passed all 20 checks. [Hosted CI for the exact commit also passed](https://github.com/openclaw/openclaw/actions/runs/34481104776).

### Response to the live-proof request

Maintainer disposition: skip the additional live-terminal request for this fixture-only cleanup. The completed source review found no code defect and recognized the verified maintainer authorship: this PR changes no production code, terminal command, protocol, policy or platform integration. The evidence above is actual execution of the changed test fixtures with their existing fake backends; it is not a claim of a live terminal, node-host or provider session. The local independent review and the completed ClawSweeper source review both confirm that the existing shared helper is the appropriate owner and that all behavior assertions remain intact.

The proof-classification mismatch is a separate follow-up: GitHub reports `author_association=CONTRIBUTOR` for this PR but confirms `steipete` has repository-admin permission. ClawSweeper's [external-author classifier](https://github.com/openclaw/clawsweeper/blob/fcaef5fe567b5ae6698d44c37357e12fd3bad60f/src/clawsweeper-runtime.ts#L1043) consumes the association without that independently verified permission. Its [host proof policy](https://github.com/openclaw/clawsweeper/blob/fcaef5fe567b5ae6698d44c37357e12fd3bad60f/src/clawsweeper-proof-policy.ts#L42) consequently treats the recorded not-applicable assessment as insufficient. This PR leaves that policy unchanged and follows the normal CI, completed-review and native merge gates.
