### PR TITLE
refactor(agents): remove duplicate CLI retirement test

### DIFF
--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -994,19 +994,6 @@ describe("runCliAgent before_agent_reply seam", () => {
     }
   });
 
-  it("retires the immutable session ID without resolving a rebound session key", async () => {
-    executePreparedCliRunMock.mockResolvedValue({ text: "real reply" });
-
-    await runCliAgent({ ...baseRunParams, cleanupBundleMcpOnRunEnd: true });
-
-    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledTimes(1);
-    expect(retireSessionMcpRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: "test-session", reason: "cli-run-end" }),
-    );
-    expect(retireSessionMcpRuntimeForSessionKeyMock).not.toHaveBeenCalled();
-    expect(closeMcpLoopbackServerMock).not.toHaveBeenCalled();
-  });
-
   it("preserves confirmed delivery when session MCP retirement fails", async () => {
     executePreparedCliRunMock.mockResolvedValue({
       text: "",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The CLI session-retirement tests repeat the same cleanup scenario and assertions without adding coverage.

## Why This Change Was Made

Remove the weaker duplicate. The retained case uses the same inputs and preserves all four retirement assertions, plus a backend execution-count assertion. Concurrent authenticated MCP streams, rebound session keys, and retirement failures keep their distinct coverage.

## User Impact

No runtime behavior changes. This removes one test case and 13 test lines; production code, helpers, imports, and the remaining assertions are unchanged.

## Evidence

- Full ordered agents-core test file: 38 actual passes, 0 skipped, including real loopback/SSE and rebound cases.
- All 20 selected changed checks passed, with targeted formatting and diff checks.
- Fresh scoped P2 review completed with no actionable findings. Raw review chunks and aggregate confidence were preserved.

No live Codex execution, global HTTP/lifecycle validation, or local full-repository test run is claimed.
