### PR TITLE
fix(test): avoid plugin discovery in parent model matching

### DIFF
--- a/src/channels/model-overrides.test.ts
+++ b/src/channels/model-overrides.test.ts
@@ -49,20 +49,21 @@ describe("resolveChannelModelOverride", () => {
       expected: { model: "demo-provider/demo-topic-model", matchKey: "-100123:topic:99" },
     },
     {
+      // Use the registered thread fixture; an unknown id triggers real plugin discovery.
       name: "falls back to parent session key when thread id does not match",
       input: {
         cfg: {
           channels: {
             modelByChannel: {
-              "demo-thread": {
+              discord: {
                 "123": "demo-provider/demo-parent-model",
               },
             },
           },
         } as unknown as OpenClawConfig,
-        channel: "demo-thread",
+        channel: "discord",
         groupId: "999",
-        parentSessionKey: "agent:main:demo-thread:channel:123:thread:456",
+        parentSessionKey: "agent:main:discord:channel:123:thread:456",
       },
       expected: { model: "demo-provider/demo-parent-model", matchKey: "123" },
     },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a model-override parent-key test spends tens of seconds discovering real plugins instead of exercising its registered channel fixture. The case took 94.120 seconds in main CI run 34511630079.

## Why This Change Was Made

Use the existing registered Discord fixture for generic thread-parent matching. A prior fixture rename left the case using an unregistered channel ID, so it entered bundled discovery and activation before falling back to generic parsing. The shared registry already provides the required generic thread resolver.

Keep the same unrelated group ID, parent/thread IDs, selected model and match-key assertions. Explicit absent-plugin and bundled-fallback cases remain in the unchanged session-conversation suites. No production code, mock, worker, timeout, cache or shard policy changes.

## User Impact

Faster test execution with the same 19 model-override cases and assertions. No application behavior change. Test-only delta: +4/-3; production and test support: zero.

## Evidence

Same focused wrapper command and existing CI one-worker setting, original/candidate/restored-original:

| Measurement | Original | Candidate | Restored original |
| --- | ---: | ---: | ---: |
| Parent-key case | 21.618s | 0.001s | 19.504s |
| Whole command | 35.83s | 9.30s | 27.28s |
| Passed cases | 19 | 19 | 19 |

The restored original remains slow after warmed runs, establishing the fixture effect rather than just cache warming. Final candidate plus both session-conversation sibling files passed all 29 cases. Formatting and the complete selected changed-file gate passed. Independent P2 review found no actionable findings.

The local timings used Node 24.19.0 and pnpm 12.3.4; they are not a CI-wide speedup estimate. In the observed [artifact-check job](https://github.com/openclaw/openclaw/actions/runs/34511630079/job/102987911239), the channels command overlapped other readers, so removing this case's 94-second cost cannot be subtracted directly from the whole workflow.
