### PR TITLE
fix(models): preserve exact authored pricing

### DIFF
--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -196,6 +196,7 @@ export function buildConfiguredFallbackModel(params: {
               cfg,
               configuredModel,
               catalogCost: staticCatalogModel?.cost,
+              providerMetadataOwners: params.providerMetadataOwners,
             }),
             contextWindow: resolvedFallbackContextWindow,
             contextTokens: configuredModel?.contextTokens ?? staticCatalogModel?.contextTokens,

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -3,10 +3,8 @@ import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catal
 import { asOptionalRecord as readModelParams } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { mergeModelCost } from "../../config/model-cost.js";
-import {
-  findConfiguredProviderModel,
-  matchesProviderScopedModelId,
-} from "../../config/model-provider-config.js";
+import { findConfiguredProviderModel } from "../../config/model-provider-config.js";
+import { materializeConfiguredProviderModelRows } from "../../config/model-provider-rows.js";
 import { projectConfigOntoRuntimeSourceSnapshot } from "../../config/runtime-source-projection.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Api, Model } from "../../llm/types.js";
@@ -172,31 +170,25 @@ export function mergeConfiguredModelCost(params: {
   cfg?: OpenClawConfig;
   configuredModel?: NonNullable<InlineProviderConfig["models"]>[number];
   catalogCost?: Model["cost"];
+  providerMetadataOwners?: PluginMetadataSnapshotOwnerMaps;
 }): Model["cost"] {
   let authoredCost = params.configuredModel?.cost;
   if (params.cfg && params.configuredModel) {
     const source = projectConfigOntoRuntimeSourceSnapshot(params.cfg);
     if (source !== params.cfg) {
-      const modelId = normalizeConfiguredProviderCatalogModelId(
-        params.provider,
-        params.configuredModel.id,
-      ).trim();
-      const sourceModels = resolveConfiguredProviderConfig(source, params.provider)?.models?.filter(
-        (model) =>
-          matchesProviderScopedModelId({
-            candidateId: normalizeConfiguredProviderCatalogModelId(
-              params.provider,
-              model.id,
-            ).trim(),
-            provider: params.provider,
-            modelId,
-          }),
-      );
-      if (sourceModels?.length) {
-        authoredCost = sourceModels.reduce<Model["cost"] | undefined>(
-          (cost, model) => mergeModelCost(model.cost, cost),
-          undefined,
-        );
+      // Source aliases resolve once; the selected runtime ID already names its row.
+      const modelId = params.configuredModel.id.trim();
+      const sourceModel = materializeConfiguredProviderModelRows(
+        { models: resolveConfiguredProviderConfig(source, params.provider)?.models ?? [] },
+        (id) =>
+          normalizeConfiguredProviderCatalogModelId(
+            params.provider,
+            id,
+            params.providerMetadataOwners?.modelIdNormalizationPolicies,
+          ),
+      ).models.find((model) => model.id === modelId);
+      if (sourceModel) {
+        authoredCost = sourceModel.cost;
       }
     }
   }
@@ -610,6 +602,7 @@ export function applyConfiguredProviderOverrides(params: {
             cfg: params.cfg,
             configuredModel: metadataOverrideModel,
             catalogCost: discoveredModel.cost,
+            providerMetadataOwners: params.providerMetadataOwners,
           }),
           contextWindow,
           contextTokens: metadataOverrideModel?.contextTokens ?? discoveredModel.contextTokens,

--- a/src/agents/embedded-agent-runner/model.configured-pricing.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.configured-pricing.test-support.ts
@@ -1,0 +1,164 @@
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
+
+export const catalogCost = {
+  input: 11,
+  output: 22,
+  cacheRead: 3,
+  cacheWrite: 4,
+  tieredPricing: [
+    {
+      input: 33,
+      output: 44,
+      cacheRead: 5,
+      cacheWrite: 6,
+      range: [0, Infinity] as [number, number],
+    },
+  ],
+};
+export const staleCost = { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 };
+const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+export const flatCatalogCost = { input: 11, output: 22, cacheRead: 3, cacheWrite: 4 };
+const authoredTier = { ...staleCost, range: [0, Infinity] as [number, number] };
+export const sourceRow = (id: string, cost?: Partial<ModelDefinitionConfig["cost"]>) => ({
+  id,
+  ...(cost === undefined ? {} : { cost }),
+});
+
+type ConfiguredPricingCase = {
+  name: string;
+  cost?: Partial<ModelDefinitionConfig["cost"]>;
+  expected: ModelDefinitionConfig["cost"];
+  missingSource?: boolean;
+  sourceModels?: ReturnType<typeof sourceRow>[];
+  provider?: string;
+  modelId?: string;
+  configuredId?: string;
+  noSnapshot?: boolean;
+};
+
+export const configuredPricingCases: ConfiguredPricingCase[] = [
+  { name: "omitted", expected: catalogCost },
+  { name: "empty", cost: {}, expected: catalogCost },
+  {
+    name: "partial",
+    cost: { input: 7 },
+    expected: { input: 7, output: 22, cacheRead: 3, cacheWrite: 4 },
+  },
+  { name: "zero", cost: zeroCost, expected: zeroCost },
+  { name: "full", cost: staleCost, expected: staleCost },
+  {
+    name: "empty tiers",
+    cost: { tieredPricing: [] },
+    expected: { input: 11, output: 22, cacheRead: 3, cacheWrite: 4 },
+  },
+  {
+    name: "authored tiers",
+    cost: { tieredPricing: [{ ...staleCost, range: [0] }] },
+    expected: { ...catalogCost, tieredPricing: [{ ...staleCost, range: [0, Infinity] }] },
+  },
+  { name: "missing source row", missingSource: true, expected: staleCost },
+  {
+    name: "alias before sparse exact row",
+    provider: "anthropic",
+    modelId: "claude-opus-5",
+    sourceModels: [sourceRow("opus", { input: 99, output: 98 }), sourceRow("claude-opus-5")],
+    expected: catalogCost,
+  },
+  {
+    name: "alias after sparse exact row",
+    provider: "anthropic",
+    modelId: "claude-opus-5",
+    sourceModels: [sourceRow("claude-opus-5"), sourceRow("opus", { input: 99, output: 98 })],
+    expected: catalogCost,
+  },
+  {
+    name: "alias before partial exact row",
+    provider: "anthropic",
+    modelId: "claude-opus-5",
+    sourceModels: [
+      sourceRow("opus", { input: 99, output: 98 }),
+      sourceRow("claude-opus-5", { input: 7 }),
+    ],
+    expected: { ...flatCatalogCost, input: 7 },
+  },
+  {
+    name: "alias after partial exact row",
+    provider: "anthropic",
+    modelId: "claude-opus-5",
+    sourceModels: [
+      sourceRow("claude-opus-5", { input: 7 }),
+      sourceRow("opus", { input: 99, output: 98 }),
+    ],
+    expected: { ...flatCatalogCost, input: 7 },
+  },
+  {
+    name: "self-prefix before sparse literal row",
+    provider: "custom",
+    sourceModels: [sourceRow("custom/priced-model", { input: 88 }), sourceRow("priced-model")],
+    expected: catalogCost,
+  },
+  {
+    name: "self-prefix after sparse literal row",
+    provider: "custom",
+    sourceModels: [sourceRow("priced-model"), sourceRow("custom/priced-model", { output: 87 })],
+    expected: catalogCost,
+  },
+  {
+    name: "bare row beside a selected literal namespace",
+    provider: "custom",
+    modelId: "custom/priced-model",
+    sourceModels: [sourceRow("priced-model", { input: 88 }), sourceRow("custom/priced-model")],
+    expected: catalogCost,
+  },
+  {
+    name: "selected legacy-prefixed row without an exact sibling",
+    provider: "custom",
+    configuredId: "custom/priced-model",
+    sourceModels: [sourceRow("custom/priced-model", { input: 7 })],
+    expected: { ...flatCatalogCost, input: 7 },
+  },
+  {
+    name: "same-spelling partial costs",
+    sourceModels: [
+      sourceRow("priced-model", { input: 7 }),
+      sourceRow(" priced-model ", { output: 8, cacheRead: 0 }),
+      sourceRow("priced-model", { input: 99, cacheWrite: 2 }),
+    ],
+    expected: { input: 7, output: 8, cacheRead: 0, cacheWrite: 2 },
+  },
+  {
+    name: "same-spelling explicit zero cost",
+    sourceModels: [sourceRow("priced-model", zeroCost), sourceRow("priced-model", { input: 99 })],
+    expected: zeroCost,
+  },
+  {
+    name: "same-spelling flat price before tiers",
+    sourceModels: [
+      sourceRow("priced-model", { input: 7 }),
+      sourceRow("priced-model", { tieredPricing: [authoredTier] }),
+    ],
+    expected: { ...flatCatalogCost, input: 7 },
+  },
+  {
+    name: "same-spelling authored tiers",
+    sourceModels: [
+      sourceRow("priced-model", { tieredPricing: [authoredTier] }),
+      sourceRow("priced-model", { input: 7 }),
+    ],
+    expected: { ...flatCatalogCost, input: 7, tieredPricing: [authoredTier] },
+  },
+  {
+    name: "same-spelling explicit empty tiers",
+    sourceModels: [
+      sourceRow("priced-model", { tieredPricing: [] }),
+      sourceRow("priced-model", { input: 7 }),
+    ],
+    expected: { ...flatCatalogCost, input: 7 },
+  },
+  {
+    name: "same-spelling empty cost before a partial price",
+    sourceModels: [sourceRow("priced-model", {}), sourceRow("priced-model", { output: 8 })],
+    expected: { ...flatCatalogCost, output: 8 },
+  },
+  { name: "independent runtime without source snapshot", noSnapshot: true, expected: staleCost },
+];

--- a/src/agents/embedded-agent-runner/model.configured-pricing.test.ts
+++ b/src/agents/embedded-agent-runner/model.configured-pricing.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { buildConfiguredFallbackModel } from "./model.configured-fallback.js";
+import { applyConfiguredProviderOverrides } from "./model.configured-overrides.js";
+import {
+  catalogCost,
+  flatCatalogCost,
+  sourceRow,
+  staleCost,
+} from "./model.configured-pricing.test-support.js";
+import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
+import { makeModel } from "./model.test-harness.js";
+
+afterEach(clearRuntimeConfigSnapshot);
+function createRuntimeHooks() {
+  return createProviderRuntimeTestMock({
+    handledDynamicProviders: ["google-antigravity", "zai", "openai"],
+  });
+}
+
+describe("captured configured pricing policies", () => {
+  it.each([false, true])(
+    "uses captured pricing aliases once with a cloned config: %s",
+    (cloneRuntime) => {
+      const provider = "pricing-fixture";
+      const model = {
+        ...makeModel("middle"),
+        api: "openai-completions" as const,
+        input: ["text" as const],
+        contextWindow: 1,
+        cost: staleCost,
+      };
+      const providerConfig = { baseUrl: "https://models.example/v1", models: [model] };
+      const runtime: OpenClawConfig = { models: { providers: { [provider]: providerConfig } } };
+      const source = {
+        models: {
+          providers: {
+            [provider]: { ...providerConfig, models: [sourceRow("latest", { input: 7 })] },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setRuntimeConfigSnapshot(runtime, source);
+      const cfg = cloneRuntime ? structuredClone(runtime) : runtime;
+      const captured = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: provider,
+            providers: [provider],
+            modelIdNormalization: {
+              providers: { [provider]: { aliases: { latest: "middle", middle: "final" } } },
+            },
+          },
+        ],
+      });
+      const discoveredModel = {
+        ...model,
+        provider,
+        baseUrl: providerConfig.baseUrl,
+        cost: catalogCost,
+      };
+      withPluginMetadataSnapshotScope(createPluginMetadataSnapshotFixture(), () => {
+        const result = applyConfiguredProviderOverrides({
+          provider,
+          discoveredModel,
+          providerConfig,
+          modelId: "middle",
+          cfg,
+          manifestAlias: { provider },
+          providerMetadataOwners: captured.owners,
+          runtimeHooks: createRuntimeHooks(),
+        });
+        const fallback = buildConfiguredFallbackModel({
+          provider,
+          modelId: "middle",
+          cfg,
+          manifestAlias: { provider },
+          providerMetadataOwners: captured.owners,
+          getStaticCatalogModel: () => discoveredModel,
+          runtimeHooks: createRuntimeHooks(),
+        });
+        expect(result.id).toBe("middle");
+        expect(fallback?.id).toBe("middle");
+        expect(result.cost).toEqual({ ...flatCatalogCost, input: 7 });
+        expect(fallback?.cost).toEqual({ ...flatCatalogCost, input: 7 });
+      });
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -5,10 +5,14 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../../config/runtime-snapshot.js";
-import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { discoverModels } from "../agent-model-discovery.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { buildConfiguredFallbackModel } from "./model.configured-fallback.js";
+import {
+  catalogCost,
+  configuredPricingCases,
+  staleCost,
+} from "./model.configured-pricing.test-support.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
@@ -204,56 +208,20 @@ async function resolveAnthropicModelWithProviderOverrides(overrides: Partial<Mod
 }
 
 describe("resolveModel forward-compat errors and overrides", () => {
-  const catalogCost = {
-    input: 11,
-    output: 22,
-    cacheRead: 3,
-    cacheWrite: 4,
-    tieredPricing: [
-      {
-        input: 33,
-        output: 44,
-        cacheRead: 5,
-        cacheWrite: 6,
-        range: [0, Infinity] as [number, number],
-      },
-    ],
-  };
-  const staleCost = { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 };
-  const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-  it.each<{
-    name: string;
-    cost?: Partial<ModelDefinitionConfig["cost"]>;
-    expected: ModelDefinitionConfig["cost"];
-    missingSource?: boolean;
-  }>([
-    { name: "omitted", expected: catalogCost },
-    { name: "empty", cost: {}, expected: catalogCost },
-    {
-      name: "partial",
-      cost: { input: 7 },
-      expected: { input: 7, output: 22, cacheRead: 3, cacheWrite: 4 },
-    },
-    { name: "zero", cost: zeroCost, expected: zeroCost },
-    { name: "full", cost: staleCost, expected: staleCost },
-    {
-      name: "empty tiers",
-      cost: { tieredPricing: [] },
-      expected: { input: 11, output: 22, cacheRead: 3, cacheWrite: 4 },
-    },
-    {
-      name: "authored tiers",
-      cost: { tieredPricing: [{ ...staleCost, range: [0] }] },
-      expected: { ...catalogCost, tieredPricing: [{ ...staleCost, range: [0, Infinity] }] },
-    },
-    { name: "missing source row", missingSource: true, expected: staleCost },
-  ])(
+  it.each(configuredPricingCases)(
     "resolves authored $name cost over the complete discovered schedule",
-    async ({ cost, expected, missingSource }) => {
-      const provider = "pricing-fixture";
-      const modelId = "priced-model";
+    async ({
+      cost,
+      expected,
+      missingSource,
+      sourceModels,
+      provider = "pricing-fixture",
+      modelId = "priced-model",
+      configuredId = modelId,
+      noSnapshot,
+    }) => {
       const model = {
-        ...makeModel(modelId),
+        ...makeModel(configuredId),
         api: "openai-completions" as const,
         input: ["text", "image"] as Array<"text" | "image">,
         contextWindow: 8192,
@@ -266,52 +234,59 @@ describe("resolveModel forward-compat errors and overrides", () => {
       const source = {
         models: {
           providers: {
-            " Pricing-Fixture ": {
+            [` ${provider.toUpperCase()} `]: {
               ...providerConfig,
-              models: missingSource
-                ? []
-                : [
-                    {
-                      id: " priced-model ",
-                      contextWindow: 8192,
-                      ...(cost === undefined ? {} : { cost }),
-                    },
-                  ],
+              models:
+                sourceModels ??
+                (missingSource
+                  ? []
+                  : [
+                      {
+                        id: ` ${modelId} `,
+                        contextWindow: 8192,
+                        ...(cost === undefined ? {} : { cost }),
+                      },
+                    ]),
             },
           },
         },
       } as unknown as OpenClawConfig;
       const catalogModel = {
         ...model,
+        id: modelId,
         provider,
         baseUrl: providerConfig.baseUrl,
         cost: catalogCost,
       };
       mockDiscoveredModel(discoverModels, { provider, modelId, templateModel: catalogModel });
-      setRuntimeConfigSnapshot(runtime, source);
+      if (!noSnapshot) {
+        setRuntimeConfigSnapshot(runtime, source);
+      }
 
-      const result = await resolveModelForTest(provider, modelId, "/tmp/agent", runtime);
-      const fallback = buildConfiguredFallbackModel({
-        provider,
-        modelId,
-        cfg: runtime,
-        manifestAlias: { provider },
-        getStaticCatalogModel: () => catalogModel,
-        runtimeHooks: createRuntimeHooks(),
-      });
+      for (const cfg of [runtime, structuredClone(runtime)]) {
+        const result = await resolveModelForTest(provider, modelId, "/tmp/agent", cfg);
+        const fallback = buildConfiguredFallbackModel({
+          provider,
+          modelId,
+          cfg,
+          manifestAlias: { provider },
+          getStaticCatalogModel: () => catalogModel,
+          runtimeHooks: createRuntimeHooks(),
+        });
 
-      expect(result.error).toBeUndefined();
-      expect(result.model).toMatchObject({
-        provider,
-        id: modelId,
-        input: model.input,
-        contextWindow: 8192,
-        maxTokens: 512,
-        compat: { supportsTools: false },
-        cost: expected,
-      });
-      expect(result.model?.cost).toEqual(expected);
-      expect(fallback?.cost).toEqual(expected);
+        expect(result.error).toBeUndefined();
+        expect(result.model).toMatchObject({
+          provider,
+          id: configuredId,
+          input: model.input,
+          contextWindow: 8192,
+          maxTokens: 512,
+          compat: { supportsTools: false },
+          cost: expected,
+        });
+        expect(result.model?.cost).toEqual(expected);
+        expect(fallback?.cost).toEqual(expected);
+      }
     },
   );
 

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -10,33 +10,6 @@ type MergedModelProviderEntry = {
   providerConfig: ModelProviderConfig;
 };
 
-export function matchesProviderScopedModelId(params: {
-  candidateId?: string;
-  provider: string;
-  modelId: string;
-  normalizeModelId?: (modelId: string) => string;
-}): boolean {
-  const { candidateId, provider, modelId } = params;
-  if (candidateId === modelId) {
-    return true;
-  }
-  const slashIndex = candidateId?.indexOf("/") ?? -1;
-  if (!candidateId) {
-    return false;
-  }
-  if (
-    slashIndex > 0 &&
-    candidateId.slice(slashIndex + 1) === modelId &&
-    normalizeProviderId(candidateId.slice(0, slashIndex)) === normalizeProviderId(provider)
-  ) {
-    return true;
-  }
-  return params.normalizeModelId
-    ? params.normalizeModelId(stripSelfProviderModelPrefix(provider, candidateId)) ===
-        params.normalizeModelId(stripSelfProviderModelPrefix(provider, modelId))
-    : false;
-}
-
 /** Uses the same authored row for transport materialization and early auth selection. */
 export function findConfiguredProviderModel<T extends { id: string }>(
   providerConfig: { models?: readonly T[] } | undefined,


### PR DESCRIPTION
Related: #130706, #142100. Builds on #144034.

## What Problem This Solves

Runtime pricing could merge prices from an alias or a similarly spelled row into an exact configured model. It also normalized selected model IDs again while recovering authored prices, so alias chains could select a different row.

## Why This Change Was Made

Use the existing configured-row materializer to recover authored costs, preserving exact-row precedence and resolving source aliases once. Pass the captured normalization policies through both runtime overrides and configured fallback. Remove the obsolete scoped matcher.

This removes 33 production lines across three files. Same-spelling partial costs, explicit zero, and tiered pricing retain their existing merge rules. No storage or configuration surface changes.

## User Impact

An exact configured model keeps its own authored price fields. Omitted fields retain the catalog schedule instead of receiving another row's prices or materialized defaults.

## Evidence

- The original source produced eight intended regression failures, with seventeen controls passing.
- All 177 focused cases passed, including selected-model rematerialization. After extracting test fixtures to meet the file-size guard, all 57 affected cases passed again; the public-resolver pricing table and assertion body are unchanged.
- The complete changed gate and fresh P2 review passed on the final six-file commit. The extraction adds no production test seam or lint exception.
- One normal full build of `0c54207e6d045042e7973fc8e3eb6f58e68165d8` passed, including declarations. Through emitted `resolveModelAsync` and real registries, all 32 pricing cases passed, with 64 observations of the intended caller paths. V8 coverage confirmed execution of both override and configured-fallback owners.
- All 11,931 build files remained unchanged; 943 inventoried compiled modules loaded with zero checkout TypeScript imports or HTTP requests. Owned processes exited and synthetic state was removed. Eight additional compiled A/B controls reproduced the explicitly inherited limitation below.
- Exact-head CI remains required before landing.

A known limitation remains: retained configurations still consult the current global runtime/source pair. A separate baseline/candidate comparison reproduced identical behavior in both directions of an authorship switch, including distinct byte-identical runtimes, same-object rebinds, and retained originals/clones through both cost callers. This cut fixes row selection within the supplied source; it does not establish retained-source isolation.
