### PR TITLE
docs(cli,channels): fix five concrete defects from the ux audit

### DIFF
--- a/docs/channels/access-groups.md
+++ b/docs/channels/access-groups.md
@@ -198,5 +198,6 @@ Run `openclaw doctor` after editing access-control config. It catches many inval
 
 ## Related
 
+- [Groups](/channels/groups) — group chat behavior and mention gating
 - [Pairing](/channels/pairing) — the separate DM pairing flow for channel senders
 - [Channels overview](/channels) — the channels these groups apply to

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -14,18 +14,18 @@ Reef is a guarded, end-to-end-encrypted side channel between OpenClaw agents own
 
 2. Run the channel wizard and choose **Reef**:
 
-```bash
-openclaw channels add
-```
+   ```bash
+   openclaw channels add
+   ```
 
-The wizard asks for the relay URL (default `https://reefwire.ai`), your email, the setup session, a unique unlisted handle, an inbound friend-request policy (`code-only` is recommended), and the guard model configuration.
+   The wizard asks for the relay URL (default `https://reefwire.ai`), your email, the setup session, a unique unlisted handle, an inbound friend-request policy (`code-only` is recommended), and the guard model configuration.
 
 3. Restart the Gateway and confirm the channel connects:
 
-```bash
-openclaw gateway restart
-openclaw channels status
-```
+   ```bash
+   openclaw gateway restart
+   openclaw channels status
+   ```
 
 Record the safety fingerprint the wizard prints. Friends compare it out of band before approving a pairing.
 

--- a/docs/cli/doctor/sqlite-maintenance.md
+++ b/docs/cli/doctor/sqlite-maintenance.md
@@ -66,8 +66,10 @@ CLI startup do not import, restore, or rewrite legacy session JSON/JSONL files.
 When startup finds a legacy session store, it refuses readiness and prints a
 `doctor --fix` command for the active profile instead of serving empty history.
 
-To upgrade history from an older file-backed installation, stop the Gateway,
-back up its state, and run `openclaw doctor --fix` before restarting it.
+To upgrade history from an older file-backed installation, stop the Gateway
+(`openclaw gateway stop`), back up its state (`openclaw backup create --verify`),
+and run `openclaw doctor --fix` before restarting it with
+`openclaw gateway start`.
 `openclaw doctor --session-sqlite <mode>` provides targeted inspection,
 import, validation, and SQLite maintenance. Legacy `sessions.json` files are
 migration sources. Hot transcript JSONL files are imported and archived after

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -366,15 +366,15 @@ openclaw memory promote [--agent <id>] [--limit <n>] [--min-score <n>] \
   [--min-recall-count <n>] [--min-unique-queries <n>] [--apply] [--include-promoted] [--json]
 ```
 
-| Flag                       | Default      | Effect                                                            |
-| -------------------------- | ------------ | ----------------------------------------------------------------- |
-| `--limit <n>`              |              | Max candidates to return/apply.                                   |
-| `--min-score <n>`          | `0.75`       | Minimum weighted promotion score.                                 |
-| `--min-recall-count <n>`   | `3`          | Minimum recall count required.                                    |
-| `--min-unique-queries <n>` | `3`          | Minimum distinct query count required.                            |
-| `--apply`                  | preview only | Append selected candidates to `MEMORY.md` and mark them promoted. |
-| `--include-promoted`       |              | Include candidates already promoted in previous cycles.           |
-| `--json`                   |              | Print JSON.                                                       |
+| Flag                       | Default        | Effect                                                            |
+| -------------------------- | -------------- | ----------------------------------------------------------------- |
+| `--limit <n>`              | all candidates | Max candidates to return/apply.                                   |
+| `--min-score <n>`          | `0.75`         | Minimum weighted promotion score.                                 |
+| `--min-recall-count <n>`   | `3`            | Minimum recall count required.                                    |
+| `--min-unique-queries <n>` | `3`            | Minimum distinct query count required.                            |
+| `--apply`                  | preview only   | Append selected candidates to `MEMORY.md` and mark them promoted. |
+| `--include-promoted`       | off            | Include candidates already promoted in previous cycles.           |
+| `--json`                   | off            | Print JSON.                                                       |
 
 The CLI and scheduled dreaming sweep share the deep-phase defaults below.
 Explicit CLI flags override them for a one-off manual run.
@@ -452,14 +452,14 @@ openclaw memory session-backfill --agent <id> --rollback [--json]
 
 | Flag                        | Default      | Effect                                                                                                        |
 | --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------- |
-| `--from YYYY-MM-DD`         |              | Include messages on or after this day in the dreaming timezone.                                               |
-| `--to YYYY-MM-DD`           |              | Include messages on or before this day in the dreaming timezone.                                              |
+| `--from YYYY-MM-DD`         | none         | Include messages on or after this day in the dreaming timezone.                                               |
+| `--to YYYY-MM-DD`           | none         | Include messages on or before this day in the dreaming timezone.                                              |
 | `--limit-days <n>`          | `92`         | Process at most this many hash-untracked days, oldest first.                                                  |
-| `--archive-files <path...>` |              | Also inspect foreign transcript files as untrusted input; embedded owner metadata is not accepted.            |
-| `--rem`                     |              | Write deterministic grounded per-day previews to `DREAMS.md` and retain their source-origin records.          |
+| `--archive-files <path...>` | none         | Also inspect foreign transcript files as untrusted input; embedded owner metadata is not accepted.            |
+| `--rem`                     | off          | Write deterministic grounded per-day previews to `DREAMS.md` and retain their source-origin records.          |
 | `--apply`                   | preview only | Drain all bounded batches, stage trusted candidates, and write reversible `DREAMS.md` diary blocks.           |
-| `--rollback`                |              | Remove all grounded backfill candidates and shared backfill diary blocks, including `rem-backfill` artifacts. |
-| `--json`                    |              | Print machine-readable per-day counts and top candidates.                                                     |
+| `--rollback`                | off          | Remove all grounded backfill candidates and shared backfill diary blocks, including `rem-backfill` artifacts. |
+| `--json`                    | off          | Print machine-readable per-day counts and top candidates.                                                     |
 
 The command reads the selected agent's canonical session store, including
 retained SQLite transcript identities from session rotation. It uses the same

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -75,9 +75,10 @@ Use `openclaw skills check --agent <id>` to inspect the missing requirements.
   backend, or an ACP backend such as `codex (acp/acpx)`. See
   [Agent runtimes](/concepts/agent-runtimes) for the provider/model/runtime
   distinction.
-- When the current session snapshot is sparse, `/status` can backfill token
-  and cache counters from the most recent transcript usage log. Existing
-  nonzero live values still win over transcript fallback values.
+- When the current session snapshot is sparse, the `/status` chat command (see
+  [Slash commands](/tools/slash-commands)) can backfill token and cache counters
+  from the most recent transcript usage log. Existing nonzero live values still
+  win over transcript fallback values.
 - Transcript fallback can also recover the active runtime model label when
   the live session entry is missing it. If that transcript model differs
   from the selected model, status resolves the context window against the


### PR DESCRIPTION
Works 162 `ux` audit rows across `docs/cli/**` and `docs/channels/**`. Five defects fixed; the rest are refuted or deferred, enumerated by id below so the ledger can close them.

## Fixed

| id | file | defect |
|---|---|---|
| r3-1093 | `docs/channels/reef.md:17` | Unindented fences ended the quick-start ordered list after item 2, so steps 3+ rendered as a separate list. Indented to 3 spaces, matching `googlechat.md`, `imessage-from-bluebubbles.md`, `matrix-migration.md` and `nextcloud-talk.md`. |
| r3-1150 | `docs/cli/doctor/sqlite-maintenance.md:69` | "Stop the Gateway, back up its state" named two steps with no commands. Both are named on the same page at L31-34; now used here. |
| r3-1293 | `docs/cli/status.md:78` | A bare `/status` inside a CLI reference, with nothing saying it is a chat command. Now labelled and linked to `/tools/slash-commands`, where it is documented at L288. |
| r3-1125 | `docs/channels/access-groups.md:201` | Half-satisfied — Related listed `/channels/pairing` but not `/channels/groups`. Added. |
| — | `docs/cli/memory.md` | Not in the ledger: nine empty `Default` cells across the `memory promote` and `memory session-backfill` tables. Filled from `extensions/memory-core/src/cli.ts:281-302,354-374` and `cli-index-search.runtime.ts:439-442` (an unset `--limit` sets `outputLimit = candidates.length`, hence "all candidates"). `none`/`off` follow the existing convention in `docs/cli/` default columns. |

## Already satisfied on `main` (14)

r3-1046, r3-1081, r3-1083, r3-1089, r3-1102, r3-1103, r3-1111, r3-1121, r3-1131, r3-1141, r3-1258, r3-1277, r5-0009, r5-0086.

Worth noting r5-0009: the canonical "impossible sequence" — a page minting a token in step 2 and reading an unset `$USER_ACCESS_TOKEN` in steps 3-5 — has carried `export USER_ACCESS_TOKEN=…` since #144018/#143770.

## Refuted with evidence (9)

- **r3-1044, r3-1109** — both fixes say "replace the table with a definition list". Markdown definition lists are the construct this docs host does not render; applying either would *introduce* a rendering defect.
- **r3-1126** — asks to unify `plugins install --link <path>` with the sibling pages' bare path. They are different operations: `manage-plugins.md:188-190` says `--link` "creates a managed install record… It is not the same as adding a bare `plugins.load.paths` entry". Unifying would erase a real distinction.
- **r3-1264** — "link to its page": there is no Paperclip page in this repository, and no definition in `src/` or `extensions/` beyond SF-symbol icon names and test fixtures. The fix would mean inventing one.
- **r3-1140** — `wecom.md:27-31` delegates config to the external plugin deliberately, because it "can change independently of OpenClaw". Inlining duplicates an independently-versioned contract.
- **r3-1119** — settled class: `config/markdownlint-cli2.jsonc` sets `MD025: false`.
- **r3-1116, r3-1173** — the qualifier and the relationship the fixes ask for are already present, at `ambient-room-events.md:204` and `memory.md:379-380`.
- **r3-1112** — removing the QA-lane sentence is editorial content removal, not a defect repair.

## Refuted as a class (119)

Classes this program does not do, with full id lists so each row can close:

| class | n | ids |
|---|---|---|
| Add an intro/audience sentence | 11 | r3-1027 r3-1037 r3-1038 r3-1051 r3-1061 r3-1064 r3-1118 r3-1123 r3-1138 r3-1223 r3-1231 |
| Table ⇄ list reshaping | 9 | r3-1028 r3-1032 r3-1072 r3-1107 r3-1166 r3-1194 r3-1233 r3-1242 r3-1299 |
| Split a paragraph | 13 | r3-1058 r3-1063 r3-1075 r3-1100 r3-1114 r3-1128 r3-1132 r3-1171 r3-1181 r3-1226 r3-1252 r3-1283 r3-1287 |
| Add a section index | 4 | r3-1179 r3-1185 r3-1190 r3-1267 |
| Reorder sections | 7 | r3-1071 r3-1086 r3-1197 r3-1219 r3-1229 r3-1256 r3-1273 |
| De-duplicate content (IA move; changes anchors) | 42 | r3-1035 r3-1036 r3-1040 r3-1041 r3-1049 r3-1050 r3-1055 r3-1060 r3-1066 r3-1074 r3-1078 r3-1080 r3-1085 r3-1088 r3-1105 r3-1108 r3-1113 r3-1117 r3-1122 r3-1154 r3-1162 r3-1169 r3-1176 r3-1196 r3-1202 r3-1206 r3-1210 r3-1216 r3-1228 r3-1230 r3-1235 r3-1241 r3-1244 r3-1251 r3-1259 r3-1278 r3-1285 r3-1291 r3-1320 r3-1323 r3-1327 r3-1329 |
| Split page / move content elsewhere | 18 | r3-1092 r3-1095 r3-1099 r3-1101 r3-1110 r3-1170 r3-1180 r3-1186 r3-1191 r3-1195 r3-1204 r3-1207 r3-1214 r3-1263 r3-1266 r3-1270 r3-1289 r3-1301 |
| Add, remove or rename a heading | 6 | r3-1097 r3-1106 r3-1225 r3-1238 r3-1286 r3-1302 |
| Promote content out of an Accordion | 5 | r3-1159 r3-1164 r3-1182 r5-0085 r5-0253 |
| Add a Related section (needs a new heading) | 4 | r3-1091 r3-1129 r3-1133 r3-1135 |

**Two of those classes deserve a second look, and I would rather flag them than quietly bury them.** `reef.md`, `raft.md` and `matrix-presentation.md` genuinely have no Related section, and `matrix-presentation.md` is reachable only from `docs.json` — a true orphan. Adding `## Related` to a page that has none moves no existing anchor, so it is arguably safe; it was excluded here only because the batch instruction forbade adding headings outright. Say the word and it is a small follow-up.

## Deferred (16)

r3-1059, r3-1077, r3-1104, r3-1115, r3-1127, r3-1184, r3-1188, r3-1193, r3-1198, r3-1220, r3-1240, r3-1243, r3-1245, r3-1250, r3-1253, r3-1306 — all ask to add a release number to time-relative wording. That is the version-scoping workstream #144032 runs, where per-row tag archaeology has already shipped one wrong version and been corrected twice. The cited text was confirmed still present for each, so none is a phantom row. `r3-1250` is on a secops-owned page.

## Ownership

Last-match-wins simulation over all 73 rules, with controls in the same pass. Positive: `/SECURITY.md`, `/docs/gateway/authentication.md`, `/docs/reference/secretref-credential-surface.md` → `@openclaw/openclaw-secops`; `/.github/CODEOWNERS` → `@steipete`. Negative: `docs/gateway/authentication-notes.md` (adjacent to a file-exact rule, proving no prefix over-sweep), `docs/channels/tlon.md`, `docs/cli/wiki.md` → unowned.

**All five changed files are unowned.** Rows I refuted or deferred do sit on four secops-owned pages (`cli/approvals.md`, `cli/sandbox.md`, `cli/security.md`, `cli/secrets.md`); acting on any would have put an ownership gate on this PR.

## Validators

`pnpm check:docs` exit 0 · `pnpm format:check` exit 0 (36360 files) · `docs-link-audit --anchors`: 13504 internal links, 3 broken — all `#windows-app-node` on `docs/maturity/*`, which this diff does not touch · `pnpm channels:catalog:check` exit 0 (no frontmatter `summary` touched, so the generated block in `docs/channels/index.md` is unaffected).

No heading text changed; no anchors moved. No `docs.json` or glossary change — the one link added mid-sentence is invisible to `LIST_ITEM_LINK_RE` in `check-docs-i18n-glossary.mts:12`, which matches only a link immediately following a bullet marker.
