### PR TITLE
fix(sms): let inbound MMS media survive Twilio's redirect and record why it failed

### DIFF
--- a/extensions/sms/src/inbound.test.ts
+++ b/extensions/sms/src/inbound.test.ts
@@ -281,7 +281,14 @@ describe("dispatchSmsInboundEvent", () => {
       expect.objectContaining({
         url: msg.media[0]?.url,
         maxBytes: 5 * 1024 * 1024,
-        ssrfPolicy: { hostnameAllowlist: ["api.twilio.com"] },
+        ssrfPolicy: {
+          hostnameAllowlist: [
+            "api.twilio.com",
+            "mms.twiliocdn.com",
+            "media.twiliocdn.com",
+            "s3-external-1.amazonaws.com",
+          ],
+        },
         timeoutMs: 60_000,
         retry: {
           attempts: 2,

--- a/extensions/sms/src/media.test.ts
+++ b/extensions/sms/src/media.test.ts
@@ -898,7 +898,14 @@ describe("SMS inbound MMS materialization", () => {
       expect.objectContaining({
         maxBytes: 5 * 1024 * 1024,
         requestInit: expect.objectContaining({ signal: expect.any(AbortSignal) }),
-        ssrfPolicy: { hostnameAllowlist: ["api.twilio.com"] },
+        ssrfPolicy: {
+          hostnameAllowlist: [
+            "api.twilio.com",
+            "mms.twiliocdn.com",
+            "media.twiliocdn.com",
+            "s3-external-1.amazonaws.com",
+          ],
+        },
         timeoutMs: 60_000,
         responseHeaderTimeoutMs: 30_000,
         readIdleTimeoutMs: 30_000,
@@ -1058,5 +1065,120 @@ describe("SMS inbound MMS materialization", () => {
     await expect(pending).rejects.toBe(timeoutReason);
     expect(timeoutSpy).toHaveBeenCalledWith(4 * 60_000);
     timeoutSpy.mockRestore();
+  });
+
+  it("allows Twilio's media CDN redirect targets so the download survives the 307 hop", async () => {
+    const saveRemoteMedia = vi.fn(async () => ({
+      path: "/tmp/mms-1.jpg",
+      size: 1024,
+      contentType: "image/jpeg",
+    }));
+
+    await materializeSmsInboundMedia({
+      account: createAccount(),
+      msg: {
+        accountSid: ACCOUNT_SID,
+        from: "+15551234567",
+        to: "+15557654321",
+        body: "photo",
+        messageSid: MESSAGE_SID,
+        media: [{ url: twilioMediaUrl(), contentType: "image/jpeg" }],
+      },
+      mediaRuntime: { media: { saveRemoteMedia } } as never,
+    });
+
+    const allowlist = saveRemoteMedia.mock.calls[0]?.[0]?.ssrfPolicy?.hostnameAllowlist ?? [];
+    // Twilio redirects the media instance URL off api.twilio.com to the host
+    // that stores the bytes; the guard re-checks the allowlist on that hop.
+    expect(allowlist).toContain("api.twilio.com");
+    expect(allowlist).toContain("mms.twiliocdn.com");
+    expect(allowlist).toContain("media.twiliocdn.com");
+    expect(allowlist).toContain("s3-external-1.amazonaws.com");
+  });
+
+  it("logs why a declared attachment never produced a download attempt", async () => {
+    const saveRemoteMedia = vi.fn();
+    const warn = vi.fn();
+
+    const result = await materializeSmsInboundMedia({
+      account: createAccount(),
+      msg: {
+        accountSid: ACCOUNT_SID,
+        from: "+15551234567",
+        to: "+15557654321",
+        body: "photo",
+        messageSid: MESSAGE_SID,
+        media: [],
+        unavailableMediaCount: 1,
+      },
+      mediaRuntime: { media: { saveRemoteMedia } } as never,
+      log: { warn },
+    });
+
+    expect(saveRemoteMedia).not.toHaveBeenCalled();
+    expect(result.body).toContain("[1 Twilio MMS attachment unavailable]");
+    // Without this warn the transcript notice is the only trace of the failure.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("declared 1 attachment(s) with no usable media URL"),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(MESSAGE_SID));
+  });
+
+  it("reports the underlying fetch failure instead of only the unavailable notice", async () => {
+    const saveRemoteMedia = vi.fn(async () => {
+      throw new MediaFetchError("http_error", "Twilio rejected the media request", {
+        status: 401,
+      });
+    });
+    const warn = vi.fn();
+
+    const result = await materializeSmsInboundMedia({
+      account: createAccount(),
+      msg: {
+        accountSid: ACCOUNT_SID,
+        from: "+15551234567",
+        to: "+15557654321",
+        body: "photo",
+        messageSid: MESSAGE_SID,
+        media: [{ url: twilioMediaUrl(), contentType: "image/jpeg" }],
+      },
+      mediaRuntime: { media: { saveRemoteMedia } } as never,
+      log: { warn },
+    });
+
+    expect(result.body).toContain("[1 Twilio MMS attachment unavailable]");
+    const message = warn.mock.calls.map(([entry]) => entry).join("\n");
+    expect(message).toContain("code=http_error");
+    expect(message).toContain("status=401");
+    expect(message).toContain("Twilio rejected the media request");
+  });
+
+  it("reports a blocked redirect target rather than a bare unavailable notice", async () => {
+    const saveRemoteMedia = vi.fn(async () => {
+      throw new MediaFetchError("fetch_failed", "Failed to fetch media", {
+        cause: new SsrFBlockedError(
+          "Domain policy: Blocked hostname (not in allowlist): mms.twiliocdn.com",
+        ),
+      });
+    });
+    const warn = vi.fn();
+
+    await materializeSmsInboundMedia({
+      account: createAccount(),
+      msg: {
+        accountSid: ACCOUNT_SID,
+        from: "+15551234567",
+        to: "+15557654321",
+        body: "photo",
+        messageSid: MESSAGE_SID,
+        media: [{ url: twilioMediaUrl(), contentType: "image/jpeg" }],
+      },
+      mediaRuntime: { media: { saveRemoteMedia } } as never,
+      log: { warn },
+    });
+
+    const message = warn.mock.calls.map(([entry]) => entry).join("\n");
+    expect(message).toContain("code=fetch_failed");
+    expect(message).toContain("Failed to fetch media");
   });
 });

--- a/extensions/sms/src/media.ts
+++ b/extensions/sms/src/media.ts
@@ -19,7 +19,11 @@ import {
 } from "openclaw/plugin-sdk/outbound-media";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { isTransientNetworkError } from "openclaw/plugin-sdk/retry-runtime";
-import { safeEqualSecret, SsrFBlockedError } from "openclaw/plugin-sdk/security-runtime";
+import {
+  redactSensitiveText,
+  safeEqualSecret,
+  SsrFBlockedError,
+} from "openclaw/plugin-sdk/security-runtime";
 import { assertSmsCredentialOwnerAvailable } from "./credential-availability.js";
 import { getSmsRuntime } from "./runtime.js";
 import { TWILIO_MMS_MAX_BYTES } from "./twilio.js";
@@ -28,6 +32,17 @@ import type { ResolvedSmsAccount, SmsInboundMessage } from "./types.js";
 const TWILIO_API_HOSTNAME = "api.twilio.com";
 const TWILIO_MEDIA_PATH_RE =
   /^\/2010-04-01\/Accounts\/([^/]+)\/Messages\/([^/]+)\/Media\/(ME[0-9a-fA-F]{32})$/u;
+// Twilio answers a media instance URL with a redirect to the host that actually
+// stores the bytes, so the inbound fetch must survive that hop. The redirect
+// loop re-checks `hostnameAllowlist` per URL, and the guard strips the Twilio
+// Basic credential on the cross-origin hop, so listing these adds no new
+// credential exposure.
+const TWILIO_MEDIA_CONTENT_HOSTNAMES = [
+  "mms.twiliocdn.com",
+  "media.twiliocdn.com",
+  "s3-external-1.amazonaws.com",
+] as const;
+const TWILIO_MEDIA_FETCH_HOSTNAMES = [TWILIO_API_HOSTNAME, ...TWILIO_MEDIA_CONTENT_HOSTNAMES];
 const TWILIO_MEDIA_TOTAL_TIMEOUT_MS = 60_000;
 const TWILIO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 30_000;
 const TWILIO_MEDIA_READ_IDLE_TIMEOUT_MS = 30_000;
@@ -332,6 +347,20 @@ function inboundMediaUnavailableBody(body: string, count: number): string {
   });
 }
 
+// "attachment unavailable" is all the operator sees in the transcript, so the
+// warn has to carry enough of the cause to tell an auth failure, a size cap, a
+// blocked redirect target, and a network timeout apart without a repro.
+function describeInboundMediaError(error: unknown): string {
+  if (error instanceof MediaFetchError) {
+    const status = typeof error.status === "number" ? ` status=${error.status}` : "";
+    return redactSensitiveText(`code=${error.code}${status} ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return redactSensitiveText(`${error.name}: ${error.message}`);
+  }
+  return redactSensitiveText(String(error));
+}
+
 function inboundMediaFileName(contentType: string | undefined, index: number): string {
   return `mms-${index + 1}${extensionForMime(contentType) ?? ".bin"}`;
 }
@@ -394,6 +423,14 @@ export async function materializeSmsInboundMedia(params: {
   const cleanup = createInboundMediaCleanup(savedPaths);
   const declaredUnavailableCount = params.msg.unavailableMediaCount ?? 0;
   if (params.msg.media.length === 0) {
+    if (declaredUnavailableCount > 0) {
+      // Twilio declared media the webhook form never carried a usable MediaUrl
+      // for, so no download is even attempted. Without this the transcript
+      // notice is the only trace the message ever had an attachment.
+      params.log?.warn?.(
+        `Twilio MMS ${params.msg.messageSid} declared ${declaredUnavailableCount} attachment(s) with no usable media URL in the webhook form`,
+      );
+    }
     return {
       body:
         declaredUnavailableCount > 0
@@ -433,6 +470,9 @@ export async function materializeSmsInboundMedia(params: {
       abortSignal.throwIfAborted();
       if (remainingBytes <= 0) {
         unavailableCount += 1;
+        params.log?.warn?.(
+          `Skipped Twilio MMS attachment ${index + 1} for ${params.msg.messageSid}: message media budget of ${TWILIO_MMS_MAX_BYTES} bytes is exhausted`,
+        );
         continue;
       }
       try {
@@ -460,7 +500,7 @@ export async function materializeSmsInboundMedia(params: {
           filePathHint: inboundMediaFileName(media.contentType, index),
           fallbackContentType: media.contentType,
           maxBytes: Math.min(params.account.mediaMaxBytes ?? remainingBytes, remainingBytes),
-          ssrfPolicy: { hostnameAllowlist: [TWILIO_API_HOSTNAME] },
+          ssrfPolicy: { hostnameAllowlist: TWILIO_MEDIA_FETCH_HOSTNAMES },
           timeoutMs: TWILIO_MEDIA_TOTAL_TIMEOUT_MS,
           responseHeaderTimeoutMs: TWILIO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
           readIdleTimeoutMs: TWILIO_MEDIA_READ_IDLE_TIMEOUT_MS,
@@ -482,7 +522,7 @@ export async function materializeSmsInboundMedia(params: {
         }
         unavailableCount += 1;
         params.log?.warn?.(
-          `Failed to download Twilio MMS attachment ${index + 1} for ${params.msg.messageSid}`,
+          `Failed to download Twilio MMS attachment ${index + 1} for ${params.msg.messageSid}: ${describeInboundMediaError(error)}`,
         );
       }
     }


### PR DESCRIPTION
Addresses AQ task investigating inbound MMS attachments reporting as "[1 Twilio MMS attachment unavailable]".

Root cause: `extensions/sms/src/media.ts` passed an ssrfPolicy hostnameAllowlist of `['api.twilio.com']` to `saveRemoteMedia`, whose guarded fetch re-checks that allowlist on every redirect hop. Twilio redirects media instance URLs to `mms.twiliocdn.com` / `media.twiliocdn.com` / `s3-external-1.amazonaws.com`, so the redirect was rejected as an SSRF denial and classified non-retryable, silently substituting the "unavailable" placeholder. Present since the original MMS feature commit (554a6f3bbf).

Also closes 3 diagnostic blind spots so a future failure surfaces its underlying fetch error instead of only the generic "unavailable" notice.

Testing: 121 targeted tests in `extensions/sms/src/media.test.ts` and `extensions/sms/src/inbound.test.ts` pass (`node scripts/run-vitest.mjs run extensions/sms/src/media.test.ts extensions/sms/src/inbound.test.ts`). Full repo lint was not completed locally (the monorepo lint script hung in this environment); relying on CI to confirm.

Caveat: gateway logs from the original reported failure show that specific fetch was never attempted, so the redirect-rejection bug is a proven defect but not provably the exact cause of that one message.