### PR TITLE
fix(sessions): fall back to remote-tracking default branches for session diffs

### DIFF
--- a/src/sessions/session-diff-base.test.ts
+++ b/src/sessions/session-diff-base.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionDiffBase } from "./session-diff-revisions.js";
+
+type GitOutput = (
+  cwd: string,
+  args: string[],
+  okCodes?: readonly number[],
+) => Promise<string | null>;
+
+function createGitOut(responses: Record<string, string | null>) {
+  return vi.fn(async (_cwd: string, args: string[]): Promise<string | null> => {
+    const key = args.join(" ");
+    if (key in responses) {
+      return responses[key];
+    }
+    return null;
+  }) as unknown as GitOutput;
+}
+
+describe("resolveSessionDiffBase remote-tracking fallback", () => {
+  let gitOut: ReturnType<typeof createGitOut>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses origin/main merge base when origin/HEAD and local main are absent", async () => {
+    gitOut = createGitOut({
+      "symbolic-ref --short refs/remotes/origin/HEAD": null,
+      "rev-parse --verify --quiet main": null,
+      "rev-parse --verify --quiet master": null,
+      "rev-parse --verify --quiet origin/main": "abc123\n",
+      "merge-base origin/main HEAD": "merge001\n",
+    });
+
+    const result = await resolveSessionDiffBase({
+      branch: "feature/x",
+      gitOut,
+      root: "/repo",
+    });
+
+    expect(result).toEqual({ base: "merge001", baseRef: "origin/main" });
+  });
+
+  it("uses origin/master when origin/main is absent", async () => {
+    gitOut = createGitOut({
+      "symbolic-ref --short refs/remotes/origin/HEAD": null,
+      "rev-parse --verify --quiet main": null,
+      "rev-parse --verify --quiet master": null,
+      "rev-parse --verify --quiet origin/main": null,
+      "rev-parse --verify --quiet origin/master": "def456\n",
+      "merge-base origin/master HEAD": "merge002\n",
+    });
+
+    const result = await resolveSessionDiffBase({
+      branch: "feature/y",
+      gitOut,
+      root: "/repo",
+    });
+
+    expect(result).toEqual({ base: "merge002", baseRef: "origin/master" });
+  });
+
+  it("falls back to HEAD when no remote-tracking default exists", async () => {
+    gitOut = createGitOut({
+      "symbolic-ref --short refs/remotes/origin/HEAD": null,
+      "rev-parse --verify --quiet main": null,
+      "rev-parse --verify --quiet master": null,
+      "rev-parse --verify --quiet origin/main": null,
+      "rev-parse --verify --quiet origin/master": null,
+    });
+
+    const result = await resolveSessionDiffBase({
+      branch: "feature/z",
+      gitOut,
+      root: "/repo",
+    });
+
+    expect(result).toEqual({ base: "HEAD", baseRef: "HEAD" });
+  });
+
+  it("prefers origin/HEAD discovery when available", async () => {
+    gitOut = createGitOut({
+      "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+      "merge-base origin/main HEAD": "merge003\n",
+    });
+
+    const result = await resolveSessionDiffBase({
+      branch: "feature/w",
+      gitOut,
+      root: "/repo",
+    });
+
+    expect(result).toEqual({ base: "merge003", baseRef: "main" });
+  });
+});

--- a/src/sessions/session-diff-base.test.ts
+++ b/src/sessions/session-diff-base.test.ts
@@ -11,7 +11,7 @@ function createGitOut(responses: Record<string, string | null>) {
   return vi.fn(async (_cwd: string, args: string[]): Promise<string | null> => {
     const key = args.join(" ");
     if (key in responses) {
-      return responses[key];
+      return responses[key] ?? null;
     }
     return null;
   }) as unknown as GitOutput;

--- a/src/sessions/session-diff-revisions.ts
+++ b/src/sessions/session-diff-revisions.ts
@@ -45,6 +45,22 @@ export async function resolveSessionDiffBase(params: {
         }
       }
     }
+    // Remote-tracking default branches exist even when origin/HEAD and local
+    // main/master are absent (issue #144205).
+    for (const candidate of ["origin/main", "origin/master"]) {
+      const verified = await params.gitOut(params.root, [
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        candidate,
+      ]);
+      if (verified?.trim()) {
+        const mergeBase = await params.gitOut(params.root, ["merge-base", candidate, "HEAD"]);
+        if (mergeBase?.trim()) {
+          return { base: mergeBase.trim(), baseRef: candidate };
+        }
+      }
+    }
   }
   return { base: "HEAD", baseRef: "HEAD" };
 }


### PR DESCRIPTION
## What Problem This Solves

When `origin/HEAD` is absent and local `main`/`master` don't exist, `resolveSessionDiffBase()` falls back to `HEAD` — making All changes omit committed branch changes. The remote-tracking branch `origin/main` exists in this scenario but was never tried (#144205).

## What This Changes

After the local `main`/`master` loop fails, the resolver now also tries `origin/main` and `origin/master` before falling back to `HEAD`.

## Evidence

New unit tests in `src/sessions/session-diff-base.test.ts` (4/4 passing):

- `origin/main` used as merge base when `origin/HEAD` and local branches are absent
- `origin/master` used when `origin/main` is absent
- HEAD fallback when no remote-tracking default exists
- `origin/HEAD` discovery still preferred when available

Fixes #144205