### PR TITLE
fix(agents): honor selected provider in tool inventory

### DIFF
--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -149,9 +149,28 @@ describe("acquireEffectiveToolInventoryRuntimeModelContext", () => {
     ["prefixed fallback", "custom", "configured", "custom/configured", undefined],
     ["case-insensitive fallback", "custom", "configured", "Configured", undefined],
     ["static alias", "xai", "grok-4.3-latest", "grok-4.3", undefined],
+    ["exact provider key", "custom", "configured", "configured", undefined, "custom", "Custom"],
+    ["provider case fallback", "custom", "configured", "configured", undefined, "Custom"],
+    [
+      "merged trimmed provider keys",
+      "custom",
+      "configured",
+      "configured",
+      undefined,
+      " custom ",
+      "custom",
+    ],
   ] as const)(
     "uses configured model context without acquiring a runtime lease (%s)",
-    async (_case, provider, modelId, rowId, siblingId) => {
+    async (
+      _case,
+      provider,
+      modelId,
+      rowId,
+      siblingId,
+      providerKey?: string,
+      siblingProviderKey?: string,
+    ) => {
       const { acquireEffectiveToolInventoryRuntimeModelContext, resolveConfiguredModelCompat } =
         await import("./tools-effective-inventory.js");
       const configuredModel = {
@@ -164,7 +183,23 @@ describe("acquireEffectiveToolInventoryRuntimeModelContext", () => {
       const cfg = makeOpenClawConfigFixture({
         models: {
           providers: {
-            [provider]: {
+            ...(siblingProviderKey
+              ? {
+                  [siblingProviderKey]: {
+                    baseUrl: "https://sibling.example.invalid",
+                    api: "openai-completions" as const,
+                    models: [
+                      {
+                        ...configuredModel,
+                        name: "Sibling provider",
+                        compat: { supportsTools: false },
+                      },
+                    ],
+                  },
+                }
+              : {}),
+            [providerKey ?? provider]: {
+              baseUrl: "https://configured.example.invalid",
               api: "anthropic-messages",
               models: [
                 ...(siblingId

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -3,16 +3,16 @@
  *
  * Builds model-visible tool lists after profile, provider, plugin, policy, and compatibility filters.
  */
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/config.js";
-import { findConfiguredProviderModel } from "../config/model-provider-config.js";
+import {
+  findConfiguredProviderModel,
+  resolveMergedModelProviderConfig,
+} from "../config/model-provider-config.js";
 import { extractModelCompat } from "../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtime.js";
@@ -171,7 +171,7 @@ function resolveStaticToolInventoryRuntimeModelContext(params: {
   }
   const agentId = params.agentId?.trim() || resolveSessionAgentId({ config: params.cfg });
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
-  const providerConfig = findNormalizedProviderValue(params.cfg.models?.providers, provider);
+  const providerConfig = resolveMergedModelProviderConfig(params.cfg, provider);
   const configuredModel = findConfiguredProviderModel(providerConfig, provider, modelId, (id) =>
     normalizeLowercaseStringOrEmpty(normalizeStaticProviderModelId(provider, id)),
   );
@@ -312,7 +312,7 @@ export function resolveConfiguredModelCompat(params: {
   if (!provider || !modelId) {
     return undefined;
   }
-  const providerConfig = findNormalizedProviderValue(params.cfg.models?.providers, provider);
+  const providerConfig = resolveMergedModelProviderConfig(params.cfg, provider);
   const match = findConfiguredProviderModel(providerConfig, provider, modelId, (id) =>
     normalizeLowercaseStringOrEmpty(normalizeStaticProviderModelId(provider, id)),
   );


### PR DESCRIPTION
Related: #144010

## What Problem This Solves

Fixes an issue where a session's effective tool inventory could use a sibling provider configuration when provider keys differed only by case or surrounding whitespace. Its transport and compatibility metadata could disagree with the selected provider.

## Why This Change Was Made

Use the existing provider-config resolver for both static inventory metadata and model compatibility. It prefers the exact normalized key, preserves case-insensitive fallback, and merges trim-equivalent entries in authored order. Model-ID selection, bundled fallback and dynamic runtime ownership retain their existing behavior.

## User Impact

Effective tool inventories consistently use the selected provider's configuration, including tool compatibility settings.

## Evidence

The existing regression table now includes exact-provider collisions, case fallback and trimmed-key merging. On unchanged production, two cases selected the sibling API/name/compatibility and failed; all 14 cases pass after the fix with identical test bytes. Another 47 sibling cases and all 29 canonical changed checks pass. Independent review found no actionable findings.

Assertions use literal expected metadata and require zero dynamic runtime acquisition for configured models. No live provider, Gateway or Codex execution is claimed. Production LOC is unchanged; tests add 35 lines net.
