### PR TITLE
fix(gateway): apply the session sharing predicate to session read-by-key RPCs

### DIFF
--- a/src/gateway/server-methods/session-read-visibility-boundary.ts
+++ b/src/gateway/server-methods/session-read-visibility-boundary.ts
@@ -1,0 +1,74 @@
+import type { ErrorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
+import {
+  authorizeIncognitoSessionTarget,
+  hiddenSessionNotFound,
+} from "../session-sharing-policy.js";
+import { createSessionReadVisibilityFilter } from "../session-sharing.js";
+import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+export type AdmittedSessionReadTarget = {
+  agentId: string;
+  canonicalKey: string;
+  sessionId: string | undefined;
+  storePath: string | undefined;
+};
+
+export function authorizeSessionReadTarget(params: {
+  canonicalKey: string;
+  cfg: OpenClawConfig;
+  client: GatewayClient | null;
+  entry: SessionEntry | undefined;
+  sessionKey: string;
+}): ErrorShape | null {
+  const incognitoError = authorizeIncognitoSessionTarget({
+    client: params.client,
+    sessionKey: params.sessionKey,
+    target: params.entry ? { canonicalKey: params.canonicalKey, entry: params.entry } : null,
+  });
+  if (incognitoError) {
+    return incognitoError;
+  }
+  const entryFilter = createSessionReadVisibilityFilter(params.client, params.cfg);
+  return params.entry && entryFilter && !entryFilter(params.canonicalKey, params.entry)
+    ? hiddenSessionNotFound(params.sessionKey)
+    : null;
+}
+
+export function revalidateSessionReadTarget(params: {
+  admitted: AdmittedSessionReadTarget;
+  client: GatewayClient | null;
+  context: GatewayRequestContext;
+  requestedAgentId?: string;
+  sessionKey: string;
+}): ErrorShape | null {
+  const cfg = params.context.getRuntimeConfig();
+  const requestedAgent = resolveRequestedSessionAgentId(
+    cfg,
+    params.sessionKey,
+    params.requestedAgentId,
+  );
+  if (!requestedAgent.ok || requestedAgent.agentId !== params.admitted.agentId) {
+    return hiddenSessionNotFound(params.sessionKey);
+  }
+  const current = loadGatewaySessionEntryReadOnly(params.sessionKey, {
+    ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+  });
+  if (
+    current.canonicalKey !== params.admitted.canonicalKey ||
+    current.storePath !== params.admitted.storePath ||
+    current.entry?.sessionId !== params.admitted.sessionId
+  ) {
+    return hiddenSessionNotFound(params.sessionKey);
+  }
+  return authorizeSessionReadTarget({
+    canonicalKey: current.canonicalKey,
+    cfg,
+    client: params.client,
+    entry: current.entry,
+    sessionKey: params.sessionKey,
+  });
+}

--- a/src/gateway/server-methods/sessions-diff.ts
+++ b/src/gateway/server-methods/sessions-diff.ts
@@ -13,6 +13,11 @@ import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-ke
 import { applySessionDiffBaseline, loadCheckoutDiff } from "../../sessions/session-diff.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
+import {
+  authorizeSessionReadTarget,
+  revalidateSessionReadTarget,
+  type AdmittedSessionReadTarget,
+} from "./session-read-visibility-boundary.js";
 import { loadRepositoryArtifactDiff } from "./session-repository-artifacts.js";
 import { resolveRepositoryWorkspaceAccess } from "./session-repository-workspace-access.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
@@ -95,7 +100,7 @@ export async function loadSessionDiff(
 }
 
 export const sessionsDiffHandlers: GatewayRequestHandlers = {
-  "sessions.diff": async ({ params, respond, context }) => {
+  "sessions.diff": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsDiffParams, "sessions.diff", respond)) {
       return;
     }
@@ -120,15 +125,44 @@ export const sessionsDiffHandlers: GatewayRequestHandlers = {
       respond(false, undefined, requestedAgent.error);
       return;
     }
-    respond(
-      true,
-      await loadSessionDiff(
-        {
-          ...params,
-          ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
-        },
-        context,
-      ),
+    const target = loadGatewaySessionEntryReadOnly(params.sessionKey, {
+      ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+    });
+    const admissionError = authorizeSessionReadTarget({
+      canonicalKey: target.canonicalKey,
+      cfg: context.getRuntimeConfig(),
+      client,
+      entry: target.entry,
+      sessionKey: params.sessionKey,
+    });
+    if (admissionError) {
+      respond(false, undefined, admissionError);
+      return;
+    }
+    const admitted: AdmittedSessionReadTarget = {
+      agentId: requestedAgent.agentId,
+      canonicalKey: target.canonicalKey,
+      sessionId: target.entry?.sessionId,
+      storePath: target.storePath,
+    };
+    const diff = await loadSessionDiff(
+      {
+        ...params,
+        ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+      },
+      context,
     );
+    const staleError = revalidateSessionReadTarget({
+      admitted,
+      client,
+      context,
+      ...(params.agentId ? { requestedAgentId: params.agentId } : {}),
+      sessionKey: params.sessionKey,
+    });
+    if (staleError) {
+      respond(false, undefined, staleError);
+      return;
+    }
+    respond(true, diff);
   },
 };

--- a/src/gateway/server-methods/sessions-files-visibility.test.ts
+++ b/src/gateway/server-methods/sessions-files-visibility.test.ts
@@ -1,0 +1,413 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+import { prepareSessionCreatorProfile } from "../session-creator.js";
+import { createProfileSessionEntryFilter } from "../session-sharing.js";
+import { sessionsDiffHandlers } from "./sessions-diff.js";
+import { sessionsFilesHandlers } from "./sessions-files.js";
+import {
+  assistantToolCall,
+  createVisibleMessagesMock,
+  prepareSessionFilesTest,
+  removeWorkspaceFixture,
+  visibleMessageEvent,
+} from "./sessions-files.test-support.js";
+import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+
+const hoisted = vi.hoisted(() => ({
+  execOpenPath: vi.fn(),
+  loadSessionEntry: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(),
+  resolveDefaultAgentId: vi.fn(),
+  readSessionTranscriptVisibleMessageDeltaCore: vi.fn(),
+}));
+
+vi.mock("./open-path.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./open-path.js")>()),
+  execOpenPath: hoisted.execOpenPath,
+}));
+
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
+  resolveAgentWorkspaceDir: hoisted.resolveAgentWorkspaceDir,
+  resolveDefaultAgentId: hoisted.resolveDefaultAgentId,
+}));
+
+vi.mock("../session-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../session-utils.js")>()),
+  loadSessionEntry: hoisted.loadSessionEntry,
+  loadGatewaySessionEntryReadOnly: hoisted.loadSessionEntry,
+}));
+
+vi.mock("../session-transcript-readers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../session-transcript-readers.js")>()),
+  readSessionTranscriptVisibleMessageDeltaCore:
+    hoisted.readSessionTranscriptVisibleMessageDeltaCore,
+}));
+
+const mockVisibleMessages = createVisibleMessagesMock(
+  hoisted.readSessionTranscriptVisibleMessageDeltaCore,
+);
+
+const SESSION_KEY = "agent:main:main";
+
+const cfg = { agents: { list: [{ id: "main", default: true }] } } as never;
+const rolesCfg = {
+  agents: { list: [{ id: "main", default: true }] },
+  gateway: {
+    roles: {
+      default: "limited",
+      definitions: {
+        limited: { sessions: { others: "view" }, agents: "*", scopes: ["operator.read"] },
+      },
+    },
+  },
+} as never;
+const restrictedRolesCfg = {
+  agents: { list: [{ id: "main", default: true }] },
+  gateway: {
+    roles: {
+      default: "limited",
+      definitions: {
+        limited: { sessions: { others: "none" }, agents: "*", scopes: ["operator.read"] },
+      },
+    },
+  },
+} as never;
+const INCOGNITO_SESSION_KEY = "agent:main:dashboard:incognito-probe";
+
+function operatorClient(profileId: string | undefined, scopes: string[]) {
+  return {
+    connId: `conn-${profileId ?? "anonymous"}`,
+    connect: {
+      role: "operator",
+      scopes,
+      client: { id: "openclaw-control-ui", mode: "operator", version: "1", platform: "linux" },
+    },
+    ...(profileId ? { authenticatedUserProfile: { profileId } } : {}),
+  } as never;
+}
+
+let ALICE: string;
+let BOB: string;
+let bobClient: unknown;
+let aliceClient: unknown;
+let adminClient: unknown;
+const unidentifiedClient = operatorClient(undefined, ["operator.read"]);
+
+async function invoke(
+  handlers: GatewayRequestHandlers,
+  method: string,
+  params: Record<string, unknown>,
+  client: unknown,
+  getRuntimeConfig: () => unknown = () => cfg,
+) {
+  const calls: { ok: boolean; payload?: unknown; error?: unknown }[] = [];
+  const respond: RespondFn = (ok, payload, error) => {
+    calls.push({ ok, payload, error });
+  };
+  await handlers[method]?.({
+    req: { type: "req", id: method, method, params: {} },
+    params,
+    client,
+    isWebchatConnect: () => false,
+    respond,
+    context: { getRuntimeConfig } as never,
+  } as never);
+  expect(calls).toHaveLength(1);
+  return calls[0] as { ok: boolean; payload?: any; error?: any };
+}
+
+function readSessionAs(
+  client: unknown,
+  getRuntimeConfig: () => unknown = () => cfg,
+  sessionKey: string = SESSION_KEY,
+) {
+  return {
+    list: () =>
+      invoke(
+        sessionsFilesHandlers,
+        "sessions.files.list",
+        { sessionKey },
+        client,
+        getRuntimeConfig,
+      ),
+    get: () =>
+      invoke(
+        sessionsFilesHandlers,
+        "sessions.files.get",
+        { sessionKey, path: "src/readme.md" },
+        client,
+        getRuntimeConfig,
+      ),
+    diff: () =>
+      invoke(sessionsDiffHandlers, "sessions.diff", { sessionKey }, client, getRuntimeConfig),
+  };
+}
+
+describe("session read-by-key visibility for sessions.files.* and sessions.diff", () => {
+  let workspaceRoot: string;
+  let home: TempHomeEnv;
+
+  beforeEach(async () => {
+    home = await createTempHomeEnv("openclaw-session-files-visibility-");
+    ALICE = ensureProfileForEmail("files-visibility-alice@example.test").id;
+    BOB = ensureProfileForEmail("files-visibility-bob@example.test").id;
+    aliceClient = operatorClient(ALICE, ["operator.read"]);
+    bobClient = operatorClient(BOB, ["operator.read"]);
+    adminClient = operatorClient(ensureProfileForEmail("files-visibility-admin@example.test").id, [
+      "operator.read",
+      "operator.admin",
+    ]);
+    workspaceRoot = prepareSessionFilesTest(hoisted, mockVisibleMessages);
+    hoisted.loadSessionEntry.mockReturnValue({
+      agentId: "main",
+      canonicalKey: SESSION_KEY,
+      cfg,
+      storePath: path.join(workspaceRoot, ".sessions.json"),
+      entry: {
+        sessionId: "sess-main",
+        sessionFile: "sess-main.jsonl",
+        spawnedCwd: workspaceRoot,
+        visibility: "draft",
+        createdActor: { type: "human", source: "profile", id: ALICE },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    removeWorkspaceFixture(workspaceRoot);
+    closeOpenClawStateDatabaseForTest();
+    await home.restore();
+  });
+
+  it("hides the fixture session from a non-creator under the shared sharing predicate", () => {
+    const entryFilter = createProfileSessionEntryFilter(
+      { profileId: BOB },
+      prepareSessionCreatorProfile(BOB, new Set<string>()),
+    );
+    expect(
+      entryFilter(SESSION_KEY, {
+        createdActor: { type: "human", source: "profile", id: ALICE },
+        visibility: "draft",
+      } as never),
+    ).toBe(false);
+  });
+
+  it("refuses sessions.files.list, sessions.files.get and sessions.diff for a non-creator under operator roles", async () => {
+    const bob = readSessionAs(bobClient, () => rolesCfg);
+
+    const list = await bob.list();
+    expect(list.ok).toBe(false);
+    expect(list.payload).toBeUndefined();
+    expect(String(list.error?.message)).toContain("was not found");
+
+    const get = await bob.get();
+    expect(get.ok).toBe(false);
+    expect(get.payload).toBeUndefined();
+
+    const diff = await bob.diff();
+    expect(diff.ok).toBe(false);
+    expect(diff.payload).toBeUndefined();
+  }, 600_000);
+
+  it("still serves the session creator under operator roles", async () => {
+    const alice = readSessionAs(aliceClient, () => rolesCfg);
+
+    const list = await alice.list();
+    expect(list.ok).toBe(true);
+    expect(list.payload?.root).toBe(workspaceRoot);
+    expect(list.payload?.files?.length).toBeGreaterThan(0);
+
+    const get = await alice.get();
+    expect(get.ok).toBe(true);
+    expect(get.payload?.file?.content).toBe("# Read me\n");
+
+    expect((await alice.diff()).ok).toBe(true);
+  }, 600_000);
+
+  it("still serves a gateway admin under operator roles", async () => {
+    const admin = readSessionAs(adminClient, () => rolesCfg);
+
+    expect((await admin.list()).payload?.root).toBe(workspaceRoot);
+    expect((await admin.get()).payload?.file?.content).toBe("# Read me\n");
+    expect((await admin.diff()).ok).toBe(true);
+  }, 600_000);
+
+  it("leaves an unidentified single-user gateway caller unaffected", async () => {
+    const owner = readSessionAs(unidentifiedClient);
+
+    expect((await owner.list()).payload?.root).toBe(workspaceRoot);
+    expect((await owner.get()).payload?.file?.content).toBe("# Read me\n");
+    expect((await owner.diff()).ok).toBe(true);
+  }, 600_000);
+
+  it("preserves foreign draft reads for an identified caller when no operator roles exist", async () => {
+    const bob = readSessionAs(bobClient);
+
+    const list = await bob.list();
+    expect(list.ok).toBe(true);
+    expect(list.payload?.root).toBe(workspaceRoot);
+    expect(list.payload?.files?.length).toBeGreaterThan(0);
+
+    const get = await bob.get();
+    expect(get.ok).toBe(true);
+    expect(get.payload?.file?.content).toBe("# Read me\n");
+
+    expect((await bob.diff()).ok).toBe(true);
+  }, 600_000);
+
+  it("still refuses an incognito session for an identified caller without operator roles", async () => {
+    hoisted.loadSessionEntry.mockReturnValue({
+      agentId: "main",
+      canonicalKey: INCOGNITO_SESSION_KEY,
+      cfg,
+      storePath: path.join(workspaceRoot, ".sessions.json"),
+      entry: {
+        sessionId: "sess-incognito",
+        sessionFile: "sess-incognito.jsonl",
+        spawnedCwd: workspaceRoot,
+        incognito: true,
+        createdActor: { type: "human", source: "profile", id: ALICE },
+      },
+    });
+    const bob = readSessionAs(bobClient, () => cfg, INCOGNITO_SESSION_KEY);
+
+    const list = await bob.list();
+    expect(list.ok).toBe(false);
+    expect(String(list.error?.message)).toContain("was not found");
+
+    expect((await bob.get()).ok).toBe(false);
+    expect((await bob.diff()).ok).toBe(false);
+  }, 600_000);
+
+  it("keeps the unknown-session response shape for a missing session", async () => {
+    hoisted.loadSessionEntry.mockReturnValue({
+      agentId: "main",
+      canonicalKey: SESSION_KEY,
+      cfg,
+      storePath: undefined,
+      entry: undefined,
+    });
+
+    const bob = readSessionAs(bobClient, () => rolesCfg);
+    const list = await bob.list();
+    expect(list.ok).toBe(true);
+    expect(list.payload?.files).toEqual([]);
+
+    const get = await bob.get();
+    expect(get.ok).toBe(false);
+    expect(get.error?.details?.path).toBe("src/readme.md");
+  }, 600_000);
+
+  describe("authority lifetime across the asynchronous read", () => {
+    let liveEntry: Record<string, unknown>;
+    let liveCfg: unknown;
+
+    function sharedEntry(sessionId: string, visibility: string) {
+      return {
+        sessionId,
+        sessionFile: `${sessionId}.jsonl`,
+        spawnedCwd: workspaceRoot,
+        visibility,
+        createdActor: { type: "human", source: "profile", id: ALICE },
+      };
+    }
+
+    function transcriptPage(hasMore: boolean) {
+      return {
+        kind: "page",
+        cursor: hasMore ? "visible-messages-page-1" : "visible-messages-final",
+        events: hasMore
+          ? [visibleMessageEvent(assistantToolCall("read", { path: "src/readme.md" }), 1)]
+          : [],
+        hasMore,
+        serializedBytes: 100,
+      };
+    }
+
+    function armChangeDuringRead(change: () => void) {
+      let fired = false;
+      const fire = () => {
+        if (fired) {
+          return;
+        }
+        fired = true;
+        change();
+      };
+      let pages = 0;
+      hoisted.readSessionTranscriptVisibleMessageDeltaCore.mockImplementation(() => {
+        pages += 1;
+        if (pages === 1) {
+          return transcriptPage(true);
+        }
+        fire();
+        return transcriptPage(false);
+      });
+      let loads = 0;
+      hoisted.loadSessionEntry.mockImplementation(() => {
+        loads += 1;
+        if (loads === 2) {
+          fire();
+        }
+        return {
+          agentId: "main",
+          canonicalKey: SESSION_KEY,
+          cfg,
+          storePath: path.join(workspaceRoot, ".sessions.json"),
+          entry: liveEntry,
+        };
+      });
+    }
+
+    async function readWhile(read: "list" | "get" | "diff", change: () => void) {
+      liveEntry = sharedEntry("sess-main", "shared");
+      liveCfg = rolesCfg;
+      armChangeDuringRead(change);
+      return await readSessionAs(bobClient, () => liveCfg)[read]();
+    }
+
+    it("serves a shared session that stays visible for the whole read", async () => {
+      for (const read of ["list", "get", "diff"] as const) {
+        const response = await readWhile(read, () => {});
+        expect(response.ok, read).toBe(true);
+        expect(response.error, read).toBeUndefined();
+      }
+    }, 600_000);
+
+    it("suppresses the payload when the session becomes a draft during the read", async () => {
+      for (const read of ["list", "get", "diff"] as const) {
+        const response = await readWhile(read, () => {
+          liveEntry = sharedEntry("sess-main", "draft");
+        });
+        expect(response.ok, read).toBe(false);
+        expect(response.payload, read).toBeUndefined();
+        expect(String(response.error?.message), read).toContain("was not found");
+      }
+    }, 600_000);
+
+    it("suppresses the payload when the caller role is restricted during the read", async () => {
+      for (const read of ["list", "get", "diff"] as const) {
+        const response = await readWhile(read, () => {
+          liveCfg = restrictedRolesCfg;
+        });
+        expect(response.ok, read).toBe(false);
+        expect(response.payload, read).toBeUndefined();
+        expect(String(response.error?.message), read).toContain("was not found");
+      }
+    }, 600_000);
+
+    it("suppresses the payload when the same key is replaced during the read", async () => {
+      for (const read of ["list", "get", "diff"] as const) {
+        const response = await readWhile(read, () => {
+          liveEntry = sharedEntry("sess-main-replacement", "shared");
+        });
+        expect(response.ok, read).toBe(false);
+        expect(response.payload, read).toBeUndefined();
+        expect(String(response.error?.message), read).toContain("was not found");
+      }
+    }, 600_000);
+  });
+});

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -31,9 +31,19 @@ import {
   resolveOpenPathCommand,
   sanitizePathForLog,
 } from "./open-path.js";
+import {
+  authorizeSessionReadTarget,
+  revalidateSessionReadTarget,
+  type AdmittedSessionReadTarget,
+} from "./session-read-visibility-boundary.js";
 import { getRepositoryArtifact, listRepositoryArtifacts } from "./session-repository-artifacts.js";
 import { resolveRepositoryWorkspaceAccess } from "./session-repository-workspace-access.js";
-import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+  RespondFn,
+} from "./types.js";
 import { assertValidParams } from "./validation.js";
 import {
   getSessionWorkspaceFile,
@@ -293,17 +303,40 @@ export function resolveLocalSessionWorkspaceRoot(params: {
   return loaded.entry?.execNode ? undefined : loaded.root;
 }
 
-async function loadSessionFiles(params: {
+async function loadVisibleSessionFiles(params: {
   sessionKey: string;
-  agentId?: string;
+  agentId: string;
+  client: GatewayClient | null;
+  respond: RespondFn;
   context: GatewayRequestContext;
 }): Promise<
-  LoadedSessionFiles & { repository?: ReturnType<typeof resolveRepositoryWorkspaceAccess> }
+  | (LoadedSessionFiles & {
+      admitted: AdmittedSessionReadTarget;
+      repository?: ReturnType<typeof resolveRepositoryWorkspaceAccess>;
+    })
+  | undefined
 > {
   const loaded = loadSessionFileRoot(params);
   const { storePath, entry, canonicalKey, agentId } = loaded;
+  const admissionError = authorizeSessionReadTarget({
+    canonicalKey,
+    cfg: params.context.getRuntimeConfig(),
+    client: params.client,
+    entry,
+    sessionKey: params.sessionKey,
+  });
+  if (admissionError) {
+    params.respond(false, undefined, admissionError);
+    return undefined;
+  }
+  const admitted: AdmittedSessionReadTarget = {
+    agentId: params.agentId,
+    canonicalKey,
+    sessionId: entry?.sessionId,
+    storePath,
+  };
   if (!entry?.sessionId || !storePath || !agentId) {
-    return { files: [] };
+    return { admitted, files: [] };
   }
   const repository = resolveRepositoryWorkspaceAccess(loaded, params.context);
   const scope = {
@@ -321,6 +354,7 @@ async function loadSessionFiles(params: {
     `${agentId}\0${entry.sessionId}\0${target.storePath ?? ""}`,
   );
   return {
+    admitted,
     repository,
     root: loaded.root,
     fileRoot: loaded.fileRoot,
@@ -384,7 +418,7 @@ function requireSessionFilesAgentId(params: {
 
 /** Gateway handlers for session files and workspace browsing. */
 export const sessionsFilesHandlers: GatewayRequestHandlers = {
-  "sessions.files.list": async ({ params, respond, context }) => {
+  "sessions.files.list": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(params, validateSessionsFilesListParams, "sessions.files.list", respond)
     ) {
@@ -399,7 +433,10 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
     if (!agentId) {
       return;
     }
-    const loaded = await loadSessionFiles({ ...params, agentId, context });
+    const loaded = await loadVisibleSessionFiles({ ...params, agentId, client, respond, context });
+    if (!loaded) {
+      return;
+    }
     const request = { files: loaded.files, path: params.path, search: params.search };
     const result =
       loaded.repository?.kind === "stored"
@@ -407,13 +444,24 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
         : loaded.repository
           ? await loaded.repository.inspect("list", request)
           : await listSessionWorkspaceFiles({ ...loaded, ...request });
+    const staleError = revalidateSessionReadTarget({
+      admitted: loaded.admitted,
+      client,
+      context,
+      ...(params.agentId ? { requestedAgentId: params.agentId } : {}),
+      sessionKey: params.sessionKey,
+    });
+    if (staleError) {
+      respond(false, undefined, staleError);
+      return;
+    }
     respond(true, {
       sessionKey: params.sessionKey,
       ...result,
       ...(loaded.repository ? { root: undefined } : {}),
     });
   },
-  "sessions.files.get": async ({ params, respond, context }) => {
+  "sessions.files.get": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsFilesGetParams, "sessions.files.get", respond)) {
       return;
     }
@@ -426,7 +474,10 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
     if (!agentId) {
       return;
     }
-    const loaded = await loadSessionFiles({ ...params, agentId, context });
+    const loaded = await loadVisibleSessionFiles({ ...params, agentId, client, respond, context });
+    if (!loaded) {
+      return;
+    }
     const request = { files: loaded.files, path: params.path };
     const result =
       loaded.repository?.kind === "stored"
@@ -434,6 +485,17 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
         : loaded.repository
           ? await loaded.repository.inspect("get", request)
           : await getSessionWorkspaceFile({ ...loaded, ...request });
+    const staleError = revalidateSessionReadTarget({
+      admitted: loaded.admitted,
+      client,
+      context,
+      ...(params.agentId ? { requestedAgentId: params.agentId } : {}),
+      sessionKey: params.sessionKey,
+    });
+    if (staleError) {
+      respond(false, undefined, staleError);
+      return;
+    }
     if (!result.file || result.file.missing) {
       respondSessionFileNotFound(respond, params.path);
       return;

--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -1,8 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { validateSessionsDescribeParams } from "../../../packages/gateway-protocol/src/index.js";
-import { hasOperatorBoundary } from "../operator-role-policy.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
-import { createSessionListEntryFilter } from "../session-sharing.js";
+import { createSessionReadVisibilityFilter } from "../session-sharing.js";
 import { readRecentSessionMessagesWithStatsAsync } from "../session-transcript-readers.js";
 import { buildSessionListRowMetadataContext } from "../session-utils-projection.js";
 import { createGatewaySessionEntryReader } from "../session-utils-store-lookup.js";
@@ -12,15 +11,6 @@ import { readSessionPlacementFields } from "./session-placement-read-projection.
 import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-function createRoleVisibilityFilter(
-  client: Parameters<typeof hasOperatorBoundary>[0],
-  cfg: Parameters<typeof hasOperatorBoundary>[1],
-) {
-  return hasOperatorBoundary(client, cfg)
-    ? createSessionListEntryFilter({ client, cfg })
-    : undefined;
-}
 
 export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
   "sessions.describe": async ({ params, respond, context, client }) => {
@@ -56,7 +46,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       includeStoreChildEntries: true,
       ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
     });
-    const boundaryFilter = createRoleVisibilityFilter(client, cfg);
+    const boundaryFilter = createSessionReadVisibilityFilter(client, cfg);
     if (!entry || boundaryFilter?.(target.canonicalKey, entry) === false) {
       respond(true, { session: null }, undefined);
       return;
@@ -119,7 +109,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       cfg,
       agentId: requestedAgent.agentId,
     });
-    const boundaryFilter = createRoleVisibilityFilter(client, cfg);
+    const boundaryFilter = createSessionReadVisibilityFilter(client, cfg);
     if (!entry?.sessionId || boundaryFilter?.(target.canonicalKey, entry) === false) {
       respond(true, { messages: [] }, undefined);
       return;
@@ -152,7 +142,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
           agentId: currentRequestedAgent.agentId,
         })
       : null;
-    const currentBoundaryFilter = createRoleVisibilityFilter(client, currentCfg);
+    const currentBoundaryFilter = createSessionReadVisibilityFilter(client, currentCfg);
     if (
       !current ||
       current.target.agentId !== target.agentId ||

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -238,7 +238,7 @@ export function isResolvedIncognitoSession(params: {
 export function authorizeIncognitoSessionTarget(params: {
   client: GatewayClient | null;
   sessionKey: string;
-  target: SessionSharingTarget | null;
+  target: Pick<SessionSharingTarget, "canonicalKey" | "entry"> | null;
 }): ErrorShape | null {
   if (!isIncognitoSessionTarget(params)) {
     return null;

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isIncognitoSessionKey } from "../routing/session-key.js";
 import {
   authorizeGatewaySessionCreation,
+  hasOperatorBoundary,
   operatorSessionCap,
   resolveGatewayOperatorRoleActor,
 } from "./operator-role-policy.js";
@@ -574,6 +575,15 @@ export function createSessionListEntryFilter(
   }
   const sessionCap = params.cfg ? operatorSessionCap(params.client, params.cfg) : undefined;
   return createProfileSessionEntryFilter({ profileId: identity.id, sessionCap }, isCreator);
+}
+
+export function createSessionReadVisibilityFilter(
+  client: GatewayClient | null,
+  cfg: OpenClawConfig,
+): ReturnType<typeof createSessionListEntryFilter> {
+  return hasOperatorBoundary(client, cfg)
+    ? createSessionListEntryFilter({ client, cfg })
+    : undefined;
 }
 
 export function createProfileSessionEntryFilter(


### PR DESCRIPTION
## Summary

On a multi-identity Gateway, `sessions.files.list`, `sessions.files.get` and `sessions.diff` serve another person's `draft` session to any identified operator holding `operator.read`, as long as that caller can name the session key. `sessions.list` hides the same session from the same caller, and every sibling read-by-key surface refuses it.

Trigger condition: `gateway.roles` configured, a session whose `visibility` is `draft` and whose `createdActor` profile differs from the caller's `authenticatedUserProfile.profileId`, and a non-incognito session key.

What the caller receives today:

- `sessions.files.list` returns the touched-file inventory plus `root`, the absolute filesystem path of the other person's checkout, and with `path`/`search` an arbitrary directory listing under it.
- `sessions.files.get` returns the file body as a string plus its SHA-256, for any path under that root, up to the 256 KiB preview cap.
- `sessions.diff` returns the full checkout diff including uncommitted working-tree changes.

Scope note: keys are not handed out, since drafts are excluded from `sessions.list`. But keys are guessable (`agent:main:main` and channel-derived forms), and a session that was visible before its owner switched it to `draft` leaves its key already known.

Single-user Gateways are unaffected: their caller resolves to `GATEWAY_OWNER_PROFILE_ID`, `sharingIdentity` returns `undefined`, and the predicate is never built.

## Root cause

OpenClaw has exactly one predicate that decides whether an identified operator may see a given session by key, `createSessionListEntryFilter` / `createProfileSessionEntryFilter` in `src/gateway/session-sharing.ts`. Its final clause is the only place drafts are excluded for non-creators anywhere in the tree:

```ts
// the shared predicate, unchanged by this PR
  return (sessionKey, entry) =>
    entry.incognito !== true &&
    !isIncognitoSessionKey(sessionKey) &&
    (creatorMatches(entry.createdActor) ||
      (params.sessionCap !== "none" && resolveSessionVisibility(entry) !== "draft"));
```

The three handlers never bind `client`, so they can never call it. They are also absent from `SESSION_TARGET_FIELDS_BY_METHOD` (`src/gateway/session-method-policy.ts`), so the router's session fence resolves `targetRefs` to `undefined` and returns `{ error: null }` without ever reaching `authorizeSessionSharingTarget`.

The pre-dispatch fence still scrapes `sessionKey` through `resolveDirectSessionTargets`, which is why incognito-keyed sessions and roles with `sessions.others: "none"` stay protected. A `draft` session owned by a different profile is caught by neither path.

Note that the write sibling in the same file, `sessions.files.set`, does take `sessionMutationAuthorization` and use it. Only the reads are open.

## Fix

Apply the same predicate at the same boundary the merged exact-key read repair #136900 already established, so these three RPCs match `sessions.get` and `sessions.describe` exactly rather than inventing a stricter rule.

That boundary was a private helper in `sessions-read-by-key.ts`. This PR promotes it to the module that owns the predicate and routes all five read RPCs through the single definition, so the two cannot drift apart later:

```ts
// after: src/gateway/session-sharing.ts
export function createSessionReadVisibilityFilter(
  client: GatewayClient | null,
  cfg: OpenClawConfig,
): ReturnType<typeof createSessionListEntryFilter> {
  return hasOperatorBoundary(client, cfg)
    ? createSessionListEntryFilter({ client, cfg })
    : undefined;
}
```

`sessions-read-by-key.ts` drops its local copy and imports this one. The behavior there is unchanged, expression for expression.

The read admission for these three RPCs, plus the post-read recheck described in the next section, now live in one owner, `src/gateway/server-methods/session-read-visibility-boundary.ts`. Incognito is role independent, matching what `sessions.search` already does in `sessions-read.ts`; draft filtering is gated on the operator-role boundary:

```ts
// after: src/gateway/server-methods/session-read-visibility-boundary.ts
export function authorizeSessionReadTarget(params: {
  canonicalKey: string;
  cfg: OpenClawConfig;
  client: GatewayClient | null;
  entry: SessionEntry | undefined;
  sessionKey: string;
}): ErrorShape | null {
  const incognitoError = authorizeIncognitoSessionTarget({
    client: params.client,
    sessionKey: params.sessionKey,
    target: params.entry ? { canonicalKey: params.canonicalKey, entry: params.entry } : null,
  });
  if (incognitoError) {
    return incognitoError;
  }
  const entryFilter = createSessionReadVisibilityFilter(params.client, params.cfg);
  return params.entry && entryFilter && !entryFilter(params.canonicalKey, params.entry)
    ? hiddenSessionNotFound(params.sessionKey)
    : null;
}
```

`sessions.diff` and the single point both `sessions.files.*` handlers funnel through each call this once before any awaited work.

Why this is correct:

- `hiddenSessionNotFound` is the existing refusal for exactly this case and is already used by `chat-history-handler.ts`. The caller cannot distinguish a hidden session from an absent one, which is the intended behavior.
- The draft guard is conditional on `loaded.entry`, so a genuinely unknown session keeps its current response byte for byte: `sessions.files.list` still answers `ok: true` with an empty inventory, `sessions.files.get` still answers `session_file_not_found`, and `sessions.diff` still answers `unknown_session`.
- `createSessionReadVisibilityFilter` returns `undefined` for a Gateway admin, for an unidentified single-user caller, and for any identified caller on a Gateway with no `gateway.roles`, so all three keep their current access with no extra work.
- Admission runs before the transcript fold and before any workspace read, so a refused caller costs one store read rather than a full touched-files pass.

## Authority lifetime across the asynchronous read

Admission alone was not sufficient, and the previous revision stopped there. All three RPCs decided visibility, then awaited real work before answering: `sessions.files.*` await the SQLite touched-files fold and then a workspace listing or file read, and `sessions.diff` awaits `loadSessionDiff`, which shells out to git. A caller admitted while the session was `shared` still received the payload if, during that window, the session became a `draft`, its role was narrowed, or the same key was replaced by a different session. `AGENTS.md` states the rule this violated: revalidate after awaited work and immediately before the side effect.

The sibling already had the answer. `sessions.get` rechecks after `readRecentSessionMessagesWithStatsAsync` by reloading the runtime config and the canonical target, comparing identity, and re-applying the current predicate. This PR reuses that shape rather than inventing a second mechanism, in the same owner as the admission check:

```ts
// after: src/gateway/server-methods/session-read-visibility-boundary.ts
export function revalidateSessionReadTarget(params: {
  admitted: AdmittedSessionReadTarget;
  client: GatewayClient | null;
  context: GatewayRequestContext;
  requestedAgentId?: string;
  sessionKey: string;
}): ErrorShape | null {
  const cfg = params.context.getRuntimeConfig();
  const requestedAgent = resolveRequestedSessionAgentId(
    cfg,
    params.sessionKey,
    params.requestedAgentId,
  );
  if (!requestedAgent.ok || requestedAgent.agentId !== params.admitted.agentId) {
    return hiddenSessionNotFound(params.sessionKey);
  }
  const current = loadGatewaySessionEntryReadOnly(params.sessionKey, {
    ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
  });
  if (
    current.canonicalKey !== params.admitted.canonicalKey ||
    current.storePath !== params.admitted.storePath ||
    current.entry?.sessionId !== params.admitted.sessionId
  ) {
    return hiddenSessionNotFound(params.sessionKey);
  }
  return authorizeSessionReadTarget({
    canonicalKey: current.canonicalKey,
    cfg,
    client: params.client,
    entry: current.entry,
    sessionKey: params.sessionKey,
  });
}
```

Placement: `sessions.files.list` and `sessions.files.get` call it after the workspace read resolves and before any response is built, so the too-large and not-found branches are behind it too. `sessions.diff` calls it after `loadSessionDiff` returns and before `respond`. The admitted snapshot carries the resolved agent id, the canonical key, the store path and the session id, so a re-resolved agent, a relocated store, or a replaced session id all read as stale.

A read whose authority is unchanged is unaffected: the recheck costs one more store read on the success path, and the payload is returned exactly as before.

## Compatibility

This keeps the resolution of the earlier blocking review finding: the predicate is still constructed only behind `hasOperatorBoundary`, so identified callers on Gateways with no `gateway.roles` are not newly restricted, at admission or at the recheck.

- **Identified caller, no `gateway.roles`.** Unchanged from current main and from v2026.9.3. `hasOperatorBoundary` is false, no filter is built, and the caller keeps listings, file bodies and diffs for a foreign draft. This is the mode #136900 deliberately preserved for `sessions.get` and `sessions.describe`, with an identified `no roles` row in its regression matrix. These three RPCs now honor the same row.
- **Identified caller, `gateway.roles` configured.** Foreign drafts are refused, which is the defect being fixed and matches the sibling exact-key reads.
- **Gateway admin and unidentified single-user caller.** Unchanged, the predicate returns `undefined` for both.
- **Incognito sessions.** Refused for identified non-admin callers regardless of roles, through `authorizeIncognitoSessionTarget`. This is the one deliberate tightening, and it is not new policy: it is the same role-independent check `sessions.search` already applies in `sessions-read.ts`. Retaining it was requested in review.
- **Same-key replacement and store relocation.** Previously these produced a payload derived from one session identity and labeled with the requested key. They now refuse rather than answer with a mixed-identity result.

## Why this is the right boundary

The handler owns the read visibility check. That is not an opinion about layering, it is the arrangement the rest of the codebase already uses. Every other session read-by-key surface applies this predicate in its own handler:

1. `sessions.get` and `sessions.describe` at `src/gateway/server-methods/sessions-read-by-key.ts`, through the helper this PR promotes, including the post-read recheck this PR mirrors.
2. `chat.history` at `src/gateway/server-methods/chat-history-handler.ts`, responding `hiddenSessionNotFound(canonicalKey)`.
3. `controlUi.sessionPreview` at `src/gateway/server-methods/control-ui.ts`, whose comment states the invariant outright: "Hover previews must not reveal more than sessions.list: apply the same incognito/draft sharing predicate so a member cannot preview-by-key a session the sidebar hides from them."
4. `artifacts.*` at `src/gateway/server-methods/artifacts-session-resolution.ts`, same `operator.read`, same session-keyed shape.
5. `sessions.usage*` at `src/gateway/server-methods/usage.ts`.
6. `cron.*` at `src/gateway/server-methods/cron.ts`.
7. `projects.list` at `src/gateway/server-methods/projects.ts`.
8. HTTP `/sessions/:key/history` at `src/gateway/sessions-history-http.ts`, which synthesizes a client from request auth rather than skipping the check.

The policy table is the wrong lever. Adding these methods to `SESSION_TARGET_FIELDS_BY_METHOD` drives the mutation gate `authorizeSessionSharingTarget`, which returns participation-required errors. Applying a mutation-participation error to a read is semantically wrong and would break legitimate read access to `read-only` and `suggest` sessions. The codebase says so itself: `READ_ONLY_SESSION_TARGET_METHODS` exists precisely to exempt read methods from that gate. Reads carry their own visibility check in the handler, which is what this patch adds.

Deliberate follow-ups, not fixed here: `board.get` and `session.discussion.info` share the same defect but have different owners and different risk profiles, and each deserves its own change.

On framing: `docs/concepts/multi-user.md` says draft visibility "is a coordination feature, not a security boundary." I agree, and this is not filed as a security fix. The argument that survives that sentence is consistency. The same page states that "Catalog listings and progress updates recheck current session visibility for each recipient," and the `control-ui.ts` comment states the same rule for by-key reads. Eight surfaces honor it. These three do not, and they happen to carry the highest-value payload of the set: a checkout path, file contents, and an uncommitted diff. Severity P2.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-files-visibility.test.ts` on the patched tree: 1 file passed, 12 tests passed.
- The same file with only the three revalidation call sites reverted to the previous revision: 3 failed, 9 passed. The three failures are exactly the new transitions, so they fail on the original defect.
- Regression coverage in that file: role-enabled refusal across all three methods, identified no-role compatibility, incognito refusal without roles, the creator, a Gateway admin, an unidentified single-user caller, the shared predicate itself, the unchanged response shape for a genuinely missing session, a control case where the session stays visible for the whole read, and the three concurrent transitions (visibility revoked to draft, caller role narrowed, same key replaced) applied to each of the three RPCs.
- `oxfmt --check` on the four changed files: clean. `git diff --check`: clean.
- Remaining lint, typecheck and full-suite gates are delegated to GitHub CI on this head.

## Real behavior proof
Behavior addressed: an identified `operator.read` caller who is not the session creator can read another person's `draft` session checkout path, file contents and uncommitted diff by naming its session key on a Gateway with `gateway.roles` configured, and a caller admitted while the session was shared can still receive that payload after the session becomes a draft, after its role is narrowed, or after the same key is replaced during the asynchronous read.
Real environment tested: the real `sessionsFilesHandlers` and `sessionsDiffHandlers` exports, the real `createSessionReadVisibilityFilter` / `createSessionListEntryFilter` / `createProfileSessionEntryFilter` predicate, the real `hasOperatorBoundary` role policy reading real `gateway.roles` config, the real `loadGatewaySessionEntryReadOnly` store reader, the real `replaceSessionEntry` writer, the real `persistSessionTranscriptTurn` transcript writer and the real `ensureProfileForEmail` profile store, driven on pristine main 1a2e8cddfcdc7b810b26a19776d66c826fb0dcdf, then on the previous revision 99eb58a76b766fd87e8a94ee184139ec1c64ed34, then on this head 3f2b6a2be4ef7ee28fc4c62c95ec312a23dabebc, with identical inputs and the same state database across all three runs. The caller was a real `GatewayClient` carrying a real profile id, the session checkout was a real git repository with one committed file and one uncommitted edit, and the concurrent change was applied to the real session store and the real runtime config while the handler promise was in flight, after the handler had already admitted the caller and yielded on its first await. Nothing on the authorization path was substituted; only the surrounding process was isolated, with `HOME` and `OPENCLAW_STATE_DIR` pointed at a scratch directory.
Exact steps or command run after this patch: create a git checkout holding `src/readme.md`, commit it, append an uncommitted line, write a `visibility: "shared"` session entry for `agent:main:proof-alpha` owned by another profile through `replaceSessionEntry`, seed one assistant tool-call turn through `persistSessionTranscriptTurn`, then for each of `sessions.files.list`, `sessions.files.get` and `sessions.diff` start the handler, apply one change while it is in flight (nothing, the session made a draft, the role narrowed to `sessions.others: "none"`, or the same key replaced by a different session id), await the response, and print it; repeat the whole matrix against pristine main, against the previous revision, and against this head.
Evidence after fix:
```
# BEFORE (pristine main 1a2e8cddfcdc)
[base 1a2e8cddfcdc] shared session, no change during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[base 1a2e8cddfcdc] shared session, no change during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[base 1a2e8cddfcdc] shared session, no change during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[base 1a2e8cddfcdc] foreign draft session, no change during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[base 1a2e8cddfcdc] foreign draft session, no change during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[base 1a2e8cddfcdc] foreign draft session, no change during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[base 1a2e8cddfcdc] shared session made a draft during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[base 1a2e8cddfcdc] shared session made a draft during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[base 1a2e8cddfcdc] shared session made a draft during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[base 1a2e8cddfcdc] caller role narrowed to none during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[base 1a2e8cddfcdc] caller role narrowed to none during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[base 1a2e8cddfcdc] caller role narrowed to none during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[base 1a2e8cddfcdc] same key replaced during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[base 1a2e8cddfcdc] same key replaced during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[base 1a2e8cddfcdc] same key replaced during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0

# MIDDLE (previous revision 99eb58a76b76, admission-only guard, identical inputs)
[admission-only 99eb58a76b76] shared session, no change during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[admission-only 99eb58a76b76] shared session, no change during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[admission-only 99eb58a76b76] shared session, no change during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[admission-only 99eb58a76b76] foreign draft session, no change during the read | sessions.files.list -> refused: Session "agent:main:proof-alpha" was not found.
[admission-only 99eb58a76b76] foreign draft session, no change during the read | sessions.files.get -> refused: Session "agent:main:proof-alpha" was not found.
[admission-only 99eb58a76b76] foreign draft session, no change during the read | sessions.diff -> refused: Session "agent:main:proof-alpha" was not found.
[admission-only 99eb58a76b76] shared session made a draft during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[admission-only 99eb58a76b76] shared session made a draft during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[admission-only 99eb58a76b76] shared session made a draft during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[admission-only 99eb58a76b76] caller role narrowed to none during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[admission-only 99eb58a76b76] caller role narrowed to none during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[admission-only 99eb58a76b76] caller role narrowed to none during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[admission-only 99eb58a76b76] same key replaced during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[admission-only 99eb58a76b76] same key replaced during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[admission-only 99eb58a76b76] same key replaced during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0

# AFTER (this patch, head 3f2b6a2be4ef, identical inputs)
[head 3f2b6a2be4ef] shared session, no change during the read | sessions.files.list -> served: root=/tmp/oc-144169-workspace files=[src/readme.md]
[head 3f2b6a2be4ef] shared session, no change during the read | sessions.files.get -> served: body="# alpha\nsecret roadmap line\n"
[head 3f2b6a2be4ef] shared session, no change during the read | sessions.diff -> served: changed=[src/readme.md] additions=1 deletions=0
[head 3f2b6a2be4ef] foreign draft session, no change during the read | sessions.files.list -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] foreign draft session, no change during the read | sessions.files.get -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] foreign draft session, no change during the read | sessions.diff -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] shared session made a draft during the read | sessions.files.list -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] shared session made a draft during the read | sessions.files.get -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] shared session made a draft during the read | sessions.diff -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] caller role narrowed to none during the read | sessions.files.list -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] caller role narrowed to none during the read | sessions.files.get -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] caller role narrowed to none during the read | sessions.diff -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] same key replaced during the read | sessions.files.list -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] same key replaced during the read | sessions.files.get -> refused: Session "agent:main:proof-alpha" was not found.
[head 3f2b6a2be4ef] same key replaced during the read | sessions.diff -> refused: Session "agent:main:proof-alpha" was not found.
```
Observed result after fix: on pristine main all fifteen runs hand the foreign caller the other person's absolute checkout path, her file body and her uncommitted working-tree diff. On the previous revision the static foreign draft is refused but the three changes applied while the read was in flight still hand over all three payloads. On this head the same fifteen runs, same inputs, same state database, answer `Session "agent:main:proof-alpha" was not found.` for the static foreign draft and for all nine in-flight changes, while the one shared session whose authority never moved is still served in full with `root`, the file body and the real git working-tree counts.
What was not tested: the proof drove the handler exports directly rather than a live WebSocket Gateway, so the router's pre-dispatch fence and scope gate were not exercised end to end. It covers only the local-workspace branch, not the cloud repository-workspace branch of `sessions.files.*`; that branch reaches the same recheck, but its remote inspection path was not driven. The incognito tightening is covered by regression coverage rather than by this transcript, which uses a non-incognito session. The concurrent change was applied from the same process rather than from a second Gateway client, so it lands deterministically between the handler's awaits rather than at an arbitrary interleaving. `board.get` and `session.discussion.info` are named above as follow-ups and are not covered. Full build and typecheck were not run locally on this head.
