### PR TITLE
refactor: share resource cleanup for side questions

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 /**
  * Runs `/btw` side questions against the active conversation without resuming
@@ -28,12 +27,7 @@ import type {
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { isModelSelectionLocked } from "../sessions/model-overrides.js";
-import {
-  AsyncWorkScope,
-  captureAsyncWorkTracker,
-  getAsyncWorkSignal,
-} from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
+import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
@@ -723,32 +717,14 @@ async function withBtwPreparedRuntime(
   input: Parameters<typeof acquirePublishedPreparedModelRuntime>[0],
   run: (snapshot: PreparedModelRuntimeSnapshot) => Promise<ReplyPayload | undefined>,
 ): Promise<ReplyPayload | undefined> {
-  const result = createDeferredCore<ReplyPayload | undefined>();
-  const trackOwner = captureAsyncWorkTracker();
-  const parentSignal = getAsyncWorkSignal();
-  void trackOwner(async () => {
+  return await runWithAsyncWorkResources(async (onAcquired, captureWorkContext) => {
     const lease = await acquirePublishedPreparedModelRuntime(input);
-    const work = new AsyncWorkScope();
-    const runInScope = work.run(() =>
-      withPluginRuntimeGenerationScope(lease.snapshot, () => AsyncLocalStorage.snapshot()),
-    );
-    const closeWork = () => runInScope(() => work.beginClose(parentSignal?.reason));
-    parentSignal?.addEventListener("abort", closeWork, { once: true });
-    if (parentSignal?.aborted) {
-      closeWork();
-    }
-    try {
-      result.resolve(await runInScope(() => work.track(() => run(lease.snapshot))));
-    } catch (error) {
-      result.reject(error);
-    } finally {
-      await work.runWhenIdle(() => undefined);
-      await runInScope(() => work.drain());
-      parentSignal?.removeEventListener("abort", closeWork);
-      lease.release();
-    }
-  }).catch((error: unknown) => result.reject(error));
-  return await result.promise;
+    onAcquired(lease);
+    return withPluginRuntimeGenerationScope(lease.snapshot, () => {
+      captureWorkContext();
+      return run(lease.snapshot);
+    });
+  });
 }
 
 /** Answers a side question using sanitized session context and no tool execution. */

--- a/src/agents/prepared-model-runtime.published-resources.test.ts
+++ b/src/agents/prepared-model-runtime.published-resources.test.ts
@@ -4,6 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { OpenClawSchema } from "../config/zod-schema.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   resetPluginLoaderTestStateForTest,
@@ -25,7 +26,10 @@ import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runt
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 
 const selectedSource = vi.hoisted(() => {
-  const state: { input?: PreparedModelRuntimeInput } = {};
+  const state: {
+    input?: PreparedModelRuntimeInput;
+    acquisition?: { entered: () => void; completion: Promise<void> };
+  } = {};
   return state;
 });
 
@@ -37,13 +41,27 @@ vi.mock("./prepared-model-runtime.js", async (importOriginal) => {
     loadPreparedModelRuntimeSnapshot: (
       input: Parameters<typeof runtime.loadPreparedModelRuntimeSnapshot>[0],
     ) => runtime.loadPreparedModelRuntimeSnapshot(selectedSource.input ?? input),
-    acquirePublishedPreparedModelRuntime: (
+    acquirePublishedPreparedModelRuntime: async (
       input: Parameters<typeof runtime.acquirePublishedPreparedModelRuntime>[0],
-    ) => runtime.acquirePublishedPreparedModelRuntime(selectedSource.input ?? input),
+    ) => {
+      const lease = await runtime.acquirePublishedPreparedModelRuntime(
+        selectedSource.input ?? input,
+      );
+      selectedSource.acquisition?.entered();
+      await selectedSource.acquisition?.completion;
+      return lease;
+    },
   };
 });
 
-it.each(["published borrow", "BTW harness cleanup", "BTW parent close"] as const)(
+const publishedRuntimeResourceModes = [
+  "published borrow",
+  "BTW harness cleanup",
+  "BTW parent close",
+  "BTW parent close during acquisition",
+] as const;
+
+it.each(publishedRuntimeResourceModes)(
   "retains an acquired SQLite source through %s and replacement",
   async (mode) => {
     await withOpenClawTestState({ label: "published-runtime-resources" }, async (state) => {
@@ -116,10 +134,12 @@ module.exports = {
       async runSideQuestion() {
         try {
           bridge.requestSignal.current = bridge.getRequestSignal();
-          bridge.requestSignal.current?.addEventListener("abort", () => {
+          const observeAbort = () => {
             bridge.abortRegistry.current = bridge.getRegistry();
             bridge.abortObserved.resolve();
-          }, { once: true });
+          };
+          bridge.requestSignal.current?.addEventListener("abort", observeAbort, { once: true });
+          if (bridge.requestSignal.current?.aborted) observeAbort();
           bridge.entered.resolve();
           await bridge.finish.promise;
           return { text: String(database.prepare("SELECT value FROM answer").get().value) };
@@ -136,10 +156,11 @@ module.exports = {
       );
       const config: OpenClawConfig = {
         agents: {
+          entries: { main: {} },
           defaults: {
             model: { primary: `${pluginId}/model` },
             workspace: state.workspaceDir,
-            agentRuntime: { id: pluginId },
+            models: { [`${pluginId}/model`]: { agentRuntime: { id: pluginId } } },
           },
         },
         models: {
@@ -168,6 +189,7 @@ module.exports = {
           entries: { [pluginId]: { enabled: true } },
         },
       };
+      expect(OpenClawSchema.safeParse(config).success).toBe(true);
       const input = {
         config,
         agentId: "main",
@@ -191,6 +213,9 @@ module.exports = {
             | Awaited<ReturnType<typeof acquireReadOnlyPreparedModelRuntime>>
             | undefined;
           const owner = new AsyncWorkScope();
+          const acquisitionEntered = createDeferredCore();
+          const acquisitionFinish = createDeferredCore();
+          const cancellationReason = new Error("BTW parent closed");
           let sideQuestion: ReturnType<typeof runBtwSideQuestion> | undefined;
           try {
             first = await acquireReadOnlyPreparedModelRuntime(input, undefined, "static");
@@ -203,6 +228,12 @@ module.exports = {
               expect(borrower.snapshot).toBe(first.snapshot);
             } else {
               selectedSource.input = input;
+              if (mode === "BTW parent close during acquisition") {
+                selectedSource.acquisition = {
+                  entered: acquisitionEntered.resolve,
+                  completion: acquisitionFinish.promise,
+                };
+              }
               sideQuestion = owner.track(() =>
                 runBtwSideQuestion({
                   cfg: config,
@@ -222,6 +253,17 @@ module.exports = {
                   resolvedReasoningLevel: "off",
                 }),
               );
+              if (mode === "BTW parent close during acquisition") {
+                await Promise.race([
+                  acquisitionEntered.promise,
+                  sideQuestion.then(() => {
+                    throw new Error("BTW did not enter acquisition");
+                  }),
+                ]);
+                owner.beginClose(cancellationReason);
+                expect(original.disposals).toBe(0);
+                acquisitionFinish.resolve();
+              }
               await Promise.race([
                 bridge.entered.promise,
                 sideQuestion.then(() => {
@@ -229,10 +271,11 @@ module.exports = {
                 }),
               ]);
               if (mode === "BTW parent close") {
-                const reason = new Error("BTW parent closed");
-                owner.beginClose(reason);
+                owner.beginClose(cancellationReason);
+              }
+              if (mode.startsWith("BTW parent close")) {
                 expect(bridge.requestSignal.current?.aborted).toBe(true);
-                expect(bridge.requestSignal.current?.reason).toBe(reason);
+                expect(bridge.requestSignal.current?.reason).toBe(cancellationReason);
               }
               first.release();
             }
@@ -265,10 +308,12 @@ module.exports = {
             replacement.release();
             await expect.poll(() => successor.disposals).toBe(1);
           } finally {
+            acquisitionFinish.resolve();
             bridge.finish.resolve();
             bridge.cleanupFinish.resolve();
             await Promise.allSettled([sideQuestion, owner.drain()]);
             selectedSource.input = undefined;
+            selectedSource.acquisition = undefined;
             first?.release();
             borrower?.release();
             replacement?.release();


### PR DESCRIPTION
Related: #143716, #143366

## What Problem This Solves

BTW side questions maintained their own resource-cleanup loop alongside the shared owner already used by TTS and isolated completion. Keeping those implementations aligned required duplicating cancellation, generation-context and late-work handling.

## Why This Change Was Made

Use the existing shared resource helper while acquiring the same published generation and capturing its context before execution. Remove 24 production lines without changing model/harness selection, response behavior, or standalone/configured publication policy.

## User Impact

No intended behavior change. Side questions continue to retain their selected resources through actual provider and harness cleanup, including when the parent closes during acquisition.

## Evidence

- All 82 focused BTW and native resource cases passed on both the original production code and the refactor. One added table case verifies cancellation during acquisition handoff, exact generation, late SQLite reads, replacement and once-close/reopen. The existing managed-source input adapter is retained; the fixture now validates canonical config.
- Full changed-file gate passed, including types, all three dead-export scans, lint/format, database guards and zero runtime import cycles. Independent Codex review found no actionable P0–P2 issues. Ordinary build passed in 264.79s.
- Compiled synthetic proof passed in 2.51s through the real BTW entry point, with parent cancellation, held harness cleanup and normal cleanup context. Ordinary standalone publication remains raw. A separate compiled owned-publication control verifies replacement/disposal; it is not presented as default managed BTW disposal. The native fixture covers that managed composition.
- All 40,717 tracked source files and 14,628 artifacts matched their seals after proof; no TypeScript fallback or external inference was used. The successful configuration passed the built schema, and its full log contained no errors or fallback diagnostics. An earlier probe stopped before application execution because its driver mistook the schema object for a function; that preflight check was corrected and the failure retained.
- Observed test runs were 41.74s/2.26 GB peak RSS before and 31.32s/2.28 GB after. Compiled cold admission was 273.84ms and warm result plus cleanup signal was 3.34ms. These are individual synthetic observations, not a benchmark or speedup claim.

Hosted CI passed on the final head: [run 34506348766](https://github.com/openclaw/openclaw/actions/runs/34506348766). Two unrelated fixture failures cleared in targeted unchanged recoveries: iMessage dispatch polling and frozen-target subprocess admission checks. A bounded diagnostic replay preserved the latter's 20-second deadline and verified the expected missing-blob refusal; no production code, test assertions, or deadlines were changed for CI recovery.
