### PR TITLE
docs(install,providers,platforms,web): fix 17 concrete defects from the ux audit

### DIFF
--- a/docs/install/cloudflare.md
+++ b/docs/install/cloudflare.md
@@ -17,7 +17,8 @@ Run one OpenClaw installation behind a Cloudflare Worker and a named Durable Obj
 
 - A Cloudflare account with Workers, Containers, and R2 available
 - Docker Buildx with `linux/amd64` support
-- A public Docker Hub repository for the derived image
+- A public Docker Hub repository for the derived image, and a `docker login` session that can push to it
+- An S3-compatible CLI such as the AWS CLI, used later to verify Litestream replication
 - Node.js and npm
 - Provider and channel credentials for your OpenClaw setup
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -94,7 +94,7 @@ Namespace: openclaw (configurable via OPENCLAW_NAMESPACE)
 
 The Deployment probes `/readyz` for startup and traffic readiness with a five-minute startup budget, and `/healthz` for liveness. Every probe asserts the JSON probe contract rather than the status code alone, because the Control UI answers unknown paths with a catch-all `200`; a status-only check would pass forever against an image whose probe route does not exist yet.
 
-`/startupz` is the better traffic-admission probe because it ignores channel health, so one failing channel account cannot evict an otherwise healthy Gateway from Service endpoints. It requires an image built from the release that introduced it, which is newer than the tag pinned above. After pinning such an image, switch the startup and readiness probes to `/startupz` and keep `/readyz` for monitoring that should include channel-account health.
+`/startupz` is the better traffic-admission probe because it ignores channel health, so one failing channel account cannot evict an otherwise healthy Gateway from Service endpoints. It requires an image built from `2026.8.1` or newer, the release that introduced it, which is newer than the tag pinned above. After pinning such an image, switch the startup and readiness probes to `/startupz` and keep `/readyz` for monitoring that should include channel-account health.
 
 ## Customization
 

--- a/docs/install/nix.md
+++ b/docs/install/nix.md
@@ -30,7 +30,8 @@ The [nix-openclaw](https://github.com/openclaw/nix-openclaw) repo is the source 
     Use the agent-first template from the nix-openclaw repo:
     ```bash
     mkdir -p ~/code/openclaw-local
-    # Copy templates/agent-first/flake.nix from the nix-openclaw repo
+    git clone https://github.com/openclaw/nix-openclaw.git /tmp/nix-openclaw
+    cp /tmp/nix-openclaw/templates/agent-first/flake.nix ~/code/openclaw-local/flake.nix
     ```
   </Step>
   <Step title="Configure secrets">

--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -130,7 +130,17 @@ Happens on the free tier (no persistent disk). Upgrade to a paid plan, or regula
 If builds succeed but deploys fail, the service may be taking too long to start or `/startupz` may not be reachable. Check:
 
 - Build logs for errors
-- Whether the container runs locally with `docker build && docker run`
+- Whether the container runs locally with the same image and command Render uses
+
+Reproduce the Render container locally from a checkout of the repository:
+
+```bash
+docker build -t openclaw:local -f Dockerfile .
+docker run --rm -p 8080:8080 -e OPENCLAW_GATEWAY_PORT=8080 openclaw:local \
+  node openclaw.mjs gateway --allow-unconfigured
+```
+
+See [Docker](/install/docker) for the full local container workflow.
 
 ## Next steps
 

--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -136,9 +136,19 @@ Reproduce the Render container locally from a checkout of the repository:
 
 ```bash
 docker build -t openclaw:local -f Dockerfile .
-docker run --rm -p 8080:8080 -e OPENCLAW_GATEWAY_PORT=8080 openclaw:local \
-  node openclaw.mjs gateway --allow-unconfigured
+docker run --rm -p 8080:8080 \
+  -e OPENCLAW_GATEWAY_PORT=8080 \
+  -e OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)" \
+  -e OPENCLAW_STATE_DIR=/data/.openclaw \
+  -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
+  openclaw:local node openclaw.mjs gateway --allow-unconfigured
 ```
+
+The token is required, not optional: in a container the Gateway selects the
+auto bind mode, and it refuses to bind a non-loopback address without a shared
+secret. `--allow-unconfigured` waives the configuration prerequisite, not that
+guard. Render supplies the value from the blueprint's `generateValue: true`; a
+throwaway one is fine locally.
 
 See [Docker](/install/docker) for the full local container workflow.
 

--- a/docs/install/render.mdx
+++ b/docs/install/render.mdx
@@ -139,8 +139,6 @@ docker build -t openclaw:local -f Dockerfile .
 docker run --rm -p 8080:8080 \
   -e OPENCLAW_GATEWAY_PORT=8080 \
   -e OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)" \
-  -e OPENCLAW_STATE_DIR=/data/.openclaw \
-  -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   openclaw:local node openclaw.mjs gateway --allow-unconfigured
 ```
 
@@ -149,6 +147,13 @@ auto bind mode, and it refuses to bind a non-loopback address without a shared
 secret. `--allow-unconfigured` waives the configuration prerequisite, not that
 guard. Render supplies the value from the blueprint's `generateValue: true`; a
 throwaway one is fine locally.
+
+Leave `OPENCLAW_STATE_DIR` and `OPENCLAW_WORKSPACE_DIR` unset here. Render sets
+them to paths on its mounted disk, but the image prepares only its own
+`node`-owned directories and runs as that user, so pointing them at an unmounted
+`/data` fails when the Gateway creates its lock directory. State lands under the
+image's defaults and is discarded with the container, which is what you want for
+a health-check reproduction.
 
 See [Docker](/install/docker) for the full local container workflow.
 

--- a/docs/install/update-troubleshooting.md
+++ b/docs/install/update-troubleshooting.md
@@ -100,9 +100,11 @@ the CLI fallback on the Gateway host.
 - `deps-install-failed`, `build-failed`, `ui-build-failed`: inspect the failing
   step, fix the dependency or build error, then retry.
 - `global-install-failed`: retry after checking package-manager ownership and
-  permissions. Re-run the installer if the package install is incomplete.
-- `doctor-failed`: run Doctor on the Gateway host, resolve its findings, then
-  retry.
+  permissions. Re-run the [installer](/install/installer) if the package
+  install is incomplete.
+- `doctor-failed`: run `openclaw doctor` on the Gateway host, resolve its
+  findings, then retry. See [Doctor](/cli/doctor) for the check list and
+  `--fix` behavior.
 - `restart-disabled`, `restart-unavailable`: restore a supported supervisor or
   enable Gateway restarts before retrying.
 - `restart-unhealthy`, `restart-revision-mismatch`,

--- a/docs/install/upstash.md
+++ b/docs/install/upstash.md
@@ -39,6 +39,14 @@ The keepalive options reduce idle tunnel drops during onboarding.
 
 ## Install OpenClaw
 
+Check the Box's runtime versions first, because the install command depends on
+the npm version:
+
+```bash
+node -v
+npm -v
+```
+
 Inside the Box, use the following command on npm 12 or npm 11.16+. On npm 11.15
 and earlier, omit `--allow-scripts=openclaw`.
 

--- a/docs/nodes/voicewake.md
+++ b/docs/nodes/voicewake.md
@@ -8,6 +8,7 @@ title: "Voice wake"
 
 Wake words are **one global list owned by the Gateway** — there are no per-node custom lists. Any node or app UI can edit the list; the Gateway persists the change and broadcasts it to every connected client.
 
+- **Control UI**: wake-word editor under **Settings → Talk**.
 - **macOS**: local Voice Wake enable/disable toggle. Requires macOS 26+; see [Voice wake (macOS)](/platforms/mac/voicewake) for runtime/PTT details.
 - **iOS**: local Voice Wake enable/disable toggle in Settings.
 - **Android**: local Voice Wake enable/disable toggle and wake-word editor in Settings → Voice. Requires Android on-device speech recognition.

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -54,6 +54,10 @@ of being treated as a missing service; check the LaunchAgent and retry.
 
 ## Manual recovery
 
+Read the version to install from the app: choose **About OpenClaw** in the
+menu bar, or run `openclaw-mac status --json`, which reports the app version
+and build.
+
 For a manual install, use Node 26 (recommended) or another supported release:
 Node 24.16+ or Node 26.1+. Install `openclaw` globally:
 

--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -48,7 +48,7 @@ private Node worker from the canonical package artifact for every requested
 pnpm packer; Corepack-only setups are supported. Packaging verifies native
 capabilities and worker readiness in temporary state before and after signing,
 then replaces the previous app. `scripts/restart-mac.sh` uses
-the same path; `SKIP_TSC=1` no longer bypasses the runtime build. Existing
+the same path; `SKIP_TSC=1` does not bypass the runtime build. Existing
 content-checked build caches still avoid unnecessary declaration work.
 
 Each worker keeps native binaries that support its architecture and omits
@@ -96,7 +96,9 @@ The packaged app embeds the canonical `scripts/install-cli.sh` installer. On a
 fresh profile, choose **This Mac** during onboarding; the app installs the
 matching user-space CLI and runtime before starting the Gateway wizard.
 
-For manual development recovery, install the matching CLI yourself:
+For manual development recovery, install the matching CLI yourself. Read the
+version from the app: choose **About OpenClaw** in the menu bar, or run
+`openclaw-mac status --json`, which reports the app version and build.
 
 The npm command below is for npm 12 or npm 11.16+. On npm 11.15 and earlier,
 omit `--allow-scripts=openclaw`.

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -13,7 +13,7 @@ OpenClaw can host **PeekabooBridge** as a local, permission-aware UI automation 
 ## What this is (and is not)
 
 - **Host**: OpenClaw.app can act as a PeekabooBridge host.
-- **Client**: the `peekaboo` CLI (there is no separate `openclaw ui ...` surface).
+- **Client**: the `peekaboo` CLI, installed from [peekaboo.sh](https://peekaboo.sh/) (there is no separate `openclaw ui ...` surface).
 - **UI**: visual overlays stay in Peekaboo.app. OpenClaw is a thin broker host.
 
 ## Relationship to other desktop-control paths

--- a/docs/providers/ollama/model-discovery.md
+++ b/docs/providers/ollama/model-discovery.md
@@ -93,7 +93,9 @@ provider and `/api/tags` is unreachable, OpenClaw records that run as
 5 minutes per host, so repeated cron jobs against a stopped daemon do not all
 launch failing requests.
 
-Live verification:
+Live verification. These are contributor commands: run them from a checkout of
+the `openclaw/openclaw` repository with `pnpm install` already done, not from a
+packaged CLI install.
 
 ```bash
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_OLLAMA=1 OPENCLAW_LIVE_OLLAMA_WEB_SEARCH=0 \

--- a/docs/providers/ollama/setup.md
+++ b/docs/providers/ollama/setup.md
@@ -99,9 +99,16 @@ sidebarTitle: "Setup"
         For hybrid cloud access, run `ollama signin` on the same host.
       </Step>
       <Step title="Set a credential">
+        For a local or LAN host, any value works:
+
         ```bash
-        export OLLAMA_API_KEY="ollama-local"    # local/LAN host, any value works
-        export OLLAMA_API_KEY="your-real-key"   # https://ollama.com only
+        export OLLAMA_API_KEY="ollama-local"
+        ```
+
+        For `https://ollama.com`, use the real key instead:
+
+        ```bash
+        export OLLAMA_API_KEY="your-real-key"
         ```
 
         Or in config: `openclaw config set models.providers.ollama.apiKey "OLLAMA_API_KEY"`.

--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -268,10 +268,6 @@ renderer assets. Reload after correcting the asset access rules.
 
 Assistant messages can render hosted web content inline with the `[embed ...]` shortcode. The iframe sandbox policy is controlled by `gateway.controlUi.embedSandbox`:
 
-Widgets created by `show_widget` load through the authenticated Gateway connection in every sandbox mode, including while settings are loading. In `strict` mode, their content remains visible but scripted interactions are disabled.
-
-The core [`show_widget`](/tools/show-widget) tool renders self-contained SVG or HTML directly from a tool call. The browser and supported native chat clients advertise the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Channel plugins such as Discord Activities can register contextual presenters behind that same tool. Channel-originated runs without an eligible presenter or inline client do not receive it.
-
 <Tabs>
   <Tab title="strict">
     Disables script execution inside hosted embeds.
@@ -299,6 +295,10 @@ Use `trusted` only when the embedded document genuinely needs same-origin behavi
 </Warning>
 
 Absolute external `http(s)` embed URLs stay blocked by default. To let `[embed url="https://..."]` load third-party pages, set `gateway.controlUi.allowExternalEmbedUrls: true`.
+
+Widgets created by `show_widget` load through the authenticated Gateway connection in every sandbox mode, including while settings are loading. In `strict` mode, their content remains visible but scripted interactions are disabled.
+
+The core [`show_widget`](/tools/show-widget) tool renders self-contained SVG or HTML directly from a tool call. The browser and supported native chat clients advertise the `inline-widgets` Gateway capability, and the resulting Canvas document remains available when chat history reloads. Channel plugins such as Discord Activities can register contextual presenters behind that same tool. Channel-originated runs without an eligible presenter or inline client do not receive it.
 
 ## Chat transcript layout
 

--- a/docs/web/control-ui/development.md
+++ b/docs/web/control-ui/development.md
@@ -9,6 +9,10 @@ sidebarTitle: "Build and develop"
 
 Contributor notes for building the Control UI and running it against a Gateway you choose.
 
+Every command on this page runs from a checkout of the `openclaw/openclaw`
+repository with `pnpm install` already done. A packaged CLI install has no
+`pnpm` scripts.
+
 ## Build and develop the UI
 
 The Gateway serves static files from `dist/control-ui`:

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -47,7 +47,7 @@ After subscribing, **Settings → Notifications** exposes two preference layers:
 
 Single-user Gateways use their durable owner profile for account defaults, so those preferences follow the owner across devices. Connections without a profile keep the controls but store preferences only with the current browser subscription. Preferences never grant access: every delivery still rechecks the paired device, current role and scopes, authenticated profile, and session visibility. Multi-user events without an authoritative session owner are suppressed instead of being broadcast to every operator.
 
-The default preserves the original behavior: approval request and resolution notifications are enabled, while newly added attention categories are opt-in. Quiet hours suppress matching sends rather than queueing stale alerts for later delivery.
+By default, approval request and resolution notifications are enabled, and every other attention category is opt-in. Quiet hours suppress matching sends rather than queueing stale alerts for later delivery.
 
 Selecting an attention notification opens its question, conversation, or automation run on the Gateway that produced it. **Agent finished** waits for completion. A parent waiting for child agents does not count as finished. Automation failures use **Scheduled task failures**, without also generating a **Background task failures** alert for the same run.
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -19,7 +19,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket. N
 
 1. Start the gateway.
 2. Open the WebChat UI (macOS/iOS app) or the Control UI chat tab.
-3. Ensure a valid gateway auth path is configured (shared-secret by default, even on loopback).
+3. Ensure a valid gateway auth path is configured (shared-secret by default, even on loopback). See [Auth basics (local vs remote)](/web/dashboard#auth-basics-local-vs-remote).
 
 ## How it works
 


### PR DESCRIPTION
Works 187 `ux` audit rows across `docs/install/**`, `docs/providers/**`, `docs/platforms/**`, `docs/nodes/**` and `docs/web/**`. Seventeen defects fixed; the rest refuted or deferred, enumerated by id so the ledger can close them.

## Fixed (17)

**Missing prerequisites — a step needs something the page never says to have**

| id | file | what was missing |
|---|---|---|
| r3-1737 | `install/cloudflare.md:19` | "What you need" omitted the `docker login` that the Publish step's `--push` requires, and the S3-compatible CLI the verification step invokes (`aws s3 ls`). |
| r3-2087 | `providers/ollama/model-discovery.md:96` | `pnpm test:live` needs a source checkout with dependencies installed; the page never said so. |
| r3-2536 | `web/control-ui/development.md:10` | Every command on the page is `pnpm ui:*`, unavailable from a packaged install. |
| r3-1784 | `install/upstash.md:42` | The install command branches on npm version with no way to read it. Added `node -v` / `npm -v`. |

**Commands that cannot run as written**

| id | file | defect |
|---|---|---|
| r3-1775 | `install/render.mdx:133` | A `docker build && docker run` pair that is not how Render deploys this. Replaced with the image and command Render actually uses, from the blueprint at lines 30/33. |
| r3-1778 | `install/nix.md:31` | The bash fence contained a comment where the command belongs. Replaced with the `git clone` + `cp` of the exact template path the page already names. |
| r3-2086 | `providers/ollama/setup.md:103` | One fence exported `OLLAMA_API_KEY` twice, and a copied block ended on `your-real-key`. Split into two fences with their conditions as prose. |

**Placeholders with no stated source**

r3-1866 (`platforms/mac/dev-setup.md:99`) and r3-1870 (`platforms/mac/bundled-gateway.md:60`) both wrote `openclaw@<version>` with nothing saying where `<version>` comes from. Both now name **About OpenClaw** (`menu-bar.md:29`, `signing.md:47`) and `openclaw-mac status --json` (`xpc.md:54`).

**Stale or contradictory concrete values**

- **r3-1838** — `nodes/voicewake.md:9`. The summary said "Any node or app UI can edit the list" while the body listed only Android as having an editor. `ui/src/pages/config/talk.ts:19,313` renders `renderVoiceWakeEditor`, so the Control UI **Settings → Talk** surface was simply missing from the body.
- **r3-2562** — `web/notifications.md:50`. "preserves the original behavior … newly added attention categories" left the actual default unreadable. Restated as which categories are on and that every other is opt-in.
- **r3-1867** — `platforms/mac/dev-setup.md:51`. "`SKIP_TSC=1` no longer bypasses the runtime build" → "does not bypass". Present-tense restatement, no version invented.
- **r3-1752** — `install/kubernetes.md:97`. `/startupz` was introduced by `8190c326ce4` (#122477); first containing tag `v2026.8.1`, which is also its first stable tag. The page pins `2026.7.1-2-slim`, so the relative claim was true but unusable to a reader — the release is now named.

**Missing links where the page names a thing and stops**

r3-1771 (`install/update-troubleshooting.md:102` — `doctor-failed` named a tool with no command, `global-install-failed` named "the installer" with no link), r3-1859 (`platforms/mac/peekaboo.md:16` — the `peekaboo` CLI as client with no install path; linked `peekaboo.sh`, the URL already used at `platforms/android.md:162`), r3-2557 (`web/webchat.md:22` — auth prerequisite with no link).

**Structure**

r3-2535 (`web/control-ui/chat.md:269`) — the colon introducing the sandbox `<Tabs>` was separated from it by two `show_widget` paragraphs; those moved below the Warning so the colon introduces the options it promises.

## Already satisfied on `main` (1)

r3-2142 — `providers/fal.md:23` now has a `Get an API key` step linking `fal.ai/dashboard/keys`. Its second clause (add a verify command) is an enhancement, not a defect, and was not done.

## Refuted with evidence (11)

**r3-2083 is the one worth reading.** It asks to document that an `apiKey` value equal to an env var name reads that variable. `parseEnvTemplateSecretRef` (`src/config/types.secrets.ts:95-113`) accepts only `$NAME` / `${NAME}` — a bare `"OLLAMA_API_KEY"` is a literal secret string. Writing the sentence would document behavior the code does not have. Left the file untouched.

One observation for a maintainer rather than a change I should make: this is the only `apiKey "NAME"` form in `docs/`; every other page uses `"${NAME}"`. Whether that line means a literal or an env reference is an author's call.

- **r3-1835** — pipe-enum notation in a schema block reads as "one of", and a real value appears two lines above in the CLI form.
- **r3-2081** — untagged fences are settled non-defects (`"MD040": false`). The second half is not locatable: the page split into `docs/providers/openai/*` and no such config example survives.
- **r3-1742, r3-1754, r3-1891, r3-2092, r3-2544, r3-2550, r3-2554, r3-2559** — hedge-wording rows with no stale or contradictory value underneath. Specifically: **r3-2092** describes **xAI's** behavior, which no OpenClaw release governs; **r3-2544**'s "v1" names the Telegram Mini App's first iteration, not a release, and deleting its non-goals list would drop real limitations; **r3-2554**'s premise is false — the "legacy" rows at `urls.md:416` are live redirects, so there is no retirement release; **r3-2550**'s cited line does not contain the quoted words, and "read-only today by design" is design intent, not a dated change; **r3-1891** would invent a commitment by dating "Linux companion apps are planned".

## Refuted as a class (154)

- **Intro/audience paragraph (23):** r3-1725 r3-1743 r3-1745 r3-1760 r3-1769 r3-1777 r3-1786 r3-1792 r3-1833 r3-1840 r3-1844 r3-1848 r3-1868 r3-1876 r3-1879 r3-1881 r3-1885 r3-1890 r3-2109 r3-2122 r3-2179 r3-2556 r3-2564
- **Reorder sections (12):** r3-1803 r3-1808 r3-1814 r3-1821 r3-1825 r3-1872 r3-2094 r3-2101 r3-2113 r3-2138 r3-2206 r3-2551
- **Move content elsewhere / split a page (17):** r3-1729 r3-1755 r3-1865 r3-1869 r3-1873 r3-1880 r3-2119 r3-2123 r3-2126 r3-2129 r3-2144 r3-2197 r3-2198 r3-2199 r3-2208 r3-2543 r3-2545
- **Heading rename, addition or level change (9):** r3-1826 r3-1882 r3-2088 r3-2096 r3-2134 r3-2548 r3-2552 r3-2565 r5-0033 — all change or add published anchors. r5-0033 is additionally settled by `"MD025": false`.
- **Split a paragraph into a list (13):** r3-1719 r3-1734 r3-1804 r3-1810 r3-1816 r3-1827 r3-1852 r3-2084 r3-2090 r3-2161 r3-2182 r3-2185 r3-2546
- **Table → list (16):** r3-1720 r3-1730 r3-1749 r3-1787 r3-1798 r3-1805 r3-1822 r3-1824 r3-1831 r3-1854 r3-1889 r3-2085 r3-2091 r3-2106 r3-2135 r3-2553
- **Hoist content out of accordions (7):** r5-0232 r5-0233 r5-0239 r5-0247 r5-0248 r5-0251 r5-0252
- **Terminology harmonization (1):** r3-2547
- **De-duplicate across or within pages (56):** r3-1724 r3-1728 r3-1732 r3-1736 r3-1740 r3-1746 r3-1748 r3-1757 r3-1759 r3-1763 r3-1765 r3-1772 r3-1773 r3-1782 r3-1791 r3-1795 r3-1801 r3-1820 r3-1823 r3-1837 r3-1851 r3-1857 r3-1863 r3-1864 r3-1871 r3-1875 r3-1878 r3-1883 r3-2089 r3-2093 r3-2099 r3-2104 r3-2108 r3-2112 r3-2125 r3-2128 r3-2133 r3-2137 r3-2141 r3-2147 r3-2157 r3-2158 r3-2162 r3-2164 r3-2172 r3-2174 r3-2175 r3-2176 r3-2178 r3-2192 r3-2539 r3-2540 r3-2541 r3-2560 r3-2563 r3-2567

## Deferred (4)

r3-1841, r3-1845, r3-1850, r3-1860 — reciprocal links. The backlinks genuinely do not exist, and all four targets are already reachable from the platforms index, so these are link-graph additions rather than defect repairs; each also needs a zh-CN glossary source on the file every sibling agent rebases through.

## Ownership

Last-match-wins simulation with positive and negative controls in the same pass. Positive: `SECURITY.md`, `docs/gateway/authentication.md`, `docs/reference/secretref-credential-surface.md` → `@openclaw/openclaw-secops`. Negative controls stay unowned. **All 16 changed files are unowned** — CODEOWNERS has no entry under `docs/install`, `docs/providers`, `docs/platforms`, `docs/nodes` or `docs/web`.

## Validators

`pnpm check:docs` exit 0 (format-docs 1280 files; markdownlint 1279 files, 0 issues) · `pnpm format:check` exit 0, 36360 files · `docs-link-audit --anchors`: 13506 internal links, 3 broken, all the known `#windows-app-node` baseline on `docs/maturity/*`; none of the 16 changed files appears in that error list.

No heading text changed. No generator writes any changed page (grepped `scripts/` for each basename and full path; the only hit is a comment in `scripts/k8s/manifests/deployment.yaml:34`), and no `summary:` frontmatter was touched, so the channel catalog is unaffected. Glossary untouched and not required — every added link is external, mid-bullet, or in a paragraph.
