### PR TITLE
fix(perf): isolate benchmark subprocess transport

### DIFF
--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -1,5 +1,5 @@
 // Bench Cli Startup script supports OpenClaw repository automation.
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -159,6 +159,133 @@ const DEFAULT_TIMEOUT_KILL_GRACE_MS = 1_000;
 const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const DEFAULT_ENTRY = "openclaw.mjs";
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
+
+type SampleTransport = {
+  prefix: string[];
+  binary: string;
+  env: Record<string, string>;
+  cwd: string;
+};
+
+function sampleTransport(): SampleTransport | undefined {
+  const raw = process.env.OPENCLAW_BENCH_TRANSPORT_JSON;
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value: unknown = JSON.parse(raw);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid benchmark transport");
+  }
+  const prefix = "prefix" in value ? value.prefix : undefined;
+  const binary = "binary" in value ? value.binary : undefined;
+  const env = "env" in value ? value.env : undefined;
+  const cwd = "cwd" in value ? value.cwd : undefined;
+  if (
+    !Array.isArray(prefix) ||
+    prefix.length === 0 ||
+    !prefix.every(
+      (part: unknown) => typeof part === "string" && part.length > 0 && !part.includes("\0"),
+    ) ||
+    typeof prefix[0] !== "string" ||
+    !path.isAbsolute(prefix[0]) ||
+    typeof binary !== "string" ||
+    !path.isAbsolute(binary) ||
+    binary.includes("\0") ||
+    !env ||
+    typeof env !== "object" ||
+    Array.isArray(env)
+  ) {
+    throw new Error("Invalid benchmark transport");
+  }
+  const fixedEnv: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(env)) {
+    if (!/^[A-Z_][A-Z0-9_]*$/u.test(key) || typeof entry !== "string" || entry.includes("\0")) {
+      throw new Error("Invalid benchmark transport environment");
+    }
+    fixedEnv[key] = entry;
+  }
+  if (!fixedEnv.HOME || !path.isAbsolute(fixedEnv.HOME) || !fixedEnv.PATH) {
+    throw new Error("Benchmark transport requires fixed HOME and PATH");
+  }
+  const directory = cwd === undefined ? fixedEnv.HOME : cwd;
+  if (typeof directory !== "string" || !path.isAbsolute(directory) || directory.includes("\0")) {
+    throw new Error("Invalid benchmark transport cwd");
+  }
+  return { prefix, binary, env: fixedEnv, cwd: directory };
+}
+
+function transportedCommand(
+  transport: SampleTransport,
+  args: string[],
+  env: Record<string, string> = {},
+  timeoutMs?: number,
+): { command: string; args: string[] } {
+  return {
+    command: expectDefined(transport.prefix[0], "benchmark transport command"),
+    args: [
+      ...transport.prefix.slice(1),
+      "/usr/bin/env",
+      "-C",
+      transport.cwd,
+      "-i",
+      ...Object.entries({ ...transport.env, ...env }).map(([key, value]) => `${key}=${value}`),
+      ...(timeoutMs === undefined
+        ? []
+        : ["/usr/bin/timeout", "--signal=TERM", "--kill-after=1s", `${timeoutMs / 1000}s`]),
+      transport.binary,
+      ...args,
+    ],
+  };
+}
+
+function sampleFilesystem(
+  transport: SampleTransport,
+  operation: "create" | "prepare" | "remove",
+  root?: string,
+  config?: Record<string, unknown> | null,
+  hook?: string,
+): string {
+  // Only the SUT opens these paths. Its replies are never read as paths on the runner.
+  const launch = transportedCommand(transport, [
+    "--input-type=module",
+    "-e",
+    `import fs from "node:fs"; import os from "node:os"; import path from "node:path";
+const {operation,root,config,hook} = JSON.parse(fs.readFileSync(0,"utf8"));
+if (operation === "create") process.stdout.write(fs.mkdtempSync(path.join(os.tmpdir(),"openclaw-cli-bench-home-")));
+else if (operation === "prepare") {
+  fs.mkdirSync(path.join(root,".openclaw"),{recursive:true});
+  if (config) fs.writeFileSync(path.join(root,".openclaw/openclaw.json"),JSON.stringify(config)+"\\n");
+  fs.writeFileSync(path.join(root,"measure-rss.mjs"),hook);
+} else if (operation === "remove") fs.rmSync(root,{recursive:true,force:true});
+else throw new Error("Invalid sample filesystem operation");`,
+  ]);
+  return execFileSync(launch.command, launch.args, {
+    input: JSON.stringify({ operation, root, config, hook }),
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 64 * 1024,
+    env: { PATH: process.env.PATH },
+  });
+}
+
+function createSampleRoot(transport?: SampleTransport): string {
+  if (!transport) {
+    return mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"));
+  }
+  const root = sampleFilesystem(transport, "create");
+  if (!path.isAbsolute(root) || /[\0\r\n]/u.test(root)) {
+    throw new Error("Invalid SUT sample directory");
+  }
+  return root;
+}
+
+function removeSampleRoot(root: string, transport?: SampleTransport): void {
+  if (transport) {
+    sampleFilesystem(transport, "remove", root);
+  } else {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
 function resolveTimeoutKillGraceMs(env: NodeJS.ProcessEnv): number {
   const raw = env.VITEST ? env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS : undefined;
@@ -954,18 +1081,35 @@ async function runSample(params: {
   rssHookPath: string;
   runRoot?: string;
 }): Promise<Sample> {
-  const runRoot = params.runRoot ?? mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"));
+  const transport = sampleTransport();
+  const runRoot = params.runRoot ?? createSampleRoot(transport);
   const ownsRunRoot = params.runRoot == null;
   const stateDir = path.join(runRoot, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
   const configFixture = buildConfigFixture(params.commandCase);
-  if (configFixture) {
+  let rssHookPath = params.rssHookPath;
+  if (transport) {
+    sampleFilesystem(
+      transport,
+      "prepare",
+      runRoot,
+      configFixture,
+      readFileSync(rssHookPath, "utf8"),
+    );
+    rssHookPath = path.join(runRoot, "measure-rss.mjs");
+  } else if (configFixture) {
     mkdirSync(stateDir, { recursive: true });
     writeFileSync(configPath, `${JSON.stringify(configFixture, null, 2)}\n`, "utf8");
   }
   const nodeArgs = [
+    ...(transport
+      ? [
+          "--import",
+          `data:text/javascript,${encodeURIComponent(`process.chdir(${JSON.stringify(path.dirname(params.entry))});`)}`,
+        ]
+      : []),
     "--import",
-    nodeImportSpecifierForPath(params.rssHookPath),
+    nodeImportSpecifierForPath(rssHookPath),
     ...buildCpuOrHeapFlags({
       cpuProfDir: params.cpuProfDir,
       heapProfDir: params.heapProfDir,
@@ -989,29 +1133,45 @@ async function runSample(params: {
 
   try {
     return await new Promise<Sample>((resolve) => {
-      const proc = spawn(process.execPath, nodeArgs, {
+      const sampleEnv = {
+        HOME: runRoot,
+        USERPROFILE: runRoot,
+        OPENCLAW_HOME: runRoot,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_HIDE_BANNER: "1",
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+        ...(memoryDirectory
+          ? {
+              OPENCLAW_BENCH_MEMORY: JSON.stringify({
+                directory: memoryDirectory,
+                entries: memoryInvocationEntries(params.entry),
+                args: params.commandCase.args,
+              }),
+            }
+          : {}),
+      };
+      const launch = transport
+        ? transportedCommand(
+            transport,
+            nodeArgs,
+            {
+              ...sampleEnv,
+              ...(process.env.OPENCLAW_GATEWAY_TOKEN
+                ? { OPENCLAW_GATEWAY_TOKEN: process.env.OPENCLAW_GATEWAY_TOKEN }
+                : {}),
+              ...(process.env.OPENCLAW_GATEWAY_PORT
+                ? { OPENCLAW_GATEWAY_PORT: process.env.OPENCLAW_GATEWAY_PORT }
+                : {}),
+            },
+            params.timeoutMs,
+          )
+        : { command: process.execPath, args: nodeArgs };
+      const proc = spawn(launch.command, launch.args, {
         cwd: process.cwd(),
         detached: process.platform !== "win32",
-        env: {
-          ...process.env,
-          HOME: runRoot,
-          USERPROFILE: runRoot,
-          OPENCLAW_HOME: runRoot,
-          OPENCLAW_STATE_DIR: stateDir,
-          OPENCLAW_CONFIG_PATH: configPath,
-          OPENCLAW_HIDE_BANNER: "1",
-          NO_COLOR: "1",
-          FORCE_COLOR: "0",
-          ...(memoryDirectory
-            ? {
-                OPENCLAW_BENCH_MEMORY: JSON.stringify({
-                  directory: memoryDirectory,
-                  entries: memoryInvocationEntries(params.entry),
-                  args: params.commandCase.args,
-                }),
-              }
-            : {}),
-        },
+        env: transport ? { PATH: process.env.PATH } : { ...process.env, ...sampleEnv },
         stdio: ["ignore", "pipe", "pipe"],
       });
 
@@ -1112,7 +1272,7 @@ async function runSample(params: {
       rmSync(memoryDirectory, { recursive: true, force: true });
     }
     if (ownsRunRoot) {
-      rmSync(runRoot, { recursive: true, force: true });
+      removeSampleRoot(runRoot, transport);
     }
   }
 }
@@ -1179,10 +1339,9 @@ async function runCase(params: {
   const warmupSamples: Sample[] = [];
   const samples: Sample[] = [];
   const totalRuns = params.warmup + params.runs;
+  const transport = sampleTransport();
   const caseRunRoot =
-    params.commandCase.stateScope === "case"
-      ? mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"))
-      : undefined;
+    params.commandCase.stateScope === "case" ? createSampleRoot(transport) : undefined;
   try {
     for (let i = 0; i < totalRuns; i += 1) {
       const sample = await runSample({ ...params, runRoot: caseRunRoot });
@@ -1195,7 +1354,7 @@ async function runCase(params: {
     return { warmupSamples, samples };
   } finally {
     if (caseRunRoot) {
-      rmSync(caseRunRoot, { recursive: true, force: true });
+      removeSampleRoot(caseRunRoot, transport);
     }
   }
 }
@@ -1457,6 +1616,15 @@ async function main(): Promise<void> {
   }
 
   const options = parseOptions();
+  const transport = sampleTransport();
+  if (transport && options.runtimeRss) {
+    throw new Error("Cross-user runtime RSS sampling is not supported");
+  }
+  if (transport && (options.cpuProfDir || options.heapProfDir)) {
+    throw new Error(
+      "Cross-user CLI profiles must be collected through the SUT diagnostic exporter",
+    );
+  }
   if (options.compareBaseline || options.compareCandidate) {
     if (!options.compareBaseline || !options.compareCandidate) {
       throw new Error("--compare-baseline and --compare-candidate must be provided together");

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -14,8 +14,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import {
+  assertCompatibleCliStartupExecutionModes,
   assertCompatibleCliStartupMemoryMetrics,
   CLI_RUNTIME_MEMORY_METRIC,
+  type CliStartupExecutionMode,
   cliStartupMemoryMetric,
 } from "./lib/cli-startup-memory-contract.mts";
 import {
@@ -93,6 +95,7 @@ type CaseSummary = {
 
 type SuiteResult = {
   entry: string;
+  executionMode?: CliStartupExecutionMode;
   memoryMetric?: string;
   cases: Array<{
     id: string;
@@ -1408,6 +1411,7 @@ function printDelta(primary: SuiteResult, secondary: SuiteResult): void {
 }
 
 function buildCaseDeltas(primary: SuiteResult, secondary: SuiteResult): CaseDelta[] {
+  assertCompatibleCliStartupExecutionModes(primary, secondary);
   assertCompatibleCliStartupMemoryMetrics(primary, secondary);
   const primaryById = new Map(primary.cases.map((commandCase) => [commandCase.id, commandCase]));
   const deltas: CaseDelta[] = [];
@@ -1485,6 +1489,7 @@ export function collectFailedSamples(result: SuiteResult): string[] {
 
 async function buildSuiteResult(params: {
   entry: string;
+  executionMode: CliStartupExecutionMode;
   options: CliOptions;
   rssHookPath: string;
 }): Promise<SuiteResult> {
@@ -1525,6 +1530,7 @@ async function buildSuiteResult(params: {
   }
   return {
     entry: params.entry,
+    executionMode: params.executionMode,
     ...(params.options.runtimeRss ? { memoryMetric: CLI_RUNTIME_MEMORY_METRIC } : {}),
     cases,
   };
@@ -1648,12 +1654,14 @@ async function main(): Promise<void> {
   try {
     const primary = await buildSuiteResult({
       entry: options.entryPrimary,
+      executionMode: transport ? "transport" : "native",
       options,
       rssHookPath,
     });
     const secondary = options.entrySecondary
       ? await buildSuiteResult({
           entry: options.entrySecondary,
+          executionMode: transport ? "transport" : "native",
           options,
           rssHookPath,
         })

--- a/scripts/lib/cli-startup-memory-contract.mts
+++ b/scripts/lib/cli-startup-memory-contract.mts
@@ -1,6 +1,36 @@
 // Saved CLI reports must not compare last-exiting-process RSS with attributed runtime RSS.
 export const CLI_RUNTIME_MEMORY_METRIC = "cli-runtime-max-rss-v1";
 
+export type CliStartupExecutionMode = "native" | "transport";
+
+export function cliStartupExecutionMode(suite: unknown): CliStartupExecutionMode {
+  const mode =
+    typeof suite === "object" && suite !== null && "executionMode" in suite
+      ? suite.executionMode
+      : undefined;
+  // Reports predating transport measured native execution only.
+  if (mode === undefined) {
+    return "native";
+  }
+  if (mode !== "native" && mode !== "transport") {
+    throw new Error(`Unknown CLI execution mode: ${JSON.stringify(mode)}`);
+  }
+  return mode;
+}
+
+export function assertCompatibleCliStartupExecutionModes(
+  baseline: unknown,
+  candidate: unknown,
+): void {
+  const before = cliStartupExecutionMode(baseline);
+  const after = cliStartupExecutionMode(candidate);
+  if (before !== after) {
+    throw new Error(
+      `Incompatible CLI execution modes: ${before} vs ${after}. Collect both reports with the same execution mode; transport startup is part of the measurement.`,
+    );
+  }
+}
+
 export function cliStartupMemoryMetric(suite: unknown): string {
   const metric =
     typeof suite === "object" && suite !== null && "memoryMetric" in suite

--- a/scripts/openclaw-performance-source-summary.mts
+++ b/scripts/openclaw-performance-source-summary.mts
@@ -8,7 +8,9 @@ import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
 import {
+  assertCompatibleCliStartupExecutionModes,
   assertCompatibleCliStartupMemoryMetrics,
+  cliStartupExecutionMode,
   cliStartupMemoryMetric,
 } from "./lib/cli-startup-memory-contract.mts";
 import { isStartupTraceDuration } from "./lib/gateway-startup-trace-ranking.js";
@@ -303,6 +305,7 @@ function validateStartupArtifact(startup: JsonValue, filePath: string) {
 }
 
 function validateCliArtifact(cli: JsonValue, filePath: string) {
+  cliStartupExecutionMode(valueAt(cli, "primary"));
   cliStartupMemoryMetric(valueAt(cli, "primary"));
   const cases = objectArray(valueAt(cli, "primary", "cases"));
   if (cases.length === 0) {
@@ -639,6 +642,10 @@ function buildCliMemoryDeltaRows(current: JsonValue, baseline: JsonValue) {
   if (!current || !baseline) {
     return [];
   }
+  assertCompatibleCliStartupExecutionModes(
+    valueAt(baseline, "primary"),
+    valueAt(current, "primary"),
+  );
   assertCompatibleCliStartupMemoryMetrics(
     valueAt(baseline, "primary"),
     valueAt(current, "primary"),

--- a/scripts/test-cli-startup-bench-budget.mts
+++ b/scripts/test-cli-startup-bench-budget.mts
@@ -6,7 +6,9 @@ import { z } from "zod";
 import { booleanFlag, intFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
 import { budgetFloatFlag, readBudgetEnvNumber } from "./lib/budget-number-args.mts";
 import {
+  assertCompatibleCliStartupExecutionModes,
   assertCompatibleCliStartupMemoryMetrics,
+  cliStartupExecutionMode,
   cliStartupMemoryMetric,
 } from "./lib/cli-startup-memory-contract.mts";
 import { readJsonFile } from "./test-report-utils.mts";
@@ -216,8 +218,13 @@ const matchedBaselineCaseIds = [...baselineCases.keys()].filter((id) => currentC
 let failed = false;
 
 try {
+  cliStartupExecutionMode(isRecord(current) ? current.primary : undefined);
   cliStartupMemoryMetric(isRecord(current) ? current.primary : undefined);
   if (!opts.skipBaseline) {
+    assertCompatibleCliStartupExecutionModes(
+      isRecord(baseline) ? baseline.primary : undefined,
+      isRecord(current) ? current.primary : undefined,
+    );
     assertCompatibleCliStartupMemoryMetrics(
       isRecord(baseline) ? baseline.primary : undefined,
       isRecord(current) ? current.primary : undefined,

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -23,6 +23,157 @@ function runBenchmarkCli(args: string[]) {
 describe("bench-cli-startup", () => {
   const memoryTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+  it("routes synthetic samples and their state through the explicit transport without runner environment", () => {
+    const tempDirs = createTempDirTracker();
+    const root = tempDirs.make("openclaw-cli-transport-");
+    try {
+      const prefix = join(root, "transport.mjs");
+      const entry = join(root, "entry.mjs");
+      const calls = join(root, "calls.jsonl");
+      const output = join(root, "report.json");
+      writeFileSync(
+        prefix,
+        `import assert from "node:assert/strict";
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+const args = process.argv.slice(2);
+assert.equal(args.shift(), "/usr/bin/env");
+assert.equal(args.shift(), "-C");
+const cwd = args.shift();
+assert.equal(cwd, ${JSON.stringify(root)});
+assert.equal(args.shift(), "-i");
+const env = {};
+while (args[0]?.includes("=") && !args[0].startsWith("/")) {
+  const value = args.shift(), index = value.indexOf("=");
+  env[value.slice(0,index)] = value.slice(index+1);
+}
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify({args,env})+"\\n");
+if (args[0] === "/usr/bin/timeout") {
+  assert.deepEqual(args.splice(0,4), ["/usr/bin/timeout","--signal=TERM","--kill-after=1s","5s"]);
+}
+const result = spawnSync(args[0],args.slice(1),{env,cwd,stdio:"inherit"});
+process.exit(result.status ?? 99);
+`,
+      );
+      writeFileSync(
+        entry,
+        `import assert from "node:assert/strict";
+import fs from "node:fs";
+assert.equal(process.env.SUT_FIXTURE,"yes");
+assert.equal(process.env.RUNNER_PRIVATE_CANARY,undefined);
+assert.equal(process.env.OPENCLAW_BENCH_TRANSPORT_JSON,undefined);
+assert.equal(process.cwd(),${JSON.stringify(root)});
+fs.writeFileSync(process.env.OPENCLAW_STATE_DIR+"/witness","sample");
+console.log("fixture version");
+`,
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "scripts/bench-cli-startup.ts",
+          "--entry",
+          entry,
+          "--case",
+          "version",
+          "--runs",
+          "1",
+          "--warmup",
+          "0",
+          "--timeout-ms",
+          "5000",
+          "--json",
+          "--output",
+          output,
+        ],
+        {
+          cwd: resolve(__dirname, "../.."),
+          env: {
+            ...process.env,
+            RUNNER_PRIVATE_CANARY: "must-not-forward",
+            OPENCLAW_BENCH_TRANSPORT_JSON: JSON.stringify({
+              prefix: [process.execPath, prefix],
+              binary: process.execPath,
+              env: { HOME: root, PATH: process.env.PATH, SUT_FIXTURE: "yes" },
+            }),
+          },
+          encoding: "utf8",
+          timeout: 15_000,
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(readFileSync(output, "utf8")).primary.cases[0].samples).toMatchObject([
+        { exitCode: 0, signal: null },
+      ]);
+      const invocations = readFileSync(calls, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(invocations).toHaveLength(4);
+      expect(invocations.filter((call) => call.args.includes("/usr/bin/timeout"))).toHaveLength(1);
+      expect(invocations.every((call) => call.env.RUNNER_PRIVATE_CANARY === undefined)).toBe(true);
+    } finally {
+      tempDirs.cleanup();
+    }
+  });
+
+  it.each(["{}", '{"prefix":["relative"],"binary":"/node","env":{}}'])(
+    "rejects malformed cross-user transport before candidate execution: %s",
+    (transport) => {
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", "scripts/bench-cli-startup.ts", "--entry", "/not-executed"],
+        {
+          env: { ...process.env, OPENCLAW_BENCH_TRANSPORT_JSON: transport },
+          encoding: "utf8",
+        },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Invalid benchmark transport");
+      expect(result.stdout).toBe("");
+    },
+  );
+
+  it("rejects transported runtime RSS before launching the SUT filesystem helper", () => {
+    const root = memoryTempDirs.make("openclaw-cli-rss-transport-");
+    const prefix = join(root, "transport.mjs");
+    const witness = join(root, "prefix-launched");
+    writeFileSync(
+      prefix,
+      `import fs from "node:fs";
+fs.writeFileSync(${JSON.stringify(witness)}, "launched");
+throw new Error("SUT prefix must not launch");`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "scripts/bench-cli-startup.ts",
+        "--runtime-rss",
+        "--entry",
+        join(root, "missing-entry.mjs"),
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          OPENCLAW_BENCH_TRANSPORT_JSON: JSON.stringify({
+            prefix: [process.execPath, prefix],
+            binary: process.execPath,
+            env: { HOME: root, PATH: process.env.PATH },
+          }),
+        },
+        encoding: "utf8",
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(existsSync(witness)).toBe(false);
+    expect(result.stderr.trim()).toBe("Cross-user runtime RSS sampling is not supported");
+    expect(result.stdout).toBe("");
+  });
+
   it.each(["warning", "ca", "windows"])(
     "preserves legacy RSS and opts into runtime RSS through the actual %s respawn plan",
     (mode) => {

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -103,9 +103,9 @@ console.log("fixture version");
         },
       );
       expect(result.status, result.stderr).toBe(0);
-      expect(JSON.parse(readFileSync(output, "utf8")).primary.cases[0].samples).toMatchObject([
-        { exitCode: 0, signal: null },
-      ]);
+      const report = JSON.parse(readFileSync(output, "utf8"));
+      expect(report.primary.executionMode).toBe("transport");
+      expect(report.primary.cases[0].samples).toMatchObject([{ exitCode: 0, signal: null }]);
       const invocations = readFileSync(calls, "utf8")
         .trim()
         .split("\n")
@@ -271,7 +271,9 @@ if (isMainThread && !runtime) {
         ...(runtimeRss ? ["--runtime-rss"] : []),
       ]);
       expect(result.status, result.stderr).toBe(0);
-      const sample = JSON.parse(result.stdout).primary.cases[0].samples[0];
+      const report = JSON.parse(result.stdout);
+      expect(report.primary.executionMode).toBe("native");
+      const sample = report.primary.cases[0].samples[0];
       expect(sample.maxRssMb).toBeGreaterThan(0);
       if (runtimeRss) {
         expect(sample.firstOutputMs).toBeNull();
@@ -697,6 +699,41 @@ try {
       ]);
       expect(compatible.status, compatible.stderr).toBe(0);
       expect(JSON.parse(compatible.stdout)).toEqual(comparison);
+
+      for (const [before, after, error] of [
+        [undefined, "native", null],
+        ["native", undefined, null],
+        ["native", "native", null],
+        ["transport", "transport", null],
+        [undefined, "transport", "Incompatible CLI execution modes"],
+        ["transport", "native", "Incompatible CLI execution modes"],
+        ["unknown", "unknown", "Unknown CLI execution mode"],
+        [null, "native", "Unknown CLI execution mode"],
+        ["native", 1, "Unknown CLI execution mode"],
+      ] satisfies Array<[unknown, unknown, string | null]>) {
+        writeFileSync(
+          baselinePath,
+          JSON.stringify({ primary: { ...makeReport(100, 50).primary, executionMode: before } }),
+        );
+        writeFileSync(
+          candidatePath,
+          JSON.stringify({ primary: { ...makeReport(125, 60).primary, executionMode: after } }),
+        );
+        const result = runBenchmarkCli([
+          "--compare-baseline",
+          baselinePath,
+          "--compare-candidate",
+          candidatePath,
+          "--json",
+        ]);
+        expect(result.status, result.stderr).toBe(error ? 1 : 0);
+        if (error) {
+          expect(result.stderr).toContain(error);
+          expect(result.stdout).toBe("");
+        } else {
+          expect(JSON.parse(result.stdout)).toEqual(comparison);
+        }
+      }
     } finally {
       tempDirs.cleanup();
     }

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -106,9 +106,10 @@ describe("CLI startup benchmark script spawners", () => {
     const tmpDir = tempDirs.make("openclaw-bench-rss-contract-");
     const baselinePath = path.join(tmpDir, "baseline.json");
     const reportPath = path.join(tmpDir, "current.json");
-    const makeReport = (rss: number, memoryMetric?: string) => ({
+    const makeReport = (rss: number, memoryMetric?: string, executionMode?: unknown) => ({
       primary: {
         memoryMetric,
+        executionMode,
         cases: [
           {
             id: "version",
@@ -119,7 +120,7 @@ describe("CLI startup benchmark script spawners", () => {
         ],
       },
     });
-    const run = () =>
+    const run = (skipBaseline = false) =>
       spawnSync(
         process.execPath,
         [
@@ -132,6 +133,7 @@ describe("CLI startup benchmark script spawners", () => {
           reportPath,
           "--preset",
           "startup",
+          ...(skipBaseline ? ["--skip-baseline"] : []),
         ],
         {
           cwd: process.cwd(),
@@ -158,6 +160,34 @@ describe("CLI startup benchmark script spawners", () => {
 
     fs.writeFileSync(reportPath, JSON.stringify(makeReport(10, "unknown-metric")));
     expect(run().stderr).toContain("Unknown CLI RSS metric");
+
+    for (const [before, after, error] of [
+      [undefined, "native", null],
+      ["native", undefined, null],
+      ["native", "native", null],
+      ["transport", "transport", null],
+      [undefined, "transport", "Incompatible CLI execution modes"],
+      ["transport", "native", "Incompatible CLI execution modes"],
+      ["unknown", "unknown", "Unknown CLI execution mode"],
+      [null, "native", "Unknown CLI execution mode"],
+      ["native", 1, "Unknown CLI execution mode"],
+    ] satisfies Array<[unknown, unknown, string | null]>) {
+      fs.writeFileSync(baselinePath, JSON.stringify(makeReport(10, undefined, before)));
+      fs.writeFileSync(reportPath, JSON.stringify(makeReport(10, undefined, after)));
+      const result = run();
+      expect(result.status, result.stderr).toBe(error ? 1 : 0);
+      if (error) {
+        expect(result.stderr).toContain(error);
+      }
+    }
+    for (const mode of [null, "unknown", 1]) {
+      fs.writeFileSync(reportPath, JSON.stringify(makeReport(10, undefined, mode)));
+      const result = run(true);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Unknown CLI execution mode");
+    }
+    fs.writeFileSync(reportPath, JSON.stringify(makeReport(10, undefined, "transport")));
+    expect(run(true).status).toBe(0);
   });
 
   it("use the active Node executable for benchmark child processes", () => {

--- a/test/scripts/openclaw-performance-source-summary.test.ts
+++ b/test/scripts/openclaw-performance-source-summary.test.ts
@@ -131,6 +131,31 @@ it("labels CLI RSS semantics and rejects mixed-metric memory trends", () => {
   cli.primary.memoryMetric = "unknown-metric";
   writeJson(cliPath, cli);
   expect(() => buildMarkdown(sourceDir, baselineDir)).toThrow("Unknown CLI RSS metric");
+
+  delete cli.primary.memoryMetric;
+  for (const [before, after, error] of [
+    [undefined, "native", null],
+    ["native", undefined, null],
+    ["native", "native", null],
+    ["transport", "transport", null],
+    [undefined, "transport", "Incompatible CLI execution modes"],
+    ["transport", "native", "Incompatible CLI execution modes"],
+    ["unknown", "unknown", "Unknown CLI execution mode"],
+    [null, "native", "Unknown CLI execution mode"],
+    ["native", 1, "Unknown CLI execution mode"],
+  ] satisfies Array<[unknown, unknown, string | null]>) {
+    writeJson(path.join(baselineDir, "cli-startup.json"), {
+      primary: { ...cli.primary, executionMode: before },
+    });
+    writeJson(cliPath, { primary: { ...cli.primary, executionMode: after } });
+    if (error) {
+      expect(() => buildMarkdown(sourceDir, baselineDir)).toThrow(error);
+    } else {
+      expect(buildMarkdown(sourceDir, baselineDir)).toContain("RSS metric: legacy-last-marker");
+    }
+  }
+  writeJson(cliPath, { primary: { ...cli.primary, executionMode: null } });
+  expect(() => buildMarkdown(sourceDir, null)).toThrow("Unknown CLI execution mode");
 });
 
 function writeSqliteV2Fixture(


### PR DESCRIPTION
## What Problem This Solves

Isolated CLI benchmarks must launch candidate code outside evaluator authority
without comparing transported timings against direct-native measurements.

## Why This Change Was Made

Adds benchmark subprocess transport and an explicit native-versus-transport
execution-mode marker. Saved comparisons, budget evaluation and source-summary
consumption reject mixed modes rather than silently combining incompatible
measurements.

Ordinary native execution and runtime-RSS behavior remain intact. Unsupported
transport/runtime-RSS combinations reject before prefix execution.

## User Impact

CLI benchmarking remains available through the isolated source lane, with
transport overhead identified rather than hidden in native baselines.

Existing route: https://github.com/openclaw/openclaw/pull/144159.
Harness: https://github.com/openclaw/openclaw/pull/144162.
Activation: https://github.com/openclaw/openclaw/pull/127240.

## Evidence

- Head: `d91704b4fbdbb47f6b036f198ec433d476cc331e`.
- Five intended red regressions; 65/65 owner/sibling tests passed.
- Scoped review: zero P0-P2 findings.
- Formatting and change classification passed; classification is not the
  full changed gate.
- Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34524503837)
  succeeded (`pull_request`, attempt 1, `ci.yml`): 93 terminal jobs,
  76 successful and 17 skipped; gate `103034639461` passed.
  Skipped jobs are not proof.
- Local full gates did not complete; hosted required CI passed. Cross-principal Linux execution/timing and
  cleanup proof is a final activation gate with landed dependencies; it has
  not passed.

Punchcard-Session: coral-orchard-orchard-d4
