### PR TITLE
fix(test): drain session fixtures before removing state

### DIFF
--- a/src/agents/sessions/session-manager-mutation-boundaries.test.ts
+++ b/src/agents/sessions/session-manager-mutation-boundaries.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   appendTranscriptMessage,
   loadTranscriptEventsSync,
@@ -13,11 +13,32 @@ import {
   deferOpenClawAgentPostCommitPublication,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { cleanupSessionStateForTest } from "../../test-utils/session-state-cleanup.js";
 import { rewriteTranscriptEntriesInSessionManager } from "../embedded-agent-runner/transcript-rewrite.js";
 import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { SessionManager } from "./session-manager.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = createTempDirTracker();
+
+afterEach(async () => {
+  // Reconcile workers can otherwise retain the shared state lock into later tests.
+  const stateDirs = [...tempDirs.dirs];
+  const errors: unknown[] = [];
+  for (const stateDir of stateDirs) {
+    try {
+      await cleanupSessionStateForTest({ stateDir });
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Session fixture cleanup failed");
+  }
+  tempDirs.cleanup();
+});
 
 it("publishes the rewritten view before commit observers append", async () => {
   const dir = tempDirs.make("openclaw-rewrite-observer-");


### PR DESCRIPTION
Related: #144034
Related: #137381

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where session regression tests leave native transcript-reconcile workers running after their fixture directories are deleted. In shared `unit-fast` workers, that work can overlap later TaskFlow teardown and contend on the shared-state lifecycle lock.

The investigation started with the [TaskFlow teardown failures in CI](https://github.com/openclaw/openclaw/actions/runs/34477195589/job/102870861165). The unchanged CI base reproduced the failures, so the model-defaults change in #144034 is not required to trigger them.

## Why This Change Was Made

The fixture now drains each owned root through the existing `cleanupSessionStateForTest` helper before removing its directories. Teardown attempts every root sequentially, preserves the directories and tracker if any drain fails, and reports one original error or aggregates multiple failures.

The change is confined to one test file: **+23 / -2 lines**, with every test body unchanged. It retains the session rewrite regression coverage contributed by @jalehman in #137381.

## User Impact

Developers get complete fixture cleanup in shared-worker test runs. Production behavior, database coordination, and runtime APIs are unchanged.

## Evidence

- Final `pnpm check:changed`: passed (exit 0) on the frozen final source. The earlier lint failure remains in the local evidence; this is a completed whole-gate rerun after its correction.
- P2 autoreview: scoped-clean on the exact final source.
- Linux x64, Node v24.19.0, SQLite 3.53.3: explicit original-order pair of the session fixture and TaskFlow tests passed **14/14**.
- The retained three-worker Linux CI cohort passed **8,984 tests**, with **8 skipped**, across **695 files** (694 passed, one skipped). The main-based repair includes 695 of the original 696 cohort paths; the extra inline-defaults test belongs to #144034 and was absent at the repair base.
- Native tracing covered all **seven fixture removals** and **four reconcile workers**: no fixture-owned database/coordinator activity occurred after cleanup, no native database/coordinator state remained active at removal, and no coordinator errors occurred. Worker-exit callback timing was not used as the success condition.
- The host and Linux candidate source hashes matched, and the candidate remained unchanged throughout proof. No build was needed for this test-only change.

Attribution limit: the earlier baseline run reproduced TaskFlow failures, while later instrumented runs identified escaped native owners and same-path contention separately. Those instrumented runs did not capture a failing TaskFlow stack with the native holder fully correlated. The repair is supported by the fixture ownership defect and direct cleanup-boundary proof.
