### PR TITLE
fix(doctor): preserve selected model context in tool diagnostics

### DIFF
--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -2,6 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { createOpenClawCodingTools } from "../../../agents/agent-tools.js";
 import type { AnyAgentTool } from "../../../agents/tools/common.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeGenerationScope } from "../../../plugins/runtime/generation-scope.js";
 import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 
 const toolState = vi.hoisted(() => ({
@@ -183,6 +186,70 @@ describe("active tool schema doctor warnings", () => {
         modelId: "llama-3.1-8b-instant",
         modelApi: "openai-completions",
       }),
+    );
+  });
+
+  it("uses the selected primary model metadata for active tool diagnostics", async () => {
+    const realRuntime = await vi.importActual<
+      typeof import("../../../agents/embedded-agent-runner/model.js")
+    >("../../../agents/embedded-agent-runner/model.js");
+    const provider = "doctor-selected";
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: provider,
+          providers: [provider],
+          modelIdNormalization: {
+            providers: { [provider]: { aliases: { entry: "middle", middle: "final" } } },
+          },
+        },
+      ],
+    });
+    const stores = realRuntime.createEmptyAgentDiscoveryStores();
+    stores.modelRegistry.registerProvider(provider, {
+      api: "openai-completions",
+      baseUrl: "https://doctor-selected.example/v1",
+      models: [
+        {
+          id: "middle",
+          name: "middle",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32000,
+          maxTokens: 4096,
+        },
+        {
+          id: "final",
+          name: "final",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 4096,
+          maxTokens: 4096,
+        },
+      ],
+    });
+    const selected: string[] = [];
+    toolState.resolveModelAsync.mockImplementation(
+      async (...args: Parameters<typeof realRuntime.resolveModelAsync>) => {
+        selected.push(args[1]);
+        return await realRuntime.resolveModelAsync(args[0], args[1], args[2], args[3], {
+          ...args[4],
+          ...stores,
+          skipProviderRuntimeHooks: true,
+        });
+      },
+    );
+    const cfg: OpenClawConfig = { agents: { defaults: { model: `${provider}/entry` } } };
+    expect(
+      await withPluginRuntimeGenerationScope({ metadataSnapshot }, () =>
+        collectActiveToolSchemaProjectionWarnings({ cfg, env: { HOME: "/tmp/doctor-selected" } }),
+      ),
+    ).toEqual([]);
+    expect(selected).toEqual(["middle"]);
+    expect(toolState.createTools).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: "middle", modelContextWindowTokens: 32000 }),
     );
   });
 

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -45,6 +45,7 @@ async function resolveRuntimeModelContext(params: {
     params.agentDir,
     params.cfg,
     {
+      modelIdSource: "selected",
       agentId: params.agentId,
       workspaceDir: params.workspaceDir,
       skipAgentDiscovery: true,


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Doctor could check active tools using a different model's context window when
the configured primary used a manifest alias. With entry → middle → final,
the diagnostic labeled tools as middle but used final's 4,096-token context
instead of middle's 32,000-token context.

## Why This Change Was Made

Doctor already selects the primary under its captured plugin metadata scope.
Its runtime metadata lookup now preserves that selected model ID, avoiding a
second alias pass while retaining provider ownership and transport resolution.

## User Impact

Active tool diagnostics use the metadata belonging to the selected primary
model. The fix adds one production line and a regression at the tool
construction boundary.

## Evidence

- The regression failed on the baseline with context 4,096 instead of 32,000;
  all 56 focused Doctor and preview tests passed after the fix.
- The complete changed gate passed against the pinned base. Independent P2
  review was clean, and a normal full build passed with SDK declarations and
  Control UI assets.
- Actual compiled `doctor --non-interactive --no-workspace-suggestions` ran
  in fresh owned state with a plugin installed through the real CLI. The
  public schema hook observed the expected selected/materialized IDs and
  context sizes in all four cases below, with 39 tools each. Every Doctor
  command completed and exited successfully.

| Authored primary | Selected / materialized model | Context |
| --- | --- | ---: |
| Alias entry | middle / middle | 32,000 |
| Raw middle alias | final / final | 4,096 |
| Exact ID | exact / exact | 16,384 |
| Custom provider with native API owner | exact / exact; custom provider preserved | 24,576 |

The compiled-only source-import rejection control passed. All 12,239 outputs
across the build root and 15 workspace-package output roots remained unchanged,
and every owned child process exited. This is real CLI/Doctor diagnostic proof
with synthetic plugins, not authenticated provider inference.
