### PR TITLE
refactor: reuse account setup in Twilio send tests

### DIFF
--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -289,21 +289,9 @@ describe("Twilio SMS helpers", () => {
 
     await expect(
       sendSmsViaTwilio({
-        account: {
-          accountId: "default",
-          enabled: true,
-          accountSid: "AC123",
-          authToken: "secret",
-          fromNumber: "+15557654321",
-          messagingServiceSid: "",
-          defaultTo: "",
-          webhookPath: "/webhooks/sms",
+        account: createAccount({
           publicWebhookUrl: "https://gateway.example.com/webhooks/sms#rp=4xx",
-          dangerouslyDisableSignatureValidation: false,
-          dmPolicy: "pairing",
-          allowFrom: [],
-          textChunkLimit: 1500,
-        },
+        }),
         to: "+15551234567",
         text: "hello",
         fetchImpl,
@@ -723,21 +711,7 @@ describe("Twilio SMS helpers", () => {
     );
 
     await sendSmsViaTwilio({
-      account: {
-        accountId: "default",
-        enabled: true,
-        accountSid: "AC123",
-        authToken: "secret",
-        fromNumber: "",
-        messagingServiceSid: "MG123",
-        defaultTo: "",
-        webhookPath: "/webhooks/sms",
-        publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
-        dangerouslyDisableSignatureValidation: false,
-        dmPolicy: "pairing",
-        allowFrom: [],
-        textChunkLimit: 1500,
-      },
+      account: createAccount({ fromNumber: "", messagingServiceSid: "MG123" }),
       to: "+15551234567",
       text: "hello",
       fetchImpl,
@@ -763,21 +737,7 @@ describe("Twilio SMS helpers", () => {
     );
 
     await sendSmsViaTwilio({
-      account: {
-        accountId: "default",
-        enabled: true,
-        accountSid: "AC123",
-        authToken: "secret",
-        fromNumber: "+15557654321",
-        messagingServiceSid: "MG123",
-        defaultTo: "",
-        webhookPath: "/webhooks/sms",
-        publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
-        dangerouslyDisableSignatureValidation: false,
-        dmPolicy: "pairing",
-        allowFrom: [],
-        textChunkLimit: 1500,
-      },
+      account: createAccount({ fromNumber: "+15557654321", messagingServiceSid: "MG123" }),
       to: "+15551234567",
       text: "hello",
       fetchImpl,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three Twilio send tests repeat complete account fixtures despite an existing local account helper, obscuring the few sender and callback settings that distinguish each case.

## Why This Change Was Made

Reuse the existing helper at those three sites. Keep both sender fields explicit in sender-choice cases and retain the callback URL's existing retry-policy fragment. Send options, mock fetch functions, response timing, and all expected outputs remain unchanged.

## User Impact

No production behavior change. This removes 40 net test lines while retaining all existing SMS test cases and assertions.

## Evidence

The complete existing Twilio test file passed before and after: 68 cases in identical order, zero failures or skips. Reconstructing the original three literals yields the exact original file. All 13 ordered account fields match, and the unchanged helper produces distinct accounts and allowlist arrays for each call.

Only the existing mocked transport suite ran; no live SMS or Twilio API calls were made. This cleanup does not claim a measured runtime improvement.

The mapped changed-file gate passed, including extension-test typechecking, lint, formatting and guards. Fresh independent review found no actionable P0–P2 findings.
