### PR TITLE
fix(update): stop plugin persistence after updater authority is lost

### DIFF
--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -39,6 +39,7 @@ export async function convergeUpdatePlugins(params: {
   packageUpdateNodeRunner?: string;
   updateStepTimeoutMs: number;
   beforeDoctor?: () => Promise<void>;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<{
   resultWithPostUpdate: UpdateRunResult;
   postUpdateConfigSnapshot?: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
@@ -150,6 +151,7 @@ export async function convergeUpdatePlugins(params: {
             acceptCapabilities: params.opts.acceptCapabilities,
             timeoutMs: params.updateStepTimeoutMs,
             pluginInstallRecords,
+            beforePersistentEffect: params.beforePersistentEffect,
           });
         });
       }

--- a/src/cli/update-cli/update-command-plugin-caller.test.ts
+++ b/src/cli/update-cli/update-command-plugin-caller.test.ts
@@ -1,0 +1,273 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as convergence from "../../commands/doctor/shared/post-core-plugin-convergence.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import * as temporaryState from "../../infra/tmp-openclaw-dir.js";
+import { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } from "../../infra/update-control-plane-sentinel.js";
+import { createUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import { readPersistedInstalledPluginIndexRowSync } from "../../plugins/installed-plugin-index-row.js";
+import { defaultRuntime, ExitError } from "../../runtime.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { VERSION } from "../../version.js";
+import * as configPreparation from "./update-command-config.js";
+import {
+  releaseUpdateCommandPreflightForHandoff,
+  withUpdateCommandExecutor,
+} from "./update-command-executor.js";
+import { finishUpdate, type FinishUpdateParams } from "./update-command-post-update.js";
+import { UpdateCommandPendingRecoveryFailure } from "./update-command-result.js";
+import { withUpdateCommandTerminalResult } from "./update-command-terminal.js";
+import { withUpdateFailureTriage } from "./update-command-triage.js";
+
+const transport = vi.hoisted(() => ({ exec: vi.fn(), command: vi.fn() }));
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
+  runExec: transport.exec,
+  runCommandWithTimeout: transport.command,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("connected in-process plugin finalization authority", () => {
+  it.each([
+    "healthy",
+    "index-revoked",
+    "config-revoked",
+    "run-replaced",
+    "fence-replaced",
+  ] as const)("protects persistence and terminal behavior with %s", async (scenario) => {
+    await withOpenClawTestState(
+      {
+        label: `plugin-caller-${scenario}`,
+        env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_UPDATE_RUN_HANDOFF: undefined },
+      },
+      async (state) => {
+        const control = state.path("control");
+        const otherRoot = state.path("other-install");
+        await fs.mkdir(control);
+        await fs.mkdir(otherRoot);
+        await fs.mkdir(state.path("dist"));
+        await fs.writeFile(state.path("dist", "entry.js"), "// Inert transport fixture.\n");
+        await fs.writeFile(
+          state.path("package.json"),
+          JSON.stringify({ name: "openclaw", version: VERSION }),
+        );
+        vi.spyOn(temporaryState, "resolvePreferredOpenClawTmpDir").mockReturnValue(control);
+        const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+        const error = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+        let assertOriginalCurrent: (() => void) | undefined;
+        let runAtPublication: ReturnType<typeof getUpdateRun>;
+        const json = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {
+          // The CLI terminal owner publishes only after the real executor closes.
+          expect(assertOriginalCurrent).toBeDefined();
+          expect(assertOriginalCurrent).toThrow();
+          runAtPublication = getUpdateRun(created.runId, { env: state.env });
+        });
+        transport.command
+          .mockReset()
+          .mockRejectedValue(new Error("Unexpected package/native command"));
+        transport.exec.mockReset().mockImplementation(async (_file, args: string[]) => {
+          if (args[0] !== state.path("dist", "entry.js")) {
+            throw new Error("Unexpected external entrypoint");
+          }
+          if (args[1] === "doctor" || (args[1] === "config" && args[2] === "validate")) {
+            return { stdout: JSON.stringify({ ok: true, checksRun: 1, findings: [] }), stderr: "" };
+          }
+          throw new Error("Unexpected external command");
+        });
+
+        // Restore an authored setting dropped during core update. Both snapshots are real;
+        // this forces the plugin commit without a package fetch or fake convergence result.
+        const authoredChannels = { telegram: { enabled: false } };
+        await state.writeConfig({ plugins: { enabled: false }, channels: authoredChannels });
+        const configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+        const currentConfig = { plugins: { enabled: false } };
+        await state.writeConfig(currentConfig);
+        await writePersistedInstalledPluginIndexInstallRecords(
+          {},
+          { config: currentConfig, env: state.env },
+        );
+        const originalConfig = await fs.readFile(state.configPath, "utf8");
+        const diagnosticPath = await state.writeText(
+          "retained-diagnostic.json",
+          "retained diagnostic\n",
+        );
+        const metaPath = await state.writeJson("sentinel-meta.json", {
+          version: 1,
+          meta: { triageContextPath: diagnosticPath },
+        });
+        const targetEnv = {
+          ...state.env,
+          OPENCLAW_UPDATE_RUN_HANDOFF: "1",
+          [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
+        };
+        const created = createUpdateRun({ trigger: "cli" }, { env: state.env });
+        const readIndex = () => readPersistedInstalledPluginIndexRowSync({ env: state.env });
+        let indexAtConvergence: ReturnType<typeof readIndex>;
+        let runAtConvergence: ReturnType<typeof getUpdateRun>;
+        let configBoundaryReached = false;
+        let refused: unknown;
+        let completed: Awaited<ReturnType<typeof finishUpdate>> | undefined;
+
+        const run: NonNullable<FinishUpdateParams["opts"]["run"]> = {
+          runId: created.runId,
+          env: state.env,
+        };
+        const execution = () =>
+          withUpdateCommandExecutor(created.runId, async (executor) => {
+            // Revocation uses the real direct-owner release API. No synthetic assertCurrent
+            // or plugin lease substitutes for the native executor's ownership check.
+            const fence = await executor.enter(state.root, { preflight: true });
+            run.executorFence = fence;
+            assertOriginalCurrent = fence.assertCurrent;
+            return withUpdateCommandExecutor("independent-live-owner", async (otherExecutor) => {
+              const otherFence = await otherExecutor.enter(otherRoot);
+              const params: FinishUpdateParams = {
+                root: state.root,
+                result: {
+                  status: "skipped",
+                  reason: "already-current",
+                  mode: "npm",
+                  root: state.root,
+                  steps: [],
+                  durationMs: 0,
+                },
+                coreAlreadyCurrent: true,
+                mutationStarted: false,
+                shouldRestart: false,
+                installKindChanged: false,
+                configSnapshot,
+                requestedChannel: null,
+                storedChannel: "stable",
+                channel: "stable",
+                downgradeRisk: false,
+                opts: { json: true, yes: true, run },
+                controlPlaneUpdateSentinelMeta: null,
+                preUpdatePluginInstallRecords: {},
+                startedAt: Date.now(),
+                updateStepTimeoutMs: 1_000,
+              };
+              const converge = convergence.runPostCorePluginConvergence;
+              vi.spyOn(convergence, "runPostCorePluginConvergence").mockImplementationOnce(
+                async (input) => {
+                  const result = await converge(input);
+                  fence.assertCurrent();
+                  otherFence.assertCurrent();
+                  indexAtConvergence = readIndex();
+                  runAtConvergence = getUpdateRun(created.runId, { env: state.env });
+                  if (scenario === "index-revoked") {
+                    releaseUpdateCommandPreflightForHandoff(fence);
+                  } else if (scenario === "run-replaced") {
+                    params.opts.run = { ...run };
+                  } else if (scenario === "fence-replaced") {
+                    run.executorFence = otherFence;
+                  }
+                  return result;
+                },
+              );
+              const prepare = configPreparation.preparePostCorePluginConfig;
+              vi.spyOn(configPreparation, "preparePostCorePluginConfig").mockImplementationOnce(
+                async (input) => {
+                  const prepared = await prepare(input);
+                  const beforeCommit = prepared.configWriteOptions.beforeCommit;
+                  prepared.configWriteOptions.beforeCommit = async () => {
+                    await beforeCommit?.();
+                    configBoundaryReached = true;
+                    if (scenario === "config-revoked") {
+                      fence.assertCurrent();
+                      expect(readIndex()).not.toEqual(indexAtConvergence);
+                      releaseUpdateCommandPreflightForHandoff(fence);
+                    }
+                  };
+                  return prepared;
+                },
+              );
+              try {
+                completed = await finishUpdate(params);
+              } catch (cause) {
+                refused = cause;
+                // Refusal cannot rewrite history before terminal settlement. The later
+                // terminal row is diagnostic publication, not renewed mutation authority.
+                expect(getUpdateRun(created.runId, { env: state.env })).toEqual(runAtConvergence);
+                expect(json).not.toHaveBeenCalled();
+                throw cause;
+              }
+            });
+          });
+        const terminal = withUpdateFailureTriage(
+          { json: true, yes: true, run },
+          { root: state.root, env: targetEnv },
+          async () => {
+            await withUpdateCommandTerminalResult(run, execution);
+          },
+        );
+        if (scenario === "healthy") {
+          await terminal;
+          expect(refused).toBeUndefined();
+          expect(completed).toMatchObject({
+            status: "ok",
+            postUpdate: { plugins: { changed: true, status: "ok", warnings: [] } },
+          });
+          expect(JSON.parse(await fs.readFile(state.configPath, "utf8")).channels).toEqual(
+            authoredChannels,
+          );
+          expect(readIndex()).not.toEqual(indexAtConvergence);
+          expect(runAtPublication?.status).toBe("succeeded");
+          expect(configBoundaryReached).toBe(true);
+          expect(transport.exec).toHaveBeenCalled();
+        } else {
+          await expect(terminal).rejects.toMatchObject({ code: 1, name: new ExitError(1).name });
+          expect(refused).toBeInstanceOf(UpdateCommandPendingRecoveryFailure);
+          expect(refused).toMatchObject({
+            automaticTriage: undefined,
+            result: { status: "error" },
+          });
+          expect(await fs.readFile(state.configPath, "utf8")).toBe(originalConfig);
+          // Config refusal rolls back the tentative index through its existing owner.
+          // Index refusal must not write even a new index revision.
+          if (scenario === "config-revoked") {
+            expect(JSON.parse(readIndex()!.value_json).index).toEqual(
+              JSON.parse(indexAtConvergence!.value_json).index,
+            );
+            expect(configBoundaryReached).toBe(true);
+          } else {
+            expect(readIndex()).toEqual(indexAtConvergence);
+            expect(configBoundaryReached).toBe(false);
+          }
+          const reported = json.mock.calls[0]?.[0];
+          expect(reported).toMatchObject({
+            status: "error",
+            reason: "update-executor-settlement-failed",
+            steps: [
+              {
+                name: "update executor settlement",
+                exitCode: 1,
+                stderrTail: expect.stringContaining(
+                  scenario === "run-replaced" || scenario === "fence-replaced"
+                    ? "Package finalization lost its original executor."
+                    : "Update executor ownership is no longer current.",
+                ),
+              },
+            ],
+          });
+          expect(runAtPublication).toMatchObject({
+            status: "failed",
+            reason: "update-executor-settlement-failed",
+          });
+          expect(transport.exec).not.toHaveBeenCalled();
+          expect(error).not.toHaveBeenCalled();
+        }
+        expect(indexAtConvergence).toBeDefined();
+        expect(runAtPublication).toBeDefined();
+        expect(getUpdateRun(created.runId, { env: state.env })).toEqual(runAtPublication);
+        expect(await fs.readFile(diagnosticPath, "utf8")).toBe("retained diagnostic\n");
+        expect(transport.command).not.toHaveBeenCalled();
+        expect(json.mock.calls).toHaveLength(1);
+        expect(log).not.toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/src/cli/update-cli/update-command-plugins.persistence.test.ts
+++ b/src/cli/update-cli/update-command-plugins.persistence.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { readConfigFileSnapshot } from "../../config/config.js";
+import {
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../../plugins/installed-plugin-index-records.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+const mocks = vi.hoisted(() => ({ convergence: vi.fn() }));
+vi.mock("../../commands/doctor/shared/post-core-plugin-convergence.js", () => ({
+  runPostCorePluginConvergence: mocks.convergence,
+}));
+import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
+
+describe("updater plugin commit cancellation", () => {
+  it.each(["index", "config"] as const)(
+    "refuses a cancelled %s write through the real commit owner",
+    async (effect) => {
+      await withOpenClawTestState({ label: `updater-plugin-${effect}` }, async (state) => {
+        const cfg = { plugins: { enabled: false } };
+        await state.writeConfig(cfg);
+        const originalConfig = await fs.readFile(state.configPath, "utf8");
+        await writePersistedInstalledPluginIndexInstallRecords({}, { config: cfg, env: state.env });
+        const controller = new AbortController();
+        const refusal = new Error(`initiating updater revoked before ${effect}`);
+        mocks.convergence.mockImplementationOnce(async () => {
+          await Promise.resolve();
+          if (effect === "index") {
+            controller.abort(refusal);
+          }
+          return {
+            changes: [],
+            warnings: [],
+            errored: false,
+            smokeFailures: [],
+            installRecords: { next: { source: "archive" } },
+          };
+        });
+        const params = {
+          root: state.root,
+          channel: "stable" as const,
+          configSnapshot: await readConfigFileSnapshot(),
+          configWriteOptions: {
+            beforeCommit: () => {
+              if (effect === "config") {
+                controller.abort(refusal);
+              }
+            },
+          },
+          configChanged: true,
+          pluginInstallRecords: {},
+          timeoutMs: 1_000,
+          json: true,
+          beforePersistentEffect: () => controller.signal.throwIfAborted(),
+        };
+        await expect(updatePluginsAfterCoreUpdate(params)).rejects.toBe(refusal);
+        expect(await fs.readFile(state.configPath, "utf8")).toBe(originalConfig);
+        expect(await readPersistedInstalledPluginIndexInstallRecords({ env: state.env })).toEqual(
+          {},
+        );
+      });
+    },
+  );
+});

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -107,6 +107,7 @@ function isActionableSkippedPostUpdateOutcome(outcome: PluginUpdateOutcome): boo
 
 export async function updatePluginsAfterCoreUpdate(params: {
   root: string;
+  beforePersistentEffect?: () => void | Promise<void>;
   channel: UpdateChannel;
   configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
   configWriteOptions: ConfigWriteOptions;
@@ -289,6 +290,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     env: process.env,
     compatibilityHostVersion: coreVersion ?? undefined,
     baselineInstallRecords: convergenceBaselineRecords,
+    beforePersistentEffect: params.beforePersistentEffect,
     ...capabilityConsent,
   });
   for (const change of convergence.changes) {
@@ -366,6 +368,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     // Installed plugin metadata can own migrations that this process has not loaded yet.
     // Finalization runs fresh doctor plus strict validation before the update can complete.
     await commitPluginInstallRecordsWithConfig({
+      beforePersistentEffect: params.beforePersistentEffect,
       previousInstallRecords: pluginInstallRecords,
       nextInstallRecords,
       nextConfig,
@@ -376,6 +379,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
         skipPluginValidation: true,
       },
     });
+    await params.beforePersistentEffect?.();
     await refreshPluginRegistryAfterConfigMutation({
       configPath: params.configSnapshot.path,
       reason: "source-changed",

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -437,7 +437,8 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
 
     const postUpdateRoot = params.result.root ?? params.root;
     const convergePlugins = async (beforeDoctor?: () => Promise<void>) => {
-      const convergence = await convergeUpdatePlugins({ ...params, beforeDoctor });
+      const pluginParams = { ...params, beforeDoctor, beforePersistentEffect: assertCurrent };
+      const convergence = await convergeUpdatePlugins(pluginParams);
       if (convergence.resultWithPostUpdate.status === "error") {
         triageAllowed = !convergence.cancelled;
         const reported = await reportResult(convergence.resultWithPostUpdate);

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -76,6 +76,7 @@ export async function repairMissingConfiguredPluginInstalls(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
+  beforePersistentEffect?: () => void | Promise<void>;
   /**
    * Optional pre-seeded records. When provided, this map is used instead of
    * the disk-loaded install-record snapshot. Pass the in-memory records
@@ -91,6 +92,7 @@ export async function repairMissingConfiguredPluginInstalls(params: {
     pluginIds: collectConfiguredPluginIds(params.cfg, params.env),
     channelIds: collectConfiguredChannelIds(params.cfg, params.env),
     blockedPluginIds: collectBlockedPluginIds(params.cfg),
+    beforePersistentEffect: params.beforePersistentEffect,
     ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
     ...(params.baselineRecords ? { baselineRecords: params.baselineRecords } : {}),
   });
@@ -139,10 +141,35 @@ async function repairMissingPluginInstalls(params: {
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<RepairMissingPluginInstallsResult> {
-  // Baseline, awaited review, package publication, and the index write share one generation.
-  return await withPluginLifecycleLease({ env: params.env }, () =>
-    repairMissingPluginInstallsWithLease(params),
-  );
+  // Install attempts can normalize exceptions into ordinary repair outcomes.
+  // Preserve the initiating owner's first refusal, including transient read
+  // failures, across that conversion and every later persistent effect.
+  let effectFailure: { error: unknown } | undefined;
+  const beforePersistentEffect = params.beforePersistentEffect
+    ? async () => {
+        if (effectFailure) {
+          throw effectFailure.error;
+        }
+        try {
+          await params.beforePersistentEffect?.();
+        } catch (error) {
+          effectFailure ??= { error };
+          throw effectFailure.error;
+        }
+      }
+    : undefined;
+  try {
+    // Baseline, awaited review, package publication, and the index write share one generation.
+    const result = await withPluginLifecycleLease({ env: params.env }, () =>
+      repairMissingPluginInstallsWithLease({ ...params, beforePersistentEffect }),
+    );
+    if (effectFailure) {
+      throw effectFailure.error;
+    }
+    return result;
+  } catch (error) {
+    throw effectFailure ? effectFailure.error : error;
+  }
 }
 
 async function repairMissingPluginInstallsWithLease(
@@ -407,6 +434,8 @@ async function repairMissingPluginInstallsWithLease(
         (!installedRecord?.installPath ||
           !installPathsEqual(resolveUserPath(installedRecord.installPath, env), removalPath))
       ) {
+        // Authority refusal is not a recoverable package-cleanup warning.
+        await params.beforePersistentEffect?.();
         try {
           await rm(removalPath, { recursive: true, force: true });
         } catch (error) {

--- a/src/commands/doctor/shared/post-core-plugin-convergence.persistence.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.persistence.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginInstallRecord } from "../../../config/types.plugins.js";
+import {
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../../../plugins/installed-plugin-index-records.js";
+import { withPluginLifecycleLease } from "../../../plugins/plugin-lifecycle-lease.js";
+import { runPluginUpdateAttempt } from "../../../plugins/update-attempt.js";
+import * as pluginUpdates from "../../../plugins/update.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { repairMissingConfiguredPluginInstalls } from "./missing-configured-plugin-install.js";
+import { runPostCorePluginConvergence } from "./post-core-plugin-convergence.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("post-core plugin persistence cancellation", () => {
+  it.each([false, true])("preserves the repair index when cancelled=%s", async (cancelled) => {
+    await withOpenClawTestState({ label: "plugin-repair-cancellation" }, async (state) => {
+      const cfg = { plugins: { enabled: false } };
+      const previous: Record<string, PluginInstallRecord> = { previous: { source: "archive" } };
+      const next: Record<string, PluginInstallRecord> = { next: { source: "archive" } };
+      await writePersistedInstalledPluginIndexInstallRecords(previous, {
+        config: cfg,
+        env: state.env,
+      });
+      const controller = new AbortController();
+      const refusal = new Error("initiating operation cancelled during repair");
+      await withPluginLifecycleLease({ env: state.env }, async () => {
+        const params = {
+          cfg,
+          env: state.env,
+          baselineRecords: next,
+          beforePersistentEffect: () => controller.signal.throwIfAborted(),
+        };
+        const repair = repairMissingConfiguredPluginInstalls(params);
+        if (cancelled) {
+          controller.abort(refusal);
+          await expect(repair).rejects.toBe(refusal);
+        } else {
+          await repair;
+        }
+      });
+      expect(await readPersistedInstalledPluginIndexInstallRecords({ env: state.env })).toEqual(
+        cancelled ? previous : next,
+      );
+    });
+  });
+
+  it("retains an initiating-owner read failure across install error normalization", async () => {
+    await withOpenClawTestState({ label: "plugin-repair-normalized-refusal" }, async (state) => {
+      const cfg = { plugins: { entries: { peerplugin: { enabled: true } } } };
+      const record = {
+        source: "npm" as const,
+        spec: "peerplugin@1.0.0",
+        installPath: state.statePath("extensions", "peerplugin"),
+      };
+      await writePersistedInstalledPluginIndexInstallRecords({}, { config: cfg, env: state.env });
+      const refusal = new Error("initiating-owner store read failed");
+      let checks = 0;
+      vi.spyOn(pluginUpdates, "updateNpmInstalledPlugins").mockImplementationOnce(
+        async (params) => {
+          // The real attempt owner catches installer exceptions. No package child is launched here.
+          const attempt = await runPluginUpdateAttempt({
+            pluginId: "peerplugin",
+            record,
+            config: params.config,
+            dryRun: false,
+            effectiveSpec: record.spec,
+            trustedSourceLinkedOfficialInstall: false,
+            logger: {},
+            installNpmSpecForUpdate: async () => {
+              await Promise.resolve();
+              await params.beforePersistentEffect?.();
+              return { ok: false, error: "fixture installer did not publish" };
+            },
+          });
+          if (attempt.kind !== "exception") {
+            throw new Error("fixture expected normalized refusal");
+          }
+          expect(attempt.error).toBe(refusal);
+          return {
+            config: params.config,
+            changed: false,
+            outcomes: [{ pluginId: "peerplugin", status: "error", message: attempt.message }],
+          };
+        },
+      );
+      const repair = repairMissingConfiguredPluginInstalls({
+        cfg,
+        env: state.env,
+        baselineRecords: { peerplugin: record },
+        beforePersistentEffect: () => {
+          if (checks++ === 0) {
+            throw refusal;
+          }
+        },
+      });
+      await expect(repair).rejects.toBe(refusal);
+      expect(await readPersistedInstalledPluginIndexInstallRecords({ env: state.env })).toEqual({});
+    });
+  });
+
+  it.each([
+    ["managed", "mkdir"],
+    ["managed", "unlink"],
+    ["managed", "rm"],
+    ["managed", "symlink"],
+    ["registered", "unlink"],
+  ] as const)(
+    "keeps refusal blocking before the actual %s host-link %s effect",
+    async (layout, effect) => {
+      await withOpenClawTestState({ label: `plugin-host-${effect}` }, async (state) => {
+        const cfg = { plugins: { enabled: false } };
+        const packageDir =
+          layout === "managed"
+            ? state.statePath("npm", "node_modules", "peer-plugin")
+            : state.statePath("extensions", "peer-plugin");
+        const nodeModules = path.join(packageDir, "node_modules");
+        const linkPath = path.join(nodeModules, "openclaw");
+        fs.mkdirSync(packageDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "peer-plugin",
+            version: "1.0.0",
+            peerDependencies: { openclaw: "*" },
+          }),
+        );
+        if (effect !== "mkdir") {
+          fs.mkdirSync(nodeModules, { recursive: true });
+          if (effect === "rm") {
+            fs.mkdirSync(linkPath);
+            fs.writeFileSync(path.join(linkPath, "package.json"), '{"name":"openclaw"}');
+          } else {
+            fs.symlinkSync(state.root, linkPath, "junction");
+          }
+        }
+        const controller = new AbortController();
+        const refusal = new Error("initiating operation revoked after host-link probe");
+        if (effect === "symlink") {
+          const unlink = fs.promises.unlink.bind(fs.promises);
+          vi.spyOn(fs.promises, "unlink").mockImplementation(async (file) => {
+            await unlink(file);
+            if (file === linkPath) {
+              controller.abort(refusal);
+            }
+          });
+        } else {
+          const lstat = fs.promises.lstat.bind(fs.promises);
+          vi.spyOn(fs.promises, "lstat").mockImplementation(async (...args) => {
+            try {
+              return await lstat(...args);
+            } finally {
+              if (args[0] === (effect === "mkdir" ? nodeModules : linkPath)) {
+                controller.abort(refusal);
+              }
+            }
+          });
+        }
+        const baselineInstallRecords: Record<string, PluginInstallRecord> =
+          layout === "managed"
+            ? {}
+            : {
+                "peer-plugin": {
+                  source: "npm",
+                  spec: "peer-plugin@1.0.0",
+                  installPath: packageDir,
+                },
+              };
+        const params = {
+          cfg,
+          env: state.env,
+          baselineInstallRecords,
+          beforePersistentEffect: () => controller.signal.throwIfAborted(),
+        };
+        await expect(runPostCorePluginConvergence(params)).rejects.toBe(refusal);
+        if (effect === "mkdir") {
+          expect(fs.existsSync(nodeModules)).toBe(false);
+        } else if (effect === "symlink") {
+          expect(fs.existsSync(linkPath)).toBe(false);
+        } else if (effect === "rm") {
+          expect(fs.readFileSync(path.join(linkPath, "package.json"), "utf8")).toBe(
+            '{"name":"openclaw"}',
+          );
+          expect(fs.lstatSync(linkPath).isDirectory()).toBe(true);
+        } else {
+          expect(fs.readlinkSync(linkPath)).toBe(state.root);
+        }
+      });
+    },
+  );
+});

--- a/src/commands/doctor/shared/post-core-plugin-convergence.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.ts
@@ -74,32 +74,60 @@ function smokeFailureGuidance(failure: PluginPayloadSmokeFailure): string[] {
 async function repairInstalledNpmOpenClawHostLinks(params: {
   env: NodeJS.ProcessEnv;
   installRecords: Record<string, PluginInstallRecord>;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<{
   changes: string[];
   warnings: PostCoreConvergenceWarning[];
   packageReadFailures: Array<{ error: unknown; packageDir: string }>;
 }> {
   const packageReadFailures: Array<{ error: unknown; packageDir: string }> = [];
+  let effectFailure: { error: unknown } | undefined;
+  const beforePersistentEffect = params.beforePersistentEffect
+    ? async () => {
+        if (effectFailure) {
+          throw effectFailure.error;
+        }
+        try {
+          await params.beforePersistentEffect?.();
+        } catch (error) {
+          effectFailure ??= { error };
+          throw effectFailure.error;
+        }
+      }
+    : undefined;
   try {
     const npmRoots = await listManagedPluginNpmRoots(resolveDefaultPluginNpmDir(params.env));
-    const results = await Promise.all(
+    const results = await Promise.allSettled(
       npmRoots.map((npmRoot) =>
         relinkOpenClawPeerDependenciesInManagedNpmRoot({
           npmRoot,
           logger: {},
+          beforePersistentEffect,
           onPackageReadError: (error, packageDir) => {
             packageReadFailures.push({ error, packageDir });
           },
         }),
       ),
     );
-    const repaired = results.reduce((total, result) => total + result.repaired, 0);
+    // Join every admitted repair before reporting failure; Promise.all would
+    // leave sibling link mutations running after convergence rejected.
+    if (effectFailure) {
+      throw effectFailure.error;
+    }
+    let repaired = 0;
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+      repaired += result.value.repaired;
+    }
     // Legacy npm-owned installs live under extensions/, outside every managed npm project root.
     const registeredRepair = await reconcileRegisteredOpenClawHostLinks({
       installRecords: params.installRecords,
       extensionsDir: resolveDefaultPluginExtensionsDir(params.env),
       env: params.env,
       mode: "repair",
+      beforePersistentEffect,
       onPackageReadError: (error, packageDir) => {
         packageReadFailures.push({ error, packageDir });
       },
@@ -119,6 +147,9 @@ async function repairInstalledNpmOpenClawHostLinks(params: {
       packageReadFailures,
     };
   } catch (err) {
+    if (effectFailure) {
+      throw effectFailure.error;
+    }
     const message = `Failed to repair managed npm OpenClaw host peer links: ${err instanceof Error ? err.message : String(err)}`;
     return {
       changes: [],
@@ -165,6 +196,7 @@ export async function runPostCorePluginConvergence(params: {
    */
   baselineInstallRecords?: Record<string, PluginInstallRecord>;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<PostCoreConvergenceResult> {
   const env: NodeJS.ProcessEnv = {
     ...params.env,
@@ -173,6 +205,7 @@ export async function runPostCorePluginConvergence(params: {
   };
   // Retire obsolete managed shadows before relinking or smoke-checking them. A package that
   // became bundled with the new core must not survive into the next startup's contract graph.
+  await params.beforePersistentEffect?.();
   const staleManagedNpmBundledPluginRepair = maybeRepairStaleManagedNpmBundledPlugins({
     config: params.cfg,
     env,
@@ -193,6 +226,7 @@ export async function runPostCorePluginConvergence(params: {
     env,
     ...(prunedBaseline ? { baselineRecords: prunedBaseline.records } : {}),
     onCapabilityConsent: params.onCapabilityConsent,
+    beforePersistentEffect: params.beforePersistentEffect,
   });
 
   const warnings: PostCoreConvergenceWarning[] = repair.warnings.map((message) => ({
@@ -203,6 +237,7 @@ export async function runPostCorePluginConvergence(params: {
   const peerLinkRepair = await repairInstalledNpmOpenClawHostLinks({
     env,
     installRecords: repair.records,
+    beforePersistentEffect: params.beforePersistentEffect,
   });
   warnings.push(...peerLinkRepair.warnings);
   const notices: PostCoreConvergenceWarning[] = (repair.notices ?? []).map((message) => ({

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -220,6 +220,7 @@ export async function auditDeclaredOpenClawHostDependency(params: {
 async function ensureRealNodeModulesDir(params: {
   installedDir: string;
   logger: PluginPeerLinkLogger;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<string | null> {
   const nodeModulesDir = path.join(params.installedDir, "node_modules");
   try {
@@ -237,6 +238,7 @@ async function ensureRealNodeModulesDir(params: {
     }
   }
 
+  await params.beforePersistentEffect?.();
   await fs.mkdir(nodeModulesDir, { recursive: true });
   const created = await fs.lstat(nodeModulesDir);
   if (!created.isDirectory() || created.isSymbolicLink()) {
@@ -253,10 +255,12 @@ async function linkOpenClawPeerDependency(params: {
   installedDir: string;
   peerName: string;
   logger: PluginPeerLinkLogger;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<OpenClawPeerLinkResult> {
   const nodeModulesDir = await ensureRealNodeModulesDir({
     installedDir: params.installedDir,
     logger: params.logger,
+    beforePersistentEffect: params.beforePersistentEffect,
   });
   if (!nodeModulesDir) {
     return "skipped";
@@ -269,39 +273,57 @@ async function linkOpenClawPeerDependency(params: {
     return "unchanged";
   }
 
+  const warnFailure = (err: unknown): OpenClawPeerLinkResult => {
+    params.logger.warn?.(`Failed to symlink peerDependency "${params.peerName}": ${String(err)}`);
+    return "skipped";
+  };
+  let existing;
   try {
-    const existing = await fs.lstat(linkPath).catch((err: unknown) => {
+    existing = await fs.lstat(linkPath).catch((err: unknown) => {
       if (hasErrnoCode(err, "ENOENT")) {
         return null;
       }
       throw err;
     });
-    if (existing) {
-      if (!existing.isSymbolicLink()) {
-        if (params.peerName === "openclaw" && existing.isDirectory()) {
-          const existingPackageName = await readPackageName(linkPath);
-          if (existingPackageName === "openclaw") {
-            await fs.rm(linkPath, { recursive: true, force: true });
-            await fs.symlink(params.hostRoot, linkPath, "junction");
-            params.logger.info?.(
-              `Linked peerDependency "${params.peerName}" -> ${params.hostRoot}`,
-            );
-            return "linked";
-          }
-        }
-        params.logger.warn?.(
-          `Skipping openclaw peerDependency link because ${linkPath} already exists and is not a symlink.`,
-        );
-        return "skipped";
-      }
-      await fs.unlink(linkPath);
+    if (
+      existing &&
+      !existing.isSymbolicLink() &&
+      !(
+        params.peerName === "openclaw" &&
+        existing.isDirectory() &&
+        (await readPackageName(linkPath)) === "openclaw"
+      )
+    ) {
+      params.logger.warn?.(
+        `Skipping openclaw peerDependency link because ${linkPath} already exists and is not a symlink.`,
+      );
+      return "skipped";
     }
+  } catch (err) {
+    return warnFailure(err);
+  }
+
+  // Keep initiating-owner refusal outside filesystem warning conversion. Each
+  // awaited mutation also separates the next effect from its authority check.
+  if (existing) {
+    await params.beforePersistentEffect?.();
+    try {
+      if (existing.isSymbolicLink()) {
+        await fs.unlink(linkPath);
+      } else {
+        await fs.rm(linkPath, { recursive: true, force: true });
+      }
+    } catch (err) {
+      return warnFailure(err);
+    }
+  }
+  await params.beforePersistentEffect?.();
+  try {
     await fs.symlink(params.hostRoot, linkPath, "junction");
     params.logger.info?.(`Linked peerDependency "${params.peerName}" -> ${params.hostRoot}`);
     return "linked";
   } catch (err) {
-    params.logger.warn?.(`Failed to symlink peerDependency "${params.peerName}": ${String(err)}`);
-    return "skipped";
+    return warnFailure(err);
   }
 }
 
@@ -321,6 +343,7 @@ export async function linkOpenClawPeerDependencies(params: {
   logger: PluginPeerLinkLogger;
   /** Explicit source setup uses its selected checkout instead of the running host. */
   hostRoot?: string;
+  beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<{ repaired: number; skipped: number }> {
   const peers = Object.keys(params.peerDependencies).filter((name) => name === "openclaw");
   if (peers.length === 0) {
@@ -349,6 +372,7 @@ export async function linkOpenClawPeerDependencies(params: {
       installedDir: params.installedDir,
       peerName,
       logger: params.logger,
+      beforePersistentEffect: params.beforePersistentEffect,
     });
     if (result === "linked") {
       repaired += 1;
@@ -369,6 +393,7 @@ export async function reconcileRegisteredOpenClawHostLinks(params: {
   env?: NodeJS.ProcessEnv;
   mode: "audit" | "repair";
   logger?: PluginPeerLinkLogger;
+  beforePersistentEffect?: () => void | Promise<void>;
   onPackageReadError?: (error: unknown, packageDir: string) => void;
 }): Promise<RegisteredOpenClawHostLinkResult> {
   const extensionsRoot = path.resolve(params.extensionsDir);
@@ -446,6 +471,7 @@ export async function reconcileRegisteredOpenClawHostLinks(params: {
       installedDir: packageDir,
       peerDependencies: dependencies,
       logger: params.logger ?? {},
+      beforePersistentEffect: params.beforePersistentEffect,
     });
     repaired += result.repaired;
     skipped += result.skipped;
@@ -456,6 +482,7 @@ export async function reconcileRegisteredOpenClawHostLinks(params: {
 export async function relinkOpenClawPeerDependenciesInManagedNpmRoot(params: {
   npmRoot: string;
   logger: PluginPeerLinkLogger;
+  beforePersistentEffect?: () => void | Promise<void>;
   onPackageReadError?: (error: unknown, packageDir: string) => void;
 }): Promise<RelinkManagedNpmRootResult> {
   let checked = 0;
@@ -482,6 +509,7 @@ export async function relinkOpenClawPeerDependenciesInManagedNpmRoot(params: {
       installedDir: packageDir,
       peerDependencies: openClawLinkDependencies,
       logger: params.logger,
+      beforePersistentEffect: params.beforePersistentEffect,
     });
     attempted += 1;
     repaired += result.repaired;


### PR DESCRIPTION
Related: #143767, #143861, #143921

## What Problem This Solves

Fixes an issue where users running an update could have plugin state rewritten after the initiating updater lost authority. A final refusal could arrive only after config or install-index changes, and some repair paths could turn an authority failure into an ordinary warning.

## Why This Change Was Made

Forward the existing finalization assertion through in-process plugin convergence to the existing persistence hooks. Check the selected peer-link mutations at their write boundaries and retain the original refusal across repair error normalization. Ordinary plugin-management calls and recoverable plugin warnings keep their existing behavior.

This is a bounded in-process persistence correction. It does not introduce a new executor or recovery system, enable the fresh-finalizer route, or claim package-child and all-plugin custody. It preserves the landed terminal settlement/reporting behavior.

## User Impact

The covered plugin config, install-index, and host-link writes stop when their initiating owner refuses further effects. The update reports failure without starting automatic repair for that authority refusal. Normal authorized plugin convergence remains available.

## Evidence

- Five connected caller cases pass on pinned main c0b128344ce496c26c922c9f3a932a44289fb0f2 with the complete contribution: healthy owner, index/config-boundary revocation, equal-ID run substitution, and live-fence substitution.
- The composed tests use real config/index/ledger owners and the real direct executor and terminal owner. They verify unchanged protected state, publication after executor closure, one failure report, and no triage transport or diagnostic-artifact rewrite. External package/native effects are inert test boundaries.
- Frozen finite component proof is reused for the byte-identical seven-file component. It is not represented as a new main-wide test run. The historical caller RED reproduced four persistence failures; the adapted terminal composition is new GREEN proof, not a replayed baseline.
- All required selected changed checks completed, and independent P0/P1/P2 review found no actionable findings on the exact source. The gate preserves its original max-lines failure and explicit successful continuation after a caller-only compaction; passed broad scans were not replayed.

Fresh-finalizer integration still requires a qualified real delegated receiver. Package-child/cohort effects, marker/compensation authority, refresh internals, borrowed/stolen-row settlement, installed behavior and parent-death proof remain outside this contribution.

The published tree is byte-identical to the locally qualified tree. A current-main comparison found no drift in the six production paths or ten recorded dependency owners. Fresh-finalizer work is separate and is not a prerequisite for this in-process fix.

## Data-model compatibility

The change enforces the already-selected initiating-owner boundary; it does not introduce a schema, migration, serialized field, retention rule, transaction implementation, or new writer. At the reviewed head, `src/state`, `src/config/types.plugins.ts`, and the plugin install-record commit, installed-index store/write/record, and managed-NPM retention implementations are byte-identical to the qualified base `c0b128344ce496c26c922c9f3a932a44289fb0f2`.

The two Doctor repair/convergence files only forward the existing persistence assertion, keep its refusal sticky through warning normalization, and join work. Existing stores continue to read and write the same values. The real-store healthy caller control checks the existing authorized write path; revocation/substitution controls check that protected config and index data remain unchanged; the component controls retain ordinary no-hook behavior. There is no changed format to migrate or backfill, so a migration round-trip is not an applicable additional gate for this patch.
