### PR TITLE
fix(cli): inherit migrate options placed before the subcommand

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -38,11 +38,13 @@ openclaw onboard --import-from hermes --import-source ~/.hermes
 
 Running `openclaw migrate <provider>` with no other flags plans, previews, and (in a TTY) prompts before applying. `openclaw migrate plan <provider>` and `openclaw migrate apply <provider>` split preview and apply into separate subcommands with the same flags.
 
+Shared flags work in either position, so `openclaw migrate --no-auth-credentials apply hermes --yes` and `openclaw migrate apply hermes --no-auth-credentials --yes` behave the same. A flag placed on the subcommand overrides the same flag placed before it. `--dry-run` is the exception: `openclaw migrate apply` rejects it instead of applying, because apply always changes state.
+
 <ParamField path="<provider>" type="string">
   Name of a registered migration provider, for example `hermes`. Run `openclaw migrate list` to see installed providers.
 </ParamField>
 <ParamField path="--dry-run" type="boolean">
-  Build the plan and exit without changing state.
+  Build the plan and exit without changing state. Not accepted by `openclaw migrate apply`; use `openclaw migrate plan <provider>` instead.
 </ParamField>
 <ParamField path="--from <path>" type="string">
   Override the source state directory. Hermes follows `$HERMES_HOME` and the active profile, then uses the platform default (`~/.hermes` or `%LOCALAPPDATA%\hermes`). Codex defaults to `~/.codex` (or `$CODEX_HOME`), Claude defaults to `~/.claude`.

--- a/src/cli/program/register.migrate.test.ts
+++ b/src/cli/program/register.migrate.test.ts
@@ -1,9 +1,10 @@
 // Migrate CLI registration tests cover public option forwarding.
-import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenClawCommand } from "./openclaw-command.js";
 import { registerMigrateCommand } from "./register.migrate.js";
 
 const mocks = vi.hoisted(() => ({
+  ExitError: class ExitError extends Error {},
   migrateApplyCommand: vi.fn(),
   migrateDefaultCommand: vi.fn(),
   migrateListCommand: vi.fn(),
@@ -23,11 +24,13 @@ vi.mock("../../commands/migrate.js", () => ({
 }));
 
 vi.mock("../../runtime.js", () => ({
+  ExitError: mocks.ExitError,
   defaultRuntime: mocks.runtime,
 }));
 
 async function runCli(args: string[]): Promise<void> {
-  const program = new Command();
+  const program = new OpenClawCommand();
+  program.enablePositionalOptions();
   registerMigrateCommand(program);
   await program.parseAsync(args, { from: "user" });
 }
@@ -66,7 +69,180 @@ describe("registerMigrateCommand", () => {
     ]);
     expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
       mocks.runtime,
-      expect.objectContaining({ targetAgentId: "research", itemIds: ["auth:openai"] }),
+      expect.objectContaining({ targetAgentId: "research", itemIds: ["auth:openai"], yes: true }),
     );
+  });
+
+  it("keeps an explicit --no-auth-credentials opt-out placed before apply", async () => {
+    await runCli(["migrate", "--no-auth-credentials", "apply", "hermes", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ provider: "hermes", authCredentials: false, yes: true }),
+    );
+  });
+
+  it("keeps an explicit --no-auth-credentials opt-out placed before plan", async () => {
+    await runCli(["migrate", "--no-auth-credentials", "plan", "hermes"]);
+
+    expect(mocks.migratePlanCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ provider: "hermes", authCredentials: false }),
+    );
+  });
+
+  it("keeps auth credentials enabled when neither placement opts out", async () => {
+    await runCli(["migrate", "apply", "hermes", "--yes"]);
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ authCredentials: true }),
+    );
+
+    await runCli(["migrate", "plan", "hermes"]);
+    expect(mocks.migratePlanCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ authCredentials: true }),
+    );
+  });
+
+  it("honors --no-auth-credentials placed on the subcommand itself", async () => {
+    await runCli(["migrate", "apply", "hermes", "--no-auth-credentials", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ authCredentials: false }),
+    );
+  });
+
+  it("inherits parent-placed --json into list", async () => {
+    await runCli(["migrate", "--json", "list"]);
+    expect(mocks.migrateListCommand).toHaveBeenCalledWith(mocks.runtime, { json: true });
+
+    await runCli(["migrate", "list"]);
+    expect(mocks.migrateListCommand).toHaveBeenLastCalledWith(mocks.runtime, { json: false });
+  });
+
+  it("inherits parent-placed selection and source options into plan", async () => {
+    await runCli([
+      "migrate",
+      "--from",
+      "/tmp/other-source",
+      "--skill",
+      "alpha",
+      "--plugin",
+      "beta",
+      "--include-secrets",
+      "--overwrite",
+      "--json",
+      "plan",
+      "hermes",
+    ]);
+
+    expect(mocks.migratePlanCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        provider: "hermes",
+        source: "/tmp/other-source",
+        skills: ["alpha"],
+        plugins: ["beta"],
+        includeSecrets: true,
+        overwrite: true,
+        json: true,
+      }),
+    );
+  });
+
+  it("inherits parent-placed apply-only options", async () => {
+    await runCli([
+      "migrate",
+      "--yes",
+      "--no-backup",
+      "--force",
+      "--backup-output",
+      "/tmp/backup.tgz",
+      "apply",
+      "hermes",
+    ]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        provider: "hermes",
+        yes: true,
+        noBackup: true,
+        force: true,
+        backupOutput: "/tmp/backup.tgz",
+      }),
+    );
+  });
+
+  it("keeps the pre-migration backup when neither placement passes --no-backup", async () => {
+    await runCli(["migrate", "apply", "hermes", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ noBackup: false }),
+    );
+  });
+
+  it("honors --no-backup placed on the subcommand itself", async () => {
+    await runCli(["migrate", "apply", "hermes", "--no-backup", "--force", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({ noBackup: true }),
+    );
+  });
+
+  it("prefers subcommand placement over parent placement", async () => {
+    await runCli([
+      "migrate",
+      "--from",
+      "/tmp/parent-source",
+      "--agent",
+      "parent-agent",
+      "--skill",
+      "parent-skill",
+      "--item",
+      "auth:parent",
+      "apply",
+      "hermes",
+      "--from",
+      "/tmp/child-source",
+      "--agent",
+      "child-agent",
+      "--skill",
+      "child-skill",
+      "--item",
+      "auth:child",
+      "--yes",
+    ]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        source: "/tmp/child-source",
+        targetAgentId: "child-agent",
+        skills: ["child-skill"],
+        itemIds: ["auth:child"],
+      }),
+    );
+  });
+
+  it("rejects --dry-run placed before apply instead of silently applying", async () => {
+    await runCli(["migrate", "--dry-run", "apply", "hermes", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).not.toHaveBeenCalled();
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("--dry-run is not supported for `openclaw migrate apply`"),
+    );
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("still applies when --dry-run is absent", async () => {
+    await runCli(["migrate", "apply", "hermes", "--yes"]);
+
+    expect(mocks.migrateApplyCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -10,6 +10,7 @@ import {
 } from "../../commands/migrate.js";
 import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
+import { inheritOptionFromParent } from "../command-options.js";
 import { formatHelpExamples } from "../help-format.js";
 
 function collectMigrationSkill(value: string, previous: string[] | undefined): string[] {
@@ -24,9 +25,8 @@ function collectMigrationItem(value: string, previous: string[] | undefined): st
   return [...(previous ?? []), value];
 }
 
-function readMigrationItems(value: unknown, command?: Command): string[] | undefined {
-  const selected = Array.isArray(value) ? value : command?.parent?.opts().item;
-  return normalizeOptionalTrimmedStringList(selected);
+function readMigrationOption<T>(command: Command, name: string, value: T): T {
+  return inheritOptionFromParent<T>(command, name) ?? value;
 }
 
 function addMigrationSkillOption(command: Command): Command {
@@ -87,12 +87,39 @@ function readVerifyPluginApps(value: unknown): boolean {
   return value === true;
 }
 
-function readMigrationTargetAgentId(value: unknown, command: Command): string | undefined {
-  if (typeof value === "string") {
-    return value;
+function readSharedMigrationOptions(opts: Record<string, unknown>, command: Command) {
+  const agent = readMigrationOption(command, "agent", opts.agent);
+  return {
+    source: readMigrationOption(command, "from", opts.from as string | undefined),
+    targetAgentId: typeof agent === "string" ? agent : undefined,
+    includeSecrets:
+      readMigrationOption(command, "includeSecrets", opts.includeSecrets) === true
+        ? true
+        : undefined,
+    authCredentials: readMigrationOption(
+      command,
+      "authCredentials",
+      opts.authCredentials as boolean | undefined,
+    ),
+    overwrite: Boolean(readMigrationOption(command, "overwrite", opts.overwrite)),
+    skills: normalizeOptionalTrimmedStringList(readMigrationOption(command, "skill", opts.skill)),
+    plugins: normalizeOptionalTrimmedStringList(
+      readMigrationOption(command, "plugin", opts.plugin),
+    ),
+    itemIds: normalizeOptionalTrimmedStringList(readMigrationOption(command, "item", opts.item)),
+    verifyPluginApps: readVerifyPluginApps(
+      readMigrationOption(command, "verifyPluginApps", opts.verifyPluginApps),
+    ),
+    json: Boolean(readMigrationOption(command, "json", opts.json)),
+  };
+}
+
+function rejectUnsupportedApplyDryRun(command: Command): void {
+  if (inheritOptionFromParent<boolean>(command, "dryRun") === true) {
+    throw new Error(
+      "--dry-run is not supported for `openclaw migrate apply`. Run `openclaw migrate plan <provider>` or `openclaw migrate <provider> --dry-run` instead.",
+    );
   }
-  const parentValue = command.parent?.opts().agent;
-  return typeof parentValue === "string" ? parentValue : undefined;
 }
 
 /** Register migration commands and shared provider/item selection flags. */
@@ -157,7 +184,7 @@ export function registerMigrateCommand(program: Command) {
           overwrite: Boolean(opts.overwrite),
           skills: normalizeOptionalTrimmedStringList(opts.skill),
           plugins: normalizeOptionalTrimmedStringList(opts.plugin),
-          itemIds: readMigrationItems(opts.item),
+          itemIds: normalizeOptionalTrimmedStringList(opts.item),
           verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
           dryRun: Boolean(opts.dryRun),
           yes: Boolean(opts.yes),
@@ -173,9 +200,11 @@ export function registerMigrateCommand(program: Command) {
     .command("list")
     .description("List migration providers")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        await migrateListCommand(defaultRuntime, { json: Boolean(opts.json) });
+        await migrateListCommand(defaultRuntime, {
+          json: Boolean(readMigrationOption(command, "json", opts.json)),
+        });
       });
     });
 
@@ -187,16 +216,7 @@ export function registerMigrateCommand(program: Command) {
     await runCommandWithRuntime(defaultRuntime, async () => {
       await migratePlanCommand(defaultRuntime, {
         provider: provider as string,
-        source: opts.from as string | undefined,
-        targetAgentId: readMigrationTargetAgentId(opts.agent, command),
-        includeSecrets: opts.includeSecrets === true ? true : undefined,
-        authCredentials: opts.authCredentials as boolean | undefined,
-        overwrite: Boolean(opts.overwrite),
-        skills: normalizeOptionalTrimmedStringList(opts.skill),
-        plugins: normalizeOptionalTrimmedStringList(opts.plugin),
-        itemIds: readMigrationItems(opts.item, command),
-        verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
-        json: Boolean(opts.json),
+        ...readSharedMigrationOptions(opts, command),
       });
     });
   });
@@ -210,22 +230,18 @@ export function registerMigrateCommand(program: Command) {
     .option("--force", "Allow dangerous options such as --no-backup", false)
     .action(async (provider, opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        rejectUnsupportedApplyDryRun(command);
         await migrateApplyCommand(defaultRuntime, {
           provider: provider as string,
-          source: opts.from as string | undefined,
-          targetAgentId: readMigrationTargetAgentId(opts.agent, command),
-          includeSecrets: opts.includeSecrets === true ? true : undefined,
-          authCredentials: opts.authCredentials as boolean | undefined,
-          overwrite: Boolean(opts.overwrite),
-          skills: normalizeOptionalTrimmedStringList(opts.skill),
-          plugins: normalizeOptionalTrimmedStringList(opts.plugin),
-          itemIds: readMigrationItems(opts.item, command),
-          verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
-          yes: Boolean(opts.yes),
-          backupOutput: opts.backupOutput as string | undefined,
-          noBackup: opts.backup === false,
-          force: Boolean(opts.force),
-          json: Boolean(opts.json),
+          ...readSharedMigrationOptions(opts, command),
+          yes: Boolean(readMigrationOption(command, "yes", opts.yes)),
+          backupOutput: readMigrationOption(
+            command,
+            "backupOutput",
+            opts.backupOutput as string | undefined,
+          ),
+          noBackup: readMigrationOption(command, "backup", opts.backup) === false,
+          force: Boolean(readMigrationOption(command, "force", opts.force)),
         });
       });
     });


### PR DESCRIPTION
## Summary
`openclaw migrate` documents its shared flags as usable on the group or on the `list` / `plan` / `apply` leaves, but the leaves silently discard almost every flag placed before the subcommand name.

The sharpest case reverses a credential opt-out. `openclaw migrate --no-auth-credentials plan hermes --include-secrets` is the documented way to say "import this Hermes profile, but not its auth credentials". The opt-out is dropped, so the plan keeps `secret:openai` at `action: "create"` and writes the source `.env` API key into the agent auth store. Moving the same flag onto the leaf skips it correctly, so the two placements disagree on whether a credential is imported.

Alongside that: `openclaw migrate --from /path plan hermes` plans against the default source and then tells the operator to "Pass --from <path> if it lives elsewhere", `openclaw migrate --json list` prints human output, `openclaw migrate --skill alpha apply hermes --yes` drops the filter and migrates every discoverable item, and `openclaw migrate --dry-run apply hermes --yes` performs a real migration and writes state.

Only `--agent` and `--item` had ad hoc parent fallbacks, so the intent that parent placement works was already in the code; the other twelve options never got the same treatment.

Fixes #127312.

## Root cause
The root program calls `enablePositionalOptions()` (`src/cli/program/build-program.ts:11`) but `migrate` does not, so Commander lets the `migrate` group consume any shared flag that appears before the subcommand name and dispatches to the leaf with it stripped. The leaf actions then build their handler arguments from leaf-local `opts` only, where `--no-` booleans already hold Commander's `true` default and everything else is `undefined` or `false`.

`src/cli/program/register.migrate.ts:211-229` (apply), the same shape at `:186-200` (plan):

```before
    .action(async (provider, opts, command) => {
      await runCommandWithRuntime(defaultRuntime, async () => {
        await migrateApplyCommand(defaultRuntime, {
          provider: provider as string,
          source: opts.from as string | undefined,
          targetAgentId: readMigrationTargetAgentId(opts.agent, command),
          includeSecrets: opts.includeSecrets === true ? true : undefined,
          authCredentials: opts.authCredentials as boolean | undefined,
          overwrite: Boolean(opts.overwrite),
          skills: normalizeOptionalTrimmedStringList(opts.skill),
          plugins: normalizeOptionalTrimmedStringList(opts.plugin),
          itemIds: readMigrationItems(opts.item, command),
          verifyPluginApps: readVerifyPluginApps(opts.verifyPluginApps),
          yes: Boolean(opts.yes),
          backupOutput: opts.backupOutput as string | undefined,
          noBackup: opts.backup === false,
          force: Boolean(opts.force),
          json: Boolean(opts.json),
        });
      });
    });
```

`opts.authCredentials` is Commander's `--no-` default `true`, so the clamp at `src/commands/migrate.ts:73` (`if (opts.authCredentials === false) includeSecrets = false`) never fires. That clamp is the only thing that can override an operator's `--include-secrets`, so the opt-out disappears on the one path that imports secret material.

## Fix
Read every shared option through the existing source-aware `inheritOptionFromParent` helper (`src/cli/command-options.ts:33`) and shape the common plan/apply payload once, replacing the two field-specific parent lookups:

```after
function readMigrationOption<T>(command: Command, name: string, value: T): T {
  return inheritOptionFromParent<T>(command, name) ?? value;
}

function readSharedMigrationOptions(opts: Record<string, unknown>, command: Command) {
  const agent = readMigrationOption(command, "agent", opts.agent);
  return {
    source: readMigrationOption(command, "from", opts.from as string | undefined),
    targetAgentId: typeof agent === "string" ? agent : undefined,
    includeSecrets:
      readMigrationOption(command, "includeSecrets", opts.includeSecrets) === true
        ? true
        : undefined,
    authCredentials: readMigrationOption(
      command,
      "authCredentials",
      opts.authCredentials as boolean | undefined,
    ),
    overwrite: Boolean(readMigrationOption(command, "overwrite", opts.overwrite)),
    skills: normalizeOptionalTrimmedStringList(readMigrationOption(command, "skill", opts.skill)),
    plugins: normalizeOptionalTrimmedStringList(
      readMigrationOption(command, "plugin", opts.plugin),
    ),
    itemIds: normalizeOptionalTrimmedStringList(readMigrationOption(command, "item", opts.item)),
    verifyPluginApps: readVerifyPluginApps(
      readMigrationOption(command, "verifyPluginApps", opts.verifyPluginApps),
    ),
    json: Boolean(readMigrationOption(command, "json", opts.json)),
  };
}

function rejectUnsupportedApplyDryRun(command: Command): void {
  if (inheritOptionFromParent<boolean>(command, "dryRun") === true) {
    throw new Error(
      "--dry-run is not supported for `openclaw migrate apply`. Run `openclaw migrate plan <provider>` or `openclaw migrate <provider> --dry-run` instead.",
    );
  }
}
```

`inheritOptionFromParent` returns `undefined` when the child set the value itself, so `?? value` keeps leaf placement winning, and it skips ancestor values whose source is `default`. That is what makes the negated booleans work: `--no-auth-credentials` and `--no-backup` sit on the leaf as `true` with source `default`, so a plain `??` on the leaf value could never consult the group, while the source-aware lookup can. All three states behave correctly: `--no-x` on the leaf wins, `--no-x` on the group is inherited, and absent everywhere stays `true`.

`--dry-run` is the one shared flag `apply` genuinely cannot honor, so it is rejected with a message pointing at `plan`, mirroring `createUpdateLeafAction` in `src/cli/update-cli.ts:75-80`. `apply` never declared `--dry-run` itself, so leaf placement already errored; only the silently ignored group placement changes.

## Why this is the right boundary
`register.migrate.ts` is the owner of option shaping for the migrate leaves, and `inheritOptionFromParent` is the repository's existing contract for bounded, source-aware parent inheritance, already used by `channels-cli.ts:84`, `models-accounts-cli.ts:18`, `acp-cli.ts:66` and `update-cli.ts:26/45/76`. Nothing in the parser, in `build-program.ts`, or in the migrate command owner changes.

This is a recurring, maintainer-accepted P2 bug class with merged fixes for the same shape on other commands: #126447 (daemon `--json` before subcommands), #116587 (inherited flags after nested subcommands), #130847 (gateway `--port` on the status leaf), #125256 (nested agent exec `--timeout`), and #18725 (parent/subcommand option collisions). None of them covered `migrate`.

All three leaves are covered together rather than fixing one sibling and leaving the others: `plan` and `apply` share one reader, and `list` inherits `--json`. Leaf-placement behavior is preserved unchanged, and the two ad hoc `--agent` / `--item` parent lookups are folded into the same helper instead of a third mechanism being added. `docs/cli/migrate.md` is updated for the placement rule and the `apply --dry-run` rejection.

## Verification
The suite results below were recorded on the identical patch before this rebase; the rebase changed no source, test or docs bytes, and GitHub CI revalidates them on this head.

- `node scripts/run-vitest.mjs src/cli/program/register.migrate.test.ts`: 13 passed (13), 1 file passed.
- With `src/cli/program/register.migrate.ts` restored to pristine `origin/main` and the new test file kept, the same command reports 6 failed / 7 passed: the five new parent-placement assertions plus the `--dry-run` rejection fail on main and pass with this patch. The pre-existing leaf-placement case keeps passing in both trees, which is the regression guard for "child placement still wins".
- `node scripts/run-vitest.mjs src/cli/command-options.test.ts src/cli/update-cli.option-collisions.test.ts src/cli/program/build-program.test.ts src/cli/program/command-registry.test.ts`: 138 passed (138).
- The registration suite harness was moved from a bare `new Command()` to `OpenClawCommand` + `enablePositionalOptions()` so it matches `build-program.ts`. A bare `new Command()` harness reports both placements broken, which is a harness artifact rather than the defect.
- Formatting and typechecking are delegated to GitHub CI and were not run locally.

## Real behavior proof
Behavior addressed: `openclaw migrate` silently discarded shared flags placed before `list` / `plan` / `apply`. A `--no-auth-credentials` opt-out written before the subcommand was reversed and the source `.env` credential was imported anyway, `--from` was ignored while the error text asked for `--from`, `--json` printed human output, and `--dry-run` before `apply` performed a real migration.

Real environment tested: the real `openclaw` CLI entry point `src/entry.ts`, driven end to end on pristine base `db2666090f196b07ec84867972a6c5f571b1b013` and on this patch `78fa4c09a69d2932c74568ad7d840251d15f4aa3`, in two worktrees of the same repository. The real bundled `migrate-hermes` provider is loaded through the real plugin loader and every migration handler is unmodified, so the output below is the provider's own plan and the files it actually wrote. Each run used its own isolated `HOME` and a synthetic Hermes profile containing only placeholder values (`config.yaml` with one MCP server, `.env` with a fake `OPENAI_API_KEY`, `AGENTS.md`, `memories/MEMORY.md`, one skill). No real credentials, endpoints or personal paths are involved. Both trees were invoked identically as `node --import ./scripts/tsx.mjs src/entry.ts`; because an unbuilt checkout has no `dist/`, both trees were given the same thin `dist/plugin-sdk/<name>.js` re-export stubs pointing at `src/plugin-sdk/<name>.ts` so the plugin export map resolves. That harness is byte-identical in both trees and touches no migration or CLI code, so the only difference between the two columns is the commit under test. In the transcript below the two long sandbox directories are shortened to `/sandbox/hermes-src`, `/sandbox/home-before` and `/sandbox/home-after` for readability; nothing else is altered.

Exact steps or command run after this patch: `openclaw migrate --json list`; `openclaw migrate --no-auth-credentials plan hermes --from SRC --include-secrets --json`; `openclaw migrate --from SRC plan hermes --json`; `openclaw migrate --dry-run apply hermes --from SRC --yes`, each run once against each of the two commits.

Evidence after fix:
```
=========================  1. openclaw migrate --json list  =========================

--- BEFORE (base db2666090f196b07ec84867972a6c5f571b1b013) ---
claude	Claude - Import Claude Code auto-memory, instructions, MCP servers, and skills.
hermes	Hermes - Import Hermes config, memories, skills, and supported credentials.

--- AFTER (head 78fa4c09a69d2932c74568ad7d840251d15f4aa3) ---
{
  "providers": [
    {
      "id": "claude",
      "label": "Claude",
      "description": "Import Claude Code auto-memory, instructions, MCP servers, and skills."
    },
    {
      "id": "hermes",
      "label": "Hermes",
      "description": "Import Hermes config, memories, skills, and supported credentials."
    }
  ]
}

===  2. openclaw migrate --no-auth-credentials plan hermes --from SRC --include-secrets --json  ===

--- BEFORE (base) ---
  "summary": {
    "total": 7,
    "planned": 7,
    "migrated": 0,
    "skipped": 0,
    "conflicts": 0,
    "errors": 0,
    "sensitive": 2
  },
      "id": "config:mcp-server:demo-notes",
      "kind": "config",
      "action": "merge",
      "target": "mcp.servers.demo-notes",
      "status": "planned",
      "message": "Import Hermes MCP server definition \"demo-notes\".",
      "sensitive": true,
      "details": {
        "path": [
          "mcp",
          "servers"
        ],
        "value": "[redacted]"
      }
      "id": "secret:openai",
      "kind": "secret",
      "action": "create",
      "source": "/sandbox/hermes-src/.env",
      "target": "/sandbox/home-before/.openclaw/agents/main/agent/openclaw-agent.sqlite#openai:hermes-import",
      "status": "planned",
      "sensitive": true,
      "details": {
        "envVar": "OPENAI_API_KEY",
        "provider": "openai",
        "profileId": "openai:hermes-import"
      }

--- AFTER (head) ---
  "summary": {
    "total": 8,
    "planned": 6,
    "migrated": 0,
    "skipped": 2,
    "conflicts": 0,
    "errors": 0,
    "sensitive": 1
  },
      "id": "config:mcp-server:demo-notes",
      "kind": "config",
      "action": "merge",
      "target": "mcp.servers.demo-notes",
      "status": "planned",
      "message": "Import Hermes MCP server definition \"demo-notes\".",
      "sensitive": false,
      "details": {
        "path": [
          "mcp",
          "servers"
        ],
        "value": {
          "demo-notes": {
            "command": "npx",
            "args": [
              "-y",
              "demo-notes-mcp"
            ]
      "id": "manual:mcp-server-secrets:demo-notes",
      "kind": "manual",
      "action": "manual",
      "source": "config.yaml:mcp_servers.demo-notes",
      "status": "skipped",
      "message": "Hermes MCP server \"demo-notes\" has environment-backed values that were not imported without secret consent.",
      "reason": "Re-run with --include-secrets or configure these values manually."
      "id": "secret:openai",
      "kind": "secret",
      "action": "skip",
      "source": "/sandbox/hermes-src/.env",
      "target": "/sandbox/home-after/.openclaw/agents/main/agent/openclaw-agent.sqlite#openai:hermes-import",
      "status": "skipped",
      "sensitive": true,
      "reason": "auth credential migration not selected",
      "details": {
        "envVar": "OPENAI_API_KEY",
        "provider": "openai",
        "profileId": "openai:hermes-import"
      }

===============  3. openclaw migrate --from SRC plan hermes --json  ===============

--- BEFORE (base) ---
{
  "ok": false,
  "error": {
    "type": "cli_error",
    "message": "Hermes state was not found at /sandbox/home-before/.hermes. Pass --from <path> if it lives elsewhere."
  }
}
[openclaw] The CLI command failed.
[openclaw] Reason: Hermes state was not found at /sandbox/home-before/.hermes. Pass --from <path> if it lives elsewhere.

--- AFTER (head) ---
{
  "providerId": "hermes",
  "source": "/sandbox/hermes-src",
  "target": "/sandbox/home-after/.openclaw/workspace",
  "summary": {
    "total": 8,
    "planned": 6,
    "migrated": 0,

===========  4. openclaw migrate --dry-run apply hermes --from SRC --yes  ===========

--- BEFORE (base) ---
Backup: skipped (no existing OpenClaw state found)
Report: /sandbox/home-before/.openclaw/migration/hermes/2026-09-12T01-02-27.674Z
(exit 0)
state written under HOME/.openclaw:
~/.openclaw/openclaw.json.bak
~/.openclaw/openclaw.json
~/.openclaw/openclaw.json.bak.1
~/.openclaw/config-journal-fingerprint.key
~/.openclaw/workspace/MEMORY.md
~/.openclaw/workspace/AGENTS.md
~/.openclaw/state/openclaw.sqlite
~/.openclaw/workspace/skills/demo-skill/SKILL.md
~/.openclaw/migration/hermes/2026-09-12T01-02-27.674Z/summary.md
~/.openclaw/migration/hermes/2026-09-12T01-02-27.674Z/report.json

--- AFTER (head) ---
--dry-run is not supported for `openclaw migrate apply`. Run `openclaw migrate plan <provider>` or `openclaw migrate <provider> --dry-run` instead.
(exit 1)
state written under HOME/.openclaw:
(none)
```

Observed result after fix: With the same argv and the same unmodified Hermes provider, the credential opt-out now reaches the provider, so `secret:openai` moves from `action: "create"` / `planned` to `action: "skip"` / `skipped` with reason `auth credential migration not selected`, and the MCP server item drops from `sensitive: true` with a withheld value to `sensitive: false` carrying only `command` and `args`, plus a manual follow-up item. `--from` now selects the given source instead of failing on the default path, `migrate --json list` emits the real provider JSON document instead of the human table, and `--dry-run` before `apply` aborts with exit 1 having written nothing, where the base commit wrote ten files including `openclaw.json`, the agent state database and the imported workspace files.

What was not tested: the `codex` migration provider was not driven, because its runtime dependencies are not installed in this environment; the two providers exercised are `hermes` end to end and `claude` through the provider listing. Windows argv handling was not exercised. The synthetic Hermes profile covers config, MCP, memory, workspace, skill and `.env` credential items, but not Hermes OAuth credential files.

## ClawSweeper review

The completed review of `4e24af304c388cc291f051d3b525786964bab611` found no actionable patch or security defects. The earlier requests for real provider behavior proof and correction of the credential-consent claim were already addressed in the evidence above.

The latest request, **Add data-model compatibility proof**, does not require an additional data migration test: this patch changes only CLI option forwarding, parser coverage, documentation, and an exact shrink-only assertion baseline. It changes no schema, stored representation, provider contract, migration writer, updater driver, or recovery behavior. Existing explicit leaf flags retain their behavior and precedence, as the parser regressions prove. The source-runtime before/after evidence above uses the same synthetic Hermes profile and unmodified provider handlers. Additional data-model compatibility testing is therefore skipped as inapplicable; no code finding remains unaddressed.

## Maintainer validation

Re-ran the real parser regression with only the production patch reversed: 6 failed / 7 passed, demonstrating discarded parent options and an apply call despite parent `--dry-run`. Restoring the patch passed all 123 tests across the registration and existing option-inheritance suites. The migration command suites also passed: 118 tests across 10 files. The empty CI refresh commit changes no source, tests, or documentation.

Release-note context: `openclaw migrate` accepts shared options before or after the subcommand, preserves explicit leaf overrides, and rejects parent `--dry-run` before `apply` can change state. Fixes #127312. Thanks @yetval (#144111).


The required assertion baseline is now reduced from 12 to 10 for `src/cli/program/register.migrate.ts`, recording the two removed casts. This exact shrink passed focused P1 review; it adds no suppression or runtime behavior change.

Observed unrelated CI failure: run [34789052759](https://github.com/openclaw/openclaw/actions/runs/34789052759), job `checks-node-compact-large-20`, reported `expected "timeout", received "internal_error"` in the Code Mode deadline test. The maintainer classified it as a fake-timer/real-worker race outside this PR. The same shard passed without test or production changes in run [34789592691](https://github.com/openclaw/openclaw/actions/runs/34789592691) on `4e24af304c388cc291f051d3b525786964bab611`.

