### PR TITLE
refactor(plugins): remove duplicate metadata scope test

### DIFF
--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -502,14 +502,6 @@ describe("current plugin metadata snapshot", () => {
     }
   });
 
-  it("rejects a workspace-scoped snapshot when the caller does not provide workspace scope", () => {
-    const config = { plugins: { allow: ["demo"] } };
-    const snapshot = createSnapshot({ config, workspaceDir: "/workspace/a" });
-    setCurrentPluginMetadataSnapshot(snapshot, { config });
-
-    expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
-  });
-
   it("can opt into reusing the stored workspace scope for unscoped control-plane readers", () => {
     const config = { plugins: { allow: ["demo"] } };
     const snapshot = createSnapshot({ config, workspaceDir: "/workspace/a" });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Maintainer-requested test cleanup: the standalone missing-workspace rejection case repeats coverage already present in the matching-config/workspace test.

## Why This Change Was Made

Remove the redundant case. The retained test uses the same fresh config, workspace-scoped snapshot, and setter, checks the identical unscoped rejection, and also verifies matching and mismatched config/workspace behavior.

## User Impact

No runtime behavior change. One test case and eight lines are removed; all other cases, assertions, helpers, and imports remain unchanged.

## Evidence

- Full ordered `src/plugins/current-plugin-metadata-snapshot.test.ts` through the plugins lane: 36 actual passes, zero skips.
- All 20 selected changed checks passed, plus targeted formatting and diff checks.
- One fresh P2 review: scoped-clean, no findings.

No live plugin or Gateway execution, installed-package compatibility, or local full-repository test run is claimed.
