### PR TITLE
fix(update): keep retired handoff records from refusing unrelated sources

### DIFF
--- a/src/infra/update-managed-service-handoff-lease.ts
+++ b/src/infra/update-managed-service-handoff-lease.ts
@@ -23,6 +23,7 @@ import {
 } from "./update-managed-service-handoff-database.js";
 import { assertNoRetainedSourceBorrower } from "./update-managed-service-handoff-retained-custody.js";
 import {
+  isRetiredManagedHandoffLeasePayload,
   managedHandoffBootSchema,
   parseManagedHandoffLeasePayload,
   type HandoffProcessIdentity,
@@ -628,7 +629,14 @@ export function createManagedHandoffLeaseStore(
         leaseQueries(db)
           .selectFrom("managed_update_handoffs")
           .select(["install_root", "owner", "payload_json", "updated_at"]),
-      ).rows.map((entry) => handle(entry.install_root, entry)),
+      ).rows.flatMap((entry) =>
+        // A retired record decodes exactly, so unlike unreadable data it proves
+        // the row predates native custody and cannot borrow any source. Every
+        // other undecodable row still refuses.
+        isRetiredManagedHandoffLeasePayload(entry.payload_json)
+          ? []
+          : [handle(entry.install_root, entry)],
+      ),
     );
   }
   function assertSourceUnborrowed(resource: string) {

--- a/src/infra/update-managed-service-handoff-retired-records.test.ts
+++ b/src/infra/update-managed-service-handoff-retired-records.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createManagedHandoffLeaseStore } from "./update-managed-service-handoff-lease.js";
+
+const fixture = vi.hoisted(() => ({ root: "" }));
+vi.mock("./tmp-openclaw-dir.js", () => ({ resolvePreferredOpenClawTmpDir: () => fixture.root }));
+
+let store: ReturnType<typeof createManagedHandoffLeaseStore>;
+let unrelatedConfig: string;
+
+function databasePath() {
+  return path.join(fixture.root, "managed-update-handoffs.sqlite");
+}
+
+/** Seed a foreign row the way an older build left one behind in the shared tmp store. */
+function seedRow(installRoot: string, owner: string, payload: string) {
+  const db = new DatabaseSync(databasePath());
+  try {
+    db.prepare(
+      "INSERT INTO managed_update_handoffs (install_root, owner, payload_json, updated_at) VALUES (?, ?, ?, ?)",
+    ).run(installRoot, owner, payload, Date.now());
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  fixture.root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "handoff-retired-")));
+  fs.chmodSync(fixture.root, 0o700);
+  unrelatedConfig = path.join(fixture.root, "openclaw.json");
+  fs.writeFileSync(unrelatedConfig, "{}");
+  store = createManagedHandoffLeaseStore();
+  // Acquiring one lease creates the shared table every install root writes into.
+  const acquired = store.acquire(path.join(fixture.root, "install"), "owner", { kind: "update" });
+  expect(acquired.kind).toBe("acquired");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(fixture.root, { recursive: true, force: true });
+});
+
+it("keeps an unrelated source usable beside a retired lease record", () => {
+  seedRow(
+    path.join(fixture.root, "legacy-install"),
+    "systemd-boundary",
+    JSON.stringify({ version: 1, pid: 4242, startIdentity: "1788399465" }),
+  );
+
+  expect(() => store.assertSourceUnborrowed(unrelatedConfig)).not.toThrow();
+});
+
+it("still refuses an unrelated source beside an undecodable lease record", () => {
+  seedRow(
+    path.join(fixture.root, "unknown-install"),
+    "unknown",
+    JSON.stringify({ version: 9, borrows: "something this build cannot read" }),
+  );
+
+  expect(() => store.assertSourceUnborrowed(unrelatedConfig)).toThrow(
+    /existing managed handoff lease is incompatible/u,
+  );
+});

--- a/src/infra/update-managed-service-handoff-schema.ts
+++ b/src/infra/update-managed-service-handoff-schema.ts
@@ -85,10 +85,26 @@ export type HandoffNativeLifetime = z.infer<typeof nativeLifetimeSchema>;
 export type ManagedHandoffLeaseAction = z.infer<typeof actionSchema>;
 export type ManagedHandoffLeasePayload = z.infer<typeof payloadSchema>;
 
+// A retired v1 record names one process. It predates both the executor/helper
+// split and native custody, so it can never carry a v3 borrower.
+const retiredPayloadSchema = z.strictObject({
+  version: z.literal(1),
+  ...processIdentitySchema.shape,
+});
+
 export function parseManagedHandoffLeasePayload(value: string) {
   try {
     return payloadSchema.parse(JSON.parse(value));
   } catch {
     return null;
+  }
+}
+
+/** Distinguish an exactly decoded retired record from unreadable prospective data. */
+export function isRetiredManagedHandoffLeasePayload(value: string): boolean {
+  try {
+    return retiredPayloadSchema.safeParse(JSON.parse(value)).success;
+  } catch {
+    return false;
   }
 }


### PR DESCRIPTION
## Problem

Every config write fails on any host that carries a leftover version 1 managed
handoff lease record:

```
Error: existing managed handoff lease is incompatible; retain diagnostics and run openclaw triage manually
 ❯ handle src/infra/update-managed-service-handoff-lease.ts:185:13
 ❯ readRetainedSources src/infra/update-managed-service-handoff-lease.ts:625:12
 ❯ Object.assertSourceUnborrowed src/infra/update-managed-service-handoff-lease.ts:635:46
 ❯ assertResourceUnborrowed src/config/write-lock.ts:104:38
 ❯ withConfigWriteLock src/config/write-lock.ts:105:3
 ❯ withConfigMutationLock src/config/mutate.ts:212:13
```

`withConfigWriteLock` calls `assertSourceUnborrowed(configPath)` before any
mutation. That scan read **every** row of the machine-global lease store at
`<tmp>/openclaw/managed-update-handoffs.sqlite` through `handle()`, which throws
for any payload the current schema cannot parse. `payloadSchema` accepts only
`version` 2 and 3, but older builds wrote
`{"version":1,"pid":N,"startIdentity":"..."}` rows into that same shared table.

One such row anywhere in the file therefore breaks config mutation for every
install root on the machine — permanently, with an error that names triage
rather than the actual remedy — until someone deletes a file in a temp
directory. On this development host 14 of 27 rows are version 1, which is why
`src/state/local-onboarding-state.test.ts` fails 3 of 13 on a clean checkout of
`main`. CI never sees it because runners start with an empty `/tmp/openclaw`.

## Solution

Refusing on undecodable data is deliberate and stays: `assertNoRetainedSourceBorrower`
only refuses `version === 3` native-custody records, and unreadable bytes cannot
prove a row is not one.

A version 1 record is not unreadable. It decodes exactly, names a single
process, and predates both the executor/helper split and native custody, so it
provably cannot carry a v3 borrower. Recognize that retired shape with a strict
schema and skip exactly those rows in `readRetainedSources`. Anything else that
fails to decode still refuses.

The lease type and every acquire/bind/retarget/release path are untouched;
`readRetainedSources` is only reached from `assertSourceUnborrowed`.

## Impact

Config writes, onboarding, and `openclaw doctor --fix` work again on hosts that
ran a build old enough to write version 1 leases, without weakening the custody
refusal that protects a real native borrower.

## Evidence

`src/infra/update-managed-service-handoff-retired-records.test.ts` seeds the two
cases directly. It fails on the original code:

```
× keeps an unrelated source usable beside a retired lease record
  → expected [Function] to not throw an error but 'Error: existing managed handoff lease…' was thrown
Test Files  1 failed (1)
```

and passes with this change, while "still refuses an unrelated source beside an
undecodable lease record" passes in both, pinning the conservative behavior.

End to end on this host, whose shared lease store holds those 14 version 1 rows,
`src/state/local-onboarding-state.test.ts` goes from 3 failed / 10 passed to
**13 passed**.

- 11 handoff, retained-custody, write-lock, and onboarding test files — 294
  passed, 2 skipped, 0 failed
- `node scripts/check-changed.mjs` — exit 0
- Independent Codex review (P2) — `scoped-clean`
