### PR TITLE
refactor(agents): remove duplicate OpenAI routing test

### DIFF
--- a/src/agents/openai-routing.test.ts
+++ b/src/agents/openai-routing.test.ts
@@ -392,24 +392,6 @@ describe("OpenAI runtime routing policy", () => {
     ).toBe("openai");
   });
 
-  it("checks legacy Codex auth before canonical OpenAI for pre-doctor state", () => {
-    const config = {
-      auth: {
-        order: {
-          openai: ["openai:work", "openai:backup"],
-        },
-      },
-    } satisfies OpenClawConfig;
-
-    expect(
-      listOpenAIAuthProfileProvidersForAgentRuntime({
-        provider: "openai",
-        harnessRuntime: "openclaw",
-        config,
-      }),
-    ).toEqual(["openai"]);
-  });
-
   it("keeps explicit OpenAI OpenClaw API-key auth order ahead of Codex backups", () => {
     const config = {
       auth: {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The OpenAI routing suite repeats the same canonical-provider auth-order check in a weaker case, adding maintenance without distinct coverage.

## Why This Change Was Made

Remove the duplicate pre-doctor-titled case. The retained canonical OpenAI case uses the same configuration, provider, runtime, and expected auth-provider list, and additionally checks both runtime-provider resolvers.

## User Impact

No runtime behavior changes. One test case and 18 test lines are removed; all other cases, assertions, imports, and helpers remain unchanged.

## Evidence

- Full ordered agents-core file: 30 actual passes, 0 skips.
- Targeted formatting and diff checks passed.
- All 20 selected changed-file checks passed, including the three dead-export scans.
- Fresh scoped P2 review completed with no findings.

This is test-only canonical-provider bookkeeping, not migration proof. No live Codex, provider, OAuth, installed-package, or local full-repository test run is claimed.
