### PR TITLE
refactor(cron): share store discovery across delivery previews

### DIFF
--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -110,6 +110,27 @@ export function extractDeliveryInfoBatch(
   } catch {
     return results;
   }
+  let storeTargets: ReturnType<typeof resolveAllAgentSessionStoreTargetsSync> | undefined;
+  function prepareDeliveryLookup(sessionKey: string, baseSessionKey: string): DeliveryLookup {
+    const { agentId, canonicalKey: canonicalBaseKey } = resolveSessionStoreIdentity({
+      cfg,
+      sessionKey: baseSessionKey,
+    });
+    const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey, storeAgentId: agentId });
+    const storePaths = new Set([resolveSessionStorePathCore(cfg.session?.store, { agentId })]);
+    // Share only successful discovery within this synchronous batch. A later request
+    // can retry a failure; every new batch discovers fresh targets, primary path first.
+    for (const target of (storeTargets ??= resolveAllAgentSessionStoreTargetsSync(cfg))) {
+      if (target.agentId === agentId) {
+        storePaths.add(target.storePath);
+      }
+    }
+    return {
+      sessionKeys: [sessionKey, canonicalKey],
+      baseKeys: [baseSessionKey, canonicalBaseKey],
+      storePaths: [...storePaths],
+    };
+  }
   const reads: Array<{
     storePath: string;
     sessionKeys: string[];
@@ -120,7 +141,7 @@ export function extractDeliveryInfoBatch(
       return [];
     }
     try {
-      const lookup = prepareDeliveryLookup({ cfg, sessionKey, baseSessionKey });
+      const lookup = prepareDeliveryLookup(sessionKey, baseSessionKey);
       // Incognito keyed reads retain their existing process-owned handle lifetime.
       const readIndexes = isIncognitoSessionKey(sessionKey)
         ? undefined
@@ -253,19 +274,6 @@ function lazyDeliveryIndex(scope: {
   };
 }
 
-function resolveDeliveryStorePaths(cfg: OpenClawConfig, agentId: string): string[] {
-  const paths = new Set<string>();
-  paths.add(resolveSessionStorePathCore(cfg.session?.store, { agentId }));
-  // Delivery can be restored from any resolved agent target; store order keeps the configured
-  // primary path first while still covering per-agent stores.
-  for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    if (target.agentId === agentId) {
-      paths.add(target.storePath);
-    }
-  }
-  return [...paths];
-}
-
 function findSessionEntryInStore(store: DeliveryStoreRead, keys: readonly string[]) {
   let bestEntry: SessionEntry | undefined;
   let bestUpdatedAt = 0;
@@ -377,27 +385,6 @@ function buildFreshestSessionEntryIndex(store: SessionEntryReadView): Map<string
     }
   }
   return index;
-}
-
-function prepareDeliveryLookup(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  baseSessionKey: string;
-}): DeliveryLookup {
-  const { agentId, canonicalKey: canonicalBaseKey } = resolveSessionStoreIdentity({
-    cfg: params.cfg,
-    sessionKey: params.baseSessionKey,
-  });
-  const canonicalKey = resolveSessionStoreKey({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    storeAgentId: agentId,
-  });
-  return {
-    sessionKeys: [params.sessionKey, canonicalKey],
-    baseKeys: [params.baseSessionKey, canonicalBaseKey],
-    storePaths: resolveDeliveryStorePaths(params.cfg, agentId),
-  };
 }
 
 function loadDeliverySessionEntry(

--- a/src/cron/delivery-preview.current-origin.test.ts
+++ b/src/cron/delivery-preview.current-origin.test.ts
@@ -1,5 +1,6 @@
+import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import {
   replaceSessionEntry,
@@ -90,6 +91,9 @@ describe("current cron delivery origin", () => {
         sql.includes('from "session_nodes"') ? "sessions" : null,
       );
       const jobs = Array.from({ length: 53 }, (_, index) => ({ ...job, id: `preview-${index}` }));
+      const agentsRoot = path.dirname(path.dirname(path.dirname(storePath)));
+      // Observe the real filesystem call; the discovery owner and its results stay intact.
+      const rosterReads = vi.spyOn(fs, "readdirSync");
       try {
         const previews = await resolveCronDeliveryPreviews({ cfg, jobs });
         expect(Object.keys(previews)).toEqual(jobs.map((entry) => entry.id));
@@ -100,8 +104,12 @@ describe("current cron delivery origin", () => {
         ).toBe(true);
         // One store-sized read scope, independent of the number of repeated jobs.
         expect(reads.rowCounts.sessions).toBeLessThanOrEqual(4 * 65);
+        expect(
+          rosterReads.mock.calls.filter(([directory]) => directory === agentsRoot),
+        ).toHaveLength(1);
       } finally {
         reads.restore();
+        rosterReads.mockRestore();
       }
       await replaceSessionEntry(
         { agentId: "main", storePath, sessionKey: job.sessionKey! },
@@ -113,12 +121,20 @@ describe("current cron delivery origin", () => {
           }),
         },
       );
-      const refreshed = await resolveCronDeliveryPreviews({ cfg, jobs });
-      expect(
-        Object.values(refreshed).every(
-          (preview) => preview.label === "announce -> telegram:recipient",
-        ),
-      ).toBe(true);
+      const refreshedRosterReads = vi.spyOn(fs, "readdirSync");
+      try {
+        const refreshed = await resolveCronDeliveryPreviews({ cfg, jobs });
+        expect(
+          Object.values(refreshed).every(
+            (preview) => preview.label === "announce -> telegram:recipient",
+          ),
+        ).toBe(true);
+        expect(
+          refreshedRosterReads.mock.calls.filter(([directory]) => directory === agentsRoot),
+        ).toHaveLength(1);
+      } finally {
+        refreshedRosterReads.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
Related: #144014

## What Problem This Solves

Listing cron jobs with delivery previews repeated the full agent-store discovery for each session-linked job, even though the previews already shared one read batch. A 53-job request performed 53 scans of the same agent directory.

## Why This Change Was Made

Keep one successful discovery result within the synchronous delivery batch and fold its preparation into that owner. Each agent still searches its primary store first, and each new batch discovers current targets. Failed discovery remains retryable by the next logical lookup.

## User Impact

CLI job listings and callers requesting delivery previews do less repeated filesystem work while retaining current route selection and freshness. The current Automations UI disables these previews, so this change makes no claim about its rendering latency.

## Evidence

The existing 53-job regression failed on unchanged production with 53 physical agent-directory reads. With identical test bytes, the repaired first batch reads once; a second request also reads once and observes the updated route. The spy forwards real filesystem calls, and the fixture uses actual isolated SQLite state.

All 119 cases in four owner/sibling files and all 29 canonical changed checks pass. Independent review found no actionable findings. Production shrinks by 13 lines; the existing test grows by 16.

Operation counts establish the removed work. Whole-command timings include compilation and different baseline completion depth, so no percentage speedup is claimed. Incognito and discovery-error retry retain their existing source paths; no live channel or Gateway execution was used.
