### PR TITLE
refactor: simplify subagent transcript handling

### DIFF
--- a/extensions/codex/harness.task-history.test.ts
+++ b/extensions/codex/harness.task-history.test.ts
@@ -185,6 +185,17 @@ async function fixture(supervised = false) {
   };
 }
 
+function stampHistoryOwner(f: Awaited<ReturnType<typeof fixture>>, lifecycleRevision?: string) {
+  const owner = createCodexNativeSubagentHistoryOwner({
+    parentThreadId: f.binding.threadId,
+    sessionId: f.identity.sessionId,
+    lifecycleRevision,
+    binding: f.binding,
+  })!;
+  f.params.task = { ...f.params.task, detail: { nativeHistory: owner } };
+  return owner;
+}
+
 describe("native subagent history through the harness", () => {
   it("renders user, reasoning, tool call/result, and active assistant content in chronological order", async () => {
     const f = await fixture();
@@ -294,16 +305,7 @@ describe("native subagent history through the harness", () => {
   it("keeps completed child history and pagination when the parent starts a replacement thread", async () => {
     const f = await fixture();
     f.threads.set("parent-thread", { id: "parent-thread", projectId: null, parentThreadId: null });
-    f.params.task = {
-      ...f.params.task,
-      detail: {
-        nativeHistory: createCodexNativeSubagentHistoryOwner({
-          parentThreadId: f.binding.threadId,
-          sessionId: f.identity.sessionId,
-          binding: f.binding,
-        })!,
-      },
-    };
+    stampHistoryOwner(f);
     f.items.push(
       ...Array.from({ length: 5 }, (_, index) =>
         item(`item-${index}`, { text: `message ${index}` }),
@@ -325,13 +327,7 @@ describe("native subagent history through the harness", () => {
     "rejects a changed %s before opening the native history store",
     async (change) => {
       const f = await fixture();
-      const owner = createCodexNativeSubagentHistoryOwner({
-        parentThreadId: f.binding.threadId,
-        sessionId: f.identity.sessionId,
-        lifecycleRevision: "parent-lifecycle",
-        binding: f.binding,
-      })!;
-      f.params.task = { ...f.params.task, detail: { nativeHistory: owner } };
+      const owner = stampHistoryOwner(f, "parent-lifecycle");
       if (change === "session" || change === "lifecycle") {
         await upsertSessionEntry({
           agentId: "main",
@@ -369,13 +365,7 @@ describe("native subagent history through the harness", () => {
 
   it("preserves history through repeated compaction transfers in the same session lifecycle", async () => {
     const f = await fixture();
-    const owner = createCodexNativeSubagentHistoryOwner({
-      parentThreadId: f.binding.threadId,
-      sessionId: f.identity.sessionId,
-      lifecycleRevision: "parent-lifecycle",
-      binding: f.binding,
-    })!;
-    f.params.task = { ...f.params.task, detail: { nativeHistory: owner } };
+    stampHistoryOwner(f, "parent-lifecycle");
     f.items.push(item("answer", { text: "Original child result" }));
     const before = await f.read();
     let previousSessionId = f.identity.sessionId;
@@ -458,30 +448,6 @@ describe("native subagent history through the harness", () => {
     },
   );
 
-  it("rechecks the parent binding after awaiting ancestor metadata", async () => {
-    const f = await fixture();
-    f.thread.parentThreadId = "worker-1";
-    f.threads.set("worker-1", { id: "worker-1", projectId: null, parentThreadId: "parent-thread" });
-    const request = native.request.getMockImplementation()!;
-    native.request.mockImplementation(async (method, params) => {
-      const result = await request(method, params);
-      if (method === "thread/read" && params.threadId === "worker-1") {
-        await f.bindingStore.mutate(f.identity, {
-          kind: "patch",
-          threadId: "parent-thread",
-          patch: { appServerRuntimeFingerprint: "changed" },
-        });
-      }
-      return result;
-    });
-    await expect(f.read()).rejects.toThrow("parent changed");
-    expect(native.request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/read",
-      "thread/read",
-    ]);
-    expect(native.release).toHaveBeenCalledOnce();
-  });
-
   it("rejects copied thread ids from a different native store", async () => {
     const f = await fixture();
     native.acquire.mockResolvedValueOnce({
@@ -494,43 +460,59 @@ describe("native subagent history through the harness", () => {
     expect(native.release).toHaveBeenCalledOnce();
   });
 
-  it("rejects an awaited page after the harness is disposed", async () => {
-    const f = await fixture();
-    f.items.push(item("answer", { text: "Pending result" }));
-    const request = native.request.getMockImplementation()!;
-    native.request.mockImplementation(async (method, params) => {
-      const result = await request(method, params);
-      if (method === "thread/items/list") {
-        await f.harness.dispose?.();
-      }
-      return result;
-    });
-    await expect(f.read()).rejects.toThrow("harness is disposed");
-    expect(native.release).toHaveBeenCalledOnce();
-  });
-
-  it.each(["session", "lifecycle"] as const)(
-    "rechecks the parent %s after awaited history reads",
+  it.each(["binding", "disposal", "session", "lifecycle"] as const)(
+    "rejects %s changes after awaited native reads",
     async (change) => {
       const f = await fixture();
+      f.items.push(item("answer", { text: "Pending result" }));
+      if (change === "binding") {
+        f.thread.parentThreadId = "worker-1";
+        f.threads.set("worker-1", {
+          id: "worker-1",
+          projectId: null,
+          parentThreadId: "parent-thread",
+        });
+      }
       const request = native.request.getMockImplementation()!;
       native.request.mockImplementation(async (method, params) => {
         const result = await request(method, params);
-        if (method === "thread/items/list") {
-          await upsertSessionEntry({
-            agentId: "main",
-            sessionKey: f.params.task.requesterSessionKey,
-            storePath: f.storePath,
-            entry: {
-              sessionId: change === "session" ? "replacement-session" : f.identity.sessionId,
-              lifecycleRevision: "replacement-lifecycle",
-              updatedAt: 2,
-            },
-          });
+        const revoke =
+          change === "binding"
+            ? method === "thread/read" && params.threadId === "worker-1"
+            : method === "thread/items/list";
+        if (revoke) {
+          if (change === "binding") {
+            await f.bindingStore.mutate(f.identity, {
+              kind: "patch",
+              threadId: "parent-thread",
+              patch: { appServerRuntimeFingerprint: "changed" },
+            });
+          } else if (change === "disposal") {
+            await f.harness.dispose?.();
+          } else {
+            await upsertSessionEntry({
+              agentId: "main",
+              sessionKey: f.params.task.requesterSessionKey,
+              storePath: f.storePath,
+              entry: {
+                sessionId: change === "session" ? "replacement-session" : f.identity.sessionId,
+                lifecycleRevision: "replacement-lifecycle",
+                updatedAt: 2,
+              },
+            });
+          }
         }
         return result;
       });
-      await expect(f.read()).rejects.toThrow("parent changed");
+      await expect(f.read()).rejects.toThrow(
+        change === "disposal" ? "harness is disposed" : "parent changed",
+      );
+      if (change === "binding") {
+        expect(native.request.mock.calls.map(([method]) => method)).toEqual([
+          "thread/read",
+          "thread/read",
+        ]);
+      }
       expect(native.release).toHaveBeenCalledOnce();
     },
   );

--- a/extensions/codex/src/app-server/native-subagent-history-owner.ts
+++ b/extensions/codex/src/app-server/native-subagent-history-owner.ts
@@ -1,13 +1,16 @@
 import { createHash } from "node:crypto";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { z } from "zod";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 
-export type CodexNativeSubagentHistoryOwner = {
-  parentThreadId: string;
-  sessionId: string;
-  lifecycleRevision?: string;
-  connectionFingerprint: string;
-};
+const nonBlankString = z.string().refine((value) => Boolean(value.trim()));
+const historyOwnerSchema = z.object({
+  parentThreadId: nonBlankString,
+  sessionId: nonBlankString,
+  lifecycleRevision: nonBlankString.optional(),
+  connectionFingerprint: z.string().regex(/^[a-f0-9]{64}$/u),
+});
+export type CodexNativeSubagentHistoryOwner = z.infer<typeof historyOwnerSchema>;
 
 export function codexNativeSubagentHistoryConnectionFingerprint(
   binding: CodexAppServerThreadBinding,
@@ -50,25 +53,10 @@ export function readCodexNativeSubagentHistoryOwner(
   if (value === undefined) {
     return undefined;
   }
-  const owner = asOptionalRecord(value);
-  if (
-    typeof owner?.parentThreadId !== "string" ||
-    !owner.parentThreadId.trim() ||
-    typeof owner.sessionId !== "string" ||
-    !owner.sessionId.trim() ||
-    (owner.lifecycleRevision !== undefined &&
-      (typeof owner.lifecycleRevision !== "string" || !owner.lifecycleRevision.trim())) ||
-    typeof owner.connectionFingerprint !== "string" ||
-    !/^[a-f0-9]{64}$/u.test(owner.connectionFingerprint)
-  ) {
+  const owner = historyOwnerSchema.safeParse(value);
+  if (!owner.success) {
     throw new Error("Subagent history owner is invalid.");
   }
-  return {
-    parentThreadId: owner.parentThreadId,
-    sessionId: owner.sessionId,
-    ...(typeof owner.lifecycleRevision === "string"
-      ? { lifecycleRevision: owner.lifecycleRevision }
-      : {}),
-    connectionFingerprint: owner.connectionFingerprint,
-  };
+  const { lifecycleRevision, ...required } = owner.data;
+  return lifecycleRevision === undefined ? required : { ...required, lifecycleRevision };
 }

--- a/extensions/codex/src/app-server/native-subagent-history.ts
+++ b/extensions/codex/src/app-server/native-subagent-history.ts
@@ -15,7 +15,7 @@ import {
   buildCodexAppServerConnectionFingerprint,
   buildCodexAppServerRuntimeFingerprint,
 } from "./plugin-app-cache-key.js";
-import type { CodexThread } from "./protocol.js";
+import type { CodexAppServerRequestParams, CodexThread } from "./protocol.js";
 import { sessionBindingIdentity } from "./session-binding-record.js";
 import type { CodexAppServerBindingStore } from "./session-binding.js";
 import {
@@ -147,12 +147,16 @@ export async function readCodexNativeSubagentHistory(
     ) {
       throw new Error("Subagent connection changed; reconnect its parent session.");
     }
-    const { thread } = await client.request(
-      "thread/read",
-      { threadId, includeTurns: false },
-      { assertCurrent },
-    );
-    assertCurrent();
+    const read = async <M extends "thread/read" | "thread/items/list" | "thread/turns/list">(
+      method: M,
+      request: CodexAppServerRequestParams<M>,
+    ) => {
+      assertCurrent();
+      const result = await client.request(method, request, { assertCurrent });
+      assertCurrent();
+      return result;
+    };
+    const { thread } = await read("thread/read", { threadId, includeTurns: false });
     if (thread.id !== threadId || threadId === historyParentThreadId) {
       throw new Error("Subagent transcript does not belong to this parent session.");
     }
@@ -168,12 +172,7 @@ export async function readCodexNativeSubagentHistory(
         throw new Error("Subagent transcript does not belong to this parent session.");
       }
       visited.add(parentId);
-      const response = await client.request(
-        "thread/read",
-        { threadId: parentId, includeTurns: false },
-        { assertCurrent },
-      );
-      assertCurrent();
+      const response = await read("thread/read", { threadId: parentId, includeTurns: false });
       if (response.thread.id !== parentId) {
         throw new Error("Subagent transcript does not belong to this parent session.");
       }
@@ -181,18 +180,8 @@ export async function readCodexNativeSubagentHistory(
     }
     const page = await readCodexThreadHistoryPage(
       {
-        listItemPage: async (request) => {
-          assertCurrent();
-          const result = await client.request("thread/items/list", request, { assertCurrent });
-          assertCurrent();
-          return result;
-        },
-        listTurnPage: async (request) => {
-          assertCurrent();
-          const result = await client.request("thread/turns/list", request, { assertCurrent });
-          assertCurrent();
-          return result;
-        },
+        listItemPage: (request) => read("thread/items/list", request),
+        listTurnPage: (request) => read("thread/turns/list", request),
       },
       thread,
       {

--- a/src/gateway/server-methods/task-history.ts
+++ b/src/gateway/server-methods/task-history.ts
@@ -5,6 +5,7 @@ import {
   ErrorCodes,
   errorShape,
   validateTasksHistoryParams,
+  type ErrorCode,
   type TasksHistoryResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
@@ -58,6 +59,8 @@ export const taskHistoryHandler: GatewayRequestHandler = async (opts) => {
   if (!assertValidParams(params, validateTasksHistoryParams, "tasks.history", respond)) {
     return;
   }
+  const fail = (message: string, code: ErrorCode = ErrorCodes.UNAVAILABLE) =>
+    respond(false, undefined, errorShape(code, message));
   const task = getTaskById(params.taskId);
   const allowed = (value: TaskRecord | undefined): value is TaskRecord =>
     Boolean(
@@ -69,22 +72,25 @@ export const taskHistoryHandler: GatewayRequestHandler = async (opts) => {
       }),
     );
   if (!allowed(task)) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "Task not found."));
+    fail("Task not found.", ErrorCodes.INVALID_REQUEST);
     return;
   }
   const binding = historyBinding(task);
+  const sessionKey = taskTranscriptSessionKey(task);
   let cursor: string | undefined;
+  let offset = 0;
   try {
     cursor = decodeCursor(params.cursor, binding);
+    if (sessionKey && cursor !== undefined) {
+      offset = Number(cursor);
+      if (!Number.isSafeInteger(offset) || offset < 0) {
+        throw new Error("Invalid task history offset");
+      }
+    }
   } catch {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, "Invalid task history cursor. Refresh the task."),
-    );
+    fail("Invalid task history cursor. Refresh the task.", ErrorCodes.INVALID_REQUEST);
     return;
   }
-  const sessionKey = taskTranscriptSessionKey(task);
   const harness = resolveTaskHistoryHarness(task);
   let active = true;
   const assertCurrent = () => {
@@ -122,15 +128,6 @@ export const taskHistoryHandler: GatewayRequestHandler = async (opts) => {
   try {
     const limit = params.limit ?? 100;
     if (sessionKey) {
-      const offset = cursor === undefined ? 0 : Number(cursor);
-      if (!Number.isSafeInteger(offset) || offset < 0) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "Invalid task history cursor. Refresh the task."),
-        );
-        return;
-      }
       const { chatHistoryHandlers } = await import("./chat-history-handler.js");
       assertCurrent();
       const childAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? task.agentId;
@@ -175,21 +172,10 @@ export const taskHistoryHandler: GatewayRequestHandler = async (opts) => {
         }),
       );
     } else {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, "This task has no readable transcript."),
-      );
+      fail("This task has no readable transcript.");
     }
   } catch {
-    respond(
-      false,
-      undefined,
-      errorShape(
-        ErrorCodes.UNAVAILABLE,
-        "Unable to load this task's transcript. Refresh the task and try again.",
-      ),
-    );
+    fail("Unable to load this task's transcript. Refresh the task and try again.");
   } finally {
     active = false;
   }

--- a/ui/src/pages/chat/components/chat-task-detail-state.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.ts
@@ -21,13 +21,11 @@ type TaskTranscriptLoad = { status: "loading" } | LoadedTaskTranscript | { statu
 type TaskDetailState = {
   client: GatewayBrowserClient;
   connectionEpoch: number | undefined;
-  eventVersion: number;
-  refreshedEventVersion: number;
+  refreshPending: boolean;
   inFlight: boolean;
   lastRequestStartedAt: number;
   load: TaskTranscriptLoad;
   refreshTimer: number | null;
-  requestId: number;
   olderCursors: Set<string>;
   taskId: string;
 };
@@ -81,25 +79,21 @@ function transcriptEntryKey(message: unknown): string | undefined {
   if (!identity) {
     return undefined;
   }
-  const key = identity.externalSource
+  return identity.externalSource
     ? `external:${identity.externalSource}`
     : identity.id
       ? `id:${identity.id}`
       : identity.sequence == null
         ? undefined
         : `seq:${identity.sequence}`;
-  return key;
 }
 
-function mergeTranscriptMessages(earlier: unknown[], later: unknown[]): unknown[] {
+function transcriptOverlap(earlier: unknown[], later: unknown[]): number {
   const laterKeys = new Set(later.map(transcriptEntryKey).filter(Boolean));
-  const overlap = earlier.findIndex((message) => {
+  return earlier.findIndex((message) => {
     const key = transcriptEntryKey(message);
     return key !== undefined && laterKeys.has(key);
   });
-  // An entry can project into several rows. Replace the overlapping tail as a
-  // whole so updated, added, and removed siblings stay together.
-  return [...earlier.slice(0, overlap < 0 ? earlier.length : overlap), ...later];
 }
 
 async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, cursor?: string) {
@@ -117,12 +111,11 @@ async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, 
     host.requestUpdate?.();
     return;
   }
-  const requestId = ++state.requestId;
-  const eventVersion = state.eventVersion;
   const previous = state.load.status === "loaded" ? state.load : undefined;
   state.inFlight = true;
   if (!cursor) {
     state.lastRequestStartedAt = Date.now();
+    state.refreshPending = false;
   }
   state.load = previous ? { ...previous, loading: true, error: undefined } : { status: "loading" };
   host.requestUpdate?.();
@@ -134,12 +127,11 @@ async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, 
       ...(cursor ? { cursor } : {}),
     });
     const messages = visibleChatHistoryMessages(result.messages);
-    const previousKeys = new Set(previous?.messages.map(transcriptEntryKey).filter(Boolean));
-    const overlaps = messages.some((message) => {
-      const key = transcriptEntryKey(message);
-      return key !== undefined && previousKeys.has(key);
-    });
-    const retainPrevious = previous !== undefined && (cursor !== undefined || overlaps);
+    const previousMessages = previous?.messages ?? [];
+    const earlier = cursor ? messages : previousMessages;
+    const later = cursor ? previousMessages : messages;
+    const overlap = transcriptOverlap(earlier, later);
+    const retainPrevious = previous !== undefined && (cursor !== undefined || overlap >= 0);
     if (cursor) {
       state.olderCursors.add(cursor);
     } else if (!retainPrevious) {
@@ -149,10 +141,9 @@ async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, 
     }
     load = {
       status: "loaded",
+      // Replace whole overlapping entries, including their projected siblings.
       messages: retainPrevious
-        ? cursor
-          ? mergeTranscriptMessages(messages, previous.messages)
-          : mergeTranscriptMessages(previous.messages, messages)
+        ? [...earlier.slice(0, overlap < 0 ? earlier.length : overlap), ...later]
         : messages,
       // Only overlapping refreshes preserve the oldest boundary already loaded.
       nextCursor:
@@ -171,7 +162,6 @@ async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, 
   const current = host.taskDetailState;
   if (
     current !== state ||
-    current.requestId !== requestId ||
     host.client !== client ||
     host.connectionEpoch !== state.connectionEpoch
   ) {
@@ -179,12 +169,9 @@ async function loadTranscriptPage(host: TaskDetailHost, state: TaskDetailState, 
   }
   state.inFlight = false;
   state.load = load;
-  if (!cursor) {
-    state.refreshedEventVersion = eventVersion;
-  }
   host.requestUpdate?.();
   // Also refresh after events received during an older-page request.
-  if (state.eventVersion > state.refreshedEventVersion) {
+  if (state.refreshPending) {
     scheduleTranscriptLoad(host, state);
   }
 }
@@ -210,13 +197,11 @@ export function readTaskTranscript(
   const next: TaskDetailState = {
     client,
     connectionEpoch: host.connectionEpoch,
-    eventVersion: 0,
-    refreshedEventVersion: 0,
+    refreshPending: false,
     inFlight: false,
     lastRequestStartedAt: Number.NEGATIVE_INFINITY,
     load: { status: "loading" },
     refreshTimer: null,
-    requestId: 0,
     olderCursors: new Set(),
     taskId: selection.taskId,
   };
@@ -266,8 +251,8 @@ export function observeTaskDetailEvent(
   if (event.action !== "upserted" || event.task.id !== state.taskId) {
     return;
   }
-  state.eventVersion += 1;
-  // A terminal version remains pending through an in-flight or throttled read,
+  state.refreshPending = true;
+  // Terminal events remain pending through an in-flight or throttled read,
   // so the next request is always the final task-session snapshot.
   scheduleTranscriptLoad(host, state);
 }


### PR DESCRIPTION
Related: #143747, #143869

## What Problem This Solves

Maintainer-requested cleanup of the subagent transcript implementation. The shared viewer and history readers had duplicate request bookkeeping, ownership parsing, error responses, and test setup that made the working flow harder to maintain.

## Why This Change Was Made

Use one pending-refresh flag and one overlap calculation in the UI, one typed wrapper for fenced native reads, and one existing Zod schema as the owner type and validator. Consolidate cursor-error handling and repeated regression setup while preserving every ownership, lifecycle, paging, and error contract.

## User Impact

No intended behavior or appearance change. The same Subagent transcript view, refresh/retry behavior, legacy handling, and parent-replacement/restart protections remain, with **70 fewer lines overall: 52 production and 18 test lines**.

## Evidence

- All 65 focused Gateway, native-history, registration-import, UI state, renderer, and retained-pane tests passed; all existing scenarios and behavioral assertions remain.
- Gateway tests passed on the original and simplified handler. Suite timings were 29.78s and 22.51s respectively; these are verification timings, not a performance claim.
- Independent review found no actionable P0–P2 issue.
- The pinned Codex 0.153.4 [metadata and paging contract](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L1656) was inspected directly. Native method parameters and metadata-only ancestry reads are unchanged.
- All changed-scope repository checks and the full build passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34498345962) passed.
- Real-provider proof on `dd744003a682`: managed history (2 pages/4 rows) and native history (4 pages/4 rows), stable message IDs, exact paged/full equality, and real linked tool results. Restarting the isolated Gateway over the same SQLite store preserved both complete histories and the native owner locator; both transcripts rendered in the actual browser afterward.
- The first live attempt returned a generic unavailable error for one native read after restart. A bounded diagnostic run and a fresh build with that diagnostic removed both passed. No retries, relaxed checks, or production diagnostic changes were added; the isolated initial failure did not reproduce.

- Post-merge verification on latest main `0f68d696c3cc9c93bb45048f8c72036e577490de` passed after a fresh build: real managed/native history paging, stable IDs, linked tool results, unchanged full histories after Gateway restart over SQLite, and actual browser rendering. The earlier isolated failure did not reproduce. The task checkout is clean and the isolated Gateway/native home were cleaned up.

### Before

Prior inspected live proof from #143869, using synthetic test data:

![Before: shared native subagent transcript](https://github.com/user-attachments/assets/a6940a27-6075-4367-b3b3-e1c9c2c9f167)

### After

Exact PR build after a real Gateway restart, using synthetic test data:

![After: shared native subagent transcript](https://github.com/user-attachments/assets/c4eb3878-ff05-4ee4-9143-fca309e293b5)

![After: managed subagent transcript](https://github.com/user-attachments/assets/1ec8ba4a-cf9d-42a6-9239-e98ed6a11597)
