### PR TITLE
refactor(agents): remove duplicate billing message test

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -374,11 +374,6 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
-  it("returns a friendly billing message for insufficient credits", () => {
-    const msg = makeAssistantError("insufficient credits");
-    const result = formatAssistantErrorText(msg);
-    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
-  });
   it("includes provider and assistant model in billing message when provider is given", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg, { provider: "Anthropic" });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The assistant error-text tests repeat an insufficient-credits scenario without adding coverage.

## Why This Change Was Made

Remove the weaker duplicate. The retained generic-provider case uses the same fixture and formatter call, preserves the exact billing-message assertion, and also verifies the generic API-provider wording. The OpenAI fixture and all provider/model, authentication, prepared-provider, and HTTP 429 neighbors remain unchanged.

## User Impact

No runtime behavior changes. This removes one case and five test lines, with no changes to production code, helpers, imports, or remaining assertions.

## Evidence

- Full ordered unit-fast test file: 110 actual passes, 0 skipped.
- All 20 selected changed checks passed, along with targeted formatting and diff checks.
- Fresh scoped P2 review completed with no actionable findings.

No live provider execution, global-runtime validation, installed-package proof, or local full-repository test run is claimed.
