### PR TITLE
fix: keep Pi catalog rename fixtures on one filesystem

### DIFF
--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -224,7 +224,9 @@ describe("Pi session catalog", () => {
 
   it("recognizes Pi sessions when the agent directory uses a symlinked path", async () => {
     const sessionDirectory = await createPiStore();
-    const agentDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-agent-real-"));
+    const agentDirectory = await fs.mkdtemp(
+      path.join(path.dirname(sessionDirectory), "openclaw-pi-agent-real-"),
+    );
     const symlinkParent = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-agent-link-"));
     const linkedAgentDirectory = path.join(symlinkParent, "agent");
     temporaryDirectories.push(agentDirectory, symlinkParent);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the Pi catalog's positive symlink-path test fails during fixture setup when the preferred OpenClaw temp root and the worker temp directory are on different filesystems. The observed Linux failure was EXDEV from the directory rename, before the symlink or catalog call ran.

## Why This Change Was Made

Create the real agent directory beside the existing session directory so the native rename stays on one filesystem. The rename, symlink location, environment assignments, cleanup ownership, and existing session/continuation assertion remain unchanged. No production code or helper API changes.

## User Impact

No user-visible behavior change. This preserves the existing symlink-path contract while making its test fixture portable across split temp mounts. The formatted test-only change adds two net lines.

## Evidence

- Preserved original Linux full-run failure at source e9ab9c9: the rename source was under /tmp/openclaw, while its destination was under the worker's /work temp namespace. The run's mount receipt recorded different devices.
- Harmless synthetic filesystem proof confirmed same-device sibling placement, content and inode preservation through rename, correct owned symlink resolution, and complete cleanup. No product code or race probe was invoked.
- Complete existing pi-session-catalog.test.ts suite on Node26.8.1/macOS at base17f74b9: 20 passed before and 20 after, zero pending, with identical ordered case names/statuses. Local original success is expected on one filesystem; it is not a claim of Linux after-fix proof.
- Exact whole-file inverse verification preserves everything outside the one changed parent expression. Required mapped static gate passed, and fresh independent P2 review found no actionable findings.

No full-suite readiness or runtime-savings claim is made.
