### PR TITLE
refactor(update): retire obsolete post-activation stop path

### DIFF
--- a/src/cli/update-cli/update-command-service-command.process.test.ts
+++ b/src/cli/update-cli/update-command-service-command.process.test.ts
@@ -5,12 +5,10 @@ import { formatCliProcessFailure, runCliProcessChild } from "../cli-process-chil
 it.each([
   "restart",
   "install",
-  "stop",
   "missing candidate",
   "executor revoked",
   "restart revoked",
   "install revoked",
-  "stop revoked",
 ] as const)("handles %s after replacing the updater's module files", async (scenario) => {
   await withOpenClawTestState(
     { prefix: "openclaw-update-command-replacement-", scenario: "minimal", applyEnv: false },
@@ -24,7 +22,7 @@ it.each([
           import { pathToFileURL } from "node:url";
 
           const scenario = ${JSON.stringify(scenario)};
-          const action = scenario.startsWith("install") ? "install" : scenario.startsWith("stop") ? "stop" : "restart";
+          const action = scenario.startsWith("install") ? "install" : "restart";
           const root = ${JSON.stringify(state.path("installation"))};
           const dist = path.join(root, "dist");
           const receipt = path.join(root, "candidate.json");

--- a/src/cli/update-cli/update-command-service-command.ts
+++ b/src/cli/update-cli/update-command-service-command.ts
@@ -49,7 +49,7 @@ export async function runUpdatedInstallGatewayCommand(
     assertCurrent?: () => void;
     serviceLoadBoundary?: UpdateServiceLoadBoundary;
   },
-  action: "install" | "restart" | "stop",
+  action: "install" | "restart",
   preserveDefinition = false,
 ): Promise<"accepted" | "unverified"> {
   const run = params.opts.run;
@@ -84,7 +84,7 @@ export async function runUpdatedInstallGatewayCommand(
     );
   }
   const args = ["gateway", action];
-  if (installing || action === "stop") {
+  if (installing) {
     args.push("--force");
   } else if (preserveDefinition) {
     args.push("--preserve-definition");
@@ -142,9 +142,8 @@ export async function runUpdatedInstallGatewayCommand(
   if (exited && res.code === 0) {
     return response?.action === action &&
       response.ok === true &&
-      ((action === "restart" &&
-        (response.result === "restarted" || response.result === "scheduled")) ||
-        (action === "stop" && (response.result === "stopped" || response.result === "not-loaded")))
+      action === "restart" &&
+      (response.result === "restarted" || response.result === "scheduled")
       ? "accepted"
       : "unverified";
   }

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -26,7 +26,6 @@ import { defaultRuntime } from "../../runtime.js";
 import { UpdatePreMutationError, type UpdateCommandOptions } from "./shared.js";
 import { gatewayMaintenanceBlockMessage } from "./update-command-handoff.js";
 import { UpdateCommandRecoveryPendingError } from "./update-command-recovery.js";
-import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
 import type { PreManagedServiceStop } from "./update-command-service-context-types.js";
 import {
   assertGatewayServiceAdmissionUnchanged,
@@ -333,7 +332,6 @@ type ManagedServiceStopParams = {
     PreManagedServiceStop,
     "serviceEnv" | "serviceUpdateVerdict" | "serviceManagerUid"
   >;
-  activatedInstall?: { packageUpdateNodeRunner?: string; invocationCwd?: string };
   onStopped?: (state: PreManagedServiceStop) => void;
   timeoutMs?: number;
 };
@@ -591,39 +589,13 @@ async function stopManagedServiceBeforeMutableUpdate(
         env: params.updateRun.env,
       });
     }
-    const stop = async (assertStopCurrent: () => void) => {
-      if (params.activatedInstall) {
-        // Activation Doctor may have stamped newer config. Keep its service stop
-        // in that runtime too; the old parent's destructive-action guard is valid.
-        const stopped = await runUpdatedInstallGatewayCommand(
-          {
-            result: { root: params.root },
-            opts: { json: params.jsonMode },
-            invocationEnv: process.env,
-            serviceEnv: currentState.env,
-            timeoutMs: params.timeoutMs,
-            nodeRunner: params.activatedInstall.packageUpdateNodeRunner,
-            invocationCwd: params.activatedInstall.invocationCwd,
-            assertCurrent: assertStopCurrent,
-          },
-          "stop",
-        );
-        if (stopped !== "accepted") {
-          throw new Error(
-            "Updated Gateway CLI did not confirm the service stopped for plugin maintenance.",
-          );
-        }
-      } else {
-        await service.stop({
-          env: currentState.env,
-          stdout: params.jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout,
-          assertCurrent: assertStopCurrent,
-          // Native stop may unload the service before a later port check fails.
-          onMutation: () => params.onStopped?.({ ...inspected, stopped: true, stoppedAtMs }),
-        });
-      }
-    };
-    await stop(assertCurrent);
+    await service.stop({
+      env: currentState.env,
+      stdout: params.jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout,
+      assertCurrent,
+      // Native stop may unload the service before a later port check fails.
+      onMutation: () => params.onStopped?.({ ...inspected, stopped: true, stoppedAtMs }),
+    });
     assertCurrent();
     if (windowsTaskAutoStartRecovery) {
       await abortWindowsTaskUpdateIfInterrupted(windowsTaskAutoStartRecovery);

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -415,16 +415,9 @@ type PluginMaintenanceFixture = InstallRootTransitionFixture & {
 };
 
 export function registerPluginMaintenanceTests(getFixture: () => PluginMaintenanceFixture) {
-  it.each(
-    (["git", "npm"] as const).flatMap((mode) =>
-      (["stopped", "not-loaded", "unverified", "failed"] as const).map((stopResult) => ({
-        mode,
-        stopResult,
-      })),
-    ),
-  )(
-    "delegates $mode activation and post-handoff plugin maintenance after candidate doctor stamps newer config ($stopResult)",
-    async ({ mode, stopResult }) => {
+  it.each(["git", "npm"] as const)(
+    "delegates %s activation and post-handoff Doctor after newer config is stamped",
+    async (mode) => {
       const { root, run, mocks, writeConfig } = getFixture();
       const before = await maybeStopManagedServiceBeforeMutableUpdate({
         updateInstallKind: mode === "git" ? "git" : "package",
@@ -496,56 +489,6 @@ export function registerPluginMaintenanceTests(getFixture: () => PluginMaintenan
       );
 
       process.env.OPENCLAW_UPDATE_RUN_HANDOFF = "1";
-      mocks.child.mockImplementation(async () => {
-        mocks.events.push("fresh CLI stop");
-        mocks.running = false;
-        return {
-          code: stopResult === "failed" ? 1 : 0,
-          stdout:
-            stopResult === "unverified"
-              ? ""
-              : JSON.stringify({
-                  action: "stop",
-                  ok: stopResult !== "failed",
-                  result: stopResult,
-                }),
-          stderr: "",
-          signal: null,
-          killed: false,
-          termination: "exit",
-        };
-      });
-      const maintenance = maybeStopManagedServiceBeforeMutableUpdate({
-        root,
-        updateInstallKind: mode === "git" ? "git" : "package",
-        shouldRestart: true,
-        jsonMode: true,
-        expectedService: {
-          serviceEnv: state.env,
-          serviceUpdateVerdict: verdict,
-          serviceManagerUid: before.serviceManagerUid,
-        },
-        activatedInstall: { packageUpdateNodeRunner: process.execPath },
-        timeoutMs: 1000,
-      });
-      if (stopResult === "unverified" || stopResult === "failed") {
-        await expect(maintenance).rejects.toThrow(
-          stopResult === "unverified"
-            ? "did not confirm the service stopped"
-            : "updated install stop failed",
-        );
-        return;
-      }
-      expect((await maintenance).stopped).toBe(true);
-      expect(mocks.child.mock.lastCall?.[0]).toEqual([
-        process.execPath,
-        path.join(root, "dist", "index.js"),
-        "gateway",
-        "stop",
-        "--force",
-        "--json",
-      ]);
-      expect(mocks.child.mock.lastCall?.[1]).toMatchObject({ cwd: root });
       vi.mocked(runExec).mockResolvedValueOnce({ stdout: "", stderr: "" });
       await runUpdateFinalizationDoctorInFreshProcess({
         root,


### PR DESCRIPTION
Related: #140339

## What Problem This Solves

Completes the managed-update lifecycle cutover in #140339. Updates now keep plugin convergence inside the original stopped interval, or park an already-current core before Doctor; obsolete post-activation stop handling still remained alongside that flow.

## Why This Change Was Made

Remove the unused private `activatedInstall` input and its alternate stop path, then retire the updated-install helper's now-unused `stop` action. Native stop keeps the same revalidated environment, authority callback, mutation reporting, and Windows compensation. The public `gateway stop` command and migrated-finalizer input remain unchanged.

The associated tests retain Git/package activation after a newer config stamp, fresh Doctor, stale-parent version guards, and install/restart process ownership. The complete change removes 27 production and 59 test/support code lines.

## User Impact

No intended user-visible behavior change. Managed updates retain their existing stop, activation, recovery, and verification behavior with one fewer private execution path to maintain.

## Evidence

- Original source: **520/520 passed**; candidate: **512/512 passed** across the same 18 selected files. Eight mode/stop-outcome rows become two retained activation/Doctor cases, and two private-stop process cases retire. All 510 other case identities passed in both runs, including 21 selected public-stop cases.
- Production/test typechecks, targeted lint, all three dead-export scans, and the complete 29-step changed gate passed. The test runner's original and candidate runtime builds also passed. Independent P2 review found no actionable findings.
- On Linux/Node 24.19.0, the integrity-pinned published OpenClaw 2026.9.3 updater modules were loaded before replacing their task-owned files. Retained old code accepted synthetic replacement public `gateway stop --force --json` responses and a matching migrated-worker run receipt, rejected a wrong terminal run ID, and preserved data-only recovery metadata. This proves the historical module/process boundary; it is not a full upgrade or live Gateway test.
