### PR TITLE
fix(media): resolve image aliases with the request's metadata

### DIFF
--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -222,7 +222,6 @@ export async function resolveImageRuntime(
   params: ImageRuntimeParams,
   onAcquired: (resources: ImageRuntimeResources) => void,
 ): Promise<PreparedImageRuntime> {
-  const resolvedRef = normalizeModelRef(params.provider, params.model);
   const workspaceDir =
     params.workspaceDir ??
     (params.agentId ? resolveAgentWorkspaceDir(params.cfg ?? {}, params.agentId) : undefined);
@@ -232,6 +231,11 @@ export async function resolveImageRuntime(
     ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
   };
   const suppliedSnapshot = params.preparedModelRuntime as PreparedModelRuntimeSnapshot | undefined;
+  let resolvedRef = suppliedSnapshot
+    ? normalizeModelRef(params.provider, params.model, {
+        manifestPlugins: suppliedSnapshot.metadataSnapshot,
+      })
+    : { provider: params.provider, model: params.model };
   const suppliedClaim = suppliedSnapshot
     ? retainPreparedModelRuntimeSnapshotResources(suppliedSnapshot)
     : undefined;
@@ -244,16 +248,24 @@ export async function resolveImageRuntime(
           config: params.cfg ?? {},
           ...(runtimeParams.workspaceDir ? { workspaceDir: runtimeParams.workspaceDir } : {}),
           loadRuntimePlugins: true,
-          runtimePluginSelections: [
-            {
-              provider: resolvedRef.provider,
-              modelId: resolvedRef.model,
-              ...(params.agentId ? { agentId: params.agentId } : {}),
-            },
-          ],
         },
         // The request already chose a model; full inventory discovery must stay outside setup.
-        { catalogMode: "static", abortSignal: params.signal },
+        {
+          catalogMode: "static",
+          abortSignal: params.signal,
+          deriveRuntimePluginSelections: ({ metadataSnapshot }) => {
+            resolvedRef = normalizeModelRef(params.provider, params.model, {
+              manifestPlugins: metadataSnapshot,
+            });
+            return [
+              {
+                provider: resolvedRef.provider,
+                modelId: resolvedRef.model,
+                ...(params.agentId ? { agentId: params.agentId } : {}),
+              },
+            ];
+          },
+        },
       );
   // The operation owns release before setup can leave asynchronous cleanup behind.
   onAcquired({
@@ -276,6 +288,7 @@ export async function resolveImageRuntime(
     Pick<NonNullable<Parameters<typeof resolveModelAsync>[4]>, "authStorage" | "modelRegistry">
   >;
   const resolveOptions = {
+    modelIdSource: "selected" as const,
     allowBundledStaticCatalogFallback: true,
     ...preparedStores,
     preparedModelRuntime: preparedRuntime,

--- a/src/media-understanding/image.runtime-profile.test.ts
+++ b/src/media-understanding/image.runtime-profile.test.ts
@@ -568,11 +568,8 @@ describe("describeImageWithModelCore", () => {
       expect.objectContaining({
         workspaceDir: "/tmp/openclaw-workspace",
         loadRuntimePlugins: true,
-        runtimePluginSelections: [
-          { provider: "google", modelId: "gemini-2.5-flash", agentId: "vision-agent" },
-        ],
       }),
-      { catalogMode: "static", abortSignal: expect.any(AbortSignal) },
+      expect.objectContaining({ catalogMode: "static", abortSignal: expect.any(AbortSignal) }),
     );
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
       "google",

--- a/src/media-understanding/image.selected-model.test.ts
+++ b/src/media-understanding/image.selected-model.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEmptyAgentDiscoveryStores } from "../agents/embedded-agent-runner/model.js";
+import type { PreparedModelRuntimeSnapshot } from "../agents/prepared-model-runtime.js";
+import { makeProviderModelFixture } from "../agents/test-helpers/provider-model-fixture.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { resolveImageRuntime } from "./image-model-runtime.js";
+
+const provider = "image-selected-model";
+const baseUrl = "https://image-selected-model.example/v1";
+
+describe("image model selection ownership", () => {
+  it.each(
+    (["entry", "middle", "plain"] as const).flatMap((input) =>
+      ([false, true] as const).flatMap((scoped) =>
+        ([undefined, "openai-completions"] as const).map((api) => ({ input, scoped, api })),
+      ),
+    ),
+  )(
+    "uses supplied metadata for $input with scoped hooks=$scoped and provider API=$api",
+    async ({ input, scoped, api }) => {
+      await withOpenClawTestState({ label: "image-selected-model" }, async (state) => {
+        const cfg: OpenClawConfig = {
+          agents: { defaults: { workspace: state.workspaceDir } },
+          models: {
+            providers: {
+              [provider]: {
+                baseUrl,
+                apiKey: "synthetic-fixture",
+                ...(api ? { api } : {}),
+                models: [],
+              },
+            },
+          },
+        };
+        await state.writeConfig(cfg);
+        const metadataSnapshot = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: provider,
+              providers: [provider],
+              modelIdNormalization: {
+                providers: {
+                  [provider]: {
+                    aliases: { entry: "middle", middle: "final", hooked: "wrong" },
+                  },
+                },
+              },
+            },
+          ],
+        });
+        const ambientMetadata = createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: provider,
+              providers: [provider],
+              modelIdNormalization: {
+                providers: { [provider]: { aliases: { entry: "wrong" } } },
+              },
+            },
+          ],
+        });
+        const normalizeModelId = vi.fn(({ modelId }: { modelId: string }) =>
+          modelId === "middle" ? "hooked" : modelId,
+        );
+        const pluginRegistry = createEmptyPluginRegistry();
+        pluginRegistry.providers.push({
+          pluginId: provider,
+          source: "synthetic-image-provider",
+          provider: { id: provider, label: provider, auth: [], normalizeModelId },
+        });
+        const stores = createEmptyAgentDiscoveryStores();
+        const rows = ["final", "middle", "plain", "hooked", "wrong"].map((id) =>
+          Object.assign(
+            makeProviderModelFixture({
+              provider,
+              id,
+              api: "openai-completions",
+              baseUrl,
+              input: ["text", "image"],
+            }),
+            { contextWindow: 16_000, maxTokens: 4_096 },
+          ),
+        );
+        stores.modelRegistry.registerProvider(provider, {
+          api: "openai-completions",
+          baseUrl,
+          models: rows,
+        });
+        const snapshot: PreparedModelRuntimeSnapshot = {
+          catalogOwner: undefined,
+          agentId: "main",
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          activeProjectKeys: [],
+          config: cfg,
+          observationConfig: cfg,
+          isCurrent: () => true,
+          authModes: {},
+          metadataSnapshot,
+          pluginRegistry,
+          allowGatewaySubagentBinding: false,
+          modelCatalog: { entries: [], routeVariants: [] },
+          configuredRuntimeModels: rows.map((model) => ({ provider, modelId: model.id, model })),
+          inlineProviderModels: [],
+          createStores: () => stores,
+        };
+        const expected =
+          input === "entry"
+            ? scoped
+              ? "hooked"
+              : "middle"
+            : input === "middle"
+              ? "final"
+              : "plain";
+        const run = async () => {
+          let release: (() => void) | undefined;
+          try {
+            const runtime = await resolveImageRuntime(
+              {
+                cfg,
+                agentDir: state.agentDir(),
+                provider,
+                model: input,
+                preparedModelRuntime: snapshot,
+              },
+              (resources) => {
+                release = resources.release;
+              },
+            );
+            expect(runtime.model).toMatchObject({
+              id: expected,
+              provider,
+              api: "openai-completions",
+              baseUrl,
+            });
+          } finally {
+            release?.();
+          }
+        };
+        if (scoped) {
+          await withPluginRuntimeGenerationScope(
+            { metadataSnapshot: ambientMetadata, pluginRegistry },
+            run,
+          );
+        } else {
+          await run();
+        }
+        if (scoped) {
+          expect(normalizeModelId).toHaveBeenCalledExactlyOnceWith({
+            provider,
+            modelId: input === "entry" ? "middle" : input === "middle" ? "final" : "plain",
+          });
+        } else {
+          expect(normalizeModelId).not.toHaveBeenCalled();
+        }
+      });
+    },
+  );
+});

--- a/src/media-understanding/image.test-support.ts
+++ b/src/media-understanding/image.test-support.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { afterEach, beforeEach, vi } from "vitest";
-import { createEmptyPluginMetadataSnapshot } from "../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
+import type { PreparedModelRuntimeLeaseOptions } from "../agents/prepared-model-runtime.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 
 export const API_KEY_FIELD = ["api", "Key"].join("") as "apiKey";
 const REQUIRE_API_KEY_FIELD = ["require", "ApiKey"].join("");
@@ -168,19 +170,29 @@ export function installImageRuntimeTestHooks({
     getApiKeyForModelMock.mockResolvedValue({ apiKey, source: "test", mode: "oauth" });
     resolveApiKeyForProviderCoreMock.mockResolvedValue({ apiKey, source: "test", mode: "oauth" });
     acquireAgentRunPreparedModelRuntimeMock.mockImplementation(
-      async (input: { agentDir: string; config: object; workspaceDir?: string }) => ({
-        snapshot: {
-          agentDir: input.agentDir,
+      async (
+        input: { agentDir: string; config: OpenClawConfig; workspaceDir?: string },
+        options?: PreparedModelRuntimeLeaseOptions,
+      ) => {
+        const metadataSnapshot = resolvePluginMetadataSnapshot({
           config: input.config,
           workspaceDir: input.workspaceDir,
-          metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
-          createStores: () => ({
-            authStorage: preparedAuthStorage,
-            modelRegistry: {},
-          }),
-        },
-        release: releasePreparedModelRuntimeMock,
-      }),
+        });
+        options?.deriveRuntimePluginSelections?.({ config: input.config, metadataSnapshot });
+        return {
+          snapshot: {
+            agentDir: input.agentDir,
+            config: input.config,
+            workspaceDir: input.workspaceDir,
+            metadataSnapshot,
+            createStores: () => ({
+              authStorage: preparedAuthStorage,
+              modelRegistry: {},
+            }),
+          },
+          release: releasePreparedModelRuntimeMock,
+        };
+      },
     );
     fetchMock.mockImplementation(async () =>
       Response.json({

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -534,7 +534,7 @@ describe("describeImageWithModelCore", () => {
         agentDir: "/tmp/openclaw-agent",
         workspaceDir: "/tmp/openclaw-workspace",
       }),
-      { catalogMode: "static", abortSignal: expect.any(AbortSignal) },
+      expect.objectContaining({ catalogMode: "static", abortSignal: expect.any(AbortSignal) }),
     );
     expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce();
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
@@ -543,6 +543,7 @@ describe("describeImageWithModelCore", () => {
       "/tmp/openclaw-agent",
       {},
       {
+        modelIdSource: "selected",
         allowBundledStaticCatalogFallback: true,
         authStorage: preparedAuthStorage,
         modelRegistry: {},
@@ -616,6 +617,7 @@ describe("describeImageWithModelCore", () => {
       "/tmp/openclaw-agent",
       {},
       {
+        modelIdSource: "selected",
         allowBundledStaticCatalogFallback: true,
         authStorage: preparedAuthStorage,
         modelRegistry: {},


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where image descriptions could use the wrong model when a caller supplied model metadata that differed from another active context, or when a selected alias was interpreted again. For an alias chain such as `entry → middle → final`, the selected image model must remain `middle`.

## Why This Change Was Made

Resolve the raw model reference using the supplied runtime metadata or the existing acquisition callback's admitted metadata, then preserve that selection during materialization. The acquisition callback always starts from the original request. Existing runtime-hook scope, resource transfer, cancellation, credentials, and transport ownership remain intact.

## User Impact

Image requests use their own model metadata and retain the selected model, including cold starts. This focused cut is separate from image-tool request cleanup and PDF selection.

## Evidence

- The baseline produced four intended wrong-model failures and eight passing controls when supplied and ambient metadata differed. All 78 focused tests pass with the repair, covering both provider API modes, scoped and unscoped hooks, profile refresh, timeouts, cancellation, and resources.
- Six cold source cases pass on both baseline and candidate, preserving working raw alias selection.
- The complete changed gate, fresh P2 review, and one normal full `pnpm build` passed, including declarations.
- Six fresh processes exercised the emitted public image facade through six real loopback HTTP requests on `1b6ee039f7b2a518b12f9903865214d9c318c8dd`. Every deliberate source-import control was rejected, with no unexpected source imports or external network attempts.
- All 14,098 built files across the runtime and workspace package outputs remained unchanged. Every owned process exited, and the listener and sockets closed.

This is compiled runtime proof with a synthetic loopback provider, not hosted-provider inference or a fresh npm installation. Production delta: **+13 lines**; tests and support: **+174 lines**. Exact-head CI and native prepare must pass before landing.
