### PR TITLE
test: reuse platform fixtures and remove duplicate launchd case

### DIFF
--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -32,10 +32,6 @@ beforeEach(() => {
   probePortUsage.mockRejectedValue(new Error("unexpected port probe"));
 });
 
-function setPlatform(value: NodeJS.Platform) {
-  mockProcessPlatform(value);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -89,14 +85,14 @@ describe("resolveGatewayService", () => {
     { platform: "linux" as const, label: "systemd user", loadedText: "enabled" },
     { platform: "win32" as const, label: "Scheduled Task", loadedText: "registered" },
   ])("returns the registered adapter for $platform", ({ platform, label, loadedText }) => {
-    setPlatform(platform);
+    mockProcessPlatform(platform);
     const service = resolveGatewayService();
     expect(service.label).toBe(label);
     expect(service.loadedText).toBe(loadedText);
   });
 
   it("returns a read-only unsupported-platform adapter", async () => {
-    setPlatform("aix");
+    mockProcessPlatform("aix");
     const service = resolveGatewayService();
 
     await expect(service.readCommand(process.env)).resolves.toBeNull();
@@ -154,7 +150,7 @@ describe("resolveGatewayService", () => {
   });
 
   it("guards every native service mutation when an external supervisor owns lifecycle", async () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     const service = resolveGatewayService();
     const env = { OPENCLAW_SUPERVISOR_MODE: "external" };
     const installArgs = {
@@ -248,7 +244,7 @@ describe("readGatewayServiceState", () => {
       ];
       const snapshot = captureEnv(keys);
       try {
-        setPlatform("linux");
+        mockProcessPlatform("linux");
         for (const key of keys) {
           delete process.env[key];
         }

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SpawnResult } from "../process/exec-result.js";
+import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 
 type DetectBinary = typeof import("./detect-binary.js").detectBinary;
 
@@ -66,7 +67,7 @@ afterEach(() => {
 
 describe("openUrl", () => {
   it("returns true after a normal zero exit", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockProcessPlatform("win32");
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "development");
 
@@ -74,7 +75,7 @@ describe("openUrl", () => {
   });
 
   it("returns false after a non-zero exit", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockProcessPlatform("win32");
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "development");
     runCommandWithTimeoutMock.mockResolvedValueOnce({
@@ -90,7 +91,7 @@ describe("openUrl", () => {
   });
 
   it("returns false after a timeout", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockProcessPlatform("win32");
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "development");
     runCommandWithTimeoutMock.mockResolvedValueOnce({
@@ -108,7 +109,7 @@ describe("openUrl", () => {
 
 describe("resolveBrowserOpenCommand", () => {
   it("retains process-level WSL detection caching through the resolver", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    mockProcessPlatform("linux");
     vi.stubEnv("DISPLAY", "");
     vi.stubEnv("WAYLAND_DISPLAY", "");
     vi.stubEnv("WSL_INTEROP", "");
@@ -150,7 +151,7 @@ describe("resolveBrowserOpenCommand", () => {
   });
 
   it("does not resolve Windows browser launching through a relative SystemRoot", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockProcessPlatform("win32");
     vi.stubEnv("SystemRoot", ".\\fake-root");
     vi.stubEnv("windir", ".\\fake-windir");
 
@@ -163,7 +164,7 @@ describe("resolveBrowserOpenCommand", () => {
 
   it("prefers the registry-backed Windows system root over process env", async () => {
     getWindowsInstallRootsMock.mockReturnValue({ systemRoot: "D:\\Windows" });
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockProcessPlatform("win32");
     vi.stubEnv("SystemRoot", "C:\\PoisonedWindows");
 
     const resolved = await resolveBrowserOpenCommand();
@@ -174,7 +175,7 @@ describe("resolveBrowserOpenCommand", () => {
   });
 
   it("resolves macOS open even when SSH environment variables are present", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    mockProcessPlatform("darwin");
     vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
     detectBinaryMock.mockResolvedValueOnce(true);
 
@@ -185,7 +186,7 @@ describe("resolveBrowserOpenCommand", () => {
   });
 
   it("still refuses browser launch over Linux SSH without a display", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    mockProcessPlatform("linux");
     vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
 
     const resolved = await resolveBrowserOpenCommand();

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -63,10 +63,6 @@ const {
   signalVerifiedGatewayPidSync,
 } = await import("./gateway-processes.js");
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 describe("gateway-processes", () => {
   beforeEach(() => {
     spawnSyncMock.mockReset();
@@ -82,7 +78,7 @@ describe("gateway-processes", () => {
   });
 
   it("signals only verified gateway processes", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     readFileSyncMock.mockReturnValue("node\0gateway\0");
     parseProcCmdlineMock.mockReturnValue(["node", "gateway"]);
     isGatewayArgvMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
@@ -97,7 +93,7 @@ describe("gateway-processes", () => {
   });
 
   it("swallows ESRCH when a verified gateway process exits before the signal", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     readFileSyncMock.mockReturnValue("node\0gateway\0");
     parseProcCmdlineMock.mockReturnValue(["node", "gateway"]);
     isGatewayArgvMock.mockReturnValue(true);
@@ -111,7 +107,7 @@ describe("gateway-processes", () => {
   });
 
   it("re-throws non-ESRCH kill errors", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     readFileSyncMock.mockReturnValue("node\0gateway\0");
     parseProcCmdlineMock.mockReturnValue(["node", "gateway"]);
     isGatewayArgvMock.mockReturnValue(true);
@@ -124,7 +120,7 @@ describe("gateway-processes", () => {
   });
 
   it("dedupes and filters verified gateway listener pids on unix and windows", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     findGatewayPidsOnPortSyncMock.mockReturnValue([process.pid, 200, 200, 300, -1]);
     readFileSyncMock.mockReturnValueOnce("openclaw-gateway\0gateway\0");
     readFileSyncMock.mockReturnValueOnce("python\0-m\0http.server\0");
@@ -134,7 +130,7 @@ describe("gateway-processes", () => {
     isGatewayArgvMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
 
     expect(findVerifiedGatewayListenerPidsOnPortSync(18789)).toEqual([200]);
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     spawnSyncMock
       .mockReturnValueOnce({
         error: null,
@@ -153,7 +149,7 @@ describe("gateway-processes", () => {
   });
 
   it("falls back from powershell to trusted netstat for windows listener pids", () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     spawnSyncMock
       .mockReturnValueOnce({
         error: new Error("powershell missing"),

--- a/src/infra/path-guards.test.ts
+++ b/src/infra/path-guards.test.ts
@@ -8,10 +8,6 @@ import {
   normalizeWindowsPathPreservingCase,
 } from "./path-guards.js";
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -77,7 +73,7 @@ describe("isPathInside", () => {
   });
 
   it("uses win32 path semantics for windows containment checks", () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
 
     for (const [basePath, targetPath, expected] of [
       [String.raw`C:\workspace\root`, String.raw`C:\workspace\root`, true],
@@ -102,7 +98,7 @@ describe("isPathStrictlyInside", () => {
   });
 
   it("uses win32 path semantics for strict containment checks", () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
 
     for (const [basePath, targetPath, expected] of [
       [String.raw`C:\workspace\root`, String.raw`C:\workspace\root`, false],

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -89,7 +89,7 @@ function mockWindowsCommands(params: {
   powershell?: CommandReply;
   wmic?: CommandReply;
 }): void {
-  setPlatform("win32");
+  mockProcessPlatform("win32");
   runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
     const command = argv[0];
     const reply =
@@ -104,10 +104,6 @@ function mockWindowsCommands(params: {
               : undefined;
     return resolveCommandReply(reply);
   });
-}
-
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
 }
 
 async function listenServer(
@@ -881,7 +877,7 @@ describeUnix("inspectPortUsage", () => {
 
 describe("inspectPortUsage on Windows", () => {
   it("classifies SSH through locale-independent tasklist CSV output", async () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
       const command = argv[0];
       if (command === getWindowsSystem32ExePath("netstat.exe")) {

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -47,10 +47,6 @@ const originalArgv = [...process.argv];
 const originalExecArgv = [...process.execArgv];
 const envSnapshot = captureFullEnv();
 
-function setPlatform(platform: NodeJS.Platform) {
-  mockProcessPlatform(platform);
-}
-
 afterEach(() => {
   envSnapshot.restore();
   process.argv = [...originalArgv];
@@ -83,7 +79,7 @@ function mockDetachedChild(pid: number) {
 }
 
 function expectLaunchdSupervisedWithHandoff(params?: { launchJobLabel?: string }) {
-  setPlatform("darwin");
+  mockProcessPlatform("darwin");
   if (params?.launchJobLabel) {
     process.env.LAUNCH_JOB_LABEL = params.launchJobLabel;
   }
@@ -109,7 +105,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("keeps OPENCLAW_NO_RESPAWN ahead of inherited supervisor hints", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.OPENCLAW_NO_RESPAWN = "1";
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
 
@@ -127,7 +123,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised for a real gateway launchd job without the injected marker", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
 
     const result = restartGatewayProcessWithFreshPid();
@@ -140,7 +136,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised for a real gateway XPC launchd job without the injected marker", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.XPC_SERVICE_NAME = "ai.openclaw.gateway";
 
     const result = restartGatewayProcessWithFreshPid();
@@ -151,13 +147,9 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns supervised on macOS when launchd label is set", () => {
-    expectLaunchdSupervisedWithHandoff({ launchJobLabel: "ai.openclaw.gateway" });
-  });
-
   it("returns failed when the launchd handoff cannot be scheduled", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
     scheduleLaunchdHandoffMock.mockReturnValue({ ok: false, error: "spawn EPERM" });
 
@@ -169,7 +161,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("launchd supervisor never returns failed regardless of triggerOpenClawRestart outcome", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
     // Even if triggerOpenClawRestart *would* fail, launchd path must not call it.
     triggerOpenClawRestartMock.mockReturnValue({
@@ -185,7 +177,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.env.INVOCATION_ID = "abc123";
     process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
 
@@ -199,7 +191,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("does not treat inherited XPC_SERVICE_NAME as launchd supervision", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.XPC_SERVICE_NAME = "ai.openclaw.mac";
     process.env.OPENCLAW_PROFILE = "mac";
 
@@ -216,7 +208,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("uses in-process restart on unmanaged Unix so custom supervisors keep the tracked PID", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.execArgv = ["--import", "tsx"];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
     spawnMock.mockReturnValue({ pid: 4242, unref: vi.fn() });
@@ -237,7 +229,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when OPENCLAW_SYSTEMD_UNIT is set", () => {
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
@@ -246,7 +238,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("exits to external supervision without invoking inherited native restart hooks", () => {
     clearSupervisorHints();
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     process.env.OPENCLAW_SUPERVISOR_MODE = "external";
     process.env.OPENCLAW_WINDOWS_TASK_NAME = "OpenClaw Gateway";
 
@@ -259,7 +251,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when OpenClaw gateway task markers are set on Windows", () => {
     clearSupervisorHints();
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
     triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "schtasks" });
@@ -271,7 +263,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("keeps generic service markers out of non-Windows supervisor detection", () => {
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
 
@@ -287,7 +279,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns disabled on Windows without Scheduled Task markers", () => {
     clearSupervisorHints();
-    setPlatform("win32");
+    mockProcessPlatform("win32");
 
     const result = restartGatewayProcessWithFreshPid();
 
@@ -299,7 +291,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("returns disabled in containers so PID 1 stays alive for in-process restart", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     isContainerEnvironmentMock.mockReturnValue(true);
 
     const result = restartGatewayProcessWithFreshPid();
@@ -313,7 +305,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("ignores node task script hints for gateway restart detection on Windows", () => {
     clearSupervisorHints();
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     process.env.OPENCLAW_TASK_SCRIPT = "C:\\openclaw\\node.cmd";
     process.env.OPENCLAW_TASK_SCRIPT_NAME = "node.cmd";
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
@@ -329,7 +321,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("does not attempt detached spawn on unmanaged Unix even if spawn would throw", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
 
     spawnMock.mockImplementation(() => {
       throw new Error("spawn failed");
@@ -356,7 +348,7 @@ describe("respawnGatewayProcessForUpdate", () => {
 
   it("allows detached respawn on unmanaged Windows during updates", () => {
     clearSupervisorHints();
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     process.execArgv = [];
     process.argv = [
       "C:\\Program Files\\node.exe",
@@ -383,7 +375,7 @@ describe("respawnGatewayProcessForUpdate", () => {
 
   it("rewrites a pnpm-versioned OpenClaw entry before detached update respawn", () => {
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.execArgv = [];
     process.argv = [
       "/usr/local/bin/node",
@@ -409,7 +401,7 @@ describe("respawnGatewayProcessForUpdate", () => {
 
   it("does not rewrite another package's pnpm-versioned entry", () => {
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.execArgv = [];
     const entry =
       "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
@@ -427,7 +419,7 @@ describe("respawnGatewayProcessForUpdate", () => {
 
   it("spawns a detached update process when macOS only has inherited XPC state", () => {
     clearSupervisorHints();
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     process.env.XPC_SERVICE_NAME = "ai.openclaw.mac";
     process.execArgv = [];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
@@ -450,7 +442,7 @@ describe("respawnGatewayProcessForUpdate", () => {
 
   it("registers a no-op detached child error listener before unref", () => {
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     process.execArgv = [];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
     const child = mockDetachedChild(9191);
@@ -472,7 +464,7 @@ describe("respawnGatewayProcessForUpdate", () => {
   it("returns failed when update detached respawn throws", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
 
     spawnMock.mockImplementation(() => {
       throw new Error("spawn failed");

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -60,10 +60,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 function requireFirstSpawnSyncCall(): [unknown, unknown, unknown] {
   const [call] = spawnSyncMock.mock.calls;
   if (!call) {
@@ -198,7 +194,7 @@ describe.runIf(process.platform !== "win32")("cleanStaleGatewayProcessesSync", (
 
 describe("triggerOpenClawRestart", () => {
   it("does not kickstart after bootstrap registers an unloaded LaunchAgent", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     withEnv(
       { VITEST: undefined, NODE_ENV: undefined, HOME: "/Users/test", OPENCLAW_PROFILE: "default" },
       () => {
@@ -231,7 +227,7 @@ describe("triggerOpenClawRestart", () => {
   });
 
   it("continues when launchctl bootstrap reports the service is already loaded", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     withEnv(
       { VITEST: undefined, NODE_ENV: undefined, HOME: "/Users/test", OPENCLAW_PROFILE: "default" },
       () => {

--- a/src/infra/wsl.test.ts
+++ b/src/infra/wsl.test.ts
@@ -32,10 +32,6 @@ let isWSL2Sync: typeof import("./wsl.js").isWSL2Sync;
 let isWSL: typeof import("./wsl.js").isWSL;
 let resetWSLStateForTests: typeof import("./wsl.js").resetWSLStateForTests;
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 describe("wsl detection", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -50,7 +46,7 @@ describe("wsl detection", () => {
     deleteTestEnvValue("WSLENV");
     readFileSyncMock.mockReset();
     readFileMock.mockReset();
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     resetWSLStateForTests();
   });
 
@@ -103,7 +99,7 @@ describe("wsl detection", () => {
   });
 
   it("returns false for sync detection on non-linux platforms", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     expect(isWSLSync()).toBe(false);
     expect(isWSL2Sync()).toBe(false);
     expect(readFileSyncMock).not.toHaveBeenCalled();
@@ -135,7 +131,7 @@ describe("wsl detection", () => {
   });
 
   it("returns false for async detection on non-linux platforms without reading osrelease", async () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     await expect(isWSL()).resolves.toBe(false);
     expect(readFileMock).not.toHaveBeenCalled();
   });

--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -9,10 +9,6 @@ import {
   isConfigPathTruthyWithDefaults,
 } from "./config-eval.js";
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
@@ -87,7 +83,7 @@ describe("config-eval helpers", () => {
   });
 
   it("returns the active runtime platform", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     expect(
       evaluateRuntimeEligibility({
         os: ["darwin"],
@@ -99,7 +95,7 @@ describe("config-eval helpers", () => {
   });
 
   it("caches binary lookups until PATH changes", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
     vi.stubEnv("PATH", ["/missing/bin", "/found/bin"].join(path.delimiter));
     const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
       if (String(candidate) === path.join("/found/bin", "tool")) {
@@ -123,7 +119,7 @@ describe("config-eval helpers", () => {
   });
 
   it("checks PATHEXT candidates and invalidates cached hits when PATHEXT changes", () => {
-    setPlatform("win32");
+    mockProcessPlatform("win32");
     const toolsDir = path.join(path.sep, "tools");
     vi.stubEnv("PATH", toolsDir);
     vi.stubEnv("PATHEXT", ".EXE;.CMD");
@@ -158,7 +154,7 @@ describe("config-eval helpers", () => {
     "finds a newly installed binary on unchanged $platform PATH",
     ({ platform, suffix }) => {
       withTempDirSync({ prefix: "openclaw-binary-probe-" }, (binDir) => {
-        setPlatform(platform);
+        mockProcessPlatform(platform);
         vi.stubEnv("PATH", binDir);
         vi.stubEnv("PATHEXT", ".EXE;.CMD");
         expect(hasBinary("fixture-tool")).toBe(false);
@@ -229,7 +225,7 @@ describe("evaluateRuntimeEligibility", () => {
   });
 
   it("accepts entries when remote platform satisfies OS requirements", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
     const result = evaluateRuntimeEligibility({
       os: ["linux"],
       remotePlatforms: ["linux"],

--- a/src/shared/entry-status.test.ts
+++ b/src/shared/entry-status.test.ts
@@ -3,17 +3,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import { evaluateEntryRequirementsForCurrentPlatform } from "./entry-status.js";
 
-function setPlatform(platform: NodeJS.Platform): void {
-  mockProcessPlatform(platform);
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("shared/entry-status", () => {
   it("combines metadata presentation fields with evaluated requirements", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
 
     const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,
@@ -65,7 +61,7 @@ describe("shared/entry-status", () => {
   });
 
   it("evaluates OS requirements against process.platform", () => {
-    setPlatform("darwin");
+    mockProcessPlatform("darwin");
 
     const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,
@@ -84,7 +80,7 @@ describe("shared/entry-status", () => {
   });
 
   it("combines frontmatter presentation with always-on requirements", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
 
     const result = evaluateEntryRequirementsForCurrentPlatform({
       always: true,
@@ -127,7 +123,7 @@ describe("shared/entry-status", () => {
   });
 
   it("returns empty requirements when metadata and frontmatter are missing", () => {
-    setPlatform("linux");
+    mockProcessPlatform("linux");
 
     const result = evaluateEntryRequirementsForCurrentPlatform({
       always: false,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Platform tests repeat a shared process-platform fixture behind nine local wrappers and eight direct getter spies. The respawn suite also repeats a positive launchd case through the same five-assertion helper.

## Why This Change Was Made

Call the canonical platform fixture directly and remove only the redundant launchd case. Retain the earlier case with controlled supervisor hints, the stock-marker and gateway-label variants, external-supervisor precedence, handoff failures and existing cleanup.

## User Impact

Ten test files remove a net 39 lines. Production code and public APIs are unchanged. All 385 assertion sites remain; one duplicated test case is removed.

## Evidence

The same eleven full suites ran before and after through `node scripts/run-vitest.mjs`, including the unchanged supervisor-markers sibling. Baseline: 257 passed and one Windows-only tasklist case skipped (258 total). Candidate: 256 passed and the same case skipped (257 total). The complete candidate inventory matches baseline minus exactly the approved redundant case; all remaining identities, statuses and per-suite ordering match.

All 20 required changed-file checks passed. Independent review found no actionable issues through P2. Proof ran on macOS with Node 26.5.0 and controlled platform/service fixtures; the native Windows tasklist case remains skipped on this host.

Focused proof command:

```sh
node scripts/run-vitest.mjs src/infra/wsl.test.ts src/infra/browser-open.test.ts src/daemon/service.test.ts src/infra/gateway-processes.test.ts src/infra/path-guards.test.ts src/infra/ports.test.ts src/infra/process-respawn.test.ts src/infra/restart.test.ts src/shared/config-eval.test.ts src/shared/entry-status.test.ts src/infra/supervisor-markers.test.ts
```
