### PR TITLE
refactor: share completed Matrix verification test setup

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -117,7 +117,6 @@ extensions/line/src/bot-handlers.test.ts
 extensions/lmstudio/src/setup.test.ts
 extensions/lmstudio/src/setup.ts
 extensions/matrix/src/cli.test.ts
-extensions/matrix/src/matrix/actions/verification.test.ts
 extensions/matrix/src/matrix/monitor/events.test.ts
 extensions/matrix/src/matrix/monitor/handler.test.ts
 extensions/matrix/src/matrix/sdk.test.ts

--- a/extensions/matrix/src/matrix/actions/verification.test.ts
+++ b/extensions/matrix/src/matrix/actions/verification.test.ts
@@ -102,6 +102,35 @@ describe("matrix verification actions", () => {
     });
   });
 
+  function mockCompletedSelfVerificationCrypto() {
+    const requested = {
+      completed: false,
+      hasSas: false,
+      id: "verification-1",
+      phaseName: "requested",
+      transactionId: "tx-self",
+    };
+    const sas = {
+      ...requested,
+      hasSas: true,
+      phaseName: "started",
+      sas: {
+        decimal: [1, 2, 3],
+      },
+    };
+    const completed = {
+      ...sas,
+      completed: true,
+      phaseName: "done",
+    };
+    return {
+      confirmVerificationSas: vi.fn(async () => completed),
+      listVerifications: vi.fn(async () => [sas]),
+      requestVerification: vi.fn(async () => requested),
+      startVerification: vi.fn(async () => sas),
+    };
+  }
+
   function mockVerifiedOwnerStatus() {
     return {
       backup: {
@@ -499,32 +528,7 @@ describe("matrix verification actions", () => {
   });
 
   it("does not complete self-verification until the OpenClaw device has full Matrix identity trust", async () => {
-    const requested = {
-      completed: false,
-      hasSas: false,
-      id: "verification-1",
-      phaseName: "requested",
-      transactionId: "tx-self",
-    };
-    const sas = {
-      ...requested,
-      hasSas: true,
-      phaseName: "started",
-      sas: {
-        decimal: [1, 2, 3],
-      },
-    };
-    const completed = {
-      ...sas,
-      completed: true,
-      phaseName: "done",
-    };
-    const crypto = {
-      confirmVerificationSas: vi.fn(async () => completed),
-      listVerifications: vi.fn(async () => [sas]),
-      requestVerification: vi.fn(async () => requested),
-      startVerification: vi.fn(async () => sas),
-    };
+    const crypto = mockCompletedSelfVerificationCrypto();
     const getOwnDeviceVerificationStatus = vi
       .fn()
       .mockResolvedValueOnce(mockUnverifiedOwnerStatus())
@@ -563,32 +567,7 @@ describe("matrix verification actions", () => {
   });
 
   it("does not let the SDK identity-only status read hang completed self-verification", async () => {
-    const requested = {
-      completed: false,
-      hasSas: false,
-      id: "verification-1",
-      phaseName: "requested",
-      transactionId: "tx-self",
-    };
-    const sas = {
-      ...requested,
-      hasSas: true,
-      phaseName: "started",
-      sas: {
-        decimal: [1, 2, 3],
-      },
-    };
-    const completed = {
-      ...sas,
-      completed: true,
-      phaseName: "done",
-    };
-    const crypto = {
-      confirmVerificationSas: vi.fn(async () => completed),
-      listVerifications: vi.fn(async () => [sas]),
-      requestVerification: vi.fn(async () => requested),
-      startVerification: vi.fn(async () => sas),
-    };
+    const crypto = mockCompletedSelfVerificationCrypto();
     const getOwnDeviceIdentityVerificationStatus = vi.fn(
       async () => await new Promise<never>(() => {}),
     );
@@ -626,32 +605,7 @@ describe("matrix verification actions", () => {
   });
 
   it("does not complete self-verification until cross-signing keys are published", async () => {
-    const requested = {
-      completed: false,
-      hasSas: false,
-      id: "verification-1",
-      phaseName: "requested",
-      transactionId: "tx-self",
-    };
-    const sas = {
-      ...requested,
-      hasSas: true,
-      phaseName: "started",
-      sas: {
-        decimal: [1, 2, 3],
-      },
-    };
-    const completed = {
-      ...sas,
-      completed: true,
-      phaseName: "done",
-    };
-    const crypto = {
-      confirmVerificationSas: vi.fn(async () => completed),
-      listVerifications: vi.fn(async () => [sas]),
-      requestVerification: vi.fn(async () => requested),
-      startVerification: vi.fn(async () => sas),
-    };
+    const crypto = mockCompletedSelfVerificationCrypto();
     const getOwnDeviceVerificationStatus = vi.fn(async () => mockVerifiedOwnerStatus());
     const getOwnCrossSigningPublicationStatus = vi
       .fn()
@@ -825,32 +779,7 @@ describe("matrix verification actions", () => {
   });
 
   it("allows completed self-verification when only backup health remains degraded", async () => {
-    const requested = {
-      completed: false,
-      hasSas: false,
-      id: "verification-1",
-      phaseName: "requested",
-      transactionId: "tx-self",
-    };
-    const sas = {
-      ...requested,
-      hasSas: true,
-      phaseName: "started",
-      sas: {
-        decimal: [1, 2, 3],
-      },
-    };
-    const completed = {
-      ...sas,
-      completed: true,
-      phaseName: "done",
-    };
-    const crypto = {
-      confirmVerificationSas: vi.fn(async () => completed),
-      listVerifications: vi.fn(async () => [sas]),
-      requestVerification: vi.fn(async () => requested),
-      startVerification: vi.fn(async () => sas),
-    };
+    const crypto = mockCompletedSelfVerificationCrypto();
     const bootstrapOwnDeviceVerification = vi.fn(async () => ({
       crossSigning: mockCrossSigningPublicationStatus(),
       success: false,
@@ -1094,4 +1023,3 @@ describe("matrix verification actions", () => {
     expect(summary.error).toMatch(/verifier rejected mid-protocol/);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Four Matrix self-verification tests repeat the same requested/SAS/completed crypto setup, obscuring the independent trust and publication conditions each case exercises.

## Why This Change Was Made

Use one local synchronous fixture helper for exactly those four identical blocks. Each call creates fresh summaries and spies while preserving the shared SAS payload within that fixture. Trust, publication, hanging-status-read, and degraded-backup assertions remain in their original cases.

## User Impact

No production behavior change. This removes 72 net test lines without removing any of the 24 existing cases or weakening their assertions.

## Evidence

The complete existing verification test file passed before and after: 24 cases in identical order with zero failures or skips. Expanding the four helper calls reconstructs the exact original file. An isolated helper check using the installed Vitest spy implementation confirms distinct spies and objects across fixtures, retained SAS sharing within each fixture, and fresh callback promises/list arrays.

Only existing synthetic fixtures were used; no live Matrix/network operations, keys, or new adversarial cases. No measured runtime improvement is claimed.

The reduction also makes the previous max-lines suppression unnecessary, so it is removed.
The corresponding stale max-lines baseline entry is pruned as well.

The final two-file mapped gate passed, including extension-test typechecking, extension/script lint, formatting and ratchets. Fresh independent review found no actionable P0–P2 findings. The initial gate exposed a missing private workspace dependency link; one normal frozen-lockfile install repaired it without source/lock changes.

Exact-head CI passed after one retry of the unrelated tooling shard and its dependent gate. The original failure was the existing root Vitest project-graph subprocess exceeding its 120-second timeout; no graph assertion, timeout, source, or configuration was changed. The cause of that isolated timeout remains unestablished.
