### PR TITLE
refactor(policy): preserve diagnostics with shared validation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -908,10 +908,7 @@ extensions/parallel/src/parallel-web-search-provider.runtime.ts	2
 extensions/perplexity/src/perplexity-web-search-provider.shared.ts	1
 extensions/pixverse/video-generation-provider.ts	2
 extensions/policy/src/cli.ts	1
-extensions/policy/src/doctor/access-findings.ts	1
-extensions/policy/src/doctor/access-shapes.ts	2
 extensions/policy/src/doctor/automatic-repairs.ts	7
-extensions/policy/src/doctor/data-auth-shapes.ts	1
 extensions/policy/src/doctor/evaluation.ts	4
 extensions/policy/src/doctor/exec-approval-findings.ts	1
 extensions/policy/src/doctor/policy-runtime.ts	2

--- a/extensions/policy/src/doctor/access-findings.ts
+++ b/extensions/policy/src/doctor/access-findings.ts
@@ -1,57 +1,28 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { CHECK_IDS } from "./check-ids.js";
+import { createOrderedPolicyShape } from "./ordered-shape.js";
 import { SUPPORTED_AUTH_PROFILE_METADATA } from "./policy-constants.js";
-import { isChannelDenyRule, unsupportedPolicyKey } from "./shape-helpers.js";
-import { ocPathSegment } from "./utils.js";
+import { isChannelDenyRule } from "./shape-helpers.js";
 
 export function authProfileMetadataRequirementFindings(
   policy: unknown,
   policyPath: string,
   policyDocName: string,
 ): readonly HealthFinding[] {
-  if (
-    !isRecord(policy) ||
-    !isRecord(policy.auth) ||
-    !isRecord(policy.auth.profiles) ||
-    policy.auth.profiles.requireMetadata === undefined
-  ) {
-    return [];
-  }
-  if (!Array.isArray(policy.auth.profiles.requireMetadata)) {
-    return [
-      {
-        checkId: CHECK_IDS.policyInvalidFile,
-        severity: "error",
-        message: `${policyPath} auth.profiles.requireMetadata must be an array of metadata keys.`,
-        source: "policy",
-        path: policyPath,
-        target: `oc://${policyDocName}/auth/profiles/requireMetadata`,
-        fixHint: `Use supported metadata keys: ${SUPPORTED_AUTH_PROFILE_METADATA.join(", ")}.`,
-      },
-    ];
-  }
-  const invalidIndex = policy.auth.profiles.requireMetadata.findIndex(
-    (entry) =>
-      typeof entry !== "string" ||
-      !SUPPORTED_AUTH_PROFILE_METADATA.includes(
-        entry.trim().toLowerCase() as (typeof SUPPORTED_AUTH_PROFILE_METADATA)[number],
-      ),
-  );
-  if (invalidIndex < 0) {
-    return [];
-  }
-  return [
-    {
-      checkId: CHECK_IDS.policyInvalidFile,
-      severity: "error",
-      message: `${policyPath} auth.profiles.requireMetadata[${invalidIndex}] must be a supported metadata key.`,
-      source: "policy",
-      path: policyPath,
-      target: `oc://${policyDocName}/auth/profiles/requireMetadata/#${invalidIndex}`,
-      fixHint: `Use supported metadata keys: ${SUPPORTED_AUTH_PROFILE_METADATA.join(", ")}.`,
+  const shape = createOrderedPolicyShape(policy, { policyPath, policyDocName });
+  const finding = shape.list("auth.profiles.requireMetadata", {
+    allowed: SUPPORTED_AUTH_PROFILE_METADATA,
+    normalize: "lower",
+    array: {
+      message: "{policy} {property} must be an array of metadata keys.",
+      hint: "Use supported metadata keys: {allowed}.",
     },
-  ];
+    entry: {
+      message: "{policy} {property}[{index}] must be a supported metadata key.",
+      hint: "Use supported metadata keys: {allowed}.",
+    },
+  });
+  return finding === undefined ? [] : [finding];
 }
 
 export function invalidChannelDenyRuleFindings(
@@ -59,70 +30,59 @@ export function invalidChannelDenyRuleFindings(
   policyPath: string,
   policyDocName: string,
 ): readonly HealthFinding[] {
-  if (!isRecord(policy) || !isRecord(policy.channels) || policy.channels.denyRules === undefined) {
+  const shape = createOrderedPolicyShape(policy, { policyPath, policyDocName });
+  const rules = shape.value("channels.denyRules");
+  if (rules === undefined) {
     return [];
   }
-  if (!Array.isArray(policy.channels.denyRules)) {
+  if (!Array.isArray(rules)) {
     return [
-      {
-        checkId: CHECK_IDS.policyInvalidFile,
-        severity: "error",
-        message: `${policyPath} channels.denyRules must be an array.`,
-        source: "policy",
-        path: policyPath,
-        target: `oc://${policyDocName}/channels/denyRules`,
-        fixHint: `Fix ${policyPath} so channel deny rules are an array.`,
-      },
+      shape.finding("channels.denyRules", {
+        message: "{policy} {property} must be an array.",
+        hint: "Fix {policy} so channel deny rules are an array.",
+      }),
     ];
   }
-  for (const [index, rule] of policy.channels.denyRules.entries()) {
+  for (const [index, rule] of rules.entries()) {
     if (!isRecord(rule)) {
       continue;
     }
-    const unsupportedRuleKey = unsupportedPolicyKey(rule, ["id", "reason", "when"]);
-    if (unsupportedRuleKey !== undefined) {
-      return [
-        {
-          checkId: CHECK_IDS.policyInvalidFile,
-          severity: "error",
-          message: `${policyPath} channels.denyRules[${index}].${unsupportedRuleKey} is not supported in channel deny rules.`,
-          source: "policy",
-          path: policyPath,
-          target: `oc://${policyDocName}/channels/denyRules/#${index}/${ocPathSegment(unsupportedRuleKey)}`,
-          fixHint: `Remove channels.denyRules[${index}].${unsupportedRuleKey} or use id, when.provider, and reason.`,
-        },
-      ];
+    const entry = createOrderedPolicyShape(rule, {
+      policyPath,
+      policyDocName,
+      propertyPrefix: "channels.denyRules[" + index + "]",
+      targetPrefix: "channels/denyRules/#" + index,
+    });
+    const finding =
+      entry.keys(
+        "",
+        ["id", "reason", "when"],
+        "",
+        "Remove {unsupported} or use id, when.provider, and reason.",
+        "{policy} {unsupported} is not supported in channel deny rules.",
+      ) ??
+      entry.keys(
+        "when",
+        ["provider"],
+        "",
+        "Remove {unsupported} or use when.provider.",
+        "{policy} {unsupported} is not supported in channel deny rules.",
+      );
+    if (finding !== undefined) {
+      return [finding];
     }
-    if (isRecord(rule.when)) {
-      const unsupportedWhenKey = unsupportedPolicyKey(rule.when, ["provider"]);
-      if (unsupportedWhenKey !== undefined) {
-        return [
+  }
+  const index = rules.findIndex((rule) => !isChannelDenyRule(rule));
+  return index < 0
+    ? []
+    : [
+        shape.finding(
+          "channels.denyRules",
           {
-            checkId: CHECK_IDS.policyInvalidFile,
-            severity: "error",
-            message: `${policyPath} channels.denyRules[${index}].when.${unsupportedWhenKey} is not supported in channel deny rules.`,
-            source: "policy",
-            path: policyPath,
-            target: `oc://${policyDocName}/channels/denyRules/#${index}/when/${ocPathSegment(unsupportedWhenKey)}`,
-            fixHint: `Remove channels.denyRules[${index}].when.${unsupportedWhenKey} or use when.provider.`,
+            message: "{policy} {property}[{index}] must define when.provider as a string.",
+            hint: "Fix {policy} so each channel deny rule has a provider match.",
           },
-        ];
-      }
-    }
-  }
-  const invalid = policy.channels.denyRules.findIndex((rule) => !isChannelDenyRule(rule));
-  if (invalid < 0) {
-    return [];
-  }
-  return [
-    {
-      checkId: CHECK_IDS.policyInvalidFile,
-      severity: "error",
-      message: `${policyPath} channels.denyRules[${invalid}] must define when.provider as a string.`,
-      source: "policy",
-      path: policyPath,
-      target: `oc://${policyDocName}/channels/denyRules/#${invalid}`,
-      fixHint: `Fix ${policyPath} so each channel deny rule has a provider match.`,
-    },
-  ];
+          { index },
+        ),
+      ];
 }

--- a/extensions/policy/src/doctor/access-shapes.ts
+++ b/extensions/policy/src/doctor/access-shapes.ts
@@ -1,266 +1,142 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { execApprovalAllowlistExpectedShapeFinding } from "./exec-approval-rules.js";
+import {
+  createOrderedPolicyShape,
+  firstPolicyShapeFinding,
+  type PolicyShapeContext,
+} from "./ordered-shape.js";
 import {
   SUPPORTED_DM_POLICIES,
   SUPPORTED_DM_SCOPES,
   SUPPORTED_EXEC_APPROVAL_SECURITY,
 } from "./policy-constants.js";
-import {
-  policyShapeFinding,
-  policyStringArrayPropertyShapeFinding,
-  unsupportedPolicyKey,
-} from "./shape-helpers.js";
-import { ocPathSegment } from "./utils.js";
 
 export function ingressPolicyShapeFinding(
   value: unknown,
-  params: {
-    readonly policyDocName: string;
-    readonly policyPath: string;
-    readonly targetPrefix?: string;
-    readonly propertyPrefix?: string;
+  params: PolicyShapeContext & {
     readonly allowSession?: boolean;
   },
 ): HealthFinding | undefined {
-  const targetPrefix = params.targetPrefix ?? "ingress";
-  const propertyPrefix = params.propertyPrefix ?? "ingress";
-  const allowSession = params.allowSession ?? true;
   if (value === undefined) {
     return undefined;
   }
-  if (!isRecord(value)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}`,
-      `${params.policyPath} ${propertyPrefix} must be an object.`,
-      `Fix ${params.policyPath} so ${propertyPrefix} is an object.`,
-    );
-  }
-  if (!allowSession && value.session !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/session`,
-      `${params.policyPath} ${propertyPrefix}.session is not supported by the channelIds selector.`,
-      `Move session ingress rules to top-level ingress; scoped ingress currently supports ingress.channels.*.`,
-    );
-  }
-  const unsupportedIngressKey = unsupportedPolicyKey(value, ["channels", "session"]);
-  if (unsupportedIngressKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/${ocPathSegment(unsupportedIngressKey)}`,
-      `${params.policyPath} ${propertyPrefix}.${unsupportedIngressKey} is not supported in ingress policy.`,
-      `Remove ${propertyPrefix}.${unsupportedIngressKey} or use ingress.session or ingress.channels.`,
-    );
-  }
-  for (const section of ["session", "channels"] as const) {
-    if (value[section] !== undefined && !isRecord(value[section])) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/${section}`,
-        `${params.policyPath} ${propertyPrefix}.${section} must be an object.`,
-        `Fix ${params.policyPath} so ${propertyPrefix}.${section} is an object.`,
-      );
+  const context = {
+    ...params,
+    propertyPrefix: params.propertyPrefix ?? "ingress",
+    targetPrefix: params.targetPrefix ?? "ingress",
+  };
+  const shape = createOrderedPolicyShape(value, context);
+  function* findings() {
+    yield shape.object("");
+    if (params.allowSession === false && shape.value("session") !== undefined) {
+      yield shape.finding("session", {
+        message: "{policy} {property} is not supported by the channelIds selector.",
+        hint: "Move session ingress rules to top-level ingress; scoped ingress currently supports ingress.channels.*.",
+      });
     }
-  }
-  const session = isRecord(value.session) ? value.session : {};
-  const unsupportedSessionKey = unsupportedPolicyKey(session, ["requireDmScope"]);
-  if (unsupportedSessionKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/session/${ocPathSegment(unsupportedSessionKey)}`,
-      `${params.policyPath} ${propertyPrefix}.session.${unsupportedSessionKey} is not supported in ingress policy.`,
-      `Remove ${propertyPrefix}.session.${unsupportedSessionKey} or use ${propertyPrefix}.session.requireDmScope.`,
+    yield shape.keys(
+      "",
+      ["channels", "session"],
+      "ingress",
+      "Remove {unsupported} or use ingress.session or ingress.channels.",
     );
-  }
-  if (
-    session.requireDmScope !== undefined &&
-    !SUPPORTED_DM_SCOPES.includes(session.requireDmScope as (typeof SUPPORTED_DM_SCOPES)[number])
-  ) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/session/requireDmScope`,
-      `${params.policyPath} ${propertyPrefix}.session.requireDmScope must be a supported DM scope.`,
-      `Use supported DM scopes: ${SUPPORTED_DM_SCOPES.join(", ")}.`,
+    yield shape.object("session");
+    yield shape.object("channels");
+    yield shape.keys(
+      "session",
+      ["requireDmScope"],
+      "ingress",
+      "Remove {unsupported} or use {property}.requireDmScope.",
     );
-  }
-  const channels = isRecord(value.channels) ? value.channels : {};
-  const unsupportedChannelsKey = unsupportedPolicyKey(channels, [
-    "allowDmPolicies",
-    "denyOpenGroups",
-    "requireMentionInGroups",
-  ]);
-  if (unsupportedChannelsKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/channels/${ocPathSegment(unsupportedChannelsKey)}`,
-      `${params.policyPath} ${propertyPrefix}.channels.${unsupportedChannelsKey} is not supported in ingress policy.`,
-      `Remove ${propertyPrefix}.channels.${unsupportedChannelsKey} or use a supported ingress channel policy rule.`,
+    yield shape.enum("session.requireDmScope", SUPPORTED_DM_SCOPES, {
+      message: "{policy} {property} must be a supported DM scope.",
+      hint: "Use supported DM scopes: {allowed}.",
+    });
+    yield shape.keys(
+      "channels",
+      ["allowDmPolicies", "denyOpenGroups", "requireMentionInGroups"],
+      "ingress",
+      "Remove {unsupported} or use a supported ingress channel policy rule.",
     );
+    yield shape.list("channels.allowDmPolicies", {
+      allowed: SUPPORTED_DM_POLICIES,
+      valueName: "DM policy",
+    });
+    yield shape.boolean("channels.denyOpenGroups");
+    yield shape.boolean("channels.requireMentionInGroups");
   }
-  const allowDmPoliciesFinding = policyStringArrayPropertyShapeFinding(channels.allowDmPolicies, {
-    allowed: SUPPORTED_DM_POLICIES,
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    property: `${propertyPrefix}.channels.allowDmPolicies`,
-    target: `${targetPrefix}/channels/allowDmPolicies`,
-    valueName: "DM policy",
-  });
-  if (allowDmPoliciesFinding !== undefined) {
-    return allowDmPoliciesFinding;
-  }
-  for (const key of ["denyOpenGroups", "requireMentionInGroups"] as const) {
-    if (channels[key] !== undefined && typeof channels[key] !== "boolean") {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/channels/${key}`,
-        `${params.policyPath} ${propertyPrefix}.channels.${key} must be a boolean.`,
-        `Set ${propertyPrefix}.channels.${key} to true or false.`,
-      );
-    }
-  }
-  return undefined;
+  return firstPolicyShapeFinding(findings());
 }
 
 export function execApprovalsPolicyShapeFinding(
   value: unknown,
-  params: {
-    readonly policyDocName: string;
-    readonly policyPath: string;
-    readonly targetPrefix?: string;
-    readonly propertyPrefix?: string;
+  params: PolicyShapeContext & {
     readonly allowDefaults?: boolean;
   },
 ): HealthFinding | undefined {
-  const targetPrefix = params.targetPrefix ?? "execApprovals";
-  const propertyPrefix = params.propertyPrefix ?? "execApprovals";
-  const allowDefaults = params.allowDefaults ?? true;
   if (value === undefined) {
     return undefined;
   }
-  if (!isRecord(value)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}`,
-      `${params.policyPath} ${propertyPrefix} must be an object.`,
-      `Fix ${params.policyPath} so ${propertyPrefix} is an object.`,
+  const context = {
+    ...params,
+    propertyPrefix: params.propertyPrefix ?? "execApprovals",
+    targetPrefix: params.targetPrefix ?? "execApprovals",
+  };
+  const shape = createOrderedPolicyShape(value, context);
+  const allowDefaults = params.allowDefaults ?? true;
+  function* findings() {
+    yield shape.object("");
+    yield shape.keys(
+      "",
+      allowDefaults ? ["agents", "defaults", "requireFile"] : ["agents"],
+      "exec approvals",
+      "Remove {unsupported} or use a supported execApprovals rule.",
     );
-  }
-  const unsupportedTopLevel = unsupportedPolicyKey(
-    value,
-    allowDefaults ? ["agents", "defaults", "requireFile"] : ["agents"],
-  );
-  if (unsupportedTopLevel !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/${ocPathSegment(unsupportedTopLevel)}`,
-      `${params.policyPath} ${propertyPrefix}.${unsupportedTopLevel} is not supported in exec approvals policy.`,
-      `Remove ${propertyPrefix}.${unsupportedTopLevel} or use a supported execApprovals rule.`,
-    );
-  }
-  if (value.requireFile !== undefined && typeof value.requireFile !== "boolean") {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/requireFile`,
-      `${params.policyPath} ${propertyPrefix}.requireFile must be a boolean.`,
-      `Set execApprovals.requireFile to true or false.`,
-    );
-  }
-  for (const section of (allowDefaults ? ["defaults", "agents"] : ["agents"]) as readonly (
-    | "agents"
-    | "defaults"
-  )[]) {
-    if (value[section] !== undefined && !isRecord(value[section])) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/${section}`,
-        `${params.policyPath} ${propertyPrefix}.${section} must be an object.`,
-        `Fix ${params.policyPath} so ${propertyPrefix}.${section} is an object.`,
-      );
+    yield shape.boolean("requireFile", "Set execApprovals.requireFile to true or false.");
+    for (const section of allowDefaults ? ["defaults", "agents"] : ["agents"]) {
+      yield shape.object(section);
     }
-  }
-  const defaults = allowDefaults && isRecord(value.defaults) ? value.defaults : {};
-  const unsupportedDefaultsKey = unsupportedPolicyKey(defaults, ["allowSecurity"]);
-  if (unsupportedDefaultsKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/defaults/${ocPathSegment(unsupportedDefaultsKey)}`,
-      `${params.policyPath} ${propertyPrefix}.defaults.${unsupportedDefaultsKey} is not supported in exec approvals policy.`,
-      `Use execApprovals.defaults.allowSecurity or remove the unsupported rule.`,
+    if (allowDefaults) {
+      yield shape.keys(
+        "defaults",
+        ["allowSecurity"],
+        "exec approvals",
+        "Use execApprovals.defaults.allowSecurity or remove the unsupported rule.",
+      );
+      yield shape.list("defaults.allowSecurity", {
+        allowed: SUPPORTED_EXEC_APPROVAL_SECURITY,
+        valueName: "exec approval security mode",
+      });
+    }
+    yield shape.keys(
+      "agents",
+      ["allowAutoAllowSkills", "allowSecurity", "allowlist"],
+      "exec approvals",
+      "Use execApprovals.agents.allowSecurity, execApprovals.agents.allowAutoAllowSkills, or execApprovals.agents.allowlist.expected.",
     );
-  }
-  const defaultsSecurityFinding = policyStringArrayPropertyShapeFinding(defaults.allowSecurity, {
-    allowed: SUPPORTED_EXEC_APPROVAL_SECURITY,
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    property: `${propertyPrefix}.defaults.allowSecurity`,
-    target: `${targetPrefix}/defaults/allowSecurity`,
-    valueName: "exec approval security mode",
-  });
-  if (defaultsSecurityFinding !== undefined) {
-    return defaultsSecurityFinding;
-  }
-  const agents = isRecord(value.agents) ? value.agents : {};
-  const unsupportedAgentsKey = unsupportedPolicyKey(agents, [
-    "allowAutoAllowSkills",
-    "allowSecurity",
-    "allowlist",
-  ]);
-  if (unsupportedAgentsKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/agents/${ocPathSegment(unsupportedAgentsKey)}`,
-      `${params.policyPath} ${propertyPrefix}.agents.${unsupportedAgentsKey} is not supported in exec approvals policy.`,
-      `Use execApprovals.agents.allowSecurity, execApprovals.agents.allowAutoAllowSkills, or execApprovals.agents.allowlist.expected.`,
+    yield shape.list("agents.allowSecurity", {
+      allowed: SUPPORTED_EXEC_APPROVAL_SECURITY,
+      valueName: "exec approval security mode",
+    });
+    yield shape.boolean(
+      "agents.allowAutoAllowSkills",
+      "Set execApprovals.agents.allowAutoAllowSkills to true or false.",
     );
-  }
-  const agentSecurityFinding = policyStringArrayPropertyShapeFinding(agents.allowSecurity, {
-    allowed: SUPPORTED_EXEC_APPROVAL_SECURITY,
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    property: `${propertyPrefix}.agents.allowSecurity`,
-    target: `${targetPrefix}/agents/allowSecurity`,
-    valueName: "exec approval security mode",
-  });
-  if (agentSecurityFinding !== undefined) {
-    return agentSecurityFinding;
-  }
-  if (
-    agents.allowAutoAllowSkills !== undefined &&
-    typeof agents.allowAutoAllowSkills !== "boolean"
-  ) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/agents/allowAutoAllowSkills`,
-      `${params.policyPath} ${propertyPrefix}.agents.allowAutoAllowSkills must be a boolean.`,
-      `Set execApprovals.agents.allowAutoAllowSkills to true or false.`,
+    yield shape.object("agents.allowlist");
+    yield shape.keys(
+      "agents.allowlist",
+      ["expected"],
+      "exec approvals",
+      "Use execApprovals.agents.allowlist.expected or remove the unsupported rule.",
     );
+    yield execApprovalAllowlistExpectedShapeFinding(shape.value("agents.allowlist.expected"), {
+      policyDocName: params.policyDocName,
+      policyPath: params.policyPath,
+      property: context.propertyPrefix + ".agents.allowlist.expected",
+      target: context.targetPrefix + "/agents/allowlist/expected",
+    });
   }
-  if (agents.allowlist !== undefined && !isRecord(agents.allowlist)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/agents/allowlist`,
-      `${params.policyPath} ${propertyPrefix}.agents.allowlist must be an object.`,
-      `Fix ${params.policyPath} so ${propertyPrefix}.agents.allowlist is an object.`,
-    );
-  }
-  const allowlist = isRecord(agents.allowlist) ? agents.allowlist : {};
-  const unsupportedAllowlistKey = unsupportedPolicyKey(allowlist, ["expected"]);
-  if (unsupportedAllowlistKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${targetPrefix}/agents/allowlist/${ocPathSegment(unsupportedAllowlistKey)}`,
-      `${params.policyPath} ${propertyPrefix}.agents.allowlist.${unsupportedAllowlistKey} is not supported in exec approvals policy.`,
-      `Use execApprovals.agents.allowlist.expected or remove the unsupported rule.`,
-    );
-  }
-  return execApprovalAllowlistExpectedShapeFinding(allowlist.expected, {
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    property: `${propertyPrefix}.agents.allowlist.expected`,
-    target: `${targetPrefix}/agents/allowlist/expected`,
-  });
+  return firstPolicyShapeFinding(findings());
 }
 
 export function scopedDataHandlingPolicyShapeFinding(
@@ -272,47 +148,34 @@ export function scopedDataHandlingPolicyShapeFinding(
     readonly scopeName: string;
   },
 ): HealthFinding | undefined {
-  const unsupportedKey = Object.keys(dataHandling).find((key) => key !== "memory");
-  if (unsupportedKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/${ocPathSegment(unsupportedKey)}`,
-      `${params.policyPath} scopes.${params.scopeName}.dataHandling.${unsupportedKey} is not a supported scoped policy section.`,
-      `Move global data-handling rules to top-level dataHandling, or use dataHandling.memory with agentIds.`,
+  const shape = createOrderedPolicyShape(dataHandling, {
+    ...params,
+    propertyPrefix: "scopes." + params.scopeName + ".dataHandling",
+    targetPrefix: params.targetPrefix + "/dataHandling",
+  });
+  function* findings() {
+    yield shape.keys(
+      "",
+      ["memory"],
+      "",
+      "Move global data-handling rules to top-level dataHandling, or use dataHandling.memory with agentIds.",
+      "{policy} {unsupported} is not a supported scoped policy section.",
+    );
+    yield shape.object(
+      "memory",
+      "Fix {policy} so the scoped dataHandling.memory policy section is an object.",
+    );
+    yield shape.keys(
+      "memory",
+      ["denySessionTranscriptIndexing"],
+      "",
+      "Use dataHandling.memory.denySessionTranscriptIndexing or remove the unsupported rule.",
+      "{policy} {unsupported} is not a supported scoped policy rule.",
+    );
+    yield shape.boolean(
+      "memory.denySessionTranscriptIndexing",
+      "Set dataHandling.memory.denySessionTranscriptIndexing to true or false.",
     );
   }
-  if (dataHandling.memory !== undefined && !isRecord(dataHandling.memory)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory`,
-      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory must be an object.`,
-      `Fix ${params.policyPath} so the scoped dataHandling.memory policy section is an object.`,
-    );
-  }
-  if (!isRecord(dataHandling.memory)) {
-    return undefined;
-  }
-  const unsupportedMemoryKey = Object.keys(dataHandling.memory).find(
-    (key) => key !== "denySessionTranscriptIndexing",
-  );
-  if (unsupportedMemoryKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory/${ocPathSegment(unsupportedMemoryKey)}`,
-      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory.${unsupportedMemoryKey} is not a supported scoped policy rule.`,
-      `Use dataHandling.memory.denySessionTranscriptIndexing or remove the unsupported rule.`,
-    );
-  }
-  if (
-    dataHandling.memory.denySessionTranscriptIndexing !== undefined &&
-    typeof dataHandling.memory.denySessionTranscriptIndexing !== "boolean"
-  ) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.targetPrefix}/dataHandling/memory/denySessionTranscriptIndexing`,
-      `${params.policyPath} scopes.${params.scopeName}.dataHandling.memory.denySessionTranscriptIndexing must be a boolean.`,
-      `Set dataHandling.memory.denySessionTranscriptIndexing to true or false.`,
-    );
-  }
-  return undefined;
+  return firstPolicyShapeFinding(findings());
 }

--- a/extensions/policy/src/doctor/data-auth-shapes.ts
+++ b/extensions/policy/src/doctor/data-auth-shapes.ts
@@ -1,173 +1,55 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyDataHandlingEvidence, PolicyEvidence } from "../policy-state.js";
-import { getPolicyPath } from "../policy-value.js";
+import {
+  collectPolicyShapeFindings,
+  createOrderedPolicyShape,
+  firstPolicyShapeFinding,
+} from "./ordered-shape.js";
 import { SUPPORTED_AUTH_PROFILE_MODES } from "./policy-constants.js";
-import { policyShapeFinding, unsupportedPolicyKey } from "./shape-helpers.js";
-import { ocPathSegment } from "./utils.js";
 
 export function dataHandlingPolicyShapeFindings(
   policy: unknown,
   policyPath: string,
   policyDocName: string,
 ): readonly HealthFinding[] {
-  if (!isRecord(policy)) {
+  if (!isRecord(policy) || !isRecord(policy.dataHandling)) {
     return [];
   }
-  if (!isRecord(policy.dataHandling)) {
-    return [];
+  const shape = createOrderedPolicyShape(policy, { policyPath, policyDocName });
+  const sections = [
+    ["sensitiveLogging", "requireRedaction"],
+    ["telemetry", "denyContentCapture"],
+    ["retention", "requireSessionMaintenance"],
+    ["memory", "denySessionTranscriptIndexing"],
+  ] as const;
+  function* sectionRules(section: string, rule: string) {
+    yield shape.keys(
+      "dataHandling." + section,
+      [rule],
+      "data-handling",
+      "Remove {unsupported} or use {property}." + rule + ".",
+    );
+    yield shape.boolean("dataHandling." + section + "." + rule);
   }
-  return [
-    policySectionUnsupportedKeyFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling",
-      targetPath: "dataHandling",
-      sectionName: "data-handling",
-      allowedKeys: ["memory", "retention", "sensitiveLogging", "telemetry"],
-    }),
-    dataHandlingSectionShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.sensitiveLogging",
-      targetPath: "dataHandling/sensitiveLogging",
-      section: "sensitiveLogging",
-    }),
-    dataHandlingSectionShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.telemetry",
-      targetPath: "dataHandling/telemetry",
-      section: "telemetry",
-    }),
-    dataHandlingSectionShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.retention",
-      targetPath: "dataHandling/retention",
-      section: "retention",
-    }),
-    dataHandlingSectionShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.memory",
-      targetPath: "dataHandling/memory",
-      section: "memory",
-    }),
-    dataHandlingBooleanShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.sensitiveLogging.requireRedaction",
-      targetPath: "dataHandling/sensitiveLogging/requireRedaction",
-      path: ["sensitiveLogging", "requireRedaction"],
-    }),
-    dataHandlingBooleanShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.telemetry.denyContentCapture",
-      targetPath: "dataHandling/telemetry/denyContentCapture",
-      path: ["telemetry", "denyContentCapture"],
-    }),
-    dataHandlingBooleanShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.retention.requireSessionMaintenance",
-      targetPath: "dataHandling/retention/requireSessionMaintenance",
-      path: ["retention", "requireSessionMaintenance"],
-    }),
-    dataHandlingBooleanShapeFinding(policy.dataHandling, {
-      policyPath,
-      policyDocName,
-      propertyPath: "dataHandling.memory.denySessionTranscriptIndexing",
-      targetPath: "dataHandling/memory/denySessionTranscriptIndexing",
-      path: ["memory", "denySessionTranscriptIndexing"],
-    }),
-  ].filter((finding): finding is HealthFinding => finding !== undefined);
-}
-
-function policySectionUnsupportedKeyFinding(
-  value: Record<string, unknown>,
-  params: {
-    readonly policyPath: string;
-    readonly policyDocName: string;
-    readonly propertyPath: string;
-    readonly targetPath: string;
-    readonly sectionName: string;
-    readonly allowedKeys: readonly string[];
-  },
-): HealthFinding | undefined {
-  const unsupportedKey = unsupportedPolicyKey(value, params.allowedKeys);
-  if (unsupportedKey === undefined) {
-    return undefined;
-  }
-  return policyShapeFinding(
-    params.policyPath,
-    `oc://${params.policyDocName}/${params.targetPath}/${ocPathSegment(unsupportedKey)}`,
-    `${params.policyPath} ${params.propertyPath}.${unsupportedKey} is not supported in ${params.sectionName} policy.`,
-    `Remove ${params.propertyPath}.${unsupportedKey} or use a supported ${params.sectionName} policy rule.`,
-  );
-}
-
-function dataHandlingSectionShapeFinding(
-  dataHandling: Record<string, unknown>,
-  params: {
-    readonly policyPath: string;
-    readonly policyDocName: string;
-    readonly propertyPath: string;
-    readonly targetPath: string;
-    readonly section: string;
-  },
-): HealthFinding | undefined {
-  const value = dataHandling[params.section];
-  if (value === undefined || isRecord(value)) {
-    return undefined;
-  }
-  return policyShapeFinding(
-    params.policyPath,
-    `oc://${params.policyDocName}/${params.targetPath}`,
-    `${params.policyPath} ${params.propertyPath} must be an object.`,
-    `Fix ${params.propertyPath} so it contains boolean policy rules.`,
-  );
-}
-
-function dataHandlingBooleanShapeFinding(
-  dataHandling: unknown,
-  params: {
-    readonly policyPath: string;
-    readonly policyDocName: string;
-    readonly propertyPath: string;
-    readonly targetPath: string;
-    readonly path: readonly string[];
-  },
-): HealthFinding | undefined {
-  const value = getPolicyPath(dataHandling, params.path);
-  if (isRecord(dataHandling) && typeof params.path[0] === "string") {
-    const section = dataHandling[params.path[0]];
-    if (isRecord(section) && typeof params.path[1] === "string") {
-      const sectionPath = params.path.slice(0, -1).join(".");
-      const unsupportedKey = unsupportedPolicyKey(section, [params.path[1]]);
-      if (unsupportedKey !== undefined) {
-        return policyShapeFinding(
-          params.policyPath,
-          `oc://${params.policyDocName}/${params.targetPath
-            .split("/")
-            .slice(0, -1)
-            .join("/")}/${ocPathSegment(unsupportedKey)}`,
-          `${params.policyPath} dataHandling.${sectionPath}.${unsupportedKey} is not supported in data-handling policy.`,
-          `Remove dataHandling.${sectionPath}.${unsupportedKey} or use ${params.propertyPath}.`,
-        );
-      }
+  function* findings() {
+    yield shape.keys(
+      "dataHandling",
+      ["memory", "retention", "sensitiveLogging", "telemetry"],
+      "data-handling",
+      "Remove {unsupported} or use a supported data-handling policy rule.",
+    );
+    for (const [section] of sections) {
+      yield shape.object(
+        "dataHandling." + section,
+        "Fix {property} so it contains boolean policy rules.",
+      );
+    }
+    for (const [section, rule] of sections) {
+      yield firstPolicyShapeFinding(sectionRules(section, rule));
     }
   }
-  if (value === undefined || typeof value === "boolean") {
-    return undefined;
-  }
-  return policyShapeFinding(
-    params.policyPath,
-    `oc://${params.policyDocName}/${params.targetPath}`,
-    `${params.policyPath} ${params.propertyPath} must be a boolean.`,
-    `Set ${params.propertyPath} to true or false.`,
-  );
+  return collectPolicyShapeFindings(findings());
 }
 
 export function dataHandlingEntries(
@@ -178,7 +60,9 @@ export function dataHandlingEntries(
 }
 
 export function dataHandlingLabel(entry: PolicyDataHandlingEvidence): string {
-  return entry.agentId === undefined ? "Global data handling config" : `agent '${entry.agentId}'`;
+  return entry.agentId === undefined
+    ? "Global data handling config"
+    : "agent '" + entry.agentId + "'";
 }
 
 export function secretPolicyShapeFindings(
@@ -189,44 +73,22 @@ export function secretPolicyShapeFindings(
   if (!isRecord(policy) || !isRecord(policy.secrets)) {
     return [];
   }
-  const findings: HealthFinding[] = [];
-  for (const key of ["requireManagedProviders", "allowInsecureProviders"] as const) {
-    if (policy.secrets[key] !== undefined && typeof policy.secrets[key] !== "boolean") {
-      findings.push(
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/secrets/${key}`,
-          `${policyPath} secrets.${key} must be a boolean.`,
-          `Set secrets.${key} to true or false.`,
-        ),
-      );
-    }
+  const shape = createOrderedPolicyShape(policy, { policyPath, policyDocName });
+  function* findings() {
+    yield shape.boolean("secrets.requireManagedProviders");
+    yield shape.boolean("secrets.allowInsecureProviders");
+    yield shape.list("secrets.denySources", {
+      array: {
+        message: "{policy} {property} must be an array of source names.",
+        hint: 'Use an array such as ["exec"] or remove secrets.denySources.',
+      },
+      entry: {
+        message: "{policy} {property}[{index}] must be a non-empty source name.",
+        hint: "Use non-empty source names such as env, file, exec, or openclaw.",
+      },
+    });
   }
-  if (policy.secrets.denySources !== undefined && !Array.isArray(policy.secrets.denySources)) {
-    findings.push(
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/secrets/denySources`,
-        `${policyPath} secrets.denySources must be an array of source names.`,
-        'Use an array such as ["exec"] or remove secrets.denySources.',
-      ),
-    );
-  } else if (Array.isArray(policy.secrets.denySources)) {
-    const invalidIndex = policy.secrets.denySources.findIndex(
-      (entry) => typeof entry !== "string" || entry.trim() === "",
-    );
-    if (invalidIndex >= 0) {
-      findings.push(
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/secrets/denySources/#${invalidIndex}`,
-          `${policyPath} secrets.denySources[${invalidIndex}] must be a non-empty source name.`,
-          "Use non-empty source names such as env, file, exec, or openclaw.",
-        ),
-      );
-    }
-  }
-  return findings;
+  return collectPolicyShapeFindings(findings());
 }
 
 export function authProfileAllowModesShapeFindings(
@@ -234,40 +96,18 @@ export function authProfileAllowModesShapeFindings(
   policyPath: string,
   policyDocName: string,
 ): readonly HealthFinding[] {
-  if (
-    !isRecord(policy) ||
-    !isRecord(policy.auth) ||
-    !isRecord(policy.auth.profiles) ||
-    policy.auth.profiles.allowModes === undefined
-  ) {
-    return [];
-  }
-  if (!Array.isArray(policy.auth.profiles.allowModes)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/auth/profiles/allowModes`,
-        `${policyPath} auth.profiles.allowModes must be an array of auth modes.`,
-        `Use supported auth modes: ${SUPPORTED_AUTH_PROFILE_MODES.join(", ")}.`,
-      ),
-    ];
-  }
-  const invalidIndex = policy.auth.profiles.allowModes.findIndex(
-    (entry) =>
-      typeof entry !== "string" ||
-      !SUPPORTED_AUTH_PROFILE_MODES.includes(
-        entry.trim().toLowerCase() as (typeof SUPPORTED_AUTH_PROFILE_MODES)[number],
-      ),
-  );
-  if (invalidIndex < 0) {
-    return [];
-  }
-  return [
-    policyShapeFinding(
-      policyPath,
-      `oc://${policyDocName}/auth/profiles/allowModes/#${invalidIndex}`,
-      `${policyPath} auth.profiles.allowModes[${invalidIndex}] must be a supported auth mode.`,
-      `Use supported auth modes: ${SUPPORTED_AUTH_PROFILE_MODES.join(", ")}.`,
-    ),
-  ];
+  const shape = createOrderedPolicyShape(policy, { policyPath, policyDocName });
+  const finding = shape.list("auth.profiles.allowModes", {
+    allowed: SUPPORTED_AUTH_PROFILE_MODES,
+    normalize: "lower",
+    array: {
+      message: "{policy} {property} must be an array of auth modes.",
+      hint: "Use supported auth modes: {allowed}.",
+    },
+    entry: {
+      message: "{policy} {property}[{index}] must be a supported auth mode.",
+      hint: "Use supported auth modes: {allowed}.",
+    },
+  });
+  return finding === undefined ? [] : [finding];
 }

--- a/extensions/policy/src/doctor/ordered-shape.ts
+++ b/extensions/policy/src/doctor/ordered-shape.ts
@@ -1,0 +1,224 @@
+import type { HealthFinding } from "openclaw/plugin-sdk/health";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { getPolicyPath } from "../policy-value.js";
+import { readExecApprovalAllowlistRequirements } from "./exec-approval-rules.js";
+import type { PolicyRuleMetadata } from "./metadata.js";
+import { policyShapeFinding } from "./shape-helpers.js";
+import { ocPathSegment } from "./utils.js";
+
+export type PolicyShapeContext = {
+  readonly policyDocName: string;
+  readonly policyPath: string;
+  readonly propertyPrefix?: string;
+  readonly targetPrefix?: string;
+};
+
+type Diagnostic = { readonly message: string; readonly hint: string };
+type ListDiagnostic = {
+  readonly array?: Diagnostic;
+  readonly entry?: Diagnostic;
+  readonly allowed?: readonly string[];
+  readonly normalize?: "raw" | "trim" | "lower";
+  readonly valueName?: string;
+};
+
+export function policyRuleValueIsValid(metadata: PolicyRuleMetadata, value: unknown): boolean {
+  switch (metadata.valueType) {
+    case "boolean":
+      return typeof value === "boolean";
+    case "channel-provider-deny-rules":
+      return (
+        Array.isArray(value) &&
+        value.every(
+          (entry) =>
+            isRecord(entry) &&
+            isRecord(entry.when) &&
+            typeof entry.when.provider === "string" &&
+            entry.when.provider.trim() !== "",
+        )
+      );
+    case "routing-probes":
+      return Array.isArray(value);
+    case "string-list":
+    case "string": {
+      if (
+        metadata.valueType === "string-list" &&
+        metadata.policyPath.join(".") === "execApprovals.agents.allowlist.expected"
+      ) {
+        return readExecApprovalAllowlistRequirements(value, []) !== undefined;
+      }
+      const allowed = metadata.allowedValues ?? metadata.orderedValues;
+      return (
+        stringListIssue(
+          metadata.valueType === "string" ? [value] : value,
+          metadata.caseSensitive === true ? allowed : allowed?.map((entry) => entry.toLowerCase()),
+          metadata.caseSensitive === true ? "trim" : "lower",
+          false,
+        ) === undefined
+      );
+    }
+  }
+  return false;
+}
+
+export function firstPolicyShapeFinding(
+  findings: Iterable<HealthFinding | undefined>,
+): HealthFinding | undefined {
+  for (const finding of findings) {
+    if (finding !== undefined) {
+      return finding;
+    }
+  }
+  return undefined;
+}
+
+export function collectPolicyShapeFindings(
+  findings: Iterable<HealthFinding | undefined>,
+): HealthFinding[] {
+  return Array.from(findings).filter((finding): finding is HealthFinding => finding !== undefined);
+}
+
+function stringListIssue(
+  value: unknown,
+  allowed?: readonly string[],
+  normalize: "raw" | "trim" | "lower" = "trim",
+  visitHoles = true,
+): { kind: "array" } | { kind: "entry"; index: number } | undefined {
+  if (!Array.isArray(value)) {
+    return { kind: "array" };
+  }
+  const index = value.findIndex((entry, entryIndex) => {
+    if (!visitHoles && !(entryIndex in value)) {
+      return false;
+    }
+    if (typeof entry !== "string") {
+      return true;
+    }
+    const normalized =
+      normalize === "raw"
+        ? entry
+        : normalize === "lower"
+          ? entry.trim().toLowerCase()
+          : entry.trim();
+    return normalized === "" || (allowed !== undefined && !allowed.includes(normalized));
+  });
+  return index < 0 ? undefined : { kind: "entry", index };
+}
+
+/** Executes primitive checks; callers retain their explicit first/all diagnostic schedule. */
+export function createOrderedPolicyShape(value: unknown, context: PolicyShapeContext) {
+  const paths = (path: string) => {
+    const parts = path === "" ? [] : path.split(".");
+    return {
+      value: getPolicyPath(value, parts),
+      property: [context.propertyPrefix, ...parts].filter((part) => part !== undefined).join("."),
+      target: [context.targetPrefix, ...parts.map(ocPathSegment)]
+        .filter((part) => part !== undefined)
+        .join("/"),
+      hasTarget: context.targetPrefix !== undefined || parts.length > 0,
+    };
+  };
+  const diagnostic = (
+    path: string,
+    text: Diagnostic,
+    detail: { key?: string; index?: number; valueName?: string; allowed?: readonly string[] } = {},
+  ) => {
+    const location = paths(path);
+    const property = location.property;
+    const fields: Record<string, string> = {
+      policy: context.policyPath,
+      property,
+      key: detail.key ?? "",
+      index: String(detail.index ?? ""),
+      unsupported: property + "." + (detail.key ?? ""),
+      valueName: detail.valueName ?? "",
+      allowed: detail.allowed?.join(", ") ?? "",
+    };
+    const render = (template: string) =>
+      template.replace(
+        /\{(policy|property|key|index|unsupported|valueName|allowed)\}/g,
+        (_, key: string) => fields[key]!,
+      );
+    const suffix =
+      detail.key !== undefined
+        ? "/" + ocPathSegment(detail.key)
+        : detail.index !== undefined
+          ? "/#" + detail.index
+          : "";
+    return policyShapeFinding(
+      context.policyPath,
+      "oc://" + context.policyDocName + (location.hasTarget ? "/" + location.target : "") + suffix,
+      render(text.message),
+      render(text.hint),
+    );
+  };
+  return {
+    value: (path: string) => paths(path).value,
+    finding: diagnostic,
+    object(path: string, hint = "Fix {policy} so {property} is an object.", required = false) {
+      const current = paths(path).value;
+      return (current === undefined && !required) || isRecord(current)
+        ? undefined
+        : diagnostic(path, {
+            message: "{policy} {property} must be an object.",
+            hint,
+          });
+    },
+    keys(
+      path: string,
+      allowed: readonly string[],
+      section: string,
+      hint: string,
+      message = "{policy} {unsupported} is not supported in " + section + " policy.",
+    ) {
+      const current = paths(path).value;
+      if (!isRecord(current)) {
+        return undefined;
+      }
+      const key = Object.keys(current).find((entry) => !allowed.includes(entry));
+      return key === undefined ? undefined : diagnostic(path, { message, hint }, { key });
+    },
+    boolean(path: string, hint = "Set {property} to true or false.") {
+      const current = paths(path).value;
+      return current === undefined || typeof current === "boolean"
+        ? undefined
+        : diagnostic(path, {
+            message: "{policy} {property} must be a boolean.",
+            hint,
+          });
+    },
+    enum(path: string, allowed: readonly string[], text: Diagnostic) {
+      const current = paths(path).value;
+      return current === undefined || (typeof current === "string" && allowed.includes(current))
+        ? undefined
+        : diagnostic(path, text, { allowed });
+    },
+    list(path: string, options: ListDiagnostic = {}) {
+      const current = paths(path).value;
+      if (current === undefined) {
+        return undefined;
+      }
+      const issue = stringListIssue(current, options.allowed, options.normalize);
+      if (issue === undefined) {
+        return undefined;
+      }
+      const text =
+        issue.kind === "array"
+          ? (options.array ?? {
+              message: "{policy} {property} must be an array.",
+              hint: "Fix {policy} so {property} is an array of {valueName}s.",
+            })
+          : (options.entry ?? {
+              message: "{policy} {property}[{index}] must be a supported {valueName}.",
+              hint:
+                "Use non-empty {valueName} entries." +
+                (options.allowed === undefined ? "" : " Supported values: {allowed}."),
+            });
+      return diagnostic(path, text, {
+        ...(issue.kind === "entry" ? { index: issue.index } : {}),
+        valueName: options.valueName,
+        allowed: options.allowed,
+      });
+    },
+  };
+}

--- a/extensions/policy/src/doctor/policy-shape.ts
+++ b/extensions/policy/src/doctor/policy-shape.ts
@@ -1,16 +1,12 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { execApprovalsPolicyShapeFinding, ingressPolicyShapeFinding } from "./access-shapes.js";
+import { createOrderedPolicyShape, firstPolicyShapeFinding } from "./ordered-shape.js";
 import { SUPPORTED_POLICY_SECTIONS } from "./policy-constants.js";
 import { posturePolicyShapeFinding } from "./posture-shapes.js";
 import { routingPolicyShapeFinding } from "./routing-shapes.js";
 import { scopedPolicyShapeFinding } from "./scoped-policy-shape.js";
-import {
-  policyShapeFinding,
-  policyStringArrayShapeFinding,
-  unsupportedPolicyKey,
-} from "./shape-helpers.js";
-import { ocPathSegment } from "./utils.js";
+import { policyShapeFinding } from "./shape-helpers.js";
 
 export function policyContainerShapeFindings(
   policy: unknown,
@@ -21,337 +17,105 @@ export function policyContainerShapeFindings(
     return [
       policyShapeFinding(
         policyPath,
-        `oc://${policyDocName}`,
-        `${policyPath} must contain a policy object.`,
-        `Fix ${policyPath} so the top-level policy is an object.`,
+        "oc://" + policyDocName,
+        policyPath + " must contain a policy object.",
+        "Fix " + policyPath + " so the top-level policy is an object.",
       ),
     ];
   }
-  const unsupportedTopLevel = unsupportedPolicyKey(policy, SUPPORTED_POLICY_SECTIONS);
-  if (unsupportedTopLevel !== undefined) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/${ocPathSegment(unsupportedTopLevel)}`,
-        `${policyPath} ${unsupportedTopLevel} is not a supported policy section.`,
-        `Remove ${unsupportedTopLevel} or use a supported policy section.`,
-      ),
-    ];
-  }
-  if (policy.tools !== undefined && !isRecord(policy.tools)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/tools`,
-        `${policyPath} tools must be an object.`,
-        `Fix ${policyPath} so tools is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.tools)) {
-    const postureFinding = posturePolicyShapeFinding("tools", policy.tools, {
-      policyDocName,
-      policyPath,
-    });
-    if (postureFinding !== undefined) {
-      return [postureFinding];
+  const document = policy;
+  const params = { policyPath, policyDocName };
+  const shape = createOrderedPolicyShape(document, params);
+  function* allowDeny(path: string, valueName: string) {
+    yield shape.object(path);
+    yield shape.keys(
+      path,
+      ["allow", "deny"],
+      "",
+      "Remove {unsupported} or use {property}.allow or {property}.deny.",
+      "{policy} {unsupported} is not supported in policy.",
+    );
+    for (const key of ["allow", "deny"]) {
+      yield shape.list(path + "." + key, {
+        valueName,
+        entry: {
+          message: "{policy} {property}[{index}] must be a non-empty string.",
+          hint: "Fix {policy} so each {property} entry is a {valueName}.",
+        },
+      });
     }
   }
-  if (policy.channels !== undefined && !isRecord(policy.channels)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/channels`,
-        `${policyPath} channels must be an object.`,
-        `Fix ${policyPath} so channels is an object.`,
-      ),
-    ];
+  function* findings() {
+    yield shape.keys(
+      "",
+      SUPPORTED_POLICY_SECTIONS,
+      "",
+      "Remove {key} or use a supported policy section.",
+      "{policy} {key} is not a supported policy section.",
+    );
+    yield shape.object("tools");
+    yield posturePolicyShapeFinding("tools", document.tools, params);
+    yield shape.object("channels");
+    yield shape.keys(
+      "channels",
+      ["denyRules"],
+      "channel",
+      "Remove {unsupported} or use channels.denyRules.",
+    );
+    yield shape.object("mcp");
+    yield shape.keys("mcp", ["servers"], "MCP", "Remove {unsupported} or use mcp.servers.");
+    yield shape.object("dataHandling");
+    yield* allowDeny("mcp.servers", "MCP server id");
+    yield shape.object("models");
+    yield shape.keys(
+      "models",
+      ["providers"],
+      "model",
+      "Remove {unsupported} or use models.providers.",
+    );
+    yield* allowDeny("models.providers", "model provider id");
+    yield shape.object("network");
+    yield shape.keys(
+      "network",
+      ["privateNetwork"],
+      "network",
+      "Remove {unsupported} or use network.privateNetwork.",
+    );
+    yield shape.object("network.privateNetwork");
+    yield shape.keys(
+      "network.privateNetwork",
+      ["allow"],
+      "network",
+      "Remove {unsupported} or use network.privateNetwork.allow.",
+    );
+    yield shape.boolean(
+      "network.privateNetwork.allow",
+      "Fix {policy} so {property} is true or false.",
+    );
+    yield shape.object("secrets");
+    yield shape.keys(
+      "secrets",
+      ["allowInsecureProviders", "denySources", "requireManagedProviders"],
+      "secrets",
+      "Remove {unsupported} or use a supported secrets policy rule.",
+    );
+    yield shape.object("auth");
+    yield shape.keys("auth", ["profiles"], "auth", "Remove {unsupported} or use auth.profiles.");
+    yield shape.object("auth.profiles");
+    yield shape.keys(
+      "auth.profiles",
+      ["allowModes", "requireMetadata"],
+      "auth profile",
+      "Remove {unsupported} or use a supported auth profile policy rule.",
+    );
+    yield execApprovalsPolicyShapeFinding(document.execApprovals, params);
+    yield posturePolicyShapeFinding("sandbox", document.sandbox, params);
+    yield ingressPolicyShapeFinding(document.ingress, params);
+    yield posturePolicyShapeFinding("gateway", document.gateway, params);
+    yield routingPolicyShapeFinding(document.routing, params);
+    yield posturePolicyShapeFinding("agents", document.agents, params);
+    yield scopedPolicyShapeFinding(document.scopes, { ...params, policy: document });
   }
-  if (isRecord(policy.channels)) {
-    const unsupportedChannelKey = unsupportedPolicyKey(policy.channels, ["denyRules"]);
-    if (unsupportedChannelKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/channels/${ocPathSegment(unsupportedChannelKey)}`,
-          `${policyPath} channels.${unsupportedChannelKey} is not supported in channel policy.`,
-          `Remove channels.${unsupportedChannelKey} or use channels.denyRules.`,
-        ),
-      ];
-    }
-  }
-  if (policy.mcp !== undefined && !isRecord(policy.mcp)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/mcp`,
-        `${policyPath} mcp must be an object.`,
-        `Fix ${policyPath} so mcp is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.mcp)) {
-    const unsupportedMcpKey = unsupportedPolicyKey(policy.mcp, ["servers"]);
-    if (unsupportedMcpKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/mcp/${ocPathSegment(unsupportedMcpKey)}`,
-          `${policyPath} mcp.${unsupportedMcpKey} is not supported in MCP policy.`,
-          `Remove mcp.${unsupportedMcpKey} or use mcp.servers.`,
-        ),
-      ];
-    }
-  }
-  if (policy.dataHandling !== undefined && !isRecord(policy.dataHandling)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/dataHandling`,
-        `${policyPath} dataHandling must be an object.`,
-        `Fix ${policyPath} so dataHandling is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.mcp)) {
-    const finding = policyStringArrayShapeFinding(policy.mcp.servers, {
-      property: "mcp.servers",
-      policyDocName,
-      policyPath,
-      target: "mcp/servers",
-      valueName: "MCP server id",
-    });
-    if (finding !== undefined) {
-      return [finding];
-    }
-  }
-  if (policy.models !== undefined && !isRecord(policy.models)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/models`,
-        `${policyPath} models must be an object.`,
-        `Fix ${policyPath} so models is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.models)) {
-    const unsupportedModelsKey = unsupportedPolicyKey(policy.models, ["providers"]);
-    if (unsupportedModelsKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/models/${ocPathSegment(unsupportedModelsKey)}`,
-          `${policyPath} models.${unsupportedModelsKey} is not supported in model policy.`,
-          `Remove models.${unsupportedModelsKey} or use models.providers.`,
-        ),
-      ];
-    }
-  }
-  if (isRecord(policy.models)) {
-    const finding = policyStringArrayShapeFinding(policy.models.providers, {
-      property: "models.providers",
-      policyDocName,
-      policyPath,
-      target: "models/providers",
-      valueName: "model provider id",
-    });
-    if (finding !== undefined) {
-      return [finding];
-    }
-  }
-  if (policy.network !== undefined && !isRecord(policy.network)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/network`,
-        `${policyPath} network must be an object.`,
-        `Fix ${policyPath} so network is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.network)) {
-    const unsupportedNetworkKey = unsupportedPolicyKey(policy.network, ["privateNetwork"]);
-    if (unsupportedNetworkKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/network/${ocPathSegment(unsupportedNetworkKey)}`,
-          `${policyPath} network.${unsupportedNetworkKey} is not supported in network policy.`,
-          `Remove network.${unsupportedNetworkKey} or use network.privateNetwork.`,
-        ),
-      ];
-    }
-    if (policy.network.privateNetwork !== undefined && !isRecord(policy.network.privateNetwork)) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/network/privateNetwork`,
-          `${policyPath} network.privateNetwork must be an object.`,
-          `Fix ${policyPath} so network.privateNetwork is an object.`,
-        ),
-      ];
-    }
-    if (isRecord(policy.network.privateNetwork)) {
-      const unsupportedPrivateNetworkKey = unsupportedPolicyKey(policy.network.privateNetwork, [
-        "allow",
-      ]);
-      if (unsupportedPrivateNetworkKey !== undefined) {
-        return [
-          policyShapeFinding(
-            policyPath,
-            `oc://${policyDocName}/network/privateNetwork/${ocPathSegment(unsupportedPrivateNetworkKey)}`,
-            `${policyPath} network.privateNetwork.${unsupportedPrivateNetworkKey} is not supported in network policy.`,
-            `Remove network.privateNetwork.${unsupportedPrivateNetworkKey} or use network.privateNetwork.allow.`,
-          ),
-        ];
-      }
-    }
-    if (
-      isRecord(policy.network.privateNetwork) &&
-      policy.network.privateNetwork.allow !== undefined &&
-      typeof policy.network.privateNetwork.allow !== "boolean"
-    ) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/network/privateNetwork/allow`,
-          `${policyPath} network.privateNetwork.allow must be a boolean.`,
-          `Fix ${policyPath} so network.privateNetwork.allow is true or false.`,
-        ),
-      ];
-    }
-  }
-  if (policy.secrets !== undefined && !isRecord(policy.secrets)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/secrets`,
-        `${policyPath} secrets must be an object.`,
-        `Fix ${policyPath} so secrets is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.secrets)) {
-    const unsupportedSecretsKey = unsupportedPolicyKey(policy.secrets, [
-      "allowInsecureProviders",
-      "denySources",
-      "requireManagedProviders",
-    ]);
-    if (unsupportedSecretsKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/secrets/${ocPathSegment(unsupportedSecretsKey)}`,
-          `${policyPath} secrets.${unsupportedSecretsKey} is not supported in secrets policy.`,
-          `Remove secrets.${unsupportedSecretsKey} or use a supported secrets policy rule.`,
-        ),
-      ];
-    }
-  }
-  if (policy.auth !== undefined && !isRecord(policy.auth)) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/auth`,
-        `${policyPath} auth must be an object.`,
-        `Fix ${policyPath} so auth is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.auth)) {
-    const unsupportedAuthKey = unsupportedPolicyKey(policy.auth, ["profiles"]);
-    if (unsupportedAuthKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/auth/${ocPathSegment(unsupportedAuthKey)}`,
-          `${policyPath} auth.${unsupportedAuthKey} is not supported in auth policy.`,
-          `Remove auth.${unsupportedAuthKey} or use auth.profiles.`,
-        ),
-      ];
-    }
-  }
-  if (
-    isRecord(policy.auth) &&
-    policy.auth.profiles !== undefined &&
-    !isRecord(policy.auth.profiles)
-  ) {
-    return [
-      policyShapeFinding(
-        policyPath,
-        `oc://${policyDocName}/auth/profiles`,
-        `${policyPath} auth.profiles must be an object.`,
-        `Fix ${policyPath} so auth.profiles is an object.`,
-      ),
-    ];
-  }
-  if (isRecord(policy.auth) && isRecord(policy.auth.profiles)) {
-    const unsupportedProfilesKey = unsupportedPolicyKey(policy.auth.profiles, [
-      "allowModes",
-      "requireMetadata",
-    ]);
-    if (unsupportedProfilesKey !== undefined) {
-      return [
-        policyShapeFinding(
-          policyPath,
-          `oc://${policyDocName}/auth/profiles/${ocPathSegment(unsupportedProfilesKey)}`,
-          `${policyPath} auth.profiles.${unsupportedProfilesKey} is not supported in auth profile policy.`,
-          `Remove auth.profiles.${unsupportedProfilesKey} or use a supported auth profile policy rule.`,
-        ),
-      ];
-    }
-  }
-
-  const execApprovalsFinding = execApprovalsPolicyShapeFinding(policy.execApprovals, {
-    policyDocName,
-    policyPath,
-  });
-  if (execApprovalsFinding !== undefined) {
-    return [execApprovalsFinding];
-  }
-  const sandboxFinding = posturePolicyShapeFinding("sandbox", policy.sandbox, {
-    policyDocName,
-    policyPath,
-  });
-  if (sandboxFinding !== undefined) {
-    return [sandboxFinding];
-  }
-  const ingressFindingValue = ingressPolicyShapeFinding(policy.ingress, {
-    policyDocName,
-    policyPath,
-  });
-  if (ingressFindingValue !== undefined) {
-    return [ingressFindingValue];
-  }
-  const gatewayFinding = posturePolicyShapeFinding("gateway", policy.gateway, {
-    policyDocName,
-    policyPath,
-  });
-  if (gatewayFinding !== undefined) {
-    return [gatewayFinding];
-  }
-  const routingFinding = routingPolicyShapeFinding(policy.routing, {
-    policyDocName,
-    policyPath,
-  });
-  if (routingFinding !== undefined) {
-    return [routingFinding];
-  }
-  const agentsFinding = posturePolicyShapeFinding("agents", policy.agents, {
-    policyDocName,
-    policyPath,
-  });
-  if (agentsFinding !== undefined) {
-    return [agentsFinding];
-  }
-  const scopesFinding = scopedPolicyShapeFinding(policy.scopes, {
-    policyDocName,
-    policyPath,
-    policy,
-  });
-  if (scopesFinding !== undefined) {
-    return [scopesFinding];
-  }
-  return [];
+  const finding = firstPolicyShapeFinding(findings());
+  return finding === undefined ? [] : [finding];
 }

--- a/extensions/policy/src/doctor/posture-shapes.ts
+++ b/extensions/policy/src/doctor/posture-shapes.ts
@@ -1,9 +1,6 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { getPolicyPath } from "../policy-value.js";
 import { POLICY_RULE_METADATA, type PolicyRuleMetadata } from "./metadata.js";
-import { policyShapeFinding, policyStringArrayPropertyShapeFinding } from "./shape-helpers.js";
-import { ocPathSegment } from "./utils.js";
+import { createOrderedPolicyShape, firstPolicyShapeFinding } from "./ordered-shape.js";
 
 type PostureShape = "agents" | "workspace" | "tools" | "scoped-tools" | "sandbox" | "gateway";
 type ShapeContext = {
@@ -23,7 +20,7 @@ type ShapeStep =
   | {
       readonly kind: "keys";
       readonly path: readonly string[];
-      readonly allowed: ReadonlySet<string>;
+      readonly allowed: readonly string[];
       readonly section: string;
       readonly hint: string | { readonly key: string };
       readonly scoped: boolean;
@@ -61,7 +58,7 @@ function keys(
       }
     }
   }
-  return { kind: "keys", path: prefix, allowed, section, hint, scoped };
+  return { kind: "keys", path: prefix, allowed: [...allowed], section, hint, scoped };
 }
 
 function rule(path: string, valueName = "", style?: ListStyle["kind"]): ShapeStep {
@@ -168,83 +165,49 @@ export function posturePolicyShapeFinding(
   const root =
     shape === "workspace" ? "agents.workspace" : shape === "scoped-tools" ? "tools" : shape;
   const rootDepth = root.split(".").length;
-  const propertyPrefix = params.propertyPrefix ?? root;
-  const targetPrefix = params.targetPrefix ?? root.replaceAll(".", "/");
-  for (const step of shapes[shape]) {
-    const relative = step.path.slice(rootDepth);
-    const current = getPolicyPath(value, relative);
-    if (current === undefined) {
-      continue;
-    }
-    const property = [propertyPrefix, ...relative].join(".");
-    const target = `oc://${params.policyDocName}/${[targetPrefix, ...relative.map(ocPathSegment)].join("/")}`;
-    if (step.kind === "object") {
-      if (!isRecord(current)) {
-        return policyShapeFinding(
-          params.policyPath,
-          target,
-          `${params.policyPath} ${property} must be an object.`,
-          `Fix ${params.policyPath} so ${property} is an object.`,
-        );
-      }
-    } else if (step.kind === "keys") {
-      if (!isRecord(current)) {
-        continue;
-      }
-      const unknown = Object.keys(current).find((key) => !step.allowed.has(key));
-      if (unknown !== undefined) {
-        const unsupported = `${property}.${unknown}`;
-        const hint = typeof step.hint === "string" ? step.hint : `${property}.${step.hint.key}`;
-        return policyShapeFinding(
-          params.policyPath,
-          `${target}/${ocPathSegment(unknown)}`,
-          `${params.policyPath} ${unsupported} is not supported in ${step.section} policy.`,
+  const validator = createOrderedPolicyShape(value, {
+    ...params,
+    propertyPrefix: params.propertyPrefix ?? root,
+    targetPrefix: params.targetPrefix ?? root.replaceAll(".", "/"),
+  });
+  function* findings() {
+    for (const step of shapes[shape]) {
+      const path = step.path.slice(rootDepth).join(".");
+      if (step.kind === "object") {
+        yield validator.object(path);
+      } else if (step.kind === "keys") {
+        const hint = typeof step.hint === "string" ? step.hint : "{property}." + step.hint.key;
+        yield validator.keys(
+          path,
+          step.allowed,
+          step.section,
           step.scoped
-            ? `Move ${unsupported} to top-level tools or use a supported scoped tools posture rule.`
-            : `Remove ${unsupported} or use ${hint}.`,
+            ? "Move {unsupported} to top-level tools or use a supported scoped tools posture rule."
+            : "Remove {unsupported} or use " + hint + ".",
         );
-      }
-    } else if (step.metadata.valueType === "boolean") {
-      if (typeof current !== "boolean") {
-        return policyShapeFinding(
-          params.policyPath,
-          target,
-          `${params.policyPath} ${property} must be a boolean.`,
-          shape === "gateway"
-            ? `Fix ${params.policyPath} so ${property} is true or false.`
-            : `Set ${property} to true or false.`,
+      } else if (step.metadata.valueType === "boolean") {
+        yield validator.boolean(
+          path,
+          shape === "gateway" ? "Fix {policy} so {property} is true or false." : undefined,
         );
-      }
-    } else {
-      const finding =
-        step.style === undefined
-          ? policyStringArrayPropertyShapeFinding(current, {
-              allowed: step.metadata.allowedValues,
-              policyDocName: params.policyDocName,
-              policyPath: params.policyPath,
-              property,
-              target: [targetPrefix, ...relative.map(ocPathSegment)].join("/"),
-              valueName: step.valueName,
-            })
-          : customListShapeFinding(current, step.style, {
-              policyPath: params.policyPath,
-              property,
-              target,
-            });
-      if (finding !== undefined) {
-        return finding;
+      } else if (step.style === undefined) {
+        yield validator.list(path, {
+          allowed: step.metadata.allowedValues,
+          valueName: step.valueName,
+        });
+      } else {
+        yield customListShapeFinding(validator, path, step.style);
       }
     }
   }
-  return undefined;
+  return firstPolicyShapeFinding(findings());
 }
 
 function customListShapeFinding(
-  value: unknown,
+  validator: ReturnType<typeof createOrderedPolicyShape>,
+  path: string,
   style: ListStyle,
-  params: { readonly policyPath: string; readonly property: string; readonly target: string },
 ): HealthFinding | undefined {
-  const { property, policyPath, target } = params;
   let arrayHint: string;
   let entryHint: string;
   let entryMessage: string;
@@ -256,13 +219,13 @@ function customListShapeFinding(
       break;
     case "workspace-tools":
       arrayHint = 'Use tool ids such as ["exec", "process", "write", "edit", "apply_patch"].';
-      entryHint = `Use supported tool ids: ${style.allowed.join(", ")}.`;
+      entryHint = "Use supported tool ids: {allowed}.";
       entryMessage = "must be a supported agent workspace tool id.";
       break;
     case "http-endpoints":
       arrayHint =
         'Use an array of endpoint ids such as ["responses"] or remove gateway.http.denyEndpoints.';
-      entryHint = `Use supported endpoint ids: ${style.allowed.join(", ")}.`;
+      entryHint = "Use supported endpoint ids: {allowed}.";
       entryMessage = "must be a supported endpoint id.";
       break;
     case "node-commands":
@@ -272,29 +235,10 @@ function customListShapeFinding(
       entryMessage = "must be a non-empty node command id.";
       break;
   }
-  if (!Array.isArray(value)) {
-    return policyShapeFinding(
-      policyPath,
-      target,
-      `${policyPath} ${property} must be an array.`,
-      arrayHint,
-    );
-  }
-  const invalidIndex = value.findIndex((entry) => {
-    if (typeof entry !== "string") {
-      return true;
-    }
-    // Workspace access accepts exact enum bytes; the other list forms trim entries.
-    return style.kind === "node-commands"
-      ? entry.trim() === ""
-      : !style.allowed.includes(style.kind === "workspace-access" ? entry : entry.trim());
+  return validator.list(path, {
+    allowed: style.kind === "node-commands" ? undefined : style.allowed,
+    normalize: style.kind === "workspace-access" ? "raw" : "trim",
+    array: { message: "{policy} {property} must be an array.", hint: arrayHint },
+    entry: { message: "{policy} {property}[{index}] " + entryMessage, hint: entryHint },
   });
-  return invalidIndex < 0
-    ? undefined
-    : policyShapeFinding(
-        policyPath,
-        `${target}/#${invalidIndex}`,
-        `${policyPath} ${property}[${invalidIndex}] ${entryMessage}`,
-        entryHint,
-      );
 }

--- a/extensions/policy/src/doctor/scoped-policy-shape.ts
+++ b/extensions/policy/src/doctor/scoped-policy-shape.ts
@@ -6,10 +6,10 @@ import {
   ingressPolicyShapeFinding,
   scopedDataHandlingPolicyShapeFinding,
 } from "./access-shapes.js";
+import { createOrderedPolicyShape, firstPolicyShapeFinding } from "./ordered-shape.js";
 import { normalizePolicyChannelId } from "./policy-runtime.js";
 import { duplicateScopedPolicyFieldFinding } from "./policy-scope.js";
 import { posturePolicyShapeFinding } from "./posture-shapes.js";
-import { policyShapeFinding, policyStringArrayPropertyShapeFinding } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
 
 export function scopedPolicyShapeFinding(
@@ -23,251 +23,163 @@ export function scopedPolicyShapeFinding(
   if (value === undefined) {
     return undefined;
   }
-  if (!isRecord(value)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/scopes`,
-      `${params.policyPath} scopes must be an object.`,
-      `Fix ${params.policyPath} so scopes maps scope names to policy overlays with selectors such as agentIds.`,
-    );
-  }
-  for (const [scopeName, overlay] of Object.entries(value)) {
-    const targetPrefix = `scopes/${ocPathSegment(scopeName)}`;
-    if (!isRecord(overlay)) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}`,
-        `${params.policyPath} scopes.${scopeName} must be an object.`,
-        `Fix ${params.policyPath} so the named policy scope is an object.`,
-      );
-    }
-    const hasAgentIds = overlay.agentIds !== undefined;
-    const hasChannelIds = overlay.channelIds !== undefined;
-    if (!hasAgentIds && !hasChannelIds) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}`,
-        `${params.policyPath} scopes.${scopeName} must define at least one selector.`,
-        `List agentIds for agent-scoped policy or channelIds for channel-scoped ingress policy.`,
-      );
-    }
-    const agentIdsFinding = scopedSelectorShapeFinding(overlay.agentIds, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      property: `scopes.${scopeName}.agentIds`,
-      target: `${targetPrefix}/agentIds`,
-      valueName: "agent id",
-      normalize: normalizeAgentId,
-    });
-    if (agentIdsFinding !== undefined) {
-      return agentIdsFinding;
-    }
-    const channelIdsFinding = scopedSelectorShapeFinding(overlay.channelIds, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      property: `scopes.${scopeName}.channelIds`,
-      target: `${targetPrefix}/channelIds`,
-      valueName: "channel id",
-      normalize: normalizePolicyChannelId,
-    });
-    if (channelIdsFinding !== undefined) {
-      return channelIdsFinding;
-    }
-    if (overlay.ingress !== undefined && !hasChannelIds) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/ingress`,
-        `${params.policyPath} scopes.${scopeName}.ingress requires the channelIds selector.`,
-        `Move global ingress rules to top-level ingress, or list channelIds for channel-scoped ingress policy.`,
-      );
-    }
-    if (
-      (overlay.agents !== undefined ||
-        overlay.dataHandling !== undefined ||
-        overlay.execApprovals !== undefined ||
-        overlay.tools !== undefined ||
-        overlay.sandbox !== undefined) &&
-      !hasAgentIds
-    ) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}`,
-        `${params.policyPath} scopes.${scopeName} uses agent-scoped sections without agentIds.`,
-        `List agentIds for agents.workspace, dataHandling.memory, tools, or sandbox policy sections.`,
-      );
-    }
-    const unsupportedKey = Object.keys(overlay).find(
-      (key) =>
-        key !== "agentIds" &&
-        key !== "channelIds" &&
-        key !== "agents" &&
-        key !== "dataHandling" &&
-        key !== "execApprovals" &&
-        key !== "tools" &&
-        key !== "sandbox" &&
-        key !== "ingress",
-    );
-    if (unsupportedKey !== undefined) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/${ocPathSegment(unsupportedKey)}`,
-        `${params.policyPath} scopes.${scopeName}.${unsupportedKey} is not a supported scoped policy section.`,
-        `Use agentIds with agents.workspace, dataHandling.memory, execApprovals, tools, or sandbox, and channelIds with ingress.channels.`,
-      );
-    }
-    if (overlay.dataHandling !== undefined && !isRecord(overlay.dataHandling)) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/dataHandling`,
-        `${params.policyPath} scopes.${scopeName}.dataHandling must be an object.`,
-        `Fix ${params.policyPath} so the scoped dataHandling policy section is an object.`,
-      );
-    }
-    if (isRecord(overlay.dataHandling)) {
-      const scopedDataHandlingFinding = scopedDataHandlingPolicyShapeFinding(overlay.dataHandling, {
-        policyPath: params.policyPath,
-        policyDocName: params.policyDocName,
-        targetPrefix,
-        scopeName,
-      });
-      if (scopedDataHandlingFinding !== undefined) {
-        return scopedDataHandlingFinding;
-      }
-    }
-    if (overlay.agents !== undefined && !isRecord(overlay.agents)) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/agents`,
-        `${params.policyPath} scopes.${scopeName}.agents must be an object.`,
-        `Fix ${params.policyPath} so the scoped agents policy section is an object.`,
-      );
-    }
-    const scopedAgents = isRecord(overlay.agents) ? overlay.agents : {};
-    const unsupportedAgentKey = Object.keys(scopedAgents).find((key) => key !== "workspace");
-    if (unsupportedAgentKey !== undefined) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/agents/${ocPathSegment(unsupportedAgentKey)}`,
-        `${params.policyPath} scopes.${scopeName}.agents.${unsupportedAgentKey} is not supported by the agentIds selector.`,
-        `Move the rule under agents.workspace or a supported scoped top-level section.`,
-      );
-    }
-    const workspaceFinding = posturePolicyShapeFinding("workspace", scopedAgents.workspace, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      targetPrefix: `${targetPrefix}/agents/workspace`,
-      propertyPrefix: `scopes.${scopeName}.agents.workspace`,
-    });
-    if (workspaceFinding !== undefined) {
-      return workspaceFinding;
-    }
-
-    const scopedExecApprovalsFinding = execApprovalsPolicyShapeFinding(overlay.execApprovals, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      targetPrefix: `${targetPrefix}/execApprovals`,
-      propertyPrefix: `scopes.${scopeName}.execApprovals`,
-      allowDefaults: false,
-    });
-    if (scopedExecApprovalsFinding !== undefined) {
-      return scopedExecApprovalsFinding;
-    }
-    if (overlay.tools !== undefined && !isRecord(overlay.tools)) {
-      return policyShapeFinding(
-        params.policyPath,
-        `oc://${params.policyDocName}/${targetPrefix}/tools`,
-        `${params.policyPath} scopes.${scopeName}.tools must be an object.`,
-        `Fix ${params.policyPath} so the scoped tools policy overlay is an object.`,
-      );
-    }
-    if (isRecord(overlay.tools)) {
-      const toolsFinding = posturePolicyShapeFinding("scoped-tools", overlay.tools, {
-        policyDocName: params.policyDocName,
-        policyPath: params.policyPath,
-        targetPrefix: `${targetPrefix}/tools`,
-        propertyPrefix: `scopes.${scopeName}.tools`,
-      });
-      if (toolsFinding !== undefined) {
-        return toolsFinding;
-      }
-    }
-    const sandboxFinding = posturePolicyShapeFinding("sandbox", overlay.sandbox, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      targetPrefix: `${targetPrefix}/sandbox`,
-      propertyPrefix: `scopes.${scopeName}.sandbox`,
-    });
-    if (sandboxFinding !== undefined) {
-      return sandboxFinding;
-    }
-    const ingressFindingLocal = ingressPolicyShapeFinding(overlay.ingress, {
-      policyDocName: params.policyDocName,
-      policyPath: params.policyPath,
-      targetPrefix: `${targetPrefix}/ingress`,
-      propertyPrefix: `scopes.${scopeName}.ingress`,
-      allowSession: false,
-    });
-    if (ingressFindingLocal !== undefined) {
-      return ingressFindingLocal;
-    }
-  }
-  return duplicateScopedPolicyFieldFinding(value, {
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    policy: params.policy,
+  const root = createOrderedPolicyShape(value, {
+    ...params,
+    propertyPrefix: "scopes",
+    targetPrefix: "scopes",
   });
+  if (!isRecord(value)) {
+    return root.object(
+      "",
+      "Fix {policy} so scopes maps scope names to policy overlays with selectors such as agentIds.",
+    );
+  }
+  const scopes = value;
+  function* findings() {
+    for (const [scopeName, overlay] of Object.entries(scopes)) {
+      const targetPrefix = "scopes/" + ocPathSegment(scopeName);
+      const propertyPrefix = "scopes." + scopeName;
+      const shape = createOrderedPolicyShape(overlay, { ...params, propertyPrefix, targetPrefix });
+      yield shape.object("", "Fix {policy} so the named policy scope is an object.", true);
+      const hasAgentIds = shape.value("agentIds") !== undefined;
+      const hasChannelIds = shape.value("channelIds") !== undefined;
+      if (!hasAgentIds && !hasChannelIds) {
+        yield shape.finding("", {
+          message: "{policy} {property} must define at least one selector.",
+          hint: "List agentIds for agent-scoped policy or channelIds for channel-scoped ingress policy.",
+        });
+      }
+      yield scopedSelectorShapeFinding(shape, "agentIds", "agent");
+      yield scopedSelectorShapeFinding(shape, "channelIds", "channel");
+      if (shape.value("ingress") !== undefined && !hasChannelIds) {
+        yield shape.finding("ingress", {
+          message: "{policy} {property} requires the channelIds selector.",
+          hint: "Move global ingress rules to top-level ingress, or list channelIds for channel-scoped ingress policy.",
+        });
+      }
+      if (
+        ["agents", "dataHandling", "execApprovals", "tools", "sandbox"].some(
+          (section) => shape.value(section) !== undefined,
+        ) &&
+        !hasAgentIds
+      ) {
+        yield shape.finding("", {
+          message: "{policy} {property} uses agent-scoped sections without agentIds.",
+          hint: "List agentIds for agents.workspace, dataHandling.memory, tools, or sandbox policy sections.",
+        });
+      }
+      yield shape.keys(
+        "",
+        [
+          "agentIds",
+          "channelIds",
+          "agents",
+          "dataHandling",
+          "execApprovals",
+          "tools",
+          "sandbox",
+          "ingress",
+        ],
+        "",
+        "Use agentIds with agents.workspace, dataHandling.memory, execApprovals, tools, or sandbox, and channelIds with ingress.channels.",
+        "{policy} {unsupported} is not a supported scoped policy section.",
+      );
+      yield shape.object(
+        "dataHandling",
+        "Fix {policy} so the scoped dataHandling policy section is an object.",
+      );
+      const dataHandling = shape.value("dataHandling");
+      if (isRecord(dataHandling)) {
+        yield scopedDataHandlingPolicyShapeFinding(dataHandling, {
+          ...params,
+          targetPrefix,
+          scopeName,
+        });
+      }
+      yield shape.object(
+        "agents",
+        "Fix {policy} so the scoped agents policy section is an object.",
+      );
+      yield shape.keys(
+        "agents",
+        ["workspace"],
+        "",
+        "Move the rule under agents.workspace or a supported scoped top-level section.",
+        "{policy} {unsupported} is not supported by the agentIds selector.",
+      );
+      const sectionParams = (section: string) => ({
+        ...params,
+        targetPrefix: targetPrefix + "/" + section.replaceAll(".", "/"),
+        propertyPrefix: propertyPrefix + "." + section,
+      });
+      yield posturePolicyShapeFinding(
+        "workspace",
+        shape.value("agents.workspace"),
+        sectionParams("agents.workspace"),
+      );
+      yield execApprovalsPolicyShapeFinding(shape.value("execApprovals"), {
+        ...sectionParams("execApprovals"),
+        allowDefaults: false,
+      });
+      yield shape.object("tools", "Fix {policy} so the scoped tools policy overlay is an object.");
+      yield posturePolicyShapeFinding("scoped-tools", shape.value("tools"), sectionParams("tools"));
+      yield posturePolicyShapeFinding("sandbox", shape.value("sandbox"), sectionParams("sandbox"));
+      yield ingressPolicyShapeFinding(shape.value("ingress"), {
+        ...sectionParams("ingress"),
+        allowSession: false,
+      });
+    }
+    yield duplicateScopedPolicyFieldFinding(scopes, params);
+  }
+  return firstPolicyShapeFinding(findings());
 }
 
 function scopedSelectorShapeFinding(
-  value: unknown,
-  params: {
-    readonly policyDocName: string;
-    readonly policyPath: string;
-    readonly property: string;
-    readonly target: string;
-    readonly valueName: string;
-    readonly normalize: (value: string) => string;
-  },
+  shape: ReturnType<typeof createOrderedPolicyShape>,
+  path: string,
+  kind: "agent" | "channel",
 ): HealthFinding | undefined {
-  const selectorFinding = policyStringArrayPropertyShapeFinding(value, {
-    policyDocName: params.policyDocName,
-    policyPath: params.policyPath,
-    property: params.property,
-    target: params.target,
-    valueName: params.valueName,
-  });
-  if (selectorFinding !== undefined) {
-    return selectorFinding;
+  const valueName = kind + " id";
+  const finding = shape.list(path, { valueName });
+  if (finding !== undefined) {
+    return finding;
   }
-  if (value === undefined) {
+  const value = shape.value(path);
+  if (!Array.isArray(value)) {
     return undefined;
   }
-  if (Array.isArray(value) && value.length === 0) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.target}`,
-      `${params.policyPath} ${params.property} must include at least one ${params.valueName}.`,
-      `Add one or more ${params.valueName}s to ${params.policyPath} ${params.property}.`,
+  if (value.length === 0) {
+    return shape.finding(
+      path,
+      {
+        message: "{policy} {property} must include at least one {valueName}.",
+        hint: "Add one or more {valueName}s to {policy} {property}.",
+      },
+      { valueName },
     );
   }
-  if (Array.isArray(value)) {
-    const seen = new Map<string, number>();
-    for (const [index, rawValue] of value.entries()) {
-      if (typeof rawValue !== "string") {
-        continue;
-      }
-      const normalized = params.normalize(rawValue);
-      const previous = seen.get(normalized);
-      if (previous !== undefined) {
-        return policyShapeFinding(
-          params.policyPath,
-          `oc://${params.policyDocName}/${params.target}/#${index}`,
-          `${params.policyPath} ${params.property}[${index}] duplicates ${params.property}[${previous}] after normalization.`,
-          `List each ${params.valueName} only once per named policy scope.`,
-        );
-      }
-      seen.set(normalized, index);
+  const seen = new Map<string, number>();
+  for (const [index, rawValue] of value.entries()) {
+    if (typeof rawValue !== "string") {
+      continue;
     }
+    const normalized =
+      kind === "agent" ? normalizeAgentId(rawValue) : normalizePolicyChannelId(rawValue);
+    const previous = seen.get(normalized);
+    if (previous !== undefined) {
+      return shape.finding(
+        path,
+        {
+          message:
+            "{policy} {property}[{index}] duplicates {property}[" +
+            previous +
+            "] after normalization.",
+          hint: "List each {valueName} only once per named policy scope.",
+        },
+        { index, valueName },
+      );
+    }
+    seen.set(normalized, index);
   }
   return undefined;
 }

--- a/extensions/policy/src/doctor/shape-helpers.ts
+++ b/extensions/policy/src/doctor/shape-helpers.ts
@@ -1,7 +1,6 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CHECK_IDS } from "./check-ids.js";
-import { ocPathSegment } from "./utils.js";
 
 export function unsupportedPolicyKey(
   value: Record<string, unknown>,
@@ -22,106 +21,6 @@ export function isChannelDenyRule(value: unknown): value is {
     (value.reason === undefined || typeof value.reason === "string") &&
     isRecord(value.when) &&
     typeof value.when.provider === "string"
-  );
-}
-
-export function policyStringArrayShapeFinding(
-  value: unknown,
-  params: {
-    readonly property: string;
-    readonly policyDocName: string;
-    readonly policyPath: string;
-    readonly target: string;
-    readonly valueName: string;
-  },
-): HealthFinding | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!isRecord(value)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.target}`,
-      `${params.policyPath} ${params.property} must be an object.`,
-      `Fix ${params.policyPath} so ${params.property} is an object.`,
-    );
-  }
-  const unsupportedKey = unsupportedPolicyKey(value, ["allow", "deny"]);
-  if (unsupportedKey !== undefined) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.target}/${ocPathSegment(unsupportedKey)}`,
-      `${params.policyPath} ${params.property}.${unsupportedKey} is not supported in policy.`,
-      `Remove ${params.property}.${unsupportedKey} or use ${params.property}.allow or ${params.property}.deny.`,
-    );
-  }
-  for (const key of ["allow", "deny"] as const) {
-    const entries = value[key];
-    if (entries === undefined) {
-      continue;
-    }
-    const target = `oc://${params.policyDocName}/${params.target}/${key}`;
-    if (!Array.isArray(entries)) {
-      return policyShapeFinding(
-        params.policyPath,
-        target,
-        `${params.policyPath} ${params.property}.${key} must be an array.`,
-        `Fix ${params.policyPath} so ${params.property}.${key} is an array of ${params.valueName}s.`,
-      );
-    }
-    const invalidIndex = entries.findIndex(
-      (entry) => typeof entry !== "string" || entry.trim() === "",
-    );
-    if (invalidIndex >= 0) {
-      return policyShapeFinding(
-        params.policyPath,
-        `${target}/#${invalidIndex}`,
-        `${params.policyPath} ${params.property}.${key}[${invalidIndex}] must be a non-empty string.`,
-        `Fix ${params.policyPath} so each ${params.property}.${key} entry is a ${params.valueName}.`,
-      );
-    }
-  }
-  return undefined;
-}
-
-export function policyStringArrayPropertyShapeFinding(
-  value: unknown,
-  params: {
-    readonly allowed?: readonly string[];
-    readonly property: string;
-    readonly policyDocName: string;
-    readonly policyPath: string;
-    readonly target: string;
-    readonly valueName: string;
-  },
-): HealthFinding | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Array.isArray(value)) {
-    return policyShapeFinding(
-      params.policyPath,
-      `oc://${params.policyDocName}/${params.target}`,
-      `${params.policyPath} ${params.property} must be an array.`,
-      `Fix ${params.policyPath} so ${params.property} is an array of ${params.valueName}s.`,
-    );
-  }
-  const invalidIndex = value.findIndex((entry) => {
-    if (typeof entry !== "string" || entry.trim() === "") {
-      return true;
-    }
-    return params.allowed !== undefined && !params.allowed.includes(entry.trim());
-  });
-  if (invalidIndex < 0) {
-    return undefined;
-  }
-  const allowedHint =
-    params.allowed === undefined ? "" : ` Supported values: ${params.allowed.join(", ")}.`;
-  return policyShapeFinding(
-    params.policyPath,
-    `oc://${params.policyDocName}/${params.target}/#${invalidIndex}`,
-    `${params.policyPath} ${params.property}[${invalidIndex}] must be a supported ${params.valueName}.`,
-    `Use non-empty ${params.valueName} entries.${allowedHint}`,
   );
 }
 

--- a/extensions/policy/src/policy-conformance.ts
+++ b/extensions/policy/src/policy-conformance.ts
@@ -5,7 +5,7 @@ import JSON5 from "json5";
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { readExecApprovalAllowlistRequirements } from "./doctor/exec-approval-rules.js";
+import { policyRuleValueIsValid } from "./doctor/ordered-shape.js";
 import {
   isPolicyValueAtLeastAsStrict,
   policyContainerShapeFindings,
@@ -341,66 +341,6 @@ function baselineRuleIsNoOp(metadata: PolicyRuleMetadata, baseline: unknown): bo
       return policyRuleListIsEmpty(baseline);
   }
   return false;
-}
-
-function policyRuleValueIsValid(metadata: PolicyRuleMetadata, value: unknown): boolean {
-  switch (metadata.valueType) {
-    case "boolean":
-      return typeof value === "boolean";
-    case "channel-provider-deny-rules":
-      return (
-        Array.isArray(value) &&
-        value.every((entry) => {
-          if (!isRecord(entry)) {
-            return false;
-          }
-          const when = entry.when;
-          return isRecord(when) && typeof when.provider === "string" && when.provider.trim() !== "";
-        })
-      );
-    case "string":
-      return typeof value === "string" && policyStringIsAllowed(metadata, value);
-    case "string-list":
-      if (!Array.isArray(value)) {
-        return false;
-      }
-      if (isExecApprovalAllowlistExpectedRule(metadata)) {
-        return readExecApprovalAllowlistRequirements(value, []) !== undefined;
-      }
-      return value.every(
-        (entry) =>
-          typeof entry === "string" &&
-          entry.trim() !== "" &&
-          policyStringIsAllowed(metadata, entry),
-      );
-    case "routing-probes":
-      return Array.isArray(value);
-  }
-  return false;
-}
-
-function isExecApprovalAllowlistExpectedRule(metadata: PolicyRuleMetadata): boolean {
-  return metadata.policyPath.join(".") === "execApprovals.agents.allowlist.expected";
-}
-
-function policyStringIsAllowed(metadata: PolicyRuleMetadata, value: string): boolean {
-  const normalized = metadata.caseSensitive === true ? value.trim() : value.trim().toLowerCase();
-  if (normalized === "") {
-    return false;
-  }
-  if (metadata.allowedValues !== undefined) {
-    const allowed = metadata.allowedValues.map((entry) =>
-      metadata.caseSensitive === true ? entry : entry.toLowerCase(),
-    );
-    return allowed.includes(normalized);
-  }
-  if (metadata.orderedValues === undefined) {
-    return true;
-  }
-  const allowed = metadata.orderedValues.map((entry) =>
-    metadata.caseSensitive === true ? entry : entry.toLowerCase(),
-  );
-  return allowed.includes(normalized);
 }
 
 function policyRuleListIsEmpty(value: unknown): boolean {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Policy authors rely on stable diagnostics from policy checks, scoped checks, and conformance comparisons. This maintainer-requested refactor reduces the maintenance burden of keeping those validation workflows consistent as rules evolve.

## Why This Change Was Made

Share typed object, key, Boolean, enum, and string-list checks while keeping each workflow's first-error or multi-error schedule explicit. Remove the superseded array and comparison-local validators; retain the existing routing, exec-allowlist, strictness, claim-coalescing, and attestation owners.

## User Impact

No intended user-visible behavior change. Policy acceptance, diagnostic text and ordering, path escaping, scoped participation, and attestation inputs are preserved, including explicitly empty prefixes and sparse versus undefined array entries.

The complete change removes 651 production code lines, including all replacement helpers and types. Three obsolete assertion-baseline rows also disappear after four casts were removed; no exceptions or tests are added. Total source reduction is 657 physical lines.

## Evidence

Local proof uses base `0a0074dc6aef73b5f6c71d02bad340314ca74f48` with the exact reviewed patch:

- All 361 existing tests in the container-diagnostics, file-based conformance, and Doctor-registration suites pass. No assertions or cases were removed or weakened.
- 58,679 baseline/candidate comparisons over 4,096 synthetic inputs preserve complete diagnostic outputs, including field order, simultaneous faults, escaped scope names, empty prefixes, and actual conformance file inputs with colliding basenames. This is bounded differential evidence, not an exhaustive equivalence proof.
- The required changed-file gate passes: production and test typechecks, Doctor declaration/closure tests, SDK and dependency guards, all unused-export scans, lint, and zero runtime import cycles. The initial assertion-ratchet failure was resolved only by deleting its three now-zero rows.
- Managed P2 autoreview is scoped-clean, and final source verification matches the reviewed state. Current-main comparison found no drift in the affected Policy files or relevant consumers and helpers.

This does not claim a live Gateway run or package-installation proof. Hosted CI remains pending for the published head.
