### PR TITLE
fix(infra): report SQLite snapshot source cleanup failures

### DIFF
--- a/src/infra/sqlite-snapshot-source.ts
+++ b/src/infra/sqlite-snapshot-source.ts
@@ -1,5 +1,6 @@
 // Keep source lifetime pinned while the snapshot owner consumes live or private bytes.
 import fs, { type BigIntStats } from "node:fs";
+import path from "node:path";
 import {
   createPrivateSqliteTempDirectorySync,
   resolvePrivateSqliteSnapshotStagingRoot,
@@ -123,22 +124,44 @@ export async function withSqliteSnapshotSource<T>(
   operation: (sourcePath: string) => Promise<T>,
 ): Promise<T> {
   let prepared = await prepareSqliteSnapshotSource(pathname);
+  let outcome: { value: T } | { cause: unknown };
   try {
-    try {
-      return prepared
+    outcome = {
+      value: prepared
         ? await operation(prepared.location)
-        : await withSqliteSourceHandleAsync(pathname, () => operation(pathname));
-    } catch (error) {
-      if (prepared) {
-        throw error;
+        : await withSqliteSourceHandleAsync(pathname, () => operation(pathname)),
+    };
+  } catch (error) {
+    if (prepared) {
+      outcome = { cause: error };
+    } else {
+      try {
+        prepared = await prepareSqliteSnapshotSource(pathname);
+        if (!prepared) {
+          outcome = { cause: error };
+        } else {
+          outcome = { value: await operation(prepared.location) };
+        }
+      } catch (retryError) {
+        outcome = { cause: retryError };
       }
-      prepared = await prepareSqliteSnapshotSource(pathname);
-      if (!prepared) {
-        throw error;
-      }
-      return await operation(prepared.location);
     }
-  } finally {
-    prepared?.cleanup();
   }
+  if (prepared) {
+    if (!prepared.cleanup()) {
+      // The exit retry is best-effort, not proof that this private copy was removed.
+      const readFailure =
+        "cause" in outcome
+          ? `${outcome.cause instanceof Error ? outcome.cause.message : String(outcome.cause)}; `
+          : "";
+      throw new Error(
+        `${readFailure}SQLite snapshot cleanup failed: ${path.dirname(prepared.location)}. Check directory permissions and available storage before retrying.`,
+        "cause" in outcome ? outcome : undefined,
+      );
+    }
+  }
+  if ("cause" in outcome) {
+    throw outcome.cause;
+  }
+  return outcome.value;
 }


### PR DESCRIPTION
## What Problem This Solves

When the system creates a temporary read-only copy of a SQLite database to safely inspect it during a snapshot, the copy should be deleted after use. If deletion failed (e.g. disk full, permission error), the failure was silently ignored — temporary directories accumulated on disk with no warning to the user or operator. This change makes cleanup failures visible by throwing a diagnostic error instead of swallowing the cleanup result.

- **Problem**: `withSqliteSnapshotSource` called `prepared?.cleanup()` in a `finally` block without checking its boolean return value. When `removeTempDirectory` failed, the `false` return was discarded and the function returned normally, leaving stale snapshot directories behind.
- **Solution**: Capture the operation outcome (value or error) first, then check `cleanup()`'s return value. If cleanup fails, throw an error with a diagnostic message including the snapshot directory path and the original operation error as `cause`. If cleanup succeeds but the operation failed, rethrow the original error.
- **What changed**: `src/infra/sqlite-snapshot-source.ts` — `withSqliteSnapshotSource` rewritten from `try/finally { cleanup() }` to an outcome-capture pattern that checks the cleanup return value, aligning with the fix established in #143844.
- **What did NOT change**: The retry logic (re-preparing a snapshot when the first attempt had no journal) is preserved. Normal-path behavior (cleanup succeeds, operation succeeds) is unchanged. No other call sites or functions in the file were modified.

## Why This Change Was Made

This is the same anti-pattern fixed in #143844 (`withStateDatabaseSnapshot`) and sibling fixes BUG-069 through BUG-073: `prepared.cleanup()` returns a boolean indicating whether the temporary directory was actually removed, but `withSqliteSnapshotSource` ignored it. The `prepareSqliteSnapshotSource` path calls `prepareSqliteReadOnlyLocation` without an `AbortSignal`, so `adoptPreparedLocation` gets `requireCleanup=false` — meaning cleanup failures return `false` without throwing internally. The caller is responsible for checking the return value, which this fix does.

The outcome-capture pattern is slightly more involved than #143844's template because `withSqliteSnapshotSource` has a retry path: when the first operation fails and no snapshot was prepared (no journal file), it re-prepares and retries. The inner `try/catch` captures the retry outcome correctly, and the outer cleanup check covers both the original and retry paths.

- **Best fix**: Yes — aligns with the established #143844 pattern. The extra nesting is required by the existing retry logic, not added complexity.
- **Risk**: Cleanup failures that were previously silent will now surface as errors. This is the intended behavior change. Callers that depended on silent cleanup failures are not expected to exist — stale temp directories are never desirable.

## User Impact

Operators and users will now see a clear error message when a SQLite snapshot directory cannot be removed, including the directory path and guidance to check permissions and available storage. Previously, these failures were invisible, allowing temporary files to accumulate until disk space was exhausted with no diagnostic trail.

## Evidence

**Live command verification** — `node --import tsx` directly exercising `withSqliteSnapshotSource` with four scenarios:

```console
$ cd /home/code/github/openclaw-wt-074 && node --import tsx ./proof-bug074.mjs
=== Setup ===
DB path: /tmp/bug074-hg90zS/test.sqlite
Journal exists: true

=== Test 1: Normal (operation succeeds, cleanup succeeds) ===
Result: {"value":"hello"}
PASS: returned operation value

=== Test 2: Cleanup failure (operation succeeds, cleanup fails) ===
Error message: SQLite snapshot cleanup failed: /home/0668000539/.cache/openclaw/openclaw-sqlite-readonly-606540-7g2O7V/openclaw-sqlite-readonly-606733-Jh37Fv. Check directory permissions and available storage before retrying.
PASS: threw cleanup failure error with diagnostic message

=== Test 3: Operation failure + cleanup success ===
Error message: operation-boom
PASS: threw original operation error

=== Test 4: Operation failure + cleanup failure ===
Error message: operation-boom; SQLite snapshot cleanup failed: /home/0668000539/.cache/openclaw/openclaw-sqlite-readonly-606540-K9WwxW/openclaw-sqlite-readonly-606823-roLhqj. Check directory permissions and available storage before retrying.
Cause: operation-boom
PASS: threw cleanup error with operation error as cause

=== All tests done ===
```

Test 1 confirms the normal path returns the operation value unchanged. Test 2 confirms cleanup failure now throws a diagnostic error. Test 3 confirms operation errors still propagate when cleanup succeeds. Test 4 confirms cleanup failure includes the operation error as `cause`.

**Existing test regression** — no breakage in related test suites:

```console
$ node scripts/run-vitest.mjs src/state/openclaw-state-db-readonly.exclusion.test.ts --run
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ node scripts/run-vitest.mjs src/infra/sqlite-snapshot.test.ts --run
 Test Files  1 passed (1)
      Tests  38 passed | 2 skipped (40)
```

**What was not tested**: No live Gateway or channel flow tested. The `withSqliteSnapshotSource` retry path (operation fails with `!prepared`, re-prepares snapshot) was not directly exercised in the proof script, but is covered by the existing `openclaw-state-db-readonly.exclusion.test.ts` suite which passed.

**Open PR collision check**: searched open PR topics and scanned changed-file lists for `src/infra/sqlite-snapshot-source.ts`; no open PR touched it. Related canonical PR #143844 fixed the same anti-pattern in `withStateDatabaseSnapshot` — this is a different call site, not a duplicate.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex (gpt-5.6-sol)
- Prompts / session excerpts: available on request
- Confirmed understanding of code changes: Yes — can explain every line. The outcome-capture pattern replaces `try/finally { cleanup() }` to check the boolean return of `prepared.cleanup()`, with nested try-catch to handle the retry path where `!prepared` triggers a re-preparation attempt.
- autoreview: N/A (not run in this worktree due to symlink node_modules limitation)
