### PR TITLE
feat(ui): show reported Gateway isolation

### DIFF
--- a/packages/gateway-protocol/src/schema/system-info.test.ts
+++ b/packages/gateway-protocol/src/schema/system-info.test.ts
@@ -34,6 +34,24 @@ describe("SystemInfoResultSchema", () => {
     expect(Value.Check(SystemInfoResultSchema, validSystemInfo)).toBe(true);
   });
 
+  it.each(["enabled", "disabled"] as const)(
+    "accepts the optional Gateway isolation state %s",
+    (gatewayIsolation) => {
+      expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, gatewayIsolation })).toBe(
+        true,
+      );
+    },
+  );
+
+  it("rejects an invalid Gateway isolation state", () => {
+    expect(
+      Value.Check(SystemInfoResultSchema, {
+        ...validSystemInfo,
+        gatewayIsolation: "unknown",
+      }),
+    ).toBe(false);
+  });
+
   it("rejects extra properties", () => {
     expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, extra: true })).toBe(false);
   });

--- a/packages/gateway-protocol/src/schema/system-info.ts
+++ b/packages/gateway-protocol/src/schema/system-info.ts
@@ -45,6 +45,7 @@ export const SystemInfoResultSchema = closedObject({
       }),
     ),
   ),
+  gatewayIsolation: Type.Optional(Type.Enum(["enabled", "disabled"] as const, { type: "string" })),
   /** Resolved utility model for the configured default agent. */
   defaultAgentUtilityModel: Type.Optional(UtilityModelStatusSchema),
 });

--- a/src/gateway/server-methods/system-info.test.ts
+++ b/src/gateway/server-methods/system-info.test.ts
@@ -44,7 +44,10 @@ describe("system.info", () => {
     vi.spyOn(os, "platform").mockReturnValue("darwin");
     mocks.runCommandWithTimeout.mockReset().mockImplementation(mountedVolumeOutput);
   });
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
 
   it("returns a schema-valid host resource snapshot", async () => {
     const respond = vi.fn();
@@ -125,6 +128,48 @@ describe("system.info", () => {
           ? []
           : [{ path: payload.diskPath, totalBytes: 2048, availableBytes: 1024 }],
       );
+    },
+  );
+
+  it.each(["enabled", "disabled"] as const)(
+    "reports the strict host isolation posture %s",
+    async (gatewayIsolation) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_ISOLATION", gatewayIsolation);
+      vi.resetModules();
+      const { systemHandlers: freshSystemHandlers } = await import("./system.js");
+      const respond = vi.fn();
+
+      await expectDefined(
+        freshSystemHandlers["system.info"],
+        "system.info handler",
+      )({
+        params: {},
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as unknown as GatewayRequestHandlerOptions);
+
+      expect(respond.mock.calls[0]?.[1]).toHaveProperty("gatewayIsolation", gatewayIsolation);
+    },
+  );
+
+  it.each([undefined, "", "ENABLED", "unknown"])(
+    "omits an absent, empty, or invalid host isolation posture %s",
+    async (gatewayIsolation) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_ISOLATION", gatewayIsolation);
+      vi.resetModules();
+      const { systemHandlers: freshSystemHandlers } = await import("./system.js");
+      const respond = vi.fn();
+
+      await expectDefined(
+        freshSystemHandlers["system.info"],
+        "system.info handler",
+      )({
+        params: {},
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as unknown as GatewayRequestHandlerOptions);
+
+      expect(respond.mock.calls[0]?.[1]).not.toHaveProperty("gatewayIsolation");
     },
   );
 });

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -49,6 +49,15 @@ import { assertValidParams } from "./validation.js";
 
 let advertisedLanHostPromise: Promise<string | null> | null = null;
 
+function readGatewayIsolation(): SystemInfoResult["gatewayIsolation"] {
+  const value = process.env.OPENCLAW_GATEWAY_ISOLATION;
+  return value === "enabled" || value === "disabled" ? value : undefined;
+}
+
+// The launch environment defines this process's posture. Keep it stable across
+// polling so the reported state cannot diverge from how the Gateway started.
+const gatewayIsolation = readGatewayIsolation();
+
 function resolveCachedAdvertisedLanHost(): Promise<string | null> {
   // Route discovery may spawn a platform command. Keep the result process-stable
   // so each visible Settings page does not repeat that work every ten seconds.
@@ -116,6 +125,7 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
           diskPath: stateDir,
         }
       : {}),
+    ...(gatewayIsolation ? { gatewayIsolation } : {}),
     defaultAgentUtilityModel,
   };
 }

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -40,7 +40,7 @@ const enSettings = {
     },
     gatewayIsolation: {
       title: "Gateway Isolation",
-      reportedState: "Reported Gateway isolation",
+      reportedState: "Reported Gateway Isolation",
       changeWithCli: "Change with CLI",
       instruction: "Run from your signed-in Windows user session.",
     },

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -38,6 +38,12 @@ const enSettings = {
       hideSecret: "Hide secret",
       toggleSecretVisibility: "Toggle secret visibility",
     },
+    gatewayIsolation: {
+      title: "Gateway isolation",
+      reportedState: "Reported Gateway isolation",
+      changeWithCli: "Change with CLI",
+      instruction: "Run from the signed-in Gateway user session.",
+    },
   },
   cloudWorkersPage: {
     snapshots: {

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -39,10 +39,10 @@ const enSettings = {
       toggleSecretVisibility: "Toggle secret visibility",
     },
     gatewayIsolation: {
-      title: "Gateway isolation",
+      title: "Gateway Isolation",
       reportedState: "Reported Gateway isolation",
       changeWithCli: "Change with CLI",
-      instruction: "Run from the signed-in Gateway user session.",
+      instruction: "Run from your signed-in Windows user session.",
     },
   },
   cloudWorkersPage: {

--- a/ui/src/pages/connection/system-section.ts
+++ b/ui/src/pages/connection/system-section.ts
@@ -1,8 +1,10 @@
 import { html, nothing } from "lit";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import {
+  renderSettingsRow,
   renderSettingsSection,
   renderSettingsStatus,
+  renderSettingsValue,
   type SettingsSectionProps,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -62,14 +64,14 @@ function renderSystemStat(stat: SystemStat) {
   return html`
     <div class="config-host__stat" title=${stat.path ?? stat.title ?? ""}>
       <div class="config-host__stat-label">
-        ${stat.label}${
-          stat.path ? html` <span class="config-host__stat-path">${stat.path}</span>` : nothing
-        }
+        ${stat.label}${stat.path
+          ? html` <span class="config-host__stat-path">${stat.path}</span>`
+          : nothing}
       </div>
       <div class="config-host__stat-value">
-        ${stat.value}${
-          stat.unit ? html` <span class="config-host__stat-unit">${stat.unit}</span>` : nothing
-        }
+        ${stat.value}${stat.unit
+          ? html` <span class="config-host__stat-unit">${stat.unit}</span>`
+          : nothing}
       </div>
       ${stat.usedFraction == null ? nothing : renderSystemMeter(label, stat.usedFraction)}
       ${stat.detail ? html`<div class="config-host__stat-detail">${stat.detail}</div>` : nothing}
@@ -157,6 +159,29 @@ function buildSystemStatsPlaceholder(): SystemStat[] {
   ];
 }
 
+function renderGatewayIsolationSection(info: SystemInfoResult | null | undefined) {
+  const gatewayIsolation = info?.gatewayIsolation;
+  if (!gatewayIsolation) {
+    return nothing;
+  }
+  const enabled = gatewayIsolation === "enabled";
+  const command = `clawctl gateway-isolation ${enabled ? "disable" : "enable"}`;
+  return renderSettingsSection({ title: t("connection.gatewayIsolation.title") }, [
+    renderSettingsRow({
+      title: t("connection.gatewayIsolation.reportedState"),
+      control: renderSettingsStatus({
+        kind: enabled ? "ok" : "warn",
+        label: t(enabled ? "common.enabled" : "common.disabled"),
+      }),
+    }),
+    renderSettingsRow({
+      title: t("connection.gatewayIsolation.changeWithCli"),
+      description: t("connection.gatewayIsolation.instruction"),
+      control: renderSettingsValue(command, { mono: true }),
+    }),
+  ]);
+}
+
 /** Gateway host section with the stable settings-search scroll target id. */
 export function renderSystemSection(props: SystemSectionProps) {
   if (props.systemInfoUnavailable) {
@@ -195,14 +220,12 @@ export function renderSystemSection(props: SystemSectionProps) {
                 ${info ? `${info.osLabel} · ${info.arch}` : placeholder}
               </div>
               <div class="config-host__meta">
-                ${
-                  info
-                    ? t("quickSettings.system.runtime", {
-                        version: info.nodeVersion,
-                        pid: String(info.pid),
-                      })
-                    : placeholder
-                }
+                ${info
+                  ? t("quickSettings.system.runtime", {
+                      version: info.nodeVersion,
+                      pid: String(info.pid),
+                    })
+                  : placeholder}
               </div>
               ${address ? html`<code class="config-host__address">${address}</code>` : nothing}
             </div>
@@ -211,5 +234,6 @@ export function renderSystemSection(props: SystemSectionProps) {
         `,
       )}
     </div>
+    ${renderGatewayIsolationSection(info)}
   `;
 }

--- a/ui/src/pages/connection/system-section.ts
+++ b/ui/src/pages/connection/system-section.ts
@@ -1,10 +1,10 @@
 import { html, nothing } from "lit";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
+import { renderCopyButton } from "../../components/copy-button.ts";
 import {
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsStatus,
-  renderSettingsValue,
   type SettingsSectionProps,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -177,7 +177,13 @@ function renderGatewayIsolationSection(info: SystemInfoResult | null | undefined
     renderSettingsRow({
       title: t("connection.gatewayIsolation.changeWithCli"),
       description: t("connection.gatewayIsolation.instruction"),
-      control: renderSettingsValue(command, { mono: true }),
+      control: html`
+        <div class="gateway-isolation-command">
+          <code translate="no">${command}</code>
+          ${renderCopyButton(command, t("connection.help.copyCommand"))}
+        </div>
+      `,
+      stacked: true,
     }),
   ]);
 }

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import { deviceSystemInfo } from "../../test-helpers/devices-fixtures.ts";
@@ -291,26 +291,55 @@ describe("connection view rendering", () => {
       expectedCommand: "clawctl gateway-isolation enable",
     },
   ])(
-    "shows the reported $gatewayIsolation Gateway isolation posture",
-    ({ gatewayIsolation, expectedState, expectedCommand }) => {
-      const container = document.createElement("div");
-      render(
-        renderConnection(
-          createConnectionProps({
-            systemInfo: { ...deviceSystemInfo, gatewayIsolation },
-          }),
-        ),
-        container,
-      );
+    "shows the reported $gatewayIsolation Gateway Isolation posture",
+    async ({ gatewayIsolation, expectedState, expectedCommand }) => {
+      const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+      const container = document.body.appendChild(document.createElement("div"));
 
-      const isolationHeading = Array.from(
-        container.querySelectorAll<HTMLElement>(".settings-section__heading"),
-      ).find((heading) => heading.textContent?.trim() === "Gateway isolation");
-      const isolationSection = isolationHeading?.closest(".settings-section");
-      expect(isolationSection).not.toBeNull();
-      expect(isolationSection?.textContent).toContain("Reported Gateway isolation");
-      expect(isolationSection?.textContent).toContain(expectedState);
-      expect(isolationSection?.textContent).toContain(expectedCommand);
+      try {
+        render(
+          renderConnection(
+            createConnectionProps({
+              systemInfo: { ...deviceSystemInfo, gatewayIsolation },
+            }),
+          ),
+          container,
+        );
+
+        const isolationHeading = Array.from(
+          container.querySelectorAll<HTMLElement>(".settings-section__heading"),
+        ).find((heading) => heading.textContent?.trim() === "Gateway Isolation");
+        const isolationSection = isolationHeading?.closest(".settings-section");
+        expect(isolationSection).not.toBeNull();
+        expect(isolationSection?.textContent).toContain("Reported Gateway isolation");
+        expect(isolationSection?.textContent).toContain(expectedState);
+        expect(isolationSection?.textContent).toContain(
+          "Run from your signed-in Windows user session.",
+        );
+
+        const command = isolationSection?.querySelector("code");
+        expect(command?.textContent?.trim()).toBe(expectedCommand);
+        const copyButton = isolationSection?.querySelector<HTMLButtonElement>(
+          'button[aria-label="Copy command"]',
+        );
+        expect(copyButton).not.toBeNull();
+        copyButton?.click();
+        await vi.waitFor(() => {
+          expect(writeText).toHaveBeenCalledWith(expectedCommand);
+        });
+      } finally {
+        container.remove();
+        if (clipboardDescriptor) {
+          Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+        } else {
+          Reflect.deleteProperty(navigator, "clipboard");
+        }
+      }
     },
   );
 

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -4,6 +4,7 @@ import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
+import { deviceSystemInfo } from "../../test-helpers/devices-fixtures.ts";
 import { renderConnection } from "./view.ts";
 
 type ConnectionProps = Parameters<typeof renderConnection>[0];
@@ -277,6 +278,41 @@ describe("connection view rendering", () => {
       expect(container.textContent).not.toContain("/Users/operator/.openclaw");
     }
   });
+
+  it.each([
+    {
+      gatewayIsolation: "enabled" as const,
+      expectedState: "Enabled",
+      expectedCommand: "clawctl gateway-isolation disable",
+    },
+    {
+      gatewayIsolation: "disabled" as const,
+      expectedState: "Disabled",
+      expectedCommand: "clawctl gateway-isolation enable",
+    },
+  ])(
+    "shows the reported $gatewayIsolation Gateway isolation posture",
+    ({ gatewayIsolation, expectedState, expectedCommand }) => {
+      const container = document.createElement("div");
+      render(
+        renderConnection(
+          createConnectionProps({
+            systemInfo: { ...deviceSystemInfo, gatewayIsolation },
+          }),
+        ),
+        container,
+      );
+
+      const isolationHeading = Array.from(
+        container.querySelectorAll<HTMLElement>(".settings-section__heading"),
+      ).find((heading) => heading.textContent?.trim() === "Gateway isolation");
+      const isolationSection = isolationHeading?.closest(".settings-section");
+      expect(isolationSection).not.toBeNull();
+      expect(isolationSection?.textContent).toContain("Reported Gateway isolation");
+      expect(isolationSection?.textContent).toContain(expectedState);
+      expect(isolationSection?.textContent).toContain(expectedCommand);
+    },
+  );
 
   it("escalates host meter tones and hides the section when the RPC is unavailable", async () => {
     const container = document.createElement("div");

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -316,7 +316,7 @@ describe("connection view rendering", () => {
         ).find((heading) => heading.textContent?.trim() === "Gateway Isolation");
         const isolationSection = isolationHeading?.closest(".settings-section");
         expect(isolationSection).not.toBeNull();
-        expect(isolationSection?.textContent).toContain("Reported Gateway isolation");
+        expect(isolationSection?.textContent).toContain("Reported Gateway Isolation");
         expect(isolationSection?.textContent).toContain(expectedState);
         expect(isolationSection?.textContent).toContain(
           "Run from your signed-in Windows user session.",

--- a/ui/src/styles/connection.css
+++ b/ui/src/styles/connection.css
@@ -112,6 +112,55 @@
   background: var(--danger);
 }
 
+.gateway-isolation-command {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-width: 0;
+}
+
+.gateway-isolation-command code {
+  flex: 1 1 20rem;
+  min-width: min(100%, 20rem);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: var(--text-strong);
+  font-family: var(--mono);
+  font-size: var(--control-ui-text-xs);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+
+.gateway-isolation-command .chat-copy-btn__icon {
+  position: relative;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.gateway-isolation-command .chat-copy-btn__icon-copy,
+.gateway-isolation-command .chat-copy-btn__icon-check {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  transition: opacity 150ms ease;
+}
+
+.gateway-isolation-command .chat-copy-btn__icon-check,
+.gateway-isolation-command .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
+  opacity: 0;
+}
+
+.gateway-isolation-command .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
+  opacity: 1;
+}
+
 @media (max-width: 640px) {
   .config-host {
     grid-template-columns: 1fr;


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft dependency:** This PR remains draft until Agent Session support is checked into `openclaw/openclaw-windows-packaging` and the corresponding Windows packaging integration is publicly available.

## What Problem This Solves

The Control UI does not currently show the Gateway isolation posture reported by the running Gateway. Operators therefore cannot confirm from Settings whether Gateway isolation is enabled or identify the command needed to change it.

## Why This Change Was Made

This adds an optional `gatewayIsolation` field to `system.info`, reports the launch-time `OPENCLAW_GATEWAY_ISOLATION` posture when it is valid, and renders that state in Connection settings with a copyable `clawctl gateway-isolation` command. The field is optional: when it is absent, the new section is not rendered, preserving existing behavior on all current platforms and Gateway versions.

## User Impact

Operators using a Gateway that reports isolation can see whether it is enabled and copy the appropriate command to change it. Platforms and Gateway versions that do not report the optional field remain unchanged.

## Evidence

Focused tests were added, but local Vitest, tsgo/changed checks, UI i18n verification, and browser proof could not run because the worktree package-feed proxy returned 404s and public npm TLS failed. Oxfmt and `git diff --check` passed. Independent review found no material issue.

PR CI and screenshot are pending.