### PR TITLE
fix(hooks): claim session memory filenames exclusively

### DIFF
--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -3,6 +3,7 @@ import { isMissingPathError } from "../infra/errors.js";
 import { canonicalPathFromExistingAncestor } from "../infra/fs-safe.js";
 import { logWarn } from "../logger.js";
 import {
+  claimMemoryArtifactCreateProvenance,
   clearMemoryArtifactProvenance,
   normalizeMemoryArtifactRelativePath,
   recordMemoryArtifactWriteProvenance,
@@ -18,6 +19,14 @@ export type MemoryWriteProvenanceObserver = {
     commit: () => Promise<void>;
   }) => Promise<void>;
   clearAfterDelete: (absolutePath: string, contentBefore: string) => Promise<void>;
+};
+
+export type MemoryExclusiveCreateObserver = {
+  createExclusive: (params: {
+    absolutePath: string;
+    contentAfter: string;
+    commit: () => Promise<void>;
+  }) => Promise<"created" | "occupied">;
 };
 
 type ProvenanceWriteOperations = {
@@ -108,7 +117,7 @@ export function createMemoryWriteProvenanceObserver(params: {
   sessionId?: string;
   sessionKey?: string;
   now?: () => number;
-}): MemoryWriteProvenanceObserver {
+}): MemoryWriteProvenanceObserver & MemoryExclusiveCreateObserver {
   const now = params.now ?? Date.now;
   const resolvePath = params.resolvePath ?? canonicalPathFromExistingAncestor;
   const resolveRelativePath = async (absolutePath: string) => {
@@ -151,6 +160,43 @@ export function createMemoryWriteProvenanceObserver(params: {
         }
         throw error;
       }
+    },
+    createExclusive: async ({ absolutePath, contentAfter, commit }) => {
+      const relativePath = await resolveRelativePath(absolutePath);
+      if (!relativePath) {
+        await commit();
+        return "created";
+      }
+      const claim = await claimMemoryArtifactCreateProvenance({
+        workspaceDir: params.workspaceDir,
+        relativePath,
+        contentAfter,
+        originClass: params.resolveOriginClass(),
+        observedAt: now(),
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      });
+      if (claim.status === "occupied") {
+        return "occupied";
+      }
+      if (claim.status === "unclassified") {
+        await commit();
+        return "created";
+      }
+      try {
+        await commit();
+      } catch (error) {
+        try {
+          await claim.rollback();
+        } catch (rollbackError) {
+          throw new Error(
+            `File create failed and memory provenance rollback also failed: ${String(error)}`,
+            { cause: rollbackError },
+          );
+        }
+        throw error;
+      }
+      return "created";
     },
     clearAfterDelete: async (absolutePath, contentBefore) => {
       const relativePath = await resolveRelativePath(absolutePath);

--- a/src/hooks/bundled/session-memory/handler-auto-reset.test.ts
+++ b/src/hooks/bundled/session-memory/handler-auto-reset.test.ts
@@ -1,12 +1,86 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { replaceTranscriptEvents } from "../../../config/sessions/session-accessor.js";
+import { listMemoryArtifactProvenance } from "../../../memory/memory-artifact-provenance.js";
+import { resetPluginStateStoreForTests } from "../../../plugin-state/plugin-state-store.js";
+import { withStateDirEnv } from "../../../test-helpers/state-dir-env.js";
 import { createInternalHookEvent } from "../../internal-hooks.js";
 import handler, { flushSessionMemoryWritesForTest } from "./handler.js";
+
+type ProvenanceRecordObservation = {
+  relativePath: string;
+  originClass: "agent" | "untrusted";
+  destinationExists: boolean;
+  markdownFilesPresent: string[];
+};
+
+const provenanceObservations = vi.hoisted(() => ({
+  records: [] as ProvenanceRecordObservation[],
+}));
+
+const claimBarrier = vi.hoisted(() => ({
+  contenders: 0,
+  relativePath: undefined as string | undefined,
+  arrived: 0,
+  pending: undefined as Promise<void> | undefined,
+  release: undefined as (() => void) | undefined,
+}));
+
+const awaitClaimBarrier = vi.hoisted(() => async (relativePath: string): Promise<void> => {
+  if (claimBarrier.contenders <= 0) {
+    return;
+  }
+  claimBarrier.relativePath ??= relativePath;
+  if (claimBarrier.relativePath !== relativePath) {
+    return;
+  }
+  claimBarrier.pending ??= new Promise<void>((resolve) => {
+    claimBarrier.release = resolve;
+  });
+  claimBarrier.arrived += 1;
+  if (claimBarrier.arrived >= claimBarrier.contenders) {
+    claimBarrier.release?.();
+  }
+  await claimBarrier.pending;
+});
+
+vi.mock("../../../memory/memory-artifact-provenance.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../memory/memory-artifact-provenance.js")>();
+  const nodeFs = await import("node:fs/promises");
+  const nodePath = await import("node:path");
+  return {
+    ...actual,
+    claimMemoryArtifactCreateProvenance: async (
+      params: Parameters<typeof actual.claimMemoryArtifactCreateProvenance>[0],
+    ) => {
+      const destination = nodePath.default.join(params.workspaceDir, params.relativePath);
+      await awaitClaimBarrier(params.relativePath);
+      const claim = await actual.claimMemoryArtifactCreateProvenance(params);
+      if (claim.status !== "claimed") {
+        return claim;
+      }
+      provenanceObservations.records.push({
+        relativePath: params.relativePath,
+        originClass: params.originClass,
+        destinationExists: await nodeFs.default
+          .lstat(destination)
+          .then(() => true)
+          .catch(() => false),
+        markdownFilesPresent: await nodeFs.default
+          .readdir(nodePath.default.dirname(destination))
+          .then((entries) => entries.filter((entry) => entry.endsWith(".md")).sort())
+          .catch(() => []),
+      });
+      return claim;
+    },
+  };
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -15,11 +89,104 @@ describe("session-memory automatic reset", () => {
 
   beforeEach(() => {
     tempDir = tempDirs.make("openclaw-session-memory-auto-");
+    provenanceObservations.records.length = 0;
+    claimBarrier.contenders = 0;
+    claimBarrier.relativePath = undefined;
+    claimBarrier.arrived = 0;
+    claimBarrier.pending = undefined;
+    claimBarrier.release = undefined;
   });
 
   afterEach(async () => {
     await flushSessionMemoryWritesForTest();
+    resetPluginStateStoreForTests();
   });
+
+  const rolloverAt = new Date("2026-03-04T05:06:07.000Z");
+
+  function makeConfig(storePath: string): OpenClawConfig {
+    return {
+      agents: { defaults: { workspace: tempDir } },
+      session: { store: storePath },
+    } satisfies OpenClawConfig;
+  }
+
+  async function storeRolloverTranscript(params: {
+    storePath: string;
+    sessionId: string;
+    sessionKey: string;
+    marker: string;
+    senderIsOwner?: boolean;
+  }): Promise<void> {
+    await replaceTranscriptEvents(
+      {
+        agentId: "main",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+      },
+      [
+        {
+          type: "message",
+          id: `${params.sessionId}-user`,
+          parentId: null,
+          message: {
+            role: "user",
+            content: `Remember ${params.marker}`,
+            __openclaw: { senderIsOwner: params.senderIsOwner ?? true },
+          },
+        },
+        {
+          type: "message",
+          id: `${params.sessionId}-assistant`,
+          parentId: `${params.sessionId}-user`,
+          message: { role: "assistant", content: "Captured automatically" },
+        },
+      ],
+    );
+  }
+
+  function buildRolloverEvent(params: {
+    cfg: OpenClawConfig;
+    storePath: string;
+    sessionId: string;
+    sessionKey: string;
+  }) {
+    return {
+      ...createInternalHookEvent("session", "auto-reset", params.sessionKey, {
+        cfg: params.cfg,
+        agentId: "main",
+        workspaceDir: tempDir,
+        storePath: params.storePath,
+        sessionEntry: { sessionId: params.sessionId },
+        reason: "daily",
+      }),
+      timestamp: rolloverAt,
+    };
+  }
+
+  async function runRollover(params: {
+    storePath: string;
+    sessionId: string;
+    sessionKey: string;
+    marker: string;
+    senderIsOwner?: boolean;
+  }): Promise<void> {
+    await storeRolloverTranscript(params);
+    await handler(
+      buildRolloverEvent({
+        cfg: makeConfig(params.storePath),
+        storePath: params.storePath,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      }),
+    );
+  }
+
+  async function resolveCapturedBasename(memoryDir: string): Promise<string> {
+    const files = await fs.readdir(memoryDir);
+    return expectDefined(files[0], "files[0] test invariant").replace(/\.md$/u, "");
+  }
 
   it.each(["daily", "idle"] as const)(
     "creates memory from the ended session on %s reset",
@@ -74,4 +241,356 @@ describe("session-memory automatic reset", () => {
       expect(memoryContent).toContain(`assistant: ${JSON.stringify("Captured automatically")}`);
     },
   );
+
+  it("keeps both rollovers when two sessions reset in the same minute", async () => {
+    const storePath = path.join(tempDir, "sessions.json");
+    const cfg = {
+      agents: { defaults: { workspace: tempDir } },
+      session: { store: storePath },
+    } satisfies OpenClawConfig;
+    const sessions = [
+      { sessionKey: "agent:main:chat-alpha", sessionId: "alpha-session", marker: "ALPHA-ONLY" },
+      { sessionKey: "agent:main:chat-beta", sessionId: "beta-session", marker: "BETA-ONLY" },
+    ];
+
+    for (const session of sessions) {
+      await replaceTranscriptEvents(
+        {
+          agentId: "main",
+          sessionId: session.sessionId,
+          sessionKey: session.sessionKey,
+          storePath,
+        },
+        [
+          {
+            type: "message",
+            id: `${session.sessionId}-user`,
+            parentId: null,
+            message: {
+              role: "user",
+              content: `Remember ${session.marker}`,
+              __openclaw: { senderIsOwner: true },
+            },
+          },
+          {
+            type: "message",
+            id: `${session.sessionId}-assistant`,
+            parentId: `${session.sessionId}-user`,
+            message: { role: "assistant", content: "Captured automatically" },
+          },
+        ],
+      );
+    }
+
+    const events = sessions.map((session) => ({
+      ...createInternalHookEvent("session", "auto-reset", session.sessionKey, {
+        cfg,
+        agentId: "main",
+        workspaceDir: tempDir,
+        storePath,
+        sessionEntry: { sessionId: session.sessionId },
+        reason: "daily",
+      }),
+      timestamp: rolloverAt,
+    }));
+
+    await Promise.all(events.map((event) => handler(event)));
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = (await fs.readdir(memoryDir)).sort();
+    expect(files).toHaveLength(2);
+    const contents = await Promise.all(
+      files.map(async (file) => await fs.readFile(path.join(memoryDir, file), "utf8")),
+    );
+    for (const session of sessions) {
+      expect(
+        contents.filter((content) => content.includes(`Remember ${session.marker}`)),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("keeps the capture when every numbered filename is already occupied", async () => {
+    const storePath = path.join(tempDir, "sessions.json");
+    await runRollover({
+      storePath,
+      sessionId: "first-session",
+      sessionKey: "agent:main:chat-first",
+      marker: "FIRST-ONLY",
+    });
+
+    const memoryDir = path.join(tempDir, "memory");
+    const basename = await resolveCapturedBasename(memoryDir);
+    for (let suffix = 2; suffix <= 64; suffix += 1) {
+      await fs.writeFile(path.join(memoryDir, `${basename}-${suffix}.md`), "occupied", "utf8");
+    }
+
+    await runRollover({
+      storePath,
+      sessionId: "late-session",
+      sessionKey: "agent:main:chat-late",
+      marker: "LATE-ONLY",
+    });
+
+    const files = await fs.readdir(memoryDir);
+    expect(files).toHaveLength(65);
+    const contents = await Promise.all(
+      files.map(async (file) => await fs.readFile(path.join(memoryDir, file), "utf8")),
+    );
+    expect(contents.filter((content) => content.includes("Remember LATE-ONLY"))).toHaveLength(1);
+  });
+
+  it("skips occupied candidates that are not regular files", async () => {
+    const storePath = path.join(tempDir, "sessions.json");
+    await runRollover({
+      storePath,
+      sessionId: "first-session",
+      sessionKey: "agent:main:chat-first",
+      marker: "FIRST-ONLY",
+    });
+
+    const memoryDir = path.join(tempDir, "memory");
+    const basename = await resolveCapturedBasename(memoryDir);
+    await fs.mkdir(path.join(memoryDir, `${basename}-2.md`));
+    await fs.link(path.join(memoryDir, `${basename}.md`), path.join(memoryDir, `${basename}-3.md`));
+
+    await runRollover({
+      storePath,
+      sessionId: "late-session",
+      sessionKey: "agent:main:chat-late",
+      marker: "LATE-ONLY",
+    });
+
+    const captured = await fs.readFile(path.join(memoryDir, `${basename}-4.md`), "utf8");
+    expect(captured).toContain("Remember LATE-ONLY");
+  });
+
+  it("preserves provenance of an occupied artifact when concurrent rollovers lose the claim", async () => {
+    await withStateDirEnv("openclaw-session-memory-provenance-", async () => {
+      const storePath = path.join(tempDir, "sessions.json");
+      await runRollover({
+        storePath,
+        sessionId: "origin-session",
+        sessionKey: "agent:main:chat-origin",
+        marker: "ORIGIN-ONLY",
+      });
+
+      const memoryDir = path.join(tempDir, "memory");
+      const basename = await resolveCapturedBasename(memoryDir);
+      const occupied = `${basename}.md`;
+      const readProvenance = async () => {
+        const entries = await listMemoryArtifactProvenance({ workspaceDir: tempDir });
+        return entries.find((entry) => entry.relativePath.endsWith(occupied))?.provenance;
+      };
+      const before = expectDefined(await readProvenance(), "origin provenance test invariant");
+      expect(before.sessionId).toBe("origin-session");
+
+      const losers = [
+        { sessionId: "alpha-session", sessionKey: "agent:main:chat-alpha", marker: "ALPHA-ONLY" },
+        { sessionId: "beta-session", sessionKey: "agent:main:chat-beta", marker: "BETA-ONLY" },
+      ];
+      for (const loser of losers) {
+        await storeRolloverTranscript({ storePath, ...loser });
+      }
+      await Promise.all(
+        losers.map(async (loser) =>
+          handler(
+            buildRolloverEvent({
+              cfg: makeConfig(storePath),
+              storePath,
+              sessionId: loser.sessionId,
+              sessionKey: loser.sessionKey,
+            }),
+          ),
+        ),
+      );
+
+      expect(await readProvenance()).toEqual(before);
+      expect(await fs.readFile(path.join(memoryDir, occupied), "utf8")).toContain(
+        "Remember ORIGIN-ONLY",
+      );
+      expect(await fs.readdir(memoryDir)).toHaveLength(3);
+    });
+  });
+
+  it.each([
+    {
+      name: "owner capture",
+      senderIsOwner: true,
+      marker: "OWNER-ONLY",
+      expectedOrigin: "agent",
+    },
+    {
+      name: "non-owner capture",
+      senderIsOwner: false,
+      marker: "NON-OWNER-ONLY",
+      expectedOrigin: "untrusted",
+    },
+  ] as const)("publishes a $name without exposing an untracked memory path", async (testCase) => {
+    await withStateDirEnv("openclaw-session-memory-window-", async () => {
+      const storePath = path.join(tempDir, "sessions.json");
+      await runRollover({
+        storePath,
+        sessionId: `${testCase.expectedOrigin}-session`,
+        sessionKey: `agent:main:chat-${testCase.expectedOrigin}`,
+        marker: testCase.marker,
+        senderIsOwner: testCase.senderIsOwner,
+      });
+
+      const memoryDir = path.join(tempDir, "memory");
+      const files = await fs.readdir(memoryDir);
+      const filename = expectDefined(files[0], "session memory file test invariant");
+      expect(files).toHaveLength(1);
+      expect(provenanceObservations.records).toEqual([
+        {
+          relativePath: `memory/${filename}`,
+          originClass: testCase.expectedOrigin,
+          destinationExists: false,
+          markdownFilesPresent: [],
+        },
+      ]);
+
+      const entries = await listMemoryArtifactProvenance({ workspaceDir: tempDir });
+      expect(entries).toEqual([
+        {
+          relativePath: `memory/${filename}`,
+          provenance: expect.objectContaining({ originClass: testCase.expectedOrigin }),
+        },
+      ]);
+      expect(await fs.readFile(path.join(memoryDir, filename), "utf8")).toContain(
+        `Remember ${testCase.marker}`,
+      );
+    });
+  });
+
+  it("keeps each provenance record with its own capture when three claims overlap", async () => {
+    await withStateDirEnv("openclaw-session-memory-three-way-", async () => {
+      const storePath = path.join(tempDir, "sessions.json");
+      const contenders = [
+        {
+          sessionId: "alpha-session",
+          sessionKey: "agent:main:chat-alpha",
+          marker: "ALPHA-ONLY",
+          senderIsOwner: true,
+          expectedOrigin: "agent" as const,
+        },
+        {
+          sessionId: "beta-session",
+          sessionKey: "agent:main:chat-beta",
+          marker: "BETA-ONLY",
+          senderIsOwner: false,
+          expectedOrigin: "untrusted" as const,
+        },
+        {
+          sessionId: "gamma-session",
+          sessionKey: "agent:main:chat-gamma",
+          marker: "GAMMA-ONLY",
+          senderIsOwner: true,
+          expectedOrigin: "agent" as const,
+        },
+      ];
+      for (const contender of contenders) {
+        await storeRolloverTranscript({ storePath, ...contender });
+      }
+
+      claimBarrier.contenders = contenders.length;
+      await Promise.all(
+        contenders.map(async (contender) =>
+          handler(
+            buildRolloverEvent({
+              cfg: makeConfig(storePath),
+              storePath,
+              sessionId: contender.sessionId,
+              sessionKey: contender.sessionKey,
+            }),
+          ),
+        ),
+      );
+
+      const memoryDir = path.join(tempDir, "memory");
+      expect(await fs.readdir(memoryDir)).toHaveLength(contenders.length);
+      expect(provenanceObservations.records).toHaveLength(contenders.length);
+      expect(provenanceObservations.records.map((record) => record.destinationExists)).toEqual([
+        false,
+        false,
+        false,
+      ]);
+
+      const entries = await listMemoryArtifactProvenance({ workspaceDir: tempDir });
+      expect(entries).toHaveLength(contenders.length);
+      const observed = await Promise.all(
+        entries.map(async (entry) => {
+          const content = await fs.readFile(path.join(tempDir, entry.relativePath), "utf8");
+          const owner = expectDefined(
+            contenders.find((contender) => content.includes(`Remember ${contender.marker}`)),
+            "capture owner test invariant",
+          );
+          return {
+            marker: owner.marker,
+            sessionId: entry.provenance.sessionId,
+            sessionKey: entry.provenance.sessionKey,
+            originClass: entry.provenance.originClass,
+            hashMatchesContent:
+              entry.provenance.fileHash === createHash("sha256").update(content).digest("hex"),
+          };
+        }),
+      );
+      expect(observed.sort((left, right) => left.marker.localeCompare(right.marker))).toEqual(
+        contenders
+          .map((contender) => ({
+            marker: contender.marker,
+            sessionId: contender.sessionId,
+            sessionKey: contender.sessionKey,
+            originClass: contender.expectedOrigin,
+            hashMatchesContent: true,
+          }))
+          .sort((left, right) => left.marker.localeCompare(right.marker)),
+      );
+    });
+  });
+
+  it("retains untrusted classification when a non-owner capture follows an owner capture", async () => {
+    await withStateDirEnv("openclaw-session-memory-interleave-", async () => {
+      const storePath = path.join(tempDir, "sessions.json");
+      await runRollover({
+        storePath,
+        sessionId: "owner-session",
+        sessionKey: "agent:main:chat-owner",
+        marker: "OWNER-FIRST",
+        senderIsOwner: true,
+      });
+      await runRollover({
+        storePath,
+        sessionId: "intruder-session",
+        sessionKey: "agent:main:chat-intruder",
+        marker: "INTRUDER-SECOND",
+        senderIsOwner: false,
+      });
+
+      const memoryDir = path.join(tempDir, "memory");
+      expect(provenanceObservations.records.map((record) => record.destinationExists)).toEqual([
+        false,
+        false,
+      ]);
+      const entries = (await listMemoryArtifactProvenance({ workspaceDir: tempDir })).sort(
+        (left, right) => left.relativePath.localeCompare(right.relativePath),
+      );
+      const classified = await Promise.all(
+        entries.map(async (entry) => ({
+          originClass: entry.provenance.originClass,
+          marker: (await fs.readFile(path.join(tempDir, entry.relativePath), "utf8")).includes(
+            "Remember OWNER-FIRST",
+          )
+            ? "OWNER-FIRST"
+            : "INTRUDER-SECOND",
+        })),
+      );
+      expect(classified).toEqual(
+        expect.arrayContaining([
+          { originClass: "agent", marker: "OWNER-FIRST" },
+          { originClass: "untrusted", marker: "INTRUDER-SECOND" },
+        ]),
+      );
+      expect(await fs.readdir(memoryDir)).toHaveLength(2);
+    });
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -42,6 +42,9 @@ const loggerMocks = vi.hoisted(() => ({
 
 const memoryProvenanceMocks = vi.hoisted(() => ({
   recordMemoryArtifactWriteProvenance: vi.fn().mockResolvedValue(undefined),
+  claimMemoryArtifactCreateProvenance: vi
+    .fn()
+    .mockResolvedValue({ status: "claimed", rollback: async () => {} }),
 }));
 
 vi.mock("../../../logging/subsystem.js", () => ({
@@ -51,6 +54,7 @@ vi.mock("../../../logging/subsystem.js", () => ({
 vi.mock("../../../memory/memory-artifact-provenance.js", () => ({
   normalizeMemoryArtifactRelativePath: (relativePath: string) => relativePath,
   recordMemoryArtifactWriteProvenance: memoryProvenanceMocks.recordMemoryArtifactWriteProvenance,
+  claimMemoryArtifactCreateProvenance: memoryProvenanceMocks.claimMemoryArtifactCreateProvenance,
   clearMemoryArtifactProvenance: vi.fn(),
 }));
 
@@ -412,21 +416,20 @@ describe("session-memory hook", () => {
       expectedOrigin: "untrusted",
     },
   ] as const)("records $name provenance before committing the file", async (testCase) => {
-    memoryProvenanceMocks.recordMemoryArtifactWriteProvenance.mockClear();
+    memoryProvenanceMocks.claimMemoryArtifactCreateProvenance.mockClear();
     let observedWrite:
       | {
           workspaceDir: string;
           relativePath: string;
-          contentBefore: string;
           contentAfter: string;
           originClass: "agent" | "untrusted";
         }
       | undefined;
-    memoryProvenanceMocks.recordMemoryArtifactWriteProvenance.mockImplementationOnce(
+    memoryProvenanceMocks.claimMemoryArtifactCreateProvenance.mockImplementationOnce(
       async (write) => {
         observedWrite = write;
         await expectPathMissing(path.join(write.workspaceDir, write.relativePath));
-        return undefined;
+        return { status: "claimed", rollback: async () => {} };
       },
     );
     const sessionContent = [
@@ -460,18 +463,17 @@ describe("session-memory hook", () => {
     const filename = expectDefined(files[0], "session memory file");
 
     expect(files).toHaveLength(1);
-    expect(memoryProvenanceMocks.recordMemoryArtifactWriteProvenance).toHaveBeenCalledOnce();
+    expect(memoryProvenanceMocks.claimMemoryArtifactCreateProvenance).toHaveBeenCalledOnce();
     expect(observedWrite).toMatchObject({
       workspaceDir: tempDir,
       relativePath: `memory/${filename}`,
-      contentBefore: "",
       contentAfter: memoryContent,
       originClass: testCase.expectedOrigin,
     });
   });
 
   it("does not commit session memory when provenance recording fails", async () => {
-    memoryProvenanceMocks.recordMemoryArtifactWriteProvenance.mockRejectedValueOnce(
+    memoryProvenanceMocks.claimMemoryArtifactCreateProvenance.mockRejectedValueOnce(
       new Error("provenance unavailable"),
     );
     const sessionContent = [

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -5,6 +5,7 @@
  * Creates a new dated memory file with a timestamp slug by default
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -14,12 +15,15 @@ import {
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
 import { resolveUserTimezone } from "../../../agents/date-time.js";
-import { createMemoryWriteProvenanceObserver } from "../../../agents/memory-write-provenance.js";
+import {
+  createMemoryWriteProvenanceObserver,
+  type MemoryExclusiveCreateObserver,
+} from "../../../agents/memory-write-provenance.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isVitestRuntimeEnv } from "../../../infra/env.js";
-import { root } from "../../../infra/fs-safe.js";
+import { FsSafeError, root, type Root } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../../process/gateway-work-admission.js";
 import { parseAgentSessionKey, toAgentStoreSessionKey } from "../../../routing/session-key.js";
@@ -71,26 +75,82 @@ function formatLocalSessionTimestamp(
   };
 }
 
-async function resolveAvailableMemoryFilename(params: {
-  memoryDir: string;
-  dateStr: string;
-  slug: string;
-}): Promise<string> {
-  const basename = `${params.dateStr}-${params.slug}`;
-  let suffix = 1;
+const MAX_MEMORY_FILENAME_SUFFIX_ATTEMPTS = 64;
+const MAX_MEMORY_FILENAME_UNIQUE_ATTEMPTS = 8;
+const OCCUPIED_MEMORY_PATH_CODES = new Set(["already-exists", "not-file", "path-alias"]);
 
-  while (true) {
-    const filename = suffix === 1 ? `${basename}.md` : `${basename}-${suffix}.md`;
+function buildMemoryFilename(basename: string, suffix: number): string {
+  return suffix === 1 ? `${basename}.md` : `${basename}-${suffix}.md`;
+}
+
+function* iterateMemoryFilenameCandidates(basename: string): Generator<string> {
+  for (let suffix = 1; suffix <= MAX_MEMORY_FILENAME_SUFFIX_ATTEMPTS; suffix += 1) {
+    yield buildMemoryFilename(basename, suffix);
+  }
+  for (let attempt = 0; attempt < MAX_MEMORY_FILENAME_UNIQUE_ATTEMPTS; attempt += 1) {
+    yield `${basename}-${randomUUID().slice(0, 8)}.md`;
+  }
+}
+
+async function memoryCandidateExists(candidatePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(candidatePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isOccupiedMemoryCandidate(err: unknown, candidatePath: string): Promise<boolean> {
+  if (!(err instanceof FsSafeError) || !OCCUPIED_MEMORY_PATH_CODES.has(err.code)) {
+    return false;
+  }
+  return await memoryCandidateExists(candidatePath);
+}
+
+async function claimMemoryFilename(params: {
+  memoryRoot: Root;
+  memoryDir: string;
+  basename: string;
+  entry: string;
+  provenanceObserver: MemoryExclusiveCreateObserver;
+}): Promise<{ filename: string; filePath: string }> {
+  let lastOccupiedError: unknown;
+  for (const candidate of iterateMemoryFilenameCandidates(params.basename)) {
+    const candidatePath = path.join(params.memoryDir, candidate);
+    if (await memoryCandidateExists(candidatePath)) {
+      log.debug("Memory filename already taken, trying next candidate", {
+        filename: candidate,
+      });
+      continue;
+    }
     try {
-      await fs.access(path.join(params.memoryDir, filename));
-      suffix += 1;
-    } catch (err) {
-      if ((err as { code?: string }).code === "ENOENT") {
-        return filename;
+      const outcome = await params.provenanceObserver.createExclusive({
+        absolutePath: candidatePath,
+        contentAfter: params.entry,
+        commit: async () =>
+          await params.memoryRoot.create(candidate, params.entry, { encoding: "utf-8" }),
+      });
+      if (outcome === "occupied") {
+        log.debug("Memory filename reserved by a concurrent capture, trying next candidate", {
+          filename: candidate,
+        });
+        continue;
       }
-      throw err;
+      return { filename: candidate, filePath: candidatePath };
+    } catch (err) {
+      if (!(await isOccupiedMemoryCandidate(err, candidatePath))) {
+        throw err;
+      }
+      lastOccupiedError = err;
+      log.debug("Memory filename claimed concurrently, trying next candidate", {
+        filename: candidate,
+      });
     }
   }
+  throw new Error(`Unable to claim a session memory filename for ${params.basename}`, {
+    cause: lastOccupiedError,
+  });
 }
 
 function resolveDisplaySessionKey(params: {
@@ -209,13 +269,8 @@ async function saveSessionMemoryNow(
       log.debug("Using fallback timestamp slug", { slug });
     }
 
-    // Create filename with date and slug
-    const filename = await resolveAvailableMemoryFilename({ memoryDir, dateStr, slug });
-    const memoryFilePath = path.join(memoryDir, filename);
-    log.debug("Memory file path resolved", {
-      filename,
-      path: shortenHomePath(memoryFilePath),
-    });
+    const memoryBasename = `${dateStr}-${slug}`;
+    log.debug("Memory file basename resolved", { basename: memoryBasename });
 
     const timeStr = localTimestamp.time;
 
@@ -262,13 +317,14 @@ async function saveSessionMemoryNow(
       sessionKey: event.sessionKey,
       now: () => now.getTime(),
     });
-    const commit = () => memoryRoot.write(filename, entry, { encoding: "utf-8" });
-    await provenanceObserver.write({
-      absolutePath: memoryFilePath,
-      contentBefore: "",
-      contentAfter: entry,
-      commit,
+    const claimed = await claimMemoryFilename({
+      memoryRoot,
+      memoryDir,
+      basename: memoryBasename,
+      entry,
+      provenanceObserver,
     });
+    const memoryFilePath = claimed.filePath;
     log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)

--- a/src/memory/memory-artifact-provenance.test.ts
+++ b/src/memory/memory-artifact-provenance.test.ts
@@ -7,6 +7,7 @@ import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-stor
 import { createDeferredCore } from "../shared/deferred.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
+  claimMemoryArtifactCreateProvenance,
   clearMemoryArtifactProvenance,
   listMemoryArtifactProvenance,
   normalizeMemoryArtifactRelativePath,
@@ -182,6 +183,52 @@ describe("memory artifact provenance", () => {
         originClass: "agent",
         observedAt: 2,
       });
+    });
+  });
+
+  it("grants one exclusive create claim per path and rolls back only its own record", async () => {
+    await withStateDirEnv("openclaw-memory-artifact-", async ({ tempRoot }) => {
+      const address = { workspaceDir: tempRoot, relativePath: "memory/2026-03-04-rollover.md" };
+      const claim = (contentAfter: string, observedAt: number, sessionId: string) =>
+        claimMemoryArtifactCreateProvenance({
+          ...address,
+          contentAfter,
+          originClass: "agent",
+          observedAt,
+          sessionId,
+        });
+
+      const winner = await claim("winner", 1, "winner-session");
+      expect(winner.status).toBe("claimed");
+      for (const loser of ["first-loser", "second-loser"]) {
+        expect(await claim(loser, 2, `${loser}-session`)).toEqual({ status: "occupied" });
+      }
+      await expect(readMemoryArtifactProvenance(address)).resolves.toMatchObject({
+        sessionId: "winner-session",
+        observedAt: 1,
+      });
+
+      const superseding = await claimMemoryArtifactCreateProvenance({
+        ...address,
+        relativePath: "memory/2026-03-04-rollover-2.md",
+        contentAfter: "next",
+        originClass: "agent",
+        observedAt: 3,
+        sessionId: "next-session",
+      });
+      expect(superseding.status).toBe("claimed");
+      if (superseding.status === "claimed") {
+        await superseding.rollback();
+      }
+      await expect(readMemoryArtifactProvenance(address)).resolves.toMatchObject({
+        sessionId: "winner-session",
+      });
+      await expect(
+        readMemoryArtifactProvenance({
+          workspaceDir: tempRoot,
+          relativePath: "memory/2026-03-04-rollover-2.md",
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/memory/memory-artifact-provenance.ts
+++ b/src/memory/memory-artifact-provenance.ts
@@ -179,6 +179,55 @@ export async function recordMemoryArtifactWriteProvenance(params: {
   };
 }
 
+export type MemoryArtifactCreateClaim =
+  | { status: "claimed"; rollback: () => Promise<void> }
+  | { status: "occupied" }
+  | { status: "unclassified" };
+
+export async function claimMemoryArtifactCreateProvenance(params: {
+  workspaceDir: string;
+  relativePath: string;
+  contentAfter: string;
+  originClass: MemoryArtifactOriginClass;
+  observedAt: number;
+  sessionId?: string;
+  sessionKey?: string;
+}): Promise<MemoryArtifactCreateClaim> {
+  const address = resolveAddress(params);
+  if (!address) {
+    return { status: "unclassified" };
+  }
+  const store = openStore();
+  const reservationId = randomUUID();
+  const claimed = await store.update(address.storeKey, (current) =>
+    current === undefined
+      ? {
+          version: 1,
+          workspaceKey: address.workspaceKey,
+          relativePath: address.relativePath,
+          fileHash: sha256(params.contentAfter),
+          originClass: params.originClass,
+          observedAt: params.observedAt,
+          ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          reservationId,
+        }
+      : undefined,
+  );
+  if (!claimed) {
+    return { status: "occupied" };
+  }
+  return {
+    status: "claimed",
+    rollback: async () => {
+      await openStore().deleteIf(
+        address.storeKey,
+        (current) => current.reservationId === reservationId,
+      );
+    },
+  };
+}
+
 export async function clearMemoryArtifactProvenance(params: {
   workspaceDir: string;
   relativePath: string;


### PR DESCRIPTION
## Summary
When one agent serves several chats and they roll over in the same minute, the `session-memory` bundled hook writes every rollover into the same `<workspace>/memory/<YYYY-MM-DD>-<HHMM>.md` file. Each rollover truncates the previous one, so only the last session's context survives, while `Session context saved to ...` is logged for every rollover with the same path. The user loses a memory artifact they can see in their workspace and gets a success message saying it was saved.

Trigger: two or more sessions of one agent cross the daily or idle reset boundary within the same minute, or `/new` is issued in two chats at once. All sessions of an agent resolve the same `memoryDir`, and the default non-LLM slug is minute-resolution, so the candidate filename is identical.

## Root cause
`src/hooks/bundled/session-memory/handler.ts` resolved a free filename with `fs.access` and then committed with the overwriting primitive several `await`s later.

```ts
// before
const filename = await resolveAvailableMemoryFilename({ memoryDir, dateStr, slug });
const memoryFilePath = path.join(memoryDir, filename);

// ... entry construction, root(), provenance observer ...

const commit = () => memoryRoot.write(filename, entry, { encoding: "utf-8" });
await provenanceObserver.write({
  absolutePath: memoryFilePath,
  contentBefore: "",
  contentAfter: entry,
  commit,
});
```

The name is checked at one point and used at another, with real `await` gaps in between (`root(memoryDir)`, provenance reservation, and for the LLM-slug configuration the model call itself). `Root.write` is the overwriting primitive; `Root.create` is the exclusive one. Two rollovers that both observe the name as free both call `write`, and the second truncates the first.

Auto-reset dispatch is detached and unserialized, so the handler runs genuinely overlap: `src/auto-reply/reply/session.ts` calls `emitSessionAutoResetHook`, which fires the internal hook under a bare `void` with no per-sessionKey queue. `src/gateway/session-reset-service.ts` uses the same entry point. The handler itself takes no lock.

## Fix
Publication is one operation: the candidate filename is created exclusively with the entry content already in it, and provenance is reserved before that filename exists.

```ts
// after
for (const candidate of iterateMemoryFilenameCandidates(params.basename)) {
  const candidatePath = path.join(params.memoryDir, candidate);
  if (await memoryCandidateExists(candidatePath)) {
    continue;
  }
  try {
    const outcome = await params.provenanceObserver.createExclusive({
      absolutePath: candidatePath,
      contentAfter: params.entry,
      commit: async () =>
        await params.memoryRoot.create(candidate, params.entry, { encoding: "utf-8" }),
    });
    if (outcome === "occupied") {
      continue;
    }
    return { filename: candidate, filePath: candidatePath };
  } catch (err) {
    if (!(await isOccupiedMemoryCandidate(err, candidatePath))) {
      throw err;
    }
    lastOccupiedError = err;
  }
}
```

`Root.create` passes `overwrite: false`, which reaches `fs.open` with `O_CREAT | O_EXCL` and writes the entry into the file descriptor it just created, so the name appears to readers only with its content in place and its provenance already on record.

The reservation that precedes it is now exclusive too. `claimMemoryArtifactCreateProvenance` writes the record for a candidate path inside the store's write transaction, and only when that path has no record at all:

```ts
const claimed = await store.update(address.storeKey, (current) =>
  current === undefined
    ? { version: 1, /* ... */ originClass: params.originClass, reservationId }
    : undefined,
);
if (!claimed) {
  return { status: "occupied" };
}
```

A capture that loses the reservation never touches the filesystem and has no record to undo; a capture that wins and then loses the exclusive create deletes only its own reservation, because by construction there is no displaced predecessor to restore.

## Why the diff reaches the provenance owner
The previous revision kept the whole change inside the hook and used `MemoryWriteProvenanceObserver.write` for publication. That entry point is built for overwriting an artifact the caller already owns: it reserves unconditionally, keeps the record it displaced, and restores that record if the commit fails. Applied to a brand new path it turns several captures into several simultaneous reservation holders for one absent name, and the `reservationId` guard in `recordMemoryArtifactWriteProvenance` only proves that the rollback owns the current record, not that the predecessor it restores is still valid. With contenders A, B and C reserving in that order, A creates the file, B's rollback is a no-op because C's reservation is current, and C's rollback then restores B's record onto A's file, which is the defect the last review identified.

Locking around that sequence inside the hook would not fix it, because the record that ends up wrong is written by the provenance owner, not by the hook. Making the reservation itself the point of mutual exclusion does fix it, and it belongs with the owner of that record. `src/memory/memory-artifact-provenance.ts` gains one exported claim function, `src/agents/memory-write-provenance.ts` gains the matching `createExclusive` observer method, and `recordMemoryArtifactWriteProvenance`, its rollback semantics and every existing caller of `write` are untouched. The store's `update` runs the comparison and the write in one SQLite write transaction, so the claim holds between processes sharing a workspace as well as inside one.

Exclusivity then lives in one place per fact: the filesystem decides who owns the name, the provenance store decides who may reserve it, and both are asked before the artifact is visible. A stale record for a path whose file was deleted outside the observer makes that one candidate name unavailable and the capture moves to the next candidate, which is the conservative direction.

## Relationship to the accepted sequential fix
This is the concurrent half of a defect whose sequential half is already fixed and accepted. #77749 (`61383aff4b8`, "fix(hooks): avoid session memory filename collisions") introduced the suffix loop precisely because two same-minute rollovers must not share a file. That fix works when the rollovers are ordered, because the first one has already landed on disk by the time the second scans. It does nothing when they overlap. The change here keeps that behavior and its regression coverage intact and closes the overlapping case with the same filename scheme.

The LLM-slug path is covered by construction. The claim is keyed on `memoryBasename`, which is `${dateStr}-${slug}` regardless of whether `slug` came from `generateSlugViaLLM` or from the minute fallback, and the claim sits after slug resolution. The LLM path is in fact the more exposed one on main, since the provider call is an additional and much longer await between the old check and the old use.

Single-session behavior is unchanged: the first candidate is `${basename}.md` with no suffix, and the file the user ends up with is the same one main would have produced.

## Review items from the previous cycle

**Failed claims no longer restore another loser's provenance (the P2 finding, and the session-state merge risk).** This is the change described above. The reservation is exclusive, so one path has one reservation holder at a time, losers return before any filesystem work, and a rollback can only ever delete its own record. The three-contender interleaving the review described is unreachable because B and C never obtain a reservation for A's path. The runtime evidence below drives six overlapping captures per round for fifteen rounds: on the previously reviewed head fifteen of fifteen rounds ended with a provenance record attached to the wrong capture; on this head none do.

**Provenance is still recorded before the artifact exists.** The claim writes the record while the path is absent and the exclusive create publishes the content, so the ordering the previous cycle asked for is preserved. `resolveMemoryPathClassification` answers `untrusted` for a non-owner capture at the first moment the file can be seen, with its content already readable, in every scenario below.

**Regression coverage now forces the interleaving.** `src/hooks/bundled/session-memory/handler-auto-reset.test.ts` gains a case that holds three captures at the claim for one candidate until all three have arrived, then asserts each published artifact carries its own session id, its own content hash and its own origin class. `src/memory/memory-artifact-provenance.test.ts` gains a case for the claim primitive itself: one claim per path, later claims occupied, and a rollback that touches only its own record.

**Sibling handler suite.** `src/hooks/bundled/session-memory/handler.test.ts` changes in one place: its module mock for `src/memory/memory-artifact-provenance.js` now also exports the claim function the handler calls, and the two provenance cases observe that function instead of `recordMemoryArtifactWriteProvenance`. The assertions are otherwise unchanged, including that the destination is absent when provenance is recorded and that no file is written when provenance recording fails. Every other case in that file is untouched.

**Captures survive past the numbered names.** Numbered suffixes run to 64 and are then followed by unique-token candidates, so a date and slug whose numbered names are all occupied keeps its capture instead of throwing it away.

**Occupied candidates are skipped whatever shape they have.** `Root.create` reports an occupied directory as `not-file` and an occupied hard link or symlink as `path-alias`, not `already-exists`. A candidate is treated as occupied when the error carries one of those three codes and an `lstat` of the candidate path confirms something is actually there. A path-security failure with nothing at the candidate path still propagates, so an aliased `memoryDir` is not silently retried 64 times.

**Still a maintainer call, unchanged from the last cycle.** Memory Core resolves an artifact's origin class before it reads the content and never revalidates it at publication (`extensions/memory-core/src/memory/manager-embedding-ops.ts`, with the untracked default at `extensions/memory-core/src/memory/memory-path-provenance.ts:63`). Nothing in this hook can close that; it is a Memory Core ordering decision. The same applies to whether a capture that loses a race and lands on a later filename should ever be able to inherit a conservative classification: with this change it cannot, because each claim starts from an empty record, but the general overwrite path still applies the sticky-untrusted rule by design.

## Verification
- `node scripts/run-vitest.mjs src/hooks/bundled/session-memory/handler-auto-reset.test.ts` on this tree: `Test Files 1 passed (1)`, `Tests 10 passed (10)`, including the new three-contender case.
- `node scripts/run-vitest.mjs src/hooks/bundled/session-memory/handler.test.ts src/memory/memory-artifact-provenance.test.ts src/agents/memory-write-provenance.test.ts`: `26 passed`, `14 passed` and `7 passed`. That covers the sibling handler suite the last review flagged, the provenance owner including its existing rollback cases, and the observer.
- `node_modules/.bin/oxfmt` was run on all six changed files.
- Branch rebased onto `2f97cdbacace6e5db2bea3043d64b8797e338d62`.
- Not run on this host: `tsgo` and `oxlint`. This box cannot hold the typecheck lane in memory, so a type error in the new code or in the new test code would surface only in CI, not locally. No local gate result is claimed beyond the three commands above.

## Real behavior proof
Behavior addressed: sessions of one agent rolling over in the same minute collapsed into one `<workspace>/memory/2026-03-04-0506.md`, losing every capture but the last, and the exclusive claim that repairs that must leave each surviving artifact with its own session identity, its own content hash and its own origin class, and must never let a Memory Core index pass read an untracked memory path and treat a non-owner transcript as trusted.
Real environment tested: the real `session-memory` hook handler from `src/hooks/bundled/session-memory/handler.ts` driven through the real `createInternalHookEvent` dispatch over real temporary workspace directories, interleaved in one process with the real Memory Core path classifier `resolveMemoryPathClassification` from `extensions/memory-core/src/memory/memory-path-provenance.ts` called in the order `prepareIndexEntry` calls it; run on pristine main `2f97cdbacace6e5db2bea3043d64b8797e338d62`, then on the head reviewed at revision 4 `428274b9b8577cfa200fd5f704c3b8fe558d4331`, then on this patched tree `c0c0a0a9fdbd10187c69b0512becefd54be4b44c`, with identical inputs and a pinned rollover timestamp. Transcripts were written through the real `replaceTranscriptEvents` session store, the real fs-safe `Root` performed every filesystem mutation, the real memory provenance observer wrapped every commit, and provenance was read back through the real `listMemoryArtifactProvenance` against a real state directory. The only substitution is module resolution: the Memory Core plugin's `openclaw/plugin-sdk/*` specifiers were resolved to the same in-repo host SDK source modules rather than to `dist`, because this checkout has no build output.
Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=<scratch>/state HOME=<scratch>/home TZ=UTC node --import tsx --import ./register.mjs ./probe.mts` and `... PROOF_CONTENDERS=6 PROOF_ROUNDS=15 node --import tsx --import ./register.mjs ./sweep.mts`. The first driver runs four scenarios against separate workspaces at the pinned timestamp `2026-03-04T05:06:07.000Z`: an owner rollover alone, a non-owner rollover alone, an owner rollover concurrent with a non-owner rollover, and three overlapping rollovers in one workspace; in each scenario an index pass opens on every `.md` path as it becomes visible and resolves its origin the way `prepareIndexEntry` does before reading content. The second driver raises the overlap to six concurrent rollovers per workspace and repeats it fifteen times, then reports every published artifact whose recorded session id or recorded content hash does not belong to the capture actually stored in that file.
Evidence after fix:
```
# BEFORE (pristine main 2f97cdbacace6e5db2bea3043d64b8797e338d62)
[three overlapping rollovers, same minute]
  artifacts kept: 1 -> 2026-03-04-0506.md
  2026-03-04-0506.md: carries=GAMMA-ONLY originClassAtFirstSight=untrusted bytesAtFirstSight=219
    recorded provenance: originClass=untrusted sessionId=gamma-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  ALPHA-ONLY retained copies: 0
  BETA-ONLY retained copies: 0
  GAMMA-ONLY retained copies: 1
overlapping rollovers per round: 6, rounds: 15, rounds with a provenance record attached to the wrong capture: 0, captures lost overall: 75

# BEFORE (head reviewed at revision 4, 428274b9b8577cfa200fd5f704c3b8fe558d4331, identical inputs)
[three overlapping rollovers, same minute]
  artifacts kept: 3 -> 2026-03-04-0506-2.md, 2026-03-04-0506-3.md, 2026-03-04-0506.md
  2026-03-04-0506-2.md: carries=BETA-ONLY originClassAtFirstSight=untrusted bytesAtFirstSight=216
    recorded provenance: originClass=untrusted sessionId=beta-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  2026-03-04-0506-3.md: carries=GAMMA-ONLY originClassAtFirstSight=agent bytesAtFirstSight=219
    recorded provenance: originClass=agent sessionId=gamma-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  2026-03-04-0506.md: carries=ALPHA-ONLY originClassAtFirstSight=agent bytesAtFirstSight=219
    recorded provenance: originClass=agent sessionId=alpha-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  ALPHA-ONLY retained copies: 1
  BETA-ONLY retained copies: 1
  GAMMA-ONLY retained copies: 1
overlapping rollovers per round: 6, rounds: 15, rounds with a provenance record attached to the wrong capture: 15, captures lost overall: 0
  round 1 2026-03-04-0506-2.md: carries=R1C1 recordedSessionId=round-1-contender-4-session recordDescribesThisFile=false originClass=untrusted
  round 1 2026-03-04-0506-3.md: carries=R1C2 recordedSessionId=round-1-contender-4-session recordDescribesThisFile=false originClass=untrusted
  round 1 2026-03-04-0506-4.md: carries=R1C3 recordedSessionId=round-1-contender-4-session recordDescribesThisFile=false originClass=untrusted
  round 2 2026-03-04-0506-2.md: carries=R2C1 recordedSessionId=round-2-contender-4-session recordDescribesThisFile=false originClass=untrusted

# AFTER (this patch at c0c0a0a9fdbd10187c69b0512becefd54be4b44c, identical inputs)
[owner rollover] owner=true
  index pass opened on first visible artifact: name=2026-03-04-0506.md originClass=agent bytesAtClassify=219
  artifact after hook completed: name=2026-03-04-0506.md bytes=219 carries_OWNER-ONLY=true
  recorded provenance: path=memory/2026-03-04-0506.md originClass=agent
  index pass would publish: originClass=agent withTranscriptContent=true automaticContextEligible=true
[non-owner rollover] owner=false
  index pass opened on first visible artifact: name=2026-03-04-0506.md originClass=untrusted bytesAtClassify=228
  artifact after hook completed: name=2026-03-04-0506.md bytes=228 carries_INTRUDER-ONLY=true
  recorded provenance: path=memory/2026-03-04-0506.md originClass=untrusted
  index pass would publish: originClass=untrusted withTranscriptContent=true automaticContextEligible=false
[concurrent owner and non-owner rollover, same minute]
  artifacts kept: 2 -> 2026-03-04-0506-2.md, 2026-03-04-0506.md
  2026-03-04-0506-2.md: carries=INTRUDER-ONLY originClassAtFirstSight=untrusted bytesAtFirstSight=238
    recorded provenance: originClass=untrusted sessionId=race-intruder-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  2026-03-04-0506.md: carries=OWNER-ONLY originClassAtFirstSight=agent bytesAtFirstSight=229
    recorded provenance: originClass=agent sessionId=race-owner-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  OWNER-ONLY retained copies: 1
  INTRUDER-ONLY retained copies: 1
[three overlapping rollovers, same minute]
  artifacts kept: 3 -> 2026-03-04-0506-2.md, 2026-03-04-0506-3.md, 2026-03-04-0506.md
  2026-03-04-0506-2.md: carries=BETA-ONLY originClassAtFirstSight=untrusted bytesAtFirstSight=216
    recorded provenance: originClass=untrusted sessionId=beta-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  2026-03-04-0506-3.md: carries=GAMMA-ONLY originClassAtFirstSight=agent bytesAtFirstSight=219
    recorded provenance: originClass=agent sessionId=gamma-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  2026-03-04-0506.md: carries=ALPHA-ONLY originClassAtFirstSight=agent bytesAtFirstSight=219
    recorded provenance: originClass=agent sessionId=alpha-session recordDescribesThisFile=true recordBelongsToCaptureInThisFile=true
  ALPHA-ONLY retained copies: 1
  BETA-ONLY retained copies: 1
  GAMMA-ONLY retained copies: 1
overlapping rollovers per round: 6, rounds: 15, rounds with a provenance record attached to the wrong capture: 0, captures lost overall: 0
```
Observed result after fix: on pristine main six overlapping rollovers per round kept one artifact per round and 75 of 90 captures were gone. On the head reviewed at revision 4 every capture survived, but in fifteen of fifteen rounds at least one surviving artifact carried a provenance record belonging to a different capture, with `recordDescribesThisFile=false` and one losing session id spread across several artifacts, exactly the rollback interleaving the review described. On this head all 90 captures survive and no artifact carries another capture's record: `rounds with a provenance record attached to the wrong capture: 0, captures lost overall: 0`. The four scenario runs show the same at the artifact level: three overlapping rollovers publish three files, each with its own marker, its own session id, `recordDescribesThisFile=true`, and the origin class its own sender earned, and the non-owner capture answers `untrusted` from the first moment it can be seen, with its content already readable, `bytesAtFirstSight=216`.
What was not tested: only same-process overlap was driven. Two OpenClaw processes sharing one workspace directory are not covered here; `Root.create` reaches `O_CREAT | O_EXCL` and the claim runs inside one SQLite write transaction, so both should hold across processes on a local filesystem, but that was not driven, and network filesystems where `O_EXCL` is weak were not driven either. The full Memory Core chunk and embedding publication was not driven; the classifier call that decides origin and the hook that produces the artifact were driven for real, and the persisted chunk origin is inferred from the classification `prepareIndexEntry` carries. The LLM-slug configuration was exercised only through the shared claim path, not with a live model call. The unique-token candidates past suffix 64 were driven as a group, not to their own exhaustion. No build output was produced, so the Memory Core plugin ran from its source modules with the host SDK specifiers resolved to the in-repo sources.

https://claude.ai/code/session_0141MfnPJYgyybnqkv98rhfr
