### PR TITLE
refactor(wear): share initial state for phone changes

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearViewModel.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearViewModel.kt
@@ -58,41 +58,7 @@ internal data class WearUiState(
   val agentPulseFailure: WearConversationFailure? = null,
 )
 
-internal fun WearUiState.resetForPhoneChange(): WearUiState =
-  copy(
-    loading = true,
-    connected = false,
-    phoneNodeId = null,
-    agents = emptyList(),
-    activeAgentId = null,
-    selectedModelRef = null,
-    models = emptyList(),
-    proxyCapabilities = emptySet(),
-    sessions = emptyList(),
-    selectedSession = null,
-    phoneActiveSessionKey = null,
-    sessionSearchQuery = null,
-    sessionSearchResults = emptyList(),
-    sessionSearchHasMore = false,
-    sessionSearchNextOffset = null,
-    modelSearchQuery = null,
-    modelSearchResults = emptyList(),
-    messages = emptyList(),
-    streamText = null,
-    activeRunId = null,
-    sending = false,
-    realtimeTalk = WearRealtimeTalkSnapshot(),
-    realtimeCapturing = false,
-    realtimePlaying = false,
-    realtimeMouthLevel = 0f,
-    realtimePlaybackFailed = false,
-    talkBusy = false,
-    controlBusy = false,
-    failure = null,
-    agentPulse = null,
-    agentPulseLoading = false,
-    agentPulseFailure = null,
-  )
+internal fun WearUiState.resetForPhoneChange(): WearUiState = WearUiState()
 
 internal fun WearUiState.switchAgentContext(agentId: String): WearUiState =
   copy(


### PR DESCRIPTION
## What Problem This Solves

Switching paired phones must return the Wear companion to its initial loading state without carrying session, conversation, or reply state from the previous phone. This maintainer-requested cleanup keeps that reset aligned with initial startup.

## Why This Change Was Made

Construct a fresh `WearUiState` in the existing phone-change reset instead of repeating all 32 constructor defaults. The constructor becomes the single owner of those defaults, removing 34 lines while preserving the named reset, its lifecycle caller, and the partial agent/session resets.

## User Impact

No user-visible behavior change. Changing phones still clears the same state and creates a fresh realtime Talk snapshot.

## Evidence

- All 36 `WearProxyClientTest` cases passed, including the unchanged `phoneChangeClearsPhoneLocalSessionState` case.
- Wear debug assembly, Android lint, and Kotlin lint passed using the repository-pinned Java 21 toolchain.
- The changed-file gate passed, including Kotlin lint for app, benchmark, Wear, and shared modules and the native state schema guard.
- Managed autoreview was clean through P2; `git diff --check` passed. No tests, dependencies, schemas, or UI appearance changed.

Hosted CI [run 34496378750, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34496378750/attempts/2) passed on the same head: 34 jobs, with 8 successful and 26 skipped. Attempt 1 encountered a Temurin 21.0.10 JVM crash in Play tests and an onboarding assertion in the unchanged phone app. The original method and its full class passed unchanged locally. The single failed-job rerun used GitHub-hosted Ubuntu instead of Blacksmith under the existing routing policy; both test jobs executed successfully. These results do not establish or repair the original failure causes.
