### PR TITLE
feat(ui): show reported Gateway isolation

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18974,6 +18974,7 @@ public struct SystemInfoResult: Codable, Sendable {
     public let diskavailablebytes: Int?
     public let diskpath: String?
     public let disks: [[String: AnyCodable]]?
+    public let gatewayisolation: String?
     public let defaultagentutilitymodel: AnyCodable?
 
     public init(
@@ -18998,6 +18999,7 @@ public struct SystemInfoResult: Codable, Sendable {
         diskavailablebytes: Int? = nil,
         diskpath: String? = nil,
         disks: [[String: AnyCodable]]? = nil,
+        gatewayisolation: String? = nil,
         defaultagentutilitymodel: AnyCodable? = nil)
     {
         self.machinename = machinename
@@ -19021,6 +19023,7 @@ public struct SystemInfoResult: Codable, Sendable {
         self.diskavailablebytes = diskavailablebytes
         self.diskpath = diskpath
         self.disks = disks
+        self.gatewayisolation = gatewayisolation
         self.defaultagentutilitymodel = defaultagentutilitymodel
     }
 
@@ -19046,6 +19049,7 @@ public struct SystemInfoResult: Codable, Sendable {
         case diskavailablebytes = "diskAvailableBytes"
         case diskpath = "diskPath"
         case disks
+        case gatewayisolation = "gatewayIsolation"
         case defaultagentutilitymodel = "defaultAgentUtilityModel"
     }
 }

--- a/packages/gateway-protocol/src/schema/system-info.test.ts
+++ b/packages/gateway-protocol/src/schema/system-info.test.ts
@@ -34,6 +34,24 @@ describe("SystemInfoResultSchema", () => {
     expect(Value.Check(SystemInfoResultSchema, validSystemInfo)).toBe(true);
   });
 
+  it.each(["enabled", "disabled"] as const)(
+    "accepts the optional Gateway isolation state %s",
+    (gatewayIsolation) => {
+      expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, gatewayIsolation })).toBe(
+        true,
+      );
+    },
+  );
+
+  it("rejects an invalid Gateway isolation state", () => {
+    expect(
+      Value.Check(SystemInfoResultSchema, {
+        ...validSystemInfo,
+        gatewayIsolation: "unknown",
+      }),
+    ).toBe(false);
+  });
+
   it("rejects extra properties", () => {
     expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, extra: true })).toBe(false);
   });

--- a/packages/gateway-protocol/src/schema/system-info.ts
+++ b/packages/gateway-protocol/src/schema/system-info.ts
@@ -45,6 +45,7 @@ export const SystemInfoResultSchema = closedObject({
       }),
     ),
   ),
+  gatewayIsolation: Type.Optional(Type.Enum(["enabled", "disabled"] as const, { type: "string" })),
   /** Resolved utility model for the configured default agent. */
   defaultAgentUtilityModel: Type.Optional(UtilityModelStatusSchema),
 });

--- a/src/gateway/server-methods/system-info.test.ts
+++ b/src/gateway/server-methods/system-info.test.ts
@@ -44,7 +44,10 @@ describe("system.info", () => {
     vi.spyOn(os, "platform").mockReturnValue("darwin");
     mocks.runCommandWithTimeout.mockReset().mockImplementation(mountedVolumeOutput);
   });
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
 
   it("returns a schema-valid host resource snapshot", async () => {
     const respond = vi.fn();
@@ -125,6 +128,48 @@ describe("system.info", () => {
           ? []
           : [{ path: payload.diskPath, totalBytes: 2048, availableBytes: 1024 }],
       );
+    },
+  );
+
+  it.each(["enabled", "disabled"] as const)(
+    "reports the strict host isolation posture %s",
+    async (gatewayIsolation) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_ISOLATION", gatewayIsolation);
+      vi.resetModules();
+      const { systemHandlers: freshSystemHandlers } = await import("./system.js");
+      const respond = vi.fn();
+
+      await expectDefined(
+        freshSystemHandlers["system.info"],
+        "system.info handler",
+      )({
+        params: {},
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as unknown as GatewayRequestHandlerOptions);
+
+      expect(respond.mock.calls[0]?.[1]).toHaveProperty("gatewayIsolation", gatewayIsolation);
+    },
+  );
+
+  it.each([undefined, "", "ENABLED", "unknown"])(
+    "omits an absent, empty, or invalid host isolation posture %s",
+    async (gatewayIsolation) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_ISOLATION", gatewayIsolation);
+      vi.resetModules();
+      const { systemHandlers: freshSystemHandlers } = await import("./system.js");
+      const respond = vi.fn();
+
+      await expectDefined(
+        freshSystemHandlers["system.info"],
+        "system.info handler",
+      )({
+        params: {},
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as unknown as GatewayRequestHandlerOptions);
+
+      expect(respond.mock.calls[0]?.[1]).not.toHaveProperty("gatewayIsolation");
     },
   );
 });

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -49,6 +49,15 @@ import { assertValidParams } from "./validation.js";
 
 let advertisedLanHostPromise: Promise<string | null> | null = null;
 
+function readGatewayIsolation(): SystemInfoResult["gatewayIsolation"] {
+  const value = process.env.OPENCLAW_GATEWAY_ISOLATION;
+  return value === "enabled" || value === "disabled" ? value : undefined;
+}
+
+// The launch environment defines this process's posture. Keep it stable across
+// polling so the reported state cannot diverge from how the Gateway started.
+const gatewayIsolation = readGatewayIsolation();
+
 function resolveCachedAdvertisedLanHost(): Promise<string | null> {
   // Route discovery may spawn a platform command. Keep the result process-stable
   // so each visible Settings page does not repeat that work every ten seconds.
@@ -116,6 +125,7 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
           diskPath: stateDir,
         }
       : {}),
+    ...(gatewayIsolation ? { gatewayIsolation } : {}),
     defaultAgentUtilityModel,
   };
 }

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -38,6 +38,12 @@ const enSettings = {
       hideSecret: "Hide secret",
       toggleSecretVisibility: "Toggle secret visibility",
     },
+    gatewayIsolation: {
+      title: "Gateway Isolation",
+      reportedState: "Reported Gateway Isolation",
+      changeWithCli: "Change with CLI",
+      instruction: "Run from the signed-in user session on the Gateway host.",
+    },
   },
   cloudWorkersPage: {
     snapshots: {

--- a/ui/src/pages/connection/system-section.ts
+++ b/ui/src/pages/connection/system-section.ts
@@ -1,6 +1,8 @@
 import { html, nothing } from "lit";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
+import { renderConnectCommand } from "../../components/connect-command.ts";
 import {
+  renderSettingsRow,
   renderSettingsSection,
   renderSettingsStatus,
   type SettingsSectionProps,
@@ -157,6 +159,30 @@ function buildSystemStatsPlaceholder(): SystemStat[] {
   ];
 }
 
+function renderGatewayIsolationSection(info: SystemInfoResult | null | undefined) {
+  const gatewayIsolation = info?.gatewayIsolation;
+  if (!gatewayIsolation) {
+    return nothing;
+  }
+  const enabled = gatewayIsolation === "enabled";
+  const command = `clawctl gateway-isolation ${enabled ? "disable" : "enable"}`;
+  return renderSettingsSection({ title: t("connection.gatewayIsolation.title") }, [
+    renderSettingsRow({
+      title: t("connection.gatewayIsolation.reportedState"),
+      control: renderSettingsStatus({
+        kind: enabled ? "ok" : "warn",
+        label: t(enabled ? "common.enabled" : "common.disabled"),
+      }),
+    }),
+    renderSettingsRow({
+      title: t("connection.gatewayIsolation.changeWithCli"),
+      description: t("connection.gatewayIsolation.instruction"),
+      control: renderConnectCommand(command),
+      stacked: true,
+    }),
+  ]);
+}
+
 /** Gateway host section with the stable settings-search scroll target id. */
 export function renderSystemSection(props: SystemSectionProps) {
   if (props.systemInfoUnavailable) {
@@ -211,5 +237,6 @@ export function renderSystemSection(props: SystemSectionProps) {
         `,
       )}
     </div>
+    ${renderGatewayIsolationSection(info)}
   `;
 }

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -1,9 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
+import { deviceSystemInfo } from "../../test-helpers/devices-fixtures.ts";
 import { renderConnection } from "./view.ts";
 
 type ConnectionProps = Parameters<typeof renderConnection>[0];
@@ -277,6 +278,70 @@ describe("connection view rendering", () => {
       expect(container.textContent).not.toContain("/Users/operator/.openclaw");
     }
   });
+
+  it.each([
+    {
+      gatewayIsolation: "enabled" as const,
+      expectedState: "Enabled",
+      expectedCommand: "clawctl gateway-isolation disable",
+    },
+    {
+      gatewayIsolation: "disabled" as const,
+      expectedState: "Disabled",
+      expectedCommand: "clawctl gateway-isolation enable",
+    },
+  ])(
+    "shows the reported $gatewayIsolation Gateway Isolation posture",
+    async ({ gatewayIsolation, expectedState, expectedCommand }) => {
+      const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+      const container = document.body.appendChild(document.createElement("div"));
+
+      try {
+        render(
+          renderConnection(
+            createConnectionProps({
+              systemInfo: { ...deviceSystemInfo, gatewayIsolation },
+            }),
+          ),
+          container,
+        );
+
+        const isolationHeading = Array.from(
+          container.querySelectorAll<HTMLElement>(".settings-section__heading"),
+        ).find((heading) => heading.textContent?.trim() === "Gateway Isolation");
+        const isolationSection = isolationHeading?.closest(".settings-section");
+        expect(isolationSection).not.toBeNull();
+        expect(isolationSection?.textContent).toContain("Reported Gateway Isolation");
+        expect(isolationSection?.textContent).toContain(expectedState);
+        expect(isolationSection?.textContent).toContain(
+          "Run from the signed-in user session on the Gateway host.",
+        );
+
+        const command = isolationSection?.querySelector("code");
+        expect(command?.textContent?.trim()).toBe(expectedCommand);
+        const copyButton = isolationSection?.querySelector<HTMLButtonElement>(
+          'button[aria-label="Copy command"]',
+        );
+        expect(copyButton).not.toBeNull();
+        copyButton?.click();
+        await vi.waitFor(() => {
+          expect(writeText).toHaveBeenCalledWith(expectedCommand);
+        });
+      } finally {
+        container.remove();
+        if (clipboardDescriptor) {
+          Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+        } else {
+          Reflect.deleteProperty(navigator, "clipboard");
+        }
+      }
+    },
+  );
 
   it("escalates host meter tones and hides the section when the RPC is unavailable", async () => {
     const container = document.createElement("div");

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -454,6 +454,7 @@ openclaw-session-owner-chip {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   margin: 4px 0 2px;
   padding: 5px 8px 5px 10px;
   background: var(--bg);
@@ -474,10 +475,12 @@ openclaw-session-owner-chip {
 
 .login-gate__command code {
   flex: 1;
+  min-width: 0;
   margin: 0;
   padding: 0;
   background: transparent;
   border: 0;
+  overflow-wrap: anywhere;
 }
 
 .login-gate__command--hero {
@@ -515,29 +518,28 @@ openclaw-session-owner-chip {
   background: var(--card);
 }
 
-/* The copy glyph swap normally ships with chat styles, which the gate renders
-   without; own it here so the check never shows beside the copy icon. */
-.login-gate .chat-copy-btn__icon {
+/* Copy buttons also render on pages without chat styles. */
+.chat-copy-btn__icon {
   position: relative;
   display: inline-flex;
   width: 14px;
   height: 14px;
 }
 
-.login-gate .chat-copy-btn__icon-copy,
-.login-gate .chat-copy-btn__icon-check {
+.chat-copy-btn__icon-copy,
+.chat-copy-btn__icon-check {
   position: absolute;
   top: 0;
   left: 0;
   transition: opacity var(--duration-fast) ease;
 }
 
-.login-gate .chat-copy-btn__icon-check,
-.login-gate .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
+.chat-copy-btn__icon-check,
+.chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-copy {
   opacity: 0;
 }
 
-.login-gate .chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
+.chat-copy-btn[data-copy-state="copied"] .chat-copy-btn__icon-check {
   opacity: 1;
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft dependency:** This PR intentionally remains draft until Agent Session support is checked into `openclaw/openclaw-windows-packaging` and the corresponding Windows packaging integration is publicly available. The current public [packaging producer commit](https://github.com/ChazGo/openclaw-windows-packaging/commit/613cf63bf9edf2cf6b62bfa78e5ac2d159e39168) proves the strict `disabled` projection for its signed-in-user launch path with 55/55 solution tests, but `clawctl gateway-isolation` and the fail-closed `enabled` Agent Session launch are not public yet.

## What Problem This Solves

The Control UI does not currently show the **Gateway Isolation** posture reported by the running Gateway. Operators therefore cannot confirm from Settings whether **Reported Gateway Isolation** is enabled or identify the command needed to change it.

## Why This Change Was Made

This adds an optional `gatewayIsolation` field to `system.info`, reports the launch-time `OPENCLAW_GATEWAY_ISOLATION` posture only when it is exactly `enabled` or `disabled`, and renders a read-only **Gateway Isolation** section in Connection settings with the reported state and inverse `clawctl gateway-isolation` command. When the optional field is absent, the new section is not rendered, so existing platforms and Gateways remain unchanged.

## User Impact

Operators using a Gateway that reports isolation can see the reported posture and copy the appropriate host command. The UI adds no write RPC, process control, platform inference, session implementation, or behavior for unsupported Gateways.

## Evidence

The screenshot below was captured from the real Control UI built at exact head `7949dcbc451693f10986253931e04ebbe0edcdb9` by [`dist-runtime-build` artifact 10171223596](https://github.com/ChazGo/openclaw/actions/runs/34523610745/artifacts/10171223596) in [CI run 34523610745](https://github.com/ChazGo/openclaw/actions/runs/34523610745). The repository's mocked-Gateway browser harness advertised `system.info`, returned `gatewayIsolation: "enabled"`, observed the UI request, rendered the inverse command, and reported no browser errors.

![Gateway Isolation enabled in Connection settings](https://github.com/user-attachments/assets/55287a0b-ee93-433b-9676-9f85cc095159)

### Exact-head real Gateway proof

The same exact head was hydrated as a complete Windows x64 runtime, installed on Windows with Node 26.7.0, and launched against isolated disposable state. Its runtime ZIP SHA-256 is `04973F8AE49A598CD50A6FDA262E5119396E6F06AD6AF04AA812397E10CCC009`. A real Control UI browser connected to each real Gateway over WebSocket and observed `system.info`.

| Launch environment | Observed UI | Clipboard result |
|---|---|---|
| `OPENCLAW_GATEWAY_ISOLATION=enabled` | **Enabled** with inverse disable command | `clawctl gateway-isolation disable` |
| `OPENCLAW_GATEWAY_ISOLATION=disabled` | **Disabled** with inverse enable command | `clawctl gateway-isolation enable` |
| Variable omitted | Gateway Isolation section absent | Not applicable |

No browser console or page errors were observed in any of the three runs.

![Reported Gateway Isolation enabled from a real exact-head Gateway](https://github.com/user-attachments/assets/756f8ab0-2a6f-44ac-9fc4-7b050f5e7aeb)

![Reported Gateway Isolation disabled from a real exact-head Gateway](https://github.com/user-attachments/assets/4043af24-0963-4ea7-a64d-8666642eb8db)

This proves the exact-head environment-reader → `system.info` → Control UI → clipboard path. The environment values were injected directly for these branch-level runs; this evidence does **not** claim that the unfinished public Windows packaging command or Agent Session isolation is implemented or proven.

The exact-head run completed with 176 successful jobs and 6 skipped jobs. Six underlying jobs failed: the genuine environment-name ratchet at 494 names against the 493 budget, the strict generated-locale release check that current contributor policy intentionally excludes from source PRs while the deterministic source verifier passes, a Control UI performance comparison against the fork's unrelated stale `main`, and three unrelated full-matrix tests in release validation, session reclamation timing, and chat reset fixtures. [Explicit owner approval has been requested](https://github.com/openclaw/openclaw/pull/144243#issuecomment-5624775331) before changing the protected environment budget.

[ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/144243#issuecomment-5622957766) found no actionable correctness defect in the focused patch and kept the draft blocked on the public packaging integration, environment-contract approval, and real end-to-end host proof.