### PR TITLE
perf(tailscale): remove unreachable application search

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -87,8 +87,7 @@ function isTransientTailscaleStatusError(error: unknown): boolean {
  * Locate Tailscale binary using multiple strategies:
  * 1. PATH lookup (via which command)
  * 2. Known macOS app path
- * 3. find /Applications for Tailscale.app
- * 4. locate database (if available)
+ * 3. locate database (if available)
  *
  * @returns Path to Tailscale binary or null if not found
  */
@@ -123,30 +122,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
     return macAppPath;
   }
 
-  // Strategy 3: find command in /Applications
-  try {
-    const { stdout } = await runExec(
-      "find",
-      [
-        "/Applications",
-        "-maxdepth",
-        "3",
-        "-name",
-        "Tailscale",
-        "-path",
-        "*/Tailscale.app/Contents/MacOS/Tailscale",
-      ],
-      { timeoutMs: 5000 },
-    );
-    const found = stdout.trim().split("\n")[0];
-    if (found && (await checkBinary(found))) {
-      return found;
-    }
-  } catch {
-    // find failed, continue
-  }
-
-  // Strategy 4: locate command
+  // Strategy 3: locate command
   try {
     const { stdout } = await runExec("locate", ["Tailscale.app"]);
     const candidates = stdout


### PR DESCRIPTION
Closes #144375

## What Problem This Solves

The fallback Tailscale search runs find with maximum depth three, then requires a Tailscale.app/Contents/MacOS/Tailscale path whose file is at depth four or deeper. That branch cannot produce its required result.

## Why This Change Was Made

Remove the unreachable subprocess search and update the strategy comments. PATH discovery, the fixed application path, locate fallback, binary validation and cached lookup stay in place.

## User Impact

The discovery fallback avoids a process that cannot succeed and removes 24 production lines. Working lookup, setup, route and authentication paths remain unchanged. No configuration, schema, dependency or migration changes.

## Evidence

Native find over an isolated synthetic Applications tree returns no matches at depth three and exactly the required binary path at depth four; both commands exit successfully. The fixture was removed, and no real application inventory was queried.

All 119 existing Tailscale/setup/configure tests, the full selected changed gate and independent P2 review pass. No new test file or repeated suite was needed; no standalone build was selected. No measured startup, latency or RSS improvement is claimed.
