### PR TITLE
refactor(image): share provider request dispatch

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -673,22 +673,6 @@ async function runImagePrompt(params: {
       }
       const describeImage =
         imageProvider?.describeImage ?? imageToolProviderDeps.describeImageWithModel;
-      if (params.images.length === 1) {
-        const image = params.images.at(0);
-        if (!image) {
-          throw new Error("Image input disappeared during model execution");
-        }
-        // A run cancelled mid-dispatch must not buy another provider call.
-        params.signal?.throwIfAborted();
-        const described = await describeImage({
-          buffer: image.buffer,
-          fileName: "image-1",
-          mime: image.mimeType,
-          ...request,
-        });
-        return { text: described.text, provider, model: described.model ?? modelId };
-      }
-
       const parts: string[] = [];
       for (const [index, image] of params.images.entries()) {
         // A run cancelled mid-dispatch must not buy another provider call.
@@ -698,8 +682,14 @@ async function runImagePrompt(params: {
           fileName: `image-${index + 1}`,
           mime: image.mimeType,
           ...request,
-          prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
+          prompt:
+            params.images.length === 1
+              ? params.prompt
+              : `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
         });
+        if (params.images.length === 1) {
+          return { text: described.text, provider, model: described.model ?? modelId };
+        }
         parts.push(`Image ${index + 1}:\n${described.text.trim()}`);
       }
       return {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -637,6 +637,22 @@ async function runImagePrompt(params: {
         provider,
         providerRegistry,
       );
+      const request = {
+        provider,
+        model: modelId,
+        prompt: params.prompt,
+        maxTokens: resolveImageToolMaxTokens(undefined),
+        timeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
+        cfg: providerCfg,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        agentDir: params.agentDir,
+        authStore: params.authStore,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        ...(params.preparedModelRuntime
+          ? { preparedModelRuntime: params.preparedModelRuntime }
+          : {}),
+      };
       if (
         params.images.length > 1 &&
         (imageProvider?.describeImages || !imageProvider?.describeImage)
@@ -651,20 +667,7 @@ async function runImagePrompt(params: {
             fileName: `image-${index + 1}`,
             mime: image.mimeType,
           })),
-          provider,
-          model: modelId,
-          prompt: params.prompt,
-          maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs,
-          ...(params.signal ? { signal: params.signal } : {}),
-          cfg: providerCfg,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
-          agentDir: params.agentDir,
-          authStore: params.authStore,
-          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-          ...(params.preparedModelRuntime
-            ? { preparedModelRuntime: params.preparedModelRuntime }
-            : {}),
+          ...request,
         });
         return { text: described.text, provider, model: described.model ?? modelId };
       }
@@ -681,20 +684,7 @@ async function runImagePrompt(params: {
           buffer: image.buffer,
           fileName: "image-1",
           mime: image.mimeType,
-          provider,
-          model: modelId,
-          prompt: params.prompt,
-          maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs,
-          ...(params.signal ? { signal: params.signal } : {}),
-          cfg: providerCfg,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
-          agentDir: params.agentDir,
-          authStore: params.authStore,
-          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-          ...(params.preparedModelRuntime
-            ? { preparedModelRuntime: params.preparedModelRuntime }
-            : {}),
+          ...request,
         });
         return { text: described.text, provider, model: described.model ?? modelId };
       }
@@ -707,20 +697,8 @@ async function runImagePrompt(params: {
           buffer: image.buffer,
           fileName: `image-${index + 1}`,
           mime: image.mimeType,
-          provider,
-          model: modelId,
+          ...request,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
-          maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs,
-          ...(params.signal ? { signal: params.signal } : {}),
-          cfg: providerCfg,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
-          agentDir: params.agentDir,
-          authStore: params.authStore,
-          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-          ...(params.preparedModelRuntime
-            ? { preparedModelRuntime: params.preparedModelRuntime }
-            : {}),
         });
         parts.push(`Image ${index + 1}:\n${described.text.trim()}`);
       }


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Image-tool requests repeated the same provider options across batch, single-image and sequential dispatch. Those copies made request isolation, formatting and cancellation behavior harder to maintain consistently.

## Why This Change Was Made

Capture common fields once per fallback attempt and use the existing loop for single-image and sequential calls. Every provider invocation still receives a fresh top-level request. The private caller constructs a fresh dense image array, so the unreachable missing-image guard is removed with the duplicate branch.

## User Impact

Single-image requests retain their original prompt, untrimmed provider text and returned model. Multi-image requests retain ordered filenames, prompt suffixes and result formatting. Batch requests, cancellation, timeouts, auth references and lazy fallback loading retain their behavior.

## Evidence

- All 116 existing image-tool and provider-loading tests passed; no new tests were needed for this refactor.
- The full changed gate and fresh P2 review covered the complete change against `cb0569aa703b432ca34752f571a5084f3759f2c8`.
- One normal full build passed on `475b82ee99e6bfb9f4a4716f94af0767e9c2d6ee`.
- Five compiled cases passed through the actual emitted tool builder: single, batch, sequential request mutation, pre-abort, and cancellation during the first pending response. Synthetic images and real loopback HTTP verified exact prompts, image order, request isolation, and no second request after cancellation.
- Every source-import denial control passed. Source and all 15,616 inventoried output entries stayed unchanged. All children and sockets closed, and isolated state was removed.

The compiled proof uses the ordinary unprepared builder and a synthetic provider; prepared paths are covered by the existing focused suites. Production delta: **−32 lines in one file**. Exact-head CI and native prepare must pass before landing.
