### PR TITLE
fix(plugin-state): reduce redundant quota work during large updates

### DIFF
--- a/src/plugin-state/plugin-state-store.retention.test.ts
+++ b/src/plugin-state/plugin-state-store.retention.test.ts
@@ -1,0 +1,409 @@
+// Plugin state retention preserves quotas, eviction order, and rollback.
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  createPluginStateKeyedStore,
+  registerPluginStateSyncSequencedJournalEntry,
+  resetPluginStateStoreForTests,
+  sweepExpiredPluginStateEntries,
+} from "./plugin-state-store.js";
+import {
+  clearPluginStateStoreForTests,
+  seedPluginStateEntriesForTests,
+  setMaxPluginStateEntriesPerPluginForTests,
+} from "./plugin-state-store.test-helpers.js";
+import { PluginStateStoreError } from "./plugin-state-store.types.js";
+
+let testState: OpenClawTestState;
+
+beforeAll(async () => {
+  testState = await createOpenClawTestState({ label: "plugin-state-retention" });
+});
+
+beforeEach(() => {
+  testState.applyEnv();
+  clearPluginStateStoreForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  setMaxPluginStateEntriesPerPluginForTests(undefined);
+  resetPluginStateStoreForTests({ closeDatabase: false });
+});
+
+afterAll(async () => {
+  resetPluginStateStoreForTests();
+  await testState.cleanup();
+});
+
+describe("plugin state keyed store", () => {
+  it("evicts oldest live entries over maxEntries with bounded database calls", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    seedPluginStateEntriesForTests(
+      Array.from({ length: 64 }, (_, index) => ({
+        pluginId: "discord",
+        namespace: "evict",
+        key: `key-${String(index).padStart(2, "0")}`,
+        value: index,
+        createdAt: Math.floor(index / 2),
+      })),
+    );
+    const store = createPluginStateKeyedStore("discord", { namespace: "evict", maxEntries: 3 });
+    const statements = trackSqliteStatementExecutions(
+      openOpenClawStateDatabase().db,
+      ["delete"],
+      (sql) => (sql.startsWith('delete from "plugin_state_entries"') ? "delete" : null),
+    );
+    try {
+      await store.register("a-protected", 64);
+    } finally {
+      statements.restore();
+    }
+
+    // One bounded expiry sweep plus eviction must not scale with the victim count.
+    expect(statements.counts.delete).toBeLessThanOrEqual(2);
+    expect(await store.entries()).toEqual([
+      { key: "key-62", value: 62, createdAt: 31 },
+      { key: "key-63", value: 63, createdAt: 31 },
+      { key: "a-protected", value: 64, createdAt: 1000 },
+    ]);
+  });
+
+  it("keeps the just-registered key when namespace eviction timestamps tie", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const store = createPluginStateKeyedStore<number>("discord", {
+      namespace: "evict-tie-register",
+      maxEntries: 1,
+    });
+
+    await store.register("z", 1);
+    await store.register("a", 2);
+
+    await expect(store.entries()).resolves.toEqual([{ key: "a", value: 2, createdAt: 1000 }]);
+    await expect(store.lookup("z")).resolves.toBeUndefined();
+  });
+
+  it.each([3, 5])(
+    "enforces plugin quota without a redundant namespace count at maxEntries %i",
+    async (maxEntries) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1000);
+      setMaxPluginStateEntriesPerPluginForTests(3);
+      const pluginId = "quota-plugin";
+      const namespace = "quota";
+      seedPluginStateEntriesForTests([
+        ...["a-protected", "b", "c", "d", "e", "z"].map((key) => ({
+          pluginId,
+          namespace,
+          key,
+          value: key,
+          createdAt: 1000,
+        })),
+        { pluginId, namespace: "sibling", key: "peer", value: "sibling", createdAt: 1 },
+        {
+          pluginId: "foreign-plugin",
+          namespace,
+          key: "peer",
+          value: "foreign",
+          createdAt: 1,
+        },
+      ]);
+      const store = createPluginStateKeyedStore<string>(pluginId, { namespace, maxEntries });
+      const sibling = createPluginStateKeyedStore<string>(pluginId, {
+        namespace: "sibling",
+        maxEntries: 3,
+      });
+      const foreign = createPluginStateKeyedStore<string>("foreign-plugin", {
+        namespace,
+        maxEntries,
+      });
+      const statements = trackSqliteStatementExecutions(
+        openOpenClawStateDatabase().db,
+        ["namespace", "plugin"],
+        (sql) => {
+          if (!sql.startsWith('select count(*) as "count" from "plugin_state_entries"')) {
+            return null;
+          }
+          return sql.includes('"namespace" = ?') ? "namespace" : "plugin";
+        },
+      );
+      try {
+        await store.register("a-protected", "updated");
+      } finally {
+        statements.restore();
+      }
+
+      await expect(store.entries()).resolves.toEqual([
+        { key: "a-protected", value: "updated", createdAt: 1000 },
+        { key: "z", value: "z", createdAt: 1000 },
+      ]);
+      await expect(sibling.entries()).resolves.toEqual([
+        { key: "peer", value: "sibling", createdAt: 1 },
+      ]);
+      await expect(foreign.entries()).resolves.toEqual([
+        { key: "peer", value: "foreign", createdAt: 1 },
+      ]);
+      expect(statements.counts.namespace).toBe(0);
+      expect(statements.counts.plugin).toBe(1);
+    },
+  );
+
+  it("keeps a same-millisecond registerIfAbsent claim during namespace eviction", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const store = createPluginStateKeyedStore<number>("discord", {
+      namespace: "evict-tie-claim",
+      maxEntries: 1,
+    });
+
+    await expect(store.registerIfAbsent("z", 1)).resolves.toBe(true);
+    await expect(store.registerIfAbsent("a", 2)).resolves.toBe(true);
+
+    await expect(store.entries()).resolves.toEqual([{ key: "a", value: 2, createdAt: 1000 }]);
+    await expect(store.lookup("z")).resolves.toBeUndefined();
+  });
+
+  it("evicts current namespace rows when sibling namespaces consume plugin row budget", async () => {
+    const maxPluginEntries = 40;
+    setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: maxPluginEntries - 11 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.message-cache",
+        key: `k-${entryIndex}`,
+        value: { kind: "message", entryIndex },
+      })),
+      ...Array.from({ length: 11 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.topic-name-cache",
+        key: `topic-${entryIndex}`,
+        value: { kind: "topic", entryIndex },
+      })),
+    ]);
+
+    const messageStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.message-cache",
+      maxEntries: maxPluginEntries,
+    });
+    const topicStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.topic-name-cache",
+      maxEntries: 100,
+    });
+
+    await expect(
+      messageStore.register("new-message", { kind: "message", fresh: true }),
+    ).resolves.toBeUndefined();
+
+    await expect(messageStore.lookup("k-0")).resolves.toBeUndefined();
+    await expect(messageStore.lookup("new-message")).resolves.toEqual({
+      kind: "message",
+      fresh: true,
+    });
+    await expect(topicStore.lookup("topic-0")).resolves.toEqual({
+      kind: "topic",
+      entryIndex: 0,
+    });
+    await expect(messageStore.entries()).resolves.toHaveLength(maxPluginEntries - 11);
+    await expect(topicStore.entries()).resolves.toHaveLength(11);
+  });
+
+  it.each([true, false])(
+    "sheds sequenced journal rows without evicting durable sibling state (existing cursor: %s)",
+    async (existingCursor) => {
+      const maxPluginEntries = 40;
+      setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
+      seedPluginStateEntriesForTests([
+        ...Array.from({ length: maxPluginEntries - 3 }, (_, entryIndex) => ({
+          pluginId: "memory-core",
+          namespace: "durable-state",
+          key: `durable-${entryIndex}`,
+          value: { entryIndex },
+        })),
+        {
+          pluginId: "memory-core",
+          namespace: "memory-host.event-migration-checkpoints",
+          key: "generation",
+          value: { kind: "raw-checkpoint" },
+        },
+        ...(existingCursor
+          ? [
+              {
+                pluginId: "memory-core",
+                namespace: "memory-host.event-cursors",
+                key: "workspace",
+                value: { kind: "cursor", lastSequence: 1 },
+              },
+            ]
+          : [
+              {
+                pluginId: "memory-core",
+                namespace: "memory-host.events",
+                key: "event-2",
+                value: { sequence: 2 },
+              },
+            ]),
+        {
+          pluginId: "memory-core",
+          namespace: "memory-host.events",
+          key: "event-1",
+          value: { sequence: 1 },
+        },
+      ]);
+
+      expect(
+        registerPluginStateSyncSequencedJournalEntry({
+          pluginId: "memory-core",
+          cursorOptions: {
+            namespace: "memory-host.event-cursors",
+            maxEntries: 1_000,
+          },
+          cursorKey: "workspace",
+          journalOptions: { namespace: "memory-host.events", maxEntries: 10_000 },
+          initialSequence: existingCursor ? 0 : 2,
+          journalKey: (sequence) => `event-${sequence}`,
+          journalValue: (sequence) => ({ sequence }),
+        }),
+      ).toBe(existingCursor ? 2 : 3);
+
+      const durable = createPluginStateKeyedStore("memory-core", {
+        namespace: "durable-state",
+        maxEntries: maxPluginEntries,
+      });
+      const checkpoints = createPluginStateKeyedStore("memory-core", {
+        namespace: "memory-host.event-migration-checkpoints",
+        maxEntries: 10_000,
+        overflowPolicy: "reject-new",
+      });
+      const journal = createPluginStateKeyedStore("memory-core", {
+        namespace: "memory-host.events",
+        maxEntries: 10_000,
+      });
+      const cursor = createPluginStateKeyedStore("memory-core", {
+        namespace: "memory-host.event-cursors",
+        maxEntries: 1_000,
+      });
+      await expect(durable.lookup("durable-0")).resolves.toEqual({ entryIndex: 0 });
+      await expect(checkpoints.lookup("generation")).resolves.toEqual({
+        kind: "raw-checkpoint",
+      });
+      await expect(journal.lookup("event-1")).resolves.toBeUndefined();
+      if (existingCursor) {
+        await expect(journal.lookup("event-2")).resolves.toEqual({ sequence: 2 });
+      } else {
+        await expect(journal.lookup("event-2")).resolves.toBeUndefined();
+        await expect(journal.lookup("event-3")).resolves.toEqual({ sequence: 3 });
+      }
+      await expect(cursor.lookup("workspace")).resolves.toEqual({
+        kind: "cursor",
+        lastSequence: existingCursor ? 2 : 3,
+      });
+    },
+  );
+
+  it("leaves room for Telegram sibling namespaces at their persistent budgets", async () => {
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: 3_000 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.message-cache",
+        key: `message-${entryIndex}`,
+        value: { kind: "message", entryIndex },
+      })),
+      ...Array.from({ length: 2_047 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.topic-name-cache",
+        key: `topic-${entryIndex}`,
+        value: { kind: "topic", updatedAt: entryIndex },
+      })),
+      ...Array.from({ length: 127 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.bot-info-cache",
+        key: `bot-${entryIndex}`,
+        value: { kind: "bot-info", fetchedAt: String(entryIndex) },
+      })),
+    ]);
+
+    const topicStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.topic-name-cache",
+      maxEntries: 2_048,
+    });
+    const botInfoStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.bot-info-cache",
+      maxEntries: 128,
+    });
+
+    await expect(
+      topicStore.register("topic-final", { kind: "topic", updatedAt: 2_048 }),
+    ).resolves.toBeUndefined();
+    await expect(
+      botInfoStore.register("default", { kind: "bot-info", fetchedAt: "now" }),
+    ).resolves.toBeUndefined();
+
+    await expect(topicStore.lookup("topic-final")).resolves.toEqual({
+      kind: "topic",
+      updatedAt: 2_048,
+    });
+    await expect(botInfoStore.lookup("default")).resolves.toEqual({
+      kind: "bot-info",
+      fetchedAt: "now",
+    });
+  });
+
+  it("rolls back plugin overflow when the current namespace cannot shed enough rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const maxPluginEntries = 3;
+    setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: maxPluginEntries }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.topic-name-cache",
+        key: `topic-${entryIndex}`,
+        value: { entryIndex },
+      })),
+      ...Array.from({ length: 5 }, (_, entryIndex) => ({
+        pluginId: "telegram",
+        namespace: "telegram.message-cache",
+        key: `old-${entryIndex}`,
+        value: { entryIndex },
+        createdAt: entryIndex,
+      })),
+      {
+        pluginId: "telegram",
+        namespace: "telegram.message-cache",
+        key: "expired",
+        value: "expired",
+        expiresAt: 1000,
+      },
+    ]);
+
+    const messageStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.message-cache",
+      maxEntries: maxPluginEntries,
+    });
+    const topicStore = createPluginStateKeyedStore("telegram", {
+      namespace: "telegram.topic-name-cache",
+      maxEntries: maxPluginEntries,
+    });
+    const originalMessages = await messageStore.entries();
+    const originalTopics = await topicStore.entries();
+
+    const registration = messageStore.register("new-message", { fresh: true });
+    await expect(registration).rejects.toBeInstanceOf(PluginStateStoreError);
+    await expect(registration).rejects.toMatchObject({
+      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+      operation: "register",
+    });
+    await expect(messageStore.lookup("new-message")).resolves.toBeUndefined();
+    await expect(topicStore.lookup("topic-0")).resolves.toEqual({ entryIndex: 0 });
+    await expect(messageStore.entries()).resolves.toEqual(originalMessages);
+    await expect(topicStore.entries()).resolves.toEqual(originalTopics);
+    expect(sweepExpiredPluginStateEntries()).toBe(1);
+  });
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -556,28 +556,33 @@ function enforcePostRegisterLimits(params: {
   if (params.overflowPolicy === "reject-new") {
     return;
   }
-  const namespaceCount =
-    params.retention?.namespaceCount ??
-    countLivePluginStateNamespaceEntries(params.store.db, {
-      pluginId: params.pluginId,
-      namespace: params.namespace,
-      now: params.now,
-    });
-  if (namespaceCount > params.maxEntries) {
-    const deleted = deleteOldestPluginStateNamespaceEntries(params.store.db, {
-      pluginId: params.pluginId,
-      namespace: params.namespace,
-      protectedKey: params.protectedKey,
-      now: params.now,
-      limit: namespaceCount - params.maxEntries,
-    });
-    if (params.retention) {
-      params.retention.namespaceCount -= deleted;
-      params.retention.pluginCount -= deleted;
+  const maxPluginEntries =
+    params.enforcePluginLimit === false ? undefined : resolveMaxPluginStateEntriesPerPlugin();
+  // A plugin cap no larger than the namespace cap sheds the same oldest prefix.
+  if (params.retention || maxPluginEntries === undefined || params.maxEntries < maxPluginEntries) {
+    const namespaceCount =
+      params.retention?.namespaceCount ??
+      countLivePluginStateNamespaceEntries(params.store.db, {
+        pluginId: params.pluginId,
+        namespace: params.namespace,
+        now: params.now,
+      });
+    if (namespaceCount > params.maxEntries) {
+      const deleted = deleteOldestPluginStateNamespaceEntries(params.store.db, {
+        pluginId: params.pluginId,
+        namespace: params.namespace,
+        protectedKey: params.protectedKey,
+        now: params.now,
+        limit: namespaceCount - params.maxEntries,
+      });
+      if (params.retention) {
+        params.retention.namespaceCount -= deleted;
+        params.retention.pluginCount -= deleted;
+      }
     }
   }
 
-  if (params.enforcePluginLimit === false) {
+  if (maxPluginEntries === undefined) {
     return;
   }
 
@@ -587,7 +592,6 @@ function enforcePostRegisterLimits(params: {
       pluginId: params.pluginId,
       now: params.now,
     });
-  const maxPluginEntries = resolveMaxPluginStateEntriesPerPlugin();
   if (pluginCount <= maxPluginEntries) {
     return;
   }

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -3,7 +3,6 @@ import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   closeOpenClawStateDatabaseByPath,
@@ -23,7 +22,6 @@ import {
   createPluginStateKeyedStore,
   createPluginStateSyncKeyedStore,
   pluginStateEntriesInKeyRange,
-  registerPluginStateSyncSequencedJournalEntry,
   resetPluginStateStoreForTests,
   sweepExpiredPluginStateEntries,
 } from "./plugin-state-store.js";
@@ -202,6 +200,7 @@ describe("plugin state keyed store", () => {
 
   it("updates a key from the current stored value", async () => {
     await withPluginStateTestState(async () => {
+      setMaxPluginStateEntriesPerPluginForTests(10);
       const store = createPluginStateSyncKeyedStore<{ count: number }>("discord", {
         namespace: "sync-update",
         maxEntries: 10,
@@ -341,6 +340,7 @@ describe("plugin state keyed store", () => {
   it("rejects new durable rows at capacity without evicting or blocking updates", async () => {
     await withPluginStateTestState(async () => {
       vi.useFakeTimers();
+      setMaxPluginStateEntriesPerPluginForTests(2);
       const store = createPluginStateKeyedStore<number>("codex", {
         namespace: "durable-bindings",
         maxEntries: 2,
@@ -353,12 +353,16 @@ describe("plugin state keyed store", () => {
 
       await expect(store.register("third", 3)).rejects.toMatchObject({
         code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+        operation: "register",
+        message: "Plugin state namespace durable-bindings for codex reached its 2-row limit.",
       });
       await expect(store.registerIfAbsent("first", 99)).resolves.toBe(false);
       vi.setSystemTime(3000);
       await expect(store.update("first", () => 10)).resolves.toBe(true);
       await expect(store.update("third", () => 3)).rejects.toMatchObject({
         code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+        operation: "register",
+        message: "Plugin state namespace durable-bindings for codex reached its 2-row limit.",
       });
       await expect(store.entries()).resolves.toEqual([
         expect.objectContaining({ key: "second", value: 2 }),
@@ -550,269 +554,6 @@ describe("plugin state keyed store", () => {
       } finally {
         nowSpy.mockRestore();
       }
-    });
-  });
-
-  it("evicts oldest live entries over maxEntries with bounded database calls", async () => {
-    await withPluginStateTestState(async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(1000);
-      seedPluginStateEntriesForTests(
-        Array.from({ length: 64 }, (_, index) => ({
-          pluginId: "discord",
-          namespace: "evict",
-          key: `key-${String(index).padStart(2, "0")}`,
-          value: index,
-          createdAt: Math.floor(index / 2),
-        })),
-      );
-      const store = createPluginStateKeyedStore("discord", { namespace: "evict", maxEntries: 3 });
-      const statements = trackSqliteStatementExecutions(
-        openOpenClawStateDatabase().db,
-        ["delete"],
-        (sql) => (sql.startsWith('delete from "plugin_state_entries"') ? "delete" : null),
-      );
-      try {
-        await store.register("a-protected", 64);
-      } finally {
-        statements.restore();
-      }
-
-      // One bounded expiry sweep plus eviction must not scale with the victim count.
-      expect(statements.counts.delete).toBeLessThanOrEqual(2);
-      expect(await store.entries()).toEqual([
-        { key: "key-62", value: 62, createdAt: 31 },
-        { key: "key-63", value: 63, createdAt: 31 },
-        { key: "a-protected", value: 64, createdAt: 1000 },
-      ]);
-    });
-  });
-
-  it("keeps the just-registered key when namespace eviction timestamps tie", async () => {
-    await withPluginStateTestState(async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(1000);
-      const store = createPluginStateKeyedStore<number>("discord", {
-        namespace: "evict-tie-register",
-        maxEntries: 1,
-      });
-
-      await store.register("z", 1);
-      await store.register("a", 2);
-
-      await expect(store.entries()).resolves.toEqual([{ key: "a", value: 2, createdAt: 1000 }]);
-      await expect(store.lookup("z")).resolves.toBeUndefined();
-    });
-  });
-
-  it("keeps a same-millisecond registerIfAbsent claim during namespace eviction", async () => {
-    await withPluginStateTestState(async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(1000);
-      const store = createPluginStateKeyedStore<number>("discord", {
-        namespace: "evict-tie-claim",
-        maxEntries: 1,
-      });
-
-      await expect(store.registerIfAbsent("z", 1)).resolves.toBe(true);
-      await expect(store.registerIfAbsent("a", 2)).resolves.toBe(true);
-
-      await expect(store.entries()).resolves.toEqual([{ key: "a", value: 2, createdAt: 1000 }]);
-      await expect(store.lookup("z")).resolves.toBeUndefined();
-    });
-  });
-
-  it("evicts current namespace rows when sibling namespaces consume plugin row budget", async () => {
-    await withPluginStateTestState(async () => {
-      const maxPluginEntries = 40;
-      setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
-      seedPluginStateEntriesForTests([
-        ...Array.from({ length: maxPluginEntries - 11 }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.message-cache",
-          key: `k-${entryIndex}`,
-          value: { kind: "message", entryIndex },
-        })),
-        ...Array.from({ length: 11 }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.topic-name-cache",
-          key: `topic-${entryIndex}`,
-          value: { kind: "topic", entryIndex },
-        })),
-      ]);
-
-      const messageStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.message-cache",
-        maxEntries: maxPluginEntries,
-      });
-      const topicStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.topic-name-cache",
-        maxEntries: 100,
-      });
-
-      await expect(
-        messageStore.register("new-message", { kind: "message", fresh: true }),
-      ).resolves.toBeUndefined();
-
-      await expect(messageStore.lookup("k-0")).resolves.toBeUndefined();
-      await expect(messageStore.lookup("new-message")).resolves.toEqual({
-        kind: "message",
-        fresh: true,
-      });
-      await expect(topicStore.lookup("topic-0")).resolves.toEqual({
-        kind: "topic",
-        entryIndex: 0,
-      });
-      await expect(messageStore.entries()).resolves.toHaveLength(maxPluginEntries - 11);
-      await expect(topicStore.entries()).resolves.toHaveLength(11);
-    });
-  });
-
-  it("sheds sequenced journal rows without evicting durable sibling state", async () => {
-    await withPluginStateTestState(async () => {
-      const maxPluginEntries = 40;
-      setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
-      seedPluginStateEntriesForTests([
-        ...Array.from({ length: maxPluginEntries - 3 }, (_, entryIndex) => ({
-          pluginId: "memory-core",
-          namespace: "durable-state",
-          key: `durable-${entryIndex}`,
-          value: { entryIndex },
-        })),
-        {
-          pluginId: "memory-core",
-          namespace: "memory-host.event-migration-checkpoints",
-          key: "generation",
-          value: { kind: "raw-checkpoint" },
-        },
-        {
-          pluginId: "memory-core",
-          namespace: "memory-host.event-cursors",
-          key: "workspace",
-          value: { kind: "cursor", lastSequence: 1 },
-        },
-        {
-          pluginId: "memory-core",
-          namespace: "memory-host.events",
-          key: "event-1",
-          value: { sequence: 1 },
-        },
-      ]);
-
-      expect(
-        registerPluginStateSyncSequencedJournalEntry({
-          pluginId: "memory-core",
-          cursorOptions: {
-            namespace: "memory-host.event-cursors",
-            maxEntries: 1_000,
-          },
-          cursorKey: "workspace",
-          journalOptions: { namespace: "memory-host.events", maxEntries: 10_000 },
-          initialSequence: 0,
-          journalKey: (sequence) => `event-${sequence}`,
-          journalValue: (sequence) => ({ sequence }),
-        }),
-      ).toBe(2);
-
-      const durable = createPluginStateKeyedStore("memory-core", {
-        namespace: "durable-state",
-        maxEntries: maxPluginEntries,
-      });
-      const checkpoints = createPluginStateKeyedStore("memory-core", {
-        namespace: "memory-host.event-migration-checkpoints",
-        maxEntries: 10_000,
-        overflowPolicy: "reject-new",
-      });
-      const journal = createPluginStateKeyedStore("memory-core", {
-        namespace: "memory-host.events",
-        maxEntries: 10_000,
-      });
-      await expect(durable.lookup("durable-0")).resolves.toEqual({ entryIndex: 0 });
-      await expect(checkpoints.lookup("generation")).resolves.toEqual({
-        kind: "raw-checkpoint",
-      });
-      await expect(journal.lookup("event-1")).resolves.toBeUndefined();
-      await expect(journal.lookup("event-2")).resolves.toEqual({ sequence: 2 });
-    });
-  });
-
-  it("leaves room for Telegram sibling namespaces at their persistent budgets", async () => {
-    await withPluginStateTestState(async () => {
-      seedPluginStateEntriesForTests([
-        ...Array.from({ length: 3_000 }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.message-cache",
-          key: `message-${entryIndex}`,
-          value: { kind: "message", entryIndex },
-        })),
-        ...Array.from({ length: 2_047 }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.topic-name-cache",
-          key: `topic-${entryIndex}`,
-          value: { kind: "topic", updatedAt: entryIndex },
-        })),
-        ...Array.from({ length: 127 }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.bot-info-cache",
-          key: `bot-${entryIndex}`,
-          value: { kind: "bot-info", fetchedAt: String(entryIndex) },
-        })),
-      ]);
-
-      const topicStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.topic-name-cache",
-        maxEntries: 2_048,
-      });
-      const botInfoStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.bot-info-cache",
-        maxEntries: 128,
-      });
-
-      await expect(
-        topicStore.register("topic-final", { kind: "topic", updatedAt: 2_048 }),
-      ).resolves.toBeUndefined();
-      await expect(
-        botInfoStore.register("default", { kind: "bot-info", fetchedAt: "now" }),
-      ).resolves.toBeUndefined();
-
-      await expect(topicStore.lookup("topic-final")).resolves.toEqual({
-        kind: "topic",
-        updatedAt: 2_048,
-      });
-      await expect(botInfoStore.lookup("default")).resolves.toEqual({
-        kind: "bot-info",
-        fetchedAt: "now",
-      });
-    });
-  });
-
-  it("rejects plugin overflow when the current namespace cannot shed old rows", async () => {
-    await withPluginStateTestState(async () => {
-      const maxPluginEntries = 40;
-      setMaxPluginStateEntriesPerPluginForTests(maxPluginEntries);
-      seedPluginStateEntriesForTests(
-        Array.from({ length: maxPluginEntries }, (_, entryIndex) => ({
-          pluginId: "telegram",
-          namespace: "telegram.topic-name-cache",
-          key: `topic-${entryIndex}`,
-          value: { entryIndex },
-        })),
-      );
-
-      const messageStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.message-cache",
-        maxEntries: maxPluginEntries,
-      });
-      const topicStore = createPluginStateKeyedStore("telegram", {
-        namespace: "telegram.topic-name-cache",
-        maxEntries: maxPluginEntries,
-      });
-
-      await expectPluginStateStoreError(messageStore.register("new-message", { fresh: true }), {
-        code: "PLUGIN_STATE_LIMIT_EXCEEDED",
-      });
-      await expect(messageStore.lookup("new-message")).resolves.toBeUndefined();
-      await expect(topicStore.lookup("topic-0")).resolves.toEqual({ entryIndex: 0 });
     });
   });
 


### PR DESCRIPTION
Related: #137525

## What Problem This Solves

Resolves avoidable synchronous database work during large plugin-state updates, including memory workspace replacements, when the plugin-wide retention limit is already equal to or stricter than the namespace limit.

## Why This Change Was Made

Ordinary `evict-oldest` writes now use the existing plugin quota check to enforce both limits when the namespace cap is at least the plugin cap. The plugin check selects the same oldest eligible rows from the current namespace, preserves the written key and sibling namespaces, and retains rollback when the store starts over capacity.

Reject-new admission, namespace-only journal cursor enforcement, Doctor retention, expiry cleanup, timestamp/TTL handling, and per-call transactions retain their existing paths. This bounded query improvement changes neither the schema nor the public API.

## User Impact

Eligible plugin-state writes perform one fewer quota scan. Whole-plugin counts and complete listings remain, so this does not claim to resolve every delay reported in #137525.

## Evidence

- Both new work-count cases fail on the original implementation with one namespace COUNT instead of zero, after their retained-row and sibling/foreign preservation assertions pass.
- All 66 focused tests pass across five suites covering stores, retention, expiry, Doctor imports, and errors. They include initially overfull state, protected-key ties, insufficient-victim rollback, and deferred journal cursor enforcement. Changed-code checks pass; independent review found no actionable findings.
- One synthetic Linux x64 source/API workload on Node 24.19.0 / SQLite 3.53.3 observed zero namespace counts for 64 updates, versus 64 in the retained baseline. It retained all 64 plugin counts, point reads, upserts, and zero-deletion expiry sweeps; one listing returned 50,000 live rows. All 49,938 untouched rows matched before and after. Both resulting databases passed independent full SQLite integrity and data checks. This proves deterministic work reduction, not a cross-host timing speedup.
- [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34500217524): the workload passed, but the original artifact export exited 7 at its 30-second deadline. A separately authorized read-only native download recovered the finalized archive; its exact size, original partial prefix, original manifest, all listed file hashes, and source identity were verified. The original whole-archive control digest was unavailable. The lease is stopped; the export failure remains a recorded qualification.
