### PR TITLE
fix(channels): resolve DM allowlist wildcards after channel normalization

### DIFF
--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -1,9 +1,12 @@
 // Feishu tests cover policy plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
 import {
   hasExplicitFeishuGroupConfig,
+  normalizeFeishuAllowEntry,
+  resolveFeishuDmIngressAccess,
   resolveFeishuGroupConfig,
   resolveFeishuGroupSenderActivationIngressAccess,
   resolveFeishuGroupToolPolicy,
@@ -274,5 +277,41 @@ describe("resolveFeishuGroupSenderActivationIngressAccess", () => {
         senderUserId: "on_user_123",
       }),
     ).resolves.toBe("allow");
+  });
+});
+
+describe("feishu pinned main-DM owner", () => {
+  async function dmAdmission(allowFrom: string[]): Promise<string> {
+    return (
+      await resolveFeishuDmIngressAccess({
+        cfg: createCfg({}),
+        accountId: "default",
+        dmPolicy: "allowlist",
+        allowFrom,
+        senderOpenId: "ou_stranger_0001",
+        conversationId: "oc_chat_0001",
+        mayPair: false,
+      })
+    ).ingress.admission;
+  }
+
+  function pinnedOwner(allowFrom: string[]): string | null {
+    return resolvePinnedMainDmOwnerFromAllowlist({
+      dmScope: "main",
+      allowFrom,
+      normalizeEntry: normalizeFeishuAllowEntry,
+    });
+  }
+
+  it.each(["*", "feishu:*", "lark:*", "user:*"])(
+    "admits any sender for %s and leaves the main DM owner unpinned",
+    async (entry) => {
+      await expect(dmAdmission([entry])).resolves.toBe("dispatch");
+      expect(pinnedOwner([entry])).toBeNull();
+    },
+  );
+
+  it("still pins a single configured owner", () => {
+    expect(pinnedOwner(["feishu:ou_owner_0001"])).toBe("user:ou_owner_0001");
   });
 });

--- a/extensions/mattermost/src/mattermost/ingress-identity.test.ts
+++ b/extensions/mattermost/src/mattermost/ingress-identity.test.ts
@@ -1,0 +1,22 @@
+import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
+import { describe, expect, it } from "vitest";
+import { normalizeMattermostAllowEntry } from "./ingress-identity.js";
+
+function pinnedOwner(allowFrom: string[]): string | null {
+  return resolvePinnedMainDmOwnerFromAllowlist({
+    dmScope: "main",
+    allowFrom,
+    normalizeEntry: normalizeMattermostAllowEntry,
+  });
+}
+
+describe("mattermost pinned main-DM owner", () => {
+  it.each(["*", "mattermost:*", "user:*"])("leaves the main DM owner unpinned for %s", (entry) => {
+    expect(normalizeMattermostAllowEntry(entry)).toBe("*");
+    expect(pinnedOwner([entry])).toBeNull();
+  });
+
+  it("still pins a single configured owner", () => {
+    expect(pinnedOwner(["mattermost:@Owner"])).toBe("owner");
+  });
+});

--- a/extensions/slack/src/monitor/allow-list.test.ts
+++ b/extensions/slack/src/monitor/allow-list.test.ts
@@ -1,8 +1,10 @@
 // Slack tests cover allow list plugin behavior.
+import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it } from "vitest";
 import {
   normalizeAllowList,
   normalizeAllowListLower,
+  normalizeSlackAllowOwnerEntry,
   normalizeSlackSlug,
   resolveSlackAllowListMatch,
   resolveSlackUserAllowListForTeam,
@@ -125,5 +127,24 @@ describe("slack/allow-list", () => {
         teamId: "T11111111",
       }),
     ).toEqual(["w01234567", "team:t11111111:user:u01234567"]);
+  });
+});
+
+describe("slack pinned main-DM owner", () => {
+  function pinnedOwner(allowFrom: string[]): string | null {
+    return resolvePinnedMainDmOwnerFromAllowlist({
+      dmScope: "main",
+      allowFrom,
+      normalizeEntry: normalizeSlackAllowOwnerEntry,
+    });
+  }
+
+  it.each(["*", "slack:*", "user:*"])("leaves the main DM owner unpinned for %s", (entry) => {
+    expect(normalizeSlackAllowOwnerEntry(entry)).toBeUndefined();
+    expect(pinnedOwner([entry])).toBeNull();
+  });
+
+  it("still pins a single configured owner", () => {
+    expect(pinnedOwner(["slack:U01234567"])).toBe("u01234567");
   });
 });

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -93,6 +93,7 @@ function mergeResolvedAllowlists(
     matchedEntryIds,
     hasConfiguredEntries: scopedAllowlists.some((allowlist) => allowlist.hasConfiguredEntries),
     hasMatchableEntries: scopedAllowlists.some((allowlist) => allowlist.hasMatchableEntries),
+    hasLiteralWildcard: scopedAllowlists.some((allowlist) => allowlist.hasLiteralWildcard),
     hasWildcard: scopedAllowlists.some((allowlist) => allowlist.hasWildcard),
     accessGroups: {
       referenced: uniqueStrings(
@@ -169,6 +170,11 @@ export function applyIdentifierAuthenticationPolicy(
     hasMatchableEntries: allowlist.normalizedEntries.some(
       (entry) => !rejectedEntryIds.has(entry.opaqueEntryId),
     ),
+    hasWildcard:
+      allowlist.hasLiteralWildcard ||
+      allowlist.normalizedEntries.some(
+        (entry) => entry.wildcard === true && !rejectedEntryIds.has(entry.opaqueEntryId),
+      ),
     match: {
       matched: matchedEntryIds.length > 0,
       matchedEntryIds,

--- a/src/channels/message-access/dm-allow-state.test.ts
+++ b/src/channels/message-access/dm-allow-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveDmAllowAuditState } from "./dm-allow-state.js";
+
+function normalizeEntry(raw: string): string {
+  const trimmed = raw
+    .trim()
+    .replace(/^(demo|user):/i, "")
+    .trim();
+  return trimmed.toLowerCase();
+}
+
+async function auditState(allowFrom: string[]) {
+  return await resolveDmAllowAuditState({
+    provider: "demo",
+    accountId: "default",
+    allowFrom,
+    dmPolicy: "open",
+    normalizeEntry,
+  });
+}
+
+describe("resolveDmAllowAuditState", () => {
+  it.each(["*", "demo:*", "user:*"])("reports %s as an open DM allowlist", async (entry) => {
+    await expect(auditState([entry])).resolves.toEqual({
+      hasWildcard: true,
+      admittedPrincipals: [],
+    });
+  });
+
+  it("keeps narrow allowlists unchanged", async () => {
+    await expect(auditState(["demo:Owner-1", "owner-2"])).resolves.toEqual({
+      hasWildcard: false,
+      admittedPrincipals: ["owner-1", "owner-2"],
+    });
+  });
+
+  it("keeps configured owners alongside a prefixed wildcard", async () => {
+    await expect(auditState(["demo:*", "demo:Owner-1"])).resolves.toEqual({
+      hasWildcard: true,
+      admittedPrincipals: ["owner-1"],
+    });
+  });
+
+  it("merges persisted principals", async () => {
+    await expect(
+      resolveDmAllowAuditState({
+        provider: "demo",
+        accountId: "default",
+        allowFrom: ["demo:*"],
+        dmPolicy: "pairing",
+        normalizeEntry,
+        readStore: async () => ["demo:Paired-1"],
+      }),
+    ).resolves.toEqual({ hasWildcard: true, admittedPrincipals: ["paired-1"] });
+  });
+});

--- a/src/channels/message-access/dm-allow-state.ts
+++ b/src/channels/message-access/dm-allow-state.ts
@@ -14,7 +14,6 @@ export async function resolveDmAllowAuditState(params: {
   const configAllowFrom = normalizeStringEntries(
     Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
   );
-  const hasWildcard = configAllowFrom.includes("*");
   const storeAllowFrom = await readChannelIngressStoreAllowFromForDmPolicy({
     provider: params.provider,
     accountId: params.accountId,
@@ -23,12 +22,15 @@ export async function resolveDmAllowAuditState(params: {
   });
   const normalizeEntry = params.normalizeEntry ?? ((value: string) => value);
   const normalizedCfg = normalizeStringEntries(
-    configAllowFrom.filter((value) => value !== "*").map((value) => normalizeEntry(value)),
+    configAllowFrom.map((value) => (value === "*" ? "*" : normalizeEntry(value))),
   );
+  const hasWildcard = normalizedCfg.includes("*");
   const normalizedStore = normalizeStringEntries(
     storeAllowFrom.map((value) => normalizeEntry(value)),
   );
-  const admittedPrincipals = Array.from(new Set([...normalizedCfg, ...normalizedStore]));
+  const admittedPrincipals = Array.from(
+    new Set([...normalizedCfg.filter((value) => value !== "*"), ...normalizedStore]),
+  );
   return {
     hasWildcard,
     admittedPrincipals,

--- a/src/channels/message-access/message-access.test.ts
+++ b/src/channels/message-access/message-access.test.ts
@@ -310,4 +310,69 @@ describe("channel ingress DM allowlist wildcards", () => {
   it("keeps a narrow DM allowlist without a wildcard", async () => {
     await expect(dmHasWildcard(["demo:sender-1"])).resolves.toBe(false);
   });
+
+  const authenticatedWildcardIdentity = defineStableChannelIngressIdentity({
+    authentication: "verified",
+    normalizeEntry: (raw) =>
+      raw
+        .trim()
+        .replace(/^demo:/i, "")
+        .trim() || null,
+    isWildcardEntry: (entry) =>
+      entry
+        .trim()
+        .replace(/^demo:/i, "")
+        .trim() === "*",
+  });
+
+  function claimedSubject(
+    authentication: "verified" | "unverified",
+  ): InternalChannelIngressSubject {
+    return {
+      identifiers: [{ opaqueId: "stableId", kind: "stable-id", value: "sender-1", authentication }],
+    };
+  }
+
+  async function openDmSenderGate(params: {
+    entries: string[];
+    authentication: "verified" | "unverified";
+  }) {
+    const state = await resolveChannelIngressState(
+      baseInput({
+        adapter: createIdentityAdapter(authenticatedWildcardIdentity),
+        subject: claimedSubject(params.authentication),
+        allowlists: { dm: params.entries },
+      }),
+    );
+    const decision = decideChannelIngress(state, {
+      dmPolicy: "open",
+      groupPolicy: "disabled",
+      minIdentifierAuthentication: "verified",
+    });
+    return {
+      admission: decision.admission,
+      gate: decision.graph.gates.find((entry) => entry.id === "sender:dm"),
+    };
+  }
+
+  it("admits a normalized wildcard for an accepted sender claim", async () => {
+    const result = await openDmSenderGate({ entries: ["demo:*"], authentication: "verified" });
+    expect(result.admission).toBe("dispatch");
+    expectRecordFields(result.gate, { effect: "allow", reasonCode: "dm_policy_open" });
+  });
+
+  it("blocks a normalized wildcard when authentication rejects every match", async () => {
+    const result = await openDmSenderGate({ entries: ["demo:*"], authentication: "unverified" });
+    expect(result.admission).toBe("drop");
+    expectRecordFields(result.gate, {
+      effect: "block-dispatch",
+      reasonCode: "dm_policy_not_allowlisted",
+    });
+  });
+
+  it("keeps a literal wildcard open for a rejected sender claim", async () => {
+    const result = await openDmSenderGate({ entries: ["*"], authentication: "unverified" });
+    expect(result.admission).toBe("dispatch");
+    expectRecordFields(result.gate, { effect: "allow", reasonCode: "dm_policy_open" });
+  });
 });

--- a/src/channels/message-access/message-access.test.ts
+++ b/src/channels/message-access/message-access.test.ts
@@ -1,6 +1,7 @@
 // Message access tests cover channel message visibility and permission helpers.
 import { describe, expect, it } from "vitest";
 import { decideChannelIngress } from "./decision.js";
+import { createIdentityAdapter, defineStableChannelIngressIdentity } from "./runtime-identity.js";
 import { resolveChannelIngressState } from "./state.js";
 import type {
   ChannelIngressPolicyInput,
@@ -275,5 +276,38 @@ describe("channel message access ingress", () => {
         reasonCode: "sender_not_required",
       });
     }
+  });
+});
+
+describe("channel ingress DM allowlist wildcards", () => {
+  const prefixedWildcardIdentity = defineStableChannelIngressIdentity({
+    normalizeEntry: (raw) =>
+      raw
+        .trim()
+        .replace(/^demo:/i, "")
+        .trim() || null,
+    isWildcardEntry: (entry) =>
+      entry
+        .trim()
+        .replace(/^demo:/i, "")
+        .trim() === "*",
+  });
+
+  async function dmHasWildcard(entries: string[]): Promise<boolean> {
+    const state = await resolveChannelIngressState(
+      baseInput({
+        adapter: createIdentityAdapter(prefixedWildcardIdentity),
+        allowlists: { dm: entries },
+      }),
+    );
+    return state.allowlists.dm.hasWildcard;
+  }
+
+  it.each(["*", "demo:*"])("reports %s as a wildcard DM allowlist", async (entry) => {
+    await expect(dmHasWildcard([entry])).resolves.toBe(true);
+  });
+
+  it("keeps a narrow DM allowlist without a wildcard", async () => {
+    await expect(dmHasWildcard(["demo:sender-1"])).resolves.toBe(false);
   });
 });

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -424,6 +424,7 @@ async function resolveIngressAllowlist(params: {
     matchedEntryIds: match.matchedEntryIds,
     hasConfiguredEntries: entries.length > 0,
     hasMatchableEntries: direct.normalizedEntries.length > 0 || groups.normalizedEntries.length > 0,
+    hasLiteralWildcard: directEntries.includes("*"),
     hasWildcard:
       directEntries.includes("*") ||
       direct.normalizedEntries.some((entry) => entry.wildcard === true),

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -424,7 +424,9 @@ async function resolveIngressAllowlist(params: {
     matchedEntryIds: match.matchedEntryIds,
     hasConfiguredEntries: entries.length > 0,
     hasMatchableEntries: direct.normalizedEntries.length > 0 || groups.normalizedEntries.length > 0,
-    hasWildcard: directEntries.includes("*"),
+    hasWildcard:
+      directEntries.includes("*") ||
+      direct.normalizedEntries.some((entry) => entry.wildcard === true),
     accessGroups: groups.accessGroups,
     match,
   };

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -157,6 +157,7 @@ export type ResolvedIngressAllowlist = {
 };
 
 export type NormalizedIngressAllowlist = Omit<ResolvedIngressAllowlist, "normalizedEntries"> & {
+  hasLiteralWildcard: boolean;
   normalizedEntries: Array<
     ChannelIngressNormalizedEntry & { authentication: IdentifierAuthentication }
   >;

--- a/src/security/audit-channel-dm-policy.test.ts
+++ b/src/security/audit-channel-dm-policy.test.ts
@@ -29,6 +29,7 @@ function createDmPlugin(
     id?: "telegram" | "whatsapp";
     accounts?: Record<string, { policy?: string; allowFrom: Array<string | number> }>;
     dmRouting?: NonNullable<ChannelPlugin["security"]>["dmRouting"];
+    normalizeEntry?: (raw: string) => string;
   } = {},
 ): ChannelPlugin {
   const id = params.id ?? "whatsapp";
@@ -47,6 +48,7 @@ function createDmPlugin(
             policyPath: `channels.${id}.accounts.${resolvedAccountId}.dmPolicy`,
             allowFromPath: `channels.${id}.accounts.${resolvedAccountId}.`,
             approveHint: `approve ${resolvedAccountId}`,
+            ...(params.normalizeEntry ? { normalizeEntry: params.normalizeEntry } : {}),
           }
         : null;
     },
@@ -587,5 +589,66 @@ describe("security audit channel dm policy", () => {
 
     expect(requireFinding(findings, "channels.whatsapp.dm.open").severity).toBe("critical");
     expect(collisionFindings(findings)).toHaveLength(1);
+  });
+});
+
+describe("security audit channel dm wildcard allowlists", () => {
+  const stripChannelPrefix = (raw: string): string =>
+    raw
+      .trim()
+      .replace(/^(whatsapp|user):/i, "")
+      .trim();
+
+  async function lockedFindings(params: {
+    policy: string;
+    allowFrom: Array<string | number>;
+  }): Promise<ChannelSecurityFinding[]> {
+    const findings = await collectChannelSecurityFindingsCore({
+      cfg: { agents: { entries: { main: {} } } },
+      plugins: [
+        createDmPlugin({
+          accounts: { default: { policy: params.policy, allowFrom: params.allowFrom } },
+          normalizeEntry: stripChannelPrefix,
+        }),
+      ],
+    });
+    return findings.filter((finding) => finding.checkId === "channels.whatsapp.dm.locked");
+  }
+
+  it.each([
+    { policy: "allowlist", allowFrom: ["whatsapp:*"] },
+    { policy: "allowlist", allowFrom: ["user:*"] },
+    { policy: "allowlist", allowFrom: ["*"] },
+    { policy: "pairing", allowFrom: ["whatsapp:*"] },
+  ])("does not report DMs as locked for $policy with $allowFrom", async (params) => {
+    await expect(lockedFindings(params)).resolves.toHaveLength(0);
+  });
+
+  it.each([
+    { policy: "allowlist", allowFrom: [] },
+    { policy: "pairing", allowFrom: [] },
+  ])("still reports DMs as locked for $policy with no admitted senders", async (params) => {
+    const findings = await lockedFindings(params);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ severity: "info" });
+  });
+
+  it("evaluates the anyone principal for a prefixed wildcard", async () => {
+    const findings = await collectChannelSecurityFindingsCore({
+      cfg: { agents: { entries: { main: {}, research: {} } } },
+      plugins: [
+        createDmPlugin({
+          accounts: { default: { policy: "allowlist", allowFrom: ["whatsapp:*"] } },
+          normalizeEntry: stripChannelPrefix,
+        }),
+      ],
+    });
+
+    expect(findings.some((finding) => finding.checkId === "channels.whatsapp.dm.locked")).toBe(
+      false,
+    );
+    expect(
+      requireFinding(findings, "channels.whatsapp.routing.owner_missing.default").severity,
+    ).toBe("warn");
   });
 });

--- a/src/security/audit-channel-dm-policy.test.ts
+++ b/src/security/audit-channel-dm-policy.test.ts
@@ -633,6 +633,36 @@ describe("security audit channel dm wildcard allowlists", () => {
     expect(findings[0]).toMatchObject({ severity: "info" });
   });
 
+  async function openDmCheckIds(allowFrom: Array<string | number>): Promise<string[]> {
+    const findings = await collectChannelSecurityFindingsCore({
+      cfg: { agents: { entries: { main: {} } } },
+      plugins: [
+        createDmPlugin({
+          accounts: { default: { policy: "open", allowFrom } },
+          normalizeEntry: stripChannelPrefix,
+        }),
+      ],
+    });
+    return findings
+      .filter((finding) => finding.checkId.startsWith("channels.whatsapp.dm."))
+      .map((finding) => finding.checkId);
+  }
+
+  it.each([["whatsapp:*"], ["user:*"]])(
+    "keeps the open DM validity warning for %s",
+    async (entry) => {
+      const checkIds = await openDmCheckIds([entry]);
+      expect(checkIds).toContain("channels.whatsapp.dm.open");
+      expect(checkIds).toContain("channels.whatsapp.dm.open_invalid");
+    },
+  );
+
+  it("omits the open DM validity warning for a literal wildcard", async () => {
+    const checkIds = await openDmCheckIds(["*"]);
+    expect(checkIds).toContain("channels.whatsapp.dm.open");
+    expect(checkIds).not.toContain("channels.whatsapp.dm.open_invalid");
+  });
+
   it("evaluates the anyone principal for a prefixed wildcard", async () => {
     const findings = await collectChannelSecurityFindingsCore({
       cfg: { agents: { entries: { main: {}, research: {} } } },

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -16,6 +16,7 @@ import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-ins
 import { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
 import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { evaluateDmPolicyAllowFromDependency } from "../config/zod-schema.core.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   listExactDirectMessageBindingPeerIds,
@@ -263,7 +264,11 @@ export async function collectChannelSecurityFindingsCore(params: {
         detail: `${policyPath}="open" allows anyone to DM the bot.`,
         remediation: `Use pairing/allowlist; if you really need open DMs, ensure ${allowFromKey} includes "*".`,
       });
-      if (!hasWildcard) {
+      const configuredWildcardViolation = evaluateDmPolicyAllowFromDependency({
+        policy: input.dmPolicy,
+        allowFrom: input.allowFrom ?? undefined,
+      });
+      if (configuredWildcardViolation === "open_requires_wildcard") {
         findings.push({
           checkId: `channels.${input.provider}.dm.open_invalid`,
           severity: "warn",

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -283,7 +283,7 @@ export async function collectChannelSecurityFindingsCore(params: {
       return auditState;
     }
 
-    if (input.dmPolicy !== "open" && auditState.admittedPrincipals.length === 0) {
+    if (input.dmPolicy !== "open" && !hasWildcard && auditState.admittedPrincipals.length === 0) {
       findings.push({
         checkId: `channels.${input.provider}.dm.locked`,
         severity: "info",

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolvePinnedMainDmOwnerFromAllowlist } from "./dm-policy-shared.js";
+
+function collapsePrefixToWildcard(entry: string): string | undefined {
+  const trimmed = entry
+    .trim()
+    .replace(/^(demo|user):/i, "")
+    .trim();
+  return trimmed || undefined;
+}
+
+function rejectWildcard(entry: string): string | undefined {
+  const trimmed = entry.trim();
+  if (!trimmed || trimmed === "*") {
+    return undefined;
+  }
+  return trimmed.replace(/^user:/i, "").trim() || undefined;
+}
+
+function pin(
+  allowFrom: string[],
+  normalizeEntry: (entry: string) => string | undefined,
+): string | null {
+  return resolvePinnedMainDmOwnerFromAllowlist({ dmScope: "main", allowFrom, normalizeEntry });
+}
+
+describe("resolvePinnedMainDmOwnerFromAllowlist", () => {
+  it.each(["demo:*", "user:*", "  demo:*  "])(
+    "leaves %s unpinned when the channel normalizer resolves it to a wildcard",
+    (entry) => {
+      expect(collapsePrefixToWildcard(entry)).toBe("*");
+      expect(pin([entry], collapsePrefixToWildcard)).toBeNull();
+    },
+  );
+
+  it("keeps a raw wildcard unpinned for normalizers that reject it", () => {
+    expect(rejectWildcard("*")).toBeUndefined();
+    expect(pin(["*"], rejectWildcard)).toBeNull();
+    expect(pin(["*"], collapsePrefixToWildcard)).toBeNull();
+  });
+
+  it("keeps a prefixed wildcard unpinned next to a named owner", () => {
+    expect(pin(["demo:*", "demo:owner-1"], collapsePrefixToWildcard)).toBeNull();
+  });
+
+  it("still pins a single normalized owner", () => {
+    expect(pin(["demo:owner-1"], collapsePrefixToWildcard)).toBe("owner-1");
+    expect(pin(["user:owner-1"], rejectWildcard)).toBe("owner-1");
+    expect(pin(["demo:owner-1", "demo:owner-2"], collapsePrefixToWildcard)).toBeNull();
+  });
+});

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -29,6 +29,9 @@ export function resolvePinnedMainDmOwnerFromAllowlist(params: {
         .filter((entry): entry is string => Boolean(entry)),
     ),
   );
+  if (normalizedOwners.includes("*")) {
+    return null;
+  }
   return normalizedOwners.length === 1
     ? expectDefined(normalizedOwners[0], "normalized owners entry at 0")
     : null;


### PR DESCRIPTION
## Summary
An operator who writes the provider-prefixed wildcard in a channel DM allowlist (`feishu:*`, `lark:*` or `user:*` on Feishu, `mattermost:*` or `user:*` on Mattermost) gets a channel that is fully open at admission but that every literal-`"*"` consumer reads as a one-entry allowlist. Two things break for that operator.

Routing. `resolvePinnedMainDmOwnerFromAllowlist` returns `"*"` as the pinned main-DM owner. The channel then installs `mainDmOwnerPin: { ownerRecipient: "*", senderRecipient: <sender> }` and `shouldSkipPinnedMainDmRouteUpdate` skips whenever owner and sender differ. No real sender id equals `"*"`, so the main DM session never records a delivery target, and a session that already had one keeps the stale target forever. Anything that resolves `channel: "last"` for that session (cron `announce` jobs, heartbeat and proactive messages, `openclaw message` to the last route) is silently undeliverable or goes to the wrong peer.

Security audit. `resolveDmAllowAuditState` reports `hasWildcard: false` and lists a bogus admitted sender literally named `*`, so `openclaw security audit` presents a wide-open DM channel as an ordinary narrow allowlist: no enumeration of bound DM peers, no evaluation of the "anyone" sender, and no shared-session exposure finding.

Admission itself was already correct on main. What was wrong is every downstream consumer that decided "is this a wildcard?" on the raw config string instead of asking the channel.

## Root cause
The channel adapter decides what a wildcard is through its own normalizer, but three consumers tested the raw entry for a literal `"*"`.

`src/security/dm-policy-shared.ts:22` runs its literal guard before `normalizeEntry`. `normalizeFeishuAllowEntry` maps `feishu:*`, `lark:*` and `user:*` to `"*"` (`extensions/feishu/src/policy.ts:47-62`), and the Feishu ingress descriptor uses that same function for `isWildcardEntry` (`policy.ts:44`), so admission really is open to everyone. The guard misses, `normalizedOwners` becomes `["*"]` with length 1, and the helper returns `"*"` as a pinned owner. `normalizeMattermostAllowEntry` has the same shape (`extensions/mattermost/src/mattermost/ingress-identity.ts:29-45`).

`src/channels/message-access/dm-allow-state.ts:17` derived `hasWildcard` from the raw config. `mattermost:*` survived the `!== "*"` filter, normalized to `"*"`, and landed in `admittedPrincipals` while `hasWildcard` stayed `false`, which skipped the wildcard path in `src/security/audit-channel.ts:398-412` so the audit never called `listExactDirectMessageBindingPeerIds` and never evaluated the "anyone" sender.

`src/channels/message-access/state.ts:427` repeated the literal test for `NormalizedIngressAllowlist.hasWildcard`, which feeds `participantOutcomeAffecting` (`src/channels/message-access/runtime.ts:723-729`) and the `dmPolicy: "open"` branch in `src/channels/message-access/sender-gates.ts:93`.

## Fix
Ask the normalizer first, then test for the wildcard.

- `src/security/dm-policy-shared.ts`: test `normalizedOwners.includes("*")` after normalization, so a normalizer-resolved wildcard stays unpinned.
- `src/channels/message-access/dm-allow-state.ts`: normalize first, derive `hasWildcard` from the normalized list, and drop `"*"` from `admittedPrincipals`.
- `src/channels/message-access/state.ts`: read the wildcard flag off the entry the adapter already stamped through the descriptor's `isWildcardEntry` (`src/channels/message-access/runtime-identity.ts:162-178`), keeping the literal test as an additive fallback for adapters that do not stamp it, and record the raw literal `"*"` declaration separately as `hasLiteralWildcard`.
- `src/channels/message-access/allowlist.ts`: recompute `hasWildcard` inside `applyIdentifierAuthenticationPolicy`, so a normalized wildcard only keeps admitting while at least one wildcard entry survives the authentication result. A literal `"*"` keeps admitting without an identifier match, which is the shipped meaning of an open allowlist.
- `src/security/audit-channel.ts`: require `!hasWildcard` in the locked-DM predicate, and take the `dm.open_invalid` validity warning from `evaluateDmPolicyAllowFromDependency` instead of from the audit wildcard state.

The raw-`"*"` short-circuit in `dm-policy-shared.ts` stays, because Slack (`normalizeSlackAllowOwnerEntry`) and Signal (`normalizeSignalAllowRecipient`) return `undefined` for a wildcard: normalizing first would drop the entry entirely and a bare `["*"]` would then look like an empty list. In `dm-allow-state.ts` a literal `"*"` is likewise never handed to the normalizer, so channels that reject it keep behaving exactly as before.

### Review round 2: the two findings from the previous verdict
Both were real and both are fixed in this revision.

[P1 and the security item] Preserve authentication rejection when enabling normalized wildcards. Correct: on the previous head, `hasWildcard` was set before authentication filtering and then passed through `applyIdentifierAuthenticationPolicy` untouched, so `senderGateForDirect` took its open-policy shortcut even when every matched entry had been rejected for an insufficient identifier claim. With `dmPolicy: "open"`, `allowFrom: ["mattermost:*"]` and `minIdentifierAuthentication: "verified"`, an unverified sender reached dispatch. The fix carries the raw literal declaration as `hasLiteralWildcard` and recomputes `hasWildcard` from the surviving wildcard entries inside the policy function, which is where rejection is resolved. A literal `"*"` is unchanged, because it admits without an identifier match and has no claim to compare. The proof below shows both an accepted and a rejected sender claim at the ingress boundary, and the new cases in `message-access.test.ts` cover the accepted claim, the rejected claim and the preserved literal wildcard.

[P2] Keep open-DM validity warnings aligned with the configuration schema. Correct: moving the flag also suppressed `channels.<id>.dm.open_invalid` for `dmPolicy: "open"` with only `mattermost:*`, while the Mattermost schema still calls `requireOpenAllowFrom` and `evaluateDmPolicyAllowFromDependency` still requires a literal trimmed `"*"` (`src/config/zod-schema.core.ts:714-744`). The audit now asks that canonical dependency check for the validity warning, so the audit and the configuration validator cannot drift, and the normalized wildcard state stays in charge of exposure and routing analysis only. The proof shows `dm.open_invalid` present both before and after this patch for `mattermost:*`, alongside the new shared-session exposure finding.

### The locked-DM guard, and what it fixes beyond this branch
Once a normalized wildcard is no longer an admitted sender, `admittedPrincipals` is empty for a wildcard-only allowlist. The consumer at `src/security/audit-channel.ts:286` treated an empty list under `allowlist` or `pairing` as "DMs are locked; unknown senders are blocked or receive a pairing code". Under those policies admission does not go through `hasWildcard` at all: it goes through `match.matched`, and `createIdentityAdapter` collapses a wildcard entry to `{ value: "*", wildcard: true }` which `matchSubject` pairs with any sender (`runtime-identity.ts:166-176`, `:211-237`). A wildcard-only allowlist therefore admits everyone, and reporting it as locked is false reassurance. This was already true on main for a bare `"*"`. `allowFrom: []` still reports locked.

## Why this is the right boundary
`resolvePinnedMainDmOwnerFromAllowlist` is the single owner of this policy for roughly twelve channels (Feishu, Mattermost, Slack, Signal, Discord, Telegram, WhatsApp, iMessage, Matrix, LINE, plus `src/infra/event-session-routing.ts`). Fixing it per channel would re-duplicate the policy in every caller, which is exactly what the shared helper exists to prevent. The same reasoning applies to `resolveDmAllowAuditState` and `resolveIngressAllowlist`: they own the audit view and the normalized ingress state.

Sibling surfaces. The authentication repair lives in `applyIdentifierAuthenticationPolicy` and `resolveIngressAllowlist`, the shared ingress kernel every channel adapter runs through, so Feishu, Mattermost, Slack, Signal, Discord, msteams, IRC, Google Chat and the rest are fixed together rather than one at a time. No per-channel wildcard admission code exists to fix separately.

Slack and Signal are proven unaffected by the routing half. Both normalizers return `undefined` for a wildcard, so `normalizedOwners` never contains `"*"` and the raw short-circuit remains the only path that fires. Feishu registers only `collectWarnings` and `collectAuditFindings` (`extensions/feishu/src/channel.ts:2002`) and no `resolveDmPolicy`, so `resolveDmAllowAuditState` is never reached for Feishu through the registered adapter: Feishu is affected by the routing half only. Mattermost does reach it, because `createRestrictSendersChannelSecurity` passes `normalizeDmEntry` through as `normalizeEntry` (`extensions/mattermost/src/channel.ts:141`, `src/plugin-sdk/channel-policy.ts:433`), which is why the proof is driven through the registered Mattermost channel plugin.

## Owner decisions still open
Neither is author-actionable, and neither is worked around in this diff.

1. Existing prefixed-wildcard installations will resume updating the shared main session's delivery target. The proof block shows that directly: a main session seeded with `channel:dm-operator` keeps that recipient on current main and moves to the newest inbound DM peer with this patch. That is the intended repair, but it changes the recipient of subsequent last-route sends on upgrade and needs owner acceptance.
2. Sponsorship for the restricted security path. This touches the shared DM policy and ingress authentication surface, so it needs a security owner to sponsor it.

## Scope note
A wildcard-only allowlist under `dmPolicy: "allowlist"` still emits no DM finding of its own after this patch, exactly as before it. Adding a positive "this allowlist admits everyone" finding is a real gap but a separate policy decision about audit vocabulary, so it is deliberately not in this diff.

## Verification
Rebased onto `e14b3ddac2e5ea9dbb450057b7436c22a012a89b`. Scoped runs with `node scripts/run-vitest.mjs`:

- `src/channels/message-access/message-access.test.ts`, `src/security/audit-channel-dm-policy.test.ts`, `src/channels/message-access/dm-allow-state.test.ts`, `src/security/dm-policy-shared.test.ts`: 4 files, 61 tests passed.
- `src/channels/message-access/identifier-authentication.test.ts`, `src/channels/message-access/runtime-identity.test.ts`, `src/security/audit-channel-entry-authentication.test.ts`: passed, so the existing authentication contract is unchanged.
- `extensions/feishu/src/policy.test.ts`, `extensions/mattermost/src/mattermost/ingress-identity.test.ts`, `extensions/slack/src/monitor/allow-list.test.ts`: passed.
- `src/channels/message-access/admission-evidence.test.ts`, `src/channels/message-access/context-builder-callers.test.ts`, `src/channels/message-access/participant-input.test.ts`, `src/plugins/registry-runtime.channel-ingress.test.ts`, `extensions/mattermost/src/mattermost/monitor.authz.test.ts`: passed.
- `oxfmt --check` clean on all six changed files.
- Reverting only the production files and rerunning the two edited suites fails the new wildcard assertions and keeps the preserved-behavior assertions green, so the new coverage fails on the original defect.
- Typechecking is delegated to GitHub checks on this host.

## Real behavior proof
Behavior addressed: A prefixed DM allowlist wildcard (`feishu:*`, `lark:*`, `user:*`, `mattermost:*`) admits every sender but is resolved as a single pinned main-DM owner named `*`, which freezes the main DM session delivery target, and the registered channel security audit misreports the same allowlist as narrow; while normalized wildcard admission must still respect `minIdentifierAuthentication`, so a below-threshold sender is refused before the turn handoff.
Real environment tested: the real registered Mattermost channel plugin `mattermostPlugin` driven through the real `collectChannelSecurityFindingsCore`, the same collector `openclaw security audit` uses; the real shared ingress resolver `resolveStableChannelMessageIngress` driven with the real `mattermostIngressIdentity` descriptor and the real Mattermost drop-log formatter `formatMattermostDirectMessageDropLog`; and the real main-DM route recorder `recordInboundSession` writing to a real on-disk session store resolved by `resolveSessionStorePathCore`, read back through `loadSessionEntryReadOnly`, with the pin built by the real `resolvePinnedMainDmOwnerFromAllowlist` and `normalizeMattermostAllowEntry` exactly as `extensions/mattermost/src/mattermost/monitor-turn.ts:432-450` builds it. Nothing on these paths was stubbed and no network boundary was replaced; the only hand-built value is the inbound message context record. Run on pristine `main` e14b3ddac2e5ea9dbb450057b7436c22a012a89b with the six production files at their base contents, and on head 1bf20e4e402db9998348716c47dc5380959268f1, with identical inputs and a wiped state directory for each run.
Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=<scratch dir> HOME=<scratch dir> ./node_modules/.bin/tsx ./proof-144147.mts` from the worktree root, driving the registered Mattermost security audit for `allowFrom: ["mattermost:*"]` under `dmPolicy: "open"` and `dmPolicy: "allowlist"`, then the main-DM delivery route for a fresh session and for a session already holding another recipient, then inbound DM admission for a server-authenticated sender and for a below-threshold sender under `minIdentifierAuthentication: "verified"`.
Evidence after fix:
```
# BEFORE (pristine main e14b3ddac2e5ea9dbb450057b7436c22a012a89b)
# registered mattermost audit, dmPolicy=open allowFrom=["mattermost:*"]
  critical channels.mattermost.dm.open
  warn     channels.mattermost.dm.open_invalid
# registered mattermost audit, dmPolicy=allowlist allowFrom=["mattermost:*"]
  (no dm or routing findings)
# main-dm delivery route, allowFrom=["mattermost:*"] dmScope=main
  pinned main-dm owner = "*"
  mattermost: skip main-session last route for user-alpha (pinned owner *)
  fresh session, target after inbound dm = (none recorded)
  seeded session, target before inbound dm = mattermost channel:dm-operator
  mattermost: skip main-session last route for user-alpha (pinned owner *)
  seeded session, target after inbound dm = mattermost channel:dm-operator
# inbound dm admission, dmPolicy=open allowFrom=["mattermost:*"] minIdentifierAuthentication=verified
  server-authenticated sender verdict=allow reasonCode=dm_policy_allowlisted gate=allow thresholdRemovedMatch=false
  turn handoff reached = yes
  below-threshold sender      verdict=block reasonCode=dm_policy_not_allowlisted gate=block-dispatch thresholdRemovedMatch=true
  mattermost: drop dm sender=user-alpha (dmPolicy=open reason=dm_policy_not_allowlisted hint=add-allowFrom-wildcard)
  turn handoff reached = no

# AFTER (this patch, identical inputs, head 1bf20e4e402db9998348716c47dc5380959268f1)
# registered mattermost audit, dmPolicy=open allowFrom=["mattermost:*"]
  critical channels.mattermost.dm.open
  warn     channels.mattermost.dm.open_invalid
  warn     channels.dm.session_collision.mattermost-default.1
# registered mattermost audit, dmPolicy=allowlist allowFrom=["mattermost:*"]
  warn     channels.dm.session_collision.mattermost-default.1
# main-dm delivery route, allowFrom=["mattermost:*"] dmScope=main
  pinned main-dm owner = null
  fresh session, target after inbound dm = mattermost channel:dm-alpha
  seeded session, target before inbound dm = mattermost channel:dm-operator
  seeded session, target after inbound dm = mattermost channel:dm-alpha
# inbound dm admission, dmPolicy=open allowFrom=["mattermost:*"] minIdentifierAuthentication=verified
  server-authenticated sender verdict=allow reasonCode=dm_policy_open gate=allow thresholdRemovedMatch=false
  turn handoff reached = yes
  below-threshold sender      verdict=block reasonCode=dm_policy_not_allowlisted gate=block-dispatch thresholdRemovedMatch=true
  mattermost: drop dm sender=user-alpha (dmPolicy=open reason=dm_policy_not_allowlisted hint=add-allowFrom-wildcard)
  turn handoff reached = no
```
Observed result after fix: On pristine main the registered Mattermost audit reports no shared-session exposure for `mattermost:*` and the main-DM route resolver pins owner `"*"`, so the recorder skips every update and the main session holds no recipient at all on a fresh session and a stale `channel:dm-operator` on a seeded one; with the patch the owner resolves to `null`, both sessions record the real inbound peer `channel:dm-alpha`, the audit adds the shared-session exposure warning while the schema validity warning `dm.open_invalid` is still emitted for the prefixed wildcard, and at the ingress boundary the server-authenticated sender is admitted and reaches the turn handoff while the below-threshold sender is refused with `gate=block-dispatch` and the channel's own drop line, never reaching it.
What was not tested: no live Mattermost server, WebSocket session or HTTP call was made, so the transport layer is exercised only through the plugin's resolved account config; no Feishu, Slack, Signal or Discord runtime was driven, and those channels rest on the shared helper coverage plus their own normalizer suites; the full repository build and typecheck were not run on this host.
