### PR TITLE
fix(usage): keep total-only and cache-only footers

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -117,9 +117,12 @@ With no config the prior behavior holds (footer off until `/usage`). Use
 
 ## Custom `/usage full` footer
 
-`/usage tokens` always renders a plain `Usage: X in / Y out` line (plus cache and
-estimated-cost suffixes when available). Only `/usage full` renders the richer
-footer described below.
+`/usage tokens` renders a plain `Usage: X in / Y out` line with cache counters
+when available. Missing input or output counts stay `?`; OpenClaw does not infer
+the split from a total. When neither direction is reported, a known total appears
+as `Usage: 1.3k total`. Cache counters remain visible even when input, output, and
+total counts are unavailable. This mode never estimates cost. Only `/usage full`
+renders the richer footer described below.
 
 `/usage full` shows a built-in compact footer with model, reasoning, fast/slow,
 context window, and cost when those fields are available. No template file is

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -25,24 +25,29 @@ const formatResponseUsageLine = (
   }
   const input = usage.input;
   const output = usage.output;
+  const hasSplitTokens = typeof input === "number" || typeof output === "number";
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";
   const outputLabel = typeof output === "number" ? formatTokenCount(output) : "?";
+  const totalLabel =
+    !hasSplitTokens && typeof usage.total === "number"
+      ? `${formatTokenCount(usage.total)} total`
+      : undefined;
   const cacheRead = typeof usage.cacheRead === "number" ? usage.cacheRead : undefined;
   const cacheWrite = typeof usage.cacheWrite === "number" ? usage.cacheWrite : undefined;
   const canPriceUsage =
     usage.cost !== undefined || (typeof input === "number" && typeof output === "number");
   const cost = params.showCost && canPriceUsage ? estimateAggregateUsageCost(params) : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  if (typeof input !== "number" && typeof output !== "number" && !costLabel) {
-    return null;
-  }
   const cacheSuffix =
     (typeof cacheRead === "number" && cacheRead > 0) ||
     (typeof cacheWrite === "number" && cacheWrite > 0)
       ? ` · cache ${formatTokenCount(cacheRead ?? 0)} cached / ${formatTokenCount(cacheWrite ?? 0)} new`
       : "";
+  if (!hasSplitTokens && !totalLabel && !cacheSuffix && !costLabel) {
+    return null;
+  }
   const suffix = costLabel ? ` · est ${costLabel}` : "";
-  return `Usage: ${inputLabel} in / ${outputLabel} out${cacheSuffix}${suffix}`;
+  return `Usage: ${totalLabel ?? `${inputLabel} in / ${outputLabel} out`}${cacheSuffix}${suffix}`;
 };
 
 export const resolveResponseUsageLine = (params: {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -7,6 +7,7 @@ import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest"
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import { parseCliOutput } from "../../agents/cli-output.js";
 import type { RunEmbeddedAgentInternalParams } from "../../agents/embedded-agent-runner/run/internal-params.js";
 import {
   abortEmbeddedAgentRun,
@@ -2801,14 +2802,51 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).not.toContain("· session ");
   });
 
-  it("does not append session key when responseUsage=tokens", async () => {
+  it.each([
+    {
+      name: "split token counts",
+      usage: { input_tokens: 12, output_tokens: 3, cacheRead: 4, cacheWrite: 2 },
+      expected: "Usage: 12 in / 3 out · cache 4 cached / 2 new",
+    },
+    {
+      name: "input-only counts",
+      usage: { input_tokens: 12, total_tokens: 15 },
+      expected: "Usage: 12 in / ? out",
+    },
+    {
+      name: "output-only counts",
+      usage: { output_tokens: 3, total_tokens: 15 },
+      expected: "Usage: ? in / 3 out",
+    },
+    {
+      name: "total-only counts",
+      usage: { total_tokens: 1250 },
+      expected: "Usage: 1.3k total",
+    },
+    {
+      name: "cache-only counts",
+      usage: { cacheRead: 800, cacheWrite: 200 },
+      expected: "Usage: ? in / ? out · cache 800 cached / 200 new",
+    },
+    {
+      name: "total and cache counts without a split",
+      usage: { total_tokens: 1250, cacheRead: 800, cacheWrite: 200 },
+      expected: "Usage: 1.3k total · cache 800 cached / 200 new",
+    },
+  ])("shows $name without cost or session keys in tokens mode", async ({ usage, expected }) => {
+    const output = parseCliOutput({
+      raw: JSON.stringify({ result: "ok", usage }),
+      backend: { command: "fixture-cli" },
+      providerId: "fixture-cli",
+      outputMode: "json",
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "ok" }],
+      payloads: [{ text: output.text }],
       meta: {
         agentMeta: {
           provider: "amazon-bedrock",
           model: "us.anthropic.claude-sonnet-4-6",
-          usage: { input: 12, output: 3, cacheRead: 4, cacheWrite: 2 },
+          usage: output.usage,
         },
       },
     });
@@ -2837,8 +2875,7 @@ describe("runReplyAgent response usage footer", () => {
     });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
-    expect(text).toContain("Usage:");
-    expect(text).toContain("cache 4 cached / 2 new");
+    expect(text).toBe(`ok\n${expected}`);
     expect(text).not.toContain("est $");
     expect(text).not.toContain("· session ");
   });

--- a/src/auto-reply/reply/followup-delivery-payloads.test.ts
+++ b/src/auto-reply/reply/followup-delivery-payloads.test.ts
@@ -9,7 +9,7 @@ vi.mock("../../channels/plugins/index.js", () => ({
   getLoadedChannelPlugin: () => undefined,
 }));
 
-const baseConfig = {} as OpenClawConfig;
+const baseConfig: OpenClawConfig = {};
 
 describe("resolveFollowupDeliveryPayloads", () => {
   it("drops payloads without visible content", () => {

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -113,6 +113,22 @@ function createAccounting(
   } as never;
 }
 
+const createDefaults = (onBlockReply: (payload: ReplyPayload) => Promise<void>) => ({
+  defaultModel: "claude",
+  typingMode: "never" as const,
+  typing: {
+    onReplyStart: vi.fn(async () => {}),
+    startTypingLoop: vi.fn(async () => {}),
+    startTypingOnText: vi.fn(async () => {}),
+    refreshTypingTtl: vi.fn(),
+    isActive: vi.fn(() => false),
+    markRunComplete: vi.fn(),
+    markDispatchIdle: vi.fn(),
+    cleanup: vi.fn(),
+  },
+  opts: { onBlockReply },
+});
+
 describe("resolveFollowupDeliveryDecision", () => {
   const sourceReplyTarget = {
     tool: "message",
@@ -123,6 +139,56 @@ describe("resolveFollowupDeliveryDecision", () => {
   const progressTarget = { ...sourceReplyTarget, sourceReplyFinal: false };
   const finalTarget = { ...sourceReplyTarget, sourceReplyFinal: true };
   const progressPayload = { text: "Still working", sourceReplyFinal: false };
+
+  it.each([
+    {
+      name: "total-only usage",
+      usage: { total: 1250 },
+      sessionMode: undefined,
+      expected: "queued reply\nUsage: 1.3k total",
+    },
+    {
+      name: "cache-only usage",
+      usage: { cacheRead: 800, cacheWrite: 200 },
+      sessionMode: undefined,
+      expected: "queued reply\nUsage: ? in / ? out · cache 800 cached / 200 new",
+    },
+    {
+      name: "an explicit usage-off preference",
+      usage: { total: 1250 },
+      sessionMode: "off",
+      expected: "queued reply",
+    },
+  ] as const)(
+    "delivers $name through the queued footer owner",
+    async ({ usage, sessionMode, expected }) => {
+      const turn = createTurn({ config: { messages: { responseUsage: "tokens" } } });
+      const sourceDispatcher = vi.fn(async () => {});
+      turn.queued.originatingChannel = "webchat";
+      turn.queued.originatingTo = undefined;
+      turn.queued.queuedFollowupReplyDisposition = { kind: "deliver", deliver: sourceDispatcher };
+      turn.session.current = () => ({
+        sessionId: "session",
+        updatedAt: 1,
+        responseUsage: sessionMode,
+      });
+
+      const decision = resolveFollowupDeliveryDecision({
+        turn,
+        execution: createSettledExecution("queued reply"),
+        accounting: createAccounting([{ text: "queued reply" }], { usage }),
+      });
+      const delivery = await deliverFollowupDecision({
+        decision,
+        turn,
+        defaults: createDefaults(vi.fn(async () => {})),
+        runId: turn.runId,
+        runFollowup: vi.fn(async () => {}),
+      });
+      expect(delivery).toMatchObject({ kind: "completed", payloads: [{ text: expected }] });
+      expect(sourceDispatcher).not.toHaveBeenCalled();
+    },
+  );
 
   it("delivers a yield acknowledgment after accepting a child spawn", () => {
     const execution = createSettledExecution();
@@ -586,22 +652,6 @@ describe("resolveFollowupDeliveryDecision", () => {
 });
 
 describe("deliverFollowupDecision", () => {
-  const createDefaults = (onBlockReply: (payload: ReplyPayload) => Promise<void>) => ({
-    defaultModel: "claude",
-    typingMode: "never" as const,
-    typing: {
-      onReplyStart: vi.fn(async () => {}),
-      startTypingLoop: vi.fn(async () => {}),
-      startTypingOnText: vi.fn(async () => {}),
-      refreshTypingTtl: vi.fn(),
-      isActive: vi.fn(() => false),
-      markRunComplete: vi.fn(),
-      markDispatchIdle: vi.fn(),
-      cleanup: vi.fn(),
-    },
-    opts: { onBlockReply },
-  });
-
   it("keeps dispatcher-only delivery out of a routable origin", async () => {
     const onBlockReply = vi.fn(async (_payload: ReplyPayload) => {});
     deliveryState.followupRoute = { route: "dispatcher" };

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -564,20 +564,33 @@ describe("createFollowupRunner", () => {
     const typing = createTypingController();
     const turn = createTurn(order);
     const execution = createRejectedExecution(order);
+    const sourceDelivery = vi.fn(async () => {
+      order.push("completion");
+    });
+    turn.queued.queuedFollowupReplyDisposition = { kind: "deliver", deliver: sourceDelivery };
+    const decision = {
+      kind: "deliver" as const,
+      payloads: [{ text: "done\nUsage: 1.3k total" } satisfies ReplyPayload],
+    };
     state.admit.mockResolvedValue({ kind: "admitted", turn });
     state.execute.mockResolvedValue(execution);
     state.account.mockImplementation(async () => {
       order.push("accounted");
-      return undefined;
+      return { payloadArray: [{ text: "raw accounting reply" }] };
     });
     state.resolveDecision.mockImplementation(() => {
       order.push("decision");
-      return { kind: "deliver", payloads: [{ text: "done" } satisfies ReplyPayload] };
+      return decision;
     });
-    state.deliver.mockImplementation(async () => {
-      order.push("delivered");
-      return { kind: "completed", payloads: [] };
-    });
+    state.deliver.mockImplementation(
+      async (
+        params: Parameters<typeof import("./followup-delivery.js").deliverFollowupDecision>[0],
+      ) => {
+        expect(params.decision).toEqual(decision);
+        order.push("delivered");
+        return { kind: "completed", payloads: decision.payloads };
+      },
+    );
     state.completeLifecycle.mockImplementation(() => order.push("lifecycle-complete"));
 
     await createFollowupRunner({
@@ -596,10 +609,14 @@ describe("createFollowupRunner", () => {
       "accounted",
       "decision",
       "delivered",
+      "completion",
       "presentation-settled",
       "lifecycle-complete",
       "operation-complete",
     ]);
+    expect(sourceDelivery).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ payloads: decision.payloads }),
+    );
     expect(state.clearRunContext).toHaveBeenCalledWith("run-1");
   });
 


### PR DESCRIPTION
Related: #93937. Thanks @RichChen01 for the earlier total-only usage report.

## What Problem This Solves

Fixes an issue where `/usage tokens` replies omitted their footer when a runtime reported only total tokens or cache counters. Ordinary and queued reply accounting preserved the usage, but the shared formatter discarded it.

## Why This Change Was Made

Show a known total as `Usage: 1.3k total` when neither input nor output is available. Keep cache counters visible and mark unknown directions as `?`. Existing partial counts retain precedence; pricing and the compact `/usage full` template keep their behavior.

Tests protect the current queued delivery and completion ownership, including the registered runner's use of formatted payloads. The upstream payload-test organization is preserved.

## User Impact

Replies retain available usage information without inventing an input/output split or estimated cost. The usage guide explains incomplete-count cases.

## Evidence

On the refreshed main baseline, five intended missing-footer failures reproduce across ordinary and queued reply boundaries, with nine passing controls. The candidate passes 118 selected cases covering ordinary replies, pricing/metadata, full/off modes, queued delivery, payload normalization, completion classification, recovery and source callbacks.

The queued cases exercise the real decision/delivery handoff. An existing registered-runner case separately verifies that the decision reaches delivery and that the returned formatted payload is published once. These are complementary boundary tests using synthetic data and the existing mocked runtime/transport stages.

Two earlier generic CLI parsing/result-settlement checks retain unchanged direct inputs and remain separately qualified historical evidence. All 29 canonical changed-file stages pass on the refreshed head. Fresh independent review completed both passes with no actionable findings. No live provider, native client or channel-delivery claim is made.
