### PR TITLE
fix(agents): stop reporting over-limit tool params as invalid integers

### DIFF
--- a/src/agents/tools/common.params.test.ts
+++ b/src/agents/tools/common.params.test.ts
@@ -132,6 +132,18 @@ describe("readNumberParam", () => {
     ).toThrow("deleteDays must be an integer from 0 to 7");
   });
 
+  it("names the bound when a max-constrained param exceeds it", () => {
+    // Without an explicit message the over-max branch used to reuse the
+    // "not an integer" text, so a caller sending a valid integer above the cap
+    // was told its value was not an integer and never learned the bound.
+    expect(() => readPositiveIntegerParam({ limit: 26 }, "limit", { max: 25 })).toThrow(
+      "limit must be a positive integer no greater than 25",
+    );
+    expect(() => readNonNegativeIntegerParam({ offset: 8 }, "offset", { max: 7 })).toThrow(
+      "offset must be a non-negative integer no greater than 7",
+    );
+  });
+
   it("treats empty or whitespace-only strings as unset for optional positive integer params", () => {
     // Tool-calling models routinely emit empty-string defaults for optional
     // params (e.g. Telegram replyTo/threadId) they are not actually setting.

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -243,7 +243,9 @@ export function readPositiveIntegerParam(
     }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
-    throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
+    throw new ToolInputError(
+      options.message ?? `${key} must be a positive integer no greater than ${options.max}`,
+    );
   }
   return value;
 }
@@ -267,7 +269,9 @@ export function readNonNegativeIntegerParam(
     }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
-    throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);
+    throw new ToolInputError(
+      options.message ?? `${key} must be a non-negative integer no greater than ${options.max}`,
+    );
   }
   return value;
 }

--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -172,7 +172,7 @@ describe("sessions_search tool", () => {
       "query must not be empty",
     );
     await expect(tool.execute("call-2", { query: "ok", limit: 26 })).rejects.toThrow(
-      "limit must be a positive integer",
+      "limit must be a positive integer no greater than 25",
     );
     await expect(tool.execute("call-3", { query: "x".repeat(4097) })).rejects.toThrow(
       "query must not exceed 4096 characters",


### PR DESCRIPTION
> **Corrected 2026-09-10.** The original version of this description claimed this defect affects `sessions_search` on current builds. That was wrong, and chasing the after-fix proof ClawSweeper asked for is what surfaced it. The corrected analysis is below; the code change is unchanged. See the review-response comment for the delta.

## What Problem This Solves

`readPositiveIntegerParam` and `readNonNegativeIntegerParam` reuse the "must be a positive/non-negative integer" text for their exceeds-max branch:

```ts
if (value !== undefined && options.max !== undefined && value > options.max) {
  throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
}
```

A caller passing a valid integer above the cap is told its value is not an integer, and the message never names the bound. There is nothing to correct toward.

**Reachability matters here, and I got it wrong the first time.** A caller is shielded from this branch if its declared input schema already bounds the value, because schema validation runs before the handler. `sessions_search` declares `limit: optionalPositiveIntegerSchema({ maximum: SESSIONS_SEARCH_MAX_LIMIT })`, so on a real gateway `limit: 50` is rejected earlier with an accurate message:

```
Invalid arguments for tool "sessions_search": limit: must be <= 25.
```

Verified on a live 2026.9.3 deployment with `limit: 50` and `limit: 26`. The unit test reaches the reader message only because it calls `tool.execute` directly, bypassing schema validation.

**The reachable caller today is the ollama node-inference `run` action.** `extensions/ollama/src/node-inference.ts:486,488` read `maxTokens` and `timeoutMs` imperatively with no bounded schema, so an over-limit value there does produce the contradictory message. The same file passes explicit messages for the same two params in its chat handler (lines 327-336) and omits them in the `run` path — the inconsistency this default invites.

So this is a latent-defect fix plus defense in depth for the two shared readers, not a user-visible `sessions_search` fix.

Related: #119937. Note for that PR: the same reachability finding applies to it, since the schema already rejects over-limit `limit` before the handler runs.

## Why This Change Was Made

Fixed in the shared readers rather than at each call site, so every caller that omits an explicit `message` gets a correct default instead of each one having to remember. The wording copies what call sites already pass by hand (`cron-tool.ts:279`), keeping messages consistent. Callers supplying their own `message` are unaffected, and no schema, tool description, or prompt snapshot is touched.

## User Impact

Narrow and mostly preventive. A caller that overshoots a bounded parameter with no schema bound — the ollama `run` action today — receives a message naming the limit rather than one contradicting its input. Nothing changes for callers whose schema already bounds the value, `sessions_search` included.

## Evidence

- **Baseline `c55297caa246aedabd1fe349cc59ee3558f5e07e`**, tests applied without the source change: `pnpm test src/agents/tools/common.params.test.ts src/agents/tools/sessions-search-tool.test.ts` → **2 failed | 36 passed**, `Expected: "limit must be a positive integer no greater than 25"` / `Received: "limit must be a positive integer"`.
- **Candidate `49666092ecb`**, same command → **38 passed**.
- `common.params.test.ts` gains coverage for the max branch *without* an explicit message; neither reader had any.
- Regression sweep: `pnpm test src/agents/tools/` → **120 files, 2693 passed, 1 skipped**. `pnpm test:extension ollama` → **30 files, 821 passed**. `pnpm check` → exit 0.
- **Live-deployment check (2026.9.3), which is what corrected the framing:** a real agent turn calling `sessions_search` with `limit: 50` and `limit: 26` returns the schema message above, not the reader message — so the branch is not reachable through that tool.

**On after-fix real-behavior proof:** I cannot supply it. The only caller that reaches this branch today is the ollama `run` action, and I have no Ollama node to drive it. What I have is the unit coverage above plus the live check that establishes where the branch is and is not reachable. If maintainers would rather not carry a latent fix without runtime proof, say so and I will close this.

AI-assisted.
