### PR TITLE
test(clawhub): reuse catalog HTTP fixtures

### DIFF
--- a/src/infra/clawhub-plugin-catalog.test.ts
+++ b/src/infra/clawhub-plugin-catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { jsonResponse, requestUrl } from "../test-helpers/http.js";
 import {
   fetchAllOfficialClawHubPlugins,
   fetchClawHubPluginCatalog,
@@ -6,17 +7,6 @@ import {
   fetchClawHubPluginVersionCategories,
   fetchClawHubPluginDetail,
 } from "./clawhub-plugin-catalog.js";
-
-function jsonResponse(value: unknown): Response {
-  return new Response(JSON.stringify(value), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-function requestUrl(input: string | URL | Request): string {
-  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-}
 
 const remotePlugin = {
   name: "memory-plus",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

ClawHub's catalog tests duplicate JSON response construction and fetch-input URL normalization that the shared HTTP test helper already provides.

## Why This Change Was Made

Import the existing helpers directly and remove the two local copies. Every fixture payload, assertion and await stays unchanged, including pagination, request ordering, category normalization, skipped authentication and optional security metadata failures.

## User Impact

Developer-only cleanup: 10 fewer lines of test scaffolding in one file. Production code, the shared helper and public APIs are unchanged; no tests are removed.

## Evidence

The complete catalog and packages suites each ran before and after through the normal runner:

```sh
node scripts/run-vitest.mjs src/infra/clawhub-plugin-catalog.test.ts src/infra/clawhub-packages.test.ts
```

Both runs passed all 18 cases with no skips on Node 26.5.0. Native reports have matching case identities, outcomes and order within each suite; source stayed unchanged during both runs. Verbose and JSON reporters captured the results.

All 20 required local changed-file checks and independent final source review passed. These tests use mocked fetches and real Response streams; they do not make live ClawHub requests. Existing specialized stream, timeout and malformed-input fixtures remain unchanged.
