### PR TITLE
docs(tools): fill three gaps found in the ux audit

### DIFF
--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -313,7 +313,8 @@ Restart the gateway after changing this value.
 ACP sessions run without an interactive TTY for file-write and shell-exec
 permission prompts. This does not disable ACP form or URL elicitation during a
 channel-delivered turn: those requests use transient Gateway questions instead.
-The acpx plugin provides two config keys that control harness permissions:
+The acpx plugin provides two config keys that control harness permissions,
+`permissionMode` and `nonInteractivePermissions`, documented below.
 
 These ACPX harness permissions are separate from OpenClaw exec approvals and separate from CLI-backend vendor bypass flags such as Claude CLI `--permission-mode bypassPermissions`. ACPX `approve-all` is the harness-level break-glass switch for ACP sessions.
 

--- a/docs/tools/browser/remote.md
+++ b/docs/tools/browser/remote.md
@@ -13,7 +13,7 @@ read_when:
   Targetless actions can launch it (for example, `open`, `navigate`, or `openclaw browser start`). Actions that name a
   tab by `targetId`, tab id, or label never start a stopped browser, because a new browser cannot
   contain that tab; start the browser or open a new tab, then select a current target.
-- **Remote control (node host):** run a node host on the machine that has the browser; the Gateway proxies browser actions to it.
+- **Remote control (node host):** run a node host on the machine that has the browser; the Gateway proxies browser actions to it. Set the node host up first — see [Nodes](/nodes).
 - **Remote CDP:** set `browser.profiles.<name>.cdpUrl` (or `browser.cdpUrl`) to
   attach to a remote Chromium-based browser. In this case, OpenClaw will not launch a local browser.
 - For externally managed CDP services on loopback (for example Browserless in

--- a/docs/tools/tts/quickstart.md
+++ b/docs/tools/tts/quickstart.md
@@ -44,6 +44,11 @@ OpenClaw picks the first configured provider in registry auto-select order.
 The built-in `tts` agent tool is explicit-intent only: ordinary chat stays
 text unless the user asks for audio, uses `/tts`, or enables Auto-TTS/directive
 speech.
+
+Channels that send native voice notes (Feishu, WhatsApp) need `ffmpeg` installed
+on the Gateway host so OpenClaw can transcode the provider's output to Ogg/Opus.
+Without it, Feishu falls back to a plain file attachment and the WhatsApp send
+fails. See [TTS output](/tools/tts/output) for the transcoding rules.
 </Note>
 
 ## Supported providers


### PR DESCRIPTION
Works 189 `ux` audit rows across `docs/tools/**` and `docs/plugins/**`. Four defects fixed; the rest are refuted or deferred, enumerated by id so the ledger can close them.

## Fixed

**r3-1942 — `docs/plugins/sdk-subpaths.md`, 125 rows.** Every row read `Private-local after July 2026; …`, a forward-looking qualifier for a transition that landed on 2026-07-19 in `c7e7ac27289` (#111451). All 125 named subpaths are in `scripts/lib/plugin-sdk-private-local-only-subpaths.json` today, so the qualifier is not just stale — it implies a future state that is now the present. The bare `Private-local;` form was already in use once on the page, so this converges on the page's own style rather than coining one.

The diff is 126 `-` lines and 126 `+` lines with the only unmatched line either side being the file header, i.e. a strict one-for-one substitution. `src/plugins/contracts/plugin-sdk-subpaths.test.ts` reads this page (line 490) and gates the change: 18/18 pass. No subpath name changed, so the whole-document set assertion that pins this file is untouched.

**r3-2355 — `docs/tools/tts/quickstart.md:44.`** The quickstart had no `ffmpeg` prerequisite, and `tts/output.md:43` says a WhatsApp voice note **send fails** without it — no fallback. Added to the existing `<Note>`, no new heading.

**r3-2448 — `docs/tools/acp-agents-setup.md:316.`** A colon promised two config keys, then two unrelated paragraphs ran before `### permissionMode`. The keys are now named in the sentence that promises them.

**r3-2349 — `docs/tools/browser/remote.md:16.`** The node-host prerequisite was named with no link to its setup.

## Already satisfied on `main` (15)

r3-1967, r3-1989, r3-2002, r3-2016, r3-2018, r3-2021, r3-2035, r3-2055, r3-2067, r3-2072, r3-2337, r3-2413, r3-2499, r3-2502, r3-2527. Each verified audit-era-present → now-absent by reading `git show a4514a0aff9:<file>`.

Two are worth naming. **r3-2035**'s suggested fix would have added an import for `finalizeInboundContext` — a symbol deliberately *not* exported from that subpath; the page now says so explicitly instead. And the definition-list rendering defect class is **empty repo-wide**: `grep -rn "^: " docs/` returns 0, so both rows citing it (r3-2055, r3-2067) were already fixed.

## Refuted with evidence (14)

- **r3-2027** — asks to normalize `cfg` → `config` in a sample as a typo. It is not: `src/channels/message-access/runtime.ts:240` reads `accessGroups: base.accessGroups ?? base.cfg?.accessGroups` — `cfg` is the global OpenClaw config, `config` the channel config. Normalizing would make the sample semantically wrong.
- **r3-2040** — premise false. There is no published snippet page: `docs/snippets/plugin-publish/` holds two JSON files and appears nowhere in `docs/docs.json`. Both citing pages consistently treat it as a repo path.
- **r3-2039** — premise false. The `clawhub` CLI is introduced at its point of use, `building-plugins.md:222` and `:226` (`npm i -g clawhub`).
- **r3-1975** — premise false at the audit-era commit as well. The controls are **Run Claude / Run OpenAI**, and they use the Gateway task-tracked agent-run path with explicit models, not harness plugins.
- **r3-2071, r3-2501** — the disclaimer each asks for is already on the page, before the examples.
- **r3-2451** — the `(current)` it asks to remove is inside an H2 at `acp-agents-setup.md:28`; removing it changes a published anchor.
- **r3-1964, r3-2380, r3-2399, r3-2406, r3-2419, r3-2449, r3-2503** — each requires renaming or adding a heading.

## Refuted as a class (138)

| class | n | ids |
|---|---|---|
| Add an intro paragraph | 7 | r3-1897 r3-2020 r3-2032 r3-2049 r3-2063 r3-2432 r3-2529 |
| Add a section index / move first task up | 17 | r3-1953 r3-1984 r3-2000 r3-2028 r3-2033 r3-2050 r3-2064 r3-2348 r3-2386 r3-2404 r3-2411 r3-2417 r3-2433 r3-2436 r3-2441 r3-2463 r3-2478 |
| Split the page / move sections elsewhere | 18 | r3-2065 r3-2070 r3-2398 r3-2405 r3-2412 r3-2418 r3-2421 r3-2440 r3-2446 r3-2450 r3-2454 r3-2460 r3-2467 r3-2475 r3-2477 r3-2479 r3-2481 r3-2504 |
| Gloss terms / add a table column | 3 | r3-1945 r3-1954 r3-1979 |
| Reorder sections | 3 | r3-1973 r3-2431 r3-2459 |
| Split a paragraph | 17 | r3-1907 r3-1913 r3-1916 r3-1946 r3-1993 r3-2014 r3-2024 r3-2068 r3-2351 r3-2359 r3-2372 r3-2376 r3-2407 r3-2422 r3-2442 r3-2455 r3-2470 |
| Table ⇄ list conversion | 19 | r3-1901 r3-1908 r3-1914 r3-1929 r3-1958 r3-1969 r3-1986 r3-2013 r3-2030 r3-2059 r3-2073 r3-2373 r3-2377 r3-2389 r3-2400 r3-2423 r3-2429 r3-2476 r3-2482 |
| Promote accordion content | 7 | r3-1922 r3-1966 r3-1980 r3-2342 r3-2366 r5-0240 r5-0246 |
| Reciprocal backlinks | 9 | r3-1936 r3-1940 r3-1971 r3-1976 r3-1981 r3-2381 r3-2387 r3-2390 r3-2393 |
| De-duplicate across or within pages | 38 | r3-1892 r3-1896 r3-1906 r3-1949 r3-1982 r3-1990 r3-1995 r3-1999 r3-2023 r3-2037 r3-2042 r3-2062 r3-2076 r3-2341 r3-2346 r3-2347 r3-2364 r3-2369 r3-2384 r3-2388 r3-2391 r3-2395 r3-2396 r3-2403 r3-2410 r3-2420 r3-2426 r3-2437 r3-2447 r3-2466 r3-2487 r3-2496 r3-2507 r3-2511 r3-2523 r5-0120 r5-0198 r5-0207 |

Four of those target the **generated** tree and would need a generator change rather than a page edit: r3-1993 and r3-1995 (`docs/plugins/plugin-inventory.md`), r5-0198 and r5-0207 (`docs/plugins/reference/**`), all written by `scripts/generate-plugin-inventory-doc.mts`.

## Deferred (18) — version-scoping lane

r3-1894, r3-1951, r3-2006, r3-2008, r3-2025, r3-2075, r3-2340, r3-2345, r3-2354, r3-2363, r3-2462, r3-2471, r3-2474, r3-2483, r3-2484, r3-2485, r3-2494, r3-2533. Each cited text was confirmed still present, so none is a phantom row. They belong to the workstream #144032 runs, which has already been corrected twice on release dating; per-row tag archaeology wants that lane's discipline, not a side pass. r3-1894's target has since split into `docs/plugins/manifest/{capabilities,models,package-json}.md`.

## Ownership

Last-match-wins simulation over all 64 rules with positive and negative controls in the same pass. Positive: `docs/gateway/authentication.md`, `docs/reference/secretref-credential-surface.md`, `SECURITY.md` → `@openclaw/openclaw-secops`. Negative: `README.md`, `docs/tools/index.md`, `docs/plugins/community.md` → unowned. **All four changed files are unowned.**

## Validators

`pnpm check:docs` exit 0 (markdownlint 1279 files) · `pnpm format:check` exit 0 (36360 files) · `format-docs --check` clean, 1280 files · `docs-link-audit --anchors`: 13504 internal links, 3 broken, all the known `#windows-app-node` baseline on `docs/maturity/*` which this diff does not touch · `plugin-sdk-subpaths.test.ts` 18/18.

No heading text changed. No `docs.json` or glossary change — neither added link starts a list item, so `LIST_ITEM_LINK_RE` in `check-docs-i18n-glossary.mts:12` does not apply, confirmed by `check:docs` passing.
