### PR TITLE
test(openrouter): keep cleanup timeout fixtures on acquired streams

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -249,6 +249,9 @@ describe("openrouter music generation provider", () => {
   it.each(["completed", "provider error", "timeout"] as const)(
     "releases a capture tee after %s without waiting for its sibling",
     async (outcome) => {
+      // Hold wall time so the deadline reaches the acquired stream's tee cleanup.
+      // Real timers still drive the 1ms stalled-stream timeout.
+      vi.setSystemTime(1_000);
       const cancel = vi.fn();
       const lines =
         outcome === "completed"
@@ -419,6 +422,8 @@ describe("openrouter music generation provider", () => {
   });
 
   it("times out stalled OpenRouter audio streams after headers", async () => {
+    // Freeze wall time so the timeout comes from reading the acquired response body.
+    vi.setSystemTime(1_000);
     postJsonRequestMock.mockResolvedValue({
       response: stalledSseResponse(
         `data: ${JSON.stringify({ choices: [{ delta: { audio: { transcript: "start" } } }] })}\n`,


### PR DESCRIPTION
## What Problem This Solves

Related: #144106. Its [CI extension shard](https://github.com/openclaw/openclaw/actions/runs/34490433326/job/102915827600) failed while waiting for the OpenRouter music capture test's request `release()` callback. The assertion never reached the later cancellation check.

The shared HTTP test helper now delegates real deadline policy after #144024. The fixture's one-millisecond absolute deadline can expire during setup, before any response/release pair is acquired, instead of exercising the stream cleanup regression from #141754. The separate test named “after headers” had the same possibility of passing through an earlier timeout.

## Why This Change Was Made

Freeze Date locally in those existing tests with `vi.setSystemTime(1_000)`, leaving native timers running. This makes the existing one-millisecond stalled-stream timer exercise an acquired response. The existing `afterEach` restores real time.

All original cases, 1 ms/1,000 ms limits, error expectations, release/cancel/lock assertions and `finally` cleanup remain. No production change, global mock rollback, fake-timer conversion, extra wait, dependency change or public API change. **Production LOC: 0. Tests: +5/-0.**

## User Impact

No runtime behavior change. CI now tests the intended acquired-response cleanup and after-header timeout paths without depending on completing setup inside one wall-clock millisecond.

## Evidence

- Original local music file: 26 passing tests. An initial namespace-spy diagnostic was inconclusive and fully restored; it is not cited as a reproduction.
- A separate controlled `Date.now()` diagnostic advanced 2 ms between actual deadline-owner reads. It reproduced the same release-wait failure: creation at 1,002 ms, remaining-time check at 1,004 ms, timeout rejection with POST/release/cancel all zero before fixture cleanup. This proves that failure mechanism, **not the historical scheduling of the uninstrumented CI run**.
- The three-line capture fixture passed all 26 tests. A temporary one-line awaited-cancellation fault then failed all three capture cases, confirming that the clock control did not hide the original ownership regression. Production was restored exactly. That fault proof remains bound to the three-line fixture; the additional two lines affect the separate after-header test.
- Final five-line candidate: **55 music/usage tests passed across both complete files**, including the sibling OpenRouter capture-release behavior. Formatting and diff checks passed. These are local Node 26.8.1 fixture tests, not live OpenRouter requests.
- The [normal configured changed gate](https://github.com/openclaw/openclaw/actions/runs/34496828230) passed all 19 stages on Linux Node 24.19.0 / pnpm 12.3.4: source `f38466d134d9f43104ae217b103b2b4db470d325`, exact candidate tree `77c0d4d516fcf00e6b1e4e45fd5ad9b3993c3426`, wrapper exit 0, 9m42s command. Its one-shot lease completed and temporary checkout/registration were removed. The nonfatal external portal-sync warning is retained.
- Managed precommit review and a separate review of exact signed commit `7da429b432713f17fa3734af0814ebcf9e377584` both passed through P2 with no findings. The commit has exactly the gate-tested tree. Hosted PR CI and normal native preparation remain required before landing.

The failed Inline CI checkout was merge `4d54f2aa8811e9a55a67c2a5d24e0ad16f1c4fd6`, combining its seven-path refactor with main `f38466d134d9f43104ae217b103b2b4db470d325`; neither this test nor the deadline helper was changed by that refactor. Two initial log downloads failed before returning content; the complete job-specific log was subsequently retrieved without rerunning CI.
