### PR TITLE
test(ui): reuse terminal test fixtures

### DIFF
--- a/ui/src/components/terminal/terminal-panel-upload.test.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.test.ts
@@ -1,10 +1,12 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { TerminalGatewayClient } from "./terminal-connection.ts";
+import { terminalOpenResult } from "./terminal-panel.test-support.ts";
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
 const TERMINAL_UPLOAD_RETENTION_MS = 24 * 60 * 60 * 1000;
@@ -57,26 +59,6 @@ function terminalUploadFile(name: string, content: string): File {
     value: async () => new TextEncoder().encode(content).buffer,
   });
   return file;
-}
-
-function terminalOpenResult(sessionId: string) {
-  return {
-    sessionId,
-    agentId: "ops",
-    shell: "/bin/zsh",
-    cwd: "/work/ops",
-    confined: false,
-  };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
 }
 
 describe("OpenClawTerminalPanel upload lifecycle", () => {
@@ -184,7 +166,7 @@ describe("OpenClawTerminalPanel upload lifecycle", () => {
     const controller = createTerminalController();
     createGhosttyTerminalMock.mockResolvedValue(controller);
     const requests: Array<{ method: string; params: unknown; signal?: AbortSignal }> = [];
-    const failedUpload = deferred<{ path: string; size: number }>();
+    const failedUpload = createDeferred<{ path: string; size: number }>();
     let notesAttempts = 0;
     const client: TerminalGatewayClient = {
       forceReconnect: () => {},
@@ -324,7 +306,7 @@ describe("OpenClawTerminalPanel upload lifecycle", () => {
   it("cancels an active batch without pasting staged paths", async () => {
     const controller = createTerminalController();
     createGhosttyTerminalMock.mockResolvedValue(controller);
-    const pendingUpload = deferred<{ path: string; size: number }>();
+    const pendingUpload = createDeferred<{ path: string; size: number }>();
     let uploadSignal: AbortSignal | undefined;
     const client: TerminalGatewayClient = {
       forceReconnect: () => {},
@@ -379,19 +361,13 @@ describe("OpenClawTerminalPanel upload lifecycle", () => {
   it("cancels a pending upload when its terminal tab closes", async () => {
     const controller = createTerminalController();
     createGhosttyTerminalMock.mockResolvedValue(controller);
-    const pendingUpload = deferred<{ path: string; size: number }>();
+    const pendingUpload = createDeferred<{ path: string; size: number }>();
     let uploadSignal: AbortSignal | undefined;
     const client: TerminalGatewayClient = {
       forceReconnect: () => {},
       request: async <T>(method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
         if (method === "terminal.open") {
-          return {
-            sessionId: "session-1",
-            agentId: "ops",
-            shell: "/bin/zsh",
-            cwd: "/work/ops",
-            confined: false,
-          } as T;
+          return terminalOpenResult("session-1") as T;
         }
         if (method === "terminal.upload") {
           uploadSignal = options?.signal;

--- a/ui/src/components/terminal/terminal-task-queue.test.ts
+++ b/ui/src/components/terminal/terminal-task-queue.test.ts
@@ -1,19 +1,12 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 describe("TerminalTaskQueue", () => {
   it("drains superseded work before starting the next generation", async () => {
     const queue = new TerminalTaskQueue();
-    const release = deferred();
+    const release = createDeferred();
     const events: string[] = [];
     const stale = queue.enqueue(async (isCurrent) => {
       events.push("stale:start");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Terminal upload and task-queue tests duplicate deferred Promise construction, and the upload suite repeats the shared terminal-open result fixture.

## Why This Change Was Made

Reuse the existing fixtures while preserving typed upload results, rejection handling, task supersession ordering and fresh barriers for each call. Controller and readiness fixtures keep their distinct behavior.

## User Impact

Test scaffolding only: the two-file cleanup removes a net 31 lines, with no production or public API changes. Upload, cancellation, expiry and queue assertions remain.

## Evidence

The full upload, task-queue and main-panel suites are selected through the normal runner:

```sh
node scripts/run-vitest.mjs ui/src/components/terminal/terminal-panel-upload.test.ts ui/src/components/terminal/terminal-task-queue.test.ts ui/src/components/terminal/terminal-panel.test.ts
```

All 40 cases passed before and after the change with identical case identities and per-suite order on Node 26.5.0. All 18 required changed-file checks passed, and independent review found no actionable issues through P2. This is fixture-level proof with mocked terminal and Gateway interactions, not live terminal, upload or backend verification.
