### PR TITLE
test(auth): share stale fallback profile fixtures

### DIFF
--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -113,6 +113,33 @@ async function readPersistedStore(agentDir: string): Promise<AuthProfileStore> {
   return readAuthProfileStoreForTest(agentDir);
 }
 
+function createStaleLastGoodStore(
+  staleProfileId: string,
+  healthyProfileId: string,
+): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      [staleProfileId]: {
+        type: "oauth",
+        provider: "openai",
+        access: "stale-access-token",
+        refresh: "stale-refresh-token",
+        expires: Date.now() - 60_000,
+      },
+      [healthyProfileId]: {
+        type: "oauth",
+        provider: "openai",
+        access: "healthy-access-token",
+        refresh: "healthy-refresh-token",
+        expires: Date.now() + 60 * 60_000,
+        email: "user@example.test",
+      },
+    },
+    lastGood: { openai: staleProfileId },
+  };
+}
+
 function mockRotatedOpenAICodexRefresh() {
   refreshProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({
     type: "oauth",
@@ -1151,30 +1178,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
   it("clears stale lastGood before selecting an alternate Codex OAuth profile", async () => {
     const staleProfileId = "openai:default";
     const healthyProfileId = "openai:user@example.test";
-    saveAuthProfileStore(
-      {
-        version: 1,
-        profiles: {
-          [staleProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "stale-access-token",
-            refresh: "stale-refresh-token",
-            expires: Date.now() - 60_000,
-          },
-          [healthyProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "healthy-access-token",
-            refresh: "healthy-refresh-token",
-            expires: Date.now() + 60 * 60_000,
-            email: "user@example.test",
-          },
-        },
-        lastGood: { openai: staleProfileId },
-      },
-      agentDir,
-    );
+    saveAuthProfileStore(createStaleLastGoodStore(staleProfileId, healthyProfileId), agentDir);
     getOAuthApiKeyMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
@@ -1200,30 +1204,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
   it("does not select an alternate Codex OAuth profile for a locked profile", async () => {
     const staleProfileId = "openai:default";
     const healthyProfileId = "openai:user@example.test";
-    saveAuthProfileStore(
-      {
-        version: 1,
-        profiles: {
-          [staleProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "stale-access-token",
-            refresh: "stale-refresh-token",
-            expires: Date.now() - 60_000,
-          },
-          [healthyProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "healthy-access-token",
-            refresh: "healthy-refresh-token",
-            expires: Date.now() + 60 * 60_000,
-            email: "user@example.test",
-          },
-        },
-        lastGood: { openai: staleProfileId },
-      },
-      agentDir,
-    );
+    saveAuthProfileStore(createStaleLastGoodStore(staleProfileId, healthyProfileId), agentDir);
     getOAuthApiKeyMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
@@ -1246,30 +1227,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
   it("reports the alternate Codex OAuth profile after stale lastGood fallback", async () => {
     const staleProfileId = "openai:default";
     const healthyProfileId = "openai:user@example.test";
-    saveAuthProfileStore(
-      {
-        version: 1,
-        profiles: {
-          [staleProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "stale-access-token",
-            refresh: "stale-refresh-token",
-            expires: Date.now() - 60_000,
-          },
-          [healthyProfileId]: {
-            type: "oauth",
-            provider: "openai",
-            access: "healthy-access-token",
-            refresh: "healthy-refresh-token",
-            expires: Date.now() + 60 * 60_000,
-            email: "user@example.test",
-          },
-        },
-        lastGood: { openai: staleProfileId },
-      },
-      agentDir,
-    );
+    saveAuthProfileStore(createStaleLastGoodStore(staleProfileId, healthyProfileId), agentDir);
     getOAuthApiKeyMock.mockImplementationOnce(async () => {
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three OAuth fallback tests repeat the same stale/healthy profile store, obscuring their distinct assertions about stale selection, locked profiles, and alternate-profile reporting.

## Why This Change Was Made

Extract the shared input into a local fixture builder that creates a fresh nested store for each call. Keep persistence, refresh-error injection, and every independent assertion at the original call sites, including the order of both expiry clock reads.

## User Impact

No runtime or authentication behavior changes. This removes 42 net test lines while retaining all existing cases and their selection and persistence contracts.

## Evidence

- The full affected file and two fallback/error siblings passed before and after: 50 identical ordered cases, no failures or skips, on Node 24.19.0.
- Expanding the helper recovers the original whole-file AST tokens, accounting explicitly for three trailing argument commas removed by formatting. Fresh nested objects and expiry clock order were verified.
- The mapped changed-file gate and fresh independent review passed. The initial gate stopped on formatting only; native formatting was applied before the final checks.
