### PR TITLE
fix(doctor): report schema guard snapshot cleanup failures

### DIFF
--- a/src/commands/doctor-update-schema-guard.ts
+++ b/src/commands/doctor-update-schema-guard.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
@@ -16,31 +17,79 @@ import { readStateSchemaPublicationBlocker } from "../state/openclaw-state-schem
 import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
 import { VERSION } from "../version.js";
 
-async function readDrivingUpdater(): Promise<
-  { version: string; canDeferStateSchema: boolean } | undefined
-> {
-  // The runtime ledger reader consults quarantine state. This diagnostic must
-  // not open any live database, including a quarantine store needing recovery.
-  const snapshot = await prepareSqliteReadOnlyLocation(resolveOpenClawStateSqlitePath(), {
-    preserveSourceArtifacts: true,
-  });
+type DrivingUpdater = { version: string; canDeferStateSchema: boolean };
+
+/**
+ * The guard reads the driving updater through a private SQLite snapshot. A
+ * missing or unreadable run — including snapshot preparation failure — cannot
+ * prove the driver writes the ledger and is tolerated (the upgrade proceeds).
+ * A snapshot cleanup failure is a real
+ * storage problem, but it does not change the schema decision the guard already
+ * determined from a successful read, so it is reported as a warning through the
+ * runtime output path rather than aborting an otherwise permitted upgrade.
+ */
+type DrivingUpdaterRead = {
+  updater: DrivingUpdater | undefined;
+  cleanupWarning: string | undefined;
+};
+
+function describeSnapshotCleanupFailure(stagingDir: string, cause: unknown): string {
+  const readFailure =
+    cause === undefined
+      ? ""
+      : `${cause instanceof Error ? cause.message : typeof cause === "string" ? cause : JSON.stringify(cause)}; `;
+  return `${readFailure}State database snapshot cleanup failed: ${stagingDir}. Check directory permissions and available storage before retrying.`;
+}
+
+async function readDrivingUpdater(): Promise<DrivingUpdaterRead> {
+  let snapshot: Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>>;
+  try {
+    // The runtime ledger reader consults quarantine state. This diagnostic must
+    // not open any live database, including a quarantine store needing recovery.
+    snapshot = await prepareSqliteReadOnlyLocation(resolveOpenClawStateSqlitePath(), {
+      preserveSourceArtifacts: true,
+    });
+  } catch {
+    // A missing or unreadable source, staging failure, or worker read error
+    // cannot prove the driver writes the ledger; the guard tolerates it and
+    // proceeds without an updater, matching the pre-fix boundary.
+    return { updater: undefined, cleanupWarning: undefined };
+  }
+  let outcome: { value: DrivingUpdater | undefined } | { cause: unknown };
   try {
     const database = openNodeSqliteDatabase(snapshot.location, { readOnly: true });
     try {
       const blocker = readStateSchemaPublicationBlocker(database);
-      return blocker
+      outcome = blocker
         ? {
-            version: blocker.updaterVersion,
-            canDeferStateSchema: tableExists(database, "config_machine_state"),
+            value: {
+              version: blocker.updaterVersion,
+              canDeferStateSchema: tableExists(database, "config_machine_state"),
+            },
           }
-        : undefined;
+        : { value: undefined };
     } finally {
       clearNodeSqliteKyselyCacheForDatabase(database);
       database.close();
     }
-  } finally {
-    snapshot.cleanup();
+  } catch (cause) {
+    outcome = { cause };
   }
+  // The exit retry is best-effort, not proof that this private copy was removed.
+  // A cleanup failure is reported as a warning but does not replace the schema
+  // decision already determined from a successful read.
+  const cleanupWarning = snapshot.cleanup()
+    ? undefined
+    : describeSnapshotCleanupFailure(
+        path.dirname(snapshot.location),
+        "cause" in outcome ? outcome.cause : undefined,
+      );
+  if ("cause" in outcome) {
+    // A missing or unreadable run cannot prove the driver writes the ledger;
+    // the guard tolerates the read failure and proceeds without an updater.
+    return { updater: undefined, cleanupWarning };
+  }
+  return { updater: outcome.value, cleanupWarning };
 }
 
 /** Refuse before CLI capture or Doctor maintenance can open writable state. */
@@ -64,11 +113,18 @@ export async function guardUpdateDoctorSchemaUpgrade(options: {
   if (!schemas.pendingMigrations?.length) {
     return;
   }
-  let updater: Awaited<ReturnType<typeof readDrivingUpdater>>;
-  try {
-    updater = await readDrivingUpdater();
-  } catch {
-    // A missing or unreadable run cannot prove that the driver writes the ledger.
+  // Read failures are tolerated (no proof of a driving updater); a cleanup
+  // failure is surfaced as a warning without aborting the upgrade.
+  const { updater, cleanupWarning } = await readDrivingUpdater();
+  if (cleanupWarning) {
+    // In JSON mode the guard runs before console capture is installed, so
+    // runtime.log (console.log → stdout) would prefix the JSON output and
+    // make it unparseable. Write directly to stderr instead.
+    if (options.json) {
+      process.stderr.write(`${cleanupWarning}\n`);
+    } else {
+      options.runtime.log(cleanupWarning);
+    }
   }
   if (!updater) {
     return;


### PR DESCRIPTION
## What Problem This Solves

During an update, the schema safety guard creates a temporary read-only copy of the state database to check whether a driving updater is active; when removal of that temporary copy failed, the failure was silently ignored and the copy accumulated on disk with no signal. This fix checks the cleanup result and surfaces a diagnostic warning on failure, while preserving the guard's existing schema decision and upgrade-flow behavior.

- Problem: `readDrivingUpdater` in `src/commands/doctor-update-schema-guard.ts` called `snapshot.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` fails (disk full, permission denied, file-handle contention), `cleanup()` returns `false` but the caller ignored it, leaving the temporary SQLite copy behind with no error signal.
- Solution: Capture the read outcome first (value or caught cause), then check `snapshot.cleanup()`. On cleanup failure, build a diagnostic warning string and return it alongside the updater; the guard emits the warning and proceeds with the existing schema decision unchanged. Snapshot preparation failures are caught and tolerated (no updater), matching the pre-fix boundary. In JSON mode the warning is written directly to `process.stderr` so it does not corrupt stdout JSON output (the guard runs before console capture is installed).
- What changed: `src/commands/doctor-update-schema-guard.ts` — `readDrivingUpdater` returns `{ updater, cleanupWarning }`; `prepareSqliteReadOnlyLocation` is wrapped in a try/catch for preparation-failure tolerance; `guardUpdateDoctorSchemaUpgrade` routes the warning to stderr in JSON mode or `runtime.log` otherwise.
- What did NOT change: The inner `try/finally` that closes the database handle is preserved. The read logic, schema validation, blocker detection, refusal policy, and call sites are unchanged. Normal-path behavior (cleanup succeeds) is identical to before.

## Why This Change Was Made

This is the same anti-pattern that #143844 fixed in `update-candidate-state.ts`: a `prepareSqliteReadOnlyLocation*` call site that ignores the `cleanup()` return value. Two sibling call sites already check the return value and surface cleanup failure. This call site was missed.

The fix follows the #143844 outcome-capture + cleanup-check template with adaptations for this call site: (1) cleanup failure is a non-fatal warning because the guard's empty catch tolerates read failures and a fatal throw would be swallowed; (2) snapshot preparation failures are caught inside `readDrivingUpdater` to preserve main's tolerating boundary; (3) in JSON mode the warning goes to `process.stderr` because the guard runs before `installConsoleCapture` and `runtime.log` (console.log → stdout) would prefix the JSON output.

## Evidence

Real behavior proof using real SQLite fixtures + `fs.rmSync` fault injection (EACCES on `openclaw-sqlite-readonly-*` staging directories). Test 4 uses a missing source DB to trigger `prepareSqliteReadOnlyLocation` rejection. Test 5 verifies JSON-mode stderr routing.

```console
$ node --import tsx /home/code/github/contributions/BUG/BUG-073-evidence/proof.mjs

Test 1: cleanup fail + read ok   → threw=false, warning via runtime.log ✅
Test 2: cleanup fail + read fail → threw=false, warning with read cause  ✅
Test 3: normal path              → threw=false, logCalls=[] (no warning)  ✅
Test 4: preparation fail         → threw=false, logCalls=[] (tolerated)   ✅
Test 5: JSON mode + cleanup fail → warning on stderr, stdout clean        ✅

All 5 tests passed.
```

Pre-fix verification (PR head `8e612eb`, same proof): Test 5 FAIL — warning appeared on stdout (via `runtime.log` → `console.log`), stderr empty. This confirms the JSON-output corruption ClawSweeper identified.

Behavior matrix:

```text
scenario                        => pre-fix (main)         => post-fix result
cleanup fails, read succeeds    => silent (temp left)     => warning via runtime.log, upgrade proceeds
cleanup fails, read fails       => silent (temp left)     => warning with read cause, upgrade proceeds
cleanup succeeds, read ok       => guard proceeds         => guard proceeds (unchanged, no warning)
preparation fails (no source)   => tolerated (main)       => tolerated (no throw, no warning)
cleanup fails, JSON mode        => warning on stdout      => warning on stderr (stdout clean for JSON)
```

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (Claude Sonnet 4.6)
- Round 3: ClawSweeper identified that `runtime.log` (console.log → stdout) in JSON mode runs before `installConsoleCapture`, corrupting JSON output. Fixed by routing JSON-mode warnings to `process.stderr.write` directly. Added Test 5 for stderr routing with pre-fix/post-fix双向验证.
- Confirmed understanding of code changes: Yes.
- autoreview: N/A (worktree; oxfmt + oxlint + tsgo core + vitest 25 tests passed)
