### PR TITLE
improve(models): reduce repeated work when browsing models

### DIFF
--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -89,22 +89,27 @@ function resolveModelsListView(params: Record<string, unknown>): ModelCatalogBro
 export function createGatewayAgentModelCatalogProjector(params: ModelsListAuthProjectionParams) {
   const authProjection = createModelsListAuthProjection(params);
   const { evaluateEntry, evaluateNative, snapshot } = authProjection;
-  const view = createModelCatalogView({
-    cfg: params.cfg,
-    catalog: snapshot.entries,
-    routeVariants: snapshot.routeVariants.length > 0 ? snapshot.routeVariants : snapshot.entries,
-  });
   let projectedCatalog: Promise<ModelCatalogEntry[]> | undefined;
   return {
     ...authProjection,
-    projectCatalog: () =>
-      (projectedCatalog ??= Promise.all(
+    projectCatalog: () => {
+      if (projectedCatalog) {
+        return projectedCatalog;
+      }
+      const view = createModelCatalogView({
+        cfg: params.cfg,
+        catalog: snapshot.entries,
+        routeVariants:
+          snapshot.routeVariants.length > 0 ? snapshot.routeVariants : snapshot.entries,
+      });
+      return (projectedCatalog = Promise.all(
         view.logicalEntries.map(async (entry) => {
           const routeVariants = view.variantsOf(entry) ?? [entry];
           const evaluation = evaluateNative(entry, await evaluateEntry(entry, routeVariants));
           return view.project(entry, evaluation).runtimeEntry;
         }),
-      )),
+      ));
+    },
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Opening a model picker or browsing the prepared catalog repeated a complete catalog-indexing pass that ordinary model-list requests never used. The extra work grew with the published catalog.

## Why This Change Was Made

The shared projector now builds its private route view when `projectCatalog()` is first called and retains the existing single projection Promise. Public model-list preparation continues through its existing visibility owner. Chat metadata and provider inventory still construct the private view synchronously when they consume it.

## User Impact

Ordinary model browsing avoids one unused variant traversal and its logical-row index. Request-local account authorization, current native readiness, publication fencing, and explicit refresh retain their existing owners.

## Evidence

The original-source and candidate registered-handler runs used 64, 512, and 2,048 synthetic rows, with eight fixed batches of ten warm calls per size. The unused private-view traversal changed from one to zero; complete serialized responses matched byte for byte, and both versions performed zero discovery calls. Measured medians were 22.41→20.88 ms, 187.05→160.28 ms, and 712.36→700.11 ms respectively. These source-loaded handler-plus-serialization timings include assertion overhead and were collected sequentially on a busy host whose load changed; they do not establish a production speedup.

All 157 focused tests passed across published inventory, model/session account selection, OpenAI route projection, native availability, and chat-metadata lifecycle. Fresh independent review found no actionable findings through P2, and the changed-file gate passed after fixing one formatting wrap.

[Linux Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34488160464) built the exact selected source and exercised 12 real CLI/Gateway requests: configured, default, all, and provider-config, three rounds each. Every response preserved the three expected ordered synthetic model identities, with no provider connection. The build owner and all 13 Gateway/client process owners joined and released; the lease was stopped after preserving and independently checking the artifacts. This proves synthetic catalog-flow parity and cleanup, not provider inference or production stall resolution.

Production change: +13/−8 lines. Existing semantic coverage and the original-versus-candidate complexity proof cover this bounded preparation change; no implementation-call-count test was added.
