### PR TITLE
perf(imessage): bound content work while coalescing messages

### DIFF
--- a/extensions/imessage/src/monitor/coalesce.test-support.ts
+++ b/extensions/imessage/src/monitor/coalesce.test-support.ts
@@ -66,62 +66,133 @@ describe("combineIMessagePayloads", () => {
     expect(merged.attachments).toEqual([{ original_path: "/tmp/a.jpg", mime_type: "image/jpeg" }]);
   });
 
-  it("dedupes identical text appearing in both rows (URL in text and balloon)", () => {
-    const a = makePayload({ text: "https://example.com", guid: "row-1" });
-    const b = makePayload({ text: "https://example.com", guid: "row-2" });
-    const merged = combineIMessagePayloads([a, b]);
+  it.each([
+    {
+      label: "identical URL text and balloon",
+      texts: ["https://example.com", "https://example.com"],
+      expected: "https://example.com",
+    },
+    {
+      label: "trimmed case variants and distinct suffixes",
+      texts: ["  MIXED ", "mixed", "Mixed suffix", "mIxEd"],
+      expected: "MIXED Mixed suffix",
+    },
+    {
+      label: "Unicode lowercase expansion",
+      texts: ["\u0130", "i\u0307", "tail"],
+      expected: "\u0130 tail",
+    },
+  ])("dedupes full message text: $label", ({ texts, expected }) => {
+    const merged = combineIMessagePayloads(
+      texts.map((text, index) => makePayload({ text, guid: `row-${index}` })),
+    );
 
-    expect(merged.text).toBe("https://example.com");
-    expect(merged.coalescedMessageGuids).toEqual(["row-1", "row-2"]);
+    expect(merged.text).toBe(expected);
+    expect(merged.coalescedMessageGuids).toEqual(texts.map((_, index) => `row-${index}`));
   });
 
-  it("caps merged text length and appends the truncated marker", () => {
-    const longA = makePayload({ text: "A".repeat(3000), guid: "row-1" });
-    const longB = makePayload({ text: "B".repeat(3000), guid: "row-2" });
-    const merged = combineIMessagePayloads([longA, longB]);
+  it.each([
+    {
+      label: "part of a later distinct message",
+      texts: ["A".repeat(3000), "B".repeat(3000)],
+      expected: `${"A".repeat(3000)} ${"B".repeat(999)}…[truncated]`,
+    },
+    {
+      label: "exactly full text followed only by blanks and duplicates",
+      texts: ["A".repeat(4000), " \t\n", "a".repeat(4000)],
+      expected: "A".repeat(4000),
+    },
+    {
+      label: "a distinct message after an exactly full prefix and its duplicate",
+      texts: ["A".repeat(4000), "a".repeat(4000), "later"],
+      expected: `${"A".repeat(4000)}…[truncated]`,
+    },
+    {
+      label: "a surrogate pair crossing the limit",
+      texts: [`${"A".repeat(3999)}😀`, "tail"],
+      expected: `${"A".repeat(3999)}…[truncated]`,
+    },
+    {
+      label: "a separator at the limit",
+      texts: ["A".repeat(3999), "tail"],
+      expected: `${"A".repeat(3999)} …[truncated]`,
+    },
+  ])("preserves the exact bounded text for $label", ({ texts, expected }) => {
+    const guids = texts.map((_, index) => `row-${index}`);
+    const merged = combineIMessagePayloads(
+      texts.map((text, index) => makePayload({ text, guid: guids[index] })),
+    );
 
-    expect(merged.text?.endsWith("…[truncated]")).toBe(true);
-    expect(merged.text?.length).toBeLessThanOrEqual(4000 + "…[truncated]".length);
+    expect(merged.text).toBe(expected);
+    expect(merged.coalescedMessageGuids).toEqual(guids);
   });
 
-  it("caps the attachment count", () => {
-    // 5 attachments per row × 6 rows = 30 attachments offered, capped at 20.
-    // Stays under the entry cap so the merge isn't pruned for that reason.
-    const payloads = Array.from({ length: 6 }, (_, i) =>
+  it("keeps the first 20 attachments from the first nine and final entries", () => {
+    const firstAttachment = { original_path: "/tmp/first.jpg", mime_type: "image/jpeg" };
+    const latestAttachments = Array.from({ length: 25 }, (_, index) => ({
+      original_path: `/tmp/latest-${index}.jpg`,
+      mime_type: "image/jpeg",
+    }));
+    const attachmentsByRow: Record<number, IMessagePayload["attachments"]> = {
+      8: [firstAttachment],
+      9: [{ original_path: "/tmp/dropped.jpg", mime_type: "image/jpeg" }],
+      11: latestAttachments,
+    };
+    const payloads = Array.from({ length: 12 }, (_, i) =>
       makePayload({
         guid: `row-${i}`,
-        attachments: Array.from({ length: 5 }, (_Local, j) => ({
-          original_path: `/tmp/${i}-${j}.jpg`,
-          mime_type: "image/jpeg",
-        })),
+        attachments: attachmentsByRow[i] ?? null,
       }),
     );
     const merged = combineIMessagePayloads(payloads);
 
-    expect(merged.attachments?.length).toBe(20);
+    expect(merged.attachments).toEqual([firstAttachment, ...latestAttachments.slice(0, 19)]);
   });
 
-  it("keeps first + most recent when entry count exceeds the cap, but tracks every GUID", () => {
+  it("keeps first nine plus last content while preserving metadata from dropped entries", () => {
+    const metadataByRow: Record<number, Partial<IMessagePayload>> = {
+      9: {
+        created_at: "2025-01-02T02:00:00+14:00",
+        thread_originator_guid: "first-thread-parent",
+        reply_to_guid: "first-reply-parent",
+        reply_to_text: "first parent quote",
+        reply_to_sender: "+15555550199",
+      },
+      10: {
+        created_at: "2025-01-02T01:00:00Z",
+        reply_to_guid: "later-parent",
+        reply_to_text: "later parent quote",
+      },
+      11: { id: 999, guid: " row-0 " },
+      12: { guid: " row-12 " },
+    };
     const payloads = Array.from({ length: 25 }, (_, i) =>
       makePayload({
         id: i,
         text: `msg ${i}`,
         guid: `row-${i}`,
         created_at: new Date(Date.UTC(2025, 0, 1, 0, 0, i)).toISOString(),
+        ...metadataByRow[i],
       }),
     );
     const merged = combineIMessagePayloads(payloads);
 
-    // First payload's GUID anchors the merged shape.
-    expect(merged.guid).toBe("row-0");
-    // Every source GUID is tracked, even those whose text was dropped by the cap.
-    expect(merged.coalescedMessageGuids?.length).toBe(25);
-    expect(merged.coalescedMessageGuids?.[0]).toBe("row-0");
-    expect(merged.coalescedMessageGuids?.[24]).toBe("row-24");
-    // Merged text contains only the bounded first entries plus the latest.
-    expect(merged.text).toContain("msg 0");
-    expect(merged.text).toContain("msg 24");
-    expect(merged.text).not.toContain("msg 10"); // dropped by cap
+    expect(merged).toMatchObject({
+      guid: "row-0",
+      text: "msg 0 msg 1 msg 2 msg 3 msg 4 msg 5 msg 6 msg 7 msg 8 msg 24",
+      created_at: "2025-01-02T02:00:00+14:00",
+      thread_originator_guid: "first-thread-parent",
+      reply_to_guid: "first-reply-parent",
+      reply_to_text: "first parent quote",
+      reply_to_sender: "+15555550199",
+      coalescedCatchupCursor: {
+        lastSeenMs: Date.parse("2025-01-02T01:00:00Z"),
+        lastSeenRowid: 999,
+      },
+    });
+    expect(merged.coalescedMessageGuids).toEqual(
+      Array.from({ length: 25 }, (_, i) => `row-${i}`).filter((guid) => guid !== "row-11"),
+    );
   });
 
   it("preserves reply context from any entry that carries one", () => {

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -1,11 +1,7 @@
 // Imessage plugin module implements the same-sender inbound debounce merge.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import type { IMessagePayload } from "./types.js";
-
-// Keep the merge contract narrow (caps, ID tracking, reply-context preference)
-// so a future SDK lift into `openclaw/plugin-sdk/channel-inbound` is a
-// mechanical extraction instead of a behavioral redesign.
+import type { IMessageAttachment, IMessagePayload } from "./types.js";
 
 /**
  * Bounds on the merged output when multiple inbound iMessage payloads are
@@ -50,87 +46,84 @@ export function combineIMessagePayloads(payloads: IMessagePayload[]): CoalescedI
     return first;
   }
 
-  const last = expectDefined(payloads.at(-1), "last iMessage payload to coalesce");
-
-  // Cap entries: keep first (preserves command/context) + most recent
-  // (preserves latest payload) when a flood exceeds the cap.
-  const boundedPayloads =
-    payloads.length > MAX_COALESCED_ENTRIES
-      ? [...payloads.slice(0, MAX_COALESCED_ENTRIES - 1), last]
-      : payloads;
-
-  // Combine text across bounded entries, skipping duplicate message text.
   const seenTexts = new Set<string>();
   const textParts: string[] = [];
-  for (const payload of boundedPayloads) {
-    const text = (payload.text ?? "").trim();
-    if (!text) {
-      continue;
-    }
-    const normalized = text.toLowerCase();
-    if (seenTexts.has(normalized)) {
-      continue;
-    }
-    seenTexts.add(normalized);
-    textParts.push(text);
-  }
-  let combinedText = textParts.join(" ");
-  if (combinedText.length > MAX_COALESCED_TEXT_CHARS) {
-    combinedText = `${sliceUtf16Safe(combinedText, 0, MAX_COALESCED_TEXT_CHARS)}…[truncated]`;
-  }
-
-  // Merge attachments across bounded entries, capped to keep downstream media
-  // fan-out proportional to a single message.
-  const allAttachments = boundedPayloads
-    .flatMap((p) => p.attachments ?? [])
-    .slice(0, MAX_COALESCED_ATTACHMENTS);
-
-  // Latest `created_at` (lexically max ISO-8601 string) so downstream sees
-  // the freshest activity timestamp. Falls back to `first.created_at` if no
-  // entries carry a usable timestamp.
-  const createdAts = payloads
-    .map((p) => p.created_at)
-    .filter((c): c is string => typeof c === "string" && c.length > 0);
-  const latestCreatedAt =
-    createdAts.length > 0 ? createdAts.reduce((a, b) => (a > b ? a : b)) : first.created_at;
-
+  const allAttachments: IMessageAttachment[] = [];
+  const seenGuids = new Set<string>();
+  const coalescedMessageGuids: string[] = [];
+  let textLength = 0;
+  let latestCreatedAt: string | undefined;
   let maxRowid = -Infinity;
   let maxDateMs = -Infinity;
+  let reply: IMessagePayload | undefined;
+  let payloadIndex = 0;
   for (const payload of payloads) {
+    const keepContent =
+      payloadIndex < MAX_COALESCED_ENTRIES - 1 || payloadIndex === payloads.length - 1;
+    payloadIndex += 1;
+    // Preserve lexical timestamp selection independently of the parsed recovery timestamp.
+    const createdAt = payload.created_at;
+    if (
+      typeof createdAt === "string" &&
+      createdAt.length > 0 &&
+      (latestCreatedAt === undefined || createdAt > latestCreatedAt)
+    ) {
+      latestCreatedAt = createdAt;
+    }
     if (typeof payload.id === "number" && Number.isFinite(payload.id)) {
       maxRowid = Math.max(maxRowid, payload.id);
     }
-    const dateMs =
-      typeof payload.created_at === "string" ? Date.parse(payload.created_at) : Number.NaN;
+    const dateMs = typeof createdAt === "string" ? Date.parse(createdAt) : Number.NaN;
     if (Number.isFinite(dateMs)) {
       maxDateMs = Math.max(maxDateMs, dateMs);
     }
-  }
-
-  // Walk the unbounded `payloads` so even GUIDs whose text/attachments were
-  // dropped by the cap are still remembered for downstream dedupe.
-  const seenGuids = new Set<string>();
-  const coalescedMessageGuids: string[] = [];
-  for (const payload of payloads) {
     const guid = payload.guid?.trim();
-    if (!guid || seenGuids.has(guid)) {
+    if (guid && !seenGuids.has(guid)) {
+      seenGuids.add(guid);
+      coalescedMessageGuids.push(guid);
+    }
+    if (!reply && (payload.thread_originator_guid != null || payload.reply_to_guid != null)) {
+      reply = payload;
+    }
+
+    // Only content is capped to the first entries plus the last; every row contributes metadata.
+    if (!keepContent) {
       continue;
     }
-    seenGuids.add(guid);
-    coalescedMessageGuids.push(guid);
+    const text = textLength <= MAX_COALESCED_TEXT_CHARS ? (payload.text ?? "").trim() : "";
+    if (text) {
+      const normalized = seenTexts.size > 0 ? text.toLowerCase() : undefined;
+      if (normalized === undefined || !seenTexts.has(normalized)) {
+        const separatorLength = textParts.length > 0 ? 1 : 0;
+        // One lookahead code unit preserves the final surrogate-safe cut and proves overflow.
+        const part = text.slice(0, MAX_COALESCED_TEXT_CHARS + 1 - textLength - separatorLength);
+        textParts.push(part);
+        textLength += separatorLength + part.length;
+        if (textLength <= MAX_COALESCED_TEXT_CHARS) {
+          seenTexts.add(normalized ?? text.toLowerCase());
+        }
+      }
+    }
+    if (allAttachments.length < MAX_COALESCED_ATTACHMENTS) {
+      for (const attachment of payload.attachments ?? []) {
+        allAttachments.push(attachment);
+        if (allAttachments.length === MAX_COALESCED_ATTACHMENTS) {
+          break;
+        }
+      }
+    }
   }
-
-  // Keep both parent GUIDs and their quote fields attached to the same source.
-  const reply =
-    payloads.find(
-      (payload) => payload.thread_originator_guid != null || payload.reply_to_guid != null,
-    ) ?? first;
+  let combinedText = textParts.join(" ");
+  if (textLength > MAX_COALESCED_TEXT_CHARS) {
+    combinedText = `${sliceUtf16Safe(combinedText, 0, MAX_COALESCED_TEXT_CHARS)}…[truncated]`;
+  }
+  reply ??= first;
 
   return {
     ...first,
     text: combinedText,
     attachments: allAttachments.length > 0 ? allAttachments : null,
-    created_at: latestCreatedAt,
+    created_at: latestCreatedAt ?? first.created_at,
     thread_originator_guid: reply.thread_originator_guid ?? null,
     reply_to_guid: reply.reply_to_guid ?? null,
     reply_to_text: reply.reply_to_text ?? null,


### PR DESCRIPTION
Closes #144364

## What Problem This Solves

iMessage coalescing first builds complete text, attachment and timestamp collections and trims them afterward. Content beyond the established limits therefore does unnecessary normalization and collection work.

## Why This Change Was Made

Bound content while walking the input once. Retain the first permitted entries plus the last, stop collecting attachments at the existing cap, and keep one text lookahead code unit so the final surrogate-safe truncation and marker remain unchanged. Every input row still contributes GUID deduplication, recovery maxima, lexical timestamp selection and reply-context choice.

## User Impact

Merged text, caps, attachment order, reply fields and dropped-content metadata keep their contracts. The implementation removes seven production lines and adds 71 net test lines without changing public APIs, configuration or persistence.

## Evidence

The existing monitor/debounce suites pass before (279 tests) and after (285 tests), including six additional boundary cases. The full selected changed gate and source-bound P2 review pass; runtime imports, hot/lazy entrypoints, SDK exports and dependencies are unchanged, so a normal build was not required.

Before/after correctness commands recorded 17.71 seconds / 2,605,514,752 bytes maximum RSS and 16.75 seconds / 2,113,372,160 bytes. They are single sequential runs with different test counts, not isolated performance measurements. No allocation or RSS gain is claimed, and bounded string length does not guarantee a strict V8 substring backing-storage bound. Proof uses isolated monitor/debounce fixtures, not a live iMessage service.
