### PR TITLE
fix(media): bind local media roots to the active session

### DIFF
--- a/src/auto-reply/reply/agent-turn-attachments.ts
+++ b/src/auto-reply/reply/agent-turn-attachments.ts
@@ -104,6 +104,9 @@ export async function resolveAgentTurnAttachments(params: {
       cfg: params.cfg,
       ctx: params.ctx,
     }),
+    // The scoped root set is authoritative: merging sessionless defaults back in would restore
+    // the shared workspace/sandbox parents for sandboxed sessions.
+    includeDefaultLocalPathRoots: false,
   });
   const results: AgentTurnAttachment[] = [];
   const resultIndexes: number[] = [];

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -334,10 +334,32 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("stages absolute workspace media paths before sandbox mapping", async () => {
+  it("blocks absolute host-workspace media staging for sandboxed sessions with workspaceAccess none", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
+      workspaceAccess: "none",
+    });
+    const absolutePath = "/Users/peter/.openclaw/workspace/reports/screenshot.png";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [absolutePath],
+    });
+
+    expectNoMedia(result);
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("stages absolute workspace media paths before sandbox mapping when the workspace is mounted", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+      workspaceAccess: "rw",
     });
     const absolutePath = "/Users/peter/.openclaw/workspace/reports/screenshot.png";
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -14,6 +14,7 @@ import {
   resolveSandboxedMediaSource,
 } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
+import type { SandboxWorkspaceAccess } from "../../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { sanitizeUntrustedFileName } from "../../infra/fs-safe-advanced.js";
@@ -144,11 +145,21 @@ export function createReplyMediaPathNormalizer(params: {
   });
   const explicitSandboxRoot = params.sandboxRoot?.trim();
   let sandboxWorkspacePromise:
-    | Promise<{ root: string; containerWorkdir?: string } | undefined>
+    | Promise<
+        | {
+            root: string;
+            containerWorkdir?: string;
+            workspaceAccess: SandboxWorkspaceAccess;
+          }
+        | undefined
+      >
     | undefined = explicitSandboxRoot
     ? Promise.resolve({
         root: explicitSandboxRoot,
         containerWorkdir: params.sandboxContainerWorkdir,
+        // Explicit sandbox roots carry no access metadata; fail closed so host-workspace
+        // staging cannot be reached through sandboxed send paths.
+        workspaceAccess: "none" as SandboxWorkspaceAccess,
       })
     : undefined;
   const persistedMediaBySource = new Map<string, Promise<{ path: string; contentType?: string }>>();
@@ -162,18 +173,27 @@ export function createReplyMediaPathNormalizer(params: {
         workspaceDir: params.workspaceDir,
       }).then((sandbox) =>
         sandbox
-          ? { root: sandbox.workspaceDir, containerWorkdir: sandbox.containerWorkdir }
+          ? {
+              root: sandbox.workspaceDir,
+              containerWorkdir: sandbox.containerWorkdir,
+              // Fail closed when access metadata is absent: treat as unmounted.
+              workspaceAccess: sandbox.workspaceAccess ?? "none",
+            }
           : undefined,
       );
     }
     return await sandboxWorkspacePromise;
   };
 
-  const resolveMediaAccessForSource = (media: string, sessionWorkspaceDir?: string) =>
+  const resolveMediaAccessForSource = (
+    media: string,
+    sessionWorkspaceDir?: string,
+    workspaceDir?: string,
+  ) =>
     resolveAgentScopedOutboundMediaAccess({
       cfg: params.cfg,
       agentId,
-      workspaceDir: params.workspaceDir,
+      workspaceDir: workspaceDir ?? params.workspaceDir,
       ...(sessionWorkspaceDir ? { sessionWorkspaceDir } : {}),
       mediaSources: [media],
       mediaAccess: params.mediaAccess,
@@ -193,6 +213,7 @@ export function createReplyMediaPathNormalizer(params: {
   const persistLocalReplyMedia = async (
     media: string,
     sessionWorkspaceDir?: string,
+    workspaceDir?: string,
   ): Promise<{ path: string; contentType?: string }> => {
     if (!isLikelyLocalMediaSource(media)) {
       return { path: media };
@@ -209,7 +230,7 @@ export function createReplyMediaPathNormalizer(params: {
       return await cached;
     }
     const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
-      mediaAccess: resolveMediaAccessForSource(media, sessionWorkspaceDir),
+      mediaAccess: resolveMediaAccessForSource(media, sessionWorkspaceDir, workspaceDir),
     })
       .then((saved) => ({
         ...saved,
@@ -257,7 +278,14 @@ export function createReplyMediaPathNormalizer(params: {
     if (isPassThroughRemoteMediaSource(media)) {
       return { mediaUrl: media, trustedLocalMedia: false };
     }
-    const absoluteWorkspaceMedia = resolveAbsoluteWorkspaceMedia(media);
+    const sandboxWorkspace = await resolveSandboxWorkspace();
+    // A sandboxed session whose workspace is not mounted into the sandbox
+    // (workspaceAccess "none") must not read host-workspace files through media
+    // staging; the sandbox branch below owns those paths and fails closed.
+    const workspaceMounted = !sandboxWorkspace || sandboxWorkspace.workspaceAccess !== "none";
+    const absoluteWorkspaceMedia = workspaceMounted
+      ? resolveAbsoluteWorkspaceMedia(media)
+      : undefined;
     if (absoluteWorkspaceMedia) {
       const persisted = await persistLocalReplyMedia(absoluteWorkspaceMedia);
       return {
@@ -273,7 +301,6 @@ export function createReplyMediaPathNormalizer(params: {
       !media.startsWith("~") &&
       !path.isAbsolute(media) &&
       !WINDOWS_DRIVE_RE.test(media);
-    const sandboxWorkspace = await resolveSandboxWorkspace();
     if (sandboxWorkspace) {
       let sandboxResolvedMedia: string;
       try {
@@ -291,7 +318,13 @@ export function createReplyMediaPathNormalizer(params: {
         }
         throw err;
       }
-      const persisted = await persistLocalReplyMedia(sandboxResolvedMedia, sandboxWorkspace.root);
+      const persisted = await persistLocalReplyMedia(
+        sandboxResolvedMedia,
+        sandboxWorkspace.root,
+        // Without a mounted workspace, the session's media workspace is its sandbox,
+        // never the host agent workspace.
+        workspaceMounted ? undefined : sandboxWorkspace.root,
+      );
       return {
         mediaUrl: persisted.path,
         trustedLocalMedia: true,

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -159,6 +159,8 @@ export function createReplyMediaPathNormalizer(params: {
         containerWorkdir: params.sandboxContainerWorkdir,
         // Explicit sandbox roots carry no access metadata; fail closed so host-workspace
         // staging cannot be reached through sandboxed send paths.
+        // SAFETY: explicit roots have no session access metadata; "none" is the fail-closed
+        // default matching the documented explicit-root compatibility posture.
         workspaceAccess: "none" as SandboxWorkspaceAccess,
       })
     : undefined;

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -159,8 +159,7 @@ export function createReplyMediaPathNormalizer(params: {
         containerWorkdir: params.sandboxContainerWorkdir,
         // Explicit sandbox roots carry no access metadata; fail closed so host-workspace
         // staging cannot be reached through sandboxed send paths.
-        // SAFETY: explicit roots have no session access metadata; "none" is the fail-closed
-        // default matching the documented explicit-root compatibility posture.
+        // SAFETY: explicit roots have no access metadata, so the fail-closed "none" default preserves the explicit-root compatibility posture.
         workspaceAccess: "none" as SandboxWorkspaceAccess,
       })
     : undefined;

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -12,7 +12,10 @@ import {
   recordAssistantManagedMediaUrls,
   type PrepareAssistantTranscriptMessage,
 } from "../../config/sessions/transcript-assistant-delivery.js";
-import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
@@ -220,11 +223,10 @@ export function createChatSendReplyDispatch(params: {
       ...(agentId ? { agentId } : {}),
     });
     const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-    const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
-      cfg,
-      agentId,
-      mediaSources: latestStorePath ? [latestStorePath] : undefined,
-    });
+    const mediaLocalRoots = appendLocalMediaParentRoots(
+      getAgentScopedMediaLocalRoots(cfg, agentId),
+      latestStorePath ? [latestStorePath] : undefined,
+    );
     const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads([transcriptPayload], {
       localRoots: mediaLocalRoots,
       onLocalAudioAccessDenied: (err) => {

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -12,10 +12,7 @@ import {
   recordAssistantManagedMediaUrls,
   type PrepareAssistantTranscriptMessage,
 } from "../../config/sessions/transcript-assistant-delivery.js";
-import {
-  appendLocalMediaParentRoots,
-  getAgentScopedMediaLocalRoots,
-} from "../../media/local-roots.js";
+import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
@@ -223,10 +220,11 @@ export function createChatSendReplyDispatch(params: {
       ...(agentId ? { agentId } : {}),
     });
     const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-    const mediaLocalRoots = appendLocalMediaParentRoots(
-      getAgentScopedMediaLocalRoots(cfg, agentId),
-      latestStorePath ? [latestStorePath] : undefined,
-    );
+    const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
+      cfg,
+      agentId,
+      mediaSources: latestStorePath ? [latestStorePath] : undefined,
+    });
     const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads([transcriptPayload], {
       localRoots: mediaLocalRoots,
       onLocalAudioAccessDenied: (err) => {

--- a/src/gateway/server-methods/chat-send-reply-finalization.ts
+++ b/src/gateway/server-methods/chat-send-reply-finalization.ts
@@ -1,7 +1,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-delivery.js";
-import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { appendChatCanvasBlocksToMessage } from "../chat-display-projection.canvas.js";
 import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachments.js";
 import { loadSessionEntry } from "../session-utils.js";
@@ -255,11 +258,10 @@ export async function finalizeChatSendDispatchedReplies(params: {
       : loadSessionEntry(sessionKey, sessionLoadOptions);
   const { storePath: latestStorePath, entry: latestEntry } = resolvedTranscriptSession;
   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-  const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
-    cfg,
-    agentId: transcriptAgentId,
-    mediaSources: latestStorePath ? [latestStorePath] : undefined,
-  });
+  const mediaLocalRoots = appendLocalMediaParentRoots(
+    getAgentScopedMediaLocalRoots(cfg, transcriptAgentId),
+    latestStorePath ? [latestStorePath] : undefined,
+  );
   let managedMediaPrepareFailed = false;
   const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(finalPayloads, {
     localRoots: mediaLocalRoots,

--- a/src/gateway/server-methods/chat-send-reply-finalization.ts
+++ b/src/gateway/server-methods/chat-send-reply-finalization.ts
@@ -1,10 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-delivery.js";
-import {
-  appendLocalMediaParentRoots,
-  getAgentScopedMediaLocalRoots,
-} from "../../media/local-roots.js";
+import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
 import { appendChatCanvasBlocksToMessage } from "../chat-display-projection.canvas.js";
 import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachments.js";
 import { loadSessionEntry } from "../session-utils.js";
@@ -258,10 +255,11 @@ export async function finalizeChatSendDispatchedReplies(params: {
       : loadSessionEntry(sessionKey, sessionLoadOptions);
   const { storePath: latestStorePath, entry: latestEntry } = resolvedTranscriptSession;
   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-  const mediaLocalRoots = appendLocalMediaParentRoots(
-    getAgentScopedMediaLocalRoots(cfg, transcriptAgentId),
-    latestStorePath ? [latestStorePath] : undefined,
-  );
+  const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
+    cfg,
+    agentId: transcriptAgentId,
+    mediaSources: latestStorePath ? [latestStorePath] : undefined,
+  });
   let managedMediaPrepareFailed = false;
   const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(finalPayloads, {
     localRoots: mediaLocalRoots,

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -5,10 +5,7 @@ import {
 } from "../../auto-reply/reply-payload.js";
 import type { QueuedFollowupReplyBatch } from "../../auto-reply/reply/queue/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import {
-  appendLocalMediaParentRoots,
-  getAgentScopedMediaLocalRoots,
-} from "../../media/local-roots.js";
+import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
 import { appendChatCanvasBlocksToMessage } from "../chat-display-projection.canvas.js";
 import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachments.js";
 import { loadSessionEntry } from "../session-utils.js";
@@ -241,10 +238,11 @@ async function finalizeChatSendAgentReplyPayloads(
     sessionLoadOptions,
   );
   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-  const mediaLocalRoots = appendLocalMediaParentRoots(
-    getAgentScopedMediaLocalRoots(cfg, agentId),
-    latestStorePath ? [latestStorePath] : undefined,
-  );
+  const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
+    cfg,
+    agentId,
+    mediaSources: latestStorePath ? [latestStorePath] : undefined,
+  });
   const buildReplyContent = async (payloads: typeof finalPayloads) => {
     const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
       localRoots: mediaLocalRoots,

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -5,7 +5,10 @@ import {
 } from "../../auto-reply/reply-payload.js";
 import type { QueuedFollowupReplyBatch } from "../../auto-reply/reply/queue/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { appendChatCanvasBlocksToMessage } from "../chat-display-projection.canvas.js";
 import { attachManagedOutgoingMediaToMessage } from "../managed-image-attachments.js";
 import { loadSessionEntry } from "../session-utils.js";
@@ -238,11 +241,10 @@ async function finalizeChatSendAgentReplyPayloads(
     sessionLoadOptions,
   );
   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-  const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
-    cfg,
-    agentId,
-    mediaSources: latestStorePath ? [latestStorePath] : undefined,
-  });
+  const mediaLocalRoots = appendLocalMediaParentRoots(
+    getAgentScopedMediaLocalRoots(cfg, agentId),
+    latestStorePath ? [latestStorePath] : undefined,
+  );
   const buildReplyContent = async (payloads: typeof finalPayloads) => {
     const mediaMessage = await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
       localRoots: mediaLocalRoots,

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -164,6 +164,9 @@ export async function applyMediaUnderstanding(params: {
       ctx,
       workspaceDir: params.workspaceDir,
     }),
+    // The scoped root set is authoritative: merging sessionless defaults back in would restore
+    // the shared workspace/sandbox parents for sandboxed sessions.
+    includeDefaultLocalPathRoots: false,
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
     workspaceDir: params.workspaceDir,
   });

--- a/src/media-understanding/attachments.cache.test.ts
+++ b/src/media-understanding/attachments.cache.test.ts
@@ -5,6 +5,7 @@ import JSZip from "jszip";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { MediaAttachmentCache } from "./attachments.js";
+import { resolveMediaAttachmentLocalRoots } from "./runner.attachments.js";
 
 const { buildRandomTempFilePathMock, readRemoteMediaBufferMock } = vi.hoisted(() => ({
   buildRandomTempFilePathMock: vi.fn(),
@@ -36,6 +37,59 @@ const PNG_1X1 = Buffer.from(
 const AMBIGUOUS_WEBM = Buffer.from("1a45dfa3874282847765626d", "hex");
 
 describe("media understanding attachment cache", () => {
+  it("keeps session-scoped attachment roots authoritative through the cache getBuffer path", async () => {
+    await withTestDir({ prefix: "openclaw-media-cache-session-scoped-" }, async (base) => {
+      const stateDir = path.join(base, "state");
+      const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "session-a");
+      const siblingDir = path.join(stateDir, "sandboxes", "session-b");
+      const sharedWorkspaceDir = path.join(stateDir, "workspace");
+      for (const dir of [sessionWorkspaceDir, siblingDir, sharedWorkspaceDir]) {
+        await fs.mkdir(dir, { recursive: true });
+      }
+      const ownFile = path.join(sessionWorkspaceDir, "own.txt");
+      const siblingFile = path.join(siblingDir, "sibling.txt");
+      const hostWorkspaceFile = path.join(sharedWorkspaceDir, "host-secret.txt");
+      await fs.writeFile(ownFile, "OWN-SANDBOX-CONTENT");
+      await fs.writeFile(siblingFile, "SIBLING-SANDBOX-CONTENT");
+      await fs.writeFile(hostWorkspaceFile, "SHARED-HOST-WORKSPACE-CONTENT");
+
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      try {
+        const roots = resolveMediaAttachmentLocalRoots({
+          cfg: {} as never,
+          ctx: {} as never,
+          workspaceDir: sessionWorkspaceDir,
+        });
+        // Production construction (apply.ts / file-context.ts): the scoped root set is
+        // authoritative — merging sessionless defaults back in would restore the shared
+        // workspace/sandbox parents for sandboxed sessions.
+        const cache = new MediaAttachmentCache(
+          [
+            { index: 0, path: ownFile },
+            { index: 1, path: siblingFile },
+            { index: 2, path: hostWorkspaceFile },
+          ],
+          { localPathRoots: roots, includeDefaultLocalPathRoots: false },
+        );
+
+        const own = await cache.getBuffer({
+          attachmentIndex: 0,
+          maxBytes: 1024,
+          timeoutMs: 1000,
+        });
+        expect(own.buffer.toString()).toBe("OWN-SANDBOX-CONTENT");
+        await expect(
+          cache.getBuffer({ attachmentIndex: 1, maxBytes: 1024, timeoutMs: 1000 }),
+        ).rejects.toThrow(/outside allowed roots/i);
+        await expect(
+          cache.getBuffer({ attachmentIndex: 2, maxBytes: 1024, timeoutMs: 1000 }),
+        ).rejects.toThrow(/outside allowed roots/i);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     buildRandomTempFilePathMock.mockReset();

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -23,7 +23,7 @@ import {
   type MediaFetchRetryOptions,
   MediaFetchError,
 } from "../media/fetch.js";
-import { getDefaultMediaLocalRoots } from "../media/local-roots.js";
+import { getSessionSafeDefaultMediaLocalRoots } from "../media/local-roots.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
@@ -93,8 +93,9 @@ function concreteMime(mime: string | undefined): string | undefined {
 
 function getDefaultLocalPathRoots(): readonly string[] {
   // Default local roots are process-stable inbound attachment locations; merge
-  // once and reuse for cache instances.
-  defaultLocalPathRoots ??= mergeInboundPathRoots(getDefaultMediaLocalRoots());
+  // once and reuse for cache instances. Shared isolation parents (the shared
+  // sandboxes tree) are excluded so sibling sandboxes stay unreadable.
+  defaultLocalPathRoots ??= mergeInboundPathRoots(getSessionSafeDefaultMediaLocalRoots());
   return defaultLocalPathRoots;
 }
 

--- a/src/media-understanding/file-context.ts
+++ b/src/media-understanding/file-context.ts
@@ -333,6 +333,9 @@ export async function renderInboundDocumentContext(params: {
       ctx,
       workspaceDir: params.workspaceDir,
     }),
+    // The scoped root set is authoritative: merging sessionless defaults back in would restore
+    // the shared workspace/sandbox parents for sandboxed sessions.
+    includeDefaultLocalPathRoots: false,
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
     workspaceDir: params.workspaceDir,
   });

--- a/src/media-understanding/runner.attachments.ts
+++ b/src/media-understanding/runner.attachments.ts
@@ -42,8 +42,10 @@ export function resolveMediaAttachmentLocalRoots(params: {
   );
   return mergeInboundPathRoots(
     // Session-safe defaults: the shared sandboxes parent (and sibling sandboxes) never becomes an
-    // attachment-read root just because the process default list contains it.
-    getSessionSafeDefaultMediaLocalRoots(),
+    // attachment-read root just because the process default list contains it, and the shared
+    // workspace parent is dropped whenever the caller's session workspace lives elsewhere
+    // (e.g. an active sandbox).
+    getSessionSafeDefaultMediaLocalRoots(params.workspaceDir),
     workspaceDirs,
     params.workspaceDir ? [path.resolve(params.workspaceDir)] : undefined,
     resolveChannelInboundAttachmentRoots(params),

--- a/src/media-understanding/runner.attachments.ts
+++ b/src/media-understanding/runner.attachments.ts
@@ -5,7 +5,7 @@ import { mergeInboundPathRoots } from "@openclaw/media-core/inbound-path-policy"
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveChannelInboundAttachmentRoots } from "../media/channel-inbound-roots.js";
-import { getDefaultMediaLocalRoots } from "../media/local-roots.js";
+import { getSessionSafeDefaultMediaLocalRoots } from "../media/local-roots.js";
 import { normalizeMediaFacts } from "../media/media-facts.js";
 import {
   MediaAttachmentCache,
@@ -41,7 +41,9 @@ export function resolveMediaAttachmentLocalRoots(params: {
     fact.workspaceDir ? [path.resolve(fact.workspaceDir)] : [],
   );
   return mergeInboundPathRoots(
-    getDefaultMediaLocalRoots(),
+    // Session-safe defaults: the shared sandboxes parent (and sibling sandboxes) never becomes an
+    // attachment-read root just because the process default list contains it.
+    getSessionSafeDefaultMediaLocalRoots(),
     workspaceDirs,
     params.workspaceDir ? [path.resolve(params.workspaceDir)] : undefined,
     resolveChannelInboundAttachmentRoots(params),

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -10,6 +10,7 @@ import {
   getAgentScopedMediaLocalRoots as getAgentScopedMediaLocalRootsBase,
   getAgentScopedMediaLocalRootsForSources as getAgentScopedMediaLocalRootsForSourcesBase,
   getDefaultMediaLocalRoots,
+  getSessionSafeDefaultMediaLocalRoots,
 } from "./local-roots.js";
 
 function loadedConfig(config: OpenClawConfig): OpenClawConfig {
@@ -143,6 +144,90 @@ describe("local media roots", () => {
       expectedExcluded: expectedExcluded.map((suffix) => path.join(stateDir, suffix)),
       minLength,
     });
+  });
+
+  it("does not promote sibling sandbox directories via source-parent expansion", () => {
+    const stateDir = path.join("/tmp", "openclaw-sibling-sandbox-expansion-state");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "session-a");
+    const siblingFile = path.join(stateDir, "sandboxes", "session-b", "secret.txt");
+
+    const roots = withStateDir(stateDir, () =>
+      getAgentScopedMediaLocalRootsForSources({
+        cfg: {},
+        agentId: "ops",
+        mediaSources: [siblingFile],
+        sessionWorkspaceDir,
+      }),
+    );
+
+    expectNormalizedRootsContain(roots, [sessionWorkspaceDir]);
+    expectNormalizedRootsExclude(roots, [
+      path.join(stateDir, "sandboxes"),
+      path.join(stateDir, "sandboxes", "session-b"),
+    ]);
+  });
+
+  it("does not re-add the shared workspace via source-parent expansion for sandboxed sessions", () => {
+    const stateDir = path.join("/tmp", "openclaw-shared-workspace-expansion-state");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "session-a");
+    const sharedWorkspaceFile = path.join(stateDir, "workspace", "notes.png");
+
+    const roots = withStateDir(stateDir, () =>
+      getAgentScopedMediaLocalRootsForSources({
+        cfg: {},
+        agentId: "ops",
+        mediaSources: [sharedWorkspaceFile],
+        sessionWorkspaceDir,
+      }),
+    );
+
+    expectNormalizedRootsExclude(roots, [path.join(stateDir, "workspace")]);
+  });
+
+  it("keeps parent expansion for locations outside shared isolation parents", () => {
+    const stateDir = path.join("/tmp", "openclaw-parent-expansion-state");
+    const externalDir =
+      process.platform === "win32" ? "C:\\Users\\peter\\Downloads" : "/Users/peter/Downloads";
+
+    const roots = withStateDir(stateDir, () =>
+      getAgentScopedMediaLocalRootsForSources({
+        cfg: {},
+        agentId: "ops",
+        mediaSources: [path.join(externalDir, "clip.mp4")],
+      }),
+    );
+
+    expectNormalizedRootsContain(roots, [externalDir]);
+    expectNormalizedRootsExclude(roots, [path.join(stateDir, "sandboxes")]);
+  });
+
+  it("keeps own sandbox parents readable via source-parent expansion", () => {
+    const stateDir = path.join("/tmp", "openclaw-own-sandbox-expansion-state");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "session-a");
+    const ownFile = path.join(sessionWorkspaceDir, "media", "clip.mp4");
+
+    const roots = withStateDir(stateDir, () =>
+      getAgentScopedMediaLocalRootsForSources({
+        cfg: {},
+        agentId: "ops",
+        mediaSources: [ownFile],
+        sessionWorkspaceDir,
+      }),
+    );
+
+    expectNormalizedRootsContain(roots, [path.join(sessionWorkspaceDir, "media")]);
+  });
+
+  it("excludes shared sandbox parents from session-safe default attachment roots", () => {
+    const stateDir = path.join("/tmp", "openclaw-session-safe-defaults-state");
+
+    const roots = withStateDir(stateDir, () => getSessionSafeDefaultMediaLocalRoots());
+
+    expectNormalizedRootsExclude(roots, [
+      path.join(stateDir, "sandboxes"),
+      path.join(stateDir, "sandboxes", "session-a"),
+    ]);
+    expectNormalizedRootsContain(roots, [path.join(stateDir, "workspace")]);
   });
 
   it("adds concrete parent roots for local media sources without widening to filesystem root", () => {

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -230,6 +230,34 @@ describe("local media roots", () => {
     expectNormalizedRootsContain(roots, [path.join(stateDir, "workspace")]);
   });
 
+  it("drops the shared workspace from session-safe attachment roots for sandboxed sessions", () => {
+    const stateDir = path.join("/tmp", "openclaw-session-safe-sandbox-state");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "session-a");
+
+    const roots = withStateDir(stateDir, () =>
+      getSessionSafeDefaultMediaLocalRoots(sessionWorkspaceDir),
+    );
+
+    // The session workspace itself is merged back by the caller
+    // (resolveMediaAttachmentLocalRoots adds params.workspaceDir explicitly).
+    expectNormalizedRootsExclude(roots, [
+      path.join(stateDir, "workspace"),
+      path.join(stateDir, "sandboxes"),
+      path.join(stateDir, "sandboxes", "session-b"),
+    ]);
+  });
+
+  it("keeps the shared workspace in session-safe attachment roots when the session workspace lives inside it", () => {
+    const stateDir = path.join("/tmp", "openclaw-session-safe-host-workspace-state");
+
+    const roots = withStateDir(stateDir, () =>
+      getSessionSafeDefaultMediaLocalRoots(path.join(stateDir, "workspace")),
+    );
+
+    expectNormalizedRootsContain(roots, [path.join(stateDir, "workspace")]);
+    expectNormalizedRootsExclude(roots, [path.join(stateDir, "sandboxes")]);
+  });
+
   it("adds concrete parent roots for local media sources without widening to filesystem root", () => {
     const picturesDir =
       process.platform === "win32" ? "C:\\Users\\peter\\Pictures" : "/Users/peter/Pictures";

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -114,9 +114,12 @@ function filterSharedMediaLocalRoots(
  * Inbound attachment processing must not inherit sibling-sandbox grants from the process default
  * list; callers re-add their own session/agent workspace explicitly when one applies.
  */
-export function getSessionSafeDefaultMediaLocalRoots(): readonly string[] {
+export function getSessionSafeDefaultMediaLocalRoots(
+  sessionWorkspaceDir?: string,
+): readonly string[] {
   return filterSharedMediaLocalRoots(getDefaultMediaLocalRoots(), {
     resolvedStateDir: path.resolve(resolveStateDir()),
+    sessionWorkspaceDir,
   });
 }
 

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/tool-fs-policy.js";
 import { resolveDeliveryQueueMediaDir, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { resolveConfigDir } from "../utils.js";
 import { resolveLocalMediaPath } from "./local-media-path.js";
@@ -59,6 +60,67 @@ export function getDefaultMediaLocalRoots(): readonly string[] {
 }
 
 /**
+ * Drops shared isolation parents from a media root list.
+ *
+ * Roots overlapping the shared `<state>/sandboxes` parent are removed unless they live inside the
+ * supplied session workspace, so sibling sandboxes and the shared parent itself never re-enter the
+ * allowlist through base construction or source-parent expansion. The shared `<state>/workspace`
+ * parent is removed only when the caller supplies a session workspace outside it (a sandboxed
+ * session); callers without session context keep the legacy shared-workspace grant.
+ */
+function filterSharedMediaLocalRoots(
+  roots: readonly string[],
+  context: { resolvedStateDir: string; sessionWorkspaceDir?: string },
+): string[] {
+  const sandboxesDir = path.join(context.resolvedStateDir, "sandboxes");
+  const workspaceDir = path.join(context.resolvedStateDir, "workspace");
+  const sessionWorkspaceDir = context.sessionWorkspaceDir
+    ? path.resolve(context.sessionWorkspaceDir)
+    : undefined;
+  const isInsideOrEqual = (parent: string, child: string): boolean =>
+    child === parent || isPathInside(parent, child);
+  // The shared sandboxes parent itself (or any ancestor of it) is never a valid session workspace:
+  // passing it must not re-admit the shared sandbox tree.
+  const validSessionWorkspaceDir =
+    sessionWorkspaceDir !== undefined && !isInsideOrEqual(sessionWorkspaceDir, sandboxesDir)
+      ? sessionWorkspaceDir
+      : undefined;
+  const overlaps = (sharedDir: string, root: string): boolean =>
+    isInsideOrEqual(sharedDir, root) || isInsideOrEqual(root, sharedDir);
+  const filtered: string[] = [];
+  for (const root of roots) {
+    const resolvedRoot = path.resolve(root);
+    const withinSessionWorkspace =
+      validSessionWorkspaceDir !== undefined &&
+      isInsideOrEqual(validSessionWorkspaceDir, resolvedRoot);
+    if (overlaps(sandboxesDir, resolvedRoot) && !withinSessionWorkspace) {
+      continue;
+    }
+    if (
+      sessionWorkspaceDir !== undefined &&
+      overlaps(workspaceDir, resolvedRoot) &&
+      !withinSessionWorkspace
+    ) {
+      continue;
+    }
+    filtered.push(resolvedRoot);
+  }
+  return filtered;
+}
+
+/**
+ * Default local media roots with shared isolation parents removed.
+ *
+ * Inbound attachment processing must not inherit sibling-sandbox grants from the process default
+ * list; callers re-add their own session/agent workspace explicitly when one applies.
+ */
+export function getSessionSafeDefaultMediaLocalRoots(): readonly string[] {
+  return filterSharedMediaLocalRoots(getDefaultMediaLocalRoots(), {
+    resolvedStateDir: path.resolve(resolveStateDir()),
+  });
+}
+
+/**
  * Adds exact agent/session workspaces without exposing shared agent or sandbox roots.
  *
  * Callers that need to send media from a sandbox must pass the authoritative active
@@ -72,12 +134,9 @@ export function getAgentScopedMediaLocalRoots(
 ): readonly string[] {
   const stateDir = resolveStateDir();
   const resolvedStateDir = path.resolve(stateDir);
-  const roots = buildMediaLocalRoots(stateDir, resolveConfigDir()).filter((root) => {
-    const resolvedRoot = path.resolve(root);
-    if (resolvedRoot === path.join(resolvedStateDir, "sandboxes")) {
-      return false;
-    }
-    return !sessionWorkspaceDir || resolvedRoot !== path.join(resolvedStateDir, "workspace");
+  const roots = filterSharedMediaLocalRoots(buildMediaLocalRoots(stateDir, resolveConfigDir()), {
+    resolvedStateDir,
+    sessionWorkspaceDir,
   });
   const normalizedAgentId = normalizeOptionalString(agentId);
   const workspaceDir =
@@ -140,5 +199,16 @@ export function getAgentScopedMediaLocalRootsForSources(params: {
   if (!resolveEffectiveToolFsRootExpansionAllowed({ cfg: params.cfg, agentId: params.agentId })) {
     return roots;
   }
-  return appendLocalMediaParentRoots(roots, params.mediaSources);
+  const expanded = appendLocalMediaParentRoots(roots, params.mediaSources);
+  // Source-parent expansion must not re-promote shared isolation parents (a shared workspace or
+  // sibling sandbox must not become readable just because the caller named a file there).
+  const addedParents = expanded.filter((root) => !roots.includes(root));
+  const confinedParents = filterSharedMediaLocalRoots(addedParents, {
+    resolvedStateDir: path.resolve(resolveStateDir()),
+    sessionWorkspaceDir: params.sessionWorkspaceDir,
+  });
+  if (confinedParents.length === addedParents.length) {
+    return expanded;
+  }
+  return Array.from(new Set([...roots, ...confinedParents]));
 }

--- a/src/plugin-sdk/media-local-roots.test.ts
+++ b/src/plugin-sdk/media-local-roots.test.ts
@@ -74,6 +74,44 @@ describe("plugin SDK media local roots", () => {
     await expectActiveAllowedAndSiblingDenied(fixture, localRoots);
   });
 
+  it("keeps trusted session-context callers sandbox-capable when root expansion is enabled", async () => {
+    // Exercises the newly confined expansion branch: with workspaceOnly disabled (the default),
+    // a caller with trusted session context keeps parent expansion inside its own sandbox and
+    // still cannot reach sibling sandboxes.
+    const baseDir = tempDirs.make("plugin-sdk-media-roots-expansion-");
+    const stateDir = path.join(baseDir, "state");
+    const agentWorkspaceDir = path.join(baseDir, "workspace-main");
+    const sessionWorkspaceDir = path.join(stateDir, "sandboxes", "active");
+    const siblingWorkspaceDir = path.join(stateDir, "sandboxes", "sibling");
+    const ownNestedFile = path.join(sessionWorkspaceDir, "media", "clip.txt");
+    const siblingFile = path.join(siblingWorkspaceDir, "secret.txt");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    await fs.mkdir(agentWorkspaceDir, { recursive: true });
+    await fs.mkdir(path.dirname(ownNestedFile), { recursive: true });
+    await fs.mkdir(siblingWorkspaceDir, { recursive: true });
+    await fs.writeFile(ownNestedFile, "own-media");
+    await fs.writeFile(siblingFile, "sibling-secret");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", workspace: agentWorkspaceDir }] },
+      };
+      const localRoots = getAgentScopedMediaLocalRootsForSources({
+        cfg,
+        agentId: "main",
+        mediaSources: [ownNestedFile, siblingFile],
+        sessionWorkspaceDir,
+      });
+
+      const own = await loadWebMediaRaw(ownNestedFile, { localRoots });
+      expect(own.buffer.toString()).toBe("own-media");
+      await expect(loadWebMediaRaw(siblingFile, { localRoots })).rejects.toThrow(
+        /not under an allowed directory/i,
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("fails closed for a legacy caller that omits active-session context", async () => {
     const fixture = await createSandboxFixture();
     const localRoots = getAgentScopedMediaLocalRoots(fixture.cfg, "main");


### PR DESCRIPTION
## Summary

A sandboxed session could make the Gateway read files outside its sandbox — sibling sandboxes and the shared host workspace — through the media pipelines, even with `workspaceAccess: "none"` (the default). #143521 made base media roots session-scoped, but three construction paths still re-granted the shared parents downstream. This PR closes those paths, **completing** #143521 without touching #138856's display layer.

## What was wrong

The sandbox media-read contract had three gaps — each re-introducing a parent that #143521 had removed:

1. **Source-parent expansion re-promoted shared parents** (`src/media/local-roots.ts`) — naming a file re-authorized its directory, so naming `<state>/sandboxes/<other>/secret.txt` re-added the sibling sandbox and the shared `sandboxes` parent to the allowlist.
2. **The attachment pipeline never received the session filter** (`src/media-understanding/`, `src/plugin-sdk/`) — attachment-cache roots still defaulted to the shared sandbox parent, and the cache merged sessionless default roots back over session-scoped ones, restoring them at construction.
3. **Reply media staging ignored the sandbox access mode** (`src/auto-reply/reply/reply-media-paths.ts`) — host-workspace absolute paths were staged regardless of `workspaceAccess`, so `none` didn't mean "not mounted".

Net effect: model-steered media paths in a sandboxed session could read **sibling session sandboxes** and **host-workspace files** through both the outbound reply and inbound attachment pipelines.

## Why this design

- **Fail closed before bytes move**: rejected paths stop at the boundary check — no staging, no byte consumption; media surfaces through the existing per-file "Delivery failed" path, not silent drops.
- **Session-scoped roots are authoritative end-to-end**: the filtered root set computed once is what the cache reads; no downstream merge re-adds what upstream removed.
- **`workspaceAccess` is the contract**: `none` (default) → host-workspace paths fail closed through the sandbox boundary; `ro`/`rw` → the workspace is mounted and staging keeps working.
- **No config surface, no migration**: no defaults flip; legitimate grants (own sandbox, explicitly mounted workspaces, managed media, external-attachment parent expansion) are preserved and test-covered.

## Why this does not conflict with #143521 or #138856

These PRs govern **different layers** of the same principle — media access follows the session's actual workspace context:

| PR | Layer it governs | Relation to this PR |
|---|---|---|
| #143521 | Gateway pipeline: base media roots become session-scoped | **Completed.** #143521 removed shared parents at base construction; this PR closes the three downstream paths that re-added them (expansion, cache merge, staging). Its contract tests pass unchanged on this branch. |
| #138856 | Control UI display: previews honor the session's filesystem-protection mode | **Untouched.** This diff contains no `ui/` and no `src/gateway/` files; the preview-serving path (`assistant-media-policy`, `control-ui`, `http-image-response`) is not modified, and its test suites pass on this branch. |

Concretely: what a **browser may display** (#138856) and what a **sandboxed pipeline may read** (#143521 + this PR) are separate checks with separate owners. Narrowing the latter does not reopen the former — a project-worktree session keeps its own workspace roots in both layers. The two PRs do share `src/media/local-roots.ts`; our branch is based on a revision that already includes #138856, and the changes compose (additive filtering helpers vs. display policy).

## Evidence (final effects on this head)

Exercised through the **real production owners** — unmocked sandbox resolution, real sink chain, real staging — via throwaway state dirs (private reproduction retained in the advisory):

| Path named | `workspaceAccess` | Outcome | Bytes moved? |
|---|---|---|---|
| own sandbox file | `none` | **STAGED / READ OK** | yes (allowed) |
| sibling sandbox file | `none` | **DROPPED** before staging | **none** |
| unmounted host-workspace file | `none` | **DROPPED** before staging | **none** |
| host-workspace file | `rw` (mounted) | **STAGED OK** | yes (unchanged behavior) |
| relative host-workspace path | `rw` | **STAGED OK** | yes (unchanged behavior) |

Outbound reader (`resolveOutboundAttachmentFromUrl`) and attachment-cache `getBuffer` observations match: allowed reads succeed; sibling/unmounted/outside-roots reads are rejected before consumption.

## SDK / caller upgrade contract

- `getAgentScopedMediaLocalRoots` / `…ForSources` (plugin-sdk) keep their existing contract: **trusted session context keeps that session's access**; callers that omit session context now **fail closed** for sandbox files rather than silently keeping shared-parent grants.
- Covered by `plugin-sdk/media-local-roots.test.ts`, including the expansion branch with trusted context (own nested sandbox file readable; sibling blocked).

## Boundary decisions requested from security owners

Three explicit asks so this PR can merge with clear ownership (posted as a comment for @openclaw/openclaw-secops):

1. Accept the **bounded repair**: this PR does not claim complete inbound host-workspace isolation — ordinary inbound processing retains the pre-existing caller-workspace grant (production callers pass the host agent workspace to media understanding). Excluded from claims, documented for owner ownership.
2. Accept the **session-context upgrade contract** for third-party SDK callers (fail-closed transition above).
3. Confirm the **explicit-root compatibility posture**: explicit-root normalizer callers are treated as unmounted (fail-closed).

## Testing

- New: sibling-sandbox and shared-workspace expansion confinement, session-safe attachment defaults, cache-construction authority (final `getBuffer` reads), `workspaceAccess`-gated staging (none blocks / rw stages), SDK expansion-branch contract.
- Unchanged-green: local roots, read capability, reply media paths, media-understanding attachments, chat-send attachments, gateway media policy, UI attachment availability — including the #143521 and #138856 suites, run on this branch (212-test composition run).
- No public issue is linked; the report arrived through the private advisory process.
