### PR TITLE
fix(state): report readonly snapshot cleanup failures

### DIFF
--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -105,11 +105,29 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   const prepared = isArtifactPreservingStateRead()
     ? prepareSqliteReadOnlyLocationSync(pathname)
     : undefined;
+  let outcome: { value: T } | { cause: unknown };
   try {
-    return withOpenClawStateReadOnlyLocation(operation, pathname, prepared?.location ?? pathname);
-  } finally {
-    prepared?.cleanup();
+    outcome = {
+      value: withOpenClawStateReadOnlyLocation(operation, pathname, prepared?.location ?? pathname),
+    };
+  } catch (cause) {
+    outcome = { cause };
   }
+  if (prepared && !prepared.cleanup()) {
+    // The exit retry is best-effort, not proof that this private copy was removed.
+    const readFailure =
+      "cause" in outcome
+        ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+        : "";
+    throw new Error(
+      `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+      "cause" in outcome ? outcome : undefined,
+    );
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }
 
 function withOpenClawStateReadOnlyLocation<T>(
@@ -200,12 +218,30 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync
     const prepared = await prepareSqliteReadOnlyLocation(pathname, {
       preserveSourceArtifacts: true,
     });
+    let outcome: { value: T } | { cause: unknown };
     try {
       // Verification can quarantine the live path while the snapshot child is running.
       openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
-      return withOpenClawStateReadOnlyLocation(operation, pathname, prepared.location);
-    } finally {
-      prepared.cleanup();
+      outcome = {
+        value: withOpenClawStateReadOnlyLocation(operation, pathname, prepared.location),
+      };
+    } catch (cause) {
+      outcome = { cause };
     }
+    if (!prepared.cleanup()) {
+      // The exit retry is best-effort, not proof that this private copy was removed.
+      const readFailure =
+        "cause" in outcome
+          ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+          : "";
+      throw new Error(
+        `${readFailure}State database snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+        "cause" in outcome ? outcome : undefined,
+      );
+    }
+    if ("cause" in outcome) {
+      throw outcome.cause;
+    }
+    return outcome.value;
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`withFreshOpenClawStateDatabaseReadOnly` (sync) and `withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync` (async) in `src/state/openclaw-state-db-readonly.ts` create temporary SQLite read-only snapshots but ignore the `cleanup()` return value in their `finally` blocks. When `removeTempDirectory` fails (disk full, permission denied, or file handle contention), `cleanup()` returns `false` but the caller ignores it, leaving the temporary copy behind with no diagnostic signal.

- Problem: Two call sites (`:105` sync `prepareSqliteReadOnlyLocationSync` + `:200` async `prepareSqliteReadOnlyLocation`) call `prepared?.cleanup()` / `prepared.cleanup()` in `finally` without checking the boolean return value.
- Solution: Capture the read outcome first (value or caught cause), then check `prepared.cleanup()` and throw a diagnostic error with the staging directory path and actionable guidance if cleanup fails. When `prepared` is `undefined` (non-artifact-preserving sync read), cleanup checking is correctly skipped.
- What changed: `src/state/openclaw-state-db-readonly.ts` — replaced `finally { prepared?.cleanup(); }` with an outcome-capture + cleanup-check pattern in both functions, matching the #143844 template.
- What did NOT change: The inner `withOpenClawStateReadOnlyLocation` that opens/closes the database handle is preserved. The `undefined`-prepared path (non-artifact-preserving sync read) behaves identically to before.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Sibling call sites (`shared-store-bootstrap.ts`, `openclaw-state-ownership.ts`, `update-candidate-state.ts`) already check the return value and throw on failure, confirming this is the project's expected pattern. These two call sites were missed.

The fix follows the #143844 template with one adaptation for the sync path: `prepared` can be `undefined` when `artifactPreservingReadOnly` is disabled, so the cleanup check uses `if (prepared && !prepared.cleanup())` to skip the check when no snapshot was created. The async path always has a defined `prepared` (it's only reached when artifact preservation is active), so it uses `if (!prepared.cleanup())` directly.

- Best fix: Yes — minimal, directly aligned with the #143844 pattern, with the correct adaptation for the optional `prepared` case in the sync path.
- Alternative: Making `adoptPreparedLocation` default `requireCleanup = true` would fix all call sites at once, but changes the shared primitive's contract and risks unintended throws in call sites that intentionally tolerate cleanup failure. Per-site fixes are safer.
- Risk: Low. Normal-path behavior is unchanged. The undefined-prepared path (no snapshot) is unaffected. The only new behavior is a diagnostic error thrown when cleanup fails, which was previously silent.

## User Impact

Operators will now see a clear diagnostic error when temporary snapshot cleanup fails during read-only state database inspection, instead of silent temporary file accumulation. The error message includes the staging directory path and guidance to check permissions and available storage.

## Evidence

Live command verification using `node --import tsx` with a real SQLite state database fixture and an `fs.rmSync` fault injection preload:

```console
$ node /home/code/github/contributions/BUG/BUG-072-evidence/proof.mjs

=== Test 1: Sync path — cleanup failure ===
{"ok":false,"message":"State database snapshot cleanup failed: /tmp/bug072-DXGNP5/cache-sync-fault/openclaw-1000/openclaw-sqlite-readonly-4136611-EKnfyl/openclaw-sqlite-readonly-4136739-uKwQVX. Check directory permissions and available storage before retrying."}
✅ PASS: Sync cleanup failure throws diagnostic error

=== Test 2: Sync path — normal ===
{"ok":true,"value":"committed"}
✅ PASS: Sync normal path returns data

=== Test 3: Async path — cleanup failure ===
{"ok":false,"message":"State database snapshot cleanup failed: /tmp/bug072-DXGNP5/cache-async-fault/openclaw-1000/openclaw-sqlite-readonly-4136919-GUTiqB/openclaw-sqlite-readonly-4137003-9EFi3V. Check directory permissions and available storage before retrying."}
✅ PASS: Async cleanup failure throws diagnostic error

=== Test 4: Async path — normal ===
{"ok":true,"value":"committed"}
✅ PASS: Async normal path returns data

=== All 4 tests passed ===
```

Behavior matrix:

```text
scenario                    sync path    async path
cleanup failure + read ok   throws       throws
cleanup ok + read ok        returns      returns
no snapshot (sync only)     returns      n/a
```

Existing test suite: 21 tests in `src/state/openclaw-state-db-readonly.test.ts` all pass.

## AI Assistance

This PR was prepared with AI assistance. The AI identified the missing cleanup return-value check by applying the `removeTempDirectory` anchor pattern (grep for all `prepareSqliteReadOnlyLocation*` call sites that don't check `cleanup()` return value), verified the bug against `origin/main`, and implemented the fix following the #143844 template. The AI understands the code: both functions create private SQLite snapshots for read-only state inspection, and `cleanup()` returns `false` when `removeTempDirectory` fails, which was previously silently swallowed.
