### PR TITLE
fix(mattermost): redact active credentials in errors

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -698,7 +698,7 @@ extensions/matrix/src/test-runtime.ts	10
 extensions/matrix/src/tool-actions.ts	1
 extensions/mattermost/src/channel.ts	8
 extensions/mattermost/src/gateway-auth-bypass.ts	3
-extensions/mattermost/src/mattermost/client.ts	9
+extensions/mattermost/src/mattermost/client.ts	8
 extensions/mattermost/src/mattermost/directory.ts	2
 extensions/mattermost/src/mattermost/interactions.ts	4
 extensions/mattermost/src/mattermost/model-picker.ts	1

--- a/extensions/mattermost/src/mattermost/client.error-redaction.test.ts
+++ b/extensions/mattermost/src/mattermost/client.error-redaction.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { createMattermostClient, readMattermostError, uploadMattermostFile } from "./client.js";
+
+describe("Mattermost reflected credential diagnostics", () => {
+  it.each([
+    {
+      name: "bare text",
+      contentType: "text/plain",
+      body: "upstream rejected abcdefghijklmnopqrstuvwxyz",
+      expected: "upstream rejected ***",
+    },
+    {
+      name: "bare JSON message",
+      contentType: "application/json",
+      body: '{"message":"upstream rejected abcdefghijklmnopqrstuvwxyz"}',
+      expected: "upstream rejected ***",
+    },
+    {
+      name: "serialized object fallback",
+      contentType: "application/json",
+      body: '{"context":"retry later","echoed":"abcdefghijklmnopqrstuvwxyz"}',
+      expected: '{"context":"retry later","echoed":"***"}',
+    },
+    {
+      name: "object-valued message",
+      contentType: "application/json",
+      body: '{"message":{"context":"retry later","echoed":"abcdefghijklmnopqrstuvwxyz"}}',
+      expected: '{"message":{"context":"retry later","echoed":"***"}}',
+    },
+    {
+      name: "array-valued message",
+      contentType: "application/json",
+      body: '{"message":["retry later","abcdefghijklmnopqrstuvwxyz"]}',
+      expected: '{"message":["retry later","***"]}',
+    },
+    {
+      name: "non-string message without credentials",
+      contentType: "application/json",
+      body: '{"message":503,"context":"retry later"}',
+      expected: '{"message":503,"context":"retry later"}',
+    },
+  ])("redacts the active credential and preserves $name diagnostics", async (scenario) => {
+    const response = new Response(scenario.body, {
+      status: 503,
+      headers: { "content-type": scenario.contentType },
+    });
+
+    const detail = await readMattermostError(response, {
+      Authorization: "Bearer abcdefghijklmnopqrstuvwxyz",
+    });
+
+    expect(detail).toBe(scenario.expected);
+  });
+
+  it("redacts a credential cut by the error-body limit and cancels unread data", async () => {
+    const safePrefix = "upstream diagnostic " + ".".repeat(8192 - 20 - 12);
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(safePrefix + "abcdefghijklmnopqrstuvwxyz unread suffix"),
+          );
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 503, headers: { "content-type": "text/plain" } },
+    );
+
+    const detail = await readMattermostError(response, {
+      Authorization: "Bearer abcdefghijklmnopqrstuvwxyz",
+    });
+
+    expect(detail).toBe(safePrefix + "***");
+    expect(canceled).toBe(true);
+  });
+  it.each(["request", "upload"] as const)(
+    "redacts an active bare credential reflected by the %s path",
+    async (route) => {
+      const client = createMattermostClient({
+        baseUrl: "https://chat.example.com",
+        botToken: "abcdefghijklmnopqrstuvwxyz",
+        fetchImpl: async (_url, init) => {
+          const authorization = new Headers(init?.headers).get("Authorization");
+          expect(authorization).toBe("Bearer abcdefghijklmnopqrstuvwxyz");
+          return new Response(`upstream rejected ${authorization?.slice(7)}`, {
+            status: 503,
+            statusText: "Service Unavailable",
+          });
+        },
+      });
+
+      const operation =
+        route === "request"
+          ? client.request("/users/me")
+          : uploadMattermostFile(client, {
+              channelId: "channel-1",
+              buffer: Buffer.from("fixture upload"),
+              fileName: "proof.txt",
+              contentType: "text/plain",
+            });
+
+      await expect(operation).rejects.toThrow(
+        "Mattermost API 503 Service Unavailable: upstream rejected ***",
+      );
+    },
+  );
+});

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -158,7 +158,7 @@ describe("readMattermostError", () => {
     const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
     const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
 
-    await expect(readMattermostError(response)).resolves.toBe("");
+    await expect(readMattermostError(response, {})).resolves.toBe("");
 
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(textSpy).not.toHaveBeenCalled();
@@ -172,10 +172,69 @@ describe("readMattermostError", () => {
     const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
     const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
 
-    await expect(readMattermostError(response)).resolves.toBe("invalid token");
+    await expect(readMattermostError(response, {})).resolves.toBe("invalid token");
 
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("redacts reflected credentials in non-JSON error bodies", async () => {
+    // A self-hosted or misbehaving server can echo the request's Authorization
+    // header back in its error body; the surfaced detail must not carry it.
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(`Request failed\nAuthorization: Bearer ${token}\n`, {
+      status: 500,
+      headers: { "content-type": "text/plain" },
+    });
+
+    const detail = await readMattermostError(response, { Authorization: `Bearer ${token}` });
+
+    expect(detail).not.toContain(token);
+    expect(detail).toContain("Request failed");
+  });
+
+  it("redacts reflected credentials in JSON error messages", async () => {
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(JSON.stringify({ message: `auth failed for Bearer ${token}` }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response, { Authorization: `Bearer ${token}` });
+
+    expect(detail).not.toContain(token);
+    expect(detail).toBe("auth failed for ***");
+  });
+
+  it("redacts JSON-escaped credentials after decoding", async () => {
+    // Raw literal: \u0020 decodes to a space and \u0061 to "a". Escapes bypass
+    // literal credential matching on the serialized body, so redaction must
+    // run on the decoded message, not the raw JSON text.
+    const body = String.raw`{"message":"Bearer\u0020\u0061bcdefghijklmnopqrstuvwxyz"}`;
+    const response = new Response(body, {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response, {
+      Authorization: "Bearer abcdefghijklmnopqrstuvwxyz",
+    });
+
+    expect(detail).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(detail).toBe("***");
+  });
+
+  it("redacts credentials in non-JSON bodies served with a JSON content type", async () => {
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(`upstream error: Bearer ${token}`, {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response, { Authorization: `Bearer ${token}` });
+
+    expect(detail).not.toContain(token);
+    expect(detail).toContain("upstream error");
   });
 });
 

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -177,6 +177,33 @@ describe("readMattermostError", () => {
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(textSpy).not.toHaveBeenCalled();
   });
+
+  it("redacts reflected credentials in non-JSON error bodies", async () => {
+    // A self-hosted or misbehaving server can echo the request's Authorization
+    // header back in its error body; the surfaced detail must not carry it.
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(`Request failed\nAuthorization: Bearer ${token}\n`, {
+      status: 500,
+      headers: { "content-type": "text/plain" },
+    });
+
+    const detail = await readMattermostError(response);
+
+    expect(detail).not.toContain(token);
+    expect(detail).toContain("Request failed");
+  });
+
+  it("redacts reflected credentials in JSON error messages", async () => {
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(JSON.stringify({ message: `auth failed for Bearer ${token}` }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response);
+
+    expect(detail).not.toContain(token);
+  });
 });
 
 // ── createMattermostClient ───────────────────────────────────────────

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -204,6 +204,34 @@ describe("readMattermostError", () => {
 
     expect(detail).not.toContain(token);
   });
+
+  it("redacts JSON-escaped credentials after decoding", async () => {
+    // Raw literal: \u0020 decodes to a space and \u0061 to "a". Escapes bypass
+    // literal credential matching on the serialized body, so redaction must
+    // run on the decoded message, not the raw JSON text.
+    const body = String.raw`{"message":"Bearer\u0020\u0061bcdefghijklmnopqrstuvwxyz"}`;
+    const response = new Response(body, {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response);
+
+    expect(detail).not.toContain("Bearer abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("redacts credentials in non-JSON bodies served with a JSON content type", async () => {
+    const token = "mm-bot-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = new Response(`upstream error: Bearer ${token}`, {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+
+    const detail = await readMattermostError(response);
+
+    expect(detail).not.toContain(token);
+    expect(detail).toContain("upstream error");
+  });
 });
 
 // ── createMattermostClient ───────────────────────────────────────────

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -7,9 +7,12 @@ import { responseWithRelease } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
-  readResponseTextLimited,
+  redactProviderResponseErrorText,
 } from "openclaw/plugin-sdk/provider-http";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import {
+  readResponseTextPrefix,
+  readResponseWithLimit,
+} from "openclaw/plugin-sdk/response-limit-runtime";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import {
   fetchWithSsrFGuard,
@@ -146,21 +149,34 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
   return new TextDecoder().decode(bytes);
 }
 
-export async function readMattermostError(res: Response): Promise<string> {
+export async function readMattermostError(
+  res: Response,
+  requestHeaders: HeadersInit,
+): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
-  const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
+  const { text, truncated } = await readResponseTextPrefix(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES, {
+    chunkTimeoutMs: 10_000,
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`error body read stalled for ${chunkTimeoutMs}ms`),
+  });
+  let detail = text;
   if (contentType.includes("application/json")) {
     try {
-      const data = JSON.parse(text) as { message?: string } | undefined;
-      if (data?.message) {
-        return data.message;
-      }
-      return JSON.stringify(data);
+      const data: unknown = JSON.parse(text);
+      detail =
+        data !== null &&
+        typeof data === "object" &&
+        "message" in data &&
+        typeof data.message === "string" &&
+        data.message
+          ? data.message
+          : JSON.stringify(data);
     } catch {
-      return text;
+      // A mislabeled or truncated JSON response retains its bounded text diagnostic.
     }
   }
-  return text;
+  // Decode first, then mask the active credential, including a clipped suffix.
+  return redactProviderResponseErrorText(detail, requestHeaders, { sourceTruncated: truncated });
 }
 
 export function createMattermostClient(params: {
@@ -244,7 +260,7 @@ export function createMattermostClient(params: {
     }
     const res = await fetchImpl(url, { ...init, headers });
     if (!res.ok) {
-      const detail = await readMattermostError(res);
+      const detail = await readMattermostError(res, headers);
       throw new Error(
         `Mattermost API ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
       );
@@ -699,16 +715,15 @@ export async function uploadMattermostFile(
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 
+  const headers = { Authorization: `Bearer ${client.token}` };
   const res = await client.fetchImpl(`${client.apiBaseUrl}/files`, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${client.token}`,
-    },
+    headers,
     body: form,
   });
 
   if (!res.ok) {
-    const detail = await readMattermostError(res);
+    const detail = await readMattermostError(res, headers);
     throw new Error(`Mattermost API ${res.status} ${res.statusText}: ${detail || "unknown error"}`);
   }
   const data = await readProviderJsonResponse<{ file_infos?: MattermostFileInfo[] }>(

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -4,6 +4,7 @@ import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-i
 import { collectErrorGraphCandidates } from "openclaw/plugin-sdk/error-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { responseWithRelease } from "openclaw/plugin-sdk/fetch-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
@@ -149,18 +150,21 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
+  // Remote API errors can reflect the request's Authorization header. Force
+  // tool-payload redaction before the text enters any surfaced error message.
+  const redacted = redactToolPayloadText(text);
   if (contentType.includes("application/json")) {
     try {
-      const data = JSON.parse(text) as { message?: string } | undefined;
+      const data = JSON.parse(redacted) as { message?: string } | undefined;
       if (data?.message) {
         return data.message;
       }
       return JSON.stringify(data);
     } catch {
-      return text;
+      return redacted;
     }
   }
-  return text;
+  return redacted;
 }
 
 export function createMattermostClient(params: {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -150,21 +150,21 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
-  // Remote API errors can reflect the request's Authorization header. Force
-  // tool-payload redaction before the text enters any surfaced error message.
-  const redacted = redactToolPayloadText(text);
+  // Redact only the final surfaced string, after JSON decoding. Redacting the
+  // serialized body would let \uXXXX-escaped credentials decode back to plaintext
+  // after the check, and could corrupt valid JSON before parsing.
   if (contentType.includes("application/json")) {
     try {
-      const data = JSON.parse(redacted) as { message?: string } | undefined;
+      const data = JSON.parse(text) as { message?: string } | undefined;
       if (data?.message) {
-        return data.message;
+        return redactToolPayloadText(data.message);
       }
-      return JSON.stringify(data);
+      return redactToolPayloadText(JSON.stringify(data));
     } catch {
-      return redacted;
+      // Non-JSON body despite the content type; fall through to the raw text.
     }
   }
-  return redacted;
+  return redactToolPayloadText(text);
 }
 
 export function createMattermostClient(params: {

--- a/extensions/mattermost/src/mattermost/probe.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.test.ts
@@ -157,6 +157,29 @@ describe("probeMattermost", () => {
     expect(mockRelease).toHaveBeenCalledTimes(1);
   });
 
+  it("returns a string diagnostic without a reflected active credential in an object message", async () => {
+    mockFetchGuard.mockImplementationOnce(async ({ init }: { init: RequestInit }) => {
+      const authorization = new Headers(init.headers).get("Authorization");
+      expect(authorization).toBe("Bearer abcdefghijklmnopqrstuvwxyz");
+      return {
+        response: new Response(
+          JSON.stringify({ message: { context: "retry later", echoed: authorization?.slice(7) } }),
+          { status: 503, headers: { "content-type": "application/json" } },
+        ),
+        release: mockRelease,
+      };
+    });
+
+    const result = await probeMattermost("https://mm.example.com", "abcdefghijklmnopqrstuvwxyz");
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 503,
+      error: '{"message":{"context":"retry later","echoed":"***"}}',
+    });
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to statusText when error body is empty", async () => {
     mockFetchGuard.mockResolvedValueOnce({
       response: new Response("", {

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -35,6 +35,7 @@ export async function probeMattermost(
     return { ok: false, error: "baseUrl missing" };
   }
   const url = `${normalized}/api/v4/users/me`;
+  const headers = { Authorization: `Bearer ${botToken}` };
   return await runChannelProbe(
     undefined,
     async ({ elapsedMs }) => {
@@ -43,7 +44,7 @@ export async function probeMattermost(
       const { response: res, release } = await fetchWithSsrFGuard({
         url,
         init: {
-          headers: { Authorization: `Bearer ${botToken}` },
+          headers,
         },
         auditContext: "mattermost-probe",
         policy: ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork),
@@ -54,7 +55,7 @@ export async function probeMattermost(
       const requestElapsedMs = elapsedMs();
       try {
         if (!res.ok) {
-          const detail = await readMattermostError(res);
+          const detail = await readMattermostError(res, headers);
           return {
             ok: false,
             status: res.status,


### PR DESCRIPTION
Closes #144173. Related historical work: #123223.

## What Problem This Solves

Mattermost error responses can reflect the active bot credential into Gateway probe results, send diagnostics, logs, and persisted delivery errors. Current main also lets an object or array in a JSON `message` escape as a non-string probe error.

## Why This Change Was Made

Keep one redaction boundary at `readMattermostError`. Decode the bounded JSON first, select a string message or serialize the remaining value, then use the existing request-header-aware SDK redactor. Request, upload, and probe callers supply the actual headers they sent. This masks opaque bare credentials as well as labeled bearer values without relying on ambient secret registration.

Preserve the bounded reader's truncation fact so a credential cut by the 8 KiB limit is also masked. The existing idle timeout, network guard, redirect handling, request deadlines, status context, successful responses, and delivery policy stay intact. The assertion ratchet decreases one entry from 9 to 8 after removing the unchecked JSON cast.

This retains the contributor's parse-before-redaction correction and ancestry. It also closes the bare-token and malformed-message gaps found during the independent security review. No public configuration, schema, dependency, or secret registry is added.

## Evidence

Exact baseline: `ce405b8d252e`. Exact candidate: `349443da96d4`.

Controlled loopback HTTP/WebSocket proof uses a synthetic Mattermost account, the normal private-network opt-in, the built Gateway, and authenticated public `channels.status` and `send` calls. The server reflects the Authorization value it actually receives. This exercises production Gateway/plugin/client code; it is not a third-party Mattermost deployment test.

| Observed boundary | Baseline | Candidate |
| --- | --- | --- |
| Probe error containing a reflected header | Full credential returned | Credential replaced with `***`; status and context retained |
| Bare credential in send errors | Full credential in public error, Gateway log, and delivery diagnostics | Credential masked at the shared reader |
| Object/array JSON message | Non-string probe error containing the credential | Useful serialized string with masked credential |
| Credential cut at the body limit | Retained credential prefix | Retained prefix masked; body remains bounded |
| Successful text and file sends | Valid receipts | Valid receipts |

The public matrix covers plain text, JSON messages, Unicode-escaped JSON, mismatched content type, serialized-object fallback, object/array messages, bare values, and truncated bodies. Upload errors use the same reader. Separate real transport controls confirm private-network denial makes no server request, cross-origin redirects withhold Authorization, and a stalled probe returns its configured timeout.

A complete scan of captured candidate Gateway logs and five SQLite files found no full synthetic credential in diagnostics. Baseline evidence identifies four leaking log lines and eight delivery-error cells. No model turn was exercised; the observed downstream surfaces are Gateway results/logs and persisted delivery diagnostics. This repair prevents newly produced diagnostics from leaking; it does not rewrite historical records.

Native validation: 76 focused client/probe/redaction tests passed, with formatting, scoped lint, ratchets, and the repository hook. Ten new cases fail on the incoming implementation for credential, output-type, and clipped-prefix defects. The initial zero-case transfer and other setup failures remain in the private history and are not counted as proof.

Fresh independent source/security review is clean. Fresh source-blind runtime acceptance completed all four public and network-control runs. It also found no full credential or clipped prefix in captured candidate diagnostics, logs, or stored delivery errors. Full private captures, fixture sources, build identities, source custody and failure history are retained; public text omits tokens and private execution metadata.
