### PR TITLE
fix(ui): remove misleading links from position previews

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -870,7 +870,6 @@ a:where(
     .markdown a,
     .markdown-body a,
     .chat-session-rail__answer a,
-    .chat-position-rail__preview-copy a,
     .dreams-diary__para a
   ):not(:where(.btn, [role="button"])) {
   text-decoration: underline;

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -245,6 +245,13 @@
   font-family: var(--mono);
 }
 
+/* The inert preview cannot open links; the marker jumps to the full message. */
+.chat-position-rail__preview-copy a {
+  color: inherit;
+  text-decoration: none;
+  cursor: inherit;
+}
+
 .chat-thread-inner > :first-child {
   margin-top: 0 !important;
 }

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -290,6 +290,7 @@ describeCursorPolicy("Control UI cursor policy", () => {
             ".person-activity-link",
             ".markdown-github-item",
             ".markdown-file-link",
+            ".chat-position-rail__preview-copy a",
           ],
         ],
         [
@@ -299,8 +300,7 @@ describeCursorPolicy("Control UI cursor policy", () => {
             "#docs-link",
             "#chat-content-link",
             "#sidebar-content-link",
-            ".markdown-bare-url",
-            "#preview-github-link",
+            ".markdown-bare-url:not(.chat-position-rail__preview-copy a)",
             ".activity-entry__run-link",
             ".settings-row__value",
             ".memory-page__link",
@@ -322,6 +322,13 @@ describeCursorPolicy("Control UI cursor policy", () => {
         }
       }
       const personLink = page.locator("#person-link");
+      for (const link of await page.locator(".chat-position-rail__preview-copy a").all()) {
+        expect(await link.evaluate((element) => getComputedStyle(element).color)).toBe(
+          await page
+            .locator(".chat-position-rail__preview-copy")
+            .evaluate((element) => getComputedStyle(element).color),
+        );
+      }
       if (!hasTouch) {
         await personLink.hover();
         expect(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing the conversation position rail saw underlined, accent-colored links in message previews even though those previews cannot open links.

## Why This Change Was Made

Render links as ordinary text inside the inert preview. The rail marker continues to navigate to the full message, where links remain usable. Rich text formatting and the preview's keyboard behavior stay intact.

## User Impact

Message previews no longer suggest unavailable link actions.

## Evidence

The existing browser style regression failed on the original CSS in all four light/dark and touch/non-touch cases, then passed with the fix. All 15 focused style and position-rail tests passed. Verified the rendered mock-Gateway UI in Chrome with synthetic messages, including keyboard marker navigation and the full message's retained hyperlink.

Before:

![Inert preview misleadingly displays a hyperlink](https://github.com/user-attachments/assets/a8c9c6cb-04d8-4825-a8f6-e08e2dfce6c8)

After:

![Preview displays ordinary text while the full message retains its hyperlink](https://github.com/user-attachments/assets/54d27238-c41b-49fb-b4ba-3592331512e4)

Independent P0–P2 review found no actionable issues. Local changed checks passed through i18n verification, then the core-test typecheck stopped because its declaration guard rejects this worktree's borrowed compiler installation; exact-head hosted CI supplies the remaining typecheck evidence.
