### PR TITLE
refactor: simplify repeated Quick Chat test inputs

### DIFF
--- a/test/linux-quickchat-stream.test.ts
+++ b/test/linux-quickchat-stream.test.ts
@@ -50,6 +50,24 @@ const { assembleChatDelta, chatMessageText, chatMessageWidgets, resolveInlineWid
     resolveInlineWidgetUrl: (surface: unknown, target: unknown) => string | null;
   };
 
+function canvasMessage(role: string, url: string) {
+  return {
+    role,
+    content: [
+      {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          sandbox: "scripts",
+          url,
+        },
+      },
+    ],
+  };
+}
+
 function createFakeElement(tagName = "div") {
   const classes = new Set();
   const children: any[] = [];
@@ -484,21 +502,8 @@ test("canvas previews are accepted only for safe assistant widgets", () => {
   assert.notEqual(cjkWidget?.key, cjkViewId);
   assert.ok(Buffer.byteLength(cjkWidget?.key ?? "", "utf8") <= 256);
   assert.equal(
-    chatMessageWidgets({
-      role: "tool",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/tool/index.html",
-          },
-        },
-      ],
-    }).length,
+    chatMessageWidgets(canvasMessage("tool", "/__openclaw__/canvas/documents/tool/index.html"))
+      .length,
     0,
   );
   assert.equal(
@@ -519,21 +524,9 @@ test("canvas previews are accepted only for safe assistant widgets", () => {
     0,
   );
   assert.equal(
-    chatMessageWidgets({
-      role: "assistant",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/%252e%252e/private-file",
-          },
-        },
-      ],
-    }).length,
+    chatMessageWidgets(
+      canvasMessage("assistant", "/__openclaw__/canvas/documents/%252e%252e/private-file"),
+    ).length,
     0,
   );
 });
@@ -706,21 +699,7 @@ test("expired Canvas capability refreshes before a new widget loads", async () =
     agentId: "work",
     runId: "refresh-run",
     state: "final",
-    message: {
-      role: "assistant",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/status/index.html",
-          },
-        },
-      ],
-    },
+    message: canvasMessage("assistant", "/__openclaw__/canvas/documents/status/index.html"),
   });
 
   await harness.flushSurfaceRefresh();
@@ -794,21 +773,7 @@ test("unchanged gateway state does not renew a failed Canvas capability", async 
     agentId: "work",
     runId: "state-run",
     state: "delta",
-    message: {
-      role: "assistant",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/status/index.html",
-          },
-        },
-      ],
-    },
+    message: canvasMessage("assistant", "/__openclaw__/canvas/documents/status/index.html"),
   });
   await harness.flushSurfaceRefresh();
   assert.equal(harness.widgetSurfaceRefreshCount(), 1);
@@ -821,21 +786,7 @@ test("unchanged gateway state does not renew a failed Canvas capability", async 
     agentId: "work",
     runId: "state-run",
     state: "delta",
-    message: {
-      role: "assistant",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/retry/index.html",
-          },
-        },
-      ],
-    },
+    message: canvasMessage("assistant", "/__openclaw__/canvas/documents/retry/index.html"),
   });
   await harness.flushSurfaceRefresh();
   assert.equal(harness.widgetSurfaceRefreshCount(), 2);
@@ -853,21 +804,7 @@ test("clearing the widget reply restores semantic text-only layout", async () =>
     agentId: "work",
     runId: "widget-run",
     state: "delta",
-    message: {
-      role: "assistant",
-      content: [
-        {
-          type: "canvas",
-          preview: {
-            kind: "canvas",
-            surface: "assistant_message",
-            render: "url",
-            sandbox: "scripts",
-            url: "/__openclaw__/canvas/documents/status/index.html",
-          },
-        },
-      ],
-    },
+    message: canvasMessage("assistant", "/__openclaw__/canvas/documents/status/index.html"),
   });
   await harness.flushWidgets();
   assert.equal(harness.syncedHasWidgets(), true);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Six Quick Chat test inputs repeat the same Canvas message structure, making the role and URL differences harder to scan and maintain.

## Why This Change Was Made

Use one local synchronous helper for that exact input shape, keeping each role and raw URL explicit at its call site. Expected outputs, distinct input variants, all 20 cases, and their lifecycle ordering remain unchanged.

## User Impact

No production behavior changes. This removes 63 net test lines without removing any test invocation or weakening widget, capability-refresh, streaming, or layout assertions.

## Evidence

The complete existing Quick Chat suite passed before and after: 20 cases in the same order, with no failures or skips. Expanding all six helper calls back into their original literals reconstructs the complete original source AST. A bounded allocation check using benign inputs confirms three fresh objects and one fresh array per call, with no shared nodes.

This is test input consolidation, not a measured runtime optimization. No browser/native application launch or additional focused security reproduction was performed.

The mapped changed-file gate passed, including root-test typechecking, formatting, lint and guards. Independent review found no actionable P0–P2 findings.
