### PR TITLE
fix(docs): reject unpublished permalink routes

### DIFF
--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -329,25 +329,8 @@ function buildAuditIndex(
 
   for (const abs of markdownFiles) {
     const rel = normalizeSlashes(path.relative(docsDir, abs));
-    const text = fs.readFileSync(abs, "utf8");
     const slug = rel.replace(/\.(md|mdx)$/i, "");
     addRoute(routes, slug);
-
-    if (!text.startsWith("---")) {
-      continue;
-    }
-
-    const end = text.indexOf("\n---", 3);
-    if (end === -1) {
-      continue;
-    }
-    const frontMatter = text.slice(3, end);
-    const match = frontMatter.match(/^permalink:\s*(.+)\s*$/m);
-    if (!match) {
-      continue;
-    }
-    const permalink = (match[1] ?? "").trim().replace(/^['"]|['"]$/g, "");
-    routes.add(normalizeRoute(permalink));
   }
 
   // Without a ClawHub checkout the mirrored tree is absent, so its pages cannot be

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -19,6 +19,7 @@ type AuditCliCase = {
   anchors?: boolean;
   diagnostics?: string[];
   files?: Record<string, string>;
+  navigation?: string[];
   redirects?: Array<{ source: string; destination: string }>;
 };
 
@@ -313,6 +314,26 @@ describe("docs-link-audit", () => {
         ":: /missing-page :: route/file not found",
       ],
     })),
+    ...[false, true].map((anchors) => ({
+      name: `unpublished permalink routes (anchors=${anchors})`,
+      anchors,
+      source: [
+        "---",
+        "permalink: /unpublished",
+        "---",
+        "[unpublished](/unpublished)",
+        "[fragment](/unpublished#connection)",
+        "[valid](/page#connection)",
+        '<a id="connection" />',
+      ],
+      navigation: ["unpublished"],
+      broken: 3,
+      diagnostics: [
+        "page.mdx:4 :: /unpublished :: route/file not found",
+        "page.mdx:5 :: /unpublished#connection :: route/file not found",
+        "docs.json:unknown :: unpublished :: navigation page not published",
+      ],
+    })),
     {
       name: "shared emitted fragments",
       anchors: true,
@@ -352,7 +373,7 @@ describe("docs-link-audit", () => {
     },
   ])(
     "audits real CLI links after $name",
-    ({ source, broken, anchors = false, diagnostics, files = {}, redirects }) => {
+    ({ source, broken, anchors = false, diagnostics, files = {}, navigation = [], redirects }) => {
       const tempDirs: string[] = [];
       const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-cli-");
       const docsRoot = path.join(fixtureRoot, "docs");
@@ -364,7 +385,7 @@ describe("docs-link-audit", () => {
       fs.writeFileSync(
         path.join(docsRoot, "docs.json"),
         JSON.stringify({
-          navigation: [],
+          navigation: [{ pages: navigation }],
           redirects:
             redirects ??
             (anchors && !diagnostics
@@ -409,7 +430,7 @@ describe("docs-link-audit", () => {
         );
         expect(result.error).toBeUndefined();
         expect(result.stderr).toBe("");
-        expect(result.status).toBe(broken ? 1 : 0);
+        expect(result.status, result.stdout).toBe(broken ? 1 : 0);
         if (!anchors) {
           expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
         }


### PR DESCRIPTION
Related: #137157

## What Problem This Solves

Fixes an issue where docs link checks accepted frontmatter permalink URLs that the publisher does not create. A page with `permalink: /unpublished` could make plain links and navigation to `/unpublished` pass even though no page or configured redirect served that route.

## Why This Change Was Made

Remove the legacy permalink inventory and use the existing physical-page, index-route and configured-redirect owners consistently. This also removes the preliminary Markdown read pass. The declared ClawHub projection and shared publishing parser retain their existing contracts.

## User Impact

Docs checks now report these missing destinations in both plain and anchor modes. Published page routes and configured redirects continue to resolve.

## Evidence

The same two actual-CLI regression cases fail before the change and pass afterward. The fixture contains two unpublished links and an unpublished navigation entry: plain mode previously reported none, while anchor mode missed the navigation entry. Both modes now report all three and retain a valid physical-page control.

All 35 owner tests and 25 canonical changed checks pass. Existing coverage retains physical/index routes, redirects, assets and ClawHub behavior. Independent review found no actionable findings.

A transparent probe of the actual CLI fixture observed Markdown `readFileSync` calls fall from two to one per file. This measures calls, not disk I/O or elapsed-time speedup. No publisher deployment or separate publisher build was performed. The change removes 17 tooling lines and adds 21 test lines.

Compatibility: this patch removes entries from a process-local route index. It changes no stored-state schema or serialization and does not rewrite Markdown, frontmatter or docs.json. The existing physical/index and configured-redirect publishing contract is unchanged. The only authored permalink in this checkout is `/security/formal-verification/`, which already matches its physical page. A frontmatter-only alias has no published destination; an intended alias should use a configured redirect to an existing page. No data migration is required.
