### PR TITLE
perf(plugins): reuse completed metadata owners

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -279,27 +279,40 @@ describe("plugin metadata snapshot", () => {
     },
   );
 
-  it("promotes one scoped lifecycle graph and reuses it across runtime resolutions", () => {
+  it.each([
+    { scope: "full", pluginIds: undefined },
+    { scope: "narrowed", pluginIds: ["demo"] },
+    { scope: "empty", pluginIds: [] },
+  ])("completes a $scope planning view and retains its lifecycle graph", ({ pluginIds }) => {
     const config = {};
     const workspaceDir = "/workspace";
     const index = makeIndex();
+    index.plugins = [...index.plugins, ...makeIndex("other").plugins];
     index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
+    const manifestRegistry = makeManifestRegistry();
+    manifestRegistry.plugins.push(...makeManifestRegistry("other").plugins);
     mockRegistrySnapshot(index);
-    const scoped = loadPluginMetadataSnapshot({
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(manifestRegistry);
+    const unscoped = loadPluginMetadataSnapshot({ config, env: {}, index, workspaceDir });
+    const planning = loadPluginMetadataSnapshot({
       config,
       env: {},
       index,
-      pluginIds: ["demo"],
+      pluginIds,
       workspaceDir,
     });
 
     const complete = completePluginMetadataSnapshot({
-      snapshot: scoped,
+      snapshot: planning,
       config,
       env: {},
       workspaceDir,
     });
     expect(complete?.pluginIds).toBeUndefined();
+    expect(complete?.plugins.map((plugin) => plugin.id)).toEqual(["demo", "other"]);
+    expect(complete?.owners).toBe(unscoped.owners);
+    expect(complete?.normalizePluginId).toBe(unscoped.normalizePluginId);
+    expect(complete?.bundledManifestRegistry).toBeDefined();
     setCurrentPluginMetadataSnapshot(complete, { config, env: {}, workspaceDir });
     loadPluginRegistrySnapshotWithMetadata.mockClear();
     loadPluginManifestRegistryForInstalledIndex.mockClear();

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -459,7 +459,10 @@ export function completePluginMetadataSnapshot(params: {
       inputs.snapshot.bundledManifestRegistry ??
       loadBundledPluginManifestRegistry({ env: inputs.env });
     const manifestRegistryMs = performance.now() - manifestStartedAt;
-    const rebased = rebasePluginMetadataSnapshotManifestRegistry(inputs.snapshot, manifestRegistry);
+    const rebased =
+      snapshot.pluginIds === undefined
+        ? snapshot
+        : rebasePluginMetadataSnapshotManifestRegistry(snapshot, manifestRegistry);
     const { pluginIds: _pluginIds, ...unscoped } = rebased;
     const completed = finalizePluginMetadataSnapshot({
       ...unscoped,


### PR DESCRIPTION
Closes #144229

## What Problem This Solves

Completing a plugin planning view can rebuild its metadata owner tables and normalization function even when the selected full snapshot already supplies them. This creates redundant lifecycle resources during completion.

## Why This Change Was Made

Keep the selected snapshot when it is already unscoped, and rebase only a still-scoped snapshot. Existing finalization, bundled manifest attachment, policy checks and complete plugin coverage remain unchanged.

## User Impact

Plugin metadata completion reuses the existing lifecycle graph instead of constructing equivalent owners again. This maintainer-requested change adds no configuration, persistent cache or public API, and makes no measured RSS or latency claim.

## Evidence

The final fixture fails on the original production code in exactly three owner-identity checks covering full, narrowed and empty planning views. All 34 final snapshot tests, the full selected changed gate and independent P2 review pass. Existing tests retain rebase, scoped projection and runtime-resolution coverage. An initial readonly-array fixture error was corrected before the final gate and review; its failure evidence is retained.
