### PR TITLE
fix(ui): resolve channel icons by owning plugin

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9443,6 +9443,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
     public let featuredat: Int?
     public let order: Double?
     public let hasicon: Bool?
+    public let channelids: [String]?
     public let install: PluginCatalogInstallAction?
     public let error: String?
     public let categories: [String]?
@@ -9466,6 +9467,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         featuredat: Int? = nil,
         order: Double? = nil,
         hasicon: Bool? = nil,
+        channelids: [String]? = nil,
         install: PluginCatalogInstallAction? = nil,
         error: String? = nil,
         categories: [String]? = nil,
@@ -9488,6 +9490,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         self.featuredat = featuredat
         self.order = order
         self.hasicon = hasicon
+        self.channelids = channelids
         self.install = install
         self.error = error
         self.categories = categories
@@ -9512,6 +9515,7 @@ public struct PluginCatalogEntry: Codable, Sendable {
         case featuredat = "featuredAt"
         case order
         case hasicon = "hasIcon"
+        case channelids = "channelIds"
         case install
         case error
         case categories

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -3,6 +3,19 @@ import OpenClawProtocol
 import Testing
 
 struct GatewayModelsCompatibilityTests {
+    @Test(arguments: [false, true])
+    func `plugin catalog channel ownership decodes old and current payloads`(hasOwnership: Bool) throws {
+        let ownership = hasOwnership ? #","channelIds":["agent-system-github"]"# : ""
+        let entry = try JSONDecoder().decode(
+            PluginCatalogEntry.self,
+            from: Data(
+                #"{"id":"agent-system","name":"Agent System","installed":true,"enabled":true,"state":"enabled"\#(ownership)}"#
+                    .utf8))
+
+        #expect(entry.id == "agent-system")
+        #expect(entry.channelids == (hasOwnership ? ["agent-system-github"] : nil))
+    }
+
     @Test(arguments: ["allowed", "denied", "expired", "cancelled"])
     func `terminal approval sources remain generic dictionaries`(_ status: String) throws {
         let expectedSource = ["agentId": "main", "sessionKey": "agent:main:approval"]

--- a/packages/gateway-protocol/src/schema/plugins.ts
+++ b/packages/gateway-protocol/src/schema/plugins.ts
@@ -165,6 +165,8 @@ export const PluginCatalogEntrySchema = closedObject({
   order: Type.Optional(Type.Number()),
   /** True when the gateway can resolve a manifest or catalog icon for this plugin identity. */
   hasIcon: Type.Optional(Type.Boolean()),
+  /** Channel identities declared by this installed plugin. */
+  channelIds: Type.Optional(Type.Array(NonEmptyString)),
   install: Type.Optional(PluginCatalogInstallActionSchema),
   error: Type.Optional(Type.String()),
   /** Ordered package or registry categories; the first category is primary. */

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -695,6 +695,7 @@ describe("plugin management service", () => {
       metadataSnapshot({
         enabled: false,
         iconPath,
+        channels: ["workboard-chat"],
       }),
     );
 
@@ -708,7 +709,11 @@ describe("plugin management service", () => {
       pluginId: "workboard",
     });
 
-    expect(catalog.plugins[0]).toMatchObject({ id: "workboard", hasIcon: true });
+    expect(catalog.plugins[0]).toMatchObject({
+      id: "workboard",
+      hasIcon: true,
+      channelIds: ["workboard-chat"],
+    });
     expect(resolved).toEqual({ kind: "file", path: iconPath, rootPath: "/tmp/workboard" });
   });
 

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -415,6 +415,9 @@ export const listManagedPlugins = withManagedPluginCache(
       if (installedIconsById.get(normalizedPluginId)) {
         plugin.hasIcon = true;
       }
+      if (manifest?.channels.length) {
+        plugin.channelIds = [...manifest.channels];
+      }
       if (error) {
         plugin.error = error;
       }

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -338,7 +338,7 @@ describe("ChannelsPage lifecycle", () => {
       return await baseRequest?.(method, params);
     });
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL) =>
         new Response(new Uint8Array([137, 80, 78, 71]), {
           status: 200,
           headers: { "Content-Type": "image/png" },

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -138,89 +138,103 @@ afterEach(() => {
 });
 
 describe("ChannelsPage lifecycle", () => {
-  it("loads plugin metadata and package icons for channel presentation", async () => {
-    const gateway = createGateway();
-    gateway.emit({
-      hello: {
-        auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
-      } as unknown as ApplicationGatewaySnapshot["hello"],
-    });
-    const source = createContext(gateway);
-    source.channels.state.channelsSnapshot = {
-      ts: 0,
-      channelOrder: ["slack"],
-      channelLabels: { slack: "slack" },
-      channelDetailLabels: { slack: "Legacy channel subtitle" },
-      channels: { slack: { configured: false } },
-      channelAccounts: {},
-      channelDefaultAccountId: {},
-    };
-    const request = vi.spyOn(gateway.snapshot.client!, "request");
-    const baseRequest = request.getMockImplementation();
-    request.mockImplementation(async (method: string, params?: unknown) => {
-      if (method === "plugins.list") {
-        return {
-          plugins: [
-            {
-              id: "slack",
-              name: "Slack",
-              description: "OpenClaw Slack channel plugin.",
-              origin: "bundled",
-              installed: true,
-              enabled: false,
-              state: "disabled",
-              hasIcon: true,
-            },
-            {
-              id: "firecrawl",
-              name: "FireCrawl",
-              description: "Crawl websites.",
-              origin: "global",
-              installed: false,
-              enabled: false,
-              state: "available",
-              hasIcon: true,
-            },
-          ],
-          diagnostics: [],
-          mutationAllowed: true,
-        };
-      }
-      return await baseRequest?.(method, params);
-    });
-    const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL) =>
-        new Response(new Uint8Array([137, 80, 78, 71]), {
-          status: 200,
-          headers: { "Content-Type": "image/png" },
-        }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:slack-plugin-icon");
-    const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
-    page.context = source.context;
-    document.body.append(page);
+  it.each([false, true])(
+    "prefers the exact plugin icon with owner first: %s",
+    async (ownerFirst) => {
+      const gateway = createGateway();
+      gateway.emit({
+        hello: {
+          auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
+        } as unknown as ApplicationGatewaySnapshot["hello"],
+      });
+      const source = createContext(gateway);
+      source.channels.state.channelsSnapshot = {
+        ts: 0,
+        channelOrder: ["slack"],
+        channelLabels: { slack: "slack" },
+        channelDetailLabels: { slack: "Legacy channel subtitle" },
+        channels: { slack: { configured: false } },
+        channelAccounts: {},
+        channelDefaultAccountId: {},
+      };
+      const request = vi.spyOn(gateway.snapshot.client!, "request");
+      const baseRequest = request.getMockImplementation();
+      const owner = {
+        id: "slack-suite",
+        name: "Suite",
+        installed: true,
+        enabled: true,
+        state: "enabled",
+        hasIcon: true,
+        channelIds: ["slack"],
+      };
+      request.mockImplementation(async (method: string, params?: unknown) => {
+        if (method === "plugins.list") {
+          return {
+            plugins: [
+              ...(ownerFirst ? [owner] : []),
+              {
+                id: "slack",
+                name: "Slack",
+                description: "OpenClaw Slack channel plugin.",
+                origin: "bundled",
+                installed: true,
+                enabled: false,
+                state: "disabled",
+                hasIcon: true,
+              },
+              {
+                id: "firecrawl",
+                name: "FireCrawl",
+                description: "Crawl websites.",
+                origin: "global",
+                installed: false,
+                enabled: false,
+                state: "available",
+                hasIcon: true,
+              },
+              ...(ownerFirst ? [] : [owner]),
+            ],
+            diagnostics: [],
+            mutationAllowed: true,
+          };
+        }
+        return await baseRequest?.(method, params);
+      });
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL) =>
+          new Response(new Uint8Array([137, 80, 78, 71]), {
+            status: 200,
+            headers: { "Content-Type": "image/png" },
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:slack-plugin-icon");
+      const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+      page.context = source.context;
+      document.body.append(page);
 
-    await vi.waitFor(() => {
-      expect(page.querySelector(".settings-row__title")?.textContent).toBe("Slack");
-      expect(page.querySelector(".settings-row__desc")?.textContent).toBe(
-        "OpenClaw Slack channel plugin.",
-      );
-      expect(page.querySelector(".channels-item img")?.getAttribute("src")).toBe(
-        "blob:slack-plugin-icon",
-      );
-    });
-    expect(request).toHaveBeenCalledWith("plugins.list", {}, expect.any(Object));
-    expect(
-      fetchMock.mock.calls
-        .map(([input]) =>
-          typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
-        )
-        .filter((url) => url.includes("/__openclaw__/plugin-icon/")),
-    ).toEqual(["/__openclaw__/plugin-icon/slack"]);
-    source.runtimeConfig.dispose();
-    source.channels.dispose();
-  });
+      await vi.waitFor(() => {
+        expect(page.querySelector(".settings-row__title")?.textContent).toBe("Slack");
+        expect(page.querySelector(".settings-row__desc")?.textContent).toBe(
+          "OpenClaw Slack channel plugin.",
+        );
+        expect(page.querySelector(".channels-item img")?.getAttribute("src")).toBe(
+          "blob:slack-plugin-icon",
+        );
+      });
+      expect(request).toHaveBeenCalledWith("plugins.list", {}, expect.any(Object));
+      expect(
+        fetchMock.mock.calls
+          .map(([input]) =>
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+          )
+          .filter((url) => url.includes("/__openclaw__/plugin-icon/")),
+      ).toEqual(["/__openclaw__/plugin-icon/slack"]);
+      source.runtimeConfig.dispose();
+      source.channels.dispose();
+    },
+  );
 
   it("loads an icon when channel status arrives after plugin metadata", async () => {
     const gateway = createGateway();
@@ -315,6 +329,7 @@ describe("ChannelsPage lifecycle", () => {
     };
     const request = vi.spyOn(gateway.snapshot.client!, "request");
     const baseRequest = request.getMockImplementation();
+    let includeSecondChannel = false;
     request.mockImplementation(async (method: string, params?: unknown) => {
       if (method === "plugins.list") {
         return {
@@ -328,11 +343,31 @@ describe("ChannelsPage lifecycle", () => {
               enabled: true,
               state: "enabled",
               hasIcon: true,
-              channelIds: ["agent-system-github"],
+              channelIds: ["agent-system-github", "agent-system-chat"],
             },
           ],
           diagnostics: [],
           mutationAllowed: true,
+        };
+      }
+      if (method === "channels.status" && includeSecondChannel) {
+        return {
+          ts: 1,
+          channelOrder: ["agent-system-github", "agent-system-chat"],
+          channelLabels: {
+            "agent-system-github": "GitHub Notifications",
+            "agent-system-chat": "Project Chat",
+          },
+          channelDetailLabels: {
+            "agent-system-github": "GitHub notification channel",
+            "agent-system-chat": "Project conversations",
+          },
+          channels: {
+            "agent-system-github": { configured: false },
+            "agent-system-chat": { configured: false },
+          },
+          channelAccounts: {},
+          channelDefaultAccountId: {},
         };
       }
       return await baseRequest?.(method, params);
@@ -345,15 +380,16 @@ describe("ChannelsPage lifecycle", () => {
         }),
     );
     vi.stubGlobal("fetch", fetchMock);
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:agent-system-plugin-icon");
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:agent-system-plugin-icon")
+      .mockReturnValue("blob:duplicate-plugin-icon");
+    const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
     const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
     page.context = source.context;
     document.body.append(page);
 
     await vi.waitFor(() => {
-      expect(page.querySelector(".settings-row__title")?.textContent).toBe(
-        "GitHub Notifications",
-      );
+      expect(page.querySelector(".settings-row__title")?.textContent).toBe("GitHub Notifications");
       expect(page.querySelector(".settings-row__desc")?.textContent).toBe(
         "GitHub notification channel",
       );
@@ -368,9 +404,99 @@ describe("ChannelsPage lifecycle", () => {
         )
         .filter((url) => url.includes("/__openclaw__/plugin-icon/")),
     ).toEqual(["/__openclaw__/plugin-icon/agent-system"]);
+    includeSecondChannel = true;
+    await source.channels.refresh(false);
+    await vi.waitFor(() => {
+      expect(
+        ["GitHub Notifications", "Project Chat"].map((label) => {
+          const row = Array.from(page.querySelectorAll(".channels-item")).find(
+            (item) => item.querySelector(".settings-row__title")?.textContent === label,
+          );
+          return row?.querySelector("img")?.getAttribute("src");
+        }),
+      ).toEqual(["blob:agent-system-plugin-icon", "blob:agent-system-plugin-icon"]);
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    page.remove();
+    expect(revoke.mock.calls).toEqual([["blob:agent-system-plugin-icon"]]);
     source.runtimeConfig.dispose();
     source.channels.dispose();
   });
+
+  it.each(["disconnect", "timeout"])(
+    "cancels the owning plugin icon request on %s",
+    async (cause) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const gateway = createGateway();
+      const source = createContext(gateway);
+      source.channels.state.channelsSnapshot = {
+        ts: 0,
+        channelOrder: ["agent-system-github"],
+        channelLabels: { "agent-system-github": "GitHub Notifications" },
+        channels: { "agent-system-github": { configured: false } },
+        channelAccounts: {},
+        channelDefaultAccountId: {},
+      };
+      const request = vi.spyOn(gateway.snapshot.client!, "request");
+      const baseRequest = request.getMockImplementation();
+      request.mockImplementation(async (method: string, params?: unknown) => {
+        if (method === "plugins.list") {
+          return {
+            plugins: [
+              {
+                id: "agent-system",
+                name: "Agent System",
+                installed: true,
+                enabled: true,
+                state: "enabled",
+                hasIcon: true,
+                channelIds: ["agent-system-github"],
+              },
+            ],
+            diagnostics: [],
+            mutationAllowed: true,
+          };
+        }
+        return await baseRequest?.(method, params);
+      });
+      const aborted = createDeferred<unknown>();
+      const fetchMock = vi.fn<typeof fetch>(
+        async (_input, init) =>
+          await new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              throw new Error("Expected icon request AbortSignal");
+            }
+            signal.addEventListener(
+              "abort",
+              () => {
+                aborted.resolve(signal.reason);
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const createUrl = vi.spyOn(URL, "createObjectURL");
+      const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+      page.context = source.context;
+      document.body.append(page);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      if (cause === "disconnect") {
+        gateway.emit({ phase: "stopped" });
+      } else {
+        await vi.advanceTimersByTimeAsync(10_000);
+      }
+      expect(await aborted.promise).toMatchObject({
+        name: cause === "disconnect" ? "AbortError" : "TimeoutError",
+      });
+      expect(createUrl).not.toHaveBeenCalled();
+      page.remove();
+      source.runtimeConfig.dispose();
+      source.channels.dispose();
+    },
+  );
 
   it("loads schema again when the runtime-config source changes", async () => {
     const gateway = createGateway();

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -471,7 +471,7 @@ describe("ChannelsPage lifecycle", () => {
               "abort",
               () => {
                 aborted.resolve(signal.reason);
-                reject(signal.reason);
+                reject(new DOMException("The operation was aborted.", "AbortError"));
               },
               { once: true },
             );

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -296,6 +296,82 @@ describe("ChannelsPage lifecycle", () => {
     source.channels.dispose();
   });
 
+  it("loads a channel icon through its distinct owning plugin id", async () => {
+    const gateway = createGateway();
+    gateway.emit({
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
+      } as unknown as ApplicationGatewaySnapshot["hello"],
+    });
+    const source = createContext(gateway);
+    source.channels.state.channelsSnapshot = {
+      ts: 0,
+      channelOrder: ["agent-system-github"],
+      channelLabels: { "agent-system-github": "GitHub Notifications" },
+      channelDetailLabels: { "agent-system-github": "GitHub notification channel" },
+      channels: { "agent-system-github": { configured: false } },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    };
+    const request = vi.spyOn(gateway.snapshot.client!, "request");
+    const baseRequest = request.getMockImplementation();
+    request.mockImplementation(async (method: string, params?: unknown) => {
+      if (method === "plugins.list") {
+        return {
+          plugins: [
+            {
+              id: "agent-system",
+              name: "Agent System",
+              description: "Manage agent workspaces.",
+              origin: "global",
+              installed: true,
+              enabled: true,
+              state: "enabled",
+              hasIcon: true,
+              channelIds: ["agent-system-github"],
+            },
+          ],
+          diagnostics: [],
+          mutationAllowed: true,
+        };
+      }
+      return await baseRequest?.(method, params);
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(new Uint8Array([137, 80, 78, 71]), {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:agent-system-plugin-icon");
+    const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+    page.context = source.context;
+    document.body.append(page);
+
+    await vi.waitFor(() => {
+      expect(page.querySelector(".settings-row__title")?.textContent).toBe(
+        "GitHub Notifications",
+      );
+      expect(page.querySelector(".settings-row__desc")?.textContent).toBe(
+        "GitHub notification channel",
+      );
+      expect(page.querySelector(".channels-item img")?.getAttribute("src")).toBe(
+        "blob:agent-system-plugin-icon",
+      );
+    });
+    expect(
+      fetchMock.mock.calls
+        .map(([input]) =>
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+        )
+        .filter((url) => url.includes("/__openclaw__/plugin-icon/")),
+    ).toEqual(["/__openclaw__/plugin-icon/agent-system"]);
+    source.runtimeConfig.dispose();
+    source.channels.dispose();
+  });
+
   it("loads schema again when the runtime-config source changes", async () => {
     const gateway = createGateway();
     const first = createContext(gateway);

--- a/ui/src/pages/channels/plugin-presentation-controller.ts
+++ b/ui/src/pages/channels/plugin-presentation-controller.ts
@@ -2,6 +2,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { PluginListResult } from "../../lib/plugins/index.ts";
 import { fetchPluginIconBlobUrl } from "../plugins/icon-loader.ts";
+import { resolveChannelIconOwner } from "./plugin-presentation.ts";
 
 const CHANNEL_PLUGIN_ICON_TIMEOUT_MS = 10_000;
 
@@ -84,33 +85,43 @@ export class ChannelPluginPresentationController {
         request.controller.abort(new DOMException("plugin icon fetch timed out", "TimeoutError")),
       CHANNEL_PLUGIN_ICON_TIMEOUT_MS,
     );
-    const channelIds = new Set(this.hooks.getChannelIds());
+    const iconTargets = new Map<string, string[]>();
+    for (const channelId of this.hooks.getChannelIds()) {
+      if (this.iconUrls[channelId]) {
+        continue;
+      }
+      const plugin = resolveChannelIconOwner(result.plugins, channelId);
+      if (!plugin) {
+        continue;
+      }
+      const channelIds = iconTargets.get(plugin.id) ?? [];
+      channelIds.push(channelId);
+      iconTargets.set(plugin.id, channelIds);
+    }
     const iconEntries = await Promise.all(
-      result.plugins
-        .filter(
-          (plugin) => plugin.hasIcon && channelIds.has(plugin.id) && !this.iconUrls[plugin.id],
-        )
-        .map(async (plugin) => {
-          const context = this.hooks.getContext();
-          const url = await fetchPluginIconBlobUrl({
-            pluginId: plugin.id,
-            resourceBasePath: context.resourceBasePath,
-            gatewayUrl: context.gateway.connection.gatewayUrl,
-            auth: {
-              hello: context.gateway.snapshot.hello,
-              settings: { token: context.gateway.connection.token },
-              password: context.gateway.connection.password,
-            },
-            signal: request.controller.signal,
-          }).catch(() => null);
-          return [plugin.id, url] as const;
-        }),
+      [...iconTargets].map(async ([pluginId, channelIds]) => {
+        const context = this.hooks.getContext();
+        const url = await fetchPluginIconBlobUrl({
+          pluginId,
+          resourceBasePath: context.resourceBasePath,
+          gatewayUrl: context.gateway.connection.gatewayUrl,
+          auth: {
+            hello: context.gateway.snapshot.hello,
+            settings: { token: context.gateway.connection.token },
+            password: context.gateway.connection.password,
+          },
+          signal: request.controller.signal,
+        }).catch(() => null);
+        return { channelIds, url };
+      }),
     );
     const loadedUrls = Object.fromEntries(
-      iconEntries.filter((entry): entry is readonly [string, string] => entry[1] !== null),
+      iconEntries.flatMap(({ channelIds, url }) =>
+        url === null ? [] : channelIds.map((channelId) => [channelId, url] as const),
+      ),
     );
     if (this.request !== request || !this.hooks.isConnected()) {
-      for (const url of Object.values(loadedUrls)) {
+      for (const url of new Set(Object.values(loadedUrls))) {
         URL.revokeObjectURL(url);
       }
       return;
@@ -141,7 +152,7 @@ export class ChannelPluginPresentationController {
     }
     this.request = null;
     this.pendingEnsureClient = null;
-    for (const url of Object.values(this.iconUrls)) {
+    for (const url of new Set(Object.values(this.iconUrls))) {
       URL.revokeObjectURL(url);
     }
     this.catalog = null;

--- a/ui/src/pages/channels/plugin-presentation-controller.ts
+++ b/ui/src/pages/channels/plugin-presentation-controller.ts
@@ -21,7 +21,7 @@ type PluginPresentationHooks = {
 
 export class ChannelPluginPresentationController {
   private catalog: PluginListResult | null = null;
-  private iconUrls: Record<string, string> = {};
+  private readonly iconUrls = new Map<string, string>();
   private request: PluginPresentationRequest | null = null;
   private pendingEnsureClient: GatewayBrowserClient | null = null;
 
@@ -32,7 +32,17 @@ export class ChannelPluginPresentationController {
   }
 
   get pluginIconUrls() {
-    return this.iconUrls;
+    if (!this.catalog) {
+      return {};
+    }
+    const plugins = this.catalog.plugins;
+    return Object.fromEntries(
+      this.hooks.getChannelIds().flatMap((channelId) => {
+        const plugin = resolveChannelIconOwner(plugins, channelId);
+        const url = plugin ? this.iconUrls.get(plugin.id) : undefined;
+        return url === undefined ? [] : [[channelId, url] as const];
+      }),
+    );
   }
 
   ensure(client: GatewayBrowserClient | null) {
@@ -85,21 +95,16 @@ export class ChannelPluginPresentationController {
         request.controller.abort(new DOMException("plugin icon fetch timed out", "TimeoutError")),
       CHANNEL_PLUGIN_ICON_TIMEOUT_MS,
     );
-    const iconTargets = new Map<string, string[]>();
+    // The plugin owns the URL, including channels that arrive in a later status snapshot.
+    const iconTargets = new Set<string>();
     for (const channelId of this.hooks.getChannelIds()) {
-      if (this.iconUrls[channelId]) {
-        continue;
-      }
       const plugin = resolveChannelIconOwner(result.plugins, channelId);
-      if (!plugin) {
-        continue;
+      if (plugin && !this.iconUrls.has(plugin.id)) {
+        iconTargets.add(plugin.id);
       }
-      const channelIds = iconTargets.get(plugin.id) ?? [];
-      channelIds.push(channelId);
-      iconTargets.set(plugin.id, channelIds);
     }
     const iconEntries = await Promise.all(
-      [...iconTargets].map(async ([pluginId, channelIds]) => {
+      [...iconTargets].map(async (pluginId) => {
         const context = this.hooks.getContext();
         const url = await fetchPluginIconBlobUrl({
           pluginId,
@@ -112,21 +117,21 @@ export class ChannelPluginPresentationController {
           },
           signal: request.controller.signal,
         }).catch(() => null);
-        return { channelIds, url };
+        return [pluginId, url] as const;
       }),
     );
-    const loadedUrls = Object.fromEntries(
-      iconEntries.flatMap(({ channelIds, url }) =>
-        url === null ? [] : channelIds.map((channelId) => [channelId, url] as const),
-      ),
+    const loadedUrls = iconEntries.filter(
+      (entry): entry is readonly [string, string] => entry[1] !== null,
     );
     if (this.request !== request || !this.hooks.isConnected()) {
-      for (const url of new Set(Object.values(loadedUrls))) {
+      for (const [, url] of loadedUrls) {
         URL.revokeObjectURL(url);
       }
       return;
     }
-    this.iconUrls = { ...this.iconUrls, ...loadedUrls };
+    for (const [pluginId, url] of loadedUrls) {
+      this.iconUrls.set(pluginId, url);
+    }
     this.hooks.requestUpdate();
   }
 
@@ -152,11 +157,11 @@ export class ChannelPluginPresentationController {
     }
     this.request = null;
     this.pendingEnsureClient = null;
-    for (const url of new Set(Object.values(this.iconUrls))) {
+    for (const url of this.iconUrls.values()) {
       URL.revokeObjectURL(url);
     }
     this.catalog = null;
-    this.iconUrls = {};
+    this.iconUrls.clear();
     this.hooks.requestUpdate();
   }
 }

--- a/ui/src/pages/channels/plugin-presentation.ts
+++ b/ui/src/pages/channels/plugin-presentation.ts
@@ -1,0 +1,11 @@
+import type { PluginCatalogItem } from "../../lib/plugins/index.ts";
+
+export function resolveChannelIconOwner(
+  plugins: readonly PluginCatalogItem[],
+  channelId: string,
+): PluginCatalogItem | undefined {
+  return (
+    plugins.find((plugin) => plugin.hasIcon && plugin.id === channelId) ??
+    plugins.find((plugin) => plugin.hasIcon && plugin.channelIds?.includes(channelId))
+  );
+}

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -117,47 +117,6 @@ describe("channels plugin presentation metadata", () => {
     );
     expect(container.textContent).not.toContain("Legacy channel subtitle");
   });
-
-  it("uses an owning plugin icon without replacing channel-authored presentation", () => {
-    const props = createProps({
-      ts: Date.now(),
-      channelOrder: ["agent-system-github"],
-      channelLabels: { "agent-system-github": "GitHub Notifications" },
-      channelDetailLabels: { "agent-system-github": "GitHub notification channel" },
-      channels: { "agent-system-github": { configured: false } },
-      channelAccounts: {},
-      channelDefaultAccountId: {},
-    });
-    props.pluginCatalog = {
-      plugins: [
-        createChannelPlugin({
-          id: "agent-system",
-          name: "Agent System",
-          description: "Manage agent workspaces.",
-          channelIds: ["agent-system-github"],
-        }),
-      ],
-      diagnostics: [],
-      mutationAllowed: true,
-    };
-    props.pluginIconUrls = { "agent-system-github": "blob:agent-system-plugin-icon" };
-    const container = document.createElement("div");
-
-    render(renderChannels(props), container);
-
-    const row = container.querySelector(".channels-item");
-    expect(row?.querySelector(".settings-row__title")?.textContent).toBe(
-      "GitHub Notifications",
-    );
-    expect(row?.querySelector(".settings-row__desc")?.textContent).toBe(
-      "GitHub notification channel",
-    );
-    expect(row?.querySelector("img")?.getAttribute("src")).toBe(
-      "blob:agent-system-plugin-icon",
-    );
-    expect(container.textContent).not.toContain("Agent System");
-    expect(container.textContent).not.toContain("Manage agent workspaces.");
-  });
 });
 
 describe("channels setup access", () => {

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -117,6 +117,47 @@ describe("channels plugin presentation metadata", () => {
     );
     expect(container.textContent).not.toContain("Legacy channel subtitle");
   });
+
+  it("uses an owning plugin icon without replacing channel-authored presentation", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["agent-system-github"],
+      channelLabels: { "agent-system-github": "GitHub Notifications" },
+      channelDetailLabels: { "agent-system-github": "GitHub notification channel" },
+      channels: { "agent-system-github": { configured: false } },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    props.pluginCatalog = {
+      plugins: [
+        createChannelPlugin({
+          id: "agent-system",
+          name: "Agent System",
+          description: "Manage agent workspaces.",
+          channelIds: ["agent-system-github"],
+        }),
+      ],
+      diagnostics: [],
+      mutationAllowed: true,
+    };
+    props.pluginIconUrls = { "agent-system-github": "blob:agent-system-plugin-icon" };
+    const container = document.createElement("div");
+
+    render(renderChannels(props), container);
+
+    const row = container.querySelector(".channels-item");
+    expect(row?.querySelector(".settings-row__title")?.textContent).toBe(
+      "GitHub Notifications",
+    );
+    expect(row?.querySelector(".settings-row__desc")?.textContent).toBe(
+      "GitHub notification channel",
+    );
+    expect(row?.querySelector("img")?.getAttribute("src")).toBe(
+      "blob:agent-system-plugin-icon",
+    );
+    expect(container.textContent).not.toContain("Agent System");
+    expect(container.textContent).not.toContain("Manage agent workspaces.");
+  });
 });
 
 describe("channels setup access", () => {

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -34,6 +34,7 @@ import {
   renderChannelRefreshAction,
   resolveChannelDisplayState,
 } from "./view.shared.ts";
+import { resolveChannelIconOwner } from "./plugin-presentation.ts";
 import type { ChannelKey, ChannelsChannelData, ChannelsProps } from "./view.types.ts";
 import { renderChannelWizard } from "./wizard-view.ts";
 
@@ -62,7 +63,7 @@ export function renderChannels(props: ChannelsProps) {
       .map((warning) => formatUiExternalText(warning)) ?? [];
   const data = buildChannelData(props);
   const selected = props.selectedChannel;
-  const selectedPlugin = selected ? resolveChannelPlugin(props, selected) : undefined;
+  const selectedIconPlugin = selected ? resolveChannelIconPlugin(props, selected) : undefined;
 
   return html`
     ${renderSettingsPage(html`
@@ -137,7 +138,7 @@ export function renderChannels(props: ChannelsProps) {
             channelId: selected,
             label: resolveChannelLabel(props, selected),
             pluginIconUrl: props.pluginIconUrls[selected],
-            preferPluginIcon: selectedPlugin?.hasIcon === true,
+            preferPluginIcon: selectedIconPlugin?.hasIcon === true,
             props,
             data,
             onClose: () => props.onCloseDetail(),
@@ -152,7 +153,7 @@ export function renderChannels(props: ChannelsProps) {
             channelLabel: (channelId) => resolveChannelLabel(props, channelId),
             channelIconUrl: (channelId) => props.pluginIconUrls[channelId],
             channelHasPluginIcon: (channelId) =>
-              resolveChannelPlugin(props, channelId)?.hasIcon === true,
+              resolveChannelIconPlugin(props, channelId)?.hasIcon === true,
             multiselectValues: props.wizardMultiselect,
             onToggleMultiselect: props.onWizardToggleMultiselect,
             textValue: props.wizardTextValue,
@@ -198,6 +199,12 @@ export function resolveChannelOrder(snapshot: ChannelsStatusSnapshot | null): Ch
 
 function resolveChannelPlugin(props: ChannelsProps, key: string) {
   return props.pluginCatalog?.plugins.find((plugin) => plugin.id === key);
+}
+
+function resolveChannelIconPlugin(props: ChannelsProps, key: string) {
+  return props.pluginCatalog
+    ? resolveChannelIconOwner(props.pluginCatalog.plugins, key)
+    : undefined;
 }
 
 function resolveChannelLabel(props: ChannelsProps, key: string): string {
@@ -277,7 +284,7 @@ function renderConnectedRow(key: ChannelKey, props: ChannelsProps) {
     >
       ${renderChannelIcon(key, label, "tile", {
         pluginIconUrl: props.pluginIconUrls[key],
-        preferPluginIcon: resolveChannelPlugin(props, key)?.hasIcon === true,
+        preferPluginIcon: resolveChannelIconPlugin(props, key)?.hasIcon === true,
       })}
       <div class="settings-row__text">
         <span class="settings-row__title">${label}</span>
@@ -306,7 +313,7 @@ function renderAvailableRow(key: ChannelKey, props: ChannelsProps) {
       >
         ${renderChannelIcon(key, label, "tile", {
           pluginIconUrl: props.pluginIconUrls[key],
-          preferPluginIcon: plugin?.hasIcon === true,
+          preferPluginIcon: resolveChannelIconPlugin(props, key)?.hasIcon === true,
         })}
         <span class="settings-row__text">
           <span class="settings-row__title">${label}</span>

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -27,6 +27,7 @@ import { t } from "../../i18n/index.ts";
 import { resolveChannelAccounts } from "../../lib/channels/index.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
+import { resolveChannelIconOwner } from "./plugin-presentation.ts";
 import { renderChannelDetail } from "./view.detail.ts";
 import { renderChannelPairingPrompt, renderChannelPairingQueue } from "./view.pairing.ts";
 import {
@@ -34,7 +35,6 @@ import {
   renderChannelRefreshAction,
   resolveChannelDisplayState,
 } from "./view.shared.ts";
-import { resolveChannelIconOwner } from "./plugin-presentation.ts";
 import type { ChannelKey, ChannelsChannelData, ChannelsProps } from "./view.types.ts";
 import { renderChannelWizard } from "./wizard-view.ts";
 


### PR DESCRIPTION
Closes #144152

## What Problem This Solves

Channels showed letter tiles when a channel ID differed from its plugin ID, even when that plugin supplied a valid icon. 

## Why This Change Was Made

The catalog exposes existing manifest ownership, and gallery, details, and setup resolve artwork through the owning plugin. Channel names and descriptions stay unchanged.

Each plugin owns one image URL. Channels that appear later reuse it, and page cleanup releases it once. Exact plugin/channel-ID matches retain priority. The existing authenticated package-icon route, trust rules, and configuration authority remain in place. The optional catalog field preserves older payload decoding.

## User Impact

Channels can use their plugin’s packaged artwork while keeping their own stable identity, name, and description. Multiple channels share one loaded plugin image.

## Evidence

### Real browser proof

An isolated Gateway served its matching Control UI with a normally installed external plugin, `agent-system`, and distinct channels `agent-system-github` and `agent-system-chat`.

- Pinned main `acbe754b931608952968d29d9548b5f2589f7d3b`: both channels showed fallback tiles; no owning-plugin icon request occurred.
- Candidate: one authenticated `GET /__openclaw__/plugin-icon/agent-system` returned PNG with HTTP 200. Both channels shared the decoded 256×256 image. Gallery, details, setup, and reload showed the packaged icon with the original text.
- Navigation released each image URL once. Invalid and missing icons showed readable fallbacks. Fresh unauthenticated requests returned 401. Normal plugin removal followed by Gateway restart removed both channels and the plugin.
- A source-blind validator independently drove the candidate and removal flows, inspected their screenshots, and separately judged the retained fallback captures.

| Surface | Before | After |
| --- | --- | --- |
| Gallery | ![Before: gallery](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/baseline-gallery.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=aac20738b279e628380cf4539c1e6f14ec7c4dbdeb21eb8eb9bc9300a65fb202) | ![After: gallery](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/candidate-gallery.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=3f0ff8257578b5b6f7908f36fc4cae82f60a0e143cae9b8128b48978912b13a4) |
| Details | ![Before: details](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/baseline-details.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=86e48e7796f77a1666aa58df454f7ec434d07898b32e1b10dea6e848611c689b) | ![After: details](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/candidate-details.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f858a119fa632e124d59e650d9066c3de0bf94890defa7f05f6200fef76b5a49) |
| Wizard | ![Before: wizard](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/baseline-wizard.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=9e9755f3238cc551dab3a70979cbf41e728dd4e0ce23963da5bbfc95165df1db) | ![After: wizard](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/candidate-wizard.png?X-Amz-Expires=604800&X-Amz-Date=20260911T013707Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=75e561d647d4eb6ec2eabe9ea8f501572e558c9eb30fd52a822d85ef4ab8874e) |

[Artifact manifest with file hashes](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-144177/public-media/20260911-013708-191645532/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260911T013709Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260911%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=0455b1ca86ec7edd9f5051d69bff11dd4209be45ec56eb04e1b069f4e8e0a031). These brokered image links expire September 18, 2026; the original captures and full private proof remain retained.

### Validation

- 161 distinct focused catalog, HTTP icon, page, view, and loader tests pass across retained runs.
- A later-sibling regression fails on the original duplicate-fetch behavior and passes with one shared URL and one release. Exact-ID priority is tested in both catalog orders; pending disconnect and timeout controls pass.
- Changed TypeScript lint, canonical protocol generation, Swift/Kotlin generated-output checks, protocol compatibility guard, source ratchets, UI copy checks, normal commit hook, and `git diff --check` pass.
- Hosted CI owns full type checking and execution of the added Swift JSONDecoder test for old and current catalog payloads. Those results remain required before landing.

No channel message delivery is claimed by this icon proof. The original contributor's implementation and commit ancestry are preserved.
