### PR TITLE
fix(agents): clamp configured input caps to model windows

### DIFF
--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -72,7 +72,7 @@ function resolveProviderModelRef(params: {
 }
 
 /** Preserve shipped self-prefixed context refs after exact configured-row selection. */
-export function resolveConfiguredProviderModel(
+function resolveConfiguredProviderModel(
   cfg: OpenClawConfig | null | undefined,
   provider: string,
   model: string,
@@ -176,6 +176,59 @@ export function resolveAnthropicFixedContextWindow(
     : ANTHROPIC_CONTEXT_1M_TOKENS;
 }
 
+/** Resolves an authored cap without lowering it to discovered model metadata. */
+export function resolveConfiguredContextTokenLimits(
+  params: Pick<ContextTokenResolutionParams, "cfg" | "modelProvider"> & {
+    provider: string;
+    model: string;
+  },
+  // Guards require whole finite tokens; cache lookup retains its existing numeric projection.
+  normalize: (value: number | undefined) => number | null | undefined = (value) =>
+    typeof value === "number" && value > 0 ? value : undefined,
+): {
+  effectiveConfiguredTokens?: number;
+  configuredContextWindow?: number;
+  fixedContextWindow?: number;
+} {
+  const provider = params.provider.trim();
+  const model = params.model.trim();
+  const configuredModel = resolveConfiguredRuntimeModel(
+    params.cfg,
+    provider,
+    params.modelProvider,
+    model,
+  );
+  const extraParamSources = resolveModelExtraParamSources({
+    config: params.cfg,
+    provider: normalizeProviderId(provider),
+    modelId: model,
+  });
+  const effectiveContext1M =
+    extraParamSources.modelParams && Object.hasOwn(extraParamSources.modelParams, "context1m")
+      ? extraParamSources.modelParams.context1m
+      : extraParamSources.defaultParams?.context1m;
+  const fixedContextWindow = resolveAnthropicFixedContextWindow(
+    normalizeProviderId(provider),
+    model,
+    { claudeCli1M: effectiveContext1M === true },
+  );
+  const configuredContextTokens = normalize(configuredModel?.contextTokens) ?? undefined;
+  const configuredContextWindow = normalize(configuredModel?.contextWindow) ?? undefined;
+  // Fixed provider contracts deliberately ignore materialized catalog windows.
+  // Other runtimes must still keep an authored effective cap below its native window.
+  const configuredTokenLimit = fixedContextWindow ?? configuredContextWindow;
+  return {
+    configuredContextWindow,
+    fixedContextWindow,
+    effectiveConfiguredTokens:
+      configuredContextTokens === undefined
+        ? undefined
+        : configuredTokenLimit === undefined
+          ? configuredContextTokens
+          : Math.min(configuredContextTokens, configuredTokenLimit),
+  };
+}
+
 export function resolveContextTokensForModelFromCache(
   params: ContextTokenResolutionParams,
   lookupContextTokens: (modelId?: string) => number | undefined = lookupCachedContextTokens,
@@ -185,36 +238,15 @@ export function resolveContextTokensForModelFromCache(
   const explicitProvider = params.provider?.trim();
 
   if (ref && explicitProvider) {
-    const configuredModel = resolveConfiguredRuntimeModel(
-      params.cfg,
-      explicitProvider,
-      params.modelProvider,
-      ref.model,
-    );
-    const extraParamSources = resolveModelExtraParamSources({
-      config: params.cfg,
-      provider: ref.provider,
-      modelId: ref.model,
-    });
-    const effectiveContext1M =
-      extraParamSources.modelParams && Object.hasOwn(extraParamSources.modelParams, "context1m")
-        ? extraParamSources.modelParams.context1m
-        : extraParamSources.defaultParams?.context1m;
-    const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model, {
-      claudeCli1M: effectiveContext1M === true,
-    });
-    const configuredContextTokens = readAuthoredModelContextTokens(configuredModel);
-    const configuredContextWindow =
-      typeof configuredModel?.contextWindow === "number" && configuredModel.contextWindow > 0
-        ? configuredModel.contextWindow
-        : undefined;
-    // Fixed provider contracts deliberately ignore materialized catalog windows.
-    // Other runtimes must still keep an authored effective cap below its native window.
-    const configuredTokenLimit = fixedContextWindow ?? configuredContextWindow;
-    if (configuredContextTokens !== undefined) {
-      return configuredTokenLimit === undefined
-        ? configuredContextTokens
-        : Math.min(configuredContextTokens, configuredTokenLimit);
+    const { effectiveConfiguredTokens, configuredContextWindow, fixedContextWindow } =
+      resolveConfiguredContextTokenLimits({
+        cfg: params.cfg,
+        provider: explicitProvider,
+        modelProvider: params.modelProvider,
+        model: ref.model,
+      });
+    if (effectiveConfiguredTokens !== undefined) {
+      return effectiveConfiguredTokens;
     }
     if (fixedContextWindow !== undefined) {
       return fixedContextWindow;

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -113,6 +113,74 @@ describe("context-window-guard", () => {
     });
   });
 
+  it.each([
+    ["caps custom input by its native window", "custom", "tiny", 3_000, 16_000, 3_000],
+    ["keeps authored input above lower discovery", "custom", "tiny", 32_000, 16_000, 16_000],
+    [
+      "keeps a native-window override without an input cap",
+      "custom",
+      "tiny",
+      32_000,
+      undefined,
+      32_000,
+    ],
+    [
+      "ignores stale native metadata for fixed models",
+      "anthropic",
+      "claude-sonnet-4-6",
+      200_000,
+      350_000,
+      350_000,
+    ],
+    [
+      "caps input by the fixed provider window",
+      "anthropic",
+      "claude-sonnet-4-6",
+      200_000,
+      2_000_000,
+      1_000_000,
+    ],
+    [
+      "ignores a non-finite cap before fixed-window clamping",
+      "anthropic",
+      "claude-sonnet-4-6",
+      200_000,
+      Infinity,
+      200_000,
+    ],
+    ["ignores a sub-token native window", "custom", "tiny", 0.5, 16_000, 16_000],
+    ["keeps whole-token guard normalization", "custom", "tiny", 32_000.9, 16_000.9, 16_000],
+  ] as const)(
+    "resolves configured context limits (%s)",
+    (_case, provider, modelId, contextWindow, contextTokens, expected) => {
+      const configured = openRouterModelConfig({ contextWindow, contextTokens });
+      const providerConfig = configured.models.providers.openrouter;
+      const cfg = {
+        models: {
+          providers: {
+            [provider]: {
+              ...providerConfig,
+              models: providerConfig.models.map((model) =>
+                Object.assign({}, model, { id: modelId }),
+              ),
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+
+      expect(
+        resolveContextWindowInfo({
+          cfg,
+          provider,
+          modelId,
+          modelContextTokens: 8_000,
+          modelContextWindow: 8_000,
+          defaultTokens: 200_000,
+        }),
+      ).toEqual({ source: "modelsConfig", tokens: expected });
+    },
+  );
+
   it.each([false, true])("uses the exact row's context window (exact first=%s)", (exactFirst) => {
     const models = openRouterModelConfig({
       contextWindow: 128_000,

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -5,7 +5,7 @@
  * more actionable remediation text.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveConfiguredProviderModel } from "./context-resolution.js";
+import { resolveConfiguredContextTokenLimits } from "./context-resolution.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 
 export const CONTEXT_WINDOW_HARD_MIN_TOKENS = 4_000;
@@ -38,9 +38,12 @@ export function resolveContextWindowInfo(params: {
   modelContextWindow?: number;
   defaultTokens: number;
 }): ContextWindowInfo {
-  const match = resolveConfiguredProviderModel(params.cfg, params.provider, params.modelId);
+  const configured = resolveConfiguredContextTokenLimits(
+    { cfg: params.cfg, provider: params.provider, model: params.modelId },
+    normalizePositiveInt,
+  );
   const fromModelsConfig =
-    normalizePositiveInt(match?.contextTokens) ?? normalizePositiveInt(match?.contextWindow);
+    configured.effectiveConfiguredTokens ?? configured.configuredContextWindow;
   const fromModel =
     normalizePositiveInt(params.modelContextTokens) ??
     normalizePositiveInt(params.modelContextWindow);

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -40,6 +40,43 @@ describe("resolveCompactionContextTokenBudget", () => {
       expect(budget).toBe(expected);
     },
   );
+
+  it.each([
+    { requested: 16_000, expected: 3_000 },
+    { requested: 2_000, expected: 2_000 },
+  ])(
+    "caps requested=$requested by the authored native window despite a larger contextTokens cap",
+    ({ requested, expected }) => {
+      const budget = resolveCompactionContextTokenBudget({
+        config: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://models.example.test/v1",
+                models: [
+                  {
+                    id: "tiny-model",
+                    name: "Tiny model",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 3_000,
+                    contextTokens: 16_000,
+                    maxTokens: 256,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        provider: "custom",
+        modelId: "tiny-model",
+        model: modelWithWindow(3_000),
+        requestedTokenBudget: requested,
+      });
+      expect(budget).toBe(expected);
+    },
+  );
 });
 
 describe("resolveEmbeddedCompactionThinkingLevel", () => {

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -242,6 +242,48 @@ function createConfiguredModel(
 }
 
 describe("resolveEmbeddedRuntimeModelPolicy", () => {
+  it("rejects an authored context window below the floor despite a larger contextTokens cap", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example.test/v1",
+            models: [
+              createConfiguredModel({
+                id: "tiny-model",
+                name: "Tiny model",
+                contextWindow: 3_000,
+                contextTokens: 16_000,
+                maxTokens: 256,
+              }),
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(() =>
+      resolveEmbeddedRuntimeModelPolicy({
+        cfg,
+        provider: "custom",
+        modelId: "tiny-model",
+        runtimeModel: {
+          ...createRuntimeModel(),
+          provider: "custom",
+          id: "tiny-model",
+          name: "Tiny model",
+          baseUrl: "https://models.example.test/v1",
+          contextWindow: 3_000,
+          contextTokens: 16_000,
+          maxTokens: 256,
+        },
+        nativeModelOwned: false,
+      }),
+    ).toThrow(
+      "Model context window too small (3000 tokens; source=modelsConfig). Minimum is 4000.",
+    );
+  });
+
   it("can read Codex OAuth context overrides for native Codex harness runs", () => {
     const cfg = {
       models: {


### PR DESCRIPTION
Related: #144009, #124303

## What Problem This Solves

Fixes an issue where a configured input cap larger than a model's native context window could bypass the startup minimum and overstate its compaction budget. A custom model with a 3,000-token native window and a 16,000-token input cap was admitted with a 16,000-token budget.

## Why This Change Was Made

Share the existing configured-limit calculation between cache reporting and the runtime guard. Apply the configured or fixed provider ceiling before checking the minimum, while preserving exact model-row selection, omitted-cap behavior and explicit overrides above lower discovered metadata.

The shared owner retains each caller's numeric rules: the guard uses finite whole tokens, while cache reporting keeps its existing positive-number projection. The configuration schema permits positive fractional native windows.

## User Impact

Startup and compaction respect configured model ceilings. A native window below the supported minimum produces the existing actionable error even when its input cap is larger.

## Evidence

Eleven regression/control cases were executed once on the baseline: four failed and seven passed. The same cases then all passed with the production repair, alongside 20 existing controls for row selection, fixed windows, explicit overrides and caller budgets. Baseline routes were completed separately because the wrapper stopped after each failing route.

An initial static pass found a test-only map-spread lint issue. Replacing it with an equivalent fresh-object Object.assign mapping preserved the cases, assertions and all production bytes; all 29 final checks then passed. Runtime tests were not repeated solely for that syntax change. Independent review found no actionable findings.

Production adds 35 lines for the shared result and existing numeric rules; the row selector becomes private. Tests add 147 lines. The focused tests cover ordinary setup/compaction and metadata helpers. The additional CLI proof below exercises persisted configuration and real agent startup with a synthetic loopback provider.

### Config-loaded startup and saved-state continuity

Six runs used the supported `pnpm openclaw agent exec` entry point. Both pinned source versions built through the normal wrapper and loaded actual config files.

| Source and state | Native window / input cap | Result | Provider requests |
| --- | --- | --- | --- |
| Baseline, fresh | 3000 / 16000 | Completes incorrectly | 1 |
| Baseline, fresh control | 5000 / 16000 | Completes | 1 |
| Candidate, baseline-created state | 3000 / 16000 | Existing minimum-4000 error | 0 |
| Candidate, fresh | 3000 / 16000 | Same error | 0 |
| Candidate, baseline-created control state | 5000 / 16000 | Completes with effective `ctx=5000` | 1 |
| Candidate, fresh control | 5000 / 16000 | Completes with effective `ctx=5000` | 1 |

Config bytes stayed identical. The reused-state cases began with byte-identical baseline-created state, including SQLite databases. Successful runs returned the fixed mock response; rejected runs emitted the existing actionable floor error before any provider dispatch. All processes closed cleanly.

This verifies source/config startup and saved-state continuity, not npm installation, a released-package upgrade, Gateway service startup, or a live provider. Each process used isolated state and an environment allowlist, with outbound traffic restricted to the task-owned loopback provider.

The intentional behavior change is accepted on this evidence: an oversized input cap no longer masks an unsupported native window. The config format and saved config bytes are unchanged; operators receive the existing guidance to correct the model limit or select a larger model.
