### PR TITLE
refactor(ui): share realtime Talk response types

### DIFF
--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -8,6 +8,7 @@ import {
   shouldAutoControlRealtimeVoiceAgentText,
 } from "../../../../src/talk/agent-run-control-shared.js";
 import type { RealtimeVoiceAgentControlMode } from "../../../../src/talk/agent-run-control-shared.js";
+import type { RealtimeVoiceBrowserSession } from "../../../../src/talk/provider-types.js";
 import type { TalkEvent } from "../../../../src/talk/talk-events.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 // Control UI chat module implements realtime talk shared behavior.
@@ -57,75 +58,26 @@ export type RealtimeTalkEventInput<TPayload = unknown> = {
   parentId?: string;
 };
 
-type RealtimeTalkAudioContract = {
-  inputEncoding: "pcm16" | "g711_ulaw";
-  inputSampleRateHz: number;
-  outputEncoding: "pcm16" | "g711_ulaw";
-  outputSampleRateHz: number;
-};
-
-export type RealtimeTalkWebRtcSdpSessionResult = {
-  provider: string;
-  transport: "webrtc";
+export type RealtimeTalkSessionResult = RealtimeVoiceBrowserSession & {
   voiceSessionId?: string;
-  clientSecret: string;
-  offerUrl?: string;
-  offerHeaders?: Record<string, string>;
-  offerResponseMaxBytes?: number;
-  model?: string;
-  voice?: string;
-  expiresAt?: number;
   consultThinkingLevel?: string;
   consultFastMode?: boolean;
 };
 
-export type RealtimeTalkJsonPcmWebSocketSessionResult = {
-  provider: string;
-  transport: "provider-websocket";
-  voiceSessionId?: string;
-  protocol: string;
-  clientSecret: string;
-  websocketUrl: string;
-  audio: RealtimeTalkAudioContract;
-  initialMessage?: unknown;
-  model?: string;
-  voice?: string;
-  expiresAt?: number;
-  consultThinkingLevel?: string;
-  consultFastMode?: boolean;
-};
+export type RealtimeTalkWebRtcSdpSessionResult = Extract<
+  RealtimeTalkSessionResult,
+  { transport: "webrtc" }
+>;
 
-export type RealtimeTalkGatewayRelaySessionResult = {
-  provider: string;
-  transport: "gateway-relay";
-  voiceSessionId?: string;
-  relaySessionId: string;
-  audio: RealtimeTalkAudioContract;
-  model?: string;
-  voice?: string;
-  expiresAt?: number;
-  consultThinkingLevel?: string;
-  consultFastMode?: boolean;
-};
+export type RealtimeTalkJsonPcmWebSocketSessionResult = Extract<
+  RealtimeTalkSessionResult,
+  { transport: "provider-websocket" }
+>;
 
-type RealtimeTalkManagedRoomSessionResult = {
-  provider: string;
-  transport: "managed-room";
-  voiceSessionId?: string;
-  roomUrl: string;
-  token?: string;
-  model?: string;
-  voice?: string;
-  expiresAt?: number;
-  consultThinkingLevel?: string;
-  consultFastMode?: boolean;
-};
-
-export type RealtimeTalkSessionResult =
-  | RealtimeTalkWebRtcSdpSessionResult
-  | RealtimeTalkJsonPcmWebSocketSessionResult
-  | RealtimeTalkGatewayRelaySessionResult
-  | RealtimeTalkManagedRoomSessionResult;
+export type RealtimeTalkGatewayRelaySessionResult = Extract<
+  RealtimeTalkSessionResult,
+  { transport: "gateway-relay" }
+>;
 
 export type RealtimeTalkTransportStartResult = "ready" | "cancelled";
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI copied the realtime Talk browser-session response shapes already owned by the Talk provider contract. Maintaining both copies makes transport fields and limits easier to drift even when the runtime flow is unchanged. This is a maintainer-requested owner-boundary cleanup.

## Why This Change Was Made

Derive the UI session union and its existing transport-specific aliases from `RealtimeVoiceBrowserSession`, adding only the three existing optional UI metadata fields. Keep all four transport discriminants, optional and mutable fields, numeric sample-rate behavior, browser audio encodings, `offerResponseMaxBytes`, and the unknown initial message intact.

Only TypeScript declarations and a type-only import change. No runtime expression, request, provider implementation, public protocol, configuration, dependency, or storage contract changes. Production LOC: **+14/-62, net 48 removed**. Tests are unchanged.

## User Impact

No visible or runtime behavior change is intended. Talk transport setup continues to use the same emitted JavaScript, while response fields now have one type owner.

## Evidence

- Original and candidate unfiltered native UI typechecks passed. The same two existing test files passed all 10 cases on both sides.
- A separate compiler-only comparison ran 22 programs across both `exactOptionalPropertyTypes` modes: all 13 exported types and seven values, generic default and five instantiations, four transport branches, and nine intentional controls. Controls detected required-field, capability, transport, encoding, number-domain, readonly and explicit-undefined differences.
- That diagnostic graph retained the same pre-existing imported-source diagnostics: 1 with EOPT disabled and 16,623 with it enabled. It is **not** a whole-program-green claim. The contract witnesses and actual native UI typecheck are separate evidence.
- The complete emitted module was byte-identical at 16,065 bytes. A deliberate value mutation changed its bytes, demonstrating that the comparison was active. The compiler comparison did not execute the application or write product source; all actual physical compiler reads were hashed before decoding the same buffers and rechecked afterward.
- The normal configured changed gate completed successfully on the exact saved tree `642251eb4b4971af4d72fd4bfcb25d1e801a9b81`, base `3e6b53c492d9bd6019983efea1c890b35a930146`, on Linux Node 24.19.0 / pnpm 12.3.4. [Testbox carrier 34480263452](https://github.com/openclaw/openclaw/actions/runs/34480263452): wrapper exit 0, 25m15s command, including core-test/UI types, all three unused-export scans and lint. The owned lease completed, temporary checkout was removed and matching local processes were absent. The later external portal-sync warning remains recorded.
- Two earlier gate attempts remain failures: R1 exited 255 during core-test typechecking without an identified cause; R2 failed a provider status request before the client observed readiness or a remote gate phase. The successful R3 was a complete unchanged run, with no provider, heap, worker, deadline, assertion or source override and no partial-pass stitching.
- Managed precommit review and a separate fresh review of exact signed commit `2ece97603ec8b1562b25a740a8db4803630ad2e4` both passed through P2 with no findings. The saved commit has exactly the gate-tested tree above. Exact-head hosted CI and normal native preparation remain required before landing.

No live provider session was executed for this type-only change; actual emitted runtime bytes are unchanged. The local proof and full changed gate apply to the recorded base/tree, not to an unexecuted moving-main tree.
