### PR TITLE
test: avoid duplicate update flows for package source forms

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -7531,34 +7531,10 @@ describe("update-cli", () => {
       expectedSpec: "OpenClaw@github:openclaw/openclaw#main",
     },
     {
-      name: "full git URL package spec",
-      options: { yes: true, tag: "https://github.com/openclaw/openclaw.git#main" },
-      packageSpec: undefined,
-      expectedSpec: "https://github.com/openclaw/openclaw.git#main",
-    },
-    {
-      name: "hosted GitHub URL package spec without git suffix",
-      options: { yes: true, tag: "https://github.com/openclaw/openclaw#main" },
-      packageSpec: undefined,
-      expectedSpec: "https://github.com/openclaw/openclaw#main",
-    },
-    {
       name: "aliased hosted GitHub URL package spec without git suffix",
       options: { yes: true, tag: "openclaw@https://github.com/openclaw/openclaw#main" },
       packageSpec: undefined,
       expectedSpec: "https://github.com/openclaw/openclaw#main",
-    },
-    {
-      name: "GitHub shorthand package spec",
-      options: { yes: true, tag: "openclaw/openclaw#main" },
-      packageSpec: undefined,
-      expectedSpec: "openclaw/openclaw#main",
-    },
-    {
-      name: "SCP-style SSH package spec",
-      options: { yes: true, tag: "git@github.com:openclaw/openclaw.git#main" },
-      packageSpec: undefined,
-      expectedSpec: "git@github.com:openclaw/openclaw.git#main",
     },
     {
       name: "OPENCLAW_UPDATE_PACKAGE_SPEC override",
@@ -7582,6 +7558,17 @@ describe("update-cli", () => {
         await updateCommand(options);
       }
       expectPackageInstallSpec(expectedSpec);
+      if (options.tag === "next") {
+        expect(fetchNpmTagVersion).toHaveBeenCalledWith(
+          expect.objectContaining({ tag: "next", spec: "openclaw@next" }),
+        );
+        expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith(
+          expect.objectContaining({ target: "9999.0.0", spec: expectedSpec }),
+        );
+      } else if (!packageSpec) {
+        expect(fetchNpmTagVersion).not.toHaveBeenCalled();
+        expect(fetchNpmPackageTargetStatus).not.toHaveBeenCalled();
+      }
     },
   );
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -179,6 +179,19 @@ describe("update global helpers", () => {
     expect(canResolveRegistryVersionForPackageTarget("/tmp/openclaw.tgz")).toBe(false);
   });
 
+  it.each([
+    "https://github.com/openclaw/openclaw.git#main",
+    "https://github.com/openclaw/openclaw#main",
+    "openclaw/openclaw#main",
+    "git@github.com:openclaw/openclaw.git#main",
+  ])("passes source package target %s through without registry resolution", (tag) => {
+    envSnapshot = captureEnv(["OPENCLAW_UPDATE_PACKAGE_SPEC"]);
+    delete process.env.OPENCLAW_UPDATE_PACKAGE_SPEC;
+
+    expect(canResolveRegistryVersionForPackageTarget(tag)).toBe(false);
+    expect(resolveGlobalInstallSpec({ packageName: "openclaw", tag, env: {} })).toBe(tag);
+  });
+
   it("resolves scoped package paths from the package manager global root", async () => {
     const globalRoot = path.join("tmp", "npm-root");
     const runCommand: CommandRunner = async () => ({


### PR DESCRIPTION
## What Problem This Solves

The slow update CLI suite repeats a complete update transaction for four package-source spellings whose packaging behavior already has focused coverage.

## Why This Change Was Made

Move those four spelling checks to the existing package-target helpers, asserting both exact install-spec preservation and registry-resolution bypass. Keep all six pack/stage/swap cases and five CLI composition cases covering dist-tags, source installation, alias normalization and environment overrides. The retained CLI cases now also assert the metadata-resolution decisions.

This changes tests only: +24/-24 lines, with zero production, support, configuration or shard changes. The original prepacking regression remains covered at its owning layer.

## User Impact

No runtime behavior changes. Developers run fewer duplicate update transactions while preserving coverage of the package-source contracts.

## Evidence

A matched local A/B/A selection passed all 18 cases in every leg. Original runs took 31.74s and 23.51s; the candidate took 19.68s. An additional original-source control took 24.94s and is retained in the comparison. CLI invocations fall from nine to five while four synchronous helper cases replace them; all six existing package transport cases remain. These are local selected-suite measurements, not a whole-CI speedup claim.

The complete global-helper file also passes all 65 cases, including environment restoration and neighboring resolution behavior. The scoped changed-file gate passes. Independent review found no actionable issues. The transport tests use the existing command-runner fixtures and real temporary filesystem operations; this PR does not claim live network/npm proof or alter any dependency contract.
