### PR TITLE
refactor(onboarding): retire dormant catalog validation

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -447,7 +447,7 @@ describe("agents add command", () => {
     },
   );
 
-  it("uses the explicit agent target and skips catalog validation", async () => {
+  it("uses the explicit agent target for auth checks and creation", async () => {
     setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
     const prompter = {
       intro: vi.fn(),
@@ -470,7 +470,6 @@ describe("agents add command", () => {
       expect.any(Object),
       expect.objectContaining({
         agentId: "jon",
-        validateCatalog: false,
       }),
     );
     expect(checkAgentCreationGateMock).toHaveBeenCalledWith("jon");

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -420,7 +420,6 @@ export async function agentsAddCommand(
         profileId,
         credential,
       })),
-      validateCatalog: false,
     });
 
     const channelSetup = createChannelSetupHooks({ runtime: wizardRuntime });

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -1,24 +1,18 @@
 // Auth-choice model check tests cover warnings for mismatched model and auth config.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveDefaultModelAuthStatus,
+  resolveDefaultModelCatalogFacts,
   warnIfModelConfigLooksOff,
 } from "./auth-choice.model-check.js";
 import { makePrompter } from "./setup/__tests__/test-utils.js";
 
-const loadModelCatalog = vi.hoisted(() => vi.fn());
-const modelCatalogMocks = vi.hoisted(() => ({
-  routeVariants: undefined as unknown[] | undefined,
-}));
+const publishPreparedModelRuntimeSnapshot = vi.hoisted(() => vi.fn());
 vi.mock("../agents/prepared-model-runtime.js", () => ({
-  publishPreparedModelRuntimeSnapshot: async (...args: unknown[]) => {
-    const entries = await loadModelCatalog(...args);
-    return {
-      modelCatalog: { entries, routeVariants: modelCatalogMocks.routeVariants ?? entries },
-    };
-  },
+  publishPreparedModelRuntimeSnapshot,
 }));
 
 const openAIRouteMocks = vi.hoisted(() => ({
@@ -50,13 +44,11 @@ vi.mock("../agents/auth-profiles.js", () => ({
 describe("warnIfModelConfigLooksOff", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    loadModelCatalog.mockResolvedValue([]);
-    modelCatalogMocks.routeVariants = undefined;
     ensureAuthProfileStore.mockReturnValue({ version: 1, profiles: {} });
     openAIRouteMocks.override = undefined;
   });
 
-  it("skips catalog validation when requested while keeping auth checks", async () => {
+  it("checks auth readiness without publishing a model catalog", async () => {
     const note = vi.fn(async (_message: string) => {});
     const prompter = makePrompter({ note });
     const config = {
@@ -67,9 +59,9 @@ describe("warnIfModelConfigLooksOff", () => {
       },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, prompter, { env: {}, validateCatalog: false });
+    await warnIfModelConfigLooksOff(config, prompter, { env: {} });
 
-    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(publishPreparedModelRuntimeSnapshot).not.toHaveBeenCalled();
     expect(ensureAuthProfileStore).toHaveBeenCalledOnce();
     expect(ensureAuthProfileStore).toHaveBeenCalledWith(
       undefined,
@@ -120,7 +112,6 @@ describe("warnIfModelConfigLooksOff", () => {
     await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
       env: {},
       pendingAuthProfiles,
-      validateCatalog: false,
     });
 
     expect(note).not.toHaveBeenCalled();
@@ -144,7 +135,6 @@ describe("warnIfModelConfigLooksOff", () => {
           },
         },
       ],
-      validateCatalog: false,
     });
 
     expect(note).toHaveBeenCalledWith(
@@ -179,7 +169,7 @@ describe("warnIfModelConfigLooksOff", () => {
       },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+    await warnIfModelConfigLooksOff(config, prompter);
 
     expect(note).not.toHaveBeenCalled();
   });
@@ -218,61 +208,11 @@ describe("warnIfModelConfigLooksOff", () => {
       },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+    await warnIfModelConfigLooksOff(config, prompter);
 
     expect(note).toHaveBeenCalledWith(
       'No auth configured for provider "openai". The agent may fail until credentials are added. Run `openclaw models auth login --provider openai`, `openclaw configure`, or set an API key env var.',
       "Model check",
-    );
-  });
-
-  it("keeps full catalog validation enabled by default", async () => {
-    const note = vi.fn(async () => {});
-    const prompter = makePrompter({ note });
-    const config = {
-      agents: {
-        defaults: {
-          model: "openai/gpt-5.5",
-        },
-      },
-    } as OpenClawConfig;
-
-    await warnIfModelConfigLooksOff(config, prompter);
-
-    expect(loadModelCatalog).toHaveBeenCalledWith(expect.objectContaining({ config }), {
-      force: true,
-      provenance: "explicit",
-    });
-  });
-
-  it("publishes validation catalogs for the selected agent", async () => {
-    const prompter = makePrompter({ note: vi.fn(async () => {}) });
-    const config = {
-      agents: {
-        defaults: { model: "openai/gpt-5.5" },
-        list: [
-          {
-            id: "worker",
-            workspace: "/tmp/openclaw-worker-workspace",
-            model: "openai/gpt-5.5",
-          },
-        ],
-      },
-    } as OpenClawConfig;
-
-    await warnIfModelConfigLooksOff(config, prompter, {
-      agentId: "worker",
-      agentDir: "/tmp/openclaw-worker-agent",
-    });
-
-    expect(loadModelCatalog).toHaveBeenCalledWith(
-      expect.objectContaining({
-        config,
-        agentId: "worker",
-        agentDir: "/tmp/openclaw-worker-agent",
-        workspaceDir: "/tmp/openclaw-worker-workspace",
-      }),
-      { force: true, provenance: "explicit" },
     );
   });
 
@@ -290,7 +230,6 @@ describe("warnIfModelConfigLooksOff", () => {
 
     const note = vi.fn(async (_message: string) => {});
     await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
-      validateCatalog: false,
       env: { OPENAI_API_KEY: "api-key" },
     });
     const warning = note.mock.calls.flatMap(([message]) => message).join("\n");
@@ -346,9 +285,7 @@ describe("warnIfModelConfigLooksOff", () => {
       code: "platform-only-model-on-chatgpt",
     });
     const note = vi.fn(async () => {});
-    await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
-      validateCatalog: false,
-    });
+    await warnIfModelConfigLooksOff(config, makePrompter({ note }));
 
     expect(note).toHaveBeenCalledWith(
       'Model route is incompatible for "openai/gpt-5.6": gpt-5.6 is available only through OpenAI Platform API-key authentication.',
@@ -356,9 +293,7 @@ describe("warnIfModelConfigLooksOff", () => {
     );
   });
 
-  it("uses selected static ChatGPT catalog facts for auth checks", async () => {
-    const note = vi.fn(async () => {});
-    const prompter = makePrompter({ note });
+  it("uses selected static ChatGPT catalog facts for auth checks", () => {
     const store = {
       version: 1,
       profiles: {
@@ -372,64 +307,79 @@ describe("warnIfModelConfigLooksOff", () => {
       },
     } satisfies AuthProfileStore;
     ensureAuthProfileStore.mockReturnValue(store);
-    loadModelCatalog.mockResolvedValue([
+    const observedRoute = {
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } satisfies Pick<ModelCatalogEntry, "api" | "baseUrl">;
+    const catalog = [
       {
         id: "gpt-5.4-nano",
         name: "GPT 5.4 Nano",
         provider: "openai",
-        api: "openai-chatgpt-responses",
-        baseUrl: "https://chatgpt.com/backend-api/codex",
+        ...observedRoute,
       },
-    ]);
+    ] satisfies ModelCatalogEntry[];
     const config = {
       agents: { defaults: { model: "openai/gpt-5.4-nano" } },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, prompter);
-
-    expect(note).not.toHaveBeenCalled();
+    const catalogFacts = resolveDefaultModelCatalogFacts(config, catalog);
+    expect(catalogFacts.observedRoutes).toEqual([observedRoute]);
+    expect(
+      resolveDefaultModelAuthStatus(config, { observedRoutes: catalogFacts.observedRoutes }),
+    ).toMatchObject({ status: "ready", hasAuth: true });
   });
 
-  it("matches shipped OpenAI aliases to their canonical catalog model", async () => {
-    const note = vi.fn(async () => {});
-    loadModelCatalog.mockResolvedValue([
+  it("matches shipped OpenAI aliases to their canonical catalog model", () => {
+    const observedRoute = {
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies Pick<ModelCatalogEntry, "api" | "baseUrl">;
+    const catalog = [
       {
         id: "gpt-5.4",
         name: "GPT 5.4",
         provider: "openai",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
+        ...observedRoute,
       },
-    ]);
+    ] satisfies ModelCatalogEntry[];
     const config = {
       agents: { defaults: { model: "openai/gpt-5.4-codex" } },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, makePrompter({ note }), {
-      env: { OPENAI_API_KEY: "api-key" },
-    });
-
-    expect(note).not.toHaveBeenCalled();
+    const catalogFacts = resolveDefaultModelCatalogFacts(config, catalog);
+    expect(catalogFacts.observedRoutes).toEqual([observedRoute]);
+    expect(
+      resolveDefaultModelAuthStatus(config, {
+        env: { OPENAI_API_KEY: "api-key" },
+        observedRoutes: catalogFacts.observedRoutes,
+      }),
+    ).toMatchObject({ status: "ready", hasAuth: true });
   });
 
   it.each([
     ["Platform first", false],
     ["ChatGPT first", true],
-  ])("uses every physical route for a logical model: %s", async (_label, chatGPTFirst) => {
+  ])("uses every physical route for a logical model: %s", (_label, chatGPTFirst) => {
+    const platformRoute = {
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies Pick<ModelCatalogEntry, "api" | "baseUrl">;
+    const chatGPTRoute = {
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } satisfies Pick<ModelCatalogEntry, "api" | "baseUrl">;
     const platform = {
       id: "gpt-5.4-nano",
       name: "GPT 5.4 Nano",
       provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    };
+      ...platformRoute,
+    } satisfies ModelCatalogEntry;
     const chatGPT = {
       ...platform,
-      api: "openai-chatgpt-responses",
-      baseUrl: "https://chatgpt.com/backend-api/codex",
-    };
-    loadModelCatalog.mockResolvedValue([platform]);
-    modelCatalogMocks.routeVariants = chatGPTFirst ? [chatGPT, platform] : [platform, chatGPT];
+      ...chatGPTRoute,
+    } satisfies ModelCatalogEntry;
+    const routeVariants = chatGPTFirst ? [chatGPT, platform] : [platform, chatGPT];
     ensureAuthProfileStore.mockReturnValue({
       version: 1,
       profiles: {
@@ -442,14 +392,17 @@ describe("warnIfModelConfigLooksOff", () => {
         },
       },
     });
-    const note = vi.fn(async () => {});
     const config = {
       agents: { defaults: { model: "openai/gpt-5.4-nano" } },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, makePrompter({ note }));
-
-    expect(note).not.toHaveBeenCalled();
+    const catalogFacts = resolveDefaultModelCatalogFacts(config, [platform], { routeVariants });
+    expect(catalogFacts.observedRoutes).toEqual(
+      chatGPTFirst ? [chatGPTRoute, platformRoute] : [platformRoute, chatGPTRoute],
+    );
+    expect(
+      resolveDefaultModelAuthStatus(config, { observedRoutes: catalogFacts.observedRoutes }),
+    ).toMatchObject({ status: "ready", hasAuth: true });
   });
 
   it("reports an unknown static transport as indeterminate instead of missing auth", async () => {
@@ -463,7 +416,7 @@ describe("warnIfModelConfigLooksOff", () => {
       status: "indeterminate",
       hasAuth: false,
     });
-    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+    await warnIfModelConfigLooksOff(config, prompter);
 
     expect(note).toHaveBeenCalledWith(
       'Auth readiness could not be confirmed for "openai/gpt-5.4-nano". Verify the selected model route and credential source before continuing.',

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -1,16 +1,9 @@
 // Post-selection model/auth sanity checks shown during onboarding and agent setup.
 import { normalizeProviderIdForAuth } from "@openclaw/model-catalog-core/provider-id";
-import {
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { createModelAuthAvailabilityResolver } from "../agents/model-auth-availability.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
-import { publishPreparedModelRuntimeSnapshot } from "../agents/prepared-model-runtime.js";
 import { buildProviderAuthRecoveryHint } from "../agents/provider-auth-recovery-hint.js";
 import { canonicalizeProviderModelId } from "../agents/provider-model-route.js";
 import type { ModelApi } from "../config/types.models.js";
@@ -133,7 +126,6 @@ function catalogRouteObservation(
 }
 
 type DefaultModelCatalogFacts = {
-  found: boolean;
   observedRoutes?: readonly ModelRouteObservation[];
 };
 
@@ -154,63 +146,25 @@ export function resolveDefaultModelCatalogFacts(
     .filter(matches)
     .map(catalogRouteObservation)
     .filter((route): route is ModelRouteObservation => route !== undefined);
-  return {
-    found: catalog.some(matches) || routeVariants.some(matches),
-    ...(observedRoutes.length > 0 ? { observedRoutes } : {}),
-  };
+  return observedRoutes.length > 0 ? { observedRoutes } : {};
 }
 
-/** Warn when the selected default model is unknown or has no usable credentials. */
+/** Warn when the selected default model does not have confirmed usable credentials. */
 export async function warnIfModelConfigLooksOff(
   config: OpenClawConfig,
   prompter: WizardPrompter,
-  options?: DefaultModelAuthOptions & { validateCatalog?: boolean },
+  options?: DefaultModelAuthOptions,
 ) {
   const ref = resolveDefaultModelForAgent({
     cfg: config,
     agentId: options?.agentId,
   });
   const warnings: string[] = [];
-  const validationAgentId = options?.agentId ?? resolveDefaultAgentId(config);
-  const snapshot =
-    options?.validateCatalog === false
-      ? { entries: [], routeVariants: [] }
-      : (
-          await publishPreparedModelRuntimeSnapshot(
-            {
-              config,
-              agentId: validationAgentId,
-              agentDir:
-                options?.agentDir ??
-                (options?.agentId
-                  ? resolveAgentDir(config, options.agentId)
-                  : resolveDefaultAgentDir(config)),
-              workspaceDir: resolveAgentWorkspaceDir(config, validationAgentId),
-            },
-            { force: true, provenance: "explicit" },
-          )
-        ).modelCatalog;
-  const catalog = snapshot.entries;
-  const catalogFacts = resolveDefaultModelCatalogFacts(config, catalog, {
-    ...(options?.agentId ? { agentId: options.agentId } : {}),
-    routeVariants: snapshot.routeVariants,
-  });
-  const observedRoutes = options?.observedRoutes ?? catalogFacts.observedRoutes;
-  if (options?.validateCatalog !== false) {
-    if (catalog.length > 0) {
-      if (!catalogFacts.found) {
-        warnings.push(
-          `Model not found: ${ref.provider}/${ref.model}. Update agents.defaults.model or run /models list.`,
-        );
-      }
-    }
-  }
-
   const authStatus = resolveDefaultModelAuthStatus(config, {
     ...(options?.agentId ? { agentId: options.agentId } : {}),
     ...(options?.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options?.env ? { env: options.env } : {}),
-    ...(observedRoutes ? { observedRoutes } : {}),
+    ...(options?.observedRoutes ? { observedRoutes: options.observedRoutes } : {}),
     ...(options?.pendingAuthProfiles ? { pendingAuthProfiles: options.pendingAuthProfiles } : {}),
   });
   if (authStatus.status === "missing") {

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -66,7 +66,7 @@ const resolveDefaultModelAuthStatus = vi.hoisted(() =>
   })),
 );
 const resolveDefaultModelCatalogFacts = vi.hoisted(() =>
-  vi.fn<() => DefaultModelCatalogFacts>(() => ({ found: true })),
+  vi.fn<() => DefaultModelCatalogFacts>(() => ({})),
 );
 const loadModelCatalog = vi.hoisted(() =>
   vi.fn<(_params?: unknown) => Promise<unknown[]>>(async () => []),
@@ -513,7 +513,7 @@ describe("finalizeSetupWizard", () => {
       hasAuth: true,
     });
     resolveDefaultModelCatalogFacts.mockReset();
-    resolveDefaultModelCatalogFacts.mockReturnValue({ found: true });
+    resolveDefaultModelCatalogFacts.mockReturnValue({});
     loadModelCatalog.mockReset();
     loadModelCatalog.mockResolvedValue([]);
   });
@@ -838,7 +838,7 @@ describe("finalizeSetupWizard", () => {
       { api: "openai-responses" as const, baseUrl: "https://api.openai.com/v1" },
     ];
     loadModelCatalog.mockResolvedValueOnce(catalog);
-    resolveDefaultModelCatalogFacts.mockReturnValueOnce({ found: true, observedRoutes });
+    resolveDefaultModelCatalogFacts.mockReturnValueOnce({ observedRoutes });
     const prompter = buildWizardPrompter({
       confirm: vi.fn(async () => false),
     });

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -167,7 +167,6 @@ describe("runSetupModelAuthStep", () => {
         agentId: "ops",
         agentDir: "/tmp/ops-agent",
         pendingAuthProfiles: [],
-        validateCatalog: false,
       });
     },
   );
@@ -415,7 +414,6 @@ describe("runSetupModelAuthStep", () => {
     expect(warnIfModelConfigLooksOff).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
       agentId: "ops",
       agentDir: "/tmp/ops-agent",
-      validateCatalog: false,
     });
   });
 
@@ -450,7 +448,6 @@ describe("runSetupModelAuthStep", () => {
       agentId: "ops",
       agentDir: "/tmp/ops-agent",
       pendingAuthProfiles,
-      validateCatalog: false,
     });
     expect(persistAuthProfiles).not.toHaveBeenCalled();
   });

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -231,7 +231,6 @@ export async function runSetupModelAuthStep(params: {
         await warnIfModelConfigLooksOff(nextConfig, prompter, {
           agentId: target.agentId,
           agentDir: target.agentDir,
-          validateCatalog: false,
         });
       }
       break;
@@ -327,7 +326,6 @@ export async function runSetupModelAuthStep(params: {
       agentId: target.agentId,
       agentDir: target.agentDir,
       pendingAuthProfiles: authProfiles,
-      validateCatalog: false,
     });
     break;
   }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2456,11 +2456,6 @@ describe("runSetupWizard", () => {
     );
     expectMockCallArgNotNull(warnIfModelConfigLooksOff, 0, 0, "model warning");
     expectMockCallArgNotNull(warnIfModelConfigLooksOff, 0, 1, "model warning");
-    expectRecordFields(
-      getMockCallArg(warnIfModelConfigLooksOff, 0, 2, "model warning"),
-      { validateCatalog: false },
-      "model warning options",
-    );
   });
 
   it("re-prompts for auth when applyAuthChoice requests retry selection", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers retain push access.

</details>

## What Problem This Solves

Onboarding and agent creation retain a model-catalog validation mode that every production caller explicitly disables. Maintaining and testing that unused mode obscures the auth-readiness checks those workflows actually perform. This is a maintainer-requested internal cleanup.

## Why This Change Was Made

Remove warning-time catalog publication, its unreachable missing-model diagnostic, and the retired option plumbing. Remove the catalog helper's `found` result after its only consumer disappears. Finalization keeps the shared catalog/auth owners and still distinguishes an absent catalog from a present catalog with no route observations.

## User Impact

No intended user-visible behavior change. Auth warnings, pending setup credentials, selected-agent targeting, model aliases, and physical route ordering remain. The change removes 48 production code lines and 47 test code lines; meaningful route tests now call the real shared helpers directly.

## Evidence

- Original source: 311 tests passed across seven owner, caller, finalization, and route suites. Candidate: 309 passed; exactly two publication-only tests retired, with the remaining case list preserved after intended title changes.
- The four retargeted route cases also passed against the original helpers. Original warning calls kept their `validateCatalog: false` mode during baseline proof.
- After the mechanical lint cleanup, all 89 owner/finalization tests passed. The final 29-step changed-file gate passed, including production/test types, lint, all three dead-export scans, database guards, and runtime import-cycle checks.
- Full `pnpm build` passed. The initial gate's redundant-spread lint finding was fixed without changing the fresh-object return contract.
- Managed Codex P2 review: scoped-clean, no findings. Final source bytes match the reviewed candidate.

Selected preservation suites:

```sh
node scripts/run-vitest.mjs \
  src/commands/auth-choice.model-check.test.ts \
  src/commands/agents.add.test.ts \
  src/wizard/setup.model-auth.test.ts \
  src/wizard/setup.finalize.test.ts \
  src/wizard/setup.test.ts \
  src/agents/model-auth-availability.test.ts \
  src/plugins/provider-model-routes.test.ts
```
