### PR TITLE
fix(ai): price the OpenAI/xAI Responses compact endpoint call so server-side compaction stops wiping run cost

### DIFF
--- a/packages/ai/src/transports/openai-responses-compact-client.ts
+++ b/packages/ai/src/transports/openai-responses-compact-client.ts
@@ -1,6 +1,12 @@
 import type { Model } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type OpenAI from "openai";
+import { calculateCost } from "../model-utils.js";
+import {
+  mapResponsesTerminalUsage,
+  type ResponsesTerminalUsagePayload,
+} from "../providers/openai-responses-terminal-usage.js";
+import type { Usage } from "../types.js";
 import type { OpenAIResponsesCompactEndpointResult } from "./openai-responses-compact-request.js";
 import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
 import { isOpenAIResponsesCompactionOutput } from "./openai-responses-compaction-window.js";
@@ -65,11 +71,21 @@ export async function postOpenAIResponsesCompaction(params: {
   ) {
     throw new Error("Responses compact endpoint did not return one trailing compaction item");
   }
+  const priced: Usage = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    ...mapResponsesTerminalUsage(usage as ResponsesTerminalUsagePayload),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+  calculateCost(params.model, priced);
   return {
     output,
     item,
     historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
-    usage,
+    usage: { ...usage, cost: priced.cost },
     model: params.model,
     replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(params.model, {
       authProfileId: params.options?.authProfileId,

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction-usage-cost.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction-usage-cost.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import "../../llm/ai-transport-host.js";
+import { postOpenAIResponsesCompaction } from "../../../packages/ai/src/transports/openai-responses-compact-client.js";
+import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
+import { normalizeUsage } from "../usage.js";
+import { buildErrorAgentMeta, buildUsageAgentMetaFields } from "./run/helpers.js";
+import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
+
+const grokModel = {
+  id: "grok-4-fast",
+  name: "grok-4-fast",
+  api: "openai-responses",
+  provider: "xai",
+  baseUrl: "https://api.x.ai/v1",
+  input: ["text"],
+  contextWindow: 2_000_000,
+  reasoning: false,
+  cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0 },
+} as never;
+
+const tieredGrokCost = {
+  input: 0.2,
+  output: 0.5,
+  cacheRead: 0.05,
+  cacheWrite: 0,
+  tieredPricing: [
+    {
+      range: [0, 128_000] as [number, number],
+      input: 0.2,
+      output: 0.5,
+      cacheRead: 0.05,
+      cacheWrite: 0,
+    },
+    {
+      range: [128_000, Number.POSITIVE_INFINITY] as [number, number],
+      input: 0.4,
+      output: 1,
+      cacheRead: 0.1,
+      cacheWrite: 0,
+    },
+  ],
+};
+
+async function compactWith(usage: Record<string, unknown>, model: unknown = grokModel) {
+  return await postOpenAIResponsesCompaction({
+    client: {
+      post: async () => ({
+        object: "response.compaction",
+        output: [{ type: "compaction", encrypted_content: "ENCRYPTED_WINDOW" }],
+        usage,
+      }),
+    } as never,
+    model: model as never,
+    request: { model: "grok-4-fast", input: [] } as never,
+    options: undefined,
+  });
+}
+
+function buildAccumulator(compactionUsage: unknown) {
+  const accumulator = createUsageAccumulator();
+  mergeUsageIntoAccumulator(
+    accumulator,
+    normalizeUsage({ input: 1_000, output: 200, cost: { total: 0.0003 } } as never),
+  );
+  if (compactionUsage !== undefined) {
+    mergeUsageIntoAccumulator(accumulator, normalizeUsage(compactionUsage as never));
+  }
+  return accumulator;
+}
+
+describe("Responses compact endpoint usage accounting", () => {
+  it("prices the compaction call against the model it was billed against", async () => {
+    const compacted = await compactWith({
+      input_tokens: 120_000,
+      output_tokens: 4_000,
+      total_tokens: 124_000,
+    });
+    expect(compacted.usage.cost).toMatchObject({
+      input: 0.024,
+      output: 0.002,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: expect.closeTo(0.026, 10),
+    });
+    expect(compacted.usage.input_tokens).toBe(120_000);
+    expect(compacted.usage.output_tokens).toBe(4_000);
+  });
+
+  it("bills cache reads at the cache rate instead of the input rate", async () => {
+    const compacted = await compactWith({
+      input_tokens: 120_000,
+      output_tokens: 4_000,
+      total_tokens: 124_000,
+      input_tokens_details: { cached_tokens: 100_000 },
+    });
+    expect(compacted.usage.cost).toMatchObject({
+      input: 0.004,
+      cacheRead: 0.005,
+      output: 0.002,
+      total: expect.closeTo(0.011, 10),
+    });
+  });
+
+  it("keeps the run's cost after a server-side compaction and counts its tokens once", async () => {
+    const compacted = await compactWith({
+      input_tokens: 120_000,
+      output_tokens: 4_000,
+      total_tokens: 124_000,
+    });
+    const meta = buildUsageAgentMetaFields({
+      usageAccumulator: buildAccumulator(compacted.usage),
+      latestUsage: undefined,
+      lastRunPromptUsage: undefined,
+    });
+    expect(meta.usage?.total).toBe(125_200);
+    expect(meta.usage?.cost?.total).toBeCloseTo(0.0263, 10);
+    expect(meta.costUsd).toBeCloseTo(0.0263, 10);
+  });
+
+  it("keeps costUsd on the error terminal path", async () => {
+    const compacted = await compactWith({
+      input_tokens: 120_000,
+      output_tokens: 4_000,
+      total_tokens: 124_000,
+    });
+    const errorMeta = buildErrorAgentMeta({
+      sessionId: "s1",
+      provider: "xai",
+      model: "grok-4-fast",
+      usageAccumulator: buildAccumulator(compacted.usage),
+      lastRunPromptUsage: undefined,
+    });
+    expect(errorMeta.usage?.total).toBe(125_200);
+    expect(errorMeta.costUsd).toBeCloseTo(0.0263, 10);
+  });
+
+  it("keeps costUsd for a tiered-pricing model", async () => {
+    const compacted = await compactWith({
+      input_tokens: 120_000,
+      output_tokens: 4_000,
+      total_tokens: 124_000,
+    });
+    const meta = buildUsageAgentMetaFields({
+      usageAccumulator: buildAccumulator(compacted.usage),
+      latestUsage: undefined,
+      lastRunPromptUsage: undefined,
+    });
+    expect(
+      estimateAggregateUsageCost({
+        usage: meta.usage,
+        provider: "xai",
+        model: "grok-4-fast",
+        cost: tieredGrokCost,
+      }),
+    ).toBeCloseTo(0.0263, 10);
+  });
+
+  it("reports a zero cost rather than throwing when the model carries no rates", async () => {
+    const compacted = await compactWith(
+      { input_tokens: 120_000, output_tokens: 4_000, total_tokens: 124_000 },
+      { ...(grokModel as object), cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    );
+    expect(compacted.usage.cost).toMatchObject({ total: 0 });
+    const meta = buildUsageAgentMetaFields({
+      usageAccumulator: buildAccumulator(compacted.usage),
+      latestUsage: undefined,
+      lastRunPromptUsage: undefined,
+    });
+    expect(meta.costUsd).toBeCloseTo(0.0003, 10);
+  });
+});


### PR DESCRIPTION
## Summary
On an OpenAI-compatible Responses route with the compact endpoint enabled, a server-side compaction wipes the run's cost accounting.

`responsesCompactEndpoint` is on by default for every Grok model (`openai-responses-payload-policy.ts:220-234` enables it for the `xai-native` endpoint class unless the user explicitly sets it to `false`, and `configured === true` turns it on for any Responses route). When that `POST /responses/compact` call fires inside a run, its usage record reaches the run accumulator with no cost attached. `mergeUsageIntoAccumulator` latches the run's cost to the sticky `"unavailable"` sentinel, which never recovers, so every later priced call in the same run is discarded too. The compaction's tokens are still added.

The run therefore reports more tokens and less money:

- `agentMeta.usage.cost` is gone for the whole run on every path.
- `costUsd` disappears entirely for tiered-rate models (`usage-format.ts` returns `undefined` for any tiered model by design, and Grok's tiered >128k schedule is exactly that shape, while compaction fires precisely when context is large) and on every error terminal (`buildErrorAgentMeta` never calls the estimator).
- Where the estimator does fire, the exact sum of per-call costs is replaced by one flat re-estimate of aggregate tokens at the last model's rates.

Visible to `openclaw agent exec` users (`agent-exec-result.ts:146-149`), gateway session cost totals, cost views, and budget gates.

### Which path actually loses the money
Worth being precise, because only one production path merges compaction usage into a run accumulator. `recordUsage` is supplied at exactly one site: `run/compaction-runtime.ts:237`, `recordUsage: (usage) => mergeUsageIntoAccumulator(input.usageAccumulator, usage)`, inside `compactEmbeddedRunForRecovery`. That is the in-run recovery compaction, and it is the same accumulator that terminal preparation turns into `agentMeta` (`run-loop.ts:195` creates it, `run/terminal-preparation.ts:80-81` reads it).

The queued/manual `/compact` path is deliberately not part of the claim: `compact.queued-execution.ts:330-333` attaches an accounting recorder carrying only `requestBudget` and `pendingUserEntryId`, with no `recordUsage`, so a manual compaction's usage never reaches a run accumulator either way. The defect is therefore scoped to in-run compaction, which is exactly the lane PR #131115 wired up.

## Root cause
`packages/ai/src/transports/openai-responses-compact-client.ts`. The compact client validates the endpoint's raw wire `usage` record for two numeric fields and returns it unmodified. It never routes the record through the canonical `mapResponsesTerminalUsage` + `calculateCost` pair that every other Responses terminal uses, even though `params.model` is in scope and is returned on the very same object.

```ts before
  return {
    output,
    item,
    historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
    usage,
    model: params.model,
```

Every other model call hands the accumulator a `Usage` whose `cost` the transport already computed. This path is the sole exception. The raw record flows out through `server-endpoint-compaction.ts:82` `params.onUsage?.(compacted.usage)`, the runner runs it through `normalizeUsage`, which looks for `raw.cost?.total`, finds nothing, and returns `cost: undefined`. `hasBillableUsage` still passes because the token buckets are non-zero, so the accumulator adds the tokens and then sets `target.cost = "unavailable"` for the rest of the run.

## Fix
Price the call where both inputs already are: inside `postOpenAIResponsesCompaction`, after the endpoint guards pass. This is the single place that owns both the billed tokens and the `Model` they were billed against, and it runs exactly once per compaction. It reuses the existing helpers rather than adding new math.

```ts after
  const priced: Usage = {
    input: 0,
    output: 0,
    cacheRead: 0,
    cacheWrite: 0,
    totalTokens: 0,
    ...mapResponsesTerminalUsage(usage as ResponsesTerminalUsagePayload),
    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
  };
  calculateCost(params.model, priced);
  return {
    output,
    item,
    historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
    usage: { ...usage, cost: priced.cost },
    model: params.model,
```

`mapResponsesTerminalUsage` splits the buckets and subtracts cache reads and writes out of the billable input bucket, so a cached compaction is billed at the cache-read rate instead of the input rate. `calculateCost` then selects the request's pricing tier and bills the separate buckets. This is the same two-step the ordinary Responses terminal already runs at `openai-responses-stream-terminal-internal.ts:313-325`.

Nothing downstream changes shape. The wire record's token fields are returned untouched, so the accumulator's token math is byte-identical; only the `cost` key is added, and `normalizeUsage` already reads `raw.cost.total`. No type change is needed either, because the result's `usage` is already declared as `Record<string, unknown> & { input_tokens: number; output_tokens: number }`.

A model whose catalog rates are all zero prices to a real `$0` rather than to `undefined`, so the accumulator stays priced instead of latching the sticky sentinel. That case is covered by the last regression case.

## Why this is the right boundary
The compact client is the only frame that holds both halves of the calculation. Downstream, `server-endpoint-compaction.ts` has the tokens but not the `Model` pricing context; upstream, the caller has neither the split buckets nor the endpoint's reported totals. And it runs exactly once per compaction, so pricing here cannot double-count.

The strongest argument that this is a gap rather than a design choice is that it is one-sided. PR #131115 (`602ccb949ee`, "fix(agents): account summarization model usage") wired BOTH compaction lanes into the run accumulator on the same day, and priced only one of them. Its diff added the endpoint handoff `params.onUsage?.(compacted.usage)` while wiring the client-side lane through a sink that receives a fully priced `Usage`.

The two sibling lanes are already correct and are deliberately untouched here:

- Anthropic server-side compaction bills inline in the message stream via `applyAnthropicMessageDeltaUsage` + `calculateCost`.
- Client-side LLM summarization emits a full priced `Usage` through `internalUsageSink`.

Neither needs a change, and touching either would risk double-billing a call that is already billed.

One adjacent site is deliberately left out of scope: `openai-responses-client.ts:326-328` assigns three bare fields onto the transport's own `output.usage` with no cost and no cache split. On this path that object is never consumed. `requestPreparedOpenAIResponsesCompaction` awaits `stream.result()` in a `finally` and discards it, and the run's token total staying at 125,200 rather than doubling is direct evidence that nothing reads it. Re-shaping it would be inert churn here and would force a widening of `OpenAIResponsesCompactEndpointResult`. It belongs in its own change if a consumer ever appears.

## Verification
- New colocated regression suite `src/agents/embedded-agent-runner/server-endpoint-compaction-usage-cost.test.ts`, six cases driving the real `postOpenAIResponsesCompaction` and then the real `normalizeUsage` -> `mergeUsageIntoAccumulator` -> `buildUsageAgentMetaFields` / `buildErrorAgentMeta` / `estimateAggregateUsageCost` chain in production order.
- Formatting, typecheck, and the suites are delegated to CI on this revision by request; nothing was gated locally.

## Real behavior proof
Behavior addressed: a server-side `/responses/compact` call on a default-on Responses route adds its tokens to the run but drops the run's dollars, and the loss is sticky for every later call in the same run.
Real environment tested: rebased onto `origin/main` db2666090f196b07ec84867972a6c5f571b1b013, head SHA 93c7266b3a930b27583c1c8b48c05718566f033b. The primary run drives the run-level compaction entrypoint, not the transport function: `attemptServerEndpointCompaction` (`src/agents/embedded-agent-runner/server-endpoint-compaction.ts`), the single production caller of the compact endpoint, invoked with `trigger: "budget"` and `extraParams: { responsesCompactEndpoint: true }` so the real `resolveOpenAIResponsesCompactEndpointPlan` gate decides. It is given a real `SessionManager` opened on a real SQLite session store created under a throwaway `OPENCLAW_STATE_DIR`, seeded with a persisted user message and a persisted assistant owner; the store path and the durable branch are printed, and after the call the store is reopened from disk to show the real transcript rewrite committed its checkpoint (`providerReplay.data`). A real `node:http` server was bound on `127.0.0.1` and answered the provider protocol over a real socket; nothing in the HTTP layer was replaced. The request was issued by the production stream stack: `resolveEmbeddedAgentStream` built the same `streamFn` a real run hands to compaction (it reported strategy `boundary-aware:openai-responses`), which dispatched through the real `openai-responses` transport, the real guarded provider fetch, and the real OpenAI SDK client resolved from the model's `baseUrl`. The real `onUsage` callback then fed the record through `normalizeUsage` into `mergeUsageIntoAccumulator`, mirroring `run/compaction-runtime.ts:237` exactly, and the accumulator was turned into `agentMeta` by the real `buildUsageAgentMetaFields`. The local server replied with `input_tokens: 120000, output_tokens: 4000, total_tokens: 124000` against a Grok model priced at 0.2/0.5/0.05 per million, and the accumulator was pre-seeded with one ordinary 1000/200 call costing 0.0003. The identical driver was run twice with byte-identical inputs: once with `packages/ai/src/transports/openai-responses-compact-client.ts` reverted to `origin/main`, and once on this patch.
Exact steps or command run after this patch: `node_modules/.bin/tsx driver-run.mts` with `OPENCLAW_STATE_DIR` pointed at a fresh throwaway directory, then `git checkout origin/main -- packages/ai/src/transports/openai-responses-compact-client.ts` and the same command again, then the patch restored. The second block below was produced the same way with the transport-level driver.
Evidence after fix:
```
# BEFORE (compact client reverted to origin/main db2666090f19)
real SessionManager store path              = /home/ubuntu/oc-tk-144158/.proof/tmp/state-cq003J/agents/main/agent/openclaw-agent.sqlite
persisted branch entries (durable reopen)   = message,message
production streamFn strategy                = boundary-aware:openai-responses
[provider-transport-fetch] [model-fetch] start provider=xai api=openai-responses model=grok-4-fast method=POST url=http://127.0.0.1:32825/v1/responses/compact timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=xai api=openai-responses model=grok-4-fast status=200 elapsedMs=866 dispatcher=new contentType=application/json
=== real HTTP requests observed by the local provider server ===
POST /v1/responses/compact bytes=342
attemptServerEndpointCompaction returned    = result
onUsage fired                               = true
onCompactionCommitted fired                 = true
durable owner providerReplay.data           = ENCRYPTED_WINDOW_PROOF
compact endpoint returned usage.cost.total   = ABSENT
compact endpoint cost breakdown             = ABSENT
run agentMeta.usage.total (tokens)          = 125200
run agentMeta.usage.cost                    = ABSENT
run agentMeta.costUsd                       = ABSENT

# AFTER (this patch, identical inputs)
real SessionManager store path              = /home/ubuntu/oc-tk-144158/.proof/tmp/state-Zk7zWC/agents/main/agent/openclaw-agent.sqlite
persisted branch entries (durable reopen)   = message,message
production streamFn strategy                = boundary-aware:openai-responses
[provider-transport-fetch] [model-fetch] start provider=xai api=openai-responses model=grok-4-fast method=POST url=http://127.0.0.1:41495/v1/responses/compact timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=xai api=openai-responses model=grok-4-fast status=200 elapsedMs=379 dispatcher=new contentType=application/json
=== real HTTP requests observed by the local provider server ===
POST /v1/responses/compact bytes=342
attemptServerEndpointCompaction returned    = result
onUsage fired                               = true
onCompactionCommitted fired                 = true
durable owner providerReplay.data           = ENCRYPTED_WINDOW_PROOF
compact endpoint returned usage.cost.total   = 0.026000000000000002
compact endpoint cost breakdown             = {"input":0.024,"output":0.002,"cacheRead":0,"cacheWrite":0,"total":0.026000000000000002}
run agentMeta.usage.total (tokens)          = 125200
run agentMeta.usage.cost                    = {"total":0.026300000000000004}
run agentMeta.costUsd                       = 0.026300000000000004
```
Additional evidence, same real local server and same production stream stack, covering the error terminal and the tiered-rate estimator, which the run-level driver does not reach:
```
# BEFORE (compact client reverted to origin/main db2666090f19)
production streamFn strategy                = boundary-aware:openai-responses
[provider-transport-fetch] [model-fetch] start provider=xai api=openai-responses model=grok-4-fast method=POST url=http://127.0.0.1:39669/v1/responses/compact timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=xai api=openai-responses model=grok-4-fast status=200 elapsedMs=552 dispatcher=new contentType=application/json
=== real HTTP requests observed by the local provider server ===
POST /v1/responses/compact bytes=361
compact endpoint returned usage.cost.total   = ABSENT
compact endpoint cost breakdown             = ABSENT
run agentMeta.usage.total (tokens)          = 125200
run agentMeta.usage.cost                    = ABSENT
run agentMeta.costUsd                       = ABSENT
error terminal agentMeta.usage.total        = 125200
error terminal agentMeta.costUsd            = ABSENT
tiered-rate model costUsd estimate          = ABSENT

# AFTER (this patch, identical inputs)
production streamFn strategy                = boundary-aware:openai-responses
[provider-transport-fetch] [model-fetch] start provider=xai api=openai-responses model=grok-4-fast method=POST url=http://127.0.0.1:36291/v1/responses/compact timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=xai api=openai-responses model=grok-4-fast status=200 elapsedMs=679 dispatcher=new contentType=application/json
=== real HTTP requests observed by the local provider server ===
POST /v1/responses/compact bytes=361
compact endpoint returned usage.cost.total   = 0.026000000000000002
compact endpoint cost breakdown             = {"input":0.024,"output":0.002,"cacheRead":0,"cacheWrite":0,"total":0.026000000000000002}
run agentMeta.usage.total (tokens)          = 125200
run agentMeta.usage.cost                    = {"total":0.026300000000000004}
run agentMeta.costUsd                       = 0.026300000000000004
error terminal agentMeta.usage.total        = 125200
error terminal agentMeta.costUsd            = 0.026300000000000004
tiered-rate model costUsd estimate          = 0.026300000000000004
```
Observed result after fix: both runs issue the same real `POST /v1/responses/compact` over a real socket and both receive HTTP 200, and the run's token total is identical at 125,200; only the money differs. Before the patch the endpoint's record carries no cost at all, the run's cost is absent, and it is still absent on the error terminal and on the tiered-rate estimate. After the patch the endpoint's record carries a real breakdown, and the run reports 0.0263, which is the one ordinary call's 0.0003 plus the compaction's own 0.026, surviving on the error terminal and on the tiered-rate model where it previously vanished outright.
What was not tested: no live xAI request was made, so the endpoint's wire body was served by a local server implementing the documented compaction response shape rather than fetched from the provider, and the figures are the catalog rates for the modelled Grok pricing rather than a provider-billed total.
