### PR TITLE
fix(cron): forward CLI auth profiles to isolated runs

### DIFF
--- a/src/agents/cli-execution-auth.test.ts
+++ b/src/agents/cli-execution-auth.test.ts
@@ -220,6 +220,50 @@ describe("resolveCliExecutionAuthProfileId", () => {
     },
   );
 
+  it("keeps native Claude login for an automatic canonical Anthropic API key", () => {
+    mocks.profiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    mocks.order.push("anthropic:default");
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: {
+          authProfileId: "anthropic:default",
+          authProfileIdSource: "auto",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not carry an automatic cross-provider profile into Claude CLI fallback", () => {
+    mocks.profiles["openai:default"] = {
+      type: "api_key",
+      provider: "openai",
+      key: "test-openai-key",
+    };
+    mocks.order.push("openai:default");
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "openai",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: {
+          authProfileId: "openai:default",
+          authProfileIdSource: "auto",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it.each(["claude-cli", "google-gemini-cli"])(
     "rejects an explicitly selected profile from another provider for %s",
     (cliExecutionProvider) => {

--- a/src/agents/cli-execution-auth.test.ts
+++ b/src/agents/cli-execution-auth.test.ts
@@ -242,6 +242,25 @@ describe("resolveCliExecutionAuthProfileId", () => {
     ).toBeUndefined();
   });
 
+  it("treats missing selection provenance as automatic for canonical profiles", () => {
+    mocks.profiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    mocks.order.push("anthropic:default");
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+        selected: { authProfileId: "anthropic:default" },
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not carry an automatic cross-provider profile into Claude CLI fallback", () => {
     mocks.profiles["openai:default"] = {
       type: "api_key",

--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -45,6 +45,7 @@ export function resolveCliExecutionAuthProfileId(params: {
 }): string | undefined {
   const loadStore = params.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
   const selectedAuthProfileId = params.selected?.authProfileId?.trim();
+  const selectedAuthProfileIdSource = params.selected?.authProfileIdSource ?? "auto";
   const store = loadStore(params.agentDir, {
     readOnly: true,
     allowKeychainPrompt: false,
@@ -66,7 +67,7 @@ export function resolveCliExecutionAuthProfileId(params: {
     // owner. Automatic selection must not replace the CLI's native identity.
     if (
       credential &&
-      params.selected?.authProfileIdSource !== "auto" &&
+      selectedAuthProfileIdSource !== "auto" &&
       (params.cliExecutionProvider === CLAUDE_CLI_PROVIDER_ID ||
         (params.cliExecutionProvider === GOOGLE_GEMINI_CLI_PROVIDER_ID &&
           credential.type === "api_key")) &&
@@ -79,7 +80,7 @@ export function resolveCliExecutionAuthProfileId(params: {
     ) {
       return selectedAuthProfileId;
     }
-    if (params.selected?.authProfileIdSource !== "auto") {
+    if (selectedAuthProfileIdSource !== "auto") {
       if (!credential) {
         throw new CliExecutionAuthProfileError(
           `No credentials found for profile "${selectedAuthProfileId}".`,

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -1,5 +1,11 @@
 // Auth profile propagation tests cover isolated agent auth profile forwarding.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOperationalRunInstanceRef,
+  prepareAgentRunAdmission,
+} from "../agents/admitted-run-context.js";
+import { saveAuthProfileStore } from "../agents/auth-profiles/store-runtime.js";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import type { AuthProfileFailurePolicy } from "../agents/embedded-agent-runner/run/auth-profile-failure-policy.types.js";
 import {
   makeIsolatedAgentJobFixture,
@@ -168,5 +174,110 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
     expect(runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
       authProfileId: "claude-cli:manual",
     });
+  });
+
+  it("executes cron auth through the prepared CLI backend boundary", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    const { prepareCliRunContext } = await import("../agents/cli-runner/prepare.js");
+    const { executePreparedCliRun } = await import("../agents/cli-runner/execute.js");
+    const agentDir = "/tmp/agent-dir";
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:managed": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "test-cron-key",
+          },
+        },
+      },
+      agentDir,
+    );
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "cron-auth-fixture",
+          pluginId: "anthropic",
+          modelProvider: "anthropic",
+          authEpochMode: "profile-only",
+          prepareExecution: async (context) => ({
+            env: { OPENCLAW_CRON_AUTH_PROOF: context.authProfileId ?? "native" },
+          }),
+          config: {
+            command: process.execPath,
+            args: ["-e", "process.stdout.write(process.env.OPENCLAW_CRON_AUTH_PROOF ?? '')"],
+            output: "text",
+            input: "arg",
+            sessionMode: "none",
+          },
+        },
+      ],
+      resolvePluginSetupCliBackend: () => undefined,
+    });
+    runCliAgentMock.mockImplementation(async () => ({
+      payloads: [{ text: "cron auth proof" }],
+      meta: { agentMeta: {} },
+    }));
+    resolveCliExecutionAuthProfileIdMock.mockReturnValue("anthropic:managed");
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+    });
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "anthropic:managed",
+      source: "user",
+      routeRequirement: "api-key",
+    });
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        cfg: {},
+        job: makeIsolatedAgentJobFixture({
+          delivery: { mode: "none" },
+          payload: { kind: "agentTurn", message: "cron auth proof" },
+        }),
+        message: "cron auth proof",
+        sessionKey: "cron:job-proof",
+        lane: "cron",
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    const cliParams = runCliAgentMock.mock.calls[0]?.[0];
+    if (!cliParams) {
+      throw new Error("Expected cron to invoke the CLI backend");
+    }
+    expect(cliParams).toMatchObject({ authProfileId: "anthropic:managed" });
+    const preparedRunAdmission = prepareAgentRunAdmission({
+      cfg: {},
+      operationalRunInstance: createOperationalRunInstanceRef(cliParams.runId),
+      facts: {
+        runId: cliParams.runId,
+        agentId: cliParams.agentId ?? "default",
+        ingress: { kind: "schedule", boundary: "cron.test", state: "present" },
+      },
+    });
+    const prepared = await prepareCliRunContext({
+      ...cliParams,
+      preparedRunAdmission,
+      assertCurrent: undefined,
+      contextEngineLogicalTurnLease: undefined,
+      userTurnTranscriptRecorder: undefined,
+      provider: "cron-auth-fixture",
+      authProfileId: "anthropic:managed",
+      workspaceDir: process.cwd(),
+      cwd: process.cwd(),
+      rootedExecution: undefined,
+      executionRoot: undefined,
+    });
+    try {
+      const output = await executePreparedCliRun(prepared);
+      expect(output.text).toBe("anthropic:managed");
+    } finally {
+      await prepared.preparedBackend.cleanup?.();
+      preparedRunAdmission.close();
+    }
   });
 });

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -8,10 +8,12 @@ import {
 import { setupRunCronIsolatedAgentTurnSuite } from "./isolated-agent/run.suite-helpers.js";
 import {
   loadRunCronIsolatedAgentTurn,
+  isCliProviderMock,
   mockRunCronFallbackPassthrough,
   resolveConfiguredModelRefMock,
   resolveSessionAuthSelectionMock,
   runEmbeddedAgentMock,
+  runCliAgentMock,
 } from "./isolated-agent/run.test-harness.js";
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
@@ -94,6 +96,53 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     expect(getEmbeddedAgentParams()).toMatchObject({
       authProfileId: "openrouter:default",
+    });
+  });
+
+  it("passes authProfileId to runCliAgent when a cron route uses the CLI backend", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+    });
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "claude-cli:manual",
+      source: "auto",
+      routeRequirement: "api-key",
+    });
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "check status" }],
+      meta: { agentMeta: {} },
+    });
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        cfg: {
+          auth: {
+            profiles: {
+              "claude-cli:manual": {
+                provider: "claude-cli",
+                mode: "api_key",
+              },
+            },
+            order: { "claude-cli": ["claude-cli:manual"] },
+          },
+        },
+        job: makeIsolatedAgentJobFixture({
+          delivery: { mode: "none" },
+          payload: { kind: "agentTurn", message: "check status" },
+        }),
+        message: "check status",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    expect(runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      authProfileId: "claude-cli:manual",
     });
   });
 });

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -1,11 +1,20 @@
 // Auth profile propagation tests cover isolated agent auth profile forwarding.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileFailurePolicy } from "../agents/embedded-agent-runner/run/auth-profile-failure-policy.types.js";
 import {
   makeIsolatedAgentJobFixture,
   makeIsolatedAgentParamsFixture,
 } from "./isolated-agent/job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./isolated-agent/run.suite-helpers.js";
+
+const resolveCliExecutionAuthProfileIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/cli-execution-auth.js", () => ({
+  CliExecutionAuthProfileError: class CliExecutionAuthProfileError extends Error {},
+  cliBackendAcceptsAuthProfileForwarding: vi.fn(),
+  resolveCliExecutionAuthProfileId: resolveCliExecutionAuthProfileIdMock,
+}));
+
 import {
   loadRunCronIsolatedAgentTurn,
   isCliProviderMock,
@@ -31,7 +40,11 @@ function getEmbeddedAgentParams(): {
 }
 
 describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", () => {
-  setupRunCronIsolatedAgentTurnSuite();
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+  beforeEach(() => {
+    resolveCliExecutionAuthProfileIdMock.mockReset();
+    resolveCliExecutionAuthProfileIdMock.mockReturnValue(undefined);
+  });
 
   it("uses transient-local auth cooldown policy for cron throttling failures", async () => {
     mockRunCronFallbackPassthrough();
@@ -110,6 +123,7 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
       source: "auto",
       routeRequirement: "api-key",
     });
+    resolveCliExecutionAuthProfileIdMock.mockReturnValue("claude-cli:manual");
     runCliAgentMock.mockResolvedValue({
       payloads: [{ text: "check status" }],
       meta: { agentMeta: {} },
@@ -141,6 +155,16 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
 
     expect(result.status).toBe("ok");
     expect(runCliAgentMock).toHaveBeenCalledOnce();
+    expect(resolveCliExecutionAuthProfileIdMock).toHaveBeenCalledWith({
+      cliExecutionProvider: "claude-cli",
+      authProfileProvider: "claude-cli",
+      config: expect.any(Object),
+      agentDir: expect.any(String),
+      selected: {
+        authProfileId: "claude-cli:manual",
+        authProfileIdSource: "auto",
+      },
+    });
     expect(runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
       authProfileId: "claude-cli:manual",
     });

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -674,6 +674,7 @@ function createCronPromptExecutor(
                 ),
                 provider: executionProvider,
                 model: modelOverride,
+                authProfileId: params.liveSelection.authProfileId,
                 thinkLevel: candidateThinkLevel,
                 timeoutMs: params.timeoutMs,
                 runId,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -7,6 +7,7 @@ import {
 } from "../../agents/admitted-run-context.js";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
+import { resolveCliExecutionAuthProfileId } from "../../agents/cli-execution-auth.js";
 import { resolveCliRuntimeToolsAllow } from "../../agents/cli-runner/tool-policy.js";
 import { settleCliSessionResult } from "../../agents/cli-session-store.js";
 import {
@@ -536,6 +537,20 @@ function createCronPromptExecutor(
         }
         const { sessionRuntimeOverride, executionProvider, cliExecution } =
           resolveCandidateExecution(providerOverride, modelOverride);
+        // Fallback candidates may use a different CLI runtime than the initial
+        // model; resolve the credential at that candidate's owner boundary.
+        const cliAuthProfileId = cliExecution
+          ? resolveCliExecutionAuthProfileId({
+              cliExecutionProvider: executionProvider,
+              authProfileProvider: params.liveSelection.provider,
+              config: params.cfgWithAgentDefaults,
+              agentDir: params.agentDir,
+              selected: {
+                authProfileId: params.liveSelection.authProfileId,
+                authProfileIdSource: params.liveSelection.authProfileIdSource,
+              },
+            })
+          : undefined;
         const candidateRuntime = resolveEffectiveAgentRuntime({
           cfg: params.cfgWithAgentDefaults,
           provider: providerOverride,
@@ -674,7 +689,7 @@ function createCronPromptExecutor(
                 ),
                 provider: executionProvider,
                 model: modelOverride,
-                authProfileId: params.liveSelection.authProfileId,
+                authProfileId: cliAuthProfileId,
                 thinkLevel: candidateThinkLevel,
                 timeoutMs: params.timeoutMs,
                 runId,


### PR DESCRIPTION
Fixes #144047

Reporter: @angeliti999

## What Problem This Solves

Scheduled cron runs using a CLI-backed model lost the auth profile selected during cron preparation. The initial profile could be forwarded unchanged to a fallback CLI candidate, allowing the wrong credential owner to reach the backend or causing a valid managed run to fall back to native login.

## Why This Change Was Made

The cron executor now resolves CLI auth at each candidate's execution-provider boundary through the existing `resolveCliExecutionAuthProfileId` owner. Candidate-owned CLI profiles may be forwarded; automatic canonical Anthropic selections preserve native Claude login; automatic cross-provider profiles are not carried into Claude CLI; explicit incompatible or missing profiles fail closed. Missing auth-selection provenance is normalized to automatic, matching the resolver contract and the candidate pattern referenced by #144266.

## User Impact

CLI-backed cron jobs keep their selected managed profile when the selected CLI backend owns it. Fallback candidates cannot inherit an unrelated automatic credential, and explicit account mismatches stop before execution. No configuration, dependency, or public API surface changes.

## Evidence

- Red-before proof on upstream base `0f68d696c3cc9c93bb45048f8c72036e577490de`: the focused cron regression failed because `runCliAgent` received no `authProfileId` (2 passed, 1 failed).
- Current head: `8d8b48c2421c1703fea14551671aa7b0a25d34d0`.
- Green-after focused cron suite:
  `node_modules\\.bin\\vitest.cmd run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent.auth-profile-propagation.test.ts --maxWorkers=1 --testTimeout=180000` — 4/4 passed.
- Candidate auth-owner suite:
  `node_modules\\.bin\\vitest.cmd run --config test/vitest/vitest.agents-core.config.ts src/agents/cli-execution-auth.test.ts` — 19/19 passed. Coverage includes native-login preservation, omitted provenance, cross-provider fallback denial, explicit incompatibility, missing profiles, and backend-owned ordered profiles.
- Installed-backend process proof at this head: the cron test executes the production `runCronIsolatedAgentTurn` path, captures `authProfileId: anthropic:managed` at the CLI dispatch boundary, then runs the captured call through a registered CLI backend fixture using the real `prepareCliRunContext` and `executePreparedCliRun`. The fixture launches a real Node child process, and the observed output is `anthropic:managed`. This proves the selected profile identity crosses the cron-to-backend boundary; it is not presented as live Claude provider E2E.
- Core typecheck passed:
  `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`.
- Targeted Oxlint, Oxfmt, and `git diff --check` passed.
- `check:changed` remains unclaimed because an earlier run was interrupted in the core-test typecheck lane.
- No live Claude credential or provider endpoint is available in this environment, so live provider E2E and provider-side token/session rotation proof are not claimed.
- Fresh autoreview was unavailable on the Windows runtime (`reviewer_unavailable`, no report produced).
- Production delta for this follow-up is +3 lines in the resolver; test delta is +130 net lines across focused resolver and cron coverage.
- Maintainer edits are enabled.

## Limitations

The deterministic installed-backend proof verifies profile identity propagation and process execution. It does not claim a live Claude login, provider token refresh, or an account reassignment during an in-flight run.
