### PR TITLE
fix(configure): show action menu for stopped disabled gateway units

### DIFF
--- a/src/commands/configure.daemon.test.ts
+++ b/src/commands/configure.daemon.test.ts
@@ -15,6 +15,7 @@ const resolveGatewayInstallToken = vi.hoisted(() => vi.fn());
 const buildGatewayInstallPlan = vi.hoisted(() => vi.fn());
 const note = vi.hoisted(() => vi.fn());
 const serviceIsLoaded = vi.hoisted(() => vi.fn(async () => false));
+const serviceHasInstalledDefinition = vi.hoisted(() => vi.fn(async () => false));
 const serviceReadCommand = vi.hoisted(() => vi.fn());
 const serviceInstall = vi.hoisted(() => vi.fn(async () => {}));
 const serviceUninstall = vi.hoisted(() => vi.fn(async () => {}));
@@ -60,6 +61,7 @@ vi.mock("../daemon/service.js", async () => {
     ...actual,
     resolveGatewayService: vi.fn(() => ({
       isLoaded: serviceIsLoaded,
+      hasInstalledDefinition: serviceHasInstalledDefinition,
       readCommand: serviceReadCommand,
       install: serviceInstall,
       uninstall: serviceUninstall,
@@ -75,8 +77,8 @@ vi.mock("./systemd-linger.js", () => ({
 describe("maybeInstallDaemon", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    progressSetLabel.mockReset();
     serviceIsLoaded.mockResolvedValue(false);
+    serviceHasInstalledDefinition.mockResolvedValue(false);
     serviceReadCommand.mockResolvedValue(null);
     serviceInstall.mockResolvedValue(undefined);
     serviceUninstall.mockReset();
@@ -255,6 +257,54 @@ describe("maybeInstallDaemon", () => {
       port: 18789,
     });
 
+    expect(serviceInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the action menu instead of reinstalling a stopped disabled unit", async () => {
+    serviceIsLoaded.mockResolvedValue(false);
+    serviceHasInstalledDefinition.mockResolvedValue(true);
+    select.mockResolvedValueOnce("skip");
+
+    const outcome = await maybeInstallDaemon({
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      port: 18789,
+    });
+
+    expect(outcome).toBe("skipped");
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway service already installed" }),
+    );
+    expect(serviceInstall).not.toHaveBeenCalled();
+    expect(serviceRestart).not.toHaveBeenCalled();
+  });
+
+  it("restarts without reinstalling when a stopped disabled unit is kept", async () => {
+    serviceIsLoaded.mockResolvedValue(false);
+    serviceHasInstalledDefinition.mockResolvedValue(true);
+    select.mockResolvedValueOnce("restart");
+
+    const outcome = await maybeInstallDaemon({
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      port: 18789,
+    });
+
+    expect(outcome).toBe("succeeded");
+    expect(serviceRestart).toHaveBeenCalledTimes(1);
+    expect(serviceInstall).not.toHaveBeenCalled();
+  });
+
+  it("installs fresh when no service definition exists", async () => {
+    serviceIsLoaded.mockResolvedValue(false);
+    serviceHasInstalledDefinition.mockResolvedValue(false);
+
+    await maybeInstallDaemon({
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      port: 18789,
+    });
+
+    expect(select).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway service already installed" }),
+    );
     expect(serviceInstall).toHaveBeenCalledTimes(1);
   });
 

--- a/src/commands/configure.daemon.ts
+++ b/src/commands/configure.daemon.ts
@@ -35,10 +35,21 @@ export async function maybeInstallDaemon(params: {
     }
     loaded = false;
   }
+  // isLoaded means enabled on systemd. A stopped and disabled unit still has
+  // an installed definition; route it to the action menu so preparation never
+  // silently re-enables and restarts it (issue 83354).
+  let hasDefinition = false;
+  if (!loaded) {
+    try {
+      hasDefinition = (await service.hasInstalledDefinition?.({ env: process.env })) ?? false;
+    } catch {
+      hasDefinition = false;
+    }
+  }
   let shouldCheckLinger = false;
   let shouldInstall = true;
   let daemonRuntime = params.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
-  if (loaded) {
+  if (loaded || hasDefinition) {
     const action = guardCancel(
       await select({
         message: "Gateway service already installed",


### PR DESCRIPTION
Fixes #83354.

## What Problem This Solves
Operator-stopped user-level gateway units get silently resurrected. MaybeInstallDaemon gated its existing-service menu on isLoaded, which resolves to enabled on systemd. A stopped and disabled unit fell through to the fresh-install path, which runs daemon-reload, enable, restart with no prompt, reclaiming the port after the operator freed it.

## Fix
When the unit is not loaded, probe hasInstalledDefinition (unit file present regardless of enablement). A present but unenrolled unit now gets the Restart/Reinstall/Skip menu instead of the auto enable+restart install path. Explicit Restart still starts the unit but leaves it disabled. Reinstall still re-enables with consent.

## Evidence
Scoped: src/commands/configure.daemon.test.ts, 13/13 pass, including 3 new tests. Failing-first verified: the 2 new stopped-unit tests fail on the unpatched source (2 failed, 11 passed) and pass with the fix (13 passed). oxfmt/oxlint clean on both touched files.

## Parked
Live systemd user-manager repro parked: no Linux host with a user manager in this environment. Proven at unit level with mocked service probes.