### PR TITLE
fix(prometheus): avoid unused private diagnostic copies

### DIFF
--- a/docs/plugins/sdk-runtime/gateway-and-nodes.md
+++ b/docs/plugins/sdk-runtime/gateway-and-nodes.md
@@ -216,6 +216,14 @@ throws after the service lease is revoked. Hosts that do not provide this
 optional capability leave runtime identity unavailable. This diagnostic fact
 does not grant authority or identify a service-reload epoch.
 
+Their `ctx.internalDiagnostics.onEvent(listener, filter?, options?)` subscription
+delivers events, trust metadata, and a frozen private-data object. Exporters that
+only need events and metadata can pass `{ includePrivateData: false }` as the
+third registration argument to skip private payload copies and receive a frozen
+empty object instead. This preserves event filters, trusted-only delivery, and
+service lease cleanup. Private data remains enabled by default; older hosts
+ignore the optional argument and retain their existing copying behavior.
+
 Long-lived services registered with `api.registerService(...)` receive a process-local
 `ctx.gatewayEvents` facade when the process runs a Gateway broadcaster; in runtimes without one the
 field is absent, so feature-detect it and keep a fallback (for example a coarse poll). Use

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -1,7 +1,12 @@
 import { createServer } from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 // Diagnostics Prometheus tests cover service plugin behavior.
-import type { DiagnosticEventPrivateData } from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
+  emitTrustedDiagnosticEventWithPrivateData,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPrivateData,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { onTrustedInternalDiagnosticEvent } from "openclaw/plugin-sdk/plugin-test-runtime";
 // Diagnostics Prometheus tests cover service plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventMetadata, DiagnosticEventPayload } from "../api.js";
@@ -24,6 +29,46 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
 }));
 
 describe("diagnostics-prometheus service", () => {
+  it("records terminal metrics without reading private diagnostic content", async () => {
+    const exporter = createDiagnosticsPrometheusExporter();
+    const readPrivateContent = vi.fn(() => ({ toolInput: { text: "private tool input" } }));
+    exporter.service.start({
+      config: {},
+      stateDir: "/tmp/openclaw-prometheus-test",
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      internalDiagnostics: {
+        emit() {},
+        onEvent: onTrustedInternalDiagnosticEvent,
+      },
+    });
+    try {
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "tool.execution.completed",
+          runId: "run-1",
+          toolCallId: "call-1",
+          toolName: "synthetic",
+          toolSource: "core",
+          durationMs: 3,
+        },
+        {
+          get toolContent() {
+            return readPrivateContent();
+          },
+        },
+      );
+      await waitForDiagnosticEventsDrained();
+      expect(exporter.render()).toContain(
+        'openclaw_tool_execution_total{error_category="none",outcome="completed",params_kind="unknown",tool="synthetic",tool_owner="none",tool_source="core"} 1',
+      );
+      expect(readPrivateContent).not.toHaveBeenCalled();
+    } finally {
+      exporter.service.stop?.();
+      await waitForDiagnosticEventsDrained();
+    }
+    expect(exporter.render()).toBe("");
+  });
+
   it("records Gateway RPC timings by method and outcomes without method multiplication", () => {
     const metrics = createMetricsHarness();
     const base = {

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -1100,15 +1100,19 @@ export function createDiagnosticsPrometheusExporter() {
           1,
         );
       }
-      unsubscribe = subscribe((event, metadata) => {
-        try {
-          recordDiagnosticEvent(store, event, metadata);
-        } catch (err) {
-          ctx.logger.error(
-            `diagnostics-prometheus: event handler failed (${event.type}): ${safeErrorMessage(err)}`,
-          );
-        }
-      });
+      unsubscribe = subscribe(
+        (event, metadata) => {
+          try {
+            recordDiagnosticEvent(store, event, metadata);
+          } catch (err) {
+            ctx.logger.error(
+              `diagnostics-prometheus: event handler failed (${event.type}): ${safeErrorMessage(err)}`,
+            );
+          }
+        },
+        undefined,
+        { includePrivateData: false },
+      );
       internalDiagnostics = ctx.internalDiagnostics as unknown as TrustedExporterDiagnosticsBridge;
       reportExporterHealth({
         signal: "metrics",

--- a/src/infra/diagnostic-events.private-data.test.ts
+++ b/src/infra/diagnostic-events.private-data.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  hasInternalDiagnosticEventInterest,
+  hasInternalDiagnosticEventListeners,
+} from "./diagnostic-event-listener-presence.js";
+import {
+  emitTrustedDiagnosticEventWithPrivateData,
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "./diagnostic-events.js";
+
+beforeEach(resetDiagnosticEventsForTest);
+afterEach(resetDiagnosticEventsForTest);
+
+it("replaces private-data policy with listener interests and clears it on reset", () => {
+  const received = vi.fn();
+  const readPrivateData = vi.fn(() => "synthetic private error");
+  const emit = () =>
+    emitTrustedDiagnosticEventWithPrivateData(
+      { type: "model.usage", usage: { input: 1 } },
+      {
+        get errorMessage() {
+          return readPrivateData();
+        },
+      },
+    );
+  const stop = onTrustedInternalDiagnosticEvent(received, { include: ["log.record"] });
+  onTrustedInternalDiagnosticEvent(
+    received,
+    { include: ["model.usage"] },
+    { includePrivateData: false },
+  );
+  expect(hasInternalDiagnosticEventInterest("log.record")).toBe(false);
+  expect(hasInternalDiagnosticEventInterest("model.usage")).toBe(true);
+  emit();
+  expect(received.mock.calls[0]?.[2]).toEqual({});
+  expect(readPrivateData).not.toHaveBeenCalled();
+
+  onTrustedInternalDiagnosticEvent(received, { include: ["model.usage"] });
+  emit();
+  expect(received.mock.calls[1]?.[2]).toEqual({ errorMessage: "synthetic private error" });
+  expect(readPrivateData).toHaveBeenCalledOnce();
+  stop();
+  expect(hasInternalDiagnosticEventInterest("model.usage")).toBe(false);
+  expect(hasInternalDiagnosticEventListeners()).toBe(false);
+  emit();
+  expect(received).toHaveBeenCalledTimes(2);
+
+  onTrustedInternalDiagnosticEvent(received, undefined, { includePrivateData: false });
+  resetDiagnosticEventsForTest();
+  expect(hasInternalDiagnosticEventListeners()).toBe(false);
+  const stopAfterReset = onTrustedInternalDiagnosticEvent(received);
+  emit();
+  expect(received.mock.calls[2]?.[2]).toEqual({ errorMessage: "synthetic private error" });
+  expect(readPrivateData).toHaveBeenCalledTimes(2);
+  stopAfterReset();
+});

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -441,12 +441,15 @@ describe("diagnostic-events", () => {
       const skillFile = "/workspace/skills/daily-brief/SKILL.md";
       const publicEvents: DiagnosticEventPayload[] = [];
       const sharedEvents: DiagnosticEventPayload[] = [];
+      const metadataOnly = vi.fn();
+      const readSkillFile = vi.fn(() => skillFile);
       const trustedEvents: Array<{
         event: DiagnosticEventPayload;
         privateData: DiagnosticEventPrivateData;
       }> = [];
       onDiagnosticEvent((event) => publicEvents.push(event));
       onInternalDiagnosticEvent((event) => sharedEvents.push(event));
+      onTrustedInternalDiagnosticEvent(metadataOnly, undefined, { includePrivateData: false });
       onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
         trustedEvents.push({ event, privateData });
       });
@@ -459,7 +462,13 @@ describe("diagnostic-events", () => {
           skillSource: "workspace",
           activation: "read",
         },
-        { skillUsage: { skillFile } },
+        {
+          skillUsage: {
+            get skillFile() {
+              return readSkillFile();
+            },
+          },
+        },
       );
       await waitForDiagnosticEventsDrained();
 
@@ -469,6 +478,13 @@ describe("diagnostic-events", () => {
       expect(trustedEvents).toHaveLength(1);
       expect(trustedEvents[0]?.event).not.toHaveProperty("skillFile");
       expect(trustedEvents[0]?.privateData.skillUsage?.skillFile).toBe(skillFile);
+      expect(readSkillFile).toHaveBeenCalledOnce();
+      expect(metadataOnly).toHaveBeenCalledExactlyOnceWith(
+        trustedEvents[0]?.event,
+        expect.objectContaining({ trusted: true }),
+        {},
+      );
+      expect(Object.isFrozen(metadataOnly.mock.calls[0]?.[2])).toBe(true);
     },
   );
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -959,6 +959,14 @@ type TrustedDiagnosticEventListener = (
   privateData: DiagnosticEventPrivateData,
 ) => void;
 
+type TrustedDiagnosticEventListenerOptions = Readonly<{ includePrivateData?: boolean }>;
+type TrustedDiagnosticEventInterest = InternalDiagnosticEventInterest<
+  DiagnosticEventPayload["type"]
+> &
+  TrustedDiagnosticEventListenerOptions;
+
+const EMPTY_DIAGNOSTIC_PRIVATE_DATA: DiagnosticEventPrivateData = Object.freeze({});
+
 type TrustedOtelDiagnosticEventPrivateData = DiagnosticEventPrivateData &
   Readonly<{
     hostPluginId?: string;
@@ -993,10 +1001,7 @@ type DiagnosticEventsGlobalState = {
     DiagnosticEventListener,
     InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined
   >;
-  trustedListeners: Map<
-    TrustedDiagnosticEventListener,
-    InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined
-  >;
+  trustedListeners: Map<TrustedDiagnosticEventListener, TrustedDiagnosticEventInterest | undefined>;
   toolExecutionListeners: Set<TrustedToolExecutionEventListener>;
   toolExecutionSeq: number;
   dispatchDepth: number;
@@ -1179,7 +1184,9 @@ function dispatchDiagnosticEvent(
       try {
         const eventForListener = cloneDiagnosticEventForListener(enriched);
         const metadataForListener = createDiagnosticMetadataForListener(metadata);
-        if (isTrustedOtelDiagnosticListener(listener)) {
+        if (interest?.includePrivateData === false) {
+          listener(eventForListener, metadataForListener, EMPTY_DIAGNOSTIC_PRIVATE_DATA);
+        } else if (isTrustedOtelDiagnosticListener(listener)) {
           listener(
             eventForListener,
             metadataForListener,
@@ -1585,11 +1592,14 @@ export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "
   });
 }
 
-function registerDiagnosticEventListener<T>(
+function registerDiagnosticEventListener<
+  T,
+  Interest extends InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
+>(
   state: DiagnosticEventsGlobalState,
-  listeners: Map<T, InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined>,
+  listeners: Map<T, Interest | undefined>,
   listener: T,
-  filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
+  filter?: Interest,
 ): () => void {
   if (listeners.has(listener)) {
     updateInternalDiagnosticEventInterest(listeners.get(listener), -1);
@@ -1619,9 +1629,13 @@ export function onInternalDiagnosticEvent(
 export function onTrustedInternalDiagnosticEvent(
   listener: TrustedDiagnosticEventListener,
   filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
+  options?: TrustedDiagnosticEventListenerOptions,
 ): () => void {
   const state = getDiagnosticEventsState();
-  return registerDiagnosticEventListener(state, state.trustedListeners, listener, filter);
+  return registerDiagnosticEventListener(state, state.trustedListeners, listener, {
+    ...filter,
+    includePrivateData: options?.includePrivateData,
+  });
 }
 
 /** Subscribes to trusted metadata-only tool execution events, even when diagnostics are disabled. */

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -390,6 +390,8 @@ export type OpenClawPluginServiceContext = {
         privateData: DiagnosticEventPrivateData,
       ) => void,
       filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
+      /** Defaults to true; false skips private payload copies and passes a frozen empty object. */
+      options?: { includePrivateData?: boolean },
     ) => () => void;
     registerTracePropagationBridge?: (bridge: DiagnosticTracePropagationBridge) => () => void;
   };

--- a/src/plugins/services.diagnostics.test.ts
+++ b/src/plugins/services.diagnostics.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { hasInternalDiagnosticEventInterest } from "../infra/diagnostic-event-listener-presence.js";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import { createEmptyPluginRegistry } from "./registry.js";
+import { startPluginServices } from "./services.js";
+import type { OpenClawPluginService } from "./types.js";
+
+beforeEach(resetDiagnosticEventsForTest);
+afterEach(resetDiagnosticEventsForTest);
+
+it.each([undefined, false])(
+  "retains filtered diagnostic interests and private policy (%s) for the exporter lifetime",
+  async (includePrivateData) => {
+    const received = vi.fn();
+    const readPrivateData = vi.fn(() => "synthetic private error");
+    const service: OpenClawPluginService = {
+      id: "diagnostics-otel",
+      start: (ctx) => {
+        ctx.internalDiagnostics!.onEvent(
+          received,
+          { include: ["log.record"] },
+          { includePrivateData },
+        );
+      },
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.services.push({ pluginId: service.id, origin: "bundled", source: "test", service });
+    const handle = await startPluginServices({ registry, config: {} });
+    try {
+      expect(hasInternalDiagnosticEventInterest("log.record")).toBe(true);
+      expect(hasInternalDiagnosticEventInterest("gateway.event_loop.sample")).toBe(false);
+      expect(hasInternalDiagnosticEventInterest("gateway.rpc")).toBe(false);
+      emitTrustedDiagnosticEventWithPrivateData(
+        { type: "log.record", level: "INFO", message: "synthetic" },
+        {
+          get errorMessage() {
+            return readPrivateData();
+          },
+        },
+      );
+      emitTrustedDiagnosticEvent({ type: "gateway.rpc", phase: "received", method: "health" });
+      emitTrustedDiagnosticEvent({
+        type: "gateway.event_loop.sample",
+        intervalMs: 1_000,
+        delayMaxMs: 1_500,
+      });
+      await waitForDiagnosticEventsDrained();
+      expect(received.mock.calls.map(([event]) => event.type)).toEqual(["log.record"]);
+      expect(readPrivateData).toHaveBeenCalledTimes(includePrivateData === false ? 0 : 1);
+      expect(received.mock.calls[0]?.[2]).toEqual(
+        includePrivateData === false ? {} : { errorMessage: "synthetic private error" },
+      );
+      expect(Object.isFrozen(received.mock.calls[0]?.[2])).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(false);
+    expect(hasInternalDiagnosticEventInterest("gateway.event_loop.sample")).toBe(false);
+    expect(hasInternalDiagnosticEventInterest("gateway.rpc")).toBe(false);
+  },
+);

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -17,7 +17,6 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import { STATE_DIR } from "../config/paths.js";
-import { hasInternalDiagnosticEventInterest } from "../infra/diagnostic-event-listener-presence.js";
 import {
   emitTrustedDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -888,36 +887,6 @@ describe("startPluginServices", () => {
       "sidecars.plugin-services.plugin~003Atest.service_a",
     ]);
     expect(new Set(measured).size).toBe(measured.length);
-  });
-
-  it("retains filtered diagnostic interests only for the exporter service lifetime", async () => {
-    const received = vi.fn();
-    const service: OpenClawPluginService = {
-      id: "diagnostics-otel",
-      start: (ctx) => {
-        ctx.internalDiagnostics!.onEvent(received, { include: ["log.record"] });
-      },
-    };
-    const handle = await startPluginServices({
-      registry: createRegistry([service], service.id, "bundled"),
-      config: createServiceConfig(),
-    });
-    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(true);
-    expect(hasInternalDiagnosticEventInterest("gateway.event_loop.sample")).toBe(false);
-    expect(hasInternalDiagnosticEventInterest("gateway.rpc")).toBe(false);
-    emitTrustedDiagnosticEvent({ type: "log.record", level: "INFO", message: "synthetic" });
-    emitTrustedDiagnosticEvent({ type: "gateway.rpc", phase: "received", method: "health" });
-    emitTrustedDiagnosticEvent({
-      type: "gateway.event_loop.sample",
-      intervalMs: 1_000,
-      delayMaxMs: 1_500,
-    });
-    await waitForDiagnosticEventsDrained();
-    expect(received.mock.calls.map(([event]) => event.type)).toEqual(["log.record"]);
-    await handle.stop();
-    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(false);
-    expect(hasInternalDiagnosticEventInterest("gateway.event_loop.sample")).toBe(false);
-    expect(hasInternalDiagnosticEventInterest("gateway.rpc")).toBe(false);
   });
 
   it("grants internal diagnostics only to trusted diagnostics exporter services", async () => {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -85,12 +85,14 @@ function createServiceContext(params: {
             params.lease.assertActive("internal diagnostic emitter");
             emitTrustedDiagnosticEventWithPrivateData(event, privateData);
           },
-          onEvent: (listener, filter) => {
+          onEvent: (listener, filter, options) => {
             params.lease.assertActive("internal diagnostic listener");
             const trustedListener = isOtelExporter
               ? markTrustedOtelDiagnosticListener(listener)
               : listener;
-            return params.lease.retain(onTrustedInternalDiagnosticEvent(trustedListener, filter));
+            return params.lease.retain(
+              onTrustedInternalDiagnosticEvent(trustedListener, filter, options),
+            );
           },
           registerTracePropagationBridge: (bridge) => {
             params.lease.assertActive("diagnostic trace propagation bridge");


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary private-content copying when operators use Prometheus alongside diagnostic model or tool content capture. Each interested Prometheus listener copied and froze the private payload even though its metrics only consume the event and trust metadata.

## Why This Change Was Made

Trusted exporter subscriptions can opt out of private data with an optional registration argument. Prometheus uses that option and receives a frozen empty third argument while retaining the existing trusted audience, filters, and service lifetime. Default private-data delivery and OTel attribution are unchanged. Older hosts ignore the optional argument and retain their existing behavior.

## User Impact

Prometheus avoids private-payload traversal and cloning while preserving model, tool, GC, and skill metrics, including trusted skill usage when diagnostics are disabled. This does not change content capture settings or diagnostic queue behavior.

## Evidence

The same small synthetic workload through the actual host service bridge and Prometheus exporter measured two private-payload native clone calls and two private-field reads before the repair, and zero of each afterward. Required metric values, rejection of untrusted events, disabled-diagnostics skill accounting, and stop cleanup passed in both runs. These counts are not allocation-byte, RSS, or CPU measurements.

The committed exporter regression failed on the original code because it read the private payload. Focused dispatcher, plugin service, and Prometheus tests passed: 87 tests across five files. Independent review found no actionable P0–P2 findings. The same before/after workload also passed on Linux through [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34488671538); both probe processes returned and the lease was independently confirmed completed. This is source behavior proof with matching shared dependencies, not two independent package installations. The final production files are byte-identical to that remote proof. All changed-scope checks passed.

Compatibility decision: retain the documented additive subscription argument. The inspected pre-change host bridge accepts the listener and filter and forwards only those arguments; an extra optional argument leaves its existing copy behavior intact. Existing plugin calls omit the option and retain the new host's default private-data delivery. The optimization therefore requires a supporting host. Independently installed host/plugin combinations remain unexercised, and these results make no production latency or CPU attribution.
