### PR TITLE
fix: preserve workspace transfer failure diagnostics

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -635,7 +635,8 @@ describe("node worker tunnel manager", () => {
       ok: false,
       error: {
         code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
-        message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+        message:
+          "workspace-transfer-failed: operation=upload stage=reconcile: socket hang up | ECONNRESET",
       },
     }));
     const transfer = {
@@ -671,7 +672,8 @@ describe("node worker tunnel manager", () => {
     ).rejects.toMatchObject({
       name: NodeWorkerWorkspaceTransferError.name,
       code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
-      message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+      message:
+        "workspace-transfer-failed: operation=upload stage=reconcile: socket hang up | ECONNRESET",
     });
     expect(workspaceInfo).toHaveBeenCalledWith("worker workspace sync path selected", {
       environmentId: "environment-1",

--- a/src/gateway/worker-environments/worker-error.ts
+++ b/src/gateway/worker-environments/worker-error.ts
@@ -1,11 +1,9 @@
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { formatErrorMessage } from "../../infra/errors.js";
+import { formatErrorMessage, formatErrorMessageWithCode } from "../../infra/errors.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 
-export function boundedWorkerError(error: unknown, maxChars = 1_024): string {
-  const redacted = redactSensitiveText(formatErrorMessage(error), { mode: "tools" })
-    .replace(/\s+/g, " ")
-    .trim();
+function boundWorkerErrorText(text: string, maxChars: number): string {
+  const redacted = redactSensitiveText(text, { mode: "tools" }).replace(/\s+/g, " ").trim();
   const message = redacted || "unknown error";
   const limit = Math.max(0, Math.floor(maxChars));
   const marker = " ... ";
@@ -16,4 +14,14 @@ export function boundedWorkerError(error: unknown, maxChars = 1_024): string {
   const headChars = Math.floor((limit - marker.length) / 2);
   const tailChars = limit - marker.length - headChars;
   return `${sliceUtf16Safe(message, 0, headChars).trimEnd()}${marker}${sliceUtf16Safe(message, -tailChars).trimStart()}`.trim();
+}
+
+/** Formats a redacted worker error graph within a fixed display bound. */
+export function boundedWorkerError(error: unknown, maxChars = 1_024): string {
+  return boundWorkerErrorText(formatErrorMessage(error), maxChars);
+}
+
+/** Includes the outer error code while preserving the standard worker diagnostic bound. */
+export function boundedWorkerErrorWithCode(error: unknown, maxChars = 1_024): string {
+  return boundWorkerErrorText(formatErrorMessageWithCode(error), maxChars);
 }

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -846,10 +846,15 @@ describe("node-host worker supervisor commands", () => {
   });
 
   it("preserves a typed workspace transfer failure across node invoke", async () => {
+    const cause = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
     const workspace = {
       exec: vi.fn(async () => {
-        throw new NodeWorkerWorkspaceTransferError(
-          "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+        throw Object.assign(
+          new NodeWorkerWorkspaceTransferError(
+            "workspace-transfer-failed: transfer did not complete",
+            { cause },
+          ),
+          { operation: "upload", stage: "reconcile" },
         );
       }),
     } as unknown as NodeWorkerWorkspaceRuntime;
@@ -870,8 +875,43 @@ describe("node-host worker supervisor commands", () => {
       ok: false,
       error: {
         code: NODE_WORKSPACE_TRANSFER_ERROR_CODE,
-        message: "workspace-transfer-failed: gateway TLS fingerprint mismatch",
+        message:
+          "workspace-transfer-failed: operation=upload stage=reconcile: socket hang up | ECONNRESET",
       },
     });
+  });
+
+  it("bounds and redacts serialized workspace transfer diagnostics", async () => {
+    const secret = "sk-abcdefghijklmnopqrstuv";
+    const cause = Object.assign(
+      new Error(`socket hang up ${"detail ".repeat(300)} Authorization: Bearer ${secret}`),
+      { code: "ECONNRESET" },
+    );
+    const workspace = {
+      exec: vi.fn(async () => {
+        throw new NodeWorkerWorkspaceTransferError(
+          "workspace-transfer-failed: transfer did not complete",
+          { cause, operation: "upload", stage: "reconcile" },
+        );
+      }),
+    } as unknown as NodeWorkerWorkspaceRuntime;
+
+    const { result } = await invokePrivate({
+      command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
+      paramsJSON: JSON.stringify({
+        gatewayNamespace: "gateway-1",
+        environmentId: "environment-1",
+        sessionId: "session-1",
+        generation: 4,
+        argv: ["openclaw-internal-workspace-transfer"],
+      }),
+      workspace,
+    });
+
+    const message = result?.error?.message ?? "";
+    expect(message).toContain("operation=upload stage=reconcile");
+    expect(message).toContain("ECONNRESET");
+    expect(message).not.toContain(secret);
+    expect(message.length).toBeLessThanOrEqual(1_024);
   });
 });

--- a/src/node-host/node-worker-supervisor-commands.ts
+++ b/src/node-host/node-worker-supervisor-commands.ts
@@ -1,5 +1,6 @@
 import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { WORKER_PUBLIC_INGRESS_PATH } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { boundedWorkerErrorWithCode } from "../gateway/worker-environments/worker-error.js";
 import {
   NODE_WORKER_BUNDLE_INSTALL_COMMAND,
   NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE,
@@ -56,6 +57,8 @@ import {
 import type { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 import { invokeNodeWorkerPortalStream } from "./portal-stream-command.js";
 
+const WORKSPACE_TRANSFER_DIAGNOSTIC_MAX_CHARS = 1_024;
+
 type NodeWorkerSupervisorCommandResult =
   | { handled: false }
   | {
@@ -81,6 +84,17 @@ type NodeWorkerSupervisorCommandResult =
         | typeof NODE_WORKSPACE_TRANSFER_ERROR_CODE;
       message: string;
     };
+
+function workspaceTransferDiagnostic(error: NodeWorkerWorkspaceTransferError): string {
+  if (!error.operation || !error.stage) {
+    return error.message;
+  }
+  const prefix = `workspace-transfer-failed: operation=${error.operation} stage=${error.stage}: `;
+  return `${prefix}${boundedWorkerErrorWithCode(
+    error.cause ?? error,
+    WORKSPACE_TRANSFER_DIAGNOSTIC_MAX_CHARS - prefix.length,
+  )}`;
+}
 
 function resolveWorkerConnectionEndpoint(params: {
   gatewayUrl?: string;
@@ -328,8 +342,9 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
             : transferFailure
               ? NODE_WORKSPACE_TRANSFER_ERROR_CODE
               : "UNAVAILABLE",
-      message:
-        invalid || bundleInstallFailure || capacityFailure || transferFailure
+      message: transferFailure
+        ? workspaceTransferDiagnostic(error)
+        : invalid || bundleInstallFailure || capacityFailure
           ? error.message
           : "node worker supervisor command failed",
     };

--- a/src/node-host/node-worker-transfer-client.test.ts
+++ b/src/node-host/node-worker-transfer-client.test.ts
@@ -611,6 +611,56 @@ describe("node worker transfer client", () => {
     },
   );
 
+  it("preserves upload stage and nested transport diagnostics", async () => {
+    const root = tempDirs.make("node-worker-transfer-diagnostics-");
+    const workspaceDir = path.join(root, "workspace");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    await fs.mkdir(workspaceDir);
+    await fs.mkdir(path.join(root, ".openclaw-worker", "manifests"), { recursive: true });
+    await fs.writeFile(
+      path.join(
+        root,
+        ".openclaw-worker",
+        "manifests",
+        `${manifestRef.slice("sha256:".length)}.json`,
+      ),
+      rawManifest,
+    );
+    const server = createHttpServer((req) => req.socket.destroy());
+    const gatewayUrl = await listen(server);
+    try {
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          environmentId: "environment-diagnostics",
+          workspaceDir,
+          manifestHome: root,
+          transfer: {
+            direction: "upload",
+            token: "upload-token",
+            baseManifestRef: manifestRef,
+            referenceManifestRef: manifestRef,
+          },
+        }),
+      ).rejects.toMatchObject({
+        message: "workspace-transfer-failed: transfer did not complete",
+        operation: "upload",
+        stage: "reconcile",
+        cause: expect.objectContaining({ code: "ECONNRESET" }),
+      });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
   it("uploads the captured snapshot when the live workspace changes before transmission", async () => {
     const root = tempDirs.make("node-worker-transfer-snapshot-");
     const workspaceDir = path.join(root, "workspace");

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -44,6 +44,7 @@ import {
   nodeWorkspaceTransferPackPath,
   nodeWorkspaceTransferReconcilePath,
   type NodeWorkerWorkspaceTransferInput,
+  type NodeWorkerWorkspaceTransferStage,
 } from "../worker/node-workspace-transfer-protocol.js";
 import {
   prepareNodeWorkerWorkspaceOverlay,
@@ -212,11 +213,13 @@ async function downloadWorkspace(params: {
   transfer: Extract<NodeWorkerWorkspaceTransferInput, { direction: "download" }>;
   prepared?: NodeWorkerPreparedWorkspaceTransfer;
   hashMemo?: WorkspaceHashMemo;
+  setStage: (stage: NodeWorkerWorkspaceTransferStage) => void;
   signal?: AbortSignal;
 }): Promise<string> {
   const startedAt = performance.now();
   let packDownloadMs: number | undefined;
   let baseSource: "prepared-project-seed" | "gateway-pack" | undefined;
+  params.setStage("manifest");
   const raw = await downloadBuffer(
     {
       gatewayUrl: params.gatewayUrl,
@@ -271,6 +274,7 @@ async function downloadWorkspace(params: {
   ) {
     throw new Error("Invalid worker attachment manifest");
   }
+  params.setStage("materialize");
   const stagingWorkspace = await tempWorkspace({
     rootDir: path.dirname(params.workspaceDir),
     prefix: `.${path.basename(params.workspaceDir)}.workspace-transfer-`,
@@ -298,6 +302,7 @@ async function downloadWorkspace(params: {
     }
     if (manifest.baseCommit && !checkpointBase && !overlay) {
       try {
+        params.setStage("base");
         let seeded = false;
         if (params.transfer.seedKey) {
           baseSource = "prepared-project-seed";
@@ -353,6 +358,7 @@ async function downloadWorkspace(params: {
         throw error;
       }
     }
+    params.setStage("materialize");
     const blobApplyStartedAt = performance.now();
     const stagingHashMemo: WorkspaceHashMemo = new Map();
     for (const directory of checkpointBase ? [] : (manifest.directories ?? [])) {
@@ -413,6 +419,7 @@ async function downloadWorkspace(params: {
     // Reuse only hashes validated on this staging filesystem. Capture still checks
     // the complete tree and current handle identities before the atomic replacement.
     if (checkpointBase && checkpointBaseRef && !overlay) {
+      params.setStage("verify");
       await applyNodeRepositoryCheckpoint({
         workspaceDir: params.workspaceDir,
         stagingRoot: staging,
@@ -424,6 +431,7 @@ async function downloadWorkspace(params: {
       });
       params.hashMemo?.clear();
     } else {
+      params.setStage("verify");
       const observed = overlay
         ? await overlay.apply(staging)
         : await captureManifest({
@@ -466,6 +474,7 @@ async function downloadWorkspace(params: {
         params.signal?.throwIfAborted();
       }
     } else if (!overlay && !checkpointBase) {
+      params.setStage("replace");
       await replaceWorkspace(params.workspaceDir, staging);
     }
     if (params.hashMemo && !overlay && !checkpointBase) {
@@ -503,8 +512,10 @@ async function uploadWorkspace(params: {
   transfer: Extract<NodeWorkerWorkspaceTransferInput, { direction: "upload" }>;
   prepared?: NodeWorkerPreparedWorkspaceTransfer;
   hashMemo?: WorkspaceHashMemo;
+  setStage: (stage: NodeWorkerWorkspaceTransferStage) => void;
   signal?: AbortSignal;
 }): Promise<string> {
+  params.setStage("base");
   if (params.transfer.publicationBaseCommit) {
     const { publicationBaseCommit, ...transfer } = params.transfer;
     return await withNodeRepositoryPublication(
@@ -534,6 +545,7 @@ async function uploadWorkspace(params: {
     "utf8",
   );
   const base = parseWorkerWorkspaceManifest(baseRaw, params.transfer.baseManifestRef);
+  params.setStage("capture");
   const currentRef = await captureManifest({
     workspaceDir: params.workspaceDir,
     manifestHome: params.manifestHome,
@@ -556,6 +568,7 @@ async function uploadWorkspace(params: {
   const changed = new Set(workerWorkspaceTransferPaths(current, base));
   const manifestBytes = Buffer.from(currentRaw);
   const baseBytes = Buffer.from(baseRaw);
+  params.setStage("snapshot");
   const snapshot = await createNodeWorkerUploadSnapshot({
     workspaceDir: params.workspaceDir,
     sources: current.entries.flatMap((entry) =>
@@ -577,6 +590,7 @@ async function uploadWorkspace(params: {
       baseBytes.byteLength +
       manifestBytes.byteLength +
       snapshot.files.reduce((total, file) => total + 8 + file.size, 0);
+    params.setStage("reconcile");
     const response = await openNodeWorkerTransferHttpRequest({
       gatewayUrl: params.gatewayUrl,
       tlsFingerprint: params.tlsFingerprint,
@@ -607,6 +621,7 @@ async function uploadWorkspace(params: {
         }
       },
     });
+    params.setStage("acknowledgement");
     await requireOk(response);
     const payload = JSON.parse(
       (await readResponseBody(response, TRANSFER_RESULT_MAX_BYTES)).toString("utf8"),
@@ -634,6 +649,10 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
   hashMemo?: WorkspaceHashMemo;
   signal?: AbortSignal;
 }): Promise<string> {
+  let stage: NodeWorkerWorkspaceTransferStage = "recover";
+  const setStage = (next: NodeWorkerWorkspaceTransferStage) => {
+    stage = next;
+  };
   try {
     if (!params.prepared) {
       await recoverWorkspaceReplacement(params.workspaceDir);
@@ -644,12 +663,14 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
           tlsFingerprint: params.gatewayTlsFingerprint,
           cloudflareAccess: params.gatewayCloudflareAccess,
           transfer: params.transfer,
+          setStage,
         })
       : await uploadWorkspace({
           ...params,
           tlsFingerprint: params.gatewayTlsFingerprint,
           cloudflareAccess: params.gatewayCloudflareAccess,
           transfer: params.transfer,
+          setStage,
         });
   } catch (error) {
     if (error instanceof NodeWorkerWorkspaceTransferError) {
@@ -677,7 +698,7 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
     }
     throw new NodeWorkerWorkspaceTransferError(
       "workspace-transfer-failed: transfer did not complete",
-      { cause: error },
+      { cause: error, operation: params.transfer.direction, stage },
     );
   }
 }

--- a/src/worker/node-workspace-transfer-protocol.ts
+++ b/src/worker/node-workspace-transfer-protocol.ts
@@ -12,6 +12,24 @@ export const NODE_WORKSPACE_EMPTY_MANIFEST_REF = `sha256:${createHash("sha256").
 export const NODE_WORKSPACE_TRANSFER_PATH = "/__openclaw__/worker-transfer/v1";
 export const NODE_WORKSPACE_TRANSFER_ERROR_CODE = "WORKSPACE_TRANSFER_FAILED";
 
+export type NodeWorkerWorkspaceTransferOperation = "download" | "upload";
+export type NodeWorkerWorkspaceTransferStage =
+  | "recover"
+  | "manifest"
+  | "base"
+  | "materialize"
+  | "verify"
+  | "replace"
+  | "capture"
+  | "snapshot"
+  | "reconcile"
+  | "acknowledgement";
+
+type NodeWorkerWorkspaceTransferErrorOptions = ErrorOptions & {
+  operation?: NodeWorkerWorkspaceTransferOperation;
+  stage?: NodeWorkerWorkspaceTransferStage;
+};
+
 const NODE_WORKSPACE_TRANSFER_INVALID_REASONS = [
   "content_length",
   "file_digest",
@@ -35,12 +53,17 @@ export function isNodeWorkspaceTransferInvalidReason(
   );
 }
 
+/** Retains private transfer context until the node boundary serializes a safe diagnostic. */
 export class NodeWorkerWorkspaceTransferError extends Error {
   readonly code = NODE_WORKSPACE_TRANSFER_ERROR_CODE;
+  readonly operation?: NodeWorkerWorkspaceTransferOperation;
+  readonly stage?: NodeWorkerWorkspaceTransferStage;
 
-  constructor(message: string, options?: ErrorOptions) {
+  constructor(message: string, options?: NodeWorkerWorkspaceTransferErrorOptions) {
     super(message, options);
     this.name = "NodeWorkerWorkspaceTransferError";
+    this.operation = options?.operation;
+    this.stage = options?.stage;
   }
 }
 


### PR DESCRIPTION
## What
Preserve bounded, sanitized workspace-transfer failure context across the node transfer client, supervisor invoke boundary, and Gateway tunnel reconstruction.

## Why
Generic transfer failures retained their nested cause only in memory. The supervisor serialized only the outer message, so operators saw `workspace-transfer-failed: transfer did not complete` without the failing operation, stage, or useful transport error code.

## Changes
- Track download/upload transfer stages
- Serialize bounded redacted nested diagnostics
- Preserve diagnostics through Gateway reconstruction
- Add client, supervisor, and tunnel regressions

## Testing
- Pre-fix regression: 2 expected failures reproduced missing operation/stage and dropped cause
- `pnpm test src/node-host/node-worker-transfer-client.test.ts src/node-host/invoke-worker-supervisor.test.ts` — 50 passed, 1 skipped
- Focused Gateway tunnel regression — passed
- `pnpm check:changed` — passed
- `pnpm build` — passed
- Mandatory autoreview — scoped clean, no actionable findings

## Limits
- No parent-child workspace sharing or initialization changes
- No timeout, retry, or live Gateway configuration/state changes
- Full `pnpm test:changed` was not used as a signal because the requested live-build base is behind current `origin/main`, selecting broad unrelated upstream tests; focused owner/boundary tests passed

---
[View the OpenClaw team session](https://openclaw-fsn1.tailf72dd7.ts.net/chat/main/dashboard/f2876c9d-ddff-4352-b12a-39ce17d7beb5)
