### PR TITLE
refactor(openai): remove duplicate realtime auth test

### DIFF
--- a/extensions/openai/realtime-voice-browser-auth.test.ts
+++ b/extensions/openai/realtime-voice-browser-auth.test.ts
@@ -73,23 +73,6 @@ describe("OpenAI realtime voice browser authentication", () => {
     restoreTestEnvironment();
   });
 
-  it("requires Platform auth for native realtime websocket bridges", async () => {
-    const provider = buildOpenAIRealtimeVoiceProvider();
-    const bridge = provider.createBridge({
-      cfg: {} as never,
-      providerConfig: { model: "gpt-realtime-2" },
-      onAudio: vi.fn(),
-      onClearAudio: vi.fn(),
-    });
-
-    await expect(bridge.connect()).rejects.toThrow(
-      "OpenAI Realtime voice requires an OpenAI Platform API key",
-    );
-
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-    expect(FakeWebSocket.instances).toHaveLength(0);
-  });
-
   it.each([
     {
       $name: "environment API key",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The OpenAI realtime bridge auth tests repeated the same missing-key failure path without protecting an additional behavior.

## Why This Change Was Made

Remove the redundant native bridge case. The retained stronger case uses the same fresh inputs, rejection, and no-HTTP/no-WebSocket assertions, and additionally verifies API-key-only profile lookup with external CLI auth excluded.

## User Impact

No runtime behavior changes. Removes one test case and 17 test lines; all other cases, assertions, imports, and helpers remain unchanged.

## Evidence

- Full ordered `extensions/openai/realtime-voice-browser-auth.test.ts`: 28 actual passes, zero skips, through the normal OpenAI provider test configuration.
- All 19 selected changed checks passed.
- Fresh P2 review: scoped-clean, no findings.

This proves the missing-auth and profile-selection boundary, not rejection of a seeded OAuth profile. No live OpenAI, WebSocket, keychain, Gateway, installed-package, or local full-repository test-suite proof is claimed.
