### PR TITLE
fix(state): install read-only SQLite lock policy at open

### DIFF
--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -81,8 +81,11 @@ export function openOpenClawAgentDatabaseReadOnly(
   if (!fs.existsSync(pathname)) {
     return { found: false, reason: "database-missing" };
   }
+  // Lock policy belongs to the open: node:sqlite has no busy handler until one
+  // is set, so a later PRAGMA leaves every earlier statement unprotected.
   const db = openNodeSqliteDatabase(pathname, {
     readOnly: true,
+    timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
     ...(behavior.allowExtension ? { allowExtension: true } : {}),
   });
   let closed = false;
@@ -96,7 +99,6 @@ export function openOpenClawAgentDatabaseReadOnly(
   };
   try {
     registerOpenClawAgentDatabaseIdentity(db);
-    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     const userVersion = assertSupportedAgentSchemaVersion(db, pathname);
     assertCanonicalAgentPersistenceVersion(db, pathname, userVersion);
     const schemaMeta = readExistingAgentSchemaMeta(db);

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -118,10 +118,15 @@ function withOpenClawStateReadOnlyLocation<T>(
   location: string,
 ): T {
   const read = () => {
-    const db = openNodeSqliteDatabase(location, { readOnly: true });
+    // node:sqlite opens without a busy handler, so a timeout installed by a
+    // later PRAGMA leaves the first statement — legacy catalog admission's
+    // sqlite_schema read — failing outright on any transient lock.
+    const db = openNodeSqliteDatabase(location, {
+      readOnly: true,
+      timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+    });
     let closeSchemaReadAdmission: (() => void) | undefined;
     try {
-      db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       closeSchemaReadAdmission = openDanglingWorkshopIndexReadAdmission(db);
       assertSupportedStateSchemaVersion(db, pathname);
       return operation({ db, path: pathname });


### PR DESCRIPTION
## Problem

CI shard `agentic-command-support` failed in
[run 34455365820](https://github.com/openclaw/openclaw/actions/runs/34455365820)
on a test that touches no SQLite code:

```
FAIL src/commands/doctor/shared/channel-plugin-blockers.test.ts > accepts an available co-owner for the same package env trigger
Error: database is locked
 ❯ src/state/openclaw-state-db-dangling-workshop-index.ts:36:8
 ❯ read src/state/openclaw-state-db-readonly.ts:124:34
Serialized Error: { code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked' }
```

It failed in 3 ms, not after the established 5000 ms busy timeout, because the
connection had no busy handler at all when that statement ran.

`node:sqlite` opens a connection with busy timeout `0`:

```
new DatabaseSync(':memory:').prepare('PRAGMA busy_timeout').get()  // { timeout: 0 }
```

A connection therefore has no busy handler until one is installed, and both
read-only openers of the shared state and agent databases installed it with a
`PRAGMA busy_timeout` *after* opening. Every statement issued before that PRAGMA
ran unprotected: the state reader's very first statement is the legacy-catalog
admission's `sqlite_schema` read, so any transient lock failed it outright.

#143908 fixed the failing ordering by moving the PRAGMA ahead of that admission
call. The ordering requirement itself remained: lock policy still depended on
which statement happened to come first inside the opener body, and inserting a
statement above the PRAGMA silently disables the busy handler again.

## Solution

Pass `timeout` to the `DatabaseSync` constructor at both read-only openers, so
the connection is born with its lock policy, and delete the now-redundant
post-open PRAGMA. `readSqliteBusyTimeout` already reads both the `busy_timeout`
and `timeout` result column names, so `runWithSqliteBusyTimeout` keeps observing
and restoring the value exactly as before.

## Impact

A fresh read-only state or agent read no longer depends on statement order for
its lock policy, and cannot regress into failing immediately on a transient
lock. No configuration, schema, or public surface changes.

## Evidence

The reported failure reproduces deterministically from the ordering alone.
Restoring the pre-#143908 order (`openDanglingWorkshopIndexReadAdmission` before
the PRAGMA) and running the regression test that #143908 added:

```
× src/state/openclaw-state-db-readonly.test.ts > waits for a transient database lock
    before a fresh read-only schema inspection 71ms
  → database is locked
Serialized Error: { code: 'ERR_SQLITE_ERROR', errcode: 5, errstr: 'database is locked' }
Test Files  1 failed (1)
```

Same signature and same immediate failure as CI. With this change:

- `src/state/openclaw-state-db-readonly.test.ts` — 21 passed
- `src/state/openclaw-agent-db.test.ts`, `src/state/openclaw-agent-db-open-authority.test.ts` — 144 passed, 4 skipped
- `node scripts/run-vitest.mjs src/commands/doctor/shared/channel-plugin-blockers.test.ts src/state/` — 1137 passed, 6 skipped, 3 failed
- `node scripts/check-changed.mjs` — exit 0
- Independent Codex review (P2) — `scoped-clean`

The three failures are `src/state/local-onboarding-state.test.ts` (`existing
managed handoff lease is incompatible`). They reproduce identically on a clean
checkout of `main` with no local modifications and are unrelated to this change;
tracked separately.

The competing writer that held the lock in that CI process is still unidentified
— the shard's Vitest worker threads each get their own temp `HOME` and state
database, so the contention is process-local. It no longer matters for
correctness here: a transient lock is now waited out at either opener.

Fixes the flake seen in #143838's CI.
