### PR TITLE
fix(auto-reply): suppress a text-only final already delivered as a caption (#144006)

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1473,6 +1473,63 @@ describe("buildReplyPayloads media filter integration", () => {
     }
   });
 
+  // Issue #144006: a block that carries explicit-TTS audio delivers its text as
+  // the channel caption. The later text-only final repeats that exact text, so a
+  // media-less final must consult the same recorded sent-text evidence as a
+  // media-bearing one.
+  it.each<DirectBlockDedupeCase>([
+    {
+      name: "suppresses a text-only final already delivered as a captioned voice block",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer." }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+    },
+    {
+      name: "suppresses a text-only final already delivered as a captioned voice block while streaming",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer." }],
+      params: { blockStreamingEnabled: true, blockReplyPipeline: null, replyToMode: "off" },
+    },
+    {
+      name: "keeps a text-only final whose text was never delivered",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Supplementary closing line." }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+      expected: { text: "Supplementary closing line." },
+    },
+    {
+      name: "keeps an error final whose text matches a delivered voice block",
+      keyPayloads: [{ text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true }],
+      directlySentBlockPayloads: [
+        { text: "Spoken answer.", mediaUrl: "/tmp/voice.ogg", audioAsVoice: true },
+      ],
+      payloads: [{ text: "Spoken answer.", isError: true }],
+      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
+      expected: { text: "Spoken answer.", isError: true },
+    },
+  ])("$name", async ({ keyPayloads, payloads, directlySentBlockPayloads, params, expected }) => {
+    const { replyPayloads } = await buildTestReplyPayloads({
+      directlySentBlockKeys: new Set(keyPayloads.map(createBlockReplyContentKey)),
+      ...(directlySentBlockPayloads ? { directlySentBlockPayloads } : {}),
+      payloads,
+      ...params,
+    });
+
+    expect(replyPayloads).toHaveLength(expected ? 1 : 0);
+    if (expected) {
+      expectFields(replyPayloads[0], expected);
+    }
+  });
+
   it("preserves final text when internal whitespace changed", async () => {
     const directlySentBlockPayloads = [
       setReplyPayloadMetadata({ text: "constx=1" }, { assistantMessageIndex: 1 }),

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -15,6 +15,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  isReplyPayloadTerminalContent,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -373,9 +374,12 @@ export async function buildReplyPayloads(params: {
         { ...payload, text: undefined, mediaUrl: undefined, mediaUrls: undefined },
         { trimText: true },
       );
+      // A media-bearing block delivers its text as the channel caption, so the
+      // same recorded sent-text evidence covers a matching text-only final.
       const wasSent = hasRichContent
         ? params.blockReplyPipeline?.hasSentExactPayload?.(payload)
-        : params.blockReplyPipeline?.hasSentPayload(payload);
+        : params.blockReplyPipeline?.hasSentPayload(payload) ||
+          (isReplyPayloadTerminalContent(payload) && hasDirectlySentText(payload));
       if (wasSent) {
         return null;
       }
@@ -404,7 +408,7 @@ export async function buildReplyPayloads(params: {
   };
   const preserveDirectlyUnsentPayload = (payload: ReplyPayload): ReplyPayload | null => {
     const reply = resolveSendableOutboundReplyParts(payload);
-    if (!reply.hasMedia || !reply.trimmedText) {
+    if (reply.hasMedia && !reply.trimmedText) {
       return payload;
     }
     return preserveUnsentMediaAfterBlockSend(payload);


### PR DESCRIPTION
Closes #144006.

## What Problem This Solves

With an explicit `tts` tool call on Telegram (`tts.auto: off`), the reporter sees the reply text twice: once as the voice note's caption and once as a standalone `sendMessage`.

An explicit `tts` tool result queues audio media (`src/agents/tools/tts-tool.ts:80-94` → `queuePendingToolMedia`, `src/agents/embedded-agent-subscribe.handlers.tools.results.ts:436-475`). The next non-reasoning assistant reply absorbs that media (`consumePendingToolMediaIntoReply`, `src/agents/embedded-agent-subscribe.handlers.messages.replies.ts:89-147`), so the block that goes to the channel carries **text + audio**, and a channel that renders media text as a caption (Telegram sets `captionedFinalText: true`, `extensions/telegram/src/setup-plugin.ts:40-42`) delivers that reply text once as the caption.

The same turn later produces a text-only final payload. `buildReplyPayloads` (`src/auto-reply/reply/agent-runner-payloads.ts`) is supposed to drop finals whose content a block already delivered, but only **media-bearing** finals consulted the recorded direct-send evidence:

- `preserveUnsentMediaAfterBlockSend` handled media-less payloads with `blockReplyPipeline.hasSentPayload` only, never `hasDirectlySentText`.
- `preserveDirectlyUnsentPayload` returned media-less payloads untouched (`if (!reply.hasMedia || !reply.trimmedText) return payload`), so the branches that drop already-sent payloads never reached the text comparison.

Because `createBlockReplyContentKey` includes the media list, a text-only final can never match the content key of the media-bearing block, so the exact-key path cannot cover it either. The result is the reported second bubble.

The fix makes media-less finals consult the same recorded delivery evidence as media-bearing ones, gated on terminal content so reasoning, commentary, status, error and fallback payloads keep their existing behavior. Text that was never delivered still ships; the audio is untouched.

## Evidence

`src/auto-reply/reply/agent-runner-payloads.test.ts` gains a table modelled on the reported shape: a block that delivered `Spoken answer.` as a captioned voice block, followed by a text-only final with identical text.

Failing first (before the fix), same file:

```
FAIL  src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > suppresses a text-only final already delivered as a captioned voice block
FAIL  src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > suppresses a text-only final already delivered as a captioned voice block while streaming
AssertionError: expected [ { text: 'Spoken answer.', …(6) } ] to have a length of +0 but got 1
 Tests  2 failed | 89 passed (91)
```

Passing after the fix, same file:

```
Test Files  1 passed (1)
      Tests  91 passed (91)
```

Command used for both runs:

```
PATH=/opt/homebrew/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner-payloads.test.ts
```

The same table keeps a final whose text was never delivered and keeps an error final. Neighbouring dedupe and pipeline suites stay green (`reply-delivery`, `reply-payloads-transport-dedupe`, `block-reply-pipeline`: 69 passed), and the whole `src/auto-reply/reply` project ran at `5651 passed, 1 failed` where the single failure is `stage-sandbox-media.scp.test.ts` timing out at 120s — that test spawns a real `scp` process tree, never imports this module, and is unrelated to this change.

`node_modules/.bin/oxlint` on both changed files reports nothing.

## Not Verified

Which runtime entry produced the reporter's turn (streaming on/off, whether the captioning block came through the block pipeline or a direct send) is **not** confirmed by a live Telegram reproduction — that needs Telegram credentials and is out of scope here. The fix closes the shared defect that lets already-delivered caption text be sent again as a text-only final; the dedupe branch it exercises is exactly the one that let a media-less final survive.
