### PR TITLE
feat(models-auth): show last-used + failure counters in auth list

### DIFF
--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -359,4 +359,45 @@ describe("modelsAuthListCommand", () => {
       },
     ]);
   });
+  it("shows last-used time and failure counters in text and JSON", async () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:user@example.com": {
+          type: "oauth",
+          provider: "openai",
+          access: "secret",
+          refresh: "secret",
+          expires: 1_800_000_000_000,
+          email: "user@example.com",
+        },
+      },
+      usageStats: {
+        "openai:user@example.com": {
+          lastUsed: 1_800_000_005_000,
+          errorCount: 3,
+          lastFailureAt: 1_800_000_008_000,
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const textRuntime = createRuntime();
+    await modelsAuthListCommand({}, textRuntime);
+    expect(textRuntime.logs.at(-1)).toContain("last used 2027-01-15T08:00:05.000Z");
+    expect(textRuntime.logs.at(-1)).toContain("errors 3");
+    expect(textRuntime.logs.at(-1)).toContain("last failure 2027-01-15T08:00:08.000Z");
+
+    const jsonRuntime = createRuntime();
+    await modelsAuthListCommand({ json: true }, jsonRuntime);
+    expect(jsonRuntime.jsonPayloads[0]).toMatchObject({
+      profiles: [
+        expect.objectContaining({
+          id: "openai:user@example.com",
+          lastUsedAt: "2027-01-15T08:00:05.000Z",
+          errorCount: 3,
+          lastFailureAt: "2027-01-15T08:00:08.000Z",
+        }),
+      ],
+    });
+  });
 });

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -24,6 +24,9 @@ type AuthProfileSummary = {
   email?: string;
   displayName?: string;
   expiresAt?: string;
+  lastUsedAt?: string;
+  lastFailureAt?: string;
+  errorCount?: number;
   cooldownUntil?: string;
   disabledUntil?: string;
   cooldownReason?: ProfileUsageStats["cooldownReason"];
@@ -68,6 +71,8 @@ function summarizeProfile(params: {
   usage?: ProfileUsageStats;
 }): AuthProfileSummary {
   const expiresAt = resolveProfileExpiry(params.profile);
+  const lastUsedAt = formatTimestamp(params.usage?.lastUsed);
+  const lastFailureAt = formatTimestamp(params.usage?.lastFailureAt);
   const cooldownUntil = formatTimestamp(params.usage?.cooldownUntil);
   const disabledUntil = formatTimestamp(params.usage?.disabledUntil);
   const disabledActive = Boolean(disabledUntil);
@@ -97,6 +102,9 @@ function summarizeProfile(params: {
     ...(params.profile.email ? { email: params.profile.email } : {}),
     ...(params.profile.displayName ? { displayName: params.profile.displayName } : {}),
     ...(expiresAt ? { expiresAt } : {}),
+    ...(lastUsedAt ? { lastUsedAt } : {}),
+    ...(params.usage?.errorCount ? { errorCount: params.usage.errorCount } : {}),
+    ...(lastFailureAt ? { lastFailureAt } : {}),
     ...(cooldownUntil ? { cooldownUntil } : {}),
     ...(disabledUntil ? { disabledUntil } : {}),
     ...(params.usage?.cooldownReason ? { cooldownReason: params.usage.cooldownReason } : {}),
@@ -112,6 +120,15 @@ function formatProfileLine(profile: AuthProfileSummary): string {
   const details = [`${profile.provider}/${profile.type}`];
   if (profile.expiresAt) {
     details.push(`expires ${profile.expiresAt}`);
+  }
+  if (profile.lastUsedAt) {
+    details.push(`last used ${profile.lastUsedAt}`);
+  }
+  if (profile.errorCount) {
+    details.push(`errors ${profile.errorCount}`);
+  }
+  if (profile.lastFailureAt) {
+    details.push(`last failure ${profile.lastFailureAt}`);
   }
   if (profile.cooldownUntil) {
     const diagnostic = profile.cooldownClassification ?? profile.cooldownReason;


### PR DESCRIPTION
Closes #144064.

## What Problem This Solves

`openclaw models auth list` does not surface when each auth profile was last used, nor its accumulated failure counters, even though this data already exists in the local auth store (`ProfileUsageStats.lastUsed / errorCount / lastFailureAt`), is already returned by the gateway (`models.auth.status` -> `lastUsedAt`), and is already rendered in the Control UI. Operators debugging auth rotation and cooldowns from the CLI cannot answer which profile is actually in use or how many recent failures a profile has accumulated.

## Change

Display-only change in `src/commands/models/auth-list.ts`; the usage record was already loaded per profile in the list path (`store.usageStats?.[profileId]`), so no plumbing was needed:

- Text: appends `last used <iso>` when `lastUsed` is present, `errors <n>` when `errorCount > 0`, and `last failure <iso>` when `lastFailureAt` is present.
- JSON: adds `lastUsedAt`, `errorCount`, and `lastFailureAt` next to the existing fields, only when present.

## Evidence

- Failing-first behavioral test in `src/commands/models/auth-list.test.ts` ("shows last-used time and failure counters in text and JSON"): red before the fix (`expected '- openai:user@example.com [openai/oau…' to contain 'last used 2027-01-15T08:00:05.000Z'`, 1 failed / 8 passed), green after (9 passed / 9).
- Scoped run: `node scripts/run-vitest.mjs run src/commands/models/auth-list.test.ts` -> `Test Files 1 passed (1)`, `Tests 9 passed (9)`.
- `oxfmt --check` on both touched files: clean. `oxlint` on both touched files: exit 0, no findings.