### PR TITLE
refactor(cloud-workers): consolidate the snapshot feature surface

### DIFF
--- a/docs/gateway/cloud-workers/per-project-default-profiles.md
+++ b/docs/gateway/cloud-workers/per-project-default-profiles.md
@@ -20,7 +20,7 @@ Use `cloudWorkers.projectProfiles` to select a default profile from a managed se
 }
 ```
 
-In **Settings → Cloud workers → Repositories**, add, edit, or delete repository defaults by selecting a configured profile. The editor validates repository identities and refuses mappings to missing profiles.
+In **Settings → Connections → Cloud workers → Repositories**, add, edit, or delete repository defaults by selecting a configured profile. The editor validates repository identities and refuses mappings to missing profiles.
 
 An explicit `profileId` or `deviceId` in `sessions.dispatch` always wins. A target-less project-profile lookup requires `operator.admin`. Deleting a profile from the Cloud workers settings also removes project defaults that reference it. If a manually configured mapping names a profile that is not present in `cloudWorkers.profiles`, dispatch fails closed and names both the repository key and missing profile. A worktree with no `origin` or no matching mapping returns a typed `INVALID_REQUEST` without provisioning or falling back to another target.
 

--- a/docs/gateway/config-cloud-workers.md
+++ b/docs/gateway/config-cloud-workers.md
@@ -21,7 +21,7 @@ Node-backed providers return an authenticated node device id for either `worker-
 
 ### Crabbox profile
 
-In **Settings → Cloud workers**, the profile editor's **Advanced** group edits warm images, setup environment names, ready workers, and suspend-after duration. The page also exposes the shared **Prepared pool** cap. Clearing optional values restores their defaults; selecting **Auto** for warm images restores automatic selection. These changes require a Gateway restart. After saving a profile, the restart notice points to **Snapshots → Build snapshot**. Saving does not start a build.
+In **Settings → Connections → Cloud workers**, the profile editor's **Advanced** group edits warm images, setup environment names, ready workers, and suspend-after duration. The page also exposes the shared **Prepared pool** cap. Clearing optional values restores their defaults; selecting **Auto** for warm images restores automatic selection. These changes require a Gateway restart. After saving a profile, the restart notice points to **Snapshots → Build snapshot**. Saving does not start a build.
 
 Snapshot retention is plugin-wide, separate from profile settings. Configure
 `plugins.entries.crabbox.config.warmImages.refreshAfter` (default `24h`, minimum

--- a/src/gateway/worker-environments/build-preparation.ts
+++ b/src/gateway/worker-environments/build-preparation.ts
@@ -74,10 +74,6 @@ export function createWorkerEnvironmentBuildPreparation(options: BuildPreparatio
       });
     } catch {
       signal.throwIfAborted();
-      throw serviceError(
-        "invalid_project",
-        "Project must be an accessible local Git checkout root with a HEAD commit",
-      );
     }
     if (!project) {
       throw serviceError(

--- a/src/gateway/worker-environments/prepared-pool.ts
+++ b/src/gateway/worker-environments/prepared-pool.ts
@@ -60,14 +60,11 @@ export function createPreparedWorkerPool(options: PoolOptions) {
   const policy = (record: Pick<WorkerEnvironmentRecord, "profileId" | "providerId">) => {
     const config = options.getConfig().cloudWorkers;
     const profile = config?.profiles?.[record.profileId];
+    const configured =
+      profile && normalizeCapabilityProviderId(profile.provider) === record.providerId;
     return {
-      configured: Boolean(
-        profile && normalizeCapabilityProviderId(profile.provider) === record.providerId,
-      ),
-      target:
-        profile && normalizeCapabilityProviderId(profile.provider) === record.providerId
-          ? (profile.readyWorkers ?? DEFAULT_READY_WORKERS)
-          : 0,
+      configured: Boolean(configured),
+      target: configured ? (profile.readyWorkers ?? DEFAULT_READY_WORKERS) : 0,
       maxTotal: config?.preparedPool?.maxTotal ?? DEFAULT_MAX_TOTAL,
     };
   };
@@ -106,15 +103,13 @@ export function createPreparedWorkerPool(options: PoolOptions) {
     for (const record of inventory) {
       const demandAtMs = demandAt(record);
       const key = groupKey(record);
-      if (
-        key &&
+      const build =
         record.preparation?.purpose === "build" &&
         record.preparation.consumedAtMs === null &&
         record.destroyRequestedAtMs === null &&
-        record.state !== "ready" &&
         record.state !== "failed" &&
-        record.state !== "destroyed"
-      ) {
+        record.state !== "destroyed";
+      if (key && build && record.state !== "ready") {
         buildingKeys.add(key);
       }
       if (
@@ -126,12 +121,7 @@ export function createPreparedWorkerPool(options: PoolOptions) {
         if (
           !previous ||
           demandAtMs > previous.demandAtMs ||
-          (demandAtMs === previous.demandAtMs &&
-            record.preparation?.purpose === "build" &&
-            record.preparation.consumedAtMs === null &&
-            record.destroyRequestedAtMs === null &&
-            record.state !== "failed" &&
-            record.state !== "destroyed")
+          (demandAtMs === previous.demandAtMs && build)
         ) {
           sources.set(key, { record, demandAtMs });
         }

--- a/ui/src/pages/cloud-workers/cloud-worker-config-save.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config-save.ts
@@ -1,0 +1,66 @@
+import type { ReactiveControllerHost } from "lit";
+import { t } from "../../i18n/index.ts";
+import type { RuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+
+type SaveState = { busy: boolean; error: string | null; notice: string | null };
+
+export class CloudWorkerConfigSave {
+  readonly state: SaveState = { busy: false, error: null, notice: null };
+
+  constructor(private readonly host: ReactiveControllerHost) {}
+
+  update(patch: Partial<SaveState>) {
+    Object.assign(this.state, patch);
+    this.host.requestUpdate();
+  }
+
+  async save(
+    runtimeConfig: RuntimeConfigCapability,
+    isCurrent: () => boolean,
+    options: {
+      build: (
+        base: Readonly<Record<string, unknown>>,
+      ) => { patch: Record<string, unknown>; replacePaths?: string[] } | { error: string };
+      note: string;
+      canDispatch: () => boolean;
+      failed: () => string;
+      success: () => string | void;
+    },
+  ): Promise<boolean> {
+    this.update({ busy: true, error: null, notice: null });
+    try {
+      const patched = await runtimeConfig.patchFromSnapshot((base) => {
+        const built = options.build(base);
+        return "error" in built
+          ? { error: t(`cloudWorkersPage.errors.${built.error}`) }
+          : {
+              options: {
+                raw: built.patch,
+                ...(built.replacePaths ? { replacePaths: built.replacePaths } : {}),
+                note: options.note,
+                canDispatch: options.canDispatch,
+              },
+            };
+      });
+      if (!isCurrent()) {
+        return false;
+      }
+      if (!patched) {
+        this.update({ error: runtimeConfig.state.lastError ?? options.failed() });
+        return false;
+      }
+      this.update({ notice: options.success() ?? null });
+      return true;
+    } catch (error) {
+      if (isCurrent()) {
+        this.update({ error: formatUiError(error) });
+      }
+      return false;
+    } finally {
+      if (isCurrent()) {
+        this.update({ busy: false });
+      }
+    }
+  }
+}

--- a/ui/src/pages/cloud-workers/cloud-worker-repositories.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-repositories.ts
@@ -10,11 +10,11 @@ import {
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
-import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { CloudWorkerConfigSave } from "./cloud-worker-config-save.ts";
 import { readCloudWorkerProfiles } from "./cloud-worker-config.ts";
 import {
   buildCloudWorkerPreparedPoolPatch,
@@ -38,18 +38,15 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
     draft: CloudWorkerRepository;
   } | null = null;
   @state() private poolDraft: string | null = null;
-  @state() private busy = false;
-  @state() private error: string | null = null;
-  @state() private notice: string | null = null;
+
+  private readonly configSave = new CloudWorkerConfigSave(this);
 
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
     invalidateRequests: () => {
       this.editor = null;
       this.poolDraft = null;
-      this.busy = false;
-      this.error = null;
-      this.notice = null;
+      this.configSave.update({ busy: false, error: null, notice: null });
     },
   });
   private readonly subscriptions = new SubscriptionsController(this).effect(
@@ -67,7 +64,7 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
   }
 
   private editable() {
-    return this.canManage && !this.busy;
+    return this.canManage && !this.configSave.state.busy;
   }
 
   private async save(
@@ -78,47 +75,17 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
     if (!scope || !this.editable()) {
       return false;
     }
-    this.busy = true;
-    this.error = null;
-    this.notice = null;
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
-    try {
-      const patched = await runtimeConfig.patchFromSnapshot((base) => {
-        const built = build(base);
-        return "error" in built
-          ? { error: t(`cloudWorkersPage.errors.${built.error}`) }
-          : {
-              options: {
-                raw: built.patch,
-                replacePaths: built.replacePaths,
-                note: "cloud workers: update repository defaults or prepared pool",
-                canDispatch: () =>
-                  isCurrent() &&
-                  canCallGatewayMethod(this.gateway.snapshot, "config.patch", "operator.admin"),
-              },
-            };
-      });
-      if (!isCurrent()) {
-        return false;
-      }
-      if (!patched) {
-        this.error =
-          runtimeConfig.state.lastError ?? t("cloudWorkersPage.errors.settingsSaveFailed");
-        return false;
-      }
-      this.notice = t("labsPage.restartRequired");
-      return true;
-    } catch (error) {
-      if (isCurrent()) {
-        this.error = formatUiError(error);
-      }
-      return false;
-    } finally {
-      if (isCurrent()) {
-        this.busy = false;
-      }
-    }
+    return this.configSave.save(runtimeConfig, isCurrent, {
+      build,
+      note: "cloud workers: update repository defaults or prepared pool",
+      canDispatch: () =>
+        isCurrent() &&
+        canCallGatewayMethod(this.gateway.snapshot, "config.patch", "operator.admin"),
+      failed: () => t("cloudWorkersPage.errors.settingsSaveFailed"),
+      success: () => t("labsPage.restartRequired"),
+    });
   }
 
   private openEditor(mapping?: CloudWorkerRepository) {
@@ -132,14 +99,13 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
         profileId: readCloudWorkerProfiles(this.config())[0]?.id ?? "",
       },
     };
-    this.error = null;
-    this.notice = null;
+    this.configSave.update({ error: null, notice: null });
   }
 
   private changeDraft(patch: Partial<CloudWorkerRepository>) {
     if (this.editor) {
       this.editor = { ...this.editor, draft: { ...this.editor.draft, ...patch } };
-      this.error = null;
+      this.configSave.update({ error: null });
     }
   }
 
@@ -222,10 +188,10 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
           control: html` <button
               class="btn btn--sm"
               type="button"
-              ?disabled=${this.busy}
+              ?disabled=${this.configSave.state.busy}
               @click=${() => {
                 this.editor = null;
-                this.error = null;
+                this.configSave.update({ error: null });
               }}
             >
               ${t("common.cancel")}
@@ -264,7 +230,7 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
               @input=${(event: Event) => {
                 if (event.currentTarget instanceof HTMLInputElement) {
                   this.poolDraft = event.currentTarget.value;
-                  this.error = null;
+                  this.configSave.update({ error: null });
                 }
               }}
               @keydown=${(event: KeyboardEvent) => {
@@ -324,8 +290,8 @@ class CloudWorkerRepositories extends OpenClawLightDomContentsElement {
           : renderSettingsEmpty(t("cloudWorkersPage.repositoriesEmpty")),
       )}
       ${this.renderEditor()}
-      ${this.error ? html`<div class="callout warning" role="alert">${this.error}</div>` : nothing}
-      ${this.notice ? html`<div class="callout warning" role="status">${this.notice}</div>` : nothing}
+      ${this.configSave.state.error ? html`<div class="callout warning" role="alert">${this.configSave.state.error}</div>` : nothing}
+      ${this.configSave.state.notice ? html`<div class="callout warning" role="status">${this.configSave.state.notice}</div>` : nothing}
     `;
   }
 }

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshot-policy.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshot-policy.ts
@@ -8,11 +8,11 @@ import { renderSettingsRow, renderSettingsSection } from "../../components/setti
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
-import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { CloudWorkerConfigSave } from "./cloud-worker-config-save.ts";
 
 registerSettingsEnglish();
 
@@ -22,16 +22,15 @@ class CloudWorkerSnapshotPolicy extends OpenClawLightDomContentsElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
   @state() private draft: PolicyDraft | null = null;
-  @state() private busy = false;
-  @state() private error: string | null = null;
   @state() private saved = false;
+
+  private readonly configSave = new CloudWorkerConfigSave(this);
 
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
     invalidateRequests: () => {
       this.draft = null;
-      this.busy = false;
-      this.error = null;
+      this.configSave.update({ busy: false, error: null });
       this.saved = false;
     },
   });
@@ -70,13 +69,13 @@ class CloudWorkerSnapshotPolicy extends OpenClawLightDomContentsElement {
       config?.configSnapshot?.hash &&
       !config.configLoading &&
       !config.configSaving &&
-      !this.busy,
+      !this.configSave.state.busy,
     );
   }
 
   private edit(patch: Partial<PolicyDraft>) {
     this.draft = { ...(this.draft ?? this.policy()), ...patch };
-    this.error = null;
+    this.configSave.update({ error: null });
     this.saved = false;
   }
 
@@ -95,57 +94,41 @@ class CloudWorkerSnapshotPolicy extends OpenClawLightDomContentsElement {
         !/^[1-9][0-9]{0,7}(m|h|d)(?![\s\S])/.test(draft[key]) ||
         parseDurationMs(draft[key]) < minimum
       ) {
-        this.error = t(`cloudWorkersPage.snapshots.${key}Invalid`);
+        this.configSave.update({ error: t(`cloudWorkersPage.snapshots.${key}Invalid`) });
         return;
       }
     }
-    this.busy = true;
-    this.error = null;
     this.saved = false;
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
-    try {
-      const patched = await runtimeConfig.patchFromSnapshot(() => ({
-        options: {
-          raw: {
-            plugins: {
-              entries: {
-                crabbox: {
-                  config: {
-                    warmImages: {
-                      refreshAfter: draft.refreshAfter,
-                      retainUnused: draft.retainUnused,
-                      keepPrevious: Number(draft.keepPrevious),
-                    },
+    await this.configSave.save(runtimeConfig, isCurrent, {
+      build: () => ({
+        patch: {
+          plugins: {
+            entries: {
+              crabbox: {
+                config: {
+                  warmImages: {
+                    refreshAfter: draft.refreshAfter,
+                    retainUnused: draft.retainUnused,
+                    keepPrevious: Number(draft.keepPrevious),
                   },
                 },
               },
             },
           },
-          note: "cloud workers: update snapshot retention policy",
-          canDispatch: () =>
-            isCurrent() &&
-            canCallGatewayMethod(this.gateway.snapshot, "config.patch", "operator.admin"),
         },
-      }));
-      if (isCurrent()) {
-        if (patched) {
-          this.draft = null;
-          this.saved = true;
-        } else {
-          this.error =
-            runtimeConfig.state.lastError ?? t("cloudWorkersPage.snapshots.policySaveFailed");
-        }
-      }
-    } catch (error) {
-      if (isCurrent()) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (isCurrent()) {
-        this.busy = false;
-      }
-    }
+      }),
+      note: "cloud workers: update snapshot retention policy",
+      canDispatch: () =>
+        isCurrent() &&
+        canCallGatewayMethod(this.gateway.snapshot, "config.patch", "operator.admin"),
+      failed: () => t("cloudWorkersPage.snapshots.policySaveFailed"),
+      success: () => {
+        this.draft = null;
+        this.saved = true;
+      },
+    });
   }
 
   override render() {
@@ -206,7 +189,7 @@ class CloudWorkerSnapshotPolicy extends OpenClawLightDomContentsElement {
             ${t("cloudWorkersPage.snapshots.savePolicy")}
           </button>`,
         })}
-        ${this.error ? html`<div class="callout warning" role="alert">${this.error}</div>` : nothing}
+        ${this.configSave.state.error ? html`<div class="callout warning" role="alert">${this.configSave.state.error}</div>` : nothing}
         ${this.saved ? html`<div class="callout" role="status">${t("cloudWorkersPage.snapshots.policySaved")}</div>` : nothing}
       `,
     );

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.test-support.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.test-support.ts
@@ -1,43 +1,7 @@
-type SnapshotFixtureImage = {
-  profileKey: string;
-  profileId?: string;
-  backend?: string;
-  machineClass?: string;
-  os?: string;
-  projectKey?: string;
-  projectLabel?: string;
-  checkpointId?: string;
-  state: "pending" | "available" | "no-image";
-  createdAtMs?: number;
-  lastDemandAtMs?: number | null;
-  baseCommit?: string;
-  runtimeIdentity?: {
-    nodeBootstrapSha256: string;
-    executionMode: "worker-turn" | "remote-exec";
-    workerBundleSha256?: string;
-  };
-  pinned?: { atMs: number };
-  previous?: {
-    checkpointId: string;
-    createdAtMs: number;
-    baseCommit?: string;
-    runtimeIdentity?: SnapshotFixtureImage["runtimeIdentity"];
-    pinned?: { atMs: number };
-  };
-  allocations: Record<string, never>;
-  allocationCount: number;
-  held: boolean;
-  retirement?: { checkpointId: string };
-  capture?: {
-    selector: string;
-    phase: "scrubbing" | "creating" | "uncertain";
-    stale: boolean;
-    startedAtMs: number;
-  };
-};
+import type { SnapshotsResult } from "./cloud-worker-snapshot-rows.ts";
 
-export function snapshotListFixture() {
-  const images: SnapshotFixtureImage[] = [
+export function snapshotListFixture(): SnapshotsResult {
+  const images: SnapshotsResult["images"] = [
     {
       profileKey: "profile-key-project",
       profileId: "linux-build",
@@ -53,9 +17,7 @@ export function snapshotListFixture() {
       baseCommit: "0123456789abcdef",
       runtimeIdentity: {
         nodeBootstrapSha256: "abcdef0123456789".repeat(4),
-        executionMode: "worker-turn",
       },
-      allocations: {},
       allocationCount: 21,
       held: true,
       retirement: { checkpointId: "image-app-predecessor" },
@@ -67,7 +29,6 @@ export function snapshotListFixture() {
       projectLabel: "github.com/acme/retiring",
       checkpointId: "image-retiring",
       state: "available",
-      allocations: {},
       allocationCount: 0,
       held: false,
       retirement: { checkpointId: "image-retiring" },
@@ -76,14 +37,12 @@ export function snapshotListFixture() {
       profileKey: "profile-key-legacy",
       projectKey: "project-key-legacy",
       state: "no-image",
-      allocations: {},
       allocationCount: 0,
       held: false,
       capture: {
         selector: "capture-uncertain",
         phase: "uncertain",
         stale: false,
-        startedAtMs: Date.now(),
       },
     },
     {
@@ -92,14 +51,12 @@ export function snapshotListFixture() {
       backend: "aws",
       machineClass: "burst",
       state: "no-image",
-      allocations: {},
       allocationCount: 1,
       held: false,
       capture: {
         selector: "capture-building",
         phase: "creating",
         stale: true,
-        startedAtMs: Date.now() - 1_800_000,
       },
     },
   ];

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, resolveGatewayErrorDetailCode } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { showConfirmDialog, type ConfirmDialogOptions } from "../../components/confirm-dialog.ts";
 import {
   renderSettingsEmpty,
   renderSettingsPage,
@@ -20,6 +20,7 @@ import {
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { showToast } from "../../lib/toast.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
@@ -83,6 +84,62 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
 
   private canCall(method: string) {
     return canCallGatewayMethod(this.gateway.snapshot, method, "operator.admin");
+  }
+
+  private async confirm(options: ConfirmDialogOptions) {
+    const confirmation = new AbortController();
+    this.confirmation = confirmation;
+    const confirmed = await showConfirmDialog({ ...options, signal: confirmation.signal });
+    if (this.confirmation === confirmation) {
+      this.confirmation = null;
+    }
+    return confirmed;
+  }
+
+  private async runConfirmedAction(
+    scope: GatewayConnectionScope,
+    lane: "cancelling" | "recovering",
+    target: string,
+    options: ConfirmDialogOptions,
+  ) {
+    const recover = lane === "recovering";
+    const method = recover ? "crabbox.images.recover" : "environments.destroy";
+    if (!(await this.confirm({ ...options, details: target }))) {
+      return;
+    }
+    if (!this.gateway.isCurrent(scope) || !this.canCall(method)) {
+      if (recover) {
+        this.error = t("cloudWorkersPage.snapshots.recoveryChanged");
+      }
+      return;
+    }
+    this[lane] = target;
+    this.error = null;
+    this.notice = null;
+    try {
+      await scope.client.request(
+        method,
+        recover
+          ? { selector: target, acknowledgeProviderCleanup: true }
+          : { environmentId: target },
+      );
+      if (this.gateway.isCurrent(scope)) {
+        this.notice = t(
+          recover
+            ? "cloudWorkersPage.snapshots.recovered"
+            : "cloudWorkersPage.snapshots.buildCancelled",
+        );
+        await this.load();
+      }
+    } catch (error) {
+      if (this.gateway.isCurrent(scope)) {
+        this.error = formatUiError(error);
+      }
+    } finally {
+      if (this.gateway.isCurrent(scope)) {
+        this[lane] = null;
+      }
+    }
   }
 
   private async load() {
@@ -269,40 +326,12 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     if (!scope || this.cancelling || this.confirmation || !this.canCall("environments.destroy")) {
       return;
     }
-    const confirmation = new AbortController();
-    this.confirmation = confirmation;
-    const confirmed = await showConfirmDialog({
+    await this.runConfirmedAction(scope, "cancelling", environment.id, {
       title: t("cloudWorkersPage.snapshots.cancelBuild"),
       message: t("cloudWorkersPage.snapshots.cancelBuildMessage"),
-      details: environment.id,
       confirmLabel: t("cloudWorkersPage.snapshots.cancelBuild"),
       danger: true,
-      signal: confirmation.signal,
     });
-    if (this.confirmation === confirmation) {
-      this.confirmation = null;
-    }
-    if (!confirmed || !this.gateway.isCurrent(scope) || !this.canCall("environments.destroy")) {
-      return;
-    }
-    this.cancelling = environment.id;
-    this.error = null;
-    this.notice = null;
-    try {
-      await scope.client.request("environments.destroy", { environmentId: environment.id });
-      if (this.gateway.isCurrent(scope)) {
-        this.notice = t("cloudWorkersPage.snapshots.buildCancelled");
-        await this.load();
-      }
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.cancelling = null;
-      }
-    }
   }
 
   private renderBuildDialog() {
@@ -398,47 +427,12 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     ) {
       return;
     }
-    const confirmation = new AbortController();
-    this.confirmation = confirmation;
-    const confirmed = await showConfirmDialog({
+    await this.runConfirmedAction(scope, "recovering", selector, {
       title: t("cloudWorkersPage.snapshots.recoverTitle"),
       message: t("cloudWorkersPage.snapshots.recoverMessage"),
-      details: selector,
       confirmLabel: t("cloudWorkersPage.snapshots.recover"),
       requiredAcknowledgement: t("cloudWorkersPage.snapshots.acknowledgement"),
-      signal: confirmation.signal,
     });
-    if (this.confirmation === confirmation) {
-      this.confirmation = null;
-    }
-    if (!confirmed) {
-      return;
-    }
-    if (!this.gateway.isCurrent(scope) || !this.canCall("crabbox.images.recover")) {
-      this.error = t("cloudWorkersPage.snapshots.recoveryChanged");
-      return;
-    }
-    this.recovering = selector;
-    this.error = null;
-    this.notice = null;
-    try {
-      await scope.client.request("crabbox.images.recover", {
-        selector,
-        acknowledgeProviderCleanup: true,
-      });
-      if (this.gateway.isCurrent(scope)) {
-        this.notice = t("cloudWorkersPage.snapshots.recovered");
-        await this.load();
-      }
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.recovering = null;
-      }
-    }
   }
 
   private deleteReason(image: SnapshotImage) {
@@ -480,19 +474,13 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     this.mutating = checkpointId;
     try {
       if (action !== "pin") {
-        const confirmation = new AbortController();
-        this.confirmation = confirmation;
-        const confirmed = await showConfirmDialog({
+        const confirmed = await this.confirm({
           title: t(`cloudWorkersPage.snapshots.${action}Title`),
           message: t(`cloudWorkersPage.snapshots.${action}Message`),
           details: checkpointId,
           confirmLabel: t(`cloudWorkersPage.snapshots.${action}`),
           danger: action === "delete",
-          signal: confirmation.signal,
         });
-        if (this.confirmation === confirmation) {
-          this.confirmation = null;
-        }
         if (!confirmed) {
           return;
         }

--- a/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-snapshots.ts
@@ -20,7 +20,6 @@ import {
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { showToast } from "../../lib/toast.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
@@ -94,52 +93,6 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
       this.confirmation = null;
     }
     return confirmed;
-  }
-
-  private async runConfirmedAction(
-    scope: GatewayConnectionScope,
-    lane: "cancelling" | "recovering",
-    target: string,
-    options: ConfirmDialogOptions,
-  ) {
-    const recover = lane === "recovering";
-    const method = recover ? "crabbox.images.recover" : "environments.destroy";
-    if (!(await this.confirm({ ...options, details: target }))) {
-      return;
-    }
-    if (!this.gateway.isCurrent(scope) || !this.canCall(method)) {
-      if (recover) {
-        this.error = t("cloudWorkersPage.snapshots.recoveryChanged");
-      }
-      return;
-    }
-    this[lane] = target;
-    this.error = null;
-    this.notice = null;
-    try {
-      await scope.client.request(
-        method,
-        recover
-          ? { selector: target, acknowledgeProviderCleanup: true }
-          : { environmentId: target },
-      );
-      if (this.gateway.isCurrent(scope)) {
-        this.notice = t(
-          recover
-            ? "cloudWorkersPage.snapshots.recovered"
-            : "cloudWorkersPage.snapshots.buildCancelled",
-        );
-        await this.load();
-      }
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this[lane] = null;
-      }
-    }
   }
 
   private async load() {
@@ -326,12 +279,34 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     if (!scope || this.cancelling || this.confirmation || !this.canCall("environments.destroy")) {
       return;
     }
-    await this.runConfirmedAction(scope, "cancelling", environment.id, {
+    const confirmed = await this.confirm({
       title: t("cloudWorkersPage.snapshots.cancelBuild"),
       message: t("cloudWorkersPage.snapshots.cancelBuildMessage"),
+      details: environment.id,
       confirmLabel: t("cloudWorkersPage.snapshots.cancelBuild"),
       danger: true,
     });
+    if (!confirmed || !this.gateway.isCurrent(scope) || !this.canCall("environments.destroy")) {
+      return;
+    }
+    this.cancelling = environment.id;
+    this.error = null;
+    this.notice = null;
+    try {
+      await scope.client.request("environments.destroy", { environmentId: environment.id });
+      if (this.gateway.isCurrent(scope)) {
+        this.notice = t("cloudWorkersPage.snapshots.buildCancelled");
+        await this.load();
+      }
+    } catch (error) {
+      if (this.gateway.isCurrent(scope)) {
+        this.error = formatUiError(error);
+      }
+    } finally {
+      if (this.gateway.isCurrent(scope)) {
+        this.cancelling = null;
+      }
+    }
   }
 
   private renderBuildDialog() {
@@ -413,7 +388,7 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     </openclaw-modal-dialog>`;
   }
 
-  private async recover(image: SnapshotImage) {
+  private async recoverCapture(image: SnapshotImage) {
     const scope = this.gateway.capture();
     const selector = image.capture?.selector;
     if (
@@ -427,12 +402,41 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
     ) {
       return;
     }
-    await this.runConfirmedAction(scope, "recovering", selector, {
+    const confirmed = await this.confirm({
       title: t("cloudWorkersPage.snapshots.recoverTitle"),
       message: t("cloudWorkersPage.snapshots.recoverMessage"),
+      details: selector,
       confirmLabel: t("cloudWorkersPage.snapshots.recover"),
       requiredAcknowledgement: t("cloudWorkersPage.snapshots.acknowledgement"),
     });
+    if (!confirmed) {
+      return;
+    }
+    if (!this.gateway.isCurrent(scope) || !this.canCall("crabbox.images.recover")) {
+      this.error = t("cloudWorkersPage.snapshots.recoveryChanged");
+      return;
+    }
+    this.recovering = selector;
+    this.error = null;
+    this.notice = null;
+    try {
+      await scope.client.request("crabbox.images.recover", {
+        selector,
+        acknowledgeProviderCleanup: true,
+      });
+      if (this.gateway.isCurrent(scope)) {
+        this.notice = t("cloudWorkersPage.snapshots.recovered");
+        await this.load();
+      }
+    } catch (error) {
+      if (this.gateway.isCurrent(scope)) {
+        this.error = formatUiError(error);
+      }
+    } finally {
+      if (this.gateway.isCurrent(scope)) {
+        this.recovering = null;
+      }
+    }
   }
 
   private deleteReason(image: SnapshotImage) {
@@ -534,7 +538,7 @@ class CloudWorkerSnapshots extends OpenClawLightDomElement {
         ? () => void this.mutateImage(image, "delete")
         : undefined,
       onRecover: this.canCall("crabbox.images.recover")
-        ? () => void this.recover(image)
+        ? () => void this.recoverCapture(image)
         : undefined,
       onRebuild:
         projectRoot &&

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -27,6 +27,7 @@ import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { CloudWorkerConfigSave } from "./cloud-worker-config-save.ts";
 import {
   buildCloudWorkerDeletePatch,
   buildCloudWorkerUpsertPatch,
@@ -34,7 +35,6 @@ import {
   createCloudWorkerDraft,
   readCloudWorkerProfiles,
   validateCloudWorkerDraft,
-  type CloudWorkerDraftError,
   type CloudWorkerProfileDraft,
   type ConfiguredCloudWorkerProfile,
 } from "./cloud-worker-config.ts";
@@ -67,9 +67,8 @@ class CloudWorkersPage extends OpenClawLightDomElement {
   @state() private catalogError: string | null = null;
   @state() private editor: EditorState = null;
   @state() private draft: CloudWorkerProfileDraft = createCloudWorkerDraft();
-  @state() private formError: string | null = null;
-  @state() private notice: string | null = null;
-  @state() private busyProfileId: string | null = null;
+
+  private readonly configSave = new CloudWorkerConfigSave(this);
 
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
@@ -95,7 +94,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
   }
 
   private resetGatewayState() {
-    this.busyProfileId = null;
+    this.configSave.update({ busy: false });
     this.advertisedProfiles = new Map();
     this.catalogLoaded = false;
     this.catalogLoading = false;
@@ -156,7 +155,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
       configState?.configSnapshot?.hash &&
       !configState.configLoading &&
       !configState.configSaving &&
-      this.busyProfileId === null,
+      !this.configSave.state.busy,
     );
   }
 
@@ -166,8 +165,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     }
     this.editor = { kind: "add" };
     this.draft = createCloudWorkerDraft();
-    this.formError = null;
-    this.notice = null;
+    this.configSave.update({ error: null, notice: null });
   }
 
   private openEdit(profile: ConfiguredCloudWorkerProfile) {
@@ -180,25 +178,20 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     }
     this.editor = { kind: "edit", profileId: profile.id };
     this.draft = createCloudWorkerDraft(profile);
-    this.formError = null;
-    this.notice = null;
+    this.configSave.update({ error: null, notice: null });
   }
 
   private closeEditor() {
-    if (this.busyProfileId !== null) {
+    if (this.configSave.state.busy) {
       return;
     }
     this.editor = null;
-    this.formError = null;
+    this.configSave.update({ error: null });
   }
 
   private patchDraft(patch: Partial<CloudWorkerProfileDraft>) {
     this.draft = { ...this.draft, ...patch };
-    this.formError = null;
-  }
-
-  private errorText(error: CloudWorkerDraftError): string {
-    return t(`cloudWorkersPage.errors.${error}`);
+    this.configSave.update({ error: null });
   }
 
   private async saveProfile(draft: CloudWorkerProfileDraft) {
@@ -214,47 +207,22 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     );
     const validationError = validateCloudWorkerDraft(draft, currentProfiles, editingId);
     if (validationError) {
-      this.formError = this.errorText(validationError);
+      this.configSave.update({ error: t(`cloudWorkersPage.errors.${validationError}`) });
       return;
     }
     const profileId = editingId ?? draft.id;
-    this.busyProfileId = profileId;
-    this.formError = null;
-    this.notice = null;
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
-    try {
-      const patched = await runtimeConfig.patchFromSnapshot((base) => {
-        const built = buildCloudWorkerUpsertPatch(base, draft, editingId);
-        return "error" in built
-          ? { error: this.errorText(built.error) }
-          : {
-              options: {
-                raw: built.patch,
-                replacePaths: built.replacePaths,
-                note: `cloud workers: ${editingId ? "update" : "add"} ${profileId}`,
-                canDispatch: isCurrent,
-              },
-            };
-      });
-      if (!isCurrent()) {
-        return;
-      }
-      if (!patched) {
-        this.formError = runtimeConfig.state.lastError ?? t("cloudWorkersPage.errors.saveFailed");
-        return;
-      }
-      this.editor = null;
-      this.notice = `${t("labsPage.restartRequired")} ${t("cloudWorkersPage.snapshots.buildAfterRestart")}`;
-    } catch (error) {
-      if (isCurrent()) {
-        this.formError = formatUiError(error);
-      }
-    } finally {
-      if (isCurrent()) {
-        this.busyProfileId = null;
-      }
-    }
+    await this.configSave.save(runtimeConfig, isCurrent, {
+      build: (base) => buildCloudWorkerUpsertPatch(base, draft, editingId),
+      note: `cloud workers: ${editingId ? "update" : "add"} ${profileId}`,
+      canDispatch: isCurrent,
+      failed: () => t("cloudWorkersPage.errors.saveFailed"),
+      success: () => {
+        this.editor = null;
+        return `${t("labsPage.restartRequired")} ${t("cloudWorkersPage.snapshots.buildAfterRestart")}`;
+      },
+    });
   }
 
   private async deleteProfile(profile: ConfiguredCloudWorkerProfile) {
@@ -282,48 +250,23 @@ class CloudWorkersPage extends OpenClawLightDomElement {
       this.context.runtimeConfig !== runtimeConfig ||
       !this.canManage()
     ) {
-      this.formError = t("cloudWorkersPage.errors.deleteFailed");
+      this.configSave.update({ error: t("cloudWorkersPage.errors.deleteFailed") });
       return;
     }
-    this.busyProfileId = profile.id;
-    this.formError = null;
-    this.notice = null;
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
-    try {
-      const patched = await runtimeConfig.patchFromSnapshot((base) => {
-        const built = buildCloudWorkerDeletePatch(base, profile.id);
-        return "error" in built
-          ? { error: this.errorText(built.error) }
-          : {
-              options: {
-                raw: built.patch,
-                replacePaths: built.replacePaths,
-                note: `cloud workers: delete ${profile.id}`,
-                canDispatch: isCurrent,
-              },
-            };
-      });
-      if (!isCurrent()) {
-        return;
-      }
-      if (!patched) {
-        this.formError = runtimeConfig.state.lastError ?? t("cloudWorkersPage.errors.deleteFailed");
-        return;
-      }
-      if (this.editor?.kind === "edit" && this.editor.profileId === profile.id) {
-        this.editor = null;
-      }
-      this.notice = t("labsPage.restartRequired");
-    } catch (error) {
-      if (isCurrent()) {
-        this.formError = formatUiError(error);
-      }
-    } finally {
-      if (isCurrent()) {
-        this.busyProfileId = null;
-      }
-    }
+    await this.configSave.save(runtimeConfig, isCurrent, {
+      build: (base) => buildCloudWorkerDeletePatch(base, profile.id),
+      note: `cloud workers: delete ${profile.id}`,
+      canDispatch: isCurrent,
+      failed: () => t("cloudWorkersPage.errors.deleteFailed"),
+      success: () => {
+        if (this.editor?.kind === "edit" && this.editor.profileId === profile.id) {
+          this.editor = null;
+        }
+        return t("labsPage.restartRequired");
+      },
+    });
   }
 
   private profileDescription(profile: ConfiguredCloudWorkerProfile): string {
@@ -392,11 +335,46 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     });
   }
 
+  private renderDraftInput(
+    field:
+      | "backend"
+      | "machineClass"
+      | "ttl"
+      | "idleTimeout"
+      | "binary"
+      | "setupEnv"
+      | "readyWorkers"
+      | "suspendAfter",
+    options: {
+      description?: ReturnType<typeof html>;
+      placeholder?: string;
+      type?: "text" | "number";
+    } = {},
+  ) {
+    return renderSettingsRow({
+      title: t(`cloudWorkersPage.fields.${field}`),
+      description: options.description ?? t(`cloudWorkersPage.fields.${field}Help`),
+      control: html`<input
+        class="settings-input mono"
+        aria-label=${t(`cloudWorkersPage.fields.${field}`)}
+        placeholder=${options.placeholder ?? nothing}
+        type=${options.type ?? nothing}
+        min=${field === "readyWorkers" ? "0" : nothing}
+        step=${field === "readyWorkers" ? "1" : nothing}
+        autocomplete="off"
+        spellcheck="false"
+        .value=${this.draft[field]}
+        ?disabled=${this.configSave.state.busy}
+        @input=${(event: Event) => this.patchDraft({ [field]: formControlValue(event) })}
+      />`,
+    });
+  }
+
   private renderEditor() {
     if (!this.editor) {
       return nothing;
     }
-    const busy = this.busyProfileId !== null;
+    const busy = this.configSave.state.busy;
     const canSave = this.canManage();
     const editing = this.editor.kind === "edit";
     const operatingSystems = editing
@@ -424,20 +402,10 @@ class CloudWorkersPage extends OpenClawLightDomElement {
                 @input=${(event: Event) => this.patchDraft({ id: formControlValue(event) })}
               />`,
         }),
-        renderSettingsRow({
-          title: t("cloudWorkersPage.fields.backend"),
+        this.renderDraftInput("backend", {
           description: html`${t("cloudWorkersPage.fields.backendHelp")}
           ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("cloudWorkersPage.providerList"))}`,
-          control: html`<input
-            class="settings-input mono"
-            aria-label=${t("cloudWorkersPage.fields.backend")}
-            placeholder=${t("cloudWorkersPage.fields.backendPlaceholder")}
-            autocomplete="off"
-            spellcheck="false"
-            .value=${this.draft.backend}
-            ?disabled=${busy}
-            @input=${(event: Event) => this.patchDraft({ backend: formControlValue(event) })}
-          />`,
+          placeholder: t("cloudWorkersPage.fields.backendPlaceholder"),
         }),
         ...(operatingSystems.length >= 2 || unadvertisedTarget
           ? [
@@ -481,46 +449,12 @@ class CloudWorkersPage extends OpenClawLightDomElement {
               }),
             ]
           : []),
-        renderSettingsRow({
-          title: t("cloudWorkersPage.fields.machineClass"),
-          description: t("cloudWorkersPage.fields.machineClassHelp"),
-          control: html`<input
-            class="settings-input mono"
-            aria-label=${t("cloudWorkersPage.fields.machineClass")}
-            autocomplete="off"
-            spellcheck="false"
-            .value=${this.draft.machineClass}
-            ?disabled=${busy}
-            @input=${(event: Event) => this.patchDraft({ machineClass: formControlValue(event) })}
-          />`,
+        this.renderDraftInput("machineClass"),
+        this.renderDraftInput("ttl", {
+          placeholder: t("cloudWorkersPage.fields.ttlPlaceholder"),
         }),
-        renderSettingsRow({
-          title: t("cloudWorkersPage.fields.ttl"),
-          description: t("cloudWorkersPage.fields.ttlHelp"),
-          control: html`<input
-            class="settings-input mono"
-            aria-label=${t("cloudWorkersPage.fields.ttl")}
-            placeholder=${t("cloudWorkersPage.fields.ttlPlaceholder")}
-            autocomplete="off"
-            spellcheck="false"
-            .value=${this.draft.ttl}
-            ?disabled=${busy}
-            @input=${(event: Event) => this.patchDraft({ ttl: formControlValue(event) })}
-          />`,
-        }),
-        renderSettingsRow({
-          title: t("cloudWorkersPage.fields.idleTimeout"),
-          description: t("cloudWorkersPage.fields.idleTimeoutHelp"),
-          control: html`<input
-            class="settings-input mono"
-            aria-label=${t("cloudWorkersPage.fields.idleTimeout")}
-            placeholder=${t("cloudWorkersPage.fields.idleTimeoutPlaceholder")}
-            autocomplete="off"
-            spellcheck="false"
-            .value=${this.draft.idleTimeout}
-            ?disabled=${busy}
-            @input=${(event: Event) => this.patchDraft({ idleTimeout: formControlValue(event) })}
-          />`,
+        this.renderDraftInput("idleTimeout", {
+          placeholder: t("cloudWorkersPage.fields.idleTimeoutPlaceholder"),
         }),
         renderSettingsRow({
           title: t("cloudWorkersPage.fields.setup"),
@@ -544,19 +478,8 @@ class CloudWorkersPage extends OpenClawLightDomElement {
           disabled: busy,
           onChange: (desktop) => this.patchDraft({ desktop }),
         }),
-        renderSettingsRow({
-          title: t("cloudWorkersPage.fields.binary"),
-          description: t("cloudWorkersPage.fields.binaryHelp"),
-          control: html`<input
-            class="settings-input mono"
-            aria-label=${t("cloudWorkersPage.fields.binary")}
-            placeholder=${t("cloudWorkersPage.fields.binaryPlaceholder")}
-            autocomplete="off"
-            spellcheck="false"
-            .value=${this.draft.binary}
-            ?disabled=${busy}
-            @input=${(event: Event) => this.patchDraft({ binary: formControlValue(event) })}
-          />`,
+        this.renderDraftInput("binary", {
+          placeholder: t("cloudWorkersPage.fields.binaryPlaceholder"),
         }),
         renderSettingsSection({ title: t("cloudWorkersPage.advanced") }, [
           renderSettingsRow({
@@ -584,29 +507,14 @@ class CloudWorkersPage extends OpenClawLightDomElement {
             </select>`,
           }),
           ...(["setupEnv", "readyWorkers", "suspendAfter"] as const).map((field) =>
-            renderSettingsRow({
-              title: t(`cloudWorkersPage.fields.${field}`),
-              description: t(`cloudWorkersPage.fields.${field}Help`),
-              control: html`<input
-                class="settings-input mono"
-                aria-label=${t(`cloudWorkersPage.fields.${field}`)}
-                type=${field === "readyWorkers" ? "number" : "text"}
-                min=${field === "readyWorkers" ? "0" : nothing}
-                step=${field === "readyWorkers" ? "1" : nothing}
-                autocomplete="off"
-                spellcheck="false"
-                .value=${this.draft[field]}
-                ?disabled=${busy}
-                @input=${(event: Event) => this.patchDraft({ [field]: formControlValue(event) })}
-              />`,
-            }),
+            this.renderDraftInput(field, { type: field === "readyWorkers" ? "number" : "text" }),
           ),
         ]),
-        ...(this.formError
+        ...(this.configSave.state.error
           ? [
               renderSettingsRow({
                 title: t("cloudWorkersPage.errors.title"),
-                description: html`<span role="alert">${this.formError}</span>`,
+                description: html`<span role="alert">${this.configSave.state.error}</span>`,
               }),
             ]
           : []),
@@ -658,13 +566,13 @@ class CloudWorkersPage extends OpenClawLightDomElement {
           : nothing
       }
       ${
-        this.formError && !this.editor
-          ? html`<div class="callout warning" role="alert">${this.formError}</div>`
+        this.configSave.state.error && !this.editor
+          ? html`<div class="callout warning" role="alert">${this.configSave.state.error}</div>`
           : nothing
       }
       ${
-        this.notice
-          ? html`<div class="callout warning" role="status">${this.notice}</div>`
+        this.configSave.state.notice
+          ? html`<div class="callout warning" role="status">${this.configSave.state.notice}</div>`
           : nothing
       }
       ${renderSettingsSection(


### PR DESCRIPTION
## What Problem This Solves

The cloud-worker snapshot feature landed across #143801, #143814, #143838, #143893, and #143929 with repeated configuration-save state, profile input rendering, confirmation handling, and a separately maintained fixture row type. This is the requested maintainer consolidation of that combined surface.

## Why This Change Was Made

Share config-save presentation and patch completion across profiles, repositories, and retention policy while preserving caller connection/config identity and dispatch checks. Reuse profile input rendering and the confirmation AbortController lifecycle. Keep `cancelBuild` and `recoverCapture` explicit, with their existing payloads, acknowledgement, post-confirmation checks, notices, errors, and cleanup.

Share preparation predicates and the existing invalid-project response. Derive snapshot fixtures from the real view types and correct two settings-navigation paths. Every test and assertion remains; only duplicated fixture types and unconsumed fixture fields were removed.

## User Impact

No behavior, config, protocol, schema, retention, or translated-copy change is intended. Production code is 99 lines smaller and test support is 43 lines smaller. Snapshot request-state and concurrency redesign remains deferred; existing plugin and persistence owners retain their contracts.

## Evidence

- The coordinator completed review through P2 with no remaining actionable findings. The subsequent rebase onto `0f68d696c3cc9c93bb45048f8c72036e577490de` was conflict-free; range-diff confirmed all four commits are patch-identical.
- Post-rebase `pnpm exec oxlint` on the eight changed TypeScript files and `git diff --check` passed.
- Post-rebase `node scripts/run-vitest.mjs ui/src/pages/cloud-workers/ ui/src/e2e/cloud-workers-snapshots.e2e.test.ts` passed: 117 unit tests and four browser tests against the mock Gateway, including confirmation-gated cancellation and acknowledgement-gated recovery. No assertions changed.
- Coordinator validation before the patch-identical rebase passed 3,225 Gateway, UI, and provider-plugin tests; 12 settings/snapshot browser tests; changed-file checks; UI build/performance checks; and i18n verification. An unchanged workspace-publication test initially hit a child-close timeout, then passed focused and complete reruns without test changes.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34500846798 — passed on `2353cb2c3b84be37e73634081eb9c61fc84a3f3a`; the bounded watcher completed `GREEN` with zero pending checks.
- The author explicitly authorized this landing and the draft is now ready. The review bot found no introduced code defect; its outstanding coordinator-handoff item is satisfied by that instruction.
- A live provider build/pin/delete run and screenshots remain outside this landing's proof; the browser tests use the mock Gateway. The overlapping #144127 remains open and unmerged at the current check.
