### PR TITLE
improve(google): default web search to Gemini 3.8 Flash

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -178,7 +178,7 @@ or let it reuse `models.providers.google.apiKey` after `GEMINI_API_KEY`:
           webSearch: {
             apiKey: "AIza...", // optional if GEMINI_API_KEY or models.providers.google.apiKey is set
             baseUrl: "https://generativelanguage.googleapis.com/v1beta", // falls back to models.providers.google.baseUrl
-            model: "gemini-3.6-flash",
+            model: "gemini-3.8-flash",
           },
         },
       },

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -50,7 +50,7 @@ citations.
                 id: "GEMINI_GATEWAY_TOKEN",
               },
             },
-            model: "gemini-3.6-flash", // default
+            model: "gemini-3.8-flash", // default
           },
         },
       },
@@ -127,13 +127,15 @@ query instead of a hard 24-hour range. `week`, `month`, `year`, and explicit
 
 ## Model selection
 
-The default model is the stable `gemini-3.6-flash`. Omitting
+The default model is the stable `gemini-3.8-flash`. Omitting
 `plugins.entries.google.config.webSearch.model` uses this default; an explicit
-model stays pinned. You can select any Gemini model that supports grounding and
-is available to your API key.
+model stays pinned. Set this field to `gemini-3.6-flash` to keep the previous
+default. You can select any Gemini model that supports grounding and is available
+to your API key.
 
 Gemini 3 grounding is billed per search query, while Gemini 2.5 grounding is
-billed per prompt. See [Google Search grounding pricing](https://ai.google.dev/gemini-api/docs/google-search#pricing).
+billed per prompt. The number of search queries can vary by model and request,
+so changing models can change grounding costs. See [Google Search grounding pricing](https://ai.google.dev/gemini-api/docs/google-search#pricing).
 
 ## Base URL overrides
 

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -484,7 +484,7 @@ describeLive("google plugin live", () => {
     expect(closeReasons).toEqual(["completed"]);
   }, 120_000);
 
-  it.each([undefined, "gemini-3.5-flash"])(
+  it.each([undefined, "gemini-3.6-flash"])(
     "runs Gemini web search with model %j",
     async (model) => {
       const provider = createGeminiWebSearchProvider();
@@ -520,7 +520,7 @@ describeLive("google plugin live", () => {
       }
 
       expect(result?.provider).toBe("gemini");
-      expect(result?.model).toBe(model ?? "gemini-3.6-flash");
+      expect(result?.model).toBe(model ?? "gemini-3.8-flash");
       expect(typeof result?.content).toBe("string");
       expect((result!.content as string).length).toBeGreaterThan(20);
       expect(Array.isArray(result?.citations)).toBe(true);
@@ -550,7 +550,7 @@ describeLive("google plugin live", () => {
       expect(process.env.GEMINI_API_KEY).toBeUndefined();
       expect(process.env.GOOGLE_API_KEY).toBeUndefined();
       expect(result?.provider).toBe("gemini");
-      expect(result?.model).toBe("gemini-3.6-flash");
+      expect(result?.model).toBe("gemini-3.8-flash");
       expect(typeof result?.content).toBe("string");
       expect((result!.content as string).length).toBeGreaterThan(20);
       expect(Array.isArray(result?.citations)).toBe(true);

--- a/extensions/google/src/gemini-web-search-provider.shared.ts
+++ b/extensions/google/src/gemini-web-search-provider.shared.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleApiBaseUrl } from "./google-api-base-url.js";
 
-const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-3.6-flash";
+const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-3.8-flash";
 
 export type GeminiConfig = {
   apiKey?: unknown;

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -177,16 +177,16 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw docs" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-3.6-flash:generateContent",
+      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-3.8-flash:generateContent",
     );
   });
 
   it.each([
-    [undefined, "gemini-3.6-flash"],
-    ["", "gemini-3.6-flash"],
-    ["  ", "gemini-3.6-flash"],
+    [undefined, "gemini-3.8-flash"],
+    ["", "gemini-3.8-flash"],
+    ["  ", "gemini-3.8-flash"],
     ["gemini-2.5-flash", "gemini-2.5-flash"],
-    [" gemini-3.5-flash ", "gemini-3.5-flash"],
+    [" gemini-3.6-flash ", "gemini-3.6-flash"],
   ])("selects model %j as %s through plugin config", async (model, expectedModel) => {
     const mockFetch = installGeminiFetch();
     const options = createGeminiToolOptions();
@@ -429,7 +429,7 @@ describe("google web search provider", () => {
 
     expect(result).toMatchObject({
       citations: [],
-      model: "gemini-3.6-flash",
+      model: "gemini-3.8-flash",
       provider: "gemini",
     });
     expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
@@ -710,7 +710,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw provider baseUrl fallback" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-3.6-flash:generateContent",
+      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-3.8-flash:generateContent",
     );
   });
 
@@ -745,7 +745,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw plugin baseUrl precedence" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-3.6-flash:generateContent",
+      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-3.8-flash:generateContent",
     );
   });
 


### PR DESCRIPTION
Related: #96974. Follow-up to #111964.

## What Problem This Solves

Gemini web search still defaults to 3.6 Flash. Advance it to the current stable [`gemini-3.8-flash`](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash), which supports Google Search grounding. 3.6 remains supported.

## Why This Change Was Made

Update the pinned default, its existing tests, and the two Google search guides. The production change is one line; the request format is unchanged.

## User Impact

Searches without a model override use 3.8. Explicit model selections remain pinned; set `plugins.entries.google.config.webSearch.model` to `gemini-3.6-flash` to retain the previous default. Search-query counts can vary by model, so grounding costs may change.

## Evidence

Node 24.16.0 / pnpm 12.3.4:

- Provider unit tests: **77/77 passed**, covering default selection, explicit pins, credential/base-URL fallback, and time filters.
- Authenticated production-provider live tests: **3/3 passed** for default 3.8, explicit 3.6, and provider-key fallback, each with answer text and citations.
- Temporary live time-filter checks: **2/2 passed** for `week` and an explicit date range; harness removed afterward.
- Formatting, production/test extension typechecks, changed-file lint, and repository guards passed. The optional dead-export scan was stopped under host memory pressure; the full default `check:changed` command therefore did not complete successfully.
- Independent API and test/docs reviews, a fresh review round, and repository `autoreview`: clean.
