### PR TITLE
fix(cron): arm the scheduler when startup catch-up fails

### DIFF
--- a/src/cron/service/ops-lifecycle.start-arm.test.ts
+++ b/src/cron/service/ops-lifecycle.start-arm.test.ts
@@ -1,0 +1,106 @@
+import { expect, it, vi } from "vitest";
+import {
+  createCronRegressionState,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { saveCronStore } from "../store.js";
+import type { CronJob } from "../types.js";
+import { start } from "./ops-lifecycle.js";
+import { onTimer } from "./timer.test-support.js";
+
+const fixtures = setupCronRegressionFixtures({ prefix: "cron-start-arm-" });
+
+function createDueMainJob(id: string, nowMs: number, nextRunAtMs: number): CronJob {
+  return {
+    id,
+    name: id,
+    enabled: true,
+    deleteAfterRun: false,
+    createdAtMs: nowMs,
+    updatedAtMs: nowMs,
+    schedule: { kind: "at", at: new Date(nextRunAtMs).toISOString() },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: id },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs },
+  };
+}
+
+function installOneShotTerminalWriteFailure(jobId: string) {
+  const database = openOpenClawStateDatabase().db;
+  let rejected = false;
+  database.function("reject_start_arm_terminal", (id: unknown, stateJson: unknown) => {
+    if (id === jobId && typeof stateJson === "string") {
+      const persisted = JSON.parse(stateJson) as CronJob["state"];
+      if (!rejected && persisted.lastRunStatus !== undefined) {
+        rejected = true;
+        throw new Error("startup terminal write failed");
+      }
+    }
+    return 0;
+  });
+  database.exec(`
+    CREATE TEMP TRIGGER reject_start_arm_terminal
+    AFTER UPDATE ON cron_jobs
+    BEGIN
+      SELECT reject_start_arm_terminal(NEW.job_id, NEW.state_json);
+    END;
+  `);
+  return () => database.exec("DROP TRIGGER IF EXISTS reject_start_arm_terminal");
+}
+
+function createStartArmState(storePath: string, nowMs: number) {
+  return createCronRegressionState({
+    storePath,
+    nowMs: () => nowMs,
+    enqueueSystemEvent: vi.fn(() => true),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    maxMissedJobsPerRestart: 40,
+  });
+}
+
+it("arms the scheduler and still rejects when startup catch-up fails", async () => {
+  const store = fixtures.makeStorePath();
+  const dueAt = Date.parse("2026-02-06T10:04:59.000Z");
+  const first = createDueMainJob("start-arm-first", dueAt, dueAt);
+  const second = createDueMainJob("start-arm-second", dueAt, dueAt);
+  await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+  const state = createStartArmState(store.storePath, dueAt + 1_000);
+  const dropTrigger = installOneShotTerminalWriteFailure(first.id);
+  try {
+    await expect(start(state)).rejects.toThrow("startup terminal write failed");
+    expect(state.timer).not.toBeNull();
+    expect(state.stopped).toBe(false);
+    expect(state.schedulingPaused).toBe(false);
+    expect(state.startupCatchup).toBeUndefined();
+  } finally {
+    dropTrigger();
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  }
+});
+
+it("re-arms on the sibling timer tick after the same catch-up failure", async () => {
+  const store = fixtures.makeStorePath();
+  const dueAt = Date.parse("2026-02-06T10:04:59.000Z");
+  const first = createDueMainJob("tick-arm-first", dueAt, dueAt);
+  const second = createDueMainJob("tick-arm-second", dueAt, dueAt);
+  await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+  const state = createStartArmState(store.storePath, dueAt + 1_000);
+  const dropTrigger = installOneShotTerminalWriteFailure(first.id);
+  try {
+    await onTimer(state).catch(() => undefined);
+    expect(state.timer).not.toBeNull();
+  } finally {
+    dropTrigger();
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  }
+});

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -184,32 +184,56 @@ export async function start(state: CronServiceState): Promise<void> {
   for (const interrupted of interruptedRuns) {
     emitInterruptedRun(state, interrupted);
   }
-  await runMissedJobs(state, {
-    skipJobIds: skipJobIds.size > 0 ? skipJobIds : undefined,
-    deferAgentTurnJobs: true,
-  });
+  let catchupFailure: { err: unknown } | undefined;
+  try {
+    await runMissedJobs(state, {
+      skipJobIds: skipJobIds.size > 0 ? skipJobIds : undefined,
+      deferAgentTurnJobs: true,
+    });
+  } catch (err) {
+    catchupFailure = { err };
+  }
 
-  await locked(state, async () => {
-    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
-    if (state.stopped) {
-      return;
-    }
-    if (listForeignReceipts(state).length === 0) {
-      const maintenance = recomputeUnownedCronSchedules(state, { recomputeExpired: true });
-      runPostPersistCronNotifications(state, maintenance.notifications);
-      applyCronRuntimeRowsToState(state, maintenance.jobs);
-    }
-    armTimer(state);
-    resumeForeignReceiptMonitor(state);
-    state.deps.log.info(
-      {
+  try {
+    await locked(state, async () => {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      if (state.stopped) {
+        return;
+      }
+      if (listForeignReceipts(state).length === 0) {
+        const maintenance = recomputeUnownedCronSchedules(state, { recomputeExpired: true });
+        runPostPersistCronNotifications(state, maintenance.notifications);
+        applyCronRuntimeRowsToState(state, maintenance.jobs);
+      }
+      armTimer(state);
+      resumeForeignReceiptMonitor(state);
+      const startupDetails = {
         enabled: true,
         jobs: state.store?.jobs.length ?? 0,
         nextWakeAtMs: nextWakeAtMs(state) ?? null,
-      },
-      "cron: started",
+      };
+      if (catchupFailure) {
+        state.deps.log.warn(
+          { ...startupDetails, err: String(catchupFailure.err) },
+          "cron: armed the scheduler after startup catch-up failed",
+        );
+        return;
+      }
+      state.deps.log.info(startupDetails, "cron: started");
+    });
+  } catch (err) {
+    if (!catchupFailure) {
+      throw err;
+    }
+    state.deps.log.warn(
+      { err: String(err) },
+      "cron: failed to arm the scheduler after startup catch-up failed",
     );
-  });
+  }
+
+  if (catchupFailure) {
+    throw catchupFailure.err;
+  }
 }
 
 /** Stops the cron service timer without mutating persisted job state. */


### PR DESCRIPTION
## Summary
One transient store failure during restart catch-up permanently disables the cron scheduler for the life of the Gateway process.

`CronService.start()` runs startup catch-up before it arms the scheduling timer. `runMissedJobs` deliberately rejects when a startup outcome's terminal store write fails (a locked or failing SQLite write, a disk error, a finalization error). That rejection escapes `start()` before `armTimer` is ever reached, so `state.timer` stays `null` while `state.stopped` and `state.schedulingPaused` are both `false`. The Gateway catches the rejection, logs `cron: failed to start: ...` and does not retry, and it also skips `reconcileExitWatchers` / `reconcileStreamWatchers`. The Gateway then comes up looking healthy while no scheduled job ever fires again. `cron list` and `cron status` still show the jobs and their next run times. Only a cron mutation that happens to call `armTimer` (add, update, enable, a manual run) or a full Gateway restart brings scheduling back.

Reachability on main: Gateway boot -> `src/gateway/server-runtime-services.ts:68` `params.cronState.cron.start()` -> `src/gateway/server-cron-lazy.ts:162` -> `src/cron/service.ts:68` `lifecycleOps.start(this.state)` -> `src/cron/service/ops-lifecycle.ts:187`.

The sibling scheduled-tick path already guarantees the opposite: `onAdmittedTimer` in `src/cron/service/timer-scheduler.ts:589` re-arms inside a `finally`, so a tick that throws still leaves the scheduler armed. `resumeScheduling` cannot heal the startup case either, because it early-returns on `!state.schedulerStarted` (`src/cron/service/ops-lifecycle.ts:238`).

Related prior attempt: #68112 described the same root cause and was closed by ClawSweeper as stalled without real behavior proof. That patch was much wider (86 changed lines in the old `ops.ts` plus 78 in `timer.ts`, including an unrelated zombie-marker detector). This one is confined to the arm boundary and carries the proof.

## Root cause
`src/cron/service/ops-lifecycle.ts:187-212` (before):

```ts before
  await runMissedJobs(state, {
    skipJobIds: skipJobIds.size > 0 ? skipJobIds : undefined,
    deferAgentTurnJobs: true,
  });

  await locked(state, async () => {
    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
    if (state.stopped) {
      return;
    }
    if (listForeignReceipts(state).length === 0) {
      const maintenance = recomputeUnownedCronSchedules(state, { recomputeExpired: true });
      runPostPersistCronNotifications(state, maintenance.notifications);
      applyCronRuntimeRowsToState(state, maintenance.jobs);
    }
    armTimer(state);
    resumeForeignReceiptMonitor(state);
    state.deps.log.info(
      {
        enabled: true,
        jobs: state.store?.jobs.length ?? 0,
        nextWakeAtMs: nextWakeAtMs(state) ?? null,
      },
      "cron: started",
    );
  });
```

`runMissedJobs` throws from `src/cron/service/timer-catchup.ts:290` and `:296` when a startup outcome cannot be finalized; the maintainers' own `src/cron/service/timer.batch-finalization.test.ts:815` pins that reject contract. Because the call is unfenced, the entire recompute plus `armTimer` plus `resumeForeignReceiptMonitor` block is skipped. Startup catch-up already cleared `state.startupCatchup` in its own `finally`, so nothing else is holding the timer down: the scheduler is simply never armed.

## Fix
`src/cron/service/ops-lifecycle.ts` (after):

```ts after
  let catchupFailure: { err: unknown } | undefined;
  try {
    await runMissedJobs(state, {
      skipJobIds: skipJobIds.size > 0 ? skipJobIds : undefined,
      deferAgentTurnJobs: true,
    });
  } catch (err) {
    catchupFailure = { err };
  }

  try {
    await locked(state, async () => {
      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
      if (state.stopped) {
        return;
      }
      if (listForeignReceipts(state).length === 0) {
        const maintenance = recomputeUnownedCronSchedules(state, { recomputeExpired: true });
        runPostPersistCronNotifications(state, maintenance.notifications);
        applyCronRuntimeRowsToState(state, maintenance.jobs);
      }
      armTimer(state);
      resumeForeignReceiptMonitor(state);
      const startupDetails = {
        enabled: true,
        jobs: state.store?.jobs.length ?? 0,
        nextWakeAtMs: nextWakeAtMs(state) ?? null,
      };
      if (catchupFailure) {
        state.deps.log.warn(
          { ...startupDetails, err: String(catchupFailure.err) },
          "cron: armed the scheduler after startup catch-up failed",
        );
        return;
      }
      state.deps.log.info(startupDetails, "cron: started");
    });
  } catch (err) {
    if (!catchupFailure) {
      throw err;
    }
    state.deps.log.warn(
      { err: String(err) },
      "cron: failed to arm the scheduler after startup catch-up failed",
    );
  }

  if (catchupFailure) {
    throw catchupFailure.err;
  }
```

A failed catch-up is held, the existing arm block runs unchanged, and the original catch-up error is then rethrown so the caller still sees the failure. The arm block keeps its own `state.stopped` guard, and `armTimer` independently refuses to arm when `state.stopped`, `state.schedulingPaused`, or `state.startupCatchup` is set, so a start that was superseded by `stop()` still arms nothing. A secondary arm failure is logged and never masks the catch-up error, and the success path keeps propagating an arm error as before. The startup log line is downgraded to a warning when the arm happened after a failed catch-up, so `cron: started` never claims a clean start.

## Why this is the right boundary
- `start()` in `ops-lifecycle.ts` is the owner of "the scheduler is armed after startup". `runMissedJobs` owns catch-up execution and its reject contract, and it is unchanged: it still releases reservations, still preserves overflow wake times, and still throws. Fixing this inside `timer-catchup.ts` would mean swallowing a real store failure at the wrong layer.
- This mirrors the sibling scheduled-tick path exactly. `onAdmittedTimer` (`src/cron/service/timer-scheduler.ts:586-592`) already re-arms in a `finally` after a throwing tick. Startup was the only entry point that could leave the timer down, and it is now the same shape.
- The recompute that now also runs on the failure path is not new policy: it is the same `recomputeUnownedCronSchedules(state, { recomputeExpired: true })` the success path performs, and the same maintenance `onAdmittedTimer` performs on its next tick. It makes the failure path converge one tick sooner instead of relying on the minute watchdog.
- `schedulerStarted` is deliberately left alone. `CronService.startOnce` (`src/cron/service.ts:66-73`) owns that flag and only sets it after `start()` resolves; the catch-up error still propagates, so a failed start is still recorded as a failed start and `server-cron-lazy.ts` still sets `underlyingStarted = false`. Setting it to `true` from inside a rejected start would tell `ensureLoadedForRead` (`src/cron/service/ops-shared.ts:64`) to stop doing read repair and would contradict the caller's own failure record. Timer-armed-while-`schedulerStarted`-is-false is already a state main produces: `reconcileForeignRunReceipts` calls `armTimer` at `ops-lifecycle.ts:115` from the foreign-receipt monitor during start.
- `resumeScheduling` still early-returns on `!schedulerStarted`, unchanged. A suspension cycle after a failed start therefore still needs the Gateway's own retry, which `server-cron-lazy.ts` performs (it calls `resumeScheduling()` and then `start()` again on the next resolve). Changing that gate is a separate lifecycle decision and is out of scope here.
- Generation fencing is unaffected. `stop()` is the only writer of `lifecycleGeneration` and it sets `state.stopped = true` in the same call, so a superseded start cannot arm a live timer, and the timer callback keeps its own generation check at `timer-scheduler.ts:148-162`.
- Behavior on a successful start is byte-for-byte the same ordering and the same `cron: started` info line.

## Verification
- `node scripts/run-vitest.mjs src/cron/service/ops-lifecycle.start-arm.test.ts` - 2 passed with the patch. The first case drives the real `start()` over a real SQLite cron store with a one-shot `AFTER UPDATE ON cron_jobs` trigger that rejects the terminal write (the technique the maintainers use in `timer.batch-finalization.test.ts`), and asserts that `start()` still rejects while `state.timer` is armed. The second case pins the sibling contract on the scheduled-tick path.
- The same scenario run on pristine `origin/main` (`17f74b9976`) before the patch existed FAILS at `expect(state.timer).not.toBeNull()` with `AssertionError: expected null not to be null`, and passes with the patch applied.
- Not run locally: the adjacent suites `src/cron/service/timer.batch-finalization.test.ts`, `src/cron/service/ops.regression.test.ts`, `src/cron/service/run-recovery.lifecycle.test.ts` and `src/cron/service/timer.regression.test.ts` were started but could not complete on this host, which ran out of memory and disk during the runs. CI covers them. The change does not touch `runMissedJobs`, `armTimer`, or any store/recovery helper, and the success path keeps the same call order and the same `cron: started` log line.
- No source or test comments were added. Formatting (`oxfmt`) and typechecking (`tsgo`) are delegated to CI.

## Real behavior proof
Behavior addressed: after a single transient cron store write failure during restart catch-up, the Gateway comes up healthy but no scheduled cron job ever fires again for the life of the process.
Real environment tested: the real production `CronService` from `src/cron/service.ts` driven through `cron.start()` (the exact call the Gateway makes at `src/gateway/server-cron-lazy.ts:162`), over a real on-disk SQLite state database and a real cron job store, with real wall-clock timers, on pristine main `17f74b9976` and on the patched tree with identical inputs. Nothing in the scheduler, store, or timer was stubbed; the one external seam forced was the SQLite write itself, via a one-shot `AFTER UPDATE ON cron_jobs` trigger that raises `disk I/O error while writing cron_jobs` on the first terminal write, standing in for a real failing or locked disk.
Exact steps or command run after this patch: seed two enabled jobs into a fresh store (one already overdue by 30s, one becoming due 30s later), install the one-shot failing trigger on the overdue job's terminal write, call `await cron.start()`, then observe the live scheduler for 70s and record every wake the service actually delivered.
Evidence after fix:
```
# BEFORE (pristine main 17f74b9976)
gateway log line          : cron: failed to start: Error: disk I/O error while writing cron_jobs
state.timer after start   : null (UNARMED)
state.stopped             : false
state.schedulingPaused    : false
start() settled           : 673 ms after seeding
upcoming-job became due   : 30000 ms after seeding
upcoming-job ran during startup catch-up: NO
upcoming-job ran within 70s of seeding: NO - never ran
all wakes delivered       : ["overdue-startup-job"]

# AFTER (this patch, identical inputs)
gateway log line          : cron: failed to start: Error: disk I/O error while writing cron_jobs
state.timer after start   : set (ARMED)
state.stopped             : false
state.schedulingPaused    : false
start() settled           : 920 ms after seeding
upcoming-job became due   : 30000 ms after seeding
upcoming-job ran during startup catch-up: NO
upcoming-job ran within 70s of seeding: YES (30169 ms after seeding)
all wakes delivered       : ["overdue-startup-job","upcoming-job"]
```
Observed result after fix: the scheduling timer that was left `null` on main is now armed after the same failed catch-up, and the job scheduled for 30s later actually fired at 30169 ms instead of never firing, while the caller still receives the identical `cron: failed to start` failure.
What was not tested: this drives `CronService.start()` directly rather than booting a full Gateway process, so the surrounding `server-runtime-services.ts` error logging and the skipped `reconcileExitWatchers` / `reconcileStreamWatchers` calls were read from source rather than observed live. The forced failure is a SQLite trigger raising on the terminal write rather than genuinely exhausted disk or a genuinely locked database file, and only the startup catch-up finalization failure was exercised, not every error `runMissedJobs` can surface.
