### PR TITLE
fix(ui): stop stale task reads after Review changes

### DIFF
--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -3,7 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { html, render, type LitElement } from "lit";
 import "./components/chat-detail-panel.ts";
-import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SessionWorkspaceGetResult, SessionWorkspaceListResult } from "../../api/types.ts";
 import type { TaskSummary } from "../../lib/tasks/task-summary.ts";
@@ -22,6 +22,7 @@ import {
   createInitializationContext,
   createSessionCapabilityFixture,
 } from "./chat-pane.test-support.ts";
+import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import { createTestTranscript } from "./chat-view.test-helpers.ts";
@@ -37,12 +38,18 @@ import {
   createSessionWorkspaceProps,
   openSessionWorkspaceFile,
   renderSessionWorkspaceRail,
+  retireSessionWorkspaceCheckout,
 } from "./components/chat-session-workspace.ts";
 import type { SidebarContent } from "./components/chat-sidebar-content-types.ts";
+import { resetTaskDetail } from "./components/chat-task-detail-state.ts";
 import { renderChatThread } from "./components/chat-thread.ts";
 import type { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
 import "./components/chat-sidebar-region.runtime.ts";
-import { threadProps } from "./components/chat-transcript.test-support.ts";
+import {
+  installTranscriptDomMocks,
+  resetTranscriptTestDom,
+  threadProps,
+} from "./components/chat-transcript.test-support.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import {
   closeSlot,
@@ -102,7 +109,7 @@ async function renderPanelFixture(
   await mount.querySelector("openclaw-panel-loading-skeleton")?.updateComplete;
 }
 
-function createReviewFixture() {
+function createReviewFixture(taskFields: Partial<TaskSummary> = {}) {
   const file = createDeferred<SessionWorkspaceGetResult | null>();
   const list = createDeferred<SessionWorkspaceListResult | null>();
   const sessions = createSessionCapabilityFixture({
@@ -116,8 +123,16 @@ function createReviewFixture() {
     { invalidate: vi.fn(), afterCommit: () => () => {} },
     mount,
   );
+  const history = vi.fn().mockResolvedValue({
+    messages: [{ role: "assistant", content: "The selected task transcript." }],
+  });
   state.client = createGatewayBrowserClientFixture({
-    request: (method) => (method === "tasks.list" ? { tasks: [] } : { artifacts: [] }),
+    request: (method, params) =>
+      method === "tasks.history"
+        ? history(params)
+        : method === "tasks.list"
+          ? { tasks: [] }
+          : { artifacts: [] },
   });
   state.connected = true;
   state.connectionEpoch = 1;
@@ -135,6 +150,7 @@ function createReviewFixture() {
     agentId: "main",
     createdAt: 1,
     updatedAt: 2,
+    ...taskFields,
   } satisfies TaskSummary;
   const backgroundTasks = {
     ...createBackgroundTasksProps(state, { presented: false }),
@@ -166,28 +182,128 @@ function createReviewFixture() {
       setObserverVisibility: vi.fn(),
       updateSidebarLayout: state.updateSidebarLayout,
     });
+  const transcript = createTestTranscript();
+  transcript.hostConnected();
+  onTestFinished(async () => {
+    file.resolve(null);
+    list.resolve(null);
+    await Promise.allSettled([file.promise, list.promise]);
+    resetTaskDetail(state);
+    transcript.hostDisconnected();
+  });
   const renderPanels = async () => {
     const definitions = sidebarPanelDefinitions({
       state,
       renderDetail: (content) =>
         renderChatDetailSlot({
           backgroundTasks,
-          chat: { paneId: "review-intent", sessionKey: state.sessionKey } as ChatProps,
+          chat: threadProps("review-intent", state.sessionKey) as ChatProps,
           content,
           host: state,
           layout: state.sidebarLayout,
-          transcript: {} as ChatTranscriptController,
+          transcript,
         }),
       workspace: renderSessionWorkspaceRail(createSessionWorkspaceProps(state), {
         embedded: true,
       }),
     } as Parameters<typeof sidebarPanelDefinitions>[0]);
     await renderPanelFixture(mount, state.sidebarLayout, definitions, rails().closePanelSlot);
+    transcript.hostUpdated();
   };
-  return { file, list, mount, preview, rails, renderPanels, sessions, state, task };
+  return { file, history, list, mount, preview, rails, renderPanels, sessions, state, task };
 }
 
 describe("chat pane embedded panels", () => {
+  describe("Review task selection lifetime", () => {
+    beforeEach(installTranscriptDomMocks);
+    afterEach(resetTranscriptTestDom);
+    it.each(["pending", "unavailable", "checkout retired", "file closed", "task closed"] as const)(
+      "stops the previous task's transcript reads when Review is %s",
+      async (selection) => {
+        vi.useFakeTimers({ toFake: ["Date"] });
+        vi.setSystemTime(10_000);
+        onTestFinished(() => {
+          vi.useRealTimers();
+        });
+        const { file, history, mount, preview, rails, renderPanels, state, task } =
+          createReviewFixture({ childSessionKey: "agent:main:subagent:review-child" });
+        rails().backgroundTasks.onOpenTaskDetail?.(task);
+        await renderPanels();
+        await renderPanels();
+        expect(mount.textContent).toContain("The selected task transcript.");
+        expect(history).toHaveBeenCalledExactlyOnceWith({ taskId: task.id, limit: 100 });
+
+        if (selection !== "task closed") {
+          openSessionWorkspaceFile(state, { path: preview.file.path });
+          await renderPanels();
+          expect(mount.querySelector('[data-panel-skeleton="review"]')).not.toBeNull();
+        }
+        if (selection === "unavailable") {
+          file.reject(new Error("Preview unavailable"));
+          await expect(file.promise).rejects.toThrow("Preview unavailable");
+        } else if (selection === "checkout retired") {
+          retireSessionWorkspaceCheckout(state);
+        } else if (selection === "file closed" || selection === "task closed") {
+          mount.querySelector<HTMLButtonElement>('button[aria-label="Close Review"]')!.click();
+        }
+        await renderPanels();
+        if (selection === "unavailable") {
+          expect(mount.querySelector('[role="alert"]')?.textContent).toContain(
+            "Preview unavailable",
+          );
+        } else if (selection === "file closed" || selection === "task closed") {
+          expect(mount.querySelector('[data-panel-slot="detail"]')).toBeNull();
+        } else if (selection === "checkout retired") {
+          expect(mount.querySelector('[data-panel-skeleton="review"]')).toBeNull();
+        }
+        vi.setSystemTime(12_000);
+        handlePageGatewayEvent(state, {
+          type: "event",
+          event: "task",
+          payload: { action: "upserted", task: { ...task, updatedAt: 3 } },
+        });
+        expect(history).toHaveBeenCalledOnce();
+        expect(mount.querySelector("[data-task-detail-panel]")).toBeNull();
+      },
+    );
+
+    it.each(["Files", "minimized"] as const)(
+      "retains the selected Review transcript while %s is presented",
+      async (presentation) => {
+        const { history, mount, rails, renderPanels, state, task } = createReviewFixture({
+          childSessionKey: "agent:main:subagent:review-child",
+        });
+        rails().backgroundTasks.onOpenTaskDetail?.(task);
+        await renderPanels();
+        await renderPanels();
+        expect(mount.textContent).toContain("The selected task transcript.");
+
+        if (presentation === "Files") {
+          state.handleOpenSidebar({
+            kind: "attachment",
+            attachmentKind: "image",
+            title: "Attachment in Files",
+            src: "/synthetic/attachment.png",
+          });
+        } else {
+          state.updateSidebarLayout(setSidebarOpen(state.sidebarLayout, false));
+        }
+        await renderPanels();
+        expect.soft(history).toHaveBeenCalledOnce();
+        expect(isSidebarSlotVisible(state.sidebarLayout, "detail")).toBe(false);
+        if (presentation === "Files") {
+          expect(
+            mount.querySelector<HTMLImageElement>(".sidebar-attachment-preview__image")?.alt,
+          ).toBe("Attachment in Files");
+        }
+        state.updateSidebarLayout(openSlot(state.sidebarLayout, "detail"));
+        await renderPanels();
+        expect(mount.textContent).toContain("The selected task transcript.");
+        expect(history).toHaveBeenCalledExactlyOnceWith({ taskId: task.id, limit: 100 });
+      },
+    );
+  });
+
   it.each(["ready", "unavailable", "error"] as const)(
     "keeps Files pending during renewed source resolution, then shows %s",
     async (outcome) => {

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -15,12 +15,14 @@ import { SIDEBAR_PANEL_SHORTCUTS } from "./chat-pane-panel-shortcuts.ts";
 import { resolveAssistantAttachmentAuthToken } from "./chat-pane-state.ts";
 import type { ChatSessionCompanionThread } from "./chat-session-companion.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { openTaskDetailId } from "./components/chat-detail-slot.ts";
 import { resolveSessionDiffSidebarContent } from "./components/chat-session-workspace.ts";
 import type {
   SidebarPanelDefinition,
   SidebarPanelTemplates,
 } from "./components/chat-sidebar-region-types.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
+import { resetTaskDetail } from "./components/chat-task-detail-state.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import type { SidebarSlotId } from "./sidebar-layout-types.ts";
 
@@ -89,6 +91,10 @@ export function sidebarPanelDefinitions(
   params?: SidebarPanelDefinitionParams,
 ): SidebarPanelDefinition[] {
   const state = params?.state;
+  // Review owns task history; rendering Files must not retire that selection.
+  if (state && openTaskDetailId(state.sidebarContent, state.sidebarLayout) === undefined) {
+    resetTaskDetail(state);
+  }
   // Metadata-only definitions have no pane context, so they describe types without offering tabs.
   const panelContext = params && {
     ...params,

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -8,7 +8,6 @@ import "./chat-sidebar.ts";
 import { assistantMediaPolicyKey } from "./chat-message-media.ts";
 import { openSessionWorkspaceFile, revealSessionWorkspaceFile } from "./chat-session-workspace.ts";
 import type { SidebarContent, SidebarSelection } from "./chat-sidebar.ts";
-import { resetTaskDetail, type TaskDetailHost } from "./chat-task-detail-state.ts";
 import { renderTaskDetailPanel } from "./chat-task-detail.ts";
 import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
 
@@ -35,11 +34,7 @@ export function renderChatDetailSlot(params: {
   transcript: ChatTranscriptController;
 }): TemplateResult {
   const { content, host } = params;
-  const taskDetailHost: TaskDetailHost = host;
   const taskId = openTaskDetailId(content, params.layout);
-  if (taskId === undefined && taskDetailHost.taskDetailState !== undefined) {
-    resetTaskDetail(taskDetailHost);
-  }
   const documents: Partial<Record<SidebarContent["kind"], TemplateResult>> = {
     task:
       taskId === undefined

--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
-import type { ChatPageHost } from "../chat-state-host.ts";
-import type { ChatProps } from "../chat-view.ts";
-import { closeSlot, openSlot, type SidebarLayout } from "../sidebar-layout.ts";
-import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
-import { renderChatDetailSlot } from "./chat-detail-slot.ts";
-import type { SidebarContent } from "./chat-sidebar.ts";
-import * as taskDetailState from "./chat-task-detail-state.ts";
 import {
   loadOlderTaskTranscript,
   observeTaskDetailEvent,
@@ -15,7 +8,6 @@ import {
   readTaskTranscript,
   type TaskDetailHost,
 } from "./chat-task-detail-state.ts";
-import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -57,55 +49,6 @@ function task(status: TaskSummary["status"]): TaskSummary {
   };
 }
 
-function backgroundTasks(selectedTask: TaskSummary): BackgroundTasksProps {
-  return {
-    sessionKey: "agent:main:main",
-    statusRowId: "chat-tasks-status-test",
-    collapsed: false,
-    narrowLayout: false,
-    connected: true,
-    canCancel: false,
-    loading: false,
-    error: null,
-    tasks: [selectedTask],
-    activeCount: selectedTask.status === "queued" || selectedTask.status === "running" ? 1 : 0,
-    subagentActivity: {
-      rows: [],
-      overflowWorking: 0,
-      taskIds: new Set(),
-      nextExpiryAt: null,
-    },
-    taskDetails: new Map(),
-    taskDetailErrors: new Map(),
-    taskDetailLoadingIds: new Set(),
-    cancellingTaskIds: new Set(),
-    finishedCollapsed: false,
-    onToggleCollapsed: () => undefined,
-    onToggleFinished: () => undefined,
-    onRefresh: () => undefined,
-    onCancel: () => undefined,
-  };
-}
-
-const taskContent = { kind: "task", taskId: "task-1" } satisfies SidebarContent;
-const fileContent = {
-  kind: "file",
-  path: "notes.txt",
-  name: "notes.txt",
-  content: "Non-task detail",
-} satisfies SidebarContent;
-
-function renderDetail(host: TaskDetailHost, content: SidebarContent, layout: SidebarLayout) {
-  renderChatDetailSlot({
-    backgroundTasks: backgroundTasks(task("running")),
-    chat: { paneId: "pane-1" } as ChatProps,
-    content,
-    host: host as ChatPageHost,
-    layout,
-    transcript: {} as ChatTranscriptController,
-  });
-}
-
 async function flushAsync() {
   await Promise.resolve();
   await Promise.resolve();
@@ -117,41 +60,6 @@ afterEach(() => {
 });
 
 describe("task detail transcript state", () => {
-  it("clears transcript state when the detail slot closes", () => {
-    const pending = deferred<never>();
-    const host = hostWith(vi.fn().mockReturnValue(pending.promise));
-    const openDetailLayout = openSlot({ columns: [] }, "detail");
-
-    renderDetail(host, taskContent, openDetailLayout);
-    expect(host.taskDetailState).toBeDefined();
-
-    renderDetail(host, taskContent, closeSlot(openDetailLayout, "detail"));
-    expect(host.taskDetailState).toBeUndefined();
-  });
-
-  it("does not reset transcript state during stable task or non-task renders", () => {
-    const pending = deferred<never>();
-    const request = vi.fn().mockReturnValue(pending.promise);
-    const host = hostWith(request);
-    const openDetailLayout = openSlot({ columns: [] }, "detail");
-    const reset = vi.spyOn(taskDetailState, "resetTaskDetail");
-
-    renderDetail(host, taskContent, openDetailLayout);
-    const openTaskState = host.taskDetailState;
-    renderDetail(host, taskContent, openDetailLayout);
-
-    expect(host.taskDetailState).toBe(openTaskState);
-    expect(request).toHaveBeenCalledOnce();
-    expect(reset).not.toHaveBeenCalled();
-
-    renderDetail(host, fileContent, openDetailLayout);
-    expect(host.taskDetailState).toBeUndefined();
-    expect(reset).toHaveBeenCalledOnce();
-
-    renderDetail(host, fileContent, openDetailLayout);
-    expect(reset).toHaveBeenCalledOnce();
-  });
-
   it("loads the selected task transcript", async () => {
     const pending = deferred<ReturnType<typeof history>>();
     const request = vi.fn().mockReturnValue(pending.promise);


### PR DESCRIPTION
Related: #143958

## What Problem This Solves

Fixes an issue where leaving a task transcript for a pending or failed file preview could keep fetching the old task's history. Opening an attachment in Files could also clear and reload a still-selected Review transcript.

## Why This Change Was Made

Reconcile task history from Review's current selection and layout before either panel renders. The generic content renderer no longer controls that lifetime, so loading/error states and independent Files rendering follow the same ownership rule. Existing task, connection, paging, and pane-retention owners keep their responsibilities.

## User Impact

Leaving a task's Review selection stops its transcript reads. Switching to Files or hiding the side panel preserves a still-selected task and its loaded transcript.

## Evidence

Mounted Review/Files tests use the real task-history loader and page event dispatcher. Before the fix, five cases fail and two controls pass; the same seven pass afterward. The selected suites passed 132 distinct cases across seven files. After correcting a test-cleanup callback's return type, the final seven cases and all 20 canonical changed checks passed. Independent review found no actionable findings.

Two tests coupled to the old renderer's internal state were replaced by tests of rendered content and history requests. Executable production line count is unchanged, with one ownership comment added; tests grow by 24 lines net. This is synthetic UI boundary proof; no real Gateway, provider, native app, or appearance change is claimed.

### Browser comparison

The same Chromium fixture mounts the production Review, Files, task transcript and attachment components with synthetic content and production CSS. Open the attachment in Files, then click Review. Before the fix, Review reloads and issues three history requests; after the fix, its loaded transcript remains visible with one request. Later mock replies are held to make the reset visible. This is a component composition proof, not a full app or live Gateway run.

The first image shows the original behavior; the second shows the repaired behavior.

![Before: returning from Files reloads the Review transcript](https://github.com/user-attachments/assets/2d8e7162-92dc-44a2-a339-2f5043e4ed18)

![After: returning from Files preserves the Review transcript](https://github.com/user-attachments/assets/92a11db4-3668-48bc-a53b-d4a398858540)