### PR TITLE
fix(ui): release retired plugin attribution entries

### DIFF
--- a/ui/src/pages/plugins/plugin-discovery-controller.test.ts
+++ b/ui/src/pages/plugins/plugin-discovery-controller.test.ts
@@ -379,16 +379,3 @@ it("surfaces partial ClawHub failures on the Featured shelf", async () => {
 
   expect(controller.featuredError).toBe("ClawHub is unavailable; local plugins remain available.");
 });
-
-it("clears cached catalog attribution when discovery ownership changes", async () => {
-  const attributed = entry(1);
-  attributed.local.pluginId = "local-plugin";
-  attributed.catalog.author = "first-gateway";
-  const { controller } = setup([{ items: [attributed] }]);
-  await controller.refresh();
-  expect(controller.attributions.get("local-plugin")?.author).toBe("first-gateway");
-
-  controller.invalidate();
-
-  expect(controller.attributions.size).toBe(0);
-});

--- a/ui/src/pages/plugins/plugin-discovery-controller.ts
+++ b/ui/src/pages/plugins/plugin-discovery-controller.ts
@@ -10,14 +10,12 @@ import type {
   PluginDiscoveryResult,
 } from "../../lib/plugins/index.ts";
 import type { PluginDiscoveryIntent } from "./catalog-results.ts";
-import type { PluginCardAttribution } from "./plugin-card.ts";
 
 const CATALOG_PAGE_SIZE = 100;
 const CATALOG_SECTION_SIZE = 8;
 
 type CatalogPageLoad = {
   items: PluginDiscoveryEntry[];
-  observed: PluginDiscoveryEntry[];
   remoteError?: string;
 };
 
@@ -111,7 +109,6 @@ export class PluginDiscoveryController {
   private committedQuery = "";
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
   private overviewRequestEpoch = 0;
-  private readonly entriesById = new Map<string, PluginDiscoveryEntry>();
   private readonly browseTask: Task;
   private readonly categoriesTask: Task;
   private readonly featuredTask: Task;
@@ -138,7 +135,6 @@ export class PluginDiscoveryController {
       onComplete: (page) => {
         this.result = { items: page.items };
         this.remoteError = page.remoteError ?? null;
-        this.rememberEntries(page.observed);
         this.gateway.onEntriesChanged?.();
       },
       onError: (error) => {
@@ -177,7 +173,6 @@ export class PluginDiscoveryController {
       onComplete: (result) => {
         this.featured = result.items.slice(0, CATALOG_SECTION_SIZE);
         this.featuredError = result.remoteError ?? null;
-        this.rememberEntries(result.items);
         this.gateway.onEntriesChanged?.();
       },
       onError: (error) => {
@@ -198,7 +193,6 @@ export class PluginDiscoveryController {
       onComplete: (result) => {
         this.trending = result.items.slice(0, CATALOG_SECTION_SIZE);
         this.trendingError = result.remoteError ?? null;
-        this.rememberEntries(result.items);
         this.gateway.onEntriesChanged?.();
       },
       onError: (error) => {
@@ -217,26 +211,6 @@ export class PluginDiscoveryController {
 
   get trendingLoading(): boolean {
     return this.gateway.isConnected() && this.trendingTask.status === TaskStatus.PENDING;
-  }
-
-  get attributions(): ReadonlyMap<string, PluginCardAttribution> {
-    const attributions = new Map<string, PluginCardAttribution>();
-    for (const entry of this.entriesById.values()) {
-      if (!entry.local.pluginId) {
-        continue;
-      }
-      attributions.set(entry.local.pluginId, {
-        ...(entry.catalog.author ? { author: entry.catalog.author } : {}),
-        official: entry.catalog.official,
-      });
-    }
-    return attributions;
-  }
-
-  private rememberEntries(entries: readonly PluginDiscoveryEntry[]): void {
-    for (const entry of entries) {
-      this.entriesById.set(entry.id, entry);
-    }
   }
 
   private async fetchAvailablePage(params: {
@@ -294,7 +268,6 @@ export class PluginDiscoveryController {
         : [...items.values()];
     return {
       items: mergedItems,
-      observed: mergedItems,
       ...(remoteError ? { remoteError } : {}),
     };
   }
@@ -345,7 +318,6 @@ export class PluginDiscoveryController {
       this.remoteError ??= page.remoteError ?? null;
     }
     const mergedItems = [...items.values()].toSorted(compareOfficialDownloads);
-    this.rememberEntries(mergedItems);
     this.result = { items: mergedItems };
     this.gateway.onEntriesChanged?.();
     this.host.requestUpdate();
@@ -395,7 +367,6 @@ export class PluginDiscoveryController {
     this.featuredError = null;
     this.trending = [];
     this.trendingError = null;
-    this.entriesById.clear();
     this.overviewRequestEpoch += 1;
   }
 


### PR DESCRIPTION
Closes #144218

## What Problem This Solves

The Plugins page still retains discovery entries in an attribution cache after the installed-plugin view stopped reading it. Repeated browsing or searching therefore keeps old catalog objects for a consumer that no longer exists.

## Why This Change Was Made

Remove the unused cache, attribution getter and collection plumbing from the existing discovery controller. Catalog cards continue to derive author and official badges from each current discovery entry, while result merging, loading/error states, request ownership and change callbacks remain in place.

## User Impact

The mounted discovery controller no longer retains old entries through this retired cache. This maintainer-requested cleanup preserves the Plugins page behavior and current attribution display; it adds no configuration or migration.

## Evidence

In the same synthetic browser flow with explicit garbage collection, all 24 replaced entries stayed reachable before and none did after; all six current entries remained live in both. Current card IDs, text, authors and official badges were preserved, with no page errors. The source E2E server used a mocked Gateway; this is not production-bundle, heap-byte, RSS or latency proof.

The existing owner suite passed before (23 tests) and after (22 tests, after removing the cache-specific test). The full selected changed gate and independent P2 review passed. Both full before/after captures were inspected and contain only synthetic data. Related: #142782, which retired the old attribution reader.

![Before: synthetic Plugins catalog with preserved authors and official badges](https://github.com/user-attachments/assets/5ef50df9-4980-4cdf-81aa-7afa3d3bd277)

![After: synthetic Plugins catalog with preserved authors and official badges](https://github.com/user-attachments/assets/48afbf08-e730-4678-974f-14604306780a)