### PR TITLE
perf(agents): append ordered CLI reasoning deltas incrementally

### DIFF
--- a/src/agents/cli-output-events.ts
+++ b/src/agents/cli-output-events.ts
@@ -394,6 +394,7 @@ type ThinkingTracker = {
   // is deduped against its own index; a single global concatenation misfires
   // once a message carries more than one thinking block (re-emits or reorders).
   streamedByIndex: Map<number, string>;
+  highestStreamedIndex: number;
   // Full thinking already emitted for the message in block order. The callback
   // contract exposes this as the running snapshot text for downstream coalescing,
   // so it stays a message-level concatenation, not a per-index value.
@@ -406,6 +407,7 @@ type ThinkingTracker = {
 export function createThinkingTracker(): ThinkingTracker {
   return {
     streamedByIndex: new Map(),
+    highestStreamedIndex: Number.NEGATIVE_INFINITY,
     emittedText: "",
     nextSyntheticBlockIndex: 0,
     progressTokens: 0,
@@ -414,6 +416,7 @@ export function createThinkingTracker(): ThinkingTracker {
 
 function resetThinkingBlockState(tracker: ThinkingTracker): void {
   tracker.streamedByIndex.clear();
+  tracker.highestStreamedIndex = Number.NEGATIVE_INFINITY;
   tracker.emittedText = "";
   tracker.currentSyntheticBlockIndex = undefined;
   tracker.nextSyntheticBlockIndex = 0;
@@ -480,8 +483,12 @@ function emitClaudeThinking(
   delta: string,
   onThinkingDelta: (delta: CliThinkingDelta) => void,
 ): void {
+  const appendToAggregate = index >= tracker.highestStreamedIndex;
   tracker.streamedByIndex.set(index, `${streamed}${delta}`);
-  tracker.emittedText = assembleThinkingTextByIndex(tracker.streamedByIndex);
+  tracker.highestStreamedIndex = Math.max(tracker.highestStreamedIndex, index);
+  tracker.emittedText = appendToAggregate
+    ? `${tracker.emittedText}${delta}`
+    : assembleThinkingTextByIndex(tracker.streamedByIndex);
   onThinkingDelta({ text: tracker.emittedText, delta, isReasoningSnapshot: true });
 }
 
@@ -579,6 +586,7 @@ export function dispatchClaudeCliThinking(params: {
         continue;
       }
       tracker.streamedByIndex.set(index, block.thinking);
+      tracker.highestStreamedIndex = Math.max(tracker.highestStreamedIndex, index);
       const text = assembleThinkingTextByIndex(tracker.streamedByIndex);
       if (text === tracker.emittedText) {
         continue;

--- a/src/agents/cli-output-reasoning.test.ts
+++ b/src/agents/cli-output-reasoning.test.ts
@@ -329,18 +329,36 @@ describe("createCliJsonlStreamingParser reasoning", () => {
       ],
     },
     {
-      name: "emits snapshot thinking blocks when no thinking deltas streamed",
+      name: "keeps snapshot-only thinking blocks ordered when later deltas arrive",
       frames: [
         claudeAssistantSnapshot("msg-1", [
           { type: "thinking", thinking: "Snapshot-only reasoning.", signature: "sig" },
           { type: "redacted_thinking", data: "opaque-blob" },
+          { type: "thinking", thinking: " Next block." },
           { type: "text", text: "Answer." },
         ]),
+        claudeThinkingDelta(" Revised.", 0),
+        claudeThinkingDelta(" Done.", 2),
       ],
       expected: [
         {
           text: "Snapshot-only reasoning.",
           delta: "Snapshot-only reasoning.",
+          isReasoningSnapshot: true,
+        },
+        {
+          text: "Snapshot-only reasoning. Next block.",
+          delta: " Next block.",
+          isReasoningSnapshot: true,
+        },
+        {
+          text: "Snapshot-only reasoning. Revised. Next block.",
+          delta: " Revised.",
+          isReasoningSnapshot: true,
+        },
+        {
+          text: "Snapshot-only reasoning. Revised. Next block. Done.",
+          delta: " Done.",
           isReasoningSnapshot: true,
         },
       ],
@@ -353,10 +371,16 @@ describe("createCliJsonlStreamingParser reasoning", () => {
           { type: "thinking", thinking: "revised thought", signature: "sig" },
           { type: "text", text: "Answer." },
         ]),
+        claudeAssistantSnapshot("msg-1", [
+          { type: "thinking", thinking: "revised thought", signature: "sig" },
+          { type: "text", text: "Answer." },
+        ]),
+        claudeThinkingDelta(" continued", 0),
       ],
       expected: [
         { text: "rough draft", delta: "rough draft", isReasoningSnapshot: true },
         { text: "revised thought", delta: "revised thought", isReasoningSnapshot: true },
+        { text: "revised thought continued", delta: " continued", isReasoningSnapshot: true },
       ],
     },
     {
@@ -368,10 +392,58 @@ describe("createCliJsonlStreamingParser reasoning", () => {
           { type: "thinking", thinking: "A", signature: "sig-a" },
           { type: "thinking", thinking: "B", signature: "sig-b" },
         ]),
+        claudeThinkingDelta("C", 0),
+        claudeThinkingDelta("D", 1),
       ],
       expected: [
         { text: "A", delta: "A", isReasoningSnapshot: true },
         { text: "AB", delta: "B", isReasoningSnapshot: true },
+        { text: "ACB", delta: "C", isReasoningSnapshot: true },
+        { text: "ACBD", delta: "D", isReasoningSnapshot: true },
+      ],
+    },
+    {
+      name: "orders new earlier thinking blocks before appending to the greatest index",
+      frames: [
+        claudeThinkingDelta("C", 2),
+        claudeThinkingDelta("A", 0),
+        claudeThinkingDelta("B", 1),
+        claudeThinkingDelta("D", 2),
+        claudeThinkingDelta("E", 0),
+      ],
+      expected: [
+        { text: "C", delta: "C", isReasoningSnapshot: true },
+        { text: "AC", delta: "A", isReasoningSnapshot: true },
+        { text: "ABC", delta: "B", isReasoningSnapshot: true },
+        { text: "ABCD", delta: "D", isReasoningSnapshot: true },
+        { text: "AEBCD", delta: "E", isReasoningSnapshot: true },
+      ],
+    },
+    {
+      name: "preserves negative, infinite, and signed-zero thinking indexes",
+      // Raw JSON preserves overflowed numeric exponents and negative zero.
+      frames: [
+        { index: "-1e400", thinking: "L" },
+        { index: "-1e400", thinking: "!" },
+        { index: "-2", thinking: "N" },
+        { index: "-0", thinking: "Z" },
+        { index: "0", thinking: "+" },
+        { index: "1e400", thinking: "H" },
+        { index: "1e400", thinking: "!" },
+        { index: "-2", thinking: "?" },
+      ].map(
+        ({ index, thinking }) =>
+          `{"type":"stream_event","event":{"type":"content_block_delta","index":${index},"delta":{"type":"thinking_delta","thinking":${JSON.stringify(thinking)}}}}`,
+      ),
+      expected: [
+        { text: "L", delta: "L", isReasoningSnapshot: true },
+        { text: "L!", delta: "!", isReasoningSnapshot: true },
+        { text: "L!N", delta: "N", isReasoningSnapshot: true },
+        { text: "L!NZ", delta: "Z", isReasoningSnapshot: true },
+        { text: "L!NZ+", delta: "+", isReasoningSnapshot: true },
+        { text: "L!NZ+H", delta: "H", isReasoningSnapshot: true },
+        { text: "L!NZ+H!", delta: "!", isReasoningSnapshot: true },
+        { text: "L!N?Z+H!", delta: "?", isReasoningSnapshot: true },
       ],
     },
     {

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -1296,21 +1296,44 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(persistCliSessionForkSuccessor).toHaveBeenCalledWith("fork-successor");
   });
 
-  it("still streams every JSONL stdout chunk with supervisor capture disabled", async () => {
+  it("streams native thinking snapshots and text with supervisor capture disabled", async () => {
     // Streaming events are emitted from live chunks, not from the final captured
     // stdout string, so users still see deltas when captureOutput is false.
-    const agentEvents: Array<{ text?: string; delta?: string }> = [];
+    const agentEvents: Array<{
+      stream: string;
+      text?: string;
+      delta?: string;
+      isReasoningSnapshot?: boolean;
+    }> = [];
     const stop = onAgentEvent((event) => {
-      if (event.stream !== "assistant") {
+      if (event.stream !== "assistant" && event.stream !== "thinking") {
         return;
       }
       agentEvents.push({
+        stream: event.stream,
         text: typeof event.data.text === "string" ? event.data.text : undefined,
         delta: typeof event.data.delta === "string" ? event.data.delta : undefined,
+        ...(event.data.isReasoningSnapshot === true ? { isReasoningSnapshot: true } : {}),
       });
     });
     const chunks = [
       `${JSON.stringify({ type: "init", session_id: "session-jsonl" })}\n`,
+      ...[
+        { index: 0, thinking: "Checking " },
+        { index: 1, thinking: "facts." },
+        { index: 0, thinking: "the " },
+        { index: 1, thinking: " Done." },
+      ].map(
+        ({ index, thinking }) =>
+          `${JSON.stringify({
+            type: "stream_event",
+            event: {
+              type: "content_block_delta",
+              index,
+              delta: { type: "thinking_delta", thinking },
+            },
+          })}\n`,
+      ),
       `${JSON.stringify({
         type: "stream_event",
         event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hello" } },
@@ -1354,8 +1377,22 @@ describe("executePreparedCliRun supervisor output capture", () => {
       expect(result.text).toBe("Hello world");
       expect(result.toolSummary).toEqual({ calls: 0, tools: [], failures: 0 });
       expect(agentEvents).toEqual([
-        { text: "Hello", delta: "Hello" },
-        { text: "Hello world", delta: " world" },
+        { stream: "thinking", text: "Checking ", delta: "Checking ", isReasoningSnapshot: true },
+        { stream: "thinking", text: "Checking facts.", delta: "facts.", isReasoningSnapshot: true },
+        {
+          stream: "thinking",
+          text: "Checking the facts.",
+          delta: "the ",
+          isReasoningSnapshot: true,
+        },
+        {
+          stream: "thinking",
+          text: "Checking the facts. Done.",
+          delta: " Done.",
+          isReasoningSnapshot: true,
+        },
+        { stream: "assistant", text: "Hello", delta: "Hello" },
+        { stream: "assistant", text: "Hello world", delta: " world" },
       ]);
       expect(context.params.onExecutionPhase).toHaveBeenCalledTimes(2);
       expect(context.params.onExecutionPhase).toHaveBeenNthCalledWith(2, {


### PR DESCRIPTION
Closes #144349

## What Problem This Solves

Ordered CLI thinking deltas repeatedly sort and reconstruct the accumulated reasoning blocks, even when the new text only extends the greatest content index.

## Why This Change Was Made

Track the current greatest index with the existing reasoning lifecycle and append those deltas directly. Earlier-index changes and complete snapshots retain the canonical sorted reconstruction. The maximum resets with its Map; late message-ID adoption, duplicate suppression and other event routing remain unchanged.

## User Impact

Reasoning output and callback behavior remain covered, while the common ordered stream avoids repeated ordering work. The change adds eight production lines and 109 test lines and preserves the landed bounded-prefix capture tests. No protocol, configuration, persistence or migration contract changes.

## Evidence

Both versions pass the same 129 tests across reasoning, JSONL, snapshots and the combined executor suite. The actual-parser benchmark matches callback counts, total characters and final text hashes. Ordering calls fall from 257 to one for a single block and from 2,056 to eight for eight blocks. The eight-block median was 16.58 versus 3.52 ms over three instrumented trials; this is a bounded observation, not a throughput guarantee.

Paired test invocations recorded 20.37 seconds / 2,048,655,360 bytes maximum RSS before and 18.65 seconds / 2,070,970,368 bytes afterward. Benchmark process RSS also rose slightly (155,058,176 to 155,582,464 bytes). Imports, caches, instrumentation and worker setup limit these observations; no retained-memory or whole-Gateway improvement is claimed. No provider or persisted-session activity was used.

The composed current-main source preserves the earlier CLI capture change. Its full selected changed gate and fresh independent P2 review pass, with no source fixes or gate reruns needed.
