### PR TITLE
fix: keep selected models in lightweight and worker inference

### DIFF
--- a/src/agents/simple-completion-runtime.selected-model.test.ts
+++ b/src/agents/simple-completion-runtime.selected-model.test.ts
@@ -1,0 +1,255 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createWorkerInferenceExecutor,
+  type WorkerInferenceExecutionParams,
+} from "../gateway/worker-environments/inference-runtime.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import {
+  acquireSimpleCompletionModel,
+  acquireSimpleCompletionModelForAgent,
+  completeWithPreparedSimpleCompletionModel,
+} from "./simple-completion-runtime.js";
+
+afterEach(async () => {
+  await resetPreparedModelRuntimeSnapshotsForTest();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  vi.restoreAllMocks();
+});
+
+describe.each([undefined, "openai-completions"] as const)(
+  "initial simple completion with provider API %s",
+  (api) => {
+    it.each(["agent", "worker", "raw"] as const)(
+      "normalizes %s input once without an ambient prepared runtime",
+      async (mode) => {
+        await withOpenClawTestState({ label: "selected-completion" }, async (state) => {
+          const requests: string[] = [];
+          const server = createServer((request, response) => {
+            let body = "";
+            request.setEncoding("utf8");
+            request.on("data", (chunk: string) => {
+              body += chunk;
+            });
+            request.on("end", () => {
+              const { model } = JSON.parse(body) as { model: string };
+              requests.push(model);
+              response.writeHead(200, { "content-type": "text/event-stream" });
+              response.end(
+                `data: ${JSON.stringify({
+                  id: "selected-completion-response",
+                  object: "chat.completion.chunk",
+                  model,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: { content: `materialized:${model}` },
+                      finish_reason: "stop",
+                    },
+                  ],
+                })}\n\ndata: [DONE]\n\n`,
+              );
+            });
+          });
+          await new Promise<void>((resolve, reject) => {
+            server.once("error", reject);
+            server.listen(0, "127.0.0.1", () => {
+              server.removeListener("error", reject);
+              resolve();
+            });
+          });
+          try {
+            const address = server.address();
+            if (!address || typeof address === "string") {
+              throw new Error("Completion fixture did not expose a TCP port");
+            }
+            const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+            const nativeFetch = globalThis.fetch;
+            vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+              const url = new URL(input instanceof Request ? input.url : input);
+              expect(url.origin).toBe(new URL(baseUrl).origin);
+              return nativeFetch(input, init);
+            });
+            const provider = "selected-completion";
+            const models = ["middle", "final", "plain"].map((id) => ({
+              id,
+              name: id,
+              provider,
+              api: "openai-completions",
+              baseUrl,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 16_000,
+              maxTokens: 4_096,
+            }));
+            await state.writeJson("provider/openclaw.plugin.json", {
+              id: provider,
+              providers: [provider],
+              configSchema: { type: "object", properties: {}, additionalProperties: false },
+              modelIdNormalization: {
+                providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
+              },
+              modelCatalog: {
+                discovery: { [provider]: "static" },
+                providers: { [provider]: { api: "openai-completions", baseUrl, models } },
+              },
+            });
+            const runtimePath = await state.writeText(
+              "provider/index.cjs",
+              `const models = ${JSON.stringify(models)};
+module.exports = {
+  id: ${JSON.stringify(provider)},
+  register(api) {
+    api.registerProvider({
+      id: ${JSON.stringify(provider)}, label: "Selected completion", auth: [],
+      resolveDynamicModel({ modelId }) { return models.find(model => model.id === modelId); },
+    });
+  },
+};
+`,
+            );
+            const cfg: OpenClawConfig = {
+              agents: {
+                defaults: {
+                  workspace: state.workspaceDir,
+                  model: {
+                    primary: `${provider}/plain`,
+                    fallbacks: [`${provider}/entry`, `${provider}/middle`],
+                  },
+                },
+              },
+              models: {
+                providers: {
+                  [provider]: { api, baseUrl, apiKey: "synthetic-fixture", models: [] },
+                },
+              },
+              plugins: {
+                allow: [provider],
+                entries: { [provider]: { enabled: true } },
+                load: { paths: [runtimePath] },
+                slots: { memory: "none" },
+              },
+            };
+            await state.writeConfig(cfg);
+            const executeWorker = createWorkerInferenceExecutor({
+              resolveSessionTarget: () => ({
+                agentId: "main",
+                sessionEntry: { sessionId: "selected-test", updatedAt: 0 },
+                sessionKey: "agent:main:main",
+                sessionStore: {},
+                storePath: state.path("unused-session-store.sqlite"),
+              }),
+              resolveSessionAuthSelection: async () => undefined,
+              recordUsage: () => {},
+            });
+
+            for (const [raw, expected] of [
+              ["entry", "middle"],
+              ["middle", "final"],
+              ["plain", "plain"],
+            ] as const) {
+              if (mode === "worker") {
+                const result = await executeWorker(workerRequest(cfg, provider, raw));
+                expect(result).toMatchObject({
+                  type: "done",
+                  message: {
+                    provider,
+                    model: expected,
+                    content: [{ type: "text", text: `materialized:${expected}` }],
+                  },
+                });
+              } else {
+                const prepared =
+                  mode === "agent"
+                    ? await acquireSimpleCompletionModelForAgent({
+                        cfg,
+                        agentId: "main",
+                        modelRef: `${provider}/${raw}`,
+                        allowBundledStaticCatalogFallback: true,
+                      })
+                    : await acquireSimpleCompletionModel({
+                        cfg,
+                        provider,
+                        modelId: raw,
+                        allowBundledStaticCatalogFallback: true,
+                      });
+                if ("error" in prepared) {
+                  throw new Error(prepared.error);
+                }
+                try {
+                  expect(prepared.model.id).toBe(expected);
+                  const result = await completeWithPreparedSimpleCompletionModel({
+                    cfg,
+                    model: prepared.model,
+                    auth: prepared.auth,
+                    context: {
+                      messages: [{ role: "user", content: "Synthetic input.", timestamp: 0 }],
+                    },
+                    options: { maxTokens: 64 },
+                  });
+                  expect(result).toMatchObject({
+                    content: [{ type: "text", text: `materialized:${expected}` }],
+                  });
+                } finally {
+                  prepared.release();
+                }
+              }
+            }
+            expect(requests).toEqual(["middle", "final", "plain"]);
+          } finally {
+            server.closeAllConnections();
+            await new Promise<void>((resolve, reject) => {
+              server.close((error) => (error ? reject(error) : resolve()));
+            });
+          }
+        });
+      },
+    );
+  },
+);
+
+function workerRequest(
+  config: OpenClawConfig,
+  provider: string,
+  model: string,
+): WorkerInferenceExecutionParams {
+  return {
+    config,
+    identity: {
+      environmentId: "selected-test",
+      credentialHash: "synthetic-fixture",
+      bundleHash: "synthetic-fixture",
+      sessionId: "selected-test",
+      runId: "selected-test",
+      ownerEpoch: 1,
+      turnClaim: {
+        sessionId: "selected-test",
+        claimId: "selected-test",
+        runId: "selected-test",
+        placementGeneration: 1,
+        owner: { kind: "worker", environmentId: "selected-test", ownerEpoch: 1 },
+      },
+      rpcSetVersion: 1,
+      protocolFeatures: ["worker-inference-v1"],
+      credentialExpiresAtMs: Number.MAX_SAFE_INTEGER,
+    },
+    request: {
+      runEpoch: 1,
+      sessionId: "selected-test",
+      runId: "selected-test",
+      turnId: "selected-test",
+      modelRef: { provider, model },
+      context: { messages: [{ role: "user", content: "Synthetic input.", timestamp: 0 }] },
+      options: { maxTokens: 64 },
+    },
+    signal: new AbortController().signal,
+    isCurrent: () => true,
+    emit: () => {},
+  };
+}

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -164,6 +164,7 @@ export type PrepareSimpleCompletionModelParams = {
   agentId?: string;
   provider: string;
   modelId: string;
+  modelIdSource?: "input" | "selected";
   agentDir?: string;
   profileId?: string;
   preferredProfile?: string;
@@ -214,6 +215,7 @@ async function prepareSimpleCompletionModelCore(
     params.agentDir,
     params.cfg,
     {
+      modelIdSource: params.modelIdSource,
       ...(params.agentId ? { agentId: params.agentId } : {}),
       ...(params.allowBundledStaticCatalogFallback !== undefined
         ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
@@ -608,6 +610,7 @@ export async function acquireSimpleCompletionModelForAgent(
           agentId: params.agentId,
           provider: selection.provider,
           modelId: selection.modelId,
+          modelIdSource: "selected",
           agentDir: selection.agentDir,
           profileId: selection.profileId,
           preferredProfile: params.preferredProfile,

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -483,6 +483,7 @@ async function resolveApprovedModel(params: {
         provider: resolved.ref.provider,
         modelId: resolved.ref.model,
         agentDir,
+        modelIdSource: "selected",
         ...(selectedProfileId ? { profileId: selectedProfileId } : {}),
         ...(selectedProfileId ? { preferredProfile: selectedProfileId } : {}),
         ...(selectedProfileId ? { bindAuthOwner: true } : {}),


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where users running lightweight agent completions or worker inference could receive output from a different model when provider aliases form a chain. With `entry → middle → final`, selection chose `middle` but preparation sent the request to `final`. Worker results could still report `middle`.

## Why This Change Was Made

Initial preparation now preserves the model identity already chosen by the agent selector or worker approval path. Raw model inputs continue to normalize normally. The change forwards the existing model-source contract through simple completion preparation without changing worker admission or runtime ownership.

## User Impact

Lightweight completions and worker inference use the model that was selected, so the reported model and the actual request agree.

## Evidence

- The exact regression fails on the base with four wrong-model failures while both raw-input controls pass. The candidate passes all six cases and 18 actual loopback HTTP requests across provider API present/absent configurations. Worker models are explicitly retained configured fallbacks; this does not assert arbitrary dynamic-model admission.
- 110 focused tests passed, including agent defaults/utility selection, auth routing, raw calls, worker inference, and plugin-generation ownership. The final fixture was rerun on both base and candidate after its HTTP-handler lint correction.
- Six additional source scenarios ran on both versions through real acquisition and HTTP. They preserve existing scoped runtime normalization and exact API-owner suppression, and confirm that the cold runtime-only hook limitation is inherited.
- The complete `pnpm check:changed` gate, fresh P2 review, and one normal `pnpm build` passed.
- The emitted package facade passed six further HTTP requests on the exact committed build. Both processes exited naturally, source-import guards passed, and all 12,230 inventoried build files remained unchanged. Worker execution is covered by the real source harness; it has no package-exported compiled executor entry.

Production delta: +4 lines.
