### PR TITLE
refactor(agents): remove duplicate OpenAI attribution test

### DIFF
--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -472,24 +472,6 @@ describe("provider attribution", () => {
     });
   });
 
-  it("maps legacy OpenAI Codex attribution to canonical OpenAI policy", () => {
-    expect(resolveProviderAttributionPolicy("openai", { OPENCLAW_VERSION: "2026.3.22" })).toEqual({
-      provider: "openai",
-      enabledByDefault: true,
-      verification: "vendor-hidden-api-spec",
-      hook: "request-headers",
-      reviewNote:
-        "OpenAI native traffic supports hidden originator/User-Agent attribution. Verified against the Codex wire contract.",
-      product: "OpenClaw",
-      version: "2026.3.22",
-      headers: {
-        originator: "openclaw",
-        version: "2026.3.22",
-        "User-Agent": "openclaw/2026.3.22",
-      },
-    });
-  });
-
   it("returns a hidden-spec xAI attribution policy", () => {
     expect(resolveProviderAttributionPolicy("xai", { OPENCLAW_VERSION: "2026.3.22" })).toEqual({
       provider: "xai",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The provider attribution suite repeated the same OpenAI policy assertion under a legacy-case title, without testing a distinct legacy input.

## Why This Change Was Made

Remove that duplicate. The retained hidden-spec OpenAI case uses the identical provider/version input and complete expected policy, and also checks the exact attribution headers.

## User Impact

No runtime behavior changes. This removes one test case and 18 lines; all other metadata, prepared-owner, endpoint and provider-capability cases remain unchanged.

## Evidence

- Complete ordered agents-core `provider-attribution.test.ts`: 43 actual passes, zero skips.
- All 20 selected changed-file checks passed, including three unused-export scans and final lint.
- Targeted formatting and whitespace checks passed.
- One scoped P2 review: no actionable findings.

No live provider/Codex/auth, migration, packaging, or local full-repository test run is claimed.
