### PR TITLE
fix(telegram): duplicate text delivered when tts voice note is sent

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -127,6 +127,7 @@ export function createReplyState(): TelegramReplyStateSlice {
     reasoningStepState: createTelegramReasoningStepState(),
     bufferedFinalSettlement: undefined as TelegramBufferedFinalSettlement | undefined,
     sentBlockMediaUrls: new Set<string>(),
+    sentBlockMediaTexts: new Set<string>(),
     splitReasoningOnNextStream: false,
   };
 }
@@ -213,6 +214,10 @@ function trackBlockMedia(
     for (const url of payload.mediaUrls) {
       turn.sentBlockMediaUrls.add(url);
     }
+    const trimmedText = payload.text?.trim();
+    if (trimmedText) {
+      turn.sentBlockMediaTexts.add(trimmedText);
+    }
   }
 }
 
@@ -230,7 +235,11 @@ export async function deliverReply(
   }
   const deduped =
     info.kind === "final"
-      ? deduplicateBlockSentMedia(normalizedPayload, turn.sentBlockMediaUrls)
+      ? deduplicateBlockSentMedia(
+          normalizedPayload,
+          turn.sentBlockMediaUrls,
+          turn.sentBlockMediaTexts,
+        )
       : normalizedPayload;
   if (!deduped) {
     return await settleTerminalNoVisibleDelivery(turn, info);

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts
@@ -101,4 +101,28 @@ describe("deduplicateBlockSentMedia", () => {
     const result = deduplicateBlockSentMedia(payload, sent);
     expect(result).toEqual({ text: "hey", mediaUrl: undefined, mediaUrls: ["/tmp/b.jpg"] });
   });
+
+  it("returns undefined when all media was sent and text was already delivered with block media", () => {
+    const payload = { text: "voice note caption", mediaUrls: ["/tmp/voice.mp3"] };
+    const sentMedia = new Set(["/tmp/voice.mp3"]);
+    const sentTexts = new Set(["voice note caption"]);
+    const result = deduplicateBlockSentMedia(payload, sentMedia, sentTexts);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns payload with empty mediaUrls when all media was sent but text is different from block text", () => {
+    const payload = { text: "new follow up text", mediaUrls: ["/tmp/voice.mp3"] };
+    const sentMedia = new Set(["/tmp/voice.mp3"]);
+    const sentTexts = new Set(["voice note caption"]);
+    const result = deduplicateBlockSentMedia(payload, sentMedia, sentTexts);
+    expect(result).toEqual({ text: "new follow up text", mediaUrls: [] });
+  });
+
+  it("handles whitespace-padded text comparison when checking already-sent block text", () => {
+    const payload = { text: "  voice note caption  \n", mediaUrls: ["/tmp/voice.mp3"] };
+    const sentMedia = new Set(["/tmp/voice.mp3"]);
+    const sentTexts = new Set(["voice note caption"]);
+    const result = deduplicateBlockSentMedia(payload, sentMedia, sentTexts);
+    expect(result).toBeUndefined();
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
+++ b/extensions/telegram/src/bot-message-dispatch.media-dedup.ts
@@ -1,7 +1,11 @@
 // Keep sent-block media out of both delivery fields so outbound planning cannot restore it.
 export function deduplicateBlockSentMedia<
   T extends { mediaUrl?: string; mediaUrls?: string[]; text?: string },
->(payload: T, sentBlockMediaUrls: ReadonlySet<string>): T | undefined {
+>(
+  payload: T,
+  sentBlockMediaUrls: ReadonlySet<string>,
+  sentBlockMediaTexts?: ReadonlySet<string>,
+): T | undefined {
   if (!payload.mediaUrls?.length || sentBlockMediaUrls.size === 0) {
     return payload;
   }
@@ -9,7 +13,9 @@ export function deduplicateBlockSentMedia<
   if (remainingMedia.length === payload.mediaUrls.length) {
     return payload;
   }
-  if (remainingMedia.length === 0 && !payload.text) {
+  const textTrimmed = payload.text?.trim();
+  const textAlreadySent = textTrimmed ? sentBlockMediaTexts?.has(textTrimmed) : false;
+  if (remainingMedia.length === 0 && (!textTrimmed || textAlreadySent)) {
     return undefined;
   }
   return {

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -218,6 +218,7 @@ export type TelegramReplyStateSlice = {
   reasoningStepState: TelegramReasoningStepState;
   bufferedFinalSettlement: TelegramBufferedFinalSettlement | undefined;
   sentBlockMediaUrls: Set<string>;
+  sentBlockMediaTexts: Set<string>;
   splitReasoningOnNextStream: boolean;
 };
 


### PR DESCRIPTION
Closes #144006

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users on Telegram would receive double delivery of their message when an explicit `tts` tool executes (first as the audio caption alongside the voice note, and immediately followed by an identical duplicate plain text message).

## Why This Change Was Made

When `embedded-agent-subscribe` emits block replies containing audio/media from the `tts` tool, Telegram dispatches the media note with the caption text. However, `TelegramReplyStateSlice` previously only tracked `sentBlockMediaUrls`. When the turn finalized, the subsequent `final` reply payload arrived with the same text and the already-sent media. Because the text remained, `deduplicateBlockSentMedia` cleared the duplicate media URLs but left the text intact, causing `deliverFinalAnswerText` to post a redundant standalone text message.

We now track `sentBlockMediaTexts` when block media is delivered with text. When deduplicating final payloads where all media has already been delivered, `deduplicateBlockSentMedia` checks if the remaining text matches the block media caption that was already sent, suppressing the duplicate final answer.

## User Impact

Telegram conversations with voice notes/TTS now cleanly receive the audio note with its caption without an annoying duplicate text message arriving right after it.

## Evidence

- Added unit test cases to `extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts`:
  - Suppresses final payload when all media was delivered and text matches the block media caption.
  - Preserves legitimate final text if it differs from the block caption.
  - Handles whitespace-padded caption comparisons correctly.
- Vitest results:
  - `extensions/telegram/src/bot-message-dispatch.media-dedup.test.ts`: 16/16 tests passing.
  - `extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts` & `extensions/telegram/src/lane-delivery.test.ts`: 62/62 tests passing.
