### PR TITLE
test: consolidate Brave startup configuration fixtures

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -434,6 +434,31 @@ function expectStartupPluginIds(params: {
   ).toEqual(params.expected);
 }
 
+function createBraveSearchStartupConfig(params: {
+  searchEnabled: boolean;
+  pluginEnabled: boolean;
+}): OpenClawConfig {
+  return {
+    channels: {},
+    tools: {
+      web: {
+        search: {
+          enabled: params.searchEnabled,
+          provider: "brave",
+        },
+      },
+    },
+    plugins: {
+      allow: ["brave"],
+      entries: {
+        brave: {
+          enabled: params.pluginEnabled,
+        },
+      },
+    },
+  };
+}
+
 function createStartupConfig(params: {
   enabledPluginIds?: string[];
   providerIds?: string[];
@@ -1056,71 +1081,17 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
     ],
     [
       "includes explicitly selected external web search providers at startup",
-      {
-        channels: {},
-        tools: {
-          web: {
-            search: {
-              enabled: true,
-              provider: "brave",
-            },
-          },
-        },
-        plugins: {
-          allow: ["brave"],
-          entries: {
-            brave: {
-              enabled: true,
-            },
-          },
-        },
-      } as OpenClawConfig,
+      createBraveSearchStartupConfig({ searchEnabled: true, pluginEnabled: true }),
       ["brave"],
     ],
     [
       "honors disabled web search when selecting startup providers",
-      {
-        channels: {},
-        tools: {
-          web: {
-            search: {
-              enabled: false,
-              provider: "brave",
-            },
-          },
-        },
-        plugins: {
-          allow: ["brave"],
-          entries: {
-            brave: {
-              enabled: true,
-            },
-          },
-        },
-      } as OpenClawConfig,
+      createBraveSearchStartupConfig({ searchEnabled: false, pluginEnabled: true }),
       [],
     ],
     [
       "honors explicit plugin disablement for configured web search providers",
-      {
-        channels: {},
-        tools: {
-          web: {
-            search: {
-              enabled: true,
-              provider: "brave",
-            },
-          },
-        },
-        plugins: {
-          allow: ["brave"],
-          entries: {
-            brave: {
-              enabled: false,
-            },
-          },
-        },
-      } as OpenClawConfig,
+      createBraveSearchStartupConfig({ searchEnabled: true, pluginEnabled: false }),
       [],
     ],
     [


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three Brave startup-selection scenarios repeat the same nested configuration. This makes their meaningful differences harder to see and maintain.

## Why This Change Was Made

Use one private fixture with required named search and plugin enablement options. Each call creates a fresh configuration; the existing case names, order, independent expected arrays and assertions remain unchanged. The existing broader startup fixture does not express web-search configuration or explicit plugin disablement.

## User Impact

No user-visible behavior change. This fixture-only cleanup removes 29 net test lines without removing cases or changing production code. No runtime improvement is claimed.

## Evidence

- Complete affected test file: all 170 cases passed before and after, with identical ordered names and statuses.
- One-off structural proof expands all three calls to the original input objects and verifies the remaining whole-source tokens are unchanged.
- Actual helper checks preserve property order, absent fields and fresh mutable graphs across repeated calls.
- Changed-file gate and independent review passed.
