### PR TITLE
perf(plugins): avoid temporary collections in provider policy lookup

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -8,6 +8,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { createPluginManifestRecordFixture } from "./plugin-metadata.test-support.js";
 import { resolveDirectBundledProviderPolicySurface } from "./provider-policy-surface.js";
 import {
   listTrustedExternalProviderPolicyOwners,
@@ -78,6 +79,120 @@ describe("provider public artifacts", () => {
       expect(resolveProviderPolicySurface(providerId)).toBeNull();
     },
   );
+
+  it.each([
+    [" FIXTURE-TEXT ", true],
+    [" fixture-cli ", true],
+    ["FIXTURE-EMBEDDING", true],
+    [" TEXT-ALIAS ", true],
+    ["cli-alias", true],
+    ["embedding-alias", true],
+    ["orphan-alias", false],
+    ["scoped-alias", false],
+    ["empty-target", false],
+    ["setup-only", false],
+    ["setup-cli", false],
+    [" ", true],
+  ] as const)("preserves declared policy ownership for %j", (query, matches) => {
+    const owner = createPluginManifestRecordFixture({
+      id: "fixture-owner",
+      origin: "global",
+      trustedOfficialInstall: true,
+      providers: [" fixture-text "],
+      cliBackends: [" FIXTURE-CLI "],
+      contracts: { embeddingProviders: [" fixture-embedding "] },
+      setup: { providers: [{ id: "setup-only" }], cliBackends: ["setup-cli"] },
+      providerAuthAliases: {
+        " text-alias ": " fixture-text ",
+        "cli-alias": "fixture-cli",
+        "embedding-alias": "fixture-embedding",
+        "orphan-alias": "missing",
+        "scoped-alias": { provider: "fixture-text", baseUrls: ["https://fixture.example.test"] },
+        "empty-target": " ",
+        "": "fixture-text",
+      },
+    });
+
+    expect(listTrustedExternalProviderPolicyOwners(query, { plugins: [owner] })).toEqual(
+      matches ? [owner] : [],
+    );
+  });
+
+  it("does not treat empty declarations as policy ownership", () => {
+    const owner = createPluginManifestRecordFixture({
+      id: "empty-owner",
+      trustedOfficialInstall: true,
+      providers: [""],
+      cliBackends: [" "],
+      contracts: { embeddingProviders: [""] },
+      providerAuthAliases: { empty: " " },
+    });
+    for (const query of ["", " ", "empty"]) {
+      expect(listTrustedExternalProviderPolicyOwners(query, { plugins: [owner] })).toEqual([]);
+    }
+  });
+
+  it("orders trusted external matches stably without reordering the registry", () => {
+    const owner = (id: string, rootDir: string, trustedOfficialInstall = true) =>
+      createPluginManifestRecordFixture({
+        id,
+        rootDir,
+        origin: "global",
+        trustedOfficialInstall,
+        providers: ["fixture-provider"],
+      });
+    const last = owner("z-owner", "/fixture/z");
+    const first = owner("a-owner", "/fixture/first");
+    const equal = owner("a-owner", "/fixture/equal");
+    const untrusted = owner("0-owner", "/fixture/untrusted", false);
+    const plugins = [last, first, untrusted, equal];
+
+    expect(listTrustedExternalProviderPolicyOwners("fixture-provider", { plugins })).toEqual([
+      first,
+      equal,
+      last,
+    ]);
+    expect(plugins).toEqual([last, first, untrusted, equal]);
+  });
+
+  it("selects the first equal-id bundled owner in stable lexical order", async () => {
+    vi.doMock("./bundled-dir.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./bundled-dir.js")>()),
+      resolveBundledPluginsDir: () => "/fixture",
+    }));
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleFromCandidatesSync: ({
+        dirName,
+      }: {
+        dirName: string;
+      }) =>
+        dirName.endsWith("-root")
+          ? { resolveThinkingProfile: () => ({ levels: [{ id: dirName }] }) }
+          : null,
+    }));
+    const { resolveBundledProviderPolicySurface: resolvePolicySurface } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=stable-owner-order");
+    const owner = (id: string, root: string) =>
+      createPluginManifestRecordFixture({
+        id,
+        rootDir: `/fixture/${root}-root`,
+        providers: ["fixture-provider"],
+      });
+    const last = owner("z-owner", "last");
+    const first = owner("a-owner", "first");
+    const equal = owner("a-owner", "equal");
+    const external = { ...owner("0-owner", "external"), origin: "global" as const };
+    const earlierUnrelated = { ...owner("0-unrelated", "unrelated"), providers: ["other"] };
+    const plugins = [last, external, first, earlierUnrelated, equal];
+
+    expect(
+      resolvePolicySurface("fixture-provider", {
+        manifestRegistry: { plugins },
+      })?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "demo" }),
+    ).toEqual({ levels: [{ id: "first-root" }] });
+    expect(plugins).toEqual([last, external, first, earlierUnrelated, equal]);
+  });
 
   it("loads a lightweight bundled provider policy artifact smoke", () => {
     const surface = resolveBundledProviderPolicySurface("openai");

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -35,40 +35,50 @@ function resolveBundledProviderPolicyPlugin(
     options.manifestRegistry ??
     options.loadManifestRegistry?.() ??
     loadPluginManifestRegistryCore();
-  for (const plugin of registry.plugins.toSorted((left, right) =>
-    left.id.localeCompare(right.id),
-  )) {
-    if (plugin.origin !== "bundled") {
+  let owner: PluginManifestRegistry["plugins"][number] | null = null;
+  for (const plugin of registry.plugins) {
+    if (plugin.origin !== "bundled" || (owner && owner.id.localeCompare(plugin.id) <= 0)) {
       continue;
     }
     if (pluginOwnsProviderPolicyRef(plugin, normalizedProviderId)) {
-      return plugin;
+      owner = plugin;
     }
   }
 
-  return null;
+  return owner;
+}
+
+function pluginDeclaresProviderPolicyRef(
+  plugin: PluginManifestRegistry["plugins"][number],
+  normalizedProviderId: string,
+): boolean {
+  const matches = (provider: string) => normalizeProviderId(provider) === normalizedProviderId;
+  return Boolean(
+    normalizedProviderId &&
+    (plugin.providers.some(matches) ||
+      plugin.cliBackends.some(matches) ||
+      plugin.contracts?.embeddingProviders?.some(matches)),
+  );
 }
 
 function pluginOwnsProviderPolicyRef(
   plugin: PluginManifestRegistry["plugins"][number],
   normalizedProviderId: string,
 ): boolean {
-  const ownedProviders = new Set(
-    [...plugin.providers, ...plugin.cliBackends, ...(plugin.contracts?.embeddingProviders ?? [])]
-      .map((provider) => normalizeProviderId(provider))
-      .filter(Boolean),
-  );
-  if (ownedProviders.has(normalizedProviderId)) {
+  if (pluginDeclaresProviderPolicyRef(plugin, normalizedProviderId)) {
     return true;
   }
 
-  for (const [rawAlias, rawTarget] of Object.entries(plugin.providerAuthAliases ?? {})) {
-    const alias = normalizeProviderId(rawAlias);
-    if (typeof rawTarget !== "string") {
-      continue;
-    }
-    const target = normalizeProviderId(rawTarget);
-    if (alias === normalizedProviderId && ownedProviders.has(target)) {
+  const aliases = plugin.providerAuthAliases;
+  if (!aliases) {
+    return false;
+  }
+  for (const [rawAlias, rawTarget] of Object.entries(aliases)) {
+    if (
+      typeof rawTarget === "string" &&
+      normalizeProviderId(rawAlias) === normalizedProviderId &&
+      pluginDeclaresProviderPolicyRef(plugin, normalizeProviderId(rawTarget))
+    ) {
       return true;
     }
   }
@@ -149,10 +159,10 @@ export function listTrustedExternalProviderPolicyOwners(
 ) {
   const normalizedProviderId = normalizeProviderId(providerId);
   return manifestRegistry.plugins
-    .toSorted((left, right) => left.id.localeCompare(right.id))
     .filter(
       (plugin) =>
         plugin.trustedOfficialInstall === true &&
         pluginOwnsProviderPolicyRef(plugin, normalizedProviderId),
-    );
+    )
+    .toSorted((left, right) => left.id.localeCompare(right.id));
 }


### PR DESCRIPTION
Closes #144288

## What Problem This Solves

Provider policy lookup repeatedly constructs a normalized ownership Set for each plugin and sorts the whole registry before selecting matching owners. This duplicates allocation on a path used to resolve lightweight provider artifacts.

## Why This Change Was Made

Check declared provider, CLI backend and embedding IDs directly. Resolve simple aliases only against those same declarations, and return early when aliases are absent. Bundled lookup tracks the first matching owner in the existing stable lexical order; external lookup sorts only the filtered matches. The registry remains unchanged.

## User Impact

Provider selection, normalization, alias scope, trust filtering and equal-ID ordering are preserved. No public API, configuration, schema, persistence or migration behavior changes. The change adds 10 production lines to replace repeated temporary collections with direct selection.

## Evidence

Both source versions pass the same 43 owner tests. Twelve fresh interleaved processes verify identical ordered outputs for two synthetic workloads with 256 records, seven queries and 8,000 measured calls per run. Median sampled allocation falls from 1,944,606,240 to 980,339,352 bytes for external lookup (49.6%) and from 1,786,972,640 to 978,775,496 bytes for bundled lookup (45.2%). The measurement includes all sampled nodes in the isolated interval, including moved helper work and collected objects; it does not establish retained heap, whole-Gateway RSS or latency savings.

The full selected changed gate, normal build and fresh independent P2 review pass. An initial lint failure required changing filtered sort to toSorted; the final source was reviewed and remeasured, and all required checks passed afterward.
