### PR TITLE
refactor(imessage): remove unused persisted echo mirror

### DIFF
--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -259,7 +259,7 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has(scope, { messageId: "guid-late" })).toBe(true);
   });
 
-  it("drops the in-memory mirror on persisted read failure so expired echoes do not match", () => {
+  it("does not match stale echoes after persisted read failure", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
     const scope = "acct:imessage:+1555";

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -34,7 +34,6 @@ function normalizeMessageId(messageId: string | undefined): string | undefined {
   return normalized;
 }
 
-let mirror: PersistedEchoEntry[] | null = null;
 let persistenceFailureLogged = false;
 function reportFailure(scope: string, err: unknown): void {
   if (persistenceFailureLogged) {
@@ -80,9 +79,9 @@ function isLiveEntry(entry: PersistedEchoEntry, now = Date.now()): boolean {
   return entry.timestamp >= cutoff && (entry.expiresAt == null || entry.expiresAt > now);
 }
 
-function loadMirrorFromStore(): void {
+function readRecentEntries(): PersistedEchoEntry[] {
   try {
-    mirror = openPersistedEchoStore()
+    return openPersistedEchoStore()
       .entries()
       .map(({ value }) => value)
       .filter((entry) => isLiveEntry(entry))
@@ -90,13 +89,8 @@ function loadMirrorFromStore(): void {
       .slice(-IMESSAGE_SENT_ECHOES_MAX_ENTRIES);
   } catch (err) {
     reportFailure("read", err);
-    mirror = [];
+    return [];
   }
-}
-
-function readRecentEntries(): PersistedEchoEntry[] {
-  loadMirrorFromStore();
-  return mirror ?? [];
 }
 
 function persistEntry(entry: PersistedEchoEntry, ttlMs?: number): string | undefined {
@@ -141,12 +135,7 @@ export function rememberPersistedIMessageEcho(params: {
   if (!entry.text && !entry.media && !entry.messageId) {
     return undefined;
   }
-  loadMirrorFromStore();
-  const key = persistEntry(entry, params.ttlMs);
-  mirror = [...(mirror ?? []), entry]
-    .filter((candidate) => isLiveEntry(candidate))
-    .slice(-IMESSAGE_SENT_ECHOES_MAX_ENTRIES);
-  return key;
+  return persistEntry(entry, params.ttlMs);
 }
 
 export function forgetPersistedIMessageEchoKey(key: string | undefined): void {
@@ -158,7 +147,6 @@ export function forgetPersistedIMessageEchoKey(key: string | undefined): void {
   } catch (err) {
     reportFailure("delete", err);
   }
-  mirror = (mirror ?? []).filter((entry) => resolveIMessageSentEchoEntryKey(entry) !== key);
 }
 
 export function hasPersistedIMessageEcho(params: {


### PR DESCRIPTION
Closes #144213

## What Problem This Solves

Recording an outgoing iMessage echo currently reads and rebuilds an in-memory copy of persisted echo entries, even though every echo lookup immediately reloads the store. This maintainer-requested cleanup removes that redundant state and work.

## Why This Change Was Made

The persisted store remains the owner. Each lookup reads the existing live, ordered, bounded entries; remember and forget use their existing store operations without rebuilding an unused mirror. Matching, TTL, pending-entry reconciliation, persistence schema and retention policy are unchanged.

## User Impact

Echo registration avoids an unused store listing and array rebuild, and the module no longer retains a duplicate entry array. Removing the incidental preread can change which operation first emits a persistence warning, or remove that unused read warning; the retained operations keep their existing failure handling. No RSS, latency, or live iMessage performance claim is made.

## Evidence

The same 166 tests across three existing suites passed before and after. The stale-read regression retains its assertions with a behavior-focused title, and the managed P2 review is clean. The full selected changed gate passed. The proof uses isolated fixtures rather than a live iMessage account; test-runtime differences are not a performance benchmark.
