### PR TITLE
refactor: retire unused setup mutation inputs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3562,7 +3562,6 @@ src/system-agent/operations-execution-helpers.ts	1
 src/system-agent/operations-parse.ts	1
 src/system-agent/probes.ts	1
 src/system-agent/rescue-message.ts	2
-src/system-agent/setup-apply.ts	1
 src/system-agent/setup-inference-activate-persist.ts	1
 src/system-agent/setup-inference-detection.ts	3
 src/system-agent/setup-inference-persist.ts	1

--- a/src/system-agent/setup-apply.test-harness.ts
+++ b/src/system-agent/setup-apply.test-harness.ts
@@ -45,7 +45,6 @@ const mocks = vi.hoisted(() => ({
   ensureWorkspace: vi.fn(),
   ensureGatewayService: vi.fn(),
   waitForGatewayReachable: vi.fn<() => Promise<{ ok: boolean; detail?: string }>>(),
-  refreshPluginRegistry: vi.fn(),
   updateExecApprovals: vi.fn(),
   ensureOnboardingAgent: vi.fn(),
   verifySetupInferenceConfig: vi.fn(),
@@ -100,10 +99,6 @@ vi.mock("../wizard/setup.gateway-config.js", () => ({
 
 vi.mock("../wizard/setup.finalize.js", () => ({
   ensureGatewayServiceForOnboarding: mocks.ensureGatewayService,
-}));
-
-vi.mock("../plugins/registry-refresh.js", () => ({
-  refreshPluginRegistryAfterConfigMutation: mocks.refreshPluginRegistry,
 }));
 
 vi.mock("../infra/exec-approvals.js", () => ({

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -121,7 +121,6 @@ describe("applySystemAgentSetup transaction boundaries", () => {
       containerWithoutUserSystemd: false,
     });
     mocks.waitForGatewayReachable.mockResolvedValue({ ok: true });
-    mocks.refreshPluginRegistry.mockResolvedValue(undefined);
     mocks.updateExecApprovals.mockResolvedValue(undefined);
     mocks.verifySetupInferenceConfig.mockResolvedValue({
       ok: true,
@@ -198,25 +197,6 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     );
     expect(mocks.state.persistedConfig?.agents?.entries).toHaveProperty("research-buddy");
     expect(mocks.state.persistedConfig?.agents?.entries).not.toHaveProperty("main");
-  });
-
-  it("does not mistake a proposal-created roster for an existing fleet", async () => {
-    const absent = snapshot(null, {}, { agents: { entries: { main: { default: true } } } });
-    setSetupCommitState({ agents: { entries: { main: { default: true } } } }, absent);
-    mocks.state.commitPreviousHash = null;
-
-    await applySystemAgentSetup(
-      baseParams({
-        expectedConfigHash: null,
-        workspace: "/tmp/requested-workspace",
-        configPatch: { agents: { entries: { main: { default: true } } } },
-      }),
-    );
-
-    expect(mocks.state.persistedConfig?.agents).toMatchObject({
-      defaults: { workspace: "/tmp/requested-workspace" },
-      entries: { main: { default: true } },
-    });
   });
 
   it.each([
@@ -409,9 +389,6 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     await applySystemAgentSetup(
       baseParams({
         workspace: "/tmp/requested-workspace",
-        configPatch: {
-          agents: { defaults: { workspace: "/tmp/patch-workspace" }, entries: null },
-        },
       }),
     );
 
@@ -530,7 +507,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     expect(mocks.state.persistedConfig).toBeUndefined();
   });
 
-  it("folds plugin and auth config into one commit while preserving concurrent edits", async () => {
+  it("preserves concurrent settings in one setup commit", async () => {
     mocks.state.commitConfig = {
       ...mocks.state.commitConfig,
       logging: { level: "debug" },
@@ -542,8 +519,6 @@ describe("applySystemAgentSetup transaction boundaries", () => {
         expectedConfigHash: "probe",
         expectedAgentId: "main",
         expectedModelRef: "openai/gpt-5.5",
-        enablePluginId: "codex",
-        configPatch: { agents: { defaults: { maxConcurrent: 7 } } },
       }),
     );
 
@@ -551,12 +526,10 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     expect(mocks.state.persistedConfig).toMatchObject({
       agents: {
         defaults: {
-          maxConcurrent: 7,
           model: { primary: "openai/gpt-5.5" },
         },
       },
       logging: { level: "debug" },
-      plugins: { entries: { codex: { enabled: true } } },
     });
     expect(result.configPath).toBe("/tmp/openclaw.json");
   });
@@ -606,7 +579,7 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     await expect(
       applySystemAgentSetup(
         baseParams({
-          model: "anthropic/claude-opus-4-8",
+          finalizeConfig: () => mainAgentModelConfig("anthropic/claude-opus-4-8"),
           expectedInferenceRoute: await projectDefaultInferenceRoute(initial),
         }),
       ),
@@ -913,17 +886,14 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     );
   });
 
-  it("returns visible post-commit workspace, approval, registry, and service failures", async () => {
+  it("returns visible post-commit workspace, approval, and service failures", async () => {
     mocks.ensureWorkspace.mockRejectedValueOnce(new Error("workspace exploded"));
     mocks.updateExecApprovals.mockRejectedValueOnce(new Error("approval exploded"));
-    mocks.refreshPluginRegistry.mockRejectedValueOnce(new Error("registry exploded"));
     mocks.ensureGatewayService.mockRejectedValueOnce(new Error("service exploded"));
 
     const result = await applySystemAgentSetup(
       baseParams({
         expectedConfigHash: "probe",
-        enablePluginId: "codex",
-        refreshPluginRegistry: true,
         surface: "cli",
       }),
     );
@@ -933,7 +903,6 @@ describe("applySystemAgentSetup transaction boundaries", () => {
       expect.arrayContaining([
         "Workspace files: workspace exploded",
         "OpenClaw exec approval: approval exploded; local model harnesses may ask again.",
-        "Plugin registry refresh failed: registry exploded",
         "Gateway service: service exploded",
       ]),
     );

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -12,11 +12,9 @@ import {
   resolveGatewayPort,
   validateConfigObjectWithPlugins,
 } from "../config/config.js";
-import { applyMergePatch } from "../config/merge-patch.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatExternalSupervisorActionRequired } from "../infra/gateway-supervision.js";
-import { enablePluginInConfig } from "../plugins/enable.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
@@ -32,11 +30,10 @@ import {
   sameSetupConfiguredRoute,
   sameSetupInferenceRoute,
 } from "./setup-inference-route-guard.js";
-import { applySystemAgentModelSelection } from "./setup-model-selection.js";
 
 /**
  * The whole first-run setup as one approved operation: the user says "yes" in
- * the conversation and this applies model + workspace + quickstart gateway
+ * the conversation and this applies workspace + quickstart gateway
  * defaults, seeds workspace bootstrap files, and (on the CLI surface) optionally installs
  * and starts the gateway service. No interactive prompts may occur here —
  * everything uses quickstart defaults, so the conversation stays the only UI.
@@ -47,10 +44,6 @@ export type SystemAgentSetupApplyParams = {
   firstAgent?: FirstOnboardingAgent;
   /** Explicit interactive approval to replace an existing fleet workspace root. */
   allowWorkspaceChange?: boolean;
-  model?: string;
-  agentRuntimeId?: string;
-  /** Pin the selected model to the exact credential that passed inference. */
-  authProfileId?: string;
   /** Exact default-agent route whose inference passed the setup gate. */
   expectedInferenceRoute?: DefaultInferenceRouteProjection;
   /** Live-probe target; setup aborts if another process switches the default agent. */
@@ -61,14 +54,8 @@ export type SystemAgentSetupApplyParams = {
   expectedModelRef?: string;
   /** Full config revision used by the live probe; null means the file was absent. */
   expectedConfigHash?: string | null;
-  /** Provider-auth config produced in the isolated manual-key flow. */
-  configPatch?: unknown;
   /** Success-gated final normalization against the config held by the write lock. */
   finalizeConfig?: (config: OpenClawConfig, sourceConfig: OpenClawConfig) => OpenClawConfig;
-  /** Plugin whose enablement belongs to the successful setup transaction. */
-  enablePluginId?: string;
-  /** Refresh an installed plugin after its success-gated enablement commits. */
-  refreshPluginRegistry?: boolean;
   /** Synchronous cross-store guard receives authored config under the final write lock. */
   assertCommitPreconditions?: (sourceConfig: OpenClawConfig) => void;
   /** Resume an interrupted local installation without restarting a running Gateway. */
@@ -147,17 +134,11 @@ export async function applySystemAgentSetup(
 ): Promise<SystemAgentSetupApplyResult> {
   const {
     workspace,
-    model,
-    agentRuntimeId,
-    authProfileId,
     expectedAgentId,
     expectedAgentDir,
     expectedModelRef,
     expectedConfigHash,
-    configPatch,
     finalizeConfig,
-    enablePluginId,
-    refreshPluginRegistry,
     assertCommitPreconditions,
     surface,
     runtime,
@@ -322,16 +303,6 @@ export async function applySystemAgentSetup(
     const currentHasRoster = hasAuthoredRosterEntries && roster.length > 0;
     const allowWorkspaceWrite = params.allowWorkspaceChange || !currentHasRoster;
     let setupBaseConfig = currentBaseConfig;
-    if (enablePluginId) {
-      const enabled = enablePluginInConfig(setupBaseConfig, enablePluginId);
-      if (!enabled.enabled) {
-        throw new Error(`Provider plugin ${enablePluginId} is ${enabled.reason}.`);
-      }
-      setupBaseConfig = enabled.config;
-    }
-    if (configPatch !== undefined) {
-      setupBaseConfig = applyMergePatch(setupBaseConfig, configPatch) as OpenClawConfig;
-    }
     if (currentHasRoster) {
       const { list: _legacyList, ...agents } = setupBaseConfig.agents ?? {};
       setupBaseConfig = {
@@ -361,16 +332,6 @@ export async function applySystemAgentSetup(
       allowWorkspaceChange: allowWorkspaceWrite,
       preserveWorkspace,
     });
-    if (model) {
-      const targetAgentId = candidate.agents?.defaults?.systemAgent?.agentId;
-      candidate = await applySystemAgentModelSelection({
-        config: candidate,
-        model,
-        ...(targetAgentId ? { targetAgentId } : {}),
-        ...(agentRuntimeId ? { agentRuntimeId } : {}),
-        ...(authProfileId ? { authProfileId } : {}),
-      });
-    }
     candidate = applySecurityAcknowledgement(candidate);
     const gateway = await configureGatewayForSetup({
       flow: "quickstart",
@@ -491,8 +452,7 @@ export async function applySystemAgentSetup(
   const lines: string[] = [
     ...sessionMigrationWarnings,
     `Workspace: ${shortenHomePath(effectiveWorkspace)}`,
-    model ? `Default model: ${model}` : undefined,
-  ].filter((line): line is string => line !== undefined);
+  ];
 
   const runCommittedFollowUp = async <T>(
     effect: () => Promise<T>,
@@ -546,25 +506,6 @@ export async function applySystemAgentSetup(
         `OpenClaw exec approval: ${formatErrorMessage(error)}; local model harnesses may ask again.`,
       ),
   );
-
-  if (refreshPluginRegistry && enablePluginId) {
-    await runCommittedFollowUp(
-      async () => {
-        const { refreshPluginRegistryAfterConfigMutation } =
-          await import("../plugins/registry-refresh.js");
-        beforePersistentApply?.();
-        await refreshPluginRegistryAfterConfigMutation({
-          configPath: committed.path,
-          reason: "source-changed",
-          traceCommand: "openclaw-setup",
-          logger: {
-            warn: (message) => lines.push(message),
-          },
-        });
-      },
-      (error) => lines.push(`Plugin registry refresh failed: ${formatErrorMessage(error)}`),
-    );
-  }
 
   let gateway: GatewayServiceSetupOutcome = { status: "ready", action: "reused" };
   if (surface === "cli") {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Setup still carries model, credential, config-patch, and plugin mutation paths that neither production caller uses. Those paths add maintenance cost and blur the boundary between establishing inference and completing workspace/Gateway setup. This is a focused, maintainer-requested reduction of unused internal code.

## Why This Change Was Made

Retire the six unused internal inputs: `model`, `agentRuntimeId`, `authProfileId`, `configPatch`, `enablePluginId`, and `refreshPluginRegistry`, together with their dependent branches and mock support. The public setup `model` selector remains a gate requiring the already verified default; inference activation and default-model changes keep their existing owner.

The change preserves first-agent target/hash rebasing, expected-route checks before and after persistence, finalization and commit preconditions, ownership fencing, plugin-default validation, workspace/approval/Gateway follow-ups, and skipped or resumed onboarding. Only the obsolete proposal-patch test is removed; mixed tests retain their live assertions, including pre-save route rejection through the existing finalizer.

## User Impact

No user-visible behavior change is intended. Setup continues to preserve verified inference and finish the remaining workspace/Gateway work. The patch removes **54 production code lines** and **32 test/support code lines**, plus **one separate generated assertion-baseline row**. Default and string-comment-aware cloc counts agree; the tracked physical-line reduction is 96.

## Evidence

- Original implementation and tests: **100 passed across 6 files**. Candidate: **99 passed across the same 6 files**, with only the obsolete proposal-patch case removed.
- The finalizer-retargeted route test also passes against original production. Removing only the candidate's pre-commit route guard makes that test fail: it receives the later post-write rejection diagnostic instead of the required pre-save diagnostic. Restoring the exact candidate makes it pass again. The failed matcher stops that mutant run before its later persistence assertions; the diagnostic is the demonstrated observation.
- **All 30 changed checks passed**, including production/test typechecking, lint, formatting, shrink-only ratchets, dead-export scans, and architecture guards.
- **Managed P2 autoreview: scoped-clean, zero findings.** Both production callers, complete recovery options, and the unchanged model/route owners were supplied as review context.
- Fresh `main` comparison found no drift in the setup source, callers, owners, or selected tests. Its unrelated assertion-baseline reductions are preserved by the merge check. No live Gateway or provider credentials were used; this is local owner-boundary proof.

Focused selection:

```sh
node scripts/run-vitest.mjs   src/system-agent/setup-apply.test.ts   src/system-agent/setup-apply.concurrency.test.ts   src/system-agent/setup-apply.model-selection.test.ts   src/system-agent/operations.setup.test.ts   src/system-agent/operations.setup-transaction.test.ts   src/commands/onboard-guided.skip.test.ts
```

The existing public setup documentation already describes inference preservation. `CHANGELOG.md` remains release-owned.
