### PR TITLE
fix(devices): report available memory instead of raw free pages on macOS

### DIFF
--- a/docs/gateway/protocol/presence.md
+++ b/docs/gateway/protocol/presence.md
@@ -55,7 +55,9 @@ encoding in `payloadJSON`):
 1-, 5-, and 15-minute averages, each finite and between 0 and 100000. Windows
 has no load average; hosts omit the field when all three readings are zero.
 Memory and disk values are non-negative integer bytes, with free or available
-bytes no greater than their total. Disk fields appear together only when the
+bytes no greater than their total. `memoryFreeBytes` counts free plus reclaimable
+memory (Node's available-memory reading), so idle file cache on macOS is not
+reported as used. Disk fields appear together only when the
 host can read capacity for the volume containing its home directory, independent
 of the worker's current directory.
 

--- a/src/gateway/server-methods/system-info.test.ts
+++ b/src/gateway/server-methods/system-info.test.ts
@@ -42,6 +42,7 @@ describe("system.info", () => {
     sampleTime += 10_001;
     vi.spyOn(Date, "now").mockReturnValue(sampleTime);
     vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(process, "availableMemory").mockReturnValue(4096);
     mocks.runCommandWithTimeout.mockReset().mockImplementation(mountedVolumeOutput);
   });
   afterEach(() => vi.restoreAllMocks());
@@ -76,6 +77,7 @@ describe("system.info", () => {
     }
     expect(payload.cpuCount).toBeGreaterThanOrEqual(1);
     expect(payload.memoryTotalBytes).toBeGreaterThan(0);
+    expect(payload.memoryFreeBytes).toBe(4096);
     expect(payload.processInstanceId).toBe(getGatewayProcessInstanceId());
     expect(payload.uptimeMs).toBeGreaterThanOrEqual(0);
     expect(payload.defaultAgentUtilityModel).toEqual({ status: "unavailable" });

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -32,6 +32,7 @@ import {
 import { tryReadDiskSpace } from "../../infra/disk-space.js";
 import { getLastHeartbeatEvent } from "../../infra/heartbeat-events.js";
 import { requestHeartbeat, setHeartbeatsEnabled } from "../../infra/heartbeat-wake.js";
+import { readHostFreeMemoryBytes } from "../../infra/host-memory.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { readSystemDisks } from "../../infra/system-disks.js";
@@ -101,7 +102,7 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
     ...(cpuModel ? { cpuModel } : {}),
     ...(loadAverage.some((value) => value !== 0) ? { loadAverage } : {}),
     memoryTotalBytes: os.totalmem(),
-    memoryFreeBytes: os.freemem(),
+    memoryFreeBytes: readHostFreeMemoryBytes(),
     // Keep the existing state-volume reading when native discovery is unavailable;
     // an empty successful discovery intentionally stays empty.
     disks:

--- a/src/infra/host-memory.ts
+++ b/src/infra/host-memory.ts
@@ -1,0 +1,11 @@
+import os from "node:os";
+
+/**
+ * Host memory that is free or reclaimable. libuv's free-memory reading counts only
+ * free pages on Darwin, so idle Macs report nearly full memory; the available-memory
+ * reading also counts inactive and purgeable pages. It reports 0 where unsupported.
+ */
+export function readHostFreeMemoryBytes(): number {
+  const available = process.availableMemory();
+  return available > 0 ? available : os.freemem();
+}

--- a/src/node-host/host-stats.test.ts
+++ b/src/node-host/host-stats.test.ts
@@ -18,7 +18,7 @@ it("bounds OS readings and reports available space on the home volume", () => {
   vi.spyOn(os, "cpus").mockReturnValue([]);
   vi.spyOn(os, "loadavg").mockReturnValue([1.25, -1, 100_001]);
   vi.spyOn(os, "totalmem").mockReturnValue(100.4);
-  vi.spyOn(os, "freemem").mockReturnValue(200);
+  vi.spyOn(process, "availableMemory").mockReturnValue(40);
   const disk = vi.spyOn(diskSpace, "tryReadDiskSpace").mockReturnValue({
     targetPath: os.homedir(),
     checkedPath: os.homedir(),
@@ -31,12 +31,18 @@ it("bounds OS readings and reports available space on the home volume", () => {
     cpuCount: 1,
     loadAverage: [1.25, 0, 100_000],
     memoryTotalBytes: 100,
-    memoryFreeBytes: 100,
+    memoryFreeBytes: 40,
     diskTotalBytes: 500,
     diskAvailableBytes: 500,
   });
   expect(disk).toHaveBeenCalledWith(os.homedir());
   expect(validateNodeHostStatsPayload(stats)).toBe(true);
+});
+
+it("falls back to free memory where the runtime cannot read available memory", () => {
+  vi.spyOn(process, "availableMemory").mockReturnValue(0);
+  vi.spyOn(os, "freemem").mockReturnValue(4096);
+  expect(sampleNodeHostStats().memoryFreeBytes).toBe(4096);
 });
 
 it.each([

--- a/src/node-host/host-stats.ts
+++ b/src/node-host/host-stats.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import type { NodeHostStatsPayload } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import { tryReadDiskSpace } from "../infra/disk-space.js";
+import { readHostFreeMemoryBytes } from "../infra/host-memory.js";
 
 function clampFinite(value: number, maximum = Number.MAX_SAFE_INTEGER): number {
   return Number.isFinite(value) ? Math.max(0, Math.min(maximum, value)) : 0;
@@ -8,7 +9,7 @@ function clampFinite(value: number, maximum = Number.MAX_SAFE_INTEGER): number {
 
 export function sampleNodeHostStats(): NodeHostStatsPayload {
   const memoryTotalBytes = Math.round(clampFinite(os.totalmem()));
-  const memoryFreeBytes = Math.round(clampFinite(os.freemem(), memoryTotalBytes));
+  const memoryFreeBytes = Math.round(clampFinite(readHostFreeMemoryBytes(), memoryTotalBytes));
   const loads = os.loadavg();
   const loadAverage: [number, number, number] = [
     clampFinite(loads[0]!, 100_000),


### PR DESCRIPTION
Closes #144176

## What Problem This Solves

Fixes an issue where the memory meter in Control UI → Devices, on both paired node rows and the Gateway row, showed close to 100% used and rendered red on any macOS host, even when the machine was idle.

## Why This Change Was Made

Both host-stat producers read `os.freemem()`, which on Darwin counts only free pages and ignores inactive and purgeable file cache, so `total - free` always lands near the total. Node's `process.availableMemory()`, available on the supported Node 24 and 26 baselines, counts reclaimable pages as well. One `readHostFreeMemoryBytes()` helper in `src/infra/host-memory.ts` now serves the node-host sampler and the Gateway `system.info` handler, and falls back to `os.freemem()` where the runtime reports no available-memory figure. The `memoryFreeBytes` wire field and the meter's 80/90% thresholds are unchanged; the field's meaning is stated in the presence protocol doc.

Not changed: the issue's `debug.overlay.memoryMb` claim concerns process heap, a different diagnostic that matches its current implementation.

## User Impact

macOS operators see a memory meter that reflects memory actually under pressure instead of a permanent danger-level shortage. Linux and Windows readings are unchanged, because libuv already reports available memory there (verified on this Linux host: `os.freemem()` and `process.availableMemory()` both return the `MemAvailable` figure).

## Evidence

- `src/node-host/host-stats.test.ts` drives the sampler through `process.availableMemory` (fails on main, where the sampler still reads `os.freemem`) and covers the free-memory fallback; `system-info.test.ts` asserts the Gateway row uses the same reader.
- `node scripts/run-vitest.mjs src/node-host/host-stats.test.ts src/gateway/server-methods/system-info.test.ts packages/gateway-protocol/src/schema/nodes.test.ts`: all passed.
- Not captured: a live macOS Control UI screenshot; this devbox is Linux. The Darwin difference is libuv's `uv_get_free_memory` (free_count only) versus `uv_get_available_memory` (free + inactive + purgeable) in `deps/uv/src/unix/darwin.c`.
- `pnpm check:changed`: pending, will update.
