### PR TITLE
refactor(scripts): avoid duplicate SDK source scans

### DIFF
--- a/scripts/check-plugin-sdk-subpath-exports.mts
+++ b/scripts/check-plugin-sdk-subpath-exports.mts
@@ -8,6 +8,7 @@ import { normalizeRepoPath, visitModuleSpecifiers } from "./lib/guard-inventory-
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   collectTypeScriptFilesFromRoots,
+  isTestLikeTypeScriptFile,
   resolveSourceRoots,
   toLine,
 } from "./lib/ts-guard-utils.mts";
@@ -19,6 +20,7 @@ const scanRoots = resolveSourceRoots(repoRoot, [
   "scripts",
   "test",
 ]);
+const extraTestSuffixes = [".test-support.ts", ".test-loader.ts", ".test-fixtures.ts"];
 
 type PluginSdkViolation = {
   file: string;
@@ -107,16 +109,6 @@ async function collectViolations(): Promise<PluginSdkViolation[]> {
   const entrypoints = readEntrypoints();
   const exports = readPackageExports();
   const privateLocalOnlySubpaths = readPrivateLocalOnlySubpaths();
-  // Workspace packages resolve private facades through root TS paths and bundle them into dist;
-  // live jiti source stages inject the same private map. Core src callers must stay relative.
-  const coreRuntimeFiles = new Set(
-    (
-      await collectTypeScriptFilesFromRoots(resolveSourceRoots(repoRoot, ["src"]), {
-        includeTests: false,
-        extraTestSuffixes: [".test-support.ts", ".test-loader.ts", ".test-fixtures.ts"],
-      })
-    ).filter((filePath) => !isGeneratedBuildArtifact(filePath)),
-  );
   const files = (await collectTypeScriptFilesFromRoots(scanRoots, { includeTests: true }))
     .filter((filePath) => !isGeneratedBuildArtifact(filePath))
     .toSorted((left, right) =>
@@ -130,6 +122,10 @@ async function collectViolations(): Promise<PluginSdkViolation[]> {
     if (!sourceText.includes("plugin-sdk") && !sourceText.includes("\\")) {
       continue;
     }
+    const repoPath = normalizeRepoPath(repoRoot, filePath);
+    // Workspace packages resolve private facades through TS paths; core runtime stays relative.
+    const isCoreRuntimeFile =
+      repoPath.startsWith("src/") && !isTestLikeTypeScriptFile(filePath, extraTestSuffixes);
     const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
 
     function push(kind: string, node: ts.Node, specifierNode: ts.Node, specifier: string): void {
@@ -138,8 +134,7 @@ async function collectViolations(): Promise<PluginSdkViolation[]> {
         return;
       }
       if (privateLocalOnlySubpaths.has(subpath)) {
-        const repoPath = normalizeRepoPath(repoRoot, filePath);
-        if (coreRuntimeFiles.has(filePath) && isRuntimeModuleReference(node)) {
+        if (isCoreRuntimeFile && isRuntimeModuleReference(node)) {
           violations.push({
             file: repoPath,
             line: toLine(sourceFile, specifierNode),
@@ -164,7 +159,7 @@ async function collectViolations(): Promise<PluginSdkViolation[]> {
       }
 
       violations.push({
-        file: normalizeRepoPath(repoRoot, filePath),
+        file: repoPath,
         line: toLine(sourceFile, specifierNode),
         kind,
         specifier,


### PR DESCRIPTION
## What Problem This Solves

The SDK subpath checker walks `src` twice on every run: once to collect core runtime files and again while collecting its complete source inventory.

## Why This Change Was Made

Classify each already-collected file using the existing test-file predicate and normalized source path. Remove the redundant traversal and set, and reuse that path for diagnostics. Public/private SDK boundaries, erased type references, test suffixes and generated-file exclusions retain the same rules.

## User Impact

The checker does less filesystem enumeration while producing the same diagnostics. This removes five tooling lines without adding an API or dependency.

## Evidence

Actual complete-repository CLI output is byte-identical before and after. The same CLI/helper closure in a 24-file synthetic workspace also produces exactly the same 26 independently expected diagnostics, covering core runtime, package, public/private, erased/inline type, test suffix and generated-path distinctions.

A transparent counter of actual directory reads observes 474 to 237 reads under `src`; all 237 directories are read once instead of twice. Other directory counts are unchanged. Total reads fall from 1,546 to 1,309 with the same unique directories. Individual runs remained approximately 15.7 seconds, so no wall-time speedup is claimed.

All 17 canonical changed checks pass, and independent review found no actionable findings. The isolated CLI fixture is retained as review evidence.
