### PR TITLE
test(update): keep staged Doctor checks at the package owner

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -8120,49 +8120,6 @@ describe("update-cli", () => {
     );
   });
 
-  it("runs package post-update doctor from the verified package root after a staged swap", async () => {
-    const tempDir = tempDirs.make("openclaw-update-staged-doctor-");
-    const { nodeModules, pkgRoot, entryPath } = await setupInstalledPackageAtNodeModules(
-      path.join(tempDir, "lib", "node_modules"),
-    );
-    primeNpmChannelTag("latest", "2026.5.14");
-    mockFileBackedPathExists();
-    mockNpmGlobalCommands(nodeModules, async (argv) => {
-      if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
-        const stagePrefix = argv[argv.indexOf("--prefix") + 1];
-        const stagePackageRoot = path.join(
-          requireValue(stagePrefix, "stage prefix"),
-          "lib",
-          "node_modules",
-          "openclaw",
-        );
-        await writeOpenClawPackageFixture(stagePackageRoot, "2026.5.14", {
-          entrySource: "export {};\n",
-          inventory: true,
-        });
-      }
-    });
-    readPackageVersion.mockImplementation(async (packageRoot: string) => {
-      const manifest = JSON.parse(
-        await fs.readFile(path.join(packageRoot, "package.json"), "utf-8"),
-      ) as { version?: string };
-      return manifest.version ?? "0.0.0";
-    });
-
-    await updateCommand({ yes: true });
-
-    const doctorCall = doctorCommandCall();
-    expect(doctorCall?.[0].slice(1)).toEqual([entryPath, "doctor", "--non-interactive", "--fix"]);
-    expect(doctorCall?.[1].cwd).toBe(pkgRoot);
-    expect(
-      (doctorCall?.[1].env as NodeJS.ProcessEnv | undefined)?.OPENCLAW_SERVICE_REPAIR_POLICY,
-    ).toBe("external");
-    expect(
-      (doctorCall?.[1].env as NodeJS.ProcessEnv | undefined)?.OPENCLAW_COMPATIBILITY_HOST_VERSION,
-    ).toBe("2026.5.14");
-    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
-  });
-
   it.each([
     { json: true, handoff: "1", expectedExitCode: 79 },
     { json: false, handoff: undefined, expectedExitCode: 1 },
@@ -8491,7 +8448,7 @@ describe("update-cli", () => {
     },
   );
 
-  it.each(["owned-running", "no-restart", "stopped", "legacy-target"] as const)(
+  it.each(["owned-running", "no-restart", "stopped"] as const)(
     "uses compatibility-checked package update without full-state startup (%s)",
     async (mode) => {
       const root = await mockPackageInstallAtCaseDir("openclaw-update-startup-admission");
@@ -8505,14 +8462,6 @@ describe("update-cli", () => {
       if (mode === "stopped") {
         serviceReadRuntime.mockResolvedValue({ status: "stopped" });
       }
-      const validate = requireValue(
-        candidateValidation.getMockImplementation(),
-        "candidate validation",
-      );
-      candidateValidation.mockImplementation(async (options) => ({
-        ...(await validate(options)),
-        checkpointContinuation: mode !== "legacy-target",
-      }));
       await invokeUpdateCli({
         yes: true,
         json: true,

--- a/src/cli/update-cli/update-command-package.test.ts
+++ b/src/cli/update-cli/update-command-package.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
+import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
 import {
   createNpmTarget,
   writePackageRoot,
@@ -88,3 +89,80 @@ it.each([
     });
   },
 );
+
+it("runs package post-update doctor from the verified package root after a staged swap", async () => {
+  await withTestDir({ prefix: "update-staged-doctor-" }, async (base) => {
+    const globalRoot = path.join(base, "prefix", "lib", "node_modules");
+    const root = path.join(globalRoot, "openclaw");
+    const entryPath = path.join(root, "dist", "index.js");
+    await writePackageRoot(root, "2026.4.21");
+    const commands = vi
+      .spyOn(processRunner, "runCommandWithTimeout")
+      .mockImplementation(async (argv, options) => {
+        if (argv[0] === "npm" && argv[1] === "i") {
+          const prefix = argv[argv.indexOf("--prefix") + 1];
+          if (!argv.includes("--prefix") || !prefix) {
+            throw new Error("Missing actual staged prefix");
+          }
+          await writePackageRoot(path.join(prefix, "lib", "node_modules", "openclaw"), "2026.5.14");
+        } else if (argv[2] === "doctor") {
+          expect(argv.slice(1)).toEqual([entryPath, "doctor", "--non-interactive", "--fix"]);
+          expect(options).toMatchObject({
+            cwd: root,
+            env: {
+              OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+              OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.14",
+            },
+          });
+          expect(
+            JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")),
+          ).toMatchObject({ version: "2026.5.14" });
+        } else {
+          throw new Error(`Unexpected package command: ${argv.join(" ")}`);
+        }
+        return {
+          stdout: "",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      });
+    let transaction: PackageUpdateTransaction | undefined;
+    try {
+      const result = await runPackageInstallUpdate({
+        root,
+        installKind: "package",
+        tag: "2026.5.14",
+        installSpec: "openclaw@2026.5.14",
+        installTarget: createNpmTarget(globalRoot),
+        installEnv: {},
+        managedServiceEnv: {
+          OPENCLAW_STATE_DIR: path.join(base, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(base, "openclaw.json"),
+        },
+        timeoutMs: 1000,
+        startedAt: Date.now(),
+        progress: {},
+        jsonMode: true,
+        validateCandidate: async () => [],
+        beforeActivate: async () => {},
+        onTransaction: (retained) => {
+          transaction = retained;
+        },
+      });
+      expect(result).toMatchObject({ status: "ok", root, after: { version: "2026.5.14" } });
+      expect(commands.mock.calls.filter(([argv]) => argv[2] === "doctor")).toHaveLength(1);
+    } finally {
+      if (transaction) {
+        const assertCurrent = () => {};
+        // This test never starts a service; restore before retiring the retained package backup.
+        const rollback = await transaction.rollback(assertCurrent);
+        const retirement = await transaction.complete({ activationVerified: false }, assertCurrent);
+        expect(rollback.exitCode).toBe(0);
+        expect(retirement).toBeUndefined();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

A staged-package Doctor test runs the full update CLI even though its distinct assertions concern the package installation owner. A separate compatibility-table variant changes a mock property that production no longer reads.

## Why This Change Was Made

Move the Doctor case into the existing package-owner tests, preserving real staging and swapping, exact Doctor argv and cwd, external service-repair policy, and installed-version propagation. The test also checks the live package version at Doctor entry and restores and retires its retained transaction through the owner API.

Remove only the stale legacy-target variant and its unused checkpointContinuation wrapper. Keep the three real update modes and the foreign-service, advisory, killed-Doctor, repair, and platform integrations.

## User Impact

No runtime behavior changes. Two full CLI invocations are removed, with the Doctor contract retained at its owning layer. Production and support code are unchanged; tests add 79 and remove 52 lines, with one fewer test overall.

## Evidence

The selected original/candidate/original runs pass 10/9/10 cases. The Doctor case takes 2.219s / 45ms / 1.724s. Whole-wrapper times are 25.73s / 23.38s / 22.84s, so this comparison does not establish a whole-wrapper speedup.

All 12 final targeted cases pass: all six package-owner cases, three compatibility modes, and the three neighboring Doctor integrations. The scoped changed-file gate passes, and independent review found no actionable issues. The existing command-boundary fixtures remain synthetic; real npm/network behavior is unchanged and is not claimed as new proof.
