### PR TITLE
fix(sessions): diagnose slow archive-pruning stages

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -458,6 +458,7 @@ The object aggregates observations across the pruning pass:
 - `admissionMs`, `cachedAdmissions`, and `asyncAdmissions` measure database
   acquisition and count its observed modes. Admission time ends at callback entry
   or acquisition failure and can include shared admission and integrity-check waits.
+  A refusal before mode selection adds admission time without incrementing either mode count.
 - `checkpointMs`, `checkpointMaxMs`, and `checkpointCalls` report total time,
   longest call, and calls entered. `checkpointIncomplete` counts calls returning
   false, which can mean a busy checkpoint or an error; it does not identify a lock

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -448,6 +448,50 @@ the warning threshold or prove that a nearby request caused the work. Rounding
 and work outside the measured subphases can leave a difference from
 `writerExecutionMs`; do not assign that remainder to a specific phase.
 
+For `session.history.archive-prune`, the same slow or failure warning can include
+one bounded `archivePruning` object. Its `trigger` is recorded at the call site:
+`initial`, `after-eviction`, or `final`. It distinguishes pruning passes within
+the maintenance flow; it does not identify the request that caused maintenance.
+
+The object aggregates observations across the pruning pass:
+
+- `admissionMs`, `cachedAdmissions`, and `asyncAdmissions` measure database
+  acquisition and count its observed modes. Admission time ends at callback entry
+  or acquisition failure and can include shared admission and integrity-check waits.
+- `checkpointMs`, `checkpointMaxMs`, and `checkpointCalls` report total time,
+  longest call, and calls entered. `checkpointIncomplete` counts calls returning
+  false, which can mean a busy checkpoint or an error; it does not identify a lock
+  holder or distinguish those outcomes. A thrown checkpoint contributes to call
+  count and time without incrementing `checkpointIncomplete`.
+- `vacuumMs`, `vacuumPasses`, and `vacuumPagesRequested` measure incremental vacuum
+  calls and their requested page counts. Requested pages are not confirmed
+  reclaimed pages.
+- `queryMs` covers existing archive-presence, candidate, unpublished-name, and
+  freelist reads. `rowDeletionMs` covers the canonical archive row-deletion
+  transaction.
+- `fileRemovalMs`, `removedFiles`, `missingFiles`, and `failedRemovals` report
+  existing file-removal outcomes. `removedFiles` counts successful canonical and
+  legacy removals. `missingFiles` counts canonical removal attempts that return
+  `ENOENT`. Other canonical failures and all unsuccessful legacy removals count
+  under `failedRemovals`; the legacy count includes missing paths, non-files,
+  and stat or removal failures.
+- `measurementMs` and `measurements` cover awaited disk-usage measurement attempts,
+  including failures and time queued for the measurement Worker, scanning, and
+  returning the result. `legacyInventoryMs` covers legacy file inventory,
+  filtering, and sorting.
+
+All durations are wall time, including asynchronous waits, rather than CPU
+measurements. `completed: false` retains partial observations when pruning
+throws; an absent stage timing field means that stage was not entered.
+`completed: true` means the pruning pass returned normally. It does not prove
+that every checkpoint completed, every removal succeeded, or the high-water
+target was reached. Rounding and unmeasured work can leave a remainder relative
+to `writerExecutionMs`; `checkpointMaxMs` is already included in `checkpointMs`.
+
+These fields reuse existing operations without additional store reads, per-file
+records, paths, names, or content. They do not change the warning threshold,
+checkpoint mode or timeout, or archive-retention behavior.
+
 ### Slow reply preparation
 
 When a reply spends a long time preparing, inspect the normal Gateway logs:

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -29,6 +29,8 @@ import {
 } from "./disk-budget-files.js";
 import { measureSessionPhysicalDiskUsage } from "./disk-budget-runtime.js";
 import { resolveSessionFilePathCore } from "./paths.js";
+import type { SqliteSessionArchivePruningDiagnostics } from "./session-accessor.sqlite-contract.js";
+import { timeArchivePruningAsync } from "./session-history-archive-pruning-diagnostics.js";
 import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import { isSessionEntryDiskBudgetEvictable } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
@@ -213,6 +215,7 @@ export async function hasRetainedSessionTranscriptArchives(storePath: string): P
 
 /** Removes oldest retained archives and legacy compact backups, remeasuring after each file. */
 export async function pruneSessionTranscriptArchivesToHighWater(params: {
+  diagnostics?: SqliteSessionArchivePruningDiagnostics;
   excludeNames?: ReadonlySet<string>;
   highWaterBytes: number;
   storePath: string;
@@ -220,23 +223,42 @@ export async function pruneSessionTranscriptArchivesToHighWater(params: {
   // Oldest-first is the hard-cap sacrifice order: under extreme pressure this
   // may prune an archive the current pass just extracted, which is preferred
   // over evicting additional sessions' searchable rows to spare a copy.
-  const files = (await readSessionsDirFiles(path.dirname(params.storePath)))
-    .filter(
-      (file) =>
-        isRetainedSessionTranscriptArchiveName(file.name) && !params.excludeNames?.has(file.name),
-    )
-    .toSorted((left, right) => left.mtimeMs - right.mtimeMs);
-  let usage = await measureSessionPhysicalDiskUsage(params.storePath);
+  const { diagnostics } = params;
+  const files = await timeArchivePruningAsync(diagnostics, "legacyInventoryMs", async () =>
+    (await readSessionsDirFiles(path.dirname(params.storePath)))
+      .filter(
+        (file) =>
+          isRetainedSessionTranscriptArchiveName(file.name) && !params.excludeNames?.has(file.name),
+      )
+      .toSorted((left, right) => left.mtimeMs - right.mtimeMs),
+  );
+  let usage = await timeArchivePruningAsync(diagnostics, "measurementMs", () =>
+    measureSessionPhysicalDiskUsage(params.storePath),
+  );
   let removedFiles = 0;
   for (const file of files) {
     if (usage.totalBytes <= params.highWaterBytes) {
       break;
     }
-    if (!(await removeFileIfExists(file.path)).ok) {
+    if (
+      !(
+        await timeArchivePruningAsync(diagnostics, "fileRemovalMs", () =>
+          removeFileIfExists(file.path),
+        )
+      ).ok
+    ) {
+      if (diagnostics) {
+        diagnostics.failedRemovals = (diagnostics.failedRemovals ?? 0) + 1;
+      }
       continue;
     }
     removedFiles += 1;
-    usage = await measureSessionPhysicalDiskUsage(params.storePath);
+    if (diagnostics) {
+      diagnostics.removedFiles = (diagnostics.removedFiles ?? 0) + 1;
+    }
+    usage = await timeArchivePruningAsync(diagnostics, "measurementMs", () =>
+      measureSessionPhysicalDiskUsage(params.storePath),
+    );
   }
   return { removedFiles, usage };
 }

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -50,8 +50,34 @@ export type SqliteSessionArtifactPreparationDiagnostics =
     completed?: boolean;
   };
 
+/** One pruning attempt retains only aggregate stage observations. */
+export type SqliteSessionArchivePruningDiagnostics = {
+  trigger: "initial" | "after-eviction" | "final";
+  admissionMs?: number;
+  cachedAdmissions?: number;
+  asyncAdmissions?: number;
+  checkpointCalls?: number;
+  checkpointIncomplete?: number;
+  checkpointMs?: number;
+  checkpointMaxMs?: number;
+  vacuumMs?: number;
+  vacuumPasses?: number;
+  vacuumPagesRequested?: number;
+  queryMs?: number;
+  rowDeletionMs?: number;
+  fileRemovalMs?: number;
+  removedFiles?: number;
+  missingFiles?: number;
+  failedRemovals?: number;
+  measurementMs?: number;
+  measurements?: number;
+  legacyInventoryMs?: number;
+  completed?: boolean;
+};
+
 export type SqliteSessionWriteDiagnostics = SqliteSessionReclamationDiagnostics & {
   artifactPreparation?: SqliteSessionArtifactPreparationDiagnostics;
+  archivePruning?: SqliteSessionArchivePruningDiagnostics;
   reclamationAdmission?: SqliteSessionReclamationAdmissionDiagnostics;
 };
 

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -26,7 +26,9 @@ async function readFailedWriterLog(failure: unknown, diagnostics?: SqliteSession
       logging.setLoggerOverride({ level: "warn", file: logPath });
       const operation = diagnostics?.artifactPreparation
         ? "session.lifecycle.artifacts-prepare"
-        : "session.transcript.batch";
+        : diagnostics?.archivePruning
+          ? "session.history.archive-prune"
+          : "session.transcript.batch";
       try {
         await expect(
           runExclusiveSqliteSessionWrite(
@@ -147,6 +149,36 @@ test("artifact preparation file logs retain numeric phases without payload field
   });
   expect(record.content).not.toContain("synthetic-private-session");
   expect(record.content).not.toContain("synthetic-private-marker");
+});
+
+test("archive pruning file logs whitelist partial stage observations", async () => {
+  const archivePruning = {
+    trigger: "initial" as const,
+    admissionMs: 1200.4,
+    asyncAdmissions: 1,
+    checkpointCalls: 2,
+    checkpointIncomplete: 1,
+    checkpointMs: 20.6,
+    checkpointMaxMs: 19.6,
+    completed: false,
+    archiveName: "synthetic-private-archive",
+    content: "synthetic-private-transcript",
+  };
+  const record = await readFailedWriterLog(new Error("synthetic pruning failure"), {
+    archivePruning,
+  });
+  expect(record.details.archivePruning).toEqual({
+    trigger: "initial",
+    admissionMs: 1200,
+    asyncAdmissions: 1,
+    checkpointCalls: 2,
+    checkpointIncomplete: 1,
+    checkpointMs: 21,
+    checkpointMaxMs: 20,
+    completed: false,
+  });
+  expect(record.content).not.toContain("synthetic-private-archive");
+  expect(record.content).not.toContain("synthetic-private-transcript");
 });
 
 test.each([false, true])(

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -32,6 +32,7 @@ import type {
   SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
   SqliteSessionArtifactPreparationDiagnostics,
+  SqliteSessionArchivePruningDiagnostics,
   SqliteSessionDatabaseAdmissionDiagnostics,
   SqliteSessionWriteDiagnostics,
 } from "./session-accessor.sqlite-contract.js";
@@ -187,6 +188,34 @@ function artifactPreparationLogFields(diagnostics: SqliteSessionArtifactPreparat
   };
 }
 
+function archivePruningLogFields(diagnostics: SqliteSessionArchivePruningDiagnostics) {
+  const milliseconds = (value: number | undefined) =>
+    value === undefined ? undefined : Math.round(value);
+  return {
+    trigger: diagnostics.trigger,
+    admissionMs: milliseconds(diagnostics.admissionMs),
+    cachedAdmissions: diagnostics.cachedAdmissions,
+    asyncAdmissions: diagnostics.asyncAdmissions,
+    checkpointCalls: diagnostics.checkpointCalls,
+    checkpointIncomplete: diagnostics.checkpointIncomplete,
+    checkpointMs: milliseconds(diagnostics.checkpointMs),
+    checkpointMaxMs: milliseconds(diagnostics.checkpointMaxMs),
+    vacuumMs: milliseconds(diagnostics.vacuumMs),
+    vacuumPasses: diagnostics.vacuumPasses,
+    vacuumPagesRequested: diagnostics.vacuumPagesRequested,
+    queryMs: milliseconds(diagnostics.queryMs),
+    rowDeletionMs: milliseconds(diagnostics.rowDeletionMs),
+    fileRemovalMs: milliseconds(diagnostics.fileRemovalMs),
+    removedFiles: diagnostics.removedFiles,
+    missingFiles: diagnostics.missingFiles,
+    failedRemovals: diagnostics.failedRemovals,
+    measurementMs: milliseconds(diagnostics.measurementMs),
+    measurements: diagnostics.measurements,
+    legacyInventoryMs: milliseconds(diagnostics.legacyInventoryMs),
+    completed: diagnostics.completed === true,
+  };
+}
+
 export async function runExclusiveSqliteSessionWrite<T>(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   fn: () => Promise<T>,
@@ -214,6 +243,9 @@ export async function runExclusiveSqliteSessionWrite<T>(
       : {}),
     ...(diagnostics?.artifactPreparation
       ? { artifactPreparation: artifactPreparationLogFields(diagnostics.artifactPreparation) }
+      : {}),
+    ...(diagnostics?.archivePruning
+      ? { archivePruning: archivePruningLogFields(diagnostics.archivePruning) }
       : {}),
     elapsedMs: Math.round(completedAt - startedAt),
     ...(timing.startedAt !== undefined && timing.finishedAt !== undefined

--- a/src/config/sessions/session-accessor.sqlite-writer-owners.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-writer-owners.test.ts
@@ -34,7 +34,7 @@ import { resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
 
 afterEach(() => vi.restoreAllMocks());
 
-function observeSlowWriters(onWarning: (operation: unknown) => void = () => {}) {
+function observeSlowWriters(onWarning: (operation: unknown, fields: object) => void = () => {}) {
   let clock = 0;
   // Cross the existing threshold deterministically; all storage and callback work remains real.
   vi.spyOn(performance, "now").mockImplementation(() => (clock += 1_001));
@@ -47,7 +47,7 @@ function observeSlowWriters(onWarning: (operation: unknown) => void = () => {}) 
         assert(fields && typeof fields === "object");
         const operation = "operation" in fields ? fields.operation : undefined;
         operations.push(operation);
-        onWarning(operation);
+        onWarning(operation, fields);
       }
       return undefined;
     });
@@ -229,72 +229,111 @@ it.each(
   },
 );
 
-it("distinguishes initial, repeated, and final archive pruning from post-deletion free-page draining", async () => {
-  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
-    const storePath = path.join(state.sessionsDir(), "sessions.json");
-    const historyKey = "agent:main:writer-history";
-    replaceSessionEntrySync(
-      { sessionKey: historyKey, storePath },
-      { sessionId: "old", updatedAt: 1 },
-    );
-    replaceTranscriptEventsSync({ sessionKey: historyKey, sessionId: "old", storePath }, [
-      { type: "session", id: "old", content: "historical payload" },
-    ]);
-    await resetSessionEntryLifecycle({
-      storePath,
-      target: { canonicalKey: historyKey, storeKeys: [historyKey] },
-      buildNextEntry: () => ({ sessionId: "current", updatedAt: Date.now() }),
-    });
-    const archivedKey = "agent:main:writer-capped";
-    replaceSessionEntrySync(
-      { sessionKey: archivedKey, storePath },
-      {
-        sessionId: "capped",
-        updatedAt: 1,
-        archivedAt: 1,
-        archiveReason: "active-session-cap",
-      },
-    );
-    replaceTranscriptEventsSync({ sessionKey: archivedKey, sessionId: "capped", storePath }, [
-      { type: "session", id: "capped", content: "capped payload".repeat(8_192) },
-    ]);
-    const operations = observeSlowWriters();
-    try {
-      expect(
-        await enforceSqliteSessionHistoryDiskBudget({
-          storePath,
-          mode: "enforce",
-          maintenance: { maxDiskBytes: 1, highWaterBytes: 0 },
-        }),
-      ).toMatchObject({ removedEntries: 2 });
-      expect(
-        operations.filter(
-          (label) =>
-            label === "session.history.archive-prune" || label === "session.history.free-pages",
-        ),
-      ).toEqual([
-        "session.history.archive-prune",
-        "session.history.archive-prune",
-        "session.history.archive-prune",
-        "session.history.free-pages",
+it.each([false, true])(
+  "distinguishes archive pruning stages and preserves incomplete checkpoint behavior (%s)",
+  async (incomplete) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const storePath = path.join(state.sessionsDir(), "sessions.json");
+      const historyKey = "agent:main:writer-history";
+      replaceSessionEntrySync(
+        { sessionKey: historyKey, storePath },
+        { sessionId: "old", updatedAt: 1 },
+      );
+      replaceTranscriptEventsSync({ sessionKey: historyKey, sessionId: "old", storePath }, [
+        { type: "session", id: "old", content: "historical payload" },
       ]);
-      expect(loadSessionEntry({ sessionKey: historyKey, storePath })?.sessionId).toBe("current");
-      expect(loadSessionEntry({ sessionKey: archivedKey, storePath })).toBeUndefined();
-      expect(
-        loadTranscriptEventsSync({ sessionKey: historyKey, sessionId: "old", storePath }),
-      ).toEqual([]);
-      expect(
-        fs.readdirSync(state.sessionsDir()).filter((name) => name.includes(".deleted.")),
-      ).toEqual([]);
+      await resetSessionEntryLifecycle({
+        storePath,
+        target: { canonicalKey: historyKey, storeKeys: [historyKey] },
+        buildNextEntry: () => ({ sessionId: "current", updatedAt: Date.now() }),
+      });
+      const archivedKey = "agent:main:writer-capped";
+      replaceSessionEntrySync(
+        { sessionKey: archivedKey, storePath },
+        {
+          sessionId: "capped",
+          updatedAt: 1,
+          archivedAt: 1,
+          archiveReason: "active-session-cap",
+        },
+      );
+      replaceTranscriptEventsSync({ sessionKey: archivedKey, sessionId: "capped", storePath }, [
+        { type: "session", id: "capped", content: "capped payload".repeat(8_192) },
+      ]);
       const database = openOpenClawAgentDatabase(
         toDatabaseOptions(resolveSqliteScope({ sessionKey: historyKey, storePath })),
       );
-      expect(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count).toBe(0);
-    } finally {
-      vi.restoreAllMocks();
-    }
-  });
-});
+      if (incomplete) {
+        const checkpoint = database.walMaintenance.checkpoint;
+        vi.spyOn(database.walMaintenance, "checkpoint").mockImplementationOnce(() => {
+          checkpoint();
+          return false;
+        });
+      }
+      const pruning: unknown[] = [];
+      const operations = observeSlowWriters((operation, fields) => {
+        if (operation === "session.history.archive-prune") {
+          pruning.push("archivePruning" in fields ? fields.archivePruning : undefined);
+        }
+      });
+      try {
+        expect(
+          await enforceSqliteSessionHistoryDiskBudget({
+            storePath,
+            mode: "enforce",
+            maintenance: { maxDiskBytes: 1, highWaterBytes: 0 },
+          }),
+        ).toMatchObject({ removedEntries: 2 });
+        expect(
+          operations.filter(
+            (label) =>
+              label === "session.history.archive-prune" || label === "session.history.free-pages",
+          ),
+        ).toEqual([
+          "session.history.archive-prune",
+          "session.history.archive-prune",
+          "session.history.archive-prune",
+          "session.history.free-pages",
+        ]);
+        expect(pruning).toEqual([
+          expect.objectContaining({ trigger: "initial", completed: true }),
+          expect.objectContaining({ trigger: "after-eviction", completed: true }),
+          expect.objectContaining({ trigger: "final", completed: true }),
+        ]);
+        expect(pruning[0]).toMatchObject({ checkpointIncomplete: incomplete ? 1 : 0 });
+        for (const diagnostic of pruning) {
+          expect(diagnostic).toMatchObject({
+            admissionMs: expect.any(Number),
+            cachedAdmissions: expect.any(Number),
+            checkpointCalls: expect.any(Number),
+            checkpointMs: expect.any(Number),
+            checkpointMaxMs: expect.any(Number),
+            queryMs: expect.any(Number),
+            measurementMs: expect.any(Number),
+            measurements: expect.any(Number),
+            legacyInventoryMs: expect.any(Number),
+          });
+        }
+        expect(pruning[1]).toMatchObject({
+          fileRemovalMs: expect.any(Number),
+          removedFiles: 1,
+          rowDeletionMs: expect.any(Number),
+        });
+        expect(loadSessionEntry({ sessionKey: historyKey, storePath })?.sessionId).toBe("current");
+        expect(loadSessionEntry({ sessionKey: archivedKey, storePath })).toBeUndefined();
+        expect(
+          loadTranscriptEventsSync({ sessionKey: historyKey, sessionId: "old", storePath }),
+        ).toEqual([]);
+        expect(
+          fs.readdirSync(state.sessionsDir()).filter((name) => name.includes(".deleted.")),
+        ).toEqual([]);
+        expect(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count).toBe(0);
+      } finally {
+        vi.restoreAllMocks();
+      }
+    });
+  },
+);
 
 it("coalesces automatic maintenance under its own planning and finalization labels", async () => {
   await withOpenClawTestState({ scenario: "minimal" }, async (state) => {

--- a/src/config/sessions/session-history-archive-pruning-diagnostics.ts
+++ b/src/config/sessions/session-history-archive-pruning-diagnostics.ts
@@ -1,0 +1,45 @@
+import { performance } from "node:perf_hooks";
+import type { SqliteSessionArchivePruningDiagnostics } from "./session-accessor.sqlite-contract.js";
+
+type PruningStage =
+  | "vacuumMs"
+  | "queryMs"
+  | "rowDeletionMs"
+  | "fileRemovalMs"
+  | "measurementMs"
+  | "legacyInventoryMs";
+
+export function timeArchivePruningSync<T>(
+  diagnostics: SqliteSessionArchivePruningDiagnostics | undefined,
+  stage: PruningStage,
+  operation: () => T,
+): T {
+  if (!diagnostics) {
+    return operation();
+  }
+  const startedAt = performance.now();
+  try {
+    return operation();
+  } finally {
+    diagnostics[stage] = (diagnostics[stage] ?? 0) + performance.now() - startedAt;
+  }
+}
+
+export async function timeArchivePruningAsync<T>(
+  diagnostics: SqliteSessionArchivePruningDiagnostics | undefined,
+  stage: PruningStage,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!diagnostics) {
+    return await operation();
+  }
+  if (stage === "measurementMs") {
+    diagnostics.measurements = (diagnostics.measurements ?? 0) + 1;
+  }
+  const startedAt = performance.now();
+  try {
+    return await operation();
+  } finally {
+    diagnostics[stage] = (diagnostics[stage] ?? 0) + performance.now() - startedAt;
+  }
+}

--- a/src/config/sessions/session-history-archive-pruning.admission.test.ts
+++ b/src/config/sessions/session-history-archive-pruning.admission.test.ts
@@ -8,6 +8,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import * as sqlite from "../../infra/node-sqlite.js";
 import * as integrity from "../../infra/sqlite-integrity-worker.js";
+import * as logging from "../../logging/logger.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesAsync,
@@ -255,6 +256,20 @@ it.each([
       ),
     );
     await blockerEntered.promise;
+    const archivePruning = { trigger: "initial" as const };
+    const warnings: unknown[] = [];
+    const getChildLogger = logging.getChildLogger;
+    vi.spyOn(logging, "getChildLogger").mockImplementation((...args) => {
+      const logger = getChildLogger(...args);
+      vi.spyOn(logger, "warn").mockImplementation((message, fields) => {
+        if (message === "SQLite session write failed") {
+          assert(fields && typeof fields === "object");
+          warnings.push("archivePruning" in fields ? fields.archivePruning : undefined);
+        }
+        return undefined;
+      });
+      return logger;
+    });
     const work = own(
       runExclusiveSqliteSessionWrite(
         options,
@@ -263,9 +278,10 @@ it.each([
           events.push("maintenance-entered");
           try {
             return boundary === "drain"
-              ? await reclaimSqliteFreePages(options)
+              ? await reclaimSqliteFreePages(options, archivePruning)
               : await pruneAllSessionTranscriptArchivesToHighWater({
                   archiveDirectory: path.dirname(archivePath),
+                  diagnostics: archivePruning,
                   databaseOptions: options,
                   highWaterBytes: 1,
                   storePath,
@@ -276,6 +292,7 @@ it.each([
           }
         },
         "session.history.archive-prune",
+        { archivePruning },
       ),
     );
     const later = own(
@@ -319,6 +336,16 @@ it.each([
     if (outcome === "revoked") {
       await expect(work).rejects.toThrow(/revoked/);
       expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+      expect(warnings).toEqual([
+        expect.objectContaining({
+          trigger: "initial",
+          completed: false,
+          asyncAdmissions: 1,
+          admissionMs: expect.any(Number),
+          checkpointCalls: expect.any(Number),
+          checkpointMs: expect.any(Number),
+        }),
+      ]);
     } else if (boundary === "drain") {
       await work;
     } else {
@@ -350,6 +377,11 @@ it.each([
       expect(fs.existsSync(archivePath)).toBe(false);
     }
     if (boundary === "drain") {
+      expect(archivePruning).toMatchObject({
+        vacuumMs: expect.any(Number),
+        vacuumPasses: expect.any(Number),
+        vacuumPagesRequested: outcome === "revoked" ? firstDrainedPages : initialFreePages,
+      });
       expect(firstDrainedPages).toBeGreaterThan(0);
       expect(firstDrainedPages).toBeLessThanOrEqual(512);
       expect(readFreePages(reopened.db)).toBe(

--- a/src/config/sessions/session-history-archive-pruning.admission.test.ts
+++ b/src/config/sessions/session-history-archive-pruning.admission.test.ts
@@ -77,6 +77,61 @@ function own<T>(promise: Promise<T>): Promise<T> {
   return promise;
 }
 
+function observePruningFailures() {
+  const warnings: unknown[] = [];
+  const getChildLogger = logging.getChildLogger;
+  vi.spyOn(logging, "getChildLogger").mockImplementation((...args) => {
+    const logger = getChildLogger(...args);
+    vi.spyOn(logger, "warn").mockImplementation((message, fields) => {
+      if (message === "SQLite session write failed") {
+        assert(fields && typeof fields === "object");
+        warnings.push("archivePruning" in fields ? fields.archivePruning : undefined);
+      }
+      return undefined;
+    });
+    return logger;
+  });
+  return warnings;
+}
+
+it("does not invent an admission mode when a warm database rejects a different owner", async () => {
+  const options = { agentId: "main", env: state.env };
+  const database = openOpenClawAgentDatabase(options);
+  const before = database.db.prepare("SELECT total_changes() AS changes").get();
+  const checkpoint = vi.spyOn(database.walMaintenance, "checkpoint");
+  const warnings = observePruningFailures();
+  const archivePruning = { trigger: "initial" as const };
+  const wrongOwner = { ...options, agentId: "other", path: database.path };
+  await expect(
+    runExclusiveSqliteSessionWrite(
+      wrongOwner,
+      async () =>
+        pruneAllSessionTranscriptArchivesToHighWater({
+          archiveDirectory: state.sessionsDir(),
+          databaseOptions: wrongOwner,
+          diagnostics: archivePruning,
+          highWaterBytes: 0,
+          storePath: path.join(state.sessionsDir(), "sessions.json"),
+        }),
+      "session.history.archive-prune",
+      { archivePruning },
+    ),
+  ).rejects.toThrow("already open for agent main; requested agent other");
+  expect(getOpenClawAgentDatabaseIfOpen(options)).toBe(database);
+  expect(checkpoint).not.toHaveBeenCalled();
+  expect(database.db.prepare("SELECT total_changes() AS changes").get()).toEqual(before);
+  expect(warnings).toEqual([
+    expect.objectContaining({
+      trigger: "initial",
+      completed: false,
+      admissionMs: expect.any(Number),
+      cachedAdmissions: undefined,
+      asyncAdmissions: undefined,
+      checkpointCalls: undefined,
+    }),
+  ]);
+});
+
 const boundaries = ["drain", "presence", "row", "unpublished", "removed-file"] as const;
 
 it.each([
@@ -257,19 +312,7 @@ it.each([
     );
     await blockerEntered.promise;
     const archivePruning = { trigger: "initial" as const };
-    const warnings: unknown[] = [];
-    const getChildLogger = logging.getChildLogger;
-    vi.spyOn(logging, "getChildLogger").mockImplementation((...args) => {
-      const logger = getChildLogger(...args);
-      vi.spyOn(logger, "warn").mockImplementation((message, fields) => {
-        if (message === "SQLite session write failed") {
-          assert(fields && typeof fields === "object");
-          warnings.push("archivePruning" in fields ? fields.archivePruning : undefined);
-        }
-        return undefined;
-      });
-      return logger;
-    });
+    const warnings = observePruningFailures();
     const work = own(
       runExclusiveSqliteSessionWrite(
         options,

--- a/src/config/sessions/session-history-archive-pruning.ts
+++ b/src/config/sessions/session-history-archive-pruning.ts
@@ -37,8 +37,11 @@ async function withArchivePruningDatabase<T>(
   } finally {
     if (diagnostics && admission?.admissionMs !== undefined) {
       diagnostics.admissionMs = (diagnostics.admissionMs ?? 0) + admission.admissionMs;
-      const count = admission.admissionMode === "cached" ? "cachedAdmissions" : "asyncAdmissions";
-      diagnostics[count] = (diagnostics[count] ?? 0) + 1;
+      if (admission.admissionMode === "cached") {
+        diagnostics.cachedAdmissions = (diagnostics.cachedAdmissions ?? 0) + 1;
+      } else if (admission.admissionMode === "async") {
+        diagnostics.asyncAdmissions = (diagnostics.asyncAdmissions ?? 0) + 1;
+      }
     }
   }
 }

--- a/src/config/sessions/session-history-archive-pruning.ts
+++ b/src/config/sessions/session-history-archive-pruning.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { setImmediate } from "node:timers/promises";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
@@ -13,10 +14,58 @@ import {
   pruneSessionTranscriptArchivesToHighWater,
   type SessionPhysicalDiskUsage,
 } from "./disk-budget.js";
+import type {
+  SqliteSessionArchivePruningDiagnostics,
+  SqliteSessionDatabaseAdmissionDiagnostics,
+} from "./session-accessor.sqlite-contract.js";
 import { getSessionKysely, withSqliteSessionDatabase } from "./session-accessor.sqlite-scope.js";
+import {
+  timeArchivePruningAsync,
+  timeArchivePruningSync,
+} from "./session-history-archive-pruning-diagnostics.js";
+
+async function withArchivePruningDatabase<T>(
+  options: OpenClawAgentDatabaseOptions,
+  diagnostics: SqliteSessionArchivePruningDiagnostics | undefined,
+  operation: (database: OpenClawAgentDatabase) => T,
+): Promise<T> {
+  const admission: SqliteSessionDatabaseAdmissionDiagnostics | undefined = diagnostics
+    ? {}
+    : undefined;
+  try {
+    return await withSqliteSessionDatabase(options, operation, undefined, admission);
+  } finally {
+    if (diagnostics && admission?.admissionMs !== undefined) {
+      diagnostics.admissionMs = (diagnostics.admissionMs ?? 0) + admission.admissionMs;
+      const count = admission.admissionMode === "cached" ? "cachedAdmissions" : "asyncAdmissions";
+      diagnostics[count] = (diagnostics[count] ?? 0) + 1;
+    }
+  }
+}
+
+function checkpointArchivePruning(
+  database: OpenClawAgentDatabase,
+  diagnostics: SqliteSessionArchivePruningDiagnostics | undefined,
+): void {
+  if (!diagnostics) {
+    database.walMaintenance.checkpoint();
+    return;
+  }
+  diagnostics.checkpointCalls = (diagnostics.checkpointCalls ?? 0) + 1;
+  const startedAt = performance.now();
+  try {
+    const completed = database.walMaintenance.checkpoint();
+    diagnostics.checkpointIncomplete = (diagnostics.checkpointIncomplete ?? 0) + Number(!completed);
+  } finally {
+    const elapsedMs = performance.now() - startedAt;
+    diagnostics.checkpointMs = (diagnostics.checkpointMs ?? 0) + elapsedMs;
+    diagnostics.checkpointMaxMs = Math.max(diagnostics.checkpointMaxMs ?? 0, elapsedMs);
+  }
+}
 
 export async function reclaimSqliteFreePages(
   databaseOptions: OpenClawAgentDatabaseOptions,
+  diagnostics?: SqliteSessionArchivePruningDiagnostics,
 ): Promise<void> {
   let remaining: number | undefined;
   while (remaining === undefined || remaining > 0) {
@@ -24,25 +73,37 @@ export async function reclaimSqliteFreePages(
       await setImmediate();
     }
     // Reacquire after yielding while the caller retains its writer section.
-    const nextRemaining = await withSqliteSessionDatabase(databaseOptions, (database) => {
-      database.walMaintenance.checkpoint();
-      // sqlite-allow-raw -- Physical budget decisions need current SQLite page accounting.
-      const freePages = () =>
-        Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count ?? 0);
-      const before = freePages();
-      if (!Number.isSafeInteger(before) || before <= 0) {
-        return undefined;
-      }
-      // Bound the entire drain to its initial freelist, even if other writers free more pages.
-      const passRemaining = Math.min(remaining ?? before, before);
-      const pages = Math.min(512, passRemaining);
-      database.db.exec(`PRAGMA incremental_vacuum(${pages});`); // sqlite-allow-raw -- Bounded maintenance outside a transaction.
-      database.walMaintenance.checkpoint();
-      if (freePages() >= before) {
-        return undefined;
-      }
-      return passRemaining - pages;
-    });
+    const nextRemaining = await withArchivePruningDatabase(
+      databaseOptions,
+      diagnostics,
+      (database) => {
+        checkpointArchivePruning(database, diagnostics);
+        // sqlite-allow-raw -- Physical budget decisions need current SQLite page accounting.
+        const freePages = () =>
+          timeArchivePruningSync(diagnostics, "queryMs", () =>
+            Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count ?? 0),
+          );
+        const before = freePages();
+        if (!Number.isSafeInteger(before) || before <= 0) {
+          return undefined;
+        }
+        // Bound the entire drain to its initial freelist, even if other writers free more pages.
+        const passRemaining = Math.min(remaining ?? before, before);
+        const pages = Math.min(512, passRemaining);
+        if (diagnostics) {
+          diagnostics.vacuumPasses = (diagnostics.vacuumPasses ?? 0) + 1;
+          diagnostics.vacuumPagesRequested = (diagnostics.vacuumPagesRequested ?? 0) + pages;
+        }
+        timeArchivePruningSync(diagnostics, "vacuumMs", () => {
+          database.db.exec(`PRAGMA incremental_vacuum(${pages});`); // sqlite-allow-raw -- Bounded maintenance outside a transaction.
+        });
+        checkpointArchivePruning(database, diagnostics);
+        if (freePages() >= before) {
+          return undefined;
+        }
+        return passRemaining - pages;
+      },
+    );
     if (nextRemaining === undefined) {
       return;
     }
@@ -113,26 +174,32 @@ function readUnpublishedSessionTranscriptArchiveNames(
 async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
   archiveDirectory: string;
   databaseOptions: OpenClawAgentDatabaseOptions;
+  diagnostics?: SqliteSessionArchivePruningDiagnostics;
   highWaterBytes: number;
   storePath: string;
 }): Promise<{ removedFiles: number; usage: SessionPhysicalDiskUsage }> {
-  let usage = await measureSessionPhysicalDiskUsage(params.storePath);
+  const { diagnostics } = params;
+  let usage = await timeArchivePruningAsync(diagnostics, "measurementMs", () =>
+    measureSessionPhysicalDiskUsage(params.storePath),
+  );
   let removedFiles = 0;
   while (usage.totalBytes > params.highWaterBytes) {
-    const row = await withSqliteSessionDatabase(params.databaseOptions, (database) => {
-      const db = getSessionKysely(database.db);
-      return executeSqliteQuerySync(
-        database.db,
-        db
-          .selectFrom("session_transcript_archives")
-          .select(["archive_name", "generation", "session_id"])
-          .where("published_at", "is not", null)
-          .orderBy("created_at", "asc")
-          .orderBy("session_id", "asc")
-          .orderBy("generation", "asc")
-          .limit(1),
-      ).rows[0];
-    });
+    const row = await withArchivePruningDatabase(params.databaseOptions, diagnostics, (database) =>
+      timeArchivePruningSync(diagnostics, "queryMs", () => {
+        const db = getSessionKysely(database.db);
+        return executeSqliteQuerySync(
+          database.db,
+          db
+            .selectFrom("session_transcript_archives")
+            .select(["archive_name", "generation", "session_id"])
+            .where("published_at", "is not", null)
+            .orderBy("created_at", "asc")
+            .orderBy("session_id", "asc")
+            .orderBy("generation", "asc")
+            .limit(1),
+        ).rows[0];
+      }),
+    );
     if (!row) {
       break;
     }
@@ -144,30 +211,45 @@ async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
       throw new Error(`Invalid canonical session archive name for ${row.session_id}`);
     }
     try {
-      await fs.promises.rm(archivePath);
+      await timeArchivePruningAsync(diagnostics, "fileRemovalMs", () =>
+        fs.promises.rm(archivePath),
+      );
       removedFiles += 1;
+      if (diagnostics) {
+        diagnostics.removedFiles = (diagnostics.removedFiles ?? 0) + 1;
+      }
     } catch (error) {
       // SAFETY: Node filesystem failures expose the documented errno code field.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         // The database is the recovery copy. Retain it unless its derived file
         // is gone, otherwise retention could leave an undeletable orphan.
+        if (diagnostics) {
+          diagnostics.failedRemovals = (diagnostics.failedRemovals ?? 0) + 1;
+        }
         break;
       }
+      if (diagnostics) {
+        diagnostics.missingFiles = (diagnostics.missingFiles ?? 0) + 1;
+      }
     }
-    await withSqliteSessionDatabase(params.databaseOptions, () =>
-      runOpenClawAgentWriteTransaction((transactionDb) => {
-        const transactionKysely = getSessionKysely(transactionDb.db);
-        executeSqliteQuerySync(
-          transactionDb.db,
-          transactionKysely
-            .deleteFrom("session_transcript_archives")
-            .where("session_id", "=", row.session_id)
-            .where("generation", "=", row.generation),
-        );
-      }, params.databaseOptions),
+    await withArchivePruningDatabase(params.databaseOptions, diagnostics, () =>
+      timeArchivePruningSync(diagnostics, "rowDeletionMs", () =>
+        runOpenClawAgentWriteTransaction((transactionDb) => {
+          const transactionKysely = getSessionKysely(transactionDb.db);
+          executeSqliteQuerySync(
+            transactionDb.db,
+            transactionKysely
+              .deleteFrom("session_transcript_archives")
+              .where("session_id", "=", row.session_id)
+              .where("generation", "=", row.generation),
+          );
+        }, params.databaseOptions),
+      ),
     );
-    await reclaimSqliteFreePages(params.databaseOptions);
-    usage = await measureSessionPhysicalDiskUsage(params.storePath);
+    await reclaimSqliteFreePages(params.databaseOptions, diagnostics);
+    usage = await timeArchivePruningAsync(diagnostics, "measurementMs", () =>
+      measureSessionPhysicalDiskUsage(params.storePath),
+    );
   }
   return { removedFiles, usage };
 }
@@ -175,28 +257,50 @@ async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
 export async function pruneAllSessionTranscriptArchivesToHighWater(params: {
   archiveDirectory: string;
   databaseOptions: OpenClawAgentDatabaseOptions;
+  diagnostics?: SqliteSessionArchivePruningDiagnostics;
   highWaterBytes: number;
   storePath: string;
 }): Promise<{ removedFiles: number; usage: SessionPhysicalDiskUsage }> {
+  const { diagnostics } = params;
   // Reclaim committed free pages before pressure can destroy a retained archive.
-  await reclaimSqliteFreePages(params.databaseOptions);
-  const canonical = (await withSqliteSessionDatabase(
+  await reclaimSqliteFreePages(params.databaseOptions, diagnostics);
+  const canonical = (await withArchivePruningDatabase(
     params.databaseOptions,
-    hasCanonicalSessionTranscriptArchivesInDatabase,
+    diagnostics,
+    (database) =>
+      timeArchivePruningSync(diagnostics, "queryMs", () =>
+        hasCanonicalSessionTranscriptArchivesInDatabase(database),
+      ),
   ))
     ? await pruneCanonicalSessionTranscriptArchivesToHighWater(params)
-    : { removedFiles: 0, usage: await measureSessionPhysicalDiskUsage(params.storePath) };
+    : {
+        removedFiles: 0,
+        usage: await timeArchivePruningAsync(diagnostics, "measurementMs", () =>
+          measureSessionPhysicalDiskUsage(params.storePath),
+        ),
+      };
   if (canonical.usage.totalBytes <= params.highWaterBytes) {
+    if (diagnostics) {
+      diagnostics.completed = true;
+    }
     return canonical;
   }
   const legacy = await pruneSessionTranscriptArchivesToHighWater({
-    excludeNames: await withSqliteSessionDatabase(
+    diagnostics,
+    excludeNames: await withArchivePruningDatabase(
       params.databaseOptions,
-      readUnpublishedSessionTranscriptArchiveNames,
+      diagnostics,
+      (database) =>
+        timeArchivePruningSync(diagnostics, "queryMs", () =>
+          readUnpublishedSessionTranscriptArchiveNames(database),
+        ),
     ),
     highWaterBytes: params.highWaterBytes,
     storePath: params.storePath,
   });
+  if (diagnostics) {
+    diagnostics.completed = true;
+  }
   return {
     removedFiles: canonical.removedFiles + legacy.removedFiles,
     usage: legacy.usage,

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -19,7 +19,10 @@ import {
 } from "./disk-budget.js";
 import { publishSessionStateArchives } from "./session-accessor.sqlite-archive-store.js";
 import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
-import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
+import type {
+  SqliteSessionArchivePruningDiagnostics,
+  SqliteSessionReclamationDiagnostics,
+} from "./session-accessor.sqlite-contract.js";
 import { emitArchivedTranscriptUpdates } from "./session-accessor.sqlite-events.js";
 import {
   collectSessionStateIdsForEntry,
@@ -492,17 +495,23 @@ async function enforceSessionHistoryMaintenanceSerialized(
   });
   const databaseOptions = toDatabaseOptions(resolved);
   const archiveDirectory = resolveSqliteTranscriptArchiveDirectory(resolved);
-  let { usage, removedFiles } = await runExclusiveSqliteSessionWrite(
-    resolved,
-    async () =>
-      pruneAllSessionTranscriptArchivesToHighWater({
-        archiveDirectory,
-        databaseOptions,
-        highWaterBytes,
-        storePath: params.storePath,
-      }),
-    "session.history.archive-prune",
-  );
+  const pruneArchives = (trigger: SqliteSessionArchivePruningDiagnostics["trigger"]) => {
+    const archivePruning: SqliteSessionArchivePruningDiagnostics = { trigger };
+    return runExclusiveSqliteSessionWrite(
+      resolved,
+      async () =>
+        pruneAllSessionTranscriptArchivesToHighWater({
+          archiveDirectory,
+          databaseOptions,
+          diagnostics: archivePruning,
+          highWaterBytes,
+          storePath: params.storePath,
+        }),
+      "session.history.archive-prune",
+      { archivePruning },
+    );
+  };
+  let { usage, removedFiles } = await pruneArchives("initial");
   let removedEntries = 0;
   const candidates = readHistoricalSessionIds({
     databaseOptions,
@@ -624,17 +633,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
       // destroyed at most once, and pruning an extracted copy beats evicting
       // additional searchable history. No prune runs between an archive write
       // and its row-deletion commit, so a sole copy is never mid-flight here.
-      const repruned = await runExclusiveSqliteSessionWrite(
-        resolved,
-        async () =>
-          pruneAllSessionTranscriptArchivesToHighWater({
-            archiveDirectory,
-            databaseOptions,
-            highWaterBytes,
-            storePath: params.storePath,
-          }),
-        "session.history.archive-prune",
-      );
+      const repruned = await pruneArchives("after-eviction");
       removedFiles += repruned.removedFiles;
       usage = repruned.usage;
     }
@@ -643,17 +642,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
   if (usage.totalBytes > highWaterBytes) {
     // Candidates are exhausted but archives may remain; finish the pass at the
     // target instead of returning over budget with removable artifacts.
-    const finalPrune = await runExclusiveSqliteSessionWrite(
-      resolved,
-      async () =>
-        pruneAllSessionTranscriptArchivesToHighWater({
-          archiveDirectory,
-          databaseOptions,
-          highWaterBytes,
-          storePath: params.storePath,
-        }),
-      "session.history.archive-prune",
-    );
+    const finalPrune = await pruneArchives("final");
     removedFiles += finalPrune.removedFiles;
     usage = finalPrune.usage;
   }


### PR DESCRIPTION
Related: #143379, #143451, #138669.

## What Problem This Solves

Resolves a problem where operators investigating slow or failed session-history archive pruning could see only the writer's total duration. That duration includes database admission, synchronous checkpoint/vacuum work, file operations, and asynchronous physical-disk measurement, so it could not identify which stage required investigation.

## Why This Change Was Made

The existing slow/failure writer warning now includes one bounded `archivePruning` object, with a fixed `initial`, `after-eviction`, or `final` trigger and aggregate stage durations and outcome counters. Timings survive failures and use a fixed serialization whitelist. Existing operations supply every observation; no additional store reads or per-file records are introduced.

Checkpoint mode and timeout, the initial-freelist/512-page vacuum bound, writer and lifecycle ownership, archive selection, file-before-row deletion, errors, and retention behavior remain unchanged. This improves diagnosis; it does not fix checkpoint blocking or assign CPU time from wall-clock durations.

## User Impact

Operators can distinguish checkpoint stalls from awaited measurement or admission delays in the existing warnings. Documentation explains incomplete checkpoint results, requested vacuum pages, partial observations, and why normal completion does not guarantee the high-water target was reached. No configuration is required.

## Evidence

- The pre-change owner/log regression run failed five new assertions because diagnostic records were absent; the other 25 tests passed. The implemented change passes all 31 focused tests, including real maintenance callsites, cold-admission revocation, incomplete checkpoint returns, and file-log whitelisting. A real warm-cache wrong-owner refusal additionally reproduced a fabricated async-admission count on the first revision; the correction preserves refusal timing while counting only explicitly observed admission modes.
- A bounded synthetic full-owner run with an independent 1.5-second reader reported 1,587 ms of checkpoint time; independent native measurements totaled 1,587.300 ms. The queued real session mutation waited 1,604 ms. Both cases drained 64 free pages, persisted the mutation, and passed integrity/FK checks. The control separately exposed 2,619 ms awaiting physical measurement with only 21 ms in checkpoints; that measurement is not claimed to be CPU or scan time.
- Additional legacy-removal/history-eviction tests: 40 passed; six lifecycle setup cases failed in unchanged config-write admission because this host has an incompatible shared managed-handoff lease. The external lease was preserved. These failures occurred before the lifecycle attempts. All six unchanged assertions subsequently passed on the isolated Linux lease at the first candidate (28 unrelated cases skipped); the local lease remains untouched.
- Isolated P2 review: no actionable findings.
- Required `node scripts/check-changed.mjs` passed, including formatting, core/core-test typechecks, lint, unused exports, storage guards, and runtime import-cycle checks.
- Final candidate `ee1973de0bb8f278017c682f8637324b13bdcef6` passed the actual full-owner replay on isolated Linux Blacksmith Testbox (Ubuntu 24.04.3, Node 24.19.0): precise checkpoint total 1,507.370 ms versus independent native total 1,507.338 ms, successful queued mutation, integrity/FK checks, and 64-to-zero free-page reclamation. Tree `d6312ac8ae3f6413f6888617ca94f0199a000ab3` and all 22 source fingerprints matched. The new warm-cache refusal regression also passed on Linux (1 selected, 13 unselected). The task-owned leases are stopped and independently confirmed complete. Lease provisioning: https://github.com/openclaw/openclaw/actions/runs/34507630564.
