### PR TITLE
fix(ui): avoid extra session reads after a queued refresh

### DIFF
--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -1,7 +1,12 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it, vi } from "vitest";
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../../src/shared/session-list-limits.ts";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  GatewayRequestError,
+  type GatewayBrowserClient,
+  type GatewayEventFrame,
+} from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import {
@@ -608,6 +613,77 @@ describe("session list requests", () => {
         resolveRequest(listResult());
         unsubscribe();
         sessions.dispose();
+      }
+    },
+  );
+
+  it.each(["before", "after"] as const)(
+    "absorbs only invalidations preceding a queued managed replacement (%s)",
+    async (eventTiming) => {
+      vi.useFakeTimers();
+      const first = createDeferred<SessionsListResult>();
+      const second = createDeferred<SessionsListResult>();
+      const secondStarted = createDeferred();
+      const row = (version: number) => ({
+        key: "agent:main:managed-refresh",
+        sessionId: "managed-refresh",
+        kind: "direct" as const,
+        archived: true,
+        updatedAt: version,
+        label: `Read ${version}`,
+      });
+      let managedCalls = 0;
+      const client = createTestGatewayClient((method, params) => {
+        if (method !== "sessions.list") {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        if (asNullableRecord(params)?.archived !== true) {
+          return sessionsResult([], 0);
+        }
+        managedCalls += 1;
+        if (managedCalls === 1) {
+          return first.promise;
+        }
+        if (managedCalls === 2) {
+          secondStarted.resolve();
+          return second.promise;
+        }
+        return sessionsResult([row(3)], 3);
+      });
+      const { gateway, emitEvent } = createGatewayHarness(client);
+      const sessions = createTestSessionCapability(gateway);
+      const query = { agentId: "main", archivedFilter: "archived" as const, limit: 17 };
+      const unsubscribe = sessions.subscribeList(query, () => undefined);
+      const event = {
+        type: "event",
+        event: "sessions.changed",
+        payload: { ...row(1), sessionKey: row(1).key, agentId: "main", reason: "update" },
+      } as const satisfies GatewayEventFrame;
+      try {
+        const initial = sessions.refreshList(query);
+        const forced = sessions.refreshList({ ...query, force: true });
+        if (eventTiming === "before") {
+          emitEvent(event);
+        }
+        first.resolve(sessionsResult([row(1)], 1));
+        await secondStarted.promise;
+        expect(managedCalls).toBe(2);
+        if (eventTiming === "after") {
+          emitEvent(event);
+        }
+        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+        second.resolve(sessionsResult([row(2)], 2));
+        await Promise.all([initial, forced]);
+        expect.soft(managedCalls).toBe(eventTiming === "before" ? 2 : 3);
+        expect(sessions.listSnapshot(query).result?.sessions[0]?.label).toBe(
+          eventTiming === "before" ? "Read 2" : "Read 3",
+        );
+      } finally {
+        first.resolve(sessionsResult([], 1));
+        second.resolve(sessionsResult([], 2));
+        unsubscribe();
+        sessions.dispose();
+        vi.useRealTimers();
       }
     },
   );

--- a/ui/src/lib/sessions/session-managed-list-refresh.ts
+++ b/ui/src/lib/sessions/session-managed-list-refresh.ts
@@ -80,14 +80,14 @@ export function createSessionManagedListRefresh(
     if (refresh.append && !entry.snapshot.result) {
       return Promise.resolve();
     }
-    if (!refresh.append) {
-      entry.coordinator.absorb();
-    }
     const isCurrent = () =>
       managedLists.get(entry.key) === entry && host.connection.isCurrent(scope);
     const drain = async () => {
       let next: ManagedSessionListRefresh | null = refresh;
       while (next && isCurrent()) {
+        if (!next.append) {
+          entry.coordinator.absorb();
+        }
         const requestParams = {
           ...entry.query,
           limit: next.append ? entry.query.limit : entry.retainedLimit,


### PR DESCRIPTION
Related: #144127

## What Problem This Solves

Filtered session lists could make an unnecessary extra request when a full refresh was queued behind an existing read. A delayed event already covered by the queued refresh could remain scheduled and cause another fetch.

## Why This Change Was Made

Consume earlier event invalidations at the start of each full replacement in the existing request drain. Initial and queued refreshes now use the same boundary. Events arriving after a read starts still request a trailing refresh, and pagination retains its pending work.

## User Impact

Session lists avoid redundant background reads while preserving later updates, page ownership and normal restoration behavior.

## Evidence

The regression varies an event immediately before versus after a queued replacement starts. Before the fix, the earlier-event case makes three requests instead of two; the later-event control correctly makes three. After the fix, all 77 owner/controller cases pass. Production moves three existing lines, with no net growth; tests add 76 lines.

The unchanged archived-restore browser scenario passes on fresh original and candidate bundles. The paired images compare the same completed restore state; they establish preserved appearance. The timing regression establishes the removed request. The separate five-versus-three CI failure encountered in #144127 remains unexplained and is not claimed fixed here.

The patch moved onto a main-based branch with all 22 relevant source inputs unchanged. Those tests and captures retain their original source binding; all 20 canonical checks were rerun successfully on the new base. Independent review found no actionable findings. Initial test-placement and receiver-binding lint failures were repaired without suppressions.

![Baseline: archived restore completes with the expected appearance](https://github.com/user-attachments/assets/da01c350-cada-4613-ac80-352877c3903c)

![Candidate: the same restored view is preserved](https://github.com/user-attachments/assets/5890fefd-3a93-4877-91e4-73bdead43c93)