### PR TITLE
fix(plugin-sdk): accept return-value gateway handlers in plugin registration type

### DIFF
--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -55,6 +55,7 @@ export function registerWorkboardGatewayMethods(params: {
             return await store.runOperation(() => handler(request));
           } catch (error) {
             respondError(request.respond, error);
+            return undefined;
           }
         },
         options,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -363,7 +363,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: one exec policy object replaces two deprecated comparator exports.
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
-      4447,
+      // +2: plugin-facing gateway handler contract and its core handler counterpart.
+      4449,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -461,8 +461,13 @@ export type GatewayRequestHandlerOptions = {
   hasCurrentClientAuthority?: () => boolean;
 };
 
-/** Single gateway method implementation. */
+/** Single core gateway method implementation. */
 export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
+
+/** Plugin-facing gateway handler; the registration adapter turns returned values into responses. */
+export type PluginGatewayRequestHandler =
+  | GatewayRequestHandler
+  | ((opts: GatewayRequestHandlerOptions) => unknown);
 
 /** Registry fragment keyed by gateway protocol method name. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -31,7 +31,11 @@ export {
   parseGatewayPayload as safeParseJson,
   respondUnavailableOnNodeInvokeError,
 } from "../gateway/server-methods/nodes.helpers.js";
-export type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
+export type {
+  GatewayRequestHandler,
+  GatewayRequestHandlers,
+  PluginGatewayRequestHandler,
+} from "../gateway/server-methods/types.js";
 export { ensureGatewayStartupAuth } from "../gateway/startup-auth.js";
 export { resolveGatewayAuth } from "../gateway/auth.js";
 

--- a/src/plugins/contracts/scheduled-turns.contract.test.ts
+++ b/src/plugins/contracts/scheduled-turns.contract.test.ts
@@ -32,6 +32,14 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../runt
 import { createPluginRecord } from "../status.test-helpers.js";
 import type { OpenClawPluginApi } from "../types.js";
 
+// Return-value gateway handlers are part of the public SDK contract. These
+// assignments must stay valid for plugins that return an implicit response.
+type PluginGatewayMethodHandler = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+const returnedGatewayHandlerResult: Awaited<ReturnType<PluginGatewayMethodHandler>> = {
+  ok: true,
+};
+void returnedGatewayHandlerResult;
+
 const workflowMocks = vi.hoisted(() => ({
   cronAdd: vi.fn(),
   cronListPage: vi.fn(),

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -2,7 +2,7 @@ import type { AgentHarness, AgentHarnessRegistrationOptions } from "../agents/ha
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
-import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import type { PluginGatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hook-types.js";
 import type { DetachedTaskLifecycleRuntime } from "../tasks/detached-task-runtime-contract.js";
 import type {
@@ -234,7 +234,7 @@ export type OpenClawPluginApi = {
    */
   registerGatewayMethod: (
     method: string,
-    handler: GatewayRequestHandler,
+    handler: PluginGatewayRequestHandler,
     opts?: {
       scope?: OperatorScope;
       profileAccess?: "independent" | "required";

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -5,7 +5,11 @@ import {
   type GatewayMethodProfileAccess,
 } from "../gateway/methods/descriptor.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
-import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
+import type {
+  GatewayRequestHandler,
+  PluginGatewayRequestHandler,
+  RespondFn,
+} from "../gateway/server-methods/types.js";
 import { normalizePluginGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -30,7 +34,9 @@ import type {
 
 const GATEWAY_METHOD_DISPATCH_CONTRACT = "authenticated-request";
 
-function adaptPluginGatewayMethodHandler(handler: GatewayRequestHandler): GatewayRequestHandler {
+function adaptPluginGatewayMethodHandler(
+  handler: PluginGatewayRequestHandler,
+): GatewayRequestHandler {
   return async (opts) => {
     let responded = false;
     const respond: RespondFn = (ok, payload, error, meta) => {
@@ -58,7 +64,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
   const registerGatewayMethod = (
     record: PluginRecord,
     method: string,
-    handler: GatewayRequestHandler,
+    handler: PluginGatewayRequestHandler,
     opts?: { scope?: OperatorScope; profileAccess?: GatewayMethodProfileAccess },
   ) => {
     const trimmed = method.trim();


### PR DESCRIPTION
## What Problem This Solves

Fixes #142718: `registerGatewayMethod` turns returned handler values into Gateway responses at runtime (since #85785), but the exported handler type still required `void | Promise<void>`, so the supported return-value style failed TypeScript with TS2345 and plugin authors needed a cast.

## Change

- Adds `PluginGatewayRequestHandler` (`GatewayRequestHandler | ((opts) => unknown)`, covering async and sync returns) and uses it for the plugin-facing `registerGatewayMethod` input only (`plugin-api.types.ts`, `registry-registrars-network.ts`). Core gateway handlers stay callback-only; the adapter's respond/return precedence is untouched.
- Exports the new type (plus `GatewayRequestHandler`) from `openclaw/plugin-sdk/gateway-runtime`; bumps the public-exports surface budget 4447 -> 4449.
- Adds a type-level regression assertion in `scheduled-turns.contract.test.ts` so a future narrowing breaks compilation.
- Follow-up: explicit `return undefined` on the workboard gateway error path, which the widened union pushed under `noImplicitReturns` (TS7030). Runtime behavior unchanged.

## Evidence

Failing-first compiler repro: a minimal consumer registering `api.registerGatewayMethod("demo.check", async () => ({ ok: true }))` against current main fails with:

```
error TS2345: Argument of type '() => Promise<{ ok: boolean; }>' is not assignable to parameter of type 'GatewayRequestHandler'.
```

(same for the sync-return shape). After this change:

- `tsgo -p tsconfig.core.json`: exit 0, 0 errors (was 2x TS2345 on the repro before the fix)
- `tsgo -p tsconfig.ui.json`, `-p tsconfig.extensions.json`: exit 0 (extensions caught one TS7030, fixed with the explicit return above)
- `tsgo -p test/tsconfig/tsconfig.core.test.plugins-platform.json`: exit 0
- `pnpm tsgo:test` (all core-test shards + extensions:test + test:root) and `tsgo:scripts`: exit 0
- `vitest run src/plugins/loader.test.ts`: 198 passed (existing #85785 return-value runtime coverage)
- `vitest run src/plugins/contracts/scheduled-turns.contract.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`: 33 passed
- `plugin-sdk-surface-report.mts --check`: passes
- `oxfmt --check` + `oxlint` on all touched files: clean