### PR TITLE
refactor(ui): share cached message extraction

### DIFF
--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -48,17 +48,24 @@ export function extractText(message: unknown): string | null {
   return processMessageText(raw, role);
 }
 
-export function extractTextCached(message: unknown): string | null {
+function readCachedMessageExtraction(
+  message: unknown,
+  cache: WeakMap<object, string | null>,
+  extract: (message: unknown) => string | null,
+): string | null {
   if (!message || typeof message !== "object") {
-    return extractText(message);
+    return extract(message);
   }
-  const obj = message;
-  if (textCache.has(obj)) {
-    return textCache.get(obj) ?? null;
+  if (cache.has(message)) {
+    return cache.get(message) ?? null;
   }
-  const value = extractText(message);
-  textCache.set(obj, value);
+  const value = extract(message);
+  cache.set(message, value);
   return value;
+}
+
+export function extractTextCached(message: unknown): string | null {
+  return readCachedMessageExtraction(message, textCache, extractText);
 }
 
 function extractThinking(message: unknown): string | null {
@@ -83,16 +90,7 @@ function extractThinking(message: unknown): string | null {
 }
 
 export function extractThinkingCached(message: unknown): string | null {
-  if (!message || typeof message !== "object") {
-    return extractThinking(message);
-  }
-  const obj = message;
-  if (thinkingCache.has(obj)) {
-    return thinkingCache.get(obj) ?? null;
-  }
-  const value = extractThinking(message);
-  thinkingCache.set(obj, value);
-  return value;
+  return readCachedMessageExtraction(message, thinkingCache, extractThinking);
 }
 
 function extractRawText(message: unknown): string | null {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of duplicated caching in Control UI chat text and
reasoning extraction. This is a behavior-preserving refactor, not a bug fix.

## Why This Change Was Made

Use one private, concrete cache-read helper while retaining the separate
module-lifetime text and thinking caches and their existing extractors. Original
object keys, lazy independent extraction, cached null and empty results,
non-object bypass, and uncached exceptions remain unchanged.

The change is limited to `ui/src/lib/chat/message-extract.ts`. No new exports,
test edits, caller changes, configuration, persistence, or appearance changes.

## User Impact

No user-visible change. Chat text projection and reasoning formatting retain
their existing behavior.

## Evidence

- Existing `message-extract.test.ts` and `chat-imported-history.test.ts`: 59 tests
  passed on the baseline and the candidate. This is preservation PASS/PASS, not
  a defect reproduction.
- Selected checks passed, including formatting, UI and selected core-test
  typechecks, dead-export checks, and targeted lint.
- Independent review found no actionable findings through P2.
- Configured Crabbox Linux proof used real Chromium with a mocked Gateway:
  `chat-reasoning-visibility.e2e.test.ts` and
  `chat-export-attribution.e2e.test.ts` passed 8/8 on the baseline and 8/8 on the
  candidate. Existing assertions cover reasoning visibility, reload, local
  toggles, formatting, copy, and export attribution.
- Source-bound comparison: baseline
  `680fc46558fd9ce72f903987a675633770202443`, candidate
  `70ad6dd13f5c16053b44776cc1eeebac5ff50b88`. The materialized candidate tree
  matched the committed source tree; source and test blobs were verified before
  both runs.
- Remote run: https://github.com/openclaw/openclaw/actions/runs/34516568702.
  Both test runs passed before the wrapper exited 1 during cleanup due to a
  transport timeout. Cleanup was subsequently recovered, and an independent
  provider status read confirmed completion. No global wrapper exit-0 claim.

Commands completed locally:

```sh
node scripts/run-vitest.mjs run --config ui/vitest.config.ts --configLoader runner \
  ui/src/lib/chat/message-extract.test.ts \
  ui/src/pages/chat/components/chat-imported-history.test.ts
node scripts/check-changed.mjs --base 680fc46558fd9ce72f903987a675633770202443 \
  -- ui/src/lib/chat/message-extract.ts
```
