### PR TITLE
fix(update): stop retired v1 handoff rows from blocking config writes

### DIFF
--- a/src/infra/update-managed-service-handoff-cleanup.ts
+++ b/src/infra/update-managed-service-handoff-cleanup.ts
@@ -4,19 +4,20 @@ import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
-/** v1 shipped in 2026.8.2. This proves cleanup eligibility, never v2 authority. */
-export function canCleanupLegacyManagedHandoff(
+/**
+ * v1 shipped in 2026.8.2. Decoding the complete retired shape proves the row is
+ * a known released claim, never v2/v3 authority and never a native borrower.
+ */
+export function readLegacyManagedHandoff(
   payload: string,
-  processState: (identity: { pid: number; startIdentity: string }) => "live" | "dead" | "unknown",
-): boolean {
+): { pid: number; startIdentity: string } | null {
   let value: unknown;
   try {
     value = JSON.parse(payload);
   } catch {
-    return false;
+    return null;
   }
-  return (
-    isRecord(value) &&
+  return isRecord(value) &&
     Object.keys(value).length === 3 &&
     value.version === 1 &&
     typeof value.pid === "number" &&
@@ -25,10 +26,19 @@ export function canCleanupLegacyManagedHandoff(
     typeof value.startIdentity === "string" &&
     Number.isSafeInteger(Number(value.startIdentity)) &&
     Number(value.startIdentity) >= 0 &&
-    String(Number(value.startIdentity)) === value.startIdentity &&
-    // The recorded process may be the updater runner, not the surviving helper.
-    processState({ pid: value.pid, startIdentity: value.startIdentity }) === "dead"
-  );
+    String(Number(value.startIdentity)) === value.startIdentity
+    ? { pid: value.pid, startIdentity: value.startIdentity }
+    : null;
+}
+
+/** Cleanup eligibility for a retired v1 claim; never v2 authority. */
+export function canCleanupLegacyManagedHandoff(
+  payload: string,
+  processState: (identity: { pid: number; startIdentity: string }) => "live" | "dead" | "unknown",
+): boolean {
+  const legacy = readLegacyManagedHandoff(payload);
+  // The recorded process may be the updater runner, not the surviving helper.
+  return legacy !== null && processState(legacy) === "dead";
 }
 
 export const MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX = "openclaw-update-run-handoff-";

--- a/src/infra/update-managed-service-handoff-lease.ts
+++ b/src/infra/update-managed-service-handoff-lease.ts
@@ -14,7 +14,10 @@ import {
   type SqliteTransactionOptions,
 } from "./sqlite-transaction.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
-import { canCleanupLegacyManagedHandoff } from "./update-managed-service-handoff-cleanup.js";
+import {
+  canCleanupLegacyManagedHandoff,
+  readLegacyManagedHandoff,
+} from "./update-managed-service-handoff-cleanup.js";
 import {
   createManagedHandoffLeaseDatabase,
   leaseQueries,
@@ -628,7 +631,12 @@ export function createManagedHandoffLeaseStore(
         leaseQueries(db)
           .selectFrom("managed_update_handoffs")
           .select(["install_root", "owner", "payload_json", "updated_at"]),
-      ).rows.map((entry) => handle(entry.install_root, entry)),
+      ).rows.flatMap((entry) =>
+        // A complete retired v1 claim records no borrower source, so it cannot
+        // reserve this resource whatever its process state. Every other shape
+        // still decodes through handle(): unknown rows refuse the caller.
+        readLegacyManagedHandoff(entry.payload_json) ? [] : [handle(entry.install_root, entry)],
+      ),
     );
   }
   function assertSourceUnborrowed(resource: string) {

--- a/src/infra/update-retained-custody.legacy.test.ts
+++ b/src/infra/update-retained-custody.legacy.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { withConfigWriteLock } from "../config/write-lock.js";
+import {
+  createManagedHandoffLeaseStore,
+  type ManagedHandoffLease,
+} from "./update-managed-service-handoff-lease.js";
+import {
+  seedRetainedBorrower,
+  type RetainedBorrowerSource,
+} from "./update-retained-custody.test-support.js";
+
+const fixture = vi.hoisted(() => ({ root: "" }));
+vi.mock("./tmp-openclaw-dir.js", () => ({ resolvePreferredOpenClawTmpDir: () => fixture.root }));
+
+let configPath: string;
+let databasePath: string;
+let store: ReturnType<typeof createManagedHandoffLeaseStore>;
+
+beforeEach(() => {
+  fixture.root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "retained-legacy-")));
+  fs.chmodSync(fixture.root, 0o700);
+  configPath = path.join(fixture.root, "openclaw.json");
+  databasePath = path.join(fixture.root, "managed-update-handoffs.sqlite");
+  store = createManagedHandoffLeaseStore();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+});
+
+function acquire(name = "install") {
+  const root = path.join(fixture.root, name);
+  fs.mkdirSync(root);
+  const result = store.acquire(root, "legacy-owner", { kind: "update" });
+  if (result.kind !== "acquired") {
+    throw new Error("fixture busy");
+  }
+  return result.lease;
+}
+function rewritePayload(lease: ManagedHandoffLease, payload: unknown) {
+  const db = new DatabaseSync(databasePath);
+  try {
+    expect(
+      db
+        .prepare("UPDATE managed_update_handoffs SET payload_json = ? WHERE install_root = ?")
+        .run(JSON.stringify(payload), lease.key).changes,
+    ).toBe(1);
+  } finally {
+    db.close();
+  }
+}
+function borrowerSource(overrides: Partial<RetainedBorrowerSource> = {}) {
+  return {
+    runId: "run",
+    transactionId: "transaction",
+    claimId: "claim",
+    revision: 1,
+    recordSha256: "a".repeat(64),
+    lifetimeId: "lifetime",
+    serviceKey: path.join(fixture.root, "unrelated-service"),
+    configPaths: [configPath],
+    ...overrides,
+  };
+}
+function writeConfig() {
+  const callback = vi.fn(async () => {
+    fs.writeFileSync(configPath, "{}");
+  });
+  return { callback, done: withConfigWriteLock(configPath, callback, {}) };
+}
+
+// A retired v1 claim records no borrower source, so it never reserved a config
+// path. Refusing every config write while one survives stranded whole installs.
+it("admits ordinary config writers alongside a retired v1 claim", async () => {
+  const legacy = acquire();
+  rewritePayload(legacy, { version: 1, pid: process.pid, startIdentity: "0" });
+
+  const { callback, done } = writeConfig();
+  await expect(done).resolves.toBeUndefined();
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(fs.readFileSync(configPath, "utf8")).toBe("{}");
+  expect(store.read(legacy.key)).toEqual({ kind: "unreadable" });
+});
+
+it("refuses config writers while an unreadable lease shape is retained", async () => {
+  const damaged = acquire();
+  // Complete v1 plus authority it never carried: prospective, not retired.
+  rewritePayload(damaged, {
+    version: 1,
+    pid: process.pid,
+    startIdentity: "0",
+    action: { kind: "update" },
+  });
+
+  const { callback, done } = writeConfig();
+  await expect(done).rejects.toThrow("incompatible");
+  expect(callback).not.toHaveBeenCalled();
+  expect(fs.existsSync(configPath)).toBe(false);
+});
+
+it("keeps refusing config writers that a retained borrower reserved", async () => {
+  const retained = acquire("retained");
+  seedRetainedBorrower(databasePath, retained, borrowerSource(), "admitted");
+  rewritePayload(acquire("released"), { version: 1, pid: process.pid, startIdentity: "0" });
+
+  const { callback, done } = writeConfig();
+  await expect(done).rejects.toThrow("native custody");
+  expect(callback).not.toHaveBeenCalled();
+  expect(fs.existsSync(configPath)).toBe(false);
+});


### PR DESCRIPTION
## Problem

A single retired v1 handoff row in the machine-shared lease database made **every config
write and every native service operation on the machine fail**, with:

```
existing managed handoff lease is incompatible; retain diagnostics and run openclaw triage manually
```

`withConfigWriteLock` and `withGatewayServiceOperationLock` call
`createManagedHandoffLeaseStore().assertSourceUnborrowed(path)` before admitting a writer.
That reads **every** row of `<tmp>/openclaw/managed-update-handoffs.sqlite` through `handle()`,
which throws for any payload the strict v2/v3 schema rejects.

Managed-handoff v1 rows (`{"version":1,pid,startIdentity}`) shipped in **2026.8.2**. They are
keyed by install roots that no longer exist, so nothing re-admits them and nothing retires them —
they simply sit in the shared database forever. Harmless until the retained-custody check
started reading them, at which point one survivor bricked config writes for the whole machine.

Observed on a clean checkout of `main`: `src/state/local-onboarding-state.test.ts` failed 3 of 13
(the three tests that reach a config write through `completeLocalSetupRecovery`), one of them by
timing out at 120s waiting on a completion lock whose competitor had already thrown. Proven at the
owner independently of any test — against the real machine database, which held 14 v1 rows next to
13 valid v2 rows:

```
store.assertSourceUnborrowed("~/.openclaw/openclaw.json")
→ THROWS: existing managed handoff lease is incompatible…
```

Deleting only the v1 rows from a copy made the same call return clean, isolating the cause exactly.

## Fix

`readRetainedSources()` now skips rows that decode as the **complete** retired v1 shape. That shape
records no `nativeBorrower`, so it can never have reserved a config path — whatever its process
state. The strictness that mattered is kept: unknown, damaged, or partially-v1 payloads still refuse
the caller through `handle()`, because unreadable prospective data cannot prove the source is
unrelated. Retained v3 custody still refuses config writers exactly as before.

`canCleanupLegacyManagedHandoff` is split into `readLegacyManagedHandoff` (shape only) plus a
liveness wrapper, so the v1 shape has one owner instead of two copies. The admission/cleanup
predicate is unchanged — cleanup eligibility still requires a positively dead process; only the
custody read, which makes no authority decision, ignores liveness.

This is +18 net production lines rather than neutral. The growth is the named split of one
predicate into two; collapsing it back would duplicate the v1 shape check in the lease store.

## Evidence

- `node scripts/run-vitest.mjs src/state/local-onboarding-state.test.ts` — **13 passed** (was 3 failed | 10 passed)
- `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-retarget.test.ts src/infra/update-retained-custody.unicode.test.ts src/infra/update-retained-custody.legacy.test.ts` — **45 passed**
- `node scripts/check-changed.mjs` — passed
- New `src/infra/update-retained-custody.legacy.test.ts` proves the user-visible flow through
  `withConfigWriteLock`, not a helper. Verified it fails on the original defect: with the fix
  reverted, 2 of its 3 tests fail with the exact production error.

## Follow-up (not in this PR)

Retired v1 rows are now harmless but still never retired, since only admission at their exact
install root can delete one. A bounded sweep of released v1 rows would be a reasonable separate change.
