### PR TITLE
fix(doctor): report schema guard snapshot cleanup failures

### DIFF
--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
@@ -16,6 +17,24 @@ import { readStateSchemaPublicationBlocker } from "../state/openclaw-state-schem
 import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
 import { VERSION } from "../version.js";
 
+/**
+ * Marks a snapshot cleanup failure so the guard can distinguish it from an
+ * unreadable driving updater. A missing or unreadable run cannot prove the
+ * driver writes the ledger and is tolerated; a cleanup failure is a real
+ * storage problem that must surface to the operator, not be swallowed.
+ */
+class DoctorSchemaSnapshotCleanupError extends Error {
+  constructor(stagingDir: string, cause: unknown) {
+    const readFailure =
+      cause === undefined ? "" : `${cause instanceof Error ? cause.message : String(cause)}; `;
+    super(
+      `${readFailure}State database snapshot cleanup failed: ${stagingDir}. Check directory permissions and available storage before retrying.`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "DoctorSchemaSnapshotCleanupError";
+  }
+}
+
 async function readDrivingUpdater(): Promise<
   { version: string; canDeferStateSchema: boolean } | undefined
 > {
@@ -24,23 +43,41 @@ async function readDrivingUpdater(): Promise<
   const snapshot = await prepareSqliteReadOnlyLocation(resolveOpenClawStateSqlitePath(), {
     preserveSourceArtifacts: true,
   });
+  let outcome:
+    | { value: { version: string; canDeferStateSchema: boolean } | undefined }
+    | {
+        cause: unknown;
+      };
   try {
     const database = openNodeSqliteDatabase(snapshot.location, { readOnly: true });
     try {
       const blocker = readStateSchemaPublicationBlocker(database);
-      return blocker
+      outcome = blocker
         ? {
-            version: blocker.updaterVersion,
-            canDeferStateSchema: tableExists(database, "config_machine_state"),
+            value: {
+              version: blocker.updaterVersion,
+              canDeferStateSchema: tableExists(database, "config_machine_state"),
+            },
           }
-        : undefined;
+        : { value: undefined };
     } finally {
       clearNodeSqliteKyselyCacheForDatabase(database);
       database.close();
     }
-  } finally {
-    snapshot.cleanup();
+  } catch (cause) {
+    outcome = { cause };
   }
+  // The exit retry is best-effort, not proof that this private copy was removed.
+  if (!snapshot.cleanup()) {
+    throw new DoctorSchemaSnapshotCleanupError(
+      path.dirname(snapshot.location),
+      "cause" in outcome ? outcome.cause : undefined,
+    );
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }
 
 /** Refuse before CLI capture or Doctor maintenance can open writable state. */
@@ -67,8 +104,13 @@ export async function guardUpdateDoctorSchemaUpgrade(options: {
   let updater: Awaited<ReturnType<typeof readDrivingUpdater>>;
   try {
     updater = await readDrivingUpdater();
-  } catch {
-    // A missing or unreadable run cannot prove that the driver writes the ledger.
+  } catch (error) {
+    // A missing or unreadable run cannot prove that the driver writes the ledger,
+    // so read failures are tolerated. A snapshot cleanup failure is a real storage
+    // problem and must surface rather than silently let the upgrade proceed.
+    if (error instanceof DoctorSchemaSnapshotCleanupError) {
+      throw error;
+    }
   }
   if (!updater) {
     return;


### PR DESCRIPTION
## What Problem This Solves

During an update, the schema safety guard creates a temporary read-only copy of the state database to check whether a driving updater is active; when removal of that temporary copy failed, the failure was silently ignored and the copy accumulated on disk with no signal. This fix checks the cleanup result and surfaces a diagnostic error on failure, while preserving the existing "tolerate an unreadable run" policy.

- Problem: `readDrivingUpdater` in `src/commands/doctor-update-schema-guard.ts` called `snapshot.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails (disk full, permission denied, file-handle contention), `cleanup()` returns `false` but the caller ignores it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Capture the read outcome first (value or caught cause), then check `snapshot.cleanup()` and throw a diagnostic `DoctorSchemaSnapshotCleanupError` with the staging directory path and actionable guidance if cleanup fails. The guard's catch still tolerates read failures (a missing or unreadable run cannot prove the driver writes the ledger) but rethrows cleanup failures instead of silently letting the upgrade proceed.
- What changed: `src/commands/doctor-update-schema-guard.ts` — added a `DoctorSchemaSnapshotCleanupError` class, refactored `readDrivingUpdater` to an outcome-capture pattern (read → check cleanup → rethrow read cause on clean cleanup), and adjusted `guardUpdateDoctorSchemaUpgrade`'s catch to distinguish read failures (swallowed, upgrade proceeds) from cleanup failures (rethrown). Added `import path from "node:path"` for the diagnostic directory path.
- What did NOT change: The inner `try/finally` that closes the database handle is preserved. The read logic, schema validation, blocker detection, and refusal policy are unchanged. Normal-path behavior (cleanup succeeds) is identical to before. The guard's two call sites (`run-main.ts`, `doctor-health.ts`) are untouched.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Two sibling call sites (`cron/store.ts` and `doctor-lint.ts`) already check the return value and throw on failure, confirming this is the project's expected pattern. This call site was missed.

The fix follows the #143844 template (outcome-capture + cleanup-check) with one adaptation specific to this call site: `readDrivingUpdater` is wrapped by `guardUpdateDoctorSchemaUpgrade` in a `catch {}` block that intentionally tolerates read failures (comment: "A missing or unreadable run cannot prove that the driver writes the ledger"). A naive template application — `if (!cleanup()) throw` inside the `finally` — would be swallowed by that empty catch, discarding the successfully-read updater value and letting the guard silently pass the upgrade, which is semantically worse than the pre-fix behavior. The `DoctorSchemaSnapshotCleanupError` type marker lets the guard's catch distinguish the two failure classes: read failures remain tolerated (upgrade proceeds, no false block), cleanup failures propagate to the operator.

- Best fix: Yes — minimal, directly aligned with the #143844 pattern, with the necessary type-marker adaptation for this call site's tolerating catch. The error class mirrors `doctor-lint.ts`'s `DoctorLintStateSnapshotError` precedent.
- Alternative: Making `adoptPreparedLocation` default `requireCleanup = true` would fix all call sites at once, but changes the shared primitive's contract and risks unintended throws in call sites that intentionally tolerate cleanup failure. Per-site fixes are safer and match how #143844 was merged.
- Risk: Low. Normal-path behavior is unchanged (Test 3 below). The only new behavior is a diagnostic error thrown when cleanup fails, which was previously silent. A cleanup failure now propagates out of the guard to its callers (`run-main.ts` / `doctor-health.ts`), which do not catch guard errors — this is intentional: a real storage problem must not be hidden inside the upgrade flow. Not tested: a real `ENOSPC` (disk-full) condition on this host; multi-process file-handle contention on Windows.

## User Impact

Operators will now see a clear diagnostic error when a temporary snapshot cannot be removed during the update schema guard check, instead of silent temporary-file accumulation. The error names the staging directory and suggests checking permissions and available storage, making the root cause actionable. When cleanup fails, the update guard surfaces the storage problem rather than silently proceeding with the schema upgrade.

## Evidence

Live command verification using `node --import tsx` driving the real `guardUpdateDoctorSchemaUpgrade` against a real SQLite state-database fixture with an `fs.rmSync` fault-injection preload. The fault only denies removal of `openclaw-sqlite-readonly-*` staging directories (the snapshot cleanup target), leaving the test fixture's own cleanup untouched.

```console
$ node /home/code/github/contributions/BUG/BUG-073-evidence/proof.mjs

=== Test 1: cleanup failure with successful read → diagnostic error ===
{
  "ok": true,
  "threw": true,
  "name": "DoctorSchemaSnapshotCleanupError",
  "message": "State database snapshot cleanup failed: /tmp/claude-1000/bug073-jZqxEp/cache-cleanup-fail/openclaw-1000/openclaw-sqlite-readonly-468659-aZts80/openclaw-sqlite-readonly-468864-BiCeYv. Check directory permissions and available storage before retrying.",
  "causeMessage": null
}
✅ PASS: cleanup failure throws DoctorSchemaSnapshotCleanupError (not swallowed)

=== Test 2: cleanup failure with read failure → diagnostic error with cause ===
{
  "ok": true,
  "threw": true,
  "name": "DoctorSchemaSnapshotCleanupError",
  "message": "Unexpected token '<', \"<<<not valid json>>>\" is not valid JSON; State database snapshot cleanup failed: /tmp/claude-1000/bug073-jZqxEp/cache-read-fail/openclaw-1000/openclaw-sqlite-readonly-468898-agxai6/openclaw-sqlite-readonly-469053-X9gDUN. Check directory permissions and available storage before retrying.",
  "causeMessage": "Unexpected token '<', \"<<<not valid json>>>\" is not valid JSON"
}
✅ PASS: cleanup failure preserves read cause in diagnostic error

=== Test 3: normal path (no fault) → guard proceeds without error ===
{
  "ok": true,
  "threw": false
}
✅ PASS: normal path proceeds (cleanup succeeds, updater undefined → guard returns)

=== All 3 tests passed ===
```

Test 2's read failure is produced without mocking `node:sqlite` (its `DatabaseSync` export is frozen and cannot be reassigned): the fixture's `update_runs` table holds a row matching the blocker query with an invalid-JSON `before_json`, so `readStateSchemaPublicationBlocker` throws a real `SyntaxError` during read, while the snapshot itself is a valid copy that `prepareSqliteReadOnlyLocation` created successfully.

Pre-fix verification (source reverted to `origin/main`, same proof): Test 1 returned `threw: false` — the cleanup failure was swallowed by the guard's empty `catch {}` and the upgrade proceeded with no signal, confirming the bug exists on canonical main.

```console
$ git checkout origin/main -- src/commands/doctor-update-schema-guard.ts
$ node /home/code/github/contributions/BUG/BUG-073-evidence/proof.mjs 2>&1 | grep -E "Test 1|threw|FAIL"
=== Test 1: cleanup failure with successful read → diagnostic error ===
  "threw": false
❌ FAIL: expected DoctorSchemaSnapshotCleanupError to propagate
```

Behavior matrix:

```text
scenario                        => pre-fix result         => post-fix result
cleanup fails, read succeeds    => silent (temp left)     => throws DoctorSchemaSnapshotCleanupError → propagates to caller
cleanup fails, read fails       => silent (temp left)     => throws DoctorSchemaSnapshotCleanupError with read cause preserved
cleanup succeeds, read ok       => guard proceeds         => guard proceeds (unchanged)
```

What was not tested: a real `ENOSPC` (disk-full) filesystem condition was not produced on this host; cleanup failure is exercised via `fs.rmSync` fault injection (EACCES) only. The guard's two call sites (`run-main.ts`, `doctor-health.ts`) are not driven end-to-end through a real update run — that would require an `OPENCLAW_UPDATE_IN_PROGRESS=1` update process and is not the contract under test; the contract is the guard's cleanup-error propagation, traced directly through `readDrivingUpdater` → `guardUpdateDoctorSchemaUpgrade`'s catch.

Open PR collision check: searched open PRs for `doctor-update-schema-guard` and scanned changed-file lists; no open PR touched this file. The file's last commit was #144022 (perf, unrelated to cleanup). This is part of a series applying the #143844 pattern to missed `prepareSqliteReadOnlyLocation*` call sites (BUG-069~075), each in its own PR.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (Claude Sonnet 4.6)
- Prompts / session excerpts: local-code-analysis fix workflow — bug discovered via `removeTempDirectory` anchor reverse-grep over `prepareSqliteReadOnlyLocation*` call sites; fix pattern derived from #143844 with a type-marker adaptation for this call site's tolerating catch; proof uses real SQLite fixtures + `fs.rmSync` fault injection
- Confirmed understanding of code changes: Yes — can explain every line; the outcome-capture + cleanup-check pattern mirrors #143844's `withStateDatabaseSnapshot` fix, and the `DoctorSchemaSnapshotCleanupError` marker is necessary because `guardUpdateDoctorSchemaUpgrade`'s empty catch would otherwise swallow a plain `throw`
- autoreview: N/A (worktree environment; oxlint + oxfmt + single-file tsgo passed)
