### PR TITLE
perf(cli): prepare ordered completion groups once

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -31,7 +31,7 @@ import { publishOutputFileAtomically } from "./output-file.runtime.js";
 import { getCoreCliCompletionGroups } from "./program/command-registry-core.js";
 import { getProgramContext } from "./program/program-context.js";
 import { removeCommandGroupNames } from "./program/register-command-groups.js";
-import { getSubCliEntries, registerSubCliByNameCore } from "./program/register.subclis-core.js";
+import { getSubCliCompletionGroups } from "./program/register.subclis-core.js";
 
 export function getCompletionScript(shell: CompletionShell, program: Command): string {
   if (shell === "zsh") {
@@ -153,16 +153,13 @@ function writeCompletionRegistrationWarning(message: string): void {
 }
 
 async function registerSubcommandsForCompletion(program: Command): Promise<void> {
-  const entries = getSubCliEntries();
-  for (const entry of entries) {
-    if (entry.name === "completion") {
-      continue;
-    }
+  for (const { name, entry } of getSubCliCompletionGroups()) {
     try {
-      await registerSubCliByNameCore(program, entry.name, process.argv, { purpose: "completion" });
+      removeCommandGroupNames(program, entry);
+      await entry.register(program);
     } catch (error) {
       writeCompletionRegistrationWarning(
-        `skipping subcommand \`${entry.name}\` while building completion cache: ${error instanceof Error ? error.message : String(error)}`,
+        `skipping subcommand \`${name}\` while building completion cache: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createInvalidConfigError } from "../config/io.invalid-config.js";
@@ -17,6 +18,8 @@ import {
 
 type PublishOutputFileAtomically =
   typeof import("./output-file.runtime.js").publishOutputFileAtomically;
+type GetSubCliCompletionGroups =
+  typeof import("./program/register.subclis-core.js").getSubCliCompletionGroups;
 
 const outputFileMocks = vi.hoisted(() => ({
   publishOutputFileAtomically: vi.fn<PublishOutputFileAtomically>(),
@@ -24,22 +27,24 @@ const outputFileMocks = vi.hoisted(() => ({
 const stderrWrites = vi.hoisted(() => vi.fn());
 const getCoreCliCompletionGroupsMock = vi.hoisted(() => vi.fn(() => []));
 const getProgramContextMock = vi.hoisted(() => vi.fn(() => null));
-const getSubCliEntriesMock = vi.hoisted(() =>
-  vi.fn(() => [
-    { name: "qa", description: "QA commands", hasSubcommands: true },
-    { name: "completion", description: "Completion", hasSubcommands: false },
-  ]),
+const { getSubCliCompletionGroupsMock, qaCompletionGroup } = vi.hoisted(() => {
+  const group = {
+    name: "qa",
+    entry: {
+      placeholders: [{ name: "qa", description: "QA commands" }],
+      register: async () => {
+        throw new Error("qa scenario pack not found: qa/scenarios/index.yaml");
+      },
+    },
+  };
+  return {
+    qaCompletionGroup: group,
+    getSubCliCompletionGroupsMock: vi.fn<GetSubCliCompletionGroups>(() => [group]),
+  };
+});
+const registerPluginCliCommandsFromValidatedConfigMock = vi.hoisted(() =>
+  vi.fn(async (_program: Command) => ({})),
 );
-const registerSubCliByNameMock = vi.hoisted(() =>
-  vi.fn(async (program: Command, name: string) => {
-    if (name === "qa") {
-      throw new Error("qa scenario pack not found: qa/scenarios/index.yaml");
-    }
-    program.command(name);
-    return true;
-  }),
-);
-const registerPluginCliCommandsFromValidatedConfigMock = vi.hoisted(() => vi.fn(async () => ({})));
 
 vi.mock("./output-file.runtime.js", async () => {
   const actual = await vi.importActual<typeof import("./output-file.runtime.js")>(
@@ -63,8 +68,7 @@ vi.mock("./program/program-context.js", () => ({
 }));
 
 vi.mock("./program/register.subclis-core.js", () => ({
-  getSubCliEntries: getSubCliEntriesMock,
-  registerSubCliByNameCore: registerSubCliByNameMock,
+  getSubCliCompletionGroups: getSubCliCompletionGroupsMock,
 }));
 
 vi.mock("../plugins/cli.js", () => ({
@@ -109,8 +113,7 @@ async function writeCompletionCacheForShell(shell: CompletionShell): Promise<str
 function expectCompletionInstallationToSkipRegistration(): void {
   expect(getProgramContextMock).not.toHaveBeenCalled();
   expect(getCoreCliCompletionGroupsMock).not.toHaveBeenCalled();
-  expect(getSubCliEntriesMock).not.toHaveBeenCalled();
-  expect(registerSubCliByNameMock).not.toHaveBeenCalled();
+  expect(getSubCliCompletionGroupsMock).not.toHaveBeenCalled();
   expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
   expect(stderrWrites).not.toHaveBeenCalled();
 }
@@ -129,8 +132,7 @@ describe("completion-cli write-state", () => {
     stderrWrites.mockReset();
     getCoreCliCompletionGroupsMock.mockClear();
     getProgramContextMock.mockClear();
-    getSubCliEntriesMock.mockClear();
-    registerSubCliByNameMock.mockClear();
+    getSubCliCompletionGroupsMock.mockClear();
     registerPluginCliCommandsFromValidatedConfigMock.mockClear();
     const stderrWriteSpy = vi.spyOn(process.stderr, "write").mockImplementation(((
       chunk: string | Uint8Array,
@@ -393,9 +395,7 @@ describe("completion-cli write-state", () => {
       expect(log).toHaveBeenCalledWith(
         "Completion installed. Restart your shell or run: source ~/.zshrc",
       );
-      expect(registerSubCliByNameMock.mock.calls).toEqual([
-        [program, "qa", process.argv, { purpose: "completion" }],
-      ]);
+      expect(getSubCliCompletionGroupsMock).toHaveBeenCalledTimes(1);
       expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledTimes(1);
       expect(stderrWrites.mock.calls).toEqual([
         [
@@ -407,38 +407,51 @@ describe("completion-cli write-state", () => {
 
   it("keeps completion cache generation alive when a subcli fails to register", async () => {
     const { registerCompletionCli } = await import("./completion-cli.js");
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
-    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
 
-    try {
-      await withEnvAsync({ HOME: homeDir, OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const program = new Command();
-        program.name("openclaw");
-        registerCompletionCli(program);
-
-        await program.parseAsync(["completion", "--write-state"], { from: "user" });
-
-        const cacheDir = path.join(stateDir, "completions");
-        expect((await fs.readdir(cacheDir)).toSorted()).toEqual([
-          "openclaw.bash",
-          "openclaw.fish",
-          "openclaw.ps1",
-          "openclaw.zsh",
-        ]);
-        expect(registerSubCliByNameMock.mock.calls).toEqual([
-          [program, "qa", process.argv, { purpose: "completion" }],
-        ]);
-        expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledTimes(1);
-        expect(stderrWrites.mock.calls).toEqual([
-          [
-            "[completion] skipping subcommand `qa` while building completion cache: qa scenario pack not found: qa/scenarios/index.yaml\n",
-          ],
-        ]);
+    await withIsolatedCompletionState(async () => {
+      getSubCliCompletionGroupsMock.mockReturnValueOnce([
+        qaCompletionGroup,
+        {
+          name: "after-qa",
+          entry: {
+            placeholders: [{ name: "after-qa", description: "Commands registered after QA" }],
+            register: async (program) => {
+              await setImmediate();
+              program.command("after-qa").option("--subcli-ready", "Async subcli option");
+            },
+          },
+        },
+      ]);
+      registerPluginCliCommandsFromValidatedConfigMock.mockImplementationOnce(async (program) => {
+        await Promise.resolve();
+        program.command("async-plugin").option("--plugin-ready", "Async plugin option");
+        return {};
       });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-      await fs.rm(homeDir, { recursive: true, force: true });
-    }
+      const program = new Command().name("openclaw");
+      registerCompletionCli(program);
+
+      await program.parseAsync(["completion", "--write-state"], { from: "user" });
+
+      const cacheDir = path.dirname(resolveCompletionCachePath("zsh", "openclaw"));
+      expect((await fs.readdir(cacheDir)).toSorted()).toEqual([
+        "openclaw.bash",
+        "openclaw.fish",
+        "openclaw.ps1",
+        "openclaw.zsh",
+      ]);
+      for (const shell of COMPLETION_SHELLS) {
+        const script = await fs.readFile(resolveCompletionCachePath(shell, "openclaw"), "utf8");
+        expect(script, shell).toContain("subcli-ready");
+        expect(script, shell).toContain("plugin-ready");
+      }
+      expect(getSubCliCompletionGroupsMock).toHaveBeenCalledTimes(1);
+      expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledTimes(1);
+      expect(stderrWrites.mock.calls).toEqual([
+        [
+          "[completion] skipping subcommand `qa` while building completion cache: qa scenario pack not found: qa/scenarios/index.yaml\n",
+        ],
+      ]);
+    });
   });
 
   it("writes core completion with a warning when invalid config prevents plugin discovery", async () => {
@@ -521,9 +534,7 @@ describe("completion-cli write-state", () => {
 
           await program.parseAsync(["completion", "--write-state"], { from: "user" });
 
-          expect(registerSubCliByNameMock.mock.calls).toEqual([
-            [program, "qa", process.argv, { purpose: "completion" }],
-          ]);
+          expect(getSubCliCompletionGroupsMock).toHaveBeenCalledTimes(1);
           expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
           expect((await fs.readdir(path.join(stateDir, "completions"))).toSorted()).toEqual([
             "openclaw.bash",

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -14,11 +14,12 @@ import {
 import { removeCommandByName } from "./command-tree.js";
 import { loadPrivateQaCliModule } from "./private-qa-cli.js";
 import {
+  findCommandGroupEntry,
   registerCommandGroupByName,
   registerCommandGroups,
   type CommandGroupEntry,
 } from "./register-command-groups.js";
-import { getSubCliEntriesCore, type SubCliDescriptor } from "./subcli-descriptors.js";
+import { getSubCliEntriesCore } from "./subcli-descriptors.js";
 
 export type SubCliRegistrationContext = {
   purpose?: "runtime" | "completion";
@@ -205,8 +206,19 @@ function resolveSubCliCommandGroups(
   );
 }
 
-export function getSubCliEntries(): ReadonlyArray<SubCliDescriptor> {
-  return getSubCliEntriesCore();
+export function getSubCliCompletionGroups(argv: string[] = process.argv) {
+  const entries = resolveSubCliCommandGroups(argv, { purpose: "completion" });
+  const groups: Array<{ name: string; entry: CommandGroupEntry }> = [];
+  let previous: CommandGroupEntry | undefined;
+  // Keep descriptor names for warnings and separated group visits for final command order.
+  for (const { name } of getSubCliEntriesCore()) {
+    const entry = findCommandGroupEntry(entries, name);
+    if (entry && entry !== previous) {
+      groups.push({ name, entry });
+    }
+    previous = entry;
+  }
+  return groups;
 }
 
 export async function registerSubCliByNameCore(

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -1,7 +1,13 @@
 // Register subCLI tests cover nested CLI command registration boundaries.
+import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { registerSubCliByName, registerSubCliCommands } from "./register.subclis.js";
+import * as subCliDescriptors from "./subcli-descriptors.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const { acpAction, registerAcpCli } = vi.hoisted(() => {
   const action = vi.fn();
@@ -45,6 +51,15 @@ const { approvalsAction, registerExecApprovalsCli } = vi.hoisted(() => {
   });
   return { approvalsAction: action, registerExecApprovalsCli: register };
 });
+
+const { registerTuiCli, registerCronCli } = vi.hoisted(() => ({
+  registerTuiCli: vi.fn((program: Command) => {
+    program.command("tui").aliases(["terminal", "chat"]);
+  }),
+  registerCronCli: vi.fn((program: Command) => {
+    program.command("cron").alias("automations");
+  }),
+}));
 
 const { registerPluginsCli, registerPluginCliCommandsFromValidatedConfig } = vi.hoisted(() => ({
   registerPluginsCli: vi.fn((program: Command) => {
@@ -90,6 +105,8 @@ vi.mock("../gateway-cli/run-command.js", () => ({ addGatewayRunCommand }));
 vi.mock("../nodes-cli.js", () => ({ registerNodesCli }));
 vi.mock("../capability-cli.js", () => ({ registerCapabilityCli }));
 vi.mock("../exec-approvals-cli.js", () => ({ registerExecApprovalsCli }));
+vi.mock("../tui-cli.js", () => ({ registerTuiCli }));
+vi.mock("../cron-cli.js", () => ({ registerCronCli }));
 vi.mock("../plugins-cli.js", () => ({ registerPluginsCli }));
 vi.mock("../channels-cli.js", () => ({ registerChannelsCli }));
 vi.mock("../resume-cli.js", () => ({ registerResumeCli }));
@@ -134,6 +151,8 @@ describe("registerSubCliCommands", () => {
     inferAction.mockClear();
     registerExecApprovalsCli.mockClear();
     approvalsAction.mockClear();
+    registerTuiCli.mockClear();
+    registerCronCli.mockClear();
     registerPluginsCli.mockClear();
     registerPluginCliCommandsFromValidatedConfig.mockClear();
     registerChannelsCli.mockClear();
@@ -178,6 +197,64 @@ describe("registerSubCliCommands", () => {
     expect(names).toContain("clawbot");
     expect(names).toContain("qa");
     expect(registerAcpCli).not.toHaveBeenCalled();
+  });
+
+  it("coalesces adjacent completion aliases while preserving separated command visits", async () => {
+    const selectedNames = new Set([
+      "infer",
+      "capability",
+      "approvals",
+      "exec-approvals",
+      "tui",
+      "resume",
+      "terminal",
+      "chat",
+      "cron",
+      "automations",
+      "completion",
+    ]);
+    const descriptors = subCliDescriptors
+      .getSubCliEntriesCore()
+      .filter(({ name }) => selectedNames.has(name));
+    const descriptorSpy = vi
+      .spyOn(subCliDescriptors, "getSubCliEntriesCore")
+      .mockReturnValue(descriptors);
+    const root = tempDirs.make("openclaw-completion-groups-");
+    try {
+      await withEnvAsync(
+        {
+          HOME: root,
+          USERPROFILE: root,
+          OPENCLAW_HOME: root,
+          OPENCLAW_STATE_DIR: path.join(root, "state"),
+          OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+          OPENCLAW_DISABLE_LAZY_SUBCOMMANDS: undefined,
+          OPENCLAW_COMPLETION_SKIP_PLUGIN_COMMANDS: "1",
+        },
+        async () => {
+          const program = createRegisteredProgram(
+            ["node", "openclaw", "completion", "--write-state"],
+            "openclaw",
+          );
+          await program.parseAsync(["completion", "--write-state"], { from: "user" });
+
+          expect(registerCapabilityCli).toHaveBeenCalledTimes(1);
+          expect(registerExecApprovalsCli).toHaveBeenCalledTimes(1);
+          expect(registerCronCli).toHaveBeenCalledTimes(1);
+          expect(registerTuiCli).toHaveBeenCalledTimes(2);
+          expect(program.commands.map((command) => command.name())).toEqual([
+            "completion",
+            "infer",
+            "approvals",
+            "resume",
+            "tui",
+            "cron",
+          ]);
+        },
+      );
+    } finally {
+      descriptorSpy.mockRestore();
+    }
   });
 
   it("omits the qa placeholder when the private qa cli is disabled", () => {


### PR DESCRIPTION
Closes #144310

## What Problem This Solves

Building shell completions repeatedly reconstructs the subcommand registration groups and visits adjacent names owned by the same registrar. This repeats registration work while producing the same completion tree.

## Why This Change Was Made

Prepare the ordered completion groups once at their existing owner. Coalesce only adjacent visits to the same group; preserve separated visits, descriptor names used in warnings, command replacement and awaited asynchronous registration. The old descriptor-only accessor has no remaining callers and is removed.

## User Impact

Generated completions and command ordering remain unchanged, including asynchronous plugin commands and aliases. There are no new CLI options, configuration, schema, persistence or migration changes. The change adds nine production lines and 88 net test lines to protect grouping, ordering and async completion behavior; no overall startup, latency or RSS improvement is claimed.

## Evidence

The new original-source regression fails because the capability registrar runs twice instead of once; the final two test files pass all 47 tests. The supported CLI launcher then generated Bash, Fish, PowerShell and Zsh completion files before and after using the same isolated configuration and synthetic async plugin. All four files match byte-for-byte and by SHA-256, retain the plugin command/alias, leave the configuration unchanged and create no shell profiles.

The normal launcher performed its required runtime rebuilds. The full selected changed gate and fresh independent P2 review pass; the selected scope did not require a separate build. An initial test-local shadowing lint error was renamed and the affected tests, review and complete gate rerun passed. Production bytes remain identical to the successful CLI parity proof.
