### PR TITLE
perf(ui): adopt completed transcript indexes without copying

### DIFF
--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -204,7 +204,10 @@ describe("chat transcript controller", () => {
           await vi.advanceTimersByTimeAsync(200);
         }
         session.syncMessageRows(
-          new Map([["retained", "expanded-row"]]),
+          new Map([
+            ["older", "expanded-row"],
+            ["retained", "expanded-row"],
+          ]),
           new Map([
             ["older", "expanded-row"],
             ["retained", "expanded-row"],
@@ -216,6 +219,7 @@ describe("chat transcript controller", () => {
         ]);
         expect(container.textContent).not.toContain("older");
         expect(session.activeMessageId(["retained"])).toBe("retained");
+        expect(session.activeMessageId(["older"])).toBeNull();
         container.dispatchEvent(new Event("touchend"));
         renderRows(next);
         expect(transcriptRows(container).map((row) => row.dataset.virtualRowKey)).toEqual([
@@ -223,6 +227,7 @@ describe("chat transcript controller", () => {
         ]);
         expect(container.textContent).toContain("older");
         expect(session.activeMessageId(["retained"])).toBe("retained");
+        expect(session.activeMessageId(["older"])).toBe("older");
       } finally {
         transcript.hostDisconnected();
         if (idleBeforeRelease) {

--- a/ui/src/pages/chat/components/chat-transcript-prepend-anchor.ts
+++ b/ui/src/pages/chat/components/chat-transcript-prepend-anchor.ts
@@ -1,10 +1,11 @@
 import type { Virtualizer } from "@tanstack/virtual-core";
 
 type ChatTranscriptPrependAnchor = { messageKey: string; rowKey: string | null; top: number };
+type TranscriptMessageKeys = Pick<ReadonlySet<string>, "keys" | "has">;
 
 /** Own the message anchor across projection capture, measurement, and restoration. */
 export class TranscriptPrependAnchor {
-  messageKeys: ReadonlySet<string> = new Set();
+  messageKeys: TranscriptMessageKeys = new Set();
   private firstMessageKey: string | undefined;
   private pending: (ChatTranscriptPrependAnchor & { measured: boolean }) | null = null;
 
@@ -81,7 +82,7 @@ export class TranscriptPrependAnchor {
 function captureTranscriptPrependAnchor(
   scrollElement: HTMLDivElement | null,
   previousFirstMessageKey: string | undefined,
-  next: ReadonlySet<string>,
+  next: TranscriptMessageKeys,
 ): ChatTranscriptPrependAnchor | null {
   const first = previousFirstMessageKey;
   if (!scrollElement || !first || first === next.keys().next().value || !next.has(first)) {

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -558,9 +558,10 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     messageRowKeysById: ReadonlyMap<string, string>,
     messageRowsByKey: ReadonlyMap<string, string>,
   ): void {
-    this.candidateMessageRowKeysById = new Map(messageRowKeysById);
-    this.candidateMessageRowsByKey = new Map(messageRowsByKey);
-    this.prependAnchor.messageKeys = new Set(messageRowsByKey.keys());
+    // The projection hands off finished indexes and never mutates them afterward.
+    this.candidateMessageRowKeysById = messageRowKeysById;
+    this.candidateMessageRowsByKey = messageRowsByKey;
+    this.prependAnchor.messageKeys = messageRowsByKey;
   }
 
   activeMessageId(messageIds: readonly string[]): string | null {


### PR DESCRIPTION
Closes #144341

## What Problem This Solves

The transcript virtualizer copies message lookup maps and builds a membership set even though each projection has already completed those indexes. This repeats collection work while presenting the same rows.

## Why This Change Was Made

Adopt the completed projection indexes and use map membership for prepend anchoring. Rows and lookup maps still commit together through the existing MCP unmount gate; a touch-held prepend keeps the previous presentation snapshot visible until commit.

## User Impact

Transcript content, message lookup, prepend behavior and reader position remain unchanged. The change adds two production lines and five test lines without a new cache, API, configuration or persistence contract.

## Evidence

Five actual renderer invocations over 800 synthetic persisted messages each avoid two map constructions and one set construction per projection: 2,400 copied collection entries at this boundary. All 800 rendered message IDs remain identical. This is an explicit constructor/entry count, not total allocation bytes, retained heap, RSS or timing evidence.

The same 51 existing tests plus one disposable measurement case passed before and after. The held-prepend test also checks that a candidate-only message ID stays out of the active lookup until commit. Two existing browser cases passed on both versions, covering missing persisted IDs and touch momentum, with zero reader-adjusted anchor drift and byte-identical inspected screenshots. All 20 selected checks and independent P2 review pass; no package, runtime-import or lazy-loading boundary changed.

![Before: synthetic behavior preservation](https://github.com/user-attachments/assets/9f23188f-dce1-43d4-99f3-9b8ab8c34a40)

![After: synthetic behavior preservation](https://github.com/user-attachments/assets/64dcf340-d159-4032-8cb8-beaad5d4a68e)