### PR TITLE
docs(google): document the literal google-vertex ADC credential marker

### DIFF
--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -151,7 +151,10 @@ Claude CLI reuse (`claude -p`) is a sanctioned OpenClaw integration path. Anthro
 ### Google Vertex and Gemini CLI runtime
 
 - `google-vertex`: managed Google Cloud access through gcloud Application
-  Default Credentials.
+  Default Credentials. Keep the `google-vertex` credential unset (ADC is
+  detected automatically) or store the literal marker `gcp-vertex-credentials`;
+  any other value is treated as an API key, and Vertex rejects requests that
+  use one. See [Vertex AI (ADC)](/providers/google).
 - `google-gemini-cli`: optional local runtime for an explicitly configured
   canonical `google/*` model.
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -153,10 +153,33 @@ the Gateway already runs inside a managed Google Cloud environment.
         ```
       </Step>
       <Step title="Set the project and location environment variables">
+        The Gateway reads `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`
+        from its own process environment, so put them where the Gateway can
+        see them.
+
+        For a Gateway you launch from the current shell:
+
         ```bash
         export GOOGLE_CLOUD_PROJECT="your-project-id"
         export GOOGLE_CLOUD_LOCATION="us-central1"
         ```
+
+        For a service-managed Gateway (systemd/launchd), exports from an
+        interactive shell never reach the running process. Persist them to the
+        global env file and restart the Gateway instead:
+
+        ```bash
+        mkdir -p ~/.openclaw
+        cat >> ~/.openclaw/.env <<'EOF'
+        GOOGLE_CLOUD_PROJECT=your-project-id
+        GOOGLE_CLOUD_LOCATION=us-central1
+        EOF
+        openclaw gateway restart
+        ```
+
+        See [Environment variables](/help/environment) for the full env
+        loading precedence (process environment, `~/.openclaw/.env`,
+        systemd/launchd).
       </Step>
       <Step title="Verify the model is available">
         ```bash
@@ -178,6 +201,7 @@ the Gateway already runs inside a managed Google Cloud environment.
     literal marker `gcp-vertex-credentials`; any other value is treated as an
     API key, and Vertex rejects requests that use one.
     </Tip>
+
   </Tab>
 </Tabs>
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -141,6 +141,44 @@ the Gateway already runs inside a managed Google Cloud environment.
     should use `google/*` model refs plus the explicit runtime selection above.
 
   </Tab>
+
+  <Tab title="Vertex AI (ADC)">
+    **For:** Gateways already running inside a managed Google Cloud
+    environment, or a workstation with `gcloud` configured.
+
+    <Steps>
+      <Step title="Authenticate with Application Default Credentials">
+        ```bash
+        gcloud auth application-default login
+        ```
+      </Step>
+      <Step title="Set the project and location environment variables">
+        ```bash
+        export GOOGLE_CLOUD_PROJECT="your-project-id"
+        export GOOGLE_CLOUD_LOCATION="us-central1"
+        ```
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider google-vertex
+        ```
+      </Step>
+    </Steps>
+
+    OpenClaw detects Application Default Credentials from
+    `GOOGLE_APPLICATION_CREDENTIALS` or the `gcloud` default locations, and
+    accepts `authorized_user`, `external_account`, and `service_account`
+    credential files.
+
+    <Tip>
+    Do not paste an AI Studio API key or an access token as the `google-vertex`
+    credential. Vertex authentication uses Application Default Credentials, and
+    OpenClaw detects them automatically from the environment above. If a setup
+    surface asks you to store a credential value for `google-vertex`, store the
+    literal marker `gcp-vertex-credentials`; any other value is treated as an
+    API key, and Vertex rejects requests that use one.
+    </Tip>
+  </Tab>
 </Tabs>
 
 <Note>


### PR DESCRIPTION
Closes #143764

## What Problem This Solves

Fixes an issue where users following the documented gcloud Application Default Credentials setup for `google-vertex` would store the wrong value (an access token or an AI Studio API key) as the provider credential, when the docs never stated which value the field requires. Requests then fail against Vertex with no hint that the stored credential is the cause.

## Why This Change Was Made

The ADC path detects credentials automatically and synthesizes the literal marker `gcp-vertex-credentials` (see `extensions/google/vertex-adc-config.ts` and the plugin manifest `credentialMarker`). Any stored non-marker value is treated as an API key, which Vertex rejects. The Google provider page gains a dedicated Vertex AI (ADC) setup tab covering the ADC and environment prerequisites, and both edited pages now state the credential rule. Documentation only; no behavior change.

## User Impact

Users setting up `google-vertex` now have in-repo instructions for the full ADC path and know to leave the credential unset or store the literal `gcp-vertex-credentials` marker, instead of guessing a value and hitting unexplained request failures.

## Evidence

- `markdownlint-cli2` with the repo config reports no issues in the two edited pages (only a pre-existing `docs/CLAUDE.md` trailing-newline issue remains, untouched here).
- The documented behavior matches `resolveGoogleVertexConfigApiKey` and `isGoogleVertexCredentialsMarker` in `extensions/google/vertex-adc-config.ts`, and the manifest `credentialMarker` in `extensions/google/openclaw.plugin.json`.
- Repro from #143764: storing the output of `gcloud auth print-access-token` as the credential fails; the documented flow keeps users on the supported marker/ADC path.