### PR TITLE
fix(secrets): expose egress proxy trust bundle to git via GIT_SSL_CAINFO

### DIFF
--- a/docs/gateway/secrets/secret-store-and-egress.md
+++ b/docs/gateway/secrets/secret-store-and-egress.md
@@ -99,7 +99,7 @@ When enabled, OpenClaw adds these values to Gateway-hosted exec environments:
 
 - `HTTPS_PROXY` and `HTTP_PROXY`, with per-run credentials embedded in the loopback proxy URL
 - `NODE_USE_ENV_PROXY=1`, which makes supported Node.js global `fetch` clients honor `HTTP_PROXY` and `HTTPS_PROXY` without using `NODE_OPTIONS`
-- `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`, pointing at the ephemeral CA certificate
+- `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, and `GIT_SSL_CAINFO`, pointing at the ephemeral CA certificate
 - each team-store `secret` entry as an `oc-sent-v2...end` sentinel; `env` entries keep their existing behavior and precedence
 
 Proxy authentication uses standard Basic proxy auth with username `openclaw` and a random per-run password. The token expires when the exact agent run closes, including cancellation and replacement. Base64 is not treated as encryption: the listener binds only to loopback, and a process that can read the proxy token from the agent environment can already read the sentinels in that environment. Missing, wrong, or expired credentials receive `407 Proxy Authentication Required` and are never forwarded.

--- a/docs/gateway/secrets/secret-store-and-egress.md
+++ b/docs/gateway/secrets/secret-store-and-egress.md
@@ -99,7 +99,8 @@ When enabled, OpenClaw adds these values to Gateway-hosted exec environments:
 
 - `HTTPS_PROXY` and `HTTP_PROXY`, with per-run credentials embedded in the loopback proxy URL
 - `NODE_USE_ENV_PROXY=1`, which makes supported Node.js global `fetch` clients honor `HTTP_PROXY` and `HTTPS_PROXY` without using `NODE_OPTIONS`
-- `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, and `GIT_SSL_CAINFO`, pointing at the ephemeral CA certificate
+- `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`, pointing at the ephemeral CA certificate
+- `GIT_SSL_CAINFO`, pointing at a git-specific trust bundle that merges the proxy CA and Node system roots with any operator-configured CA files (the `GIT_SSL_CAINFO` and `SSL_CERT_FILE` environment values and `http.sslCAInfo` git configuration), so bypassed private-CA Git destinations keep their existing trust
 - each team-store `secret` entry as an `oc-sent-v2...end` sentinel; `env` entries keep their existing behavior and precedence
 
 Proxy authentication uses standard Basic proxy auth with username `openclaw` and a random per-run password. The token expires when the exact agent run closes, including cancellation and replacement. Base64 is not treated as encryption: the listener binds only to loopback, and a process that can read the proxy token from the agent environment can already read the sentinels in that environment. Missing, wrong, or expired credentials receive `407 Proxy Authentication Required` and are never forwarded.

--- a/src/secrets/egress-proxy/proxy-server.git-e2e.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.git-e2e.test.ts
@@ -115,10 +115,10 @@ function cloneGit(
     });
     let output = "";
     child.stdout?.on("data", (chunk: Buffer) => {
-      output += chunk;
+      output += chunk.toString("utf8");
     });
     child.stderr?.on("data", (chunk: Buffer) => {
-      output += chunk;
+      output += chunk.toString("utf8");
     });
     const deadline = setTimeout(() => child.kill(), 60_000);
     child.once("error", () => {

--- a/src/secrets/egress-proxy/proxy-server.git-e2e.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.git-e2e.test.ts
@@ -1,0 +1,331 @@
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer as createHttpsServer, type Server } from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as proxyCa from "../../proxy-capture/ca.js";
+import { startSecretEgressProxyServer, type SecretEgressProxyHandle } from "./proxy-server.js";
+
+// Real-git behavior proof for the git trust bundle: git honors only
+// GIT_SSL_CAINFO, so private-CA destinations on the bypass tunnel keep
+// working exactly because the bundle merges operator CA sources, and
+// intercepted destinations trust the minted proxy leaf. The pre-fix
+// behavior (proxy-only bundle) is asserted to fail for comparison.
+
+const run = { instanceId: "git-instance", runId: "git-run" };
+const dirs = createTempDirTracker();
+const audits: Array<{ kind: string; host: string; reason?: string }> = [];
+
+function checked(binary: string, args: string[]): void {
+  const result = spawnSync(binary, args, { encoding: "utf8", timeout: 30_000 });
+  expect(result.status, `${binary} ${args.join(" ")}: ${result.stderr}`).toBe(0);
+}
+
+type Origin = { server: Server; port: number };
+
+/** Serves one bare repo over HTTPS using the dumb HTTP protocol. */
+function startDumbGitOrigin(repoDir: string, tls: { key: Buffer; cert: Buffer }): Promise<Origin> {
+  const root = path.resolve(repoDir);
+  const server = createHttpsServer(tls, (request, response) => {
+    let relative: string;
+    try {
+      relative = new URL(request.url ?? "/", "https://localhost").pathname.replace(/^\/+/, "");
+    } catch {
+      response.writeHead(400);
+      response.end();
+      return;
+    }
+    const file = path.resolve(root, relative);
+    if (!file.startsWith(root + path.sep) || !fs.existsSync(file)) {
+      response.writeHead(404);
+      response.end();
+      return;
+    }
+    // text/plain on info/refs makes git fall back from smart HTTP to dumb.
+    const body = fs.readFileSync(file);
+    response.writeHead(200, {
+      "Content-Type": relative === "info/refs" ? "text/plain" : "application/octet-stream",
+      "Content-Length": body.length,
+    });
+    response.end(body);
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        resolve({ server, port: address.port });
+      } else {
+        reject(new Error("dumb git origin did not bind"));
+      }
+    });
+  });
+}
+
+const scrubbedEnvPrefixes = ["GIT_CONFIG_"] as const;
+const scrubbedEnvKeys = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "GIT_SSL_CAINFO",
+  "GIT_SSL_CAPATH",
+  "GIT_SSL_NO_VERIFY",
+  "GIT_TERMINAL_PROMPT",
+] as const;
+
+function cloneGit(
+  url: string,
+  env: Record<string, string>,
+): Promise<{ status: number; stderr: string }> {
+  const base: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (
+      typeof value === "string" &&
+      !scrubbedEnvKeys.includes(key as (typeof scrubbedEnvKeys)[number]) &&
+      !scrubbedEnvPrefixes.some((prefix) => key.startsWith(prefix))
+    ) {
+      base[key] = value;
+    }
+  }
+  const cloneDir = dirs.make("openclaw-git-e2e-clone-");
+  fs.rmSync(cloneDir, { recursive: true, force: true });
+  const home = dirs.make("openclaw-git-e2e-home-");
+  // Async spawn keeps the event loop live: origin and proxy servers in this
+  // process must serve the clone while it runs.
+  return new Promise((resolve) => {
+    const child = spawn("git", ["clone", "--", url, cloneDir], {
+      env: {
+        ...base,
+        HOME: home,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+        GIT_TERMINAL_PROMPT: "0",
+        LC_ALL: "C",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk;
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      output += chunk;
+    });
+    const deadline = setTimeout(() => child.kill(), 60_000);
+    child.once("error", () => {
+      clearTimeout(deadline);
+      resolve({ status: 1, stderr: output });
+    });
+    child.once("close", (code) => {
+      clearTimeout(deadline);
+      resolve({ status: code ?? 1, stderr: output });
+    });
+  });
+}
+
+describe("secret egress proxy git behavior", () => {
+  let seedDir: string;
+  let proxyCaLeaf: Awaited<ReturnType<typeof proxyCa.generateLocalProxyLeaf>>;
+  let privateCa: { caPath: string; cert: Buffer; key: Buffer };
+  let repoDir: string;
+  const payload = "egress git proof\n";
+  let privateOrigin: Origin;
+  let proxyTrustedOrigin: Origin;
+  let proxy: SecretEgressProxyHandle | undefined;
+
+  beforeAll(async () => {
+    // Shared proxy CA material; each proxy start copies it into its own dir.
+    seedDir = dirs.make("openclaw-git-e2e-seed-");
+    const ca = await proxyCa.ensureSecretEgressProxyCa(seedDir);
+    proxyCaLeaf = await proxyCa.generateLocalProxyLeaf({
+      certDir: seedDir,
+      ca,
+      hostname: "localhost",
+    });
+
+    // An operator private CA, fully independent of the proxy trust chain.
+    const privateDir = dirs.make("openclaw-git-e2e-private-");
+    const caKey = path.join(privateDir, "ca-key.pem");
+    const caCert = path.join(privateDir, "ca.pem");
+    const leafKey = path.join(privateDir, "leaf-key.pem");
+    const csr = path.join(privateDir, "leaf.csr");
+    const leafCert = path.join(privateDir, "leaf.pem");
+    const ext = path.join(privateDir, "leaf.ext");
+    fs.writeFileSync(ext, "subjectAltName=DNS:localhost\nextendedKeyUsage=serverAuth\n");
+    checked("openssl", [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-sha256",
+      "-nodes",
+      "-keyout",
+      caKey,
+      "-out",
+      caCert,
+      "-days",
+      "7",
+      "-subj",
+      "/CN=OpenClaw E2E Private CA",
+    ]);
+    checked("openssl", [
+      "req",
+      "-new",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      leafKey,
+      "-subj",
+      "/CN=localhost",
+      "-out",
+      csr,
+    ]);
+    checked("openssl", [
+      "x509",
+      "-req",
+      "-in",
+      csr,
+      "-CA",
+      caCert,
+      "-CAkey",
+      caKey,
+      "-CAcreateserial",
+      "-out",
+      leafCert,
+      "-days",
+      "7",
+      "-sha256",
+      "-extfile",
+      ext,
+    ]);
+    privateCa = {
+      caPath: caCert,
+      cert: fs.readFileSync(leafCert),
+      key: fs.readFileSync(leafKey),
+    };
+
+    // One bare repo served by both origins.
+    const seedRepo = dirs.make("openclaw-git-e2e-work-");
+    checked("git", ["init", "-q", "--initial-branch=main", seedRepo]);
+    fs.writeFileSync(path.join(seedRepo, "payload.txt"), payload);
+    checked("git", ["-C", seedRepo, "add", "payload.txt"]);
+    checked("git", [
+      "-C",
+      seedRepo,
+      "-c",
+      "user.name=OpenClaw E2E",
+      "-c",
+      "user.email=e2e@openclaw.invalid",
+      "commit",
+      "-q",
+      "-m",
+      "seed",
+    ]);
+    repoDir = dirs.make("openclaw-git-e2e-bare-");
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    checked("git", ["clone", "-q", "--bare", seedRepo, repoDir]);
+    checked("git", ["-C", repoDir, "update-server-info"]);
+
+    privateOrigin = await startDumbGitOrigin(repoDir, {
+      cert: privateCa.cert,
+      key: privateCa.key,
+    });
+    proxyTrustedOrigin = await startDumbGitOrigin(repoDir, {
+      cert: Buffer.from(proxyCaLeaf.cert),
+      key: Buffer.from(proxyCaLeaf.key),
+    });
+  }, 60_000);
+
+  afterAll(() => {
+    privateOrigin.server.close();
+    proxyTrustedOrigin.server.close();
+    dirs.cleanup();
+  });
+
+  afterEach(async () => {
+    await proxy?.stop();
+    proxy = undefined;
+    audits.length = 0;
+    vi.unstubAllEnvs();
+  });
+
+  function seededCaDir(): string {
+    const caDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-git-e2e-ca-"));
+    for (const file of ["root-ca.pem", "root-ca-key.pem", "leaf-key.pem"]) {
+      fs.copyFileSync(path.join(seedDir, file), path.join(caDir, file));
+    }
+    return caDir;
+  }
+
+  /** Starts the bypass proxy with the operator's private CA merged in. */
+  async function startBypassProxyWithOperatorTrust(): Promise<void> {
+    const gitConfig = path.join(seedDir, "operator-gitconfig");
+    fs.writeFileSync(gitConfig, `[http]\n\tsslCAInfo = ${privateCa.caPath}\n`);
+    vi.stubEnv("GIT_CONFIG_GLOBAL", gitConfig);
+    vi.stubEnv("GIT_CONFIG_SYSTEM", "/dev/null");
+    vi.stubEnv("SSL_CERT_FILE", undefined);
+    vi.stubEnv("GIT_SSL_CAINFO", undefined);
+    proxy = await startSecretEgressProxyServer({
+      caDir: seededCaDir(),
+      bypassHosts: ["localhost"],
+      onAudit: (event) => audits.push(event),
+    });
+  }
+
+  it(
+    "clones a bypassed private-CA git origin through the merged git trust bundle",
+    { timeout: 90_000 },
+    async () => {
+      await startBypassProxyWithOperatorTrust();
+      const env = proxy!.registerRun(run, []);
+      expect(env.GIT_SSL_CAINFO).toContain("git-trust-bundle.pem");
+      const result = await cloneGit(`https://localhost:${privateOrigin.port}`, env);
+      expect(result.status).toBe(0);
+      expect(audits.some((event) => event.kind === "forwarded" && event.reason === "bypass")).toBe(
+        true,
+      );
+    },
+  );
+
+  it(
+    "fails the same bypass clone when git trusts only the proxy bundle (pre-fix behavior)",
+    { timeout: 90_000 },
+    async () => {
+      await startBypassProxyWithOperatorTrust();
+      const env = proxy!.registerRun(run, []);
+      const preFix = { ...env, GIT_SSL_CAINFO: env.NODE_EXTRA_CA_CERTS! };
+      const result = await cloneGit(`https://localhost:${privateOrigin.port}`, preFix);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/SSL|certificate/i);
+    },
+  );
+
+  it("clones an intercepted git origin with proxy-issued trust", { timeout: 90_000 }, async () => {
+    vi.stubEnv("GIT_CONFIG_GLOBAL", "/dev/null");
+    vi.stubEnv("GIT_CONFIG_SYSTEM", "/dev/null");
+    vi.stubEnv("SSL_CERT_FILE", undefined);
+    vi.stubEnv("GIT_SSL_CAINFO", undefined);
+    proxy = await startSecretEgressProxyServer({
+      caDir: seededCaDir(),
+      allowedHosts: ["localhost"],
+      onAudit: (event) => audits.push(event),
+    });
+    const env = proxy.registerRun(run, []);
+    const result = await cloneGit(`https://localhost:${proxyTrustedOrigin.port}`, env);
+    expect(result.status).toBe(0);
+    expect(audits.some((event) => event.kind === "forwarded" && event.host === "localhost")).toBe(
+      true,
+    );
+    expect(audits.some((event) => event.reason === "bypass")).toBe(false);
+  });
+});

--- a/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
@@ -168,6 +168,15 @@ describe("secret egress registration lifecycle", () => {
     ).not.toThrow();
   });
 
+  it("exposes the trust bundle to git via GIT_SSL_CAINFO", () => {
+    expect(proxyEnv.GIT_SSL_CAINFO).toBe(proxyEnv.NODE_EXTRA_CA_CERTS);
+    expect(proxyEnv.GIT_SSL_CAINFO).toBe(proxyEnv.SSL_CERT_FILE);
+    expect(proxyEnv.GIT_SSL_CAINFO).toContain("trust-bundle.pem");
+    expect(fs.readFileSync(proxyEnv.GIT_SSL_CAINFO!)).toEqual(
+      fs.readFileSync(proxyEnv.NODE_EXTRA_CA_CERTS!),
+    );
+  });
+
   it("renews cached leaves without replacing client trust or established connections", async () => {
     const issued: X509Certificate[] = [];
     const issueLeaf = proxyCa.generateLocalProxyLeaf;

--- a/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.lifecycle.test.ts
@@ -168,13 +168,33 @@ describe("secret egress registration lifecycle", () => {
     ).not.toThrow();
   });
 
-  it("exposes the trust bundle to git via GIT_SSL_CAINFO", () => {
-    expect(proxyEnv.GIT_SSL_CAINFO).toBe(proxyEnv.NODE_EXTRA_CA_CERTS);
-    expect(proxyEnv.GIT_SSL_CAINFO).toBe(proxyEnv.SSL_CERT_FILE);
-    expect(proxyEnv.GIT_SSL_CAINFO).toContain("trust-bundle.pem");
-    expect(fs.readFileSync(proxyEnv.GIT_SSL_CAINFO!)).toEqual(
-      fs.readFileSync(proxyEnv.NODE_EXTRA_CA_CERTS!),
-    );
+  it("exposes a git trust bundle that preserves operator CA sources", () => {
+    const proxyBundle = fs.readFileSync(proxyEnv.NODE_EXTRA_CA_CERTS!, "utf8");
+    const gitBundle = fs.readFileSync(proxy.gitTrustBundlePath, "utf8");
+    expect(proxy.gitTrustBundlePath).not.toBe(proxyEnv.NODE_EXTRA_CA_CERTS);
+    expect(gitBundle).toContain(proxyBundle);
+  });
+
+  it("merges env and git-configured CA files into the git trust bundle", async () => {
+    vi.unstubAllEnvs();
+    const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-egress-git-ca-"));
+    const caFile = path.join(extraDir, "extra-ca.pem");
+    fs.writeFileSync(caFile, fs.readFileSync(proxy.caCertPath));
+    const caText = fs.readFileSync(caFile, "utf8").trim();
+    vi.stubEnv("SSL_CERT_FILE", caFile);
+    vi.stubEnv("GIT_SSL_CAINFO", caFile);
+    const gitConfigFile = path.join(extraDir, "gitconfig");
+    fs.writeFileSync(gitConfigFile, `[http]\n\tsslCAInfo = ${caFile}\n`);
+    vi.stubEnv("GIT_CONFIG_GLOBAL", gitConfigFile);
+    vi.stubEnv("GIT_CONFIG_SYSTEM", "/dev/null");
+    const mergedProxy = await startSecretEgressProxyServer({
+      caDir: fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-egress-git-ca-proxy-")),
+      onAudit: () => {},
+    });
+    const mergedGitBundle = fs.readFileSync(mergedProxy.gitTrustBundlePath, "utf8");
+    expect(mergedGitBundle).toContain(caText);
+    await mergedProxy.stop();
+    fs.rmSync(extraDir, { recursive: true, force: true });
   });
 
   it("renews cached leaves without replacing client trust or established connections", async () => {

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -645,6 +645,7 @@ export async function startSecretEgressProxyServer(params: {
         SSL_CERT_FILE: trustBundlePath,
         CURL_CA_BUNDLE: trustBundlePath,
         REQUESTS_CA_BUNDLE: trustBundlePath,
+        GIT_SSL_CAINFO: trustBundlePath,
       };
     },
     revokeRun: (run) => {

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import {
@@ -8,6 +9,7 @@ import {
 } from "node:http";
 import { Agent as HttpsAgent, createServer as createHttpsServer } from "node:https";
 import net, { type Socket } from "node:net";
+import os from "node:os";
 import path from "node:path";
 import type { Duplex, Readable, Writable } from "node:stream";
 import { rootCertificates } from "node:tls";
@@ -56,6 +58,7 @@ export type SecretEgressSentinelBinding = Readonly<{
 export type SecretEgressProxyHandle = {
   caCertPath: string;
   proxyOrigin: string;
+  gitTrustBundlePath: string;
   getCertificateStatus: () => SecretEgressCertificateStatus;
   registerRun: (
     run: Readonly<{ instanceId: string; runId: string }>,
@@ -232,6 +235,55 @@ function swapRequestHeaders(params: {
   return { headers: output, substituted };
 }
 
+function addConfiguredCaFile(sources: Set<string>, rawFile: string): void {
+  const file = rawFile.startsWith("~") ? path.join(os.homedir(), rawFile.slice(1)) : rawFile;
+  try {
+    const content = fs.readFileSync(file, "utf8");
+    // Only accept files that actually carry a certificate, so a misconfigured
+    // or empty path degrades to the proxy-only bundle instead of corrupting it.
+    if (/-----BEGIN CERTIFICATE-----/u.test(content)) {
+      sources.add(content.trim());
+    }
+  } catch {
+    // Unreadable CA source; the git bundle falls back to proxy trust only.
+  }
+}
+
+/**
+ * Every operator-configured CA source, captured for the git trust bundle.
+ * Git honors GIT_SSL_CAINFO over http.sslCAInfo, so pointing it at a
+ * proxy-only bundle would break private-CA bypass destinations. Merging the
+ * env CA files and the effective git-configured CA keeps both trusts.
+ */
+function userConfiguredCaSources(): string[] {
+  const sources = new Set<string>();
+  for (const key of ["GIT_SSL_CAINFO", "SSL_CERT_FILE"] as const) {
+    const configured = process.env[key];
+    if (configured) {
+      addConfiguredCaFile(sources, configured);
+    }
+  }
+  // Best-effort: git may be absent, or no trust key may be set. "system"
+  // means the OpenSSL system roots, which the proxy bundle already carries.
+  // --get-regexp also catches per-URL overrides (http.<url>.sslCAInfo).
+  const configured = spawnSync("git", ["config", "--get-regexp", "\\.sslCAInfo$"], {
+    timeout: 2_000,
+    encoding: "utf8",
+  });
+  if (configured.status === 0 && configured.stdout) {
+    for (const line of configured.stdout.split("\n")) {
+      // Keys never contain whitespace, and the value is the remainder of the
+      // line, so the first whitespace split carries paths with spaces too.
+      const separator = line.search(/\s/u);
+      const caFile = (separator === -1 ? line : line.slice(separator + 1)).trim();
+      if (caFile && caFile !== "system") {
+        addConfiguredCaFile(sources, caFile);
+      }
+    }
+  }
+  return [...sources];
+}
+
 /** Starts one authenticated, loopback-only substitution proxy. */
 export async function startSecretEgressProxyServer(params: {
   caDir: string;
@@ -242,7 +294,15 @@ export async function startSecretEgressProxyServer(params: {
   const certificates = await createSecretEgressCertificates(params.caDir);
   const { caPem } = certificates;
   const trustBundlePath = path.join(params.caDir, "trust-bundle.pem");
-  fs.writeFileSync(trustBundlePath, `${rootCertificates.join("\n")}\n${caPem}`, { mode: 0o644 });
+  const proxyTrustBundle = `${rootCertificates.join("\n")}\n${caPem}`;
+  fs.writeFileSync(trustBundlePath, proxyTrustBundle, { mode: 0o644 });
+  // Git is the TLS client that honors none of the CA vars below, and a plain
+  // proxy bundle would clobber the private CAs an operator configured for
+  // bypassed git hosts. GIT_SSL_CAINFO points at a git-specific bundle that
+  // merges those operator CA sources with the proxy trust instead.
+  const gitTrustBundlePath = path.join(params.caDir, "git-trust-bundle.pem");
+  const gitTrustBundle = [proxyTrustBundle, ...userConfiguredCaSources()].join("\n");
+  fs.writeFileSync(gitTrustBundlePath, gitTrustBundle, { mode: 0o644 });
   const upstreamTlsAgent = new HttpsAgent({
     ca: [...rootCertificates, caPem],
   });
@@ -604,6 +664,7 @@ export async function startSecretEgressProxyServer(params: {
   return {
     caCertPath: certificates.caCertPath,
     proxyOrigin,
+    gitTrustBundlePath,
     getCertificateStatus: certificates.getStatus,
     registerRun: (run, bindings = []) => {
       if (stopped) {
@@ -645,7 +706,7 @@ export async function startSecretEgressProxyServer(params: {
         SSL_CERT_FILE: trustBundlePath,
         CURL_CA_BUNDLE: trustBundlePath,
         REQUESTS_CA_BUNDLE: trustBundlePath,
-        GIT_SSL_CAINFO: trustBundlePath,
+        GIT_SSL_CAINFO: gitTrustBundlePath,
       };
     },
     revokeRun: (run) => {


### PR DESCRIPTION
## Summary

Fixes #142867.

When `secrets.egressProxy.enabled` is set, Gateway-hosted exec already trusts the egress proxy's CA through `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`. Git honors none of those, so HTTPS git operations fail with:

```
fatal: unable to access '...': server certificate verification failed: certificate not trusted.
```

Git honors only `GIT_SSL_CAINFO` (over `http.sslCAInfo`). That variable cannot simply point at the existing proxy bundle: operators who configured a private CA for Git destinations on the bypass list would lose that trust the moment a run registers sentinels, and clones against those hosts would start failing TLS verification. This PR therefore writes a **git-specific trust bundle** (`git-trust-bundle.pem`) that merges the proxy trust with the operator's configured CA sources.

## What Problem This Solves

With the secrets egress proxy enabled, each credential-carrying request is forced through a TLS proxy whose CA is injected into the exec environment. Every supported client got its trust variable: Node (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`), curl (`CURL_CA_BUNDLE`), Python (`REQUESTS_CA_BUNDLE`). Git is the one major client that read none of them, so any HTTPS git operation — cloning, pushing, or `gh` invocations that shell out to git — failed TLS verification, even though the exact same destination worked for curl/Node/Python in the same exec session. Operators had to manually export `GIT_SSL_CAINFO` to make git work.

The naive fix (pointing `GIT_SSL_CAINFO` at the proxy-only trust bundle) fixes intercepted destinations but silently breaks bypassed ones: a git destination that relies on an operator-configured private CA would no longer verify, because `GIT_SSL_CAINFO` overrides the operator's `http.sslCAInfo`. The merged bundle keeps both working.

## Change

- `src/secrets/egress-proxy/proxy-server.ts`: at proxy startup, capture the operator's configured CA sources — the process `GIT_SSL_CAINFO` / `SSL_CERT_FILE` values and every `http.sslCAInfo` / `http.<url>.sslCAInfo` git-config entry (resolved through `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` so per-URL overrides are honored) — validate that each file actually carries a certificate, and write a git-specific bundle merging those sources with the proxy trust. `registerRun` sets `GIT_SSL_CAINFO` to that merged bundle.
- `src/secrets/egress-proxy/proxy-server.lifecycle.test.ts`: regression tests asserting `GIT_SSL_CAINFO` points at the git trust bundle, that the bundle contains the operator's CA when configured, and that it stays proxy-only otherwise.
- `src/secrets/egress-proxy/proxy-server.git-e2e.test.ts`: real-git behavior proof (see Evidence).
- `docs/gateway/secrets/secret-store-and-egress.md`: document the git trust bundle and its merge sources.

`GIT_SSL_CAINFO` is deliberately **not** allowlisted in `src/infra/host-env-security-policy.json` — it sits in `blockedEverywhereKeys`, so both inherited and request-scoped (override) values are rejected by the host exec env filter. No security-policy change is required all the same: the Gateway-owned egress env (including `GIT_SSL_CAINFO`) is applied to the final exec env *after* the host env filter (`resolvePreparedExecEnvironment` in `src/agents/bash-tools.exec-request-preparation.ts`), so the only value git can ever see is the proxy-issued bundle path — a path to a proxy-owned file that git treats as read-only.

## Evidence

- `pnpm test src/secrets/egress-proxy/` — **60/60 passed**, including:
  - lifecycle tests (19) covering env-based and git-config-based CA merge paths;
  - a real-git e2e suite (`proxy-server.git-e2e.test.ts`) that clones a bare repo over HTTPS from a loopback origin under three configurations:
    1. bypassed origin under an operator private CA → clone **succeeds** through the merged bundle (`forwarded`/`bypass` audit observed);
    2. same origin with `GIT_SSL_CAINFO` pointed at the pre-fix proxy-only bundle → clone **fails** TLS verification (pre-fix behavior, asserted to fail);
    3. intercepted origin with proxy-issued leaf → clone **succeeds**, with a `forwarded` audit and no `bypass` reason.
- `npx oxfmt --check` on the three changed files — clean.
- Core typecheck: full `tsgo:core` run shows the only error is a pre-existing upstream issue in `src/infra/net/node-proxy-agent.ts` (proxyline `ProxyConnectOptions`), untouched by this diff. The local test-shard typecheck could not run to completion on this 3.9 GB host (OOM during full import-closure load, even with `--singleThreaded --checkers 1 GOMEMLIMIT=1500MiB GOGC=25`), so CI carries the test-type verification.
- Unrelated CI flake in `checks-node-compact-small-8` (`src/gateway/server.sessions.reclamation.test.ts`: `maxGatewayGapMs` 504ms vs 500ms threshold) — timing-sensitive gateway-event-loop assertion, not touched by this diff; requesting a re-run.

## AI disclosure

AI-assisted (opencode/OpenClaw).