### PR TITLE
test: cover real run ownership in queued compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.queued-resources.test.ts
+++ b/src/agents/embedded-agent-runner/compact.queued-resources.test.ts
@@ -16,29 +16,6 @@ import { closePreparedModelRuntimeSnapshots } from "../prepared-model-runtime.li
 import { compactEmbeddedAgentSession } from "./compact.queued.js";
 import { waitForDeferredTurnMaintenanceForSession } from "./context-engine-maintenance.js";
 
-// Exercise the managed producer at the existing input boundary without enabling RUN disposal.
-vi.mock("../prepared-model-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../prepared-model-runtime.js")>();
-  return {
-    ...actual,
-    acquireAgentRunPreparedModelRuntime: (
-      input: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[0],
-      options: Parameters<typeof actual.acquireAgentRunPreparedModelRuntime>[1],
-    ) =>
-      actual.acquireReadOnlyPreparedModelRuntime(
-        {
-          ...input,
-          loadRuntimePlugins: true,
-          runtimePluginSelections: [
-            { provider: "queued-resource-fixture", modelId: "model", agentId: "main" },
-          ],
-        },
-        options?.abortSignal,
-        "static",
-      ),
-  };
-});
-
 it("keeps an actual prepared registration alive through queued engine maintenance and disposal", async () => {
   await withOpenClawTestState(
     { prefix: "openclaw-queued-registration-", layout: "split" },


### PR DESCRIPTION
Related: #143426, #143725

## What Problem This Solves

The queued-compaction resource regression replaced RUN acquisition with a read-only acquisition adapter. That bypassed the production selection callback and RUN owner even after ordinary RUN registration ownership landed.

## Why This Change Was Made

Remove the obsolete 23-line module override so the existing test exercises actual RUN acquisition and its selection options. Keep the fixture and all lifetime assertions unchanged.

## User Impact

No runtime behavior change. The regression now covers the production path that must retain plugin resources through deferred engine maintenance and disposal.

## Evidence

The original and updated native integration each passed. The test executes actual queued compaction with a synthetic managed donor engine and on-disk SQLite, verifies reads during maintenance and disposal, and checks once-only closure and reopening. It uses no replacement for the RUN acquisition function. This is a native source integration, not a compiled distribution or external-provider test.

Required changed-file checks passed, including types, all three dead-export scans, lint, database guards, and runtime import-cycle checks. Independent Codex review found no actionable P0–P2 findings. No production files or assertions changed.

Canonical test runs took 27.41 seconds before and 28.66 seconds after, using separate cold transform caches. These are observations of the test harness, not a performance improvement claim.
