### PR TITLE
fix: Gateway restarts fail when child processes need forced cleanup

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -30,6 +30,7 @@ import type { OpenClawPluginService } from "../plugins/types.js";
 import { getProcessSupervisor, type ManagedRun } from "../process/supervisor/index.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalMap, resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { killPidIfAlive } from "../test-utils/process-tree.js";
 import type {
   GatewayCloseParams as GatewayTeardownParams,
   GatewayClosePrepareParams,
@@ -650,22 +651,44 @@ describe("createGatewayCloseHandler", () => {
     expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
   });
 
-  it.skipIf(process.platform === "win32")(
-    "terminates supervised process trees before Gateway close returns",
-    async () => {
+  it.skipIf(process.platform === "win32").each([
+    { restart: false, ignoreTerm: false },
+    { restart: true, ignoreTerm: true },
+  ])(
+    "terminates supervised process trees before Gateway close returns (restart=$restart, ignores TERM=$ignoreTerm)",
+    async ({ restart, ignoreTerm }) => {
       const previousServiceMarker = process.env.OPENCLAW_SERVICE_MARKER;
       process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
       const supervisor = getProcessSupervisor();
       let output = "";
       let run: ManagedRun | undefined;
+      let replacementRun: ManagedRun | undefined;
+      let rootPid: number | undefined;
+      let descendantPid: number | undefined;
 
       try {
+        // Readiness follows TERM handler installation and closure of inherited descriptors.
+        const descendantScript = `
+          ${ignoreTerm ? 'process.on("SIGTERM", () => {});' : ""}
+          setInterval(() => {}, 1_000);
+          process.send("ready", () => process.disconnect());
+        `;
         run = await supervisor.spawn({
           mode: "child",
           argv: [
-            "/bin/sh",
-            "-c",
-            'sleep 60 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; wait',
+            process.execPath,
+            "-e",
+            `
+              const { spawn } = require("node:child_process");
+              const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
+                stdio: ["ignore", "ignore", "ignore", "ipc"],
+              });
+              child.once("message", () => {
+                child.once("disconnect", () => {
+                  process.stdout.write(process.pid + " " + child.pid + "\\n");
+                });
+              });
+            `,
           ],
           stdinMode: "pipe-closed",
           onStdout: (chunk) => {
@@ -674,24 +697,44 @@ describe("createGatewayCloseHandler", () => {
         });
         await vi.waitFor(() => expect(output).toMatch(/^\d+ \d+/u));
         const match = /^(\d+) (\d+)/u.exec(output);
-        const rootPid = Number(match?.[1]);
-        const descendantPid = Number(match?.[2]);
+        rootPid = Number(match?.[1]);
+        descendantPid = Number(match?.[2]);
         expect(isProcessAlive(rootPid)).toBe(true);
         expect(isProcessAlive(descendantPid)).toBe(true);
 
         const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
-        await close({ reason: "test" });
+        await close({
+          reason: restart ? "gateway restarting" : "gateway stopping",
+          ...(restart ? { restartExpectedMs: 1500, drainTimeoutMs: 0 } : {}),
+        });
 
+        // Do not poll after close: returning while either process lives is the regression.
         expect(isProcessAlive(rootPid)).toBe(false);
         expect(isProcessAlive(descendantPid)).toBe(false);
-        expect(getProcessSupervisor()).not.toBe(supervisor);
+        await expect(run.waitForExtinction!()).resolves.toBeUndefined();
+        const nextSupervisor = getProcessSupervisor();
+        expect(nextSupervisor).not.toBe(supervisor);
+        replacementRun = await nextSupervisor.spawn({
+          mode: "child",
+          argv: [process.execPath, "-e", ""],
+          exactEnv: true,
+          stdinMode: "pipe-closed",
+        });
+        await expect(replacementRun.wait()).resolves.toMatchObject({ reason: "exit", exitCode: 0 });
       } finally {
-        run?.cancel();
-        await run?.waitForExtinction?.().catch(() => undefined);
-        if (previousServiceMarker === undefined) {
-          delete process.env.OPENCLAW_SERVICE_MARKER;
-        } else {
-          process.env.OPENCLAW_SERVICE_MARKER = previousServiceMarker;
+        try {
+          run?.cancel();
+          replacementRun?.cancel();
+          killPidIfAlive(rootPid);
+          killPidIfAlive(descendantPid);
+          await run?.waitForExtinction?.().catch(() => undefined);
+          await replacementRun?.wait().catch(() => undefined);
+        } finally {
+          if (previousServiceMarker === undefined) {
+            delete process.env.OPENCLAW_SERVICE_MARKER;
+          } else {
+            process.env.OPENCLAW_SERVICE_MARKER = previousServiceMarker;
+          }
         }
       }
     },

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -432,8 +432,8 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     activePids.add(descendantPid);
 
     adapter.kill("SIGTERM");
-    await expect(adapter.wait()).rejects.toThrow("cleanup identity lost");
-    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
+    await expect(adapter.wait()).resolves.toMatchObject({ code: null });
+    await expect(adapter.waitForExtinction!()).resolves.toBeUndefined();
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
@@ -663,13 +663,15 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       adapter.kill("SIGKILL");
     }
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
-    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
+    await expect(adapter.waitForExtinction!()).resolves.toBeUndefined();
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
-  it("keeps cleanup uncertain when an escaped group retains the lineage descriptor", async () => {
-    const descendantScript = `process.send("ready"); setInterval(() => {}, 1000);`;
-    const rootScript = `
+  it.each(["SIGTERM", "SIGKILL"] as const)(
+    "keeps cleanup uncertain after %s when an escaped group retains the lineage descriptor",
+    async (signal) => {
+      const descendantScript = `process.send("ready"); setInterval(() => {}, 1000);`;
+      const rootScript = `
       const { spawn } = require("node:child_process");
       const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
         detached: true,
@@ -682,26 +684,33 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         });
       });
     `;
-    const adapter = await createChildAdapter({
-      ownProcessTree: true,
-      argv: [process.execPath, "-e", rootScript],
-      stdinMode: "pipe-closed",
-    });
-    let output = "";
-    adapter.onStdout((chunk) => {
-      output += chunk;
-    });
-    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
-    const [rootPid, descendantPid] = parsePidPair(output);
-    activePids.add(rootPid);
-    activePids.add(descendantPid);
-    adapter.kill("SIGTERM");
-    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
-    expect(isAlive(descendantPid)).toBe(true);
-    killPidIfAlive(descendantPid);
-    await waitFor(() => !isAlive(descendantPid));
-    adapter.dispose();
-  });
+      const adapter = await createChildAdapter({
+        ownProcessTree: true,
+        argv: [process.execPath, "-e", rootScript],
+        stdinMode: "pipe-closed",
+      });
+      let output = "";
+      adapter.onStdout((chunk) => {
+        output += chunk;
+      });
+      await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+      const [rootPid, descendantPid] = parsePidPair(output);
+      activePids.add(rootPid);
+      activePids.add(descendantPid);
+      try {
+        adapter.kill(signal);
+        await expect(adapter.waitForExtinction!()).rejects.toThrow("cleanup identity lost");
+        expect(isAlive(descendantPid)).toBe(true);
+      } finally {
+        killPidIfAlive(descendantPid);
+        try {
+          await waitFor(() => !isAlive(descendantPid));
+        } finally {
+          adapter.dispose();
+        }
+      }
+    },
+  );
 
   it("preserves split UTF-8 sequences on service stdout and stderr", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";

--- a/src/process/supervisor/service-child-group-anchor.retirement.test.ts
+++ b/src/process/supervisor/service-child-group-anchor.retirement.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
 import { Duplex } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
@@ -8,6 +9,7 @@ import {
   resolveRuntimeWorkerUrl,
 } from "../../infra/runtime-worker-url.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import type { ServiceChildAnchorMessage } from "./service-child-protocol.js";
 
 describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
@@ -24,9 +26,13 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
     "startup-error",
     "legacy-host",
     "unsupported-capability",
+    "forced-matching",
+    "forced-missing",
+    "forced-control-lost",
   ] as const)(
     "retires gracefully only after the closing receipt is acknowledged (%s)",
     async (acknowledgement) => {
+      const forced = acknowledgement.startsWith("forced-");
       const generation = randomUUID();
       const child = spawn(
         process.execPath,
@@ -49,6 +55,7 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
       const messages: ServiceChildAnchorMessage[] = [];
       let prearmedSequence: number | undefined;
       let outboundSequence = 0;
+      let forcedCancellationAt = 0;
       const startupFailure = acknowledgement === "pre-armed" || acknowledgement === "startup-error";
       let pending = "";
       let stderr = "";
@@ -73,6 +80,12 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
           const message = JSON.parse(pending.slice(0, newline)) as ServiceChildAnchorMessage;
           pending = pending.slice(newline + 1);
           messages.push(message);
+          if (message.type === "ready" && forced) {
+            forcedCancellationAt = performance.now();
+            control.write(
+              `${JSON.stringify({ type: "cancel", generation, sequence: ++outboundSequence, signal: "SIGKILL" })}\n`,
+            );
+          }
           if (message.type === "startup-error") {
             if (acknowledgement === "pre-armed") {
               // Both frames share the ordered control channel: the early ACK must
@@ -87,12 +100,13 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
           if (message.type !== "closing") {
             continue;
           }
-          if (acknowledgement === "control-lost") {
+          if (acknowledgement === "control-lost" || acknowledgement === "forced-control-lost") {
             control.destroy();
           } else if (acknowledgement === "relay-lost") {
             child.disconnect();
           } else if (
             acknowledgement !== "missing" &&
+            acknowledgement !== "forced-missing" &&
             acknowledgement !== "pre-armed" &&
             acknowledgement !== "legacy-host"
           ) {
@@ -113,7 +127,7 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
           type: "start",
           generation,
           command: startupFailure ? `/openclaw-missing-command-${generation}` : process.execPath,
-          args: ["-e", ""],
+          args: ["-e", forced ? "setInterval(() => {}, 1000)" : ""],
           env: {},
           stdinMode: "pipe-closed",
           controlFd: 3,
@@ -130,9 +144,11 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
         expect(messages, stderr).toEqual(
           expect.arrayContaining([
             expect.objectContaining(
-              startupFailure
-                ? { type: "startup-error", generation }
-                : { type: "root-result", generation, code: 0, signal: null },
+              forced
+                ? { type: "ready", generation }
+                : startupFailure
+                  ? { type: "startup-error", generation }
+                  : { type: "root-result", generation, code: 0, signal: null },
             ),
             expect.objectContaining({ type: "closing", generation }),
           ]),
@@ -141,6 +157,15 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
           expect(messages.find((message) => message.type === "closing")?.sequence).toBe(
             prearmedSequence,
           );
+        }
+        if (forced) {
+          expect(result, stderr).toEqual({ code: null, signal: "SIGKILL" });
+          if (acknowledgement === "forced-missing") {
+            expect(performance.now() - forcedCancellationAt).toBeGreaterThanOrEqual(
+              GRACEFUL_CANCEL_TIMEOUT_MS,
+            );
+          }
+          return;
         }
         if (
           acknowledgement === "matching" ||

--- a/src/process/supervisor/service-child-group-anchor.retirement.test.ts
+++ b/src/process/supervisor/service-child-group-anchor.retirement.test.ts
@@ -29,17 +29,19 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
     "forced-matching",
     "forced-missing",
     "forced-control-lost",
+    "forced-legacy-host",
   ] as const)(
     "retires gracefully only after the closing receipt is acknowledged (%s)",
     async (acknowledgement) => {
       const forced = acknowledgement.startsWith("forced-");
+      const legacy = acknowledgement === "legacy-host" || acknowledgement === "forced-legacy-host";
       const generation = randomUUID();
       const child = spawn(
         process.execPath,
         resolveRuntimeWorkerArgv(
           resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.serviceChildGroupAnchor),
         ),
-        { detached: true, stdio: ["ignore", "pipe", "pipe", "pipe", "ipc"] },
+        { detached: true, stdio: ["ignore", "pipe", "pipe", "pipe", "pipe", "ipc"] },
       );
       const exited = createDeferredCore<{
         code: number | null;
@@ -55,6 +57,19 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
       const messages: ServiceChildAnchorMessage[] = [];
       let prearmedSequence: number | undefined;
       let outboundSequence = 0;
+      const lineage = child.stdio[4];
+      if (!(lineage instanceof Duplex)) {
+        child.kill("SIGKILL");
+        throw new Error("Expected the host-owned lineage pipe");
+      }
+      lineage.once("end", () => {
+        if (!control.destroyed && !legacy) {
+          control.write(
+            `${JSON.stringify({ type: "lineage-closed", generation, sequence: ++outboundSequence })}\n`,
+          );
+        }
+      });
+      lineage.resume();
       let forcedCancellationAt = 0;
       const startupFailure = acknowledgement === "pre-armed" || acknowledgement === "startup-error";
       let pending = "";
@@ -131,11 +146,17 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
           env: {},
           stdinMode: "pipe-closed",
           controlFd: 3,
+          ...(legacy ? {} : { lineageFd: 4 }),
           ...(acknowledgement === "legacy-host"
             ? {}
             : { acknowledgeClosing: acknowledgement !== "unsupported-capability" }),
         });
         const result = await exited.promise;
+        if (acknowledgement === "forced-legacy-host") {
+          expect(result, stderr).toEqual({ code: null, signal: "SIGKILL" });
+          expect(messages.some((message) => message.type === "closing")).toBe(false);
+          return;
+        }
         if (acknowledgement === "unsupported-capability") {
           expect(result, stderr).toEqual({ code: 1, signal: null });
           expect(messages).toEqual([]);
@@ -183,6 +204,7 @@ describe.skipIf(process.platform === "win32")("POSIX anchor retirement", () => {
         child.kill("SIGKILL");
         await exited.promise;
         control.destroy();
+        lineage.destroy();
       }
     },
   );

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -96,12 +96,6 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     state = "closed";
-    if (hardKill) {
-      // Killing the observer cannot confirm descendant death. Missing closure
-      // leaves the host's existing ownership receipt uncertain.
-      process.kill(0, "SIGKILL");
-      return;
-    }
     // Kernel acceptance is not host consumption. Keep the read side alive so a
     // crossing cancellation cannot destroy the host's unread closing receipt.
     const requiresAcknowledgement = start.acknowledgeClosing === true;
@@ -122,7 +116,8 @@ export function runServiceChildGroupAnchor(): void {
     if (
       remainingMs <= 0 ||
       !(await Promise.race([retirementReady.promise, delay(remainingMs).then(() => false)])) ||
-      Date.now() >= deadline
+      Date.now() >= deadline ||
+      hardKill
     ) {
       process.kill(0, "SIGKILL");
       return;
@@ -201,7 +196,9 @@ export function runServiceChildGroupAnchor(): void {
       }
       await Promise.race([delay(nextObservationMs), forceCleanupRequested.promise]);
     }
-    await closeAuthority(reason, true, cleanupDeadline);
+    // Forced retirement needs the same bounded receipt join, even after TERM
+    // grace expires. Only the outside-group host can certify extinction after KILL.
+    await closeAuthority(reason, true);
   };
 
   const onControlMessage = (message: ServiceChildControlMessage) => {

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
-import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
+import { closeSync, createReadStream, createWriteStream, type WriteStream } from "node:fs";
 import { Socket } from "node:net";
 import { pipeline, type Readable } from "node:stream";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -36,7 +36,7 @@ function commandStdio(start: ServiceChildStart): {
   while (stdio.length <= lineageFd) {
     stdio.push("ignore");
   }
-  stdio[lineageFd] = "pipe";
+  stdio[lineageFd] = start.lineageFd ?? "pipe";
   return { stdio, lineageFd };
 }
 
@@ -60,6 +60,7 @@ export function runServiceChildGroupAnchor(): void {
   let stdoutDrained = false;
   let stderrDrained = false;
   let lineageClosed = false;
+  let markHostLineageClosed: (() => void) | undefined;
   let forceCleanup = false;
   const forceCleanupRequested = createDeferredCore();
   const lineageDone = createDeferredCore();
@@ -96,6 +97,12 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     state = "closed";
+    // Retained hosts have no observer outside this group. Killing the local
+    // reader with unresolved lineage must not certify escaped descendants gone.
+    if (hardKill && start.lineageFd === undefined && !lineageClosed) {
+      process.kill(0, "SIGKILL");
+      return;
+    }
     // Kernel acceptance is not host consumption. Keep the read side alive so a
     // crossing cancellation cannot destroy the host's unread closing receipt.
     const requiresAcknowledgement = start.acknowledgeClosing === true;
@@ -229,6 +236,10 @@ export function runServiceChildGroupAnchor(): void {
       startupErrorAcknowledged.resolve();
       return;
     }
+    if (message.type === "lineage-closed") {
+      markHostLineageClosed?.();
+      return;
+    }
     void requestCleanup("cancel", message.signal);
   };
 
@@ -296,14 +307,10 @@ export function runServiceChildGroupAnchor(): void {
       // Failed Bun spawns have no stdio. Preserve the spawn error before checking lineage.
       await once(command, "spawn");
     } catch (error) {
+      if (start.lineageFd !== undefined) {
+        closeSync(start.lineageFd);
+      }
       await reportStartupFailure(error instanceof Error ? error.message : String(error));
-      return;
-    }
-    // SAFETY: lineageFd was reserved as a pipe in this exact command stdio array.
-    const lineage = command.stdio[lineageFd] as Readable | null;
-    if (!lineage) {
-      await send({ type: "startup-error", error: "command lineage pipe was not created" });
-      await requestCleanup("lineage-lost", "SIGKILL");
       return;
     }
     const markLineageClosed = () => {
@@ -332,9 +339,24 @@ export function runServiceChildGroupAnchor(): void {
         })();
       }
     };
-    lineage.once("end", markLineageClosed);
-    lineage.once("close", markLineageClosed);
-    lineage.once("error", markLineageClosed);
+    if (start.lineageFd !== undefined) {
+      // Install the notification consumer before releasing the duplicate writer;
+      // actual EOF is observed by the host even when this group is killed.
+      markHostLineageClosed = markLineageClosed;
+      closeSync(start.lineageFd);
+    } else {
+      // Retained --no-restart hosts still delegate observation to the anchor.
+      // SAFETY: without a host descriptor, commandStdio reserves this entry as a pipe.
+      const lineage = command.stdio[lineageFd] as Readable | null;
+      if (!lineage) {
+        await send({ type: "startup-error", error: "command lineage pipe was not created" });
+        await requestCleanup("lineage-lost", "SIGKILL");
+        return;
+      }
+      lineage.once("end", markLineageClosed);
+      lineage.once("close", markLineageClosed);
+      lineage.once("error", markLineageClosed);
+    }
     const settleRoot = async () => {
       if (rootSettlementStarted || !rootResultDelivery || !stdoutDrained || !stderrDrained) {
         return;

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -9,6 +9,8 @@ export type ServiceChildStart = {
   stdinMode: "inherit" | "pipe-open" | "pipe-closed";
   secretFd?: number;
   controlFd?: number;
+  /** Host-owned lineage writer; absent for older hosts retained by update --no-restart. */
+  lineageFd?: number;
   /** Absent only for older Gateway hosts retained by update --no-restart. */
   acknowledgeClosing?: true;
   windowsShellCommand?: string;
@@ -20,6 +22,7 @@ export type ServiceChildControlMessage = {
 } & (
   | { type: "cancel"; signal: "SIGTERM" | "SIGKILL" }
   | { type: "startup-error-ack" }
+  | { type: "lineage-closed" }
   | { type: "closing-ack"; closingSequence: number }
 );
 

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -1,5 +1,5 @@
 import { performance } from "node:perf_hooks";
-import { Duplex } from "node:stream";
+import { Duplex, PassThrough } from "node:stream";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
@@ -37,7 +37,7 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-async function createRelay(platform: "linux" | "darwin" | "win32") {
+async function createRelay(platform: "linux" | "darwin" | "win32", retainLineage = false) {
   platformMock = mockProcessPlatform(platform);
   const groupProbe = vi.spyOn(process, "kill").mockImplementation(() => {
     throw Object.assign(new Error("synthetic missing process group"), { code: "ESRCH" });
@@ -60,8 +60,9 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
       }
     },
   });
+  const lineage = new PassThrough();
   Object.defineProperty(stub.child, "stdio", {
-    value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control],
+    value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control, lineage],
     configurable: true,
   });
   if (platform === "win32") {
@@ -120,6 +121,9 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
   };
   const closeControl = () => control.destroy();
   const exitRelay = () => {
+    if (!retainLineage) {
+      lineage.end();
+    }
     stub.disconnectMock();
     stub.emitExit(0);
   };
@@ -132,7 +136,10 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
   };
   const controlEncoding = () => control.readableEncoding;
   const killSpy = vi.spyOn(stub.child, "kill");
-  cleanups.push(close);
+  cleanups.push(() => {
+    close();
+    lineage.destroy();
+  });
   return {
     adapter,
     start,
@@ -148,6 +155,7 @@ async function createRelay(platform: "linux" | "darwin" | "win32") {
     controlEncoding,
     killSpy,
     groupProbe,
+    lineage,
   };
 }
 
@@ -161,7 +169,7 @@ function createWritableRelayChild() {
     },
   });
   Object.defineProperty(stub.child, "stdio", {
-    value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control],
+    value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control, new PassThrough()],
     configurable: true,
   });
   mocks.spawn.mockReturnValue(stub.child);
@@ -471,6 +479,46 @@ it("drains output after losing cleanup authority without erasing the observed ro
   await expect(root).resolves.toEqual({ code: 23, signal: null });
 });
 
+it("keeps extinction pending after group retirement until lineage EOF", async () => {
+  const { adapter, completeRoot, emit, close, lineage } = await createRelay("linux", true);
+  completeRoot();
+  await adapter.wait();
+  emit({ type: "closing", reason: "cancel" });
+  await nextTurn();
+  const settled = vi.fn();
+  void adapter.waitForExtinction().then(settled, settled);
+  close();
+  await nextTurn();
+  expect(settled).not.toHaveBeenCalled();
+  lineage.end();
+  await expect(adapter.waitForExtinction()).resolves.toBeUndefined();
+});
+
+it.each(["error", "close", "timeout"])(
+  "rejects extinction when the outside-group lineage reader ends with %s",
+  async (failure) => {
+    const { adapter, completeRoot, emit, close, lineage } = await createRelay("linux", true);
+    completeRoot();
+    await adapter.wait();
+    emit({ type: "closing", reason: "cancel" });
+    await nextTurn();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const rejected = expect(adapter.waitForExtinction()).rejects.toThrow("cleanup identity lost");
+      close();
+      await nextTurn();
+      if (failure === "timeout") {
+        await vi.advanceTimersByTimeAsync(GRACEFUL_CANCEL_TIMEOUT_MS);
+      } else {
+        lineage.destroy(failure === "error" ? new Error("synthetic lineage failure") : undefined);
+      }
+      await rejected;
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
+
 it("waits for relay reaping before observing POSIX group extinction", async () => {
   const { adapter, completeRoot, emit, closeControl, exitRelay, groupProbe } =
     await createRelay("darwin");
@@ -499,12 +547,14 @@ it("waits for relay reaping before observing POSIX group extinction", async () =
 });
 
 it("does not renew the group disappearance deadline after joining the relay", async () => {
-  const { adapter, completeRoot, emit, closeControl, exitRelay, groupProbe } =
+  const { adapter, completeRoot, emit, closeControl, exitRelay, groupProbe, lineage } =
     await createRelay("darwin");
   const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
   groupProbe.mockReturnValue(true);
   completeRoot();
   await adapter.wait();
+  lineage.end();
+  await nextTurn();
   emit({ type: "closing", reason: "lineage-closed" });
   await nextTurn();
   const settled = vi.fn();
@@ -549,7 +599,7 @@ it("bounds relay reaping by the original graceful cleanup deadline", async () =>
 it.each(["EPERM", "EIO", "still present"])(
   "keeps graceful cleanup uncertain when the kernel group is %s",
   async (failure) => {
-    const { adapter, completeRoot, emit, close, groupProbe } = await createRelay("linux");
+    const { adapter, completeRoot, emit, close, groupProbe, lineage } = await createRelay("linux");
     const cause =
       failure === "still present"
         ? undefined
@@ -562,6 +612,8 @@ it.each(["EPERM", "EIO", "still present"])(
     });
     completeRoot();
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    lineage.end();
+    await nextTurn();
     emit({ type: "closing", reason: "lineage-closed" });
     await nextTurn();
     // Exhaust the bounded observation window without waiting on real process time.

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -162,6 +162,7 @@ export async function createServiceChildRelayAdapter(
     useWindowsJobAnchor ? undefined : params.secretInput,
   );
   const controlFd = useWindowsJobAnchor ? undefined : reserveStdioEntry(stdio, "pipe");
+  const lineageFd = useWindowsJobAnchor ? undefined : reserveStdioEntry(stdio, "pipe");
   reserveStdioEntry(stdio, "ipc");
 
   if (params.abortSignal?.aborted) {
@@ -182,7 +183,13 @@ export async function createServiceChildRelayAdapter(
 
   // SAFETY: a defined controlFd was reserved as a pipe in this exact spawn stdio array.
   const control = controlFd === undefined ? null : (child.stdio[controlFd] as Duplex | null);
-  if (!child.connected || (!useWindowsJobAnchor && (!control || !child.stdout || !child.stderr))) {
+  // Its reader stays outside the killed process group, including escaped writers.
+  // SAFETY: lineageFd was reserved as a pipe in this exact spawn stdio array.
+  const lineage = lineageFd === undefined ? null : (child.stdio[lineageFd] as Readable | null);
+  if (
+    !child.connected ||
+    (!useWindowsJobAnchor && (!control || !lineage || !child.stdout || !child.stderr))
+  ) {
     child.kill("SIGKILL");
     const error = new Error(
       "service child cleanup identity lost: lifecycle channels were not created",
@@ -219,6 +226,7 @@ export async function createServiceChildRelayAdapter(
   let childDisconnected = false;
   let childExited = false;
   const relayExit = createDeferredCore();
+  const lineageEnd = createDeferredCore();
   let requestedSignal: "SIGTERM" | "SIGKILL" | undefined;
   let waitError: Error | undefined;
   const startup = createDeferredCore();
@@ -269,6 +277,7 @@ export async function createServiceChildRelayAdapter(
     }
     settleWait();
     extinctionCompletion.reject(waitError);
+    lineage?.destroy();
   };
 
   const sendChildMessage = (
@@ -307,6 +316,29 @@ export async function createServiceChildRelayAdapter(
     });
   };
 
+  lineage?.once("end", () => {
+    lineageEnd.resolve();
+    if (state !== "starting" && state !== "active") {
+      return;
+    }
+    void sendControlMessage({
+      type: "lineage-closed",
+      generation,
+      sequence: ++outboundSequence,
+    }).catch((error: unknown) => {
+      if (state === "starting" || state === "active") {
+        loseIdentity(toErrorObject(error, "lineage notification failed").message);
+      }
+    });
+  });
+  lineage?.once("error", (error) => loseIdentity("lineage observation failed", { cause: error }));
+  lineage?.once("close", () => {
+    if (!lineage.readableEnded) {
+      loseIdentity("lineage reader closed before EOF");
+    }
+  });
+  lineage?.resume();
+
   const onConstructionAbort = () => {
     child.kill("SIGKILL");
     // The anchor may still be cleaning its group after relay loss. Keep that
@@ -342,8 +374,8 @@ export async function createServiceChildRelayAdapter(
       loseIdentity(missingReceiptError);
       return;
     }
-    // Only kernel group disappearance certifies closure. The anchor's census is
-    // advisory: hidden or concurrently forked members can be absent from ps.
+    // Closure requires lineage EOF outside the group as well as kernel group
+    // disappearance; an escaped writer survives the anchor's group-wide KILL.
     const deadline = Date.now() + GRACEFUL_CANCEL_TIMEOUT_MS;
     if (!childExited) {
       // Control EOF can precede the relay reaping its anchor. Darwin reports
@@ -366,6 +398,26 @@ export async function createServiceChildRelayAdapter(
       if (state !== "closing") {
         return;
       }
+    }
+    if (!lineage?.readableEnded) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        loseIdentity("command lineage remained open after its anchor closed");
+        return;
+      }
+      try {
+        await withTimeout(
+          Promise.race([lineageEnd.promise, extinctionCompletion.promise]),
+          remainingMs,
+          { message: "command lineage remained open after its anchor closed" },
+        );
+      } catch {
+        loseIdentity("command lineage remained open after its anchor closed");
+        return;
+      }
+    }
+    if (state !== "closing") {
+      return;
     }
     for (;;) {
       try {
@@ -580,6 +632,7 @@ export async function createServiceChildRelayAdapter(
     stdinMode: params.stdinMode,
     secretFd: params.secretInput?.fd,
     controlFd,
+    lineageFd,
     ...(control ? { acknowledgeClosing: true as const } : {}),
     windowsShellCommand: params.windowsShellCommand,
   };

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { createWriteStream } from "node:fs";
+import { closeSync, createWriteStream } from "node:fs";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import {
   resolveRuntimeWorkerArgv,
@@ -67,6 +67,12 @@ function runServiceChildRelay(): void {
       stdio.push("ignore");
     }
     stdio[start.controlFd] = start.controlFd;
+    if (start.lineageFd !== undefined) {
+      while (stdio.length <= start.lineageFd) {
+        stdio.push("ignore");
+      }
+      stdio[start.lineageFd] = start.lineageFd;
+    }
     if (start.secretFd !== undefined) {
       while (stdio.length <= start.secretFd) {
         stdio.push("ignore");
@@ -97,6 +103,10 @@ function runServiceChildRelay(): void {
       return;
     }
     anchor.once("spawn", () => {
+      // Only the anchor and command may retain the host's lineage writer.
+      if (start.lineageFd !== undefined) {
+        closeSync(start.lineageFd);
+      }
       // The anchor inherited these outputs. Close only the relay's duplicate writers
       // so output EOF does not depend on either process giving up cleanup authority.
       if (process.versions.bun) {

--- a/src/process/supervisor/supervisor.anchored-shell.real.test.ts
+++ b/src/process/supervisor/supervisor.anchored-shell.real.test.ts
@@ -238,22 +238,14 @@ describe("supervisor anchored shell real process ownership", () => {
       try {
         await expect(fixture.run.wait()).resolves.toMatchObject({ exitCode: 0, exitSignal: null });
         const cleanup = fixture.cleanup();
-        if (ignoreTerm) {
-          await expect(cleanup).rejects.toThrow("cleanup identity lost");
-        } else {
-          await cleanup;
-          expect(isProcessAlive(pid)).toBe(false);
-        }
+        await cleanup;
+        expect(isProcessAlive(pid)).toBe(false);
         await waitForDead(pid, 5_000);
       } finally {
         await fixture.release();
         killPidIfAlive(pid);
         await waitForDead(pid, 5_000);
-        if (ignoreTerm) {
-          await expect(fixture.supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
-        } else {
-          await fixture.supervisor.shutdown();
-        }
+        await fixture.supervisor.shutdown();
       }
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users restarting the Gateway from the Control UI could leave the managed service offline when a supervised child process needed forced termination. Gateway close failed after the active-work drain, preventing the restart from completing.

## Why This Change Was Made

The POSIX process-group anchor killed itself before sending its closing receipt, so the host correctly rejected cleanup as unproven. Forced retirement now uses the bounded closing-receipt acknowledgement handshake before self-kill; the host still independently requires the receipt, relay reaping, and kernel-confirmed process-group disappearance.

Missing receipts and ambiguous ownership still fail closed. This does not add an ordinary-restart recovery owner or bypass the separately owned managed-update recovery flow.

## User Impact

Gateway restart-close can complete after reclaiming TERM-resistant supervised descendants, and the replacement process supervisor can accept work. An unresponsive host can add up to the existing five-second acknowledgement window after TERM grace expires; a responsive host normally adds one local round trip. Gateway drain and host extinction deadlines are unchanged.

## Evidence

### Failing before, passing after

- Real forced-anchor tests reproduced `ready` followed by SIGKILL and channel closure without a `closing` receipt.
- A real TERM-resistant descendant reproduced `service child cleanup identity lost: anchor channel closed without a matching closing receipt`.
- With the original production anchor restored, the Gateway restart-close regression reproduced that error and `Failed to reset global singleton lifecycle state`.
- With the fix, restart-close with `drainTimeoutMs: 0` waits for both processes to be dead, completes extinction, replaces the singleton supervisor, and successfully runs a command through the replacement.
- Negative controls retain missing-receipt, stale-identity, relay-reaping, surviving-group, kernel-error, and failed-singleton rejection.

### Validation

Passed locally:

```sh
node scripts/run-vitest.mjs \
  src/process/supervisor/service-child-group-anchor.retirement.test.ts \
  src/process/supervisor/supervisor.anchored-shell.real.test.ts \
  src/process/supervisor/service-child-relay-host.test.ts \
  src/process/supervisor/service-child-group-ownership.test.ts

node scripts/run-vitest.mjs \
  src/gateway/server-close.test.ts \
  src/cli/gateway-cli/run-loop.test.ts \
  src/process/supervisor/supervisor.test.ts \
  src/process/supervisor/supervisor.scope-extinction.test.ts

node scripts/run-vitest.mjs \
  src/process/supervisor/service-child-group-anchor.retirement.test.ts -t forced

node scripts/run-vitest.mjs \
  src/infra/update-managed-service-handoff-lifecycle.test.ts \
  -t 'parks and restores the exact user-systemd|canonical systemd service|ten minutes of validation'

node scripts/check-changed.mjs
git diff HEAD^ HEAD --check
```

Changed checks include core and core-test typechecks, formatting, lint, and repository guards. Fresh independent P0–P2 autoreview found no actionable findings.

Real process proof ran on macOS. Linux census and service-manager recovery tests use fixtures; no real Linux/systemd restart or production deployment was performed. Successful restart-close is distinct from verified old-runtime recovery, and genuinely ambiguous cleanup can still require operator recovery. Hosted CI is not claimed as passed.
