### PR TITLE
refactor(cron): remove duplicate delivery test

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1644,18 +1644,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
-  it("normal text delivery sends exactly once and sets deliveryAttempted=true", async () => {
-    const params = makeBaseParams({
-      synthesizedText: "Morning briefing complete.",
-      runStartedAt: 1_000,
-    });
-    const state = await dispatchCronDelivery(params);
-
-    expect(state.deliveryAttempted).toBe(true);
-    expect(state.delivered).toBe(true);
-    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
-  });
-
   it("applies TTS directives before direct cron announce delivery and mirrors spoken text", async () => {
     vi.mocked(deliverOutboundPayloads).mockImplementationOnce(async (deliveryParams) => {
       deliveryParams.onPayload?.({


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Cron delivery tests repeat the same normal-text delivery setup and assertions, adding maintenance without distinct coverage.

## Why This Change Was Made

Remove the weaker single-send case. The retained explicit-target awareness case uses identical fresh inputs, checks the same delivery state and single outbound call, and also verifies the result and awareness events. All other cases, including the four adapter-outcome rows, remain unchanged.

## User Impact

No runtime behavior change. Removes one duplicate case and 12 test lines; no production, helper, import, or configuration changes.

## Evidence

- Full ordered `delivery-dispatch.double-announce.test.ts` through the normal cron config: 164 actual passes, zero skips.
- All 20 selected changed-file checks passed, including the services test typecheck, three zero-entry Knip scans, and final lint.
- Scoped P2 review: no findings. An initial prelaunch dataset refusal was preserved; the corrected review excluded that optional input without changing its guard.

No live channel or Gateway execution, installation, SQLite durability, or full-repository test run is claimed.
