### PR TITLE
fix(config): preserve literal provider-prefixed model IDs

### DIFF
--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -3026,8 +3026,8 @@ describe("config io write", () => {
       await withSuiteHome(async (home) => {
         const entry = { alias: "friendly", params: { temperature: 0.2 } };
         const canonicalEntry = canonicalPresent ? { params: { temperature: 0.7 } } : entry;
-        const legacy = "openrouter/openrouter/hunter-alpha";
-        const canonical = "openrouter/hunter-alpha";
+        const legacy = "google/gemini-3-pro-preview";
+        const canonical = "google/gemini-3.1-pro-preview";
         const agents = {
           entries: { main: {} },
           defaults: {

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -1317,13 +1317,20 @@ describe("config io write prepare", () => {
     ).toEqual({ agents: { defaults, entries: { main: {}, ops: {} } }, gateway: { mode: "local" } });
   });
 
-  it("preserves authored Google model params under normalized config keys", () => {
+  it.each([
+    ["google/gemini-3-pro-preview", "google/gemini-3.1-pro-preview"],
+    ["together/moonshotai/Kimi-K2.5", "together/moonshotai/Kimi-K2.6"],
+    ["custom/custom/model", "custom/custom/model"],
+  ])("preserves separate authored model params when writing %s", (authored, canonical) => {
     const params = { thinking: { level: "high" } };
     const sourceConfig = {
       agents: {
         defaults: {
-          model: { primary: "google/gemini-3-pro-preview" },
-          models: { "google/gemini-3-pro-preview": { alias: "Gemini", params } },
+          model: { primary: authored, fallbacks: ["custom/model"] },
+          models: {
+            [authored]: { alias: "Selected", params },
+            "custom/model": { alias: "Control" },
+          },
         },
       },
     };
@@ -1332,9 +1339,10 @@ describe("config io write prepare", () => {
         runtimeConfig: {
           agents: {
             defaults: {
-              model: { primary: "google/gemini-3.1-pro-preview" },
+              model: { primary: canonical, fallbacks: ["custom/model"] },
               models: {
-                "google/gemini-3.1-pro-preview": { alias: "Gemini", params },
+                [canonical]: { alias: "Selected", params },
+                "custom/model": { alias: "Control" },
               },
             },
           },
@@ -1343,8 +1351,8 @@ describe("config io write prepare", () => {
         nextConfig: {
           agents: {
             defaults: {
-              model: { primary: "google/gemini-3.1-pro-preview" },
-              models: { "google/gemini-3.1-pro-preview": {} },
+              model: { primary: canonical, fallbacks: ["custom/model"] },
+              models: { [canonical]: {}, "custom/model": { alias: "Control" } },
             },
           },
         },
@@ -1352,8 +1360,8 @@ describe("config io write prepare", () => {
     ).toEqual({
       agents: {
         defaults: {
-          model: { primary: "google/gemini-3-pro-preview" },
-          models: { "google/gemini-3.1-pro-preview": { params } },
+          model: { primary: authored, fallbacks: ["custom/model"] },
+          models: { [canonical]: { params }, "custom/model": { alias: "Control" } },
         },
       },
     });

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -265,18 +265,23 @@ describe("applyModelDefaults", () => {
     });
   });
 
-  it.each(["google", "google-vertex", "google-gemini-cli", "myproxy/google"])(
-    "normalizes retired Gemini primary and fallback refs under %s",
-    (provider) => {
-      const retired = `${provider}/gemini-3-pro-preview`;
-      const replacement = `${provider}/gemini-3.1-pro-preview`;
+  it.each([
+    ["google/gemini-3-pro-preview", "google/gemini-3.1-pro-preview"],
+    ["google-vertex/gemini-3-pro-preview", "google-vertex/gemini-3.1-pro-preview"],
+    ["google-gemini-cli/gemini-3-pro-preview", "google-gemini-cli/gemini-3.1-pro-preview"],
+    ["myproxy/google/gemini-3-pro-preview", "myproxy/google/gemini-3.1-pro-preview"],
+    ["custom/custom/model", "custom/custom/model"],
+  ])(
+    "normalizes primary, fallback, and policy refs without merging literal namespaces: %s",
+    (authored, replacement) => {
       const cfg = {
         agents: {
           defaults: {
             model: {
-              primary: retired,
-              fallbacks: [retired, "openai/gpt-5.5"],
+              primary: authored,
+              fallbacks: [authored, "custom/model"],
             },
+            models: { [authored]: { alias: "Selected" }, "custom/model": { alias: "Control" } },
           },
         },
       } satisfies OpenClawConfig;
@@ -285,7 +290,11 @@ describe("applyModelDefaults", () => {
 
       expect(next.agents?.defaults?.model).toEqual({
         primary: replacement,
-        fallbacks: [replacement, "openai/gpt-5.5"],
+        fallbacks: [replacement, "custom/model"],
+      });
+      expect(next.agents?.defaults?.models).toEqual({
+        [replacement]: { alias: "Selected" },
+        "custom/model": { alias: "Control" },
       });
     },
   );

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -9,7 +9,6 @@ import {
   normalizeOptionalString,
   resolvePrimaryStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { modelKey } from "../shared/model-key.js";
 import type { AgentModelEntryConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentToolModelConfig } from "./types.agents-shared.js";
 
@@ -77,7 +76,7 @@ export function normalizeAgentModelRefForConfig(model: string): string {
 
   const { provider, modelId: modelSuffix } = parsed;
   const normalizedModel = normalizeProviderCatalogModelIdForConfig(provider, modelSuffix);
-  return modelKey(provider, normalizedModel);
+  return `${provider}/${normalizedModel}`;
 }
 
 /** Normalizes primary/fallback refs without replacing unchanged config values. */


### PR DESCRIPTION
Related: #130706, #142100, #134496

## What Problem This Solves

Fixes an issue where users configuring a model ID that begins with its provider name would have that namespace removed when config loaded or changed. For example, `custom/custom/model` became `custom/model`, collapsing a fallback into the primary and allowing model settings to move onto the wrong row.

## Why This Change Was Made

The config parser already separates the provider from the literal model ID. Rejoin those parsed segments directly instead of interpreting the model prefix again. Existing Google and Together migrations remain unchanged.

## User Impact

Primary models, fallbacks, and per-model settings keep distinct provider-local namespaces across config reads and writes. This restores the documented first-slash parsing contract.

## Evidence

- Two regression cases failed before the repair; six migration controls passed. The existing tables cover distinct primary/fallback references, model-setting keys, and preserved parameters during writes.
- All 463 tests across five focused config suites passed, including the complete config-write suite. Its eight source-rename variants now use the maintained Gemini retirement and retain every root/include, transform/replacement, canonical-present, and write assertion. All eight also passed in a targeted run.
- The full changed gate and a fresh P2 review passed for the complete four-file PR candidate against its original base.
- A full `pnpm build`, including declarations and UI assets, and the compiled runtime proof passed at `b0502dcfb17ddc21321e6a3895367e84c7d0c497`. This follow-up changes two test constants only; all 40,745 other tracked files match that built source byte for byte. No runtime rebuild was needed for the fixture change.
- Compiled runtime proof read config, changed the fallback alias through the production writer, and reread both distinct model rows with their original parameters. An unpinned reply made the expected HTTP `model` → 404 and `custom/model` → 200 requests, delivered the response, and persisted the exact answering model in its transcript.
- The compiled process exited normally after closing its production services; all source files and 14,639 runtime output entries remained unchanged; 5,146 loaded modules were also checked. Earlier fixture cleanup failures are preserved in the local evidence packet.

Fallback notice formatting and `/model`/`/status` projection remain separate follow-up work in #134496.

Production delta: **−1 line**; test delta: **+17 lines**. Exact-head CI and native prepare must pass before landing.
