### PR TITLE
refactor(macos): share connect credential selection

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -300,8 +300,16 @@ func resolveGatewayEndpoint(opts: ConnectOptions, config: GatewayConfig) throws 
     }
     return GatewayEndpoint(
         url: url,
-        token: resolvedToken(opts: opts, mode: resolvedMode, config: config),
-        password: resolvedPassword(opts: opts, mode: resolvedMode, config: config),
+        token: resolvedCredential(
+            opts.token,
+            mode: resolvedMode,
+            local: config.token,
+            remote: config.remoteToken),
+        password: resolvedCredential(
+            opts.password,
+            mode: resolvedMode,
+            local: config.password,
+            remote: config.remotePassword),
         mode: resolvedMode)
 }
 
@@ -321,45 +329,31 @@ private func gatewayEndpoint(
     }
     return GatewayEndpoint(
         url: url,
-        token: resolvedToken(
-            opts: opts,
+        token: resolvedCredential(
+            opts.token,
             mode: mode,
-            config: config,
+            local: config.token,
+            remote: config.remoteToken,
             inheritConfigCredentials: inheritConfigCredentials),
-        password: resolvedPassword(
-            opts: opts,
+        password: resolvedCredential(
+            opts.password,
             mode: mode,
-            config: config,
+            local: config.password,
+            remote: config.remotePassword,
             inheritConfigCredentials: inheritConfigCredentials),
         mode: mode)
 }
 
-private func resolvedToken(
-    opts: ConnectOptions,
+private func resolvedCredential(
+    _ explicit: String?,
     mode: String,
-    config: GatewayConfig,
+    local: String?,
+    remote: String?,
     inheritConfigCredentials: Bool = true) -> String?
 {
-    if let token = opts.token, !token.isEmpty { return token }
+    if let explicit, !explicit.isEmpty { return explicit }
     guard inheritConfigCredentials else { return nil }
-    if mode == "remote" {
-        return config.remoteToken
-    }
-    return config.token
-}
-
-private func resolvedPassword(
-    opts: ConnectOptions,
-    mode: String,
-    config: GatewayConfig,
-    inheritConfigCredentials: Bool = true) -> String?
-{
-    if let password = opts.password, !password.isEmpty { return password }
-    guard inheritConfigCredentials else { return nil }
-    if mode == "remote" {
-        return config.remotePassword
-    }
-    return config.password
+    return mode == "remote" ? remote : local
 }
 
 func makeGatewayConnectOptions(

--- a/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
@@ -25,6 +25,61 @@ private final class CLIConnectAuthRecorder: @unchecked Sendable {
 
 @Suite(.serialized)
 struct ConnectCommandTests {
+    @Test func `endpoint credentials preserve mode selection and explicit overrides`() throws {
+        typealias Credentials = (token: String?, password: String?)
+        let local: Credentials = ("local-token", "local-password")
+        let remote: Credentials = ("remote-token", "remote-password")
+        let whitespace: Credentials = (" \t ", "\n ")
+        let cases: [(
+            name: String,
+            args: [String],
+            configMode: String?,
+            local: Credentials,
+            remote: Credentials,
+            expected: Credentials)] = [
+            ("default local", [], nil, local, remote, local),
+            ("config remote", [], "remote", local, remote, remote),
+            (
+                "option local and empty explicit values",
+                ["--mode", "local", "--token", "", "--password", ""],
+                "remote", local, remote, local),
+            ("uppercase option remote", ["--mode", "REMOTE"], "local", local, remote, remote),
+            ("padded option is local", ["--mode", " remote "], "remote", local, remote, local),
+            (
+                "explicit token only", ["--token", " explicit-token "],
+                nil, local, remote, (" explicit-token ", local.password)),
+            (
+                "explicit whitespace password only", ["--password", " \t "],
+                "remote", local, remote, (remote.token, " \t ")),
+            ("local nil and empty", [], nil, (nil, ""), remote, (nil, "")),
+            ("remote empty and nil", [], "remote", local, ("", nil), ("", nil)),
+            ("local whitespace", [], nil, whitespace, remote, whitespace),
+            ("remote whitespace", [], "remote", local, whitespace, whitespace),
+            (
+                "explicit URL isolates empty token", [
+                    "--url", "wss://gateway.example.test", "--token", "", "--password", " \t ",
+                ],
+                "remote", local, remote, (nil, " \t ")),
+        ]
+
+        for testCase in cases {
+            var config = GatewayConfig()
+            config.mode = testCase.configMode
+            config.remoteUrl = "wss://remote.example.test"
+            config.token = testCase.local.token
+            config.password = testCase.local.password
+            config.remoteToken = testCase.remote.token
+            config.remotePassword = testCase.remote.password
+
+            let endpoint = try resolveGatewayEndpoint(
+                opts: ConnectOptions.parse(testCase.args),
+                config: config)
+
+            #expect(endpoint.token == testCase.expected.token, "\(testCase.name)")
+            #expect(endpoint.password == testCase.expected.password, "\(testCase.name)")
+        }
+    }
+
     @Test func `explicit URL never inherits config credentials`() throws {
         var config = GatewayConfig()
         config.mode = "remote"

--- a/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
@@ -32,33 +32,32 @@ struct ConnectCommandTests {
         let whitespace: Credentials = (" \t ", "\n ")
         let cases: [(
             name: String,
-            args: [String],
+            opts: ConnectOptions,
             configMode: String?,
             local: Credentials,
             remote: Credentials,
             expected: Credentials)] = [
-            ("default local", [], nil, local, remote, local),
-            ("config remote", [], "remote", local, remote, remote),
+            ("default local", .init(), nil, local, remote, local),
+            ("config remote", .init(), "remote", local, remote, remote),
             (
                 "option local and empty explicit values",
-                ["--mode", "local", "--token", "", "--password", ""],
+                .init(token: "", password: "", mode: "local"),
                 "remote", local, remote, local),
-            ("uppercase option remote", ["--mode", "REMOTE"], "local", local, remote, remote),
-            ("padded option is local", ["--mode", " remote "], "remote", local, remote, local),
+            ("uppercase option remote", .init(mode: "REMOTE"), "local", local, remote, remote),
+            ("padded option is local", .init(mode: " remote "), "remote", local, remote, local),
             (
-                "explicit token only", ["--token", " explicit-token "],
+                "explicit token only", .init(token: " explicit-token "),
                 nil, local, remote, (" explicit-token ", local.password)),
             (
-                "explicit whitespace password only", ["--password", " \t "],
+                "explicit whitespace password only", .init(password: " \t "),
                 "remote", local, remote, (remote.token, " \t ")),
-            ("local nil and empty", [], nil, (nil, ""), remote, (nil, "")),
-            ("remote empty and nil", [], "remote", local, ("", nil), ("", nil)),
-            ("local whitespace", [], nil, whitespace, remote, whitespace),
-            ("remote whitespace", [], "remote", local, whitespace, whitespace),
+            ("local nil and empty", .init(), nil, (nil, ""), remote, (nil, "")),
+            ("remote empty and nil", .init(), "remote", local, ("", nil), ("", nil)),
+            ("local whitespace", .init(), nil, whitespace, remote, whitespace),
+            ("remote whitespace", .init(), "remote", local, whitespace, whitespace),
             (
-                "explicit URL isolates empty token", [
-                    "--url", "wss://gateway.example.test", "--token", "", "--password", " \t ",
-                ],
+                "explicit URL isolates empty token",
+                .init(url: "wss://gateway.example.test", token: "", password: " \t "),
                 "remote", local, remote, (nil, " \t ")),
         ]
 
@@ -72,7 +71,7 @@ struct ConnectCommandTests {
             config.remotePassword = testCase.remote.password
 
             let endpoint = try resolveGatewayEndpoint(
-                opts: ConnectOptions.parse(testCase.args),
+                opts: testCase.opts,
                 config: config)
 
             #expect(endpoint.token == testCase.expected.token, "\(testCase.name)")


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

The macOS connect CLI maintains separate token and password selectors with identical precedence rules. This maintainer-requested consolidation keeps that credential-selection contract in one private implementation so the two fields cannot drift independently.

This is a behavior-preserving refactor, not a claim that current credential selection is broken.

## Why This Change Was Made

Replace the two selectors with one private `resolvedCredential` helper and update the four existing call sites. Preserve nonempty explicit values first, the config-inheritance guard, and exact remote-versus-local selection.

At the `resolveGatewayEndpoint` boundary, raw `ConnectOptions` and stored config credential values retain their existing byte-preserving selection behavior, independently for each field and without cross-mode fallback. The existing CLI parser trims argument values before this boundary and is unchanged; this is not a claim that CLI flags preserve whitespace.

The PR includes the corrected characterization table and the private helper consolidation. No new exports, configuration, SDK surface, credential sources, device-auth behavior, or Keychain behavior are introduced.

## User Impact

No user-visible behavior change. Explicit URLs continue to reject inherited config credentials, and existing stored-device-auth route isolation remains unchanged.

## Evidence

- One 12-row table directly constructs `ConnectOptions` and calls `resolveGatewayEndpoint`, asserting both credential fields. The five existing tests remain unchanged.
- Covers default/config/option mode precedence, uppercase and padded raw modes, nil/empty explicit values, verbatim resolver credential values, selected nil/empty/whitespace config values, asymmetric overrides, and explicit-URL isolation.
- The [initial baseline macOS run](https://github.com/openclaw/openclaw/actions/runs/34505644314/job/102967295892) compiled the tests but reported five failed assertions across four new table rows. All five original tests passed. The fixture incorrectly passed raw-value expectations through the trimming CLI parser; the correction supplies raw options directly and preserves all 12 expectations. This was a test-fixture failure, not a demonstrated production defect.
- Corrected test-only baseline `3251632d17c4052001e76ff3dd9f459cd4dea3b9` passed [hosted macOS tests on attempt 2](https://github.com/openclaw/openclaw/actions/runs/34509041186/job/102988729502): the full 12-row table and all five retained tests passed. Native default/profile partitions passed with 2,131 and 2 tests respectively; the full CI run is green.
- [Attempt 1 of that corrected baseline](https://github.com/openclaw/openclaw/actions/runs/34509041186/job/102978528617) failed before reaching the endpoint suite: an unchanged OpenClawKit session-switch test asserted transient nil across separate main-actor calls. One targeted same-head rerun passed without source changes. That unrelated timing-sensitive test is not claimed as repaired.
- Local Swift parsing and `git diff --check` passed. Fresh independent review with parser and config source context found no actionable issues through P2. No Swift tests were run on an operator desktop.
- The corrected baseline passed the pinned SwiftFormat 0.63.0 and SwiftLint 0.65.1 CI gates. Those wrappers cover source paths, not `ConnectCommandTests.swift`; direct formatter proof for that test file remains unrun.
- Candidate `752a6831c7d6be5a024d9f4cabee8c39b962aa76` contains the identical corrected test blob. Its [macOS job](https://github.com/openclaw/openclaw/actions/runs/34515754993/job/103000960317), including the Swift test step, and [required CI gate](https://github.com/openclaw/openclaw/actions/runs/34515754993/job/103010991106) passed; the full run is green. Candidate log downloads timed out without an artifact, so individual candidate test counts are not claimed or copied from baseline.
- The [exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/144214#issuecomment-5622501269) found no actionable defects and confirmed the earlier fixture finding is resolved.
- Baseline and candidate have passing hosted native CI with the same characterization table. This is PASS/PASS characterization, not a RED/GREEN production bug claim.

## Main Alignment And Current Qualification

- The successes above are historical proof for the original candidate `752a6831c7d6be5a024d9f4cabee8c39b962aa76`. Its later [CI refresh](https://github.com/openclaw/openclaw/actions/runs/34754947536) failed with UI dependency skew, a Gateway yield fixture failure, and an SDK reporter OOM at the unchanged 6144 MiB limit. All four Swift steps passed in that refresh; the overall run remains failed.
- Current head `865de03cbbb7285f6528e93744bc4e454dafc903` is a signed ordinary merge with ordered parents `752a6831c7d6be5a024d9f4cabee8c39b962aa76` and captured main `2d87daf04b78992382299d552f15ac84a86a23ed`. Both reviewed candidate blobs and the exact original two-file delta are preserved.
- The incorporated main includes the admitted dependency/routing corrections, merged canonical [PR #147028](https://github.com/openclaw/openclaw/pull/147028), and the later writer-context correction. This is not a claim that all prior failures are resolved; the SDK OOM cause remains unexplained.
- [Automatic exact-new-head CI](https://github.com/openclaw/openclaw/actions/runs/34774287786) passed for `865de03cbbb7285f6528e93744bc4e454dafc903`. The current Swift-scoped qualification does not exercise the previously failing SDK reporter or establish an OOM repair. [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/34774287871) is qualified separately by the native landing gates. The [canonical exact-head review](https://github.com/openclaw/openclaw/pull/144214#issuecomment-5622501269), completed September 13, 2026 at 18:29:07 UTC, reports no actionable correctness or security findings and no before-merge requests.
- No new local runtime proof, live Gateway/Keychain exercise, or full-current-main build is claimed. Historical failures, missing candidate per-test logs, and the direct test-file formatting limitation remain recorded. Native landing requires actual qualifying exact-head checks and review, without larger heaps or skipped gates.
