### PR TITLE
refactor(tests): share MiniMax HTTP assertion fixtures

### DIFF
--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -1,10 +1,12 @@
-// Minimax tests cover music generation provider plugin behavior.
 import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  expectAllowPrivateNetworkPolicy,
+  expectMinimaxGuardedFetchCall,
   getMinimaxProviderHttpMocks,
   installMinimaxProviderHttpMockCleanup,
   loadMinimaxMusicGenerationProviderModule,
+  mockCallArg,
 } from "./provider-http.test-helpers.js";
 
 const {
@@ -44,30 +46,6 @@ function mockMusicGenerationResponse(json: Record<string, unknown>): void {
   });
 }
 
-function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0): Record<string, unknown> {
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected mock call ${index}`);
-  }
-  return call[0] as Record<string, unknown>;
-}
-
-function expectMinimaxGuardedFetchCall(index: number, url: string) {
-  const call = fetchWithTimeoutGuardedMock.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected MiniMax guarded fetch call ${index + 1}`);
-  }
-  const [actualUrl, init, timeoutMs, fetchFn, options] = call;
-  expect(actualUrl).toBe(url);
-  expect((init as RequestInit | undefined)?.method).toBe("GET");
-  expect(Number.isInteger(timeoutMs)).toBe(true);
-  expect(timeoutMs).toBeGreaterThan(0);
-  expect(fetchFn).toBe(fetch);
-  return {
-    options: options as Record<string, unknown> | undefined,
-  };
-}
-
 function expectDownloadFetchTimeout(url: string, totalTimeoutMs: number): void {
   const call = fetchWithTimeoutMock.mock.calls[0];
   if (!call) {
@@ -79,12 +57,6 @@ function expectDownloadFetchTimeout(url: string, totalTimeoutMs: number): void {
   expect(timeoutMs).toBeGreaterThan(totalTimeoutMs - 1_000);
   expect(timeoutMs).toBeLessThanOrEqual(totalTimeoutMs);
   expect(fetchFn).toBe(fetch);
-}
-
-function expectAllowPrivateNetworkPolicy(options: Record<string, unknown> | undefined): void {
-  expect(options).toEqual({
-    ssrfPolicy: { allowPrivateNetwork: true },
-  });
 }
 
 function streamedAudioResponse(bytes: string): Response {

--- a/extensions/minimax/provider-http.test-helpers.ts
+++ b/extensions/minimax/provider-http.test-helpers.ts
@@ -1,4 +1,3 @@
-// Minimax provider module implements model/runtime integration.
 import type {
   executeProviderOperationWithRetry,
   fetchProviderDownloadResponse,
@@ -6,7 +5,7 @@ import type {
   fetchWithTimeoutGuarded,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
-import { afterEach, vi, type Mock } from "vitest";
+import { afterEach, expect, vi, type Mock } from "vitest";
 
 type ResolveProviderHttpRequestConfigParams = Parameters<
   typeof resolveProviderHttpRequestConfig
@@ -210,6 +209,42 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
     waitProviderOperationPollInterval: async () => {},
   };
 });
+
+export function mockCallArg(
+  mock: { mock: { calls: unknown[][] } },
+  index = 0,
+): Record<string, unknown> {
+  const call = mock.mock.calls[index];
+  if (!call) {
+    throw new Error(`expected mock call ${index}`);
+  }
+  return call[0] as Record<string, unknown>;
+}
+
+export function expectMinimaxGuardedFetchCall(index: number, url: string) {
+  const call = minimaxProviderHttpMocks.fetchWithTimeoutGuardedMock.mock.calls[index];
+  if (!call) {
+    throw new Error(`expected MiniMax guarded fetch call ${index + 1}`);
+  }
+  const [actualUrl, init, timeoutMs, fetchFn, options] = call;
+  expect(actualUrl).toBe(url);
+  expect((init as RequestInit | undefined)?.method).toBe("GET");
+  expect(Number.isInteger(timeoutMs)).toBe(true);
+  expect(timeoutMs).toBeGreaterThan(0);
+  expect(fetchFn).toBe(fetch);
+  return {
+    init: init as RequestInit,
+    options: options as Record<string, unknown> | undefined,
+  };
+}
+
+export function expectAllowPrivateNetworkPolicy(
+  options: Record<string, unknown> | undefined,
+): void {
+  expect(options).toEqual({
+    ssrfPolicy: { allowPrivateNetwork: true },
+  });
+}
 
 export function getMinimaxProviderHttpMocks(): MinimaxProviderHttpMocks {
   return minimaxProviderHttpMocks;

--- a/extensions/minimax/video-generation-provider.test.ts
+++ b/extensions/minimax/video-generation-provider.test.ts
@@ -1,10 +1,12 @@
-// Minimax tests cover video generation provider plugin behavior.
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  expectAllowPrivateNetworkPolicy,
+  expectMinimaxGuardedFetchCall,
   getMinimaxProviderHttpMocks,
   installMinimaxProviderHttpMockCleanup,
   loadMinimaxVideoGenerationProviderModule,
+  mockCallArg,
 } from "./provider-http.test-helpers.js";
 
 const {
@@ -12,7 +14,6 @@ const {
   postJsonRequestMock,
   executeProviderOperationWithRetryMock,
   fetchWithTimeoutMock,
-  fetchWithTimeoutGuardedMock,
   resolveProviderHttpRequestConfigMock,
 } = getMinimaxProviderHttpMocks();
 
@@ -41,37 +42,6 @@ function expectMinimaxFetchCall(index: number, url: string) {
   expect(Number.isInteger(timeoutMs)).toBe(true);
   expect(timeoutMs).toBeGreaterThan(0);
   expect(fetchFn).toBe(fetch);
-}
-
-function expectMinimaxGuardedFetchCall(index: number, url: string) {
-  const call = fetchWithTimeoutGuardedMock.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected MiniMax guarded fetch call ${index + 1}`);
-  }
-  const [actualUrl, init, timeoutMs, fetchFn, options] = call;
-  expect(actualUrl).toBe(url);
-  expect((init as RequestInit | undefined)?.method).toBe("GET");
-  expect(Number.isInteger(timeoutMs)).toBe(true);
-  expect(timeoutMs).toBeGreaterThan(0);
-  expect(fetchFn).toBe(fetch);
-  return {
-    init: init as RequestInit,
-    options: options as Record<string, unknown> | undefined,
-  };
-}
-
-function expectAllowPrivateNetworkPolicy(options: Record<string, unknown> | undefined): void {
-  expect(options).toEqual({
-    ssrfPolicy: { allowPrivateNetwork: true },
-  });
-}
-
-function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0): Record<string, unknown> {
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected mock call ${index}`);
-  }
-  return call[0] as Record<string, unknown>;
 }
 
 function streamedVideoResponse(bytes: string): Response {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

MiniMax's music and video tests duplicate the same guarded-fetch assertions around an already shared mock owner.

## Why This Change Was Made

Move those assertions into the existing HTTP test helper, using the same hoisted mock object. All test bodies and 30 helper calls are preserved. The shared result also includes `init` for music callers; they continue reading only `options`, and `init` was already read and checked before this change.

## User Impact

Developer-only consolidation: three test/support files add 43 lines and remove 66. Production behavior and public APIs are unchanged, and no test cases are removed.

## Evidence

```sh
node scripts/run-vitest.mjs extensions/minimax/music-generation-provider.test.ts extensions/minimax/video-generation-provider.test.ts
node scripts/run-vitest.mjs test/scripts/bundled-plugin-build-entries.test.ts --testNamePattern 'keeps top-level bundled plugin test helpers out of public-surface entries'
```

The full provider suites passed before and after: 42 cases with identical identities, order and statuses on Node 26.5. The named packaging case passed; its filter excluded 33 other cases. All 20 required changed-file checks passed, and independent source review found no actionable issues.

This is local mocked HTTP proof, not live MiniMax generation or a full packaging run. The shared helper remains excluded from public-surface build entries.
