### PR TITLE
fix(gateway): reject a sandbox container cwd before probing the Gateway host

### DIFF
--- a/src/gateway/server-methods/session-create-root.test.ts
+++ b/src/gateway/server-methods/session-create-root.test.ts
@@ -168,4 +168,62 @@ describe("session create filesystem root", () => {
       }),
     ).toEqual({ ok: true, value: { sessionCwd } });
   });
+
+  it("rejects a container workdir instead of probing it on the Gateway host", () => {
+    // A Docker-sandboxed agent reports its container workdir; `suggest_task` persists
+    // that value, so the Host must classify it instead of failing on a raw lstat.
+    expect(
+      prepareSessionCreateFilesystemRoot({
+        cfg,
+        targetAgentId: "main",
+        enforceSandboxContainment: true,
+        sessionCwd: "/workspace",
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message:
+          "sessions.create cwd is a container path that does not exist on the Gateway host: /workspace",
+      },
+    });
+  });
+
+  it("still probes host-owned POSIX-style paths so missing ones stay unavailable", () => {
+    // Inside the workspace, a missing entry is a Host problem and must keep reporting
+    // as unavailable rather than being misread as a container path.
+    expect(
+      prepareSessionCreateFilesystemRoot({
+        cfg,
+        targetAgentId: "main",
+        enforceSandboxContainment: true,
+        sessionCwd: path.join(workspace, "missing"),
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: expect.stringContaining("cwd is unavailable:") },
+    });
+  });
+
+  it.each([
+    ["sandbox is off", "off"],
+    ["containment is not enforced", undefined],
+  ] as const)("keeps the container-path shape unrejected when %s", (_name, mode) => {
+    if (mode) {
+      cfg.agents!.defaults!.sandbox = { mode };
+    }
+    // Without an active sandbox there is no container namespace to classify against,
+    // so the pre-existing host probe behavior must be preserved unchanged.
+    const result = prepareSessionCreateFilesystemRoot({
+      cfg,
+      targetAgentId: "main",
+      enforceSandboxContainment: mode !== undefined,
+      sessionCwd: "/workspace",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("cwd is unavailable:");
+      expect(result.error.message).not.toContain("container path");
+    }
+  });
 });

--- a/src/gateway/server-methods/session-create-root.ts
+++ b/src/gateway/server-methods/session-create-root.ts
@@ -8,6 +8,7 @@ import {
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isWindowsDrivePath } from "../../infra/archive-path.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isPathInside } from "../../infra/path-guards.js";
 
@@ -15,6 +16,22 @@ type PreparedSessionCreateRoot = {
   sessionCwd?: string;
   sessionRoot?: string;
 };
+
+/**
+ * A sandboxed agent works inside a container, so a path it reports is relative to the
+ * container mount namespace, not the Gateway host. `/workspace` is the Docker workdir and
+ * can never exist here; without this check the host probes it and fails with a raw ENOENT
+ * (`cwd is unavailable: lstat '/workspace'`), which reads like a broken install instead of
+ * a path that belongs to another filesystem.
+ *
+ * Only the shape is judged here. Host-owned paths that are genuinely missing must keep
+ * failing through the existing probe so a dangling workspace link still reports unavailable.
+ * Native host paths are platform-absolute or Windows drive paths (`C:\...` is not
+ * `path.isAbsolute` under POSIX rules, hence the second clause).
+ */
+function isContainerOnlyPath(raw: string): boolean {
+  return raw.startsWith("/") && !isWindowsDrivePath(raw) && !raw.startsWith("//");
+}
 
 export function prepareSessionCreateFilesystemRoot(params: {
   cfg: OpenClawConfig;
@@ -31,6 +48,25 @@ export function prepareSessionCreateFilesystemRoot(params: {
   try {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.targetAgentId);
     const rootCandidate = params.sessionCwd ?? workspaceDir;
+    // Classify before probing the host filesystem: only the sandbox branch below knows
+    // whether a container path is plausible, so resolve the runtime first when a cwd
+    // was requested. Doing this after `realpathSync` would let the raw ENOENT win.
+    const sandboxRuntime =
+      params.sessionCwd && params.enforceSandboxContainment
+        ? resolveSandboxRuntimeStatus({
+            cfg: params.cfg,
+            agentId: params.targetAgentId,
+            sessionKey: params.sessionKey ?? `agent:${params.targetAgentId}:dashboard:pending`,
+          })
+        : undefined;
+    if (sandboxRuntime?.sandboxed && isContainerOnlyPath(rootCandidate)) {
+      return err(
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `sessions.create cwd is a container path that does not exist on the Gateway host: ${rootCandidate}`,
+        ),
+      );
+    }
     if (!params.sessionCwd) {
       fs.mkdirSync(rootCandidate, { recursive: true });
     }
@@ -38,15 +74,10 @@ export function prepareSessionCreateFilesystemRoot(params: {
     if (!fs.statSync(sessionRoot).isDirectory()) {
       return err(errorShape(ErrorCodes.INVALID_REQUEST, "sessions.create cwd is not a directory"));
     }
-    if (params.sessionCwd && params.enforceSandboxContainment) {
-      const targetRuntime = resolveSandboxRuntimeStatus({
-        cfg: params.cfg,
-        agentId: params.targetAgentId,
-        sessionKey: params.sessionKey ?? `agent:${params.targetAgentId}:dashboard:pending`,
-      });
+    if (params.sessionCwd && sandboxRuntime) {
       // Canonical paths admit workspace aliases while rejecting links that
       // resolve outside the selected agent's workspace.
-      if (targetRuntime.sandboxed && !isPathInside(fs.realpathSync(workspaceDir), sessionRoot)) {
+      if (sandboxRuntime.sandboxed && !isPathInside(fs.realpathSync(workspaceDir), sessionRoot)) {
         return err(
           errorShape(
             ErrorCodes.INVALID_REQUEST,


### PR DESCRIPTION
## What Problem This Solves

With a Docker-sandboxed agent (`sandbox.mode=all`), accepting a task suggestion from the Control UI fails:

```
INVALID_REQUEST "sessions.create cwd is unavailable: ENOENT: no such file or directory, lstat '/workspace'"
```

The agent suggests a task without an explicit `cwd`, so `suggest_task` persists its **container** workdir `/workspace`. `taskSuggestions.create` only checks `path.isAbsolute`, which `/workspace` passes, so the card is stored. On accept, the value is handed to `sessions.create`, where `prepareSessionCreateFilesystemRoot` calls `fs.realpathSync` on it **on the Gateway host**. `/workspace` cannot exist there, the call throws, and the raw host `ENOENT` is reshaped into the message above — which reads like a broken installation rather than a path that belongs to a different filesystem. A card created with a host path accepts fine, so only the container-path case is broken.

## Why This Change Was Made

The container-to-host path translation is not sound here, so the fix classifies instead of translating. A suggestion record keeps only a bare `cwd` plus `sessionKey` and an optional `agentId`; it does not retain the mount table, the container root, or the sandbox generation that was live when the card was created. Suggestions also outlive restarts, while the sandbox may be recreated against a different mount — so mapping `/workspace` back to "the agent workspace" could silently point an old card at a different directory than the user saw.

The change moves sandbox runtime resolution **before** the host probe and rejects a container-only path with a distinct, actionable message. The ordering is the substance of the fix: today `realpathSync` runs first, so the raw `ENOENT` always wins.

`isContainerOnlyPath` judges shape only, deliberately. Host-owned paths that are genuinely missing must keep failing through the existing probe (`session-create-root.test.ts` requires missing cwd, dangling inward/outward links, and a missing workspace to keep reporting `cwd is unavailable:`), so "reject anything that does not exist" would have broken that contract. `C:\...` is not `path.isAbsolute` under POSIX rules, hence the Windows-drive clause; `//server/share` stays a host path.

## User Impact

A sandboxed agent's task card is now accepted or rejected with a message that names the actual cause, instead of a host-filesystem `ENOENT` that looks like a broken install. Non-sandboxed agents, the worktree exemption, and remote-node (`requestedExecNode`) paths are untouched.

## Evidence

### Real behavior proof: standalone script against the real code path

`proof-task-cwd-sandbox.mts` calls the real exported `prepareSessionCreateFilesystemRoot` with real filesystem access (no mocks), first with a host-resolvable cwd and then with the literal container workdir `/workspace`.

**Before the source change** (source file reverted, test harness unchanged):

```
sandboxed agent resolved: true
host cwd -> ok
container cwd -> ERR sessions.create cwd is unavailable: ENOENT: no such file or directory, lstat 'E:\workspace'
RESULT: host path preserved = true; container path rejected with a domain error (no host lstat) = false -> FAIL (defect present)
```

**After the source change** (same harness, same input):

```
sandboxed agent resolved: true
host cwd -> ok
container cwd -> ERR sessions.create cwd is a container path that does not exist on the Gateway host: /workspace
RESULT: host path preserved = true; container path rejected with a domain error (no host lstat) = true -> PASS (fixed)
```

Note the pre-fix line: the host resolved `/workspace` to the nonsense path `E:\workspace` before failing. The fix prevents that host lookup entirely.

### Regression test (defect-sensitive, verified both directions)

`src/gateway/server-methods/session-create-root.test.ts`, run via `node scripts/run-vitest.mjs`:

- **With the fix:** `Test Files 1 passed (1)` / `Tests 22 passed (22)`
- **With only the source file reverted:** `Tests 1 failed | 21 passed (22)`, and the single failure is exactly the new test:

```
FAIL  src/gateway/server-methods/session-create-root.test.ts > session create filesystem root >
      rejects a container workdir instead of probing it on the Gateway host
-  "message": "sessions.create cwd is a container path that does not exist on the Gateway host: /workspace",
```

All 21 pre-existing tests pass in both directions, including the sandbox-containment, missing-path fail-closed, and worktree-exemption cases.

### Static checks

- `node_modules/.bin/oxlint -c .oxlintrc.json <both files>` — `Found 0 warnings and 0 errors.`
- `node_modules/.bin/oxfmt --check <both files>` — `All matched files use the correct format.`

### Environment

Windows, Node v22.22.3, branch based on `upstream/main` @ `16d11819a9c`. The reproduction needs no Docker because the defect is a pure path decision made before any container is contacted.

### What was not tested

No live Docker sandbox end-to-end run: the Gateway host here has no Docker sandbox to accept a real card through the Control UI. The proof exercises the exact function that produces the reported error with the exact container path the issue names. The `suggest_task` tool call itself was read, not executed, as it requires a running sandboxed session.

## Tests and validation

- `node scripts/run-vitest.mjs src/gateway/server-methods/session-create-root.test.ts --reporter=dot` — 22 passed
- `node_modules/.bin/oxlint -c .oxlintrc.json src/gateway/server-methods/session-create-root.ts src/gateway/server-methods/session-create-root.test.ts` — 0 warnings, 0 errors
- `node_modules/.bin/oxfmt --check` on both files — clean
- Standalone proof script — FAIL before, PASS after

## Risk checklist

- Did user-visible behavior change? Yes — a sandboxed agent's container-path task card now reports an actionable error instead of a host `ENOENT`.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No. The change only makes a rejection happen earlier, before a host filesystem probe, so it narrows rather than widens what reaches the filesystem.
- Highest-risk area: the reordering of `resolveSandboxRuntimeStatus` relative to `realpathSync` in `session-create-root.ts`.
- Mitigation: the sandbox runtime is resolved only when a `sessionCwd` was requested and containment is enforced (the same condition as the pre-existing branch), the early `requestedExecNode` return is untouched, and the full existing suite passes unchanged in both directions.

<details>
<summary>🤖 AI-assisted PR</summary>
This PR was created with AI assistance. Human-run real behavior proof is included above.
Prompts used: scan open OpenClaw issues for a Diamond-rated, uncontested, self-provable defect; verify it against live `main`; reproduce it locally before changing code.
</details>
