### PR TITLE
fix(tts): preserve selected summary models

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -489,7 +489,7 @@ function parseModelRefWithCompatAlias(
   } & ModelManifestNormalizationContext,
 ): ModelRef | null {
   const exactConfiguredProviderRef = resolveExactConfiguredProviderRef(params);
-  const exactDefaultProviderRef = hasSlashFormModelRef(params.raw)
+  const exactDefaultProviderRef = params.raw.includes("/")
     ? null
     : resolveExactConfiguredProviderRef({
         ...params,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -2074,6 +2074,56 @@ describe("model-selection", () => {
   });
 
   describe("resolveModelRefFromString", () => {
+    it.each<{
+      raw: string;
+      alias?: string;
+      expected: { provider: string; model: string } | null;
+    }>([
+      { raw: "/", expected: null },
+      { raw: "provider/", expected: null },
+      { raw: "//model", expected: null },
+      { raw: "literal", expected: { provider: "provider", model: "literal" } },
+      { raw: "provider/literal", expected: { provider: "provider", model: "literal" } },
+      { raw: "provider//literal", expected: { provider: "provider", model: "/literal" } },
+      {
+        raw: "provider/provider/literal",
+        expected: { provider: "provider", model: "provider/literal" },
+      },
+      { raw: "team/quick", expected: { provider: "provider", model: "literal" } },
+      { raw: "/", alias: "/", expected: { provider: "provider", model: "literal" } },
+      { raw: "openrouter:auto", expected: { provider: "openrouter", model: "openrouter/auto" } },
+    ])(
+      "keeps configured reference syntax and alias priority for $raw",
+      ({ raw, alias, expected }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: { models: { "provider/literal": { alias: alias ?? "team/quick" } } },
+          },
+          models: {
+            providers: {
+              provider: {
+                api: "openai-completions",
+                baseUrl: "https://provider.example/v1",
+                models: [],
+              },
+            },
+          },
+        };
+        const resolved = resolveModelRefFromString({
+          cfg,
+          raw,
+          defaultProvider: "provider",
+          aliasIndex: buildModelAliasIndex({
+            cfg,
+            defaultProvider: "provider",
+            manifestPlugins: [],
+          }),
+          manifestPlugins: [],
+        });
+        expect(resolved?.ref ?? null).toEqual(expected);
+      },
+    );
+
     it("should resolve from string with alias", () => {
       const index = {
         byAlias: new Map([

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -535,12 +535,30 @@ export async function acquireSimpleCompletionModelForAgent(
     modelRef: params.modelRef,
     useUtilityModel: params.useUtilityModel,
   };
-  const tentativeRequest = resolveSimpleCompletionSelectionRequest(selectionParams);
+  return await acquireSimpleCompletionModelWithSelection(params, (manifestPlugins) =>
+    resolveSimpleCompletionSelectionRequest({ ...selectionParams, manifestPlugins }),
+  );
+}
+
+/** Captures metadata before the caller selects the model to materialize. */
+export async function acquireSimpleCompletionModelWithSelection(
+  params: Omit<
+    PrepareSimpleCompletionModelForAgentParams,
+    "agentId" | "modelRef" | "useUtilityModel" | "useAsyncModelResolution"
+  > & { agentId?: string },
+  resolveRequest: (manifestPlugins?: PluginMetadataSnapshot) => {
+    selection: Omit<AgentSimpleCompletionSelection, "agentDir">;
+    shorthandModelId?: string;
+  } | null,
+): Promise<AcquiredSimpleCompletionModelForAgent> {
+  const agentId = params.agentId ?? resolveDefaultAgentId(params.cfg);
+  const agentDir = params.agentDir?.trim() || resolveAgentDir(params.cfg, agentId);
+  const tentativeRequest = resolveRequest();
   if (!tentativeRequest) {
-    return { error: `No model configured for agent ${params.agentId}.` };
+    return { error: `No model configured for agent ${agentId}.` };
   }
   const tentativeSelection = tentativeRequest.selection;
-  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
   const pluginIdScope = createAgentRuntimeMetadataPluginIdScope({
     config: params.cfg,
     workspaceDir,
@@ -548,7 +566,7 @@ export async function acquireSimpleCompletionModelForAgent(
       {
         provider: tentativeSelection.provider,
         modelId: tentativeSelection.modelId,
-        agentId: params.agentId,
+        agentId,
       },
     ],
     ...(tentativeRequest.shorthandModelId
@@ -562,14 +580,13 @@ export async function acquireSimpleCompletionModelForAgent(
     pluginIdScope,
     allowWorkspaceScopedCurrent: true,
   });
-  const resolveSelection = () =>
-    resolveSimpleCompletionSelectionForAgent({
-      ...selectionParams,
-      manifestPlugins: metadataSnapshot,
-    });
+  const resolveSelection = () => {
+    const request = resolveRequest(metadataSnapshot);
+    return request ? { ...request.selection, agentDir } : null;
+  };
   let selection = resolveSelection();
   if (!selection) {
-    return { error: `No model configured for agent ${params.agentId}.` };
+    return { error: `No model configured for agent ${agentId}.` };
   }
   const canonicalPluginIdScope = createAgentRuntimeMetadataPluginIdScope({
     config: params.cfg,
@@ -578,7 +595,7 @@ export async function acquireSimpleCompletionModelForAgent(
       {
         provider: selection.provider,
         modelId: selection.modelId,
-        agentId: params.agentId,
+        agentId,
       },
     ],
     ...(tentativeRequest.shorthandModelId &&
@@ -597,11 +614,11 @@ export async function acquireSimpleCompletionModelForAgent(
     });
     selection = resolveSelection();
     if (!selection) {
-      return { error: `No model configured for agent ${params.agentId}.` };
+      return { error: `No model configured for agent ${agentId}.` };
     }
   }
   const acquired = await acquirePreparedSimpleCompletionModel(
-    { ...params, agentDir: selection.agentDir, pluginMetadataSnapshot: metadataSnapshot },
+    { ...params, agentId, agentDir, pluginMetadataSnapshot: metadataSnapshot },
     [{ provider: selection.provider, modelId: selection.modelId }],
     (context) =>
       prepareSimpleCompletionModelCore(

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -1,13 +1,15 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 // TTS core coordinates text preparation, provider selection, and speech output.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
-  type ModelRef,
 } from "../agents/model-selection.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
@@ -31,7 +33,7 @@ type SummarizeTextDeps = {
 };
 
 type DefaultSummarizeTextDeps = Omit<SummarizeTextDeps, "prepareSimpleCompletionModel"> & {
-  acquireSimpleCompletionModel: typeof import("../agents/simple-completion-runtime.js").acquireSimpleCompletionModel;
+  acquireSimpleCompletionModelWithSelection: typeof import("../agents/simple-completion-runtime.js").acquireSimpleCompletionModelWithSelection;
 };
 
 let defaultSummarizeTextDepsPromise: Promise<DefaultSummarizeTextDeps> | undefined;
@@ -45,7 +47,8 @@ function loadDefaultSummarizeTextDeps(): Promise<DefaultSummarizeTextDeps> {
   ]).then(([completionRuntime, { requireApiKey }]) => ({
     completeWithPreparedSimpleCompletionModel:
       completionRuntime.completeWithPreparedSimpleCompletionModel,
-    acquireSimpleCompletionModel: completionRuntime.acquireSimpleCompletionModel,
+    acquireSimpleCompletionModelWithSelection:
+      completionRuntime.acquireSimpleCompletionModelWithSelection,
     requireApiKey,
   })));
 }
@@ -57,31 +60,33 @@ type SummarizeResult = {
   outputLength: number;
 };
 
-type SummaryModelSelection = {
-  ref: ModelRef;
-  source: "summaryModel" | "default";
-};
-
-function resolveSummaryModelRef(
+function resolveSummaryModelSelection(
   cfg: OpenClawConfig,
   config: ResolvedTtsConfig,
-): SummaryModelSelection {
-  const defaultRef = resolveDefaultModelForAgent({ cfg });
+  manifestPlugins?: PluginMetadataSnapshot,
+) {
+  const defaultRef = resolveDefaultModelForAgent({ cfg, manifestPlugins });
   const override = normalizeOptionalString(config.summaryModel);
-  if (!override) {
-    return { ref: defaultRef, source: "default" };
-  }
-
-  const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: defaultRef.provider });
-  const resolved = resolveModelRefFromString({
-    raw: override,
-    defaultProvider: defaultRef.provider,
-    aliasIndex,
-  });
-  if (!resolved) {
-    return { ref: defaultRef, source: "default" };
-  }
-  return { ref: resolved.ref, source: "summaryModel" };
+  const resolved = override
+    ? resolveModelRefFromString({
+        cfg,
+        raw: override,
+        defaultProvider: defaultRef.provider,
+        aliasIndex: buildModelAliasIndex({
+          cfg,
+          defaultProvider: defaultRef.provider,
+          manifestPlugins,
+        }),
+        manifestPlugins,
+      })
+    : null;
+  const raw = resolved ? override : resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);
+  const model = raw ? splitTrailingAuthProfile(raw).model : undefined;
+  const ref = resolved?.ref ?? defaultRef;
+  return {
+    selection: { provider: ref.provider, modelId: ref.model },
+    ...(model && !model.includes("/") ? { shorthandModelId: model } : {}),
+  };
 }
 
 /** Summarize long text before synthesis using the configured summary model. */
@@ -103,7 +108,7 @@ export async function summarizeText(
   const startTime = Date.now();
   const completeSummary = async (
     prepared: Awaited<ReturnType<SummarizeTextDeps["prepareSimpleCompletionModel"]>>,
-    provider: string,
+    provider: string | undefined,
     completionDeps: Pick<
       SummarizeTextDeps,
       "completeWithPreparedSimpleCompletionModel" | "requireApiKey"
@@ -113,7 +118,10 @@ export async function summarizeText(
       throw new Error(prepared.error);
     }
     const completionModel = prepared.model;
-    const providerKey = completionDeps.requireApiKey(prepared.auth, provider);
+    const providerKey = completionDeps.requireApiKey(
+      prepared.auth,
+      provider ?? completionModel.provider,
+    );
 
     try {
       const controller = new AbortController();
@@ -180,27 +188,25 @@ export async function summarizeText(
 
   // The shipped dependency-injection argument keeps its caller-owned prepared model contract.
   if (deps) {
-    const { ref } = resolveSummaryModelRef(cfg, config);
+    const { selection } = resolveSummaryModelSelection(cfg, config);
     const prepared = await deps.prepareSimpleCompletionModel({
       cfg,
-      provider: ref.provider,
-      modelId: ref.model,
+      provider: selection.provider,
+      modelId: selection.modelId,
     });
-    return await completeSummary(prepared, ref.provider, deps);
+    return await completeSummary(prepared, selection.provider, deps);
   }
 
   const resolvedDeps = await loadDefaultSummarizeTextDeps();
-  const { ref } = resolveSummaryModelRef(cfg, config);
   return await runWithAsyncWorkResources(async (onAcquired) => {
     // Preparation precedes the request timer; the completion and its cleanup own the model.
-    const prepared = await resolvedDeps.acquireSimpleCompletionModel({
-      cfg,
-      provider: ref.provider,
-      modelId: ref.model,
-    });
+    const prepared = await resolvedDeps.acquireSimpleCompletionModelWithSelection(
+      { cfg },
+      (manifestPlugins) => resolveSummaryModelSelection(cfg, config, manifestPlugins),
+    );
     if (!("error" in prepared)) {
       onAcquired(prepared);
     }
-    return await completeSummary(prepared, ref.provider, resolvedDeps);
+    return await completeSummary(prepared, prepared.selection?.provider, resolvedDeps);
   });
 }

--- a/src/tts/tts-summary.selection.test.ts
+++ b/src/tts/tts-summary.selection.test.ts
@@ -1,0 +1,344 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireApiKey } from "../agents/model-auth.js";
+import { acquireAgentRunPreparedModelRuntime } from "../agents/prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../agents/prepared-model-runtime.test-support.js";
+import {
+  acquireSimpleCompletionModel,
+  completeWithPreparedSimpleCompletionModel,
+} from "../agents/simple-completion-runtime.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { summarizeText } from "../plugin-sdk/speech-core.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { resolveTtsConfig } from "./tts-settings.js";
+
+const provider = "tts-selected";
+
+afterEach(async () => {
+  await resetPreparedModelRuntimeSnapshotsForTest();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  vi.restoreAllMocks();
+});
+
+type FixtureOptions = {
+  api?: "openai-completions";
+  summaryModel?: string;
+  primary?: string;
+  literalRow?: string;
+  runtimeHook?: boolean;
+  bareDefault?: boolean;
+};
+
+async function withSummaryFixture(
+  options: FixtureOptions,
+  run: (cfg: OpenClawConfig, state: OpenClawTestState, requests: string[]) => Promise<void>,
+) {
+  const modelProvider = options.bareDefault ? "openai" : provider;
+  const pluginId = modelProvider;
+  await withOpenClawTestState({ label: "tts-summary-selection" }, async (state) => {
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        const { model } = JSON.parse(body) as { model: string };
+        requests.push(model);
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end(
+          `data: ${JSON.stringify({
+            id: "tts-selection-response",
+            object: "chat.completion.chunk",
+            model,
+            choices: [
+              { index: 0, delta: { content: `materialized:${model}` }, finish_reason: "stop" },
+            ],
+          })}\n\ndata: [DONE]\n\n`,
+        );
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Summary fixture did not expose a TCP port");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+      const nativeFetch = globalThis.fetch;
+      vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        expect(url.origin).toBe(new URL(baseUrl).origin);
+        return nativeFetch(input, init);
+      });
+      const models = [
+        "entry",
+        "middle",
+        "final",
+        "plain",
+        "agent-model",
+        "runtime-drift",
+        `${modelProvider}/entry`,
+      ].map((id) => ({
+        id,
+        name: id,
+        provider: modelProvider,
+        api: "openai-completions" as const,
+        baseUrl,
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 16_000,
+        maxTokens: 4_096,
+      }));
+      await state.writeJson("provider/openclaw.plugin.json", {
+        id: pluginId,
+        providers: [modelProvider],
+        modelSupport: { modelPrefixes: ["entry", "fast"] },
+        configSchema: { type: "object", properties: {}, additionalProperties: false },
+        ...(!options.runtimeHook
+          ? {
+              modelIdNormalization: {
+                providers: { [modelProvider]: { aliases: { entry: "middle", middle: "final" } } },
+              },
+            }
+          : {}),
+        modelCatalog: {
+          discovery: { [modelProvider]: "static" },
+          providers: { [modelProvider]: { api: "openai-completions", baseUrl, models } },
+        },
+      });
+      const runtimePath = await state.writeText(
+        "provider/index.cjs",
+        `const models = ${JSON.stringify(models)};
+module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    api.registerProvider({
+      id: ${JSON.stringify(modelProvider)}, label: "TTS selection", auth: [],
+      normalizeModelId({ modelId }) {
+        return ${options.runtimeHook === true} && modelId === "entry" ? "runtime-drift" : undefined;
+      },
+      resolveDynamicModel({ modelId }) { return models.find(model => model.id === modelId); },
+    });
+  },
+};
+`,
+      );
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: state.workspaceDir,
+            model: { primary: options.primary ?? `${modelProvider}/plain` },
+            models: options.bareDefault
+              ? {}
+              : {
+                  [`${modelProvider}/entry`]: { alias: "fast" },
+                  ...(options.literalRow === `${modelProvider}/entry`
+                    ? { [`${modelProvider}/${modelProvider}/entry`]: { alias: "literal" } }
+                    : {}),
+                },
+          },
+          entries: {
+            main: {
+              model: { primary: `${modelProvider}/agent-model` },
+              models: options.bareDefault
+                ? {}
+                : { [`${modelProvider}/agent-model`]: { alias: "fast" } },
+            },
+          },
+        },
+        models: {
+          providers: {
+            [modelProvider]: {
+              api: options.api,
+              baseUrl,
+              apiKey: "synthetic-fixture",
+              models: options.literalRow
+                ? models.filter(({ id }) => id === options.literalRow)
+                : [],
+            },
+          },
+        },
+        tts: { summaryModel: options.summaryModel },
+        plugins: {
+          allow: [pluginId],
+          entries: { [pluginId]: { enabled: true } },
+          load: { paths: [runtimePath] },
+          slots: { memory: "none" },
+        },
+      };
+      await state.writeConfig(cfg);
+      await run(cfg, state, requests);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+}
+
+function summaryRequest(cfg: OpenClawConfig) {
+  return {
+    cfg,
+    config: resolveTtsConfig(cfg),
+    text: "Synthetic summary input.",
+    targetLength: 100,
+    timeoutMs: 10_000,
+  };
+}
+
+describe.each([undefined, "openai-completions"] as const)(
+  "unscoped summary selection with provider API %s",
+  (api) => {
+    it.each([
+      { name: "explicit override", summaryModel: `${provider}/entry`, expected: "middle" },
+      { name: "global bare alias", summaryModel: "fast", expected: "middle" },
+      { name: "global qualified alias", summaryModel: `${provider}/fast`, expected: "middle" },
+      { name: "bare literal", summaryModel: "entry", expected: "middle" },
+      { name: "missing override", primary: `${provider}/entry`, expected: "middle" },
+      { name: "bare global default", primary: "fast", expected: "middle" },
+      { name: "invalid override", summaryModel: "/", primary: "fast", expected: "middle" },
+      { name: "profile suffix", summaryModel: "fast@work", expected: "middle" },
+      { name: "raw next alias", summaryModel: `${provider}/middle`, expected: "final" },
+      { name: "ordinary model", summaryModel: `${provider}/plain`, expected: "plain" },
+    ])("uses the global model for $name", async ({ expected, ...options }) => {
+      await withSummaryFixture({ ...options, api }, async (cfg, _state, requests) => {
+        expect(await summarizeText(summaryRequest(cfg))).toMatchObject({
+          summary: `materialized:${expected}`,
+        });
+        expect(requests).toEqual([expected]);
+      });
+    });
+
+    it.each([
+      { name: "missing override", primary: "entry", expected: "middle" },
+      { name: "invalid override", primary: "entry", summaryModel: "/", expected: "middle" },
+      {
+        name: "explicit bare override",
+        primary: "plain",
+        summaryModel: "entry",
+        expected: "middle",
+      },
+      {
+        name: "qualified primary",
+        primary: "openai/entry",
+        expected: "middle",
+      },
+      { name: "raw next alias", primary: "middle", expected: "final" },
+      { name: "ordinary primary", primary: "plain", expected: "plain" },
+    ])(
+      "uses the default provider without configured rows for $name",
+      async ({ expected, ...options }) => {
+        await withSummaryFixture(
+          { ...options, api, bareDefault: true },
+          async (cfg, _state, requests) => {
+            expect(cfg.agents?.defaults?.models).toEqual({});
+            expect(cfg.agents?.entries?.main?.models).toEqual({});
+            expect(cfg.models?.providers?.openai?.models).toEqual([]);
+            expect(await summarizeText(summaryRequest(cfg))).toMatchObject({
+              summary: `materialized:${expected}`,
+            });
+            expect(requests).toEqual([expected]);
+          },
+        );
+      },
+    );
+  },
+);
+
+it.each(["literal", `${provider}/${provider}/entry`])(
+  "preserves an exact configured API-owner model for %s",
+  async (summaryModel) => {
+    await withSummaryFixture(
+      { api: "openai-completions", summaryModel, literalRow: `${provider}/entry` },
+      async (cfg, _state, requests) => {
+        expect(await summarizeText(summaryRequest(cfg))).toMatchObject({
+          summary: `materialized:${provider}/entry`,
+        });
+        expect(requests).toEqual([`${provider}/entry`]);
+      },
+    );
+  },
+);
+
+it("keeps an exact API-owner row unchanged under a real caller's runtime hook", async () => {
+  await withSummaryFixture(
+    {
+      api: "openai-completions",
+      summaryModel: `${provider}/entry`,
+      literalRow: "entry",
+      runtimeHook: true,
+    },
+    async (cfg, state, requests) => {
+      const lease = await acquireAgentRunPreparedModelRuntime(
+        {
+          config: cfg,
+          agentId: "main",
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [{ provider, modelId: "entry" }],
+        },
+        { catalogMode: "static" },
+      );
+      try {
+        const result = await withPluginRuntimeGenerationScope(lease.snapshot, () =>
+          summarizeText(summaryRequest(cfg)),
+        );
+        expect(result.summary).toBe("materialized:entry");
+        expect(requests).toEqual(["entry"]);
+      } finally {
+        lease.release();
+      }
+    },
+  );
+});
+
+it("retains the shipped injected callback shape and caller-owned returned model", async () => {
+  await withSummaryFixture(
+    { api: "openai-completions", summaryModel: "fast@work" },
+    async (cfg, _state, requests) => {
+      const prepared = await acquireSimpleCompletionModel({ cfg, provider, modelId: "plain" });
+      if ("error" in prepared) {
+        throw new Error(prepared.error);
+      }
+      try {
+        const prepare = vi.fn(async () => prepared);
+        const result = await summarizeText(summaryRequest(cfg), {
+          prepareSimpleCompletionModel: prepare,
+          completeWithPreparedSimpleCompletionModel,
+          requireApiKey,
+        });
+        expect(prepare).toHaveBeenCalledExactlyOnceWith({ cfg, provider, modelId: "middle" });
+        expect(result.summary).toBe("materialized:plain");
+        const reused = await completeWithPreparedSimpleCompletionModel({
+          cfg,
+          model: prepared.model,
+          auth: prepared.auth,
+          context: { messages: [{ role: "user", content: "Reuse caller model.", timestamp: 0 }] },
+          options: { maxTokens: 64 },
+        });
+        expect(reused).toMatchObject({ content: [{ type: "text", text: "materialized:plain" }] });
+        expect(requests).toEqual(["plain", "plain"]);
+      } finally {
+        prepared.release();
+      }
+    },
+  );
+});

--- a/src/tts/tts-summary.test.ts
+++ b/src/tts/tts-summary.test.ts
@@ -26,7 +26,7 @@ const completion = vi.hoisted(() => ({
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
   completeWithPreparedSimpleCompletionModel: completion.complete,
-  acquireSimpleCompletionModel: completion.prepare,
+  acquireSimpleCompletionModelWithSelection: completion.prepare,
 }));
 
 const model = {


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where TTS summaries could use the wrong model when their override or global default resolves through a provider alias. With `entry → middle → final`, selecting `entry` must use `middle`; preparing that selection must not advance it to `final`.

## Why This Change Was Made

TTS now shares the lightweight completion owner's metadata capture and model acquisition while retaining global defaults and aliases. This builds on the captured bare-default repair in #144429. Agent-specific model overrides remain scoped to agent completions, and the shipped injected preparation callback keeps its three-field argument and caller-owned returned model.

The shared parser also rejects malformed slash forms before exact-default-provider lookup. An invalid summary override such as `/` can therefore fall back to the global default, while configured slash aliases and literal qualified model IDs keep their existing behavior. Production delta: **+23 lines**; test delta: **+394 lines**.

## User Impact

Summaries preserve the selected override or global default through preparation. Bare defaults without configured aliases or model rows work with the captured provider policy. Existing visible-text cleanup, timeout behavior, profile-suffix stripping, and model-resource ownership are preserved.

## Evidence

Validation targets commit `68e88ebddf11460c4270411e28518ddad0f73fc2` on the actual #144429 merge, `cc748884201771eeac74dc6d8cf0c5b758bade76`.

- Matching current-base baseline: **16 TTS failures and 20 passing controls**, plus three malformed-input failures and seven passing parser controls. Candidate: **416 tests passed across 14 files**, including 36 TTS selection cases making 37 real loopback HTTP requests, captured-default owner tests, agent completions, worker inference, runtime-hook siblings, output, and resource cleanup.
- Full `pnpm check:changed --base cc748884201771eeac74dc6d8cf0c5b758bade76 --timed` passed without skipped checks. Fresh independent P2 review found no actionable findings. The committed source matches the reviewed and tested hashes.
- One normal full `pnpm build` passed on the committed source. Expanded proof through exported production SDK entry points passed in **41 fresh processes making 46 real loopback HTTP requests**, covering overrides, aliases, global bare defaults, invalid override fallback, exact IDs, injected callback reuse, and agent-completion siblings. Every process exited naturally. All 41 deliberate source-import probes were rejected, there were zero unexpected source imports, the listener closed with zero sockets, isolated state was removed, and all **12,245 build outputs** remained unchanged.

The initial supplemental fixture registered `openai` under a different plugin ID and did not supply the intended policy owner. Its failed runs are retained as fixture diagnostics; both baseline and candidate were rerun with the enabled synthetic `openai` replacement used for the results above.

The exact API-owner suppression case under a caller-owned generation is source-tested because the package exposes no generation acquisition/scope API for an equivalent exported-package probe. The public completion SDK retains bare-result ownership for process lifetime; compiled callback proof checks model reuse and natural process exit. Cold runtime-only `normalizeModelId` behavior remains inherited. HTTP proof uses an isolated synthetic loopback provider, not a hosted vendor API.
