### PR TITLE
fix(models): align vision and compaction with selected rows

### DIFF
--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -7,8 +7,8 @@ import {
 import { findModelInCatalog, modelSupportsInput } from "../../agents/model-catalog-lookup.js";
 import { modelTransportRoutesMatch } from "../../agents/model-compat-catalog.js";
 import {
+  findConfiguredProviderModel,
   resolveMergedModelProviderConfig,
-  resolveMergedModelProviderModels,
 } from "../../config/model-provider-config.js";
 import type { resolveProviderScopedAuthProfile } from "./agent-runner-auth-profile.js";
 import type { FollowupRun } from "./queue.js";
@@ -78,10 +78,12 @@ export async function resolveRunModelHasVision(params: {
 }): Promise<boolean> {
   const { run, provider, model } = params;
   const providerConfig = resolveMergedModelProviderConfig(run.config, provider);
-  const configured = resolveMergedModelProviderModels({
-    models: providerConfig?.models,
-    normalizeModelId: normalizeLowercaseStringOrEmpty,
-  }).get(normalizeLowercaseStringOrEmpty(model));
+  const configured = findConfiguredProviderModel(
+    providerConfig,
+    provider,
+    model,
+    normalizeLowercaseStringOrEmpty,
+  );
   if (configured?.input !== undefined) {
     return modelSupportsInput(configured, "image");
   }

--- a/src/auto-reply/reply/memory-flush.test.ts
+++ b/src/auto-reply/reply/memory-flush.test.ts
@@ -2,11 +2,20 @@ import {
   applyOpenAIResponsesPayloadPolicy,
   resolveOpenAIResponsesPayloadPolicy,
 } from "@openclaw/ai/transports";
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import {
+  createEmptyAgentDiscoveryStores,
+  resolveModelWithRegistry,
+} from "../../agents/embedded-agent-runner/model.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { modelKey } from "../../shared/model-key.js";
+import { resolveRunModelHasVision } from "./agent-runner-run-params.js";
 import { resolveResponsesServerCompactionThreshold } from "./memory-flush.js";
+import { createMockFollowupRun } from "./test-helpers.js";
 
 const TEST_MODEL_ID = "gpt-5.4";
 const TEST_CONTEXT_WINDOW = 200_000;
@@ -235,6 +244,85 @@ describe("Responses server compaction host/transport parity", () => {
     expect(transportEnabled).toBe(testCase.expectedEnabled);
     expect(hostThreshold).toBe(testCase.expectedThreshold);
   });
+});
+
+describe("configured model consumer parity", () => {
+  it.each([
+    [false, "Model", true, 140_000],
+    [false, "model", false, 700_000],
+    [true, "Model", true, 140_000],
+    [true, "model", false, 700_000],
+    [false, "MODEL", true, 140_000],
+  ] as const)(
+    "matches transport with reversed=%s, model=%s",
+    async (reverse, modelId, vision, threshold) => {
+      const upper: ModelDefinitionConfig = {
+        ...buildModelConfig({ api: "openai-responses", contextTokens: 200_000 }),
+        id: "Model",
+        input: ["text", "image"],
+      };
+      const lower: ModelDefinitionConfig = {
+        ...upper,
+        id: "model",
+        input: ["text"],
+        contextTokens: 1_000_000,
+        contextWindow: 1_000_000,
+      };
+      const cfg: OpenClawConfig = {
+        plugins: { enabled: false },
+        models: {
+          providers: {
+            openai: {
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+              models: modelId === "MODEL" ? [upper] : reverse ? [lower, upper] : [upper, lower],
+            },
+          },
+        },
+      };
+      const { run } = createMockFollowupRun({
+        run: { config: cfg, provider: "openai", model: modelId },
+      });
+      await withPluginMetadataSnapshotScope(
+        createPluginMetadataSnapshotFixture(),
+        async () => {
+          const transportId = modelId === "MODEL" ? upper.id : modelId;
+          const { modelRegistry } = createEmptyAgentDiscoveryStores();
+          const transportModel = expectDefined(
+            resolveModelWithRegistry({
+              cfg,
+              provider: "openai",
+              modelId: transportId,
+              modelRegistry,
+              agentDir: run.agentDir,
+              workspaceDir: run.workspaceDir,
+            }),
+            "configured transport model",
+          );
+          const policy = resolveOpenAIResponsesPayloadPolicy(transportModel, {
+            storeMode: "provider-policy",
+            enableServerCompaction: true,
+          });
+          expect(transportModel.id).toBe(transportId);
+          expect(transportModel.input.includes("image")).toBe(vision);
+          expect(policy.compactThreshold).toBe(threshold);
+          expect({
+            vision: await resolveRunModelHasVision({ run, provider: "openai", model: modelId }),
+            threshold: resolveResponsesServerCompactionThreshold({
+              cfg,
+              provider: "openai",
+              modelId,
+              contextWindowTokens: expectDefined(
+                transportModel.contextWindow,
+                "configured transport context window",
+              ),
+            }),
+          }).toEqual({ vision, threshold });
+        },
+        { config: cfg },
+      );
+    },
+  );
 });
 
 describe("Anthropic server compaction host threshold", () => {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -6,8 +6,8 @@ import { normalizeStaticProviderModelId } from "../../agents/model-ref-shared.js
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import {
+  findConfiguredProviderModel,
   resolveMergedModelProviderConfig,
-  resolveMergedModelProviderModels,
 } from "../../config/model-provider-config.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -51,10 +51,12 @@ export function resolveResponsesServerCompactionThreshold(params: {
   const normalizeModelId = (value: string) =>
     normalizeStaticProviderModelId(normalizedProvider, value).trim().toLowerCase();
   const providerConfig = resolveMergedModelProviderConfig(params.cfg, provider);
-  const configuredModel = resolveMergedModelProviderModels({
-    models: providerConfig?.models,
+  const configuredModel = findConfiguredProviderModel(
+    providerConfig,
+    provider,
+    modelId,
     normalizeModelId,
-  }).get(normalizeModelId(modelId));
+  );
   const { defaultParams, modelParams } = resolveModelExtraParamSources({
     config: params.cfg,
     provider,


### PR DESCRIPTION
Related: #130706, #143822, #142100.

## What Problem This Solves

Vision detection and the host-side Responses compaction threshold can read a differently cased configured model row from the one used for transport. With separate `Model` and `model` rows, capabilities and thresholds can depend on row order instead of the selected model.

## Why This Change Was Made

Use the existing configured-row selector in these two consumers, retaining their existing normalization callbacks for fallback. This aligns exact row choice with request transport and adds four production lines.

## User Impact

Each literal model gets its own vision capability and compaction threshold in either row order. When no literal `MODEL` row exists but both case variants do, the shared selector consistently prefers the canonical `model` destination; this intentionally replaces the previous first-row ambiguity. A single equivalent `Model` row remains a valid fallback.

## Evidence

The two baseline mismatches were reproduced. All 50 focused tests, refreshed P2 review, and the full changed gate passed. An initial test type error was corrected using the existing typed assertion for the actual resolved context window; production was unchanged.

One sourcePerformance build at exact commit `02329d8423ad63fd1cc81d3231f14fda6efd0405` and seven compiled consumer scenarios passed. Vision and the public heartbeat compaction preflight were compared with the real resolver and transport payload policy across literal rows, both orders, single-equivalent fallback, and missing-literal cases. The preflight recorded the intended threshold and returned before compaction; no compaction execution is claimed.

All 9,256 root/workspace build files stayed unchanged. There were no source imports, network calls, or compaction starts, and state/process cleanup completed. This is compiled boundary proof; the runtime profile excludes UI and SDK declarations.
