### PR TITLE
fix(pairing): name auth mode in setup errors

### DIFF
--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -256,12 +256,8 @@ describe("pairing setup code", () => {
     options?: ResolveSetupOptions;
     expectedError: string;
   }) {
-    try {
-      const resolved = await resolvePairingSetupFromConfig(params.config, params.options);
-      expectResolvedSetupError(resolved, params.expectedError);
-    } catch (error) {
-      expect(String(error)).toContain(params.expectedError);
-    }
+    const resolved = await resolvePairingSetupFromConfig(params.config, params.options);
+    expectResolvedSetupError(resolved, params.expectedError);
   }
 
   async function expectResolveCustomGatewayRejects(params: {
@@ -516,7 +512,7 @@ describe("pairing setup code", () => {
       expectedError: "MISSING_GW_PASSWORD",
     },
   ] as const)("$name", async ({ config, options, expectedError }) => {
-    await expectResolvedSetupFailureCase({ config, options, expectedError });
+    await expect(resolvePairingSetupFromConfig(config, options)).rejects.toThrow(expectedError);
   });
 
   it.each(["none", "trusted-proxy"] as const)(

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -519,6 +519,34 @@ describe("pairing setup code", () => {
     await expectResolvedSetupFailureCase({ config, options, expectedError });
   });
 
+  it.each(["none", "trusted-proxy"] as const)(
+    "names gateway.auth.mode %s when setup code generation lacks a shared secret",
+    async (mode) => {
+      await expectResolvedSetupFailureCase({
+        config: createCustomGatewayConfig({ mode }),
+        options: { env: {} },
+        expectedError: `Pairing setup requires gateway.auth.mode "token" or "password"; current mode is "${mode}".`,
+      });
+      expect(issueDevicePairSetupBootstrapTokenMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the unconfigured-auth error when gateway.auth.mode is unset", async () => {
+    await expectResolvedSetupFailureCase({
+      config: createCustomGatewayConfig({}),
+      options: { env: {} },
+      expectedError: "Gateway auth is not configured (no token or password).",
+    });
+  });
+
+  it("keeps the configured-password fallback for trusted-proxy mode", async () => {
+    await expectResolvedCustomGatewaySetupOk({
+      auth: { mode: "trusted-proxy", password: "secret" },
+      env: {},
+      expectedAuthLabel: "password",
+    });
+  });
+
   async function resolveInferredModeWithPasswordEnv(token: SecretInput) {
     return await resolvePairingSetupFromConfig(
       {

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -322,6 +322,11 @@ function resolvePairingSetupAuthLabel(
   if (password) {
     return { label: "password" };
   }
+  if (mode === "none" || mode === "trusted-proxy") {
+    return {
+      error: `Pairing setup requires gateway.auth.mode "token" or "password"; current mode is "${mode}".`,
+    };
+  }
   return { error: "Gateway auth is not configured (no token or password)." };
 }
 


### PR DESCRIPTION
AI-assisted: yes

Closes #144124

Pairing setup now names the configured `none` or `trusted-proxy` authentication mode when no shared token/password is available. Previously, both `openclaw qr` and `device.pair.setupCode` said authentication was not configured, even though an explicit mode was configured.

The shared resolver changes only its existing failure path, after working token/password fallbacks. Authentication, pairing, secret preparation, and bootstrap issuance keep their current owners. In particular, trusted-proxy setup with a configured password still works for direct local clients. Unset mode keeps the generic error.

The test helper also stops catching its own assertion failures. Actual SecretRef promise rejections now use `rejects.toThrow`, while returned refusals are asserted directly. A private negative control demonstrated the old helper accepting a deliberately wrong short diagnostic; that same control fails with the correction. The original two long mode-message tests already failed on baseline and are not described as false-green.

| Public caller input | Baseline | Repaired result |
| --- | --- | --- |
| Explicit `none`, no shared credentials | “Gateway auth is not configured” | Names `none` and the token/password setup requirement |
| Explicit `trusted-proxy`, no shared credentials | Same misleading error | Names `trusted-proxy` and the token/password setup requirement |
| Token, password, or trusted-proxy local password | Setup generation succeeds | Success and auth labels preserved |
| Unset mode, no credentials | Generic unconfigured-auth error | Unchanged |

Validation used pinned main `9dca5870c66e03e42582950b277cb00318a4db8d` and a private composition of this PR’s exact production change plus the test correction onto that main. The compiled candidate is `c461e3ebe6850be02c8f4798d7edf10da379b404`; its build identity remains separate from the contributor-preserving final head. No source refresh or authentication-policy change was needed.

- Real compiled QR commands and real Gateway RPCs reproduced both baseline errors and verified both corrected messages. A normally paired synthetic CLI device supplied RPC admission after shared credentials were removed from each target config; no device record or handler was fabricated.
- A 14-case matrix covered 14 CLI calls and seven RPC calls. Token/password success, direct-local trusted-proxy password fallback, environment precedence, available/unavailable SecretRefs, inactive references, and unset-mode behavior were preserved. Fresh source-blind acceptance independently repeated the full matrix.
- Independent read-only SQLite observations found no setup-bootstrap additions on refusals. Successful QR/RPC calls added distinct setup records, validating that the observer detected real issuance.
- All 104 focused resolver/QR/RPC tests passed on the current-main composition. All 53 resolver tests, normal pre-commit formatting, and syntax lint also passed on the exact contributor-based publication tree.

Environment precedence, unavailable references, inactive references, and raw unset-mode behavior were tested through the CLI because Gateway startup can prepare secrets or supply default authentication before RPC execution. Available-reference RPC controls test the prepared Gateway. This proof does not claim mobile scanning/redemption, reverse-proxy identity-header integration, package/release validation, or cloud enrollment behavior. No production service, real credential, update, or live model/channel was used.
