### PR TITLE
refactor: remove unused ignore matcher compatibility

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3482,7 +3482,6 @@ src/shared/deferred.ts	1
 src/shared/frontmatter.ts	5
 src/shared/global-singleton.ts	4
 src/shared/google-turn-ordering.ts	2
-src/shared/ignore-rules.ts	10
 src/shared/json-schema-defaults.ts	28
 src/shared/lazy-runtime.ts	1
 src/shared/message-content-blocks.ts	2

--- a/src/agents/sessions/package-manager.ts
+++ b/src/agents/sessions/package-manager.ts
@@ -189,9 +189,7 @@ function collectFiles(
   }
 
   const root = rootDir ?? dir;
-  const ig = ignoreMatcher
-    ? addIgnoreRules(dir, root, ignoreMatcher, { ignoreCase: true })
-    : addIgnoreRules(dir, root);
+  const ig = addIgnoreRules(dir, root, ignoreMatcher);
 
   try {
     const entries = readdirSync(dir, { withFileTypes: true });
@@ -250,9 +248,7 @@ function collectSkillEntries(
   }
 
   const root = rootDir ?? dir;
-  const ig = ignoreMatcher
-    ? addIgnoreRules(dir, root, ignoreMatcher, { ignoreCase: true })
-    : addIgnoreRules(dir, root);
+  const ig = addIgnoreRules(dir, root, ignoreMatcher);
 
   try {
     const dirEntries = readdirSync(dir, { withFileTypes: true });

--- a/src/shared/ignore-rules.test.ts
+++ b/src/shared/ignore-rules.test.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import ignore from "ignore";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { addIgnoreRules } from "./ignore-rules.js";
 
@@ -114,9 +113,7 @@ describe("addIgnoreRules", () => {
       const nestedDir = path.join(tempDir, name);
       fs.mkdirSync(nestedDir);
       fs.writeFileSync(path.join(nestedDir, ".gitignore"), oversized, "utf-8");
-      ig = ig
-        ? addIgnoreRules(nestedDir, tempDir, ig, { ignoreCase: true })
-        : addIgnoreRules(nestedDir, tempDir);
+      ig = addIgnoreRules(nestedDir, tempDir, ig);
 
       expect(ig.ignores(name)).toBe(true);
       expect(ig.ignores(`${name}/secret.txt`)).toBe(true);
@@ -133,48 +130,15 @@ describe("addIgnoreRules", () => {
     }
   });
 
-  it("preserves case-sensitive semantics for a supplied matcher", () => {
+  it("keeps fail-closed subtree matching case-insensitive", () => {
     const nestedDir = path.join(tempDir, "Private");
     fs.mkdirSync(nestedDir);
     fs.writeFileSync(path.join(nestedDir, ".gitignore"), oversizedIgnoreFileContent(), "utf-8");
 
-    const ig = addIgnoreRules(nestedDir, tempDir, ignore({ ignorecase: false }), {
-      ignoreCase: false,
-    });
-
-    expect(ig.ignores("Private/secret.txt")).toBe(true);
-    expect(ig.ignores("private/secret.txt")).toBe(false);
-
-    const otherDir = path.join(tempDir, "Other");
-    fs.mkdirSync(otherDir);
-    fs.writeFileSync(path.join(otherDir, ".gitignore"), oversizedIgnoreFileContent(), "utf-8");
-    addIgnoreRules(otherDir, tempDir, ig, { ignoreCase: false });
-    expect(ig.ignores("Other/secret.txt")).toBe(true);
-    expect(ig.ignores("other/secret.txt")).toBe(false);
-  });
-
-  it("preserves case-insensitive semantics for a supplied default matcher", () => {
-    const nestedDir = path.join(tempDir, "Private");
-    fs.mkdirSync(nestedDir);
-    fs.writeFileSync(path.join(nestedDir, ".gitignore"), oversizedIgnoreFileContent(), "utf-8");
-
-    const ig = addIgnoreRules(nestedDir, tempDir, ignore(), { ignoreCase: true });
+    const ig = addIgnoreRules(nestedDir, tempDir);
 
     expect(ig.ignores("Private/secret.txt")).toBe(true);
     expect(ig.ignores("private/secret.txt")).toBe(true);
-  });
-
-  it("adopts the explicit case mode after matcher composition", () => {
-    const source = addIgnoreRules(tempDir, tempDir);
-    const inherited = ignore().add(source);
-    const nestedDir = path.join(tempDir, "Private");
-    fs.mkdirSync(nestedDir);
-    fs.writeFileSync(path.join(nestedDir, ".gitignore"), oversizedIgnoreFileContent(), "utf-8");
-
-    addIgnoreRules(nestedDir, tempDir, inherited, { ignoreCase: true });
-
-    expect(inherited.ignores("Private/secret.txt")).toBe(true);
-    expect(inherited.ignores("private/secret.txt")).toBe(true);
   });
 
   it("keeps fail-closed metadata when the matcher is extended", () => {
@@ -184,30 +148,10 @@ describe("addIgnoreRules", () => {
     const ig = addIgnoreRules(nestedDir, tempDir);
 
     fs.writeFileSync(path.join(tempDir, ".gitignore"), "!locked/\n!locked/secret.txt\n", "utf-8");
-    addIgnoreRules(tempDir, tempDir, ig, { ignoreCase: true });
+    expect(addIgnoreRules(tempDir, tempDir, ig)).toBe(ig);
 
     expect(ig.ignores("locked")).toBe(true);
     expect(ig.ignores("locked/secret.txt")).toBe(true);
-
-    const inherited = ignore().add(ig);
-    inherited.add("!locked/\n!locked/secret.txt");
-    expect(inherited.ignores("locked")).toBe(true);
-    expect(inherited.ignores("locked/secret.txt")).toBe(true);
-  });
-
-  it("preserves the configured ignore matcher surface", () => {
-    fs.writeFileSync(path.join(tempDir, ".gitignore"), "from-file\n", "utf-8");
-    const configured = ignore().add("preconfigured");
-
-    const ig = addIgnoreRules(tempDir, tempDir, configured, { ignoreCase: true });
-
-    expect(ig).toBe(configured);
-    expect(ig.ignores("preconfigured")).toBe(true);
-    expect(ig.test("from-file").ignored).toBe(true);
-    expect(ig.filter(["from-file", "visible"])).toEqual(["visible"]);
-    expect(["from-file", "visible"].filter(ig.createFilter())).toEqual(["visible"]);
-    ig.add("added-later");
-    expect(ig.ignores("added-later")).toBe(true);
   });
 
   it("follows a symlinked .gitignore to a regular file", () => {

--- a/src/shared/ignore-rules.ts
+++ b/src/shared/ignore-rules.ts
@@ -16,17 +16,11 @@ const IGNORE_MATCHER_MAX_PATTERN_CHARS = IGNORE_FILE_MAX_BYTES;
 const OVERSIZED_IGNORE_FILE = Symbol("oversizedIgnoreFile");
 const COMPLEX_IGNORE_FILE = Symbol("complexIgnoreFile");
 
-export type IgnoreMatcher = ReturnType<typeof ignore>;
-type IgnoreMatcherOptions = {
-  /** Match node-ignore's ignorecase option for a supplied matcher. */
-  ignoreCase: boolean;
-};
+export type IgnoreMatcher = Pick<ReturnType<typeof ignore>, "ignores">;
 
 type IgnoreMatcherState = {
+  matcher: ReturnType<typeof ignore>;
   excludedSubtrees: Set<string>;
-  caseFoldedExcludedSubtrees: Set<string>;
-  caseFoldNewSubtrees: boolean;
-  caseModeKnown: boolean;
   patternCount: number;
   patternChars: number;
 };
@@ -47,123 +41,38 @@ function setContainsLiteralSubtree(pathname: string, subtrees: Set<string>): boo
 }
 
 function isInLiteralSubtree(pathname: string, state: IgnoreMatcherState): boolean {
-  const normalized = normalizeLiteralSubtreePath(pathname);
-  return (
-    setContainsLiteralSubtree(normalized, state.excludedSubtrees) ||
-    setContainsLiteralSubtree(normalized.toLowerCase(), state.caseFoldedExcludedSubtrees)
-  );
+  const normalized = normalizeLiteralSubtreePath(pathname).toLowerCase();
+  return setContainsLiteralSubtree(normalized, state.excludedSubtrees);
 }
 
-function getIgnoreMatcherState(
-  matcher: IgnoreMatcher,
-  caseFoldNewSubtrees?: boolean,
-): IgnoreMatcherState {
-  const existing = ignoreMatcherStates.get(matcher);
-  if (existing) {
-    if (!existing.caseModeKnown && caseFoldNewSubtrees !== undefined) {
-      existing.caseFoldNewSubtrees = caseFoldNewSubtrees;
-      existing.caseModeKnown = true;
+function getIgnoreMatcherState(matcher?: IgnoreMatcher): IgnoreMatcherState {
+  if (matcher) {
+    const existing = ignoreMatcherStates.get(matcher);
+    if (!existing) {
+      throw new Error("addIgnoreRules requires a matcher returned by addIgnoreRules");
     }
     return existing;
   }
+  const ownedMatcher = ignore();
   const state: IgnoreMatcherState = {
+    matcher: ownedMatcher,
     excludedSubtrees: new Set<string>(),
-    caseFoldedExcludedSubtrees: new Set<string>(),
-    caseFoldNewSubtrees: caseFoldNewSubtrees ?? false,
-    caseModeKnown: caseFoldNewSubtrees !== undefined,
     patternCount: 0,
     patternChars: 0,
   };
-  ignoreMatcherStates.set(matcher, state);
+  ignoreMatcherStates.set(ownedMatcher, state);
 
-  const originalIgnores = matcher.ignores.bind(matcher);
-  const originalTest = matcher.test.bind(matcher);
-  const originalCheckIgnore = matcher.checkIgnore.bind(matcher);
-  matcher.ignores = ((pathname: string) => {
+  const originalIgnores = ownedMatcher.ignores.bind(ownedMatcher);
+  ownedMatcher.ignores = (pathname: string) => {
     const ignored = originalIgnores(pathname);
     return isInLiteralSubtree(pathname, state) || ignored;
-  }) as IgnoreMatcher["ignores"];
-  matcher.test = ((pathname: string) => {
-    const result = originalTest(pathname);
-    return isInLiteralSubtree(pathname, state) ? { ignored: true, unignored: false } : result;
-  }) as IgnoreMatcher["test"];
-  matcher.checkIgnore = ((pathname: string) => {
-    const result = originalCheckIgnore(pathname);
-    return isInLiteralSubtree(pathname, state) ? { ignored: true, unignored: false } : result;
-  }) as IgnoreMatcher["checkIgnore"];
-  matcher.createFilter = (() => (pathname: string) =>
-    !matcher.ignores(pathname)) as IgnoreMatcher["createFilter"];
-  matcher.filter = ((pathnames: readonly string[]) =>
-    pathnames.filter(matcher.createFilter())) as IgnoreMatcher["filter"];
-
+  };
   return state;
 }
 
-function inheritIgnoreMatcherState(
-  receiver: IgnoreMatcher,
-  pattern: Parameters<IgnoreMatcher["add"]>[0],
-): void {
-  const candidates = Array.isArray(pattern) ? pattern : [pattern];
-  for (const candidate of candidates) {
-    if (typeof candidate !== "object" || candidate === null || candidate === receiver) {
-      continue;
-    }
-    const inherited = ignoreMatcherStates.get(candidate as IgnoreMatcher);
-    if (!inherited) {
-      continue;
-    }
-    const state = getIgnoreMatcherState(receiver);
-    for (const subtree of inherited.excludedSubtrees) {
-      state.excludedSubtrees.add(subtree);
-    }
-    for (const subtree of inherited.caseFoldedExcludedSubtrees) {
-      state.caseFoldedExcludedSubtrees.add(subtree);
-    }
-    state.patternCount = Math.min(
-      IGNORE_MATCHER_MAX_PATTERNS,
-      state.patternCount + inherited.patternCount,
-    );
-    state.patternChars = Math.min(
-      IGNORE_MATCHER_MAX_PATTERN_CHARS,
-      state.patternChars + inherited.patternChars,
-    );
-  }
-}
-
-const IGNORE_ADD_STATE_PATCHED = Symbol("ignoreAddStatePatched");
-
-function installIgnoreAddStatePropagation(): void {
-  const prototype = Object.getPrototypeOf(ignore()) as IgnoreMatcher & {
-    [IGNORE_ADD_STATE_PATCHED]?: boolean;
-  };
-  if (prototype[IGNORE_ADD_STATE_PATCHED]) {
-    return;
-  }
-  const originalAdd = Reflect.get(prototype, "add") as IgnoreMatcher["add"];
-  // node-ignore implements supported matcher composition in Ignore.add().
-  // Preserve terminal deny metadata there so plain ignore().add(source)
-  // cannot silently reopen a subtree that OpenClaw failed closed.
-  prototype.add = function (
-    this: IgnoreMatcher,
-    pattern: Parameters<IgnoreMatcher["add"]>[0],
-  ): IgnoreMatcher {
-    const result = Reflect.apply(originalAdd, this, [pattern]) as IgnoreMatcher;
-    inheritIgnoreMatcherState(this, pattern);
-    return result;
-  } as IgnoreMatcher["add"];
-  Object.defineProperty(prototype, IGNORE_ADD_STATE_PATCHED, { value: true });
-}
-
-installIgnoreAddStatePropagation();
-
-function addFailClosedSubtree(matcher: IgnoreMatcher, prefix: string): void {
-  const state = getIgnoreMatcherState(matcher);
-  const normalized = normalizeLiteralSubtreePath(prefix);
-  if (state.caseFoldNewSubtrees) {
-    state.caseFoldedExcludedSubtrees.add(normalized.toLowerCase());
-  } else {
-    state.excludedSubtrees.add(normalized);
-  }
+function addFailClosedSubtree(state: IgnoreMatcherState, prefix: string): void {
+  const normalized = normalizeLiteralSubtreePath(prefix).toLowerCase();
+  state.excludedSubtrees.add(normalized);
 }
 
 function parseIgnorePatterns(
@@ -200,27 +109,10 @@ function parseIgnorePatterns(
 
 export const normalizeNativePathSeparators = (pathValue: string) => pathValue.split(sep).join("/");
 
-/** Adds nested ignore-file rules to a matcher using paths relative to the scan root. */
-export function addIgnoreRules(dir: string, rootDir: string): IgnoreMatcher;
-export function addIgnoreRules(
-  dir: string,
-  rootDir: string,
-  ig: IgnoreMatcher,
-  options: IgnoreMatcherOptions,
-): IgnoreMatcher;
-export function addIgnoreRules(
-  dir: string,
-  rootDir: string,
-  ig?: IgnoreMatcher,
-  options?: IgnoreMatcherOptions,
-): IgnoreMatcher {
-  if (ig && !options) {
-    throw new Error("addIgnoreRules requires ignoreCase when a matcher is supplied");
-  }
-  const matcher = ig ?? ignore();
-  // node-ignore does not expose its configured case mode. Keep its default;
-  // callers supplying ignorecase:false must carry that fact alongside it.
-  const state = getIgnoreMatcherState(matcher, options?.ignoreCase ?? true);
+/** Adds nested rules, optionally continuing a matcher previously returned for this scan. */
+export function addIgnoreRules(dir: string, rootDir: string, ig?: IgnoreMatcher): IgnoreMatcher {
+  const state = getIgnoreMatcherState(ig);
+  const matcher = state.matcher;
   const relativeDir = relative(rootDir, dir);
   const prefix = relativeDir ? `${normalizeNativePathSeparators(relativeDir)}/` : "";
 
@@ -236,7 +128,7 @@ export function addIgnoreRules(
       // the scan surface files the user asked to hide. Stop here so a later
       // ignore file in this directory cannot negate the exclusion and reopen a
       // subtree whose policy could not be parsed.
-      addFailClosedSubtree(matcher, prefix);
+      addFailClosedSubtree(state, prefix);
       break;
     }
     if (content === null) {
@@ -247,7 +139,7 @@ export function addIgnoreRules(
       chars: IGNORE_MATCHER_MAX_PATTERN_CHARS - state.patternChars,
     });
     if (parsed === COMPLEX_IGNORE_FILE) {
-      addFailClosedSubtree(matcher, prefix);
+      addFailClosedSubtree(state, prefix);
       break;
     }
     if (parsed.patterns.length > 0) {

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -94,9 +94,7 @@ function loadSkillsFromDirInternal(
   }
 
   const root = rootDir ?? dir;
-  const ig = ignoreMatcher
-    ? addIgnoreRules(dir, root, ignoreMatcher, { ignoreCase: true })
-    : addIgnoreRules(dir, root);
+  const ig = addIgnoreRules(dir, root, ignoreMatcher);
 
   try {
     const entries = readdirSync(dir, { withFileTypes: true });


### PR DESCRIPTION
Related: #101429

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Workspace and skill discovery still carries compatibility for matcher modes, result methods, and composition that its production scanners never use. Maintaining that unused surface requires a global `node-ignore` prototype mutation and extra denial-state synchronization. This is a focused, maintainer-requested removal of unused internal behavior.

## Why This Change Was Made

Narrow the helper’s exposed matcher type to `.ignores()` and keep continuation through `addIgnoreRules`, using the existing `WeakMap` for its concrete engine, budgets, and terminal denials. Retire raw matcher inputs, case-mode selection, alternate result-method wrappers, and cross-matcher composition support, including the global prototype hook; simplify the three affected caller expressions.

Both complete production consumers keep matchers inside private scans, reuse the same instance, and return paths or skills/diagnostics. There is no public package or Plugin SDK export of this helper. Current and stable-tag source inspection confirms the same closed inputs; the workspace-scan hardening introduced in #101429 remains intact.

## User Impact

No user-visible behavior change is intended. Scans retain byte and pattern limits, original path validation, case-insensitive literal subtree denial, later-negation resistance, ignore-file ordering, and symlink handling. The patch removes **103 production code lines and 45 test code lines**, plus **one separately generated assertion-baseline row**. Both cloc modes agree; the tracked physical-line reduction is 171.

## Evidence

- Original source, callers, and tests: **44 passed across 3 files**. Candidate: **41 retained tests passed across the same files**. The owner suite goes from 16 to 13 by retiring three unsupported compatibility cases; both real consumer suites remain unchanged at 15 and 13 tests.
- Default case folding, literal names, all scan budgets, symlinks, and same-instance extension remain covered. The mixed later-negation test keeps its live denial assertions and checks the continued matcher’s identity.
- Limits, the pattern parser, bounded file reader, and prefixing functions are byte-for-byte unchanged. The native `.ignores()` call still runs before applying terminal denial, preserving validation/error order. Direct inspection of pinned `ignore@7.0.7` confirms that `.ignores()` does not depend on the removed public-method wrappers.
- **All 30 changed checks passed**, including production/test typechecking, formatting, lint, shrink-only ratchets, dead-export scans, and architecture guards.
- **Full `pnpm build` passed**, including package/plugin declarations, import/bootstrap checks, plugin outputs, and UI build.
- **Managed P2 autoreview: scoped-clean, zero findings.** The review included complete consumers, package boundaries, and dependency method source.

Focused test selection:

```sh
node scripts/run-vitest.mjs \
  src/shared/ignore-rules.test.ts \
  src/agents/sessions/package-manager.test.ts \
  src/skills/loading/session.test.ts
```

The original run used the original source and caller signatures; the candidate run used its updated signatures. Tests used isolated temporary filesystem discovery. No live Gateway or provider credentials were needed. Existing public documentation remains accurate; `CHANGELOG.md` remains release-owned.
