### PR TITLE
refactor(tasks): omit runtime detail from status notifications

### DIFF
--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -37,6 +37,7 @@ import {
   markTaskLostById,
   markTaskTerminalById,
   recordTaskProgressByRunId,
+  reloadTaskRegistryFromStore,
 } from "../tasks/task-registry.js";
 import { getTaskRegistryObservers } from "../tasks/task-registry.store.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
@@ -780,6 +781,7 @@ describe("startGatewayEventSubscriptions", () => {
       runId: "run-throttle-primary",
       task: "Implement live progress",
       status: "running",
+      detail: { notes: [["runtime-owned task detail"]] },
     });
     const secondary = createTaskRecord({
       runtime: "subagent",
@@ -807,9 +809,15 @@ describe("startGatewayEventSubscriptions", () => {
       data: { text: "parallel" },
     });
 
-    await vi.advanceTimersByTimeAsync(999);
-    expect(broadcast).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
+    const clone = vi.spyOn(globalThis, "structuredClone");
+    try {
+      await vi.advanceTimersByTimeAsync(999);
+      expect(broadcast).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(clone).not.toHaveBeenCalled();
+    } finally {
+      clone.mockRestore();
+    }
     const firstFlush = readTaskUpserts(broadcast);
     expect(firstFlush).toHaveLength(2);
     expect(firstFlush.find((event) => event.task.id === primary.taskId)?.task.lastActivity).toBe(
@@ -859,7 +867,7 @@ describe("startGatewayEventSubscriptions", () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 
-  it("suppresses identical task summaries without delaying status transitions", async () => {
+  it("suppresses identical summaries and refreshes them after restore", async () => {
     const broadcast = vi.fn<SubscriptionParams["broadcast"]>();
     unsubs = startGatewayEventSubscriptions({ ...createParams(), broadcast });
     await waitForFast(() => expect(getTaskRegistryObservers()).not.toBeNull());
@@ -887,6 +895,18 @@ describe("startGatewayEventSubscriptions", () => {
         progressSummary: "Working",
       });
     }
+    const beforeRestore = readTaskUpserts(broadcast);
+    expect(beforeRestore).toHaveLength(1);
+    broadcast.mockClear();
+    reloadTaskRegistryFromStore();
+    expect(broadcast).toHaveBeenCalledWith("task", { action: "restored" }, { dropIfSlow: true });
+    recordTaskProgressByRunId({
+      runId,
+      runtime: "subagent",
+      lastEventAt: 200,
+      progressSummary: "Working",
+    });
+    expect(readTaskUpserts(broadcast)).toEqual(beforeRestore);
     markTaskTerminalById({ taskId: task.taskId, status: "succeeded", endedAt: 300 });
 
     const taskEvents = readTaskUpserts(broadcast);

--- a/src/tasks/task-registry-activity.ts
+++ b/src/tasks/task-registry-activity.ts
@@ -5,7 +5,7 @@ import { readCompletedFileMutationDelta } from "../agents/file-mutation-args.js"
 import { resolveFileMutationToolName } from "../agents/tool-mutation-names.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { isTerminalTaskStatus } from "./task-executor-policy.js";
-import { cloneTaskRecord } from "./task-registry-records.js";
+import { cloneTaskRecordForObserver } from "./task-registry-records.js";
 import {
   emitTaskRegistryObserverEvent,
   taskActivityByTaskId,
@@ -197,7 +197,10 @@ export function flushTaskActivity(taskId: string): void {
   }
   activity.dirty = false;
   activity.lastFlushedAt = Date.now();
-  emitTaskRegistryObserverEvent(() => ({ kind: "upserted", task: cloneTaskRecord(task) }));
+  emitTaskRegistryObserverEvent(() => ({
+    kind: "upserted",
+    task: cloneTaskRecordForObserver(task),
+  }));
 }
 
 export function clearTaskActivity(taskId: string): void {

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -15,6 +15,7 @@ import { findLatestTaskForFlowId, listTasksForFlowId } from "./task-registry-que
 import {
   cloneTaskDeliveryState,
   cloneTaskRecord,
+  cloneTaskRecordForObserver,
   normalizeTaskTimestamps,
 } from "./task-registry-records.js";
 import {
@@ -225,8 +226,8 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
   }
   emitTaskRegistryObserverEvent(() => ({
     kind: "upserted",
-    task: cloneTaskRecord(next),
-    previous: cloneTaskRecord(current),
+    task: cloneTaskRecordForObserver(next),
+    previous: cloneTaskRecordForObserver(current),
   }));
   return cloneTaskRecord(next);
 }
@@ -265,8 +266,8 @@ export function publishTaskRecordAfterAtomicStore(
   const emit = () =>
     emitTaskRegistryObserverEvent(() => ({
       kind: "upserted",
-      task: cloneTaskRecord(next),
-      ...(current ? { previous: cloneTaskRecord(current) } : {}),
+      task: cloneTaskRecordForObserver(next),
+      ...(current ? { previous: cloneTaskRecordForObserver(current) } : {}),
     }));
   if (options?.deferredObserverEvents) {
     options.deferredObserverEvents.push(emit);

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -5,7 +5,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearTaskActivity } from "./task-registry-activity.js";
 import { isActiveTaskStatus, ensureLinkedTaskFlowRegistryReady } from "./task-registry-common.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
-import { cloneTaskRecord, normalizeTaskTimestamps } from "./task-registry-records.js";
+import {
+  cloneTaskRecord,
+  cloneTaskRecordForObserver,
+  normalizeTaskTimestamps,
+} from "./task-registry-records.js";
 import {
   TASK_REGISTRY_CONTROL_RUNTIME_OVERRIDE_KEY,
   TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY,
@@ -450,7 +454,7 @@ export function deleteTaskRecordById(taskId: string): boolean {
   emitTaskRegistryObserverEvent(() => ({
     kind: "deleted",
     taskId: current.taskId,
-    previous: cloneTaskRecord(current),
+    previous: cloneTaskRecordForObserver(current),
   }));
   return true;
 }

--- a/src/tasks/task-registry-record-api.ts
+++ b/src/tasks/task-registry-record-api.ts
@@ -28,7 +28,11 @@ import {
   maybeDeliverTaskTerminalUpdate,
 } from "./task-registry-delivery.js";
 import { syncFlowFromTaskAfterTaskMutation, updateTask } from "./task-registry-mutation.js";
-import { cloneTaskRecord, normalizeTaskTimestamps } from "./task-registry-records.js";
+import {
+  cloneTaskRecord,
+  cloneTaskRecordForObserver,
+  normalizeTaskTimestamps,
+} from "./task-registry-records.js";
 import {
   addOwnerKeyIndex,
   addParentFlowIdIndex,
@@ -292,7 +296,7 @@ export function createTaskRecord(params: {
   syncFlowFromTaskAfterTaskMutation(record, "create");
   emitTaskRegistryObserverEvent(() => ({
     kind: "upserted",
-    task: cloneTaskRecord(record),
+    task: cloneTaskRecordForObserver(record),
   }));
   if (isTerminalTaskStatus(record.status)) {
     void maybeDeliverTaskTerminalUpdate(taskId);

--- a/src/tasks/task-registry-records.ts
+++ b/src/tasks/task-registry-records.ts
@@ -9,6 +9,12 @@ export function cloneTaskRecord(record: TaskRecord): TaskRecord {
   };
 }
 
+/** Observer notifications need detached metadata, never runtime-owned detail. */
+export function cloneTaskRecordForObserver(record: TaskRecord): Omit<TaskRecord, "detail"> {
+  const { detail: _detail, ...snapshot } = record;
+  return snapshot;
+}
+
 export function normalizeTaskTimestamps(task: TaskRecord): TaskRecord {
   // Detached runtimes can report lifecycle times captured before the registry
   // inserted or restored the row; keep createdAt as the visible lifecycle floor.

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -465,10 +465,7 @@ export function restoreTaskRegistryOnce() {
     rebuildRelatedSessionKeyIndex();
     taskRegistryRestoreState = { status: "ready" };
     if (restoredTasks.size > 0 || restoredDeliveryStates.size > 0) {
-      emitTaskRegistryObserverEvent(() => ({
-        kind: "restored",
-        tasks: snapshotTaskRecords(tasks),
-      }));
+      emitTaskRegistryObserverEvent(() => ({ kind: "restored" }));
     }
   } catch (error) {
     clearTaskRegistryMemory();

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -48,6 +48,7 @@ import {
   listFreshTasksForOwnerKey,
   listTaskRecords,
   markTaskTerminalById,
+  publishTaskRecordAfterAtomicStore,
   reloadTaskRegistryFromStore,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
@@ -1001,28 +1002,32 @@ describe("task-registry store runtime", () => {
     );
   });
 
-  it("emits incremental observer events for restore, mutation, and delete", () => {
+  it("emits detached observer metadata while retaining full task records", () => {
     const events: TaskRegistryObserverEvent[] = [];
+    const detail = { notes: [["retained task detail"]] };
+    const restored = { ...createStoredTask(), detail };
+    const store = createInMemoryTaskRegistryStore({
+      tasks: new Map([[restored.taskId, restored]]),
+      deliveryStates: new Map(),
+    });
     configureTaskRegistryRuntime({
-      store: {
-        ...createInMemoryTaskRegistryStore(),
-        loadSnapshot: () => ({
-          tasks: new Map([[createStoredTask().taskId, createStoredTask()]]),
-          deliveryStates: new Map(),
-        }),
-      },
+      store,
       observers: {
         onEvent: (event) => {
           events.push(event);
+          if (event.kind === "upserted") {
+            event.task.label = "observer mutation";
+            if (event.previous) {
+              event.previous.label = "previous observer mutation";
+            }
+          } else if (event.kind === "deleted") {
+            event.previous.label = "deleted observer mutation";
+          }
         },
       },
     });
 
-    expect(findTaskByRunId("run-restored")).toMatchObject({
-      runId: "run-restored",
-      taskId: "task-restored",
-      task: "Restored task",
-    });
+    expect(findTaskByRunId("run-restored")?.detail).toEqual(detail);
     const created = createTaskRecord({
       runtime: "acp",
       ownerKey: "agent:main:main",
@@ -1030,24 +1035,66 @@ describe("task-registry store runtime", () => {
       childSessionKey: "agent:codex:acp:new",
       runId: "run-new",
       task: "New task",
+      label: "Original label",
       status: "running",
       deliveryStatus: "pending",
+      detail,
     });
-    expect(deleteTaskRecordById(created.taskId)).toBe(true);
+    expect(created.label).toBe("Original label");
+    expect(created.detail).toEqual(detail);
+    expect(created.detail).not.toBe(detail);
+    expect(getTaskById(created.taskId)?.label).toBe("Original label");
 
-    expect(events.map((event) => event.kind)).toEqual(["restored", "upserted", "deleted"]);
-    expect(events[0]).toMatchObject({
-      kind: "restored",
-      tasks: [expect.objectContaining({ taskId: "task-restored" })],
+    const updated = updateTaskNotifyPolicyById({ taskId: created.taskId, notifyPolicy: "silent" });
+    expect(updated).toMatchObject({ label: "Original label", notifyPolicy: "silent", detail });
+    const completed: TaskRecord = {
+      ...created,
+      notifyPolicy: "silent",
+      status: "succeeded",
+      endedAt: Date.now(),
+    };
+    store.upsertTaskWithDeliveryState({ task: completed });
+    const deferredObserverEvents: Array<() => void> = [];
+    const published = publishTaskRecordAfterAtomicStore(completed, { deferredObserverEvents });
+    expect(published).toMatchObject({ status: "succeeded", label: "Original label", detail });
+    expect(events.map((event) => event.kind)).toEqual(["restored", "upserted", "upserted"]);
+    expect(deferredObserverEvents).toHaveLength(1);
+    deferredObserverEvents[0]!();
+    expect(getTaskById(created.taskId)).toMatchObject({
+      status: "succeeded",
+      label: "Original label",
+      detail,
     });
-    expect(events[1]).toMatchObject({
+    expect(store.loadSnapshot().tasks.get(created.taskId)?.detail).toEqual(detail);
+    expect(deleteTaskRecordById(created.taskId)).toBe(true);
+    expect(getTaskById(created.taskId)).toBeUndefined();
+    expect(store.loadSnapshot().tasks.has(created.taskId)).toBe(false);
+
+    expect(events.map((event) => event.kind)).toEqual([
+      "restored",
+      "upserted",
+      "upserted",
+      "upserted",
+      "deleted",
+    ]);
+    for (const event of events) {
+      if (event.kind === "upserted") {
+        expect(event.task).not.toHaveProperty("detail");
+        if (event.previous) {
+          expect(event.previous).not.toHaveProperty("detail");
+        }
+      } else if (event.kind === "deleted") {
+        expect(event.previous).not.toHaveProperty("detail");
+      }
+    }
+    expect(events[0]).toEqual({ kind: "restored" });
+    expect(events[3]).toMatchObject({
       kind: "upserted",
-      task: expect.objectContaining({ taskId: created.taskId }),
+      task: { taskId: created.taskId, status: "succeeded" },
+      previous: { taskId: created.taskId, status: "running" },
     });
-    expect(events[2]).toMatchObject({
-      kind: "deleted",
-      taskId: created.taskId,
-    });
+    expect(events[4]).toMatchObject({ kind: "deleted", taskId: created.taskId });
+    expect(getTaskById(restored.taskId)?.detail).toEqual(detail);
   });
 
   it("uses atomic task-plus-delivery store methods", async () => {

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -24,20 +24,21 @@ export type TaskRegistryStore = {
   close?: () => void;
 };
 
+type TaskRegistryObserverRecord = Omit<TaskRecord, "detail">;
+
 export type TaskRegistryObserverEvent =
   | {
       kind: "restored";
-      tasks: TaskRecord[];
     }
   | {
       kind: "upserted";
-      task: TaskRecord;
-      previous?: TaskRecord;
+      task: TaskRegistryObserverRecord;
+      previous?: TaskRegistryObserverRecord;
     }
   | {
       kind: "deleted";
       taskId: string;
-      previous: TaskRecord;
+      previous: TaskRegistryObserverRecord;
     };
 
 type TaskRegistryObservers = {


### PR DESCRIPTION
Closes #144114

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves unnecessary processing in background-task status updates when tasks retain nested runtime details. Registry restores also construct a full task payload that the status subscriber does not use.

## Why This Change Was Made

Task observer notifications now carry detached metadata without runtime-owned detail, and restore notifications retain only their existing reload signal. The Gateway consumes those fields for task summaries, session routing and terminal transitions.

Full task records, plugin SDK returns, queries and SQLite persistence retain their existing deep-copy behavior. Notification ordering, activity throttling, terminal-session ownership and observer disposal are unchanged.

## User Impact

Background-task status updates avoid copying retained details. Task cards, restore refreshes and full task inspection keep the same behavior; no configuration or database change is required.

## Evidence

- The original code failed the registry regression because observer records still contained nested detail, and the Gateway regression because one activity flush cloned that detail.
- All 77 tests in the affected registry and Gateway files pass, including metadata mutation isolation, retained full records, deferred atomic publication, restore refreshes, activity-before-terminal ordering and stale observer disposal.
- All 173 sibling tests pass, covering full-record SDK/runtime consumers and the observer-triggered parent-abort boundary.
- Fresh independent P2 review and the full changed gate pass. The initial gate caught the test-file size limit; restore coverage was consolidated into the existing dedup case without changing production or weakening its assertions.
- An isolated source-bound probe with one synthetic task and 11,088 bytes of JSON detail measured median synchronous flush/copy/callback time of 21.95 → 0.79 µs across three fixed processes. This is a small boundary measurement, not an end-to-end Gateway latency or allocated-byte measurement; all 36 timing batches were retained.
- [Ordinary Linux proof](https://github.com/openclaw/openclaw/actions/runs/34490444319) passed on Node 24.19.0 / SQLite 3.53.3 using actual source modules and isolated SQLite. It verifies retained full detail, detached observer metadata, the real activity timer, terminal/deferred-publication order, restore, deletion and fresh-process readback. All processes and streams closed normally, artifact hashes matched, and the Testbox lease is completed. The committed tree exactly matches this proof source. This is source-module proof; no live Gateway or package-build claim is made.
