### PR TITLE
fix: isolate task cancellation fixtures from background wakes

### DIFF
--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -910,6 +910,7 @@ describe("tasks gateway handlers", () => {
     const task = createSnapshotTask({
       taskId: "task-acp-primary",
       runtime: "acp",
+      notifyPolicy: "silent",
       childSessionKey: "agent:codex:acp:child",
       agentId: "codex",
       runId: "run-cancel-acp-gateway",
@@ -918,6 +919,7 @@ describe("tasks gateway handlers", () => {
     const siblingTask = createSnapshotTask({
       taskId: "task-acp-sibling",
       runtime: "acp",
+      notifyPolicy: "silent",
       childSessionKey: "agent:codex:acp:child",
       agentId: "codex",
       runId: "run-cancel-acp-gateway",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a shared-worker test failure where the task cancellation fixture leaves a background notification wake that later enters an unrelated chat reset provider fixture.

## Why This Change Was Made

Mark both ACP cancellation fixture tasks with the existing silent notification policy. The case continues to exercise the real Gateway cancellation handler, control-runtime arguments and persisted primary/sibling cancellation results. Automatic delivery is outside this manual-RPC case's contract; production notification defaults and the downstream reset test remain unchanged.

## User Impact

No production behavior change. Test isolation improves without clearing global queues, weakening assertions or changing heartbeat configuration.

## Evidence

- Matched two-file runs used the normal sequencer with results caching disabled and one worker. Both observed tasks before reset: original 32 passed/one missing-marker failure; candidate all 33 passed with the same case identities.
- Five existing notification checks passed, covering notified ACP cancellation and terminal/progress/blocked/fallback event and wake routing.
- Changed-file gate and independent review passed.

An earlier candidate run passed with reset first because Vitest prioritized the previous failure; it is not counted as causal repair proof. The matched runs retain normal size ordering. Local same-worker evidence comes from the selected non-isolated project and worker budget; a separate whole-shard diagnostic supplied the observed wake identity trace.
