### PR TITLE
refactor(gateway): remove duplicate ready-status test

### DIFF
--- a/src/gateway/gateway-codex-harness.live-helpers.test.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.test.ts
@@ -796,14 +796,6 @@ describe("gateway codex harness live helpers", () => {
     ).toBe(true);
   });
 
-  it("accepts the ready status emitted by current codex", () => {
-    const text = "Ready.";
-
-    expect(
-      EXPECTED_CODEX_STATUS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText)),
-    ).toBe(true);
-  });
-
   it("accepts the idle-ready status emitted by current codex", () => {
     const text = "I'm idle and ready.";
 


### PR DESCRIPTION
## What Problem This Solves

The Gateway Codex helper suite repeats a `Ready.` status check without adding independent coverage.

## Why This Change Was Made

Remove the weaker case. The retained `accepts terse ready status prose emitted by current codex` case uses the same input and inclusion assertion, then also checks the status predicate.

## User Impact

No production or runtime behavior changes. One redundant case and eight test lines are removed; all other cases, helpers, imports, and assertions remain.

## Evidence

- Full ordered `src/gateway/gateway-codex-harness.live-helpers.test.ts` through the normal gateway-core config: 58 baseline passes, then 57 post-edit passes, with zero skips.
- The same command recorded 4.398 seconds before and 3.073 seconds after. This single timing pair is not a performance-improvement claim.
- Targeted formatting, whitespace checks, and all 20 selected changed-file checks passed.
- One scoped P2 review returned no findings across two automatic partitions.

No live Gateway, provider, authentication, app-server, packaging, or full-repository runtime proof is claimed.

Related: https://github.com/openclaw/openclaw/issues/139428
