### PR TITLE
fix(sessions): include remote default branch changes in review

### DIFF
--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -348,83 +348,94 @@ describe("loadSessionDiff", () => {
     expect(committed.files).toEqual([]);
   });
 
-  it("scopes branch, working-tree, and commit diffs with branch metadata", async () => {
-    initRepo(repoRoot);
-    fs.writeFileSync(path.join(repoRoot, "base.txt"), "base\n");
-    git(repoRoot, "add", ".");
-    git(repoRoot, "commit", "-qm", "base");
-    const mergeBase = git(repoRoot, "rev-parse", "HEAD").trim();
-    git(repoRoot, "checkout", "-qb", "sibling");
-    fs.writeFileSync(path.join(repoRoot, "sibling.txt"), "sibling commit\n");
-    git(repoRoot, "add", ".");
-    git(repoRoot, "commit", "-qm", "sibling change");
-    const siblingCommit = git(repoRoot, "rev-parse", "HEAD").trim();
-    git(repoRoot, "checkout", "-q", "main");
-    git(repoRoot, "checkout", "-qb", "feature");
+  it.each(["main", "origin/main", "origin/master"])(
+    "scopes branch, working-tree, and commit diffs against %s with branch metadata",
+    async (baseRef) => {
+      initRepo(repoRoot);
+      fs.writeFileSync(path.join(repoRoot, "base.txt"), "base\n");
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-qm", "base");
+      const mergeBase = git(repoRoot, "rev-parse", "HEAD").trim();
+      git(repoRoot, "checkout", "-qb", "sibling");
+      fs.writeFileSync(path.join(repoRoot, "sibling.txt"), "sibling commit\n");
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-qm", "sibling change");
+      const siblingCommit = git(repoRoot, "rev-parse", "HEAD").trim();
+      git(repoRoot, "checkout", "-q", "main");
+      git(repoRoot, "checkout", "-qb", "feature");
+      if (baseRef !== "main") {
+        git(repoRoot, "update-ref", `refs/remotes/${baseRef}`, mergeBase);
+        git(repoRoot, "branch", "-d", "main");
+      }
 
-    fs.writeFileSync(path.join(repoRoot, "first.txt"), "first commit\n");
-    git(repoRoot, "add", ".");
-    git(repoRoot, "commit", "-qm", "first change");
-    const firstCommit = git(repoRoot, "rev-parse", "HEAD").trim();
-    fs.writeFileSync(path.join(repoRoot, "second.txt"), "second commit\n");
-    git(repoRoot, "add", ".");
-    git(repoRoot, "commit", "-qm", "second change");
-    const secondCommit = git(repoRoot, "rev-parse", "HEAD").trim();
+      fs.writeFileSync(path.join(repoRoot, "first.txt"), "first commit\n");
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-qm", "first change");
+      const firstCommit = git(repoRoot, "rev-parse", "HEAD").trim();
+      fs.writeFileSync(path.join(repoRoot, "second.txt"), "second commit\n");
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-qm", "second change");
+      const secondCommit = git(repoRoot, "rev-parse", "HEAD").trim();
 
-    fs.appendFileSync(path.join(repoRoot, "second.txt"), "working tree\n");
-    fs.writeFileSync(path.join(repoRoot, "loose.txt"), "untracked\n");
-    mockSession(repoRoot);
+      fs.appendFileSync(path.join(repoRoot, "second.txt"), "working tree\n");
+      fs.writeFileSync(path.join(repoRoot, "loose.txt"), "untracked\n");
+      mockSession(repoRoot);
 
-    const all = await loadSessionDiff({ sessionKey: "agent:main:s1" });
-    expect(all.files.map((file) => file.path)).toEqual(["first.txt", "loose.txt", "second.txt"]);
-    expect(all.aheadCount).toBe(2);
-    expect(all.commits).toEqual([
-      { sha: git(repoRoot, "rev-parse", "--short", secondCommit).trim(), subject: "second change" },
-      { sha: git(repoRoot, "rev-parse", "--short", firstCommit).trim(), subject: "first change" },
-    ]);
-    expect(all.mergeBase).toEqual({
-      sha: git(repoRoot, "rev-parse", "--short", mergeBase).trim(),
-      subject: "base",
-    });
+      const all = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+      expect(all.baseRef).toBe(baseRef);
+      expect(all.files.map((file) => file.path)).toEqual(["first.txt", "loose.txt", "second.txt"]);
+      expect(all.aheadCount).toBe(2);
+      expect(all.commits).toEqual([
+        {
+          sha: git(repoRoot, "rev-parse", "--short", secondCommit).trim(),
+          subject: "second change",
+        },
+        { sha: git(repoRoot, "rev-parse", "--short", firstCommit).trim(), subject: "first change" },
+      ]);
+      expect(all.mergeBase).toEqual({
+        sha: git(repoRoot, "rev-parse", "--short", mergeBase).trim(),
+        subject: "base",
+      });
 
-    const uncommitted = await loadSessionDiff({
-      sessionKey: "agent:main:s1",
-      scope: "uncommitted",
-    });
-    expect(uncommitted.files.map((file) => file.path)).toEqual(["loose.txt", "second.txt"]);
-    expect(uncommitted.files.find((file) => file.path === "second.txt")?.patch).toContain(
-      "+working tree",
-    );
+      const uncommitted = await loadSessionDiff({
+        sessionKey: "agent:main:s1",
+        scope: "uncommitted",
+      });
+      expect(uncommitted.files.map((file) => file.path)).toEqual(["loose.txt", "second.txt"]);
+      expect(uncommitted.files.find((file) => file.path === "second.txt")?.patch).toContain(
+        "+working tree",
+      );
 
-    const baseline = await captureSessionDiffBaseline({ cwd: repoRoot, sessionId: "s1" });
-    mockSession(repoRoot, { sessionDiffBaseline: baseline });
-    const committed = await loadSessionDiff({
-      sessionKey: "agent:main:s1",
-      scope: "commit",
-      commit: firstCommit,
-    });
-    expect(committed.files.map((file) => file.path)).toEqual(["first.txt"]);
-    expect(committed.files[0]?.patch).toContain("+first commit");
-    expect(committed.files[0]?.untracked).toBeUndefined();
-
-    for (const commit of [siblingCommit, mergeBase]) {
-      const outsideAdvertisedHistory = await loadSessionDiff({
+      const baseline = await captureSessionDiffBaseline({ cwd: repoRoot, sessionId: "s1" });
+      mockSession(repoRoot, { sessionDiffBaseline: baseline });
+      const committed = await loadSessionDiff({
         sessionKey: "agent:main:s1",
         scope: "commit",
-        commit,
+        commit: firstCommit,
       });
-      expect(outsideAdvertisedHistory.unavailableReason).toBe("unknown_commit");
-      expect(outsideAdvertisedHistory.files).toEqual([]);
-    }
+      expect(committed.files.map((file) => file.path)).toEqual(["first.txt"]);
+      expect(committed.files[0]?.patch).toContain("+first commit");
+      expect(committed.files[0]?.untracked).toBeUndefined();
 
-    const unknown = await loadSessionDiff({
-      sessionKey: "agent:main:s1",
-      scope: "commit",
-      commit: "not-a-commit",
-    });
-    expect(unknown.unavailableReason).toBe("unknown_commit");
-    expect(unknown.files).toEqual([]);
-  });
+      for (const commit of [siblingCommit, mergeBase]) {
+        const outsideAdvertisedHistory = await loadSessionDiff({
+          sessionKey: "agent:main:s1",
+          scope: "commit",
+          commit,
+        });
+        expect(outsideAdvertisedHistory.unavailableReason).toBe("unknown_commit");
+        expect(outsideAdvertisedHistory.files).toEqual([]);
+      }
+
+      const unknown = await loadSessionDiff({
+        sessionKey: "agent:main:s1",
+        scope: "commit",
+        commit: "not-a-commit",
+      });
+      expect(unknown.unavailableReason).toBe("unknown_commit");
+      expect(unknown.files).toEqual([]);
+    },
+  );
 
   it("never executes configured textconv drivers from the read RPC", async () => {
     initRepo(repoRoot);

--- a/src/sessions/session-diff-revisions.test.ts
+++ b/src/sessions/session-diff-revisions.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runGit, type GitResult } from "../agents/worktrees/git.js";
 import { createDeferredCore } from "../shared/deferred.js";
-import { resolveSessionDiffEmptyTree } from "./session-diff-revisions.js";
+import { resolveSessionDiffBase, resolveSessionDiffEmptyTree } from "./session-diff-revisions.js";
 
 vi.mock("../agents/worktrees/git.js", () => ({ runGit: vi.fn() }));
 
@@ -68,4 +68,79 @@ describe("empty-tree preparation", () => {
       expect(runGit).toHaveBeenCalledTimes(2);
     },
   );
+});
+
+describe("branch base resolution", () => {
+  it.each([
+    {
+      name: "symbolic origin/HEAD before local and remote defaults",
+      symbolicDefault: "origin/trunk",
+      refs: ["origin/trunk", "main", "master", "origin/main", "origin/master"],
+      expected: { base: "origin/trunk-base", baseRef: "trunk" },
+    },
+    {
+      name: "local main before local master and remote defaults",
+      symbolicDefault: null,
+      refs: ["main", "master", "origin/main", "origin/master"],
+      expected: { base: "main-base", baseRef: "main" },
+    },
+    {
+      name: "local master before remote defaults",
+      symbolicDefault: null,
+      refs: ["master", "origin/main", "origin/master"],
+      expected: { base: "master-base", baseRef: "master" },
+    },
+    {
+      name: "remote main before remote master",
+      symbolicDefault: null,
+      refs: ["origin/main", "origin/master"],
+      expected: { base: "origin/main-base", baseRef: "origin/main" },
+    },
+  ])("prefers $name", async ({ symbolicDefault, refs, expected }) => {
+    const mergeBases = new Map(refs.map((ref) => [ref, `${ref}-base\n`]));
+    const gitOut = async (_root: string, args: string[]) => {
+      if (args[0] === "symbolic-ref") {
+        return symbolicDefault;
+      }
+      const ref = args[0] === "rev-parse" ? args.at(-1) : args[1];
+      const mergeBase = ref ? mergeBases.get(ref) : undefined;
+      if (!mergeBase) {
+        return null;
+      }
+      return args[0] === "merge-base" ? mergeBase : `${ref}-sha\n`;
+    };
+
+    await expect(
+      resolveSessionDiffBase({ branch: "feature", gitOut, root: "/repo" }),
+    ).resolves.toEqual(expected);
+  });
+
+  it.each([undefined, "main", "master"])(
+    "keeps HEAD for branch %s even when remote defaults exist",
+    async (branch) => {
+      const gitOut = async (_root: string, args: string[]) => {
+        if (args[0] === "symbolic-ref") {
+          return null;
+        }
+        if (args[0] === "rev-parse" && args.at(-1)?.startsWith("origin/")) {
+          return "remote-sha\n";
+        }
+        if (args[0] === "merge-base" && args[1]?.startsWith("origin/")) {
+          return "remote-base\n";
+        }
+        return null;
+      };
+
+      await expect(resolveSessionDiffBase({ branch, gitOut, root: "/repo" })).resolves.toEqual({
+        base: "HEAD",
+        baseRef: "HEAD",
+      });
+    },
+  );
+
+  it("keeps HEAD when no default ref resolves", async () => {
+    await expect(
+      resolveSessionDiffBase({ branch: "feature", gitOut: async () => null, root: "/repo" }),
+    ).resolves.toEqual({ base: "HEAD", baseRef: "HEAD" });
+  });
 });

--- a/src/sessions/session-diff-revisions.test.ts
+++ b/src/sessions/session-diff-revisions.test.ts
@@ -77,9 +77,15 @@ describe("branch base resolution", () => {
       const calls: string[][] = [];
       const gitOut = vi.fn(async (_root: string, args: string[]) => {
         calls.push(args);
-        if (args[0] === "symbolic-ref") return null;
-        if (args[0] === "rev-parse" && args.at(-1) === candidate) return `${candidate}-sha\n`;
-        if (args[0] === "merge-base" && args[1] === candidate) return "merge-base-sha\n";
+        if (args[0] === "symbolic-ref") {
+          return null;
+        }
+        if (args[0] === "rev-parse" && args.at(-1) === candidate) {
+          return `${candidate}-sha\n`;
+        }
+        if (args[0] === "merge-base" && args[1] === candidate) {
+          return "merge-base-sha\n";
+        }
         return null;
       });
 
@@ -92,9 +98,15 @@ describe("branch base resolution", () => {
 
   it("keeps local main ahead of remote-tracking defaults", async () => {
     const gitOut = vi.fn(async (_root: string, args: string[]) => {
-      if (args[0] === "symbolic-ref") return null;
-      if (args[0] === "rev-parse" && args.at(-1) === "main") return "main-sha\n";
-      if (args[0] === "merge-base" && args[1] === "main") return "local-base\n";
+      if (args[0] === "symbolic-ref") {
+        return null;
+      }
+      if (args[0] === "rev-parse" && args.at(-1) === "main") {
+        return "main-sha\n";
+      }
+      if (args[0] === "merge-base" && args[1] === "main") {
+        return "local-base\n";
+      }
       return null;
     });
 

--- a/src/sessions/session-diff-revisions.test.ts
+++ b/src/sessions/session-diff-revisions.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runGit, type GitResult } from "../agents/worktrees/git.js";
 import { createDeferredCore } from "../shared/deferred.js";
-import { resolveSessionDiffEmptyTree } from "./session-diff-revisions.js";
+import { resolveSessionDiffBase, resolveSessionDiffEmptyTree } from "./session-diff-revisions.js";
 
 vi.mock("../agents/worktrees/git.js", () => ({ runGit: vi.fn() }));
 
@@ -68,4 +68,38 @@ describe("empty-tree preparation", () => {
       expect(runGit).toHaveBeenCalledTimes(2);
     },
   );
+});
+
+describe("branch base resolution", () => {
+  it.each(["origin/main", "origin/master"])(
+    "uses the remote-tracking %s ref when no symbolic or local default exists",
+    async (candidate) => {
+      const calls: string[][] = [];
+      const gitOut = vi.fn(async (_root: string, args: string[]) => {
+        calls.push(args);
+        if (args[0] === "symbolic-ref") return null;
+        if (args[0] === "rev-parse" && args.at(-1) === candidate) return `${candidate}-sha\n`;
+        if (args[0] === "merge-base" && args[1] === candidate) return "merge-base-sha\n";
+        return null;
+      });
+
+      await expect(
+        resolveSessionDiffBase({ branch: "feature", gitOut, root: "/repo" }),
+      ).resolves.toEqual({ base: "merge-base-sha", baseRef: candidate });
+      expect(calls).toContainEqual(["rev-parse", "--verify", "--quiet", candidate]);
+    },
+  );
+
+  it("keeps local main ahead of remote-tracking defaults", async () => {
+    const gitOut = vi.fn(async (_root: string, args: string[]) => {
+      if (args[0] === "symbolic-ref") return null;
+      if (args[0] === "rev-parse" && args.at(-1) === "main") return "main-sha\n";
+      if (args[0] === "merge-base" && args[1] === "main") return "local-base\n";
+      return null;
+    });
+
+    await expect(
+      resolveSessionDiffBase({ branch: "feature", gitOut, root: "/repo" }),
+    ).resolves.toEqual({ base: "local-base", baseRef: "main" });
+  });
 });

--- a/src/sessions/session-diff-revisions.ts
+++ b/src/sessions/session-diff-revisions.ts
@@ -31,7 +31,7 @@ export async function resolveSessionDiffBase(params: {
   }
   // Plain clones without origin/HEAD still get a branch-relative diff.
   if (params.branch && params.branch !== "main" && params.branch !== "master") {
-    for (const candidate of ["main", "master"]) {
+    for (const candidate of ["main", "master", "origin/main", "origin/master"]) {
       const verified = await params.gitOut(params.root, [
         "rev-parse",
         "--verify",


### PR DESCRIPTION
## Problem and fix

Fixes #144205. Review's All Changes omitted committed branch work when a feature checkout had `origin/main` or `origin/master`, but no `origin/HEAD` or local default branch. The resolver fell back to `HEAD`, which made All Changes look like Uncommitted and hid branch history.

The existing resolver now tries those two remote-tracking refs after symbolic and local defaults. It uses local Git reads and the existing merge-base path. Uncommitted keeps its `HEAD` comparison; session-start filtering, commit ancestry checks, and explicit repository bases retain their existing behavior.

## Validation

- Real isolated Gateway and served Control UI reproduced the failure on pinned main. The proof settled a session baseline through ordinary `/status` before creating committed, uncommitted, and untracked work.
- New real-Git remote-main and remote-master cases failed on baseline; the local-main control passed.
- 69 focused tests passed across resolver precedence, baseline lifecycle, Gateway diff scopes and safety controls, and live/stopped repository paths.
- Formatting, syntax lint, line-count and assertion-safety checks, and the normal commit hook passed.

- Candidate `424dd2880e15` restored the committed file and branch history in the same original session, repository and served Review UI. Uncommitted retained only tracked/untracked working changes.
- A separate fresh-session control hid all preexisting work after baseline capture. The original session remained unchanged. No model inference was required.
- Independent public reads and browser controls checked All, Uncommitted, the advertised commit, and explicit rejection of the base and an unknown commit. A capture-wrapper cleanup failure was retained; a focused recovery verified normal shutdown and unchanged refs without repeating the completed behavior cases.

Preserves the original contributor commits and credit. Full suites and type checks run in hosted CI.
