### PR TITLE
perf(sqlite): reduce repeated plugin-state write compilation

### DIFF
--- a/src/plugin-state/plugin-state-store.prepared.test.ts
+++ b/src/plugin-state/plugin-state-store.prepared.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  closePluginStateDatabase,
+  createPluginStateSyncKeyedStore,
+  resetPluginStateStoreForTests,
+} from "./plugin-state-store.js";
+import {
+  clearPluginStateStoreForTests,
+  seedPluginStateEntriesForTests,
+} from "./plugin-state-store.test-helpers.js";
+
+let testState: OpenClawTestState;
+beforeAll(async () => {
+  testState = await createOpenClawTestState({ label: "plugin-state-prepared" });
+});
+beforeEach(() => {
+  testState.applyEnv();
+  clearPluginStateStoreForTests();
+});
+afterEach(() => {
+  resetPluginStateStoreForTests();
+});
+afterAll(async () => {
+  await testState.cleanup();
+});
+
+describe("plugin state prepared queries", () => {
+  it("compiles exact reads once per connection with fresh scope and expiry bindings", () => {
+    const now = Date.now();
+    seedPluginStateEntriesForTests([
+      { pluginId: "discord", namespace: "prepared", key: "first", value: 1, expiresAt: now + 100 },
+      { pluginId: "discord", namespace: "prepared", key: "second", value: 2 },
+      { pluginId: "telegram", namespace: "prepared", key: "first", value: 3 },
+      { pluginId: "discord", namespace: "sibling", key: "first", value: 4 },
+    ]);
+    const store = createPluginStateSyncKeyedStore<number>("discord", {
+      namespace: "prepared",
+      maxEntries: 10,
+    });
+    const pluginSibling = createPluginStateSyncKeyedStore<number>("telegram", {
+      namespace: "prepared",
+      maxEntries: 10,
+    });
+    const namespaceSibling = createPluginStateSyncKeyedStore<number>("discord", {
+      namespace: "sibling",
+      maxEntries: 10,
+    });
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      for (let connection = 0; connection < 2; connection++) {
+        closePluginStateDatabase();
+        const { db } = openOpenClawStateDatabase();
+        const compile = vi.spyOn(getNodeSqliteKysely(db).getExecutor(), "compileQuery");
+        try {
+          clock.mockReturnValue(now);
+          expect(store.lookup("first")).toBe(1);
+          expect(store.lookup("second")).toBe(2);
+          expect(pluginSibling.lookup("first")).toBe(3);
+          expect(namespaceSibling.lookup("first")).toBe(4);
+          expect(store.lookup("missing")).toBeUndefined();
+          clock.mockReturnValue(now + 100);
+          expect(store.lookup("first")).toBeUndefined();
+          expect(store.lookup("second")).toBe(2);
+          expect(compile).toHaveBeenCalledOnce();
+        } finally {
+          compile.mockRestore();
+        }
+      }
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each(["register", "registerIfAbsent"] as const)(
+    "reuses %s compilation with fresh write bindings after reopening",
+    (operation) => {
+      const options = { namespace: "prepared-writes", maxEntries: 20 };
+      const stores = [
+        createPluginStateSyncKeyedStore<string>("discord", options),
+        createPluginStateSyncKeyedStore<string>("telegram", options),
+        createPluginStateSyncKeyedStore<string>("discord", {
+          ...options,
+          namespace: "prepared-sibling",
+        }),
+      ];
+      const clock = vi.spyOn(Date, "now").mockReturnValue(10_000);
+      try {
+        for (let connection = 0; connection < 2; connection++) {
+          closePluginStateDatabase();
+          const { db } = openOpenClawStateDatabase();
+          const compile = vi.spyOn(getNodeSqliteKysely(db).getExecutor(), "compileQuery");
+          try {
+            const key = `round-${connection}`;
+            for (const [index, store] of stores.entries()) {
+              clock.mockReturnValue(10_000 + index);
+              store[operation](key, `value-${index}`, { ttlMs: 100 });
+              clock.mockReturnValue(10_010 + index);
+              store[operation](`${key}-durable`, `durable-${index}`);
+              const result = store[operation](key, `replacement-${index}`);
+              if (operation === "registerIfAbsent") {
+                expect(result).toBe(false);
+              }
+              const expected =
+                operation === "registerIfAbsent"
+                  ? {
+                      key,
+                      value: `value-${index}`,
+                      createdAt: 10_000 + index,
+                      expiresAt: 10_100 + index,
+                    }
+                  : { key, value: `replacement-${index}`, createdAt: 10_010 + index };
+              expect(store.entries().filter((entry) => entry.key.startsWith(key))).toEqual([
+                expected,
+                { key: `${key}-durable`, value: `durable-${index}`, createdAt: 10_010 + index },
+              ]);
+            }
+            const writes = compile.mock.results.filter(
+              (result) => result.type === "return" && result.value.sql.startsWith("insert"),
+            );
+            expect(writes).toHaveLength(1);
+          } finally {
+            compile.mockRestore();
+          }
+        }
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -3,7 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { toUSVString } from "node:util";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
-import type { Insertable, Selectable } from "kysely";
+import type { Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -184,7 +184,7 @@ function bindPluginStateEntry(params: {
   valueJson: string;
   createdAt: number;
   expiresAt: number | null;
-}): Insertable<PluginStateEntriesTable> {
+}): PluginStateRow {
   return {
     plugin_id: params.pluginId,
     namespace: params.namespace,
@@ -195,30 +195,56 @@ function bindPluginStateEntry(params: {
   };
 }
 
-function upsertPluginStateEntry(db: DatabaseSync, row: Insertable<PluginStateEntriesTable>): void {
-  executeSqliteQuerySync(
-    db,
-    getPluginStateKysely(db)
-      .insertInto("plugin_state_entries")
-      .values(row)
-      .onConflict((conflict) =>
-        conflict.columns(["plugin_id", "namespace", "entry_key"]).doUpdateSet({
-          value_json: (eb) => eb.ref("excluded.value_json"),
-          created_at: (eb) => eb.ref("excluded.created_at"),
-          expires_at: (eb) => eb.ref("excluded.expires_at"),
-        }),
-      ),
-  );
+type PluginStateWriteQuery = ReturnType<typeof prepareSqliteQuerySync<PluginStateRow>>;
+const pluginStateUpsertQueries = new WeakMap<DatabaseSync, PluginStateWriteQuery>();
+const pluginStateInsertIfAbsentQueries = new WeakMap<DatabaseSync, PluginStateWriteQuery>();
+
+function upsertPluginStateEntry(db: DatabaseSync, row: PluginStateRow): void {
+  let query = pluginStateUpsertQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync<PluginStateRow>(db, (parameter) =>
+      getPluginStateKysely(db)
+        .insertInto("plugin_state_entries")
+        .values({
+          plugin_id: parameter((value) => value.plugin_id),
+          namespace: parameter((value) => value.namespace),
+          entry_key: parameter((value) => value.entry_key),
+          value_json: parameter((value) => value.value_json),
+          created_at: parameter((value) => value.created_at),
+          expires_at: parameter((value) => value.expires_at),
+        })
+        .onConflict((conflict) =>
+          conflict.columns(["plugin_id", "namespace", "entry_key"]).doUpdateSet({
+            value_json: (eb) => eb.ref("excluded.value_json"),
+            created_at: (eb) => eb.ref("excluded.created_at"),
+            expires_at: (eb) => eb.ref("excluded.expires_at"),
+          }),
+        ),
+    );
+    pluginStateUpsertQueries.set(db, query);
+  }
+  query(row);
 }
 
-function insertPluginStateEntryIfAbsent(
-  db: DatabaseSync,
-  row: Insertable<PluginStateEntriesTable>,
-): boolean {
-  const result = executeSqliteQuerySync(
-    db,
-    getPluginStateKysely(db).insertInto("plugin_state_entries").orIgnore().values(row),
-  );
+function insertPluginStateEntryIfAbsent(db: DatabaseSync, row: PluginStateRow): boolean {
+  let query = pluginStateInsertIfAbsentQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync<PluginStateRow>(db, (parameter) =>
+      getPluginStateKysely(db)
+        .insertInto("plugin_state_entries")
+        .orIgnore()
+        .values({
+          plugin_id: parameter((value) => value.plugin_id),
+          namespace: parameter((value) => value.namespace),
+          entry_key: parameter((value) => value.entry_key),
+          value_json: parameter((value) => value.value_json),
+          created_at: parameter((value) => value.created_at),
+          expires_at: parameter((value) => value.expires_at),
+        }),
+    );
+    pluginStateInsertIfAbsentQueries.set(db, query);
+  }
+  const result = query(row);
   return Number(result.numAffectedRows ?? 0) > 0;
 }
 

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -3,7 +3,6 @@ import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   closeOpenClawStateDatabaseByPath,
   isOpenClawStateDatabaseOpen,
@@ -108,52 +107,6 @@ describe("plugin state keyed store", () => {
       expect(store.consume("interaction:1")).toEqual({ count: 1 });
       expect(store.lookup("interaction:1")).toBeUndefined();
     });
-  });
-
-  it("compiles exact reads once per connection with fresh scope and expiry bindings", () => {
-    const now = Date.now();
-    seedPluginStateEntriesForTests([
-      { pluginId: "discord", namespace: "prepared", key: "first", value: 1, expiresAt: now + 100 },
-      { pluginId: "discord", namespace: "prepared", key: "second", value: 2 },
-      { pluginId: "telegram", namespace: "prepared", key: "first", value: 3 },
-      { pluginId: "discord", namespace: "sibling", key: "first", value: 4 },
-    ]);
-    const store = createPluginStateSyncKeyedStore<number>("discord", {
-      namespace: "prepared",
-      maxEntries: 10,
-    });
-    const pluginSibling = createPluginStateSyncKeyedStore<number>("telegram", {
-      namespace: "prepared",
-      maxEntries: 10,
-    });
-    const namespaceSibling = createPluginStateSyncKeyedStore<number>("discord", {
-      namespace: "sibling",
-      maxEntries: 10,
-    });
-    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
-    try {
-      for (let connection = 0; connection < 2; connection++) {
-        closePluginStateDatabase();
-        const { db } = openOpenClawStateDatabase();
-        const compile = vi.spyOn(getNodeSqliteKysely(db).getExecutor(), "compileQuery");
-        try {
-          clock.mockReturnValue(now);
-          expect(store.lookup("first")).toBe(1);
-          expect(store.lookup("second")).toBe(2);
-          expect(pluginSibling.lookup("first")).toBe(3);
-          expect(namespaceSibling.lookup("first")).toBe(4);
-          expect(store.lookup("missing")).toBeUndefined();
-          clock.mockReturnValue(now + 100);
-          expect(store.lookup("first")).toBeUndefined();
-          expect(store.lookup("second")).toBe(2);
-          expect(compile).toHaveBeenCalledOnce();
-        } finally {
-          compile.mockRestore();
-        }
-      }
-    } finally {
-      clock.mockRestore();
-    }
   });
 
   it("shares sync and async state while preserving their error contracts", async () => {


### PR DESCRIPTION
Related: #138758, #144198

## What Problem This Solves

Repeated plugin-state writes and Doctor imports rebuild the same database queries even when their SQLite statements are already cached.

## Why This Change Was Made

Cache fixed upsert and insert-if-absent query compilation with each physical connection, using the existing point-read pattern and fresh bindings for every call. The binder now expresses the complete row it already produces.

## User Impact

Less query-construction work during plugin-state writes and imports. SQL, conditional insertion, TTLs, quotas, transaction boundaries, and error handling are unchanged. This composes with the newly landed namespace quota-scan optimization.

## Evidence

The new public-store cases fail on the original code only at the compilation budget (9 upserts or 6 conditional inserts instead of 1), then pass with fresh plugin, namespace, key, value, timestamp, and expiry bindings across reopened connections. The existing prepared-read case moved unchanged into the focused prepared-query suite.

Before rebase, 101 focused store/helper tests and required checks passed, with a clean independent Codex review. On the final rebased code, all 56 combined store/prepared/retention/import tests, core/test types, typed lint, formatting, and real on-disk public-store smokes passed. The smokes exercise two simultaneous databases, retained-store writes after close/reopen, TTL replacement, conditional conflicts, and fresh 500-row imports, at both 1,000 and 50,000-entry namespace caps.

Seven local samples per version and cap compare the new main baseline against this candidate, with the quota optimization present in both. Median 500-row Doctor import replay time fell from 13.88 ms to 6.45 ms at the 1,000-entry cap and 15.35 ms to 6.20 ms at 50,000. Separate counters show 3,000 warmed write compilations eliminated; native INSERT preparation stayed at one. Individual-write timings were inconsistent across scenarios, and memory results varied; these synthetic measurements do not establish general throughput or memory improvements. Runtime proof used actual production APIs through the repository tooling loader and isolated synthetic state, not an operator Gateway or published package.
