### PR TITLE
test: reuse source transforms across gateway startup fixtures

### DIFF
--- a/src/cli/gateway-cli/pre-bootstrap.process.test.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.process.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   createSourceRuntime,
@@ -9,6 +9,14 @@ import {
 } from "../../commands/doctor-config-preflight.process.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+const runtimeParent = fs.realpathSync(tempDirs.make("openclaw-selection-runtime-"));
+const childTempDir = fs.realpathSync(tempDirs.make("openclaw-selection-tmp-"));
+
+beforeEach(() => {
+  // TSX keys transforms by source path. Reuse that path, but recreate package
+  // assets after the previous child has joined; scenario state stays private.
+  fs.rmSync(path.join(runtimeParent, "runtime"), { recursive: true, force: true });
+});
 
 function stateManifest(root: string): Record<string, string> {
   return Object.fromEntries(
@@ -36,7 +44,7 @@ describe("Gateway config selection before migration admission", () => {
     "prepares recovery safely for $name",
     async ({ name, code }) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-recovery-selection-"));
-      const runtimeRoot = createSourceRuntime(root);
+      const runtimeRoot = createSourceRuntime(runtimeParent);
       const stateDir = path.join(root, "state");
       fs.mkdirSync(stateDir);
       const configPath = path.join(stateDir, "openclaw.json");
@@ -72,6 +80,9 @@ describe("Gateway config selection before migration admission", () => {
       const result = await runIsolatedModuleScript(
         {
           ...process.env,
+          TMPDIR: childTempDir,
+          TEMP: childTempDir,
+          TMP: childTempDir,
           HOME: root,
           USERPROFILE: root,
           OPENCLAW_HOME: root,
@@ -123,7 +134,7 @@ describe("Gateway config selection before migration admission", () => {
     "preserves every state artifact with backup=%s",
     async (withBackup) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-readonly-bootstrap-"));
-      const runtimeRoot = createSourceRuntime(root);
+      const runtimeRoot = createSourceRuntime(runtimeParent);
       const stateDir = path.join(root, "state");
       fs.mkdirSync(stateDir);
       const configPath = path.join(stateDir, "openclaw.json");
@@ -145,6 +156,9 @@ describe("Gateway config selection before migration admission", () => {
       const before = stateManifest(stateDir);
       const env = {
         ...process.env,
+        TMPDIR: childTempDir,
+        TEMP: childTempDir,
+        TMP: childTempDir,
         HOME: root,
         USERPROFILE: root,
         OPENCLAW_HOME: root,
@@ -193,7 +207,7 @@ describe("Gateway config selection before migration admission", () => {
     "passes $flag through $dispatch startup admission without config",
     async ({ flag, suffix, dev, allowUnconfigured }) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-startup-allowance-"));
-      const runtimeRoot = createSourceRuntime(root);
+      const runtimeRoot = createSourceRuntime(runtimeParent);
       const stateDir = path.join(root, "state");
       fs.mkdirSync(stateDir);
       const configPath = path.join(stateDir, "openclaw.json");
@@ -214,7 +228,9 @@ describe("Gateway config selection before migration admission", () => {
         XDG_STATE_HOME: path.join(root, "xdg-state"),
         XDG_CACHE_HOME: path.join(root, "cache"),
         NPM_CONFIG_USERCONFIG: path.join(root, "npmrc"),
-        TMPDIR: root,
+        TMPDIR: childTempDir,
+        TEMP: childTempDir,
+        TMP: childTempDir,
         NO_COLOR: "1",
       };
       // Keep parsing, environment selection, preaction, and config admission real.


### PR DESCRIPTION
## What Problem This Solves

Gateway startup process tests repeatedly transform the same application source because every scenario gives its private package fixture a different source path. The startup-allowance cases also discard the transform cache between child processes.

## Why This Change Was Made

Reuse one fixture pathname within the test file, recreating its mutable package assets before every sequential case. Give child temporary files a separate file-owned directory so TSX can reuse its source transforms. Each scenario still gets fresh home, configuration, workspace and state directories and a fresh native Node process.

All eleven cases and their assertions remain: future-version recovery refusal, read-only state preservation, environment selection, and real fast/Commander parsing of both startup flags. The existing final Gateway action hook is unchanged. This is test-only: +21/-5 lines, zero production or dependency changes.

## User Impact

No runtime behavior changes. Developers get faster startup contract tests without adding CI shards.

## Evidence

The same two real startup-mode cases passed in a local original/candidate/original comparison: 19.98s / 14.55s / 16.07s including wrapper setup and the first cold child. The second child took 2.88s with reuse, versus 5.62s and 5.09s on the original. These are local measurements, not a whole-CI speedup claim.

The final candidate also maps Windows TEMP/TMP to the owned temporary directory. All eleven existing cases pass in original order, taking 25.00s locally including wrapper cleanup. The scoped changed-file gate passes, and independent review found no actionable issues. The installed TSX implementation keys transformations by source bytes, source path, options and compiler version; package assets are recreated rather than retained between cases. The separate built Gateway rig continues to own real listener-startup proof.
