### PR TITLE
fix(control-ui): preserve replies during IME Escape

### DIFF
--- a/ui/src/e2e/chat-flow.composer-shortcuts.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.composer-shortcuts.e2e.test.ts
@@ -12,6 +12,152 @@ import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-su
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("preserves IME reply before deliberate Escape abort", async () => {
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
+    try {
+      const page = await context.newPage();
+      const quote = "Keep this persisted message as the reply source.";
+      const gateway = await installMockGateway(page, {
+        sessionKey: "agent:main:main",
+        historyMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: quote }],
+            timestamp: 1_800_000_000_000,
+            __openclaw: { id: "ime-reply-source", seq: 1 },
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const pane = page.locator(".chat-pane-cache__pane--active");
+      const composer = pane.locator(".agent-chat__composer-combobox textarea");
+      const initialText = "Keep this run active while composing a reply.";
+      await composer.fill(initialText);
+      await pane.getByRole("button", { name: "Send message", exact: true }).click();
+      const send = await gateway.waitForRequest("chat.send");
+      const sendParams = requireRecord(send.params);
+      const sessionKey = requireString(sendParams.sessionKey, "active session");
+      const runId = requireString(sendParams.idempotencyKey, "active run");
+      expect(sendParams).toMatchObject({
+        message: initialText,
+        sessionKey: "agent:main:main",
+        idempotencyKey: runId,
+      });
+      const stop = pane.getByRole("button", { name: "Stop generating", exact: true });
+      await stop.waitFor({ state: "visible" });
+      await expect.poll(() => composer.inputValue()).toBe("");
+
+      await pane
+        .locator('.chat-bubble[data-entry-id="ime-reply-source"]')
+        .click({ button: "right" });
+      const menu = page.locator(".chat-reply-context-menu");
+      await menu.getByRole("menuitem", { name: "Reply to message", exact: true }).click();
+      await menu.waitFor({ state: "detached" });
+      const preview = pane.locator(".chat-reply-preview");
+      await preview.waitFor({ state: "visible" });
+      expect(await preview.locator(".chat-reply-preview__text").textContent()).toBe(quote);
+      expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+      const draft = "Preserve this unsent reply draft.";
+      await composer.fill(draft);
+
+      // Synthetic IME events exercise the application flow, not native IME delivery.
+      for (const mode of ["isComposing", "keyCode229"]) {
+        const fields = await composer.evaluate((element, compositionMode) => {
+          const event = new KeyboardEvent("keydown", {
+            key: "Escape",
+            bubbles: true,
+            cancelable: true,
+            isComposing: compositionMode === "isComposing",
+            keyCode: compositionMode === "keyCode229" ? 229 : 0,
+          });
+          element.dispatchEvent(event);
+          return {
+            key: event.key,
+            bubbles: event.bubbles,
+            cancelable: event.cancelable,
+            isComposing: event.isComposing,
+            keyCode: event.keyCode,
+            defaultPrevented: event.defaultPrevented,
+          };
+        }, mode);
+        expect(fields).toEqual({
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+          isComposing: mode === "isComposing",
+          keyCode: mode === "keyCode229" ? 229 : 0,
+          defaultPrevented: false,
+        });
+        expect(await preview.locator(".chat-reply-preview__text").textContent()).toBe(quote);
+        expect(await composer.inputValue()).toBe(draft);
+        expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+        await expectRequestCountStable(gateway, "chat.send", 1);
+        await expectRequestCountStable(gateway, "chat.abort", 0);
+      }
+
+      await composer.fill("");
+      await stop.waitFor({ state: "visible" });
+      const primary = pane.locator(".agent-chat__composer-actions .chat-send-btn--send");
+      expect(await primary.count()).toBe(0);
+      expect(await preview.locator(".chat-reply-preview__text").textContent()).toBe(quote);
+      const composingDraft = "Preserve this composing reply draft.";
+      await composer.evaluate((element, value) => {
+        if (!(element instanceof HTMLTextAreaElement)) {
+          throw new Error("Expected composer textarea");
+        }
+        element.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+        element.value = value;
+        element.dispatchEvent(
+          new InputEvent("input", {
+            bubbles: true,
+            data: value,
+            inputType: "insertCompositionText",
+            isComposing: true,
+          }),
+        );
+      }, composingDraft);
+      // Stop becoming a follow-up action proves the composing input rerendered the pane.
+      await primary.waitFor({ state: "visible" });
+      expect(await primary.isEnabled()).toBe(true);
+      await stop.waitFor({ state: "detached" });
+      expect(await composer.inputValue()).toBe(composingDraft);
+      expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+      await page.keyboard.press("Escape");
+      expect(await preview.locator(".chat-reply-preview__text").textContent()).toBe(quote);
+      expect(await composer.inputValue()).toBe(composingDraft);
+      expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      await expectRequestCountStable(gateway, "chat.abort", 0);
+
+      await composer.evaluate((element) => {
+        element.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+      });
+      await page.keyboard.press("Escape");
+      await preview.waitFor({ state: "detached" });
+      expect(await composer.inputValue()).toBe(composingDraft);
+      expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      await expectRequestCountStable(gateway, "chat.abort", 0);
+
+      await page.keyboard.press("Escape");
+      const abort = await gateway.waitForRequest("chat.abort");
+      const interrupted = pane.locator(".agent-chat__run-status--interrupted");
+      await interrupted.waitFor({ state: "visible" });
+      expect(await interrupted.textContent()).toContain("Interrupted");
+      await expect
+        .poll(() => pane.locator(".agent-chat__run-status-announcement").textContent())
+        .toBe("Interrupted");
+      expect(requireRecord(abort.params)).toEqual({ sessionKey, runId });
+      await stop.waitFor({ state: "detached" });
+      expect(await composer.inputValue()).toBe(composingDraft);
+      expect(await composer.evaluate((element) => document.activeElement === element)).toBe(true);
+      await expectRequestCountStable(gateway, "chat.send", 1);
+      await expectRequestCountStable(gateway, "chat.abort", 1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it.each(["queue", "steer", "collect", "followup"] as const)(
     "explains and submits the opposite of %s with modified Enter",
     async (followUpMode) => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -9368,6 +9368,55 @@ describe("right-click Reply", () => {
   const renderReply = (overrides: Partial<ChatProps> = {}) =>
     renderChatView({ replyTarget, ...overrides });
 
+  function createReplyPane(paneId: string, draft: string, quote: string) {
+    const container = document.createElement("div");
+    const host: Pick<ChatProps, "draft" | "replyTarget"> = {
+      draft,
+      replyTarget: { ...replyTarget, messageId: `${paneId}-message`, text: quote },
+    };
+    const onSend = vi.fn();
+    const onAbort = vi.fn();
+    const onDraftChange = vi.fn((next: string) => {
+      host.draft = next;
+    });
+    const onRequestUpdate = vi.fn(() => redraw());
+    const onClearReply = vi.fn(() => {
+      host.replyTarget = null;
+      redraw();
+    });
+    function redraw() {
+      renderChatInto(container, {
+        paneId,
+        sessionKey: `agent:main:${paneId}`,
+        draft: host.draft,
+        getDraft: () => host.draft,
+        replyTarget: host.replyTarget,
+        canAbort: true,
+        runActive: true,
+        onDraftChange,
+        onRequestUpdate,
+        onClearReply,
+        onSend,
+        onAbort,
+      });
+    }
+    return {
+      container,
+      host,
+      redraw,
+      onDraftChange,
+      onRequestUpdate,
+      onClearReply,
+      onSend,
+      onAbort,
+      dispose: () => {
+        render(null, container);
+        container.remove();
+        resetChatViewState(paneId, container);
+      },
+    };
+  }
+
   function dispatchContextMenu(target: EventTarget): MouseEvent {
     const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     target.dispatchEvent(event);
@@ -9701,19 +9750,172 @@ describe("right-click Reply", () => {
     expect(onClearReply).toHaveBeenCalledTimes(1);
   });
 
-  it("clears reply target on Escape when no other handler intercepted", () => {
+  it.each([false, true])("clears reply target on Escape with shiftKey=%s", (shiftKey) => {
     const onClearReply = vi.fn();
     const container = renderReply({ onClearReply });
 
     const section = container.querySelector<HTMLElement>(".card.chat");
     const evt = new KeyboardEvent("keydown", {
       key: "Escape",
+      shiftKey,
       bubbles: true,
       cancelable: true,
     });
     section!.dispatchEvent(evt);
 
+    expect(evt.defaultPrevented).toBe(true);
     expect(onClearReply).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["isComposing", "keyCode229", "live", "rerendered-live", "prevented"])(
+    "preserves the reply and draft for %s Escape before deliberate reply clearing and abort",
+    (mode) => {
+      const draft = "Keep this reply draft";
+      const quote = "Keep this quoted message";
+      const pane = createReplyPane(`reply-${mode}`, draft, quote);
+      try {
+        document.body.append(pane.container);
+        pane.redraw();
+        const textarea = getComposerTextarea(pane.container);
+        textarea.focus();
+        expect(document.activeElement).toBe(textarea);
+        expect(textarea.value).toBe(draft);
+        expect(pane.container.querySelector(".chat-reply-preview__text")?.textContent).toBe(quote);
+        const updatesBeforeComposition = pane.onRequestUpdate.mock.calls.length;
+        const live = mode === "live" || mode === "rerendered-live";
+        if (live) {
+          textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+          expect(pane.onRequestUpdate).toHaveBeenCalledTimes(updatesBeforeComposition);
+        }
+        const visibleDraft = mode === "rerendered-live" ? `${draft} composing` : draft;
+        if (mode === "rerendered-live") {
+          textarea.value = visibleDraft;
+          textarea.dispatchEvent(new InputEvent("input", { bubbles: true, isComposing: true }));
+          expect(pane.onRequestUpdate.mock.calls.length).toBeGreaterThan(updatesBeforeComposition);
+          expect(pane.onDraftChange).not.toHaveBeenCalled();
+        }
+        const event = new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+          isComposing: mode === "isComposing",
+          keyCode: mode === "keyCode229" ? 229 : 0,
+        });
+        if (mode === "prevented") {
+          event.preventDefault();
+        }
+        expect(event).toMatchObject({
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+          isComposing: mode === "isComposing",
+          keyCode: mode === "keyCode229" ? 229 : 0,
+          defaultPrevented: mode === "prevented",
+        });
+        textarea.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(mode === "prevented");
+        expect(getComposerTextarea(pane.container)).toBe(textarea);
+        expect(textarea.value).toBe(visibleDraft);
+        expect(document.activeElement).toBe(textarea);
+        expect(pane.host.draft).toBe(draft);
+        expect(pane.host.replyTarget?.text).toBe(quote);
+        expect(pane.container.querySelector(".chat-reply-preview__text")?.textContent).toBe(quote);
+        expect(pane.onClearReply).not.toHaveBeenCalled();
+        expect(pane.onSend).not.toHaveBeenCalled();
+        expect(pane.onAbort).not.toHaveBeenCalled();
+
+        if (mode === "live") {
+          textarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+        } else if (mode === "rerendered-live") {
+          textarea.blur();
+          textarea.focus();
+        }
+        expect(pane.host.draft).toBe(visibleDraft);
+        const clear = new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+        });
+        textarea.dispatchEvent(clear);
+        expect(clear.defaultPrevented).toBe(true);
+        expect(pane.onClearReply).toHaveBeenCalledOnce();
+        expect(pane.host.replyTarget).toBeNull();
+        expect(pane.container.querySelector(".chat-reply-preview")).toBeNull();
+        expect(pane.onAbort).not.toHaveBeenCalled();
+        expect(getComposerTextarea(pane.container)).toBe(textarea);
+        expect(textarea.value).toBe(visibleDraft);
+        expect(document.activeElement).toBe(textarea);
+
+        const abort = new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+        });
+        textarea.dispatchEvent(abort);
+        expect(abort.defaultPrevented).toBe(true);
+        expect(pane.onAbort).toHaveBeenCalledOnce();
+        expect(pane.onClearReply).toHaveBeenCalledOnce();
+        expect(pane.onSend).not.toHaveBeenCalled();
+        expect(pane.host.draft).toBe(visibleDraft);
+        expect(getComposerTextarea(pane.container)).toBe(textarea);
+        expect(textarea.value).toBe(visibleDraft);
+        expect(document.activeElement).toBe(textarea);
+      } finally {
+        pane.dispose();
+      }
+    },
+  );
+
+  it("keeps a composing reply isolated from Escape in another pane", () => {
+    const paneA = createReplyPane("reply-pane-a", "Draft A", "Quote A");
+    const paneB = createReplyPane("reply-pane-b", "Draft B", "Quote B");
+    try {
+      document.body.append(paneA.container, paneB.container);
+      paneA.redraw();
+      paneB.redraw();
+      const textareaA = getComposerTextarea(paneA.container);
+      const textareaB = getComposerTextarea(paneB.container);
+      textareaA.focus();
+      textareaA.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+      const escapeB = new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      });
+      textareaB.dispatchEvent(escapeB);
+
+      expect(escapeB.defaultPrevented).toBe(true);
+      expect(paneB.onClearReply).toHaveBeenCalledOnce();
+      expect(paneB.host.replyTarget).toBeNull();
+      expect(paneB.container.querySelector(".chat-reply-preview")).toBeNull();
+      const escapeA = new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      });
+      textareaA.dispatchEvent(escapeA);
+      expect(escapeA.defaultPrevented).toBe(false);
+      expect(paneA.onClearReply).not.toHaveBeenCalled();
+      expect(paneA.host.replyTarget?.text).toBe("Quote A");
+      expect(paneA.container.querySelector(".chat-reply-preview__text")?.textContent).toBe(
+        "Quote A",
+      );
+      for (const [pane, textarea, draft] of [
+        [paneA, textareaA, "Draft A"],
+        [paneB, textareaB, "Draft B"],
+      ] as const) {
+        expect(getComposerTextarea(pane.container)).toBe(textarea);
+        expect(textarea.value).toBe(draft);
+        expect(pane.host.draft).toBe(draft);
+        expect(pane.onSend).not.toHaveBeenCalled();
+        expect(pane.onAbort).not.toHaveBeenCalled();
+      }
+      expect(document.activeElement).toBe(textareaA);
+    } finally {
+      paneA.dispose();
+      paneB.dispose();
+    }
   });
 
   it("does not clear reply target when Escape is already defaultPrevented", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -34,6 +34,7 @@ import {
   renderChatTopbarNotices,
 } from "./chat-view-notices.ts";
 import { createChatAttachmentDropHandlers } from "./components/chat-attachments.ts";
+import { getChatComposerState } from "./components/chat-composer-state.ts";
 import type { ChatComposerProps } from "./components/chat-composer-types.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
 import { isImageLightboxEvent, openInlineChatImage } from "./components/chat-image-lightbox.ts";
@@ -336,7 +337,14 @@ export function renderChat(props: ChatProps) {
         ) {
           return;
         }
-        if (event.key === "Escape" && props.replyTarget && !event.defaultPrevented) {
+        if (
+          event.key === "Escape" &&
+          props.replyTarget &&
+          !event.defaultPrevented &&
+          !event.isComposing &&
+          event.keyCode !== 229 &&
+          !getChatComposerState(props.paneId).composerComposing
+        ) {
           event.preventDefault();
           props.onClearReply?.();
           return;


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/144270

## What Problem This Solves

Fixes an issue where users replying in the Control UI chat composer would lose the reply preview when Escape belonged to IME composition.

## Why This Change Was Made

The reply handler now honors composing events, key code 229, and the existing pane-local composer's event-time composition state. It preserves the established order: composition first, deliberate reply clearing next, then a separate Escape to abort an active run.

Production changes are net +8 lines; tests are net +348 lines. The section-level reply-clear owner needs the same composition exclusions as its child composer. Reusing the existing pane state avoids adding another composition tracker, global listener, or native input policy.

## User Impact

Users can retain their reply target and unsent draft during composition-related Escape. Ordinary reply clearing, subsequent abort, Shift+Escape, and other panes keep their existing behavior.

Release-note context: preserve Control UI reply previews when Escape is part of IME composition.

## Evidence

- Before the repair: five intended unit assertion failures and one intended browser reply-preservation failure. The browser baseline failed after Escape with `isComposing: true`; its key-code 229 and live-composition branches were not reached.
- After the repair: 26 focused unit tests, one complete browser case, and six sibling IME tests passed on the original test bytes. Subsequent independently reviewed changes formatted the two test files and alpha-renamed one callback parameter and its two bound reads; those local suites were not rerun on the final bytes.
- On the final candidate, E2E-only formatting and lint, UI production type checking, four UI test type graphs, and independent review passed. The accepted review artifact matches all three committed files and was reused, not rerun. A separate pinned normal-hook formatting check passed on all three files without changing their bytes.
- Exact-head CI passed on September 10, 2026: https://github.com/openclaw/openclaw/actions/runs/34514445203 (attempt 1, head `43681c5839a478cb5996d3f5b2cde7de0cb5066d`). This is the retained run, not a new CI execution.
- Fresh hosted validation on September 13, 2026: that same CI run's failed-only attempt 3 succeeded at 19:57:13 UTC on the unchanged head. Attempt 2 remains a separate failed result: one UI E2E shard stopped before tests after a dependency-download `ECONNRESET` and a secondary upstream error-handler exception; its aggregate gate failed accordingly. Other successful jobs were retained, not rerun by attempt 3. Workflow Sanity https://github.com/openclaw/openclaw/actions/runs/34513759435 attempt 2 succeeded at 19:50:49 UTC. Repository-native preparation then passed with exact-head hosted evidence; no rebase or source push was needed.
- The candidate recording exercised GUI Send, the actual Reply context menu, composing/229/live-composition Escape including input-driven rerender, deliberate reply clearing, and exactly one subsequent run-bound abort with visible and announced "Interrupted". Draft, focus, and one-send checks passed. Context/video/browser/server cleanup and source/build preservation checks completed.

Candidate-only Control UI recording with a mocked Gateway and synthetic IME events: reply and draft remain intact during composition, deliberate Escape clears the reply, and a separate Escape interrupts the active run while retaining the draft. The complete 4.72-second clip was inspected through all 118 decoded frames, represented by 67 byte-distinct images. This is complete decoded-frame inspection, not watched-playback, physical-input, or before/after proof.

https://github.com/user-attachments/assets/d89525db-14e5-45d7-8d0f-68503dd47275

Upload history: the first unauthenticated check of this asset returned HTTP 404 on September 11, 2026 at 09:40 UTC. The complete local clip inspection above is separate from public asset availability.

After this body referenced the existing asset, the single public readback on September 13, 2026 at 19:14:28 UTC returned HTTP 200, `video/webm`, 193,868 bytes, SHA256 `b290992ba209cb06db38ea36b48d2c5a8c1db69810e0e3d6edb46c3996b93299`, matching the inspected clip. No reupload was performed; this does not establish the cause of the earlier 404.

Physical IME and cross-platform delivery remain unqualified residual risks. This deterministic web-owner repair makes reply clearing honor the child composer's existing three composition signals and live pane state, without adding a native input backend or composition policy. The intended pre-fix failures, repaired application flow, pane/draft/focus coverage, and exact-head CI support this bounded change; they do not establish physical IME behavior. Released-version impact also remains unqualified.
