### PR TITLE
refactor(tests): share Slack approval configuration inputs

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -282,6 +282,27 @@ function singleButtonBlocks(blockId: string, actionId: string) {
   ];
 }
 
+function approvalContextOptions(pluginApprover: string, execApprover: string) {
+  return {
+    cfg: {
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              allowFrom: [pluginApprover],
+              execApprovals: {
+                enabled: true,
+                approvers: [execApprover],
+                target: "both",
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 function createContext(overrides?: {
   dmEnabled?: boolean;
   dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
@@ -1832,24 +1853,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("uses the typed plugin kind for unprefixed approval ids", async () => {
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            accounts: {
-              default: {
-                allowFrom: ["u123owner"],
-                execApprovals: {
-                  enabled: true,
-                  approvers: ["U999EXEC"],
-                  target: "both",
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext(approvalContextOptions("u123owner", "U999EXEC"));
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     const handler = getHandler();
@@ -1907,24 +1911,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("routes opaque legacy ids through the authorized plugin adapter", async () => {
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            accounts: {
-              default: {
-                allowFrom: ["u123owner"],
-                execApprovals: {
-                  enabled: true,
-                  approvers: ["U999EXEC"],
-                  target: "both",
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext(approvalContextOptions("u123owner", "U999EXEC"));
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     const handler = getHandler();
@@ -1982,24 +1969,9 @@ describe("registerSlackInteractionEvents", () => {
         applied: true,
         approval: { status: "allowed", decision: "allow-once" },
       });
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            accounts: {
-              default: {
-                allowFrom: ["U123OWNER"],
-                execApprovals: {
-                  enabled: true,
-                  approvers: ["U123OWNER"],
-                  target: "both",
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext(
+      approvalContextOptions("U123OWNER", "U123OWNER"),
+    );
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     await getHandler()({
@@ -2049,24 +2021,7 @@ describe("registerSlackInteractionEvents", () => {
   });
 
   it("does not treat a plugin-looking legacy id as an owner signal", async () => {
-    const { ctx, app, getHandler } = createContext({
-      cfg: {
-        channels: {
-          slack: {
-            accounts: {
-              default: {
-                allowFrom: ["U123OWNER"],
-                execApprovals: {
-                  enabled: true,
-                  approvers: ["U999EXEC"],
-                  target: "both",
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const { ctx, app, getHandler } = createContext(approvalContextOptions("U123OWNER", "U999EXEC"));
     registerSlackInteractionEvents({ ctx: ctx as never });
 
     const handler = getHandler();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four Slack interaction tests repeat the same account-scoped approval configuration, obscuring which plugin and exec approvers each scenario uses.

## Why This Change Was Made

Share the input structure through a small local fixture with two required approver arguments. Each call creates fresh objects and arrays; all four typed and legacy approval cases keep their explicit inputs, independent assertions, and callback ordering.

## User Impact

No user-visible behavior changes. This removes 45 net test lines without changing production code.

## Evidence

All 92 existing cases passed before and after across the interaction, approval-auth, and exec-approvals suites, with identical case names, order, and statuses. Expanding the four fixture calls recovers the original file exactly; the graph check confirms fresh nested objects and arrays. Changed-file checks and independent review passed.
