### PR TITLE
refactor(tests): share OpenAI embedding batch inputs

### DIFF
--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -7,6 +7,34 @@ import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
 
 const jsonlEncoder = new TextEncoder();
 
+function singleRequestBatchParams(
+  fetchImpl: typeof fetch,
+  pollIntervalMs: number,
+  timeoutMs: number,
+): Parameters<typeof runOpenAiEmbeddingBatches>[0] {
+  return {
+    openAi: {
+      baseUrl: "https://openai-compatible.example/v1",
+      headers: { Authorization: "Bearer test" },
+      model: "text-embedding-3-small",
+      fetchImpl,
+    },
+    agentId: "main",
+    requests: [
+      {
+        custom_id: "0",
+        method: "POST",
+        url: "/v1/embeddings",
+        body: { model: "text-embedding-3-small", input: "payload" },
+      },
+    ],
+    wait: true,
+    concurrency: 1,
+    pollIntervalMs,
+    timeoutMs,
+  };
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -333,27 +361,7 @@ describe("OpenAI embedding batch output", () => {
       });
 
       const rejection = expect(
-        runOpenAiEmbeddingBatches({
-          openAi: {
-            baseUrl: "https://openai-compatible.example/v1",
-            headers: { Authorization: "Bearer test" },
-            model: "text-embedding-3-small",
-            fetchImpl,
-          },
-          agentId: "main",
-          requests: [
-            {
-              custom_id: "0",
-              method: "POST",
-              url: "/v1/embeddings",
-              body: { model: "text-embedding-3-small", input: "payload" },
-            },
-          ],
-          wait: true,
-          concurrency: 1,
-          pollIntervalMs: 1,
-          timeoutMs: 1_000,
-        }),
+        runOpenAiEmbeddingBatches(singleRequestBatchParams(fetchImpl, 1, 1_000)),
       ).rejects.toThrow(`openai batch batch-0 ${terminal.status}: provider rejected request`);
       await vi.advanceTimersByTimeAsync(1);
       await rejection;
@@ -608,27 +616,7 @@ describe("OpenAI embedding batch output", () => {
     });
 
     await expect(
-      runOpenAiEmbeddingBatches({
-        openAi: {
-          baseUrl: "https://openai-compatible.example/v1",
-          headers: { Authorization: "Bearer test" },
-          model: "text-embedding-3-small",
-          fetchImpl,
-        },
-        agentId: "main",
-        requests: [
-          {
-            custom_id: "0",
-            method: "POST",
-            url: "/v1/embeddings",
-            body: { model: "text-embedding-3-small", input: "payload" },
-          },
-        ],
-        wait: true,
-        concurrency: 1,
-        pollIntervalMs: 1,
-        timeoutMs: 60_000,
-      }),
+      runOpenAiEmbeddingBatches(singleRequestBatchParams(fetchImpl, 1, 60_000)),
     ).rejects.toThrow(/openai\.batch-status/);
     expect(canceled).toBe(true);
     expect(readCount).toBeLessThan(chunkCount);
@@ -757,27 +745,9 @@ describe("OpenAI embedding batch output", () => {
       return new Response("unexpected request", { status: 500 });
     });
 
-    const byCustomId = await runOpenAiEmbeddingBatches({
-      openAi: {
-        baseUrl: "https://openai-compatible.example/v1",
-        headers: { Authorization: "Bearer test" },
-        model: "text-embedding-3-small",
-        fetchImpl,
-      },
-      agentId: "main",
-      requests: [
-        {
-          custom_id: "0",
-          method: "POST",
-          url: "/v1/embeddings",
-          body: { model: "text-embedding-3-small", input: "payload" },
-        },
-      ],
-      wait: true,
-      concurrency: 1,
-      pollIntervalMs: 1000,
-      timeoutMs: 60_000,
-    });
+    const byCustomId = await runOpenAiEmbeddingBatches(
+      singleRequestBatchParams(fetchImpl, 1_000, 60_000),
+    );
 
     expect([...byCustomId.entries()]).toEqual([["0", [1]]]);
     expect(canceled).toBe(true);
@@ -834,27 +804,7 @@ describe("OpenAI embedding batch output", () => {
 
     try {
       await expect(
-        runOpenAiEmbeddingBatches({
-          openAi: {
-            baseUrl: "https://openai-compatible.example/v1",
-            headers: { Authorization: "Bearer test" },
-            model: "text-embedding-3-small",
-            fetchImpl,
-          },
-          agentId: "main",
-          requests: [
-            {
-              custom_id: "0",
-              method: "POST",
-              url: "/v1/embeddings",
-              body: { model: "text-embedding-3-small", input: "payload" },
-            },
-          ],
-          wait: true,
-          concurrency: 1,
-          pollIntervalMs: 1000,
-          timeoutMs: 60_000,
-        }),
+        runOpenAiEmbeddingBatches(singleRequestBatchParams(fetchImpl, 1_000, 60_000)),
       ).rejects.toThrow(/openai\.batch-file-content/);
     } finally {
       await closeServer(server);
@@ -893,27 +843,7 @@ describe("OpenAI embedding batch output", () => {
       return new Response("unexpected request", { status: 500 });
     });
 
-    const result = await runOpenAiEmbeddingBatches({
-      openAi: {
-        baseUrl: "https://openai-compatible.example/v1",
-        headers: { Authorization: "Bearer test" },
-        model: "text-embedding-3-small",
-        fetchImpl,
-      },
-      agentId: "main",
-      requests: [
-        {
-          custom_id: "0",
-          method: "POST",
-          url: "/v1/embeddings",
-          body: { model: "text-embedding-3-small", input: "payload" },
-        },
-      ],
-      wait: true,
-      concurrency: 1,
-      pollIntervalMs: 1,
-      timeoutMs: 1_000,
-    });
+    const result = await runOpenAiEmbeddingBatches(singleRequestBatchParams(fetchImpl, 1, 1_000));
 
     expect(result).toEqual(new Map([["0", [1]]]));
     expect(statusCalls).toBe(2);
@@ -942,30 +872,7 @@ describe("OpenAI embedding batch output", () => {
     });
 
     await expect(
-      runOpenAiEmbeddingBatches({
-        openAi: {
-          baseUrl: "https://openai-compatible.example/v1",
-          headers: { Authorization: "Bearer test" },
-          model: "text-embedding-3-small",
-          fetchImpl,
-        },
-        agentId: "main",
-        requests: [
-          {
-            custom_id: "0",
-            method: "POST",
-            url: "/v1/embeddings",
-            body: {
-              model: "text-embedding-3-small",
-              input: "payload",
-            },
-          },
-        ],
-        wait: true,
-        concurrency: 1,
-        pollIntervalMs: 1,
-        timeoutMs: 60_000,
-      }),
+      runOpenAiEmbeddingBatches(singleRequestBatchParams(fetchImpl, 1, 60_000)),
     ).rejects.toMatchObject({ name: "ProviderHttpError", status: 400, statusCode: 400 });
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Six OpenAI embedding-batch test inputs repeat the same single-request configuration, obscuring the fetch implementation and timing values that distinguish each scenario.

## Why This Change Was Made

Share the input structure through a local fixture with three required arguments. Each call retains its exact fetch-function identity and explicit polling interval and timeout, while creating fresh nested objects and arrays. All cases, mock behavior, transport cleanup, and independent assertions remain unchanged.

## User Impact

No user-visible behavior changes. This removes 93 net test lines without changing production code or claiming runtime savings.

## Evidence

All 44 existing cases passed before and after across embedding-batch, embedding-provider, and memory-embedding-adapter suites, with identical names, order, and statuses. One-off verification recovered the original source and AST, preserved six fetch references, and checked fresh independent input graphs. Changed-file checks and independent P2 review passed.
