### PR TITLE
refactor: simplify Buzz directory relay test setup

### DIFF
--- a/extensions/buzz/src/directory-relay.test.ts
+++ b/extensions/buzz/src/directory-relay.test.ts
@@ -26,33 +26,38 @@ function createSubscriptionStub(
   return { id, close } as unknown as ReturnType<Relay["prepareSubscription"]>;
 }
 
+function createDirectoryRelayFixture() {
+  const subscriptions: SubscriptionRecord[] = [];
+  const relay = {
+    idleSince: undefined,
+    ongoingOperations: 0,
+    prepareSubscription: vi.fn(
+      (
+        filters: Filter[],
+        handlers: SubscriptionRecord["handlers"],
+      ): ReturnType<Relay["prepareSubscription"]> => {
+        const close = vi.fn();
+        subscriptions.push({ filters, handlers, close });
+        return createSubscriptionStub(`sub:${subscriptions.length}`, close);
+      },
+    ),
+    send: vi.fn(async () => {}),
+  } as unknown as Relay;
+  const directory = startBuzzDirectoryRelay({
+    relay,
+    relayPublicKey: RELAY_PUBLIC_KEY,
+    state: new BuzzDirectoryState({
+      publicKey: BOT_PUBLIC_KEY,
+      fallbackProfileName: "OpenClaw",
+      channelIds: [],
+    }),
+  });
+  return { subscriptions, directory };
+}
+
 describe("Buzz directory relay", () => {
   it("waits for EOSE and collapses queued profile replacements to the latest set", () => {
-    const subscriptions: SubscriptionRecord[] = [];
-    const relay = {
-      idleSince: undefined,
-      ongoingOperations: 0,
-      prepareSubscription: vi.fn(
-        (
-          filters: Filter[],
-          handlers: SubscriptionRecord["handlers"],
-        ): ReturnType<Relay["prepareSubscription"]> => {
-          const close = vi.fn();
-          subscriptions.push({ filters, handlers, close });
-          return createSubscriptionStub(`sub:${subscriptions.length}`, close);
-        },
-      ),
-      send: vi.fn(async () => {}),
-    } as unknown as Relay;
-    const directory = startBuzzDirectoryRelay({
-      relay,
-      relayPublicKey: RELAY_PUBLIC_KEY,
-      state: new BuzzDirectoryState({
-        publicKey: BOT_PUBLIC_KEY,
-        fallbackProfileName: "OpenClaw",
-        channelIds: [],
-      }),
-    });
+    const { subscriptions, directory } = createDirectoryRelayFixture();
 
     directory.replaceProfilePublicKeys([BOT_PUBLIC_KEY, FIRST_MEMBER_PUBLIC_KEY]);
     directory.replaceProfilePublicKeys([BOT_PUBLIC_KEY, SECOND_MEMBER_PUBLIC_KEY]);
@@ -75,31 +80,7 @@ describe("Buzz directory relay", () => {
   });
 
   it("does not start a queued profile replacement after the relay closes", () => {
-    const subscriptions: SubscriptionRecord[] = [];
-    const relay = {
-      idleSince: undefined,
-      ongoingOperations: 0,
-      prepareSubscription: vi.fn(
-        (
-          filters: Filter[],
-          handlers: SubscriptionRecord["handlers"],
-        ): ReturnType<Relay["prepareSubscription"]> => {
-          const close = vi.fn();
-          subscriptions.push({ filters, handlers, close });
-          return createSubscriptionStub(`sub:${subscriptions.length}`, close);
-        },
-      ),
-      send: vi.fn(async () => {}),
-    } as unknown as Relay;
-    const directory = startBuzzDirectoryRelay({
-      relay,
-      relayPublicKey: RELAY_PUBLIC_KEY,
-      state: new BuzzDirectoryState({
-        publicKey: BOT_PUBLIC_KEY,
-        fallbackProfileName: "OpenClaw",
-        channelIds: [],
-      }),
-    });
+    const { subscriptions, directory } = createDirectoryRelayFixture();
 
     directory.replaceProfilePublicKeys([BOT_PUBLIC_KEY, FIRST_MEMBER_PUBLIC_KEY]);
     directory.replaceProfilePublicKeys([BOT_PUBLIC_KEY, SECOND_MEMBER_PUBLIC_KEY]);
@@ -109,31 +90,7 @@ describe("Buzz directory relay", () => {
   });
 
   it("closes sibling profile subscriptions when one chunk fails", () => {
-    const subscriptions: SubscriptionRecord[] = [];
-    const relay = {
-      idleSince: undefined,
-      ongoingOperations: 0,
-      prepareSubscription: vi.fn(
-        (
-          filters: Filter[],
-          handlers: SubscriptionRecord["handlers"],
-        ): ReturnType<Relay["prepareSubscription"]> => {
-          const close = vi.fn();
-          subscriptions.push({ filters, handlers, close });
-          return createSubscriptionStub(`sub:${subscriptions.length}`, close);
-        },
-      ),
-      send: vi.fn(async () => {}),
-    } as unknown as Relay;
-    const directory = startBuzzDirectoryRelay({
-      relay,
-      relayPublicKey: RELAY_PUBLIC_KEY,
-      state: new BuzzDirectoryState({
-        publicKey: BOT_PUBLIC_KEY,
-        fallbackProfileName: "OpenClaw",
-        channelIds: [],
-      }),
-    });
+    const { subscriptions, directory } = createDirectoryRelayFixture();
 
     directory.replaceProfilePublicKeys(
       Array.from({ length: 201 }, (_, index) => index.toString(16).padStart(64, "0")),


### PR DESCRIPTION
## What Problem This Solves

Three Buzz directory relay tests repeat the same setup before exercising different subscription lifecycle events, obscuring their EOSE, queued replacement, and sibling-failure scenarios.

## Why This Change Was Made

Move only their identical initial setup into one same-file fixture. Each call creates fresh subscription records, relay mocks, directory state, and directory ownership. The existing event callbacks, lifecycle actions, and independent assertions stay in their cases. This removes 43 net test lines; the four distinct timeout/query fixtures remain unchanged.

## User Impact

No user-visible changes. Production relay behavior and all seven existing test cases remain intact.

## Evidence

- Complete `extensions/buzz/src/directory-relay.test.ts` before/after: seven passing cases in identical order on Node 26.8.1/macOS.
- Expanding the three fixture calls restores the complete original file byte for byte. Isolated allocation checks preserve fresh state, mock closures, subscription IDs, and filter/handler identity.
- Changed-file gate and independent review passed. The first gate found an absent declared QA Lab workspace dependency; a normal private frozen install restored that link, and the unchanged-source gate passed.

These are mocked relay tests, not live service proof. No runtime savings are claimed.
