### PR TITLE
fix(state): report ownership inspection snapshot cleanup failures

### DIFF
--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -170,11 +170,27 @@ function inspectJournalAwarePublicOwnership(
   databasePath: string,
 ): OpenClawExternalStateOwnership | null {
   const prepared = prepareSqliteReadOnlyLocationSync(databasePath);
+  let outcome: { value: OpenClawExternalStateOwnership | null } | { cause: unknown };
   try {
-    return inspectOwnershipThroughConnection(prepared.location, databasePath);
-  } finally {
-    prepared.cleanup();
+    outcome = { value: inspectOwnershipThroughConnection(prepared.location, databasePath) };
+  } catch (cause) {
+    outcome = { cause };
   }
+  if (!prepared.cleanup()) {
+    // The exit retry is best-effort, not proof that this private copy was removed.
+    const readFailure =
+      "cause" in outcome
+        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+        : "";
+    throw new Error(
+      `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+      "cause" in outcome ? outcome : undefined,
+    );
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }
 
 function inspectOwnershipWhileCoordinatorHeld(databasePath: string, busyTimeoutMs: number) {


### PR DESCRIPTION
## What Problem This Solves

When inspecting state database ownership, the code creates a temporary SQLite snapshot but does not verify whether it was cleaned up afterward. If cleanup fails (disk full, permission denied, or file handle contention), the failure is silently swallowed and the temporary copy accumulates without any diagnostic signal. This fix checks the cleanup return value and throws a diagnostic error on failure, matching the pattern established in #143844.

- Problem: `inspectJournalAwarePublicOwnership` calls `prepared.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails, `cleanup()` returns `false` but the caller ignores it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Capture the read outcome first (value or caught cause), then check `prepared.cleanup()` and throw a diagnostic `Error` with the staging directory path and actionable guidance if cleanup fails.
- What changed: `src/state/openclaw-state-ownership.ts` — replaced `finally { prepared.cleanup(); }` with an outcome-capture + cleanup-check pattern in `inspectJournalAwarePublicOwnership`.
- What did NOT change: The sibling function `inspectOwnershipWhileCoordinatorHeld` already has `requireCleanup=true` via its `signal` parameter and was not modified. The read logic and ownership parsing are unchanged.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`. The sync path `inspectJournalAwarePublicOwnership` uses `prepareSqliteReadOnlyLocationSync` (no signal, `requireCleanup=false`), while the async sibling `inspectOwnershipWhileCoordinatorHeld` passes `options.signal` which sets `requireCleanup=true` and already throws on cleanup failure. Only the sync path was missing the check.

- Best fix: Yes — minimal, directly aligned with the #143844 pattern.
- Risk: Low. Normal-path behavior is unchanged. The only new behavior is an error thrown when cleanup fails, which was previously silent.

## User Impact

Operators will now see a clear diagnostic error when temporary snapshot cleanup fails during state ownership inspection, instead of silent temporary file accumulation.

## Evidence

Live command verification using `node --import tsx` with a real SQLite state database fixture:

```console
$ node /home/code/github/contributions/BUG/BUG-071-evidence/proof.mjs

=== Test 1: cleanup failure ===
{
  "ok": false,
  "message": "State database snapshot cleanup failed: /tmp/bug071-wlagmQ/cache-cleanup-fail/openclaw-1000/openclaw-sqlite-readonly-3987326-OITkQ3/openclaw-sqlite-readonly-3987356-tiiuIj. Check directory permissions and available storage before retrying.",
  "cause": null
}
✅ PASS

=== Test 2: normal path ===
{
  "ok": true,
  "ownership": { "version": 1, "mode": "external", "managerId": "test-manager", "claimedAt": 1234567890 }
}
✅ PASS

=== All tests passed ===
```

What was not tested: Multi-process handle contention on Windows was not tested. Cleanup failure was simulated via `fs.rmSync` fault injection.

Open PR collision check: no open PR touched `openclaw-state-ownership.ts`. Last commit was #142522 (unrelated).

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6-terra)
- Prompts / session excerpts: local-code-analysis fix workflow — fix pattern derived from #143844
- Confirmed understanding of code changes: Yes — can explain every line
- autoreview: N/A (worktree environment; oxlint + oxfmt passed)
