### PR TITLE
test: exercise session cleanup through real queues

### DIFF
--- a/src/test-utils/session-state-cleanup.test.ts
+++ b/src/test-utils/session-state-cleanup.test.ts
@@ -13,40 +13,19 @@ import {
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import {
-  cleanupSessionStateForTest,
-  resetSessionStateCleanupRuntimeForTests,
-  setSessionStateCleanupRuntimeForTests,
-} from "./session-state-cleanup.js";
-
-const drainFileLockStateMock = vi.hoisted(() => vi.fn(async () => undefined));
-const drainSessionStoreWriterQueuesMock = vi.hoisted(() => vi.fn(async () => undefined));
-
-async function flushMicrotasks(rounds = 3): Promise<void> {
-  for (let index = 0; index < rounds; index += 1) {
-    await Promise.resolve();
-  }
-}
+import { cleanupSessionStateForTest } from "./session-state-cleanup.js";
 
 describe("cleanupSessionStateForTest", () => {
   beforeEach(() => {
     vi.useRealTimers();
     clearSessionStoreCacheForTest();
     resetFileLockStateForTest();
-    drainFileLockStateMock.mockClear();
-    drainSessionStoreWriterQueuesMock.mockClear();
-    setSessionStateCleanupRuntimeForTests({
-      drainFileLockStateForTest: drainFileLockStateMock,
-      drainSessionStoreWriterQueuesForTest: drainSessionStoreWriterQueuesMock,
-    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
     clearSessionStoreCacheForTest();
     resetFileLockStateForTest();
-    resetSessionStateCleanupRuntimeForTests();
-    vi.restoreAllMocks();
   });
 
   it("waits for in-flight session store writer queues before clearing test state", async () => {
@@ -54,14 +33,7 @@ describe("cleanupSessionStateForTest", () => {
     const storePath = path.join(fixtureRoot, "openclaw-sessions.json");
     const started = createDeferred();
     const release = createDeferred();
-    const drainRequested = createDeferred();
-    let finishDrain: () => void = () => undefined;
-    drainSessionStoreWriterQueuesMock.mockImplementationOnce(async () => {
-      drainRequested.resolve();
-      await new Promise<void>((resolve) => {
-        finishDrain = resolve;
-      });
-    });
+    let cleanupPromise: Promise<void> | undefined;
     let running: Promise<void> | undefined;
     try {
       running = runExclusiveSessionStoreWrite(storePath, async () => {
@@ -72,26 +44,23 @@ describe("cleanupSessionStateForTest", () => {
       await started.promise;
 
       let settled = false;
-      const cleanupPromise = cleanupSessionStateForTest().then(() => {
+      cleanupPromise = cleanupSessionStateForTest().then(() => {
         settled = true;
       });
 
-      await drainRequested.promise;
-      await flushMicrotasks();
+      // An empty drain settles before this event-loop checkpoint.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(settled).toBe(false);
-      expect(drainSessionStoreWriterQueuesMock).toHaveBeenCalledTimes(1);
-      expect(drainFileLockStateMock).not.toHaveBeenCalled();
 
       release.resolve();
       await running;
-      finishDrain();
       await cleanupPromise;
-
-      expect(drainFileLockStateMock).toHaveBeenCalledTimes(1);
     } finally {
       release.resolve();
-      finishDrain();
       await running?.catch(() => undefined);
+      await cleanupPromise;
       await cleanupSessionStateForTest();
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
@@ -107,7 +76,6 @@ describe("cleanupSessionStateForTest", () => {
     const release = createDeferred();
     let database: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
     let cleanupPromise: Promise<void> | undefined;
-    setSessionStateCleanupRuntimeForTests({ drainSessionStoreWriterQueuesForTest: null });
 
     const running = runExclusiveSqliteSessionWrite(
       { agentId: "main", env, path: databasePath },

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -13,39 +13,17 @@ import {
 import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 
-let fileLockDrainerForTests: typeof drainFileLockStateForTest | null = null;
-let sessionStoreWriterQueueDrainerForTests: typeof drainSessionStoreWriterQueuesForTest | null =
-  null;
-
-/** Overrides cleanup hooks so tests can drain mocked session state modules. */
-export function setSessionStateCleanupRuntimeForTests(params: {
-  drainFileLockStateForTest?: typeof drainFileLockStateForTest | null;
-  drainSessionStoreWriterQueuesForTest?: typeof drainSessionStoreWriterQueuesForTest | null;
-}): void {
-  if ("drainFileLockStateForTest" in params) {
-    fileLockDrainerForTests = params.drainFileLockStateForTest ?? null;
-  }
-  if ("drainSessionStoreWriterQueuesForTest" in params) {
-    sessionStoreWriterQueueDrainerForTests = params.drainSessionStoreWriterQueuesForTest ?? null;
-  }
-}
-
-export function resetSessionStateCleanupRuntimeForTests(): void {
-  fileLockDrainerForTests = null;
-  sessionStoreWriterQueueDrainerForTests = null;
-}
-
 export async function cleanupSessionStateForTest(
   options: { stateDir?: string } = {},
 ): Promise<void> {
-  await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
+  await drainSessionStoreWriterQueuesForTest();
   if (options.stateDir) {
     // Writers can publish deferred reconciles as the initial drain settles.
     // Finish those owners and their writes before closing fixture databases.
     await waitForSessionTranscriptIndexReconcilesInStateDir(options.stateDir);
-    await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
+    await drainSessionStoreWriterQueuesForTest();
   }
-  await (fileLockDrainerForTests ?? drainFileLockStateForTest)();
+  await drainFileLockStateForTest();
   clearSessionStoreCacheForTest();
   if (!options.stateDir) {
     return;


### PR DESCRIPTION
Closes #144245

## What Problem This Solves

Session cleanup tests override the real queue drainers, so their main waiting assertion is tied to a mocked callback rather than the actual writer queue. The override state and exported setters exist only for that test setup.

## Why This Change Was Made

Remove the unused test-only override path and have cleanup call its canonical drainers directly. The existing regression now blocks a real session writer and checks that cleanup waits for it. Deferred reconciles, file-lock draining and database-close ordering remain intact.

## User Impact

This maintainer-requested test/support cleanup removes 54 lines and makes the regression exercise the real queue boundary. It changes no production behavior and claims no Gateway speed or memory improvement.

## Evidence

The same four focused suites pass all 38 tests before and after. All 29 selected changed checks, including the dead-export scans, and independent P2 review passed with exact source hashes preserved. Sequential test timing and RSS are retained as correctness-run observations, not performance evidence.
