### PR TITLE
fix(browser): fold the retired ssrfPolicy.hostnameAllowlist into allowedHostnames instead of re-persisting it

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -715,6 +715,16 @@ describe("browser config", () => {
       expected: { allowedHostnames: ["example.com", "*.example.com"] },
     },
     {
+      name: "merges retired hostnameAllowlist into allowedHostnames without writing it back",
+      config: {
+        ssrfPolicy: {
+          allowedHostnames: ["localhost"],
+          hostnameAllowlist: ["*.example.com"],
+        },
+      } as unknown as BrowserConfig,
+      expected: { allowedHostnames: ["localhost", "*.example.com"] },
+    },
+    {
       name: "keeps configured profile cdpUrls out of the shared browser SSRF policy",
       config: withProfile("remote", {
         color: "#123456",

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -61,6 +61,12 @@ type BrowserSsrFPolicyCompat = NonNullable<BrowserConfig["ssrfPolicy"]> & {
    * still accepting old user files until doctor rewrites them.
    */
   allowPrivateNetwork?: boolean;
+  /**
+   * Retired authored key. Doctor folds it into `allowedHostnames` and the strict
+   * schema rejects a file that still carries it, so it is read only through this
+   * compat alias and never written back (#142358).
+   */
+  hostnameAllowlist?: unknown;
 };
 
 /** Browser config after defaults, derived ports, and profile defaults are applied. */
@@ -247,9 +253,18 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
   const dangerouslyAllowPrivateNetwork = rawPolicy?.dangerouslyAllowPrivateNetwork;
   const hasExplicitPrivateSetting =
     allowPrivateNetwork !== undefined || dangerouslyAllowPrivateNetwork !== undefined;
+  // Retired authored key (doctor migrates it to allowedHostnames and the schema
+  // rejects it): fold it into the canonical allowlist so the resolved policy
+  // never carries it back to disk. Matches
+  // "Merged browser.ssrfPolicy.hostnameAllowlist → allowedHostnames."
+  const { hostnameAllowlist: legacyHostnameAllowlistRaw, ...restPolicy } = { ...rawPolicy };
+  const legacyHostnameAllowlist = normalizeStringList(legacyHostnameAllowlistRaw);
   const resolved = mergeSsrFPolicies({
-    ...rawPolicy,
-    allowedHostnames: normalizeStringList(rawPolicy?.allowedHostnames),
+    ...restPolicy,
+    allowedHostnames: normalizeStringList([
+      ...(rawPolicy?.allowedHostnames ?? []),
+      ...(legacyHostnameAllowlist ?? []),
+    ]),
   });
   if (resolved && hasExplicitPrivateSetting) {
     delete resolved.allowPrivateNetwork;


### PR DESCRIPTION
## What Problem This Solves

Fixes #142358 (P0, `impact:crash-loop`). A config that still carries the retired `ssrfPolicy.hostnameAllowlist` key is written back to
`openclaw.json`, and the next reload rejects the file: the doctor migration deletes that key while loading, while `resolveBrowserSsrFPolicy`
spread the raw policy object into `mergeSsrFPolicies`, so the retired key survived the merge and travelled back into persisted config — where the
strict schema no longer accepts it. Result: a config that saves cleanly and then fails to load.

The retired `hostnameAllowlist` entries are now folded into `allowedHostnames`, the field that replaced them, and the dead key is dropped from
the merged policy — a save/reload round-trip keeps the same effective allowlist without reintroducing a schema-rejected key.

## Evidence

- `extensions/browser/src/browser/config.test.ts` — new case asserting the retired key is folded into `allowedHostnames` and not re-emitted.
- `node scripts/run-vitest.mjs run extensions/browser/src/browser/config.test.ts src/infra/net/ssrf.test.ts src/config/dead-config-keys.test.ts --maxWorkers=1 --no-file-parallelism`
  → `Tests 76 passed (76)`, `Tests 217 passed (217)`, `Tests 76 passed (76)`, exit 0 — run at head `21c4513dcd0`, rebased on `main` `3943149f8ac`.
- The retired key is read through the existing `BrowserSsrFPolicyCompat` alias (one optional field), so this adds no type assertions —
  `check-assertion-safety-ratchet` reports `OK: 3933 files, 11639 grandfathered assertions` locally, i.e. the per-file baseline is unchanged.
- Surface: 2 files, +28/−2; no new dependencies.

Closes #142358
