### PR TITLE
fix(agents): avoid sibling output limits for unlisted models

### DIFF
--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -156,10 +156,7 @@ export function buildConfiguredFallbackModel(params: {
     compat: fallbackCompat,
     reasoning: metadataModel?.reasoning,
   });
-  const configuredFallbackMaxTokens =
-    configuredModel?.maxTokens ??
-    providerConfig?.maxTokens ??
-    providerConfig?.models?.[0]?.maxTokens;
+  const configuredFallbackMaxTokens = configuredModel?.maxTokens ?? providerConfig?.maxTokens;
   const resolvedFallbackMaxTokens = configuredFallbackMaxTokens ?? staticCatalogModel?.maxTokens;
   const resolvedFallbackContextWindow =
     configuredModel?.contextWindow ?? staticCatalogModel?.contextWindow ?? DEFAULT_CONTEXT_TOKENS;

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1929,6 +1929,20 @@ describe("resolveModel", () => {
     expect(model.api).toBe("openai-completions");
   });
 
+  it("does not inherit an unrelated configured row's maxTokens for an unlisted fallback model", async () => {
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      models: [{ id: "listed-model", name: "listed-model", contextWindow: 32_768, maxTokens: 128 }],
+    });
+
+    const result = await resolveModelForTest("custom", "missing-model", state.agentDir(), cfg);
+    const model = expectResolvedModel(result);
+
+    expect(model.id).toBe("missing-model");
+    expect(model.maxTokens).toBeUndefined();
+    expect(model).not.toHaveProperty("maxTokensSource");
+  });
+
   it("defaults baseUrl-only Google fallback models to native Gemini transport", async () => {
     const cfg = makeProviderConfig("google", {
       baseUrl: "https://generativelanguage.googleapis.com",


### PR DESCRIPTION
Closes #144160

## What Problem This Solves

An unlisted model on a configured custom provider could inherit the first listed model's output limit. A sibling row capped at 128 therefore caused requests for another model to send that same cap without an authored limit for the selected model.

## Why This Change Was Made

Remove the positional sibling-row fallback from the existing model resolver. Matching model limits, explicit provider defaults, and matching catalog metadata keep their existing precedence. An unknown limit stays unset; context-window fallback and transport guards are unchanged.

## User Impact

Unlisted models no longer receive another model's output cap. Explicit limits, known model ceilings, and the remaining context budget still constrain requests normally.

## Evidence

- Packaged baseline `bc63d63bcb7c` and candidate `80d367abe52e` ran the public `openclaw agent --local --agent main --model ... --json` command against a real loopback OpenAI-compatible HTTP endpoint, with synthetic credentials and the OpenClaw runtime.
- Baseline sent `max_completion_tokens: 128` for an unlisted model whose only sibling row had that cap. Candidate sent neither `max_tokens` nor `max_completion_tokens`. Both selected the requested model and completed with the fixture's `OK` response.
- Nine matched public controls preserved listed limits, provider defaults, row precedence, compatibility field choice and headers, a genuine Mistral catalog limit, native-context clamping, public parameter precedence, and known model ceilings. Both comparison packages included the same genuine Mistral plugin; no catalog sizing was inserted into the fixture config.
- The new regression fails on the original owner with `expected 128 to be undefined`. With the fix, 167 model-resolution tests and 13 managed-transport tests pass. Formatting, targeted lint, line-count and assertion-safety checks pass; the normal commit hook ran on the isolated runner.
- Independent acceptance checked 11 fresh public requests, including unknown limits, provider defaults, real catalog metadata, headers, alias selection, and bounded public overrides.
- Additional same-input baseline controls confirm that larger public output overrides remain bounded by a listed model's known cap, and that shaped prompt/tool input can reduce the final output allowance below the native ceiling.

The HTTP endpoint supplies deterministic protocol responses. This proves actual request construction and response handling, not natural-model truncation behavior. Internal provenance labels are separate from HTTP fields; the configured catalog control preserves the catalog-derived numeric limit without claiming that the wire exposes its source label.
