### PR TITLE
refactor(cron): share outcome application for scheduled and manual runs

### DIFF
--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -697,7 +697,13 @@ describe("cron trigger evaluation", () => {
     const harness = await createHarness({ evaluateCronTrigger });
     try {
       const job = await harness.cron.add(watcher());
+      const pendingSlot = job.state.nextRunAtMs;
+      expect(pendingSlot).toEqual(expect.any(Number));
       expect(await harness.cron.run(job.id, "force")).toEqual({ ok: true, ran: true });
+      expect(harness.cron.getJob(job.id)?.state).toMatchObject({
+        nextRunAtMs: pendingSlot,
+        forcePreservedNextRunAtMs: pendingSlot,
+      });
       expect(evaluateCronTrigger).not.toHaveBeenCalled();
       expect(harness.runIsolatedAgentJob).toHaveBeenCalledOnce();
       expect(harness.events.find((event) => event.action === "finished")).toMatchObject({

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -48,95 +48,11 @@ import {
   tryFinishCronTaskRunWithoutHistory,
 } from "./task-runs.js";
 import { recordCronOutcomeForJob } from "./timer-outcome-events.js";
-import {
-  resolveCronRunScheduleOwnership,
-  resolveCronRunTriggerOwnership,
-} from "./timer-outcomes.js";
-import {
-  applyJobResult,
-  applyScriptRunResult,
-  applyTriggerNoFireResult,
-  applyTriggerRunResult,
-  armTimer,
-  authorCronRunCompletion,
-  executeJobCoreWithTimeout,
-} from "./timer.js";
+import { applyOutcomeToAuthoritativeJob } from "./timer-outcomes.js";
+import { armTimer, authorCronRunCompletion, executeJobCoreWithTimeout } from "./timer.js";
 import { wake } from "./wake.js";
 
 let nextManualRunId = 1;
-
-type ManualRunCoreResult = Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
-
-function applyManualRunOutcome(params: {
-  state: CronServiceState;
-  job: CronJob;
-  prepared: ActivatedManualRun;
-  coreResult: ManualRunCoreResult;
-  startedAt: number;
-  endedAt: number;
-  triggerSkipped: boolean;
-  mode?: CronRunMode;
-  deferredNotifications: DeferredCronNotifications;
-}): boolean {
-  const scheduleOwnership = resolveCronRunScheduleOwnership({
-    admittedJob: params.prepared.admittedJob,
-    currentJob: params.job,
-    activeJobMarker: params.prepared.activeJobMarker,
-  });
-  const triggerOwnership = resolveCronRunTriggerOwnership({
-    admittedJob: params.prepared.admittedJob,
-    currentJob: params.job,
-    activeJobMarker: params.prepared.activeJobMarker,
-  });
-  const scheduleMode =
-    scheduleOwnership === "stale"
-      ? "stale-preserve"
-      : isImmediateCronRunMode(params.mode)
-        ? "immediate-preserve"
-        : "advance";
-  if (params.triggerSkipped) {
-    applyTriggerNoFireResult(
-      params.state,
-      params.job,
-      {
-        startedAt: params.startedAt,
-        endedAt: params.endedAt,
-        triggerEval: params.coreResult.triggerEval!,
-      },
-      {
-        scheduleMode,
-        triggerOwnership,
-        deferredNotifications: params.deferredNotifications,
-      },
-    );
-    return false;
-  }
-  const removed = applyJobResult(
-    params.state,
-    params.job,
-    { ...params.coreResult, startedAt: params.startedAt, endedAt: params.endedAt },
-    {
-      scheduleMode: scheduleMode === "immediate-preserve" ? "preserve" : "advance",
-      scheduleOwnership,
-      scheduleOwnershipAtMs: params.prepared.scheduleOwnershipAtMs,
-      deferredNotifications: params.deferredNotifications,
-    },
-  );
-  applyTriggerRunResult(
-    params.job,
-    {
-      status: params.coreResult.status,
-      endedAt: params.endedAt,
-      triggerEval: params.coreResult.triggerEval,
-    },
-    { scheduleOwnership, triggerOwnership },
-  );
-  applyScriptRunResult(params.job, params.coreResult, { triggerOwnership });
-  if (params.job.schedule.kind === "stream") {
-    params.job.state.nextRunAtMs = undefined;
-  }
-  return removed;
-}
 
 async function finishPreparedManualRun(
   state: CronServiceState,
@@ -196,6 +112,23 @@ async function finishPreparedManualRun(
     }
     const endedAt = state.deps.nowMs();
     const triggerSkipped = coreResult.status === "ok" && coreResult.triggerEval?.fired === false;
+    const outcome = {
+      ...coreResult,
+      jobId,
+      job: prepared.admittedJob,
+      taskRunId,
+      activeJobMarker: prepared.activeJobMarker,
+      runReceipt: prepared.runReceipt,
+      startedAt,
+      endedAt,
+    };
+    const outcomeOptions = {
+      emit: false,
+      request: {
+        preserveCadence: isImmediateCronRunMode(mode),
+        scheduleOwnershipAtMs: prepared.scheduleOwnershipAtMs,
+      },
+    };
     const emitMissingTerminal = (required = false) => {
       const tracker = prepared.terminalTracker;
       if ((!tracker && !required) || tracker?.emitted) {
@@ -274,27 +207,11 @@ async function finishPreparedManualRun(
       const postPersistNotifications: DeferredCronNotifications = [];
       if (!triggerSkipped) {
         const taskJob = structuredClone(job);
-        applyManualRunOutcome({
-          state,
-          job: taskJob,
-          prepared,
-          coreResult,
-          startedAt,
-          endedAt,
-          triggerSkipped,
-          mode,
+        applyOutcomeToAuthoritativeJob(state, taskJob, outcome, {
+          ...outcomeOptions,
           deferredNotifications: [],
         });
-        recordCronOutcomeForJob(state, taskJob, {
-          ...coreResult,
-          jobId,
-          job: executionJob,
-          taskRunId,
-          activeJobMarker: prepared.activeJobMarker,
-          runReceipt: prepared.runReceipt,
-          startedAt,
-          endedAt,
-        });
+        recordCronOutcomeForJob(state, taskJob, { ...outcome, job: executionJob });
       }
       let removedJob: CronJob | undefined;
       try {
@@ -319,15 +236,8 @@ async function finishPreparedManualRun(
             if (!current) {
               return { value: undefined };
             }
-            const removed = applyManualRunOutcome({
-              state,
-              job: current,
-              prepared,
-              coreResult,
-              startedAt,
-              endedAt,
-              triggerSkipped,
-              mode,
+            const removed = applyOutcomeToAuthoritativeJob(state, current, outcome, {
+              ...outcomeOptions,
               deferredNotifications: postPersistNotifications,
             });
             return {

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -406,7 +406,7 @@ describe("cron service ops regressions", () => {
       scheduledAt: nowMs,
       schedule: { kind: "every", everyMs: 60_000, anchorMs: nowMs - 60_000 },
       payload: { kind: "agentTurn", message: "manual paced due slot" },
-      state: { nextRunAtMs: dueSlot, pacedNextRunAtMs: dueSlot },
+      state: { nextRunAtMs: dueSlot, pacedNextRunAtMs: dueSlot, startupCatchupAtMs: dueSlot },
     });
     job.pacing = { min: "15m", max: "4h" };
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
@@ -427,6 +427,7 @@ describe("cron service ops regressions", () => {
     expect(stored?.state.nextRunAtMs).toBe(dueSlot);
     expect(stored?.state.pacedNextRunAtMs).toBe(dueSlot);
     expect(stored?.state.forcePreservedNextRunAtMs).toBe(dueSlot);
+    expect(stored?.state.startupCatchupAtMs).toBe(dueSlot);
 
     const restarted = createCronServiceState({
       cronEnabled: false,
@@ -443,6 +444,7 @@ describe("cron service ops regressions", () => {
     expect(reloaded?.state.nextRunAtMs).toBe(dueSlot);
     expect(reloaded?.state.pacedNextRunAtMs).toBe(dueSlot);
     expect(reloaded?.state.forcePreservedNextRunAtMs).toBe(dueSlot);
+    expect(reloaded?.state.startupCatchupAtMs).toBe(dueSlot);
   });
 
   it("passes the rehydrated agentTurn payload message to isolated manual runs", async () => {

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -44,7 +44,7 @@ type CronScheduleOwnership = "current" | "stale";
 type CronTriggerOwnership = "current" | "stale";
 
 /** Checks both the admitted schedule and edits that may have returned to its original value. */
-export function resolveCronRunScheduleOwnership(params: {
+function resolveCronRunScheduleOwnership(params: {
   admittedJob: CronJob;
   currentJob: CronJob;
   activeJobMarker?: CronActiveJobMarker;
@@ -56,7 +56,7 @@ export function resolveCronRunScheduleOwnership(params: {
 }
 
 /** Keeps trigger state owned by the exact script/once definition that evaluated it. */
-export function resolveCronRunTriggerOwnership(params: {
+function resolveCronRunTriggerOwnership(params: {
   admittedJob: CronJob;
   currentJob: CronJob;
   activeJobMarker?: CronActiveJobMarker;
@@ -687,7 +687,12 @@ export function applyOutcomeToAuthoritativeJob(
   state: CronServiceState,
   job: CronJob,
   result: TimedCronRunOutcome,
-  opts?: { deferredNotifications?: DeferredCronNotifications; emit?: boolean },
+  opts?: {
+    deferredNotifications?: DeferredCronNotifications;
+    emit?: boolean;
+    // A requested run retains startup bookkeeping even when it advances ordinary cadence.
+    request?: { preserveCadence: boolean; scheduleOwnershipAtMs: number };
+  },
 ): boolean {
   const scheduleOwnership = resolveCronRunScheduleOwnership({
     admittedJob: result.job,
@@ -712,13 +717,20 @@ export function applyOutcomeToAuthoritativeJob(
         triggerEval: result.triggerEval,
       },
       {
-        scheduleMode: scheduleOwnership === "stale" ? "stale-preserve" : "advance",
+        scheduleMode:
+          scheduleOwnership === "stale"
+            ? "stale-preserve"
+            : opts?.request?.preserveCadence
+              ? "immediate-preserve"
+              : "advance",
         triggerOwnership,
         deferredNotifications: opts?.deferredNotifications,
       },
     );
-    job.state.startupCatchupAtMs = undefined;
-    if (scheduleOwnership === "current") {
+    if (!opts?.request) {
+      job.state.startupCatchupAtMs = undefined;
+    }
+    if (!opts?.request && scheduleOwnership === "current") {
       // Quiet ticks consume their old pacing slot. Only an in-flight schedule
       // edit owns a replacement override that must survive finalization.
       job.state.pacedNextRunAtMs = undefined;
@@ -727,12 +739,21 @@ export function applyOutcomeToAuthoritativeJob(
   }
 
   const shouldDelete = applyJobResult(state, job, result, {
+    scheduleMode:
+      opts?.request?.preserveCadence && scheduleOwnership === "current" ? "preserve" : "advance",
     scheduleOwnership,
+    scheduleOwnershipAtMs: opts?.request?.scheduleOwnershipAtMs,
     deferredNotifications: opts?.deferredNotifications,
   });
   applyTriggerRunResult(job, result, { scheduleOwnership, triggerOwnership });
   applyScriptRunResult(job, result, { triggerOwnership });
-  job.state.startupCatchupAtMs = undefined;
+  if (opts?.request) {
+    if (job.schedule.kind === "stream") {
+      job.state.nextRunAtMs = undefined;
+    }
+  } else {
+    job.state.startupCatchupAtMs = undefined;
+  }
 
   if (opts?.emit !== false) {
     emitCronOutcomeForJob(state, job, result);

--- a/src/cron/service/timer.quiet-finalization.test.ts
+++ b/src/cron/service/timer.quiet-finalization.test.ts
@@ -46,8 +46,8 @@ afterEach(() => {
 
 describe("cron quiet task finalization", () => {
   it.each(
-    ["timer", "retired-timer", "manual", "retired-manual"].flatMap((mode) =>
-      [false, true].map((failWrite) => ({ mode, failWrite })),
+    ["timer", "retired-timer", "manual", "retired-manual", "manual-force"].flatMap((mode) =>
+      (mode === "manual-force" ? [false] : [false, true]).map((failWrite) => ({ mode, failWrite })),
     ),
   )(
     "finalizes quiet trigger tasks only after cron state persists ($mode, failWrite=$failWrite)",
@@ -58,6 +58,17 @@ describe("cron quiet task finalization", () => {
         ...createDueIsolatedAgentJob({ now }),
         trigger: { script: "json({ fire: false })" },
       };
+      const force = mode === "manual-force";
+      const pendingSlot = now + 30 * 60_000;
+      if (force) {
+        job.pacing = { min: "15m", max: "4h" };
+        job.state = {
+          ...job.state,
+          nextRunAtMs: pendingSlot,
+          pacedNextRunAtMs: pendingSlot,
+          startupCatchupAtMs: pendingSlot,
+        };
+      }
       await writeCronStoreSnapshot({ storePath, jobs: [job] });
       const finalizedAfterPersist: boolean[] = [];
       const database = openOpenClawStateDatabase().db;
@@ -109,7 +120,14 @@ describe("cron quiet task finalization", () => {
       `);
       }
       try {
-        const execution = mode.endsWith("manual") ? run(state, job.id, "due") : onTimer(state);
+        const execution = mode.includes("manual")
+          ? run(
+              state,
+              job.id,
+              force ? "force" : "due",
+              force ? { evaluateTrigger: true } : undefined,
+            )
+          : onTimer(state);
         if (failWrite) {
           await expect(execution).rejects.toThrow("quiet row unavailable");
           expect(finalizedAfterPersist).toEqual([]);
@@ -121,6 +139,14 @@ describe("cron quiet task finalization", () => {
         }
         await execution;
         expect(finalizedAfterPersist).toEqual([true]);
+        if (force) {
+          expect((await loadCronStore(storePath)).jobs[0]?.state).toMatchObject({
+            nextRunAtMs: pendingSlot,
+            pacedNextRunAtMs: pendingSlot,
+            startupCatchupAtMs: pendingSlot,
+            forcePreservedNextRunAtMs: pendingSlot,
+          });
+        }
         const task = findCronTaskByBaseRunId(`cron:${job.id}:${now}`);
         expect(task).toMatchObject({ status: "succeeded" });
         expect(task?.detail).toEqual({

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -5,9 +5,6 @@ export type { IsolatedAgentSetupTimeoutSignal } from "./timer-execution-timeout.
 export { runsDetachedFromMainSession } from "./timer-execution-timeout.js";
 export { authorCronRunCompletion, executeJobCoreWithTimeout } from "./timer-job-runner.js";
 export { applyJobResult } from "./timer-outcomes.js";
-export { applyTriggerRunResult } from "./timer-trigger.js";
-export { applyScriptRunResult } from "./timer-outcomes.js";
-export { applyTriggerNoFireResult } from "./timer-outcomes.js";
 export { armTimer } from "./timer-scheduler.js";
 export { runMissedJobs } from "./timer-catchup.js";
 export { stopTimer } from "./timer-execution.js";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers retain push access.

</details>

## What Problem This Solves

Cron maintenance must keep scheduled runs and manual run-now consistent about outcomes, trigger ownership, and script state while preserving their different cadence and startup bookkeeping. This maintainer-requested refactor reduces the chance of those rules diverging during future changes.

## Why This Change Was Made

Manual outcome projections and authoritative job updates now use the existing outcome-application owner, carrying the admitted job snapshot and original schedule-ownership timestamp. History retains the execution snapshot, while manual and scheduled finalization lifetimes, transactions, notifications, and cleanup remain separate. The obsolete internal exports are removed with their last external caller.

## User Impact

No intended user-visible behavior change. Manual run-now still preserves a pending scheduled occurrence, and both paths continue to respect schedule/trigger edits made while a run is active. The change removes 71 production code lines and adds 34 lines of focused assertions and table coverage.

## Evidence

- The same 160 cases pass with the original production code plus the new assertions and with the final candidate. Coverage includes forced quiet runs, pending pacing/startup markers, admitted versus execution snapshots, concurrent and restored schedule/trigger edits, stream behavior, authoritative SQLite writes, and receipt finalization.
- The full changed-file gate passes, including core and core-test type checking, lint, all three dead-export scans, database/schema guards, and import-cycle checks.
- Managed Codex P2 review found no actionable findings. Final source bytes match that review.
- No tests or guards were removed, weakened, or skipped to make the change pass. The initial dependency-only collection failure was resolved with the pinned workspace installation; the dead-export guard identified the internal exports retired in this patch.

Focused original/candidate test command:

```sh
node scripts/run-vitest.mjs \
  src/cron/service/timer.quiet-finalization.test.ts \
  src/cron/service.trigger-eval.test.ts \
  src/cron/service/ops.regression.test.ts \
  src/cron/service.one-shot-schedule-ownership.test.ts \
  src/cron/service/ops.run-admission-cleanup.test.ts \
  src/cron/service.read-ops-nonblocking.test.ts \
  src/cron/service/timer.pacing.test.ts \
  src/cron/service.stream-trigger.test.ts \
  src/cron/service.startup-overflow-clobber.test.ts \
  src/cron/service/timer-outcome-finalization.receipts.test.ts
```
