### PR TITLE
refactor(ui): test asset resolution through the real filesystem

### DIFF
--- a/src/infra/control-ui-assets.fs.runtime.ts
+++ b/src/infra/control-ui-assets.fs.runtime.ts
@@ -1,9 +1,0 @@
-// Provides an fs facade for Control UI asset runtime tests.
-import fs from "node:fs";
-
-// Control UI asset tests/runtime import fs through this facade so the asset
-// resolver can be stubbed without mocking node:fs globally.
-export const existsSync = fs.existsSync.bind(fs);
-export const readFileSync = fs.readFileSync.bind(fs);
-export const statSync = fs.statSync.bind(fs);
-export const realpathSync = fs.realpathSync.bind(fs);

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -1,75 +1,23 @@
 // Tests Control UI asset discovery and expected bundled files.
+import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { RuntimeEnv } from "../runtime.js";
 
-type FakeFsEntry = { kind: "file"; content: string } | { kind: "dir" };
-
 const state = vi.hoisted(() => ({
-  entries: new Map<string, FakeFsEntry>(),
-  realpaths: new Map<string, string>(),
   runCommandWithTimeout: vi.fn(),
 }));
 
-const abs = (p: string) => path.resolve(p);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let fixtureRoot = "";
+const abs = (p: string) => path.resolve(fixtureRoot, p);
 
 function setFile(p: string, content = "") {
-  state.entries.set(abs(p), { kind: "file", content });
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
 }
-
-function setDir(p: string) {
-  state.entries.set(abs(p), { kind: "dir" });
-}
-
-vi.mock("./control-ui-assets.fs.runtime.js", async () => {
-  const actual = await import("node:fs");
-  const pathMod = await import("node:path");
-  const absInMock = (p: string) => pathMod.resolve(p);
-  const fixturesRoot = `${absInMock("fixtures")}${pathMod.sep}`;
-  const isFixturePath = (p: string) => {
-    const resolved = absInMock(p);
-    return resolved === fixturesRoot.slice(0, -1) || resolved.startsWith(fixturesRoot);
-  };
-  const readFixtureEntry = (p: string) => state.entries.get(absInMock(p));
-
-  const wrapped = {
-    existsSync: (p: string) =>
-      isFixturePath(p) ? state.entries.has(absInMock(p)) : actual.existsSync(p),
-    readFileSync: (p: string, encoding?: BufferEncoding) => {
-      if (!isFixturePath(p)) {
-        return actual.readFileSync(p, { encoding });
-      }
-      const entry = readFixtureEntry(p);
-      if (entry?.kind === "file") {
-        return entry.content;
-      }
-      throw new Error(`ENOENT: no such file, open '${p}'`);
-    },
-    statSync: (p: string) => {
-      if (!isFixturePath(p)) {
-        return actual.statSync(p);
-      }
-      const entry = readFixtureEntry(p);
-      if (entry?.kind === "file") {
-        return {
-          isFile: () => true,
-          isDirectory: () => false,
-          size: Buffer.byteLength(entry.content),
-        };
-      }
-      if (entry?.kind === "dir") {
-        return { isFile: () => false, isDirectory: () => true };
-      }
-      throw new Error(`ENOENT: no such file or directory, stat '${p}'`);
-    },
-    realpathSync: (p: string) =>
-      isFixturePath(p)
-        ? (state.realpaths.get(absInMock(p)) ?? absInMock(p))
-        : actual.realpathSync(p),
-  };
-  return wrapped;
-});
 
 vi.mock("./openclaw-root.js", () => ({
   resolveOpenClawPackageRoot: vi.fn(async () => null),
@@ -87,7 +35,7 @@ let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").re
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
 let openclawRoot: typeof import("./openclaw-root.js");
 
-describe("control UI assets helpers (fs-mocked)", () => {
+describe("control UI assets helpers", () => {
   beforeAll(async () => {
     ({
       ensureControlUiAssetsBuilt,
@@ -101,8 +49,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
   });
 
   beforeEach(() => {
-    state.entries.clear();
-    state.realpaths.clear();
+    fixtureRoot = tempDirs.make("openclaw-control-ui-assets-");
     state.runCommandWithTimeout.mockReset();
     vi.clearAllMocks();
     vi.mocked(openclawRoot.resolveOpenClawPackageRootSync).mockReset().mockReturnValue(null);
@@ -181,7 +128,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const indexPath = path.join(root, "index.html");
     setFile(outsideAsset);
     setFile(path.join(root, "assets", "startup.js"));
-    const exists = vi.spyOn(state.entries, "has");
+    const exists = vi.spyOn(fs, "existsSync");
 
     try {
       for (const reference of [
@@ -262,7 +209,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       const indexPath = path.join(bundledUiDir, "index.html");
       const document = (buildId: string) =>
         `<html data-openclaw-control-ui-build-id="${buildId}-${"a".repeat(64)}"><script src="./assets/startup.js"></script></html>`;
-      state.realpaths.set(execPath, execPath);
+      setFile(execPath);
       setFile(indexPath, document(kind === "stale" ? "runtime-a" : "runtime-b"));
       if (kind !== "incomplete") {
         setFile(path.join(bundledUiDir, "assets", "startup.js"));
@@ -528,7 +475,6 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const uiDir = path.join(root, "dist", "control-ui");
     const indexPath = path.join(uiDir, "index.html");
 
-    setDir(uiDir);
     setFile(indexPath, "<html></html>\n");
 
     expect(resolveControlUiRootOverrideSync(uiDir)).toBe(uiDir);
@@ -560,7 +506,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const bundledUiDir = abs("fixtures/OpenClaw.app/Contents/Resources/control-ui");
     setFile(path.join(bundledUiDir, "index.html"), "<html></html>\n");
 
-    state.realpaths.set(execPath, execPath);
+    setFile(execPath);
 
     expect(resolveControlUiRootSync({ execPath })).toBe(bundledUiDir);
   });
@@ -571,16 +517,23 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const realEntrypoint = path.join(pkgRoot, "dist", "index.js");
     const uiDir = path.join(pkgRoot, "dist", "control-ui");
 
-    state.realpaths.set(wrapperArgv1, realEntrypoint);
+    setFile(realEntrypoint);
+    fs.mkdirSync(path.dirname(wrapperArgv1), { recursive: true });
+    fs.symlinkSync(realEntrypoint, wrapperArgv1, "file");
     setFile(path.join(uiDir, "index.html"), "<html></html>\n");
 
-    expect(resolveControlUiRootSync({ argv1: wrapperArgv1 })).toBe(uiDir);
+    expect(
+      resolveControlUiRootSync({
+        argv1: wrapperArgv1,
+        cwd: abs("fixtures/cwd"),
+        execPath: abs("fixtures/runtime/node"),
+      }),
+    ).toBe(uiDir);
   });
 
   it("detects package-proven control-ui roots", () => {
     const pkgRoot = abs("fixtures/openclaw-package-root");
     const uiDir = path.join(pkgRoot, "dist", "control-ui");
-    setDir(uiDir);
     setFile(path.join(uiDir, "index.html"), "<html></html>\n");
     (
       openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>
@@ -596,7 +549,6 @@ describe("control UI assets helpers (fs-mocked)", () => {
   it("does not treat fallback roots as package-proven", () => {
     const pkgRoot = abs("fixtures/openclaw-package-root");
     const fallbackRoot = abs("fixtures/fallback-root/dist/control-ui");
-    setDir(fallbackRoot);
     setFile(path.join(fallbackRoot, "index.html"), "<html></html>\n");
     (
       openclawRoot.resolveOpenClawPackageRootSync as unknown as ReturnType<typeof vi.fn>

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -1,4 +1,5 @@
 // Resolves and checks packaged Control UI assets.
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
@@ -7,7 +8,6 @@ import { quoteCliArg, quotePowerShellArg } from "../cli/quote-cli-arg.js";
 import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../gateway/control-ui-root-assets.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
-import * as controlUiFsRuntime from "./control-ui-assets.fs.runtime.js";
 import { resolveOpenClawPackageRoot, resolveOpenClawPackageRootSync } from "./openclaw-root.js";
 
 export function formatControlUiSourceCommand(root: string, action: "build" | "dev"): string {
@@ -62,7 +62,7 @@ function resolveControlUiRepoRoot(opts: {
   return (
     roots.find(
       (root): root is string =>
-        root !== null && controlUiFsRuntime.existsSync(path.join(root, "ui", "vite.config.ts")),
+        root !== null && fs.existsSync(path.join(root, "ui", "vite.config.ts")),
     ) ?? null
   );
 }
@@ -79,7 +79,7 @@ async function resolveControlUiDistIndexPath(
   const normalized = path.resolve(argv1);
   const entrypointCandidates = [normalized];
   try {
-    const realpathEntrypoint = controlUiFsRuntime.realpathSync(normalized);
+    const realpathEntrypoint = fs.realpathSync(normalized);
     if (realpathEntrypoint !== normalized) {
       entrypointCandidates.push(realpathEntrypoint);
     }
@@ -111,12 +111,12 @@ async function resolveControlUiDistIndexPath(
     for (let i = 0; i < 8; i++) {
       const pkgJsonPath = path.join(dir, "package.json");
       const indexPath = path.join(dir, "dist", "control-ui", "index.html");
-      if (controlUiFsRuntime.existsSync(pkgJsonPath)) {
+      if (fs.existsSync(pkgJsonPath)) {
         try {
-          const raw = controlUiFsRuntime.readFileSync(pkgJsonPath, "utf-8");
+          const raw = fs.readFileSync(pkgJsonPath, "utf-8");
           const parsed = JSON.parse(raw) as { name?: unknown };
           if (parsed.name === "openclaw") {
-            return controlUiFsRuntime.existsSync(indexPath) ? indexPath : null;
+            return fs.existsSync(indexPath) ? indexPath : null;
           }
           // Stop at the first package boundary to avoid resolving through unrelated ancestors.
           break;
@@ -147,12 +147,12 @@ function pathsMatchByRealpathOrResolve(left: string, right: string): boolean {
   let realLeft: string;
   let realRight: string;
   try {
-    realLeft = controlUiFsRuntime.realpathSync(left);
+    realLeft = fs.realpathSync(left);
   } catch {
     realLeft = path.resolve(left);
   }
   try {
-    realRight = controlUiFsRuntime.realpathSync(right);
+    realRight = fs.realpathSync(right);
   } catch {
     realRight = path.resolve(right);
   }
@@ -169,13 +169,13 @@ function addCandidate(candidates: Set<string>, value: string | null) {
 export function resolveControlUiRootOverrideSync(rootOverride: string): string | null {
   const resolved = path.resolve(rootOverride);
   try {
-    const stats = controlUiFsRuntime.statSync(resolved);
+    const stats = fs.statSync(resolved);
     if (stats.isFile()) {
       return path.basename(resolved) === "index.html" ? path.dirname(resolved) : null;
     }
     if (stats.isDirectory()) {
       const indexPath = path.join(resolved, "index.html");
-      return controlUiFsRuntime.existsSync(indexPath) ? resolved : null;
+      return fs.existsSync(indexPath) ? resolved : null;
     }
   } catch {
     return null;
@@ -194,7 +194,7 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
       return null;
     }
     try {
-      return path.dirname(controlUiFsRuntime.realpathSync(path.resolve(argv1)));
+      return path.dirname(fs.realpathSync(path.resolve(argv1)));
     } catch {
       return null;
     }
@@ -202,7 +202,7 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
   const execDir = (() => {
     try {
       const execPath = opts.execPath ?? process.execPath;
-      return path.dirname(controlUiFsRuntime.realpathSync(execPath));
+      return path.dirname(fs.realpathSync(execPath));
     } catch {
       return null;
     }
@@ -241,7 +241,7 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
 
   for (const dir of candidates) {
     const indexPath = path.join(dir, "index.html");
-    if (controlUiFsRuntime.existsSync(indexPath)) {
+    if (fs.existsSync(indexPath)) {
       return dir;
     }
   }
@@ -295,10 +295,10 @@ function inspectControlUiAssetHealth(
   }
   let html: string;
   try {
-    if (controlUiFsRuntime.statSync(indexPath).size > 256 * 1024) {
+    if (fs.statSync(indexPath).size > 256 * 1024) {
       return { kind: "incomplete", indexPath, missingAsset: "index.html exceeds its size limit" };
     }
-    html = controlUiFsRuntime.readFileSync(indexPath, "utf8");
+    html = fs.readFileSync(indexPath, "utf8");
   } catch {
     return { kind: "missing-index", indexPath };
   }
@@ -321,7 +321,7 @@ function inspectControlUiAssetHealth(
         missingAsset: references > 128 ? "too many startup assets" : asset,
       };
     }
-    if (!controlUiFsRuntime.existsSync(path.join(path.dirname(indexPath), asset))) {
+    if (!fs.existsSync(path.join(path.dirname(indexPath), asset))) {
       return { kind: "incomplete", indexPath, missingAsset: asset };
     }
   }
@@ -395,7 +395,7 @@ export async function ensureControlUiAssetsBuilt(
   }
 
   const uiScript = path.join(repoRoot, "scripts", "ui.js");
-  if (!controlUiFsRuntime.existsSync(uiScript)) {
+  if (!fs.existsSync(uiScript)) {
     return controlUiAssetsFailure(`Control UI assets missing but ${uiScript} is unavailable.`);
   }
 


### PR DESCRIPTION
Closes #144334

## What Problem This Solves

Control UI asset resolution imports a filesystem facade whose only purpose is to let its tests replace files with an in-memory Map. That duplicates filesystem behavior and adds a production module solely for the test seam.

## Why This Change Was Made

Call the existing Node filesystem API directly and exercise it with isolated real files, directories, executable paths and a leaf-file symlink. Remove the facade and Map-backed test filesystem while preserving the resolver and asset-health assertions.

## User Impact

Asset-root selection, package boundaries, missing/incomplete assets, size limits and file identity retain their behavior. The change removes nine production lines and 48 test lines, with no new API, configuration, schema, storage or migration contract.

## Evidence

Both versions pass all 44 tests across asset resolution and Gateway HTTP identity (36 plus eight). The complete selected gate passes all 29 checks, including the three actual dead-export scans, and the final independent P2 review is clean. An initial formatter-only arrow-function line wrap was corrected without behavior changes; that exact formatting delta and the failed attempt are retained.

The focused proof ran on macOS with a real leaf-file symlink. Windows symlink permissions were not separately exercised, and no skip, copy or directory-junction fallback was added. Sequential correctness-run timing includes warm-cache effects; no speed or memory improvement is claimed.


Compatibility review: this changes the Node filesystem import and test-fixture ownership. Resolver ordering, reads, asset-health/build decisions and paths are preserved, with the same 44 resolver and HTTP-identity tests passing before and after. No schema, configuration, serialized format, retention, concurrency or migration contract changes, so migration work is not required.
