### PR TITLE
refactor(msteams): decode inline images during materialization

### DIFF
--- a/extensions/msteams/src/attachments.helpers.test.ts
+++ b/extensions/msteams/src/attachments.helpers.test.ts
@@ -121,17 +121,10 @@ describe("msteams attachment helpers", () => {
       expect(resolveMSTeamsAdvertisedMedia(attachments)).toEqual(expected);
     });
 
-    it("preserves an inline image fact when materialization limits reject it", () => {
-      const attachments = [
-        createHtmlAttachment(`<img src="data:image/png;base64,${"A".repeat(16)}" />`),
-      ];
+    it("preserves an inline image fact for malformed base64", () => {
+      const attachments = [createHtmlAttachment('<img src="data:image/png;base64,A!AA" />')];
 
-      expect(
-        resolveMSTeamsAdvertisedMedia(attachments, {
-          maxInlineBytes: 4,
-          maxInlineTotalBytes: 4,
-        }),
-      ).toEqual([{ kind: "image" }]);
+      expect(resolveMSTeamsAdvertisedMedia(attachments)).toEqual([{ kind: "image" }]);
     });
 
     it("aligns Graph hosted-content image URLs with their fallback resource id", () => {

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -1,4 +1,5 @@
 // Msteams tests cover attachments plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime, SsrFPolicy } from "../runtime-api.js";
 import { readRemoteMediaResponse } from "./attachments.test-helpers.js";
@@ -140,7 +141,7 @@ const runtimeStub = {
 type DownloadAttachmentsParams = Parameters<typeof downloadMSTeamsAttachments>[0];
 type DownloadedMedia = Awaited<ReturnType<typeof downloadMSTeamsAttachments>>;
 type DownloadAttachmentsBuildOverrides = Partial<
-  Omit<DownloadAttachmentsParams, "attachments" | "maxBytes" | "allowHosts">
+  Omit<DownloadAttachmentsParams, "attachments" | "allowHosts">
 > &
   Pick<DownloadAttachmentsParams, "allowHosts">;
 type DownloadAttachmentsNoFetchOverrides = Partial<
@@ -407,15 +408,166 @@ describe("msteams attachments", () => {
       runAttachmentDownloadSuccessCase,
     );
 
-    it("stores inline data:image base64 payloads", async () => {
-      const media = await downloadMSTeamsAttachments(
-        buildDownloadParams([
-          ...createHtmlImageAttachments([`data:image/png;base64,${PNG_BASE64}`]),
-        ]),
+    it.each([
+      ["AA==", "00"],
+      ["AAA=", "0000"],
+      ["AAAA", "000000"],
+      ["Z E = =", "64"],
+      ["A\tA==", "00"],
+    ])("preserves inline bytes and exact size limits for %s", async (payload, hex) => {
+      const data = Buffer.from(hex, "hex");
+      const attachments = createHtmlImageAttachments([`data:image/png;base64,${payload}`]);
+
+      await expect(
+        downloadMSTeamsAttachments(buildDownloadParams(attachments, { maxBytes: data.length - 1 })),
+      ).resolves.toEqual([{ kind: "image" }]);
+      expect(detectMimeMock).not.toHaveBeenCalled();
+      expect(saveMediaBufferMock).not.toHaveBeenCalled();
+
+      await expect(
+        downloadMSTeamsAttachments(buildDownloadParams(attachments, { maxBytes: data.length })),
+      ).resolves.toEqual([
+        { path: SAVED_PNG_PATH, contentType: CONTENT_TYPE_IMAGE_PNG, kind: "image" },
+      ]);
+      expect(saveMediaBufferMock).toHaveBeenCalledExactlyOnceWith(
+        data,
+        CONTENT_TYPE_IMAGE_PNG,
+        "inbound",
+        data.length,
+      );
+    });
+
+    it.each(["aGV=sbG8=", "A===", "AA", "-AAA", "A!AA", "A\nA==", "A\u00a0A=="])(
+      "keeps malformed inline base64 %s pathless without consuming the budget",
+      async (payload) => {
+        const logger = { warn: vi.fn() };
+        await expect(
+          downloadMSTeamsAttachments(
+            buildDownloadParams(
+              createHtmlImageAttachments([
+                `data:image/png;base64,${payload}`,
+                "data:image/png;base64,AQID",
+              ]),
+              { maxBytes: 3, logger },
+            ),
+          ),
+        ).resolves.toEqual([
+          { kind: "image" },
+          { path: SAVED_PNG_PATH, contentType: CONTENT_TYPE_IMAGE_PNG, kind: "image" },
+        ]);
+        expect(detectMimeMock).toHaveBeenCalledOnce();
+        expect(saveMediaBufferMock.mock.calls.map(([data]) => data)).toEqual([
+          Buffer.from([1, 2, 3]),
+        ]);
+        expect(logger.warn).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      { maxBytes: 9, saved: [true, false, false] },
+      { maxBytes: 10, saved: [true, true, false] },
+    ])(
+      "enforces the $maxBytes-byte inline budget across attachments",
+      async ({ maxBytes, saved }) => {
+        const attachments = [0, 1, 2].map(() =>
+          createHtmlAttachment(buildHtmlImageTag("data:image/png;base64,aGVsbG8=")),
+        );
+        const media = await downloadMSTeamsAttachments(
+          buildDownloadParams(attachments, { maxBytes }),
+        );
+
+        expect(media.map((item) => Boolean(item.path))).toEqual(saved);
+        expect(media.map((item) => item.kind)).toEqual(["image", "image", "image"]);
+        expect(saveMediaBufferMock.mock.calls.map(([data]) => data)).toEqual(
+          saved.filter(Boolean).map(() => Buffer.from("hello")),
+        );
+      },
+    );
+
+    it.each(["successful save", "MIME rejection", "MIME error", "save error"])(
+      "keeps the inline budget after %s and leaves room after cumulative rejection",
+      async (failure) => {
+        const logger = { warn: vi.fn() };
+        const error = new Error("inline processing failed");
+        if (failure === "MIME rejection") {
+          detectMimeMock.mockResolvedValueOnce(CONTENT_TYPE_APPLICATION_ZIP);
+        } else if (failure === "MIME error") {
+          detectMimeMock.mockRejectedValueOnce(error);
+        } else if (failure === "save error") {
+          saveMediaBufferMock.mockRejectedValueOnce(error);
+        }
+        const media = await downloadMSTeamsAttachments(
+          buildDownloadParams(
+            createHtmlImageAttachments([
+              "data:image/png;base64,aGVsbG8=",
+              "data:image/png;base64,QUJDRA==",
+              "data:image/png;base64,AQID",
+            ]),
+            { maxBytes: 8, logger },
+          ),
+        );
+
+        const savedImage = {
+          path: SAVED_PNG_PATH,
+          contentType: CONTENT_TYPE_IMAGE_PNG,
+          kind: "image",
+        };
+        expect(media).toEqual([
+          failure === "successful save" ? savedImage : { kind: "image" },
+          { kind: "image" },
+          savedImage,
+        ]);
+        expect(detectMimeMock).toHaveBeenCalledTimes(2);
+        expect(saveMediaBufferMock.mock.calls.map(([data]) => data)).toEqual(
+          failure === "successful save" || failure === "save error"
+            ? [Buffer.from("hello"), Buffer.from([1, 2, 3])]
+            : [Buffer.from([1, 2, 3])],
+        );
+        if (failure === "MIME error" || failure === "save error") {
+          expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+            "msteams inline attachment decode failed",
+            { error: error.message },
+          );
+        } else {
+          expect(logger.warn).not.toHaveBeenCalled();
+        }
+      },
+    );
+
+    it("keeps captured inline bytes while a leading remote download is pending", async () => {
+      const started = createDeferred<void>();
+      const response = createDeferred<Response>();
+      const firstInline = createHtmlAttachment(buildHtmlImageTag("data:image/png;base64,AQID"));
+      const secondInline = createHtmlAttachment(buildHtmlImageTag("data:image/png;base64,BAUG"));
+      const fetchMock = vi.fn(async () => {
+        started.resolve();
+        return await response.promise;
+      });
+      const pending = downloadMSTeamsAttachments(
+        buildDownloadParams(
+          [...createPdfAttachments(TEST_URL_DOC_PDF), firstInline, secondInline],
+          { fetchFn: asFetchFn(fetchMock) },
+        ),
       );
 
-      expectSingleMedia(media);
-      expectMediaBufferSaved();
+      try {
+        await Promise.race([started.promise, pending]);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        firstInline.content = buildHtmlImageTag("data:image/png;base64,BwgJ");
+        secondInline.content = buildHtmlImageTag("data:image/png;base64,CgsM");
+      } finally {
+        response.resolve(createBufferResponse(PDF_BUFFER, CONTENT_TYPE_APPLICATION_PDF));
+      }
+
+      await expect(pending).resolves.toEqual([
+        { path: SAVED_PDF_PATH, contentType: CONTENT_TYPE_APPLICATION_PDF, kind: "document" },
+        { path: SAVED_PNG_PATH, contentType: CONTENT_TYPE_IMAGE_PNG, kind: "image" },
+        { path: SAVED_PNG_PATH, contentType: CONTENT_TYPE_IMAGE_PNG, kind: "image" },
+      ]);
+      expect(saveMediaBufferMock.mock.calls.map(([data]) => data)).toEqual([
+        Buffer.from([1, 2, 3]),
+        Buffer.from([4, 5, 6]),
+      ]);
     });
 
     it("preserves the advertised image kind when an inline URL has an opaque MIME", async () => {
@@ -447,20 +599,6 @@ describe("msteams attachments", () => {
       );
 
       expect(media).toEqual([{ kind: "document", sourceId: "graph-file-1" }]);
-    });
-
-    it("skips inline data:image payloads whose bytes sniff as non-image", async () => {
-      detectMimeMock.mockResolvedValueOnce(CONTENT_TYPE_APPLICATION_ZIP);
-
-      const media = await downloadMSTeamsAttachments(
-        buildDownloadParams([
-          ...createHtmlImageAttachments([`data:image/png;base64,${PNG_BASE64}`]),
-        ]),
-      );
-
-      expectAttachmentMediaLength(media, 1);
-      expect(media[0]).toEqual({ kind: "image" });
-      expect(saveMediaBufferMock).not.toHaveBeenCalled();
     });
 
     it.each<AttachmentAuthRetryCase>(ATTACHMENT_AUTH_RETRY_CASES)(

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -11,10 +11,10 @@ import {
   withMSTeamsRequestDeadline,
 } from "../request-timeout.js";
 import { getMSTeamsRuntime } from "../runtime.js";
-import { resolveMSTeamsAdvertisedMedia } from "./html.js";
+import { resolveUnrepresentedHtmlAttachmentIds } from "./html.js";
 import { downloadAndStoreMSTeamsRemoteMedia } from "./remote-media.js";
 import {
-  extractInlineImageCandidates,
+  extractInlineImageReferences,
   isAdvertisedFileAttachment,
   isDownloadableAttachment,
   isRecord,
@@ -49,8 +49,7 @@ type DownloadCandidate =
   | {
       kind: "data";
       mediaKind: "image";
-      data: Buffer;
-      contentType?: string;
+      src: string;
       sourceId?: string;
     }
   | { kind: "unavailable"; mediaKind: MSTeamsInboundMedia["kind"]; sourceId?: string };
@@ -129,6 +128,74 @@ function scopeCandidatesForUrl(url: string): string[] {
       : ["https://api.botframework.com", "https://graph.microsoft.com"];
   } catch {
     return ["https://api.botframework.com", "https://graph.microsoft.com"];
+  }
+}
+
+function canonicalizeInlineBase64Payload(value: string): string | undefined {
+  let cleaned = "";
+  let padding = 0;
+  let sawPadding = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20) {
+      continue;
+    }
+    if (code === 0x3d) {
+      padding += 1;
+      if (padding > 2) {
+        return undefined;
+      }
+      sawPadding = true;
+      cleaned += "=";
+      continue;
+    }
+    const isDataChar =
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code === 0x2b ||
+      code === 0x2f;
+    if (sawPadding || !isDataChar) {
+      return undefined;
+    }
+    cleaned += value[index];
+  }
+  return cleaned && cleaned.length % 4 === 0 ? cleaned : undefined;
+}
+
+function decodeInlineDataImage(
+  src: string,
+  maxBytes: number,
+  totalBytes: number,
+): { data: Buffer; contentType: string; estimatedBytes: number } | null {
+  const match = /^data:(image\/[a-z0-9.+-]+)?(;base64)?,(.*)$/i.exec(src);
+  if (!match) {
+    return null;
+  }
+  const contentType = normalizeLowercaseStringOrEmpty(match[1] ?? "");
+  const isBase64 = Boolean(match[2]);
+  if (!isBase64) {
+    return null;
+  }
+  const payload = match[3] ?? "";
+  const canonicalPayload = canonicalizeInlineBase64Payload(payload);
+  if (!canonicalPayload) {
+    return null;
+  }
+
+  // Validation above guarantees whitespace-free base64 for this allocation-free size check.
+  const estimatedBytes = Buffer.byteLength(canonicalPayload, "base64");
+  if (
+    estimatedBytes <= 0 ||
+    (typeof maxBytes === "number" &&
+      (estimatedBytes > maxBytes || totalBytes + estimatedBytes > maxBytes))
+  ) {
+    return null;
+  }
+  try {
+    return { data: Buffer.from(canonicalPayload, "base64"), contentType, estimatedBytes };
+  } catch {
+    return null;
   }
 }
 
@@ -265,17 +332,14 @@ export async function downloadMSTeamsAttachments(params: {
         }
       );
     });
+  const maxInlineBytes = params.maxBytes;
   candidates.push(
-    ...extractInlineImageCandidates(list, {
-      maxInlineBytes: params.maxBytes,
-      maxInlineTotalBytes: params.maxBytes,
-    }).map((candidate): DownloadCandidate => {
+    ...extractInlineImageReferences(list).map((candidate): DownloadCandidate => {
       if (candidate.kind === "data") {
         return {
           kind: "data",
           mediaKind: "image",
-          data: candidate.data,
-          contentType: candidate.contentType,
+          src: candidate.src,
           sourceId: candidate.sourceId,
         };
       }
@@ -292,15 +356,11 @@ export async function downloadMSTeamsAttachments(params: {
       return { kind: "unavailable", mediaKind: "image", sourceId: candidate.sourceId };
     }),
   );
-  const advertisedMedia = resolveMSTeamsAdvertisedMedia(list, {
-    maxInlineBytes: params.maxBytes,
-    maxInlineTotalBytes: params.maxBytes,
-  });
-  for (const advertised of advertisedMedia.slice(candidates.length)) {
+  for (const sourceId of resolveUnrepresentedHtmlAttachmentIds(list)) {
     candidates.push({
       kind: "unavailable",
-      mediaKind: advertised.kind,
-      sourceId: advertised.sourceId,
+      mediaKind: "document",
+      sourceId,
     });
   }
   if (candidates.length === 0) {
@@ -308,20 +368,28 @@ export async function downloadMSTeamsAttachments(params: {
   }
 
   const out: MSTeamsInboundMedia[] = [];
+  let totalInlineBytes = 0;
   for (const candidate of candidates) {
     if (candidate.kind === "unavailable") {
       out.push(withSourceId({ kind: candidate.mediaKind }, candidate.sourceId));
       continue;
     }
     if (candidate.kind === "data") {
+      const decoded = decodeInlineDataImage(candidate.src, maxInlineBytes, totalInlineBytes);
+      if (!decoded) {
+        out.push(withSourceId({ kind: candidate.mediaKind }, candidate.sourceId));
+        continue;
+      }
+      // Accepted bytes still consume the message budget when MIME detection or saving fails.
+      totalInlineBytes += decoded.estimatedBytes;
       try {
-        const contentType = await resolveInlineDataImageMime(candidate);
+        const contentType = await resolveInlineDataImageMime(decoded);
         if (!contentType) {
           out.push(withSourceId({ kind: candidate.mediaKind }, candidate.sourceId));
           continue;
         }
         const saved = await getMSTeamsRuntime().channel.media.saveMediaBuffer(
-          candidate.data,
+          decoded.data,
           contentType,
           "inbound",
           params.maxBytes,

--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -2,7 +2,7 @@
 import {
   ATTACHMENT_TAG_RE,
   extractHtmlFromAttachment,
-  extractInlineImageCandidates,
+  extractInlineImageReferences,
   IMG_SRC_RE,
   isAdvertisedFileAttachment,
   isLikelyImageAttachment,
@@ -111,7 +111,9 @@ export function summarizeMSTeamsHtmlAttachments(
   };
 }
 
-function resolveUnrepresentedHtmlAttachmentIds(attachments: MSTeamsAttachmentLike[]): string[] {
+export function resolveUnrepresentedHtmlAttachmentIds(
+  attachments: MSTeamsAttachmentLike[],
+): string[] {
   const representedIds = new Set<string>();
   for (const attachment of attachments) {
     const contentType = normalizeContentType(attachment.contentType) ?? "";
@@ -139,14 +141,13 @@ function createAdvertisedMediaFact(
 
 export function resolveMSTeamsAdvertisedMedia(
   attachments: MSTeamsAttachmentLike[] | undefined,
-  limits?: { maxInlineBytes?: number; maxInlineTotalBytes?: number },
 ): MSTeamsInboundMedia[] {
   const list = Array.isArray(attachments) ? attachments : [];
   if (list.length === 0) {
     return [];
   }
   const fileAttachments = list.filter(isAdvertisedFileAttachment);
-  const inlineMedia = extractInlineImageCandidates(list, limits).map((candidate) =>
+  const inlineMedia = extractInlineImageReferences(list).map((candidate) =>
     createAdvertisedMediaFact("image", candidate.sourceId),
   );
   // Teams HTML uses <attachment> tags as references. A matching attachment

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyAuthorizationHeaderForUrl,
   encodeGraphShareId,
-  extractInlineImageCandidates,
   isDownloadableAttachment,
   isLikelyImageAttachment,
   isUrlAllowed,
@@ -640,74 +639,6 @@ describe("Graph shared-link helpers", () => {
     expect(tryBuildGraphSharesUrlForSharedLink("https://example.com/file.pdf")).toBeUndefined();
     expect(tryBuildGraphSharesUrlForSharedLink("not-a-url")).toBeUndefined();
   });
-});
-
-describe("msteams inline image limits", () => {
-  const smallPngDataUrl = "data:image/png;base64,aGVsbG8="; // "hello" (5 bytes)
-
-  it.each([
-    ["AA==", "00"],
-    ["AAA=", "0000"],
-    ["AAAA", "000000"],
-    ["Z E = =", "64"],
-    ["A\tA==", "00"],
-  ])("enforces exact decoded-size limits for %s", (payload, hex) => {
-    const data = Buffer.from(hex, "hex");
-    const attachments = [
-      {
-        contentType: "text/html",
-        content: `<img src="data:image/png;base64,${payload}" />`,
-      },
-    ];
-    expect(
-      extractInlineImageCandidates(attachments, { maxInlineBytes: data.length - 1 }),
-    ).toStrictEqual([{ kind: "unavailable" }]);
-    expect(
-      extractInlineImageCandidates(attachments, { maxInlineBytes: data.length }),
-    ).toStrictEqual([{ kind: "data", data, contentType: "image/png" }]);
-  });
-
-  it.each(["aGV=sbG8=", "A===", "AA", "-AAA", "A!AA"])(
-    "rejects malformed inline base64 %s",
-    (payload) => {
-      const attachments = [
-        {
-          contentType: "text/html",
-          content: `<img src="data:image/png;base64,${payload}" />`,
-        },
-      ];
-      const out = extractInlineImageCandidates(attachments, { maxInlineBytes: 10 });
-      expect(out).toStrictEqual([{ kind: "unavailable" }]);
-    },
-  );
-
-  it.each([
-    [9, ["data", "unavailable", "unavailable"]],
-    [10, ["data", "data", "unavailable"]],
-  ])(
-    "enforces cumulative inline size limit %i across attachments",
-    (maxInlineTotalBytes, kinds) => {
-      const attachments = [
-        {
-          contentType: "text/html",
-          content: `<img src="${smallPngDataUrl}" />`,
-        },
-        {
-          contentType: "text/html",
-          content: `<img src="${smallPngDataUrl}" />`,
-        },
-        {
-          contentType: "text/html",
-          content: `<img src="${smallPngDataUrl}" />`,
-        },
-      ];
-      const out = extractInlineImageCandidates(attachments, {
-        maxInlineBytes: 10,
-        maxInlineTotalBytes,
-      });
-      expect(out.map((candidate) => candidate.kind)).toEqual(kinds);
-    },
-  );
 });
 
 describe("normalizeContentType case-insensitivity", () => {

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -18,11 +18,10 @@ import {
 import { MSTEAMS_REQUEST_TIMEOUT_MS } from "../request-timeout.js";
 import type { MSTeamsAttachmentLike, MSTeamsInboundMedia } from "./types.js";
 
-type InlineImageCandidate =
+type InlineImageReference =
   | {
       kind: "data";
-      data: Buffer;
-      contentType?: string;
+      src: string;
       sourceId?: string;
     }
   | {
@@ -33,11 +32,6 @@ type InlineImageCandidate =
       sourceId?: string;
     }
   | { kind: "unavailable"; sourceId?: string };
-
-type InlineImageLimitOptions = {
-  maxInlineBytes?: number;
-  maxInlineTotalBytes?: number;
-};
 
 const IMAGE_EXT_RE = /\.(avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)$/i;
 
@@ -309,77 +303,6 @@ export function extractHtmlFromAttachment(att: MSTeamsAttachmentLike): string | 
   return text;
 }
 
-function canonicalizeInlineBase64Payload(value: string): string | undefined {
-  let cleaned = "";
-  let padding = 0;
-  let sawPadding = false;
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    if (code <= 0x20) {
-      continue;
-    }
-    if (code === 0x3d) {
-      padding += 1;
-      if (padding > 2) {
-        return undefined;
-      }
-      sawPadding = true;
-      cleaned += "=";
-      continue;
-    }
-    const isDataChar =
-      (code >= 0x41 && code <= 0x5a) ||
-      (code >= 0x61 && code <= 0x7a) ||
-      (code >= 0x30 && code <= 0x39) ||
-      code === 0x2b ||
-      code === 0x2f;
-    if (sawPadding || !isDataChar) {
-      return undefined;
-    }
-    cleaned += value[index];
-  }
-  return cleaned && cleaned.length % 4 === 0 ? cleaned : undefined;
-}
-
-function decodeDataImageWithLimits(
-  src: string,
-  opts: { maxInlineBytes?: number },
-): { candidate: InlineImageCandidate | null; estimatedBytes: number } {
-  const match = /^data:(image\/[a-z0-9.+-]+)?(;base64)?,(.*)$/i.exec(src);
-  if (!match) {
-    return { candidate: null, estimatedBytes: 0 };
-  }
-  const contentType = normalizeLowercaseStringOrEmpty(match[1] ?? "");
-  const isBase64 = Boolean(match[2]);
-  if (!isBase64) {
-    return { candidate: null, estimatedBytes: 0 };
-  }
-  const payload = match[3] ?? "";
-  const canonicalPayload = canonicalizeInlineBase64Payload(payload);
-  if (!canonicalPayload) {
-    return { candidate: null, estimatedBytes: 0 };
-  }
-
-  // Validation above guarantees whitespace-free base64 for this allocation-free size check.
-  const estimatedBytes = Buffer.byteLength(canonicalPayload, "base64");
-  if (estimatedBytes <= 0) {
-    return { candidate: null, estimatedBytes: 0 };
-  }
-  if (typeof opts.maxInlineBytes === "number" && estimatedBytes > opts.maxInlineBytes) {
-    return { candidate: null, estimatedBytes };
-  }
-
-  try {
-    const data = Buffer.from(canonicalPayload, "base64");
-    return {
-      candidate: { kind: "data", data, contentType },
-      estimatedBytes,
-    };
-  } catch {
-    return { candidate: null, estimatedBytes: 0 };
-  }
-}
-
 function fileHintFromUrl(src: string): string | undefined {
   try {
     const url = new URL(src);
@@ -390,11 +313,10 @@ function fileHintFromUrl(src: string): string | undefined {
   }
 }
 
-export function extractInlineImageCandidates(
+export function extractInlineImageReferences(
   attachments: MSTeamsAttachmentLike[],
-  limits?: InlineImageLimitOptions,
-): InlineImageCandidate[] {
-  const out: InlineImageCandidate[] = [];
+): InlineImageReference[] {
+  const out: InlineImageReference[] = [];
   const seenReferences = new Set<string>();
   const representedAttachmentIds = new Set(
     attachments.flatMap((attachment) => {
@@ -402,7 +324,6 @@ export function extractInlineImageCandidates(
       return id && !extractHtmlFromAttachment(attachment) ? [id] : [];
     }),
   );
-  let totalEstimatedInlineBytes = 0;
   for (const att of attachments) {
     const html = extractHtmlFromAttachment(att);
     if (!html) {
@@ -414,23 +335,7 @@ export function extractInlineImageCandidates(
       const src = match[1]?.trim();
       if (src) {
         if (src.startsWith("data:")) {
-          const { candidate: decoded, estimatedBytes } = decodeDataImageWithLimits(src, {
-            maxInlineBytes: limits?.maxInlineBytes,
-          });
-          if (decoded) {
-            const nextTotal = totalEstimatedInlineBytes + estimatedBytes;
-            if (
-              typeof limits?.maxInlineTotalBytes === "number" &&
-              nextTotal > limits.maxInlineTotalBytes
-            ) {
-              out.push({ kind: "unavailable" });
-            } else {
-              totalEstimatedInlineBytes = nextTotal;
-              out.push(decoded);
-            }
-          } else {
-            out.push({ kind: "unavailable" });
-          }
+          out.push({ kind: "data", src });
         } else if (!seenReferences.has(src)) {
           seenReferences.add(src);
           if (src.startsWith("cid:")) {

--- a/extensions/msteams/src/monitor-handler/inbound-facts.test.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-facts.test.ts
@@ -54,7 +54,7 @@ describe("msteams inbound facts", () => {
       }),
     });
 
-    expect(assembleMSTeamsInboundFacts({ entry, mediaMaxBytes: 1024 }).rawBody).toBe(expected);
+    expect(assembleMSTeamsInboundFacts(entry).rawBody).toBe(expected);
   });
 
   it("strips native mentions from card text when HTML has no visible text", async () => {
@@ -90,7 +90,7 @@ describe("msteams inbound facts", () => {
       }),
     });
 
-    const facts = assembleMSTeamsInboundFacts({ entry, mediaMaxBytes: 1024 });
+    const facts = assembleMSTeamsInboundFacts(entry);
 
     expect(facts.rawConversationId).toBe("19:channel@thread.tacv2;messageid=thread-root");
     expect(facts.conversationId).toBe("19:channel@thread.tacv2");

--- a/extensions/msteams/src/monitor-handler/inbound-facts.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-facts.ts
@@ -120,11 +120,7 @@ function buildStoredConversationReference(params: {
   };
 }
 
-export function assembleMSTeamsInboundFacts(params: {
-  entry: MSTeamsDebounceEntry;
-  mediaMaxBytes: number;
-}) {
-  const { entry, mediaMaxBytes } = params;
+export function assembleMSTeamsInboundFacts(entry: MSTeamsDebounceEntry) {
   const activity = entry.context.activity;
   const conversation = activity.conversation;
   const rawConversationId = conversation?.id ?? "";
@@ -136,10 +132,7 @@ export function assembleMSTeamsInboundFacts(params: {
   const threadId = isChannel
     ? (conversationMessageId ?? activity.replyToId ?? undefined)
     : undefined;
-  const advertisedMedia = resolveMSTeamsAdvertisedMedia(entry.attachments, {
-    maxInlineBytes: mediaMaxBytes,
-    maxInlineTotalBytes: mediaMaxBytes,
-  });
+  const advertisedMedia = resolveMSTeamsAdvertisedMedia(entry.attachments);
 
   return {
     ...entry,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -65,7 +65,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     core.channel.debounce.resolveInboundDebounceMs({ cfg: readConfig(), channel: "msteams" });
 
   const handleTeamsMessageNow = async (params: MSTeamsDebounceEntry) => {
-    const facts = assembleMSTeamsInboundFacts({ entry: params, mediaMaxBytes });
+    const facts = assembleMSTeamsInboundFacts(params);
     const {
       context,
       activity,


### PR DESCRIPTION
Closes #144295

## What Problem This Solves

Teams attachment discovery decodes inline images while describing advertised media, then repeats discovery and retains decoded buffers before materializing the download queue. The descriptor path needs source references and media facts, not image bytes.

## Why This Change Was Made

Carry inline data-URL references through discovery and decode each image at its existing materialization step. Reuse the unrepresented HTML attachment IDs directly instead of rebuilding all advertised media to obtain that suffix. The download owner retains canonicalization, individual and total byte limits, MIME validation, saving and unavailable-media outcomes.

## User Impact

Attachment ordering, source IDs, file-only messages, malformed data and size-limit handling remain covered. Accepted inline bytes still consume the message budget when MIME detection or saving fails. This removes 33 production lines and the eager decoded-buffer descriptors without changing a public API, SDK export, configuration or store contract.

## Evidence

Seven focused suites pass before (168 tests) and after (173 tests), including inbound facts, media and message handling. The full selected gate and fresh independent P2 review pass. The gate identified test formatting and a test-library typing mismatch; the latter now uses the existing SDK deferred helper, with all 41 affected tests passing before the final full gate.

The proof uses isolated attachment/runtime fixtures, not a live Teams service. No allocation, RSS or latency measurement is claimed. Exceptional parser/string-allocation failures still propagate but can occur after preceding remote downloads; ordinary malformed input, decoding and MIME/save failure behavior is preserved. Import edges, lazy entrypoints, package/SDK exports and dependencies are unchanged, so the scoped build rule did not require a normal build.
