### PR TITLE
refactor(scripts): share Docker diagnostic command lookup

### DIFF
--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -37,25 +37,13 @@ docker_e2e_resource_limit_temp_dir() {
   return 127
 }
 
-docker_e2e_tee_bin() {
-  if command -v tee >/dev/null 2>&1; then
-    command -v tee
+docker_e2e_diagnostic_bin() {
+  if command -v "$1" >/dev/null 2>&1; then
+    command -v "$1"
     return
   fi
-  if [ -x /usr/bin/tee ]; then
-    printf '%s\n' /usr/bin/tee
-    return
-  fi
-  return 1
-}
-
-docker_e2e_tail_bin() {
-  if command -v tail >/dev/null 2>&1; then
-    command -v tail
-    return
-  fi
-  if [ -x /usr/bin/tail ]; then
-    printf '%s\n' /usr/bin/tail
+  if [ -x "/usr/bin/$1" ]; then
+    printf '%s\n' "/usr/bin/$1"
     return
   fi
   return 1
@@ -89,7 +77,7 @@ docker_e2e_docker_run_with_resource_diagnostics() {
     return
   fi
   local tee_bin=""
-  if ! tee_bin="$(docker_e2e_tee_bin)"; then
+  if ! tee_bin="$(docker_e2e_diagnostic_bin tee)"; then
     docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
     docker_e2e_timeout_cmd \
       "$timeout_value" \
@@ -97,7 +85,7 @@ docker_e2e_docker_run_with_resource_diagnostics() {
     return
   fi
   local tail_bin=""
-  if ! tail_bin="$(docker_e2e_tail_bin)"; then
+  if ! tail_bin="$(docker_e2e_diagnostic_bin tail)"; then
     docker_e2e_remove_diagnostic_dir "$diagnostic_dir"
     docker_e2e_timeout_cmd \
       "$timeout_value" \


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of two identical command-lookup implementations in the Docker E2E resource-diagnostics helper. Keeping separate copies creates unnecessary maintenance drift risk within the same owner.

## Why This Change Was Made

Replace the private `tee` and `tail` lookup helpers with one private `docker_e2e_diagnostic_bin`, called with literal command names at the two existing call sites. Preserve shell-function and PATH precedence, the second lookup and its exit status, executable `/usr/bin` fallback, newline output, and silent failure.

The change is confined to one shell file, with 7 lines added and 19 removed. The timeout helper remains separate. The tempdir, named FIFOs, 65,536-byte capture bound, child processes, waits, stdin, Docker exit status, and cleanup flow are unchanged.

## User Impact

No intended user-visible behavior change. Docker E2E diagnostics retain the existing behavior with less duplicated implementation. No SDK, configuration, compatibility alias, or test surface is added.

## Local Evidence

- Local baseline and candidate: the same six focused existing tests passed; 291 unrelated cases were skipped in each run.
- Coverage includes resource-limit diagnostic hints, unrelated errors, canonical package-helper routing, function-priority `tail` with a named FIFO, resource defaults and overrides, missing temporary storage, and restricted-PATH stdin/exit-status handling.
- `bash -n scripts/lib/docker-e2e-resource-diagnostics.sh` and `git diff --check` passed.
- The selected `check-changed` tooling checks passed. Its formatter matched no shell files; this is not a shell-formatting claim.
- Diff-scoped cleanup and independent correctness review completed with no actionable findings.
- Repository search confirms the retired helper names have no remaining references.

## Real-Docker Evidence

The bounded Linux probe ran through the normal Crabbox 0.55.0 wrapper on the configured Blacksmith Testbox provider. The remote receiver verified source head `f3f9f5e4104e7480ae30cc7af559c508e306b449` and tree `175076118cfd28fd9b2da9bf8a7ae7d6f6db4ff3`; the unchanged probe also checked the tree and helper blobs.

Associated run: https://github.com/openclaw/openclaw/actions/runs/34519916690

| Existing entrypoint | Expected and observed Docker exit status | Probe result |
| --- | --- | --- |
| `docker_e2e_docker_cmd` | 0 | PASS |
| `docker_e2e_docker_run_cmd` | 0 | PASS |
| `docker_e2e_docker_cmd` | 37 | PASS |
| `docker_e2e_docker_run_cmd` | 37 | PASS |

Each case verified exact stdin/stdout, all 70,005 stderr bytes, and the exact final 65,536 captured bytes. Scoped observers delegated to the real `tee` and `tail` executables and required one completed call each, in distinct processes, against the same named FIFO. The `tail` call retained `-c 65536` with the FIFO as a filename. Missing capture records failed the probe, so a fallback that bypassed capture could not pass.

All four cases confirmed capture jobs finished, diagnostic files/FIFOs were removed, and the real container was removed. The aggregate probe and owned-container/temporary-root cleanup passed. No Gateway or provider credentials were used by the probe.

The original one-shot wrapper returned **exit 1**, not success: after the passing probe, automatic lease shutdown hit a provider TLS handshake timeout. One explicit stop reported completed, but its verification lookup also timed out. A subsequent authoritative status read confirmed the lease was absent. The accepted stop was not repeated, and all owned local jobs exited. The outcome is **Docker proof PASS, lease cleanup recovered**, not a wrapper PASS.

An earlier pre-execution attempt failed on provider status transport before remote source verification or probe results. Its failure and confirmed cleanup evidence are preserved; it is not classified as a candidate failure or passing proof.

## Limits

This is behavior-preserving characterization, not a bug fix with a failing baseline. Synthetic fixture errors do not establish real kernel cgroup rejection, and the real-Docker probe makes no such claim. Missing-tool and second-lookup-failure branches remain explicit coverage gaps.

## Main Alignment And Current Qualification

Signed merge `19911da3e023fb6636b329b64ee5743fb9259b3b` retains previously published head `62bd0540b44677078af860dfd3dcde5f7dee0e18` as its first parent and incorporates main `cf45ff4d6a9c13164463db860285a02c1c4f2e8c` as its second. Original head `f3f9f5e4104e7480ae30cc7af559c508e306b449` remains in its ancestry. Signature, unchanged diagnostic-helper blob, and the exact original one-file +7/-19 patch against main were verified.

The old-head [CI run34754974957](https://github.com/openclaw/openclaw/actions/runs/34754974957) remains failed. The first main alignment incorporated the reviewed UI dependency, isolated Gateway test routing, and canonical fixture repair. It is not a claim that all prior failures are resolved; the separately observed SDK reporter OOM cause remains unexplained. No heap limit was raised and no required gate was disabled or bypassed.

The subsequent [CI run34776089183](https://github.com/openclaw/openclaw/actions/runs/34776089183) also remains failed. Its `checks-node-compact-small-32` failure was an inherited five-item expectation after the routing owner added a sixth test, not a change to this Docker helper. Peter Steinberger's canonical repair [PR147293](https://github.com/openclaw/openclaw/pull/147293) landed as `01d9d686ef35edfd82a82987a6ff62f50f3e4556` and is included in the newly incorporated main. The repair preserves strict equality and adds only the missing expected target; this PR does not copy or modify that repair.

Automatic exact-head [CI34777739105](https://github.com/openclaw/openclaw/actions/runs/34777739105), attempt1, completed successfully at 19:48:25 UTC on September 13, 2026: 77 jobs succeeded and 17 were scope-selected skips, including a successful required `openclaw/ci-gate`. [Workflow Sanity34777739054](https://github.com/openclaw/openclaw/actions/runs/34777739054) also succeeded. Native preparation independently qualified both workflows at unchanged head `19911da3e023fb6636b329b64ee5743fb9259b3b`.

Two local CI watchers failed with GitHub API rate-limit errors. Their failures are preserved separately from the successful CI: a bounded read-only REST observation confirmed the terminal attempt, complete job set, required gate, and unchanged PR head. No duplicate CI was dispatched. The [canonical exact-head review](https://github.com/openclaw/openclaw/pull/144231#issuecomment-5622733184), completed at 19:40:41 UTC on September 13, 2026, reported no actionable correctness or security findings and nothing required before merge.

The six-case local comparison and four-case real-Docker evidence above remain bound to their original source and environment; neither was rerun for this main alignment. No live Gateway/provider, new-main runtime, full-suite, kernel-rejection, or SDK OOM repair claim is added.
