### PR TITLE
refactor(docs): reuse collected plugin inventory records

### DIFF
--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -711,8 +711,7 @@ function readGeneratedDocs(records: PluginRecord[]) {
   ];
 }
 
-function renderDocument() {
-  const records = collectPluginRecords();
+function renderDocument(records: PluginRecord[]) {
   const groups = {
     core: records.filter((record) => record.status === "core"),
     external: records.filter((record) => record.status === "external"),
@@ -810,7 +809,7 @@ function main(argv = process.argv.slice(2)) {
   }
 
   const records = collectPluginRecords();
-  const next = renderDocument();
+  const next = renderDocument(records);
   const docPath = path.join(ROOT, DOC_PATH);
   if (write) {
     fs.writeFileSync(docPath, next, "utf8");


### PR DESCRIPTION
## What Problem This Solves

Generating or checking plugin documentation collected and validated the same plugin metadata twice: once for the reference pages and again for the overview.

## Why This Change Was Made

Pass the already collected records to the overview renderer. Both outputs now share one collection, while the independent manifest omission/duplicate check remains unchanged.

## User Impact

Documentation generation and verification do less repeated filesystem work. Generated content and hand-written reference sections are unchanged.

## Evidence

Transparent read counting around the actual generator changed manifest reads from 608 to 304 across 152 manifests, package reads from 298 to 149, external-seed reads from two to one, and directory enumerations from four to two. The retained second manifest traversal belongs to the independent coverage guard.

Both versions passed the canonical check; the candidate write preserved every byte of all 154 generated files. All six existing helper tests, 17 canonical changed checks and independent review passed. These are work-count measurements; the cold process timings do not establish a production speedup. One tooling line removed net, with no new tests or configuration.
