### PR TITLE
fix(gateway): sandbox all assistant-media image documents

### DIFF
--- a/src/gateway/control-ui-assistant-media-policy.test.ts
+++ b/src/gateway/control-ui-assistant-media-policy.test.ts
@@ -312,6 +312,30 @@ describe("assistant image session policy", () => {
     },
   );
 
+  it.each(["full", "workspace"] as const)(
+    "sandboxes in-workspace SVG documents in %s mode",
+    async (mode) => {
+      entry.permissionMode = mode;
+      const source = path.join(project, "diagram.svg");
+      await fs.writeFile(
+        source,
+        '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>',
+      );
+      const result = await request(source);
+      expect(result.payload).toMatchObject({ available: true, mimeType: "image/svg+xml" });
+      const bytes = await request(source, {
+        ticket: String(result.payload!.mediaTicket),
+        bytes: true,
+      });
+      expect(bytes.res.statusCode).toBe(200);
+      expect(bytes.bytes).toEqual(await fs.readFile(source));
+      expect(bytes.setHeader).toHaveBeenCalledWith(
+        "content-security-policy",
+        expect.stringContaining("sandbox"),
+      );
+    },
+  );
+
   it("denies incognito images to a named profile while preserving administrator access", async () => {
     const source = path.join(project, "private.png");
     await fs.writeFile(source, PNG);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -687,7 +687,10 @@ export async function handleControlUiAssistantMediaRequest(
       }
     }
     assertCurrentPolicy();
-    if (media.outsideRoots && mediaKind === "image") {
+    // Every image served on this route becomes a same-origin document when opened
+    // directly, so workspace images get the same document sandbox as outside-root
+    // ones; in-workspace files are agent-writable and must not be privileged.
+    if (mediaKind === "image") {
       applyHttpImageContentSecurityPolicy(res);
     }
     res.setHeader("Content-Type", contentType);


### PR DESCRIPTION
## Summary

Authenticated `GET /__openclaw__/assistant-media` applies the image-document sandbox CSP (`default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; sandbox`) only when the served file is outside the allowed roots. In-workspace images — the files agent sessions can write — were served with the plain Control UI security headers instead, so an agent-writable SVG opened via the lightbox "Open original" control became an unsandboxed, same-origin active document on the gateway origin. Sibling image routes already sandbox every image regardless of file location (`sendHttpImageResponse`), and `#138856` introduced the outside-roots-only gate on this route.

## Change

- `src/gateway/control-ui.ts`: `applyHttpImageContentSecurityPolicy` now runs for every image on the assistant-media byte route (`if (mediaKind === "image")`), dropping the `media.outsideRoots &&` gate. In-workspace images get the same document sandbox as outside-root ones; the lightbox `<img>` preview is unaffected, and SVGs opened as documents can no longer script, frame external sites, or submit forms.
- `src/gateway/control-ui-assistant-media-policy.test.ts`: new `it.each(["full", "workspace"])` test pinning that an in-workspace SVG byte response sets a `content-security-policy` header containing `sandbox`.

## Compatibility

- No config surface or default changes; additive response header only.
- `<img>` rendering is unaffected (the byte-route CSP applies when the resource is opened as a document, not when embedded as an image element).
- In-workspace SVGs opened as documents now match the outside-root contract that has shipped since 2026.9.1.

## Testing

- `npx vitest run src/gateway/control-ui-assistant-media-policy.test.ts` — 37/37 pass, including the 2 new workspace-mode sandbox assertions.
- `npx vitest run src/gateway/control-ui.http.test.ts src/gateway/http-image-response.test.ts` — 174/174 pass.
- Verified live against a locally run gateway built from this branch: in-workspace SVG byte GET now sets `content-security-policy: default-src 'none'; ...; sandbox`, while non-image workspace files are unchanged.


## Live browser verification (head 88c2d903, branch-built gateway from source)

Environment: gateway run from this branch via `pnpm gateway:dev`-equivalent (`run-node.mjs --dev gateway`), loopback only, token auth, scratch state dir; Playwright Chromium 151 headless. All values below are from the exact reviewed head; token redacted.

**A. Byte-route headers for an in-workspace SVG** (`GET /__openclaw__/assistant-media?source=<workspace svg>&token=<redacted>`):

```
HTTP/1.1 200
content-type: image/svg+xml
content-disposition: inline; filename="active-diagram.svg"
content-security-policy: default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; sandbox
x-content-type-options: nosniff
x-frame-options: DENY
```

**B. Active SVG opened as a top-level document** (fixture contains an inline `<script>` that sets a marker attribute + global, a `<foreignObject><iframe src="https://example.net/…">`, and an outbound link):

- `window.__SCRIPT_RAN__`: absent; `svg[data-script-ran]`: absent — script never executed.
- Requests to `example.net`: **none** (iframe/link never fetched).
- Browser console (verbatim):

```
[error] Blocked script execution in 'http://127.0.0.1:18993/__openclaw__/assistant-media?source=%2F…%2Factive-diagram.svg&token=<redacted>' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
```

**C. Passive SVG opened as a top-level document**: renders normally (`PASSIVE OK` text visible) — passive diagrams remain viewable under the sandbox.

**D. Lightbox-style `<img>` preview preserved**: both the passive and the active workspace SVG load through `<img src="<assistant-media url>">` with `naturalWidth: 200` (render) — the stricter document policy does not affect `<img>` element loads, so chat/lightbox previews are unchanged.


## SVG rendering compatibility (ClawSweeper round 2 follow-up)

Diagnostics from a headless-browser run against the branch-built gateway (Playwright Chromium 151, loopback, token redacted). Representative workspace SVG fixtures were opened both as sandboxed documents (lightbox "Open original") and as `<img>` element loads (lightbox preview).

**Unaffected (render identically under the sandbox):**

- Structural SVG features — shapes, paths, text, paint servers (`linearGradient`), filters (`feGaussianBlur`): computed `fill` resolves to `url("#g")`; text visible. No CSP violations for these.
- All fixtures as `<img>` previews: `naturalWidth: 240` — the lightbox preview path is untouched by the document CSP.

**Intentionally restricted (document-level only; verbatim browser console):**

- Inline `<style>` / CSS: `Applying inline style violates the following Content Security Policy directive 'default-src 'none''. Either the 'unsafe-inline' keyword, a h[ash or nonce]...` — an SVG relying on internal CSS styling renders with fallback (e.g. default black fill) when opened as a document. Element `fill`/`stroke` presentation attributes are unaffected.
- External resources (`<image href>`, external fonts): `Loading the image 'https://example.net/...' violates the following Content Security Policy directive: "default-src 'none'"` — external fetches from the document are blocked; the request never completes.

**Tradeoff summary:** document-level SVG features that fetch resources or apply CSS are restricted by design — this is the same policy already applied to every image served outside the allowed roots (and the point of the shared sandbox). Users keep full-fidelity rendering through the normal preview path; direct "Open original" documents degrade only in styling/external-resource features.
