### PR TITLE
perf(agents): reuse bounded CLI prefix capture

### DIFF
--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -8,6 +8,7 @@ import {
 import { createModelCallStreamProgressReporter } from "../../logging/diagnostic-model-stream-progress.js";
 import { beginDiagnosticBackendActivity } from "../../logging/diagnostic-run-activity.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
+import { appendCapturedOutput, createCapturedOutputBuffers } from "../../process/exec-output.js";
 import type { RunExit } from "../../process/supervisor/types.js";
 import type { CliOutput, CliTerminalInterruption } from "../cli-output-contracts.js";
 import { createCliJsonlStreamingParser } from "../cli-output-stream.js";
@@ -36,30 +37,6 @@ import { createCliOutputFailoverError } from "./output-error.js";
 import type { NodeClaudePlacement, PreparedCliRunContext } from "./types.js";
 
 const CLI_RUNNER_OUTPUT_PARSE_BYTES = 1024 * 1024;
-
-function appendCliOutputParseBuffer(buffer: Buffer, chunk: string) {
-  if (!chunk) {
-    return { buffer, exceeded: false };
-  }
-  const chunkBuffer = Buffer.from(chunk);
-  if (buffer.byteLength + chunkBuffer.byteLength <= CLI_RUNNER_OUTPUT_PARSE_BYTES) {
-    return {
-      buffer: Buffer.concat([buffer, chunkBuffer], buffer.byteLength + chunkBuffer.byteLength),
-      exceeded: false,
-    };
-  }
-  const remainingBytes = CLI_RUNNER_OUTPUT_PARSE_BYTES - buffer.byteLength;
-  return {
-    buffer:
-      remainingBytes <= 0
-        ? buffer
-        : Buffer.concat(
-            [buffer, chunkBuffer.subarray(0, remainingBytes)],
-            CLI_RUNNER_OUTPUT_PARSE_BYTES,
-          ),
-    exceeded: true,
-  };
-}
 
 type ExecuteCliProcessOptions = {
   onPhase?: (phase: "send" | "resolve" | "cleanup") => void;
@@ -137,15 +114,13 @@ export async function executeCliProcess(params: {
       })
     : null;
   let stdoutTail = "";
-  let stdoutParseBuffer: Buffer = Buffer.alloc(0);
+  const stdoutCapture = createCapturedOutputBuffers();
   let stdoutBytes = 0;
   const stdoutHash = crypto.createHash("sha256");
-  let stdoutParseExceeded = false;
   let stderrTail = "";
-  let stderrParseBuffer: Buffer = Buffer.alloc(0);
+  const stderrCapture = createCapturedOutputBuffers();
   let stderrBytes = 0;
   const stderrHash = crypto.createHash("sha256");
-  let stderrParseExceeded = false;
   // Only the core lifecycle owner may publish recovery facts. Plugin records
   // carry output, never the authority or deadline used to protect its execution.
   const reportStreamProgress = createModelCallStreamProgressReporter(
@@ -171,10 +146,8 @@ export async function executeCliProcess(params: {
     stdoutBytes += chunkBytes;
     stdoutHash.update(chunk);
     stdoutTail = appendCliOutputTail(stdoutTail, chunk);
-    if (!stdoutParseExceeded) {
-      const next = appendCliOutputParseBuffer(stdoutParseBuffer, chunk);
-      stdoutParseBuffer = next.buffer;
-      stdoutParseExceeded = next.exceeded;
+    if (chunk && stdoutCapture.truncatedBytes === 0) {
+      appendCapturedOutput(stdoutCapture, chunk, CLI_RUNNER_OUTPUT_PARSE_BYTES, "head");
     }
     streamingParser?.push(chunk);
   };
@@ -183,10 +156,8 @@ export async function executeCliProcess(params: {
     stderrBytes += Buffer.byteLength(chunk);
     stderrHash.update(chunk);
     stderrTail = appendCliOutputTail(stderrTail, chunk);
-    if (!stderrParseExceeded) {
-      const next = appendCliOutputParseBuffer(stderrParseBuffer, chunk);
-      stderrParseBuffer = next.buffer;
-      stderrParseExceeded = next.exceeded;
+    if (chunk && stderrCapture.truncatedBytes === 0) {
+      appendCapturedOutput(stderrCapture, chunk, CLI_RUNNER_OUTPUT_PARSE_BYTES, "head");
     }
   };
 
@@ -377,7 +348,9 @@ export async function executeCliProcess(params: {
   }
 
   let stdout: string | undefined;
-  const readStdout = () => (stdout ??= stdoutParseBuffer.toString("utf8").trim());
+  // Preserve replacement characters when the byte limit clips a UTF-8 sequence.
+  const readStdout = () =>
+    (stdout ??= Buffer.concat(stdoutCapture.chunks, stdoutCapture.bytes).toString("utf8").trim());
   const stdoutDiagnostic = stdoutTail.trim();
   const stderrDiagnostic = stderrTail.trim();
   const processDiagnostics = {
@@ -413,7 +386,7 @@ export async function executeCliProcess(params: {
     params.outputMode === "jsonl" ? (streamingParser?.getOutput() ?? null) : null;
   const parsedStructuredOutput =
     streamedJsonlOutput ??
-    (params.outputMode === "json" && !stdoutParseExceeded
+    (params.outputMode === "json" && stdoutCapture.truncatedBytes === 0
       ? parseCliOutput({
           raw: readStdout(),
           backend: params.backend,
@@ -507,7 +480,7 @@ export async function executeCliProcess(params: {
       );
     }
     const retryEmptyFailure = result.reason === "exit" && !params.events.hasObservedCliActivity();
-    const stderr = stderrParseBuffer.toString("utf8").trim();
+    const stderr = Buffer.concat(stderrCapture.chunks, stderrCapture.bytes).toString("utf8").trim();
     throw createCliExitFailoverError({
       context: failoverContext,
       candidates: [stderr, readStdout(), stderrDiagnostic, stdoutDiagnostic],
@@ -517,7 +490,7 @@ export async function executeCliProcess(params: {
     });
   }
 
-  if (stdoutParseExceeded && !streamedJsonlOutput) {
+  if (stdoutCapture.truncatedBytes > 0 && !streamedJsonlOutput) {
     throw createCliFailoverError(
       `CLI stdout exceeded ${CLI_RUNNER_OUTPUT_PARSE_BYTES} bytes; refusing to parse truncated output.`,
       "format",

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -592,30 +592,31 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(events).toEqual(["stage:first", "spawn:first", "stage:second", "spawn:second"]);
   });
 
-  it("disables supervisor capture without parsing from the diagnostic stdout tail", async () => {
-    const fullText = `start-${"x".repeat(80 * 1024)}-end`;
+  it.each(["text", "json"] as const)(
+    "parses fragmented %s at the byte limit with supervisor capture disabled",
+    async (output) => {
+      const textBytes =
+        1024 * 1024 - (output === "json" ? Buffer.byteLength(JSON.stringify({ result: "" })) : 0);
+      const fullText = `start-${"x".repeat(textBytes - 10)}-end`;
+      const stdout = output === "json" ? JSON.stringify({ result: fullText }) : fullText;
 
-    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const input = args[0] as SupervisorSpawnInput;
-      input.onStdout?.(fullText);
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: input.captureOutput === false ? "" : fullText,
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
+      supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const input = args[0] as SupervisorSpawnInput;
+        input.onStdout?.("");
+        for (let offset = 0; offset < stdout.length; offset += 4093) {
+          input.onStdout?.(stdout.slice(offset, offset + 4093));
+        }
+        input.onStdout?.("");
+        return createManagedRun(createSuccessfulProcessExit());
       });
-    });
 
-    const result = await executePreparedCliRun(buildPreparedCliRunContext({ output: "text" }));
-    const spawnInput = requireSupervisorSpawnInput();
+      const result = await executePreparedCliRun(buildPreparedCliRunContext({ output }));
+      const spawnInput = requireSupervisorSpawnInput();
 
-    expect(spawnInput.captureOutput).toBe(false);
-    expect(result.rawText).toBe(fullText);
-  });
+      expect(spawnInput.captureOutput).toBe(false);
+      expect(result.rawText).toBe(fullText);
+    },
+  );
 
   it("passes prepared secret input to a one-shot child", async () => {
     const context = buildPreparedCliRunContext({ output: "text", provider: "claude-cli" });
@@ -636,33 +637,35 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(requireSupervisorSpawnInput()).toEqual(expect.objectContaining({ secretInput }));
   });
 
-  it("rejects oversized successful stdout instead of parsing a truncated tail", async () => {
-    const noisyPrefix = "x".repeat(2 * 1024 * 1024);
-    const finalText = "final answer";
+  it.each(["text", "json"] as const)(
+    "rejects fragmented %s one byte over the parse limit",
+    async (output) => {
+      const textBytes =
+        1024 * 1024 +
+        1 -
+        (output === "json" ? Buffer.byteLength(JSON.stringify({ result: "" })) : 0);
+      const fullText = `start-${"x".repeat(textBytes - 10)}-end`;
+      const stdout = output === "json" ? JSON.stringify({ result: fullText }) : fullText;
 
-    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const input = args[0] as SupervisorSpawnInput;
-      input.onStdout?.(noisyPrefix);
-      input.onStdout?.(finalText);
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: input.captureOutput === false ? "" : `${noisyPrefix}${finalText}`,
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
+      supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const input = args[0] as SupervisorSpawnInput;
+        for (let offset = 0; offset < stdout.length; offset += 4096) {
+          input.onStdout?.(stdout.slice(offset, offset + 4096));
+        }
+        return createManagedRun(createSuccessfulProcessExit());
       });
-    });
 
-    await expect(
-      executePreparedCliRun(buildPreparedCliRunContext({ output: "text" })),
-    ).rejects.toThrow("CLI stdout exceeded");
-    const spawnInput = requireSupervisorSpawnInput();
+      await expect(
+        executePreparedCliRun(buildPreparedCliRunContext({ output })),
+      ).rejects.toMatchObject({
+        reason: "format",
+        message: "CLI stdout exceeded 1048576 bytes; refusing to parse truncated output.",
+      });
+      const spawnInput = requireSupervisorSpawnInput();
 
-    expect(spawnInput.captureOutput).toBe(false);
-  });
+      expect(spawnInput.captureOutput).toBe(false);
+    },
+  );
 
   it("parses valid oversized JSONL output incrementally", async () => {
     // JSONL agents can emit huge tool deltas; only the incremental parser sees
@@ -752,25 +755,48 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.sessionId).toBe("resume-jsonl-session");
   });
 
-  it.each(["stdout", "stderr"] as const)(
-    "classifies failed %s from the retained parse buffer before other candidates",
-    async (stream) => {
+  it.each([
+    { stream: "stdout", clipped: false },
+    { stream: "stderr", clipped: false },
+    { stream: "stdout", clipped: true },
+    { stream: "stderr", clipped: true },
+  ] as const)(
+    "classifies failed $stream from the retained prefix (clipped UTF-8: $clipped)",
+    async ({ stream, clipped }) => {
       // The error classifier needs the retained parse buffer; the human-facing
       // diagnostic tail may contain only noise once stdout grows large.
-      const errorPrefix = `${JSON.stringify({
-        type: "result",
-        is_error: true,
-        result: "429 rate limit exceeded",
-      })}\n`;
-      const noisyTail = "x".repeat(80 * 1024);
+      const errorPrefix = clipped
+        ? "429 rate limit exceeded: "
+        : `${JSON.stringify({
+            type: "result",
+            is_error: true,
+            result: "429 rate limit exceeded",
+          })}\n`;
+      const noisyTail = "x".repeat(
+        clipped ? 1024 * 1024 - Buffer.byteLength(errorPrefix) - 1 : 80 * 1024,
+      );
+      const expectedMessage = clipped
+        ? `${errorPrefix}${noisyTail}\uFFFD`
+        : "429 rate limit exceeded";
 
       supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
         const input = args[0] as SupervisorSpawnInput;
         const emit = stream === "stderr" ? input.onStderr : input.onStdout;
         emit?.(errorPrefix);
-        emit?.(noisyTail);
+        for (let offset = 0; offset < noisyTail.length; offset += 4093) {
+          emit?.(noisyTail.slice(offset, offset + 4093));
+        }
+        if (clipped) {
+          // Only the first byte of this code point fits in the retained prefix.
+          emit?.("🙂");
+          emit?.("discarded after the prefix");
+        }
         if (stream === "stderr") {
-          input.onStdout?.(JSON.stringify({ type: "error", message: "Credit balance is too low" }));
+          input.onStdout?.(
+            clipped
+              ? "Credit balance is too low"
+              : JSON.stringify({ type: "error", message: "Credit balance is too low" }),
+          );
         }
         return createManagedRun({
           reason: "exit",
@@ -786,7 +812,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
 
       await expect(
         executePreparedCliRun(buildPreparedCliRunContext({ output: "text" })),
-      ).rejects.toMatchObject({ reason: "rate_limit", status: 429 });
+      ).rejects.toMatchObject({ reason: "rate_limit", status: 429, message: expectedMessage });
     },
   );
 


### PR DESCRIPTION
Closes #144277

## What Problem This Solves

Fragmented CLI output repeatedly copies the retained prefix as each chunk arrives. A one-MiB parse limit still permits hundreds of MiB of cumulative concatenation work before the run completes.

## Why This Change Was Made

Reuse the existing bounded head-capture owner for stdout and stderr, and concatenate lazily when the retained text is needed. Keep the current byte cap, oversized-output rejection, JSONL streaming, diagnostic hashes/tails and UTF-8 replacement decoding. The generic finalizer is intentionally not used because trimming clipped UTF-8 would change error prefixes.

## User Impact

CLI prefix capture avoids repeated whole-prefix copying and removes the duplicate local append helper. The capture retains one Buffer object per admitted chunk, so this is not a universal retained-heap or RSS improvement.

## Evidence

Both versions pass the same 80 executor/shared-retention tests. All 12 bounded benchmark comparisons preserve exact materialized bytes and cap decisions. For a one-MiB prefix, measured cumulative Buffer.concat output falls from about 512.5 MiB with one-KiB chunks and 128.5 MiB with four-KiB chunks to one MiB; retained capture objects rise from one to 1,025/257. These counters exclude other allocation paths and do not measure provider latency or total memory.

The full selected changed gate and independent P2 review pass. Suite timing/RSS includes imports and preparation and is not used as a speed or memory claim. No Gateway or provider activity was involved.

The paired 80-test executions recorded 27.69 seconds and 2,067,251,200 bytes maximum RSS before, versus 23.13 seconds and 2,058,207,232 bytes afterward. These whole-invocation observations include imports, transform caches and worker preparation; they do not isolate execution speed or retained-memory savings. The copy-volume result above is the measured optimization claim.
