### PR TITLE
fix(update): report managed recovery snapshot cleanup failures

### DIFF
--- a/src/infra/update-managed-service-recovery-presence.ts
+++ b/src/infra/update-managed-service-recovery-presence.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { assertOpenClawStateDatabaseOwner } from "../state/openclaw-state-db-maintenance.js";
 import { assertSupportedStateSchemaVersion } from "../state/openclaw-state-db-schema-version.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
@@ -22,6 +23,7 @@ export function hasManagedUpdateRecoveryRecord(pathname: string, runId: string):
     throw new Error("Managed recovery state is not a regular file.");
   }
   const prepared = prepareSqliteReadOnlyLocationSyncInProcess(pathname);
+  let outcome: { value: boolean } | { cause: unknown };
   try {
     const db = openNodeSqliteDatabase(prepared.location, { readOnly: true });
     try {
@@ -59,12 +61,27 @@ export function hasManagedUpdateRecoveryRecord(pathname: string, runId: string):
       if (!current.isFile() || current.dev !== original.dev || current.ino !== original.ino) {
         throw new Error("Managed recovery state changed during inspection.");
       }
-      return present;
+      outcome = { value: present };
     } finally {
       clearNodeSqliteKyselyCacheForDatabase(db);
       db.close();
     }
-  } finally {
-    prepared.cleanup();
+  } catch (cause) {
+    outcome = { cause };
   }
+  if (!prepared.cleanup()) {
+    // The exit retry is best-effort, not proof that this private copy was removed.
+    const readFailure =
+      "cause" in outcome
+        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+        : "";
+    throw new Error(
+      `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+      "cause" in outcome ? outcome : undefined,
+    );
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }


### PR DESCRIPTION
## What Problem This Solves

When the update manager checks for a recovery record, it creates a temporary read-only SQLite snapshot but does not verify whether the snapshot was cleaned up afterward. If cleanup fails (disk full, permission denied, or file handle contention), the failure is silently swallowed and the temporary copy accumulates without any diagnostic signal. This fix checks the cleanup return value and throws a diagnostic error on failure, matching the pattern established in #143844.

- Problem: `hasManagedUpdateRecoveryRecord` calls `prepared.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails, `cleanup()` returns `false` but the caller ignores it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Capture the read outcome first (value or caught cause), then check `prepared.cleanup()` and throw a diagnostic `Error` with the staging directory path and actionable guidance if cleanup fails. This aligns with the fix applied in #143844 for `withStateDatabaseSnapshot` in `update-candidate-state.ts`.
- What changed: `src/infra/update-managed-service-recovery-presence.ts` — replaced `finally { prepared.cleanup(); }` with an outcome-capture + cleanup-check pattern; added `import path from "node:path"` for the diagnostic directory path.
- What did NOT change: The inner `try/finally` that closes the database handle is preserved. The read logic, schema validation, and ownership checks are unchanged. Normal-path behavior (cleanup succeeds) is identical to before.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed 3 days ago in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Two sibling call sites (`cron/store.ts:272` and `doctor-lint.ts:361`) already check the return value and throw on failure, confirming this is the project's expected pattern. This call site was missed.

The fix follows the #143844 template exactly: capture outcome before cleanup, check return value, merge read failure + cleanup failure into a single diagnostic error, and rethrow the original cause if cleanup succeeds but the read failed.

### Cleanup-only failure policy (addresses ClawSweeper decision ask)

ClawSweeper flagged a compatibility concern: a cleanup-only failure (read succeeded, snapshot removal failed) now rejects an otherwise successful recovery inspection, which propagates into the managed handoff's failure policy. This is **intentional and aligned with the function's documented contract**:

`hasManagedUpdateRecoveryRecord` is documented as *"Presence only, never recovery or native-effect authority."* Its sole caller `reconcileNativeRecovery` (`update-managed-service-handoff.ts:131-139`) already treats **any** inspection exception — including cleanup-only failure — as "unknown persistence" and sets `durableNative = true` with the comment *"Unknown persistence is not permission to write history or restore a service."*

The downstream effect of `durableNative = true` is uniformly **conservative and safe**:
- `assertStateDatabaseWriteAllowed` throws rather than reopen a possibly-migrated database (`handoff.ts:221`)
- `finishManagedUpdateRun` returns early, skipping outcome recording (`handoff.ts:427`)
- `restoreGatewayService` is skipped — no service restoration attempted (`handoff.ts:890`)
- `recordUpdateRunVerification` is skipped (`handoff.ts:1120`)
- `collectUpdateFailureTriage` is skipped in the `finally` block (`handoff.ts:1875`)
- On the native-commit path, the child is **gracefully settled** (`native-settled`) rather than hard-killed (`cancelled` + `killOwnedCommand`) (`handoff.ts:1253-1254, 1241-1244`)

Rationale: if the private snapshot copy could not be removed, we cannot confirm it was cleared, so the handoff conservatively assumes native recovery may own canonical state and refuses to write history, restore a service, or reopen the database. A successful best-effort exit retry does not reverse this decision — which is correct, because the decision is about **trust in the inspection**, not about whether the file eventually disappeared. This is the same strict stance #143844 took for `withStateDatabaseSnapshot`.

This is distinct from the missing-record path (`handoff.ts:1284`, `durableNative` stays `false` → hard-cancel + kill), which remains unchanged.

- Best fix: Yes — minimal, directly aligned with the established #143844 pattern, and the conservative downstream behavior is the correct policy for an untrusted inspection.
- Alternative: Making `adoptPreparedLocation` default `requireCleanup = true` would fix all call sites at once, but that changes the shared primitive's contract and risks unintended throws in call sites that intentionally tolerate cleanup failure (e.g., error-path cleanup in `openclaw-state-db.ts`). Per-site fixes are safer and match how #143844 was merged.
- Alternative (diagnostic-only): Logging cleanup failure without throwing would preserve the successful read, but that contradicts the function's "no native-effect authority" contract — a retained private snapshot is exactly the kind of untrusted state the caller must hear about. Rejected for consistency with #143844.
- Risk: Low. Normal-path behavior is unchanged (Test 3 below). The only new behavior is an error thrown when cleanup fails, which was previously silent. The sole caller `reconcileNativeRecovery` already wraps the call in a try-catch that sets `durableNative = true` and rethrows, so the new error propagates correctly through existing error handling.

## User Impact

Operators will now see a clear diagnostic error when temporary snapshot cleanup fails during managed update recovery checks, instead of silent temporary file accumulation. The error message includes the staging directory path and guidance to check permissions and available storage, making the root cause actionable. When cleanup fails, the managed update handoff conservatively aborts native activation and suppresses legacy finalization or service restoration — the safest failure mode for an untrusted recovery inspection.

## Evidence

Two proof scripts exercise the fix. The first (`proof.mjs`) covers the reader itself; the second (`proof-composed.mjs`) drives the full recovery decision chain requested in re-review.

### Reader-level proof (real SQLite + fs.rmSync fault injection)

```console
$ node /home/code/github/contributions/BUG/BUG-069-evidence/proof.mjs

=== Test 1: cleanup failure with successful read ===
{
  "ok": false,
  "message": "State database snapshot cleanup failed: /tmp/bug069-KiEFgm/cache-cleanup-fail/openclaw-1000/openclaw-sqlite-readonly-3894793-gKn0r9. Check directory permissions and available storage before retrying.",
  "cause": null
}
✅ PASS: Cleanup failure throws diagnostic error with guidance

=== Test 2: normal path → present=true ===
{ "ok": true, "present": true }
✅ PASS: Normal path returns present=true

=== Test 3: run exists, no recovery key → present=false ===
{ "ok": true, "present": false }
✅ PASS: No recovery key returns present=false

=== All 3 tests passed ===
```

### Composed recovery proof (cleanup-only failure → full handoff decision chain)

This drives the REAL `hasManagedUpdateRecoveryRecord` (no mock) against a real SQLite fixture with `fs.rmSync` fault injection, then replays the exact handoff decision branches that consume its result — `reconcileNativeRecovery` (`handoff.ts:131-139`), the native-commit catch (`handoff.ts:1283-1285`), `rejectActivation` (`handoff.ts:1228-1244`), and the post-child catch (`handoff.ts:1772, 1777-1885`). State-variable names and branch order match the sealed handoff script verbatim.

```console
$ node /home/code/github/contributions/BUG/BUG-069-evidence/proof-composed.mjs

=== Test 1: native-commit path, cleanup-only failure → child settlement ===
{
  "durableNative": true,
  "nativeCancellation": true,
  "activationRejected": "managed-service-handoff-helper-failed",
  "childStdin": ["native-v1:systemd\n", "native-settled\n"],
  "hardKillCalled": false
}
✅ PASS: cleanup-only failure settles child via native-settled, no hard kill

=== Test 2: post-child reconciliation, cleanup-only failure → failed outcome ===
{
  "durableNative": true,
  "runOutcome": { "status": "failed", "reason": "managed-service-handoff-helper-failed" },
  "processExitCode": 1,
  "triageCollected": false,
  "serviceRestored": false
}
✅ PASS: cleanup-only failure records failed outcome, suppresses triage + service restore

=== Test 3: normal path (no fault) → native-committed, no cancellation ===
{
  "durableNative": true,
  "nativeCancellation": false,
  "childStdin": ["native-v1:systemd\n", "native-committed\n"]
}
✅ PASS: normal path commits native, no cancellation (unchanged behavior)

=== Test 4: record absent (no fault) → hard cancel (contrast to cleanup-only) ===
{
  "durableNative": false,
  "nativeCancellation": false,
  "activationRejected": "managed-service-handoff-helper-failed",
  "childStdin": ["native-v1:systemd\n", "cancelled\n", "<killOwnedCommand>"]
}
✅ PASS: missing-record path hard-cancels (distinct from cleanup-only settle)

=== All 4 composed tests passed ===
Decision matrix:
  cleanup fails, read ok  => durableNative=true  → native-settled (graceful) + failed outcome, no triage/restore
  cleanup ok, record ok   => durableNative=true  → native-committed (normal, unchanged)
  cleanup ok, no record   => durableNative=false → cancelled + hard kill (missing-row policy)
```

The matrix makes the policy explicit: cleanup-only failure and missing-record both reject activation, but via **different** child-settlement paths — cleanup failure flips `durableNative` true first (graceful `native-settled`), while missing-record leaves it false (hard `cancelled` + kill). This is the distinction ClawSweeper asked to be documented.

Behavior matrix:

```text
scenario                        => pre-fix result         => post-fix result
cleanup fails, read succeeds    => silent (temp left)     => throws "snapshot cleanup failed" → durableNative=true → graceful settle + failed outcome
cleanup succeeds, record exists => present=true           => present=true (unchanged, native-committed)
cleanup succeeds, no record     => present=false          => present=false (unchanged, hard-cancel path)
```

### Strengthened proof (transient vs persistent, durable ledger state, real EACCES)

Addresses ClawSweeper Revision 2 gaps: transient vs persistent cleanup outcomes, durable final state, and real filesystem failure without `fs.rmSync` throw mocking.

```console
$ node /home/code/github/contributions/BUG/BUG-069-evidence/proof-strengthened.mjs

=== Test 1: transient cleanup — fails first call, succeeds on retry call ===
  first call: {
  "threw": true,
  "message": "State database snapshot cleanup failed: /tmp/bug069-strengthened-sDIMvJ/cache-transient-first/openclaw-1000/openclaw-sqlite-readonly-10370-Wi51Lm. Check directory permissions and available storage before retrying."
}
  ✅ transient failure detected (throws)
  second call: {
  "threw": false,
  "present": true
}
  ✅ transient resolved, cleanup succeeds (present=true)
✅ PASS: transient cleanup failure is detected; subsequent call succeeds when condition clears

=== Test 2: persistent cleanup failure (always denied) ===
{
  "ok": false,
  "message": "State database snapshot cleanup failed: /tmp/bug069-strengthened-sDIMvJ/cache-persistent/openclaw-1000/openclaw-sqlite-readonly-10547-ituG8G. Check directory permissions and available storage before retrying.",
  "cause": null
}
✅ PASS: persistent cleanup failure throws diagnostic error

=== Test 3: durable ledger state unchanged after cleanup-only failure ===
  before: {"status":"running","phase":"requested","finished_at_ms":null}
  function result: {
  "threw": true,
  "message": "State database snapshot cleanup failed: /tmp/bug069-strengthened-sDIMvJ/cache-ledger/openclaw-1000/openclaw-sqlite-readonly-10593-1emRBb. Check directory permissions and available storage before retrying."
}
  after: {"status":"running","phase":"requested","finished_at_ms":null}
✅ PASS: ledger state unchanged (run still running/requested/unfinished) — durableNative blocks ledger finalization

=== Test 4: normal path — state DB accessible, ledger intact ===
{
  "ok": true,
  "present": true
}
✅ PASS: normal path returns present=true, ledger intact

=== Test 5: real filesystem permission denial (EACCES, no throw mock) ===
{
  "ok": false,
  "message": "State database snapshot cleanup failed: /tmp/bug069-strengthened-sDIMvJ/cache-chmod/openclaw-1000/openclaw-sqlite-readonly-10720-Edfs5L. Check directory permissions and available storage before retrying.",
  "cause": null
}
✅ PASS: real EACCES (chmod 0400 on parent) causes cleanup failure → diagnostic throw

=== All 5 strengthened tests passed ===
Coverage matrix:
  transient cleanup (1st call fails, 2nd succeeds)  => 1st: throws diagnostic; 2nd: returns present=true
  persistent cleanup (always fails)                 => throws diagnostic error with guidance
  durable ledger state after cleanup failure        => run still running/requested (durableNative blocks finalization)
  normal path                                       => present=true, ledger intact, no leftover snapshots
  real filesystem permission denial (EACCES)         => real rmSync fails with EACCES → diagnostic throw
```

**Test 1 (transient vs persistent):** A transient cleanup failure (e.g., file handle contention that resolves quickly) is detected on the first call — the function correctly throws. On a subsequent call, once the transient condition clears, cleanup succeeds and the function returns `present=true` normally. This proves the fix does not permanently block recovery: transient faults are reported, but the system self-heals on the next inspection.

**Test 3 (durable ledger state):** Proves that when cleanup fails, the SQLite `update_runs` ledger is **not modified** — the run stays `running`/`requested`/`finished_at_ms=null`. This is the conservative `durableNative=true` policy in action: `finishManagedUpdateRun` returns early at `handoff.ts:427` (`if (durableNative || !runLedger || !runOutcome) return;`), refusing to write an outcome when the inspection cannot be trusted. The ledger remains available for the admitted updater/replay owner to finalize or compensate.

**Test 5 (real EACCES):** Instead of mocking `fs.rmSync` to throw, this test makes the parent directory of the snapshot read-only (`chmod 0400`) before calling the real `fs.rmSync`. The real `rmSync` fails with a genuine `EACCES` error (not a thrown mock), exercising the actual `removeTempDirectory → fs.rmSync → catch → return false` code path.


### Bounded production handoff proof (real sealed handoff + real bundled runtime)

Addresses ClawSweeper Revision 3 blocking ask: *"a bounded execution of that owner is sufficient without a full application rollout."* This proof spawns the **REAL sealed `HANDOFF_SCRIPT`** (extracted verbatim from `update-managed-service-handoff.ts`, 81KB CJS) with the **REAL bundled `managed-handoff-runtime.mjs`** from `dist/` (1.6MB, 38895 lines, patched with the BUG-069 fix), drives the native-commit protocol through the `transfer` command path, and injects a real `fs.rmSync` fault to trigger snapshot cleanup failure.

**Why `transfer` (not `park`→`commit`):** The native-v1 → native-commit protocol only activates when `controlPending = true`, which requires `restorationArmed = false`. The `park` command sets `restorationArmed = true` (via `parkGatewayService`), disabling native protocol handling. The `transfer` command sets `outcome = "update"` without parking, keeping `restorationArmed = false` and `controlPending = true` — exactly the path the project's own test infrastructure uses (`update-managed-service-handoff-boundary.test-support.ts:460-462`).

```console
$ node /home/code/github/contributions/BUG/BUG-069-evidence/proof-bounded-handoff.mjs

=== Step 1: Staging handoff script + patched runtime ===
  Script: handoff.cjs (81366 bytes)
  Runtime: patched with cleanup-failure detection ✓

=== Step 7: Waiting for handoff readiness ===
  ✓ Handoff ready

=== Step 8: Driving transfer (non-park update path) ===
  ✓ Transferred (outcome=update, controlPending=true, restorationArmed=false)

=== Step 9: Waiting for native protocol + helper exit ===
  Exit code: 1 Signal: null

--- handoff.log ---
[...] managed update ownership transferred; validating while the gateway serves
[...] starting managed update command: bounded-handoff-proof-updater
[...] managed update update command pid=527778
[...] managed update activation failed: Error: State database snapshot cleanup failed: .../openclaw-sqlite-readonly-527770-qVdojG. Check directory permissions and available storage before retrying.
[...] managed update update command exited code=1 signal=null
[...] managed update helper completed code=1

--- native peer result ---
  NATIVE_SETTLED:Managed native control did not confirm the requested boundary.

--- ledger state ---
  update_runs: {"status":"running","phase":"requested","finished_at_ms":null}

=== Results ===
  ✅ Native peer received native-settled (graceful settle, not hard kill)
  ✅ Native peer did NOT receive native-committed (commit was rejected)
  ✅ Sealed handoff exits with code 1 (failure reported)
  ✅ Handoff log shows activation failure or settlement
  ✅ Ledger state shows failure (durableNative blocks finalization)

=== BOUNDED PRODUCTION HANDOFF PROOF PASSED ===
```

**What this proves end-to-end:**
1. `transfer` command enters update phase with `controlPending=true`, `restorationArmed=false`
2. Updater child sends `native-v1\n` → helper responds `native-v1:systemd\n` (negotiation succeeds)
3. Updater child sends `native-commit\n` → helper calls `reconcileNativeRecovery()` → `hasManagedUpdateRecoveryRecord()`
4. `fs.rmSync` fault triggers `prepared.cleanup()` → returns `false` → throws "State database snapshot cleanup failed"
5. `reconcileNativeRecovery` catches the throw, sets `durableNative = true`, rethrows
6. `rejectActivation` sees `durableNative = true` → writes `native-settled\n` (graceful settle)
7. Child receives `native-settled` and exits with code 1
8. Helper exits with code 1 (failure reported, not swallowed)
9. Ledger unchanged: `update_runs` stays `running`/`requested`/`finished_at_ms=null` (`durableNative` blocks `finishManagedUpdateRun`)

This is the **real sealed handoff script** executing the **real native protocol** with **real bundled runtime** — not a replay or branch-logic reproduction. The child settlement (`native-settled`), helper exit code (1), and ledger final state (`running`) are observed from actual process execution.

What was not tested: A real disk-full (`ENOSPC`) condition was not tested on this host. Multi-process handle contention on Windows was not tested on this host. The mock `systemctl`/`systemd-run` binaries simulate the service manager interface; a real systemd scope was not used.

Open PR collision check: searched open PRs for `update-managed-service-recovery-presence`; no open PR touched this file. The file's last commit was #140339 (feat, unrelated to cleanup). Rebased onto latest `main` (no conflicts; the 9 upstream commits since fork did not touch `recovery-presence.ts`, `handoff.ts`, or `sqlite-readonly-location.ts`).

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6-terra)
- Prompts / session excerpts: local-code-analysis fix workflow — bug discovered via source code analysis of `prepareSqliteReadOnlyLocation*` call sites; fix pattern derived from #143844; composed recovery proof added in response to ClawSweeper re-review asking for full handoff decision-chain coverage; strengthened proof (transient/persistent, durable ledger state, real EACCES) added in response to ClawSweeper Revision 2 asking for transient vs persistent outcomes and durable final state; bounded production handoff proof (real sealed HANDOFF_SCRIPT + real bundled runtime, `transfer` command path, native-v1→native-commit protocol with cleanup fault injection) added in response to ClawSweeper Revision 3 blocking ask for bounded execution without full application rollout
- Confirmed understanding of code changes: Yes — can explain every line; the outcome-capture + cleanup-check pattern mirrors #143844's `withStateDatabaseSnapshot` fix, and the downstream `durableNative` decision chain is traced through `handoff.ts:131-139, 1228-1244, 1283-1285, 1772-1885`
- autoreview: N/A (worktree environment; oxlint + manual type check passed)

