### PR TITLE
fix(auth): report shared auth legacy snapshot cleanup failures

### DIFF
--- a/src/agents/auth-profiles/shared-store-bootstrap.ts
+++ b/src/agents/auth-profiles/shared-store-bootstrap.ts
@@ -126,23 +126,39 @@ export function inspectSharedAuthLegacyRowsReadOnly(
   } catch (error) {
     throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
   }
+  let database: DatabaseSync;
   try {
-    let database: DatabaseSync;
-    try {
-      database = openNodeSqliteDatabase(prepared?.location ?? sourcePath, { readOnly: true });
-    } catch (error) {
-      throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
-    }
-    try {
-      return readSharedAuthLegacyRowsFromDatabase(database);
-    } catch (error) {
-      throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", error);
-    } finally {
-      database.close();
-    }
-  } finally {
-    prepared?.cleanup();
+    database = openNodeSqliteDatabase(prepared?.location ?? sourcePath, { readOnly: true });
+  } catch (error) {
+    throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
   }
+  let outcome: { value: SharedAuthLegacyRows } | { cause: unknown };
+  try {
+    outcome = { value: readSharedAuthLegacyRowsFromDatabase(database) };
+  } catch (cause) {
+    outcome = { cause };
+  } finally {
+    database.close();
+  }
+  if (prepared && !prepared.cleanup()) {
+    // The exit retry is best-effort, not proof that this private copy was removed.
+    const readFailure =
+      "cause" in outcome
+        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+        : "";
+    throw new SharedAuthStoreSourceInspectionError(
+      sourcePath,
+      "read",
+      new Error(
+        `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+        "cause" in outcome ? outcome : undefined,
+      ),
+    );
+  }
+  if ("cause" in outcome) {
+    throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", outcome.cause);
+  }
+  return outcome.value;
 }
 
 export function hasPendingSharedAuthCleanup(

--- a/src/agents/auth-profiles/shared-store-bootstrap.ts
+++ b/src/agents/auth-profiles/shared-store-bootstrap.ts
@@ -126,39 +126,50 @@ export function inspectSharedAuthLegacyRowsReadOnly(
   } catch (error) {
     throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
   }
-  let database: DatabaseSync;
-  try {
-    database = openNodeSqliteDatabase(prepared?.location ?? sourcePath, { readOnly: true });
-  } catch (error) {
-    throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
-  }
   let outcome: { value: SharedAuthLegacyRows } | { cause: unknown };
+  let cleanupChecked = false;
   try {
-    outcome = { value: readSharedAuthLegacyRowsFromDatabase(database) };
-  } catch (cause) {
-    outcome = { cause };
+    let database: DatabaseSync;
+    try {
+      database = openNodeSqliteDatabase(prepared?.location ?? sourcePath, { readOnly: true });
+    } catch (error) {
+      throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
+    }
+    try {
+      outcome = { value: readSharedAuthLegacyRowsFromDatabase(database) };
+    } catch (cause) {
+      outcome = { cause };
+    } finally {
+      database.close();
+    }
+    if (prepared && !prepared.cleanup()) {
+      // The exit retry is best-effort, not proof that this private copy was removed.
+      const readFailure =
+        "cause" in outcome
+          ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+          : "";
+      throw new SharedAuthStoreSourceInspectionError(
+        sourcePath,
+        "read",
+        new Error(
+          `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+          "cause" in outcome ? outcome : undefined,
+        ),
+      );
+    }
+    cleanupChecked = true;
+    if ("cause" in outcome) {
+      throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", outcome.cause);
+    }
+    return outcome.value;
   } finally {
-    database.close();
+    // Guarantee snapshot cleanup when opening or closing fails before the
+    // diagnostic check runs. The exit retry is best-effort and cannot recover
+    // a directory that cleanup() was never called on.
+    if (!cleanupChecked) {
+      prepared?.cleanup();
+    }
   }
-  if (prepared && !prepared.cleanup()) {
-    // The exit retry is best-effort, not proof that this private copy was removed.
-    const readFailure =
-      "cause" in outcome
-        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
-        : "";
-    throw new SharedAuthStoreSourceInspectionError(
-      sourcePath,
-      "read",
-      new Error(
-        `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
-        "cause" in outcome ? outcome : undefined,
-      ),
-    );
-  }
-  if ("cause" in outcome) {
-    throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", outcome.cause);
-  }
-  return outcome.value;
 }
 
 export function hasPendingSharedAuthCleanup(


### PR DESCRIPTION
## What Problem This Solves

When inspecting legacy shared auth profiles with artifact-preserving read-only mode, the code creates a temporary SQLite snapshot but does not verify whether it was cleaned up afterward. If cleanup fails (disk full, permission denied, or file handle contention), the failure is silently swallowed and the temporary copy accumulates without any diagnostic signal. This fix checks the cleanup return value and throws a diagnostic error on failure, matching the pattern established in #143844.

- Problem: `inspectSharedAuthLegacyRowsReadOnly` calls `prepared?.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails, `cleanup()` returns `false` but the caller ignores it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Capture the read outcome first (value or caught cause), then check `prepared.cleanup()` and throw a `SharedAuthStoreSourceInspectionError` with the staging directory path and actionable guidance if cleanup fails. When `prepared` is `undefined` (artifactPreservingReadOnly disabled), cleanup checking is correctly skipped.
- What changed: `src/agents/auth-profiles/shared-store-bootstrap.ts` — replaced `finally { prepared?.cleanup(); }` with an outcome-capture + cleanup-check pattern in `inspectSharedAuthLegacyRowsReadOnly`.
- What did NOT change: The inner `try/finally` that closes the database handle is preserved. The `SharedAuthStoreSourceInspectionError` wrapping is maintained for all error paths. The undefined-prepared path (no snapshot created) behaves identically to before.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Sibling call sites (`cron/store.ts:272` and `doctor-lint.ts:361`) already check the return value and throw on failure, confirming this is the project's expected pattern. This call site was missed.

The fix follows the #143844 template with one adaptation: `prepared` can be `undefined` when `artifactPreservingReadOnly` is disabled, so the cleanup check uses `if (prepared && !prepared.cleanup())` to skip the check when no snapshot was created. Errors are wrapped in `SharedAuthStoreSourceInspectionError` to preserve the existing error contract that callers depend on.

- Best fix: Yes — minimal, directly aligned with the #143844 pattern, with the correct adaptation for the optional `prepared` case.
- Alternative: Making `adoptPreparedLocation` default `requireCleanup = true` would fix all call sites at once, but changes the shared primitive's contract and risks unintended throws in call sites that intentionally tolerate cleanup failure. Per-site fixes are safer.
- Risk: Low. Normal-path behavior is unchanged. The undefined-prepared path (no snapshot) is unaffected. The only new behavior is a `SharedAuthStoreSourceInspectionError` thrown when cleanup fails, which was previously silent.

## User Impact

Operators will now see a clear diagnostic error when temporary snapshot cleanup fails during legacy shared auth inspection, instead of silent temporary file accumulation. The error message includes the staging directory path and guidance to check permissions and available storage.

## Evidence

Live command verification using `node --import tsx` with a real SQLite auth database fixture and a `fs.rmSync` fault injection preload:

```console
$ node /home/code/github/contributions/BUG/BUG-070-evidence/proof.mjs

=== Test 1: cleanup failure with successful read ===
{
  "ok": false,
  "message": "Cannot read legacy shared auth database /tmp/bug070-Pq4IxJ/auth.sqlite: State database snapshot cleanup failed: /tmp/bug070-Pq4IxJ/cache-cleanup-fail/openclaw-1000/openclaw-sqlite-readonly-3938820-L5TWzh/openclaw-sqlite-readonly-3938961-ymB8fY. Check directory permissions and available storage before retrying.",
  "code": "SHARED_AUTH_STORE_SOURCE_UNREADABLE",
  "cause": "State database snapshot cleanup failed: ..."
}
✅ PASS: Cleanup failure throws diagnostic error with guidance

=== Test 2: normal path → returns rows ===
{
  "ok": true,
  "rows": { "store": { "store_json": "{\"version\":1}", "updated_at": 1 }, "state": { "state_json": "{\"active\":true}", "updated_at": 1 } }
}
✅ PASS: Normal path returns rows

=== Test 3: no snapshot (artifactPreservingReadOnly=false) ===
{
  "ok": true,
  "rows": { "store": { "store_json": "{\"version\":1}", "updated_at": 1 }, "state": { "state_json": "{\"active\":true}", "updated_at": 1 } }
}
✅ PASS: No-snapshot path returns rows (cleanup fault ignored)

=== All 3 tests passed ===
```

Behavior matrix:

```text
scenario                                      => pre-fix result         => post-fix result
cleanup fails, read succeeds (snapshot mode)  => silent (temp left)     => throws SharedAuthStoreSourceInspectionError
cleanup succeeds, read succeeds (snapshot)    => returns rows           => returns rows (unchanged)
no snapshot (artifactPreservingReadOnly=false)=> returns rows           => returns rows (unchanged)
```

What was not tested: Multi-process handle contention on Windows was not tested on this host. The cleanup failure was simulated via `fs.rmSync` fault injection.

Open PR collision check: searched open PRs for `shared-store-bootstrap`; no open PR touched this file. Last commit was #141610 (unrelated).

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6-terra)
- Prompts / session excerpts: local-code-analysis fix workflow — bug discovered via source code analysis of `prepareSqliteReadOnlyLocation*` call sites; fix pattern derived from #143844
- Confirmed understanding of code changes: Yes — can explain every line; the outcome-capture + cleanup-check pattern mirrors #143844 with adaptation for optional `prepared`
- autoreview: N/A (worktree environment; oxlint + oxfmt passed)
