### PR TITLE
fix(sessions): sessions_send treats visible dashboard spawn children as foreign sessions and starts a stale announce run

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -2438,6 +2438,45 @@ describe("sessions tools", () => {
     expect(countMatching(calls, (call) => call.method === "agent")).toBe(1);
   });
 
+  it("sessions_send keeps the delayed continuation when a visible spawn child outlives the wait", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "agent:main:dashboard:parent-uuid";
+    const targetKey = "agent:penny:dashboard:child-uuid";
+    loadSessionEntryByKeyMock.mockImplementation((sessionKey: string) =>
+      sessionKey === targetKey
+        ? { sessionId: "child-session", updatedAt: 1, spawnedBy: requesterKey, spawnDepth: 1 }
+        : undefined,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-slow-child", status: "accepted", acceptedAt: 2000 };
+      }
+      if (request.method === "agent.wait") {
+        // The child is still running: a nonterminal timeout, not a failed run.
+        return { runId: "run-slow-child", status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = getSessionTool("sessions_send", { agentSessionKey: requesterKey });
+    const result = await tool.execute("call-slow-visible-child", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("accepted");
+    // The late reply still has a delivery path; only inline replies skip it.
+    expect(details.delivery?.status).toBe("pending");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(countMatching(calls, (call) => call.method === "agent.wait")).toBeGreaterThan(1);
+  });
+
   it("sessions_send keeps the A2A flow for dashboard threads that were not spawned by the requester", async () => {
     const requesterKey = "agent:main:dashboard:parent-uuid";
     const targetKey = "agent:main:dashboard:thread-uuid";

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -2392,6 +2392,87 @@ describe("sessions tools", () => {
     expect(calls.some((call) => call.method === "send")).toBe(false);
   });
 
+  it("sessions_send skips duplicate A2A delivery for waited visible spawn children on dashboard keys", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "agent:main:dashboard:parent-uuid";
+    const targetKey = "agent:penny:dashboard:child-uuid";
+    loadSessionEntryByKeyMock.mockImplementation((sessionKey: string) =>
+      sessionKey === targetKey
+        ? {
+            sessionId: "child-session",
+            updatedAt: 1,
+            spawnedBy: requesterKey,
+            parentSessionKey: requesterKey,
+            spawnDepth: 1,
+          }
+        : undefined,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-child", status: "accepted", acceptedAt: 2000 };
+      }
+      if (request.method === "agent.wait") {
+        return {
+          runId: "run-child",
+          status: "ok",
+          terminalReply: { disposition: "visible", text: "child reply" },
+        };
+      }
+      return {};
+    });
+
+    const tool = getSessionTool("sessions_send", { agentSessionKey: requesterKey });
+
+    const waited = await tool.execute("call-parent-owned-dashboard-child", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    const waitedDetails = sessionsSendDetails(waited.details);
+    expect(waitedDetails.status).toBe("ok");
+    expect(waitedDetails.reply).toBe("child reply");
+    expect(waitedDetails.delivery?.status).toBe("skipped");
+    expect(countMatching(calls, (call) => call.method === "agent")).toBe(1);
+  });
+
+  it("sessions_send keeps the A2A flow for dashboard threads that were not spawned by the requester", async () => {
+    const requesterKey = "agent:main:dashboard:parent-uuid";
+    const targetKey = "agent:main:dashboard:thread-uuid";
+    loadSessionEntryByKeyMock.mockImplementation((sessionKey: string) =>
+      sessionKey === targetKey
+        ? { sessionId: "thread-session", updatedAt: 1, parentSessionKey: requesterKey }
+        : undefined,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-thread", status: "accepted", acceptedAt: 2000 };
+      }
+      if (request.method === "agent.wait") {
+        return {
+          runId: "run-thread",
+          status: "ok",
+          terminalReply: { disposition: "visible", text: "thread reply" },
+        };
+      }
+      return {};
+    });
+
+    const tool = getSessionTool("sessions_send", { agentSessionKey: requesterKey });
+    const waited = await tool.execute("call-dashboard-thread", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    const waitedDetails = sessionsSendDetails(waited.details);
+    expect(waitedDetails.reply).toBe("thread reply");
+    expect(waitedDetails.delivery?.status).toBe("pending");
+  });
+
   it("sessions_send preserves threadId when announce target is hydrated via sessions.list", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -563,7 +563,9 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
           // Keep the in-process caller so materialized agent roots retain their creation stamp.
           createSessionsSendTool({
             agentId: sessionAgentId,
-            agentSessionKey: options?.agentSessionKey,
+            // Match sessions_spawn: spawned children record the durable run
+            // session as spawnedBy, so the parent check must use the same key.
+            agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
             agentChannel: options?.agentChannel,
             sandboxed: options?.sandboxed,
             config: sessionConfig,

--- a/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
+++ b/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
   return {
     stubTool,
     spawnToolOptions: vi.fn(),
+    sendToolOptions: vi.fn(),
     subagentsToolOptions: vi.fn(),
     imageGenerateToolOptions: vi.fn(),
     videoGenerateToolOptions: vi.fn(),
@@ -106,7 +107,10 @@ vi.mock("./sessions-list-tool.js", () => ({
 }));
 
 vi.mock("./sessions-send-tool.js", () => ({
-  createSessionsSendTool: () => mocks.stubTool("sessions_send"),
+  createSessionsSendTool: (options: unknown) => {
+    mocks.sendToolOptions(options);
+    return mocks.stubTool("sessions_send");
+  },
 }));
 
 vi.mock("./sessions-spawn-tool.js", () => ({
@@ -148,6 +152,7 @@ import { createOpenClawTools } from "../openclaw-tools.js";
 describe("createOpenClawTools sessions_spawn session-key selection", () => {
   beforeEach(() => {
     mocks.spawnToolOptions.mockClear();
+    mocks.sendToolOptions.mockClear();
     mocks.subagentsToolOptions.mockClear();
     mocks.imageGenerateToolOptions.mockClear();
     mocks.videoGenerateToolOptions.mockClear();
@@ -194,6 +199,26 @@ describe("createOpenClawTools sessions_spawn session-key selection", () => {
       expect.objectContaining({
         agentSessionKey: policyKey,
       }),
+    );
+  });
+
+  it("passes the durable runSessionKey to createSessionsSendTool when keys differ", () => {
+    // Regression for #144265: spawned children persist spawnedBy under the durable
+    // run session key (Gateway canonicalizes the spawn parent), so sessions_send must
+    // identify the requester with the same key or it treats its own visible child as
+    // a peer and starts the A2A announce flow after a waited reply.
+    const policyKey = "agent:main:telegram:default:direct:456";
+    const durableKey = "agent:main:telegram:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      runSessionKey: durableKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.sendToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ agentSessionKey: durableKey }),
     );
   });
 

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1058,8 +1058,11 @@ export function createSessionsSendTool(opts?: {
             });
           // A scoped grant belongs to one exact session incarnation. Do not create
           // post-return work or durable watches that could follow a reused key.
-          const skipA2AFlow =
-            skipAcpA2AFlow || skipNativeParentA2AFlow || Boolean(expectedSessionId);
+          const skipDelayedA2AFlow = skipAcpA2AFlow || Boolean(expectedSessionId);
+          // Native-parent suppression only covers a reply that already returned inline.
+          // A send is not a registered spawn run, so when the wait expires before the
+          // child finishes, nothing else delivers the late reply: keep that continuation.
+          const skipA2AFlow = skipDelayedA2AFlow || skipNativeParentA2AFlow;
           const startA2AFlow = (
             reply?: Awaited<ReturnType<typeof waitForAgentRunReply>>,
             waitRunId?: string,
@@ -1067,7 +1070,7 @@ export function createSessionsSendTool(opts?: {
             flowDisplayKey = displayKey,
             notifyRequesterOnWaitFailure = false,
           ) => {
-            if (skipA2AFlow) {
+            if (reply === undefined ? skipDelayedA2AFlow : skipA2AFlow) {
               return;
             }
             // This detached flow can outlive the tool request that launched it.
@@ -1132,6 +1135,10 @@ export function createSessionsSendTool(opts?: {
             skipA2AFlow || start.targetDisposition === "steered"
               ? ({ status: "skipped", mode: "announce" } as const)
               : ({ status: "pending", mode: "announce" } as const);
+          const delayedDelivery =
+            skipDelayedA2AFlow || start.targetDisposition === "steered"
+              ? ({ status: "skipped", mode: "announce" } as const)
+              : ({ status: "pending", mode: "announce" } as const);
           recordSessionToolActionFact({
             operation: "send",
             fact: "committed",
@@ -1177,7 +1184,7 @@ export function createSessionsSendTool(opts?: {
                 error: result.error,
                 sentBeforeError: true,
                 sessionKey: displayKey,
-                delivery,
+                delivery: delayedDelivery,
                 ...watchField,
               });
             }
@@ -1188,7 +1195,7 @@ export function createSessionsSendTool(opts?: {
                 status: "accepted",
                 sessionKey: displayKey,
                 targetDisposition: start.targetDisposition,
-                delivery,
+                delivery: delayedDelivery,
                 ...watchField,
               });
             }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -285,21 +285,24 @@ function isRequesterParentOfNativeSubagentSession(params: {
   requesterSessionKey: string | null | undefined;
   targetSessionKey: string;
 }): boolean {
-  if (
-    !params.entry ||
-    params.acpMeta ||
-    params.entry.acp ||
-    !isSubagentSessionKey(params.targetSessionKey)
-  ) {
+  if (!params.entry || params.acpMeta || params.entry.acp) {
     return false;
   }
   const requester = normalizeOptionalString(params.requesterSessionKey);
   if (!requester) {
     return false;
   }
-  const spawnedBy = normalizeOptionalString(params.entry.spawnedBy);
-  const parentSessionKey = normalizeOptionalString(params.entry.parentSessionKey);
-  return requester === spawnedBy || requester === parentSessionKey;
+  // spawnedBy is written only by the spawn policy, so it identifies a native
+  // child regardless of key shape: visible children live under persistent
+  // dashboard keys, not subagent keys. parentSessionKey also records ordinary
+  // UI threading and forks, so it only counts for subagent-keyed targets.
+  if (requester === normalizeOptionalString(params.entry.spawnedBy)) {
+    return true;
+  }
+  return (
+    isSubagentSessionKey(params.targetSessionKey) &&
+    requester === normalizeOptionalString(params.entry.parentSessionKey)
+  );
 }
 
 function isTerminalAgentWaitTimeout(result: AgentWaitResult): boolean {

--- a/test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts
@@ -3,6 +3,7 @@
 // reply must come back inline without the generic A2A announce flow.
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -356,7 +357,7 @@ describe.runIf(process.env.OPENCLAW_PROOF_VISIBLE_CHILD_SEND === "1")(
         .poll(() => provider.proof.childRequests.length, { timeout: 60_000 })
         .toBeGreaterThanOrEqual(1);
       // Let the child's own completion announcement settle before the send.
-      await new Promise((resolve) => setTimeout(resolve, 6_000));
+      await sleep(6_000);
       const childRequestsAfterSpawn = provider.proof.childRequests.length;
 
       // Turn 2: waited sessions_send to the persisted dashboard child.
@@ -374,7 +375,7 @@ describe.runIf(process.env.OPENCLAW_PROOF_VISIBLE_CHILD_SEND === "1")(
         timeoutMs: 120_000,
       });
       // Give a stray detached A2A flow time to show up before counting.
-      await new Promise((resolve) => setTimeout(resolve, 8_000));
+      await sleep(8_000);
 
       const childKey = provider.proof.childKey;
       const listing = (await gateway.call("sessions.list", { agentId: "qa", limit: 100 })) as {

--- a/test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts
@@ -1,0 +1,419 @@
+// Real-Gateway proof for #144265: a parent spawns a visible child (persistent
+// dashboard key) in one turn and later sends it a waited sessions_send. The
+// reply must come back inline without the generic A2A announce flow.
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  createQaGatewayChild,
+  startQaBusServer,
+} from "../../../../extensions/qa-lab/api.js";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const MODEL = "mock-openai/gpt-5.6-luna";
+const CHILD_MODEL = "mock-openai/gpt-5.6-luna-alt";
+const CONVERSATION = { id: "visible-child-send", kind: "direct" as const };
+const PROMPT_SPAWN = "Visible child send QA check: spawn one visible worker now.";
+const PROMPT_SEND = "Visible child send QA check: send the worker one waited message now.";
+const CHILD_MARKER = "QA-VISIBLE-CHILD-OK";
+const PARENT_READY = "QA-VISIBLE-CHILD-PARENT-READY";
+const PARENT_DONE = "QA-VISIBLE-CHILD-PARENT-DONE";
+const REPLY_STEP_MARKER = "Agent-to-agent reply step";
+const CHILD_KEY_PATTERN = /agent:qa:dashboard:[A-Za-z0-9-]+/;
+
+type SseEvent = {
+  type: string;
+  response?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+let responseSequence = 0;
+
+function buildAssistantEvents(text: string): SseEvent[] {
+  const sequence = ++responseSequence;
+  const responseId = `resp_qa_visible_child_${sequence}`;
+  const itemId = `msg_qa_visible_child_${sequence}`;
+  const part = { type: "output_text", text, annotations: [] };
+  const item = {
+    type: "message",
+    id: itemId,
+    role: "assistant",
+    status: "completed",
+    content: [part],
+  };
+  const position = { item_id: itemId, output_index: 0, content_index: 0 };
+  return [
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        created_at: Math.floor(Date.now() / 1_000),
+      },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, content: [], status: "in_progress" },
+    },
+    { type: "response.content_part.added", ...position, part: { ...part, text: "" } },
+    { type: "response.output_text.delta", ...position, delta: text },
+    { type: "response.output_text.done", ...position, text },
+    { type: "response.content_part.done", ...position, part },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 64, output_tokens: 24, total_tokens: 88 },
+      },
+    },
+  ];
+}
+
+function buildToolCallEvents(name: string, args: Record<string, unknown>): SseEvent[] {
+  const sequence = ++responseSequence;
+  const responseId = `resp_qa_visible_child_tool_${sequence}`;
+  const itemId = `fc_qa_visible_child_${sequence}`;
+  const callId = `call_qa_visible_child_${sequence}`;
+  const argumentsText = JSON.stringify(args);
+  const item = {
+    type: "function_call",
+    id: itemId,
+    call_id: callId,
+    name,
+    arguments: argumentsText,
+  };
+  return [
+    {
+      type: "response.created",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "in_progress",
+        output: [],
+        created_at: Math.floor(Date.now() / 1_000),
+      },
+    },
+    { type: "response.output_item.added", output_index: 0, item: { ...item, arguments: "" } },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: itemId,
+      output_index: 0,
+      delta: argumentsText,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: itemId,
+      output_index: 0,
+      name,
+      arguments: argumentsText,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 64, output_tokens: 24, total_tokens: 88 },
+      },
+    },
+  ];
+}
+
+function writeSse(response: ServerResponse, events: SseEvent[]): void {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  for (const event of events) {
+    response.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+  }
+  response.end();
+}
+
+type ChildRequest = { index: number; replyStep: boolean; atMs: number };
+
+async function startProofProvider() {
+  const childRequests: ChildRequest[] = [];
+  let parentRequests = 0;
+  let parentReplySteps = 0;
+  let spawnIssued = false;
+  let sendIssued = false;
+  let doneIssued = false;
+  let childKey: string | undefined;
+  let sendDeliveryStatus: string | undefined;
+  let sendInlineReply: string | undefined;
+  let sendOutputExcerpt: string | undefined;
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: "gpt-5.6-luna", object: "model" }] }));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+      const inputText = JSON.stringify(body.input ?? body);
+      // The alternate configured model identifies child requests.
+      if (body.model === CHILD_MODEL.split("/")[1]) {
+        childRequests.push({
+          index: childRequests.length + 1,
+          replyStep: inputText.includes(REPLY_STEP_MARKER),
+          atMs: Date.now(),
+        });
+        writeSse(response, buildAssistantEvents(CHILD_MARKER));
+        return;
+      }
+      parentRequests += 1;
+      if (inputText.includes(REPLY_STEP_MARKER)) {
+        // Only reachable through the A2A flow; answer without new tool calls.
+        parentReplySteps += 1;
+        writeSse(response, buildAssistantEvents(PARENT_DONE));
+        return;
+      }
+      if (!spawnIssued) {
+        spawnIssued = true;
+        writeSse(
+          response,
+          buildToolCallEvents("sessions_spawn", {
+            task: `Visible child QA worker. Return exactly ${CHILD_MARKER}.`,
+            label: "qa-visible-child",
+            visible: true,
+            mode: "run",
+            model: CHILD_MODEL,
+          }),
+        );
+        return;
+      }
+      if (!childKey) {
+        childKey = CHILD_KEY_PATTERN.exec(inputText)?.[0];
+      }
+      // Turn 2 arrives as a fresh user message after the child finished its run.
+      if (childKey && !sendIssued && inputText.includes(PROMPT_SEND)) {
+        sendIssued = true;
+        writeSse(
+          response,
+          buildToolCallEvents("sessions_send", {
+            sessionKey: childKey,
+            message: "Parent ping: reply with your marker.",
+            timeoutSeconds: 60,
+          }),
+        );
+        return;
+      }
+      if (sendIssued && !doneIssued) {
+        doneIssued = true;
+        // The tool result is JSON inside a function_call_output string.
+        const flat = inputText.replaceAll("\\n", " ").replaceAll("\\", "");
+        const outputAt = flat.lastIndexOf("function_call_output");
+        sendOutputExcerpt = flat.slice(outputAt, outputAt + 900);
+        sendDeliveryStatus = /"delivery":\s*\{\s*"status":\s*"([a-z_]+)"/.exec(
+          sendOutputExcerpt,
+        )?.[1];
+        sendInlineReply = /"reply":\s*"([^"]*)"/.exec(sendOutputExcerpt)?.[1];
+        writeSse(response, buildAssistantEvents(PARENT_DONE));
+        return;
+      }
+      writeSse(response, buildAssistantEvents(PARENT_READY));
+    })().catch(() => {
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("proof provider did not bind");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    proof: {
+      childRequests,
+      get parentRequests() {
+        return parentRequests;
+      },
+      get parentReplySteps() {
+        return parentReplySteps;
+      },
+      get childKey() {
+        return childKey;
+      },
+      get sendDeliveryStatus() {
+        return sendDeliveryStatus;
+      },
+      get sendInlineReply() {
+        return sendInlineReply;
+      },
+      get sendOutputExcerpt() {
+        return sendOutputExcerpt;
+      },
+    },
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+function withModels(config: OpenClawConfig): OpenClawConfig {
+  return {
+    ...config,
+    logging: { ...config.logging, level: "debug" },
+    agents: {
+      ...config.agents,
+      defaults: { ...config.agents?.defaults, model: { primary: MODEL } },
+      entries: {
+        ...config.agents?.entries,
+        qa: { ...config.agents?.entries?.qa, model: { primary: MODEL } },
+      },
+    },
+  };
+}
+
+describe.runIf(process.env.OPENCLAW_PROOF_VISIBLE_CHILD_SEND === "1")(
+  "sessions_send to a visible spawn child",
+  () => {
+    const cleanups: Array<() => Promise<void>> = [];
+    afterEach(async () => {
+      for (const cleanup of cleanups.splice(0).toReversed()) {
+        await cleanup();
+      }
+    });
+
+    it("returns the waited reply inline without an announce run against the child", async () => {
+      const provider = await startProofProvider();
+      cleanups.push(() => provider.stop());
+      const state = createQaBusState();
+      const transport = createQaChannelTransport(state);
+      const bus = await startQaBusServer({ state });
+      cleanups.push(() => bus.stop());
+      const owner = createQaGatewayChild();
+      cleanups.push(async () => expect((await owner.stop()).errors).toEqual([]));
+      const gateway = await owner.start({
+        repoRoot: REPO_ROOT,
+        // Built Gateway: source-mode tsx startup alone exceeds the QA child's
+        // 120 s listen deadline on this checkout.
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: ["dist/index.js"],
+          cwd: REPO_ROOT,
+          usePackagedPlugins: true,
+        },
+        providerBaseUrl: `${provider.baseUrl}/v1`,
+        providerMode: "mock-openai",
+        primaryModel: MODEL,
+        alternateModel: CHILD_MODEL,
+        transport,
+        transportBaseUrl: bus.baseUrl,
+        controlUiEnabled: false,
+        mutateConfig: withModels,
+      });
+      await transport.waitReady({ gateway });
+      const outboundCount = () =>
+        state.getSnapshot().messages.filter((message) => message.direction === "outbound").length;
+
+      // Turn 1: spawn the visible child and let its run finish.
+      const sinceSpawn = outboundCount();
+      await transport.sendInbound({
+        accountId: "default",
+        conversation: CONVERSATION,
+        senderId: CONVERSATION.id,
+        text: PROMPT_SPAWN,
+      });
+      await transport.waitForOutbound({
+        conversation: CONVERSATION,
+        sinceIndex: sinceSpawn,
+        textIncludes: PARENT_READY,
+        timeoutMs: 120_000,
+      });
+      await expect
+        .poll(() => provider.proof.childRequests.length, { timeout: 60_000 })
+        .toBeGreaterThanOrEqual(1);
+      // Let the child's own completion announcement settle before the send.
+      await new Promise((resolve) => setTimeout(resolve, 6_000));
+      const childRequestsAfterSpawn = provider.proof.childRequests.length;
+
+      // Turn 2: waited sessions_send to the persisted dashboard child.
+      const sinceSend = outboundCount();
+      await transport.sendInbound({
+        accountId: "default",
+        conversation: CONVERSATION,
+        senderId: CONVERSATION.id,
+        text: PROMPT_SEND,
+      });
+      await transport.waitForOutbound({
+        conversation: CONVERSATION,
+        sinceIndex: sinceSend,
+        textIncludes: PARENT_DONE,
+        timeoutMs: 120_000,
+      });
+      // Give a stray detached A2A flow time to show up before counting.
+      await new Promise((resolve) => setTimeout(resolve, 8_000));
+
+      const childKey = provider.proof.childKey;
+      const listing = (await gateway.call("sessions.list", { agentId: "qa", limit: 100 })) as {
+        sessions?: Array<Record<string, unknown>>;
+      };
+      const child = listing.sessions?.find((entry) => entry.key === childKey);
+      const replySteps = provider.proof.childRequests.filter((entry) => entry.replyStep);
+      const logs = gateway.logs();
+      const announceLines = logs
+        .split("\n")
+        .filter((line) => line.includes("sessions_send announce")).length;
+      console.log(
+        JSON.stringify({
+          phase: "sessions-send-visible-child",
+          childKey,
+          childSpawnedBy: child?.spawnedBy,
+          childParentSessionKey: child?.parentSessionKey,
+          childRequestsAfterSpawn,
+          childRequestsTotal: provider.proof.childRequests.length,
+          childReplyStepRequests: replySteps.length,
+          parentRequests: provider.proof.parentRequests,
+          parentReplyStepRequests: provider.proof.parentReplySteps,
+          sendDeliveryStatus: provider.proof.sendDeliveryStatus,
+          sendInlineReply: provider.proof.sendInlineReply,
+          sendOutputExcerpt: provider.proof.sendOutputExcerpt,
+          announceFlowLogLines: announceLines,
+        }),
+      );
+      expect(childKey).toMatch(CHILD_KEY_PATTERN);
+      // Persisted lineage names the requester; the dashboard key is not a subagent key.
+      expect(child?.spawnedBy).toBeTypeOf("string");
+      // The waited send returned the child's reply inline and skipped delivery.
+      expect(provider.proof.sendInlineReply).toBe(CHILD_MARKER);
+      expect(provider.proof.sendDeliveryStatus).toBe("skipped");
+      // Exactly one child run for the send; no A2A reply-step or announce run.
+      expect(provider.proof.childRequests.length).toBe(childRequestsAfterSpawn + 1);
+      expect(replySteps).toHaveLength(0);
+      expect(provider.proof.parentReplySteps).toBe(0);
+      expect(announceLines).toBe(0);
+    }, 400_000);
+  },
+);


### PR DESCRIPTION
Closes #144265

## What Problem This Solves

Fixes an issue where an agent that spawned a visible child with `sessions_spawn` (`visible: true`) and later sent it a waited `sessions_send` would trigger an extra agent-to-agent announce run against that child. The child's reply already came back inline, so the follow-up run was pure overhead, and on 2026.9.3 it could fail with `prepared model runtime plugin generation was superseded` after a roughly 30 second lane wait, logged as `sessions_send announce flow failed`.

## Why This Change Was Made

Two things kept `sessions_send` from recognizing its own visible child:

1. The native-parent guard first required the target key to be a `subagent:` key. Visible children live under persistent `dashboard:` keys, so their persisted lineage (`spawnedBy` equal to the requester) was never consulted. The guard now treats a `spawnedBy` match as authoritative regardless of key shape and keeps the `parentSessionKey` match limited to subagent keys, because that field also records ordinary UI threading and forks.
2. `createOpenClawTools` handed `sessions_send` only the channel route key (`agentSessionKey`), while `sessions_spawn` and every other session tool already receive the durable run session key (`runSessionKey ?? agentSessionKey`, see #137779). The Gateway canonicalizes the spawn parent into `spawnedBy` under that durable key, so for channel-originated parents (a DM mapped to the main session) the requester and `spawnedBy` never matched even with the guard fixed. `sessions_send` now receives the same key as its siblings.

3. Suppressing the flow is only right when the child's reply actually returned inline. A send to a spawned child is not a registered spawn run, so when the wait expires before the child finishes, the detached continuation is the only path that brings the late reply back to the parent. The native-parent skip now applies to inline replies only; a timed-out send reports `delivery.status: "pending"` and keeps its continuation (raised by ClawSweeper as a P1 on this PR).

ACP sessions, fire-and-forget sends, and unrelated senders are unchanged. Dashboard threads and forks that were not spawned by the requester still go through the normal A2A path.

## User Impact

Parents that spawn visible children and wait on `sessions_send` get the inline reply without a second announce run against the child: no stale runtime re-entry, no 30 second lane wait, no spurious `announce flow failed` warning. This also holds for parents running from a channel DM, not only for dashboard-to-dashboard spawns.

## Evidence

- Regression `sessions_send skips duplicate A2A delivery for waited visible spawn children on dashboard keys` (`src/agents/openclaw-tools.sessions.test.ts`) fails on main with `expected 'pending' to be 'skipped'` and passes with the fix.
- Boundary test `sessions_send keeps the A2A flow for dashboard threads that were not spawned by the requester` passes on main and with the fix.
- Regression `sessions_send keeps the delayed continuation when a visible spawn child outlives the wait` fails before the third commit with `expected 'skipped' to be 'pending'` and passes with it; the terminal-timeout and inline-reply tests are unchanged.
- Wiring regression `passes the durable runSessionKey to createSessionsSendTool when keys differ` (`src/agents/tools/openclaw-tools.spawn-session-key.test.ts`) fails on main (`expected "vi.fn()" to be called with arguments`) and passes with the fix.
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/openclaw-tools.spawn-session-key.test.ts`: 47 + 28 + 7 passed.
- `pnpm check:changed` on the final head (typecheck all lanes, type-aware lint, dead-export scan, changed-lane Vitest shards): passed.
- Real Gateway proof (built `dist/index.js` at this branch head, `createQaGatewayChild` with a loopback mock Responses provider, QA channel DM as the parent): turn 1 spawns a visible child through the real `sessions_spawn` tool call, turn 2 issues a waited `sessions_send` to the persisted `agent:qa:dashboard:<uuid>` key. Recorded run, redacted to loopback values only:

```text
$ OPENCLAW_PROOF_VISIBLE_CHILD_SEND=1 OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.e2e.config.ts \
    test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts

{"phase":"sessions-send-visible-child",
 "childKey":"agent:qa:dashboard:5e20d14c-2b95-4ff0-b54b-ca54f841dd60",
 "childSpawnedBy":"agent:qa:main","childParentSessionKey":"agent:qa:main",
 "childRequestsAfterSpawn":1,"childRequestsTotal":2,"childReplyStepRequests":0,
 "parentRequests":5,"parentReplyStepRequests":0,
 "sendDeliveryStatus":"skipped","sendInlineReply":"QA-VISIBLE-CHILD-OK",
 "announceFlowLogLines":0}
 ✓ returns the waited reply inline without an announce run against the child 154955ms

sessions_send tool result seen by the parent model (excerpt):
  "status": "ok",
  "delivery": { "status": "skipped", "mode": "announce" },
  "reply": "QA-VISIBLE-CHILD-OK"
```

  The same lane run against the guard-only change (before adding the factory wiring) showed `parentReplyStepRequests: 1` and one `sessions_send announce flow failed` line, which is how the second cause was found: the guard received the raw route key `agent:qa:qa-channel:default:direct:<id>` while the child was persisted with `spawnedBy: agent:qa:main`. The lane is committed as `test/e2e/qa-lab/runtime/sessions-send-visible-child.product-proof.e2e.test.ts`, gated behind `OPENCLAW_PROOF_VISIBLE_CHILD_SEND=1`, following the existing product-proof lanes in that directory.
- `autoreview` (Codex, P2 threshold) on the final four-commit branch: scoped-clean, no findings.
- CI: the hosted shard `checks-node-compact-large-18` failed once per push on two unrelated timing tests, `chat.abort-cascade.test.ts` (`residual registry roots`, `vi.waitFor`) and then `code-mode-headless.test.ts` (`expected 'internal_error' to be 'timeout'`, wall-clock deadline). Neither file is touched here; both pass locally on this branch and on main. The sessions test file resets Gateway work admission after each test, so the new tests do not leak root work into later files.
