### PR TITLE
perf(models): reuse the first-wins catalog identity index

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -17,7 +17,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
-import { dedupeByKey } from "../shared/dedupe-by-key.js";
+import { dedupeByKey, indexFirstByKey } from "../shared/dedupe-by-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "./configured-provider-fallback.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
@@ -1318,12 +1318,7 @@ export function buildConfiguredModelCatalog(params: {
   const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
   const capturedByIdentity = params.catalog?.length
-    ? new Map(
-        dedupeByKey(params.catalog, resolveModelCatalogIdentityKey).map((entry) => [
-          resolveModelCatalogIdentityKey(entry),
-          entry,
-        ]),
-      )
+    ? indexFirstByKey(params.catalog, resolveModelCatalogIdentityKey)
     : undefined;
   const catalog: ModelCatalogEntry[] = [];
   for (const [providerRaw, provider] of Object.entries(providers)) {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -6,6 +6,7 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import {
   getModelRefStatus as getNarrowModelRefStatus,
   resolveAllowedModelRefCore as resolveNarrowAllowedModelRef,
@@ -876,6 +877,37 @@ describe("model-selection", () => {
       expect(model?.provider).toBe(provider);
       expect(model?.id).toBe(expectedId);
       expect(model?.name).toBe("Gemini 3 Pro");
+    });
+
+    it("keeps the first captured route for a configured model with duplicate identities", () => {
+      const cfg = createConfiguredModelRefConfig({
+        providers: { custom: { models: [{ id: "model", name: "Configured" }] } },
+      });
+      const catalog: ModelCatalogEntry[] = [
+        {
+          provider: "custom",
+          id: "model",
+          name: "First",
+          api: "openai-responses",
+          baseUrl: "https://first.example/v1",
+        },
+        {
+          provider: "CUSTOM",
+          id: "model",
+          name: "Later",
+          api: "anthropic-messages",
+          baseUrl: "https://later.example/v1",
+        },
+      ];
+
+      expect(buildConfiguredModelCatalog({ cfg, catalog })).toMatchObject([
+        {
+          provider: "custom",
+          id: "model",
+          api: "openai-responses",
+          baseUrl: "https://first.example/v1",
+        },
+      ]);
     });
 
     it("carries configured model compat into catalog entries for provider policy", () => {

--- a/src/shared/dedupe-by-key.test.ts
+++ b/src/shared/dedupe-by-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { dedupeByKey } from "./dedupe-by-key.js";
+import { dedupeByKey, indexFirstByKey } from "./dedupe-by-key.js";
 
 describe("dedupeByKey", () => {
   it("keeps the first item for each key in stable input order", () => {
@@ -9,6 +9,12 @@ describe("dedupeByKey", () => {
     const items = Object.freeze([first, duplicate, last]);
     const keyOf = vi.fn((item: (typeof items)[number]) => item.key);
 
+    expect([...indexFirstByKey(items, keyOf)]).toEqual([
+      ["duplicate", first],
+      ["unique", last],
+    ]);
+    expect(keyOf).toHaveBeenCalledTimes(items.length);
+    keyOf.mockClear();
     const result = dedupeByKey(items, keyOf);
 
     expect(result).toEqual([first, last]);

--- a/src/shared/dedupe-by-key.ts
+++ b/src/shared/dedupe-by-key.ts
@@ -1,4 +1,7 @@
-export function dedupeByKey<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
+export function indexFirstByKey<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+): Map<string, T> {
   const deduped = new Map<string, T>();
   for (const item of items) {
     const key = keyOf(item);
@@ -6,5 +9,9 @@ export function dedupeByKey<T>(items: readonly T[], keyOf: (item: T) => string):
       deduped.set(key, item);
     }
   }
-  return [...deduped.values()];
+  return deduped;
+}
+
+export function dedupeByKey<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
+  return [...indexFirstByKey(items, keyOf).values()];
 }


### PR DESCRIPTION
Closes #144304

## What Problem This Solves

Configured model catalog construction deduplicates captured rows into a Map, converts it to an array, then evaluates every retained row's identity again to build another Map. The same first-wins index can serve the catalog directly.

## Why This Change Was Made

Extract the existing Map loop as indexFirstByKey and keep dedupeByKey as its array-returning consumer. The configured catalog reuses the index while preserving input order, first-row precedence, key normalization and fallback behavior. This avoids the repeated identity pass and intermediate array/tuple/Map reconstruction without adding a cache.

## User Impact

Selected models and their route metadata remain unchanged. The four-file change adds two production lines and 38 net test lines to preserve the shared array contract and configured first-route behavior. Existing exact allowlist and route-metadata fixes on main are retained; no configuration, schema, persistence or migration contract changes.

## Evidence

The composed current-main change passes 205 focused tests across shared deduplication, model selection, manifest workspace and catalog-metadata overlay owners, plus the full selected changed gate and fresh independent P2 review. The composition was checked against current main to preserve all surrounding route and allowlist changes.

A bounded before/after run over those four focused files passed 205 tests in each arm and recorded 12.09 seconds / 2,122,252,288 bytes maximum RSS before and 11.00 seconds / 2,115,305,472 bytes afterward. These sequential correctness-run observations include imports, caches and worker setup; they do not establish a causal speed or RSS reduction. The supported code-level improvement is removal of repeated identity work.
