### PR TITLE
fix(system-agent): guard agents.entries config writes against inference-verification bypass

### DIFF
--- a/src/system-agent/config-write-entries-route.test.ts
+++ b/src/system-agent/config-write-entries-route.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { classifyInferenceRouteConfigPath } from "./config-write-policy.js";
+import { assertConfigWriteDoesNotBypassInferenceVerification } from "./operations-execution-helpers.js";
+
+let temp: TempHomeEnv;
+
+async function assertWrite(configPath: string) {
+  await assertConfigWriteDoesNotBypassInferenceVerification({
+    kind: "config-set",
+    path: configPath,
+    value: '"x"',
+  } as never);
+}
+
+beforeEach(async () => {
+  temp = await createTempHomeEnv("openclaw-config-write-entries-");
+  const configPath = path.join(temp.home, ".openclaw", "openclaw.json");
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+  const config: OpenClawConfig = {
+    plugins: { enabled: false },
+    agents: {
+      ownership: "explicit",
+      defaults: { systemAgent: { agentId: "main" } },
+      entries: {
+        main: { name: "Main", model: "anthropic/claude-sonnet-4-5" },
+        helper: { name: "Helper", model: "anthropic/claude-haiku-4-5" },
+      },
+    },
+  };
+  await fs.writeFile(configPath, JSON.stringify(config));
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await temp?.restore();
+});
+
+describe("system-agent config writes to the canonical agents.entries shape", () => {
+  it("classifies agents.entries routing and identity fields like agents.list", () => {
+    for (const field of ["model", "models", "params", "agentRuntime"]) {
+      expect(
+        classifyInferenceRouteConfigPath(["agents", "entries", "main", field]),
+        `agents.entries.main.${field}`,
+      ).toBe(classifyInferenceRouteConfigPath(["agents", "list", "0", field]));
+    }
+    for (const field of ["id", "default", "agentDir", "name", "tools", "prompt"]) {
+      expect(
+        classifyInferenceRouteConfigPath(["agents", "entries", "main", field]),
+        `agents.entries.main.${field}`,
+      ).toBe(classifyInferenceRouteConfigPath(["agents", "list", "0", field]));
+    }
+    expect(classifyInferenceRouteConfigPath(["agents", "entries"])).toBe("blocked");
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main"])).toBe("blocked");
+  });
+
+  it("refuses a direct write to the default agent's inference route", async () => {
+    await expect(assertWrite("agents.entries.main.model")).rejects.toThrow(
+      /set_default_model|inference route/i,
+    );
+    await expect(assertWrite("agents.entries.main.models")).rejects.toThrow();
+    await expect(assertWrite("agents.entries.main.agentRuntime")).rejects.toThrow();
+    await expect(assertWrite("agents.entries.main.params")).rejects.toThrow();
+  });
+
+  it("refuses identity and topology writes for every agents.entries agent", async () => {
+    for (const agentId of ["main", "helper"]) {
+      for (const field of ["id", "default", "agentDir"]) {
+        await expect(
+          assertWrite(`agents.entries.${agentId}.${field}`),
+          `agents.entries.${agentId}.${field}`,
+        ).rejects.toThrow();
+      }
+    }
+  });
+
+  it("still allows non-routing entries edits and routing edits for non-default agents", async () => {
+    await expect(assertWrite("agents.entries.main.prompt")).resolves.toBeUndefined();
+    await expect(assertWrite("agents.entries.main.name")).resolves.toBeUndefined();
+    await expect(assertWrite("agents.entries.main.tools.profile")).resolves.toBeUndefined();
+    await expect(assertWrite("agents.entries.helper.model")).resolves.toBeUndefined();
+    await expect(assertWrite("agents.entries.helper.agentRuntime")).resolves.toBeUndefined();
+  });
+});

--- a/src/system-agent/config-write-parity.test.ts
+++ b/src/system-agent/config-write-parity.test.ts
@@ -79,4 +79,29 @@ describe("system-agent config write parity", () => {
     expect(classifyInferenceRouteConfigPath(["agents", "list", "1", "name"])).toBe("allowed");
     expect(classifyInferenceRouteConfigPath(["agents", "list", "1", "tools"])).toBe("allowed");
   });
+
+  it("classifies the canonical agents.entries shape exactly like agents.list", () => {
+    expect(classifyInferenceRouteConfigPath(["agents", "entries"])).toBe("blocked");
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main"])).toBe("blocked");
+    for (const field of ["model", "models", "params", "agentRuntime"]) {
+      expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", field])).toBe(
+        "agent-route",
+      );
+    }
+    for (const field of ["id", "default", "agentDir"]) {
+      expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", field])).toBe(
+        "blocked",
+      );
+    }
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", "name"])).toBe("allowed");
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", "prompt"])).toBe(
+      "allowed",
+    );
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", "tools"])).toBe(
+      "allowed",
+    );
+    expect(classifyInferenceRouteConfigPath(["agents", "entries", "main", "models", "think"])).toBe(
+      "agent-route",
+    );
+  });
 });

--- a/src/system-agent/config-write-policy.ts
+++ b/src/system-agent/config-write-policy.ts
@@ -42,7 +42,10 @@ export function classifyInferenceRouteConfigPath(
   if (root !== "agents") {
     return "allowed";
   }
-  if (!scope || (scope === "defaults" && !ownerOrField) || (scope === "list" && !ownerOrField)) {
+  if (
+    !scope ||
+    ((scope === "defaults" || scope === "list" || scope === "entries") && !ownerOrField)
+  ) {
     return "blocked";
   }
   if (scope === "defaults") {
@@ -50,13 +53,14 @@ export function classifyInferenceRouteConfigPath(
       ? "blocked"
       : "allowed";
   }
-  if (scope !== "list") {
+  if (scope !== "list" && scope !== "entries") {
     return "allowed";
   }
-  if (/^\d+$/.test(ownerOrField ?? "") && !field) {
+  const isEntryIndex = scope === "entries" || /^\d+$/.test(ownerOrField ?? "");
+  if (isEntryIndex && !field) {
     return "blocked";
   }
-  const routeField = /^\d+$/.test(ownerOrField ?? "") ? field : ownerOrField;
+  const routeField = isEntryIndex ? field : ownerOrField;
   // Identity/topology fields stay blocked for every agent; routing fields are
   // blocked only when the entry backs the default (system) inference route —
   // the caller resolves that from the config, since a path cannot tell.

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -330,10 +330,12 @@ export async function runConfigSetOperation(params: {
 }
 
 async function isDefaultAgentListPath(segments: readonly string[]): Promise<boolean> {
-  const listIndexSegment = segments
+  const normalizedSegments = segments
     .map((segment) => segment.trim().toLowerCase())
-    .filter(Boolean)[2];
-  if (!listIndexSegment || !/^\d+$/.test(listIndexSegment)) {
+    .filter(Boolean);
+  const isEntriesShape = normalizedSegments[1] === "entries";
+  const listIndexSegment = normalizedSegments[2];
+  if (!listIndexSegment || (!isEntriesShape && !/^\d+$/.test(listIndexSegment))) {
     // Path addresses agents.list.<field> without an index; fail closed.
     return true;
   }
@@ -343,13 +345,18 @@ async function isDefaultAgentListPath(segments: readonly string[]): Promise<bool
     return true;
   }
   const config = snapshot.sourceConfig ?? snapshot.config;
+  const defaultAgentId = config ? tryResolveAmbientOwnerAgentId(config) : undefined;
+  if (isEntriesShape) {
+    return (
+      !defaultAgentId || normalizeAgentId(listIndexSegment) === normalizeAgentId(defaultAgentId)
+    );
+  }
   const authoredList = snapshot.sourceConfigBeforeMigrations?.agents?.list;
   const entry = Array.isArray(authoredList) ? authoredList[Number(listIndexSegment)] : undefined;
   if (!entry?.id) {
     // Unknown or id-less entry: cannot prove it is off the default route.
     return true;
   }
-  const defaultAgentId = config ? tryResolveAmbientOwnerAgentId(config) : undefined;
   return !defaultAgentId || normalizeAgentId(entry.id) === normalizeAgentId(defaultAgentId);
 }
 


### PR DESCRIPTION
## Summary
The system agent's config-write guard does not recognize `agents.entries.*`, the canonical schema shape for agent configuration, so it lets the system agent write the default agent's inference route directly.

Trigger: a user chats with the system agent and it plans a `config set agents.entries.<agentId>.model` (or `models`, `params`, `agentRuntime`). The approval prompt appears, the user approves, and the write lands with no live inference check. That is exactly the failure `set_default_model` exists to prevent, since `set_default_model` runs a live inference test before saving (`src/system-agent/operations-execution-helpers.ts:566-582`). If the new value does not route, it kills the model the system agent itself runs on, so the user can no longer talk to OpenClaw to undo it and has to edit `openclaw.json` by hand from a trusted shell.

The identity and topology fields the policy declares blocked for every agent (`agentDir`, `default`, `id`) are equally writable through the same path.

## Root cause
`classifyInferenceRouteConfigPath` in `src/system-agent/config-write-policy.ts:30-68` is the static half of the policy. It handles `agents.defaults.*` and the legacy `agents.list.<n>.<field>` shape, but falls through for anything else under `agents`:

```ts
// before
  if (!scope || (scope === "defaults" && !ownerOrField) || (scope === "list" && !ownerOrField)) {
    return "blocked";
  }
  if (scope === "defaults") {
    return ["agentruntime", "model", "models", "params"].includes(ownerOrField ?? "")
      ? "blocked"
      : "allowed";
  }
  if (scope !== "list") {
    return "allowed";
  }
  if (/^\d+$/.test(ownerOrField ?? "") && !field) {
    return "blocked";
  }
  const routeField = /^\d+$/.test(ownerOrField ?? "") ? field : ownerOrField;
```

`scope !== "list"` returns `"allowed"` unconditionally for every `agents.entries.<agentId>.<field>` path, and `assertConfigWriteDoesNotBypassInferenceVerification` (`operations-execution-helpers.ts:357-363`) returns early on `"allowed"` without any check.

The guarded branch aims at a shape a modern config write cannot take. `AgentsSchema` (`src/config/zod-schema.agents.ts:29-38`) is `.strict()` over `{ownership, defaults, entries}` with no `list` key at all, and `agents.list` is documented in `src/config/types.agents.ts:113` as an internal non-serialized projection materialized by validation. So the covered shape is the legacy one and the live one is uncovered.

Measured from the real module on `03628385d33`:

```
agents.list.0.model                  => agent-route     agents.entries.main.model            => allowed
agents.list.0.agentRuntime           => agent-route     agents.entries.main.agentRuntime     => allowed
agents.list.0.agentDir               => blocked         agents.entries.main.agentDir         => allowed
agents.list.0.default                => blocked         agents.entries.main.default          => allowed
agents.list.0.id                     => blocked         agents.entries.main.id               => allowed
agents.list.0                        => blocked         agents.entries.main                  => allowed
agents.list                          => blocked         agents.entries                       => allowed
```

Reachability is the ordinary chat path: `resolveSystemAgentOperation` (`dialogue.ts:37-85`) to `parseConfigSetCommand` (`operations-parse.ts:154-182`), which accepts any parsable path, to the approval prompt, to `executeConfigWrite`, to the guard, to `runConfigSet`.

## Fix
Give `scope === "entries"` the same treatment `scope === "list"` already gets, reusing the existing identity and route field lists. For the entries shape the route field is `segments[3]`, so the index test that distinguishes `agents.list.<n>.<field>` from `agents.list.<field>` becomes one `isEntryIndex` flag:

```ts
// after
  if (
    !scope ||
    ((scope === "defaults" || scope === "list" || scope === "entries") && !ownerOrField)
  ) {
    return "blocked";
  }
  if (scope === "defaults") {
    return ["agentruntime", "model", "models", "params"].includes(ownerOrField ?? "")
      ? "blocked"
      : "allowed";
  }
  if (scope !== "list" && scope !== "entries") {
    return "allowed";
  }
  const isEntryIndex = scope === "entries" || /^\d+$/.test(ownerOrField ?? "");
  if (isEntryIndex && !field) {
    return "blocked";
  }
  const routeField = isEntryIndex ? field : ownerOrField;
```

`"agent-route"` is conditional: routing fields are blocked only for the agent that backs the default route, so the dynamic half has to resolve the entries shape too. `isDefaultAgentListPath` (`operations-execution-helpers.ts:332-352`) previously only indexed `sourceConfigBeforeMigrations.agents.list`, which is empty for a canonical config. It now resolves the entries shape by comparing `normalizeAgentId(segments[2])` against the ambient default agent id:

```ts
// after
  const isEntriesShape = normalizedSegments[1] === "entries";
  const listIndexSegment = normalizedSegments[2];
  if (!listIndexSegment || (!isEntriesShape && !/^\d+$/.test(listIndexSegment))) {
    return true;
  }
  ...
  const defaultAgentId = config ? tryResolveAmbientOwnerAgentId(config) : undefined;
  if (isEntriesShape) {
    return (
      !defaultAgentId || normalizeAgentId(listIndexSegment) === normalizeAgentId(defaultAgentId)
    );
  }
```

Both halves normalize the agent id the same way the rest of the module does, so a mixed-case path segment resolves to the same agent as the config key.

## Why this is the right boundary
`agents.entries` is the canonical schema shape and `agents.list` is a non-serialized legacy projection, so this is additive coverage of the shape a real config write actually takes, not a replacement. `agents.list` classification is unchanged: the `list` branch keeps its numeric-index test and its `agents.list.<field>` fail-closed behavior, so pre-migration legacy files stay guarded exactly as today, and the proof below shows every `agents.list.*` row byte-identical across the change.

The scope stays on per-field writes. Replacing the whole roster is already refused by `assertCanonicalAgentRosterRetainsEntries` (`src/config/io.write-prepare.ts:935-967`), so there is no second escalation to close here.

Ordinary system-agent config editing is preserved. Non-routing entries fields stay `"allowed"` (`prompt`, `name`, `tools`), and routing fields on agents that do not back the default route stay `"allowed"` as well, matching how the same policy already treats non-default agents in the list shape. `classifyInferenceRouteConfigPath` has exactly one production consumer, `assertConfigWriteDoesNotBypassInferenceVerification`, so the blast radius is that one guard.

Worth a maintainer's note but deliberately not in this diff: `isDynamicOwnerIdSegment` in `src/system-agent/config-redaction.ts:197-202` lists `plugins.entries` and `channels` but not `agents.entries`, so the approval prompt over-redacts agent ids. That is not a bug on its own and belongs to a different owner, but it is more evidence that the entries shape was overlooked across this module.

No existing test asserted the permissive behavior for entries. `src/system-agent/config-write-parity.test.ts` never mentioned `entries` under `agents` at all, which is why the gap survived; the parity contract now carries those rows.

## Verification
- `node scripts/run-vitest.mjs src/system-agent/config-write-parity.test.ts` - green, all 6 cases passed, including the new `classifies the canonical agents.entries shape exactly like agents.list` case (71ms).
- Not run to completion locally: `src/system-agent/config-write-entries-route.test.ts`, the new colocated file. The machine used for this work ran out of disk and was heavily oversubscribed, and the runner kept killing the compile stage on its no-output timeout before the file could execute. Its assertions are the same verdicts the real-runtime proof below demonstrates directly, but I am not claiming a local green for it; CI is the first full run.
- Adjacent system-agent operation suites were not run, for the same machine reason.
- Formatting and typecheck are delegated to GitHub CI, per the repository lanes.
- The before/after evidence below was produced by driving the real modules directly rather than through the runner, which is why it was unaffected by the above.

## Real behavior proof
Behavior addressed: the system agent could write the default agent's inference route and identity fields at `agents.entries.<agentId>.<field>` with no live inference verification, triggered by an approved `config set` in an ordinary system-agent chat.
Real environment tested: the real `src/system-agent/config-write-policy.ts` classifier and the real `assertConfigWriteDoesNotBypassInferenceVerification` and `runConfigSetOperation` write path, driven against a real on-disk `openclaw.json` under `OPENCLAW_CONFIG_PATH` whose default agent is `agents.entries.main`, on pristine main `03628385d33207df1df0a60cf50548e2ec8f2bdf` and on the patched tree with identical inputs; the config reader, the agent-id resolution, the policy module and the real `openclaw config set` writer all stayed real, and the only thing swapped between runs was the two production files.
Exact steps or command run after this patch: load the real policy and execution-helper modules against a real `openclaw.json` containing `agents.entries.main` (default) and `agents.entries.helper`, print the classifier verdict for each path, call the real guard for four paths, then call the real `runConfigSetOperation` for `agents.entries.main.agentDir` and re-read `openclaw.json` from disk. Captured by `git checkout origin/main -- src/system-agent/config-write-policy.ts src/system-agent/operations-execution-helpers.ts` for BEFORE, then restoring the patched files for AFTER.
Evidence after fix:
```
# BEFORE (pristine main 03628385d33207df1df0a60cf50548e2ec8f2bdf)
  agents                               => blocked
  agents.list                          => blocked
  agents.list.0                        => blocked
  agents.list.0.model                  => agent-route
  agents.list.0.agentRuntime           => agent-route
  agents.list.0.agentDir               => blocked
  agents.list.0.default                => blocked
  agents.list.0.id                     => blocked
  agents.list.0.name                   => allowed
  agents.entries                       => allowed
  agents.entries.main                  => allowed
  agents.entries.main.model            => allowed
  agents.entries.main.models           => allowed
  agents.entries.main.params           => allowed
  agents.entries.main.agentRuntime     => allowed
  agents.entries.main.agentDir         => allowed
  agents.entries.main.default          => allowed
  agents.entries.main.id               => allowed
  agents.entries.main.prompt           => allowed
  agents.entries.main.tools            => allowed
  agents.entries.helper.model          => allowed

real guard assertConfigWriteDoesNotBypassInferenceVerification:
  agents.entries.main.model        -> ACCEPTED (no verification required)
  agents.entries.main.agentDir     -> ACCEPTED (no verification required)
  agents.entries.helper.model      -> ACCEPTED (no verification required)
  agents.entries.main.prompt       -> ACCEPTED (no verification required)

real system-agent config write (runConfigSetOperation -> real cli runConfigSet):
  config set agents.entries.main.agentDir "/tmp/hijacked"
    runtime> Updated agents.entries.main.agentDir. Change will apply without restarting the gateway.
    -> WRITE APPLIED
    openclaw.json agentDir: undefined -> "/tmp/hijacked"

# AFTER (this patch, identical inputs)
  agents                               => blocked
  agents.list                          => blocked
  agents.list.0                        => blocked
  agents.list.0.model                  => agent-route
  agents.list.0.agentRuntime           => agent-route
  agents.list.0.agentDir               => blocked
  agents.list.0.default                => blocked
  agents.list.0.id                     => blocked
  agents.list.0.name                   => allowed
  agents.entries                       => blocked
  agents.entries.main                  => blocked
  agents.entries.main.model            => agent-route
  agents.entries.main.models           => agent-route
  agents.entries.main.params           => agent-route
  agents.entries.main.agentRuntime     => agent-route
  agents.entries.main.agentDir         => blocked
  agents.entries.main.default          => blocked
  agents.entries.main.id               => blocked
  agents.entries.main.prompt           => allowed
  agents.entries.main.tools            => allowed
  agents.entries.helper.model          => agent-route

real guard assertConfigWriteDoesNotBypassInferenceVerification:
  agents.entries.main.model        -> REFUSED: Direct config writes cannot change the default inference route or include alternate config. Use `set_default_model` (opt
  agents.entries.main.agentDir     -> REFUSED: Direct config writes cannot change the default inference route or include alternate config. Use `set_default_model` (opt
  agents.entries.helper.model      -> ACCEPTED (no verification required)
  agents.entries.main.prompt       -> ACCEPTED (no verification required)

real system-agent config write (runConfigSetOperation -> real cli runConfigSet):
  config set agents.entries.main.agentDir "/tmp/hijacked"
    -> WRITE REFUSED: Direct config writes cannot change the default inference route or include alternate config
    openclaw.json agentDir: undefined -> undefined
```
Observed result after fix: on pristine main the real guard accepted every `agents.entries.*` route and identity path and the real writer actually changed `agents.entries.main.agentDir` on disk, while after the patch the same real writer refuses it and `openclaw.json` is untouched, every `agents.list.*` row is byte-identical across the two runs, `agents.entries.main.prompt` stays writable, and `agents.entries.helper.model` stays writable because `helper` does not back the default route.
What was not tested: the end-to-end write of `agents.entries.main.model` could not be driven to completion in this checkout, because the writer's model-reference validation needs a dependency the shared module directory here does not resolve, so that path is shown at the guard verdict rather than as an applied on-disk change; the applied-then-refused on-disk pair uses `agents.entries.main.agentDir`. No live provider inference call was made, and the planner-to-approval leg upstream of the guard was not driven from a real chat session.
