### PR TITLE
fix(ui): unblock Bun builds and stop false dev gateway refresh prompts

### DIFF
--- a/ui/config/control-ui-locales.ts
+++ b/ui/config/control-ui-locales.ts
@@ -1,9 +1,7 @@
-import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { register } from "tsx/esm/api";
-import type { Plugin } from "vite";
+import { fileURLToPath } from "node:url";
+import { runnerImport, type Alias, type Plugin } from "vite";
 import {
   loadControlUiTranslationMemory,
   materializeControlUiLocaleCatalog,
@@ -23,33 +21,25 @@ const i18nAssetsDir = path.resolve(
 );
 const locales = new Set(CONTROL_UI_LOCALE_ENTRIES.map(({ locale }) => locale));
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const sourceCatalogUrl = pathToFileURL(
-  path.join(repoRoot, "scripts/lib/control-ui-i18n-catalog.ts"),
-).href;
+const sourceCatalogPath = path.join(repoRoot, "scripts/lib/control-ui-i18n-catalog.ts");
 
-async function loadCurrentSourceCatalog(): Promise<{
+async function loadCurrentSourceCatalog(aliases: Alias[]): Promise<{
   catalog: TranslationMap;
   watchFiles: Set<string>;
 }> {
-  const watchFiles = new Set<string>();
-  const loader = register({
-    namespace: `openclaw-control-ui-source-catalog-${randomUUID()}`,
-    onImport(url) {
-      if (url.startsWith("file:")) {
-        watchFiles.add(fileURLToPath(url));
-      }
-    },
-    tsconfig: path.join(repoRoot, "tsconfig.json"),
+  // Each runner owns a fresh source graph without Node-only loader hooks.
+  // Resolved aliases keep workspace sources in the graph, not installed package outputs.
+  const { module, dependencies } = await runnerImport<
+    typeof import("../../scripts/lib/control-ui-i18n-catalog.ts")
+  >(sourceCatalogPath, {
+    root: repoRoot,
+    resolve: { alias: aliases },
   });
-  try {
-    const module = (await loader.import(
-      sourceCatalogUrl,
-      import.meta.url,
-    )) as typeof import("../../scripts/lib/control-ui-i18n-catalog.ts");
-    return { catalog: module.loadControlUiSourceCatalog(), watchFiles };
-  } finally {
-    await loader.unregister();
-  }
+  return {
+    catalog: module.loadControlUiSourceCatalog(),
+    // Vite reports transitive files separately from the entry that also needs watching.
+    watchFiles: new Set([sourceCatalogPath, ...dependencies]),
+  };
 }
 
 type ControlUiLocaleCatalogPartition = {
@@ -92,6 +82,7 @@ function parseResolvedLocaleModuleId(id: string): { locale: string; configHints:
 }
 
 export function controlUiLocaleModulesPlugin(): Plugin {
+  let sourceAliases: Alias[] = [];
   // Both modules must share one materialization. Replacing the cache object
   // fences resolved and rejected work from an invalidated build generation.
   const createCatalogCache = () => ({
@@ -105,6 +96,9 @@ export function controlUiLocaleModulesPlugin(): Plugin {
   return {
     name: "control-ui-locale-modules",
     enforce: "pre",
+    configResolved(config) {
+      sourceAliases = config.resolve.alias;
+    },
     buildStart() {
       invalidateCatalogs();
     },
@@ -127,11 +121,13 @@ export function controlUiLocaleModulesPlugin(): Plugin {
       const memoryPath = path.join(i18nAssetsDir, `${request.locale}.tm.jsonl`);
       while (true) {
         const activeCache = catalogCache;
-        activeCache.sourceCatalogLoad ??= loadCurrentSourceCatalog().catch((error: unknown) => {
-          // A later request can retry a corrected source without a watched-file change.
-          activeCache.sourceCatalogLoad = null;
-          throw error;
-        });
+        activeCache.sourceCatalogLoad ??= loadCurrentSourceCatalog(sourceAliases).catch(
+          (error: unknown) => {
+            // A later request can retry a corrected source without a watched-file change.
+            activeCache.sourceCatalogLoad = null;
+            throw error;
+          },
+        );
         let sourceCatalogResult: Awaited<ReturnType<typeof loadCurrentSourceCatalog>>;
         try {
           sourceCatalogResult = await activeCache.sourceCatalogLoad;

--- a/ui/src/app/dev-gateway.node.test.ts
+++ b/ui/src/app/dev-gateway.node.test.ts
@@ -4,10 +4,11 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createServer as createViteServer } from "vite";
+import { createLogger, createServer as createViteServer } from "vite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { getFreePort } from "../../../src/test-utils/ports.js";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import { createControlUiDevGateway } from "../../config/control-ui-dev-gateway.ts";
 import controlUiViteConfig from "../../vite.config.ts";
 import {
@@ -26,6 +27,57 @@ afterEach(() => {
 describe("configured UI development Gateway", () => {
   it("proxies HTTP and WebSocket resources without replacing auth, Origin, or Vite", async () => {
     const requests: Array<{ path: string; authorization?: string; origin?: string }> = [];
+    const events: Array<{
+      phase: string;
+      event: string;
+      code?: string | number;
+      message?: string;
+    }> = [];
+    const proxyCloses: Promise<void>[] = [];
+    const peerCloses: Promise<number>[] = [];
+    const websocketCloses: Promise<number>[] = [];
+    const pendingWrites: Promise<void>[] = [];
+    const eventWait = new AbortController();
+    let phase = "normal";
+    let interruptUpstream = false;
+    const recordError = (event: string, error: { message: string; code?: string }) => {
+      events.push({
+        phase,
+        event,
+        code: error.code,
+        message: error.message,
+      });
+    };
+    const closed = (socket: WebSocket, endpoint: string) => {
+      const promise = new Promise<number>((resolve) => {
+        socket.on("error", (error) => recordError(`${endpoint}-error`, error));
+        socket.once("close", (code) => {
+          events.push({ phase, event: `${endpoint}-close`, code });
+          resolve(code);
+        });
+      });
+      websocketCloses.push(promise);
+      return promise;
+    };
+    const nextEvent = (socket: WebSocket, event: "open" | "message") => {
+      const promise = once(socket, event, { signal: eventWait.signal });
+      // Cleanup cancels every pending event, including a message armed before send fails.
+      void promise.catch(() => undefined);
+      return promise;
+    };
+    const withinDeadline = async <T>(promise: Promise<T>) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(() => reject(new Error(JSON.stringify(events))), 5_000);
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    };
     const upstream = createServer((request, response) => {
       requests.push({
         path: request.url ?? "",
@@ -46,95 +98,220 @@ describe("configured UI development Gateway", () => {
     const sockets = new WebSocketServer({ server: upstream });
     sockets.on("connection", (socket, request) => {
       requests.push({ path: request.url ?? "", origin: request.headers.origin });
-      socket.on("message", (data) => socket.send(data));
+      peerCloses.push(closed(socket, "gateway"));
+      socket.on("message", (data) => {
+        if (interruptUpstream) {
+          interruptUpstream = false;
+          events.push({ phase, event: "gateway-terminate-requested" });
+          socket.terminate();
+        } else if (socket.readyState === WebSocket.OPEN) {
+          socket.send(data);
+        }
+      });
     });
-    upstream.listen(0, "127.0.0.1");
-    await once(upstream, "listening");
-    const upstreamUrl = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
-    vi.stubEnv("OPENCLAW_UI_DEV_GATEWAY_URL", upstreamUrl);
-    const config = controlUiViteConfig({ command: "serve" });
-    const uiPort = await getFreePort();
-    const uiOrigin = `http://127.0.0.1:${uiPort}`;
-    const server = await createViteServer({
-      ...config,
-      configFile: false,
-      root: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.."),
-      logLevel: "silent",
-      optimizeDeps: { noDiscovery: true, include: [] },
-      server: { ...config.server, port: uiPort },
-    });
-    const gateway = createControlUiDevGateway(upstreamUrl)!.gateway;
-    vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", gateway);
-    vi.stubGlobal("location", new URL(uiOrigin));
+    let server: Awaited<ReturnType<typeof createViteServer>> | undefined;
     let socket: WebSocket | undefined;
-    try {
-      await server.listen();
-      expect(server.httpServer?.address()).toMatchObject({ address: "127.0.0.1" });
-      const resourcePath = `${uiDevGatewayResourceBasePath()}/control-ui-config.json`;
-      const denied = await fetch(`${uiOrigin}${resourcePath}`);
-      expect(denied.status).toBe(401);
-      const response = await fetch(`${uiOrigin}${resourcePath}`, {
-        headers: { Authorization: "Bearer fixture-credential", Origin: uiOrigin },
-      });
-      expect(await response.json()).toEqual({ owner: "gateway", path: "/control-ui-config.json" });
-      expect(requests.at(-1)).toEqual({
-        path: "/control-ui-config.json",
-        authorization: "Bearer fixture-credential",
-        origin: uiOrigin,
-      });
-      expect(response.headers.getSetCookie()).toEqual([
-        `fixture=opaque; Path=${gateway.proxyPath}/__openclaw__/plugins/control-ui/demo/; HttpOnly; Secure; SameSite=Strict`,
-        `other=opaque; Path=${gateway.proxyPath}/api/demo/; HttpOnly`,
-      ]);
-      const plugin = await fetch(
-        `${uiOrigin}${uiDevGatewayResourceUrl("/plugins/demo/custom-resource")}`,
-        {
-          headers: { Authorization: "Bearer fixture-credential" },
-        },
-      );
-      expect(await plugin.json()).toEqual({
-        owner: "gateway",
-        path: "/plugins/demo/custom-resource",
-      });
+    await runQaGatewayFixture(
+      async () => {
+        upstream.listen(0, "127.0.0.1");
+        await once(upstream, "listening");
+        const upstreamUrl = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+        vi.stubEnv("OPENCLAW_UI_DEV_GATEWAY_URL", upstreamUrl);
+        const config = controlUiViteConfig({ command: "serve" });
+        for (const options of Object.values(config.server?.proxy ?? {})) {
+          if (typeof options === "string") {
+            throw new Error("Expected configured development proxy options");
+          }
+          const configure = options.configure;
+          options.configure = (proxy, resolved) => {
+            configure?.(proxy, resolved);
+            proxy.on("error", (error) => recordError("proxy-error", error));
+            proxy.on("proxyReqWs", (request, _incoming, downstream) => {
+              downstream.on("error", (error) => recordError("downstream-error", error));
+              proxyCloses.push(
+                new Promise((resolve) => {
+                  downstream.once("close", () => {
+                    events.push({ phase, event: "downstream-close" });
+                    resolve();
+                  });
+                }),
+              );
+              request.once("upgrade", (_response, upstreamSocket) => {
+                upstreamSocket.on("error", (error) => recordError("upstream-error", error));
+                proxyCloses.push(
+                  new Promise((resolve) => {
+                    upstreamSocket.once("close", () => {
+                      events.push({ phase, event: "upstream-close" });
+                      resolve();
+                    });
+                  }),
+                );
+              });
+            });
+          };
+        }
+        const logger = createLogger("silent");
+        logger.error = (message, options) => {
+          recordError("vite-error", options?.error ?? new Error(message));
+        };
+        const uiPort = await getFreePort();
+        const uiOrigin = `http://127.0.0.1:${uiPort}`;
+        server = await createViteServer({
+          ...config,
+          configFile: false,
+          root: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.."),
+          logLevel: "silent",
+          customLogger: logger,
+          optimizeDeps: { noDiscovery: true, include: [] },
+          server: { ...config.server, port: uiPort },
+        });
+        const gateway = createControlUiDevGateway(upstreamUrl)!.gateway;
+        vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", gateway);
+        vi.stubGlobal("location", new URL(uiOrigin));
+        await server.listen();
+        expect(server.httpServer?.address()).toMatchObject({ address: "127.0.0.1" });
+        const resourcePath = `${uiDevGatewayResourceBasePath()}/control-ui-config.json`;
+        const denied = await fetch(`${uiOrigin}${resourcePath}`);
+        expect(denied.status).toBe(401);
+        const response = await fetch(`${uiOrigin}${resourcePath}`, {
+          headers: { Authorization: "Bearer fixture-credential", Origin: uiOrigin },
+        });
+        expect(await response.json()).toEqual({
+          owner: "gateway",
+          path: "/control-ui-config.json",
+        });
+        expect(requests.at(-1)).toEqual({
+          path: "/control-ui-config.json",
+          authorization: "Bearer fixture-credential",
+          origin: uiOrigin,
+        });
+        expect(response.headers.getSetCookie()).toEqual([
+          `fixture=opaque; Path=${gateway.proxyPath}/__openclaw__/plugins/control-ui/demo/; HttpOnly; Secure; SameSite=Strict`,
+          `other=opaque; Path=${gateway.proxyPath}/api/demo/; HttpOnly`,
+        ]);
+        const plugin = await fetch(
+          `${uiOrigin}${uiDevGatewayResourceUrl("/plugins/demo/custom-resource")}`,
+          {
+            headers: { Authorization: "Bearer fixture-credential" },
+          },
+        );
+        expect(await plugin.json()).toEqual({
+          owner: "gateway",
+          path: "/plugins/demo/custom-resource",
+        });
 
-      const gatewayRequests = requests.length;
-      const vite = await fetch(`${uiOrigin}/@vite/client`);
-      expect(vite.status).toBe(200);
-      expect(await vite.text()).toContain("vite-hmr");
-      expect(requests).toHaveLength(gatewayRequests);
+        const gatewayRequests = requests.length;
+        const vite = await fetch(`${uiOrigin}/@vite/client`);
+        expect(vite.status).toBe(200);
+        expect(await vite.text()).toContain("vite-hmr");
+        expect(requests).toHaveLength(gatewayRequests);
 
-      const previousGateway = createControlUiDevGateway("http://127.0.0.1:1")!.gateway;
-      const retired = await fetch(
-        `${uiOrigin}${previousGateway.proxyPath}/control-ui-config.json`,
-        {
-          headers: { Authorization: "Bearer retired-credential" },
-        },
-      );
-      await retired.body?.cancel();
-      expect(requests).toHaveLength(gatewayRequests);
+        const previousGateway = createControlUiDevGateway("http://127.0.0.1:1")!.gateway;
+        const retired = await fetch(
+          `${uiOrigin}${previousGateway.proxyPath}/control-ui-config.json`,
+          {
+            headers: { Authorization: "Bearer retired-credential" },
+          },
+        );
+        await retired.body?.cancel();
+        expect(requests).toHaveLength(gatewayRequests);
 
-      socket = new WebSocket(gatewayWebSocketTransportUrl(gateway.gatewayUrl), {
-        origin: uiOrigin,
-      });
-      await once(socket, "open");
-      const message = once(socket, "message");
-      socket.send("normal-gateway-frame");
-      expect(String((await message)[0])).toBe("normal-gateway-frame");
-      expect(requests.at(-1)).toEqual({ path: "/", origin: uiOrigin });
-    } finally {
-      socket?.terminate();
-      for (const client of sockets.clients) {
-        client.terminate();
-      }
-      await server.close();
-      await new Promise<void>((resolve) => {
-        sockets.close(() => resolve());
-      });
-      upstream.closeAllConnections();
-      await new Promise<void>((resolve) => {
-        upstream.close(() => resolve());
-      });
-    }
+        socket = new WebSocket(gatewayWebSocketTransportUrl(gateway.gatewayUrl), {
+          origin: uiOrigin,
+        });
+        const firstClose = closed(socket, "client");
+        await withinDeadline(nextEvent(socket, "open"));
+        const message = nextEvent(socket, "message");
+        socket.send("normal-gateway-frame");
+        expect(String((await withinDeadline(message))[0])).toBe("normal-gateway-frame");
+        expect(requests.at(-1)).toEqual({ path: "/", origin: uiOrigin });
+
+        events.push({ phase, event: "client-close-requested" });
+        socket.close(1000, "fixture-reload");
+        expect(await withinDeadline(firstClose)).toBe(1000);
+        expect(await withinDeadline(peerCloses[0]!)).toBe(1000);
+        await withinDeadline(Promise.all(proxyCloses));
+        expect(events.filter(({ event }) => event.endsWith("-error"))).toEqual([]);
+
+        phase = "upstream-abort";
+        socket = new WebSocket(gatewayWebSocketTransportUrl(gateway.gatewayUrl), {
+          origin: uiOrigin,
+        });
+        const interruptedClose = closed(socket, "client");
+        await withinDeadline(nextEvent(socket, "open"));
+        const reconnectedMessage = nextEvent(socket, "message");
+        socket.send("reconnected-gateway-frame");
+        expect(String((await withinDeadline(reconnectedMessage))[0])).toBe(
+          "reconnected-gateway-frame",
+        );
+        interruptUpstream = true;
+        const writes = Array.from(
+          { length: 32 },
+          () =>
+            new Promise<void>((resolve) => {
+              socket!.send(Buffer.alloc(64 * 1024), (error) => {
+                if (error) {
+                  recordError("client-write-error", error);
+                }
+                resolve();
+              });
+            }),
+        );
+        pendingWrites.push(...writes);
+        expect(await withinDeadline(interruptedClose)).toBe(1006);
+        expect(await withinDeadline(peerCloses[1]!)).toBe(1006);
+        await withinDeadline(Promise.all([...proxyCloses, ...writes]));
+
+        phase = "recovered";
+        socket = new WebSocket(gatewayWebSocketTransportUrl(gateway.gatewayUrl), {
+          origin: uiOrigin,
+        });
+        const recoveredClose = closed(socket, "client");
+        await withinDeadline(nextEvent(socket, "open"));
+        const recoveredMessage = nextEvent(socket, "message");
+        socket.send("recovered-gateway-frame");
+        expect(String((await withinDeadline(recoveredMessage))[0])).toBe("recovered-gateway-frame");
+        socket.close(1000, "fixture-complete");
+        expect(await withinDeadline(recoveredClose)).toBe(1000);
+        expect(await withinDeadline(peerCloses[2]!)).toBe(1000);
+        await withinDeadline(Promise.all(proxyCloses));
+        const termination = events.findIndex(
+          ({ event }) => event === "gateway-terminate-requested",
+        );
+        expect(termination).toBeGreaterThan(-1);
+        for (const error of events.filter(({ event }) => event.endsWith("-error"))) {
+          expect(events.indexOf(error), JSON.stringify(events)).toBeGreaterThan(termination);
+          expect(error.phase, JSON.stringify(events)).toBe("upstream-abort");
+          // Closing the transport can cancel queued client writes on macOS.
+          const expectedCodes =
+            error.event === "client-write-error"
+              ? ["EPIPE", "ECONNRESET", "ECANCELED"]
+              : ["EPIPE", "ECONNRESET"];
+          expect(expectedCodes, JSON.stringify(events)).toContain(error.code);
+        }
+      },
+      () => {
+        eventWait.abort();
+        socket?.terminate();
+        for (const client of sockets.clients) {
+          client.terminate();
+        }
+      },
+      async () => {
+        await server?.close();
+      },
+      () =>
+        new Promise<void>((resolve) => {
+          sockets.close(() => resolve());
+        }),
+      () => {
+        upstream.closeAllConnections();
+        return new Promise<void>((resolve) => {
+          upstream.close(() => resolve());
+        });
+      },
+      () => withinDeadline(Promise.all([...proxyCloses, ...websocketCloses, ...pendingWrites])),
+    );
   });
 
   it("keeps logical Gateway identity while translating its resource base and socket", () => {

--- a/ui/src/app/overlays-updates.ts
+++ b/ui/src/app/overlays-updates.ts
@@ -6,6 +6,7 @@ import { isReportableUpdateRun } from "../../../src/shared/update-outcome.js";
 import { GatewayRequestError } from "../api/gateway.ts";
 import type { UpdateHoldResult } from "../api/types.ts";
 import { controlUiBuildDiffersFrom } from "../build-info.ts";
+import { isConfiguredUiDevGateway } from "../dev-gateway.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import type { ConnectionBootstrapCoordinator } from "./connection-bootstrap.ts";
@@ -422,8 +423,10 @@ export function createApplicationUpdateOverlays(
       ...(connectedSourceChanged || helloChanged
         ? projectConnectedUpdateSnapshot(snapshot, next.hello)
         : {}),
+      // Vite owns this document; reloading cannot adopt its proxied Gateway's build.
       controlUiRefreshRequired: connectedSourceChanged
-        ? (Boolean(serverBuildIdentity.buildId?.trim()) || connectedEpoch > 1) &&
+        ? !isConfiguredUiDevGateway(gateway.connection.gatewayUrl) &&
+          (Boolean(serverBuildIdentity.buildId?.trim()) || connectedEpoch > 1) &&
           controlUiBuildDiffersFrom(serverBuildIdentity)
         : snapshot.controlUiRefreshRequired,
     };

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 // Control UI tests cover application-owned overlay races.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasSameOriginGatewayTransport } from "../dev-gateway.ts";
 import { createUpdateRunFixture as updateRunFixture } from "../test-helpers/update-run.ts";
 import type { ConnectionBootstrapCoordinator } from "./connection-bootstrap.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
@@ -35,6 +36,41 @@ afterEach(() => {
 });
 
 describe("Control UI refresh nudge", () => {
+  it.each([{ version: "1.0.0", buildId: "gateway-build" }, { version: "2.0.0" }])(
+    "does not ask the configured dev proxy to reload for a mismatched build (%#)",
+    (server) => {
+      const gatewayClient = client(async () => []);
+      const harness = createGatewayHarness(null, false);
+      vi.stubGlobal("location", new URL("http://localhost:5173/"));
+      vi.stubGlobal("OPENCLAW_UI_DEV_GATEWAY", {
+        gatewayUrl: harness.gateway.connection.gatewayUrl,
+        proxyPath: "/__openclaw_dev_gateway__/fixture",
+      });
+      const overlays = createApplicationOverlays(harness.gateway);
+      try {
+        expect(hasSameOriginGatewayTransport(harness.gateway.connection.gatewayUrl)).toBe(true);
+        const hello = { server } as ApplicationGatewaySnapshot["hello"];
+        harness.update({ client: gatewayClient, phase: "connected", hello });
+        expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
+
+        harness.update({ phase: "stopped", hello: null });
+        expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
+        harness.update({ phase: "connected", hello });
+        expect(overlays.snapshot.controlUiRefreshRequired).toBe(false);
+
+        harness.update({ client: null, phase: "stopped", hello: null });
+        harness.gateway.connection.gatewayUrl = "ws://other-gateway.test";
+        harness.update({ client: gatewayClient, phase: "connected", hello });
+        harness.update({ phase: "stopped", hello: null });
+        harness.update({ phase: "connected", hello });
+        expect(overlays.snapshot.controlUiRefreshRequired).toBe(true);
+      } finally {
+        overlays.dispose();
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
   it("runs automatic connection refreshes through the bootstrap coordinator", async () => {
     const request = vi.fn<RequestFn>((method) =>
       Promise.resolve(method === "exec.approval.list" ? [] : {}),

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment node
 import { createHash } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import type { Alias } from "vite";
 import { describe, expect, it, vi } from "vitest";
 import {
   hashControlUiTranslationText,
@@ -30,7 +33,7 @@ import { en } from "../i18n/locales/en.ts";
 
 const childProcessMocks = vi.hoisted(() => ({ execFileSync: vi.fn() }));
 const fsMocks = vi.hoisted(() => ({ existsSync: vi.fn(), readFileSync: vi.fn() }));
-const tsxMocks = vi.hoisted(() => ({ register: vi.fn() }));
+const viteMocks = vi.hoisted(() => ({ runnerImport: vi.fn() }));
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -45,10 +48,10 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...actual, existsSync: fsMocks.existsSync, readFileSync: fsMocks.readFileSync };
 });
 
-vi.mock("tsx/esm/api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("tsx/esm/api")>();
-  tsxMocks.register.mockImplementation(actual.register);
-  return { ...actual, register: tsxMocks.register };
+vi.mock("vite", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vite")>();
+  viteMocks.runnerImport.mockImplementation(actual.runnerImport);
+  return { ...actual, runnerImport: viteMocks.runnerImport };
 });
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -63,8 +66,24 @@ function findStringAlias(key: string) {
   return resolveTsconfigPathAliasesForVite().find((alias) => alias.find === key);
 }
 
-function controlUiLocaleModuleHooks() {
+function controlUiLocaleModuleHooks(aliases: Alias[] = []) {
   const plugin = controlUiLocaleModulesPlugin();
+  const configHook = plugin.configResolved;
+  const configResolved = typeof configHook === "function" ? configHook : configHook?.handler;
+  expect(
+    configResolved?.call(
+      {} as never,
+      {
+        resolve: {
+          alias: [
+            ...aliases,
+            ...resolveSourcePackageAliasesForVite(),
+            ...resolveTsconfigPathAliasesForVite(),
+          ],
+        },
+      } as never,
+    ),
+  ).toBeUndefined();
   const resolveHook = plugin.resolveId;
   const resolveId = typeof resolveHook === "function" ? resolveHook : resolveHook?.handler;
   const loadHook = plugin.load;
@@ -748,7 +767,17 @@ describe("Control UI Vite config", () => {
     expect(catalog.configHints).toBeTypeOf("object");
     expect(catalog.activity.title).toBeTypeOf("string");
     expect(addWatchFile).toHaveBeenCalledWith(memoryPath);
-    expect(addWatchFile).toHaveBeenCalledWith(path.join(repoRoot, "src/config/schema.hints.ts"));
+    const watchedFiles = addWatchFile.mock.calls.map(([file]) => path.normalize(file));
+    for (const source of [
+      "scripts/lib/control-ui-i18n-catalog.ts",
+      "ui/src/i18n/locales/en-activity.ts",
+      "src/config/schema.hints.ts",
+      "src/config/schema.help.ts",
+      "src/config/schema.labels.ts",
+      "packages/net-policy/src/redact-sensitive-url.ts",
+    ]) {
+      expect(watchedFiles).toContain(path.join(repoRoot, source));
+    }
   });
 
   it("bootstraps only an absent locale memory from the English catalog", async () => {
@@ -770,7 +799,7 @@ describe("Control UI Vite config", () => {
         expect([...flattenTranslations(catalog)]).toEqual([
           ...flattenTranslations(loadControlUiSourceCatalog()),
         ]);
-        expect(addWatchFile).toHaveBeenCalledWith(
+        expect(addWatchFile.mock.calls.map(([file]) => path.normalize(file))).toContain(
           path.join(repoRoot, "src/config/schema.hints.ts"),
         );
       },
@@ -802,70 +831,131 @@ describe("Control UI Vite config", () => {
     { name: "current rejected", outcome: "reject" as const, invalidate: false },
   ])("recovers a $name source-catalog generation", async ({ outcome, invalidate }) => {
     const staleImport = deferred<{
-      loadControlUiSourceCatalog: () => ReturnType<typeof loadControlUiSourceCatalog>;
+      module: { loadControlUiSourceCatalog: () => ReturnType<typeof loadControlUiSourceCatalog> };
+      dependencies: string[];
     }>();
     const currentCatalog = {
       common: { health: "current health" },
       configHints: { gateway: { auth: { token: { label: "current token" } } } },
     };
-    const staleLoader = {
-      import: vi.fn(() => staleImport.promise),
-      unregister: vi.fn(async () => undefined),
-    };
-    const currentLoader = {
-      import: vi.fn(async () => ({
-        loadControlUiSourceCatalog: () => currentCatalog,
-      })),
-      unregister: vi.fn(async () => undefined),
-    };
-    let registrations = 0;
+    let imports = 0;
+    const sourceImport = vi.fn(async () =>
+      imports++ === 0
+        ? staleImport.promise
+        : { module: { loadControlUiSourceCatalog: () => currentCatalog }, dependencies: [] },
+    );
 
     await fsMocks.existsSync.withImplementation(
       () => false,
       async () => {
-        await tsxMocks.register.withImplementation(
-          () => (registrations++ === 0 ? staleLoader : currentLoader) as never,
-          async () => {
-            const { load, watchChange } = controlUiLocaleModuleHooks();
-            let baseSourcePromise = loadControlUiLocaleModuleSource(
-              load,
-              "\0virtual:openclaw-control-ui-locale/fr",
-            );
-            await vi.waitFor(() => expect(staleLoader.import).toHaveBeenCalledOnce());
-            if (invalidate) {
-              await watchChange.call({} as never, "src/config/schema.hints.ts", {} as never);
-            }
-            if (outcome === "resolve") {
-              staleImport.resolve({
+        await viteMocks.runnerImport.withImplementation(sourceImport, async () => {
+          const { load, watchChange } = controlUiLocaleModuleHooks();
+          let baseSourcePromise = loadControlUiLocaleModuleSource(
+            load,
+            "\0virtual:openclaw-control-ui-locale/fr",
+          );
+          await vi.waitFor(() => expect(sourceImport).toHaveBeenCalledOnce());
+          if (invalidate) {
+            await watchChange.call({} as never, "src/config/schema.hints.ts", {} as never);
+          }
+          if (outcome === "resolve") {
+            staleImport.resolve({
+              module: {
                 loadControlUiSourceCatalog: () => ({
                   common: { health: "stale health" },
                   configHints: { gateway: { auth: { token: { label: "stale token" } } } },
                 }),
-              });
-            } else {
-              const error = new Error("source import failed");
-              staleImport.reject(error);
-              if (!invalidate) {
-                await expect(baseSourcePromise).rejects.toBe(error);
-                baseSourcePromise = loadControlUiLocaleModuleSource(
-                  load,
-                  "\0virtual:openclaw-control-ui-locale/fr",
-                );
-              }
+              },
+              dependencies: [],
+            });
+          } else {
+            const error = new Error("source import failed");
+            staleImport.reject(error);
+            if (!invalidate) {
+              await expect(baseSourcePromise).rejects.toBe(error);
+              baseSourcePromise = loadControlUiLocaleModuleSource(
+                load,
+                "\0virtual:openclaw-control-ui-locale/fr",
+              );
             }
-            const baseSource = await baseSourcePromise;
-            const configHintsSource = await loadControlUiLocaleModuleSource(
-              load,
-              "\0virtual:openclaw-control-ui-locale-config-hints/fr",
-            );
-            await expect(
-              executeControlUiLocaleModule("fr", baseSource, configHintsSource),
-            ).resolves.toEqual(currentCatalog);
-            expect(currentLoader.import).toHaveBeenCalledOnce();
-          },
-        );
+          }
+          const baseSource = await baseSourcePromise;
+          const configHintsSource = await loadControlUiLocaleModuleSource(
+            load,
+            "\0virtual:openclaw-control-ui-locale-config-hints/fr",
+          );
+          await expect(
+            executeControlUiLocaleModule("fr", baseSource, configHintsSource),
+          ).resolves.toEqual(currentCatalog);
+          expect(sourceImport).toHaveBeenCalledTimes(2);
+        });
       },
     );
+  });
+
+  it("reloads configured source aliases instead of installed package outputs", async () => {
+    const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "control-ui-locale-")));
+    const entry = path.join(root, "catalog.ts");
+    const dependency = path.join(root, "labels.ts");
+    const installedPackage = path.join(root, "node_modules/@fixture/labels");
+    const { runnerImport } = await vi.importActual<typeof import("vite")>("vite");
+    try {
+      await writeFile(
+        entry,
+        'import { label } from "@fixture/labels";\n' +
+          "export const loadControlUiSourceCatalog = () => " +
+          "({ common: { health: label }, configHints: { fixture: { label } } });\n",
+      );
+      await mkdir(installedPackage, { recursive: true });
+      await writeFile(
+        path.join(installedPackage, "package.json"),
+        JSON.stringify({ name: "@fixture/labels", type: "module", exports: "./index.js" }),
+      );
+      await writeFile(path.join(installedPackage, "index.js"), 'export const label = "stale";\n');
+      await writeFile(dependency, 'export const label = "first";\n');
+      await fsMocks.existsSync.withImplementation(
+        () => false,
+        async () => {
+          await viteMocks.runnerImport.withImplementation(
+            (_entry, config) => runnerImport(entry, config),
+            async () => {
+              const { load, watchChange } = controlUiLocaleModuleHooks([
+                { find: "@fixture/labels", replacement: dependency },
+              ]);
+              const addWatchFile = vi.fn();
+              const readCatalog = async () => {
+                const base = await loadControlUiLocaleModuleSource(
+                  load,
+                  "\0virtual:openclaw-control-ui-locale/fr",
+                  addWatchFile,
+                );
+                const hints = await loadControlUiLocaleModuleSource(
+                  load,
+                  "\0virtual:openclaw-control-ui-locale-config-hints/fr",
+                  addWatchFile,
+                );
+                return executeControlUiLocaleModule("fr", base, hints);
+              };
+              expect(await readCatalog()).toEqual({
+                common: { health: "first" },
+                configHints: { fixture: { label: "first" } },
+              });
+              expect(addWatchFile.mock.calls.map(([file]) => path.normalize(file))).toContain(
+                dependency,
+              );
+              await writeFile(dependency, 'export const label = "second";\n');
+              await watchChange.call({} as never, dependency, {} as never);
+              expect(await readCatalog()).toEqual({
+                common: { health: "second" },
+                configHints: { fixture: { label: "second" } },
+              });
+            },
+          );
+        },
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("invalidates a resolved locale generation at build start", async () => {
@@ -873,19 +963,16 @@ describe("Control UI Vite config", () => {
       { common: { health: "first" }, configHints: { first: { label: "first" } } },
       { common: { health: "second" }, configHints: { second: { label: "second" } } },
     ];
-    let registrations = 0;
+    let imports = 0;
 
     await fsMocks.existsSync.withImplementation(
       () => false,
       async () => {
-        await tsxMocks.register.withImplementation(
-          () =>
-            ({
-              import: vi.fn(async () => ({
-                loadControlUiSourceCatalog: () => catalogs[registrations++],
-              })),
-              unregister: vi.fn(async () => undefined),
-            }) as never,
+        await viteMocks.runnerImport.withImplementation(
+          async () => ({
+            module: { loadControlUiSourceCatalog: () => catalogs[imports++] },
+            dependencies: [],
+          }),
           async () => {
             const { buildStart, load } = controlUiLocaleModuleHooks();
             const firstBase = await loadControlUiLocaleModuleSource(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/144015

## What Problem This Solves

Fixes an issue where developers building the Control UI with Bun could stall while loading locale catalogs. It also removes false "Server updated" refresh prompts when a Vite development UI connects to its explicitly configured Gateway with a different build identity.

## Why This Change Was Made

Vite now owns locale source evaluation and cleanup through `runnerImport`, using the resolved Vite aliases so workspace sources remain in the watched dependency graph. This replaces the `tsx` registration/unregistration path while preserving fresh generations, transitive invalidation, and retry behavior.

The refresh overlay uses the existing configured-development-Gateway identity: reloading a Vite-owned document cannot adopt the proxied Gateway's build. Bundled UI refresh behavior and other Gateway connections remain unchanged. Transport regression coverage now distinguishes graceful reload, deliberate upstream abort, and successful reconnection without changing production proxy behavior.

## User Impact

- Existing Bun and Node UI build paths complete without adding a runtime fallback or changing dependencies.
- Configured development proxies stay connected across reload without a misleading refresh prompt.
- No new configuration, authentication, security, or public API contract is introduced.

## Evidence

The two commits were rebased onto `bb221a85658ce9d8798f1c2f9e8f6de4391f6512` to include the existing CI test repairs in https://github.com/openclaw/openclaw/pull/144419 and https://github.com/openclaw/openclaw/pull/144605. Both patches and all five changed file contents are unchanged by the rebase.

- Rebased head `22b377ae96e45e2b603c9ba5e1d7a35fbce4da67`: 97 tests in the three touched test files and 12 tests in the two formerly failing E2E files passed. Actual Node 24.19.0 and Bun 1.4.2 runtime assertions, ordinary `scripts/ui.js build` runs, and strict performance checks passed. Testbox exited successfully and stopped: https://github.com/openclaw/openclaw/actions/runs/34580326391.
- Earlier qualification of the identical patch: 103 unique focused tests passed; 44 were rerun after final test-only lint corrections. Node/Bun production builds and strict performance checks passed; measured gzip boot sizes were 353,045 and 353,047 bytes against that base's 353,107-byte limit.
- Earlier real Chromium connection/reload flows passed against both Vite runtimes and an isolated Bun Gateway. All four inspected captures reached rendered chat content; `refreshRequired` stayed false despite differing build IDs, with no recorded page or proxy errors. This proves authentication, connection, and reload, not model inference or chat delivery.
- All 17 core test-type graphs, UI types/i18n, guards, dead-code checks, formatting, and styles passed across the earlier qualified inputs. Final test-only corrections also passed the UI test graph and typed Oxlint. Earlier Testbox evidence: https://github.com/openclaw/openclaw/actions/runs/34513704841.
- Independent reviews and the prior completed autoreview found no actionable P0/P1 findings. That review is reused under the repository's patch-identical rebase policy; a fresh reviewer attempt exited without a verdict. Production LOC: +31/-32 (net -1); tests: +450/-150.

The Testbox links are infrastructure evidence, not exact-head normal CI-green claims. Normal PR checks and the latest head-specific review are reported by GitHub.

The earlier historical EPIPE initiator remains unknown. This PR verifies current normal/reload flows and controlled abort/recovery; it does not claim that historical cause was fixed. The macOS Node 26/fsevents worker shutdown and automatic-build error truncation follow-ups remain out of scope.
