### PR TITLE
refactor(google): share image provider metadata

### DIFF
--- a/extensions/google/generation-provider-metadata.ts
+++ b/extensions/google/generation-provider-metadata.ts
@@ -1,4 +1,5 @@
 // Google provider module implements model/runtime integration.
+import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import type {
@@ -6,6 +7,9 @@ import type {
   VideoGenerationProvider,
   VideoGenerationProviderConfiguredContext,
 } from "openclaw/plugin-sdk/video-generation";
+
+export const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image";
+export const GOOGLE_MAX_IMAGE_RESULTS = 4;
 
 export const DEFAULT_GOOGLE_MUSIC_MODEL = "lyria-3-clip-preview";
 export const GOOGLE_PRO_MUSIC_MODEL = "lyria-3-pro-preview";
@@ -31,6 +35,39 @@ function createGoogleVideoCommonCapabilities() {
     supportsSize: true,
     supportsAudio: false,
   } satisfies VideoGenerationModeCapabilities;
+}
+
+export function createGoogleImageGenerationProviderMetadata(): Omit<
+  ImageGenerationProvider,
+  "generateImage" | "isConfigured"
+> {
+  return {
+    id: "google",
+    label: "Google",
+    defaultModel: DEFAULT_GOOGLE_IMAGE_MODEL,
+    models: [DEFAULT_GOOGLE_IMAGE_MODEL, "gemini-3-pro-image"],
+    capabilities: {
+      generate: {
+        maxCount: GOOGLE_MAX_IMAGE_RESULTS,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      edit: {
+        enabled: true,
+        maxCount: GOOGLE_MAX_IMAGE_RESULTS,
+        maxInputImages: 5,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      geometry: {
+        sizes: ["1024x1024", "1024x1536", "1536x1024", "1024x1792", "1792x1024"],
+        aspectRatios: ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        resolutions: ["1K", "2K", "4K"],
+      },
+    },
+  };
 }
 
 export function createGoogleMusicGenerationProviderMetadata(): Omit<

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -22,31 +22,14 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleModelId, resolveGoogleGenerativeAiHttpRequestConfig } from "./api.js";
 import { toStandardGoogleProviderBase64 } from "./base64.js";
+import {
+  createGoogleImageGenerationProviderMetadata,
+  DEFAULT_GOOGLE_IMAGE_MODEL,
+  GOOGLE_MAX_IMAGE_RESULTS,
+} from "./generation-provider-metadata.js";
 
-const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image";
 const DEFAULT_IMAGE_TIMEOUT_MS = 180_000;
 const DEFAULT_OUTPUT_MIME = "image/png";
-const GOOGLE_MAX_IMAGE_RESULTS = 4;
-const GOOGLE_SUPPORTED_SIZES = [
-  "1024x1024",
-  "1024x1536",
-  "1536x1024",
-  "1024x1792",
-  "1792x1024",
-] as const;
-const GOOGLE_SUPPORTED_ASPECT_RATIOS = [
-  "1:1",
-  "2:3",
-  "3:2",
-  "3:4",
-  "4:3",
-  "4:5",
-  "5:4",
-  "9:16",
-  "16:9",
-  "21:9",
-] as const;
-
 const GOOGLE_IMAGE_MALFORMED_RESPONSE = "Google image generation response malformed";
 
 function normalizeGoogleImageModel(model: string | undefined): string {
@@ -142,33 +125,11 @@ function googleInlineDataFromPart(part: unknown): Record<string, unknown> | unde
 }
 
 export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
+  const { capabilities, ...metadata } = createGoogleImageGenerationProviderMetadata();
   return {
-    id: "google",
-    label: "Google",
-    defaultModel: DEFAULT_GOOGLE_IMAGE_MODEL,
-    models: [DEFAULT_GOOGLE_IMAGE_MODEL, "gemini-3-pro-image"],
+    ...metadata,
     isConfigured: (ctx) => isProviderApiKeyConfigured({ provider: "google", ...ctx }),
-    capabilities: {
-      generate: {
-        maxCount: GOOGLE_MAX_IMAGE_RESULTS,
-        supportsSize: true,
-        supportsAspectRatio: true,
-        supportsResolution: true,
-      },
-      edit: {
-        enabled: true,
-        maxCount: GOOGLE_MAX_IMAGE_RESULTS,
-        maxInputImages: 5,
-        supportsSize: true,
-        supportsAspectRatio: true,
-        supportsResolution: true,
-      },
-      geometry: {
-        sizes: [...GOOGLE_SUPPORTED_SIZES],
-        aspectRatios: [...GOOGLE_SUPPORTED_ASPECT_RATIOS],
-        resolutions: ["1K", "2K", "4K"],
-      },
-    },
+    capabilities,
     async generateImage(req) {
       const auth = await resolveApiKeyForProvider({
         provider: "google",

--- a/extensions/google/image-registration.test.ts
+++ b/extensions/google/image-registration.test.ts
@@ -1,0 +1,98 @@
+import type {
+  ImageGenerationProvider,
+  ImageGenerationRequest,
+} from "openclaw/plugin-sdk/image-generation";
+import { createCapturedPluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { expect, it, vi } from "vitest";
+import googlePlugin from "./index.js";
+
+const runtime = vi.hoisted(() => {
+  const generateImage = vi.fn<ImageGenerationProvider["generateImage"]>();
+  return {
+    moduleLoads: 0,
+    generateImage,
+    buildProvider: vi.fn(() => ({ generateImage })),
+  };
+});
+
+vi.mock("./image-generation-provider.js", () => {
+  runtime.moduleLoads += 1;
+  return { buildGoogleImageGenerationProvider: runtime.buildProvider };
+});
+
+function registerImageProvider() {
+  const captured = createCapturedPluginRegistration({ id: "google" });
+  googlePlugin.register(captured.api);
+  const provider = captured.imageGenerationProviders.find((entry) => entry.id === "google");
+  if (!provider) {
+    throw new Error("Expected the registered Google image provider");
+  }
+  return provider;
+}
+
+it("registers independent image metadata without loading the runtime and delegates generation", async () => {
+  const provider = registerImageProvider();
+  const { generateImage: _generateImage, ...metadata } = provider;
+  const expectedMetadata = {
+    id: "google",
+    label: "Google",
+    defaultModel: "gemini-3.1-flash-image",
+    models: ["gemini-3.1-flash-image", "gemini-3-pro-image"],
+    capabilities: {
+      generate: {
+        maxCount: 4,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      edit: {
+        enabled: true,
+        maxCount: 4,
+        maxInputImages: 5,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      geometry: {
+        sizes: ["1024x1024", "1024x1536", "1536x1024", "1024x1792", "1792x1024"],
+        aspectRatios: ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        resolutions: ["1K", "2K", "4K"],
+      },
+    },
+  };
+  expect(JSON.stringify(metadata)).toBe(JSON.stringify(expectedMetadata));
+  expect(Object.hasOwn(provider, "isConfigured")).toBe(false);
+
+  const second = registerImageProvider();
+  second.models?.push("fixture-mutated-model");
+  second.capabilities.generate.maxCount = 99;
+  second.capabilities.edit.maxInputImages = 99;
+  second.capabilities.geometry?.sizes?.push("fixture-mutated-size");
+  second.capabilities.geometry?.aspectRatios?.push("fixture-mutated-ratio");
+  second.capabilities.geometry?.resolutions?.push("4K");
+  expect(JSON.stringify(metadata)).toBe(JSON.stringify(expectedMetadata));
+  expect(runtime.moduleLoads).toBe(0);
+  expect(runtime.buildProvider).not.toHaveBeenCalled();
+
+  const request: ImageGenerationRequest = {
+    provider: "google",
+    model: "gemini-3-pro-image",
+    prompt: "Synthetic registration boundary fixture",
+    cfg: {},
+    size: "1536x1024",
+    inputImages: [{ buffer: Buffer.from("fixture-reference"), mimeType: "image/png" }],
+  };
+  const result = {
+    images: [{ buffer: Buffer.from("fixture-result"), mimeType: "image/png" }],
+    model: request.model,
+  };
+  runtime.generateImage.mockResolvedValue(result);
+  const secondRequest = { ...request, prompt: "Second synthetic request" };
+  expect(
+    await Promise.all([provider.generateImage(request), second.generateImage(secondRequest)]),
+  ).toEqual([result, result]);
+  expect(runtime.moduleLoads).toBe(1);
+  expect(runtime.buildProvider).toHaveBeenCalledOnce();
+  expect(runtime.generateImage).toHaveBeenNthCalledWith(1, request);
+  expect(runtime.generateImage).toHaveBeenNthCalledWith(2, secondRequest);
+});

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -7,6 +7,7 @@ import type { VideoGenerationProvider } from "openclaw/plugin-sdk/video-generati
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import {
+  createGoogleImageGenerationProviderMetadata,
   createGoogleMusicGenerationProviderMetadata,
   createGoogleVideoGenerationProviderMetadata,
 } from "./generation-provider-metadata.js";
@@ -71,31 +72,7 @@ async function loadGoogleRequiredMediaUnderstandingProvider(): Promise<GoogleMed
 
 function createLazyGoogleImageGenerationProvider(): ImageGenerationProvider {
   return {
-    id: "google",
-    label: "Google",
-    defaultModel: "gemini-3.1-flash-image",
-    models: ["gemini-3.1-flash-image", "gemini-3-pro-image"],
-    capabilities: {
-      generate: {
-        maxCount: 4,
-        supportsSize: true,
-        supportsAspectRatio: true,
-        supportsResolution: true,
-      },
-      edit: {
-        enabled: true,
-        maxCount: 4,
-        maxInputImages: 5,
-        supportsSize: true,
-        supportsAspectRatio: true,
-        supportsResolution: true,
-      },
-      geometry: {
-        sizes: ["1024x1024", "1024x1536", "1536x1024", "1024x1792", "1792x1024"],
-        aspectRatios: ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
-        resolutions: ["1K", "2K", "4K"],
-      },
-    },
+    ...createGoogleImageGenerationProviderMetadata(),
     generateImage: async (req) => (await loadGoogleImageGenerationProvider()).generateImage(req),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Google image-provider registration and runtime construction maintained separate copies of the same model and capability metadata. That duplication could let the advertised image limits or supported geometry drift between the two paths.

## Why This Change Was Made

Reuse the existing Google-owned generation metadata module for both constructions. Each call still creates fresh nested objects and arrays. The lazy registration still has no own `isConfigured` property; the runtime retains its existing callback and property order before `capabilities`. Lazy loading, generation, authentication, request options, and fallback behavior are unchanged.

Production: **+47/-72, net 25 lines removed**. Tests: **+98/-0**. No core/provider-policy, configuration, dependency, storage, protocol, or public API change.

## User Impact

No intended operator-visible behavior change. The same two models, four-result limit, five-reference edit limit, and geometry metadata remain available through the registered provider and image-provider CLI listing.

## Evidence

- Original, candidate, and restored-candidate selections each passed all 99 Google image/registration/index/music/video cases, with the same per-file case inventory and order. Separate limit and shared-mutable-metadata fault controls failed the intended retained assertions; exact restoration passed.
- Normal original and candidate full builds passed all 16 phases. Four direct built-CLI cases through the canonical isolated test instance passed, with byte-identical original/candidate stdout and stderr for unconfigured and explicitly selected Google image-provider listings. This exercised `node dist/index.js`, not the development wrapper or live image generation.
- All 25 configured changed checks passed on Linux Node 24.19.0, including both plugin type graphs, three dead-export scans, lint, six Doctor-contract tests, and import-cycle checks. [Configured Testbox run](https://github.com/openclaw/openclaw/actions/runs/34516686158). Its native result was successful and its lease and temporary checkout were cleaned up; the backing Actions projection is not a substitute for that delegated result.
- Managed P2 precommit review and a separate exact-commit P2 review completed without actionable findings. The signed commit's full tree matches the tested four-file candidate.

Proof boundaries are retained: an earlier run that cleared inherited Node settings is excluded from the accepted comparison. The paired CLI fixtures emitted the same warning while normalizing a retired `default` marker; they were not changed between variants. No live Google availability, output-quality, Gateway-session, or development-wrapper claim is made. Exact-head hosted PR CI is separate and will attach after publication.
