### PR TITLE
refactor: simplify compaction setup

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
@@ -182,10 +182,18 @@ export async function prepareCompactionHarnessAuth(params: {
         profileId: params.authProfileId ?? params.reusableRuntimeAuthPlan?.forwardedAuthProfileId,
         allowKeychainPrompt: false,
       });
+  const harnessSelectionParams = {
+    provider: params.provider,
+    modelId: params.modelId,
+    config: params.config,
+    agentId: params.runtimePolicyAgentId,
+    sessionKey: params.runtimePolicySessionKey ?? undefined,
+    agentHarnessId: params.agentHarnessId,
+    agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
+  };
   const selectPreparedHarness = (attempts: readonly PreparedAgentRuntimeAuthAttempt[]) =>
     selectAgentHarnessForPreparedModelProviders({
-      provider: params.provider,
-      modelId: params.modelId,
+      ...harnessSelectionParams,
       modelProviders: attempts.map((attempt) =>
         projectPreparedModelProvider({
           model: params.model,
@@ -193,23 +201,12 @@ export async function prepareCompactionHarnessAuth(params: {
           attemptKind: attempt.kind,
         }),
       ),
-      config: params.config,
-      agentId: params.runtimePolicyAgentId,
-      sessionKey: params.runtimePolicySessionKey ?? undefined,
-      agentHarnessId: params.agentHarnessId,
-      agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
     });
   const initialHarness = params.reusableRuntimeAuthPlan
     ? undefined
     : selectAgentHarness({
-        provider: params.provider,
-        modelId: params.modelId,
+        ...harnessSelectionParams,
         modelProvider: projectPreparedModelProvider({ model: params.model }),
-        config: params.config,
-        agentId: params.runtimePolicyAgentId,
-        sessionKey: params.runtimePolicySessionKey ?? undefined,
-        agentHarnessId: params.agentHarnessId,
-        agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
       });
   const prepare = (harness: AgentHarness) =>
     prepareAgentRuntimeAuth({

--- a/src/agents/harness/compaction.ts
+++ b/src/agents/harness/compaction.ts
@@ -436,7 +436,6 @@ export async function maybeCompactAgentHarnessSession(
     return undefined;
   }
   const compactIdentity = resolveHarnessCompactIdentity(params);
-  let resolvedRuntimeAuthPlan = runtimeAuthPlan;
   const resolveNativeToolPolicyRestricted = (targetHarness: AgentHarness) =>
     resolveAgentHarnessNativeToolPolicyRestricted(
       {
@@ -451,14 +450,6 @@ export async function maybeCompactAgentHarnessSession(
     ...params,
     agentDir: compactIdentity.agentDir,
     agentId: compactIdentity.agentId,
-    ...(resolvedRuntimeAuthPlan
-      ? {
-          runtimeAuthPlan: resolvedRuntimeAuthPlan,
-          ...(params.runtimePlan
-            ? { runtimePlan: { ...params.runtimePlan, auth: resolvedRuntimeAuthPlan } }
-            : {}),
-        }
-      : {}),
   };
   const resolved = await resolveHarnessCompactApiKey({
     agentDir: compactIdentity.agentDir,
@@ -472,7 +463,7 @@ export async function maybeCompactAgentHarnessSession(
   harness = resolved.harness;
   const nativeToolPolicyRestricted = resolveNativeToolPolicyRestricted(harness);
   compactParams.nativeToolSurface = nativeToolPolicyRestricted ? "host-isolated" : "unrestricted";
-  resolvedRuntimeAuthPlan = resolved.runtimeAuthPlan ?? resolvedRuntimeAuthPlan;
+  const resolvedRuntimeAuthPlan = resolved.runtimeAuthPlan ?? runtimeAuthPlan;
   const nativeCompaction = resolveCodexAgentHarnessNativeCompaction(harness);
   if (options.nativeCompactionRequest === "after_context_engine" && !nativeCompaction) {
     return undefined;


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Compaction setup repeats the same harness policy fields and projects native auth plans twice, making the direct, queued, and native paths harder to maintain consistently.

## Why This Change Was Made

Share one set of selection fields between initial and prepared harness selection. Keep native auth-plan projection at the final handoff, where the resolved plan is known. The existing auth fallback, pinning, and convergence policies stay with their current owners.

This removes 12 production lines across two files; no tests or configuration surfaces change.

## User Impact

No user-visible behavior change.

## Evidence

- 356 existing tests passed across native harness selection, direct/queued compaction hooks, native CLI compaction, and admitted-runtime handling.
- The complete changed gate passed for both production files, and independent P2 review found no actionable findings.
- A normal full `pnpm build` passed, including SDK declarations and export validation.
- Twelve compiled scenarios passed using the existing exported owners, a registered synthetic harness/context engine, and an isolated loopback model endpoint. They cover absent and reusable plans, direct-over-nested precedence, native pins, harness-owned auth, preserved existing keys, recoverable auth-preparation failure, queued handoff, and terminal non-convergence.
- The two direct flows were repeated with persisted summary and retained-entry readback. Four streaming loopback completions succeeded across the original runs and these readbacks. All 11,929 build outputs and the committed source remained unchanged during proof.
