### PR TITLE
perf(plugins): reuse warm source-cache records before path normalization

### DIFF
--- a/src/plugins/plugin-cache.test.ts
+++ b/src/plugins/plugin-cache.test.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "./bundle-manifest.js";
@@ -12,8 +13,14 @@ import {
   readPluginCacheFile,
   readPluginCacheJsonFile,
 } from "./plugin-cache-files.js";
-import { createPluginCache, getPluginCacheRoot, withPluginCache } from "./plugin-cache.js";
+import {
+  createPluginCache,
+  getPluginCacheRoot,
+  getPluginCacheSource,
+  withPluginCache,
+} from "./plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { preparePluginModule } from "./plugin-module-loader-cache.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -163,6 +170,42 @@ describe("plugin package facts", () => {
     ).toBe(first);
     expect(getPluginCacheRoot(root).artifacts.has("missing-surface")).toBe(true);
     expect(open).not.toHaveBeenCalled();
+  });
+
+  it("keeps checked source aliases authoritative within their explicit cache generation", () => {
+    const parent = fs.realpathSync(tempDirs.make("plugin-source-alias-"));
+    const root = path.join(parent, "package with spaces");
+    const alias = path.join(parent, "alias with spaces");
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, "api.cjs"), "module.exports = {};\n");
+    fs.symlinkSync(root, alias, process.platform === "win32" ? "junction" : "dir");
+    const aliasPath = path.join(alias, "api.cjs");
+    const owner = createPluginCache();
+    const lexicalSource = getPluginCacheSource(aliasPath, owner);
+    const prepared = withPluginCache(owner, () =>
+      preparePluginModule({
+        modulePath: aliasPath,
+        boundaryRoot: alias,
+        boundaryLabel: "plugin root",
+        rejectHardlinks: true,
+        surfaceLabel: "fixture public surface",
+      }),
+    );
+    expect(prepared.source).not.toBe(lexicalSource);
+
+    const foreign = createPluginCache();
+    const foreignSource = getPluginCacheSource(aliasPath, foreign);
+    withPluginCache(foreign, () => {
+      expect(getPluginCacheSource(aliasPath)).toBe(foreignSource);
+      for (const modulePath of [
+        aliasPath,
+        prepared.modulePath,
+        path.relative(process.cwd(), aliasPath),
+        pathToFileURL(aliasPath).href,
+      ]) {
+        expect(getPluginCacheSource(modulePath, owner)).toBe(prepared.source);
+      }
+    });
   });
 
   it("does not use a permissive hardlink read to satisfy a strict root policy", () => {

--- a/src/plugins/plugin-cache.ts
+++ b/src/plugins/plugin-cache.ts
@@ -163,6 +163,10 @@ export function getPluginCacheSource(
   modulePath: string,
   cache = getPluginCache(),
 ): PluginSourceCacheRecord {
+  const cached = cache.sources.get(cache.sourceAliases.get(modulePath) ?? modulePath);
+  if (cached) {
+    return cached;
+  }
   const lexical = path.resolve(
     modulePath.startsWith("file:") ? fileURLToPath(modulePath) : modulePath,
   );


### PR DESCRIPTION
Closes #144361

## What Problem This Solves

Warm plugin source-cache reads normalize already-cached filenames before looking up the existing record. Repeated shared public-surface loads therefore allocate path strings even when the cache has an exact hit.

## Why This Change Was Made

Check the existing source-alias mapping and exact source key first, mirroring the adjacent cache-root lookup. Aliases keep precedence over stale lexical records, the explicitly supplied cache remains authoritative, and relative/file-URL misses keep the existing normalization path. No new cache or retention policy is introduced.

## User Impact

Plugin source and export identity remain unchanged. Four production lines avoid normalization work on warm hits; the existing cache generation, alias writer and fallback semantics are preserved. No public configuration, schema, persistence or migration contract changes.

## Evidence

Both versions pass 58 cache-owner, module-loader and public-surface tests. Six fresh interleaved processes exercise 100,000 warm loads through the actual shared public-artifact loader, checking the same export identity on every call and identical checksums. Median sampled allocation falls from 221,040,616 to 60,083,016 bytes (72.8%) across the complete isolated sampling interval, including helper work and collected objects.

The full selected changed gate, normal build, isolated keyless canonical Discord entrypoint profile and independent P2 review pass. The warm result does not establish whole-Gateway memory, retained RSS or latency savings; the entrypoint profile is diagnostic only. The unchanged lockfile is a proof input, not part of this patch.
