### PR TITLE
refactor(plugins): remove duplicate missing-exporter test

### DIFF
--- a/src/plugins/one-shot-diagnostics.test.ts
+++ b/src/plugins/one-shot-diagnostics.test.ts
@@ -150,15 +150,6 @@ describe("startOneShotDiagnosticsExporters", () => {
     expect(config.diagnostics?.otel?.logsExporter).toBe("stdout");
   });
 
-  it("returns null when the scoped load registers no exporter service", async () => {
-    mockRegistryWithServices(["other-service"]);
-
-    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
-
-    expect(handle).toBeNull();
-    expect(startPluginServices).not.toHaveBeenCalled();
-  });
-
   it("drains queued diagnostic events before stopping services on flush", async () => {
     const exporterStop = vi.fn();
     const services = await mockRealExporter(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Maintainer-requested test cleanup: the standalone missing-exporter case repeats coverage already present in the warning test.

## Why This Change Was Made

Remove the redundant case. The retained test uses the same fresh other-service registry and configuration, checks the same null result and absence of service startup, and additionally verifies the missing-plugin warning.

## User Impact

No runtime behavior change. One test case and nine lines are removed; all other cases, assertions, imports, helpers, and lifecycle coverage remain unchanged.

## Evidence

- Full ordered `src/plugins/one-shot-diagnostics.test.ts` through the plugins lane: 14 actual passes, zero skips.
- All 20 selected changed checks passed, plus targeted formatting and diff checks.
- One fresh P2 invocation: scoped-clean, no findings, with final source verification.

No live OTLP, plugin or Gateway execution, installed-package compatibility, or local full-repository test run is claimed.
