### PR TITLE
improve: speed up coercion declaration checks

### DIFF
--- a/scripts/check-coercion-helper-declarations.mts
+++ b/scripts/check-coercion-helper-declarations.mts
@@ -7,6 +7,7 @@ import ts from "typescript";
 import { isCodeFile, listRepoFilesSync } from "./check-file-utils.js";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { runWithFailedTrailer } from "./lib/failed-trailer.mts";
+import { escapeRegExp } from "./lib/regexp.mjs";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { getPropertyNameText, toLine, unwrapExpression } from "./lib/ts-guard-utils.mts";
 
@@ -302,6 +303,10 @@ export const BANNED_COERCION_HELPER_NAMES: readonly BannedCoercionHelperName[] =
   ]),
 ];
 const BANNED_HELPER_NAMES: ReadonlySet<string> = new Set(BANNED_COERCION_HELPER_NAMES);
+const BANNED_HELPER_NAME_PATTERN = new RegExp(
+  [...BANNED_HELPER_NAMES].map(escapeRegExp).join("|"),
+  "u",
+);
 // One tracked-tree scan covers root configs plus config, Actions, skills, apps, plugins, and packages.
 const SCAN_ROOTS = ["."];
 const GENERATED_OR_FIXTURE_PATH_RE =
@@ -418,7 +423,7 @@ export function findBannedCoercionHelperDeclarations(
   source: string,
   file = "source.ts",
 ): CoercionHelperDeclaration[] {
-  if (![...BANNED_HELPER_NAMES].some((name) => source.includes(name))) {
+  if (!BANNED_HELPER_NAME_PATTERN.test(source)) {
     return [];
   }
   const scriptKind = file.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;

--- a/test/scripts/check-coercion-helper-declarations.test.ts
+++ b/test/scripts/check-coercion-helper-declarations.test.ts
@@ -69,6 +69,20 @@ describe("coercion helper declaration AST guard", () => {
     expect(findBannedCoercionHelperDeclarations(source, "src/example.ts")).toEqual([]);
   });
 
+  it("keeps substring admission independent across source files", () => {
+    const source = String.raw`// xreadStringx
+function read\u0053tring() {}`;
+
+    expect(
+      ["src/first.ts", "src/second.ts"].map((file) =>
+        findBannedCoercionHelperDeclarations(source, file),
+      ),
+    ).toEqual([
+      [{ file: "src/first.ts", kind: "function", line: 2, name: "readString" }],
+      [{ file: "src/second.ts", kind: "function", line: 2, name: "readString" }],
+    ]);
+  });
+
   it("allows one exact declaration and reports duplicate, unowned, and stale entries", () => {
     const declarations: CoercionHelperDeclaration[] = [
       { file: "src/allowed.ts", kind: "function", line: 2, name: "isRecord" },


### PR DESCRIPTION
## What Problem This Solves

Developers wait unnecessarily on the coercion-declaration guard during routine changed-code validation. In the measured checkout, one complete scan took about 22–23 seconds.

## Why This Change Was Made

Prepare one escaped, case-sensitive name-search regex when the guard module loads, instead of allocating a name array and separately searching for every name in every source file. The existing AST owner still decides exact declaration names, ownership, carve-outs and diagnostics. Substring admission remains unchanged, including escaped identifiers admitted by a raw substring elsewhere in the file. No cache, dependency, policy exception or new production API is added.

## User Impact

The complete scanner took about 11 seconds in both candidate observations, saving roughly 11–13 seconds on this checkout. Output and enforcement are unchanged. Five tooling lines and fourteen preservation-test lines are added.

## Evidence

- The complete owner suite passed 13 tests on both baseline and candidate with the same preservation fixture. All 20 selected changed checks passed, including both typechecks, type-aware lint, three dead-export graphs and the full declaration guard. Formatting and diff checks passed.
- Independent Codex review found no actionable P0–P2 findings. A separate data audit verified all six process receipts, source bindings, complete output and numerical comparisons.
- Fixed order: inventory, baseline, candidate, candidate, baseline, inventory. Each timed arm ran the real command `node --import ./scripts/tsx.mjs scripts/check-coercion-helper-declarations.mts` once. All four returned exit 0, identical complete output reporting 111 allowlisted declarations, and empty stderr.
- The surrounding inventories match byte-for-byte: 33,629 unique files / 356,594,190 bytes. The scanner itself is governed input; its selected baseline/candidate bytes intentionally differ. Every arm retains the same added test fixture.

| Whole-command measurement | Forward baseline → candidate | Reverse baseline → candidate |
| --- | ---: | ---: |
| Wall time | 21.779 → 11.139 s (−48.85%) | 23.422 → 10.862 s (−53.63%) |
| User + system CPU | 17.276 → 7.820 s (−54.73%) | 17.845 → 7.416 s (−58.44%) |

These are four fresh-process observations on a shared development host, with a preceding inventory warming the filesystem. They establish the measured scanner improvement, not statistical confidence, cold-disk behavior, whole-CI duration or Gateway latency. Matched peak-RSS pairs were slightly lower, but cross-pair RSS rose 0.82%/0.57% and the untimed inventory control rose 10.09%/9.19%; no stable memory benefit is claimed. No favorable reruns or samples were removed.

All owned processes joined, the candidate was restored, and the execution grants were closed. Raw receipts, full inventories and outputs remain in the task's local proof artifacts. Exact-head CI is still pending publication. Changelog changes are deferred to release generation.
