### PR TITLE
refactor(doctor): remove duplicate fallback-notice test

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3022,28 +3022,6 @@ describe("collectCodexRouteWarnings", () => {
     });
   });
 
-  it("clears mixed legacy and canonical fallback notices atomically", () => {
-    const store: Record<string, SessionEntry> = {
-      main: {
-        sessionId: "s1",
-        updatedAt: 1,
-        modelProvider: "openai",
-        model: "gpt-5.6-sol",
-        fallbackNotice: {
-          kind: "active",
-          selectedModel: "codex/gpt-5.6-sol",
-          activeModel: "openai/gpt-5.6-sol",
-          reason: "rate-limit",
-        },
-      },
-    };
-
-    const result = repairCodexSessionStoreRoutes({ store, now: 123 });
-
-    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(store.main?.fallbackNotice).toBeUndefined();
-  });
-
   it("retains a fallback notice atomically when one legacy endpoint is blocked", () => {
     const store: Record<string, SessionEntry> = {
       main: {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

The doctor route-warning suite repeats the same in-memory fallback-notice cleanup scenario without protecting a distinct behavior.

## Why This Change Was Made

Remove the weaker mixed legacy/canonical fallback-notice case. The retained runtime-intent case uses the same fresh store, repair inputs and result assertions, checks that the notices are cleared, and also verifies that runtime and harness overrides remain unset. All other cases, helpers and imports stay unchanged.

## User Impact

No runtime behavior changes. This removes one redundant test and 22 test lines while retaining the stronger coverage.

## Evidence

- Full ordered `src/commands/doctor/shared/codex-route-warnings.test.ts` under the normal commands config: 131 actual passes, 0 skipped.
- Targeted formatting and diff checks passed.
- All 20 selected changed-file checks passed.
- Fresh scoped P2 review: no findings.

This is local in-memory repair coverage. No live Codex/auth execution, SQLite transaction validation, or full-repository test run is claimed.
