### PR TITLE
fix(buzz): keep eligible rooms online and restore granted rooms

### DIFF
--- a/docs/channels/buzz.md
+++ b/docs/channels/buzz.md
@@ -109,6 +109,16 @@ exit setup.
 Every target room must contain the bot identity with the **Bot** role. An
 existing human member or ordinary room member role is not sufficient.
 
+At startup, OpenClaw skips active configured rooms where the bot lacks the Bot
+role and logs a warning for each skipped room. Other eligible rooms stay online.
+If active configured rooms remain but none has the Bot role, the account cannot
+start.
+
+When the relay reports a membership change for a skipped room, OpenClaw checks
+its signed roster again. A confirmed Bot role starts that room without restarting
+healthy rooms. A live Bot-role downgrade in a subscribed room still cancels the
+account's active work and reconnects with fresh memberships.
+
 Buzz desktop cannot reliably assign the Bot role to an externally managed
 OpenClaw identity. Use the Buzz CLI as the existing human room owner or admin:
 

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { finalizeEvent, getPublicKey, type Event, type Filter } from "nostr-tools";
+import { finalizeEvent, getPublicKey, Relay, type Event, type Filter } from "nostr-tools";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const relayMocks = vi.hoisted(() => ({
@@ -124,6 +125,11 @@ vi.mock("nostr-tools", async (importOriginal) => {
 });
 
 import { startBuzzBus } from "./buzz-bus.js";
+import { catchUpBuzzRoomHistory } from "./history-catchup.js";
+import {
+  BUZZ_REPLAY_DISPATCH_MAX_PENDING,
+  createBuzzReplayDispatchQueue,
+} from "./replay-dispatch.js";
 
 const BUZZ_NORMAL_MESSAGE_KIND = 9;
 const BUZZ_ROOM_MEMBERSHIP_KIND = 39_002;
@@ -406,6 +412,37 @@ describe("Buzz reconnect history catch-up", () => {
       `Buzz room history query closed for ${CHANNEL_ID}: relay rejected subscription`,
     ]);
     expect(relayMocks.close).toHaveBeenCalled();
+  });
+
+  it("does not request history when canceled after capacity resolves but before recovery resumes", async () => {
+    const abort = new AbortController();
+    const queue = createBuzzReplayDispatchQueue({ onTaskError: vi.fn() });
+    const capacity = createDeferred<Awaited<ReturnType<typeof queue.reserveCapacity>>>();
+    const onEvent = vi.fn();
+    try {
+      const reservation = await queue.reserveCapacity(HISTORY_LIMIT);
+      expect(reservation).toBeDefined();
+      const recovery = catchUpBuzzRoomHistory({
+        relay: new Relay("wss://buzz.example.com"),
+        channelId: CHANNEL_ID,
+        since: BASE_TIMESTAMP - 60,
+        until: BASE_TIMESTAMP,
+        limit: HISTORY_LIMIT,
+        reserveCapacity: () => capacity.promise,
+        onEvent,
+        signal: abort.signal,
+      });
+      capacity.resolve(reservation);
+      abort.abort();
+      await expect(recovery).resolves.toBe("aborted");
+      expect(relayMocks.historyRequests).toEqual([]);
+      expect(onEvent).not.toHaveBeenCalled();
+      const recoveredCapacity = await queue.reserveCapacity(BUZZ_REPLAY_DISPATCH_MAX_PENDING);
+      expect(recoveredCapacity).toBeDefined();
+      recoveredCapacity?.release();
+    } finally {
+      await queue.close();
+    }
   });
 
   it("stops an active history query quietly when the bus closes", async () => {

--- a/extensions/buzz/src/buzz-bus.lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.lifecycle.test.ts
@@ -395,24 +395,17 @@ describe("Buzz bus lifecycle", () => {
     const onMessage = vi.fn(async () => {});
     const onFatalError = vi.fn();
 
-    const bus = await startTestBus({
-      onMessage,
-      onFatalError,
-    });
-
-    await vi.waitFor(() => {
-      expect(onFatalError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Buzz inbound replay exceeded the 1024-message pending limit",
-        }),
-      );
-    });
+    await expect(startTestBus({ onMessage, onFatalError })).rejects.toThrow(
+      "Buzz inbound replay exceeded the 1024-message pending limit",
+    );
+    expect(onFatalError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Buzz inbound replay exceeded the 1024-message pending limit",
+      }),
+    );
     expect(onFatalError).toHaveBeenCalledOnce();
     expect(onMessage).not.toHaveBeenCalled();
-    expect(relayMocks.close).not.toHaveBeenCalled();
-
-    await bus.close();
-    expect(relayMocks.close).toHaveBeenCalledOnce();
+    expect(relayMocks.close).toHaveBeenCalled();
   });
 
   it("aborts active inbound dispatch and waits for its cleanup before completing shutdown", async () => {

--- a/extensions/buzz/src/buzz-bus.room-restoration.test.ts
+++ b/extensions/buzz/src/buzz-bus.room-restoration.test.ts
@@ -1,0 +1,493 @@
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { startBuzzBus, type BuzzBus } from "./buzz-bus.js";
+import { createBuzzRelayFixture } from "./buzz-relay.test-harness.js";
+
+let stateDir: string;
+beforeEach(() => {
+  // openclaw-temp-dir: allow extension tests cannot import root test helpers.
+  stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-buzz-room-restoration-"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+});
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+type BuzzRelayFixture = Awaited<ReturnType<typeof createBuzzRelayFixture>>;
+
+function seedSkippedRoom(fixture: BuzzRelayFixture) {
+  const roomId = randomUUID();
+  const createdAt = Math.floor(Date.now() / 1000);
+  fixture.events.push(
+    fixture.signRelay({
+      kind: 39000,
+      created_at: createdAt,
+      content: "",
+      tags: [
+        ["d", roomId],
+        ["name", "Skipped room"],
+        ["t", "stream"],
+      ],
+    }),
+  );
+  publishBotRole(fixture, roomId, "member", createdAt);
+  return { roomId, createdAt };
+}
+
+function publishBotRole(
+  fixture: BuzzRelayFixture,
+  roomId: string,
+  role: "bot" | "member",
+  createdAt: number,
+) {
+  fixture.broadcast(
+    fixture.signRelay({
+      kind: 39002,
+      created_at: createdAt,
+      content: "",
+      tags: [
+        ["d", roomId],
+        ["p", fixture.botPublicKey, "", role],
+        ["p", fixture.senderPublicKey, "", "member"],
+      ],
+    }),
+  );
+}
+
+function notifyBotMembership(
+  fixture: BuzzRelayFixture,
+  roomId: string,
+  kind: 44100 | 44101,
+  createdAt: number,
+) {
+  const event = fixture.signRelay({
+    kind,
+    created_at: createdAt,
+    content: JSON.stringify({
+      type: kind === 44100 ? "member_added" : "member_removed",
+      channel_id: roomId,
+    }),
+    tags: [
+      ["p", fixture.botPublicKey],
+      ["h", roomId],
+    ],
+  });
+  fixture.broadcast(event);
+  return event;
+}
+
+function roomSubscriptionIds(fixture: BuzzRelayFixture, roomId: string) {
+  return fixture.requests
+    .filter(
+      ({ filters }) =>
+        filters.some((filter) => filter.kinds?.includes(9) && filter["#h"]?.includes(roomId)) &&
+        filters.some((filter) => filter.kinds?.includes(39002)),
+    )
+    .map(({ id }) => id);
+}
+
+it("restores a skipped room without replacing healthy subscriptions", async () => {
+  const fixture = await createBuzzRelayFixture();
+  const skipped = seedSkippedRoom(fixture);
+  const messages: string[] = [];
+  const replies: string[] = [];
+  const fatal: Error[] = [];
+  let restoredTurnSignal: AbortSignal | undefined;
+  let bus: BuzzBus | undefined;
+  try {
+    bus = await startBuzzBus({
+      accountId: randomUUID(),
+      relayUrl: fixture.relayUrl,
+      privateKey: fixture.botPrivateKey,
+      channelIds: [skipped.roomId, fixture.roomId],
+      onMessage: async (message, activeBus, signal) => {
+        messages.push(message.text);
+        if (message.channelId === skipped.roomId) {
+          restoredTurnSignal = signal;
+        }
+        await activeBus.sendText({ channelId: message.channelId, text: `reply: ${message.text}` });
+        replies.push(message.text);
+      },
+      onFatalError: (error) => fatal.push(error),
+    });
+    const healthySubscriptions = roomSubscriptionIds(fixture, fixture.roomId);
+    expect(healthySubscriptions).toHaveLength(1);
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toEqual([]);
+    fixture.sendMessage("healthy before restoration");
+    await vi.waitFor(() => expect(replies).toContain("healthy before restoration"));
+
+    fixture.sendMessage("restored short history", undefined, skipped.roomId);
+    const history = fixture.pauseNextRoomHistory();
+    fixture.broadcast(
+      fixture.signRelay({
+        kind: 40099,
+        created_at: skipped.createdAt + 1,
+        content: JSON.stringify({ type: "member_joined", target: fixture.botPublicKey }),
+        tags: [["h", skipped.roomId]],
+      }),
+    );
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 1);
+    const grant = notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 1);
+    await vi.waitFor(() => {
+      expect(fatal).toEqual([]);
+      expect(roomSubscriptionIds(fixture, skipped.roomId)).toHaveLength(1);
+    });
+    await history.started;
+    fixture.sendMessage("healthy while restoration waits");
+    await vi.waitFor(() => expect(replies).toContain("healthy while restoration waits"));
+    expect(roomSubscriptionIds(fixture, fixture.roomId)).toEqual(healthySubscriptions);
+    history.release();
+    await bus.sendText({ channelId: fixture.roomId, text: "restored history ordering barrier" });
+    fixture.broadcast(grant);
+    fixture.sendMessage("restored room message", undefined, skipped.roomId);
+    await vi.waitFor(() => {
+      expect(replies).toContain("restored short history");
+      expect(replies).toContain("restored room message");
+    });
+    expect(fixture.received).toContainEqual(
+      expect.objectContaining({
+        content: "reply: restored room message",
+        tags: expect.arrayContaining([["h", skipped.roomId]]),
+      }),
+    );
+    expect(messages).toHaveLength(4);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        "healthy before restoration",
+        "healthy while restoration waits",
+        "restored short history",
+        "restored room message",
+      ]),
+    );
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toHaveLength(1);
+    expect(roomSubscriptionIds(fixture, fixture.roomId)).toEqual(healthySubscriptions);
+    expect(fixture.authenticatedSessions()).toBe(1);
+    expect(fatal).toEqual([]);
+
+    publishBotRole(fixture, skipped.roomId, "member", skipped.createdAt + 2);
+    await vi.waitFor(() => expect(fatal).toHaveLength(1));
+    expect(restoredTurnSignal?.aborted).toBe(true);
+    await expect(
+      bus.sendText({ channelId: skipped.roomId, text: "retired restored-room reply" }),
+    ).rejects.toThrow("no longer has the Bot role");
+  } finally {
+    await bus?.close();
+    await fixture.close();
+  }
+});
+
+it("discards a grant query superseded by removal and accepts a later signed grant", async () => {
+  const fixture = await createBuzzRelayFixture();
+  const skipped = seedSkippedRoom(fixture);
+  const messages: string[] = [];
+  const fatal: Error[] = [];
+  let bus: BuzzBus | undefined;
+  try {
+    bus = await startBuzzBus({
+      accountId: randomUUID(),
+      relayUrl: fixture.relayUrl,
+      privateKey: fixture.botPrivateKey,
+      channelIds: [skipped.roomId, fixture.roomId],
+      onMessage: async (message) => {
+        messages.push(message.text);
+      },
+      onFatalError: (error) => fatal.push(error),
+    });
+    const healthySubscriptions = roomSubscriptionIds(fixture, fixture.roomId);
+    const staleQuery = fixture.pauseNextMembershipQuery();
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 1);
+    notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 1);
+    await staleQuery.started;
+    publishBotRole(fixture, skipped.roomId, "member", skipped.createdAt + 2);
+    notifyBotMembership(fixture, skipped.roomId, 44101, skipped.createdAt + 2);
+    staleQuery.release();
+    await bus.sendText({ channelId: fixture.roomId, text: "removal query ordering barrier" });
+    fixture.sendMessage("healthy after superseded grant");
+    await vi.waitFor(() => expect(messages).toEqual(["healthy after superseded grant"]));
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toEqual([]);
+    expect(fatal).toEqual([]);
+
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 3);
+    notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 3);
+    await vi.waitFor(() => expect(roomSubscriptionIds(fixture, skipped.roomId)).toHaveLength(1));
+    fixture.sendMessage("restored after a fresh grant", undefined, skipped.roomId);
+    await vi.waitFor(() => expect(messages).toContain("restored after a fresh grant"));
+    expect(roomSubscriptionIds(fixture, fixture.roomId)).toEqual(healthySubscriptions);
+    expect(fixture.authenticatedSessions()).toBe(1);
+    expect(fatal).toEqual([]);
+  } finally {
+    await bus?.close();
+    await fixture.close();
+  }
+});
+
+it("retains a newer non-Bot roster when a later grant query returns an older Bot roster", async () => {
+  const fixture = await createBuzzRelayFixture();
+  const skipped = seedSkippedRoom(fixture);
+  const messages: string[] = [];
+  const fatal: Error[] = [];
+  let bus: BuzzBus | undefined;
+  try {
+    bus = await startBuzzBus({
+      accountId: randomUUID(),
+      relayUrl: fixture.relayUrl,
+      privateKey: fixture.botPrivateKey,
+      channelIds: [skipped.roomId, fixture.roomId],
+      onMessage: async (message) => {
+        messages.push(message.text);
+      },
+      onFatalError: (error) => fatal.push(error),
+    });
+    const healthySubscriptions = roomSubscriptionIds(fixture, fixture.roomId);
+    const newerDenial = fixture.signRelay({
+      kind: 39002,
+      created_at: skipped.createdAt + 3,
+      content: "",
+      tags: [
+        ["d", skipped.roomId],
+        ["p", fixture.botPublicKey, "", "member"],
+      ],
+    });
+    fixture.broadcast(newerDenial);
+    notifyBotMembership(fixture, skipped.roomId, 44101, skipped.createdAt + 3);
+    await vi.waitFor(() =>
+      expect(
+        bus?.directory
+          .listGroupMembers({ groupId: skipped.roomId })
+          .some((entry) => entry.id === fixture.senderPublicKey),
+      ).toBe(false),
+    );
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toEqual([]);
+
+    // Model a stale relay snapshot after the client has accepted the newer denial.
+    fixture.events.splice(fixture.events.indexOf(newerDenial), 1);
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 2);
+    const staleQuery = fixture.pauseNextMembershipQuery();
+    notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 4);
+    await staleQuery.started;
+    staleQuery.release();
+    await bus.sendText({ channelId: fixture.roomId, text: "stale denial ordering barrier" });
+    fixture.sendMessage("healthy after stale Bot roster");
+    await vi.waitFor(() => expect(messages).toEqual(["healthy after stale Bot roster"]));
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toEqual([]);
+    expect(
+      bus.directory
+        .listGroupMembers({ groupId: skipped.roomId })
+        .some((entry) => entry.id === fixture.senderPublicKey),
+    ).toBe(false);
+    expect(fatal).toEqual([]);
+
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 5);
+    notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 5);
+    await vi.waitFor(() => expect(roomSubscriptionIds(fixture, skipped.roomId)).toHaveLength(1));
+    fixture.sendMessage("restored by newer Bot roster", undefined, skipped.roomId);
+    await vi.waitFor(() => expect(messages).toContain("restored by newer Bot roster"));
+    expect(roomSubscriptionIds(fixture, fixture.roomId)).toEqual(healthySubscriptions);
+    expect(fatal).toEqual([]);
+  } finally {
+    await bus?.close();
+    await fixture.close();
+  }
+});
+
+it.each(["live downgrade", "shutdown before EOSE", "shutdown during reconciliation"] as const)(
+  "retires pending restoration on %s without late work",
+  async (interruption) => {
+    const fixture = await createBuzzRelayFixture();
+    const skipped = seedSkippedRoom(fixture);
+    const messages: string[] = [];
+    const fatal: Error[] = [];
+    let turnSignal: AbortSignal | undefined;
+    let bus: BuzzBus | undefined;
+    try {
+      bus = await startBuzzBus({
+        accountId: randomUUID(),
+        relayUrl: fixture.relayUrl,
+        privateKey: fixture.botPrivateKey,
+        channelIds: [skipped.roomId, fixture.roomId],
+        onMessage: async (message, _bus, signal) => {
+          messages.push(message.text);
+          turnSignal = signal;
+        },
+        onFatalError: (error) => fatal.push(error),
+      });
+      fixture.sendMessage("retained generation");
+      await vi.waitFor(() => expect(turnSignal).toBeDefined());
+      fixture.sendMessage("pending restored history", undefined, skipped.roomId);
+      const history = fixture.pauseNextRoomHistory();
+      publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 1);
+      notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 1);
+      await history.started;
+
+      let reconciliation: ReturnType<BuzzRelayFixture["pauseNextMembershipQuery"]> | undefined;
+      if (interruption === "shutdown during reconciliation") {
+        fixture.broadcast(
+          fixture.signRelay({
+            kind: 39002,
+            created_at: skipped.createdAt + 2,
+            content: "",
+            tags: [
+              ["d", skipped.roomId],
+              ["p", fixture.botPublicKey, "", "bot"],
+            ],
+          }),
+        );
+        reconciliation = fixture.pauseNextMembershipQuery();
+        history.release();
+        await reconciliation.started;
+        expect(
+          bus.directory
+            .listGroupMembers({ groupId: skipped.roomId })
+            .some((member) => member.id === fixture.senderPublicKey),
+        ).toBe(true);
+      } else if (interruption === "live downgrade") {
+        // A registered room subscription can receive a live roster before its EOSE.
+        fixture.sendUnchecked(
+          fixture.signRelay({
+            kind: 39002,
+            created_at: skipped.createdAt + 2,
+            content: "",
+            tags: [
+              ["d", skipped.roomId],
+              ["p", fixture.botPublicKey, "", "member"],
+            ],
+          }),
+        );
+        await vi.waitFor(() => expect(fatal).toHaveLength(1));
+        expect(turnSignal?.aborted).toBe(true);
+        await expect(
+          bus.sendText({ channelId: skipped.roomId, text: "pre-EOSE retired reply" }),
+        ).rejects.toThrow("no longer has the Bot role");
+      }
+
+      const membersAtStop = bus.directory.listGroupMembers({ groupId: skipped.roomId });
+      const requestsAtStop = fixture.requests.length;
+      const stopping = bus.close();
+      history.release();
+      reconciliation?.release();
+      await stopping;
+      expect(turnSignal?.aborted).toBe(true);
+      expect(messages).toEqual(["retained generation"]);
+      expect(fixture.requests).toHaveLength(requestsAtStop);
+      expect(bus.directory.listGroupMembers({ groupId: skipped.roomId })).toEqual(membersAtStop);
+      expect(fatal).toHaveLength(interruption === "live downgrade" ? 1 : 0);
+      await expect(
+        bus.sendText({ channelId: skipped.roomId, text: "closed restoration reply" }),
+      ).rejects.toThrow(
+        interruption === "live downgrade" ? "no longer has the Bot role" : "Buzz bus closed",
+      );
+    } finally {
+      await bus?.close();
+      await fixture.close();
+    }
+  },
+);
+
+it("does not open a restored room after shutdown during its roster query", async () => {
+  const fixture = await createBuzzRelayFixture();
+  const skipped = seedSkippedRoom(fixture);
+  const fatal: Error[] = [];
+  let bus: BuzzBus | undefined;
+  try {
+    bus = await startBuzzBus({
+      accountId: randomUUID(),
+      relayUrl: fixture.relayUrl,
+      privateKey: fixture.botPrivateKey,
+      channelIds: [skipped.roomId, fixture.roomId],
+      onMessage: async () => {},
+      onFatalError: (error) => fatal.push(error),
+    });
+    const query = fixture.pauseNextMembershipQuery();
+    publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 1);
+    notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 1);
+    await query.started;
+    await bus.close();
+    query.release();
+    expect(roomSubscriptionIds(fixture, skipped.roomId)).toEqual([]);
+    expect(fatal).toEqual([]);
+    await expect(
+      bus.sendText({ channelId: fixture.roomId, text: "closed generation reply" }),
+    ).rejects.toThrow("Buzz bus closed");
+  } finally {
+    await bus?.close();
+    await fixture.close();
+  }
+});
+
+it.each(["closed", "missing EOSE"] as const)(
+  "fails the account when restored room history is %s",
+  async (failure) => {
+    const fixture = await createBuzzRelayFixture();
+    const skipped = seedSkippedRoom(fixture);
+    const fatal: Error[] = [];
+    let bus: BuzzBus | undefined;
+    try {
+      bus = await startBuzzBus({
+        accountId: randomUUID(),
+        relayUrl: fixture.relayUrl,
+        privateKey: fixture.botPrivateKey,
+        channelIds: [skipped.roomId, fixture.roomId],
+        onMessage: async () => {},
+        onFatalError: (error) => fatal.push(error),
+      });
+      const history = fixture.pauseNextRoomHistory();
+      publishBotRole(fixture, skipped.roomId, "bot", skipped.createdAt + 1);
+      notifyBotMembership(fixture, skipped.roomId, 44100, skipped.createdAt + 1);
+      await history.started;
+      if (failure === "closed") {
+        history.close("fixture room history failed");
+      }
+      await vi.waitFor(() => expect(fatal).toHaveLength(1), { timeout: 11000 });
+      expect(fatal[0]?.message).toContain(failure === "closed" ? "closed" : "Timed out");
+      await expect(
+        bus.sendText({ channelId: fixture.roomId, text: "failed generation reply" }),
+      ).rejects.toThrow();
+    } finally {
+      await bus?.close();
+      await fixture.close();
+    }
+  },
+  15000,
+);
+
+it.each(["member", "absent"] as const)(
+  "fails startup when the bot is %s in every active configured room",
+  async (membership) => {
+    const fixture = await createBuzzRelayFixture();
+    const initial = fixture.events.find((event) => event.kind === 39002)!;
+    fixture.events.push(
+      fixture.signRelay({
+        kind: 39002,
+        created_at: initial.created_at + 1,
+        content: "",
+        tags: [
+          ["d", fixture.roomId],
+          ...(membership === "member" ? [["p", fixture.botPublicKey, "", "member"]] : []),
+          ["p", fixture.senderPublicKey, "", "member"],
+        ],
+      }),
+    );
+    try {
+      await expect(
+        startBuzzBus({
+          accountId: randomUUID(),
+          relayUrl: fixture.relayUrl,
+          privateKey: fixture.botPrivateKey,
+          channelIds: [fixture.roomId],
+          onMessage: async () => {},
+        }),
+      ).rejects.toThrow("Bot role");
+      expect(roomSubscriptionIds(fixture, fixture.roomId)).toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  },
+);

--- a/extensions/buzz/src/buzz-bus.socket.test.ts
+++ b/extensions/buzz/src/buzz-bus.socket.test.ts
@@ -244,6 +244,67 @@ it("finishes an admitted room turn after its sender is removed", async () => {
   }
 });
 
+it("keeps healthy rooms subscribed when a configured room lost the Bot role", async () => {
+  const fixture = await createBuzzRelayFixture();
+  // A second configured room the bot can see but is only a member of. This is
+  // the shape a demoted or abandoned room takes: it is still in the directory,
+  // so it reaches the membership gate, but the bot cannot act in it.
+  const demotedRoomId = randomUUID();
+  const seededAt = Math.floor(Date.now() / 1000);
+  fixture.events.push(
+    fixture.signRelay({
+      kind: 39000,
+      created_at: seededAt,
+      content: "",
+      tags: [
+        ["d", demotedRoomId],
+        ["name", "Demoted room"],
+        ["t", "stream"],
+      ],
+    }),
+    fixture.signRelay({
+      kind: 39002,
+      created_at: seededAt,
+      content: "",
+      tags: [
+        ["d", demotedRoomId],
+        ["p", fixture.botPublicKey, "", "member"],
+      ],
+    }),
+  );
+  const messages: string[] = [];
+  const unavailable: Error[] = [];
+  const fatal: Error[] = [];
+  let bus: BuzzBus | undefined;
+  try {
+    bus = await startBuzzBus({
+      accountId: randomUUID(),
+      relayUrl: fixture.relayUrl,
+      privateKey: fixture.botPrivateKey,
+      // The unusable room is listed first: aborting on it would have stopped
+      // the healthy room from ever being subscribed.
+      channelIds: [demotedRoomId, fixture.roomId],
+      onMessage: async (message) => {
+        messages.push(message.text);
+      },
+      onRoomUnavailable: (error) => unavailable.push(error),
+      onFatalError: (error) => fatal.push(error),
+    });
+    fixture.sendMessage("healthy room keeps delivering");
+    await vi.waitFor(() => expect(messages).toEqual(["healthy room keeps delivering"]));
+    await expect(
+      bus.sendText({ channelId: fixture.roomId, text: "healthy room keeps sending" }),
+    ).resolves.toBeTruthy();
+    expect(fatal).toEqual([]);
+    expect(unavailable).toHaveLength(1);
+    expect(unavailable[0]?.message).toContain(demotedRoomId);
+    expect(unavailable[0]?.message).toContain("does not have the Bot role");
+  } finally {
+    await bus?.close();
+    await fixture.close();
+  }
+});
+
 it("revokes the active bot immediately on a signed role downgrade", async () => {
   const fixture = await createBuzzRelayFixture();
   const fatal: Error[] = [];

--- a/extensions/buzz/src/buzz-bus.ts
+++ b/extensions/buzz/src/buzz-bus.ts
@@ -237,6 +237,7 @@ export async function startBuzzBus(options: {
   onFatalError?: (error: Error) => void;
   onDedupeError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
+  onRoomUnavailable?: (error: Error) => void;
   onPresenceError?: (error: Error) => void;
   profileName?: string;
   onProfilePublished?: (eventId: string) => void;
@@ -295,6 +296,7 @@ export async function startBuzzBus(options: {
   let directoryRelay: ReturnType<typeof startBuzzDirectoryRelay> | undefined;
   let stopPresenceHeartbeat = () => {};
   let profileTask: Promise<void> | undefined;
+  let membershipTracker: Awaited<ReturnType<typeof createBuzzRoomMembershipTracker>> | undefined;
   const bus: BuzzBus = {
     publicKey,
     directory,
@@ -341,6 +343,7 @@ export async function startBuzzBus(options: {
       directoryRelay?.close();
       replayGuard.clearMemory();
       relay.close();
+      await membershipTracker?.close();
       // Relay close rejects pending publishes; join their profile continuation afterward.
       await profileTask;
     },
@@ -372,9 +375,11 @@ export async function startBuzzBus(options: {
       configuredRoomIds: options.channelIds,
       since: sessionStartedAt,
       signal,
+      onNotification: (notification) =>
+        membershipTracker?.handleNotification(notification) ?? false,
       onFatalError: reportFatalError,
     });
-    const membershipTracker =
+    membershipTracker =
       activeChannelIds.length > 0
         ? await createBuzzRoomMembershipTracker({
             relay,
@@ -386,6 +391,7 @@ export async function startBuzzBus(options: {
             messageLimit: resolveBuzzRoomHistoryLimit(activeChannelIds.length),
             reserveDispatchCapacity: (slots) => dispatchQueue.reserveCapacity(slots),
             onHistoryError: options.onHistoryError,
+            onRoomUnavailable: options.onRoomUnavailable,
             onMessageEvent: (event, isMember, reservation) => {
               if (signal.aborted || event.pubkey === publicKey) {
                 return;

--- a/extensions/buzz/src/buzz-bus.ts
+++ b/extensions/buzz/src/buzz-bus.ts
@@ -237,6 +237,7 @@ export async function startBuzzBus(options: {
   onFatalError?: (error: Error) => void;
   onDedupeError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
+  onRoomUnavailable?: (error: Error) => void;
   onPresenceError?: (error: Error) => void;
   profileName?: string;
   onProfilePublished?: (eventId: string) => void;
@@ -386,6 +387,7 @@ export async function startBuzzBus(options: {
             messageLimit: resolveBuzzRoomHistoryLimit(activeChannelIds.length),
             reserveDispatchCapacity: (slots) => dispatchQueue.reserveCapacity(slots),
             onHistoryError: options.onHistoryError,
+            onRoomUnavailable: options.onRoomUnavailable,
             onMessageEvent: (event, isMember, reservation) => {
               if (signal.aborted || event.pubkey === publicKey) {
                 return;

--- a/extensions/buzz/src/buzz-relay.test-harness.ts
+++ b/extensions/buzz/src/buzz-relay.test-harness.ts
@@ -10,7 +10,7 @@ import {
   type Event,
   type Filter,
 } from "nostr-tools";
-import { WebSocketServer, type WebSocket } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 
 /** Signed protocol fixture, not an implementation of the upstream Buzz service. */
 export async function createBuzzRelayFixture() {
@@ -47,6 +47,7 @@ export async function createBuzzRelayFixture() {
     }),
   ];
   const received: Event[] = [];
+  const requests: Array<{ id: string; filters: Filter[] }> = [];
   const sessions = new Map<
     WebSocket,
     { challenge: string; publicKey?: string; subscriptions: Map<string, Filter[]> }
@@ -54,6 +55,9 @@ export async function createBuzzRelayFixture() {
   let presenceMode: "accept" | "reject" | "silent" = "accept";
   let authenticatedSessions = 0;
   let pauseMembershipQuery: ((respond: () => void) => void) | undefined;
+  let pauseRoomHistory:
+    | ((respond: () => void, close: (reason: string) => void) => void)
+    | undefined;
   const heldSnapshots = new Set<string>();
   const server = createServer((_request, response) => {
     response.setHeader("content-type", "application/nostr+json");
@@ -63,11 +67,18 @@ export async function createBuzzRelayFixture() {
   });
   const sockets = new WebSocketServer({ server });
   const send = (socket: WebSocket, frame: unknown[]) => socket.send(JSON.stringify(frame));
-  const storedRoom = (event: Event) =>
-    event.tags.find((tag) => tag[0] === "h")?.[1] ??
-    ([39000, 39002].includes(event.kind)
-      ? event.tags.find((tag) => tag[0] === "d")?.[1]
-      : undefined);
+  const storedRoom = (event: Event) => {
+    // Membership notifications carry a room tag but Buzz stores them globally.
+    if (event.kind === 44100 || event.kind === 44101) {
+      return undefined;
+    }
+    return (
+      event.tags.find((tag) => tag[0] === "h")?.[1] ??
+      ([39000, 39002].includes(event.kind)
+        ? event.tags.find((tag) => tag[0] === "d")?.[1]
+        : undefined)
+    );
+  };
   const matchesStored = (filter: Filter, event: Event) => {
     const { "#h": rooms, ...signedFilter } = filter;
     return rooms
@@ -128,8 +139,12 @@ export async function createBuzzRelayFixture() {
           return;
         }
         session.subscriptions.set(value, filters);
+        requests.push({ id: value, filters });
         const snapshot = [...events];
         const respond = () => {
+          if (socket.readyState !== WebSocket.OPEN) {
+            return;
+          }
           const sent = new Set<string>();
           for (const filter of filters) {
             const matching = snapshot
@@ -153,6 +168,25 @@ export async function createBuzzRelayFixture() {
             respond();
             heldSnapshots.delete(value);
           });
+        } else if (
+          pauseRoomHistory &&
+          filters.some((filter) => filter.kinds?.includes(39002)) &&
+          filters.some((filter) => filter.kinds?.includes(9))
+        ) {
+          const pause = pauseRoomHistory;
+          pauseRoomHistory = undefined;
+          heldSnapshots.add(value);
+          pause(
+            () => {
+              respond();
+              heldSnapshots.delete(value);
+            },
+            (reason) => {
+              send(socket, ["CLOSED", value, reason]);
+              session.subscriptions.delete(value);
+              heldSnapshots.delete(value);
+            },
+          );
         } else {
           respond();
         }
@@ -196,6 +230,7 @@ export async function createBuzzRelayFixture() {
     relayPublicKey,
     roomId,
     received,
+    requests,
     events,
     authenticatedSessions: () => authenticatedSessions,
     pauseNextMembershipQuery: () => {
@@ -214,6 +249,25 @@ export async function createBuzzRelayFixture() {
         },
       };
     },
+    pauseNextRoomHistory: () => {
+      let respond: (() => void) | undefined;
+      let close: ((reason: string) => void) | undefined;
+      const started = new Promise<void>((resolve) => {
+        pauseRoomHistory = (sendSnapshot, closeSubscription) => {
+          respond = sendSnapshot;
+          close = closeSubscription;
+          resolve();
+        };
+      });
+      return {
+        started,
+        release: () => {
+          respond?.();
+          respond = undefined;
+        },
+        close: (reason: string) => close?.(reason),
+      };
+    },
     setPresenceMode: (mode: typeof presenceMode) => {
       presenceMode = mode;
     },
@@ -228,9 +282,13 @@ export async function createBuzzRelayFixture() {
         }
       }
     },
-    sendMessage: (content: string, createdAt = Math.floor(Date.now() / 1000)) => {
+    sendMessage: (
+      content: string,
+      createdAt = Math.floor(Date.now() / 1000),
+      channelId = roomId,
+    ) => {
       const event = finalizeEvent(
-        { kind: 9, created_at: createdAt, content, tags: [["h", roomId]] },
+        { kind: 9, created_at: createdAt, content, tags: [["h", channelId]] },
         senderKey,
       );
       broadcast(event);

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -143,6 +143,9 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
             `[${account.accountId}] Buzz history recovery incomplete: ${error.message}`,
           );
         },
+        onRoomUnavailable: (error) => {
+          ctx.log?.warn?.(`[${account.accountId}] Buzz room skipped: ${error.message}`);
+        },
         onPresenceError: (error) => {
           ctx.log?.warn?.(
             `[${account.accountId}] Buzz presence heartbeat failed: ${error.message}`,

--- a/extensions/buzz/src/history-catchup.ts
+++ b/extensions/buzz/src/history-catchup.ts
@@ -147,6 +147,9 @@ export async function catchUpBuzzRoomHistory(params: {
     }
     let page: BuzzRoomHistoryPage;
     try {
+      if (params.signal?.aborted) {
+        return "aborted";
+      }
       page = await queryBuzzRoomHistoryPage({
         relay: params.relay,
         channelId: params.channelId,

--- a/extensions/buzz/src/room-membership-notification.ts
+++ b/extensions/buzz/src/room-membership-notification.ts
@@ -7,7 +7,7 @@ const BUZZ_MEMBER_REMOVED_NOTIFICATION_KIND = 44_101;
 
 const MEMBERSHIP_NOTIFICATION_CLOSE_REASON = "membership notification shutdown";
 
-type BuzzRoomMembershipNotification = {
+export type BuzzRoomMembershipNotification = {
   eventId: string;
   kind: typeof BUZZ_MEMBER_ADDED_NOTIFICATION_KIND | typeof BUZZ_MEMBER_REMOVED_NOTIFICATION_KIND;
   roomId: string;
@@ -48,6 +48,7 @@ export function startBuzzRoomMembershipNotifications(params: {
   configuredRoomIds: string[];
   since: number;
   signal?: AbortSignal;
+  onNotification?: (notification: BuzzRoomMembershipNotification) => boolean;
   onFatalError: (error: Error) => void;
 }): void {
   const configuredRoomIds = new Set(params.configuredRoomIds.map(parseBuzzTarget));
@@ -68,7 +69,11 @@ export function startBuzzRoomMembershipNotifications(params: {
           relayPublicKey: params.relayPublicKey,
           botPublicKey: params.botPublicKey,
         });
-        if (notification && configuredRoomIds.has(notification.roomId)) {
+        if (
+          notification &&
+          configuredRoomIds.has(notification.roomId) &&
+          !params.onNotification?.(notification)
+        ) {
           params.onFatalError(
             new Error(
               `Buzz room ${notification.roomId} membership changed; rebuilding subscriptions`,

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -363,7 +363,11 @@ export async function createBuzzRoomMembershipTracker(params: {
         if (error === undefined) {
           resolve();
         } else {
-          reject(error);
+          reject(
+            error instanceof Error
+              ? error
+              : new Error("Buzz room membership loading failed", { cause: error }),
+          );
         }
       };
       const onAbort = () =>

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -7,6 +7,7 @@ import {
   BUZZ_REPLAY_DISPATCH_MAX_PENDING,
   type BuzzReplayDispatchReservation,
 } from "./replay-dispatch.js";
+import type { BuzzRoomMembershipNotification } from "./room-membership-notification.js";
 import { queryBuzzRoomMemberships } from "./room-membership-query.js";
 import {
   BUZZ_ROOM_SYSTEM_KIND,
@@ -17,7 +18,6 @@ import {
 } from "./room-membership.js";
 
 const MEMBERSHIP_READY_TIMEOUT_MS = 10_000;
-const MEMBERSHIP_TRACKER_SETUP_CLOSE_REASON = "membership tracker setup failed";
 const BUZZ_ROOM_METADATA_EDIT_KIND = 9_002;
 const MEMBERSHIP_REFRESH_DELAYS_MS = [100, 500, 1_500, 3_000] as const;
 const MEMBERSHIP_EVENT_CACHE_MAX_ENTRIES = 10_000;
@@ -69,12 +69,15 @@ export async function createBuzzRoomMembershipTracker(params: {
   ) => void;
   onFatalError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
+  onRoomUnavailable?: (error: Error) => void;
   onMembershipsChanged?: (memberships: ReadonlyMap<string, BuzzRoomMembership>) => void;
   onRoomMetadataChanged?: (channelId: string) => void;
   signal?: AbortSignal;
 }): Promise<{
   memberships: () => ReadonlyMap<string, BuzzRoomMembership>;
   catchUpHistory: () => Promise<void>;
+  handleNotification: (notification: BuzzRoomMembershipNotification) => boolean;
+  close: () => Promise<void>;
 }> {
   type ExpectedMembership = "present" | "absent";
   type RefreshState = {
@@ -82,6 +85,7 @@ export async function createBuzzRoomMembershipTracker(params: {
     lastAttemptedGeneration: number;
     promise: Promise<void>;
   };
+  type RestoringRoom = { historical: boolean; generation: number; until?: number };
 
   const historicalRooms = new Set<string>();
   const historyPages = new Map<string, { count: number; oldest: number }>();
@@ -90,8 +94,10 @@ export async function createBuzzRoomMembershipTracker(params: {
   const deniedMembers = new Map<string, Set<string>>();
   const pendingMemberships = new Map<string, Map<string, ExpectedMembership>>();
   const refreshes = new Map<string, RefreshState>();
+  const restoringRooms = new Map<string, RestoringRoom>();
   let membershipQueryTail = Promise.resolve();
   const memberships = await queryBuzzRoomMemberships(params);
+  params.signal?.throwIfAborted();
   const effectiveMemberships = (): ReadonlyMap<string, BuzzRoomMembership> => {
     if (blockedRooms.size === 0 && deniedMembers.size === 0) {
       return memberships;
@@ -151,16 +157,17 @@ export async function createBuzzRoomMembershipTracker(params: {
     params.onMembershipsChanged?.(effectiveMemberships());
   };
   const queryMembership = (channelId: string): Promise<BuzzRoomMembership | undefined> => {
-    const query = membershipQueryTail.then(async () =>
-      (
+    const query = membershipQueryTail.then(async () => {
+      params.signal?.throwIfAborted();
+      return (
         await queryBuzzRoomMemberships({
           relay: params.relay,
           relayPublicKey: params.relayPublicKey,
           channelIds: [channelId],
           signal: params.signal,
         })
-      ).get(channelId),
-    );
+      ).get(channelId);
+    });
     membershipQueryTail = query.then(
       () => undefined,
       () => undefined,
@@ -179,6 +186,7 @@ export async function createBuzzRoomMembershipTracker(params: {
       let refreshed: BuzzRoomMembership | undefined;
       try {
         refreshed = await queryMembership(channelId);
+        params.signal?.throwIfAborted();
       } catch (error) {
         if (params.signal?.aborted) {
           throw error;
@@ -265,6 +273,14 @@ export async function createBuzzRoomMembershipTracker(params: {
     if (!change) {
       return undefined;
     }
+    const restoring = restoringRooms.get(channelId);
+    if (restoring?.historical) {
+      // The post-EOSE snapshot reconciles history without treating reverse-order changes as current.
+      return undefined;
+    }
+    if (restoring) {
+      restoring.generation += 1;
+    }
     // System events invalidate membership; the relay-signed roster decides the
     // final state. Removals deny immediately, while joins wait for confirmation.
     const expected = change.type === "member_joined" ? "present" : "absent";
@@ -283,6 +299,16 @@ export async function createBuzzRoomMembershipTracker(params: {
     return refreshMembershipOnce(channelId);
   };
   const handleRoomEvent = (event: Event, reservation?: BuzzReplayDispatchReservation) => {
+    if (params.signal?.aborted) {
+      return;
+    }
+    const channelId = event.tags.find((tag) => tag[0] === "h")?.[1];
+    const restoring = channelId ? restoringRooms.get(channelId) : undefined;
+    if (restoring && isBuzzInboundMessageKind(event.kind)) {
+      // Re-query this bounded range after roster reconciliation; do not commit it to replay yet.
+      restoring.until = Math.max(restoring.until ?? event.created_at, event.created_at);
+      return;
+    }
     if (event.kind === BUZZ_ROOM_MEMBERSHIP_KIND) {
       const membership = parseBuzzRoomMembershipEvent(event, params.relayPublicKey);
       if (
@@ -305,29 +331,49 @@ export async function createBuzzRoomMembershipTracker(params: {
     void handleSystemEvent(event)?.catch(reportSystemEventError);
   };
 
+  const skippedRooms = new Set<string>();
+  const initialRoomIds: string[] = [];
   for (const channelId of params.channelIds) {
     if (memberships.get(channelId)?.roles.get(params.botPublicKey) !== "bot") {
-      throw new Error(`Buzz bot does not have the Bot role in configured room ${channelId}`);
+      skippedRooms.add(channelId);
+      params.onRoomUnavailable?.(
+        new Error(`Buzz bot does not have the Bot role in configured room ${channelId}`),
+      );
+    } else {
+      initialRoomIds.push(channelId);
     }
   }
+  if (params.channelIds.length > 0 && initialRoomIds.length === 0) {
+    throw new Error(
+      `Buzz bot does not have the Bot role in any configured room: ${params.channelIds.join(", ")}`,
+    );
+  }
 
-  let resolveHistorical: (() => void) | undefined;
-  let rejectHistorical: ((error: Error) => void) | undefined;
-  const historicalReady = new Promise<void>((resolve, reject) => {
-    resolveHistorical = resolve;
-    rejectHistorical = reject;
-  });
-  const historicalTimeout = setTimeout(() => {
-    const error = new Error("Timed out loading Buzz room membership changes");
-    rejectHistorical?.(error);
-    params.relay.close();
-  }, MEMBERSHIP_READY_TIMEOUT_MS);
-  const subscriptions: Array<ReturnType<Relay["prepareSubscription"]>> = [];
-  try {
-    // Snapshot membership before room history so startup memory stays bounded.
-    // Buzz emits these filters in order: system changes since session start
-    // update or deny membership before the following message history is handled.
-    for (const channelId of params.channelIds) {
+  const subscribeRoom = (channelId: string): Promise<void> => {
+    params.signal?.throwIfAborted();
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        params.signal?.removeEventListener("abort", onAbort);
+        if (error === undefined) {
+          resolve();
+        } else {
+          reject(error);
+        }
+      };
+      const onAbort = () =>
+        finish(params.signal?.reason ?? new Error("Buzz membership loading aborted"));
+      const timeout = setTimeout(() => {
+        finish(new Error(`Timed out loading Buzz room membership changes for ${channelId}`));
+        params.relay.close();
+      }, MEMBERSHIP_READY_TIMEOUT_MS);
+      params.signal?.addEventListener("abort", onAbort, { once: true });
+      // System changes precede message history so revoked senders cannot enter the queue.
       const filters: Filter[] = [
         {
           kinds: [BUZZ_ROOM_SYSTEM_KIND, BUZZ_ROOM_METADATA_EDIT_KIND],
@@ -347,12 +393,15 @@ export async function createBuzzRoomMembershipTracker(params: {
           limit: params.messageLimit,
         },
       ];
-      subscriptions.push(
+      try {
         openBuzzRelaySubscription(
           params.relay,
           filters,
           {
             onevent: (event) => {
+              if (params.signal?.aborted) {
+                return;
+              }
               if (!historicalRooms.has(channelId) && isBuzzInboundMessageKind(event.kind)) {
                 const page = historyPages.get(channelId);
                 if (page) {
@@ -366,65 +415,70 @@ export async function createBuzzRoomMembershipTracker(params: {
             },
             oneose: () => {
               historicalRooms.add(channelId);
-              if (historicalRooms.size === params.channelIds.length) {
-                resolveHistorical?.();
+              const restoring = restoringRooms.get(channelId);
+              if (restoring) {
+                restoring.historical = false;
               }
+              finish();
             },
             onclose: (reason) => {
+              const error = new Error(
+                `Buzz membership subscription closed for ${channelId}: ${reason}`,
+              );
               if (!historicalRooms.has(channelId)) {
-                rejectHistorical?.(
-                  new Error(`Buzz membership subscription closed for ${channelId}: ${reason}`),
-                );
+                finish(error);
               } else if (
                 reason !== "shutdown" &&
                 reason !== "relay connection closed by us" &&
-                reason !== MEMBERSHIP_TRACKER_SETUP_CLOSE_REASON &&
                 !params.signal?.aborted
               ) {
-                params.onFatalError?.(
-                  new Error(`Buzz membership subscription closed for ${channelId}: ${reason}`),
-                );
+                reportSystemEventError(error);
               }
             },
           },
-          // Buzz routes only all-#h requests to room topics and matches #h against
-          // stored channel metadata. Signed rosters contain #d, not #h, so keep
-          // the client filters unchanged for nostr-tools signature/tag validation.
+          // Buzz routes on #h while signed rosters retain #d for client validation.
           filters.map((filter) => Object.assign({}, filter, { "#h": [channelId] })),
-        ),
-      );
-    }
-    await historicalReady;
-  } catch (error) {
-    if (params.relay.connected) {
-      for (const subscription of subscriptions) {
-        if (!subscription.closed) {
-          subscription.close(MEMBERSHIP_TRACKER_SETUP_CLOSE_REASON);
-        }
+        );
+      } catch (error) {
+        finish(error);
       }
+    });
+  };
+
+  // Initial readiness has a fixed denominator; later grants own their own EOSE waiter.
+  const initialSubscriptions: Promise<void>[] = [];
+  try {
+    for (const channelId of initialRoomIds) {
+      initialSubscriptions.push(subscribeRoom(channelId));
     }
+    await Promise.all(initialSubscriptions);
+  } catch (error) {
+    params.relay.close();
+    await Promise.allSettled(initialSubscriptions);
     throw error;
-  } finally {
-    clearTimeout(historicalTimeout);
   }
 
-  return {
-    memberships: effectiveMemberships,
-    catchUpHistory: async () => {
-      for (const channelId of params.channelIds) {
-        const page = historyPages.get(channelId);
-        if (params.signal?.aborted) {
-          return;
-        }
-        if (!page || page.count < params.messageLimit) {
-          continue;
-        }
-        try {
+  let historyTail = Promise.resolve();
+  const catchUpHistory = (channelIds: string[], recoveryUntil?: number): Promise<void> => {
+    const task = historyTail
+      .then(async () => {
+        for (const channelId of channelIds) {
+          const page = historyPages.get(channelId);
+          const until = recoveryUntil ?? page?.oldest;
+          if (params.signal?.aborted) {
+            return;
+          }
+          if (
+            until === undefined ||
+            (recoveryUntil === undefined && page && page.count < params.messageLimit)
+          ) {
+            continue;
+          }
           const outcome = await catchUpBuzzRoomHistory({
             relay: params.relay,
             channelId,
             since: params.messageSince(channelId),
-            until: page.oldest,
+            until,
             limit: params.messageLimit,
             reserveCapacity: params.reserveDispatchCapacity,
             onEvent: handleRoomEvent,
@@ -437,18 +491,101 @@ export async function createBuzzRoomMembershipTracker(params: {
               ),
             );
           }
-        } catch (error) {
-          if (params.signal?.aborted) {
-            return;
-          }
-          reportSystemEventError(
-            error instanceof Error
-              ? error
-              : new Error(`Buzz room history recovery failed for ${channelId}`, { cause: error }),
-          );
-          return;
         }
+      })
+      .catch(reportSystemEventError);
+    historyTail = task;
+    return task;
+  };
+
+  type Restoration = { generation: number; promise: Promise<void> };
+  const restorations = new Map<string, Restoration>();
+  const restoreRoom = async (channelId: string, state: Restoration): Promise<void> => {
+    while (!params.signal?.aborted) {
+      const generation = state.generation;
+      let refreshed = await queryMembership(channelId);
+      params.signal?.throwIfAborted();
+      if (generation !== state.generation) {
+        continue;
       }
+      const current = memberships.get(channelId);
+      if (current && (!refreshed || isNewerBuzzRevision(current, refreshed))) {
+        refreshed = current;
+      }
+      if (!refreshed) {
+        return;
+      }
+      if (refreshed.roles.get(params.botPublicKey) !== "bot") {
+        memberships.set(channelId, refreshed);
+        params.onMembershipsChanged?.(effectiveMemberships());
+        return;
+      }
+      replaceMembership(refreshed);
+      params.signal?.throwIfAborted();
+      // Once subscribed, even a pre-EOSE downgrade must revoke the account generation.
+      skippedRooms.delete(channelId);
+      const restoring: RestoringRoom = { historical: true, generation: 0 };
+      restoringRooms.set(channelId, restoring);
+      await subscribeRoom(channelId);
+      while (!params.signal?.aborted) {
+        // Live invalidations keep their existing bounded refresh and immediate sender denial.
+        const refresh = refreshes.get(channelId);
+        if (refresh) {
+          await refresh.promise;
+        }
+        params.signal?.throwIfAborted();
+        const reconciliationGeneration = restoring.generation;
+        let confirmed = await queryMembership(channelId);
+        params.signal?.throwIfAborted();
+        if (reconciliationGeneration !== restoring.generation || refreshes.has(channelId)) {
+          continue;
+        }
+        const latest = memberships.get(channelId);
+        if (latest && confirmed && isNewerBuzzRevision(latest, confirmed)) {
+          confirmed = latest;
+        }
+        if (!confirmed) {
+          throw new Error(`Buzz room membership missing after restoration for ${channelId}`);
+        }
+        replaceMembership(confirmed);
+        params.signal?.throwIfAborted();
+        restoringRooms.delete(channelId);
+        await catchUpHistory([channelId], restoring.until);
+        return;
+      }
+      return;
+    }
+  };
+
+  return {
+    memberships: effectiveMemberships,
+    catchUpHistory: () => catchUpHistory(initialRoomIds),
+    handleNotification: (notification) => {
+      if (params.signal?.aborted || seenEventIds.has(notification.eventId)) {
+        return true;
+      }
+      if (!skippedRooms.has(notification.roomId)) {
+        return false;
+      }
+      markSystemEventSeen(notification.eventId);
+      const existing = restorations.get(notification.roomId);
+      if (existing) {
+        existing.generation += 1;
+        return true;
+      }
+      const state: Restoration = { generation: 1, promise: Promise.resolve() };
+      restorations.set(notification.roomId, state);
+      state.promise = restoreRoom(notification.roomId, state)
+        .catch(reportSystemEventError)
+        .finally(() => restorations.delete(notification.roomId));
+      return true;
+    },
+    close: async () => {
+      await Promise.allSettled([
+        ...[...restorations.values()].map((state) => state.promise),
+        ...[...refreshes.values()].map((state) => state.promise),
+        historyTail,
+      ]);
     },
   };
 }

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -69,6 +69,7 @@ export async function createBuzzRoomMembershipTracker(params: {
   ) => void;
   onFatalError?: (error: Error) => void;
   onHistoryError?: (error: Error) => void;
+  onRoomUnavailable?: (error: Error) => void;
   onMembershipsChanged?: (memberships: ReadonlyMap<string, BuzzRoomMembership>) => void;
   onRoomMetadataChanged?: (channelId: string) => void;
   signal?: AbortSignal;
@@ -305,10 +306,24 @@ export async function createBuzzRoomMembershipTracker(params: {
     void handleSystemEvent(event)?.catch(reportSystemEventError);
   };
 
+  // A room the bot cannot read must not take the healthy rooms down with it:
+  // one deleted or demoted room used to abort this loop, so every configured
+  // room lost its subscription and the account went silent. Skip the room,
+  // surface it, and only fail when nothing is left to subscribe to.
+  const subscribedChannelIds: string[] = [];
   for (const channelId of params.channelIds) {
     if (memberships.get(channelId)?.roles.get(params.botPublicKey) !== "bot") {
-      throw new Error(`Buzz bot does not have the Bot role in configured room ${channelId}`);
+      params.onRoomUnavailable?.(
+        new Error(`Buzz bot does not have the Bot role in configured room ${channelId}`),
+      );
+      continue;
     }
+    subscribedChannelIds.push(channelId);
+  }
+  if (params.channelIds.length > 0 && subscribedChannelIds.length === 0) {
+    throw new Error(
+      `Buzz bot does not have the Bot role in any configured room: ${params.channelIds.join(", ")}`,
+    );
   }
 
   let resolveHistorical: (() => void) | undefined;
@@ -327,7 +342,7 @@ export async function createBuzzRoomMembershipTracker(params: {
     // Snapshot membership before room history so startup memory stays bounded.
     // Buzz emits these filters in order: system changes since session start
     // update or deny membership before the following message history is handled.
-    for (const channelId of params.channelIds) {
+    for (const channelId of subscribedChannelIds) {
       const filters: Filter[] = [
         {
           kinds: [BUZZ_ROOM_SYSTEM_KIND, BUZZ_ROOM_METADATA_EDIT_KIND],
@@ -366,7 +381,7 @@ export async function createBuzzRoomMembershipTracker(params: {
             },
             oneose: () => {
               historicalRooms.add(channelId);
-              if (historicalRooms.size === params.channelIds.length) {
+              if (historicalRooms.size === subscribedChannelIds.length) {
                 resolveHistorical?.();
               }
             },
@@ -411,7 +426,7 @@ export async function createBuzzRoomMembershipTracker(params: {
   return {
     memberships: effectiveMemberships,
     catchUpHistory: async () => {
-      for (const channelId of params.channelIds) {
+      for (const channelId of subscribedChannelIds) {
         const page = historyPages.get(channelId);
         if (params.signal?.aborted) {
           return;


### PR DESCRIPTION
## What Problem This Solves

One configured Buzz room without the Bot role stopped the whole account before healthy rooms could subscribe. Restoring that room also restarted healthy room subscriptions.

## Why This Change Was Made

Keep eligibility and restoration in the membership owner. Skip unavailable rooms with a bounded warning, require a current signed roster before restoring a room, and recover its history through the existing bounded replay path. Live role downgrades still cancel admitted work, and shutdown fences pending roster and history operations.

## User Impact

Eligible rooms stay online when another room is unavailable. A later signed role grant restores only that room. An account with active rooms but no eligible room remains failed. Configuration, persisted room IDs, and the separate direct-message policy are unchanged.

This extends @sla55er's original fix and preserves the contributor commit.

## Evidence

- Real isolated Gateway and Buzz plugin against a signed local relay and deterministic local model endpoint: five acknowledged replies across healthy traffic, restoration, and recovered history; the healthy connection and subscription stay unchanged.
- All-ineligible startup remains failed. A live downgrade cancels an admitted provider request without a late reply. A fresh signed message sent after revocation also receives no agent request or reply.
- 148 distinct focused tests cover membership, history, cancellation, directory, replay, presence, routing, and archive behavior.
- Separate regressions reproduce the pinned-main account outage and the original patch's account-wide restart during restoration.

Gateway captures retain their tested commit `2276cfcd014f`. The final error-normalization correction preserves those exercised paths; independent source-equivalence review and seven affected waiter tests cover the correction. Hosted type-aware lint and exact-head review remain separate gates.
