### PR TITLE
fix: prevent ambient heartbeats from disrupting the reset regression

### DIFF
--- a/src/gateway/server-methods/chat.reset-visible-yield.test.ts
+++ b/src/gateway/server-methods/chat.reset-visible-yield.test.ts
@@ -513,6 +513,7 @@ describe("visible yielded session reset", () => {
               defaults: {
                 workspace,
                 skipBootstrap: true,
+                heartbeat: { every: "0m" },
                 model: { primary: provider.modelRef },
                 models: {
                   [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The session-reset regression's strict loopback provider can receive an unrelated ambient heartbeat request without any of its scenario markers. That makes the fixture fail independently of the yielded-descendant cancellation behavior it is testing.

## Why This Change Was Made

Set the fixture's heartbeat cadence to zero, matching sibling real-provider Gateway tests. This removes recurring/broadcast enrollment while retaining the normal wake owner, permitted targeted events, real subagent delivery, and every provider/reset assertion.

## User Impact

No production behavior change. The reset test remains strict about unexpected provider calls and continues testing real yield metadata and descendant cancellation.

## Evidence

A bounded synthetic comparison issued one untargeted wake after the fixture Gateway's startup settled. With default cadence it reached the provider without a marker and failed the existing fixtureErrors assertion. With zero cadence the same request settled skipped/disabled, no heartbeat inference was observed, and the complete reset case passed, including both public cancelled-task assertions. Both arms retained all provider responses and assertions; no wake filtering or global disable was used.

The historical full-suite heartbeat's originating producer remains unknown. The controlled result establishes untargeted fixture isolation, not that historical provenance or a full-run performance improvement. The permanent change contains only the one fixture configuration line; diagnostic code and synthetic wake injection are excluded.

Uninstrumented final validation on current main plus this one-line change: the complete reset test and the existing targeted-unscheduled-wake suite passed all 53 cases with no failures or skips, using the repository test runner. The latter retains coverage for permitted targeted wakes at zero cadence and malformed/global-disabled wake rejection.

The mapped changed-file gate passed, including core-test typechecking, lint, formatting and guards. Independent review found no actionable P0–P2 findings.
