### PR TITLE
refactor: simplify Firecrawl credential test inputs

### DIFF
--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -26,6 +26,20 @@ vi.mock("./firecrawl-client.js", () => ({
   runFirecrawlScrape,
 }));
 
+function createSearchSecretRefPlugins(source: "env" | "file", provider: string, id: string) {
+  return {
+    entries: {
+      firecrawl: {
+        config: {
+          webSearch: {
+            apiKey: { source, provider, id },
+          },
+        },
+      },
+    },
+  };
+}
+
 describe("firecrawl tools", () => {
   const priorFetch = global.fetch;
   let fetchFirecrawlContent: typeof import("../api.js").fetchFirecrawlContent;
@@ -1291,21 +1305,7 @@ describe("firecrawl tools", () => {
   it("resolves env SecretRefs for Firecrawl API key without requiring a runtime snapshot", () => {
     vi.stubEnv("FIRECRAWL_API_KEY", "firecrawl-env-ref-key");
     const cfg = {
-      plugins: {
-        entries: {
-          firecrawl: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "env",
-                  provider: "default",
-                  id: "FIRECRAWL_API_KEY",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: createSearchSecretRefPlugins("env", "default", "FIRECRAWL_API_KEY"),
     } as OpenClawConfig;
 
     expect(resolveFirecrawlApiKey(cfg)).toBe("firecrawl-env-ref-key");
@@ -1314,21 +1314,7 @@ describe("firecrawl tools", () => {
   it("does not use env fallback when a non-env SecretRef is configured but unavailable", () => {
     vi.stubEnv("FIRECRAWL_API_KEY", "firecrawl-env-fallback");
     const cfg = {
-      plugins: {
-        entries: {
-          firecrawl: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "file",
-                  provider: "vault",
-                  id: "/firecrawl/api-key",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: createSearchSecretRefPlugins("file", "vault", "/firecrawl/api-key"),
     } as OpenClawConfig;
 
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
@@ -1337,21 +1323,7 @@ describe("firecrawl tools", () => {
   it("does not read arbitrary env SecretRef ids for Firecrawl API key resolution", () => {
     vi.stubEnv("UNRELATED_SECRET", "should-not-be-read");
     const cfg = {
-      plugins: {
-        entries: {
-          firecrawl: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "env",
-                  provider: "default",
-                  id: "UNRELATED_SECRET",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: createSearchSecretRefPlugins("env", "default", "UNRELATED_SECRET"),
     } as OpenClawConfig;
 
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
@@ -1368,21 +1340,7 @@ describe("firecrawl tools", () => {
           },
         },
       },
-      plugins: {
-        entries: {
-          firecrawl: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "env",
-                  provider: "firecrawl-env",
-                  id: "FIRECRAWL_API_KEY",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: createSearchSecretRefPlugins("env", "firecrawl-env", "FIRECRAWL_API_KEY"),
     } as OpenClawConfig;
 
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();
@@ -1399,21 +1357,7 @@ describe("firecrawl tools", () => {
           },
         },
       },
-      plugins: {
-        entries: {
-          firecrawl: {
-            config: {
-              webSearch: {
-                apiKey: {
-                  source: "env",
-                  provider: "firecrawl-env",
-                  id: "FIRECRAWL_API_KEY",
-                },
-              },
-            },
-          },
-        },
-      },
+      plugins: createSearchSecretRefPlugins("env", "firecrawl-env", "FIRECRAWL_API_KEY"),
     } as OpenClawConfig;
 
     expect(resolveFirecrawlApiKey(cfg)).toBeUndefined();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five Firecrawl credential-resolution cases repeat the same deeply nested plugin configuration, making their differing SecretRef inputs harder to compare.

## Why This Change Was Made

Use one same-file fixture constructor with explicit source, provider, and id arguments. Each call creates the same six fresh objects, with the same fields and key order. The separate provider policies, environment stubs, existing casts, hooks, and independent expected results remain unchanged.

## User Impact

No user-visible behavior change. This removes 56 net test lines while preserving all existing cases and credential-policy assertions. No production helper or shared API is added.

## Evidence

- Complete existing firecrawl-tools.test.ts suite: 60 passed before and 60 after, zero pending, with identical ordered case names and statuses on Node26.8.1/macOS.
- Structural proof checks all five input-only substitutions, exact values/property order, and whole-file inverse equality. Ten isolated helper calls created 60 distinct objects; mutation of one result did not affect another.
- Required mapped static gate passed. Fresh independent P2 review found no actionable findings.
- No live credentials, provider requests, new scenarios, or runtime-savings claim.
