### PR TITLE
fix(doctor): preserve reserved system agent ownership

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -459,6 +459,20 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(text).not.toContain("Examples:");
   });
 
+  it("ignores reserved system agent dirs that can never appear in agents.list", async () => {
+    createAgentDir("openclaw");
+    createAgentDir("crestodian");
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    expect(text).not.toContain("without a matching agents.list entry");
+    expect(text).not.toContain("Examples:");
+  });
+
   it("protects the shared legacy main auth-store dir for an ops-only roster", async () => {
     createAgentDir("main");
 

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -54,6 +54,7 @@ import {
 } from "../infra/state-migrations.legacy-session-store.js";
 import { listConfiguredChannelIdsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { shortenHomePath } from "../utils.js";
 import { repairHeartbeatPoisonedMainSession } from "./doctor-heartbeat-main-session-repair.js";
 import { describeHeartbeatSessionTargetIssues } from "./doctor-heartbeat-session-target.js";
@@ -215,6 +216,11 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgent
         const nestedAgentDir = path.join(agentsRoot, dirName, "agent");
         const hasNestedAgentDir = existsDir(nestedAgentDir);
         if (!hasNestedAgentDir) {
+          return false;
+        }
+        // Reserved system agent ids own a state dir but can never appear in
+        // agents.list, so their directories are never orphans.
+        if (isReservedSystemAgentId(agentId)) {
           return false;
         }
         if (


### PR DESCRIPTION
Closes #144125.

Doctor reported the system agent's own directory as lacking an `agents.list` entry and suggested restoring that entry or removing the directory. Reserved system agents cannot enter the normal roster, so that advice cannot resolve the finding safely.

The orphan scan now uses the existing reserved-ID owner to exempt `openclaw` and retained `crestodian` state. Genuine orphan warnings, shared-auth/default-directory exemptions, and filesystem handling remain unchanged.

Validation on the pinned main and signed candidate:

- A real authenticated `openclaw.chat` turn through an isolated Gateway and deterministic local provider created `agents/openclaw/agent` naturally. Public history confirmed the conversation.
- The same `openclaw doctor --no-color` command and state reported three orphans on main. The candidate reports only the ordinary orphan; every other output line remains unchanged.
- The candidate's first Doctor invocation preserved all captured file bytes and modes, both database schemas, every exported table row, the agent registry, and the three persisted conversation records.
- Nine public controls cover ordinary/configured ownership, casing, shared authentication, default-directory realpaths, incomplete/moved/symlinked directories, missing/unreadable state, and reserved-name creation rejection.
- The new regression fails on main while the other 28 tests pass. The candidate passes all 35 focused tests, formatting, syntax lint, unchanged ratchets, and the normal commit hook.

The first main Doctor run performed automatic metadata initialization and changed SQLite bytes; its missing raw before-images remain an explicit evidence limit. A separately observed main run preserved all logical data, with shared-file changes explained exactly by checkpointing already committed journal pages. The candidate then preserved the entire captured state without restoring files, changing stamps, or repeating the original turn.

The unreadable-root control preserves the existing permission error before the orphan scan; it does not claim that the scan itself ran. Doctor's warning does not automatically delete state. This repair changes its ownership advice and preserves contributor credit.
