### PR TITLE
fix(state): wait for the state lifecycle before refusing retirement

### DIFF
--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -29,13 +29,19 @@ import {
   createOpenClawDatabaseVerificationError,
   readOpenClawDatabaseQuarantine,
 } from "./openclaw-quarantine-store.js";
-import type { OpenClawStateDatabase } from "./openclaw-state-db-contract.js";
+import {
+  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  type OpenClawStateDatabase,
+} from "./openclaw-state-db-contract.js";
 import { closeTrackedStateDatabase } from "./openclaw-state-db-handle.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
 type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
   Partial<Pick<OpenClawStateDatabase, "walMaintenance">>;
+type OpenClawStateDatabaseCloseOptions = NonNullable<
+  Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0]
+> & { busyTimeoutMs?: number };
 // Failed native closes stay disposal-owned, never eligible for a successful cache hit.
 const retainedDatabaseHandles = new Map<DatabaseSync, StateDatabaseHandle>();
 let unregisterRetainedExitClose: (() => void) | undefined;
@@ -289,9 +295,14 @@ function assertOpenClawStateDatabaseFreshOpenAllowedAtPath(
 /** Explicit retirement can checkpoint WAL and must join the lifecycle writer gate. */
 function retireOpenClawStateDatabaseHandle(
   database: StateDatabaseHandle,
-  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
+  options?: OpenClawStateDatabaseCloseOptions,
 ): void {
-  const coordinator = acquireStateDatabaseCoordinator({ databasePath: database.path });
+  // Wait opportunistically within the budget; contended retirement must not write
+  // any database or sidecar bytes while a foreign lifecycle owner holds exclusion.
+  const coordinator = acquireStateDatabaseCoordinator({
+    databasePath: database.path,
+    busyTimeoutMs: options?.busyTimeoutMs ?? OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  });
   runWithSqliteCoordinator(coordinator, "state database retirement", () => {
     // Refused acquisition leaves both cache and physical ownership untouched.
     const wasCached = cachedDatabases.get(database.path)?.db === database.db;
@@ -322,7 +333,7 @@ function throwStateDatabaseCleanupErrors(errors: unknown[], message: string): vo
 /** Close cached and disposal-only handles, preserving independent cleanup failures. */
 function retireOpenClawStateDatabaseHandles(
   pathname?: string,
-  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
+  options?: OpenClawStateDatabaseCloseOptions,
 ): boolean {
   const databases = new Set<StateDatabaseHandle>([
     ...retainedDatabaseHandles.values(),
@@ -346,14 +357,15 @@ function retireOpenClawStateDatabaseHandles(
 }
 
 /** Close one cached shared state database handle by exact pathname. */
-export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
-  return retireOpenClawStateDatabaseHandles(path.resolve(pathname));
+export function closeOpenClawStateDatabaseByPath(
+  pathname: string,
+  options?: OpenClawStateDatabaseCloseOptions,
+): boolean {
+  return retireOpenClawStateDatabaseHandles(path.resolve(pathname), options);
 }
 
 /** Close all cached shared state database handles. */
-export function closeOpenClawStateDatabase(
-  options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
-): void {
+export function closeOpenClawStateDatabase(options?: OpenClawStateDatabaseCloseOptions): void {
   retireOpenClawStateDatabaseHandles(undefined, options);
 }
 

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -297,16 +297,17 @@ function retireOpenClawStateDatabaseHandle(
   database: StateDatabaseHandle,
   options?: OpenClawStateDatabaseCloseOptions,
 ): void {
+  const { busyTimeoutMs = OPENCLAW_SQLITE_BUSY_TIMEOUT_MS, ...closeOptions } = options ?? {};
   // Wait opportunistically within the budget; contended retirement must not write
   // any database or sidecar bytes while a foreign lifecycle owner holds exclusion.
   const coordinator = acquireStateDatabaseCoordinator({
     databasePath: database.path,
-    busyTimeoutMs: options?.busyTimeoutMs ?? OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+    busyTimeoutMs,
   });
   runWithSqliteCoordinator(coordinator, "state database retirement", () => {
     // Refused acquisition leaves both cache and physical ownership untouched.
     const wasCached = cachedDatabases.get(database.path)?.db === database.db;
-    const errors = closeOpenClawStateDatabaseHandle(database, options);
+    const errors = closeOpenClawStateDatabaseHandle(database, closeOptions);
     if (wasCached) {
       try {
         notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });

--- a/src/state/openclaw-state-db.coordinator.test.ts
+++ b/src/state/openclaw-state-db.coordinator.test.ts
@@ -27,7 +27,7 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   });
 });
 
-async function holdStateCoordinator(databasePath: string) {
+async function holdStateCoordinator(databasePath: string, releaseAfterMs = 0) {
   // Initialize the real coordinator location/permissions through its owner.
   const coordinator = acquireStateDatabaseCoordinator({ databasePath });
   const coordinatorPath = coordinator.path;
@@ -43,9 +43,11 @@ async function holdStateCoordinator(databasePath: string) {
     db.exec("PRAGMA journal_mode=MEMORY; BEGIN EXCLUSIVE");
     process.send({ ready: true });
     process.once("message", () => {
-      db.exec("ROLLBACK");
-      db.close();
-      process.disconnect();
+      setTimeout(() => {
+        db.exec("ROLLBACK");
+        db.close();
+        process.disconnect();
+      }, ${releaseAfterMs});
     });
   `,
     ],
@@ -103,8 +105,8 @@ describe("shared-state transaction lifecycle participation", () => {
       }, options);
       const retire = () =>
         scope === "path"
-          ? closeOpenClawStateDatabaseByPath(database.path)
-          : closeOpenClawStateDatabase();
+          ? closeOpenClawStateDatabaseByPath(database.path, { busyTimeoutMs: 0 })
+          : closeOpenClawStateDatabase({ busyTimeoutMs: 0 });
       if (custody === "retained") {
         const failure = new Error("native close refused");
         const close = vi.spyOn(database.db, "close").mockImplementation(() => {
@@ -146,6 +148,40 @@ describe("shared-state transaction lifecycle participation", () => {
       ).toEqual([{ event_key: "retained" }]);
     },
   );
+
+  it("waits out brief foreign lifecycle exclusion before default retirement", async () => {
+    const root = tempDirs.make("openclaw-state-close-wait-");
+    const options = { path: path.join(root, "openclaw.sqlite") };
+    const database = openOpenClawStateDatabase(options);
+    runOpenClawStateWriteTransaction((owner) => {
+      owner.db
+        .prepare(
+          "INSERT INTO diagnostic_events(scope,event_key,payload_json,created_at) VALUES(?,?,?,?)",
+        )
+        .run("retirement", "preserved", "{}", 1);
+    }, options);
+    const holdMs = 300;
+    const release = await holdStateCoordinator(database.path, holdMs);
+    const started = performance.now();
+    // Start the child's release timer before synchronously waiting in retirement.
+    const released = release();
+    try {
+      closeOpenClawStateDatabase();
+      expect(performance.now() - started).toBeGreaterThanOrEqual(holdMs);
+      expect(database.db.isOpen).toBe(false);
+      expect(
+        openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(database.path),
+      ).toBeUndefined();
+    } finally {
+      await released;
+    }
+    const reopened = openOpenClawStateDatabase(options);
+    expect(
+      reopened.db
+        .prepare("SELECT event_key FROM diagnostic_events WHERE scope = ?")
+        .all("retirement"),
+    ).toEqual([{ event_key: "preserved" }]);
+  });
 
   it.each(["explicit", "periodic"] as const)(
     "defers %s WAL maintenance while lifecycle exclusion is held and retries afterward",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users completing CLI or worker cleanup would receive a state-lifecycle contention error when another process briefly held lifecycle exclusion. Cleanup refused immediately and left the state database handle open even though the competing operation would soon finish.

The same race causes the intermittent `serializes concurrent additive schema upgrades across processes` failure in `src/state/openclaw-state-db.test.ts` when one probe worker retires during its sibling's upgrade.

## Why This Change Was Made

Retirement now waits up to the shared `OPENCLAW_SQLITE_BUSY_TIMEOUT_MS` (5 seconds), matching other lifecycle operations. One named close-options type carries optional `busyTimeoutMs` through global and by-path retirement while preserving `checkpointMode`. Callers can request immediate refusal with `busyTimeoutMs: 0`.

The byte-untouched refusal contract remains intact: if acquisition fails, no retirement checkpoint or close runs, cache and physical-handle custody remain owned, and contention propagates for a later retry. A PASSIVE fallback was rejected because it can write database pages while another process owns lifecycle exclusion. Reentrant file exclusion retains its gated TRUNCATE close, and eviction and the deliberate zero-wait schema/retain paths are unchanged.

The four existing refusal cases keep every assertion and explicitly select zero wait. A real child-process regression releases its lock after 300 ms and verifies default retirement waits, closes, removes the cached handle, and preserves previously committed data on reopen. No production test seam, baseline change, or concurrent schema-probe modification was added.

## User Impact

Brief lifecycle contention no longer fails update repair/finalization workers, task/task-flow stores, transcript reconciliation, setup migration, Doctor maintenance, worker shutdown, plugin-state cleanup, or ACP cleanup immediately. These callers inherit the bounded wait without changes. Persistent contention still refuses safely; retirement does not promise an unconditional close.

## Evidence

Validated locally on macOS with Node 26.8.1.

Failing-before proof: restored only `src/state/openclaw-state-db-cache.ts` to HEAD, retained the new test, ran the command below, then restored the fixed production file byte-for-byte.

```sh
node scripts/run-vitest.mjs src/state/openclaw-state-db.coordinator.test.ts -t 'waits out brief foreign lifecycle exclusion before default retirement'
```
```text
StateDatabaseCoordinatorContentionError: another OpenClaw process owns state-lifecycle
 ❯ acquireLifecycleCoordinator src/infra/state-database-coordinator.ts:109:13
    107|     });
    108|     if (!coordinator) {
    109|       throw new StateDatabaseCoordinatorContentionError(family);
       |             ^
    110|     }
    111|     heldCoordinators.set(coordinatorPath, { coordinator, references: 1…
 ❯ acquireStateDatabaseCoordinator src/infra/state-database-coordinator.ts:174:10
 ❯ retireOpenClawStateDatabaseHandle src/state/openclaw-state-db-cache.ts:294:23
 ❯ retireOpenClawStateDatabaseHandles src/state/openclaw-state-db-cache.ts:339:7
 ❯ closeOpenClawStateDatabase src/state/openclaw-state-db-cache.ts:357:3
 ❯ src/state/openclaw-state-db.coordinator.test.ts:169:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { family: 'state-lifecycle' }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 10 skipped (11)
   Start at  12:54:00
   Duration  6.41s (transform 84%, tests 9%, worker 4%, import 2%, setup 1%)

[vitest-workers] verifying completed generation before cleanup
[test] failed 1 Vitest shard in 7.79s
[test] FAILED (exit 1)
```

```sh
node scripts/run-vitest.mjs src/state/openclaw-state-db.coordinator.test.ts
```
```text

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  12:53:41
   Duration  9.50s (transform 70%, tests 21%, worker 6%, import 2%, setup 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 11.19s
```

```sh
node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts
```
```text
 ✓ |unit| src/state/openclaw-state-db.test.ts > openclaw state database > serializes concurrent additive schema upgrades across processes 1296ms
 ✓ |unit| src/state/openclaw-state-db.test.ts > openclaw state database > serializes concurrent fresh database initialization across processes 1218ms

 Test Files  1 passed (1)
      Tests  190 passed | 1 skipped (191)
   Start at  12:54:16
   Duration  38.92s (tests 68%, transform 28%, import 4%, worker 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 40.61s
```

```sh
node scripts/run-vitest.mjs src/infra/sqlite-coordinator.test.ts src/infra/state-database-coordinator.test.ts src/infra/sqlite-wal.test.ts src/infra/sqlite-wal.connection-pragmas.test.ts src/state/openclaw-state-db-cache.cleanup.test.ts src/state/openclaw-state-db-cache.retention.test.ts src/state/openclaw-state-db.corruption-recovery.test.ts src/state/openclaw-state-db-source-exclusion.test.ts src/state/openclaw-state-db-readonly.exclusion.test.ts
```
```text
 Test Files  5 passed (5)
      Tests  30 passed (30)
 Test Files  4 passed (4)
      Tests  63 passed | 8 skipped (71)
   Start at  12:55:30
   Duration  3.89s (tests 57%, transform 24%, setup 17%, import 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 2 Vitest shards in 20.05s
```

Independent Codex autoreview reported one P2 finding claiming cache eviction enters retirement. Rejected after source verification: `evictCachedOpenClawStateDatabase` calls `closeOpenClawStateDatabaseHandle` directly (line 142), bypassing `retireOpenClawStateDatabaseHandle` and the new timeout entirely. The existing corruption-eviction proof passed. No accepted actionable findings remain.

```sh
node scripts/check-changed.mjs
```
Exit 0. Core and core-test typechecks, changed-file formatting/lint, and all selected guards passed. The known declaration-boundary trap did not occur; no lint substitution was used.

```text
[check:changed] runtime sidecar loader guard
$ node --import ./scripts/tsx.mjs scripts/check-runtime-sidecar-loaders.mts
runtime-sidecar-loaders: local runtime sidecar loaders look OK.

[check:changed] runtime import cycles
$ node --import ./scripts/tsx.mjs scripts/check-import-cycles.ts
Import cycle check: 0 runtime value cycle(s).

[check:changed] webhook body guard
$ node --import ./scripts/tsx.mjs scripts/check-webhook-auth-body-order.mts

[check:changed] pairing store guard
$ node --import ./scripts/tsx.mjs scripts/check-no-pairing-store-group-auth.mts

[check:changed] pairing account guard
$ node --import ./scripts/tsx.mjs scripts/check-pairing-account-scope.mts
```

```sh
git diff --check
```
Exit 0; no output.

Production diff: +21/-9 lines. Test diff: +42/-6 lines; the coordinator test is 316 lines, below the 700-line limit.

## Known Gaps

The macOS run skipped nine existing Linux-only cases: one initialization-failure case in the main state suite and eight WAL split-brain cases in the neighboring suite. No test or assertion was newly skipped or weakened. No live Gateway or production state was modified or used for proof. Hosted CI has not been observed; this work stops after PR creation and does not merge.

## Maintainer verification (head `a191c29a59f`)

A second commit keeps the coordinator wait budget out of the WAL close options: retirement destructures `busyTimeoutMs` and forwards only `checkpointMode` to `walMaintenance.close`. Behavior is identical (an absent `checkpointMode` still selects TRUNCATE).

Independent end-to-end check of the default path, holding the coordinator from a foreign connection for the whole call:

| Tree | Outcome |
|---|---|
| before | refused after 0 ms |
| after | refused after 5324 ms |

Both leave the handle open and the database plus sidecars byte-identical, so the refusal contract is unchanged and only the wait was missing.

Re-run on the final tree: `node scripts/run-vitest.mjs src/state/openclaw-state-db.coordinator.test.ts` reported 11 passed; `node scripts/check-changed.mjs` exited 0; independent `$autoreview` (branch vs `origin/main`, P1) reported scoped-clean.

## Known Gaps and Follow-ups

`migrateLegacySkillWorkshopProposals` in `src/commands/doctor-skill-workshop-sqlite.ts` acquires the same coordinator with the identical implicit zero wait. Its immediate refusal is asserted by `src/commands/doctor-skill-workshop-coordination.test.ts`, and whether Doctor should briefly wait there is a separate product judgment, so it is deliberately left unchanged and recorded here.
