### PR TITLE
test(subagents): add regression tests for bounded registry scans during tree kill

### DIFF
--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -382,6 +382,8 @@ async function killSubagentRunTree(
         }
         result.descendants = true;
       }
+      // Active nodes already refresh descendants during killSubagentRun (prepare/run);
+      // ended nodes cannot spawn. The outer convergence loop captures late registrations.
       if (result.descendants && tree.canTraverse()) {
         await Promise.all(tree.children.map(visit));
       }

--- a/src/agents/subagents/registry/subagent-control.refresh.test.ts
+++ b/src/agents/subagents/registry/subagent-control.refresh.test.ts
@@ -12,10 +12,12 @@ import { findTaskByRunId } from "../../../tasks/task-registry.js";
 import { clearActiveEmbeddedRun, setActiveEmbeddedRun } from "../../embedded-agent-runner/runs.js";
 import { createEmbeddedRunHandle } from "../../embedded-agent-runner/runs.test-support.js";
 import { enqueueSwarmRun, releaseSwarmRun } from "../swarm/swarm-scheduler.js";
+import { killSessionSubagentRuns } from "./subagent-control-kill.js";
 import { killAllControlledSubagentRuns } from "./subagent-control.js";
 import { useSubagentControlFixture } from "./subagent-control.test-support.js";
 import { SUBAGENT_ENDED_REASON_KILLED } from "./subagent-lifecycle-events.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
+import * as registryRead from "./subagent-registry-read.js";
 import { registerSubagentRun, startQueuedSubagentRun } from "./subagent-registry.js";
 import { writeSubagentSessionEntry } from "./subagent-registry.persistence.test-support.js";
 
@@ -342,3 +344,108 @@ it.each([
     }
   },
 );
+
+it("does not repeat full-scope refreshes per node when traversing retained subagent trees", async () => {
+  const owner = "agent:main:main";
+  const nodeCount = 6;
+  for (let i = 0; i < nodeCount; i += 1) {
+    const runId = `retained-${i}`;
+    const sessionKey = `agent:main:subagent:retained-${i}`;
+    await writeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey,
+      defaultSessionId: `${runId}-session`,
+    });
+    registerSubagentRun({
+      runId,
+      childSessionKey: sessionKey,
+      requesterSessionKey: owner,
+      controllerSessionKey: owner,
+      requesterAgentId: "main",
+      requesterDisplayKey: owner,
+      task: runId,
+      cleanup: "keep",
+      collect: true,
+      queued: false,
+      expectsCompletionMessage: false,
+    });
+    const run = subagentRuns.get(runId)!;
+    run.execution.endedAt = Date.now() - 1000;
+    run.execution.status = "terminal";
+  }
+
+  const listSpy = vi.spyOn(registryRead, "listSubagentRunsForController");
+  try {
+    const result = await killSessionSubagentRuns({
+      cfg: getRuntimeConfig(),
+      sessionKey: owner,
+      agentId: "main",
+    });
+    expect(result.status).toBe("ok");
+    expect(result.killed).toBe(0);
+    // With N retained runs, full tree refresh is performed only for initial scope
+    // population and convergence checks (O(N) total checks), not per-node (O(N^2)).
+    // Each refresh pass visits N trees. 2 passes in killSubagentRunTree + 1 in withSubagentKillScope = 3 passes * N = 18.
+    // Pre-fix repeated refresh in visit() added N passes (N * N = 36 additional calls, total 54+).
+    const perPassCallCount = nodeCount;
+    const maxExpectedCalls = perPassCallCount * 4 + 1; // 1 initial lookup + at most 4 refresh passes
+    expect(listSpy.mock.calls.length).toBeLessThanOrEqual(maxExpectedCalls);
+  } finally {
+    listSpy.mockRestore();
+  }
+});
+
+it("discovers and kills active descendants through retained ancestors without redundant refreshes", async () => {
+  const owner = "agent:main:main";
+  const rootKey = "agent:main:subagent:hier-root";
+  const childKey = "agent:main:subagent:hier-child";
+  const grandChildKey = "agent:main:subagent:hier-grandchild";
+
+  for (const [runId, sessionKey, requesterSessionKey, status] of [
+    ["hier-root", rootKey, owner, "terminal"],
+    ["hier-child", childKey, rootKey, "terminal"],
+    ["hier-grandchild", grandChildKey, childKey, "queued"],
+  ] as const) {
+    await writeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey,
+      defaultSessionId: `${runId}-session`,
+    });
+    registerSubagentRun({
+      runId,
+      childSessionKey: sessionKey,
+      requesterSessionKey,
+      controllerSessionKey: requesterSessionKey,
+      requesterAgentId: "main",
+      requesterDisplayKey: requesterSessionKey,
+      task: runId,
+      cleanup: "keep",
+      collect: true,
+      queued: status === "queued",
+      expectsCompletionMessage: false,
+    });
+    const run = subagentRuns.get(runId)!;
+    if (status === "terminal") {
+      run.execution.endedAt = Date.now() - 1000;
+      run.execution.status = "terminal";
+    }
+  }
+
+  const listSpy = vi.spyOn(registryRead, "listSubagentRunsForController");
+  try {
+    const result = await killSessionSubagentRuns({
+      cfg: getRuntimeConfig(),
+      sessionKey: owner,
+      agentId: "main",
+    });
+    expect(result.status).toBe("ok");
+    expect(result.killed).toBe(1);
+    expect(subagentRuns.get("hier-grandchild")?.execution.status).toBe("terminal");
+    expect(subagentRuns.get("hier-grandchild")?.endedReason).toBe(SUBAGENT_ENDED_REASON_KILLED);
+    expect(listSpy.mock.calls.length).toBeLessThanOrEqual(20);
+  } finally {
+    listSpy.mockRestore();
+  }
+});


### PR DESCRIPTION
Related: #143389

## What Problem This Solves

Resolves an issue where WhatsApp `/new` (or session reset/cancellation) stalls for ~82 seconds when a session has accumulated retained subagent records.

In `killSubagentRunTree`, `params.scope.refresh()` was invoked inside the recursive `visit()` function on every single node in the tree. Because each `refresh()` performs a full-forest discovery across SQLite stores and disk sessions for all roots and descendants, traversing $N$ nodes triggered $N$ full-scope refreshes ($O(N^2)$ traversal work), leading to 186 full store traversals taking ~82 seconds for 184 retained runs.

While PR #143916 merged the one-line removal of `params.scope.refresh()` on `main`, `main` lacked focused unit regression tests verifying that:
1. Whole-forest controller registry scans remain bounded at $O(N)$ during tree cancellation rather than repeating per node.
2. Active child runs are reliably reached, held, and terminated when nested under multiple completed/retained ancestors.

## Why This Change Was Made

This PR adds comprehensive regression test coverage in `src/agents/subagents/registry/subagent-control.refresh.test.ts` and documents the lifecycle invariants in `src/agents/subagents/registry/subagent-control-kill.ts`:

1. **Flat Forest Bounded Scans**: Tests a forest of retained root trees and asserts that controller registry list queries are bounded to convergence loops ($\le 4$ passes, $\le 25$ total queries) rather than $O(N^2)$ per-node refreshes ($61+$ queries).
2. **Hierarchical Traversal Through Retained Ancestors**: Tests a 3-level hierarchy (`Root [terminal] -> Child [terminal] -> Grandchild [queued]`) and asserts that the active leaf is reached and cancelled (`status: "terminal"`, `endedReason: SUBAGENT_ENDED_REASON_KILLED`) while controller queries remain strictly bounded ($\le 20$ calls).
3. **Invariant Documentation**: Added explanatory comments in `subagent-control-kill.ts` explaining why active nodes refresh during `killSubagentRun` (prepare/run) while ended nodes cannot spawn and late registrations are captured by the outer convergence loop.

## User Impact

Protects session reset performance against regressions, preventing WhatsApp `/new` or CLI task cancellations from stalling on sessions with large retained subagent run histories.

## Evidence

### 1. Experimental Failing-Before vs Passing-After Regression Sensitivity

To experimentally prove regression sensitivity, `params.scope.refresh();` was temporarily reinserted into `visit()` inside `killSubagentRunTree`. Both tests failed immediately due to exceeding the call-count bounds:

**Failing-Before (with redundant `scope.refresh()` restored):**
```
 × |agents-support| src/agents/subagents/registry/subagent-control.refresh.test.ts > does not repeat full-scope refreshes per node when traversing retained subagent trees 347ms
   → expected 61 to be less than or equal to 25
 × |agents-support| src/agents/subagents/registry/subagent-control.refresh.test.ts > discovers and kills active descendants through retained ancestors without redundant refreshes 350ms
   → expected 28 to be less than or equal to 20

AssertionError: expected 61 to be less than or equal to 25
 ❯ src/agents/subagents/registry/subagent-control.refresh.test.ts:393:39

AssertionError: expected 28 to be less than or equal to 20
 ❯ src/agents/subagents/registry/subagent-control.refresh.test.ts:447:39
```

**Passing-After (without redundant `scope.refresh()`):**
```
 ✓ |agents-support| src/agents/subagents/registry/subagent-control.refresh.test.ts > does not repeat full-scope refreshes per node when traversing retained subagent trees 327ms
 ✓ |agents-support| src/agents/subagents/registry/subagent-control.refresh.test.ts > discovers and kills active descendants through retained ancestors without redundant refreshes 344ms

Test Files  1 passed (1)
Tests       10 passed (10)
Duration    21.69s
```
- Flat forest test: 19 actual calls (comfortably $\le 25$, down from 61).
- Hierarchical test: 13 actual calls (comfortably $\le 20$, down from 28).

### 2. Fast Lane Test Suite
```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts --maxWorkers=2
```
Output:
```
Test Files  1389 passed | 2 skipped (1391)
Tests       17388 passed | 9 skipped (17397)
Duration    347.22s
```
All 17,388 tests in the unit-fast suite passed with 0 failures.

### 3. Core TypeScript & Change Verification
- `node scripts/run-tsgo-core-test-shards.mjs`: Passed (exit 0)
- `node scripts/check-changed.mjs`: Passed 100% (0 type errors, 0 lint errors, 0 knip deadcode entries)

### 4. Adversarial Security & Concurrency Review
Reviewed by an independent adversarial contrarian reviewer:
- **Authorization & Controller Fencing**: Verified that authority checks (`ownsRoot`, `ensureSubagentControllerOwnsRun`) are enforced by the outer scope.
- **Escape Impossibility**: Verified that active subagents cannot escape cancellation during drain, and late registrations increase the monotonic set size, triggering the outer `while (params.scope.refresh() !== selected)` convergence loop.
- **Deadlock Immunity**: Holds are acquired hierarchically down the tree per session and unconditionally released in `finally`.
