### PR TITLE
refactor(ui): centralize Memory panel Gateway lifecycle ownership

### DIFF
--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -254,21 +254,29 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     expect(page.pendingEnabled).toBeNull();
   });
 
-  it("discards a wiki response from a replaced gateway source", async () => {
-    const pending = deferred<unknown>();
-    const client = {
-      request: vi.fn(() => pending.promise),
-    } as unknown as GatewayBrowserClient;
-    const page = createPage(contextWithGateway(client, true));
-    document.body.append(page);
-    await page.updateComplete;
+  it.each([false, true])(
+    "discards a wiki response from a replaced gateway source (Lit rebound: %s)",
+    async (rebound) => {
+      const pending = deferred<unknown>();
+      const client = {
+        request: vi.fn(() => pending.promise),
+      } as unknown as GatewayBrowserClient;
+      const page = createPage(contextWithGateway(client, true));
+      document.body.append(page);
+      await page.updateComplete;
 
-    const preview = page.openWikiPage("old.md");
-    await replaceContext(page, contextWithGateway(client, false));
-    pending.resolve({ title: "Old", path: "old.md", content: "stale" });
+      const preview = page.openWikiPage("old.md");
+      const nextContext = contextWithGateway(client, false);
+      if (rebound) {
+        await replaceContext(page, nextContext);
+      } else {
+        page.context = nextContext;
+      }
+      pending.resolve({ title: "Old", path: "old.md", content: "stale" });
 
-    await expect(preview).resolves.toBeNull();
-  });
+      await expect(preview).resolves.toBeNull();
+    },
+  );
 
   it("discards a wiki response across a same-client reconnect", async () => {
     const pending = deferred<unknown>();

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -16,6 +16,7 @@ import { t } from "../../../i18n/index.ts";
 import { currentConfigObject } from "../../../lib/config/config-state-model.ts";
 import { formatTimeMs } from "../../../lib/format.ts";
 import { isPluginEnabledInConfigSnapshot } from "../../../lib/plugin-activation.ts";
+import { GatewayPageController } from "../../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../../lit/subscriptions-controller.ts";
 import {
@@ -120,39 +121,25 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
   @state() private pendingEnabled: boolean | null = null;
 
   private readonly viewState: DreamingViewState = createDreamingViewState();
-  private gatewaySource: ApplicationGateway | null = null;
-  private gatewayBindingEpoch = 0;
-  private gatewayEpoch = 0;
-  private hasBoundGatewaySource = false;
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    onSnapshot: ({ snapshot, initial, sourceChanged }) =>
+      this.applyGatewaySnapshot(
+        snapshot,
+        initial ? "initial" : sourceChanged ? "replacement" : undefined,
+      ),
+  });
   private selectedAgentId: string | null = null;
-  private readonly subscriptions = new SubscriptionsController(this)
-    .effect(
-      () => this.context?.gateway,
-      (gateway) => {
-        const sourceReplaced = this.hasBoundGatewaySource;
-        this.hasBoundGatewaySource = true;
-        this.gatewaySource = gateway;
-        const bindingEpoch = ++this.gatewayBindingEpoch;
-        this.gatewayEpoch += 1;
-        const cleanup = gateway.subscribe((snapshot) => {
-          if (this.isGatewayBindingCurrent(gateway, bindingEpoch)) {
-            this.applyGatewaySnapshot(snapshot);
-          }
-        });
-        this.applyGatewaySnapshot(gateway.snapshot, sourceReplaced ? "replacement" : "initial");
-        return cleanup;
-      },
-    )
-    .effect(
-      () => this.context?.runtimeConfig,
-      (runtimeConfig) => {
+  private readonly subscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.runtimeConfig,
+    (runtimeConfig) => {
+      this.syncConfigSnapshot();
+      return runtimeConfig.subscribe(() => {
         this.syncConfigSnapshot();
-        return runtimeConfig.subscribe(() => {
-          this.syncConfigSnapshot();
-          this.requestUpdate();
-        });
-      },
-    );
+        this.requestUpdate();
+      });
+    },
+  );
 
   override updated(changed: PropertyValues<this>) {
     if (changed.has("agentId")) {
@@ -162,36 +149,24 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
 
   override disconnectedCallback() {
     this.subscriptions.clear();
-    this.gatewayBindingEpoch += 1;
-    this.gatewayEpoch += 1;
-    this.gatewaySource = null;
     this.resetTransientState();
     this.dreaming = createDreamingState();
     super.disconnectedCallback();
   }
 
-  private isGatewayBindingCurrent(gateway: ApplicationGateway, bindingEpoch: number): boolean {
-    return (
-      this.isConnected &&
-      this.gatewaySource === gateway &&
-      this.gatewayBindingEpoch === bindingEpoch &&
-      this.context.gateway === gateway
-    );
-  }
-
   private captureTaskScope(): DreamingTaskScope | null {
-    const gateway = this.gatewaySource;
+    const gateway = this.gateway.gateway;
     if (!gateway) {
       return null;
     }
-    return { gateway, epoch: this.gatewayEpoch, state: this.dreaming };
+    return { gateway, epoch: this.gateway.epoch, state: this.dreaming };
   }
 
   private isTaskScopeCurrent(scope: DreamingTaskScope): boolean {
     return (
       this.isConnected &&
-      this.gatewaySource === scope.gateway &&
-      this.gatewayEpoch === scope.epoch &&
+      this.gateway.gateway === scope.gateway &&
+      this.gateway.epoch === scope.epoch &&
       this.context.gateway === scope.gateway &&
       this.dreaming === scope.state
     );
@@ -223,9 +198,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
     const connectionChanged = this.dreaming.connected !== (snapshot.phase === "connected");
     const becameConnected = snapshot.phase === "connected" && !this.dreaming.connected;
     const replaceState = sourceBind === "replacement" || clientChanged || connectionChanged;
-    if (connectionChanged) {
-      this.gatewayEpoch += 1;
-    }
     if (replaceState) {
       this.dreaming = this.createGatewayState(snapshot);
       if (sourceBind !== "initial") {
@@ -252,7 +224,7 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
       return;
     }
     this.selectedAgentId = agentId;
-    this.gatewayEpoch += 1;
+    this.gateway.invalidate();
     this.resetTransientState();
     this.dreaming = this.createGatewayState();
     if (agentId && this.dreaming.connected) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

The Memory panel in Agent settings and Settings → Memory → Dreams must keep asynchronous results attached to the selected agent and current Gateway connection. This maintainer-requested cleanup reduces the maintenance burden of keeping those existing guarantees consistent across Control UI pages.

## Why This Change Was Made

Reuse the existing `GatewayPageController` for Gateway binding and request epochs while keeping Memory's task-state identity, immediate context check, selected-agent invalidation, configuration subscription, and domain state in the panel. Extend the existing stale-Wiki-response test to cover context replacement before Lit rebinds, as well as after rebinding.

This removes 27 production code lines and adds eight test lines; it adds no shared-controller machinery or new dependency.

## User Impact

No intended user-visible behavior change. Agent switches, Gateway replacement, and reconnects continue to retire old work; Memory actions, Wiki gating, settings, and rendering remain unchanged.

## Evidence

Local proof used the exact two-file candidate based on `0f68d696c3cc9c93bb45048f8c72036e577490de`:

- Original production plus the expanded tests: **21 passed** (15 Memory panel, six shared controller). Candidate plus the same tests: **21 passed**. The gated browser case was intentionally skipped in these focused invocations.
- Full changed-file gate passed, including UI and core-test typechecks, formatting, i18n, guards, dead-export checks, and changed-file lint.
- UI production build passed, including verification of all 870 finalized compressed sidecars.
- The same candidate Memory test file passed **16/16 tests, including the real Chromium scenario**, through the existing bundled E2E route. This covers both routes, selected-agent ownership, late responses, Wiki gating, and reconnects with a synthetic Gateway.
- Managed P2 review completed clean. No live Gateway or provider credentials were used.

The first browser attempt through the UI-isolated/jsdom route failed before Chromium launched: esbuild rejected the `TextEncoder`/`Uint8Array` realm invariant when Vite started inside jsdom. The successful run used the existing bundled E2E configuration, whose Node-owned global setup builds and serves the fixture. No test source, assertions, or realm globals were changed to recover the run; the original failed log is retained with the local proof.

<details>
<summary>Focused proof commands</summary>

```sh
node scripts/run-vitest.mjs \
  ui/src/pages/agents/memory/memory-panel.test.ts \
  ui/src/lit/gateway-page-controller.test.ts

node scripts/check-changed.mjs \
  --base 0f68d696c3cc9c93bb45048f8c72036e577490de -- \
  ui/src/pages/agents/memory/memory-panel.ts \
  ui/src/pages/agents/memory/memory-panel.test.ts

node scripts/ui.js build
```

For the browser run, `chromium-include.json` contains `["ui/src/pages/agents/memory/memory-panel.test.ts"]`:

```sh
OPENCLAW_UI_MEMORY_CHROMIUM_E2E=1 \
OPENCLAW_VITEST_INCLUDE_FILE="$PWD/chromium-include.json" \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/pages/agents/memory/memory-panel.test.ts
```

Toolchain: Node v24.20.0 and pnpm 12.3.4, with an independently installed frozen dependency tree.

</details>

Read-only integration against current main at `ea41203f6c6de6fee678acee8a7385484577eb84` found the two changed files, shared controller, Gateway producer, context consumers, and relevant test/build harness unchanged. The surrounding lockfile and CSS changes are unrelated to Memory. Existing proof remains bound to the stated candidate; this is not a claim of a separate main-branch test run.

The following synthetic before/after captures show the same Main-agent diary state on both routes. Each pair is byte-identical, as expected for this behavior-preserving change.

| Route | Before | After |
| --- | --- | --- |
| Agent Memory | ![Agent Memory before](https://github.com/user-attachments/assets/128f80be-ef32-46b4-999d-345ae25874bb) | ![Agent Memory after](https://github.com/user-attachments/assets/128f80be-ef32-46b4-999d-345ae25874bb) |
| Settings Memory Dreams | ![Settings Memory Dreams before](https://github.com/user-attachments/assets/36449136-f7b3-4503-96c5-bb1c02c1161f) | ![Settings Memory Dreams after](https://github.com/user-attachments/assets/36449136-f7b3-4503-96c5-bb1c02c1161f) |
