### PR TITLE
docs(wechat): document pairing limitations in plugin 2.4.8

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -17,7 +17,9 @@ Security context: [Security](/gateway/security)
 
 ## 1) DM pairing (inbound chat access)
 
-When a channel is configured with DM policy `pairing`, unknown senders get a short code and their message is **not processed** until you approve.
+DM pairing applies to channels that implement OpenClaw's pairing API. With DM
+policy `pairing`, unknown senders get a short code and their message is **not
+processed** until you approve.
 
 Default DM policies are documented in: [Security](/gateway/security)
 
@@ -74,7 +76,11 @@ WhatsApp's login QR links a WhatsApp account to OpenClaw. DM access requests
 approve people who message that account. These are separate flows.
 </Note>
 
-Supported channels (any installed channel plugin that declares pairing; external plugins such as `openclaw-weixin` can add more): `discord`, `feishu`, `googlechat`, `imessage`, `irc`, `line`, `matrix`, `mattermost`, `msteams`, `nextcloud-talk`, `nostr`, `signal`, `slack`, `sms`, `synology-chat`, `telegram`, `twitch`, `whatsapp`, `zalo`, `zalouser`.
+Supported channels include: `discord`, `feishu`, `googlechat`, `imessage`, `irc`, `line`, `matrix`, `mattermost`, `msteams`, `nextcloud-talk`, `nostr`, `signal`, `slack`, `sms`, `synology-chat`, `telegram`, `twitch`, `whatsapp`, `zalo`, `zalouser`.
+
+Installed external plugins can also support DM pairing if they implement
+OpenClaw's pairing API. Check the plugin's documentation for version-specific
+limitations.
 
 ### Reusable sender groups
 
@@ -107,7 +113,8 @@ Access groups are documented in detail here: [Access groups](/channels/access-gr
 
 ### Where the state lives
 
-Stored in the shared SQLite state database at
+For channels that use OpenClaw's pairing API, state is stored in the shared SQLite
+database at
 `~/.openclaw/state/openclaw.sqlite`:
 
 - pending requests in `channel_pairing_requests`
@@ -116,7 +123,7 @@ Stored in the shared SQLite state database at
 Account scoping behavior:
 
 - each request and approved sender is keyed by channel and account
-- runtime reads only the canonical SQLite rows; it does not merge legacy files
+- channels using the pairing API read only the canonical SQLite rows; they do not merge legacy files
 
 Older gateways wrote `<channel>-pairing.json` and
 `<channel>-<accountId>-allowFrom.json` under `~/.openclaw/credentials/`.

--- a/docs/channels/wechat.md
+++ b/docs/channels/wechat.md
@@ -85,26 +85,39 @@ openclaw config set session.dmScope per-account-channel-peer
 
 ## Access control
 
-Direct messages use the normal OpenClaw pairing and allowlist model for channel
-plugins.
+Version `2.4.8` does not register an OpenClaw pairing adapter or create pairing
+requests. The standard pairing list and approve commands cannot establish DM
+access for this version. QR login can still allow the user who scanned the code
+to chat with the bot.
 
-Approve new senders:
+This version reads a legacy account allowlist JSON file instead of OpenClaw's
+SQLite pairing store. When that list is empty, it falls back to the QR scanner's
+saved user ID. If neither provides a user ID, its sender check admits any sender
+whose message reaches the plugin.
 
-```bash
-openclaw pairing list openclaw-weixin
-openclaw pairing approve openclaw-weixin <CODE>
-```
+On current OpenClaw, startup migration and `openclaw doctor --fix` import legacy
+approvals into SQLite and remove the source file. Previously approved secondary
+senders can therefore lose access in version `2.4.8`. Revoking an approval in
+SQLite does not revoke access granted by the plugin's legacy file or scanner
+fallback.
 
-For the full access-control model, see [Pairing](/channels/pairing).
+Do not rely on standard pairing to manage or revoke DM access with version
+`2.4.8`. If you need pairing enforcement, [temporarily disable the plugin](/channels/wechat#troubleshooting)
+until a version with repaired pairing support is available.
+
+For integrations that implement OpenClaw's pairing API, see [Pairing](/channels/pairing).
 
 ## Compatibility
 
-The plugin checks the host OpenClaw version at startup.
+The package declares these OpenClaw requirements:
 
-| Plugin line | OpenClaw version                                                | npm tag  |
-| ----------- | --------------------------------------------------------------- | -------- |
-| `2.x`       | `>=2026.5.12` (current 2.4.8; early 2.x accepted `>=2026.3.22`) | `latest` |
-| `1.x`       | `>=2026.1.0 <2026.3.22`                                         | `legacy` |
+| Plugin version | Declared OpenClaw requirement | npm tag  |
+| -------------- | ----------------------------- | -------- |
+| `2.4.8`        | `>=2026.5.12`                 | `latest` |
+| `1.x`          | `>=2026.1.0 <2026.3.22`       | `legacy` |
+
+Version `2.4.8` declares `>=2026.5.12`, but its startup version guard still checks
+`>=2026.3.22`. Passing that guard alone does not satisfy the declared requirement.
 
 If the plugin reports that your OpenClaw version is too old, either update
 OpenClaw or install the legacy plugin line:


### PR DESCRIPTION
## What Problem This Solves

Fixes misleading instructions that tell WeChat plugin `2.4.8` users to establish DM access with standard OpenClaw pairing commands. This version does not register a pairing adapter or create pairing requests, although QR login can still let the scanner chat with the bot.

## Why This Change Was Made

Document the plugin's legacy allowlist and scanner fallback, including empty-list admission, lost secondary-user access after legacy approvals migrate to SQLite, and the limits of SQLite revocation. Link the existing disable procedure for operators who need pairing enforcement. Scope the general pairing guide to plugins that implement the pairing API.

The compatibility table now identifies version `2.4.8` precisely: its declared OpenClaw requirement is `>=2026.5.12`, while its startup guard checks `>=2026.3.22`.

## User Impact

Operators can distinguish QR login from pairing-controlled access and understand the limitations before relying on approval or revocation. This corrects documentation; it does not repair the external plugin's authorization behavior.

## Evidence

- Inspected the published [Tencent Weixin plugin `2.4.8`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin/v/2.4.8): package metadata, registration, channel, pairing, inbound authorization, and compiled runtime contracts. Verified the 147,547-byte archive against its published integrity and SHA-256 `cd598cac2a118f7ed73e6b3c82d91385f4af844e49d7c43fbcb716c26ba0e9fc`.
- Compared the OpenClaw pairing CLI and SQLite migration behavior with the plugin's actual reader. The published inbound authorization source matches [this pinned Tencent source](https://github.com/Tencent/openclaw-weixin/blob/70ab695f6a1ca87da4102f857a452e2acb6b37cf/src/messaging/process-message.ts#L174-L205). Independent review found no blocking findings in the exact two-file diff.
- Passed `pnpm docs:list`, targeted `oxfmt`, `git diff --check`, and `node scripts/check-changed.mjs -- docs/channels/wechat.md docs/channels/pairing.md` (docs-only plan).
- Passed `node scripts/check-docs-mdx.mjs docs/channels/wechat.md docs/channels/pairing.md` (2 files).
- `node scripts/docs-link-audit.mjs --anchors` checked 13,418 internal links. Its three failures are pre-existing `windows-app-node` fragments in unchanged maturity pages; neither changed page failed. Mirrored ClawHub fragments were unverified because their source checkout was absent.
- Fresh exact-head [CI run 34654691470](https://github.com/openclaw/openclaw/actions/runs/34654691470) passed, including `check-docs` and required `openclaw/ci-gate`, at `218f12e02a4e08d6b2baf1cc4809aaf8567fc79a`.
- Documentation only: 37 added and 17 removed lines; no production or test changes. No live WeChat flow, plugin behavior test, or older-host compatibility qualification was performed.

<!-- Punchcard-Session: silver-brook-timber-ry -->
