### PR TITLE
fix(xai): stop OAuth refresh loops caused by a stale token expiry

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -5,7 +5,7 @@ import {
   createRuntimeEnv,
   createTestWizardPrompter,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
+import { hasUsableOAuthCredential, type OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { withProxyFixture } from "openclaw/plugin-sdk/test-env";
 import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
@@ -557,45 +557,108 @@ describe("xAI OAuth", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("does not coerce partial xAI expires_in values", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
-      jsonResponse({
-        access_token: "access-2",
-        expires_in: "120s",
-      }),
-    );
-    const credential = createXaiOAuthCredential();
-
-    const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
-
-    expect(refreshed.expires).toBe(100);
-  });
-
-  it("preserves the cached xAI expiry when token lifetimes overflow safe milliseconds", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
-      jsonResponse({
+  it.each([
+    {
+      label: "does not coerce partial xAI expires_in values",
+      body: { access_token: "access-2", expires_in: "120s" },
+    },
+    {
+      label: "rejects xAI token lifetimes that overflow safe milliseconds",
+      body: {
         access_token: createJwt({ exp: Number.MAX_SAFE_INTEGER }),
         expires_in: Number.MAX_SAFE_INTEGER,
-      }),
-    );
+      },
+    },
+    {
+      label: "rejects unsafe JWT expiry fallbacks from xAI access tokens",
+      body: { access_token: createJwt({ exp: Number.MAX_SAFE_INTEGER }) },
+    },
+    {
+      label: "rejects xAI token responses that omit any expiry",
+      body: { access_token: "access-2" },
+    },
+  ])("$label instead of retaining the previous expiry", async ({ body }) => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse(body));
     const credential = createXaiOAuthCredential();
 
-    const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
-
-    expect(refreshed.expires).toBe(100);
+    await expect(
+      refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 }),
+    ).rejects.toThrow("missing a usable access-token lifetime");
   });
 
-  it("ignores unsafe JWT expiry fallbacks from xAI access tokens", async () => {
+  it("publishes a refreshed xAI credential that is usable at response time", async () => {
+    const now = 1_000;
     const fetchImpl = vi.fn<typeof fetch>(async () =>
-      jsonResponse({
-        access_token: createJwt({ exp: Number.MAX_SAFE_INTEGER }),
-      }),
+      jsonResponse({ access_token: "access-2", expires_in: 3_600 }),
     );
     const credential = createXaiOAuthCredential();
 
-    const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => 1_000 });
+    const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => now });
 
-    expect(refreshed.expires).toBe(100);
+    expect(refreshed.access).toBe("access-2");
+    expect(refreshed.expires).not.toBe(credential.expires);
+    expect(hasUsableOAuthCredential(refreshed, { now })).toBe(true);
+  });
+
+  it("derives the refreshed xAI expiry from the access-token exp claim", async () => {
+    const now = 1_000;
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ access_token: createJwt({ exp: 7_200 }) }),
+    );
+    const credential = createXaiOAuthCredential();
+
+    const refreshed = await refreshXaiOAuthCredential(credential, { fetchImpl, now: () => now });
+
+    expect(refreshed.expires).toBe(7_200_000);
+    expect(hasUsableOAuthCredential(refreshed, { now })).toBe(true);
+  });
+
+  it("rejects a device-code login whose token response has no usable lifetime", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+          device_authorization_endpoint: "https://auth.x.ai/oauth2/device/code",
+          token_endpoint: "https://auth.x.ai/oauth2/token",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          device_code: "device-code-1",
+          user_code: "ABCD-1234",
+          verification_uri: "https://accounts.x.ai/oauth2/device",
+          expires_in: 900,
+          interval: 5,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token",
+          refresh_token: "refresh-1",
+        }),
+      );
+    vi.stubGlobal("fetch", fetchImpl);
+    const ctx: ProviderAuthContext = {
+      config: {},
+      isRemote: false,
+      assertCurrent: vi.fn(),
+      openUrl: vi.fn(async () => {}),
+      prompter: createTestWizardPrompter({
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        deviceCode: vi.fn(async () => {}),
+      }),
+      runtime: { ...createRuntimeEnv(), log: vi.fn() },
+      oauth: {
+        createVpsAwareHandlers: () => {
+          throw new Error("unexpected VPS OAuth handler request");
+        },
+      },
+    } as unknown as ProviderAuthContext;
+
+    await expect(createXaiOAuthAuthMethod().run(ctx)).rejects.toThrow(
+      "missing a usable access-token lifetime",
+    );
   });
 
   it.each(["fresh", "subscription", "api"] as const)(

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -53,7 +53,9 @@ type XaiDeviceCodeDiscovery = {
 type XaiOAuthTokenResponse = {
   accessToken: string;
   refreshToken?: string;
-  expires?: number;
+  // Required: an accepted token response must carry its own Date-safe expiry so a
+  // refreshed access token can never inherit the previous token's lifetime.
+  expires: number;
   idToken?: string;
 };
 
@@ -245,11 +247,16 @@ function parseXaiOAuthTokenResponse(
   // fallback for an access-token expiry — id_token exp reflects the OIDC
   // session, not the access token, and may extend it past actual expiry.
   const expires = normalizeExpires(json.expires_in, now) ?? deriveExpiresFromJwt(accessToken);
+  if (!expires) {
+    throw new Error(
+      "xAI OAuth token response is missing a usable access-token lifetime (no valid expires_in and no safe exp claim on the access token). Re-run the login.",
+    );
+  }
   return {
     accessToken,
     ...(refreshToken ? { refreshToken } : {}),
     ...(idToken ? { idToken } : {}),
-    ...(expires ? { expires } : {}),
+    expires,
   };
 }
 
@@ -694,7 +701,8 @@ export async function refreshXaiOAuthCredential(
     provider: PROVIDER_ID,
     access: tokens.accessToken,
     refresh: tokens.refreshToken ?? refreshToken,
-    ...(tokens.expires ? { expires: tokens.expires } : {}),
+    // Always publish the new token's own expiry; never retain the previous one.
+    expires: tokens.expires,
     ...(tokens.idToken ? { idToken: tokens.idToken } : {}),
     ...(identity.email ? { email: identity.email } : {}),
     ...(identity.displayName ? { displayName: identity.displayName } : {}),


### PR DESCRIPTION
Closes #127372

## What Problem This Solves

Fixes an issue where users signed in to xAI (Grok) through OAuth would refresh their token on every single request, rotating and discarding a refresh token each time, when xAI returned a token response without a usable lifetime.

Refresh built the new credential by spreading the old one and overwriting `expires` only when the response produced a new value. A response carrying a valid `access_token` but a missing, malformed, or out-of-range `expires_in` (and no safe `exp` claim on the access token) therefore published a **new** access token stamped with the **previous** token's expiry.

The device-code login path shares the same parser, so it could also complete "successfully" and store a credential with no expiry at all, which the runtime immediately treats as unusable.

## Why This Change Was Made

The repair is in the producer of the bad credential, `parseXaiOAuthTokenResponse`, rather than in a downstream core guard, so login and refresh get one lifetime policy:

- An accepted token response must yield its own Date-safe expiry, from `expires_in` or, as the existing legitimate fallback, a safe `exp` claim on the access token. When neither is available the response is rejected with an explicit message instead of being accepted.
- `expires` is now a required field on the parsed token response, and refresh publishes it unconditionally. A refreshed access token can no longer inherit the previous token's expiry.

Failing loudly matches how sibling provider plugins already treat this contract (`extensions/chutes/oauth.ts` throws on invalid `expires_in`; `extensions/openai/openai-chatgpt-oauth-token.runtime.ts` reports `expires_in` as a missing field). No conservative default lifetime is invented, since xAI publishes no documented fallback. Non-goals: no change to retry policy, endpoint discovery, refresh-token rotation handling, or the `id_token` identity fields.

## User Impact

xAI OAuth users no longer end up with a stored credential that is expired or near-expired the moment it is written, so the refresh-on-every-request loop and the refresh-token churn behind it are gone. In the rare case where xAI returns a token with no usable lifetime, sign-in or refresh now fails with a message that names the cause and says to re-run the login, instead of silently producing a credential that never works.

## Evidence

### Scope correction, and why the loop does reach persistence on current main

The earlier version of this description claimed the stale credential is persisted, and review pushed back: the shared OAuth manager checks the refreshed credential with `hasUsableOAuthCredential(rotated, { refreshMarginMs: 0 })` at `src/agents/auth-profiles/oauth-manager.ts:1203` before settlement, so an already-expired inherited timestamp is caught there.

That check is real, and it does catch the fully-expired case. It does **not** catch the common one. Refresh normally fires *proactively*, while the credential is still valid but inside the 5 minute `DEFAULT_OAUTH_REFRESH_MARGIN_MS`. In that window the inherited timestamp is still in the future, so a zero-margin check passes and the stale credential settles and persists. The next request is still inside the margin, so it refreshes again.

I verified this end to end rather than by reading, using the **real** `createOAuthManager` settlement and persistence path, the **real** SQLite auth profile store in a temp state dir, the **real** `refreshXaiOAuthCredential`, and a **real** HTTP round trip to a local stand-in for the token endpoint (the plugin's trusted-endpoint check still sees `https://auth.x.ai/oauth2/token`). Seeded credential expires in 60s; the endpoint answers `200` with a rotated `access_token` and `refresh_token` and no `expires_in`; three consecutive `resolveOAuthAccess` calls:

**Before (`origin/main`)** — every request refreshes, every refresh persists the original expiry, every refresh burns a rotation:

```json
[{"attempt":1,"tokenEndpointHits":1,"outcome":"resolved apiKey=access-1","persistedAccess":"access-1","persistedRefresh":"refresh-1","persistedExpiresEqualsOriginal":true},
 {"attempt":2,"tokenEndpointHits":2,"outcome":"resolved apiKey=access-2","persistedAccess":"access-2","persistedRefresh":"refresh-2","persistedExpiresEqualsOriginal":true},
 {"attempt":3,"tokenEndpointHits":3,"outcome":"resolved apiKey=access-3","persistedAccess":"access-3","persistedRefresh":"refresh-3","persistedExpiresEqualsOriginal":true}]
```

**After (this PR)** — one refresh, rejected at the plugin boundary with a message that names the cause; the profile is fenced and no further token traffic is generated:

```json
[{"attempt":1,"tokenEndpointHits":1,"outcome":"threw: OAuth token refresh failed for xai: xAI OAuth token response is missing a usable access-token lifetime (no valid expires…","persistedAccess":"openclaw-oauth-refresh-fence:v1:…:failed:access:…","persistedExpiresEqualsOriginal":false},
 {"attempt":2,"tokenEndpointHits":1,"outcome":"resolved apiKey=none","persistedAccess":"openclaw-oauth-refresh-fence:v1:…:failed:access:…","persistedExpiresEqualsOriginal":false},
 {"attempt":3,"tokenEndpointHits":1,"outcome":"resolved apiKey=none","persistedAccess":"openclaw-oauth-refresh-fence:v1:…:failed:access:…","persistedExpiresEqualsOriginal":false}]
```

### On the merge risk: this reduces refresh-token loss, it does not add it

The flagged risk is that rejecting a successful response discards a rotated refresh token and can force re-authentication. The comparison above is the answer: on `origin/main` this same response **already** rotates and discards a refresh token on *every* request, indefinitely. With this change it happens once, then the profile is fenced and the user is told to sign in again. Same recovery, one burned rotation instead of one per request.

For responses that do carry a usable lifetime, nothing changes. Same harness, same real manager and store, healthy `expires_in: 3600`, three resolves — one refresh, fresh expiry persisted, next two resolves reuse it with no further token traffic:

```json
[{"attempt":1,"tokenEndpointHits":1,"outcome":"resolved apiKey=access-1","persistedAccess":"access-1","persistedExpiresEqualsOriginal":false},
 {"attempt":2,"tokenEndpointHits":1,"outcome":"resolved apiKey=access-1","persistedAccess":"access-1","persistedExpiresEqualsOriginal":false},
 {"attempt":3,"tokenEndpointHits":1,"outcome":"resolved apiKey=access-1","persistedAccess":"access-1","persistedExpiresEqualsOriginal":false}]
```

**Limitation, stated plainly:** I do not have an xAI OAuth account, so none of this is a live `auth.x.ai` observation. The manager, settlement, persistence, plugin parser, and HTTP transport are all real; the token endpoint is a local stand-in returning the response shapes at issue. A maintainer with a live xAI account can confirm the healthy path in one sign-in and one forced refresh.

### The availability tradeoff, stated for the maintainer decision

Review is right that this changes a temporarily usable state into an immediate terminal one, and that is the call to make. Concretely: on `main`, an account that receives one expiry-less successful refresh keeps working while the inherited expiry is still in the future. With this change that refresh fails, which fences the profile and requires signing in again.

I chose to fail closed for three reasons:

1. **The retained expiry is factually wrong.** The stored credential describes a lifetime that belongs to a token that no longer exists, and the runtime budgets refreshes against it.
2. **The "still usable" state is bounded and self-terminating.** It lasts only while the inherited expiry is in the future, and it spends a refresh-token rotation on every request to stay there. Once that timestamp passes, the manager's zero-margin check rejects it and the account is fenced anyway. `main` does not avoid the fence; it defers it and pays rotations until then.
3. **The alternatives are worse here.** Retrying is unsafe on this path by existing design: xAI rotates refresh tokens, and `exchangeXaiOAuthToken` deliberately does not resend one that may already be consumed. Inventing a conservative fallback lifetime has no documented xAI contract to justify it.

**What would change the answer:** if xAI is known to intermittently omit lifetime information on otherwise-valid responses, preserving availability may be worth more than the correct invariant, and this should instead surface a warning while leaving the old credential in place. I can't produce that provider-contract evidence, and I'd rather flag the question than guess at it. Both open merge-risk items come down to this one decision, and I'm happy to rework the change if the call goes the other way.

### Regression coverage

The three tests that encoded the retention behavior are replaced by rejection cases, and new cases cover the omitted-expiry response, publication usability, the JWT `exp` fallback, and device-code login. Against the pre-fix implementation the new assertions fail 5/5; with the fix they pass:

```
$ node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts   # pre-fix source
 Tests  5 failed | 32 passed (37)
   AssertionError: promise resolved "{ type: 'oauth', provider: 'xai', …(5) }" instead of rejecting

$ node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts   # with this change
 Tests  37 passed (37)
```

### Suite runs

On Node 24.21.0:

```
$ pnpm test:extension xai
 Test Files  37 passed (37)
      Tests  619 passed (619)

$ pnpm test:contracts:plugins
 Test Files  47 passed (47)
      Tests  1117 passed (1117)

$ pnpm check:changed
 (passed: format, lint, typecheck, deadcode, boundary, import-cycle guards)
```
