### PR TITLE
fix(secrets): keep store entry kind when rotating a value

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -61,7 +61,7 @@ Naming and value rules:
 - Names must match `^[A-Z][A-Z0-9_]{0,127}$`.
 - Values are limited to 64 KiB (65,536 UTF-8 bytes). An oversized value exits `2` whether it arrives from stdin, `--value`, or `--value-file`.
 - A `secret` entry may not be empty, because an empty credential cannot be diagnosed later. `get` refuses secret kinds, and listings mask them. `env` entries may be empty.
-- `--kind secret|env` overrides automatic kind detection. Otherwise names ending in a common credential suffix such as `_API_KEY`, `_TOKEN`, `_PASSWORD`, `_PRIVATE_KEY`, or `_SECRET` become `secret`, and other names become `env`.
+- `--kind secret|env` overrides automatic kind detection. Otherwise `set` and `import` keep the kind an existing entry already has, so rotating a value never changes it. That inherited kind is resolved as the write commits, so protecting an entry while a value or confirmation is still pending is never undone by the pending write. A new name ending in a common credential suffix such as `_API_KEY`, `_TOKEN`, `_PASSWORD`, `_PRIVATE_KEY`, or `_SECRET` becomes `secret`, and any other new name becomes `env`.
 
 ### Set values safely
 

--- a/src/cli/secrets-store-cli.kind-inheritance.test.ts
+++ b/src/cli/secrets-store-cli.kind-inheritance.test.ts
@@ -1,0 +1,413 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { registerSecretsCli } from "./secrets-cli.js";
+
+const mocks = await vi.hoisted(async () => {
+  const { createCliRuntimeMock } = await import("./test-runtime-mock.js");
+  return {
+    ...createCliRuntimeMock(vi),
+    database: { path: "" } as { path: string },
+    interleave: { run: undefined as (() => Promise<void>) | undefined },
+  };
+});
+
+vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("./one-shot-exit.js", () => ({
+  exitCliAfterOutput: (runtime: typeof mocks.defaultRuntime, exitCode: number) =>
+    runtime.exit(exitCode),
+}));
+vi.mock("../infra/gateway-lock.js", () => ({
+  readActiveGatewayLockIdentity: () => Promise.resolve(undefined),
+}));
+vi.mock("./secrets-store-input.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./secrets-store-input.js")>();
+  return {
+    ...actual,
+    readSecretStoreInput: async (params: Parameters<typeof actual.readSecretStoreInput>[0]) => {
+      const value = await actual.readSecretStoreInput(params);
+      await runPendingInterleave();
+      return value;
+    },
+  };
+});
+vi.mock("@clack/prompts", () => ({
+  confirm: async () => {
+    await runPendingInterleave();
+    return true;
+  },
+  isCancel: () => false,
+}));
+
+async function runPendingInterleave(): Promise<void> {
+  const pending = mocks.interleave.run;
+  mocks.interleave.run = undefined;
+  await pending?.();
+}
+vi.mock("../secrets/store/secret-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../secrets/store/secret-store.js")>();
+  const withDb = <T extends { database?: unknown }>(params: T) => ({
+    ...params,
+    database: mocks.database,
+  });
+  return {
+    ...actual,
+    listSecretStoreEntries: (p: Parameters<typeof actual.listSecretStoreEntries>[0]) =>
+      actual.listSecretStoreEntries(withDb(p)),
+    writeSecretStoreEntry: (p: Parameters<typeof actual.writeSecretStoreEntry>[0]) =>
+      actual.writeSecretStoreEntry(withDb(p)),
+    writeSecretStoreEntries: (p: Parameters<typeof actual.writeSecretStoreEntries>[0]) =>
+      actual.writeSecretStoreEntries(withDb(p)),
+    updateSecretStoreAllowedHosts: (
+      p: Parameters<typeof actual.updateSecretStoreAllowedHosts>[0],
+    ) => actual.updateSecretStoreAllowedHosts(withDb(p)),
+    readSecretStoreValue: (p: Parameters<typeof actual.readSecretStoreValue>[0]) =>
+      actual.readSecretStoreValue(withDb(p)),
+    deleteSecretStoreEntry: (p: Parameters<typeof actual.deleteSecretStoreEntry>[0]) =>
+      actual.deleteSecretStoreEntry(withDb(p)),
+    purgeExpiredSecretStoreEntries: () =>
+      actual.purgeExpiredSecretStoreEntries({ database: mocks.database }),
+  };
+});
+
+const { listSecretStoreEntries, readSecretStoreExecEnvironment } =
+  await import("../secrets/store/secret-store.js");
+
+const scope = { kind: "team" } as const;
+const roots: string[] = [];
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerSecretsCli(program);
+  return program;
+}
+
+function createStoreRoot(): string {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-store-kind-")));
+  roots.push(root);
+  mocks.database.path = path.join(root, "state.sqlite");
+  return root;
+}
+
+function writeValueFile(root: string, fileName: string, value: string): string {
+  const filePath = path.join(root, fileName);
+  fs.writeFileSync(filePath, value);
+  return filePath;
+}
+
+function entryFor(name: string) {
+  return listSecretStoreEntries({ scope, database: mocks.database }).find(
+    (entry) => entry.name === name,
+  );
+}
+
+async function protectEntry(name: string, valueFile: string, host: string): Promise<void> {
+  await createProgram().parseAsync(
+    [
+      "secrets",
+      "store",
+      "set",
+      name,
+      "--kind",
+      "secret",
+      "--value-file",
+      valueFile,
+      "--allow-host",
+      host,
+    ],
+    { from: "user" },
+  );
+}
+
+function exposureFor(name: string) {
+  const execEnvironment = readSecretStoreExecEnvironment({
+    includeSecretSentinels: true,
+    database: mocks.database,
+  });
+  return {
+    kind: entryFor(name)?.kind,
+    allowedHosts: entryFor(name)?.allowedHosts,
+    valuePreview: entryFor(name)?.valuePreview,
+    plaintextInSubprocessEnv: execEnvironment.env?.[name],
+    sealedSentinel: execEnvironment.secretSentinels?.[name] !== undefined,
+    egressBindings: execEnvironment.secretEgressBindings?.length ?? 0,
+  };
+}
+
+afterEach(() => {
+  mocks.interleave.run = undefined;
+  closeOpenClawStateDatabaseForTest();
+  mocks.runtimeLogs.length = 0;
+  mocks.runtimeErrors.length = 0;
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("secrets store kind inheritance", () => {
+  it("keeps a stored secret write-only and host-bound when only its value is rotated", async () => {
+    const root = createStoreRoot();
+    const original = writeValueFile(root, "original.txt", "sk-original-credential");
+    const rotated = writeValueFile(root, "rotated.txt", "sk-rotated-credential");
+
+    await createProgram().parseAsync(
+      [
+        "secrets",
+        "store",
+        "set",
+        "OPENAI_KEY",
+        "--kind",
+        "secret",
+        "--value-file",
+        original,
+        "--allow-host",
+        "api.openai.com",
+      ],
+      { from: "user" },
+    );
+    expect(entryFor("OPENAI_KEY")).toMatchObject({
+      kind: "secret",
+      allowedHosts: ["api.openai.com"],
+    });
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "OPENAI_KEY", "--value-file", rotated],
+      { from: "user" },
+    );
+
+    const execEnvironment = readSecretStoreExecEnvironment({
+      includeSecretSentinels: true,
+      database: mocks.database,
+    });
+    expect({
+      kind: entryFor("OPENAI_KEY")?.kind,
+      allowedHosts: entryFor("OPENAI_KEY")?.allowedHosts,
+      valuePreview: entryFor("OPENAI_KEY")?.valuePreview,
+      plaintextInSubprocessEnv: execEnvironment.env?.OPENAI_KEY,
+      sealedSentinel: execEnvironment.secretSentinels?.OPENAI_KEY !== undefined,
+      egressBindings: execEnvironment.secretEgressBindings?.length ?? 0,
+    }).toEqual({
+      kind: "secret",
+      allowedHosts: ["api.openai.com"],
+      valuePreview: undefined,
+      plaintextInSubprocessEnv: undefined,
+      sealedSentinel: true,
+      egressBindings: 1,
+    });
+  });
+
+  it("still downgrades a stored secret when --kind env is explicit", async () => {
+    const root = createStoreRoot();
+    const original = writeValueFile(root, "original.txt", "sk-original-credential");
+    const rotated = writeValueFile(root, "rotated.txt", "sk-rotated-credential");
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "OPENAI_KEY", "--kind", "secret", "--value-file", original],
+      { from: "user" },
+    );
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "OPENAI_KEY", "--kind", "env", "--value-file", rotated],
+      { from: "user" },
+    );
+
+    expect(entryFor("OPENAI_KEY")).toMatchObject({
+      kind: "env",
+      valuePreview: expect.any(String),
+    });
+  });
+
+  it("still classifies a brand-new entry from its name", async () => {
+    const root = createStoreRoot();
+    const credential = writeValueFile(root, "credential.txt", "sk-original-credential");
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--value-file", credential],
+      { from: "user" },
+    );
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_MODE", "--value", "production"],
+      { from: "user" },
+    );
+
+    expect(entryFor("SERVICE_API_KEY")?.kind).toBe("secret");
+    expect(entryFor("SERVICE_MODE")?.kind).toBe("env");
+  });
+
+  it("keeps import from downgrading an existing secret while classifying new names", async () => {
+    const root = createStoreRoot();
+    const original = writeValueFile(root, "original.txt", "sk-original-credential");
+    const dotenvPath = writeValueFile(
+      root,
+      "values.env",
+      "OPENAI_KEY=sk-rotated-credential\nSERVICE_MODE=production\n",
+    );
+
+    await createProgram().parseAsync(
+      [
+        "secrets",
+        "store",
+        "set",
+        "OPENAI_KEY",
+        "--kind",
+        "secret",
+        "--value-file",
+        original,
+        "--allow-host",
+        "api.openai.com",
+      ],
+      { from: "user" },
+    );
+    await createProgram().parseAsync(
+      ["secrets", "store", "import", "--from", dotenvPath, "--yes"],
+      { from: "user" },
+    );
+
+    expect(entryFor("OPENAI_KEY")).toMatchObject({
+      kind: "secret",
+      allowedHosts: ["api.openai.com"],
+    });
+    expect(entryFor("OPENAI_KEY")?.valuePreview).toBeUndefined();
+    expect(entryFor("SERVICE_MODE")?.kind).toBe("env");
+  });
+
+  it("applies a protection change made while set is waiting for its value", async () => {
+    const root = createStoreRoot();
+    const initial = writeValueFile(root, "initial.txt", "plain-original-value");
+    const protectedValue = writeValueFile(root, "protected.txt", "sk-protected-credential");
+    const rotated = writeValueFile(root, "rotated.txt", "sk-rotated-credential");
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--kind", "env", "--value-file", initial],
+      { from: "user" },
+    );
+    expect(entryFor("SERVICE_API_KEY")?.kind).toBe("env");
+
+    mocks.interleave.run = () => protectEntry("SERVICE_API_KEY", protectedValue, "api.example.com");
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--value-file", rotated],
+      { from: "user" },
+    );
+
+    expect(exposureFor("SERVICE_API_KEY")).toEqual({
+      kind: "secret",
+      allowedHosts: ["api.example.com"],
+      valuePreview: undefined,
+      plaintextInSubprocessEnv: undefined,
+      sealedSentinel: true,
+      egressBindings: 1,
+    });
+  });
+
+  it("applies a protection change made while import is waiting for confirmation", async () => {
+    const root = createStoreRoot();
+    const initial = writeValueFile(root, "initial.txt", "plain-original-value");
+    const protectedValue = writeValueFile(root, "protected.txt", "sk-protected-credential");
+    const dotenvPath = writeValueFile(
+      root,
+      "values.env",
+      "SERVICE_API_KEY=sk-rotated-credential\n",
+    );
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--kind", "env", "--value-file", initial],
+      { from: "user" },
+    );
+    expect(entryFor("SERVICE_API_KEY")?.kind).toBe("env");
+
+    const stdinIsTty = process.stdin.isTTY;
+    const stdoutIsTty = process.stdout.isTTY;
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+    mocks.interleave.run = () => protectEntry("SERVICE_API_KEY", protectedValue, "api.example.com");
+    try {
+      await createProgram().parseAsync(["secrets", "store", "import", "--from", dotenvPath], {
+        from: "user",
+      });
+    } finally {
+      process.stdin.isTTY = stdinIsTty;
+      process.stdout.isTTY = stdoutIsTty;
+    }
+
+    expect(exposureFor("SERVICE_API_KEY")).toEqual({
+      kind: "secret",
+      allowedHosts: ["api.example.com"],
+      valuePreview: undefined,
+      plaintextInSubprocessEnv: undefined,
+      sealedSentinel: true,
+      egressBindings: 1,
+    });
+  });
+
+  it("writes no import entry when a protection change during confirmation invalidates a later one", async () => {
+    const root = createStoreRoot();
+    const initial = writeValueFile(root, "initial.txt", "plain-original-value");
+    const protectedValue = writeValueFile(root, "protected.txt", "sk-protected-credential");
+    const dotenvPath = writeValueFile(
+      root,
+      "values.env",
+      "SERVICE_MODE=production-next\nSERVICE_API_KEY=\n",
+    );
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--kind", "env", "--value-file", initial],
+      { from: "user" },
+    );
+    expect(entryFor("SERVICE_API_KEY")?.kind).toBe("env");
+    expect(entryFor("SERVICE_MODE")).toBeUndefined();
+
+    const stdinIsTty = process.stdin.isTTY;
+    const stdoutIsTty = process.stdout.isTTY;
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+    mocks.interleave.run = () => protectEntry("SERVICE_API_KEY", protectedValue, "api.example.com");
+    try {
+      await expect(
+        createProgram().parseAsync(["secrets", "store", "import", "--from", dotenvPath], {
+          from: "user",
+        }),
+      ).rejects.toThrow("__exit__:2");
+    } finally {
+      process.stdin.isTTY = stdinIsTty;
+      process.stdout.isTTY = stdoutIsTty;
+    }
+
+    expect(mocks.runtimeErrors.join("\n")).toContain("Secret store value is empty");
+    expect(entryFor("SERVICE_MODE")).toBeUndefined();
+    expect(exposureFor("SERVICE_API_KEY")).toEqual({
+      kind: "secret",
+      allowedHosts: ["api.example.com"],
+      valuePreview: undefined,
+      plaintextInSubprocessEnv: undefined,
+      sealedSentinel: true,
+      egressBindings: 1,
+    });
+  });
+
+  it("still honours an explicit --kind when the entry changes while set waits", async () => {
+    const root = createStoreRoot();
+    const initial = writeValueFile(root, "initial.txt", "plain-original-value");
+    const protectedValue = writeValueFile(root, "protected.txt", "sk-protected-credential");
+    const rotated = writeValueFile(root, "rotated.txt", "plain-rotated-value");
+
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--kind", "env", "--value-file", initial],
+      { from: "user" },
+    );
+
+    mocks.interleave.run = () => protectEntry("SERVICE_API_KEY", protectedValue, "api.example.com");
+    await createProgram().parseAsync(
+      ["secrets", "store", "set", "SERVICE_API_KEY", "--kind", "env", "--value-file", rotated],
+      { from: "user" },
+    );
+
+    expect(entryFor("SERVICE_API_KEY")).toMatchObject({
+      kind: "env",
+      valuePreview: expect.any(String),
+    });
+    expect(entryFor("SERVICE_API_KEY")?.allowedHosts ?? []).toEqual([]);
+  });
+});

--- a/src/cli/secrets-store-cli.test.ts
+++ b/src/cli/secrets-store-cli.test.ts
@@ -12,6 +12,7 @@ const mocks = await vi.hoisted(async () => {
     list: vi.fn(),
     read: vi.fn(),
     write: vi.fn(),
+    writeBatch: vi.fn(),
     updateHosts: vi.fn(),
     remove: vi.fn(),
     purge: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock("../secrets/store/secret-store.js", async (importOriginal) => {
     listSecretStoreEntries: (params: unknown) => mocks.list(params),
     readSecretStoreValue: (params: unknown) => mocks.read(params),
     writeSecretStoreEntry: (params: unknown) => mocks.write(params),
+    writeSecretStoreEntries: (params: unknown) => mocks.writeBatch(params),
     updateSecretStoreAllowedHosts: (params: unknown) => mocks.updateHosts(params),
     deleteSecretStoreEntry: (params: unknown) => mocks.remove(params),
     purgeExpiredSecretStoreEntries: () => mocks.purge(),
@@ -66,6 +68,7 @@ beforeEach(() => {
   mocks.list.mockReset().mockReturnValue([]);
   mocks.read.mockReset();
   mocks.write.mockReset();
+  mocks.writeBatch.mockReset();
   mocks.updateHosts.mockReset();
   mocks.remove.mockReset();
   mocks.purge.mockReset();
@@ -199,6 +202,7 @@ describe("secrets store CLI", () => {
         ).rejects.toThrow("__exit__:2");
         expect(mocks.runtimeErrors.join("\n")).toContain("Secret store value is empty");
         expect(mocks.write).not.toHaveBeenCalled();
+        expect(mocks.writeBatch).not.toHaveBeenCalled();
       } finally {
         await fs.rm(root, { recursive: true, force: true });
       }
@@ -335,22 +339,24 @@ describe("secrets store CLI", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
 
-    expect(mocks.write).toHaveBeenCalledTimes(3);
-    expect(mocks.write.mock.calls[0]?.[0]).toMatchObject({
-      name: "SERVICE_URL",
-      value: "https://service.test/path with spaces",
-      kind: "env",
-    });
-    expect(mocks.write.mock.calls[1]?.[0]).toMatchObject({
-      name: "SERVICE_PRIVATE_KEY",
-      value: "-----BEGIN PRIVATE KEY-----\nmultiline-body\n-----END PRIVATE KEY-----",
-      kind: "secret",
-    });
-    expect(mocks.write.mock.calls[2]?.[0]).toMatchObject({
-      name: "SERVICE_EMPTY",
-      value: "",
-      kind: "env",
-    });
+    expect(mocks.writeBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.writeBatch.mock.calls[0]?.[0]?.entries).toEqual([
+      {
+        name: "SERVICE_URL",
+        value: "https://service.test/path with spaces",
+        kind: "env",
+      },
+      {
+        name: "SERVICE_PRIVATE_KEY",
+        value: "-----BEGIN PRIVATE KEY-----\nmultiline-body\n-----END PRIVATE KEY-----",
+        kind: "secret",
+      },
+      {
+        name: "SERVICE_EMPTY",
+        value: "",
+        kind: "env",
+      },
+    ]);
     const output = [...mocks.runtimeLogs, ...mocks.runtimeErrors].join("\n");
     expect(output).not.toContain("multiline-body");
   });

--- a/src/cli/secrets-store-cli.ts
+++ b/src/cli/secrets-store-cli.ts
@@ -209,10 +209,9 @@ export function registerSecretStoreCli(secrets: Command): void {
         const scope = teamScope(options.scope);
         const storeModule = await import("../secrets/store/secret-store.js");
         const requestedHosts = options.allowHost ?? [];
-        const hostPolicyRequested = requestedHosts.length > 0 || options.clearAllowedHosts === true;
-        const existingEntry = hostPolicyRequested
-          ? storeModule.listSecretStoreEntries({ scope }).find((entry) => entry.name === name)
-          : undefined;
+        const existingEntry = storeModule
+          .listSecretStoreEntries({ scope })
+          .find((entry) => entry.name === name);
         const kind = options.kind
           ? storeKind(options.kind, name)
           : (existingEntry?.kind ?? storeKind(undefined, name));
@@ -277,16 +276,17 @@ export function registerSecretStoreCli(secrets: Command): void {
           defaultRuntime.log(`Would ${kind === "secret" ? "write" : "set"} ${name} (${kind}).`);
           return;
         }
-        storeModule.writeSecretStoreEntry({
+        const storedKind = storeModule.writeSecretStoreEntry({
           scope,
           name,
           value,
           kind,
           ...(allowedHosts !== undefined ? { allowedHosts } : {}),
+          inheritExistingKind: options.kind === undefined,
           updatedBy: "cli",
         });
         storeModule.purgeExpiredSecretStoreEntries();
-        defaultRuntime.log(`Stored ${name} (${kind}).`);
+        defaultRuntime.log(`Stored ${name} (${storedKind}).`);
         await noteGatewayReload();
       }),
     );
@@ -391,11 +391,22 @@ export function registerSecretStoreCli(secrets: Command): void {
         if (entries.length === 0) {
           throw new SecretStoreCliFailure(2, "Import input contains no dotenv assignments.");
         }
+        const storeModule = await import("../secrets/store/secret-store.js");
+        const existingKinds = new Map(
+          storeModule
+            .listSecretStoreEntries({ scope })
+            .map((entry) => [entry.name, entry.kind] as const),
+        );
         const normalized = entries.map(([name, value]) => {
           assertStoreName(name);
-          return { name, value, kind: storeKind(options.kind, name) };
+          return {
+            name,
+            value,
+            kind: options.kind
+              ? storeKind(options.kind, name)
+              : (existingKinds.get(name) ?? storeKind(undefined, name)),
+          };
         });
-        const storeModule = await import("../secrets/store/secret-store.js");
         for (const entry of normalized) {
           storeModule.assertSecretStoreValue(entry.value, entry.kind);
         }
@@ -404,9 +415,12 @@ export function registerSecretStoreCli(secrets: Command): void {
           return;
         }
         await confirmMutation(`Import ${normalized.length} team store entries?`, options.yes);
-        for (const entry of normalized) {
-          storeModule.writeSecretStoreEntry({ scope, ...entry, updatedBy: "cli" });
-        }
+        storeModule.writeSecretStoreEntries({
+          scope,
+          entries: normalized,
+          inheritExistingKind: options.kind === undefined,
+          updatedBy: "cli",
+        });
         storeModule.purgeExpiredSecretStoreEntries();
         defaultRuntime.log(`Imported ${normalized.length} team store entries.`);
         await noteGatewayReload();

--- a/src/secrets/store/secret-store.ts
+++ b/src/secrets/store/secret-store.ts
@@ -53,6 +53,7 @@ export type SecretStoreWriteParams = {
   value: string;
   kind: SecretStoreKind;
   allowedHosts?: readonly string[];
+  inheritExistingKind?: boolean;
   updatedBy: string | null;
   database?: OpenClawStateDatabaseOptions;
 };
@@ -133,6 +134,20 @@ export function assertSecretStoreValue(value: string, kind: SecretStoreKind): vo
     throw new SecretStoreValidationError(
       "SECRET_STORE_VALUE_EMPTY",
       "Secret store value is empty. Secret entries require a value; check the command that produced it.",
+    );
+  }
+}
+
+function assertSecretStoreWriteShape(
+  value: string,
+  kind: SecretStoreKind,
+  allowedHosts: readonly string[] | undefined,
+): void {
+  assertSecretStoreValue(value, kind);
+  if (kind === "env" && allowedHosts !== undefined) {
+    throw new SecretStoreValidationError(
+      "SECRET_STORE_INVALID_ALLOWED_HOST",
+      "Allowed hosts apply only to secret entries.",
     );
   }
 }
@@ -401,89 +416,154 @@ export function readSecretStoreValue(params: {
   }
 }
 
-function writeSecretStoreEntryInternal(
-  params: SecretStoreWriteParams,
+export type SecretStoreWriteEntry = {
+  name: string;
+  value: string;
+  kind: SecretStoreKind;
+  allowedHosts?: readonly string[];
+};
+
+export type SecretStoreBatchWriteParams = {
+  scope: SecretStoreScope;
+  entries: readonly SecretStoreWriteEntry[];
+  inheritExistingKind?: boolean;
+  updatedBy: string | null;
+  database?: OpenClawStateDatabaseOptions;
+};
+
+type SecretStoreWriteResult = {
+  kind: SecretStoreKind;
+  previous: SecretStoreWriteSnapshot | undefined;
+};
+
+function writeSecretStoreEntriesInternal(
+  params: SecretStoreBatchWriteParams,
   capturePrevious: boolean,
-): SecretStoreWriteSnapshot | undefined {
-  assertSecretStoreMutationName(params.name);
-  assertSecretStoreValue(params.value, params.kind);
-  if (params.kind === "env" && params.allowedHosts !== undefined) {
-    throw new SecretStoreValidationError(
-      "SECRET_STORE_INVALID_ALLOWED_HOST",
-      "Allowed hosts apply only to secret entries.",
-    );
+): SecretStoreWriteResult[] {
+  const inheritExistingKind = params.inheritExistingKind === true;
+  for (const entry of params.entries) {
+    assertSecretStoreMutationName(entry.name);
+    if (!inheritExistingKind) {
+      assertSecretStoreWriteShape(entry.value, entry.kind, entry.allowedHosts);
+    }
   }
-  const allowedHosts =
-    params.kind === "secret" && params.allowedHosts !== undefined
-      ? normalizeSecretAllowedHosts(params.allowedHosts)
-      : undefined;
-  const allowedHostsJson = allowedHosts?.length ? JSON.stringify(allowedHosts) : null;
   const { scopeKind, scopeId } = normalizeScope(params.scope);
   const now = Date.now();
   return runOpenClawStateWriteTransaction(
     ({ db: sqlite }) => {
       ensureSecretStoreSchema(sqlite);
       const db = getNodeSqliteKysely<SecretStoreDatabase>(sqlite);
-      const previous = capturePrevious
-        ? executeSqliteQueryTakeFirstSync(
-            sqlite,
-            db
-              .selectFrom("secret_store_entries")
-              .select(["value", "kind", "allowed_hosts", "updated_by"])
-              .where("scope_kind", "=", scopeKind)
-              .where("scope_id", "=", scopeId)
-              .where("name", "=", params.name)
-              .where("deleted_at_ms", "is", null),
-          )
-        : undefined;
-      executeSqliteQuerySync(
-        sqlite,
-        db
-          .insertInto("secret_store_entries")
-          .values({
-            scope_kind: scopeKind,
-            scope_id: scopeId,
-            name: params.name,
-            value: params.value,
-            kind: params.kind,
-            created_at_ms: now,
-            updated_at_ms: now,
-            updated_by: params.updatedBy,
-            deleted_at_ms: null,
-            allowed_hosts: allowedHostsJson,
-          })
-          .onConflict((conflict) =>
-            conflict.columns(["scope_kind", "scope_id", "name"]).doUpdateSet({
-              value: params.value,
-              kind: params.kind,
+      const resolved = params.entries.map((entry) => {
+        const previous =
+          capturePrevious || inheritExistingKind
+            ? executeSqliteQueryTakeFirstSync(
+                sqlite,
+                db
+                  .selectFrom("secret_store_entries")
+                  .select(["value", "kind", "allowed_hosts", "updated_by"])
+                  .where("scope_kind", "=", scopeKind)
+                  .where("scope_id", "=", scopeId)
+                  .where("name", "=", entry.name)
+                  .where("deleted_at_ms", "is", null),
+              )
+            : undefined;
+        const kind =
+          inheritExistingKind && previous ? (previous.kind as SecretStoreKind) : entry.kind;
+        if (inheritExistingKind) {
+          assertSecretStoreWriteShape(entry.value, kind, entry.allowedHosts);
+        }
+        const allowedHosts =
+          kind === "secret" && entry.allowedHosts !== undefined
+            ? normalizeSecretAllowedHosts(entry.allowedHosts)
+            : undefined;
+        return { entry, previous, kind, allowedHosts };
+      });
+      for (const { entry, kind, allowedHosts } of resolved) {
+        const allowedHostsJson = allowedHosts?.length ? JSON.stringify(allowedHosts) : null;
+        executeSqliteQuerySync(
+          sqlite,
+          db
+            .insertInto("secret_store_entries")
+            .values({
+              scope_kind: scopeKind,
+              scope_id: scopeId,
+              name: entry.name,
+              value: entry.value,
+              kind,
+              created_at_ms: now,
               updated_at_ms: now,
               updated_by: params.updatedBy,
               deleted_at_ms: null,
-              ...(params.kind === "env"
-                ? { allowed_hosts: null }
-                : allowedHosts !== undefined
-                  ? { allowed_hosts: allowedHostsJson }
-                  : {}),
-            }),
-          ),
-      );
-      return previous
-        ? {
-            value: previous.value,
-            // SAFETY: The canonical secret_store schema and write validation restrict kind to secret|env.
-            kind: previous.kind as SecretStoreKind,
-            allowedHosts: previous.allowed_hosts,
-            updatedBy: previous.updated_by,
-          }
-        : undefined;
+              allowed_hosts: allowedHostsJson,
+            })
+            .onConflict((conflict) =>
+              conflict.columns(["scope_kind", "scope_id", "name"]).doUpdateSet({
+                value: entry.value,
+                kind,
+                updated_at_ms: now,
+                updated_by: params.updatedBy,
+                deleted_at_ms: null,
+                ...(kind === "env"
+                  ? { allowed_hosts: null }
+                  : allowedHosts !== undefined
+                    ? { allowed_hosts: allowedHostsJson }
+                    : {}),
+              }),
+            ),
+        );
+      }
+      return resolved.map(({ previous, kind }) => ({
+        kind,
+        previous:
+          capturePrevious && previous
+            ? {
+                value: previous.value,
+                // SAFETY: The canonical secret_store schema and write validation restrict kind to secret|env.
+                kind: previous.kind as SecretStoreKind,
+                allowedHosts: previous.allowed_hosts,
+                updatedBy: previous.updated_by,
+              }
+            : undefined,
+      }));
     },
     params.database,
     { operationLabel: "secrets.store.write" },
   );
 }
 
-export function writeSecretStoreEntry(params: SecretStoreWriteParams): void {
-  writeSecretStoreEntryInternal(params, false);
+function writeSecretStoreEntryInternal(
+  params: SecretStoreWriteParams,
+  capturePrevious: boolean,
+): SecretStoreWriteResult {
+  const [result] = writeSecretStoreEntriesInternal(
+    {
+      scope: params.scope,
+      entries: [
+        {
+          name: params.name,
+          value: params.value,
+          kind: params.kind,
+          allowedHosts: params.allowedHosts,
+        },
+      ],
+      inheritExistingKind: params.inheritExistingKind,
+      updatedBy: params.updatedBy,
+      database: params.database,
+    },
+    capturePrevious,
+  );
+  if (!result) {
+    throw new Error("Secret store write returned no entry result.");
+  }
+  return result;
+}
+
+export function writeSecretStoreEntry(params: SecretStoreWriteParams): SecretStoreKind {
+  return writeSecretStoreEntryInternal(params, false).kind;
+}
+
+export function writeSecretStoreEntries(params: SecretStoreBatchWriteParams): SecretStoreKind[] {
+  return writeSecretStoreEntriesInternal(params, false).map((result) => result.kind);
 }
 
 function rollbackSecretStoreEntryWrite(params: {
@@ -544,7 +624,7 @@ export function writeSecretStoreEntryWithRollback(params: SecretStoreWriteParams
   rollback: () => boolean;
 } {
   const writer = `${params.updatedBy ?? "secret-store"}:${randomUUID()}`;
-  const previous = writeSecretStoreEntryInternal({ ...params, updatedBy: writer }, true);
+  const { previous } = writeSecretStoreEntryInternal({ ...params, updatedBy: writer }, true);
   let rollbackResult: boolean | undefined;
   return {
     rollback: () => {


### PR DESCRIPTION
## Summary

`openclaw secrets store set <NAME> --value-file <path>` silently converts a write-only `secret` entry into a readable `env` entry when only the value is rotated.

The trigger is the ordinary credential-rotation path: an entry that was explicitly created with `--kind secret` under a name the automatic suffix heuristic does not classify as sensitive (`OPENAI_KEY`, `ANTHROPIC_ADMIN_KEY`, `GH_PAT`, `AWS_ACCESS_KEY_ID`), rotated with no `--kind` and no `--allow-host` / `--clear-allowed-hosts`.

After the rotation the entry is no longer write-only. `openclaw secrets store list` prints a preview of the rotated credential, `openclaw secrets store get` returns it instead of refusing, every agent subprocess receives it as plaintext in its environment rather than a sealed sentinel, and the `--allow-host` egress destination allowlist that bound the secret is deleted. Nothing warns the operator; `set` reports `Stored OPENAI_KEY (env).` and exits 0.

`openclaw secrets store import` has the same root cause and reclassifies every existing entry it rewrites.

## Root cause

`src/cli/secrets-store-cli.ts` looks the existing entry up only when a host-policy flag was passed, so the resolved kind falls back to the name heuristic on a plain value rotation:

```ts
// before
const requestedHosts = options.allowHost ?? [];
const hostPolicyRequested = requestedHosts.length > 0 || options.clearAllowedHosts === true;
const existingEntry = hostPolicyRequested
  ? storeModule.listSecretStoreEntries({ scope }).find((entry) => entry.name === name)
  : undefined;
const kind = options.kind
  ? storeKind(options.kind, name)
  : (existingEntry?.kind ?? storeKind(undefined, name));
```

With no host flags `existingEntry` is `undefined`, so `storeKind(undefined, name)` applies `isSensitiveEnvName` (`src/secrets/secret-env-name.ts`, `/_?(API_KEY|TOKEN|PASSWORD|PRIVATE_KEY|SECRET)$/i`). `OPENAI_KEY` does not match, so the operator's explicit `--kind secret` is replaced by `"env"`. `import` never looks an existing entry up at all.

The upsert in `writeSecretStoreEntryInternal` then rewrites the stored kind and, for `env`, nulls the host allowlist. Every consumer branches on the stored `row.kind`, so one wrong resolution breaks four boundaries at once: `readSecretStoreExecEnvironment` hands `env` rows to agent subprocesses as plaintext instead of sealing a sentinel and registering an egress binding, `store get` drops its write-only refusal, `renderList` prints `valuePreview`, and the refusal of `--value` on argv stops applying.

The conditional lookup shows the intent was already to inherit the stored kind; it was scoped to the host-policy branch by accident.

## Fix

Both CLI paths now inherit the stored kind, and that inheritance is resolved inside the authoritative store write transaction rather than captured in the CLI before it awaits input.

`SecretStoreWriteParams` gains an optional `inheritExistingKind`. When set, the store reads the live row inside the transaction it already opens, resolves the kind from that row, and drives value validation, the allowed-host refusal, and the `allowed_hosts` clearing from the resolved kind rather than the requested one:

```ts
// after
const kind =
  inheritExistingKind && previous ? (previous.kind as SecretStoreKind) : entry.kind;
if (inheritExistingKind) {
  assertSecretStoreWriteShape(entry.value, kind, entry.allowedHosts);
}
```

`set` and `import` pass `inheritExistingKind: options.kind === undefined`, and `writeSecretStoreEntry` returns the kind it committed so `set` reports what actually landed.

This is correct because the name heuristic is a classifier for names that have never been seen before. Once an entry exists, its stored kind is a recorded operator choice and outranks a guess made from the name. An explicit `--kind` still wins over both, in either direction, so the operator keeps full control.

Resolving at the write boundary rather than at the start of the command closes the replay window. `set` awaits `readSecretStoreInput` and `import` awaits `confirmMutation`, and both waits are human-scale. A kind captured before those waits could be replayed over a protection change committed during them, which would downgrade a freshly protected entry and delete the host allowlist the operator had just attached. Because the resolution now happens inside the same transaction as the insert, no store state can change between reading the kind and writing the row.

### Import writes its batch under one transaction

Resolving the kind at write time means a value the CLI already accepted can become invalid by the time it is written: an empty value is legal for an `env` entry and refused for a `secret` one, so an entry that a concurrent protection change turns into a secret must fail. `import` previously wrote one entry per transaction, so that failure could arrive after earlier entries of the same batch had already committed, which breaks the no-write-on-validation-failure contract the existing empty-secret refusal in `src/cli/secrets-store-cli.test.ts` relies on.

`import` now hands its whole batch to the store as one call. `writeSecretStoreEntries` resolves every live kind and validates every resulting entry before it writes any of them, inside the single `runOpenClawStateWriteTransaction` it already opened:

```ts
const resolved = params.entries.map((entry) => {
  /* live row lookup, kind resolution and assertSecretStoreWriteShape */
});
for (const { entry, kind, allowedHosts } of resolved) {
  /* upsert */
}
```

`writeSecretStoreEntry` is now a single-entry call into the same code, so the two paths cannot drift, and `writeSecretStoreEntryWithRollback` keeps its previous-value snapshot unchanged.

## Why this is the right boundary

The CLI is the only kind resolver in the codebase. The other writer of the store, the Gateway RPC `secrets.store.set`, takes `kind` as a required field of `SecretsStoreSetParamsSchema` and passes it straight through, so it never infers a kind. It does not set `inheritExistingKind`, so its behavior is unchanged and `writeSecretStoreEntry` still receives a kind its caller decided.

I considered instead refusing any `secret -> env` transition inside the store. That is wrong: an explicit `--kind env` downgrade is a legitimate operator action, and the store cannot tell an explicit downgrade from an inferred one without being told. `inheritExistingKind` is exactly that missing signal, and it keeps the policy choice with the CLI while giving the store the atomicity only the store can provide. The same reasoning puts the batch in the store rather than in the CLI: only the store owns the transaction, and a CLI-side pre-check would just recreate the window it is meant to close.

`import` is fixed in the same commit rather than left as a one-sided fix; it shares the root cause and reclassifies every existing entry it rewrites. `docs/cli/secrets.md` states that automatic detection applies to new names, that an existing entry keeps its kind, and that the inherited kind is resolved as the write commits.

## Verification

- `src/cli/secrets-store-cli.kind-inheritance.test.ts` drives the real commander program through `registerSecretsCli` against a real SQLite store in a temp directory. Eight cases pass: value-only rotation keeps a secret write-only and host-bound; an explicit `--kind env` still downgrades; a brand-new name is still classified from its name; `import` keeps an existing secret while classifying new names; a protection change made while `set` waits for its value is applied; the same while `import` waits for confirmation; a protection change that invalidates a later entry of an import batch leaves every entry of that batch unwritten; and an explicit `--kind` is still honored across that interleaving.
- The three interleaving cases fail on earlier heads of this PR and pass here, so they are regressions against the exact defects reported rather than restatements of the fix. Reverting only the batch call site to the previous per-entry loop fails the new case with `expected { name: 'SERVICE_MODE', ... } to be undefined`.
- `src/secrets/store/secret-store.test.ts` passes against the changed store, covering the existing empty-secret refusal, the allowed-host validation, the exec projection, and the hidden GitHub record paths.
- `src/cli/secrets-store-cli.test.ts` passes 15 of 15. Its import assertion now reads the single batch call instead of three separate writes, and its empty-secret refusal additionally asserts that the batch write was never reached.
- No existing assertion depended on the old fallback, so nothing had to be relaxed or rewritten.
- `tsgo` and `oxlint` were not run on this host: this box cannot hold them without exhausting memory. Only the repository formatter and the two targeted suites above were run here, so a type error confined to new code would first surface in the repository's automated checks rather than locally.
- Values used throughout are synthetic (`sk-protected-credential`, `sk-rotated-credential`, `plain-original-value`, `production-next`).

## Real behavior proof

Behavior addressed: a value-only `openclaw secrets store set` downgraded a write-only `secret` entry to a readable `env` entry, handed the credential to agent subprocesses as plaintext, and deleted its `--allow-host` egress allowlist. Inheriting the kind at write time then introduced a second failure, reported as the remaining review finding: `openclaw secrets store import` could commit an earlier entry of its batch and then fail on a later one whose kind had just been changed by another process.
Real environment tested: the real `openclaw secrets store` command line entry point (`src/entry.ts`) run as separate processes against a real SQLite secret store in a scratch `OPENCLAW_STATE_DIR`, plus a real child process spawned from the environment `readSecretStoreExecEnvironment` resolves, which is the same projection `createExecTool` gives agent commands in `src/agents/bash-tools.exec-run.ts`. The interfering process is a second real `openclaw secrets store set` run while the first command holds its confirmation prompt on a pseudo terminal. Captured on pristine main `d23730ee7c54975df5f50294dca34a06592b3590`, on the previous head of this PR `13c7014552c3e43dd8f76a235c1aee6264e8c8d2`, and on this head `66a8c01c8db76bf63ab79c506880f462856b2d1e`, with identical inputs and identical scripted timing. Only the credential values are synthetic.
Exact steps or command run after this patch: scenario A creates `OPENAI_KEY` with `--kind secret --allow-host api.openai.com`, rotates it with `openclaw secrets store set OPENAI_KEY --value-file <rotated>`, then spawns a real child from the resolved agent environment. Scenario B creates `SERVICE_API_KEY` as `--kind env`, starts `openclaw secrets store import --from values.env` where `values.env` holds `SERVICE_MODE=production-next` and an empty `SERVICE_API_KEY=`, leaves it waiting at its confirmation prompt for 12 seconds, protects `SERVICE_API_KEY` from a second process with `--kind secret --allow-host api.example.com` during that wait, answers the prompt, and then lists the store. Scenario C imports the same file with `--yes` and no interference. Each listing prints name, kind, allowed hosts and whether the value is withheld.
Evidence after fix:
```
######## pristine main d23730ee7c54
### tree: base (d23730ee7c54975df5f50294dca34a06592b3590)
--- A. protect OPENAI_KEY, then rotate only its value
Stored OPENAI_KEY (secret).
  after create:
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
Stored OPENAI_KEY (env).
  after value-only rotation:
   OPENAI_KEY kind=env allowedHosts=[] valuePreview="sk-rotated-credential"
  what a real child process receives:
   child process sees OPENAI_KEY: PLAINTEXT sk-rotated-credential
   sealed sentinel offered: false
   egress bindings: []
--- B. import while a second process protects one of its names
Stored SERVICE_API_KEY (env).
  before import:
   SERVICE_API_KEY kind=env allowedHosts=[] valuePreview="plain-original-value"
  second process protects SERVICE_API_KEY while the import prompt is pending:
   Stored SERVICE_API_KEY (secret).
  store while the prompt is still pending:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)
  import command exit code: 2
  import command output: Secret store value is empty. Secret entries require a value; check the command that produced it.
  store after the import command returned:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)

######## previous head of this PR 13c7014552c3
### tree: prev (13c7014552c3e43dd8f76a235c1aee6264e8c8d2)
--- A. protect OPENAI_KEY, then rotate only its value
Stored OPENAI_KEY (secret).
  after create:
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
Stored OPENAI_KEY (secret).
  after value-only rotation:
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
  what a real child process receives:
   child process sees OPENAI_KEY: absent
   sealed sentinel offered: true
   egress bindings: [{"name":"OPENAI_KEY","allowedHosts":["api.openai.com"]}]
--- B. import while a second process protects one of its names
Stored SERVICE_API_KEY (env).
  before import:
   SERVICE_API_KEY kind=env allowedHosts=[] valuePreview="plain-original-value"
  second process protects SERVICE_API_KEY while the import prompt is pending:
   Stored SERVICE_API_KEY (secret).
  store while the prompt is still pending:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)
  import command exit code: 2
  import command output: Secret store value is empty. Secret entries require a value; check the command that produced it.
  store after the import command returned:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)
   SERVICE_MODE kind=env allowedHosts=[] valuePreview="production-next"

######## this head 66a8c01c8db76bf63ab79c506880f462856b2d1e
### tree: new (66a8c01c8db76bf63ab79c506880f462856b2d1e)
--- A. protect OPENAI_KEY, then rotate only its value
Stored OPENAI_KEY (secret).
  after create:
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
Stored OPENAI_KEY (secret).
  after value-only rotation:
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
  what a real child process receives:
   child process sees OPENAI_KEY: absent
   sealed sentinel offered: true
   egress bindings: [{"name":"OPENAI_KEY","allowedHosts":["api.openai.com"]}]
--- B. import while a second process protects one of its names
Stored SERVICE_API_KEY (env).
  before import:
   SERVICE_API_KEY kind=env allowedHosts=[] valuePreview="plain-original-value"
  second process protects SERVICE_API_KEY while the import prompt is pending:
   Stored SERVICE_API_KEY (secret).
  store while the prompt is still pending:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)
  import command exit code: 2
  import command output: Secret store value is empty. Secret entries require a value; check the command that produced it.
  store after the import command returned:
   SERVICE_API_KEY kind=secret allowedHosts=["api.example.com"] valuePreview=(withheld)

######## this head 66a8c01c8db76bf63ab79c506880f462856b2d1e, scenario C: the same import with no interference
Stored OPENAI_KEY (secret).
Imported 2 team store entries.
   OPENAI_KEY kind=secret allowedHosts=["api.openai.com"] valuePreview=(withheld)
   SERVICE_MODE kind=env allowedHosts=[] valuePreview="production-next"
```
Observed result after fix: in scenario A the rotated entry stays `secret` on this head instead of flipping to `env`, keeps its `api.openai.com` egress binding instead of losing it, withholds the value from the listing, and hands the spawned child nothing rather than `sk-rotated-credential`. In scenario B all three runs exit 2 with the same message, but the store afterwards differs: pristine main and this head contain only the protected `SERVICE_API_KEY`, while the previous head of this PR also contains `SERVICE_MODE=production-next`, a durable write from a command that failed. This head restores the all-or-nothing behavior pristine main had, now with the kind resolved from the live row. Scenario C shows the batch still writes every entry of an uninterfered import, so the repair did not trade partial writes for no writes.
What was not tested: only the `team` scope was exercised, because it is the only scope the command line accepts today. The egress proxy was not driven end to end against a live upstream host, so the proof shows the restored binding and its allowed hosts rather than an intercepted outbound request. The Gateway RPC path was read but not driven, since it carries an explicit kind and does not request inheritance.
