### PR TITLE
fix(docs): validate examples against source plugin schemas

### DIFF
--- a/src/config/docs-config-examples.test.ts
+++ b/src/config/docs-config-examples.test.ts
@@ -3,7 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -15,6 +16,7 @@ import { auditDocsConfigExamples } from "./docs-config-examples.js";
 import { resolveRepoBundledPluginEnv } from "./repo-bundled-plugin-env.js";
 
 type SkipStat = "skippedFragment" | "skippedNonObject" | "skippedOptOut" | "skippedParseFailure";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function auditMarkdown(markdown: string): ReturnType<typeof auditDocsConfigExamples> {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-config-"));
@@ -161,6 +163,38 @@ describe("docs config examples", () => {
     } finally {
       restoreStateDirEnv(envSnapshot);
       fs.rmSync(poisonedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses source schemas instead of another working directory's plugin tree", () => {
+    const directory = tempDirs.make("openclaw-docs-config-cwd-");
+    const pluginDir = path.join(directory, "extensions", "openai");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n");
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "openai",
+        configSchema: { type: "object", properties: {}, additionalProperties: false },
+      }),
+    );
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(directory);
+    try {
+      const audit = auditMarkdown(
+        [
+          '```json5\n{ plugins: { entries: { openai: { config: { personality: "off" } } } } }\n```',
+          '```json5\n{ plugins: { entries: { openai: { config: { personalityy: "friendly" } } } } }\n```',
+        ].join("\n"),
+      );
+      expect(audit.stats.candidatesValidated).toBe(2);
+      expect(audit.findings).toEqual([
+        expect.objectContaining({
+          issuePath: "plugins.entries.openai.config",
+          message: expect.stringContaining('"personalityy"'),
+        }),
+      ]);
+    } finally {
+      cwd.mockRestore();
     }
   });
 

--- a/src/config/docs-config-examples.ts
+++ b/src/config/docs-config-examples.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import JSON5 from "json5";
 import {
@@ -126,7 +127,9 @@ function stripIncludeKeys(value: unknown): unknown {
 }
 
 function createDocsConfigValidationContext(): DocsConfigValidationContext {
-  const env = resolveRepoBundledPluginEnv(path.join(process.cwd(), "extensions"));
+  const env = resolveRepoBundledPluginEnv(
+    fileURLToPath(new URL("../../extensions", import.meta.url)),
+  );
   return {
     env,
     pluginMetadataSnapshot: loadPluginMetadataSnapshot({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where docs configuration checks could use stale built plugin schemas when launched from a checkout subdirectory. The checker read current source docs, but its working directory could change which plugin metadata validated them, producing false errors or missed retired settings.

## Why This Change Was Made

Anchor bundled source manifests beside the checker's source schema. Keep the caller's docs-input root separate, so existing docs-only fixtures still use the current schema. The shared metadata resolver, separate validators and operator-state isolation retain their existing contracts.

## User Impact

The registered checker now gives the same configuration findings from the checkout root and `docs/`, even when stale built plugin metadata is present. It changes no stored data or schema and requires no migration.

## Evidence

A fixture supplies contrasting current-source and stale-built schemas plus one docs example. Before, the actual registered command correctly rejects the retired setting from the root but incorrectly accepts it from `docs/`. After, both runs reject it with byte-identical findings. The same seven fixture files are used throughout; plugin runtime sentinels never execute.

The permanent regression also proves that an alternate working-directory plugin tree cannot reject a supported source setting. All 17 docs audit/baseline tests pass, including operator-state isolation. A clean registered command from `docs/` passes 1,289 files and 1,224 validated fences. All 30 canonical changed checks pass, and independent review found no actionable findings.

This repair covers metadata selection within a source checkout. Separate TypeScript-loader behavior from a completely external working directory, and discovery after a working directory is deleted, remain outside this change. No live provider or Gateway was used.
