### PR TITLE
fix(models): keep catalog capabilities with their routes

### DIFF
--- a/docs/concepts/model-providers/custom-providers.md
+++ b/docs/concepts/model-providers/custom-providers.md
@@ -381,6 +381,8 @@ Example (OpenAI-compatible):
 
     Recommended: set explicit values that match your proxy/model limits.
 
+    Model-selection metadata keeps capabilities tied to the API and endpoint that supplied them. A configured route change discards metadata from the previous route, while an explicit `thinkingLevelMap` is applied to the configured model.
+
   </Accordion>
   <Accordion title="Proxy-route shaping rules">
     - For `api: "openai-completions"` on non-native endpoints (any non-empty `baseUrl` whose host is not `api.openai.com`), OpenClaw forces `compat.supportsDeveloperRole: false` to avoid provider 400 errors for unsupported `developer` roles.

--- a/src/agents/model-catalog-metadata.ts
+++ b/src/agents/model-catalog-metadata.ts
@@ -1,3 +1,7 @@
+import {
+  PREPARED_THINKING_POLICY,
+  type ThinkingCatalogPolicyCarrier,
+} from "../plugins/provider-thinking-catalog.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 
@@ -33,7 +37,9 @@ function catalogRouteChanges(base: ModelCatalogEntry, overlay: ModelCatalogEntry
   );
 }
 
-function clearRouteBoundCatalogMetadata(entry: ModelCatalogEntry): ModelCatalogEntry {
+function clearRouteBoundCatalogMetadata(
+  entry: ModelCatalogEntry & ThinkingCatalogPolicyCarrier,
+): ModelCatalogEntry {
   const {
     contextWindow: _contextWindow,
     contextWindows: _contextWindows,
@@ -41,6 +47,8 @@ function clearRouteBoundCatalogMetadata(entry: ModelCatalogEntry): ModelCatalogE
     contextTokens: _contextTokens,
     reasoning: _reasoning,
     configuredReasoning: _configuredReasoning,
+    thinkingPolicyProvider: _thinkingPolicyProvider,
+    [PREPARED_THINKING_POLICY]: _thinkingPolicy,
     thinkingLevelMap: _thinkingLevelMap,
     input: _input,
     params: _params,
@@ -56,6 +64,8 @@ export function overlayCatalogMetadata(
   overlay: ModelCatalogEntry,
   options?: {
     preserveBaseCompat?: boolean;
+    /** Keep the donor transport for subsequent route projection. */
+    preserveBaseRoute?: boolean;
   },
 ): ModelCatalogEntry {
   // Catalog rows with one logical provider/id may describe different physical
@@ -92,12 +102,13 @@ export function overlayCatalogMetadata(
               }
             : {}),
         };
+  const applyRoute = !options?.preserveBaseRoute;
   return {
     ...selectionNeutralBase,
     ...contextWindowSelection,
     ...(routeChanged ? { name: overlay.name } : {}),
-    ...(overlay.api !== undefined ? { api: overlay.api } : {}),
-    ...(overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
+    ...(applyRoute && overlay.api !== undefined ? { api: overlay.api } : {}),
+    ...(applyRoute && overlay.baseUrl !== undefined ? { baseUrl: overlay.baseUrl } : {}),
     ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
     ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
     ...(overlay.reasoning !== undefined ? { reasoning: overlay.reasoning } : {}),

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -22,8 +22,8 @@ import { resolveAgentConfig } from "./agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "./configured-provider-fallback.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
 import { findModelCatalogEntry } from "./model-catalog-lookup.js";
+import { overlayCatalogMetadata } from "./model-catalog-metadata.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   createConfiguredProviderCatalogModelIdNormalizer,
@@ -652,35 +652,16 @@ function applyModelCatalogMetadata(params: {
   if (!configuredEntry && !alias) {
     return params.entry;
   }
-  const nextAlias = alias ?? params.entry.alias;
-  const nextContextWindow = configuredEntry?.contextWindow ?? params.entry.contextWindow;
-  const nextContextTokens = configuredEntry?.contextTokens ?? params.entry.contextTokens;
-  const nextReasoning = configuredEntry?.reasoning ?? params.entry.reasoning;
-  const configuredReasoning = configuredEntry?.configuredReasoning;
-  const nextInput = configuredEntry?.input ?? params.entry.input;
-  const nextParams =
-    params.entry.params || configuredEntry?.params
-      ? { ...params.entry.params, ...configuredEntry?.params }
-      : undefined;
-  const nextCompat = resolveCatalogOwnedModelCompat({
-    catalogRoute: params.entry,
-    catalogCompat: params.entry.compat,
-    configuredRoute: configuredEntry,
-    configuredCompat: configuredEntry?.compat,
-  });
-
-  return {
-    ...params.entry,
-    name: configuredEntry?.name ?? params.entry.name,
-    ...(nextAlias ? { alias: nextAlias } : {}),
-    ...(nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
-    ...(nextContextTokens !== undefined ? { contextTokens: nextContextTokens } : {}),
-    ...(nextReasoning !== undefined ? { reasoning: nextReasoning } : {}),
-    ...(configuredReasoning !== undefined ? { configuredReasoning } : {}),
-    ...(nextInput ? { input: nextInput } : {}),
-    ...(nextParams ? { params: nextParams } : {}),
-    ...(nextCompat ? { compat: nextCompat } : {}),
-  };
+  const entry = configuredEntry
+    ? {
+        ...overlayCatalogMetadata(params.entry, configuredEntry, {
+          preserveBaseCompat: true,
+          preserveBaseRoute: true,
+        }),
+        name: configuredEntry.name,
+      }
+    : params.entry;
+  return alias ? { ...entry, alias } : entry;
 }
 
 export function resolveModelRefFromString(

--- a/src/agents/model-selection.catalog-overlay.test.ts
+++ b/src/agents/model-selection.catalog-overlay.test.ts
@@ -1,0 +1,292 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { resolveThinkingProfile } from "../auto-reply/thinking.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import { validateConfigObjectRaw } from "../config/validation-core.js";
+import type { ProviderModelRouteCandidate } from "../plugin-sdk/provider-model-types.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinking.js";
+import {
+  type ModelCatalogRoutePolicy,
+  projectModelCatalogEntryForRoute,
+  resolveConfiguredModelCatalogOverrides,
+} from "./model-catalog-route.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { modelTransportRoutesMatch } from "./model-compat-catalog.js";
+import { buildAllowedModelSet } from "./model-selection-shared.js";
+
+type OverlayCase = {
+  name: string;
+  override: Partial<ModelDefinitionConfig>;
+  clearsCapturedMetadata: boolean;
+  missingRouteField?: "api" | "baseUrl";
+};
+
+const capturedRoute = {
+  api: "openai-responses",
+  baseUrl: "https://captured.example/v1",
+} as const;
+const routePolicy: ModelCatalogRoutePolicy = {
+  resolveIdentity: ({ provider, id }) => ({ id, key: `${provider}/${id}` }),
+  matchesRoute: modelTransportRoutesMatch,
+};
+
+describe("configured catalog route overlays", () => {
+  it.each<OverlayCase>([
+    { name: "same route with omitted metadata", override: {}, clearsCapturedMetadata: false },
+    {
+      name: "same route with explicit disabled reasoning",
+      override: { reasoning: false, input: ["text"], compat: { supportsTools: false } },
+      clearsCapturedMetadata: false,
+    },
+    {
+      name: "same route with explicit thinking metadata",
+      override: {
+        reasoning: true,
+        thinkingLevelMap: { off: null, max: "max" },
+        contextWindow: 32_000,
+        contextTokens: 16_000,
+        params: { configured: true },
+      },
+      clearsCapturedMetadata: false,
+    },
+    {
+      name: "same endpoint with a trailing slash",
+      override: { baseUrl: `${capturedRoute.baseUrl}/` },
+      clearsCapturedMetadata: false,
+    },
+    {
+      name: "API pin with omitted metadata",
+      override: { api: "openai-completions" },
+      clearsCapturedMetadata: true,
+    },
+    {
+      name: "endpoint pin with omitted metadata",
+      override: { baseUrl: "https://configured.example/v1" },
+      clearsCapturedMetadata: true,
+    },
+    {
+      name: "endpoint pin with explicit disabled reasoning",
+      override: {
+        baseUrl: "https://configured.example/v1",
+        reasoning: false,
+        input: ["text"],
+        compat: { supportsTools: false },
+      },
+      clearsCapturedMetadata: true,
+    },
+    {
+      name: "API pin with explicit thinking metadata",
+      override: {
+        api: "openai-completions",
+        reasoning: true,
+        input: ["text", "image"],
+        thinkingLevelMap: { off: null, max: "max" },
+        contextWindow: 32_000,
+        contextTokens: 16_000,
+        params: { configured: true },
+        compat: { supportsTools: false },
+      },
+      clearsCapturedMetadata: true,
+    },
+    {
+      name: "missing API with provider fallback",
+      override: {},
+      clearsCapturedMetadata: false,
+      missingRouteField: "api",
+    },
+    {
+      name: "missing endpoint with provider fallback",
+      override: {},
+      clearsCapturedMetadata: false,
+      missingRouteField: "baseUrl",
+    },
+    {
+      name: "missing API with explicit pin",
+      override: { api: "openai-completions" },
+      clearsCapturedMetadata: false,
+      missingRouteField: "api",
+    },
+    {
+      name: "missing endpoint with explicit pin",
+      override: { baseUrl: "https://configured.example/v1" },
+      clearsCapturedMetadata: false,
+      missingRouteField: "baseUrl",
+    },
+  ])(
+    "keeps capabilities with their owner: $name",
+    ({ override, clearsCapturedMetadata, missingRouteField }) => {
+      const source = validateConfigObjectRaw({
+        agents: {
+          entries: { main: {} },
+          defaults: {
+            models: { "route-fixture/selected": { alias: "Selected alias" } },
+            modelPolicy: { allow: ["route-fixture/selected"] },
+          },
+        },
+        models: {
+          providers: {
+            "route-fixture": {
+              ...capturedRoute,
+              models: [{ id: "selected", name: "Configured selected", ...override }],
+            },
+          },
+        },
+      });
+      if (!source.ok) {
+        throw new Error(JSON.stringify(source.issues));
+      }
+      const captured: ModelCatalogEntry = {
+        provider: "route-fixture",
+        id: "selected",
+        name: "Captured selected",
+        ...capturedRoute,
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 128_000,
+        contextWindows: [{ id: "native", label: "Native", contextWindow: 128_000 }],
+        contextWindowDefault: "native",
+        contextTokens: 96_000,
+        thinkingLevelMap: { off: null, high: "high" },
+        thinkingPolicyProvider: "fixture-thinking-owner",
+        params: { captured: true },
+        compat: { supportsTools: true },
+        mediaInput: { image: { maxBytes: 4_096 } },
+      };
+      if (missingRouteField) {
+        delete captured[missingRouteField];
+      }
+      const catalog: ModelCatalogSnapshot = { entries: [captured], routeVariants: [captured] };
+      const metadataSnapshot = createPluginMetadataSnapshotFixture();
+      const preparedPolicy = vi.fn(
+        () =>
+          ({
+            levels: [{ id: "off" }, { id: "max" }],
+            defaultLevel: "max",
+          }) as const,
+      );
+      prepareModelCatalogThinkingPolicies({
+        catalog,
+        metadataSnapshot,
+        providers: [
+          { provider: { id: "fixture-thinking-owner", resolveThinkingProfile: preparedPolicy } },
+        ],
+      });
+      const allowed = buildAllowedModelSet({
+        cfg: source.config,
+        catalog: catalog.entries,
+        defaultProvider: "route-fixture",
+        manifestPlugins: metadataSnapshot,
+      });
+      const selected = expectDefined(allowed.allowedCatalog[0], "configured selected row");
+      const route: ProviderModelRouteCandidate = {
+        ...capturedRoute,
+        api: override.api ?? capturedRoute.api,
+        baseUrl: override.baseUrl ?? capturedRoute.baseUrl,
+        authRequirement: "api-key",
+        requestTransportOverrides: "none",
+      };
+      expect(allowed.allowedCatalog).toHaveLength(1);
+      expect(selected).toMatchObject({
+        provider: "route-fixture",
+        id: "selected",
+        name: "Configured selected",
+        alias: "Selected alias",
+      });
+      for (const field of ["api", "baseUrl"] as const) {
+        expect(selected[field]).toBe(captured[field]);
+        expect(Object.hasOwn(selected, field)).toBe(Object.hasOwn(captured, field));
+      }
+      expect(
+        resolveThinkingProfile({
+          provider: selected.provider,
+          model: selected.id,
+          catalog: [selected],
+          providerPolicySource: { providers: [] },
+        }).defaultLevel,
+      ).toBe(override.reasoning === false ? "off" : clearsCapturedMetadata ? undefined : "max");
+      expect(preparedPolicy).toHaveBeenCalledTimes(clearsCapturedMetadata ? 0 : 1);
+      preparedPolicy.mockClear();
+      expect(selected.configuredReasoning).toBe(override.reasoning);
+      expect(selected.reasoning).toBe(
+        override.reasoning ?? (clearsCapturedMetadata ? undefined : true),
+      );
+      expect(selected.input).toEqual(
+        override.input ?? (clearsCapturedMetadata ? undefined : ["text", "image"]),
+      );
+      expect(selected.contextWindow).toBe(
+        override.contextWindow ?? (clearsCapturedMetadata ? undefined : 128_000),
+      );
+      expect(selected.contextTokens).toBe(
+        override.contextTokens ?? (clearsCapturedMetadata ? undefined : 96_000),
+      );
+      expect(selected.thinkingLevelMap).toEqual(
+        override.thinkingLevelMap ??
+          (clearsCapturedMetadata ? undefined : { off: null, high: "high" }),
+      );
+      if (!missingRouteField) {
+        expect(selected.compat).toEqual(
+          clearsCapturedMetadata ? override.compat : { supportsTools: true },
+        );
+      }
+      expect(selected.params).toEqual(
+        clearsCapturedMetadata ? override.params : { captured: true, ...override.params },
+      );
+      expect(selected.contextWindows).toEqual(
+        clearsCapturedMetadata ? undefined : captured.contextWindows,
+      );
+      expect(selected.contextWindowDefault).toBe(clearsCapturedMetadata ? undefined : "native");
+      expect(selected.mediaInput).toEqual(clearsCapturedMetadata ? undefined : captured.mediaInput);
+      expect(selected.thinkingPolicyProvider).toBe(
+        clearsCapturedMetadata ? undefined : "fixture-thinking-owner",
+      );
+
+      const { entry: projected, runtimeEntry } = projectModelCatalogEntryForRoute({
+        entry: selected,
+        projection: { kind: "selected", route, policy: routePolicy },
+        catalog: catalog.routeVariants,
+        overrides: resolveConfiguredModelCatalogOverrides({
+          cfg: source.config,
+          entry: selected,
+          policy: routePolicy,
+        }),
+      });
+      const hasMatchingDonor = !clearsCapturedMetadata && !missingRouteField;
+      expect(projected).toMatchObject({
+        provider: "route-fixture",
+        id: "selected",
+        name: "Configured selected",
+        alias: "Selected alias",
+        api: route.api,
+        baseUrl: route.baseUrl,
+      });
+      expect(projected.reasoning).toBe(override.reasoning ?? (hasMatchingDonor ? true : undefined));
+      expect(projected.input).toEqual(
+        override.input ?? (hasMatchingDonor ? ["text", "image"] : undefined),
+      );
+      expect(projected.contextWindow).toBe(
+        override.contextWindow ?? (hasMatchingDonor ? 128_000 : undefined),
+      );
+      expect(projected.contextTokens).toBe(
+        override.contextTokens ?? (hasMatchingDonor ? 96_000 : undefined),
+      );
+      expect(projected.thinkingLevelMap).toEqual(
+        override.thinkingLevelMap ?? (hasMatchingDonor ? { off: null, high: "high" } : undefined),
+      );
+      expect(projected.thinkingPolicyProvider).toBe(
+        hasMatchingDonor ? "fixture-thinking-owner" : undefined,
+      );
+      expect(runtimeEntry.compat).toEqual(hasMatchingDonor ? { supportsTools: true } : undefined);
+      expect(runtimeEntry.params).toEqual(hasMatchingDonor ? { captured: true } : undefined);
+      expect(
+        resolveThinkingProfile({
+          provider: projected.provider,
+          model: projected.id,
+          catalog: [projected],
+          providerPolicySource: { providers: [] },
+        }).defaultLevel,
+      ).toBe(override.reasoning === false ? "off" : hasMatchingDonor ? "max" : undefined);
+      expect(preparedPolicy).toHaveBeenCalledTimes(hasMatchingDonor ? 1 : 0);
+    },
+  );
+});


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

The model-selection catalog duplicated the shared metadata merger. When a configured API or endpoint changed, that copy could retain capabilities and a prepared thinking policy from the previous route. It also failed to apply an explicit thinking-level map.

## Why This Change Was Made

Use the existing catalog overlay owner, including its route-change checks, and clear the old thinking-policy fields with the other route-bound metadata. Keep the captured catalog row's original transport until final route projection. That preserves rejection of incompatible donors, including rows missing an API or endpoint.

This removes eight production lines across two files. The documentation describes the resulting route and thinking-map behavior. Configuration, storage, and plugin APIs are unchanged.

## User Impact

Model selection no longer carries the previous route's capabilities and thinking policy across a configured route change. Explicit thinking maps are retained. Compatible routes keep their existing capability and compatibility precedence.

## Evidence

- The original source failed five intended cases; seven controls passed, including missing-route fields, explicit pins, and provider defaults.
- The candidate passed all 355 focused tests across eight files, including the complete twelve-case route/selection/thinking table.
- The full changed-file gate, full documentation checks, and independent P2 review passed on the committed source.
- One normal full build of `f1bc414c6ab7bcd8da7546fe75a22ce2be3d7a98` passed, including SDK declarations. All twelve cases passed through the emitted production exports. The source-import rejection control also passed.
- No checkout TypeScript or fetch calls occurred. All 11,934 build files across seventeen roots remained unchanged, and all owned proof processes exited. This is compiled selection/thinking-boundary proof, not a hosted-provider request.
- Exact-head CI remains required before landing.

An earlier attempt copied configured transport onto the captured row and allowed missing-field rows to become false capability donors. That candidate was rejected. The current change preserves the captured transport and tests the final selected projection, including property omissions. It does not add a source-binding layer or claim to repair retained-source attribution across configuration generations.
