### PR TITLE
fix: keep npm-only Featured coverage independent of ACPX catalog changes

### DIFF
--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -601,6 +601,7 @@ describe("plugin management Featured authority", () => {
   });
 
   it("preserves npm-only bundled curation outside the hosted producer identity", async () => {
+    mocks.bundledEntries = [compositionEntry("acpx", { npmSpec: "@openclaw/acpx" })];
     mocks.metadata.mockReturnValue(
       metadataSnapshot({
         id: "acpx",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a failure in the plugin management Featured test suite after ACPX gained a declared ClawHub counterpart. The case promises npm-only bundled metadata but inherited ACPX's changing catalog entry.

## Why This Change Was Made

Make that case's bundled catalog explicitly npm-only using its existing fixture helper. Keep real npm install provenance and the independent `featured: true` and `order: 10` assertions. Production catalog and curation behavior are unchanged.

## User Impact

No user-visible behavior change. The regression continues to protect local curation for npm-only packages without depending on ACPX remaining npm-only.

## Evidence

- Original complete Featured suite: 47 passed, one failure at the expected Featured assertion.
- Repaired Featured and management-service suites: all 86 cases passed, preserving names and order.
- Synthetic control adding a declared ClawHub counterpart back to this fixture fails the same assertion with `featured: false`; the exact candidate was restored afterward.
- Changed-file gate and independent review passed.

The initial local baseline stopped before collection with ENOSPC. It was retained separately and rerun after completed generated artifacts were reclaimed. These checks exercise synthetic catalog metadata, not a live hosted feed.
