### PR TITLE
refactor(tests): share UI bootstrap deferred fixtures

### DIFF
--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -1,6 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { describe, expect, it, vi } from "vitest";
 import { CONTROL_UI_BASE_PATH_ATTRIBUTE } from "../../../src/gateway/control-ui-contract.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { routeIdFromPath, type RouteId } from "../app-routes.ts";
 import {
@@ -19,14 +20,6 @@ import { normalizeLegacyTerminalViewLocation } from "./startup-settings.ts";
 // performance assertion, so these waits must not inherit vi.waitFor's 1s default:
 // under a loaded CI runner that budget expires before startup reaches the step.
 const STARTUP_STEP_WAIT = { timeout: 15_000 };
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 describe("normalizeLegacyTerminalViewLocation", () => {
   it.each([
@@ -221,10 +214,8 @@ describe("bootstrapApplication", () => {
   });
 
   it("starts the first-run redirect after installing the persisted session location", async () => {
-    let resolveInitialLocation: (location: RouteLocation) => void = () => undefined;
-    const initialLocationReady = new Promise<RouteLocation>((resolve) => {
-      resolveInitialLocation = resolve;
-    });
+    const { promise: initialLocationReady, resolve: resolveInitialLocation } =
+      createDeferred<RouteLocation>();
     let currentLocation: RouteLocation = { pathname: "/", search: "", hash: "" };
     const replaceLocation = vi.fn((location: RouteLocation) => {
       currentLocation = location;
@@ -798,7 +789,7 @@ describe("bootstrapApplication", () => {
     });
     window.history.replaceState({}, "", "/settings/appearance");
     const runtime = bootstrapApplication();
-    const routerStarted = deferred<void>();
+    const routerStarted = createDeferred();
     const routerStart = vi.spyOn(runtime.router, "start").mockReturnValue(routerStarted.promise);
     const routerStop = vi.spyOn(runtime.router, "stop");
 

--- a/ui/src/app/config.test.ts
+++ b/ui/src/app/config.test.ts
@@ -1,14 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ControlUiBootstrapConfig } from "../../../src/gateway/control-ui-contract.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createApplicationConfigCapability } from "./config.ts";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 function bootstrapResponse(
   serverVersion: string,
@@ -136,7 +129,7 @@ describe("createApplicationConfigCapability", () => {
   );
 
   it("does not discard an in-flight bootstrap when an auth-only refresh skips", async () => {
-    const response = deferred<Response>();
+    const response = createDeferred<Response>();
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(() => response.promise),
@@ -152,7 +145,7 @@ describe("createApplicationConfigCapability", () => {
   });
 
   it("shares concurrent bootstrap loads with equivalent credentials", async () => {
-    const response = deferred<Response>();
+    const response = createDeferred<Response>();
     const fetchMock = vi.fn<typeof fetch>(() => response.promise);
     vi.stubGlobal("fetch", fetchMock);
     let token = "fixture-token";
@@ -172,7 +165,7 @@ describe("createApplicationConfigCapability", () => {
   });
 
   it("rejects an authenticated response after credentials are cleared by a skipped refresh", async () => {
-    const response = deferred<Response>();
+    const response = createDeferred<Response>();
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(() => response.promise),
@@ -195,7 +188,7 @@ describe("createApplicationConfigCapability", () => {
   it.each(["", "replacement-fixture-token"])(
     "rejects an authenticated response when live credentials change without another refresh: %s",
     async (nextToken) => {
-      const response = deferred<Response>();
+      const response = createDeferred<Response>();
       const fetchMock = vi.fn<typeof fetch>(() => response.promise);
       vi.stubGlobal("fetch", fetchMock);
       let token = "fixture-token";
@@ -217,8 +210,8 @@ describe("createApplicationConfigCapability", () => {
   it.each([false, true])(
     "keeps independent callers valid and publishes the newest successful response (aborted: %s)",
     async (aborted) => {
-      const firstResponse = deferred<Response>();
-      const secondResponse = deferred<Response>();
+      const firstResponse = createDeferred<Response>();
+      const secondResponse = createDeferred<Response>();
       vi.stubGlobal(
         "fetch",
         vi
@@ -245,8 +238,8 @@ describe("createApplicationConfigCapability", () => {
   );
 
   it("returns null for a bootstrap response superseded by different credentials", async () => {
-    const firstResponse = deferred<Response>();
-    const secondResponse = deferred<Response>();
+    const firstResponse = createDeferred<Response>();
+    const secondResponse = createDeferred<Response>();
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockImplementationOnce(() => firstResponse.promise)

--- a/ui/src/app/connection-bootstrap.test.ts
+++ b/ui/src/app/connection-bootstrap.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createConnectionBootstrapCoordinator } from "./connection-bootstrap.ts";
-
-function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 describe("connection bootstrap coordinator", () => {
   it("deduplicates bootstrap work and caps its connection concurrency", async () => {
@@ -15,10 +8,10 @@ describe("connection bootstrap coordinator", () => {
     coordinator.synchronize({ client: {}, connected: true });
     let active = 0;
     let maximum = 0;
-    const first = deferred();
-    const second = deferred();
-    const third = deferred();
-    const run = (completion: ReturnType<typeof deferred>) => async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    const third = createDeferred();
+    const run = (completion: ReturnType<typeof createDeferred<void>>) => async () => {
       active += 1;
       maximum = Math.max(maximum, active);
       await completion.promise;
@@ -45,12 +38,12 @@ describe("connection bootstrap coordinator", () => {
     async (boundary) => {
       const coordinator = createConnectionBootstrapCoordinator();
       coordinator.synchronize({ client: {}, connected: true });
-      const first = deferred();
-      const second = deferred();
+      const first = createDeferred();
+      const second = createDeferred();
       let boundaryReturned = false;
       let startedAfterBoundary = false;
       let staleStarted = false;
-      const block = (completion: ReturnType<typeof deferred>) => async () => {
+      const block = (completion: ReturnType<typeof createDeferred<void>>) => async () => {
         startedAfterBoundary ||= boundaryReturned;
         await completion.promise;
       };
@@ -81,8 +74,8 @@ describe("connection bootstrap coordinator", () => {
   it("keeps a new connection's active task deduplicated after the old task finishes", async () => {
     const coordinator = createConnectionBootstrapCoordinator();
     coordinator.synchronize({ client: {}, connected: true });
-    const previous = deferred();
-    const current = deferred();
+    const previous = createDeferred();
+    const current = createDeferred();
     const runPrevious = vi.fn(async () => await previous.promise);
     const runCurrent = vi.fn(async () => await current.promise);
     const runDuplicate = vi.fn(async () => {});


### PR DESCRIPTION
## What Problem This Solves

The Control UI bootstrap tests maintained three local deferred-promise factories and a separate eager resolver capture even though the shared test helper already owns this setup. Maintaining those copies adds no behavioral coverage.

## Why This Change Was Made

Use the existing `createDeferred` helper for startup routing, pending bootstrap responses and connection coordination. All existing assertions, response fixtures, waits and ordering checks remain. Concrete response/location payload types and both `ReturnType<typeof createDeferred<void>>` annotations stay explicit; the ordinary void call uses the helper's default. The shared helper also returns an unused rejection capability; these tests consume only the promise and resolver.

## User Impact

No user-visible or production change. The three test files lose 23 lines overall (+23/-46), with no new test helper or runtime seam.

## Evidence

The original and final candidate each passed all 65 existing cases through `node scripts/run-vitest.mjs ui/src/app/bootstrap.test.ts ui/src/app/config.test.ts ui/src/app/connection-bootstrap.test.ts` on Node 26.5.0/macOS. Both normal native report sets retain 24 shared UI cases and 41 isolated UI cases. Startup/stop ordering, request supersession, connection-generation isolation and credential handling assertions remain covered.

These are local jsdom tests with existing mocks, not a live browser or Gateway exercise. An intermediate scoped lint run caught one unnecessary default type argument; the final candidate removes it while preserving the required type captures. All 18 required changed-file checks passed, including the affected test typecheck and lint. Independent Codex review is clean through P2.
