### PR TITLE
fix(sessions): rebind CLI session state on compaction checkpoint branch and restore

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -2,10 +2,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import {
   readPersistedAuthProfileStateRaw,
   writePersistedAuthProfileStateRaw,
 } from "../../agents/auth-profiles/sqlite.js";
+import { prepareCliHistoryBoundary } from "../../agents/cli-runner/history-boundary.js";
+import {
+  buildCliSessionHistoryPrompt,
+  loadCliSessionPromptContext,
+} from "../../agents/cli-runner/session-history.js";
+import type { PreparedCliRunContext } from "../../agents/cli-runner/types.js";
+import { CURRENT_SESSION_VERSION, SessionManager } from "../../agents/sessions/session-manager.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
@@ -24,8 +32,11 @@ import {
   readSessionArchiveContentSync,
 } from "./archive-compression.js";
 import { isSessionArchiveArtifactName } from "./artifacts.js";
+import { runWithCliHistoryWriter, type CliHistoryWriter } from "./cli-history-boundary.js";
+import { getCliSessionBinding } from "./cli-session-binding.js";
 import {
   appendTranscriptEvent,
+  appendTranscriptEventSync,
   appendTranscriptMessage,
   cleanupSessionLifecycleArtifactsCore,
   listSessionEntriesCore,
@@ -62,6 +73,7 @@ import {
 } from "./session-accessor.sqlite-entry.js";
 import { forkSessionEntryFromParentTarget } from "./session-accessor.sqlite-parent-session.js";
 import { loadTranscriptEventsSync } from "./session-accessor.sqlite-read.js";
+import { readSessionTranscriptWatermark } from "./session-accessor.sqlite-transcript-watermark.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
 import type { InternalSessionEntry, SessionCompactionCheckpoint, SessionEntry } from "./types.js";
@@ -2698,6 +2710,440 @@ describe("sqlite session normalization", () => {
       expect.objectContaining({ id: "pre-msg", type: "message" }),
     ]);
     expect(fs.existsSync(path.join(paths.tempDir, `${result.entry.sessionId}.jsonl`))).toBe(false);
+  });
+
+  it("clears CLI session bindings when branching and restoring a checkpoint", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceScope = {
+      agentId: "main",
+      env,
+      sessionId: "source-session",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const preCompactionScope = {
+      ...sourceScope,
+      sessionId: "pre-compaction-session",
+    };
+    const sourceEntryScope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-cli-binding",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "source-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 12,
+      tokensAfter: 24,
+      tokensVersion: 1,
+      preCompaction: {
+        sessionId: "pre-compaction-session",
+        leafId: "pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "post-msg-1",
+      },
+    };
+
+    await replaceTranscriptEvents(preCompactionScope, [
+      { type: "session", id: "pre-compaction-session", cwd: paths.tempDir },
+      { type: "message", id: "pre-msg", parentId: null, message: { content: "pre" } },
+    ]);
+    await replaceTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "post-msg-1", parentId: null, message: { content: "post" } },
+    ]);
+    const sourceEntry: InternalSessionEntry = {
+      label: "Source",
+      sessionId: "source-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+      claudeCliSessionId: "native-post-compaction",
+      cliSessionIds: { "claude-cli": "native-post-compaction" },
+      cliSessionBindings: { "claude-cli": { sessionId: "native-post-compaction" } },
+    };
+    await upsertSessionEntryCore(sourceEntryScope, sourceEntry);
+
+    const branched = await branchCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: "agent:main:checkpoint-cli-binding",
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (branched.status !== "created") {
+      throw new Error(`expected branch creation, got ${branched.status}`);
+    }
+    const branchedEntry = branched.entry as InternalSessionEntry;
+    expect(branchedEntry.sessionId).not.toBe("source-session");
+    expect(branchedEntry.claudeCliSessionId).toBeUndefined();
+    expect(branchedEntry.cliSessionIds).toBeUndefined();
+    expect(branchedEntry.cliSessionBindings).toBeUndefined();
+    expect(branchedEntry.compactionCheckpoints).toBeUndefined();
+    expect(getCliSessionBinding(branchedEntry, "claude-cli")).toBeUndefined();
+
+    const restored = await restoreCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (restored.status !== "created") {
+      throw new Error(`expected restore creation, got ${restored.status}`);
+    }
+    const restoredEntry = restored.entry as InternalSessionEntry;
+    expect(restoredEntry.sessionId).not.toBe("source-session");
+    expect(restoredEntry.claudeCliSessionId).toBeUndefined();
+    expect(restoredEntry.cliSessionIds).toBeUndefined();
+    expect(restoredEntry.cliSessionBindings).toBeUndefined();
+    expect(restoredEntry.compactionCheckpoints).toEqual([checkpoint]);
+    expect(getCliSessionBinding(restoredEntry, "claude-cli")).toBeUndefined();
+    expect(branchedEntry.cliHistoryBoundary).toBeUndefined();
+    expect(restoredEntry.cliHistoryBoundary).toBeUndefined();
+    expect(loadSessionEntry(sourceEntryScope)).toEqual(restored.entry);
+  });
+
+  const CHECKPOINT_HISTORY_FINGERPRINT = "b".repeat(64);
+
+  async function seedCheckpointHistoryOwner(boundaryMaxSeq?: number) {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sourceScope = {
+      agentId: "main",
+      env,
+      sessionId: "owned-source",
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    const sourceEntryScope = {
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:main",
+      storePath: paths.sqlitePath,
+    };
+    await replaceTranscriptEvents(sourceScope, [
+      { type: "session", id: "owned-source", cwd: paths.tempDir },
+      { type: "message", id: "owned-1", parentId: null, message: { content: "first" } },
+      { type: "message", id: "owned-2", parentId: "owned-1", message: { content: "second" } },
+    ]);
+    const sourceWatermark = readSessionTranscriptWatermark(sourceScope);
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-owned-history",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "owned-source",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 12,
+      tokensAfter: 24,
+      tokensVersion: 1,
+      preCompaction: { sessionId: "owned-source", leafId: "owned-2" },
+      postCompaction: { sessionId: "owned-source", entryId: "owned-2" },
+    };
+    const sourceEntry: InternalSessionEntry = {
+      label: "Owned",
+      sessionId: "owned-source",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+      claudeCliSessionId: "native-pre-checkpoint",
+      cliSessionIds: { "claude-cli": "native-pre-checkpoint" },
+      cliSessionBindings: { "claude-cli": { sessionId: "native-pre-checkpoint" } },
+      cliHistoryBoundary: {
+        version: 1,
+        sessionId: "owned-source",
+        state: "known",
+        authFingerprint: CHECKPOINT_HISTORY_FINGERPRINT,
+        generation: sourceWatermark.generation,
+        maxSeq: boundaryMaxSeq ?? sourceWatermark.maxSeq,
+        writerRunId: "owner-run",
+      },
+    };
+    await upsertSessionEntryCore(sourceEntryScope, sourceEntry);
+    return { checkpoint, env, sourceEntry, sourceEntryScope };
+  }
+
+  it("re-owns the copied CLI history boundary on both checkpoint successors", async () => {
+    const { checkpoint, env, sourceEntry, sourceEntryScope } = await seedCheckpointHistoryOwner();
+
+    const branched = await branchCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: "agent:main:checkpoint-owned-history",
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (branched.status !== "created") {
+      throw new Error(`expected branch creation, got ${branched.status}`);
+    }
+    const restored = await restoreCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (restored.status !== "created") {
+      throw new Error(`expected restore creation, got ${restored.status}`);
+    }
+
+    for (const [successor, sessionKey] of [
+      [branched.entry as InternalSessionEntry, "agent:main:checkpoint-owned-history"],
+      [restored.entry as InternalSessionEntry, sourceEntryScope.sessionKey],
+    ] as const) {
+      const watermark = readSessionTranscriptWatermark({
+        agentId: "main",
+        env,
+        sessionId: successor.sessionId,
+        sessionKey,
+        storePath: paths.sqlitePath,
+      });
+      expect(successor.sessionId).not.toBe("owned-source");
+      expect(successor.cliSessionBindings).toBeUndefined();
+      expect(successor.cliHistoryBoundary).toEqual({
+        version: 1,
+        sessionId: successor.sessionId,
+        state: "known",
+        authFingerprint: CHECKPOINT_HISTORY_FINGERPRINT,
+        generation: watermark.generation,
+        maxSeq: watermark.maxSeq,
+        writerRunId: "owner-run",
+      });
+    }
+  });
+
+  it("leaves the checkpoint successor unowned when the source boundary stops short of the fork", async () => {
+    const { checkpoint, env, sourceEntry, sourceEntryScope } = await seedCheckpointHistoryOwner(0);
+
+    const branched = await branchCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: "agent:main:checkpoint-partial-history",
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (branched.status !== "created") {
+      throw new Error(`expected branch creation, got ${branched.status}`);
+    }
+    const branchedEntry = branched.entry as InternalSessionEntry;
+    expect(branchedEntry.sessionId).not.toBe("owned-source");
+    expect(branchedEntry.cliSessionBindings).toBeUndefined();
+    expect(branchedEntry.cliHistoryBoundary).toBeUndefined();
+  });
+
+  it("keeps the copied history owned when a retained checkpoint is restored again", async () => {
+    const { checkpoint, env, sourceEntry, sourceEntryScope } = await seedCheckpointHistoryOwner();
+
+    const first = await restoreCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: sourceEntry,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (first.status !== "created") {
+      throw new Error(`expected restore creation, got ${first.status}`);
+    }
+    const firstEntry = first.entry as InternalSessionEntry;
+    const again = await restoreCompactionCheckpointSession({
+      agentId: "main",
+      env,
+      expectedState: firstEntry,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (again.status !== "created") {
+      throw new Error(`expected repeated restore creation, got ${again.status}`);
+    }
+    const againEntry = again.entry as InternalSessionEntry;
+    expect(againEntry.sessionId).not.toBe(firstEntry.sessionId);
+    expect(againEntry.sessionId).not.toBe("owned-source");
+    expect(againEntry.cliSessionBindings).toBeUndefined();
+    const watermark = readSessionTranscriptWatermark({
+      agentId: "main",
+      env,
+      sessionId: againEntry.sessionId,
+      sessionKey: sourceEntryScope.sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    expect(againEntry.cliHistoryBoundary).toEqual({
+      version: 1,
+      sessionId: againEntry.sessionId,
+      state: "known",
+      authFingerprint: CHECKPOINT_HISTORY_FINGERPRINT,
+      generation: watermark.generation,
+      maxSeq: watermark.maxSeq,
+      writerRunId: "owner-run",
+    });
+    expect(
+      loadTranscriptEventsSync({
+        agentId: "main",
+        env,
+        sessionId: againEntry.sessionId,
+        sessionKey: sourceEntryScope.sessionKey,
+        storePath: paths.sqlitePath,
+      })
+        .filter((event) => event.type === "message")
+        .map((event) => (event as { id?: string }).id),
+    ).toEqual(["owned-1", "owned-2"]);
+  });
+
+  const CHECKPOINT_OWNER_TOKEN = "checkpoint-owner-account";
+  const CHECKPOINT_OTHER_TOKEN = "checkpoint-other-account";
+  let checkpointTurn = 0;
+
+  async function driveCheckpointCliTurn(
+    target: { agentId: string; sessionId: string; sessionKey: string; storePath: string },
+    token: string,
+    action: (
+      writer: CliHistoryWriter | undefined,
+      params: PreparedCliRunContext["params"],
+    ) => Promise<void>,
+  ) {
+    const runId = `checkpoint-cli-run-${++checkpointTurn}`;
+    await patchSessionEntryCore(target, (entry) => ({ ...entry, activeWriterRunId: runId }));
+    const admission = prepareSystemAgentRunAdmission({}, runId, "main", "checkpoint-history");
+    try {
+      const params: PreparedCliRunContext["params"] = {
+        admittedRunContext: await admission.admit("embedded"),
+        runId,
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        sessionFile: target.sessionKey,
+        sessionTarget: target,
+        provider: "claude-cli",
+        model: "sonnet",
+        prompt: "what did we decide",
+        workspaceDir: paths.tempDir,
+        timeoutMs: 1000,
+      };
+      const writer = await prepareCliHistoryBoundary(params, {
+        credential: { type: "token", provider: "claude-cli", token },
+      });
+      await runWithCliHistoryWriter(writer, async () => await action(writer, params));
+    } finally {
+      admission.close();
+    }
+  }
+
+  async function readReseededHistory(allowed: boolean, params: PreparedCliRunContext["params"]) {
+    return (
+      buildCliSessionHistoryPrompt({
+        messages: (
+          await loadCliSessionPromptContext({
+            sessionTarget: params.sessionTarget,
+            allowRawTranscriptReseed: true,
+            rawTranscriptReseedReason: allowed ? "missing-transcript" : "auth-unknown",
+          })
+        ).reseedMessages,
+        prompt: "what did we decide",
+        maxHistoryChars: 8192,
+      }) ?? ""
+    );
+  }
+
+  it("serves a repeated checkpoint restore its history only to the owning live run", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const sessionKey = "agent:main:main";
+    const entryScope = { agentId: "main", env, sessionKey, storePath: paths.sqlitePath };
+    const target = {
+      agentId: "main",
+      sessionId: "checkpoint-live-source",
+      sessionKey,
+      storePath: paths.sqlitePath,
+    };
+    await upsertSessionEntryCore(entryScope, { sessionId: target.sessionId, updatedAt: 1 });
+    appendTranscriptEventSync(target, {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: target.sessionId,
+      cwd: paths.tempDir,
+      timestamp: new Date(0).toISOString(),
+    });
+    await driveCheckpointCliTurn(target, CHECKPOINT_OWNER_TOKEN, async (writer) => {
+      expect(writer).toBeDefined();
+      const manager = SessionManager.open(target, paths.tempDir);
+      manager.appendMessage({ role: "user", content: "deploy the canary build", timestamp: 1 });
+      manager.appendMessage({ role: "assistant", content: "canary build deployed", timestamp: 2 });
+    });
+    await driveCheckpointCliTurn(target, CHECKPOINT_OWNER_TOKEN, async (writer) => {
+      expect(writer).toBeDefined();
+    });
+    const leafId = loadTranscriptEventsSync({ ...target, env })
+      .filter((event) => event.type === "message")
+      .map((event) => (event as { id?: string }).id)
+      .at(-1);
+    if (!leafId) {
+      throw new Error("expected a seeded transcript leaf");
+    }
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-live-history",
+      sessionKey,
+      sessionId: target.sessionId,
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 12,
+      tokensAfter: 6,
+      tokensVersion: 1,
+      preCompaction: { sessionId: target.sessionId, leafId, entryId: leafId },
+      postCompaction: { sessionId: target.sessionId, entryId: leafId },
+    };
+    await patchSessionEntryCore(entryScope, (entry) => ({
+      ...entry,
+      compactionCheckpoints: [checkpoint],
+      claudeCliSessionId: "native-pre-checkpoint",
+      cliSessionIds: { "claude-cli": "native-pre-checkpoint" },
+      cliSessionBindings: { "claude-cli": { sessionId: "native-pre-checkpoint" } },
+    }));
+
+    const restoreOnce = async () => {
+      const current = loadSessionEntry(entryScope) as InternalSessionEntry;
+      const result = await restoreCompactionCheckpointSession({
+        agentId: "main",
+        env,
+        expectedState: current,
+        storePath: paths.sqlitePath,
+        sessionKey,
+        checkpointId: checkpoint.checkpointId,
+      });
+      if (result.status !== "created") {
+        throw new Error(`expected restore creation, got ${result.status}`);
+      }
+      return result.entry as InternalSessionEntry;
+    };
+    await restoreOnce();
+    const restoredAgain = await restoreOnce();
+    expect(getCliSessionBinding(restoredAgain, "claude-cli")).toBeUndefined();
+
+    const successor = { ...target, sessionId: restoredAgain.sessionId };
+    await driveCheckpointCliTurn(successor, CHECKPOINT_OWNER_TOKEN, async (writer, params) => {
+      expect(writer).toBeDefined();
+      expect(await readReseededHistory(true, params)).toContain("deploy the canary build");
+      await patchSessionEntryCore(entryScope, (entry) => ({
+        ...entry,
+        activeWriterRunId: "revoked-successor-run",
+      }));
+      expect(() => writer?.assertReadable()).toThrow(
+        "CLI history authority changed before execution",
+      );
+    });
+    await driveCheckpointCliTurn(successor, CHECKPOINT_OTHER_TOKEN, async (writer, params) => {
+      expect(writer).toBeUndefined();
+      expect(await readReseededHistory(false, params)).not.toContain("deploy the canary build");
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -5,6 +5,8 @@ import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { isKnownCliHistoryBoundary, type CliHistoryBoundary } from "./cli-history-boundary.js";
+import { clearAllCliSessions } from "./cli-session-binding.js";
 import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
 import {
   collectSessionEntryLookupKeys,
@@ -23,6 +25,10 @@ import {
   toDatabaseOptions,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
+import {
+  readNextTranscriptSeq,
+  readTranscriptGenerationInTransaction,
+} from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import { findSessionTranscriptHeader } from "./session-entry-codec.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
@@ -185,6 +191,7 @@ function applySqliteCompactionCheckpointSessionOperationInTransaction(
   }
   const forked = forkSqliteCheckpointTranscriptInTransaction(database, resolved, {
     checkpoint,
+    currentSessionId: currentEntry.sessionId,
     legacySource: operation.legacySource,
     targetSessionKey: targetKey,
   });
@@ -192,10 +199,17 @@ function applySqliteCompactionCheckpointSessionOperationInTransaction(
     return forked;
   }
 
+  const cliHistoryBoundary = resolveCheckpointSuccessorCliHistoryBoundary(database, {
+    currentEntry,
+    nextSessionId: forked.sessionId,
+    ...(forked.sourceSessionId ? { sourceSessionId: forked.sourceSessionId } : {}),
+    ...(forked.sourceMaxSeq !== undefined ? { sourceMaxSeq: forked.sourceMaxSeq } : {}),
+  });
   const nextEntry =
     operation.kind === "branch"
       ? cloneSqliteCheckpointSessionEntry({
           currentEntry,
+          ...(cliHistoryBoundary ? { cliHistoryBoundary } : {}),
           creation: operation.creation,
           label: currentEntry.label?.trim()
             ? `${currentEntry.label.trim()} (checkpoint)`
@@ -206,6 +220,7 @@ function applySqliteCompactionCheckpointSessionOperationInTransaction(
         })
       : cloneSqliteCheckpointSessionEntry({
           currentEntry,
+          ...(cliHistoryBoundary ? { cliHistoryBoundary } : {}),
           nextSessionId: forked.sessionId,
           preserveCompactionCheckpoints: true,
           totalTokens: forked.totalTokens,
@@ -224,6 +239,7 @@ function forkSqliteCheckpointTranscriptInTransaction(
   resolved: ResolvedSqliteScope,
   params: {
     checkpoint: SessionCompactionCheckpoint;
+    currentSessionId: string;
     legacySource?: SqliteCompactionCheckpointLegacySource;
     targetSessionKey: string;
   },
@@ -233,10 +249,15 @@ function forkSqliteCheckpointTranscriptInTransaction(
       sessionId: string;
       sessionFile: string;
       totalTokens?: number;
+      sourceSessionId?: string;
+      sourceMaxSeq?: number;
     }
   | { status: "missing-boundary" }
   | { status: "failed" } {
-  const sources = resolveSqliteCheckpointTranscriptForkSources(params.checkpoint);
+  const sources = resolveSqliteCheckpointTranscriptForkSources(
+    params.checkpoint,
+    params.currentSessionId,
+  );
   if (sources.length === 0) {
     return { status: "missing-boundary" };
   }
@@ -247,12 +268,13 @@ function forkSqliteCheckpointTranscriptInTransaction(
     | {
         source: SqliteCheckpointTranscriptForkSource;
         rows: TranscriptEvent[];
+        maxSeq: number;
       }
     | undefined;
   for (const source of sources) {
     const rows = readSqliteTranscriptRowsForFork(database, source);
     if (rows.status === "created") {
-      selected = { source, rows: rows.events };
+      selected = { source, rows: rows.events, maxSeq: rows.maxSeq };
       break;
     }
     lastFailure = rows;
@@ -286,6 +308,9 @@ function forkSqliteCheckpointTranscriptInTransaction(
     sessionId,
     sessionFile,
     ...(typeof totalTokens === "number" ? { totalTokens } : {}),
+    ...(selected
+      ? { sourceSessionId: selected.source.sessionId, sourceMaxSeq: selected.maxSeq }
+      : {}),
   };
 }
 
@@ -306,12 +331,19 @@ function resolvePreparedLegacyCheckpointSource(
 
 function resolveSqliteCheckpointTranscriptForkSources(
   checkpoint: SessionCompactionCheckpoint,
+  currentSessionId: string,
 ): SqliteCheckpointTranscriptForkSource[] {
   const sources: SqliteCheckpointTranscriptForkSource[] = [];
+  const addForkSourceWithCurrentCopy = (source: SqliteCheckpointTranscriptForkSource) => {
+    if (source.leafId && source.sessionId !== currentSessionId) {
+      sources.push({ ...source, sessionId: currentSessionId });
+    }
+    sources.push(source);
+  };
   const checkpointTokensTrusted = checkpoint.tokensVersion === SESSION_TOTAL_TOKENS_VERSION;
   if (checkpoint.preCompaction.sessionId) {
     const preLeafId = checkpoint.preCompaction.entryId ?? checkpoint.preCompaction.leafId;
-    sources.push({
+    addForkSourceWithCurrentCopy({
       sessionId: checkpoint.preCompaction.sessionId,
       ...(preLeafId ? { leafId: preLeafId } : {}),
       ...(checkpointTokensTrusted && typeof checkpoint.tokensBefore === "number"
@@ -322,7 +354,7 @@ function resolveSqliteCheckpointTranscriptForkSources(
 
   const postLeafId = checkpoint.postCompaction.entryId ?? checkpoint.postCompaction.leafId;
   if (checkpoint.postCompaction.sessionId && postLeafId) {
-    sources.push({
+    addForkSourceWithCurrentCopy({
       sessionId: checkpoint.postCompaction.sessionId,
       leafId: postLeafId,
       ...(checkpointTokensTrusted && typeof checkpoint.tokensAfter === "number"
@@ -337,7 +369,9 @@ function resolveSqliteCheckpointTranscriptForkSources(
 function readSqliteTranscriptRowsForFork(
   database: OpenClawAgentDatabase,
   source: { sessionId: string; leafId?: string },
-): { status: "created"; events: TranscriptEvent[] } | { status: "missing-boundary" | "failed" } {
+):
+  | { status: "created"; events: TranscriptEvent[]; maxSeq: number }
+  | { status: "missing-boundary" | "failed" } {
   const boundarySeq = source.leafId
     ? readTranscriptIdentityByEventId(database, source.sessionId, source.leafId)?.seq
     : undefined;
@@ -362,6 +396,7 @@ function readSqliteTranscriptRowsForFork(
     return {
       status: "created",
       events: rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent),
+      maxSeq: rows.reduce((highest, row) => Math.max(highest, Number(row.seq)), 0),
     };
   } catch {
     return { status: "failed" };
@@ -389,10 +424,11 @@ function cloneSqliteCheckpointSessionEntry(params: {
   parentSessionKey?: string;
   totalTokens?: number;
   preserveCompactionCheckpoints?: boolean;
+  cliHistoryBoundary?: CliHistoryBoundary;
 }): SessionEntry {
   const hasTotalTokens =
     typeof params.totalTokens === "number" && Number.isFinite(params.totalTokens);
-  return {
+  const cloned: SessionEntry = {
     ...params.currentEntry,
     // A new branch belongs to its requester, including an explicitly absent
     // sandbox floor. Restore and actorless branches retain the source stamp.
@@ -427,6 +463,48 @@ function cloneSqliteCheckpointSessionEntry(params: {
     compactionCheckpoints: params.preserveCompactionCheckpoints
       ? params.currentEntry.compactionCheckpoints
       : undefined,
+  };
+  clearAllCliSessions(cloned);
+  cloned.cliHistoryBoundary = params.cliHistoryBoundary;
+  return cloned;
+}
+
+function resolveCheckpointSuccessorCliHistoryBoundary(
+  database: OpenClawAgentDatabase,
+  params: {
+    currentEntry: SessionEntry;
+    nextSessionId: string;
+    sourceSessionId?: string;
+    sourceMaxSeq?: number;
+  },
+): CliHistoryBoundary | undefined {
+  const stored = params.currentEntry.cliHistoryBoundary;
+  if (
+    !isKnownCliHistoryBoundary(stored) ||
+    !params.sourceSessionId ||
+    params.sourceMaxSeq === undefined ||
+    stored.sessionId !== params.currentEntry.sessionId ||
+    params.sourceSessionId !== params.currentEntry.sessionId ||
+    stored.generation === null ||
+    stored.maxSeq === null ||
+    stored.maxSeq < params.sourceMaxSeq ||
+    stored.generation !== readTranscriptGenerationInTransaction(database, params.sourceSessionId)
+  ) {
+    return undefined;
+  }
+  const generation = readTranscriptGenerationInTransaction(database, params.nextSessionId);
+  const maxSeq = readNextTranscriptSeq(database, params.nextSessionId) - 1;
+  if (!generation || maxSeq < 0) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    sessionId: params.nextSessionId,
+    state: "known",
+    authFingerprint: stored.authFingerprint,
+    generation,
+    maxSeq,
+    writerRunId: stored.writerRunId,
   };
 }
 


### PR DESCRIPTION
## Summary
On a session that has a compaction checkpoint and a live native CLI conversation (for example a `claude-cli` backed session), `sessions.compaction.restore` reports success and rewinds the local transcript, but the model keeps answering from the post-compaction native conversation. `sessions.compaction.branch` has the mirror problem: the new session key inherits the parent's native session id, so two OpenClaw sessions interleave turns into one native conversation.

Trigger: a session with at least one stored compaction checkpoint and a stored CLI session binding, then branch or restore that checkpoint. Restoring the same retained checkpoint a second time has the same visible outcome for a different reason, covered below.

## Root cause
`src/config/sessions/session-accessor.sqlite-checkpoint.ts`

Branch and restore both mint a brand new `sessionId` and fork a fresh transcript at the checkpoint boundary via `forkSqliteCheckpointTranscriptInTransaction`, then project the successor entry through `cloneSqliteCheckpointSessionEntry`. That clone spreads `...currentEntry` and clears the run, usage and token fields, but it never touched any CLI session state. Two session-scoped fields therefore survived a session rotation that invalidates both:

1. `cliSessionBindings` / `cliSessionIds` / `claudeCliSessionId` still name the source's native conversation, so the next turn resumes the conversation the checkpoint was meant to undo.
2. `cliHistoryBoundary` still names the source `sessionId` and the source transcript `generation`, so it is a proof about a transcript the successor does not have.

The second one is why clearing the binding alone is not a complete repair. With the binding gone and a stale boundary present, `prepareCliHistoryBoundary` rejects the boundary on the `sessionId` mismatch (`src/agents/cli-runner/history-boundary.ts`), and it cannot fall through to the proven-empty path because the forked conversation is not empty. `prepare.ts` then selects `auth-unknown` and `loadCliSessionPromptContext` returns no history. The successor starts a fresh native conversation with nothing in it.

Repeated restore, the P1 raised in the last review: a restore keeps the stored checkpoint positions, and those positions keep naming the transcript the checkpoint was captured on. After one restore the live session owns only its own copy of those rows, so the next restore of the same retained checkpoint forked a foreign session. Ownership could not be proven for rows read out of a session the boundary says nothing about, the successor was left unowned, and the operation still reported `created`. The next CLI turn selected `auth-unknown` and opened an empty conversation.

## Fix
Three changes in the one transaction that both operations share.

Clear the native binding with the same `clearAllCliSessions()` helper every other rotation path already uses, and stop inheriting the source's history proof.

Re-stamp that proof onto the forked transcript when, and only when, the source boundary actually covers every row the fork copied. `resolveCheckpointSuccessorCliHistoryBoundary` requires all of:

- the stored boundary is a `known` proof naming the source `sessionId`
- the fork read from the source session itself, not a legacy blob or a cross-session checkpoint position
- the boundary `generation` still equals the source transcript's live generation
- the boundary `maxSeq` is at or beyond the highest seq the fork copied

It then writes a boundary carrying the successor `sessionId` and the forked transcript's own `generation` and `maxSeq`, keeping the source `authFingerprint` and `writerRunId`. The fingerprint is the account check, so a different account on the next turn is still refused. If any condition fails, the successor is left unowned rather than inheriting a stale proof.

For the repeated restore, resolve the fork source against the transcript the live session owns before falling back to the position the checkpoint recorded:

```ts
const addForkSourceWithCurrentCopy = (source: SqliteCheckpointTranscriptForkSource) => {
  if (source.leafId && source.sessionId !== currentSessionId) {
    sources.push({ ...source, sessionId: currentSessionId });
  }
  sources.push(source);
};
```

A retained checkpoint position is only re-pointed at the live session when an exact leaf id bounds it, and `readSqliteTranscriptRowsForFork` still has to find that leaf in that session, so the copied rows are the same rows. A position without a leaf keeps naming the recorded session, because reading the live session unbounded would copy the rows the checkpoint exists to drop. This picks the first of the two directions review offered, preserving verifiable ownership rather than refusing the operation, and it needs no new failure status, no relaxed check and no schema change. The account, generation, coverage and live-run safeguards are untouched: the successor still has to satisfy all of them, and a source that cannot satisfy them is still left unowned.

Branch after a restore takes the same path, so the two operations stay symmetric.

## Why this is the right boundary
`cloneSqliteCheckpointSessionEntry` is the single place where both branch and restore project the successor entry, so one repair covers both operations and cannot drift apart later. The near duplicate rewind clone at `src/config/sessions/session-accessor.sqlite-message-cut.ts` already carries the comment "A rotated transcript cannot resume provider/runtime identity from the old tail" and clears the binding there; the checkpoint clone was the one rotation that was missed.

Re-ownership is done at the checkpoint, not in `prepareCliHistoryBoundary`, because the checkpoint transaction is the only place that knows the copy happened and can see both transcripts at once. Nothing in the CLI runner's admission rules is relaxed.

Deliberate scope boundary: the message-cut sibling also clears `agentHarnessId`, `contextTokens`, `contextBudgetStatus` and `compactionCount`. This patch does not touch those. Whether a checkpoint successor should also drop harness identity and compaction accounting is a policy question with its own user-visible consequences, and it is not needed here. Happy to extend if a maintainer wants that alignment.

Known residual, stated rather than hidden: a checkpoint whose recorded position cannot be located in the live session, for example an imported or legacy-sourced position with no exact leaf, still produces an unowned successor. That is the existing accepted contract from #140294, which deliberately refuses unverifiable history, and this patch does not widen it.

## Regression coverage
`src/config/sessions/session-accessor.conformance.test.ts`

- the existing checkpoint case now also asserts the successor does not inherit the source history proof
- both the branch and the restore successor carry a re-owned boundary whose `sessionId`, `generation` and `maxSeq` match the forked transcript while the `authFingerprint` is preserved
- a source boundary that stops short of the copied rows leaves the successor unowned
- restoring the same retained checkpoint a second time still produces an owned successor whose boundary matches its own transcript, and the copied conversation rows are present
- a new case drives the real preparation path on the twice-restored successor: the owning account receives the checkpoint conversation, a revoked successor run is rejected by the history writer's `assertReadable` before execution, and a second account is refused and receives no checkpoint history

## Verification
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.conformance.test.ts` passes 52 cases on this head; the two repeated-restore cases fail on the previously reviewed head `8de35315747`
- `node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts src/agents/cli-runner/history-boundary.test.ts` passes, covering the gateway checkpoint handlers and the account boundary contract this patch transfers
- `oxfmt` clean on both changed files
- full typecheck and full build not run locally on this box; CI owns them

## Real behavior proof
Behavior addressed: branching or restoring a compaction checkpoint on a session with a live native CLI binding rotates the local transcript but leaves the successor pointing at the old native conversation, so the next turn resumes the conversation the checkpoint was meant to undo; clearing only that binding replaces the wrong context with no context, and restoring the same retained checkpoint again lands in the same empty state while still reporting success.

Real environment tested: the real production runtime driven end to end on pristine `origin/main` `550353573e3` and on this patched head `fad01fa8d2c`, identical inputs, plus one middle run on the previously reviewed head `8de35315747` to isolate the repeated-restore finding. Real `node:sqlite` store on disk under a scratch state directory, real `compactionCheckpointStore` from `src/agents/embedded-agent-runner/compaction-checkpoint.ts` for capture and persistence, real `persistCompactionCheckpoint`, real `branchCheckpointSession` / `restoreCheckpointSession`, and then the real next-turn path the CLI runner uses: `prepareSystemAgentRunAdmission`, `prepareCliHistoryBoundary`, `loadCliSessionPromptContext` and `buildCliSessionHistoryPrompt`, with the binding read through the real `getCliSessionBinding` and the execution-boundary authority check `executePreparedCliRun` installs as its pre-send assertion. No stubs and no doubles; the only thing not driven is the `claude` subprocess itself. Account fingerprints, transcript generations and leaf ids are redacted; the accounts are synthetic.

Exact steps or command run after this patch: seed a SQLite backed session, take a real first CLI turn that establishes a genuine `cliHistoryBoundary` under a `claude-cli` account credential and writes two conversation messages through the granted history writer, take a second turn so the proof covers every row, persist the native binding the backend would return (`native-pre-checkpoint`), capture and persist one manual compaction checkpoint at the live leaf, then branch the checkpoint, restore it, restore the same retained checkpoint again, and drive each successor's first CLI turn, printing the native conversation the successor would resume, whether the history writer was granted, the reseed reason `prepare.ts` would select, the messages handed to the model, the size of the prompt actually sent to the backend and whether it carries the checkpoint conversation, then revoke the successor's live run and re-run the execution authority check, then repeat the successor turn under a second account.

Evidence after fix:
```
# BEFORE (pristine main 550353573e3)
SOURCE   boundary={"version":1,"sessionId":"checkpoint-source","state":"known","authFingerprint":"<account-fingerprint redacted>","generation":"<generation redacted>","maxSeq":2,"writerRunId":"cli-run-2"} binding={"claude-cli":{"sessionId":"native-pre-checkpoint"}}
CHECKPOINT preCompaction={"sessionId":"checkpoint-source","leafId":"<leaf redacted>","entryId":"<leaf redacted>"}
BRANCH   result=created
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
BRANCH   nativeResume=native-pre-checkpoint historyWriter=refused reseedReason=auth-unknown restoredMessages=0
BRANCH   restoredContext=[]
BRANCH   promptSentToBackend chars=0 carriesCheckpointHistory=false
RESTORE  result=created
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
RESTORE  nativeResume=native-pre-checkpoint historyWriter=refused reseedReason=auth-unknown restoredMessages=0
RESTORE  restoredContext=[]
RESTORE  promptSentToBackend chars=0 carriesCheckpointHistory=false
RESTORE2 result=created
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
RESTORE2 nativeResume=native-pre-checkpoint historyWriter=refused reseedReason=auth-unknown restoredMessages=0
RESTORE2 restoredContext=[]
RESTORE2 promptSentToBackend chars=0 carriesCheckpointHistory=false
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
OTHERACCT nativeResume=native-pre-checkpoint historyWriter=refused reseedReason=auth-unknown restoredMessages=0
OTHERACCT restoredContext=[]
OTHERACCT promptSentToBackend chars=0 carriesCheckpointHistory=false

# MIDDLE (previously reviewed head 8de35315747, identical inputs)
SOURCE   boundary={"version":1,"sessionId":"checkpoint-source","state":"known","authFingerprint":"<account-fingerprint redacted>","generation":"<generation redacted>","maxSeq":2,"writerRunId":"cli-run-2"} binding={"claude-cli":{"sessionId":"native-pre-checkpoint"}}
CHECKPOINT preCompaction={"sessionId":"checkpoint-source","leafId":"<leaf redacted>","entryId":"<leaf redacted>"}
BRANCH   result=created
BRANCH   nativeResume=none historyWriter=granted reseedReason=missing-transcript restoredMessages=2
BRANCH   restoredContext=["user:deploy the canary build","assistant:canary build deployed"]
BRANCH   promptSentToBackend chars=466 carriesCheckpointHistory=true
RESTORE  result=created
RESTORE  nativeResume=none historyWriter=granted reseedReason=missing-transcript restoredMessages=2
RESTORE  restoredContext=["user:deploy the canary build","assistant:canary build deployed"]
RESTORE  promptSentToBackend chars=466 carriesCheckpointHistory=true
RESTORE2 result=created
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
RESTORE2 nativeResume=none historyWriter=refused reseedReason=auth-unknown restoredMessages=0
RESTORE2 restoredContext=[]
RESTORE2 promptSentToBackend chars=0 carriesCheckpointHistory=false
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
OTHERACCT nativeResume=none historyWriter=refused reseedReason=auth-unknown restoredMessages=0
OTHERACCT restoredContext=[]
OTHERACCT promptSentToBackend chars=0 carriesCheckpointHistory=false

# AFTER (this patch, head fad01fa8d2c, identical inputs)
SOURCE   boundary={"version":1,"sessionId":"checkpoint-source","state":"known","authFingerprint":"<account-fingerprint redacted>","generation":"<generation redacted>","maxSeq":2,"writerRunId":"cli-run-2"} binding={"claude-cli":{"sessionId":"native-pre-checkpoint"}}
CHECKPOINT preCompaction={"sessionId":"checkpoint-source","leafId":"<leaf redacted>","entryId":"<leaf redacted>"}
BRANCH   result=created
BRANCH   nativeResume=none historyWriter=granted reseedReason=missing-transcript restoredMessages=2
BRANCH   restoredContext=["user:deploy the canary build","assistant:canary build deployed"]
BRANCH   promptSentToBackend chars=466 carriesCheckpointHistory=true
RESTORE  result=created
RESTORE  nativeResume=none historyWriter=granted reseedReason=missing-transcript restoredMessages=2
RESTORE  restoredContext=["user:deploy the canary build","assistant:canary build deployed"]
RESTORE  promptSentToBackend chars=466 carriesCheckpointHistory=true
RESTORE2 result=created
RESTORE2 nativeResume=none historyWriter=granted reseedReason=missing-transcript restoredMessages=2
RESTORE2 restoredContext=["user:deploy the canary build","assistant:canary build deployed"]
RESTORE2 promptSentToBackend chars=466 carriesCheckpointHistory=true
RESTORE2 revokedSuccessorRun=REJECTED before any backend send: CLI history authority changed before execution
[agent/cli-backend] cli session history refused across auth boundary: reason=auth-unknown
OTHERACCT nativeResume=none historyWriter=refused reseedReason=auth-unknown restoredMessages=0
OTHERACCT restoredContext=[]
OTHERACCT promptSentToBackend chars=0 carriesCheckpointHistory=false
```
Observed result after fix: on pristine main both successors resume `native-pre-checkpoint`, the conversation the checkpoint was meant to undo, and the runtime logs its refusal to hand over local history. On the previously reviewed shape the first branch and the first restore recover the two pre-checkpoint messages, but restoring the same retained checkpoint again drops back to `auth-unknown` with an empty prompt while still reporting `created`, which is the P1 raised in review. With this patch all three operations open a fresh native conversation and hand the backend the same 466 character prompt carrying the checkpoint conversation. Revoking the successor's live run between preparation and execution makes the run authority check reject it before any backend send, and driving the same successor under a second account is refused and receives an empty prompt, so the account boundary and the live-run boundary both still hold on the transferred history.
What was not tested: this drives the store, the real preparation path, and the execution-boundary authority check that `executePreparedCliRun` installs before it sends anything; it does not spawn a real `claude` binary to watch the provider open the new conversation, and it does not exercise the gateway RPC transport in front of `sessions.compaction.restore` and `.branch`. Cold-archived source transcripts are not covered; the boundary re-own reads the hot transcript tip, and a source whose generation no longer matches leaves the successor unowned, which is the safe side.

## ClawSweeper verdict items
- **Preserve usable history when restoring a retained checkpoint again (P1)**: fixed in `src/config/sessions/session-accessor.sqlite-checkpoint.ts` by resolving the fork source against the transcript the live session owns when an exact leaf bounds it, so the retained position stays provable instead of pointing at a session the boundary cannot speak for. Review offered two directions and this is the narrower one: no safeguard was removed, no new failure status was added, and the account, generation, coverage and live-run checks all still apply. The evidence block above reproduces the finding on the reviewed head and shows it repaired on this head.
- **Add real behavior proof (authority chain)**: the proof now runs past preparation to the execution boundary. It shows the reseeded prompt the backend receives for branch, restore and repeated restore, the rejection of a revoked successor run before any send, and the empty prompt a second account receives.
- **Resolve merge risk: transferred history must stay unavailable to a different account or a revoked run (P1)**: answered by the last two lines of the after block, driven on the twice-restored successor, and covered by a regression case.
- **Resolve merge risk: the durable history-transfer contract lacks recorded maintainer acceptance (P1, owner decision)**: still open and not author-actionable. This PR extends the account-bound history contract accepted in #140294 to a copied transcript. The rule it adds is narrow: a successor inherits ownership only when the source proof is `known`, names the source session, matches its live generation, and covers every copied row, and the copied rows are read from a transcript the live session owns. Both maintainer options remain real. Option 1 is to accept this bounded transfer, which is what this PR implements. Option 2 is to pause the ownership transfer entirely, keep only the binding clear, and accept that every checkpoint successor starts with no CLI history; if that is the preferred contract, say so and I will cut the transfer back to the clear-only shape rather than argue for the transfer.
- **Resolve maintainer decision**: the question in the verdict, whether restores should preserve verifiable ownership across retained checkpoint sources or refuse CLI restoration when ownership cannot be carried, is answered here as preserve-when-provable, refuse-nothing, and leave the unprovable case unowned as today. Accepting or rejecting that shape is the maintainer call.
