### PR TITLE
fix(web-fetch): keep visible text after hidden HTML

### DIFF
--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -64,6 +64,69 @@ describe("web readability extractor", () => {
     expect(extracted.title).toBe("Example Article");
   });
 
+  it.each(["text", "markdown"] as const)(
+    "excludes double-escaped script prose in %s mode",
+    async (extractMode) => {
+      const extractor = createReadabilityWebContentExtractor();
+      const result = await extractor.extract({
+        html: `<!doctype html><html><head><title>Cloud Costs</title></head><body><article>
+<script><!--<script></script><p>Secret script paragraph. These words belong only to script data, and they must never become the article text returned to the reader. The paragraph has ordinary prose and no links or unusual attributes.</p>--></script>
+<p>Visible sibling. Cloud costs depend on the services a team uses, the amount of data it stores, and the traffic its customers generate. A useful review starts with the current bill and compares each service with the work it supports. Teams can then remove unused resources, select suitable instance sizes, and set budgets for expected growth. Regular reviews make these decisions easier because each change has a clear purpose and a measured result. This visible article paragraph must remain available after extraction.</p>
+</article></body></html>`,
+        url: "https://example.com/article",
+        extractMode,
+      });
+      const extracted = requireReadabilityResult(result);
+      expect(extracted.text).toContain("Visible sibling");
+      expect(extracted.text).not.toContain("Secret script paragraph");
+      expect(extracted.title).toBe("Cloud Costs");
+    },
+  );
+
+  it.each(["text", "markdown"] as const)(
+    "does not join script delimiters across comments in %s mode",
+    async (extractMode) => {
+      const extractor = createReadabilityWebContentExtractor();
+      const result = await extractor.extract({
+        html: SAMPLE_HTML.replace(
+          "<article>",
+          "<article><script></scr<!-- -->ipt><p>Secret script paragraph. This prose belongs to script data and must remain excluded from extracted article text.</p></script>",
+        ),
+        url: "https://example.com/article",
+        extractMode,
+      });
+      const extracted = requireReadabilityResult(result);
+      expect(extracted.text).toContain("Main content starts here");
+      expect(extracted.text).not.toContain("Secret script paragraph");
+      expect(extracted.title).toBe("Example Article");
+    },
+  );
+
+  it("preserves visible content after a quoted script closer", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const result = await extractor.extract({
+      html: SAMPLE_HTML.replace("<article>", '<article><script>x</script data-note="<!--">'),
+      url: "https://example.com/article",
+      extractMode: "text",
+    });
+    const extracted = requireReadabilityResult(result);
+    expect(extracted.text).toContain("Main content starts here");
+    expect(extracted.title).toBe("Example Article");
+  });
+
+  it("preserves JSON-LD article titles while filtering script text", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const result = await extractor.extract({
+      html: `<!doctype html><html><head><title>Site home</title><script type="application/ld+json">{"@context": "https://schema.org", "@type": "Article", "headline": "Cloud Spending Review"}</script></head><body><article><p>Visible sibling. Cloud costs depend on the services a team uses, the amount of data it stores, and the traffic its customers generate. A useful review starts with the current bill and compares each service with the work it supports. Teams can then remove unused resources, select suitable instance sizes, and set budgets for expected growth. Regular reviews make these decisions easier because each change has a clear purpose and a measured result. This visible article paragraph must remain available after extraction.</p>
+</article></body></html>`,
+      url: "https://example.com/article",
+      extractMode: "text",
+    });
+    const extracted = requireReadabilityResult(result);
+    expect(extracted.text).toContain("Visible sibling");
+    expect(extracted.title).toBe("Cloud Spending Review");
+  });
+
   it("does not count void tags toward the nesting limit", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const html = SAMPLE_HTML.replace("<article>", `<article>${"<BR>".repeat(3100)}`);

--- a/src/agents/tools/web-fetch-html-tag.ts
+++ b/src/agents/tools/web-fetch-html-tag.ts
@@ -63,15 +63,11 @@ function startsWithClosingTag(html: string, start: number, tagName: string): boo
   return isTagBoundary(html[start + 2 + tagName.length]);
 }
 
-export function readRawTextOpenTagName(
-  html: string,
-  start: number,
-  tagNames: ReadonlySet<string> = RAW_TEXT_TAGS,
-): string | undefined {
+export function readRawTextOpenTagName(html: string, start: number): string | undefined {
   if (html[start] !== "<" || html[start + 1] === "/") {
     return undefined;
   }
-  for (const tagName of tagNames) {
+  for (const tagName of RAW_TEXT_TAGS) {
     let matches = true;
     for (let offset = 0; offset < tagName.length; offset += 1) {
       if (asciiLower(html[start + 1 + offset] ?? "") !== tagName[offset]) {
@@ -200,42 +196,33 @@ export function readTagToken(
   }
 
   const raw = html.slice(start + 1, end);
-  const body = rendering ? raw : raw.trim();
+  const body = raw;
   let pos = 0;
-  while (pos < body.length && isAsciiWhitespace(body.charAt(pos))) {
-    pos += 1;
-  }
   const closing = body[pos] === "/";
   if (closing) {
     pos += 1;
-    while (
-      pos < body.length &&
-      (rendering ? isAsciiWhitespace(body.charAt(pos)) : /\s/.test(body.charAt(pos)))
-    ) {
-      pos += 1;
-    }
   }
-  if (pos >= body.length || body[pos] === "!" || body[pos] === "?") {
+  if (!isTagNameStartChar(body[pos] ?? "")) {
     return { token: null, next: end + 1 };
   }
 
   const nameStart = pos;
-  while (pos < body.length && isTagNameChar(body.charAt(pos))) {
-    if (!rendering && body[pos] === ".") {
-      break;
-    }
+  while (
+    pos < body.length &&
+    !isAsciiWhitespace(body.charAt(pos)) &&
+    body[pos] !== "/" &&
+    body[pos] !== ">"
+  ) {
     pos += 1;
-  }
-  if (pos === nameStart || (rendering && !isTagNameStartChar(body[nameStart] ?? ""))) {
-    const rawTextStart = rendering ? findRawTextOpenTagStart(html, start + 1, end + 1) : -1;
-    return { token: null, next: rawTextStart === -1 ? end + 1 : rawTextStart };
   }
 
   const attrs = closing ? "" : body.slice(pos);
   return {
     token: {
       closing,
-      name: body.slice(nameStart, pos).toLowerCase(),
+      name: body
+        .slice(nameStart, pos)
+        .replace(/\0|[A-Z]/g, (ch) => (ch === "\0" ? "\uFFFD" : asciiLower(ch))),
       raw,
       attrs,
       selfClosing: rendering ? isSelfClosingTagRaw(raw) : !closing && attrs.trimEnd().endsWith("/"),

--- a/src/agents/tools/web-fetch-html-tag.ts
+++ b/src/agents/tools/web-fetch-html-tag.ts
@@ -63,11 +63,15 @@ function startsWithClosingTag(html: string, start: number, tagName: string): boo
   return isTagBoundary(html[start + 2 + tagName.length]);
 }
 
-export function readRawTextOpenTagName(html: string, start: number): string | undefined {
+export function readRawTextOpenTagName(
+  html: string,
+  start: number,
+  tagNames: ReadonlySet<string> = RAW_TEXT_TAGS,
+): string | undefined {
   if (html[start] !== "<" || html[start + 1] === "/") {
     return undefined;
   }
-  for (const tagName of RAW_TEXT_TAGS) {
+  for (const tagName of tagNames) {
     let matches = true;
     for (let offset = 0; offset < tagName.length; offset += 1) {
       if (asciiLower(html[start + 1 + offset] ?? "") !== tagName[offset]) {
@@ -163,6 +167,22 @@ function isSelfClosingTagRaw(raw: string): boolean {
   );
 }
 
+export function skipHtmlComment(html: string, start: number): number {
+  if (html[start + 4] === ">") {
+    return start + 5;
+  }
+  if (html.startsWith("->", start + 4)) {
+    return start + 6;
+  }
+  for (let end = html.indexOf("--", start + 4); end !== -1; end = html.indexOf("--", end + 1)) {
+    const bracket = html[end + 2] === "!" ? end + 3 : end + 2;
+    if (html[bracket] === ">") {
+      return bracket + 1;
+    }
+  }
+  return html.length;
+}
+
 export function readTagToken(
   html: string,
   start: number,
@@ -170,14 +190,7 @@ export function readTagToken(
 ): ReadTagResult | null {
   const rendering = mode === "render";
   if (rendering && html.startsWith("<!--", start)) {
-    if (html[start + 4] === ">") {
-      return { token: null, next: start + 5 };
-    }
-    if (html.startsWith("->", start + 4)) {
-      return { token: null, next: start + 6 };
-    }
-    const commentEnd = html.indexOf("-->", start + 4);
-    return { token: null, next: commentEnd === -1 ? html.length : commentEnd + 3 };
+    return { token: null, next: skipHtmlComment(html, start) };
   }
 
   const tagEnd = findTagEnd(html, start, mode);
@@ -231,20 +244,59 @@ export function readTagToken(
   };
 }
 
-export function closeRawTextTagEnd(html: string, tagName: string, contentStart: number): number {
+export function readRawTextBounds(
+  html: string,
+  tagName: string,
+  contentStart: number,
+  mode: HtmlTagMode = "render",
+): { contentEnd: number; end: number } {
+  if (tagName === "script") {
+    // In double-escaped script data, </script> is text that returns to the escaped state.
+    let state: "data" | "escaped" | "double-escaped" = "data";
+    for (let cursor = contentStart; cursor < html.length; cursor += 1) {
+      if (state === "data" && html.startsWith("<!--", cursor)) {
+        state = "escaped";
+        // Revisit the dashes so <!--> also returns to normal script data.
+        cursor += 1;
+        continue;
+      }
+      if (state !== "data" && html.startsWith("-->", cursor)) {
+        state = "data";
+        cursor += 2;
+        continue;
+      }
+      if (html[cursor] !== "<") {
+        continue;
+      }
+      if (startsWithClosingTag(html, cursor, tagName)) {
+        if (state === "double-escaped") {
+          state = "escaped";
+          cursor += tagName.length + 1;
+          continue;
+        }
+        const closeEnd = findTagEnd(html, cursor, mode).end;
+        return { contentEnd: cursor, end: closeEnd === -1 ? html.length : closeEnd + 1 };
+      }
+      if (state === "escaped" && readRawTextOpenTagName(html, cursor) === "script") {
+        state = "double-escaped";
+        cursor += tagName.length;
+      }
+    }
+    return { contentEnd: html.length, end: html.length };
+  }
   let closeStart = html.indexOf("</", contentStart);
   while (closeStart !== -1) {
     if (startsWithClosingTag(html, closeStart, tagName)) {
-      const closeEnd = findTagEnd(html, closeStart).end;
-      return closeEnd === -1 ? html.length : closeEnd + 1;
+      const closeEnd = findTagEnd(html, closeStart, mode).end;
+      return { contentEnd: closeStart, end: closeEnd === -1 ? html.length : closeEnd + 1 };
     }
     closeStart = html.indexOf("</", closeStart + 2);
   }
-  return html.length;
+  return { contentEnd: html.length, end: html.length };
 }
 
 export function skipRawTextElement(html: string, start: number, tagName: string): number {
   const openerEnd = findTagEnd(html, start);
   const contentStart = openerEnd.end === -1 ? start + tagName.length + 1 : openerEnd.end + 1;
-  return closeRawTextTagEnd(html, tagName, contentStart);
+  return readRawTextBounds(html, tagName, contentStart).end;
 }

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -11,6 +11,72 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   const grin = String.fromCodePoint(0x1f600); // 😀 — an astral (> U+FFFF) code point
   const doubleT = String.fromCodePoint(0x1d54b); // 𝕋 — mathematical double-struck capital T
 
+  it.each(["meta\u00a0", "embed\u00a0"])(
+    "retains visible contents in the complete ordinary name %s",
+    async (name) => {
+      const result = await extractBasicHtmlContent({
+        html: `<${name}><p>Visible inside</p></${name}><p>Visible sibling</p>`,
+        extractMode: "text",
+      });
+      expect(result?.text).toBe("Visible inside\nVisible sibling");
+    },
+  );
+
+  it("filters real metadata and hidden ordinary names without removing the visible sibling", async () => {
+    const result = await extractBasicHtmlContent({
+      html: '<meta content="Secret metadata"><meta\u00a0 hidden>Secret body</meta\u00a0><p>Visible sibling</p>',
+      extractMode: "text",
+    });
+    expect(result?.text).toBe("Visible sibling");
+  });
+
+  it("matches HTML null replacement in complete tag names", async () => {
+    const result = await extractBasicHtmlContent({
+      html: "<div\u0000 hidden>Secret</div\uFFFD><p>Visible</p>",
+      extractMode: "text",
+    });
+    expect(result?.text).toBe("Visible");
+  });
+
+  it.each([
+    "<lin\u212a hidden>Secret</lin\u212a><p>Visible</p>",
+    "<trac\u212a hidden>Secret</trac\u212a><p>Visible</p>",
+    "<p hidden>Before<bloc\u212aquote>Secret</bloc\u212aquote></p><p>Visible</p>",
+  ])("keeps non-ASCII tag-name characters distinct from HTML names: %s", async (html) => {
+    const result = await extractBasicHtmlContent({ html, extractMode: "text" });
+    expect(result?.text).toContain("Visible");
+    expect(result?.text).not.toContain("Secret");
+  });
+
+  it("still recovers paragraph scope with uppercase ASCII names", async () => {
+    const result = await extractBasicHtmlContent({
+      html: "<p hidden>Secret<BLOCKQUOTE>Visible block</BLOCKQUOTE><p>Visible sibling</p>",
+      extractMode: "text",
+    });
+    expect(result?.text).toContain("Visible block");
+    expect(result?.text).toContain("Visible sibling");
+    expect(result?.text).not.toContain("Secret");
+  });
+
+  it.each([
+    "<p hidden>Before<div.foo>Secret</div.foo></p><p>Visible</p>",
+    "<p hidden>Before<p.foo>Secret</p.foo></p><p>Visible</p>",
+    "<p hidden>Before<div@click>Secret</div@click></p><p>Visible</p>",
+    "<p hidden>Before<div=note>Secret</div=note></p><p>Visible</p>",
+    "<p hidden>Before< div>Secret</ div></p><p>Visible</p>",
+    "<p hidden>Before<\u00a0div>Secret</\u00a0div></p><p>Visible</p>",
+    "<div><p hidden>Before</div.foo>Secret</p></div><p>Visible</p>",
+    "<div><p hidden>Before</ div>Secret</p></div><p>Visible</p>",
+    "<ul><li hidden>Before<li.foo>Secret</li.foo></li><li>Visible</li></ul>",
+    "<dl><dt hidden>Before<dd.foo>Secret</dd.foo></dt><dd>Visible</dd></dl>",
+    "<table><tr><td hidden>Before<th.foo>Secret</th.foo></td><td>Visible</td></tr></table>",
+    "<select><option hidden>Before<option.foo>Secret</option.foo></option><option>Visible</option></select>",
+  ])("does not recover HTML scope from an incomplete tag identity: %s", async (html) => {
+    const result = await extractBasicHtmlContent({ html, extractMode: "text" });
+    expect(result?.text).toContain("Visible");
+    expect(result?.text).not.toContain("Secret");
+  });
+
   it.each(["script.foo", "textarea.foo", "title.foo", "plaintext.foo", " script", "\u00a0script"])(
     "filters hidden content inside the ordinary element %s",
     async (name) => {

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -11,6 +11,47 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   const grin = String.fromCodePoint(0x1f600); // 😀 — an astral (> U+FFFF) code point
   const doubleT = String.fromCodePoint(0x1d54b); // 𝕋 — mathematical double-struck capital T
 
+  it.each(["script.foo", "textarea.foo", "title.foo", "plaintext.foo", " script", "\u00a0script"])(
+    "filters hidden content inside the ordinary element %s",
+    async (name) => {
+      const html = `<${name}><p hidden>Secret data</p></${name}><p>Visible sibling</p>`;
+      const result = await extractBasicHtmlContent({ html, extractMode: "text" });
+      expect(result?.text).toContain("Visible sibling");
+      expect(result?.text).not.toContain("Secret data");
+    },
+  );
+
+  it.each(["<!-->", "<!--->", "<!-- Secret comment --!>"])(
+    "retains visible text after the recovered comment boundary %s",
+    async (comment) => {
+      const result = await extractBasicHtmlContent({
+        html: `<p>Visible before</p>${comment}<p>Visible after</p>`,
+        extractMode: "text",
+      });
+      expect(result?.text).toBe("Visible before\nVisible after");
+    },
+  );
+
+  it.each(['x</script data-note="<!--">', "<!-- Secret script text</script>"])(
+    "preserves the script closing boundary around %s",
+    async (script) => {
+      const html = `<p>Visible before</p><script>${script}<p>Visible after</p>`;
+      expect(htmlToMarkdown(html).text).toBe("Visible before\nVisible after");
+      const result = await extractBasicHtmlContent({ html, extractMode: "text" });
+      expect(result?.text).toBe("Visible before\nVisible after");
+    },
+  );
+
+  it.each(["</scr<!-- -->ipt>", "</script<!-- -->>"])(
+    "keeps script delimiters separated around %s",
+    async (delimiter) => {
+      const html = `<script>${delimiter}<p>Secret data</p></script><p>Visible sibling</p>`;
+      expect(htmlToMarkdown(html).text).toBe("Visible sibling");
+      const result = await extractBasicHtmlContent({ html, extractMode: "text" });
+      expect(result?.text).toBe("Visible sibling");
+    },
+  );
+
   it("decodes astral numeric entities via code points instead of truncating to garbage", () => {
     expect(htmlToMarkdown(`<p>I &#128512; this</p>`).text).toBe(`I ${grin} this`);
     expect(htmlToMarkdown(`<p>&#x1F600;</p>`).text).toBe(grin);
@@ -72,6 +113,17 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     expect(htmlToMarkdown(`<p>Visible</p><script data=">IGNORE</script><p>Shown</p>`).text).toBe(
       "Visible\nShown",
     );
+  });
+
+  it("keeps double-escaped script data out of rendered text", () => {
+    expect(
+      htmlToMarkdown("<script><!--<script></script><p>Secret data</p>--></script><p>Visible</p>")
+        .text,
+    ).toBe("Visible");
+  });
+
+  it("returns to normal script data after an empty escaped comment", () => {
+    expect(htmlToMarkdown("<script><!--><script></script><p>Visible</p>").text).toBe("Visible");
   });
 
   it("does not end raw-text blocks inside opener attributes", () => {

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -14,7 +14,7 @@ import {
   findRawTextOpenTagStart,
   startsLikeHtmlTag,
   readTagToken,
-  closeRawTextTagEnd,
+  readRawTextBounds,
   skipRawTextElement,
 } from "./web-fetch-html-tag.js";
 import { sanitizeHtml } from "./web-fetch-visibility.js";
@@ -304,7 +304,7 @@ function htmlFragmentToMarkdown(html: string): { text: string; title?: string } 
     }
 
     if (RAW_TEXT_TAGS.has(token.name)) {
-      i = closeRawTextTagEnd(html, token.name, i);
+      i = readRawTextBounds(html, token.name, i).end;
       continue;
     }
     if (BLOCK_BREAK_TAGS.has(token.name)) {

--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -233,6 +233,42 @@ describe("sanitizeHtml", () => {
     expect(result).not.toContain("Still hidden");
   });
 
+  it("keeps elements whose attribute value merely mentions hidden", async () => {
+    const html =
+      '<html><body><article title="The hidden cost of cloud"><h1>Cloud Costs</h1>' +
+      "<p>Real body text of the article.</p></article></body></html>";
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Cloud Costs");
+    expect(result).toContain("Real body text of the article.");
+  });
+
+  it("keeps the page when a body attribute value mentions hidden", async () => {
+    const html =
+      '<html><body aria-label="Show hidden replies"><h1>Thread</h1><p>Every reply in this thread.</p></body></html>';
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Thread");
+    expect(result).toContain("Every reply in this thread.");
+  });
+
+  it("stops the drop region at the container of an optional-end-tag hidden element", async () => {
+    // <li> may legally omit its end tag; the drop must not swallow the rest of
+    // the document past the closing container tag.
+    const html =
+      '<html><body><ul><li class="d-none">Nav item<li>Visible item</ul>' +
+      "<p>Article body follows here.</p></body></html>";
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Visible item");
+    expect(result).toContain("Article body follows here.");
+    expect(result).not.toContain("Nav item");
+  });
+
+  it("still strips an optional-end-tag hidden element closed by its container", async () => {
+    const html = '<ul><li class="d-none">Dropped nav item</ul><p>Kept body</p>';
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Dropped nav item");
+    expect(result).toContain("Kept body");
+  });
+
   it("handles malformed HTML gracefully", async () => {
     const html = "<p>Unclosed <div>Nested";
     await expect(sanitizeHtml(html)).resolves.toContain("Unclosed");

--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -5,6 +5,39 @@ import { stripInvisibleUnicode } from "../../infra/unicode-visibility.js";
 import { sanitizeHtml } from "./web-fetch-visibility.js";
 
 describe("sanitizeHtml", () => {
+  it.each(["meta\u00a0", "embed\u00a0"])(
+    "retains visible contents in the complete ordinary name %s",
+    async (name) => {
+      const html = `<${name}><p>Visible inside</p></${name}><p>Visible sibling</p>`;
+      expect(await sanitizeHtml(html)).toBe(html);
+    },
+  );
+
+  it("filters real metadata and hidden ordinary names without removing the visible sibling", async () => {
+    const html =
+      '<meta content="Secret metadata"><meta\u00a0 hidden>Secret body</meta\u00a0><p>Visible sibling</p>';
+    expect(await sanitizeHtml(html)).toBe("<p>Visible sibling</p>");
+  });
+
+  it.each([
+    "<p hidden>Before<div.foo>Secret</div.foo></p><p>Visible</p>",
+    "<p hidden>Before<p.foo>Secret</p.foo></p><p>Visible</p>",
+    "<p hidden>Before<div@click>Secret</div@click></p><p>Visible</p>",
+    "<p hidden>Before<div=note>Secret</div=note></p><p>Visible</p>",
+    "<p hidden>Before< div>Secret</ div></p><p>Visible</p>",
+    "<p hidden>Before<\u00a0div>Secret</\u00a0div></p><p>Visible</p>",
+    "<div><p hidden>Before</div.foo>Secret</p></div><p>Visible</p>",
+    "<div><p hidden>Before</ div>Secret</p></div><p>Visible</p>",
+    "<ul><li hidden>Before<li.foo>Secret</li.foo></li><li>Visible</li></ul>",
+    "<dl><dt hidden>Before<dd.foo>Secret</dd.foo></dt><dd>Visible</dd></dl>",
+    "<table><tr><td hidden>Before<th.foo>Secret</th.foo></td><td>Visible</td></tr></table>",
+    "<select><option hidden>Before<option.foo>Secret</option.foo></option><option>Visible</option></select>",
+  ])("does not recover HTML scope from an incomplete tag identity: %s", async (html) => {
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Visible");
+    expect(result).not.toContain("Secret");
+  });
+
   it.each(["script.foo", "textarea.foo", "title.foo", "plaintext.foo", " script", "\u00a0script"])(
     "checks hidden descendants when %s is not a raw-text element",
     async (name) => {

--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -269,6 +269,51 @@ describe("sanitizeHtml", () => {
     expect(result).toContain("Kept body");
   });
 
+  it("classifies hidden after attribute names the tag grammar cannot classify", async () => {
+    // Framework attribute syntax (`@click`, `(click)`) is legal in attribute
+    // names; the reader must consume such names and keep scanning, or every
+    // later visibility lookup silently returns undefined and the hidden
+    // subtree escapes filtering.
+    const at = '<p>Visible</p><div @click="noop" hidden>Secret</div><p>Trailing</p>';
+    const atResult = await sanitizeHtml(at);
+    expect(atResult).toContain("Visible");
+    expect(atResult).toContain("Trailing");
+    expect(atResult).not.toContain("Secret");
+
+    const paren = '<div (click)="noop" hidden>Secret</div>';
+    expect(await sanitizeHtml(paren)).not.toContain("Secret");
+  });
+
+  it("classifies hidden class and style after framework attribute names", async () => {
+    const classed = '<div @click="noop" class="hidden">Secret class</div>';
+    expect(await sanitizeHtml(classed)).not.toContain("Secret class");
+
+    const styled = '<div @click="noop" style="display:none">Secret style</div>';
+    expect(await sanitizeHtml(styled)).not.toContain("Secret style");
+  });
+
+  it("keeps the hidden region open across a nested same-name descendant", async () => {
+    // A same-name element reached across an intervening container is a
+    // descendant, not a sibling: implicit closure must not release the outer
+    // drop region, or the nested content escapes filtering.
+    const html = "<ul><li hidden>Outer<ul><li>Secret</li></ul></li></ul><p>Visible</p>";
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Visible");
+    expect(result).not.toContain("Outer");
+    expect(result).not.toContain("Secret");
+  });
+
+  it("does not end a hidden region on a stray closing tag", async () => {
+    // An unmatched closing tag inside a hidden element is not evidence that
+    // the hidden element ended; the region must stay suppressed until its own
+    // container closes.
+    const html = "<div hidden>Before</span>Secret</div><p>Visible</p>";
+    const result = await sanitizeHtml(html);
+    expect(result).toContain("Visible");
+    expect(result).not.toContain("Before");
+    expect(result).not.toContain("Secret");
+  });
+
   it("handles malformed HTML gracefully", async () => {
     const html = "<p>Unclosed <div>Nested";
     await expect(sanitizeHtml(html)).resolves.toContain("Unclosed");

--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -5,6 +5,16 @@ import { stripInvisibleUnicode } from "../../infra/unicode-visibility.js";
 import { sanitizeHtml } from "./web-fetch-visibility.js";
 
 describe("sanitizeHtml", () => {
+  it.each(["script.foo", "textarea.foo", "title.foo", "plaintext.foo", " script", "\u00a0script"])(
+    "checks hidden descendants when %s is not a raw-text element",
+    async (name) => {
+      const html = `<${name}><p hidden>Secret data</p></${name}><p>Visible sibling</p>`;
+      const result = await sanitizeHtml(html);
+      expect(result).not.toContain("Secret data");
+      expect(result).toContain("Visible sibling");
+    },
+  );
+
   it("reuses compiled visibility matchers across styled elements", async () => {
     const styledElements = 256;
     const html = Array.from(
@@ -269,49 +279,172 @@ describe("sanitizeHtml", () => {
     expect(result).toContain("Kept body");
   });
 
-  it("classifies hidden after attribute names the tag grammar cannot classify", async () => {
-    // Framework attribute syntax (`@click`, `(click)`) is legal in attribute
-    // names; the reader must consume such names and keep scanning, or every
-    // later visibility lookup silently returns undefined and the hidden
-    // subtree escapes filtering.
-    const at = '<p>Visible</p><div @click="noop" hidden>Secret</div><p>Trailing</p>';
-    const atResult = await sanitizeHtml(at);
-    expect(atResult).toContain("Visible");
-    expect(atResult).toContain("Trailing");
-    expect(atResult).not.toContain("Secret");
-
-    const paren = '<div (click)="noop" hidden>Secret</div>';
-    expect(await sanitizeHtml(paren)).not.toContain("Secret");
-  });
-
-  it("classifies hidden class and style after framework attribute names", async () => {
-    const classed = '<div @click="noop" class="hidden">Secret class</div>';
-    expect(await sanitizeHtml(classed)).not.toContain("Secret class");
-
-    const styled = '<div @click="noop" style="display:none">Secret style</div>';
-    expect(await sanitizeHtml(styled)).not.toContain("Secret style");
-  });
-
-  it("keeps the hidden region open across a nested same-name descendant", async () => {
-    // A same-name element reached across an intervening container is a
-    // descendant, not a sibling: implicit closure must not release the outer
-    // drop region, or the nested content escapes filtering.
-    const html = "<ul><li hidden>Outer<ul><li>Secret</li></ul></li></ul><p>Visible</p>";
-    const result = await sanitizeHtml(html);
-    expect(result).toContain("Visible");
-    expect(result).not.toContain("Outer");
+  it.each([
+    '@click="noop" hidden',
+    '[class]="state" aria-hidden="true"',
+    '@click = "noop()" class="d-none"',
+    '[style] = "state" style="display:none"',
+  ])("reads visibility after framework attributes: %s", async (attrs) => {
+    const result = await sanitizeHtml(`<div ${attrs}>Secret</div><p>Visible sibling</p>`);
     expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
   });
 
-  it("does not end a hidden region on a stray closing tag", async () => {
-    // An unmatched closing tag inside a hidden element is not evidence that
-    // the hidden element ended; the region must stay suppressed until its own
-    // container closes.
-    const html = "<div hidden>Before</span>Secret</div><p>Visible</p>";
+  it.each([
+    'hidden@click="noop"',
+    'hidden-prefix="value"',
+    '@click = "show hidden replies"',
+    '[label]="show hidden replies"',
+    'title="class=hidden aria-hidden=true style=display:none"',
+  ])("keeps unrelated complete attributes: %s", async (attrs) => {
+    expect(await sanitizeHtml(`<div ${attrs}>Visible article</div>`)).toContain("Visible article");
+  });
+
+  it.each([
+    "<ul><li hidden>Secret outer<ul><li>Secret inner</li></ul>Secret tail</li><li>Visible sibling</li></ul>",
+    "<ul><li hidden>Secret<blockquote><li>Secret nested</li></blockquote></li><li>Visible sibling</li></ul>",
+    "<ul><li hidden>Secret outer<math><mtext><li>Secret inner</li></mtext></math>Secret tail</li><li>Visible sibling</li></ul>",
+    "<ul><li hidden>Secret outer<svg><foreignObject><li>Secret inner</li></foreignObject></svg>Secret tail</li><li>Visible sibling</li></ul>",
+    '<div hidden><ul><li hidden>Secret<li data-note="Secret attribute">Secret next</ul>Secret tail</div><p>Visible sibling</p>',
+    "<div hidden>Secret before</span>Secret after</div><p>Visible sibling</p>",
+    "<div hidden>Secret before</ul>Secret after</div><p>Visible sibling</p>",
+    "<p>Visible sibling</p><div hidden>Secret</body>Secret unclosed",
+  ])("preserves the hidden owner across nested and unmatched tags: %s", async (html) => {
     const result = await sanitizeHtml(html);
-    expect(result).toContain("Visible");
-    expect(result).not.toContain("Before");
     expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["ul", "ol", "menu"])("closes omitted list items within their %s owner", async (list) => {
+    const result = await sanitizeHtml(
+      `<${list}><li hidden><span>Secret<li>Visible sibling</${list}><p>Article after</p>`,
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+    expect(result).toContain("Article after");
+  });
+
+  it.each([
+    "<p hidden>Secret<p>Visible sibling</p>",
+    "<p hidden>Secret<div>Visible sibling</div>",
+    "<dl><dt hidden>Secret<dd>Visible sibling</dd></dl>",
+    "<dl><dd hidden>Secret<dt>Visible sibling</dt></dl>",
+    "<table><tr><td hidden>Secret<td>Visible sibling</td></tr></table>",
+    "<table><tr hidden><td>Secret<tr><td>Visible sibling</td></tr></table>",
+    "<select><option hidden>Secret<option>Visible sibling</option></select>",
+    "<select><optgroup><option hidden>Secret<optgroup><option>Visible sibling</option></optgroup></select>",
+    "<article><p hidden>Secret</article><p>Visible sibling</p>",
+    "<dl><dd hidden>Secret</dl><p>Visible sibling</p>",
+    "<table><tr><td hidden>Secret</table><p>Visible sibling</p>",
+    "<table><tr><td><p hidden>Secret</table><p>Visible sibling</p>",
+  ])("closes optional elements only within their owning scope: %s", async (html) => {
+    const result = await sanitizeHtml(html + "<p>Article after</p>");
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+    expect(result).toContain("Article after");
+  });
+
+  it.each([
+    "<dl><dd hidden>Secret<dl><dt>Secret inner</dt></dl>Secret tail</dd><dt>Visible sibling</dt></dl>",
+    "<table><tr hidden><td>Secret<table><tr><td>Secret inner</td></tr></table>Secret tail</td></tr><tr><td>Visible sibling</td></tr></table>",
+    "<div hidden><p>Secret<p>Secret sibling</p></div><p>Visible sibling</p>",
+    "<div hidden><dl><dt>Secret<dd>Secret sibling</dd></dl></div><p>Visible sibling</p>",
+  ])("keeps hidden ancestors across optional-element families: %s", async (html) => {
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["script", "textarea"])("keeps %s data inside its hidden paragraph", async (tag) => {
+    const result = await sanitizeHtml(
+      `<p hidden>Secret before<${tag}><p>Secret data</p></${tag}>Secret tail</p><p>Visible sibling</p>`,
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["script", "textarea"])("does not read table starts from %s data", async (tag) => {
+    const result = await sanitizeHtml(
+      `<table><tr><td hidden>Secret<${tag}><td>Secret data</td></${tag}>Secret tail</td></tr></table><p>Visible sibling</p>`,
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["script", "textarea"])("keeps an unfinished %s region hidden", async (tag) => {
+    const result = await sanitizeHtml(
+      `<p>Visible prefix</p><p hidden>Secret<${tag}><p>Secret data`,
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible prefix");
+  });
+
+  it.each([
+    "<p hidden>Secret before<script><!--<script></script><p>Secret data</p>--></script>Secret tail</p><p>Visible sibling</p>",
+    "<p hidden>Secret before<script><!--<ScRiPt></sCrIpT><p>Secret data</p>--></script>Secret tail</p><p>Visible sibling</p>",
+  ])("keeps double-escaped script data in its hidden owner: %s", async (html) => {
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["script", "textarea"])(
+    "ignores the HTML %s opener slash for opaque text",
+    async (tag) => {
+      const result = await sanitizeHtml(
+        `<p hidden>Secret before<${tag}/><p>Secret data</p></${tag}>Secret tail</p><p>Visible sibling</p>`,
+      );
+      expect(result).not.toContain("Secret");
+      expect(result).toContain("Visible sibling");
+    },
+  );
+
+  it("preserves self-closing foreign text elements", async () => {
+    const result = await sanitizeHtml(
+      '<math><title hidden data-note="Secret"/><mtext>Visible sibling</mtext></math>',
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+  });
+
+  it.each(["td", "th", "tr", "tbody", "thead", "tfoot"])(
+    "ignores misplaced %s starts when resolving a hidden paragraph",
+    async (tag) => {
+      const result = await sanitizeHtml(
+        `<p hidden>Secret before<${tag}>Secret data</${tag}>Secret tail</p><p>Visible sibling</p>`,
+      );
+      expect(result).not.toContain("Secret");
+      expect(result).toContain("Visible sibling");
+    },
+  );
+
+  it.each(["option", "optgroup"])(
+    "keeps datalist %s descendants inside the hidden owner",
+    async (tag) => {
+      const result = await sanitizeHtml(
+        `<datalist><${tag} hidden>Secret outer<span><${tag}>Secret inner</${tag}></span>Secret tail</${tag}></datalist><p>Visible sibling</p>`,
+      );
+      expect(result).not.toContain("Secret");
+      expect(result).toContain("Visible sibling");
+    },
+  );
+
+  it("keeps ordinary omitted datalist option siblings", async () => {
+    const result = await sanitizeHtml(
+      "<datalist><option hidden>Secret<option>Visible sibling</option></datalist><p>Article after</p>",
+    );
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
+    expect(result).toContain("Article after");
+  });
+
+  it.each([
+    "<math><title><mtext hidden>Secret foreign title</mtext></title></math><p>Visible sibling</p>",
+    "<math><mtext><p hidden>Secret before<script><p>Secret data</p></script>Secret tail</p><p>Visible sibling</p></mtext></math>",
+  ])("keeps foreign markup and HTML integration-point text distinct: %s", async (html) => {
+    const result = await sanitizeHtml(html);
+    expect(result).not.toContain("Secret");
+    expect(result).toContain("Visible sibling");
   });
 
   it("handles malformed HTML gracefully", async () => {

--- a/src/agents/tools/web-fetch-visibility.tool-extraction.test.ts
+++ b/src/agents/tools/web-fetch-visibility.tool-extraction.test.ts
@@ -5,11 +5,13 @@ import { createServer } from "node:http";
 // keep visible content and drop hidden content. The unit tests in
 // web-fetch-visibility.test.ts pin the sanitizer; this file pins the user
 // visible web_fetch output.
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import type { LookupFn } from "../../infra/net/ssrf.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createWebFetchTool } from "./web-fetch.js";
 
 const PAGES: Record<string, string> = {
+  "/implicit-nested-siblings":
+    "<ul><li hidden><ul><li>A<li>B</li></ul>Secret</li></ul><p>Visible</p>",
+  "/unmatched-container": "<p hidden>Before</div>Secret</p><p>Visible</p>",
   "/framework-attrs": [
     "<html><head><title>Framework Attributes</title></head><body>",
     "<p>Pricing starts at nine dollars.</p>",
@@ -57,14 +59,9 @@ async function startPageServer(): Promise<{ server: Server; baseUrl: string }> {
 describe("web_fetch visibility through the real tool execute path", () => {
   let server: Server;
   let baseUrl: string;
-  const lookupMock = vi.fn();
 
   beforeAll(async () => {
     ({ server, baseUrl } = await startPageServer());
-    lookupMock.mockImplementation(async (hostname: string) => {
-      void hostname;
-      return [{ address: "127.0.0.1", family: 4 }];
-    });
   });
 
   afterAll(async () => {
@@ -75,7 +72,6 @@ describe("web_fetch visibility through the real tool execute path", () => {
 
   function createTool(): ReturnType<typeof createWebFetchTool> {
     return createWebFetchTool({
-      lookupFn: lookupMock as unknown as LookupFn,
       config: {
         // The visibility sanitizer runs on the basic-extraction fallback path
         // (no plugin content extractors); this proof exercises that path.
@@ -93,11 +89,25 @@ describe("web_fetch visibility through the real tool execute path", () => {
   }
 
   async function extract(path: string): Promise<string> {
-    const result = await createTool()?.execute?.("call", { url: `${baseUrl}${path}` });
-    const details = result?.details as { text?: string } | undefined;
-    expect(details?.text, "web_fetch should return extracted text").toBeTruthy();
-    return details?.text ?? "";
+    const tool = createTool();
+    if (!tool) {
+      throw new Error("expected enabled web_fetch tool");
+    }
+    const result = await tool.execute("call", { url: `${baseUrl}${path}` });
+    return result.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
   }
+
+  it.each(["/implicit-nested-siblings", "/unmatched-container"])(
+    "keeps hidden owners across %s",
+    async (path) => {
+      const text = await extract(path);
+      expect(text).toContain("Visible");
+      expect(text).not.toContain("Secret");
+    },
+  );
 
   it("keeps visible content and drops hidden content after framework attributes", async () => {
     const text = await extract("/framework-attrs");

--- a/src/agents/tools/web-fetch-visibility.tool-extraction.test.ts
+++ b/src/agents/tools/web-fetch-visibility.tool-extraction.test.ts
@@ -1,0 +1,124 @@
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+// Tool-level visibility proof: a real HTTP transfer through the real web_fetch
+// execute path (basic extraction, which runs the visibility sanitizer) must
+// keep visible content and drop hidden content. The unit tests in
+// web-fetch-visibility.test.ts pin the sanitizer; this file pins the user
+// visible web_fetch output.
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../../infra/net/ssrf.js";
+import { createWebFetchTool } from "./web-fetch.js";
+
+const PAGES: Record<string, string> = {
+  "/framework-attrs": [
+    "<html><head><title>Framework Attributes</title></head><body>",
+    "<p>Pricing starts at nine dollars.</p>",
+    '<div @click="noop" hidden>Secret framework note</div>',
+    '<div (click)="noop" class="hidden">Secret class note</div>',
+    "<p>Support is available around the clock.</p>",
+    "</body></html>",
+  ].join(""),
+  "/nested-list": [
+    "<html><head><title>Nested List</title></head><body>",
+    "<p>Menu overview follows.</p>",
+    "<ul><li hidden>Outer<ul><li>Secret list note</li></ul></li></ul>",
+    "<p>Menu overview ends.</p>",
+    "</body></html>",
+  ].join(""),
+  "/stray-closer": [
+    "<html><head><title>Stray Closer</title></head><body>",
+    "<div hidden>Before</span>Secret stray note</div>",
+    "<p>Visible article body.</p>",
+    "</body></html>",
+  ].join(""),
+};
+
+async function startPageServer(): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    const page = PAGES[req.url ?? ""];
+    if (!page) {
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("not found");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end(page);
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected a loopback TCP address for the page server");
+  }
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+describe("web_fetch visibility through the real tool execute path", () => {
+  let server: Server;
+  let baseUrl: string;
+  const lookupMock = vi.fn();
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startPageServer());
+    lookupMock.mockImplementation(async (hostname: string) => {
+      void hostname;
+      return [{ address: "127.0.0.1", family: 4 }];
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  function createTool(): ReturnType<typeof createWebFetchTool> {
+    return createWebFetchTool({
+      lookupFn: lookupMock as unknown as LookupFn,
+      config: {
+        // The visibility sanitizer runs on the basic-extraction fallback path
+        // (no plugin content extractors); this proof exercises that path.
+        plugins: { enabled: false },
+        tools: {
+          web: {
+            fetch: {
+              cacheTtlMinutes: 0,
+              ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async function extract(path: string): Promise<string> {
+    const result = await createTool()?.execute?.("call", { url: `${baseUrl}${path}` });
+    const details = result?.details as { text?: string } | undefined;
+    expect(details?.text, "web_fetch should return extracted text").toBeTruthy();
+    return details?.text ?? "";
+  }
+
+  it("keeps visible content and drops hidden content after framework attributes", async () => {
+    const text = await extract("/framework-attrs");
+    expect(text).toContain("Pricing starts at nine dollars.");
+    expect(text).toContain("Support is available around the clock.");
+    expect(text).not.toContain("Secret framework note");
+    expect(text).not.toContain("Secret class note");
+  });
+
+  it("keeps the hidden region open across a nested same-name descendant", async () => {
+    const text = await extract("/nested-list");
+    expect(text).toContain("Menu overview follows.");
+    expect(text).toContain("Menu overview ends.");
+    expect(text).not.toContain("Outer");
+    expect(text).not.toContain("Secret list note");
+  });
+
+  it("does not release a hidden region on a stray closing tag", async () => {
+    const text = await extract("/stray-closer");
+    expect(text).toContain("Visible article body.");
+    expect(text).not.toContain("Before");
+    expect(text).not.toContain("Secret stray note");
+  });
+});

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -9,10 +9,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import {
   readRawTextBounds,
-  readRawTextOpenTagName,
   isAsciiWhitespace,
   readTagToken,
   skipHtmlComment,
+  startsLikeHtmlTag,
 } from "./web-fetch-html-tag.js";
 
 // Compile property matchers once: this list is checked for every styled element.
@@ -193,9 +193,7 @@ const readClass = createAttributeReader("class");
 const readStyle = createAttributeReader("style");
 const readEncoding = createAttributeReader("encoding");
 
-function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
-  const tagName = normalizeLowercaseStringOrEmpty(tagNameRaw);
-
+function shouldRemoveElement(tagName: string, attrs: string): boolean {
   if (["meta", "template", "svg", "canvas", "iframe", "object", "embed"].includes(tagName)) {
     return true;
   }
@@ -611,6 +609,14 @@ function removeMarkedElements(html: string): string {
       continue;
     }
 
+    if (!startsLikeHtmlTag(html, tagStart)) {
+      if (hiddenRoot < 0) {
+        output += "<";
+      }
+      cursor = tagStart + 1;
+      continue;
+    }
+
     const read = readTagToken(html, tagStart, "visibility");
     if (!read) {
       if (hiddenRoot < 0) {
@@ -640,12 +646,7 @@ function removeMarkedElements(html: string): string {
     } else if (namespace === "html" && (parsed.name === "math" || parsed.name === "svg")) {
       namespace = parsed.name;
     }
-    if (
-      !parsed.closing &&
-      namespace === "html" &&
-      OPAQUE_TEXT_ELEMENTS.has(parsed.name) &&
-      readRawTextOpenTagName(html, tagStart, OPAQUE_TEXT_ELEMENTS) === parsed.name
-    ) {
+    if (!parsed.closing && namespace === "html" && OPAQUE_TEXT_ELEMENTS.has(parsed.name)) {
       closeForStart(parsed.name);
       const bounds =
         parsed.name === "plaintext"

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -7,7 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readTagToken } from "./web-fetch-html-tag.js";
+import { isAsciiWhitespace, isTagNameChar, readTagToken } from "./web-fetch-html-tag.js";
 
 // Compile property matchers once: this list is checked for every styled element.
 const HIDDEN_STYLE_PATTERNS = (
@@ -119,15 +119,56 @@ function isStyleHidden(style: string): boolean {
   return false;
 }
 
-// The fixed visibility attributes share one grammar; each reader compiles it once per process.
+// The fixed visibility attributes share one reader grammar. It walks real
+// attribute names instead of matching the raw attribute text: a substring like
+// "hidden" inside a quoted value (`title="The hidden cost of cloud"`) is part
+// of a value, not an attribute, and must not flip visibility.
 function createAttributeReader(attribute: "aria-hidden" | "class" | "hidden" | "style" | "type") {
-  const pattern = new RegExp(
-    `(?:^|\\s)${attribute}(?:\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+)))?`,
-    "i",
-  );
   return (attrs: string): string | undefined => {
-    const match = attrs.match(pattern);
-    return match ? (match[1] ?? match[2] ?? match[3] ?? "") : undefined;
+    let pos = 0;
+    while (pos < attrs.length) {
+      while (
+        pos < attrs.length &&
+        (isAsciiWhitespace(attrs.charAt(pos)) || attrs.charAt(pos) === "/")
+      ) {
+        pos += 1;
+      }
+      const nameStart = pos;
+      while (pos < attrs.length && isTagNameChar(attrs.charAt(pos))) {
+        pos += 1;
+      }
+      if (pos === nameStart) {
+        break;
+      }
+      const name = attrs.slice(nameStart, pos).toLowerCase();
+      while (pos < attrs.length && isAsciiWhitespace(attrs.charAt(pos))) {
+        pos += 1;
+      }
+      let value = "";
+      if (attrs.charAt(pos) === "=") {
+        pos += 1;
+        while (pos < attrs.length && isAsciiWhitespace(attrs.charAt(pos))) {
+          pos += 1;
+        }
+        const quote = attrs.charAt(pos);
+        if (quote === '"' || quote === "'") {
+          const valueStart = pos + 1;
+          const valueEnd = attrs.indexOf(quote, valueStart);
+          value = valueEnd === -1 ? attrs.slice(valueStart) : attrs.slice(valueStart, valueEnd);
+          pos = valueEnd === -1 ? attrs.length : valueEnd + 1;
+        } else {
+          const valueStart = pos;
+          while (pos < attrs.length && !isAsciiWhitespace(attrs.charAt(pos))) {
+            pos += 1;
+          }
+          value = attrs.slice(valueStart, pos);
+        }
+      }
+      if (name === attribute) {
+        return value;
+      }
+    }
+    return undefined;
   };
 }
 
@@ -176,6 +217,23 @@ function popDroppedElement(dropStack: string[], tagName: string): void {
   }
 }
 
+// These elements may legally omit their end tag, and HTML closes a dropped one
+// implicitly when the same-name sibling or an ancestor end tag arrives. Without
+// this, a dropped <li>/<p>/<td> swallows the rest of the document.
+const OPTIONALLY_CLOSED_ELEMENTS = new Set(["dd", "dt", "li", "option", "p", "td", "th", "tr"]);
+
+function closeImplicitlyDroppedElement(dropStack: string[], tagName: string): boolean {
+  if (!OPTIONALLY_CLOSED_ELEMENTS.has(tagName)) {
+    return false;
+  }
+  const index = dropStack.lastIndexOf(tagName);
+  if (index >= 0) {
+    dropStack.length = index;
+    return true;
+  }
+  return false;
+}
+
 function removeMarkedElements(html: string): string {
   let output = "";
   let cursor = 0;
@@ -220,9 +278,28 @@ function removeMarkedElements(html: string): string {
 
     if (dropStack.length > 0) {
       if (parsed.closing) {
-        popDroppedElement(dropStack, parsed.name);
+        if (dropStack.lastIndexOf(parsed.name) < 0) {
+          // The dropped element's own end tag was omitted, so this ancestor end
+          // tag closes the drop region. The ancestor's end tag belongs to the
+          // surviving markup.
+          dropStack.length = 0;
+          output += token;
+        } else {
+          popDroppedElement(dropStack, parsed.name);
+        }
       } else if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
-        dropStack.push(parsed.name);
+        if (closeImplicitlyDroppedElement(dropStack, parsed.name)) {
+          // A same-name sibling implicitly closed the dropped element (HTML
+          // omits </li>/<p>/<td> freely). Re-evaluate this sibling: it is only
+          // dropped when it is hidden in its own right.
+          if (!shouldRemoveElement(parsed.name, parsed.attrs)) {
+            output += token;
+          } else {
+            dropStack.push(parsed.name);
+          }
+        } else {
+          dropStack.push(parsed.name);
+        }
       }
       cursor = read.next;
       continue;

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -7,7 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isAsciiWhitespace, isTagNameChar, readTagToken } from "./web-fetch-html-tag.js";
+import { isAsciiWhitespace, readTagToken } from "./web-fetch-html-tag.js";
 
 // Compile property matchers once: this list is checked for every styled element.
 const HIDDEN_STYLE_PATTERNS = (
@@ -119,6 +119,14 @@ function isStyleHidden(style: string): boolean {
   return false;
 }
 
+// HTML attribute names are wider than tag names: framework syntax like
+// `@click` or `(click)` is legal, and stopping at the first such character
+// would abandon the whole attribute list and let a later `hidden`, `class`,
+// or `style` escape visibility filtering.
+function isAttributeNameChar(value: string): boolean {
+  return value !== "" && !isAsciiWhitespace(value) && value !== "/" && value !== "=";
+}
+
 // The fixed visibility attributes share one reader grammar. It walks real
 // attribute names instead of matching the raw attribute text: a substring like
 // "hidden" inside a quoted value (`title="The hidden cost of cloud"`) is part
@@ -134,11 +142,14 @@ function createAttributeReader(attribute: "aria-hidden" | "class" | "hidden" | "
         pos += 1;
       }
       const nameStart = pos;
-      while (pos < attrs.length && isTagNameChar(attrs.charAt(pos))) {
+      while (pos < attrs.length && isAttributeNameChar(attrs.charAt(pos))) {
         pos += 1;
       }
       if (pos === nameStart) {
-        break;
+        // Nothing consumable here (a stray separator): skip it and keep
+        // scanning so later attributes are still classified.
+        pos += 1;
+        continue;
       }
       const name = attrs.slice(nameStart, pos).toLowerCase();
       while (pos < attrs.length && isAsciiWhitespace(attrs.charAt(pos))) {
@@ -222,16 +233,92 @@ function popDroppedElement(dropStack: string[], tagName: string): void {
 // this, a dropped <li>/<p>/<td> swallows the rest of the document.
 const OPTIONALLY_CLOSED_ELEMENTS = new Set(["dd", "dt", "li", "option", "p", "td", "th", "tr"]);
 
+// When one of these container end tags arrives, it implicitly closes the
+// keyed still-open element, because HTML lets those elements omit their end
+// tag and closes them via the container instead.
+const IMPLICIT_CONTAINER_CLOSE = new Map<string, ReadonlySet<string>>([
+  ["dd", new Set(["dl"])],
+  ["dt", new Set(["dl"])],
+  ["li", new Set(["menu", "ol", "ul"])],
+  ["option", new Set(["datalist", "optgroup", "select"])],
+  [
+    "p",
+    new Set([
+      "address",
+      "article",
+      "aside",
+      "blockquote",
+      "body",
+      "details",
+      "dialog",
+      "div",
+      "dl",
+      "fieldset",
+      "figcaption",
+      "figure",
+      "footer",
+      "form",
+      "header",
+      "hgroup",
+      "li",
+      "main",
+      "menu",
+      "nav",
+      "ol",
+      "section",
+      "table",
+      "td",
+      "th",
+      "ul",
+    ]),
+  ],
+  ["td", new Set(["table", "tr"])],
+  ["th", new Set(["table", "tr"])],
+  ["tr", new Set(["table"])],
+]);
+
+// A same-name element reached across an intervening container (a nested <ul>
+// between two <li>s) is a descendant, not a sibling: closing it would release
+// the outer drop region and leak its content. Only implied-end-tag elements
+// (<p>) may sit between true siblings.
+function findSiblingScopeIndex(dropStack: string[], tagName: string): number {
+  for (let index = dropStack.length - 1; index >= 0; index -= 1) {
+    const name = dropStack[index] ?? "";
+    if (name === tagName) {
+      return index;
+    }
+    if (name !== "p") {
+      return -1;
+    }
+  }
+  return -1;
+}
+
 function closeImplicitlyDroppedElement(dropStack: string[], tagName: string): boolean {
   if (!OPTIONALLY_CLOSED_ELEMENTS.has(tagName)) {
     return false;
   }
-  const index = dropStack.lastIndexOf(tagName);
+  const index = findSiblingScopeIndex(dropStack, tagName);
   if (index >= 0) {
     dropStack.length = index;
     return true;
   }
   return false;
+}
+
+// An end tag for an element that was never opened is only trustworthy as a
+// region terminator when it is a container that implicitly closes a still-open
+// dropped element (like </ul> closing an omitted </li>). Any other unmatched
+// closer is stray markup, and releasing the region on it would leak the rest
+// of the hidden subtree.
+function findImplicitContainerCloseIndex(dropStack: string[], tagName: string): number {
+  for (let index = dropStack.length - 1; index >= 0; index -= 1) {
+    const containers = IMPLICIT_CONTAINER_CLOSE.get(dropStack[index] ?? "");
+    if (containers?.has(tagName)) {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function removeMarkedElements(html: string): string {
@@ -278,14 +365,19 @@ function removeMarkedElements(html: string): string {
 
     if (dropStack.length > 0) {
       if (parsed.closing) {
-        if (dropStack.lastIndexOf(parsed.name) < 0) {
-          // The dropped element's own end tag was omitted, so this ancestor end
-          // tag closes the drop region. The ancestor's end tag belongs to the
-          // surviving markup.
-          dropStack.length = 0;
-          output += token;
-        } else {
+        if (dropStack.lastIndexOf(parsed.name) >= 0) {
           popDroppedElement(dropStack, parsed.name);
+        } else {
+          const implicitCloseIndex = findImplicitContainerCloseIndex(dropStack, parsed.name);
+          if (implicitCloseIndex >= 0) {
+            // The dropped element's own end tag was omitted, so this container
+            // end tag closes the drop region. The container's end tag belongs
+            // to the surviving markup.
+            dropStack.length = implicitCloseIndex;
+            output += token;
+          }
+          // Otherwise this closer matches nothing still open: stray markup
+          // inside the hidden region stays suppressed.
         }
       } else if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
         if (closeImplicitlyDroppedElement(dropStack, parsed.name)) {

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -7,7 +7,13 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isAsciiWhitespace, readTagToken } from "./web-fetch-html-tag.js";
+import {
+  readRawTextBounds,
+  readRawTextOpenTagName,
+  isAsciiWhitespace,
+  readTagToken,
+  skipHtmlComment,
+} from "./web-fetch-html-tag.js";
 
 // Compile property matchers once: this list is checked for every styled element.
 const HIDDEN_STYLE_PATTERNS = (
@@ -119,19 +125,10 @@ function isStyleHidden(style: string): boolean {
   return false;
 }
 
-// HTML attribute names are wider than tag names: framework syntax like
-// `@click` or `(click)` is legal, and stopping at the first such character
-// would abandon the whole attribute list and let a later `hidden`, `class`,
-// or `style` escape visibility filtering.
-function isAttributeNameChar(value: string): boolean {
-  return value !== "" && !isAsciiWhitespace(value) && value !== "/" && value !== "=";
-}
-
-// The fixed visibility attributes share one reader grammar. It walks real
-// attribute names instead of matching the raw attribute text: a substring like
-// "hidden" inside a quoted value (`title="The hidden cost of cloud"`) is part
-// of a value, not an attribute, and must not flip visibility.
-function createAttributeReader(attribute: "aria-hidden" | "class" | "hidden" | "style" | "type") {
+// Consume complete attributes so quoted values and framework names cannot become visibility names.
+function createAttributeReader(
+  attribute: "aria-hidden" | "class" | "hidden" | "style" | "type" | "encoding",
+) {
   return (attrs: string): string | undefined => {
     let pos = 0;
     while (pos < attrs.length) {
@@ -142,14 +139,20 @@ function createAttributeReader(attribute: "aria-hidden" | "class" | "hidden" | "
         pos += 1;
       }
       const nameStart = pos;
-      while (pos < attrs.length && isAttributeNameChar(attrs.charAt(pos))) {
+      // A leading equals sign is part of a malformed name, not a new value boundary.
+      if (attrs.charAt(pos) === "=") {
+        pos += 1;
+      }
+      while (
+        pos < attrs.length &&
+        !isAsciiWhitespace(attrs.charAt(pos)) &&
+        attrs.charAt(pos) !== "/" &&
+        attrs.charAt(pos) !== "="
+      ) {
         pos += 1;
       }
       if (pos === nameStart) {
-        // Nothing consumable here (a stray separator): skip it and keep
-        // scanning so later attributes are still classified.
-        pos += 1;
-        continue;
+        break;
       }
       const name = attrs.slice(nameStart, pos).toLowerCase();
       while (pos < attrs.length && isAsciiWhitespace(attrs.charAt(pos))) {
@@ -188,6 +191,7 @@ const readAriaHidden = createAttributeReader("aria-hidden");
 const readHidden = createAttributeReader("hidden");
 const readClass = createAttributeReader("class");
 const readStyle = createAttributeReader("style");
+const readEncoding = createAttributeReader("encoding");
 
 function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
   const tagName = normalizeLowercaseStringOrEmpty(tagNameRaw);
@@ -221,133 +225,395 @@ function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
   return false;
 }
 
-function popDroppedElement(dropStack: string[], tagName: string): void {
-  const index = dropStack.lastIndexOf(tagName);
-  if (index >= 0) {
-    dropStack.length = index;
-  }
-}
-
-// These elements may legally omit their end tag, and HTML closes a dropped one
-// implicitly when the same-name sibling or an ancestor end tag arrives. Without
-// this, a dropped <li>/<p>/<td> swallows the rest of the document.
-const OPTIONALLY_CLOSED_ELEMENTS = new Set(["dd", "dt", "li", "option", "p", "td", "th", "tr"]);
-
-// When one of these container end tags arrives, it implicitly closes the
-// keyed still-open element, because HTML lets those elements omit their end
-// tag and closes them via the container instead.
-const IMPLICIT_CONTAINER_CLOSE = new Map<string, ReadonlySet<string>>([
-  ["dd", new Set(["dl"])],
-  ["dt", new Set(["dl"])],
-  ["li", new Set(["menu", "ol", "ul"])],
-  ["option", new Set(["datalist", "optgroup", "select"])],
-  [
-    "p",
-    new Set([
-      "address",
-      "article",
-      "aside",
-      "blockquote",
-      "body",
-      "details",
-      "dialog",
-      "div",
-      "dl",
-      "fieldset",
-      "figcaption",
-      "figure",
-      "footer",
-      "form",
-      "header",
-      "hgroup",
-      "li",
-      "main",
-      "menu",
-      "nav",
-      "ol",
-      "section",
-      "table",
-      "td",
-      "th",
-      "ul",
-    ]),
-  ],
-  ["td", new Set(["table", "tr"])],
-  ["th", new Set(["table", "tr"])],
-  ["tr", new Set(["table"])],
+const LIST_CONTAINERS = new Set(["ul", "ol", "menu"]);
+const OPAQUE_TEXT_ELEMENTS = new Set([
+  "script",
+  "style",
+  "noscript",
+  "textarea",
+  "title",
+  "xmp",
+  "iframe",
+  "noembed",
+  "noframes",
+  "plaintext",
+]);
+const MATH_TEXT_INTEGRATION_POINTS = new Set(["mi", "mo", "mn", "ms", "mtext"]);
+const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"]);
+// HTML's li start-tag rule stops at special elements other than address, div, and p.
+// Foreign-content containers also retain scope; void elements never enter the stack.
+const LIST_ITEM_BOUNDARIES = new Set([
+  "applet",
+  "article",
+  "aside",
+  "blockquote",
+  "body",
+  "button",
+  "caption",
+  "center",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "html",
+  "iframe",
+  "listing",
+  "main",
+  "marquee",
+  "math",
+  "menu",
+  "nav",
+  "noembed",
+  "noframes",
+  "noscript",
+  "object",
+  "ol",
+  "plaintext",
+  "pre",
+  "script",
+  "search",
+  "section",
+  "select",
+  "style",
+  "summary",
+  "svg",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "tr",
+  "ul",
+  "xmp",
 ]);
 
-// A same-name element reached across an intervening container (a nested <ul>
-// between two <li>s) is a descendant, not a sibling: closing it would release
-// the outer drop region and leak its content. Only implied-end-tag elements
-// (<p>) may sit between true siblings.
-function findSiblingScopeIndex(dropStack: string[], tagName: string): number {
-  for (let index = dropStack.length - 1; index >= 0; index -= 1) {
-    const name = dropStack[index] ?? "";
-    if (name === tagName) {
-      return index;
-    }
-    if (name !== "p") {
-      return -1;
-    }
-  }
-  return -1;
-}
+const DEFINITION_ITEMS = new Set(["dt", "dd"]);
+const LIST_ITEMS = new Set(["li"]);
+const DEFINITION_CONTAINERS = new Set(["dl"]);
+const PARAGRAPH_CLOSE_START = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "dd",
+  "details",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hgroup",
+  "hr",
+  "li",
+  "listing",
+  "main",
+  "menu",
+  "nav",
+  "ol",
+  "p",
+  "plaintext",
+  "pre",
+  "search",
+  "section",
+  "table",
+  "ul",
+  "xmp",
+]);
+const BUTTON_SCOPE_BOUNDARIES = new Set([
+  "applet",
+  "button",
+  "caption",
+  "html",
+  "marquee",
+  "math",
+  "object",
+  "svg",
+  "table",
+  "td",
+  "template",
+  "th",
+]);
+const TABLE_SCOPE_BOUNDARIES = new Set(["html", "math", "svg", "table", "template"]);
+const PARAGRAPH_REQUIRED_END_PARENTS = new Set([
+  "a",
+  "audio",
+  "del",
+  "ins",
+  "map",
+  "noscript",
+  "video",
+]);
+const ROW_GROUPS = new Set(["tbody", "thead", "tfoot"]);
 
-function closeImplicitlyDroppedElement(dropStack: string[], tagName: string): boolean {
-  if (!OPTIONALLY_CLOSED_ELEMENTS.has(tagName)) {
-    return false;
-  }
-  const index = findSiblingScopeIndex(dropStack, tagName);
-  if (index >= 0) {
-    dropStack.length = index;
-    return true;
-  }
-  return false;
-}
-
-// An end tag for an element that was never opened is only trustworthy as a
-// region terminator when it is a container that implicitly closes a still-open
-// dropped element (like </ul> closing an omitted </li>). Any other unmatched
-// closer is stray markup, and releasing the region on it would leak the rest
-// of the hidden subtree.
-function findImplicitContainerCloseIndex(dropStack: string[], tagName: string): number {
-  for (let index = dropStack.length - 1; index >= 0; index -= 1) {
-    const containers = IMPLICIT_CONTAINER_CLOSE.get(dropStack[index] ?? "");
-    if (containers?.has(tagName)) {
-      return index;
-    }
-  }
-  return -1;
-}
+type OpenElement = {
+  name: string;
+  previousSameName: number | undefined;
+  special: number;
+  buttonBoundary: number;
+  tableBoundary: number;
+  selectOwner: number;
+  namespace: "html" | "math" | "svg";
+  childNamespace: "html" | "math" | "svg";
+};
 
 function removeMarkedElements(html: string): string {
   let output = "";
   let cursor = 0;
-  const dropStack: string[] = [];
+  // Scope facts belong to each open frame and restore when it closes. Indexed names
+  // avoid rescanning unchanged ancestry for malformed closers or repeated siblings.
+  const elements: OpenElement[] = [
+    {
+      name: "",
+      previousSameName: undefined,
+      special: 0,
+      buttonBoundary: 0,
+      tableBoundary: 0,
+      selectOwner: -1,
+      namespace: "html",
+      childNamespace: "html",
+    },
+  ];
+  const positions = new Map<string, number>();
+  let hiddenRoot = -1;
+
+  function closeElements(index: number): void {
+    while (elements.length > index) {
+      const element = elements.pop()!;
+      if (element.previousSameName === undefined) {
+        positions.delete(element.name);
+      } else {
+        positions.set(element.name, element.previousSameName);
+      }
+    }
+  }
+
+  function closeOptionalElement(index: number): void {
+    // Recovery cannot close a genuinely unclosed, non-optional hidden descendant.
+    if (
+      index > 0 &&
+      elements[index]!.namespace === "html" &&
+      (hiddenRoot < 0 || hiddenRoot <= index)
+    ) {
+      closeElements(index);
+      if (hiddenRoot === index) {
+        hiddenRoot = -1;
+      }
+    }
+  }
+
+  function lastOpen(names: readonly string[]): number {
+    let index = -1;
+    for (const name of names) {
+      const position = positions.get(name);
+      if (position !== undefined && position > index) {
+        index = position;
+      }
+    }
+    return index;
+  }
+
+  function scopedItem(items: Set<string>, owners: Set<string>): number {
+    const index = elements.at(-1)!.special;
+    if (index > 0 && items.has(elements[index]!.name)) {
+      const owner = elements[index - 1]!.special;
+      if (owners.has(elements[owner]!.name)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  function paragraph(): number {
+    const index = positions.get("p");
+    return index !== undefined && index > elements.at(-1)!.buttonBoundary ? index : -1;
+  }
+
+  function tableScope() {
+    const table = elements.at(-1)!.tableBoundary;
+    const owner = elements[table]!.name === "table" ? table : -1;
+    const group = lastOpen(["tbody", "thead", "tfoot"]);
+    const row = lastOpen(["tr"]);
+    const cell = lastOpen(["td", "th"]);
+    return {
+      owner,
+      group: owner >= 0 && group > owner ? group : owner,
+      row: owner >= 0 && row > owner ? row : -1,
+      cell: owner >= 0 && row > owner && cell > row ? cell : -1,
+    };
+  }
+
+  function optionScope() {
+    const owner = elements.at(-1)!.selectOwner;
+    const group = lastOpen(["optgroup"]);
+    const option = lastOpen(["option"]);
+    return {
+      owner,
+      group: owner >= 0 && group > owner ? group : -1,
+      option: owner >= 0 && option > owner ? option : -1,
+    };
+  }
+
+  function closesOptionalElement(element: number, index: number): boolean {
+    if (element <= 0 || index >= element || elements[element]!.namespace !== "html") {
+      return false;
+    }
+    const name = elements[element]!.name;
+    if (name === "li" || DEFINITION_ITEMS.has(name)) {
+      const item =
+        name === "li"
+          ? scopedItem(LIST_ITEMS, LIST_CONTAINERS)
+          : scopedItem(DEFINITION_ITEMS, DEFINITION_CONTAINERS);
+      return item === element && elements[element - 1]!.special === index;
+    }
+    if (name === "p") {
+      const parent = elements[element - 1]!.name;
+      return (
+        paragraph() === element &&
+        !PARAGRAPH_REQUIRED_END_PARENTS.has(parent) &&
+        !parent.includes("-") &&
+        (index === element - 1 || closesOptionalElement(element - 1, index))
+      );
+    }
+    if (name === "td" || name === "th" || name === "tr" || ROW_GROUPS.has(name)) {
+      const scope = tableScope();
+      if (name === "td" || name === "th") {
+        return scope.cell === element && [scope.row, scope.group, scope.owner].includes(index);
+      }
+      if (name === "tr") {
+        return scope.row === element && [scope.group, scope.owner].includes(index);
+      }
+      return scope.group === element && index === scope.owner;
+    }
+    if (name === "option" || name === "optgroup") {
+      const scope = optionScope();
+      return name === "option"
+        ? scope.option === element && [scope.group, scope.owner].includes(index)
+        : scope.group === element && index === scope.owner;
+    }
+    return false;
+  }
+
+  function closeForStart(name: string): void {
+    if (PARAGRAPH_CLOSE_START.has(name)) {
+      closeOptionalElement(paragraph());
+    }
+    if (name === "li") {
+      closeOptionalElement(scopedItem(LIST_ITEMS, LIST_CONTAINERS));
+    } else if (DEFINITION_ITEMS.has(name)) {
+      closeOptionalElement(scopedItem(DEFINITION_ITEMS, DEFINITION_CONTAINERS));
+    } else if (name === "td" || name === "th" || name === "tr" || ROW_GROUPS.has(name)) {
+      if (tableScope().cell > 0) {
+        closeOptionalElement(paragraph());
+      }
+      closeOptionalElement(tableScope().cell);
+      if (name === "tr" || ROW_GROUPS.has(name)) {
+        closeOptionalElement(tableScope().row);
+      }
+      if (ROW_GROUPS.has(name)) {
+        const scope = tableScope();
+        if (scope.group > scope.owner) {
+          closeOptionalElement(scope.group);
+        }
+      }
+    } else if (name === "option" || name === "optgroup") {
+      const scope = optionScope();
+      const inSelect = scope.owner >= 0 && elements[scope.owner]!.name === "select";
+      // Body-mode datalist parsing only closes an option that is the current node.
+      if (inSelect || elements.at(-1)!.name === "option") {
+        closeOptionalElement(scope.option);
+      }
+      if (name === "optgroup" && inSelect) {
+        closeOptionalElement(scope.group);
+      }
+    }
+  }
+
+  function openElement(name: string, attrs: string, namespace: OpenElement["namespace"]): void {
+    const parent = elements.at(-1)!;
+    const index = elements.length;
+    const foreign = name === "math" || name === "svg";
+    const encoding =
+      namespace === "math" && name === "annotation-xml"
+        ? readEncoding(attrs)?.toLowerCase()
+        : undefined;
+    const htmlChildren =
+      (namespace === "math" &&
+        (MATH_TEXT_INTEGRATION_POINTS.has(name) ||
+          encoding === "text/html" ||
+          encoding === "application/xhtml+xml")) ||
+      (namespace === "svg" && SVG_HTML_INTEGRATION_POINTS.has(name));
+    elements.push({
+      name,
+      previousSameName: positions.get(name),
+      special: name === "li" || LIST_ITEM_BOUNDARIES.has(name) ? index : parent.special,
+      buttonBoundary: BUTTON_SCOPE_BOUNDARIES.has(name) ? index : parent.buttonBoundary,
+      tableBoundary: TABLE_SCOPE_BOUNDARIES.has(name) ? index : parent.tableBoundary,
+      selectOwner:
+        name === "select" || name === "datalist"
+          ? index
+          : foreign || name === "html" || name === "template"
+            ? -1
+            : parent.selectOwner,
+      namespace,
+      childNamespace: htmlChildren ? "html" : namespace,
+    });
+    positions.set(name, index);
+  }
 
   while (cursor < html.length) {
     const tagStart = html.indexOf("<", cursor);
     if (tagStart < 0) {
-      if (dropStack.length === 0) {
+      if (hiddenRoot < 0) {
         output += html.slice(cursor);
       }
       break;
     }
 
-    if (dropStack.length === 0) {
+    if (hiddenRoot < 0) {
       output += html.slice(cursor, tagStart);
     }
 
     if (html.startsWith("<!--", tagStart)) {
-      const commentEnd = html.indexOf("-->", tagStart + 4);
-      cursor = commentEnd < 0 ? html.length : commentEnd + 3;
+      cursor = skipHtmlComment(html, tagStart);
       continue;
     }
 
     const read = readTagToken(html, tagStart, "visibility");
     if (!read) {
-      if (dropStack.length === 0) {
+      if (hiddenRoot < 0) {
         output += html.slice(tagStart);
       }
       break;
@@ -356,55 +622,78 @@ function removeMarkedElements(html: string): string {
     const token = html.slice(tagStart, read.next);
     const parsed = read.token;
     if (!parsed) {
-      if (dropStack.length === 0) {
+      if (hiddenRoot < 0) {
         output += token;
       }
       cursor = read.next;
       continue;
     }
 
-    if (dropStack.length > 0) {
-      if (parsed.closing) {
-        if (dropStack.lastIndexOf(parsed.name) >= 0) {
-          popDroppedElement(dropStack, parsed.name);
-        } else {
-          const implicitCloseIndex = findImplicitContainerCloseIndex(dropStack, parsed.name);
-          if (implicitCloseIndex >= 0) {
-            // The dropped element's own end tag was omitted, so this container
-            // end tag closes the drop region. The container's end tag belongs
-            // to the surviving markup.
-            dropStack.length = implicitCloseIndex;
-            output += token;
-          }
-          // Otherwise this closer matches nothing still open: stray markup
-          // inside the hidden region stays suppressed.
-        }
-      } else if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
-        if (closeImplicitlyDroppedElement(dropStack, parsed.name)) {
-          // A same-name sibling implicitly closed the dropped element (HTML
-          // omits </li>/<p>/<td> freely). Re-evaluate this sibling: it is only
-          // dropped when it is hidden in its own right.
-          if (!shouldRemoveElement(parsed.name, parsed.attrs)) {
-            output += token;
-          } else {
-            dropStack.push(parsed.name);
-          }
-        } else {
-          dropStack.push(parsed.name);
-        }
+    const parent = elements.at(-1)!;
+    let namespace = parent.childNamespace;
+    if (
+      parent.namespace === "math" &&
+      MATH_TEXT_INTEGRATION_POINTS.has(parent.name) &&
+      (parsed.name === "mglyph" || parsed.name === "malignmark")
+    ) {
+      namespace = "math";
+    } else if (namespace === "html" && (parsed.name === "math" || parsed.name === "svg")) {
+      namespace = parsed.name;
+    }
+    if (
+      !parsed.closing &&
+      namespace === "html" &&
+      OPAQUE_TEXT_ELEMENTS.has(parsed.name) &&
+      readRawTextOpenTagName(html, tagStart, OPAQUE_TEXT_ELEMENTS) === parsed.name
+    ) {
+      closeForStart(parsed.name);
+      const bounds =
+        parsed.name === "plaintext"
+          ? { contentEnd: html.length, end: html.length }
+          : readRawTextBounds(html, parsed.name, read.next, "visibility");
+      if (hiddenRoot < 0 && !shouldRemoveElement(parsed.name, parsed.attrs)) {
+        // Readability's DOM parser does not recognize double-escaped script data.
+        // Empty comments preserve token boundaries without retaining their hidden text.
+        output +=
+          parsed.name === "script"
+            ? token +
+              html
+                .slice(read.next, bounds.contentEnd)
+                .replace(/<!--[\s\S]*?(?:-->|$)/g, "<!---->") +
+              html.slice(bounds.contentEnd, bounds.end)
+            : html.slice(tagStart, bounds.end);
       }
-      cursor = read.next;
+      cursor = bounds.end;
       continue;
     }
 
     if (parsed.closing) {
-      output += token;
-    } else if (shouldRemoveElement(parsed.name, parsed.attrs)) {
-      if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
-        dropStack.push(parsed.name);
+      const index = positions.get(parsed.name);
+      const visible = hiddenRoot < 0;
+      const closesHiddenOptional = index !== undefined && closesOptionalElement(hiddenRoot, index);
+      if (index !== undefined && (visible || index >= hiddenRoot || closesHiddenOptional)) {
+        closeElements(index);
+        if (hiddenRoot >= index) {
+          hiddenRoot = -1;
+        }
+      }
+      if (visible || closesHiddenOptional) {
+        output += token;
       }
     } else {
-      output += token;
+      if (namespace === "html") {
+        closeForStart(parsed.name);
+      }
+      const hidden = hiddenRoot >= 0 || shouldRemoveElement(parsed.name, parsed.attrs);
+      if (!hidden) {
+        output += token;
+      }
+      if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
+        if (hidden && hiddenRoot < 0) {
+          hiddenRoot = elements.length;
+        }
+        openElement(parsed.name, parsed.attrs, namespace);
+      }
     }
     cursor = read.next;
   }


### PR DESCRIPTION
Closes #144150.

## What Problem This Solves

`web_fetch` can discard an article when an ordinary attribute value contains “hidden”, or when a hidden list item, paragraph, table cell, definition item, or option omits its legal ending. Related malformed comment and script boundaries can also swallow later visible text.

## Why This Change Was Made

Read complete attribute names and values, and keep hidden state with the actual open-element scope. Nested descendants and unmatched closing tags cannot release a hidden ancestor. The shared scanner keeps script text opaque, preserves complete tag names and closing tokens, and handles comment endings consistently before both extraction routes.

The indexed element stack avoids repeated full-depth searches on malformed pages. No parser dependency or network-access policy is added.

## User Impact

Visible articles and siblings survive harmless attribute values, legal omitted endings, and the tested malformed boundaries. Real hidden attributes, classes, styles, script data and comment contents remain excluded. Readability, basic extraction and JSON-LD titles retain their applicable behavior.

## Evidence

- Paired public agent commands invoked production `web_fetch` against hosted HTML and captured the subsequent provider requests. Main loses the original article/list inputs; corrected results retain their visible text and exclude hidden controls.
- 253 focused sanitizer, renderer, Readability, real HTTP tool, output-contract and provider-fallback tests pass. Ordinary lint and repository guards pass. Full types remain with hosted CI.
- Affected public runs pass the reported boundaries across basic and Readability extraction, text/Markdown, script delimiters, quoted closing tags, recovered comments and title metadata. Further checks preserve complete tag identities across scope, Unicode and void-element decisions. The latest seven checks retain visible content inside ordinary non-ASCII names while excluding hidden descendants; the prior 38-check matrix covers the complete-name scope cutover. All earlier failed inputs remain in the retained review evidence.
- Independent source/security review has no actionable findings. Source-blind acceptance confirms the original behaviors and repaired comment/tag boundaries, including actual basic fallback, inner visible content, raw-text controls, both modes and structured titles. The latest independent passes add 15 cases for complete names and visible children, including six actual basic-fallback results.
- Measured malformed-input comparison: a 700 KB unmatched-closer input exceeded 15 seconds in an earlier candidate; the complete-name candidate completed in 36–67 ms (main: 30–45 ms). A 640 KB deep-list input fell from about 2 seconds to 25–48 ms (main: 12–27 ms). Limits and assertions were not raised.

The separate `maxChars: 180` closing-wrapper truncation also occurs on main with plain visible HTML. Its output owner is unchanged; this PR does not claim to fix it.

Contributor ancestry and credit from @ruel225 are preserved.
