### PR TITLE
fix(ui): keep snapshot builds visible when image loading fails

### DIFF
--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.test.ts
@@ -711,6 +711,88 @@ describe("Snapshot builds", () => {
     }
   });
 
+  it.each(["provisioning", "failed"] as const)(
+    "shows an admitted %s build when the first image inventory fails",
+    async (state) => {
+      let environments = [
+        buildFixture(state, state === "failed" ? "Setup recipe failed" : undefined),
+      ];
+      let failImages = true;
+      const result = { ...snapshotListFixture(), images: [], legacyLeases: [] };
+      const fixture = mountPage(buildMethods, {
+        response: (method) => {
+          if (method === "environments.list") {
+            return { environments };
+          }
+          if (method === "crabbox.images.list") {
+            if (failImages) {
+              throw new Error("Image inventory is unavailable");
+            }
+            return result;
+          }
+          if (method === "environments.destroy") {
+            environments = [];
+            return {};
+          }
+          return undefined;
+        },
+      });
+      try {
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        await waitForFast(() =>
+          expect(fixture.page.textContent).toContain("No cloud worker profiles"),
+        );
+        button(fixture.page, "Snapshots").click();
+        await waitForFast(() =>
+          expect(fixture.page.textContent).toContain("Image inventory is unavailable"),
+        );
+        const snapshots = expectDefined(
+          fixture.page.querySelector("openclaw-cloud-worker-snapshots"),
+          "Snapshots view",
+        );
+        expect(snapshots.textContent).toContain("build-app");
+        const imageTotal = () =>
+          [...snapshots.querySelectorAll(".settings-summary dt")].find(
+            (entry) => entry.textContent === "Images",
+          )?.nextElementSibling?.textContent;
+        expect(imageTotal()).toBeUndefined();
+        const imageReads = () =>
+          fixture.request.mock.calls.filter(([method]) => method === "crabbox.images.list").length;
+        const readsBeforePoll = imageReads();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(imageReads()).toBe(readsBeforePoll + (state === "provisioning" ? 1 : 0));
+        if (state === "provisioning") {
+          expect(snapshots.textContent).toContain("Provisioning");
+          expect(button(snapshots, "Cancel").disabled).toBe(false);
+          button(snapshots, "Cancel").click();
+          await waitForFast(() =>
+            expect(fixture.request).toHaveBeenCalledWith("environments.destroy", {
+              environmentId: "build-app",
+            }),
+          );
+          await waitForFast(() => expect(snapshots.textContent).not.toContain("build-app"));
+        } else {
+          expect(snapshots.textContent).toContain("Setup recipe failed");
+          expect(
+            [...snapshots.querySelectorAll("button")].some(
+              (entry) => entry.textContent?.trim() === "Cancel",
+            ),
+          ).toBe(false);
+        }
+        failImages = false;
+        await waitForFast(() => expect(button(snapshots, "Refresh").disabled).toBe(false));
+        button(snapshots, "Refresh").click();
+        await waitForFast(() => expect(imageTotal()).toBe("0"));
+        expect(snapshots.textContent).not.toContain("Image inventory is unavailable");
+        if (state === "failed") {
+          expect(snapshots.textContent).toContain("Setup recipe failed");
+        }
+      } finally {
+        fixture.dispose();
+      }
+    },
+  );
+
   it("retains an admitted active build and polling when the image inventory fails", async () => {
     let environments: Array<ReturnType<typeof buildFixture>> = [];
     let failImages = false;

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
@@ -552,12 +552,12 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     });
   }
 
-  private renderImages(result: SnapshotsResult) {
+  private renderImages(result: SnapshotsResult | null) {
     const groups = new Map<
       string | undefined,
       { profile?: SnapshotProfile; images: SnapshotImage[]; builds: EnvironmentSummary[] }
-    >(result.profiles.map((profile) => [profile.id, { profile, images: [], builds: [] }]));
-    for (const image of result.images) {
+    >((result?.profiles ?? []).map((profile) => [profile.id, { profile, images: [], builds: [] }]));
+    for (const image of result?.images ?? []) {
       const group = groups.get(image.profileId) ?? { images: [], builds: [] };
       group.images.push(image);
       groups.set(image.profileId, group);
@@ -574,36 +574,42 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
       ),
     );
     return html`
-      ${renderSettingsSummary([
-        {
-          label: t("cloudWorkersPage.snapshots.images"),
-          value: result.images.filter((image) => image.checkpointId).length,
-        },
-        {
-          label: t("cloudWorkersPage.snapshots.building"),
-          value:
-            this.builds.length +
-            result.images.filter(
-              (image) =>
-                image.capture &&
-                image.capture.phase !== "uncertain" &&
-                (!image.capture.leaseId || !buildLeases.has(image.capture.leaseId)),
-            ).length,
-        },
-        {
-          label: t("cloudWorkersPage.snapshots.held"),
-          value: result.images.filter((image) => image.held).length,
-        },
-        {
-          label: t("cloudWorkersPage.snapshots.attention"),
-          value:
-            this.failedBuilds.length +
-            result.images.filter(
-              (image) =>
-                image.retirement || image.capture?.phase === "uncertain" || image.capture?.stale,
-            ).length,
-        },
-      ])}
+      ${
+        result
+          ? renderSettingsSummary([
+              {
+                label: t("cloudWorkersPage.snapshots.images"),
+                value: result.images.filter((image) => image.checkpointId).length,
+              },
+              {
+                label: t("cloudWorkersPage.snapshots.building"),
+                value:
+                  this.builds.length +
+                  result.images.filter(
+                    (image) =>
+                      image.capture &&
+                      image.capture.phase !== "uncertain" &&
+                      (!image.capture.leaseId || !buildLeases.has(image.capture.leaseId)),
+                  ).length,
+              },
+              {
+                label: t("cloudWorkersPage.snapshots.held"),
+                value: result.images.filter((image) => image.held).length,
+              },
+              {
+                label: t("cloudWorkersPage.snapshots.attention"),
+                value:
+                  this.failedBuilds.length +
+                  result.images.filter(
+                    (image) =>
+                      image.retirement ||
+                      image.capture?.phase === "uncertain" ||
+                      image.capture?.stale,
+                  ).length,
+              },
+            ])
+          : nothing
+      }
       ${
         groups.size
           ? [...groups].map(([id, group]) => {
@@ -640,7 +646,7 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
           : renderSettingsEmpty(t("cloudWorkersPage.snapshots.empty"))
       }
       ${
-        result.legacyLeases.length
+        result?.legacyLeases.length
           ? renderSettingsSection(
               {
                 title: t("cloudWorkersPage.snapshots.migration"),
@@ -686,7 +692,7 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
       )}
       ${this.error ? html`<div class="callout warning" role="alert">${this.error}</div>` : nothing}
       ${this.notice ? html`<div class="callout" role="status">${this.notice}</div>` : nothing}
-      ${this.result ? this.renderImages(this.result) : this.loading ? renderSettingsEmpty(t("common.loading")) : nothing}
+      ${this.result || this.builds.length || this.failedBuilds.length ? this.renderImages(this.result) : this.loading ? renderSettingsEmpty(t("common.loading")) : nothing}
       <openclaw-cloud-worker-snapshot-policy></openclaw-cloud-worker-snapshot-policy>
       ${this.renderBuildDialog()}
     `);


### PR DESCRIPTION
Related: #143929

## What Problem This Solves

The Snapshots page hides active and failed builds when its first image-inventory request fails. Operators lose the visible Cancel action and recorded build errors even though the worker list loaded successfully.

## Why This Change Was Made

Render known builds through the existing grouped snapshot view independently of image-inventory availability. Keep image-derived totals absent until inventory succeeds, while retaining the existing polling, confirmation, cancellation and connection ownership.

## User Impact

Operators can see build progress, cancel an active build and read a failed build's error while image inventory is unavailable. Refresh restores the complete image summary after recovery.

## Evidence

The candidate is refreshed onto main ea41203f6c6d, preserving the newer confirmation owner and typed fixtures. The same two first-load regression cases fail on that baseline because the build row is missing and pass with the repair. All 38 cases across the Snapshots page, Cloud Workers page and Gateway page controller pass, along with all 20 canonical changed checks. Fresh independent review found no actionable findings.

A fresh production UI bundle passes the four existing snapshot browser flows: preparing a build, cancelling through the actual confirmation dialog, acknowledging recovery, and pinning/unpinning/deleting an image. The unchanged stale-archive browser case also passes. The earlier CI run 34494388814 failed that archive case with five requests instead of three; the local passing replay does not explain that failure, and its assertions and timeouts remain unchanged. The separate roster scheduling fix in #144239 is not included here.

The attached before/after captures use the same Chromium driver with the actual page and styles and synthetic Gateway responses. Before, only the inventory error appears. After, both known builds, the enabled Cancel button and the worker failure remain visible; image totals stay unknown. These are component browser captures, complemented by the bundled app tests above. No live Gateway, real provider or cloud lease was used.

![Before: the initial image inventory failure hides known builds and Cancel](https://github.com/user-attachments/assets/b9e255fe-183c-4f38-94b1-2094b6bd37d0)

![After: known builds, Cancel and build errors stay visible with unknown image totals](https://github.com/user-attachments/assets/8dd81806-0933-49d0-9ead-71c1f667e549)