### PR TITLE
fix(logs): clear retired records when the tailed file disappears

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -45,6 +45,8 @@ The Control UI Logs tab tails this file via the gateway (`logs.tail`). The CLI d
 openclaw logs --follow
 ```
 
+If a tail read observes that the active file has disappeared, the Control UI clears its previous records and follows the recreated file. Missing files still return an empty tail; filesystem read errors remain visible.
+
 ### Verbose vs. log levels
 
 - **File logs** are controlled exclusively by `logging.level`.

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -187,6 +187,38 @@ describe("readConfiguredLogTail", () => {
     expect(fileShrink.skippedBytes).toBeUndefined();
   });
 
+  it.each(["missing", "empty"])(
+    "resets a positive cursor when its file becomes %s",
+    async (state) => {
+      const { readConfiguredLogTail } = await import("./log-tail.js");
+      const file = path.join(tempDirs.make("openclaw-log-tail-"), "configured.log");
+      await fs.writeFile(file, "retired record\n");
+      setLoggerOverride({ file });
+      const initial = await readConfiguredLogTail();
+
+      if (state === "missing") {
+        await fs.unlink(file);
+      } else {
+        await fs.writeFile(file, "");
+      }
+      const cleared = await readConfiguredLogTail({ cursor: initial.cursor });
+      expect.soft(cleared).toMatchObject({ cursor: 0, size: 0, lines: [], reset: true });
+      for (const cursor of [undefined, 0]) {
+        expect(await readConfiguredLogTail({ cursor })).toMatchObject({
+          cursor: 0,
+          lines: [],
+          reset: false,
+        });
+      }
+
+      await fs.writeFile(file, "replacement record\n");
+      expect(await readConfiguredLogTail({ cursor: cleared.cursor })).toMatchObject({
+        lines: ["replacement record"],
+        reset: false,
+      });
+    },
+  );
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -77,18 +77,7 @@ async function readLogSlice(params: {
   maxBytes: number;
   filter?: (line: string) => boolean;
 }): Promise<Omit<LogTailPayload, "file">> {
-  const stat = await fs.stat(params.file).catch(missingPathToNull);
-  if (!stat) {
-    return {
-      cursor: 0,
-      size: 0,
-      lines: [],
-      truncated: false,
-      reset: false,
-    };
-  }
-
-  const size = stat.size;
+  const size = (await fs.stat(params.file).catch(missingPathToNull))?.size ?? 0;
   const maxBytes = clamp(params.maxBytes, 1, MAX_BYTES);
   const limit = clamp(params.limit, 1, MAX_LIMIT);
   let cursor =

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -1,7 +1,7 @@
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { text } from "node:stream/consumers";
-import type { Page } from "playwright";
+import type { Page, WebSocket } from "playwright";
 import { expect, it } from "vitest";
 import type { GatewayServer } from "../../../src/gateway/server-public.ts";
 import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
@@ -139,6 +139,8 @@ suite.define(() => {
           },
           async ({ page }) => {
             const pageErrors: string[] = [];
+            let latestSocket: WebSocket | undefined;
+            page.on("websocket", (socket) => (latestSocket = socket));
             page.on("pageerror", (error) => pageErrors.push(String(error)));
             const url = new URL("logs", suite.server.baseUrl);
             url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
@@ -235,6 +237,53 @@ suite.define(() => {
                 "source B after reconnect",
               ]);
             await capture(page, "03-reconnected-tail-complete.png");
+
+            if (!latestSocket) {
+              throw new Error("Logs did not open a Gateway connection");
+            }
+            const missingTail = latestSocket.waitForEvent("framereceived", {
+              timeout: 15_000,
+              predicate: ({ payload }) => {
+                const frame: {
+                  type: string;
+                  ok?: boolean;
+                  payload?: { file: string; cursor: number };
+                } = JSON.parse(payload.toString());
+                return (
+                  frame.type === "res" &&
+                  frame.ok === true &&
+                  frame.payload?.file === sourceB &&
+                  frame.payload.cursor === 0
+                );
+              },
+            });
+            await unlink(sourceB);
+            const missingResponse = await missingTail;
+            if (captureUiProof) {
+              await writeFile(
+                path.join(suite.artifactDir, "04-missing-tail.json"),
+                missingResponse.payload.toString(),
+              );
+            }
+            const replacement = logLine("source B replacement", "info", 8);
+            await writeFile(sourceB, `${replacement}\n`, "utf8");
+            await page.getByText("source B replacement", { exact: true }).waitFor();
+            await capture(page, "04-recreated-tail.png");
+            expect.soft(await visibleMessages(page)).toEqual(["source B replacement"]);
+            const replacementDownload = page.waitForEvent("download");
+            await page.getByRole("button", { name: "Export visible" }).click();
+            const replacementStream = await (await replacementDownload).createReadStream();
+            if (!replacementStream) {
+              throw new Error("replacement log export did not provide a readable download");
+            }
+            const replacementExport = await text(replacementStream);
+            if (captureUiProof) {
+              await writeFile(
+                path.join(suite.artifactDir, "04-recreated-export.log"),
+                replacementExport,
+              );
+            }
+            expect.soft(replacementExport).toBe(`${replacement}\n`);
             expect(pageErrors).toEqual([]);
           },
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI Logs page displayed and exported retired records alongside a replacement file after observing that its configured log file had disappeared. The reader returned cursor zero without telling clients to discard the previous tail.

## Why This Change Was Made

Treat an absent file as size zero in the shared reader and reuse its existing shrink/reset path. The unchanged UI then clears the retired records. This removes 11 production lines and preserves cursorless reads, rolling selection, byte limits, filtering, redaction and operational error handling.

## User Impact

After an observed disappearance, the Logs page and its export follow the recreated file. This covers a missing file observed between polls; it does not add inode tracking for replacements that occur entirely between reads.

## Evidence

The reader regression fails before the repair. The existing real-Gateway Logs lifecycle also reproduces four visible/exported records instead of the single replacement after the missing-file response. The same assertions pass after the repair, and the saved response changes from `reset: false` to `reset: true`.

All 74 distinct owner, sibling and browser cases and all 30 canonical changed checks pass. Independent review found no actionable findings. Proof uses a fresh production UI bundle, a task-owned loopback Gateway and synthetic logs under generic temporary paths; no operator Gateway or real logs are involved.

The before/after captures show the actual display after recreation. Their version footer and “Server updated” badge are fixed fixture metadata, not release-version proof. The export assertions independently verify the same correction.

![Before: retired records remain alongside the replacement](https://github.com/user-attachments/assets/58f32e7b-6a8b-4688-ae52-17ab09103d52)

![After: only replacement log records remain](https://github.com/user-attachments/assets/8ec19200-fa5d-4202-b94b-0b83ee8cf68b)

CI run 34525345506 initially timed out in an unchanged profiler repeated-help test. An isolated replay of the exact CI merge passed all 35 profiler cases on Linux x64 Node 24.19.0; it used x64 emulation and ran the file separately, so the original timeout remains unexplained. The original failure is preserved, and the single failed-job retry on the same PR head passed. No deadline, assertion or profiler code was changed.
