### PR TITLE
perf(build): skip hashes before mandatory cache restores

### DIFF
--- a/scripts/lib/build-artifact-cache.mts
+++ b/scripts/lib/build-artifact-cache.mts
@@ -403,7 +403,8 @@ export function resolveBuildStepCacheState(
     const relativeOutputFiles = outputFiles.map((file) => portableRelativePath(artifactRoot, file));
     const stampedOutputs = Object.keys(stamp?.outputs ?? {});
     const requiredOutputs = resolveCacheRequiredOutputs(step.cache, params.env ?? process.env);
-    const actualOutputsPresent =
+    const actualOutputsAcceptable =
+      step.cache.restore !== "always" &&
       artifactRecordMismatch(artifactRoot, stamp, signature, requiredOutputs) === undefined;
     const cachedOutputMismatch = artifactRecordMismatch(
       outputRoot,
@@ -414,10 +415,7 @@ export function resolveBuildStepCacheState(
     const cachedOutputsPresent = cachedOutputMismatch === undefined;
     const stampMatches =
       (!params.inputSignature || consumedInputs !== undefined) && stamp?.signature === signature;
-    const alwaysRestore = step.cache.restore === "always";
-    const actualOutputsAcceptable = actualOutputsPresent && !alwaysRestore;
-    const restorable =
-      stampMatches && cachedOutputsPresent && (alwaysRestore || !actualOutputsPresent);
+    const restorable = stampMatches && cachedOutputsPresent && !actualOutputsAcceptable;
     const fresh = stampMatches && (actualOutputsAcceptable || cachedOutputsPresent);
     return {
       cacheable: true,

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -1793,18 +1793,28 @@ describe("resolveBuildStepCacheState", () => {
       const cacheState = resolveBuildStepCacheState(alwaysRestoreStep, { rootDir });
       writeBuildStepCacheStamp(alwaysRestoreStep, cacheState, { rootDir });
       fs.writeFileSync(outputPath, "overwritten by earlier build step");
+      const obsoletePath = path.join(rootDir, "dist/obsolete.js");
+      fs.writeFileSync(obsoletePath, "obsolete output");
 
-      const restorable = resolveBuildStepCacheState(alwaysRestoreStep, { rootDir });
+      const readSpy = vi.spyOn(fs, "readFileSync");
+      let restorable: ReturnType<typeof resolveBuildStepCacheState>;
+      try {
+        restorable = resolveBuildStepCacheState(alwaysRestoreStep, { rootDir });
+        expect(readSpy.mock.calls.map(([file]) => file)).not.toContain(outputPath);
+      } finally {
+        readSpy.mockRestore();
+      }
       expect(restorable.cacheable).toBe(true);
       expect(restorable.fresh).toBe(true);
       expect(restorable.reason).toBe("fresh-cache");
-      expect(restorable.outputFiles).toBe(1);
+      expect(restorable.outputFiles).toBe(2);
       expect(restorable.restorable).toBe(true);
-      expect(restorable.relativeOutputFiles).toEqual(["dist/output.js"]);
+      expect(restorable.relativeOutputFiles).toEqual(["dist/obsolete.js", "dist/output.js"]);
       expect(restorable.stampedOutputs).toEqual(["dist/output.js"]);
 
       expect(restoreBuildStepCacheOutputs(restorable, { rootDir })).toBe(true);
       expect(fs.readFileSync(outputPath, "utf8")).toBe("output");
+      expect(fs.existsSync(obsoletePath)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Closes #144241

## What Problem This Solves

Build steps configured to always restore cached outputs still read and hash the destination files before overwriting them. That work cannot make the existing destination eligible for reuse.

## Why This Change Was Made

Skip destination validation for mandatory restores and keep the existing cached-source validation and input-signature checks. Ordinary warm lookups still validate their outputs, and restore still removes obsolete generated files.

## User Impact

Mandatory cache restores avoid unnecessary destination reads without changing cache integrity checks, restore eligibility or generated output cleanup. No broad build-time or memory improvement is claimed.

## Evidence

The extended existing restore test fails on the original code because the destination is read, then passes on the change. All 96 build/cache owner tests, the full selected changed gate and independent P2 review pass, retaining stale-cache and replaced-record integrity coverage. No new helper export or cache-source read-count assertion was added.
