### PR TITLE
fix(system-agent): surface the exact harness mismatch from bound verification

### DIFF
--- a/src/system-agent/revalidate-inference-owner.ts
+++ b/src/system-agent/revalidate-inference-owner.ts
@@ -15,6 +15,7 @@ import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js"
 import type { SystemAgentConfiguredRoute } from "./inference-route.js";
 import { parseRef } from "./setup-inference-plan-helpers.js";
 import {
+  assertEmbeddedHarnessMatch,
   createSystemAgentVerifiedInferenceBinding,
   type SystemAgentVerifiedInferenceBinding,
   type SystemAgentVerifiedInferenceDeps,
@@ -91,6 +92,12 @@ export async function revalidateSetupInferenceOwner(params: {
   const successfulHarnessId =
     params.auth.agentHarnessId?.trim() ||
     (configuredHarnessId && configuredHarnessId !== "auto" ? configuredHarnessId : undefined);
+  if (params.route.runner === "embedded") {
+    assertEmbeddedHarnessMatch({
+      configuredHarnessId,
+      reportedHarnessId: params.auth.agentHarnessId?.trim() || undefined,
+    });
+  }
   const createBinding = () =>
     (
       params.deps.createSystemAgentVerifiedInferenceBinding ??

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -6778,6 +6778,96 @@ describe("verifySetupInference", () => {
       await removeOAuthTestTempRoot(stateDir);
     }
   });
+  it("surfaces the exact harness mismatch to bound verification", async () => {
+    const stateDir = await suiteTempRootTracker.make("case");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const profileId = "openai:default";
+    const credential = {
+      type: "oauth" as const,
+      provider: "openai",
+      access: "test-access",
+      refresh: "test-refresh",
+      expires: Date.now() + 3_600_000,
+    };
+    const authFingerprint = fingerprintAuthProfileCredential({ profileId, credential });
+    if (!authFingerprint) {
+      throw new Error("missing external Codex auth fingerprint");
+    }
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-sol" },
+          models: {
+            "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+      plugins: { entries: { codex: { enabled: true } } },
+    } satisfies OpenClawConfig;
+    const externalStore = vi.fn(
+      (_agentDir?: string, options?: { externalCliProviderIds?: Iterable<string> }) => {
+        const exposeCodexProfile = Array.from(options?.externalCliProviderIds ?? []).includes(
+          "openai",
+        );
+        return {
+          version: 1,
+          profiles: exposeCodexProfile ? { [profileId]: credential } : {},
+          runtimeExternalProfileIds: exposeCodexProfile ? [profileId] : [],
+          runtimeExternalProfileIdsAuthoritative: true,
+        };
+      },
+    );
+    const runEmbeddedAgent = vi.fn(async (params: SuccessfulRunParams) => {
+      params.onSuccessfulAuthBinding?.({
+        authProfileId: profileId,
+        agentHarnessId: "openclaw",
+        authFingerprint,
+        modelId: "gpt-5.6-sol",
+        modelApi: "openai-responses",
+      });
+      return {
+        meta: {
+          durationMs: 1,
+          finalAssistantVisibleText: "OK",
+          executionTrace: { winnerProvider: "openai", winnerModel: "gpt-5.6-sol" },
+        },
+      };
+    });
+    const readConfigFileSnapshot = vi.fn(async () => ({
+      exists: true,
+      valid: true,
+      config,
+      runtimeConfig: config,
+      sourceConfig: config,
+    }));
+    const validateAgentHarnessRuntimeArtifact = vi.fn(async () => true);
+    const createVerifiedInferenceBinding = vi.fn(
+      (params: Parameters<typeof createSystemAgentVerifiedInferenceBinding>[0]) =>
+        createSystemAgentVerifiedInferenceBinding({
+          ...params,
+          deps: { ...params.deps, validateAgentHarnessRuntimeArtifact },
+        }),
+    );
+    try {
+      const verification = await verifySetupInference({
+        bindSession: true,
+        deps: {
+          readConfigFileSnapshot: readConfigFileSnapshot as never,
+          loadAuthProfileStoreForRuntime: externalStore as never,
+          ensureAuthProfileStore: externalStore as never,
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          createSystemAgentVerifiedInferenceBinding: createVerifiedInferenceBinding,
+        },
+      });
+      expect(verification).toMatchObject({ ok: false, status: "auth" });
+      if (verification.ok) {
+        throw new Error("expected the harness mismatch to fail bound verification");
+      }
+      expect(verification.error).toContain('used agent harness "openclaw" instead of "codex"');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 
   it("does not repeat an unbound verification after automatic profile selection", async () => {
     const config = {

--- a/src/system-agent/verified-inference.ts
+++ b/src/system-agent/verified-inference.ts
@@ -659,6 +659,22 @@ async function resolveCurrentAuthFingerprint(params: {
   return fingerprintResolvedProviderAuth(auth);
 }
 
+export function assertEmbeddedHarnessMatch(params: {
+  configuredHarnessId?: string;
+  reportedHarnessId?: string;
+}): void {
+  if (
+    params.reportedHarnessId &&
+    params.configuredHarnessId &&
+    params.configuredHarnessId !== "auto" &&
+    params.reportedHarnessId !== params.configuredHarnessId
+  ) {
+    throw new Error(
+      `The successful inference run used agent harness "${params.reportedHarnessId}" instead of "${params.configuredHarnessId}".`,
+    );
+  }
+}
+
 export async function createSystemAgentVerifiedInferenceBinding(params: {
   configuredRoute: SystemAgentConfiguredRoute;
   executionRoute: SystemAgentConfiguredRoute;
@@ -696,16 +712,7 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
     if ((!configuredHarnessId || configuredHarnessId === "auto") && !reportedHarnessId) {
       throw new Error("The successful inference run did not report its exact agent harness.");
     }
-    if (
-      reportedHarnessId &&
-      configuredHarnessId &&
-      configuredHarnessId !== "auto" &&
-      reportedHarnessId !== configuredHarnessId
-    ) {
-      throw new Error(
-        `The successful inference run used agent harness "${reportedHarnessId}" instead of "${configuredHarnessId}".`,
-      );
-    }
+    assertEmbeddedHarnessMatch({ configuredHarnessId, reportedHarnessId });
     successfulHarnessId = reportedHarnessId ?? configuredHarnessId;
   }
   const execution =


### PR DESCRIPTION
Fixes #134471.

## What Problem This Solves

On a healthy Codex route, managed control (Gateway functions.openclaw path) fails before dispatch with a generic owner-drift error that hides the real cause. When the successful probe run reports a different embedded agent harness than the configured one (for example configured codex vs reported openclaw), bound verification surfaced 'The verified inference owner changed before activation completed. Retry the inference check. (Could not load the openclaw runtime plugin.)' instead of naming the harness mismatch. Root cause: revalidateSetupInferenceOwner attempted plugin generation for the reported harness before comparing it with the configured embedded harness, so the misleading plugin-load failure replaced the true mismatch cause wholesale.

## Evidence

- New regression test 'surfaces the exact harness mismatch to bound verification' in src/system-agent/setup-inference.test.ts drives the exact Gateway caller shape (verifySetupInference with bindSession:true, configured codex harness, reported openclaw harness). Failing output before the fix: 'The verified inference owner changed before activation completed. Retry the inference check. (Could not load the openclaw runtime plugin.)'. Passes after.
- Scoped suites green, 276 passed: setup-inference.test.ts, inference-fallback.test.ts, verified-inference.test.ts, setup-inference-error-reporting.test.ts, setup-inference-test.test.ts, gateway/server-methods/system-agent.test.ts.
- oxfmt --check and oxlint --deny-warnings clean on all touched files.

## Change

This keeps owner validation fail-closed and propagates the specific cause instead of replacing it wholesale:

- verified-inference.ts: new shared assertEmbeddedHarnessMatch helper, single-sourcing the 'used agent harness X instead of Y' message the binding check already threw.
- revalidate-inference-owner.ts: fail fast with that specific error when a concrete configured embedded harness differs from the reported one, before plugin generation. The redaction path is unchanged.

Commits are stacked red-then-green: failing regression test first, narrow fix on top.

Conflict watch: open PR #116302 also touches verified-inference.ts (SecretRef setup). This PR does not absorb it; the helper hunk is small and should rebase cleanly.

Parked: live Codex runtime diagnosis (needs Linux/systemd env, not available here); proved with unit-level tests instead.