### PR TITLE
fix(crabbox): reuse managed CLI across QA and remote proof

### DIFF
--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -139,23 +139,10 @@ jobs:
       - name: Build Mantis harness
         run: pnpm build
 
-      - name: Setup Go for Crabbox CLI
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.x"
-          cache: false
-
       - name: Install Crabbox CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-          install_dir="${RUNNER_TEMP}/crabbox"
-          mkdir -p "$install_dir" "$HOME/.local/bin"
-          python3 -I -S "$CI_GIT_OWNER" --git 120 clone --depth 1 https://github.com/openclaw/crabbox.git "$install_dir/src"
-          go build -C "$install_dir/src" -o "$HOME/.local/bin/crabbox" ./cmd/crabbox
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/crabbox" --version
-          "$HOME/.local/bin/crabbox" warmup --help 2>&1 | grep -q -- "-desktop"
+        env:
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-crabbox-setup
+        run: node scripts/crabbox-setup.mjs
 
       - name: Prepare baseline and candidate worktrees
         shell: bash

--- a/.github/workflows/mantis-discord-thread-attachment.yml
+++ b/.github/workflows/mantis-discord-thread-attachment.yml
@@ -141,23 +141,10 @@ jobs:
       - name: Build Mantis harness
         run: pnpm build
 
-      - name: Setup Go for Crabbox CLI
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.x"
-          cache: false
-
       - name: Install Crabbox CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-          install_dir="${RUNNER_TEMP}/crabbox"
-          mkdir -p "$install_dir" "$HOME/.local/bin"
-          python3 -I -S "$CI_GIT_OWNER" --git 120 clone --depth 1 https://github.com/openclaw/crabbox.git "$install_dir/src"
-          go build -C "$install_dir/src" -o "$HOME/.local/bin/crabbox" ./cmd/crabbox
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/crabbox" --version
-          "$HOME/.local/bin/crabbox" warmup --help 2>&1 | grep -q -- "-desktop"
+        env:
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-crabbox-setup
+        run: node scripts/crabbox-setup.mjs
 
       - name: Prepare baseline and candidate worktrees
         shell: bash

--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -70,7 +70,6 @@ env:
   NODE_VERSION: "24.x"
   OPENCLAW_BUILD_PRIVATE_QA: "1"
   OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
-  CRABBOX_REF: main
 
 jobs:
   authorize_actor:
@@ -160,31 +159,10 @@ jobs:
           restore-keys: |
             mantis-slack-pnpm-${{ runner.os }}-${{ env.NODE_VERSION }}-
 
-      - name: Setup Go for Crabbox CLI
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.x"
-          cache: false
-
       - name: Install Crabbox CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-          install_dir="${RUNNER_TEMP}/crabbox"
-          mkdir -p "$install_dir" "$HOME/.local/bin"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 init "$install_dir/src"
-          (
-            cd "$install_dir/src"
-            python3 -I -S "$CI_GIT_OWNER" --checkout-git 0 remote add origin https://github.com/openclaw/crabbox.git
-            python3 -I -S "$CI_GIT_OWNER" --checkout-git 120 fetch --depth 1 origin "$CRABBOX_REF"
-            python3 -I -S "$CI_GIT_OWNER" --checkout-git 0 checkout --detach FETCH_HEAD
-          )
-          go build -C "$install_dir/src" -o "$HOME/.local/bin/crabbox" ./cmd/crabbox
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/crabbox" --version
-          "$HOME/.local/bin/crabbox" warmup --help > "$install_dir/warmup-help.txt" 2>&1
-          grep -q -- "-desktop" "$install_dir/warmup-help.txt"
-          "$HOME/.local/bin/crabbox" media preview --help >/dev/null
+        env:
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-crabbox-setup
+        run: node scripts/crabbox-setup.mjs
 
       - name: Prepare candidate worktree
         env:

--- a/.github/workflows/mantis-telegram-bot-e2e-proof.yml
+++ b/.github/workflows/mantis-telegram-bot-e2e-proof.yml
@@ -151,19 +151,11 @@ jobs:
           git archive "$GITHUB_WORKFLOW_SHA" |
             podman build --memory 16g --cpu-period 100000 --cpu-quota 200000 --file scripts/mantis/telegram-test-server-proof.Dockerfile \
               --tag localhost/mantis-telegram-proof -
-      - name: Install pinned Crabbox for disposable candidate lifecycle
+      - name: Install Crabbox for disposable candidate lifecycle
         if: ${{ inputs.scenario == 'telegram-bot-e2e-proof' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          install_dir="$RUNNER_TEMP/mantis-crabbox"
-          mkdir -p "$install_dir/bin"
-          curl --fail --location --proto '=https' --tlsv1.2 \
-            https://github.com/openclaw/crabbox/releases/download/v0.50.0/crabbox_0.50.0_linux_amd64.tar.gz \
-            --output "$install_dir/crabbox.tar.gz"
-          printf '%s  %s\n' 8ab55a0302e7119a45e7522c2fff2d4e295496c33766c87cf619f342824cab75 "$install_dir/crabbox.tar.gz" | sha256sum --check
-          tar -xzf "$install_dir/crabbox.tar.gz" -C "$install_dir/bin" crabbox
-          echo "$install_dir/bin" >> "$GITHUB_PATH"
+        env:
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-crabbox-setup
+        run: node scripts/crabbox-setup.mjs
       - name: Build exact candidate without credentials or network
         env:
           CANDIDATE_SHA: ${{ inputs.candidate_ref }}

--- a/docs/reference/test/remote-proof.md
+++ b/docs/reference/test/remote-proof.md
@@ -135,14 +135,18 @@ proof.
 
 The wrapper checks an executable sibling `../crabbox/bin/crabbox`, then `PATH`,
 then the sibling of the Git common checkout. Verify the selected binary and
-its source rather than trusting a directory name. If it needs repair or is
-missing, use a clean task-owned checkout of
-[Crabbox](https://github.com/openclaw/crabbox), build `./cmd/crabbox` into a
-task-owned binary directory, and leave other checkouts and the operator's
-installed binary untouched. The existing
+its source rather than trusting a directory name. The plugin installs a verified
+managed copy when the selected executable is missing or outdated. For an explicit
+[Crabbox](https://github.com/openclaw/crabbox) source repair, build `./cmd/crabbox`
+in a clean task-owned checkout and leave the operator's installation untouched. The existing
 `OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY=1` setting skips the first sibling
 candidate; a task binary on `PATH` then takes precedence over the common-checkout
 candidate. A dirty or occupied sibling is not a reason to stop and ask.
+
+Mantis uses the same plugin-owned discovery and managed installation. Its workflows
+prepare the executable with `node scripts/crabbox-setup.mjs`; the command prints
+the selected binary and verified version as JSON and, in GitHub Actions, adds its
+directory to `GITHUB_PATH`. Later QA and media commands reuse that executable.
 
 For a selected trusted Testbox lane:
 

--- a/docs/reference/test/remote-proof.md
+++ b/docs/reference/test/remote-proof.md
@@ -143,7 +143,9 @@ in a clean task-owned checkout and leave the operator's installation untouched. 
 candidate; a task binary on `PATH` then takes precedence over the common-checkout
 candidate. A dirty or occupied sibling is not a reason to stop and ask.
 
-Mantis uses the same plugin-owned discovery and managed installation. Its workflows
+Mantis uses the same plugin-owned discovery and managed installation. Relative
+executable overrides and `PATH` entries resolve from its requested `--repo-root`,
+and version probes run there with the same environment as lease commands. Its workflows
 prepare the executable with `node scripts/crabbox-setup.mjs`; the command prints
 the selected binary and verified version as JSON and, in GitHub Actions, adds its
 directory to `GITHUB_PATH`. Later QA and media commands reuse that executable.

--- a/extensions/crabbox/cli-runtime-api.ts
+++ b/extensions/crabbox/cli-runtime-api.ts
@@ -1,1 +1,2 @@
-export { ensureManagedCrabboxBinary } from "./src/crabbox-managed-binary.js";
+export { findCrabboxBinary, resolveCrabboxBinary } from "./src/crabbox-binary.js";
+export { ensureManagedCrabboxBinary, type CrabboxBinary } from "./src/crabbox-managed-binary.js";

--- a/extensions/crabbox/index.test.ts
+++ b/extensions/crabbox/index.test.ts
@@ -79,9 +79,10 @@ function stopGeneration(services: OpenClawPluginService[]): void | Promise<void>
 
 describe("Crabbox plugin generation lifecycle", () => {
   beforeEach(() => {
-    vi.spyOn(managedBinary, "ensureManagedCrabboxBinary").mockImplementation(
-      async (params) => params?.binary ?? "crabbox",
-    );
+    vi.spyOn(managedBinary, "ensureManagedCrabboxBinary").mockImplementation(async (params) => ({
+      binary: params?.binary ?? "crabbox",
+      version: "0.55.0",
+    }));
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -348,7 +349,7 @@ describe("Crabbox plugin generation lifecycle", () => {
           started.resolve(params.signal);
           await finish.promise;
           params.signal.throwIfAborted();
-          return params.binary ?? "crabbox";
+          return { binary: params.binary ?? "crabbox", version: "0.55.0" };
         });
       }
       const generation = registerCrabboxGeneration();

--- a/extensions/crabbox/package.json
+++ b/extensions/crabbox/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw cloud worker provider backed by the Crabbox CLI",
   "type": "module",
+  "exports": {
+    "./cli-runtime-api.js": "./cli-runtime-api.ts"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/extensions/crabbox/src/crabbox-binary.ts
+++ b/extensions/crabbox/src/crabbox-binary.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type CrabboxBinaryOptions = {
+  explicit?: string;
+  isExecutable?: (candidate: string) => boolean;
+  openclawRoot?: string;
+  pathEnv?: string;
+  platform?: NodeJS.Platform;
+};
+
+function isExecutableFile(candidate: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!fs.statSync(candidate).isFile()) {
+      return false;
+    }
+    fs.accessSync(candidate, platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function binaryCandidates(base: string, platform: NodeJS.Platform): string[] {
+  return platform === "win32"
+    ? [".exe", ".cmd", ".bat", ".com", ""].map((suffix) => `${base}${suffix}`)
+    : [base];
+}
+
+export function resolveCrabboxBinary(params: CrabboxBinaryOptions): string {
+  return params.explicit || findCrabboxBinary(params) || "crabbox";
+}
+
+export function findCrabboxBinary(params: CrabboxBinaryOptions): string | undefined {
+  const platform = params.platform ?? process.platform;
+  const isExecutable =
+    params.isExecutable ?? ((candidate) => isExecutableFile(candidate, platform));
+  if (params.explicit) {
+    return isExecutable(params.explicit) ? params.explicit : undefined;
+  }
+  if (params.openclawRoot) {
+    const siblingBase = path.resolve(params.openclawRoot, "../crabbox/bin/crabbox");
+    for (const candidate of binaryCandidates(siblingBase, platform)) {
+      if (isExecutable(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  const delimiter = platform === "win32" ? ";" : ":";
+  const executableNames = binaryCandidates("crabbox", platform);
+  for (const directory of (params.pathEnv ?? "").split(delimiter)) {
+    if (!directory) {
+      continue;
+    }
+    for (const name of executableNames) {
+      const candidate = path.resolve(directory, name);
+      if (isExecutable(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}

--- a/extensions/crabbox/src/crabbox-binary.ts
+++ b/extensions/crabbox/src/crabbox-binary.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 type CrabboxBinaryOptions = {
+  cwd?: string;
   explicit?: string;
   isExecutable?: (candidate: string) => boolean;
   openclawRoot?: string;
@@ -36,10 +37,15 @@ export function findCrabboxBinary(params: CrabboxBinaryOptions): string | undefi
   const isExecutable =
     params.isExecutable ?? ((candidate) => isExecutableFile(candidate, platform));
   if (params.explicit) {
-    return isExecutable(params.explicit) ? params.explicit : undefined;
+    const candidate = params.cwd ? path.resolve(params.cwd, params.explicit) : params.explicit;
+    return isExecutable(candidate) ? params.explicit : undefined;
   }
   if (params.openclawRoot) {
-    const siblingBase = path.resolve(params.openclawRoot, "../crabbox/bin/crabbox");
+    const siblingBase = path.resolve(
+      params.cwd ?? ".",
+      params.openclawRoot,
+      "../crabbox/bin/crabbox",
+    );
     for (const candidate of binaryCandidates(siblingBase, platform)) {
       if (isExecutable(candidate)) {
         return candidate;
@@ -53,7 +59,7 @@ export function findCrabboxBinary(params: CrabboxBinaryOptions): string | undefi
       continue;
     }
     for (const name of executableNames) {
-      const candidate = path.resolve(directory, name);
+      const candidate = path.resolve(params.cwd ?? ".", directory, name);
       if (isExecutable(candidate)) {
         return candidate;
       }

--- a/extensions/crabbox/src/crabbox-managed-binary.test.ts
+++ b/extensions/crabbox/src/crabbox-managed-binary.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import JSZip from "jszip";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { buildTimeoutAbortSignal, createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
 import * as network from "openclaw/plugin-sdk/ssrf-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import * as tar from "tar";
@@ -69,13 +70,36 @@ async function fixture(version = "0.54.0") {
 }
 
 describe("managed Crabbox", () => {
+  it("probes the executable in the caller's supplied environment", async () => {
+    const root = tempDirs.make("crabbox-probe-env-");
+    const binary = path.join(root, "crabbox");
+    const env = { PATH: root, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    const command = vi.spyOn(processRuntime, "runCommandWithTimeout").mockResolvedValue({
+      stdout: "crabbox 0.56.0",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    await expect(ensureManagedCrabboxBinary({ binary, env })).resolves.toEqual({
+      binary,
+      version: "0.56.0",
+    });
+    expect(command).toHaveBeenCalledExactlyOnceWith(
+      [binary, "--version"],
+      expect.objectContaining({ baseEnv: env }),
+    );
+  });
+
   it.each(["0.55.0", "0.55.1", "1.0.0"])(
     "uses supported operator version %s without network or state mutation",
     async (version) => {
       const test = await fixture(version);
       await expect(
         ensureManagedCrabboxBinary({ binary: test.candidate, env: test.env, runCommand }),
-      ).resolves.toBe(test.candidate);
+      ).resolves.toEqual({ binary: test.candidate, version });
       expect(test.fetch).not.toHaveBeenCalled();
       await expect(fs.access(test.env.OPENCLAW_STATE_DIR)).rejects.toMatchObject({
         code: "ENOENT",
@@ -86,7 +110,10 @@ describe("managed Crabbox", () => {
   it("upgrades an old candidate, preserves its complete distribution, and reuses it offline", async () => {
     const test = await fixture();
     const params = { binary: test.candidate, env: test.env, runCommand };
-    await expect(ensureManagedCrabboxBinary(params)).resolves.toBe(test.binary);
+    await expect(ensureManagedCrabboxBinary(params)).resolves.toEqual({
+      binary: test.binary,
+      version: CRABBOX_MIN_VERSION,
+    });
     expect(await fs.readFile(test.candidate, "utf8")).toBe("0.54.0");
     expect(
       await fs.readFile(path.join(path.dirname(test.binary), "companion-helper"), "utf8"),
@@ -98,8 +125,12 @@ describe("managed Crabbox", () => {
         );
       }
     }
+    await fs.writeFile(test.binary, "0.56.0");
     test.fetch.mockRejectedValue(new Error("offline"));
-    await expect(ensureManagedCrabboxBinary(params)).resolves.toBe(test.binary);
+    await expect(ensureManagedCrabboxBinary(params)).resolves.toEqual({
+      binary: test.binary,
+      version: "0.56.0",
+    });
     expect(test.fetch).toHaveBeenCalledTimes(2);
     expect(await fs.readdir(path.dirname(path.dirname(test.binary)))).toEqual([
       path.basename(path.dirname(test.binary)),
@@ -111,7 +142,7 @@ describe("managed Crabbox", () => {
     await fs.rm(test.candidate);
     await expect(
       ensureManagedCrabboxBinary({ binary: test.candidate, env: test.env, runCommand }),
-    ).resolves.toBe(test.binary);
+    ).resolves.toEqual({ binary: test.binary, version: CRABBOX_MIN_VERSION });
   });
 
   it("rejects mismatched archive bytes without publication and permits a later retry", async () => {
@@ -125,7 +156,10 @@ describe("managed Crabbox", () => {
     await expect(ensureManagedCrabboxBinary(params)).rejects.toThrow("checksum mismatch");
     expect(await fs.readdir(path.dirname(path.dirname(test.binary)))).toEqual([]);
     expect(await fs.readFile(test.candidate, "utf8")).toBe("0.54.0");
-    await expect(ensureManagedCrabboxBinary(params)).resolves.toBe(test.binary);
+    await expect(ensureManagedCrabboxBinary(params)).resolves.toEqual({
+      binary: test.binary,
+      version: CRABBOX_MIN_VERSION,
+    });
   });
 
   it("rejects an executable whose version disagrees with the verified release", async () => {
@@ -180,7 +214,7 @@ describe("managed Crabbox", () => {
       finish.resolve();
       await retained;
     }
-    await expect(retained).resolves.toBe(test.binary);
+    await expect(retained).resolves.toEqual({ binary: test.binary, version: CRABBOX_MIN_VERSION });
     expect(test.fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -204,7 +238,10 @@ describe("managed Crabbox", () => {
     controller.abort(new Error("caller stopped"));
     await result;
     expect(await fs.readdir(path.dirname(path.dirname(test.binary)))).toEqual([]);
-    await expect(ensureManagedCrabboxBinary(params)).resolves.toBe(test.binary);
+    await expect(ensureManagedCrabboxBinary(params)).resolves.toEqual({
+      binary: test.binary,
+      version: CRABBOX_MIN_VERSION,
+    });
   });
 
   it("uses another process's verified installation when it wins publication", async () => {
@@ -213,13 +250,14 @@ describe("managed Crabbox", () => {
     vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
       if (destination === path.dirname(test.binary) && typeof source === "string") {
         await fs.cp(source, destination, { recursive: true });
+        await fs.writeFile(test.binary, "0.56.0");
         throw Object.assign(new Error("destination exists"), { code: "EEXIST" });
       }
       await rename(source, destination);
     });
     await expect(
       ensureManagedCrabboxBinary({ binary: test.candidate, env: test.env, runCommand }),
-    ).resolves.toBe(test.binary);
+    ).resolves.toEqual({ binary: test.binary, version: "0.56.0" });
     expect(
       await fs.readFile(path.join(path.dirname(test.binary), "companion-helper"), "utf8"),
     ).toBe("keep me");
@@ -237,7 +275,7 @@ describe("managed Crabbox", () => {
       await fs.writeFile(path.join(destination, "operator-note"), "preserve this");
       await expect(
         ensureManagedCrabboxBinary({ binary: test.candidate, env: test.env, runCommand }),
-      ).resolves.toBe(test.binary);
+      ).resolves.toEqual({ binary: test.binary, version: CRABBOX_MIN_VERSION });
       expect(await fs.readFile(test.binary, "utf8")).toBe(CRABBOX_MIN_VERSION);
       expect(await fs.readFile(test.candidate, "utf8")).toBe("0.54.0");
       const parent = path.dirname(destination);
@@ -309,7 +347,10 @@ describe("managed Crabbox", () => {
       "corrupt",
     );
     test.fetch.mockRejectedValue(new Error("offline"));
-    await expect(ensureManagedCrabboxBinary(params)).resolves.toBe(test.binary);
+    await expect(ensureManagedCrabboxBinary(params)).resolves.toEqual({
+      binary: test.binary,
+      version: CRABBOX_MIN_VERSION,
+    });
   });
 
   it("refuses a symlinked managed directory without changing its target", async () => {
@@ -407,7 +448,9 @@ describe("managed Crabbox", () => {
       await vi.advanceTimersByTimeAsync(1);
       vi.useRealTimers();
       if (succeeds) {
-        await expect(result).resolves.toEqual({ value: test.binary });
+        await expect(result).resolves.toEqual({
+          value: { binary: test.binary, version: CRABBOX_MIN_VERSION },
+        });
       } else {
         await expect(result).resolves.toEqual({
           error: expect.objectContaining({ name: "TimeoutError" }),

--- a/extensions/crabbox/src/crabbox-managed-binary.test.ts
+++ b/extensions/crabbox/src/crabbox-managed-binary.test.ts
@@ -70,7 +70,7 @@ async function fixture(version = "0.54.0") {
 }
 
 describe("managed Crabbox", () => {
-  it("probes the executable in the caller's supplied environment", async () => {
+  it("probes the executable in the caller's supplied environment and working directory", async () => {
     const root = tempDirs.make("crabbox-probe-env-");
     const binary = path.join(root, "crabbox");
     const env = { PATH: root, OPENCLAW_STATE_DIR: path.join(root, "state") };
@@ -83,13 +83,13 @@ describe("managed Crabbox", () => {
       termination: "exit",
     });
 
-    await expect(ensureManagedCrabboxBinary({ binary, env })).resolves.toEqual({
+    await expect(ensureManagedCrabboxBinary({ binary, env, cwd: root })).resolves.toEqual({
       binary,
       version: "0.56.0",
     });
     expect(command).toHaveBeenCalledExactlyOnceWith(
       [binary, "--version"],
-      expect.objectContaining({ baseEnv: env }),
+      expect.objectContaining({ baseEnv: env, cwd: root }),
     );
   });
 

--- a/extensions/crabbox/src/crabbox-managed-binary.ts
+++ b/extensions/crabbox/src/crabbox-managed-binary.ts
@@ -17,6 +17,8 @@ const VERSION_TIMEOUT_MS = 5_000;
 const DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
 const DOWNLOAD_TOTAL_TIMEOUT_MS = 10 * 60_000;
 
+export type CrabboxBinary = { binary: string; version: string };
+
 type CrabboxVersionProbe =
   | { status: "supported"; version: string }
   | { status: "outdated"; version: string }
@@ -159,11 +161,13 @@ async function probeInstallation(
   binary: string,
   runCommand: CrabboxCommandRunner,
   signal: AbortSignal,
-) {
+): Promise<CrabboxBinary | undefined> {
   const stat = await fs.lstat(binary).catch(() => undefined);
-  return (
-    stat?.isFile() && (await probeCrabboxVersion(binary, runCommand, signal)).status === "supported"
-  );
+  if (!stat?.isFile()) {
+    return undefined;
+  }
+  const result = await probeCrabboxVersion(binary, runCommand, signal);
+  return result.status === "supported" ? { binary, version: result.version } : undefined;
 }
 
 async function inspectInstallationDirectory(destination: string) {
@@ -184,13 +188,14 @@ async function inspectInstallationDirectory(destination: string) {
 
 async function publishInstallation(params: {
   binary: string;
+  version: string;
   payload: string;
   runCommand: CrabboxCommandRunner;
   signal: AbortSignal;
-}): Promise<void> {
+}): Promise<CrabboxBinary> {
   const { binary, payload, runCommand, signal } = params;
   const destination = path.dirname(binary);
-  await withFileLock(
+  return withFileLock(
     `${destination}.publication`,
     {
       retries: { retries: 100, factor: 1, minTimeout: 100, maxTimeout: 100 },
@@ -200,8 +205,9 @@ async function publishInstallation(params: {
     async () => {
       signal.throwIfAborted();
       const existing = await inspectInstallationDirectory(destination);
-      if (existing && (await probeInstallation(binary, runCommand, signal))) {
-        return;
+      const installed = existing ? await probeInstallation(binary, runCommand, signal) : undefined;
+      if (installed) {
+        return installed;
       }
       signal.throwIfAborted();
       let recovery: string | undefined;
@@ -214,6 +220,7 @@ async function publishInstallation(params: {
         signal.throwIfAborted();
         // Publish the whole distribution so Darwin companion executables stay beside the CLI.
         await fs.rename(payload, destination);
+        return { binary, version: params.version };
       } catch (error) {
         // Cooperating installers hold the same lock. Retain ambiguous externally changed state.
         if (recovery) {
@@ -230,12 +237,11 @@ async function publishInstallation(params: {
             );
           }
         }
-        if (
-          !signal.aborted &&
-          (await inspectInstallationDirectory(destination)) &&
-          (await probeInstallation(binary, runCommand, signal))
-        ) {
-          return;
+        if (!signal.aborted && (await inspectInstallationDirectory(destination))) {
+          const winner = await probeInstallation(binary, runCommand, signal);
+          if (winner) {
+            return winner;
+          }
         }
         if (recovery) {
           throw new Error(
@@ -253,11 +259,12 @@ async function installManagedBinary(
   binary: string,
   runCommand: CrabboxCommandRunner,
   signal: AbortSignal,
-): Promise<string> {
+): Promise<CrabboxBinary> {
   const destination = path.dirname(binary);
   await inspectInstallationDirectory(destination);
-  if (await probeInstallation(binary, runCommand, signal)) {
-    return binary;
+  const installed = await probeInstallation(binary, runCommand, signal);
+  if (installed) {
+    return installed;
   }
   const parent = path.dirname(destination);
   await fs.mkdir(parent, { recursive: true, mode: 0o700 });
@@ -303,17 +310,27 @@ async function installManagedBinary(
       onFiltered: "reject-archive",
     });
     const stagedBinary = path.join(payload, target.executable);
-    if (!(await probeInstallation(stagedBinary, runCommand, signal))) {
+    const staged = await probeInstallation(stagedBinary, runCommand, signal);
+    if (!staged) {
       throw new Error(`Downloaded Crabbox executable does not satisfy ${CRABBOX_MIN_VERSION}`);
     }
-    await publishInstallation({ binary, payload, runCommand, signal });
-    return binary;
+    return await publishInstallation({
+      binary,
+      version: staged.version,
+      payload,
+      runCommand,
+      signal,
+    });
   } finally {
     await fs.rm(staging, { recursive: true, force: true });
   }
 }
 
-type Acquisition = { promise: Promise<string>; controller: AbortController; waiters: number };
+type Acquisition = {
+  promise: Promise<CrabboxBinary>;
+  controller: AbortController;
+  waiters: number;
+};
 const acquisitions = new Map<string, Acquisition>();
 
 export async function ensureManagedCrabboxBinary(
@@ -323,16 +340,19 @@ export async function ensureManagedCrabboxBinary(
     env?: NodeJS.ProcessEnv;
     signal?: AbortSignal;
   } = {},
-): Promise<string> {
+): Promise<CrabboxBinary> {
   const { signal } = params;
-  const runCommand = params.runCommand ?? runCommandWithTimeout;
+  const runCommand: CrabboxCommandRunner =
+    params.runCommand ??
+    ((argv, options) => runCommandWithTimeout(argv, { ...options, baseEnv: params.env }));
   const candidate = params.binary ?? "crabbox";
   const binary = resolveManagedCrabboxBinaryPath(params.env);
   if (path.resolve(candidate) === binary) {
     await inspectInstallationDirectory(path.dirname(binary));
   }
-  if ((await probeCrabboxVersion(candidate, runCommand, signal)).status === "supported") {
-    return candidate;
+  const preferred = await probeCrabboxVersion(candidate, runCommand, signal);
+  if (preferred.status === "supported") {
+    return { binary: candidate, version: preferred.version };
   }
   let acquisition = acquisitions.get(binary);
   if (acquisition?.controller.signal.aborted) {

--- a/extensions/crabbox/src/crabbox-managed-binary.ts
+++ b/extensions/crabbox/src/crabbox-managed-binary.ts
@@ -336,6 +336,7 @@ const acquisitions = new Map<string, Acquisition>();
 export async function ensureManagedCrabboxBinary(
   params: {
     binary?: string;
+    cwd?: string;
     runCommand?: CrabboxCommandRunner;
     env?: NodeJS.ProcessEnv;
     signal?: AbortSignal;
@@ -344,10 +345,11 @@ export async function ensureManagedCrabboxBinary(
   const { signal } = params;
   const runCommand: CrabboxCommandRunner =
     params.runCommand ??
-    ((argv, options) => runCommandWithTimeout(argv, { ...options, baseEnv: params.env }));
+    ((argv, options) =>
+      runCommandWithTimeout(argv, { ...options, baseEnv: params.env, cwd: params.cwd }));
   const candidate = params.binary ?? "crabbox";
   const binary = resolveManagedCrabboxBinaryPath(params.env);
-  if (path.resolve(candidate) === binary) {
+  if (path.resolve(params.cwd ?? ".", candidate) === binary) {
     await inspectInstallationDirectory(path.dirname(binary));
   }
   const preferred = await probeCrabboxVersion(candidate, runCommand, signal);

--- a/extensions/crabbox/src/crabbox-worker-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-profile.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import {
   WorkerProviderError,
@@ -93,8 +92,6 @@ export type CrabboxMachineShape = Readonly<{
   cpu?: number;
   memoryGb?: number;
 }>;
-
-type IsExecutable = (candidate: string) => boolean;
 
 export const CRABBOX_WORKER_PROVIDER_ID = "crabbox";
 
@@ -418,72 +415,6 @@ export function buildCrabboxAllocationArgs(
     args.push("--desktop", "--browser", "--desktop-env", "xfce");
   }
   return args;
-}
-
-function defaultIsExecutable(candidate: string, platform: NodeJS.Platform): boolean {
-  try {
-    if (!fs.statSync(candidate).isFile()) {
-      return false;
-    }
-    fs.accessSync(candidate, platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function binaryCandidates(base: string, platform: NodeJS.Platform): string[] {
-  return platform === "win32"
-    ? [".exe", ".cmd", ".bat", ".com", ""].map((suffix) => `${base}${suffix}`)
-    : [base];
-}
-
-export function resolveCrabboxBinary(params: {
-  explicit?: string;
-  isExecutable?: IsExecutable;
-  openclawRoot: string;
-  pathEnv?: string;
-  platform?: NodeJS.Platform;
-}): string {
-  if (params.explicit) {
-    return params.explicit;
-  }
-  return findCrabboxBinary(params) ?? "crabbox";
-}
-
-export function findCrabboxBinary(params: {
-  explicit?: string;
-  isExecutable?: IsExecutable;
-  openclawRoot: string;
-  pathEnv?: string;
-  platform?: NodeJS.Platform;
-}): string | undefined {
-  const platform = params.platform ?? process.platform;
-  const isExecutable =
-    params.isExecutable ?? ((candidate) => defaultIsExecutable(candidate, platform));
-  if (params.explicit) {
-    return isExecutable(params.explicit) ? params.explicit : undefined;
-  }
-  const siblingBase = path.resolve(params.openclawRoot, "../crabbox/bin/crabbox");
-  for (const candidate of binaryCandidates(siblingBase, platform)) {
-    if (isExecutable(candidate)) {
-      return candidate;
-    }
-  }
-  const delimiter = platform === "win32" ? ";" : ":";
-  const executableNames = binaryCandidates("crabbox", platform);
-  for (const directory of (params.pathEnv ?? "").split(delimiter)) {
-    if (!directory) {
-      continue;
-    }
-    for (const name of executableNames) {
-      const candidate = path.resolve(directory, name);
-      if (isExecutable(candidate)) {
-        return candidate;
-      }
-    }
-  }
-  return undefined;
 }
 
 export function resolveOpenClawRoot(pluginRoot: string | undefined): string {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -13,14 +13,10 @@ import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ensureManagedCrabboxBinary } from "./crabbox-managed-binary.js";
+import { findCrabboxBinary, resolveCrabboxBinary } from "./crabbox-binary.js";
+import { ensureManagedCrabboxBinary, type CrabboxBinary } from "./crabbox-managed-binary.js";
 import { createNodeBootstrapFixture } from "./crabbox-worker-node-enrollment.test-support.js";
-import {
-  findCrabboxBinary,
-  operationLeaseId,
-  parseCrabboxProfile,
-  resolveCrabboxBinary,
-} from "./crabbox-worker-profile.js";
+import { operationLeaseId, parseCrabboxProfile } from "./crabbox-worker-profile.js";
 import { createCrabboxWorkerProvider, resolveOpenClawRoot } from "./crabbox-worker-provider.js";
 import {
   CRABBOX_COMMAND_SETTLEMENT_TIMEOUT_MS,
@@ -31,7 +27,10 @@ import {
 } from "./crabbox-worker-timeouts.js";
 
 vi.mock("./crabbox-managed-binary.js", () => ({
-  ensureManagedCrabboxBinary: vi.fn(async ({ binary }: { binary: string }) => binary),
+  ensureManagedCrabboxBinary: vi.fn(async ({ binary }: { binary: string }) => ({
+    binary,
+    version: "0.55.0",
+  })),
 }));
 
 const OPERATION_ID = `provision:v2:${"0".repeat(64)}`;
@@ -76,7 +75,10 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
 beforeEach(() => {
   vi.mocked(ensureManagedCrabboxBinary)
     .mockReset()
-    .mockImplementation(async (params) => params?.binary ?? "crabbox");
+    .mockImplementation(async (params) => ({
+      binary: params?.binary ?? "crabbox",
+      version: "0.55.0",
+    }));
   // Provider instances share durable state within a replay test, never across test cases.
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-crabbox-provider-"));
 });
@@ -292,7 +294,10 @@ describe("Crabbox worker provider", () => {
 
   it("uses the managed binary for discovery and the complete worker lifecycle", async () => {
     const managedBinary = path.resolve(path.sep, "managed", "crabbox");
-    vi.mocked(ensureManagedCrabboxBinary).mockResolvedValue(managedBinary);
+    vi.mocked(ensureManagedCrabboxBinary).mockResolvedValue({
+      binary: managedBinary,
+      version: "0.55.0",
+    });
     const runCommand = vi.fn<CrabboxCommandRunner>(async (argv) => {
       if (argv[1] === "providers") {
         return commandResult({
@@ -353,7 +358,7 @@ describe("Crabbox worker provider", () => {
 
   it("does not allocate after cancellation during managed binary acquisition", async () => {
     const acquisitionStarted = createDeferred<void>();
-    const acquisition = createDeferred<string>();
+    const acquisition = createDeferred<CrabboxBinary>();
     vi.mocked(ensureManagedCrabboxBinary).mockImplementation(() => {
       acquisitionStarted.resolve();
       return acquisition.promise;
@@ -370,7 +375,10 @@ describe("Crabbox worker provider", () => {
 
     await acquisitionStarted.promise;
     controller.abort();
-    acquisition.resolve(path.resolve(path.sep, "managed", "crabbox"));
+    acquisition.resolve({
+      binary: path.resolve(path.sep, "managed", "crabbox"),
+      version: "0.55.0",
+    });
     await rejected;
 
     expect(runCommand).not.toHaveBeenCalled();
@@ -3287,7 +3295,7 @@ describe("Crabbox worker provider", () => {
     vi.useFakeTimers();
     const heartbeatStarted = createDeferred<AbortSignal>();
     const acquisitionStarted = createDeferred<void>();
-    const acquisition = createDeferred<string>();
+    const acquisition = createDeferred<CrabboxBinary>();
     let heartbeatCount = 0;
     const provider = providerWithRunner(async (argv, options) => {
       if (argv[1] === "inspect") {
@@ -3684,6 +3692,12 @@ describe("Crabbox binary resolution", () => {
     ).toBe(SIBLING_BINARY);
     expect(
       resolveCrabboxBinary({
+        pathEnv: toolsDir,
+        isExecutable: (candidate) => candidate === SIBLING_BINARY || candidate === pathBinary,
+      }),
+    ).toBe(pathBinary);
+    expect(
+      resolveCrabboxBinary({
         openclawRoot: OPENCLAW_ROOT,
         pathEnv: [path.resolve(path.sep, "not-executable"), toolsDir].join(path.delimiter),
         isExecutable: (candidate) => candidate === pathBinary,
@@ -3703,6 +3717,48 @@ describe("Crabbox binary resolution", () => {
         isExecutable: () => false,
       }),
     ).toBe("crabbox");
+  });
+
+  it.each([
+    { extensions: ["", ".com", ".bat", ".cmd", ".exe"], preferred: ".exe" },
+    { extensions: ["", ".com", ".bat", ".cmd"], preferred: ".cmd" },
+    { extensions: ["", ".com", ".bat"], preferred: ".bat" },
+    { extensions: ["", ".com"], preferred: ".com" },
+    { extensions: [""], preferred: "" },
+  ])("selects the preferred Windows executable suffix $preferred", ({ extensions, preferred }) => {
+    const toolsDir = path.resolve(path.sep, "tools");
+    const pathBinary = path.join(toolsDir, "crabbox");
+    const executables = new Set(
+      [SIBLING_BINARY, pathBinary].flatMap((binary) =>
+        extensions.map((extension) => `${binary}${extension}`),
+      ),
+    );
+    const discovery = {
+      platform: "win32" as const,
+      pathEnv: toolsDir,
+      isExecutable: (candidate: string) => executables.has(candidate),
+    };
+
+    expect(resolveCrabboxBinary(discovery)).toBe(`${pathBinary}${preferred}`);
+    expect(resolveCrabboxBinary({ ...discovery, openclawRoot: OPENCLAW_ROOT })).toBe(
+      `${SIBLING_BINARY}${preferred}`,
+    );
+  });
+
+  it("preserves Windows PATH directory order ahead of executable suffix preference", () => {
+    const first = path.resolve(path.sep, "first-tools");
+    const second = path.resolve(path.sep, "second-tools");
+    const firstBinary = path.join(first, "crabbox.cmd");
+    const secondBinary = path.join(second, "crabbox.exe");
+    const executables = new Set([firstBinary, secondBinary]);
+
+    expect(
+      resolveCrabboxBinary({
+        platform: "win32",
+        pathEnv: `${first};${second}`,
+        isExecutable: (candidate) => executables.has(candidate),
+      }),
+    ).toBe(firstBinary);
   });
 
   it("distinguishes executable discovery from the dispatch fallback", () => {

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveCrabboxBinary } from "./crabbox-binary.js";
 import { ensureManagedCrabboxBinary } from "./crabbox-managed-binary.js";
 import { crabboxCommandError } from "./crabbox-worker-command-error.js";
 import {
@@ -34,7 +35,6 @@ import {
   operationSlug,
   parseCrabboxOperatingSystem,
   parseCrabboxProfile,
-  resolveCrabboxBinary,
   resolveCrabboxProvisionProfile,
   resolveCrabboxWarmImageProfile,
 } from "./crabbox-worker-profile.js";
@@ -204,7 +204,7 @@ export function createCrabboxWorkerProvider(
     if (existing) {
       return existing;
     }
-    const binary = await ensureManagedCrabboxBinary({ binary: candidate, runCommand, signal });
+    const { binary } = await ensureManagedCrabboxBinary({ binary: candidate, runCommand, signal });
     binaries.set(candidate, binary);
     return binary;
   };

--- a/extensions/crabbox/src/crabbox-worker-warm-image-maintenance.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image-maintenance.test.ts
@@ -46,7 +46,7 @@ describe("Crabbox idle image maintenance", () => {
       if (params?.binary === "/opt/b/crabbox") {
         throw new Error("fixture binary acquisition unavailable");
       }
-      return params?.binary ?? "crabbox";
+      return { binary: params?.binary ?? "crabbox", version: "0.55.0" };
     });
     const store = openWarmImageStore();
     store.register("expired", expiredImage("chk_expired"));

--- a/extensions/crabbox/src/crabbox-worker-warm-image.test-support.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image.test-support.ts
@@ -82,9 +82,10 @@ export function createWarmProvider(
   > = {},
 ) {
   vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-  vi.spyOn(managedBinary, "ensureManagedCrabboxBinary").mockImplementation(
-    async (params) => params?.binary ?? "crabbox",
-  );
+  vi.spyOn(managedBinary, "ensureManagedCrabboxBinary").mockImplementation(async (params) => ({
+    binary: params?.binary ?? "crabbox",
+    version: "0.55.0",
+  }));
   const calls: CommandCall[] = [];
   const warn = vi.fn();
   const provider = createCrabboxWorkerProvider({

--- a/extensions/crabbox/src/doctor.test.ts
+++ b/extensions/crabbox/src/doctor.test.ts
@@ -113,7 +113,10 @@ describe("Crabbox worker doctor", () => {
     vi.spyOn(managedBinary, "resolveManagedCrabboxBinaryPath").mockReturnValue("/managed/crabbox");
     const install = vi
       .spyOn(managedBinary, "ensureManagedCrabboxBinary")
-      .mockImplementation(async ({ binary } = {}) => binary ?? "crabbox");
+      .mockImplementation(async ({ binary } = {}) => ({
+        binary: binary ?? "crabbox",
+        version: "0.55.0",
+      }));
     const check = captureCrabboxDoctorCheck();
     const findings = [{ checkId: CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID }] as never;
     const ctx = context();

--- a/extensions/crabbox/src/doctor.ts
+++ b/extensions/crabbox/src/doctor.ts
@@ -3,8 +3,9 @@ import {
   asOptionalRecord as readRecord,
   normalizeOptionalString as nonEmptyString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { findCrabboxBinary } from "./crabbox-binary.js";
 import * as managedBinary from "./crabbox-managed-binary.js";
-import { CRABBOX_WORKER_PROVIDER_ID, findCrabboxBinary } from "./crabbox-worker-profile.js";
+import { CRABBOX_WORKER_PROVIDER_ID } from "./crabbox-worker-profile.js";
 import {
   crabboxWarmImageRecoveryHint,
   CRABBOX_WARM_IMAGE_WAIT_HINT,
@@ -96,7 +97,7 @@ function createCrabboxCloudWorkerProfileCheck(openclawRoot: string): HealthCheck
         return { status: "skipped", changes: [] };
       }
       try {
-        const binary = await managedBinary.ensureManagedCrabboxBinary({
+        const { binary } = await managedBinary.ensureManagedCrabboxBinary({
           binary: managedBinary.resolveManagedCrabboxBinaryPath(ctx.env),
           env: ctx.env,
         });

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -15,6 +15,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@openclaw/crabbox-provider": "workspace:*",
     "@openclaw/discord": "workspace:*",
     "@openclaw/matrix": "workspace:*",
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/qa-lab/src/mantis/crabbox-runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.test.ts
@@ -1,10 +1,63 @@
-// Qa Lab tests cover Crabbox runtime behavior.
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as network from "openclaw/plugin-sdk/ssrf-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type CommandRunner,
   copyCrabboxArtifacts,
   defaultCommandRunner,
+  resolveCrabboxBin,
 } from "./crabbox-runtime.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+describe("Mantis Crabbox binary admission", () => {
+  it.each(["relative explicit", "relative PATH", "bare explicit"])(
+    "resolves and probes %s from the requested repository instead of the launch directory",
+    async (selection) => {
+      const root = tempDirs.make("mantis-crabbox-cwd-");
+      const repoRoot = path.join(root, "requested-repo");
+      const binDir = path.join(repoRoot, "tools");
+      const filename = process.platform === "win32" ? "crabbox.cmd" : "crabbox";
+      const executable = path.join(binDir, filename);
+      const cwdFile = path.join(root, "probe-cwd.txt");
+      await fs.mkdir(binDir, { recursive: true });
+      await fs.writeFile(
+        executable,
+        process.platform === "win32"
+          ? '@echo off\r\n> "%CRABBOX_PROBE_CWD_FILE%" echo %CD%\r\necho crabbox 0.55.0\r\n'
+          : '#!/bin/sh\npwd -P > "$CRABBOX_PROBE_CWD_FILE"\nprintf "crabbox 0.55.0\\n"\n',
+        { mode: 0o755 },
+      );
+      const download = vi
+        .spyOn(network, "fetchWithSsrFGuard")
+        .mockRejectedValue(new Error("supported repository binary must not trigger a download"));
+      const explicit =
+        selection === "relative explicit"
+          ? path.join("tools", filename)
+          : selection === "bare explicit"
+            ? "crabbox"
+            : undefined;
+      const env = {
+        ...process.env,
+        PATH: "tools",
+        CRABBOX_PROBE_CWD_FILE: cwdFile,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+      };
+
+      expect(process.cwd()).not.toBe(repoRoot);
+      await expect(
+        resolveCrabboxBin({ env, envName: "OPENCLAW_MANTIS_CRABBOX_BIN", explicit, repoRoot }),
+      ).resolves.toBe(explicit ?? executable);
+      expect(await fs.realpath((await fs.readFile(cwdFile, "utf8")).trim())).toBe(
+        await fs.realpath(repoRoot),
+      );
+      expect(download).not.toHaveBeenCalled();
+    },
+  );
+});
 
 describe("Crabbox command runner", () => {
   it("preserves UTF-8 split across child-process pipe chunks", async () => {

--- a/extensions/qa-lab/src/mantis/crabbox-runtime.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.ts
@@ -1,7 +1,8 @@
-// Qa Lab plugin module implements crabbox runtime behavior.
 import { spawn, type SpawnOptions } from "node:child_process";
-import path from "node:path";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
+import {
+  ensureManagedCrabboxBinary,
+  resolveCrabboxBinary,
+} from "@openclaw/crabbox-provider/cli-runtime-api.js";
 import { trimToValue } from "../mantis-options.runtime.js";
 
 type CommandResult = {
@@ -77,15 +78,13 @@ export async function resolveCrabboxBin(params: {
   explicit?: string;
   repoRoot: string;
 }) {
-  const configured = trimToValue(params.explicit) ?? trimToValue(params.env[params.envName]);
-  if (configured) {
-    return configured;
-  }
-  const sibling = path.resolve(params.repoRoot, "../crabbox/bin/crabbox");
-  if (await pathExists(sibling)) {
-    return sibling;
-  }
-  return "crabbox";
+  const candidate = resolveCrabboxBinary({
+    explicit: trimToValue(params.explicit) ?? trimToValue(params.env[params.envName]),
+    openclawRoot: params.repoRoot,
+    pathEnv: params.env.PATH,
+  });
+  const { binary } = await ensureManagedCrabboxBinary({ binary: candidate, env: params.env });
+  return binary;
 }
 
 function extractLeaseId(output: string) {

--- a/extensions/qa-lab/src/mantis/crabbox-runtime.ts
+++ b/extensions/qa-lab/src/mantis/crabbox-runtime.ts
@@ -79,11 +79,16 @@ export async function resolveCrabboxBin(params: {
   repoRoot: string;
 }) {
   const candidate = resolveCrabboxBinary({
+    cwd: params.repoRoot,
     explicit: trimToValue(params.explicit) ?? trimToValue(params.env[params.envName]),
     openclawRoot: params.repoRoot,
     pathEnv: params.env.PATH,
   });
-  const { binary } = await ensureManagedCrabboxBinary({ binary: candidate, env: params.env });
+  const { binary } = await ensureManagedCrabboxBinary({
+    binary: candidate,
+    cwd: params.repoRoot,
+    env: params.env,
+  });
   return binary;
 }
 

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
@@ -1,9 +1,21 @@
-// Qa Lab tests cover desktop browser smoke plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { ensureManagedCrabboxBinary } from "@openclaw/crabbox-provider/cli-runtime-api.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMantisDesktopBrowserSmoke } from "./desktop-browser-smoke.runtime.js";
+
+vi.mock("@openclaw/crabbox-provider/cli-runtime-api.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@openclaw/crabbox-provider/cli-runtime-api.js")>();
+  return {
+    ...actual,
+    ensureManagedCrabboxBinary: vi.fn(async ({ binary }: { binary: string }) => ({
+      binary,
+      version: "0.55.0",
+    })),
+  };
+});
 
 describe("mantis desktop browser smoke runtime", () => {
   let repoRoot: string;
@@ -16,13 +28,32 @@ describe("mantis desktop browser smoke runtime", () => {
     await fs.rm(repoRoot, { force: true, recursive: true });
   });
 
-  it("leases a desktop box, runs a visible browser, copies artifacts, and stops on pass", async () => {
+  it("stops before leasing when the managed binary cannot be prepared", async () => {
+    const runner = vi.fn();
+    vi.mocked(ensureManagedCrabboxBinary).mockRejectedValueOnce(new Error("release unavailable"));
+
+    await expect(
+      runMantisDesktopBrowserSmoke({
+        commandRunner: runner,
+        crabboxBin: "/tmp/outdated-crabbox",
+        repoRoot,
+      }),
+    ).rejects.toThrow("release unavailable");
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("uses the managed binary to lease a desktop, run a browser, copy artifacts, and stop", async () => {
+    vi.mocked(ensureManagedCrabboxBinary).mockResolvedValueOnce({
+      binary: "/tmp/crabbox",
+      version: "0.55.0",
+    });
     await fs.mkdir(path.join(repoRoot, "qa-artifacts"), { recursive: true });
     await fs.writeFile(path.join(repoRoot, "qa-artifacts", "timeline.html"), "<h1>Mantis</h1>");
     const commands: { args: readonly string[]; command: string; env?: NodeJS.ProcessEnv }[] = [];
     const runtimeEnv = {
       PATH: process.env.PATH,
       CRABBOX_COORDINATOR_TOKEN: "runtime-token",
+      OPENCLAW_MANTIS_CRABBOX_BIN: "/tmp/environment-crabbox",
       OPENCLAW_MANTIS_CRABBOX_PROVIDER: "hetzner",
     };
     const runner = vi.fn(
@@ -64,7 +95,7 @@ describe("mantis desktop browser smoke runtime", () => {
     const result = await runMantisDesktopBrowserSmoke({
       browserUrl: "https://openclaw.ai/docs",
       commandRunner: runner,
-      crabboxBin: "/tmp/crabbox",
+      crabboxBin: "/tmp/outdated-crabbox",
       env: runtimeEnv,
       htmlFile: "qa-artifacts/timeline.html",
       now: () => new Date("2026-05-04T12:00:00.000Z"),
@@ -73,6 +104,10 @@ describe("mantis desktop browser smoke runtime", () => {
     });
 
     expect(result.status).toBe("pass");
+    expect(ensureManagedCrabboxBinary).toHaveBeenCalledWith({
+      binary: "/tmp/outdated-crabbox",
+      env: runtimeEnv,
+    });
     expect(commands.map((entry) => [entry.command, entry.args[0]])).toEqual([
       ["/tmp/crabbox", "warmup"],
       ["/tmp/crabbox", "inspect"],

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.test.ts
@@ -106,6 +106,7 @@ describe("mantis desktop browser smoke runtime", () => {
     expect(result.status).toBe("pass");
     expect(ensureManagedCrabboxBinary).toHaveBeenCalledWith({
       binary: "/tmp/outdated-crabbox",
+      cwd: repoRoot,
       env: runtimeEnv,
     });
     expect(commands.map((entry) => [entry.command, entry.args[0]])).toEqual([

--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -1,4 +1,3 @@
-// Qa Lab plugin module implements desktop browser smoke behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -1,10 +1,21 @@
-// Qa Lab tests cover slack desktop smoke plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMantisSlackDesktopSmoke } from "./slack-desktop-smoke.runtime.js";
+
+vi.mock("@openclaw/crabbox-provider/cli-runtime-api.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@openclaw/crabbox-provider/cli-runtime-api.js")>();
+  return {
+    ...actual,
+    ensureManagedCrabboxBinary: vi.fn(async ({ binary }: { binary: string }) => ({
+      binary,
+      version: "0.55.0",
+    })),
+  };
+});
 
 function describeFetchInput(input: RequestInfo | URL) {
   if (typeof input === "string") {

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -1,4 +1,3 @@
-// Qa Lab plugin module implements slack desktop smoke behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.test.ts
@@ -1,10 +1,21 @@
-// Qa Lab tests cover visual task plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runMantisVisualDriver, runMantisVisualTask } from "./visual-task.runtime.js";
+
+vi.mock("@openclaw/crabbox-provider/cli-runtime-api.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@openclaw/crabbox-provider/cli-runtime-api.js")>();
+  return {
+    ...actual,
+    ensureManagedCrabboxBinary: vi.fn(async ({ binary }: { binary: string }) => ({
+      binary,
+      version: "0.55.0",
+    })),
+  };
+});
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.ts
@@ -1,4 +1,3 @@
-// Qa Lab plugin module implements visual task behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1837,6 +1837,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@openclaw/crabbox-provider':
+        specifier: workspace:*
+        version: link:../crabbox
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord

--- a/scripts/crabbox-setup.mjs
+++ b/scripts/crabbox-setup.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
+
+await runTsxCliShim(import.meta.url, { implementation: "./crabbox-setup.mts" });

--- a/scripts/crabbox-setup.mts
+++ b/scripts/crabbox-setup.mts
@@ -1,0 +1,19 @@
+import { appendFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ensureManagedCrabboxBinary,
+  resolveCrabboxBinary,
+} from "../extensions/crabbox/cli-runtime-api.js";
+import { resolvePathEnvKey } from "./windows-cmd-helpers.mjs";
+
+const cli = await ensureManagedCrabboxBinary({
+  binary: resolveCrabboxBinary({
+    openclawRoot: resolve(dirname(fileURLToPath(import.meta.url)), ".."),
+    pathEnv: process.env[resolvePathEnvKey(process.env)],
+  }),
+});
+if (process.env.GITHUB_PATH) {
+  await appendFile(process.env.GITHUB_PATH, `${dirname(cli.binary)}\n`);
+}
+console.log(JSON.stringify(cli));

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-// Resolves a supported Crabbox binary through the bundled plugin before delegation.
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
   accessSync,
@@ -25,7 +24,11 @@ import { delimiter, dirname, extname, isAbsolute, relative, resolve } from "node
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { ensureManagedCrabboxBinary } from "../extensions/crabbox/cli-runtime-api.js";
+import {
+  ensureManagedCrabboxBinary,
+  findCrabboxBinary,
+  type CrabboxBinary,
+} from "../extensions/crabbox/cli-runtime-api.js";
 import { crabboxProviderChain, normalizeCrabboxWorkload } from "./crabbox-routing-policy.mts";
 import {
   prepareCrabboxSourceCapsule,
@@ -62,26 +65,24 @@ type DoctorResult = { ok: boolean; provider: string; checks: DoctorCheck[] };
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CRABBOX_METADATA_PROBE_TIMEOUT_MS = 5_000;
 const MAX_TIMING_JSON_LINE_CHARS = 1024 * 1024;
-// A cold Crabbox (first call after an upgrade, or one on a loaded machine) can
-// exceed the snappy default probe timeout while it renders `run --help` or does
-// first-run init. Retry the metadata probes once with this generous timeout so a
-// single slow probe does not hard-fail the wrapper and block all remote validation.
+// Cold help rendering can exceed the normal metadata deadline.
 const CRABBOX_METADATA_PROBE_RETRY_TIMEOUT_MS = 20_000;
 const ignoreRepoBinary = process.env.OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY === "1";
-const repoLocal = ignoreRepoBinary ? null : resolveCrabboxBinary(process.platform);
-const pathLocal = resolvePathBinary("crabbox", process.env, process.platform);
 const candidateBinary =
-  repoLocal ??
-  pathLocal ??
+  findCrabboxBinary({
+    openclawRoot: ignoreRepoBinary ? undefined : repoRoot,
+    pathEnv: process.env[resolvePathEnvKey(process.env)],
+  }) ??
   resolveGitCommonCrabboxBinary(process.env, process.platform) ??
   "crabbox";
-let binary: string;
+let cli: CrabboxBinary;
 try {
-  binary = await ensureManagedCrabboxBinary({ binary: candidateBinary });
+  cli = await ensureManagedCrabboxBinary({ binary: candidateBinary });
 } catch (error) {
   console.error(`[crabbox] ${error instanceof Error ? error.message : String(error)}`);
   process.exit(2);
 }
+const { binary, version } = cli;
 const args = process.argv.slice(2);
 
 if (args[0] === "--") {
@@ -136,16 +137,6 @@ function commandCandidates(command: string, platform: Platform) {
   return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, `${command}.com`, command];
 }
 
-function resolveCrabboxBinary(platform: Platform) {
-  const base = resolve(repoRoot, "../crabbox/bin/crabbox");
-  for (const candidate of commandCandidates(base, platform)) {
-    if (isExecutableFile(candidate, platform)) {
-      return candidate;
-    }
-  }
-  return null;
-}
-
 function resolvePathBinary(command: string, env: ProcessEnv, platform: Platform) {
   const pathValue = env[resolvePathEnvKey(env)] ?? "";
   for (const dir of pathValue.split(delimiter).filter(Boolean)) {
@@ -178,13 +169,10 @@ function resolveGitCommonCrabboxBinary(env: ProcessEnv, platform: Platform) {
   const absoluteGitCommonDir = isAbsolute(gitCommonDir)
     ? gitCommonDir
     : resolve(repoRoot, gitCommonDir);
-  const base = resolve(absoluteGitCommonDir, "../..", "crabbox/bin/crabbox");
-  for (const candidate of commandCandidates(base, platform)) {
-    if (isExecutableFile(candidate, platform)) {
-      return candidate;
-    }
-  }
-  return null;
+  return findCrabboxBinary({
+    openclawRoot: resolve(absoluteGitCommonDir, ".."),
+    platform,
+  });
 }
 
 function isExecutableFile(path: PathLike, platform: Platform) {
@@ -481,12 +469,7 @@ function recoveryCommandArgument(value: string) {
   return `'${text.replaceAll("'", "'\\''")}'`;
 }
 
-// Probe Crabbox metadata (`--version` / `run --help`) with one generous retry.
-// A cold Crabbox can be SIGKILLed by the snappy default timeout or emit nothing
-// on the first call, then be instant and clean on the next. Retrying keeps the
-// warm path fast (one ~instant probe) while stopping a single slow probe from
-// tripping the sanity/provider-list guards and blocking all remote validation.
-function probeCrabboxMetadata(command: string, commandArgs: string[]) {
+function probeCrabboxHelp(command: string, commandArgs: string[]) {
   const first = checkedOutput(command, commandArgs);
   if (first.status === 0 && first.text.length > 0) {
     return first;
@@ -3713,23 +3696,17 @@ function applyRunTransforms(
   }
 }
 
-const version = probeCrabboxMetadata(binary, ["--version"]);
 const helpCommand = workloadCommand ? args.slice(0, userArgStart) : ["run"];
-const help = probeCrabboxMetadata(binary, [...helpCommand, "--help"]);
+const help = probeCrabboxHelp(binary, [...helpCommand, "--help"]);
 const providers = parseProvidersFromHelp(help.text);
 commandValueOptionsFromHelp = parseCommandValueOptionsFromHelp(help.text);
 const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
 
-if (
-  version.status !== 0 ||
-  version.text.length === 0 ||
-  help.status !== 0 ||
-  commandValueOptionsFromHelp.size === 0
-) {
+if (help.status !== 0 || commandValueOptionsFromHelp.size === 0) {
   console.error(
-    `[crabbox] bin=${displayBinary} version=${version.text || "unknown"} providers=${providers.join(",") || "unknown"}`,
+    `[crabbox] bin=${displayBinary} version=${version} providers=${providers.join(",") || "unknown"}`,
   );
-  console.error("[crabbox] selected binary failed basic --version/--help sanity checks");
+  console.error("[crabbox] selected binary failed --help sanity checks");
   process.exit(2);
 }
 
@@ -3787,7 +3764,7 @@ let normalizedArgs = ensureAwsMacOnDemandMarket(
 );
 
 console.error(
-  `[crabbox] bin=${displayBinary} version=${version.text || "unknown"} provider=${provider || "unknown"} providers=${providers.join(",") || "unknown"}`,
+  `[crabbox] bin=${displayBinary} version=${version} provider=${provider || "unknown"} providers=${providers.join(",") || "unknown"}`,
 );
 if (providerSelection.source === "policy") {
   console.error(

--- a/test/scripts/ci-git-owner.test-support.ts
+++ b/test/scripts/ci-git-owner.test-support.ts
@@ -571,8 +571,6 @@ ${run}`;
         ),
         rebases: report.commands.filter(({ tool, args }) => tool === "git" && args[0] === "rebase"),
         pushes: report.commands.filter(({ tool, args }) => tool === "git" && args[0] === "push"),
-        go: report.commands.filter(({ tool }) => tool === "go"),
-        crabbox: report.commands.filter(({ tool }) => tool === "crabbox"),
         checkouts: report.commands.filter(
           ({ tool, args }) => tool === "git" && args[0] === "checkout",
         ),

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -688,110 +688,6 @@ posixIt.each([
   55_000,
 );
 
-const mantisInstallers = [
-  { workflow: "discord-status-reactions", job: "run_status_reactions", fetch: false },
-  { workflow: "discord-thread-attachment", job: "run_thread_attachment", fetch: false },
-  { workflow: "slack-desktop-smoke", job: "run_slack_desktop", fetch: true },
-];
-
-posixIt.each([
-  ...mantisInstallers.map((profile) => ({ ...profile, failure: false })),
-  ...mantisInstallers
-    .filter(({ workflow }) => workflow !== "discord-thread-attachment")
-    .map((profile) => Object.assign({}, profile, { failure: true })),
-])(
-  "Mantis installer Git owner drains before checkout/build/probes: $workflow (cleanup failure=$failure)",
-  async ({ workflow, job, fetch, failure }) => {
-    const result = failure ? "cleanup-failure" : 0;
-    const report = await runCiGitStep({
-      workflow: {
-        file: `.github/workflows/mantis-${workflow}.yml`,
-        job,
-        step: "Install Crabbox CLI",
-      },
-      fetchResults: fetch ? [result] : [],
-      cloneResults: fetch ? [] : [result],
-      realClock: true,
-      realDrain: false,
-      poisonPython: true,
-      env: { CRABBOX_REF: "main" },
-    });
-    expect(report.code, report.output).toBe(failure ? 125 : 0);
-    expect(report.readyAttempts).toEqual([1]);
-    const source = path.join(report.runnerTemp, "crabbox/src");
-    const binary = path.join(report.runnerTemp, "home/.local/bin/crabbox");
-    const gitCommand = (cwd: string, args: string[]) => ({
-      tool: "git",
-      cwd,
-      args,
-      configuration: [],
-    });
-    expect(report.commands.filter(({ tool }) => tool === "git")).toEqual(
-      fetch
-        ? [
-            gitCommand(report.workspace, ["init", source]),
-            gitCommand(source, [
-              "remote",
-              "add",
-              "origin",
-              "https://github.com/openclaw/crabbox.git",
-            ]),
-            gitCommand(source, ["fetch", "--depth", "1", "origin", "main"]),
-            ...(failure ? [] : [gitCommand(source, ["checkout", "--detach", "FETCH_HEAD"])]),
-          ]
-        : [
-            gitCommand(report.workspace, [
-              "clone",
-              "--depth",
-              "1",
-              "https://github.com/openclaw/crabbox.git",
-              source,
-            ]),
-          ],
-    );
-    expect(report.clones).toHaveLength(fetch ? 0 : 1);
-    expect(report.fetches).toHaveLength(fetch ? 1 : 0);
-    expect(report.worktrees).toEqual([]);
-    expect(report.go).toEqual(
-      failure
-        ? []
-        : [
-            {
-              tool: "go",
-              cwd: report.workspace,
-              args: ["build", "-C", source, "-o", binary, "./cmd/crabbox"],
-            },
-          ],
-    );
-    const probes = [
-      ["--version"],
-      ["warmup", "--help"],
-      ...(fetch ? [["media", "preview", "--help"]] : []),
-    ];
-    expect(report.crabbox).toEqual(
-      failure ? [] : probes.map((args) => ({ tool: "crabbox", cwd: report.workspace, args })),
-    );
-    expect(report.commands.filter(({ tool }) => tool === "pnpm")).toEqual([]);
-    expect(report.boundaries.map(({ name }) => name)).toEqual([
-      ...(fetch ? ["init", "fetch:1"] : ["clone:1"]),
-      ...(failure
-        ? []
-        : [...(fetch ? ["checkout"] : []), "consumer:go", ...probes.map(() => "consumer:crabbox")]),
-      "exit",
-    ]);
-    expect(report.githubPath).toBe(failure ? "" : `${path.dirname(binary)}\n`);
-    expect(report.githubOutput).toBe("");
-    expect(report.githubEnv).toBe("");
-    expect(report.githubSummary).toBe("");
-    if (failure) {
-      expect(report.output).toContain("Git ownership/setup failed");
-    } else {
-      expect(report.output).toContain("crabbox fixture");
-    }
-  },
-  55_000,
-);
-
 const mantisWorktrees = [
   {
     workflow: "discord-status-reactions",
@@ -887,8 +783,6 @@ posixIt.each([
     );
     expect(report.clones).toEqual([]);
     expect(report.fetches).toEqual([]);
-    expect(report.go).toEqual([]);
-    expect(report.crabbox).toEqual([]);
     expect(report.boundaries.map(({ name }) => name)).toEqual([
       ...attempted.map((_, index) => `worktree:${index + 1}`),
       ...(failure

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -879,7 +879,10 @@ describe("scripts/crabbox-wrapper", () => {
     });
 
     expect(result.status, result.stderr).toBe(0);
-    const binary = path.join(makeFakeCrabbox(defaultProviderHelp), "crabbox");
+    const binary = path.join(
+      makeFakeCrabbox(defaultProviderHelp),
+      process.platform === "win32" ? "crabbox.cmd" : "crabbox",
+    );
     expect(JSON.parse(result.stdout)).toEqual({ binary, version: "0.56.0" });
     expect(readFileSync(githubPath, "utf8")).toBe(`${path.dirname(binary)}\n`);
     expect(readInvocations(invocationLog)).toEqual([["--version"]]);

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1,4 +1,3 @@
-// Crabbox Wrapper tests cover crabbox wrapper script behavior.
 import { spawn, spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -38,6 +37,7 @@ const artifactTempDirs = useAutoCleanupTempDirTracker(afterEach);
 const repoRoot = process.cwd();
 const bundledWrapperPath = path.join(repoRoot, ".tmp", `crabbox-wrapper-test-${process.pid}.mjs`);
 const realBundledWrapperPath = bundledWrapperPath.replace(".mjs", "-real.mjs");
+let bundledSetupPath: string;
 const fakeCrabboxBinDirs = new Map<string, string>();
 const fakeGitBinDirs = new Map<string, string>();
 const timingPreloads = new Map<string, string>();
@@ -209,6 +209,9 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
       crabboxPath,
       [
         'if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then',
+        '  if [ -n "${OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG:-}" ]; then',
+        `    printf '%s\\n' '["--version"]' >> "$OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG"`,
+        "  fi",
         `  printf '%s\\n' "\${OPENCLAW_FAKE_CRABBOX_VERSION:-crabbox 0.55.0}"`,
         "  exit 0",
         "fi",
@@ -812,6 +815,15 @@ describe("scripts/crabbox-wrapper", () => {
       ...bundleOptions,
       outfile: realBundledWrapperPath,
     });
+    bundledSetupPath = path.join(
+      makeTempDir(tempDirs, "openclaw-crabbox-setup-"),
+      "openclaw/scripts/crabbox-setup.mjs",
+    );
+    buildSync({
+      ...bundleOptions,
+      entryPoints: [path.join(repoRoot, "scripts/crabbox-setup.mts")],
+      outfile: bundledSetupPath,
+    });
     // Argument routing tests isolate source preparation; the real-Git fixture below
     // executes the unmocked producer and generated receiver together.
     const producerStub = path.join(
@@ -847,6 +859,31 @@ describe("scripts/crabbox-wrapper", () => {
       outfile: bundledWrapperPath,
     });
     runSourceWrapper("provider: aws\n", ["--version"]);
+  });
+
+  it("prepares the supported executable for later workflow steps", () => {
+    const directory = invocationLogTempDirs.make("openclaw-crabbox-setup-path-");
+    const githubPath = path.join(directory, "github-path");
+    const invocationLog = makeInvocationLog();
+    const result = spawnSync(process.execPath, [bundledSetupPath], {
+      cwd: directory,
+      encoding: "utf8",
+      env: wrapperEnv(defaultProviderHelp, {
+        env: {
+          GITHUB_PATH: githubPath,
+          OPENCLAW_STATE_DIR: path.join(directory, "state"),
+          OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.56.0",
+          OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: invocationLog,
+        },
+      }),
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const binary = path.join(makeFakeCrabbox(defaultProviderHelp), "crabbox");
+    expect(JSON.parse(result.stdout)).toEqual({ binary, version: "0.56.0" });
+    expect(readFileSync(githubPath, "utf8")).toBe(`${path.dirname(binary)}\n`);
+    expect(readInvocations(invocationLog)).toEqual([["--version"]]);
+    expect(existsSync(path.join(directory, "state"))).toBe(false);
   });
 
   it("routes CI workloads through the first ready provider", () => {
@@ -1050,13 +1087,14 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain("chain=aws");
   });
 
-  it("uses one provider-scoped doctor per candidate and never calls standalone whoami", () => {
+  it("reuses the admitted version and runs one provider-scoped doctor per candidate", () => {
     const invocationLog = makeInvocationLog();
     const { output, result } = runSuccessfulBrokerWrapper(
       ["run", "--workload", "desktop", "--", "echo ok"],
       {
         env: {
           OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: invocationLog,
+          OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.56.0",
           OPENCLAW_FAKE_CRABBOX_UNREADY_PROVIDERS: "azure",
           OPENCLAW_FAKE_CRABBOX_WHOAMI_STATUS: "1",
         },
@@ -1066,6 +1104,8 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("aws");
     expect(result.stderr).toContain("selected=aws chain=azure,aws");
     const invocations = readInvocations(invocationLog);
+    expect(invocations.filter(([command]) => command === "--version")).toEqual([["--version"]]);
+    expect(result.stderr).toContain("version=0.56.0");
     expect(invocations.filter(([command]) => command === "doctor").map((args) => args[2])).toEqual([
       "azure",
       "aws",
@@ -3289,9 +3329,7 @@ esac
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
     expect(result.stderr).not.toContain("could not parse provider list");
-    expect(result.stderr).not.toContain(
-      "selected binary failed basic --version/--help sanity checks",
-    );
+    expect(result.stderr).not.toContain("selected binary failed --help sanity checks");
     expect(result.stderr).toContain(
       "providers=hetzner,aws,local-container,blacksmith-testbox,cloudflare",
     );

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -453,7 +453,7 @@ async function command() {
     }
     return;
   }
-  if (["gh", "node", "npm", "pnpm", "go", "crabbox"].includes(mode)) {
+  if (["gh", "node", "npm", "pnpm"].includes(mode)) {
     const cwd = insideOwnedPath(process.cwd());
     recordCommand(mode, cwd, args);
     if (options.performance && mode === "node") {
@@ -509,31 +509,6 @@ async function command() {
       }
       const result = spawnSync(process.execPath, args, { stdio: "inherit" });
       process.exit(result.status ?? 1);
-    }
-    if (mode === "go") {
-      const [build, changeDirectory, source, outputFlag, output, target] = args;
-      if (
-        build !== "build" ||
-        changeDirectory !== "-C" ||
-        outputFlag !== "-o" ||
-        target !== "./cmd/crabbox" ||
-        args.length !== 6
-      ) {
-        throw new Error("Unexpected fixture Go build arguments");
-      }
-      if (!fs.statSync(path.join(insideOwnedPath(source), ".git")).isDirectory()) {
-        throw new Error("Go build source is not a checkout");
-      }
-      writeConsumer(insideOwnedPath(output), "crabbox");
-    }
-    if (mode === "crabbox") {
-      if (args.join(" ") === "--version") {
-        fs.writeSync(1, "crabbox fixture\n");
-      } else if (args.join(" ") === "warmup --help") {
-        fs.writeSync(1, "-desktop\n");
-      } else if (args.join(" ") !== "media preview --help") {
-        throw new Error("Unexpected fixture Crabbox probe");
-      }
     }
     if (mode === "gh" && options.publisher) {
       const result = spawnSync("bash", [options.publisher.gh, ...args], { stdio: "inherit" });
@@ -1044,7 +1019,7 @@ async function supervise() {
     ...(options.docsPublish ? ["rm", "npm"] : []),
     ...(options.performance ? ["curl", "tar", "sha256sum", "npm"] : []),
     ...(options.docsAgent ? ["date"] : []),
-    ...(options.consumers ? ["gh", "node", "pnpm", "go"] : []),
+    ...(options.consumers ? ["gh", "node", "pnpm"] : []),
   ];
   for (const tool of extraTools) {
     writeConsumer(path.join(bin, tool), tool);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -46,6 +46,8 @@ const MANTIS_DISCORD_STATUS_REACTIONS_WORKFLOW =
 const MANTIS_DISCORD_THREAD_ATTACHMENT_WORKFLOW =
   ".github/workflows/mantis-discord-thread-attachment.yml";
 const MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW = ".github/workflows/mantis-slack-desktop-smoke.yml";
+const MANTIS_TELEGRAM_BOT_E2E_PROOF_WORKFLOW =
+  ".github/workflows/mantis-telegram-bot-e2e-proof.yml";
 const MANTIS_WEB_UI_CHAT_PROOF_WORKFLOW = ".github/workflows/mantis-web-ui-chat-proof.yml";
 const PACKAGE_JSON = "package.json";
 const SETUP_PNPM_STORE_CACHE_ACTION = ".github/actions/setup-pnpm-store-cache/action.yml";
@@ -9821,7 +9823,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     }
   });
 
-  it("pins Mantis installer and worktree ownership without changing retrieval or install contracts", () => {
+  it("pins Mantis worktree ownership and candidate dependency installation", () => {
     const cases = [
       [MANTIS_DISCORD_STATUS_REACTIONS_WORKFLOW, "run_status_reactions", 2],
       [MANTIS_DISCORD_THREAD_ATTACHMENT_WORKFLOW, "run_thread_attachment", 2],
@@ -9829,7 +9831,6 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       [MANTIS_WEB_UI_CHAT_PROOF_WORKFLOW, "run_web_ui_chat", 1],
     ] as const;
     const owner = 'python3 -I -S "$CI_GIT_OWNER"';
-    let clones = 0;
     let worktrees = 0;
 
     for (const [workflowPath, jobName, count] of cases) {
@@ -9880,46 +9881,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
           jobName === "run_slack_desktop",
         );
       }
-      if (jobName === "run_web_ui_chat") {
-        continue;
-      }
-      const install = workflowStep(job, "Install Crabbox CLI").run ?? "";
-      const gitCalls = install
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.includes("$CI_GIT_OWNER"));
-      const slack = jobName === "run_slack_desktop";
-      expect(gitCalls, workflowPath).toEqual(
-        slack
-          ? [
-              `${owner} --git 0 init "$install_dir/src"`,
-              `${owner} --checkout-git 0 remote add origin https://github.com/openclaw/crabbox.git`,
-              `${owner} --checkout-git 120 fetch --depth 1 origin "$CRABBOX_REF"`,
-              `${owner} --checkout-git 0 checkout --detach FETCH_HEAD`,
-            ]
-          : [
-              `${owner} --git 120 clone --depth 1 https://github.com/openclaw/crabbox.git "$install_dir/src"`,
-            ],
-      );
-      clones += gitCalls.filter((line) => line.includes("--git 120 clone")).length;
-      expect(install.startsWith("set -euo pipefail\n")).toBe(true);
-      expect(install).not.toMatch(/\b(?:for|while|until|timeout)\b|\$\?|\|\|/u);
-      expect(install).toContain(
-        'go build -C "$install_dir/src" -o "$HOME/.local/bin/crabbox" ./cmd/crabbox\necho "$HOME/.local/bin" >> "$GITHUB_PATH"\n"$HOME/.local/bin/crabbox" --version\n',
-      );
-      if (slack) {
-        expect(readWorkflow(workflowPath).env?.CRABBOX_REF).toBe("main");
-        expect(install).toContain('cd "$install_dir/src"');
-        expect(install).toContain(
-          '"$HOME/.local/bin/crabbox" warmup --help > "$install_dir/warmup-help.txt" 2>&1\ngrep -q -- "-desktop" "$install_dir/warmup-help.txt"\n"$HOME/.local/bin/crabbox" media preview --help >/dev/null',
-        );
-      } else {
-        expect(install).toContain(
-          '"$HOME/.local/bin/crabbox" warmup --help 2>&1 | grep -q -- "-desktop"',
-        );
-      }
     }
-    expect(clones).toBe(2);
     expect(worktrees).toBe(6);
     for (const workflowPath of workflowPaths().filter((file) => file.includes("/mantis-"))) {
       expect(readFileSync(workflowPath, "utf8"), workflowPath).not.toMatch(
@@ -9927,6 +9889,68 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       );
     }
   });
+
+  it.each([
+    {
+      workflowPath: MANTIS_DISCORD_STATUS_REACTIONS_WORKFLOW,
+      jobName: "run_status_reactions",
+      candidateStep: "Prepare baseline and candidate worktrees",
+    },
+    {
+      workflowPath: MANTIS_DISCORD_THREAD_ATTACHMENT_WORKFLOW,
+      jobName: "run_thread_attachment",
+      candidateStep: "Prepare baseline and candidate worktrees",
+    },
+    {
+      workflowPath: MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW,
+      jobName: "run_slack_desktop",
+      candidateStep: "Prepare candidate worktree",
+    },
+    {
+      workflowPath: MANTIS_TELEGRAM_BOT_E2E_PROOF_WORKFLOW,
+      jobName: "run_telegram_proof",
+      candidateStep: "Build exact candidate without credentials or network",
+    },
+  ])(
+    "sets up plugin-owned Crabbox before candidate execution in $jobName",
+    ({ workflowPath, jobName, candidateStep }) => {
+      const workflow = readWorkflow(workflowPath);
+      const job = workflowJob(workflowPath, jobName);
+      const telegram = jobName === "run_telegram_proof";
+      const checkout = workflowStep(
+        job,
+        telegram ? "Checkout trusted harness" : "Checkout harness ref",
+      );
+      const tooling = workflowStep(
+        job,
+        telegram ? "Setup trusted tooling" : "Setup Node environment",
+      );
+      const install = workflowStep(
+        job,
+        telegram ? "Install Crabbox for disposable candidate lifecycle" : "Install Crabbox CLI",
+      );
+      const steps = job.steps ?? [];
+
+      expect(checkout.with?.["persist-credentials"]).toBe(false);
+      expect(tooling.uses).toBe("./.github/actions/setup-node-env");
+      expect(String(tooling.with?.["install-deps"] ?? true)).toBe("true");
+      expect(steps.indexOf(tooling)).toBeGreaterThan(steps.indexOf(checkout));
+      expect(steps.indexOf(install)).toBeGreaterThan(steps.indexOf(tooling));
+      expect(steps.indexOf(install)).toBeLessThan(steps.indexOf(workflowStep(job, candidateStep)));
+      expect(install.run).toBe("node scripts/crabbox-setup.mjs");
+      expect(install.env).toEqual({
+        OPENCLAW_STATE_DIR: "${{ runner.temp }}/openclaw-crabbox-setup",
+      });
+      expect(job.env?.OPENCLAW_STATE_DIR).toBeUndefined();
+      expect(workflow.env?.OPENCLAW_STATE_DIR).toBeUndefined();
+      expect(install.if).toBe(
+        telegram ? "${{ inputs.scenario == 'telegram-bot-e2e-proof' }}" : undefined,
+      );
+      if (telegram) {
+        expect(checkout.with?.ref).toBe("${{ github.workflow_sha }}");
+      }
+    },
+  );
 
   it("maps every supported Slack approval checkpoint scenario family", () => {
     const workflow = readFileSync(MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW, "utf8");


### PR DESCRIPTION
Related: #143768

## What Problem This Solves

Fixes an issue where Mantis QA callers and workflow setup use a different Crabbox installation policy from cloud workers and remote proof. QA could keep using an outdated executable, workflows cloned and built separate copies or pinned an older release, and the proof wrapper repeated a version probe after admission.

## Why This Change Was Made

The Crabbox plugin now owns shared executable discovery and returns the selected path together with its verified version. The provider, Doctor, proof wrapper, and QA Lab consume that owner; acquisition retains cancellation, integrity checks, publication locking, and recovery copies. QA uses the existing public package API and workspace bundling pattern, preserving caller environments and its own lease lifecycle.

Four ordinary Mantis workflows use one setup command after trusted dependency setup and before candidate execution. It exposes the selected executable through `GITHUB_PATH`. Their duplicate Go/source installers and obsolete feature probes are removed, along with tests and fixture support used only by those deleted installers. The protected PR gate publisher retains its separate dependency-free, immutable-workflow bootstrap contract.

## User Impact

QA and remote proof reuse the same supported Crabbox installation, currently 0.55.0. Explicit executable precedence, Windows executable ordering, wrapper common-checkout fallback, Doctor's read-only detection, and provider cache lifetimes are preserved. QA resolves relative overrides and PATH entries from its requested `--repo-root`, with version probes and lease commands sharing that directory. Metadata probes use QA's supplied environment as their base instead of inheriting unrelated ambient variables. Operator-installed binaries and profile configuration remain intact. Offline QA hosts must provision a supported executable or managed copy before upgrading; this is the requested latest-only contract. The admission helper was introduced by #143768 after v2026.9.3, and all internal callers migrate together.

## Evidence

- 697 Crabbox plugin tests and 42 QA tests passed, including publication winner versions, discovery precedence, cancellation, failed acquisition before leasing, and managed-binary use through teardown.
- Broad tooling run: 845 passed and 31 skipped. Two new invocation-count checks exposed a missing log in the POSIX fake CLI fast path; repaired and passed on focused rerun. An unchanged dispatch-convergence subprocess deadline also passed on its focused rerun.
- The supplied-environment contract failed before switching the process helper to `baseEnv`, then passed. A real synthetic executable confirmed the caller marker was present and the ambient marker excluded.
- Live official 0.55.0 installation into isolated managed state; the wrapper and QA Lab reused that executable. Setup wrote the correct `GITHUB_PATH` directory, and the media-preview command was available. The operator-installed 0.51.0 executable remained unchanged.
- Independent full and final reviews found no actionable P0-P2 defects.
- Workflow validation passed. Docs audit: 13,235 internal links, zero broken links.
- Full build with private QA artifacts passed. Built QA and Crabbox import the same shared implementation chunk; no runtime package dependency is introduced.
- All 50 rebuilt Doctor, Gateway preflight/recovery, and strict service-replacement integration tests passed.
- Full changed-file gate passed, including all typecheck lanes, lint, import cycles, package/dependency guards, and Doctor contracts. The directory correction also passed its scoped changed-file gate and final review.
- Three real executable regressions for relative overrides, relative PATH entries, and bare commands failed before target-directory propagation and passed afterward. A final provider/QA run passed 285 tests. Refreshed runtime artifacts passed, and the real 0.55.0 CLI plus rebuilt admission API passed those same differing-directory cases.
- Initial hosted CI hit an unrelated native compiler `ETXTBSY` and an unchanged Windows transform-cache timeout; both passed on the same-head retry. Required exact-head CI passed for `42b2ea5a3af9a96f781f77fe957a18ccdddbf58b`: [final CI run](https://github.com/openclaw/openclaw/actions/runs/34502770385).
