### PR TITLE
fix(update): avoid preflight imports when scoping repair environment

### DIFF
--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -15,12 +15,12 @@ import { VERSION } from "../../version.js";
 import { readPackageVersion, type UpdateCommandOptions } from "./shared.js";
 import { preparePostCorePluginConfig } from "./update-command-config.js";
 import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import {
   continuePostCoreUpdateInFreshProcess,
   shouldResumePostCoreUpdateInFreshProcess,
 } from "./update-command-post-core.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
 export async function convergeUpdatePlugins(params: {
   coreAlreadyCurrent?: boolean;

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -51,7 +51,6 @@ import {
 import {
   captureOwnedManagedUpdateContext,
   revalidateUpdateDatabaseContext,
-  withOwnedManagedUpdateEnv,
   type OwnedManagedUpdateContext,
 } from "./update-command-managed-context.js";
 import {
@@ -61,6 +60,7 @@ import {
 import { assertUpdateCommandRecovery } from "./update-command-recovery.js";
 import { runUpdateCommandRepair } from "./update-command-repair.js";
 import type { MutableUpdateExecutionResult } from "./update-command-result.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import {
   GatewayServiceUpdateOwnershipError,
   gatewayServiceCommandUsesRoot,

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -13,9 +13,9 @@ import { renderUpdateRunReport } from "../../infra/update-run-report.js";
 import { VERSION } from "../../version.js";
 import { runDaemonRestart } from "../daemon-cli/lifecycle.js";
 import { readUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { finishUpdate } from "./update-command-post-update.js";
 import { UpdateCommandFailure } from "./update-command-result.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import {
   maybeRestartService,
   maybeStopManagedServiceBeforeMutableUpdate,

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { defaultRuntime } from "../../runtime.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
 const mocks = vi.hoisted(() => ({
   events: [] as string[],
@@ -175,7 +176,6 @@ import {
   completePostCorePluginUpdate,
   runUpdateFinalizationDoctorInFreshProcess,
 } from "./update-command-fresh-doctor.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { updatePluginsAfterCoreUpdate } from "./update-command-plugins.js";
 import { resumePostCoreUpdate } from "./update-command-resume.js";
 

--- a/src/cli/update-cli/update-command-managed-context.ts
+++ b/src/cli/update-cli/update-command-managed-context.ts
@@ -10,6 +10,7 @@ import type { PreManagedServiceStop } from "./update-command-service-context-typ
 import {
   resolveOwnedManagedUpdateEnv,
   stripGatewayServiceMarkerEnv,
+  withOwnedManagedUpdateEnv,
 } from "./update-command-service-env.js";
 
 export type OwnedManagedUpdateContext = {
@@ -65,38 +66,6 @@ export async function revalidateUpdateDatabaseContext(
     );
   }
   return current;
-}
-
-/** Run one update phase under the managed Gateway's authoritative environment. */
-export async function withOwnedManagedUpdateEnv<T>(
-  env: NodeJS.ProcessEnv | undefined,
-  run: () => Promise<T>,
-): Promise<T> {
-  if (!env) {
-    return await run();
-  }
-  // Update finalization is a single serialized CLI phase. Some plugin/config owners still read
-  // process.env, so switch the complete phase atomically and restore the caller afterward.
-  const previousEnv = { ...process.env };
-  for (const key of Object.keys(process.env)) {
-    delete process.env[key];
-  }
-  // A caller may pass process.env itself; clearing it must not erase the supplied scope.
-  const phaseEnv = env === process.env ? previousEnv : env;
-  for (const [key, value] of Object.entries(phaseEnv)) {
-    // Node stringifies undefined on assignment; unset selectors must remain absent.
-    if (value !== undefined) {
-      process.env[key] = value;
-    }
-  }
-  try {
-    return await run();
-  } finally {
-    for (const key of Object.keys(process.env)) {
-      delete process.env[key];
-    }
-    Object.assign(process.env, previousEnv);
-  }
 }
 
 export async function captureOwnedManagedUpdateContext(params: {

--- a/src/cli/update-cli/update-command-noop.ts
+++ b/src/cli/update-cli/update-command-noop.ts
@@ -14,10 +14,10 @@ import {
 import {
   captureOwnedManagedUpdateContext,
   revalidateUpdateDatabaseContext,
-  withOwnedManagedUpdateEnv,
 } from "./update-command-managed-context.js";
 import { preflightConfiguredNpmPluginTargets } from "./update-command-plugin-preflight.js";
 import { finishUpdate } from "./update-command-post-update.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import {
   GatewayServiceUpdateOwnershipError,
   resolvePackageRuntimePreflight,

--- a/src/cli/update-cli/update-command-pending-recovery.test.ts
+++ b/src/cli/update-cli/update-command-pending-recovery.test.ts
@@ -11,12 +11,12 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import * as updateShared from "./shared.js";
 import type { UpdateCommandOptions } from "./shared.js";
 import { updateFinalizeCommand } from "./update-command-finalize.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import {
   finishSuccessfulPackageSwitch,
   taskRecovery,
 } from "./update-command-post-update.test-support.js";
 import { UpdateCommandFailure } from "./update-command-result.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import { withUpdateFailureTriage } from "./update-command-triage.js";
 import { withUpdateCommandRecoveryUnwind } from "./update-command-unwind.js";
 

--- a/src/cli/update-cli/update-command-plugin-preflight.ts
+++ b/src/cli/update-cli/update-command-plugin-preflight.ts
@@ -5,7 +5,7 @@ import { resolveNpmSpecMetadata } from "../../infra/install-source-utils.js";
 import { resolveRegistryUpdateChannel, type UpdateChannel } from "../../infra/update-channels.js";
 import { resolveNpmInstallSpecsForUpdateChannel } from "../../plugins/install-channel-specs.js";
 import { UpdatePreMutationError } from "./shared.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
 /** Admit configured npm targets without installing plugins or changing live state. */
 export async function preflightConfiguredNpmPluginTargets(params: {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -15,7 +15,6 @@ import { tryWriteCompletionCache } from "./shared.js";
 import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import type { FinishUpdateParams } from "./update-command-finish-types.js";
 import { retireStandaloneGitWrapper } from "./update-command-git.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import {
   assertUpdateCommandPackageFinalization,
   createUpdateCommandFinalizationFence,
@@ -30,6 +29,7 @@ import {
   writeControlPlaneUpdateRestartSentinelBestEffort,
 } from "./update-command-result.js";
 import { rollbackFailedUpdate } from "./update-command-rollback.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import { UpdateServiceLoadBoundaryError } from "./update-command-service-load.js";
 import { createWindowsTaskAutoStartGuard } from "./update-command-service-maintenance.js";
 import { GatewayServiceUpdateOwnershipError } from "./update-command-service-plan.js";

--- a/src/cli/update-cli/update-command-repair.ts
+++ b/src/cli/update-cli/update-command-repair.ts
@@ -22,7 +22,7 @@ import {
 } from "../../infra/update-run-ledger.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import type { UpdateCommandOptions } from "./shared.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
 export async function runUpdateCommandRepair(params: {
   root: string;

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -31,9 +31,9 @@ import {
   readUpdateConfigSnapshot,
   type UpdateConfigSnapshot,
 } from "./update-command-config-snapshot.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { readPackageUpdateIdentity } from "./update-command-package.js";
 import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import { createWindowsTaskAutoStartGuard } from "./update-command-service-maintenance.js";
 import {
   maybeRestartService,

--- a/src/cli/update-cli/update-command-service-env.ts
+++ b/src/cli/update-cli/update-command-service-env.ts
@@ -63,6 +63,38 @@ export function resolveServiceRefreshEnv(
   return resolvedEnv;
 }
 
+/** Run one update phase under the managed Gateway's authoritative environment. */
+export async function withOwnedManagedUpdateEnv<T>(
+  env: NodeJS.ProcessEnv | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!env) {
+    return await run();
+  }
+  // Update finalization is a single serialized CLI phase. Some plugin/config owners still read
+  // process.env, so switch the complete phase atomically and restore the caller afterward.
+  const previousEnv = { ...process.env };
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  // A caller may pass process.env itself; clearing it must not erase the supplied scope.
+  const phaseEnv = env === process.env ? previousEnv : env;
+  for (const [key, value] of Object.entries(phaseEnv)) {
+    // Node stringifies undefined on assignment; unset selectors must remain absent.
+    if (value !== undefined) {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, previousEnv);
+  }
+}
+
 export async function withUpdateInProgressEnv<T>(
   invocationCwd: string | undefined,
   run: () => Promise<T>,

--- a/src/cli/update-cli/update-command-triage.ts
+++ b/src/cli/update-cli/update-command-triage.ts
@@ -15,7 +15,6 @@ import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
 import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { isTerminalInteractive } from "../terminal-interactivity.js";
 import { resolveNodeRunner, resolveUpdateRoot, type UpdateCommandOptions } from "./shared.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import { runInteractiveUpdateFailureAction } from "./update-command-report.js";
 import {
   isVerifiedUpdateRollback,
@@ -23,6 +22,7 @@ import {
   UpdateCommandFinalizedRecoveryFailure,
   UpdateCommandPendingRecoveryFailure,
 } from "./update-command-result.js";
+import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 
 export type UpdateTriageTarget = TriageTarget & { failureResult?: UpdateRunResult };
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -50,7 +50,6 @@ import { readUpdateChannelConfig } from "./update-command-config.js";
 import { printUpdateDryRun } from "./update-command-dry-run.js";
 import type { UpdateCommandExecutor } from "./update-command-executor.js";
 import { withUpdateCommandExecutor } from "./update-command-executor.js";
-import { withOwnedManagedUpdateEnv } from "./update-command-managed-context.js";
 import {
   reportPreMutationUpdateFailure,
   UpdateCommandFailure,
@@ -65,7 +64,11 @@ import {
   withUpdatePreviewSignals,
 } from "./update-command-run.js";
 import { preflightUpdateCommandSchemas } from "./update-command-schema.js";
-import { resolveServiceRefreshEnv, withUpdateInProgressEnv } from "./update-command-service-env.js";
+import {
+  resolveServiceRefreshEnv,
+  withUpdateInProgressEnv,
+  withOwnedManagedUpdateEnv,
+} from "./update-command-service-env.js";
 import {
   gatewayServiceCommandUsesRoot,
   resolveManagedServicePackageUpdatePlan,

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -8,7 +8,6 @@ import { exitCliAfterOutput } from "../cli/one-shot-exit.js";
 import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { createUpdateProgress } from "../cli/update-cli/progress.js";
 import { tryResolveInvocationCwd } from "../cli/update-cli/shared.js";
-import { withOwnedManagedUpdateEnv } from "../cli/update-cli/update-command-managed-context.js";
 import {
   continueMigratedUpdateInFreshProcess,
   inspectActivatedUpdateState,
@@ -20,7 +19,10 @@ import {
   createUpdateRunProgress,
   failUpdateCommandRun,
 } from "../cli/update-cli/update-command-run.js";
-import { resolveServiceRefreshEnv } from "../cli/update-cli/update-command-service-env.js";
+import {
+  resolveServiceRefreshEnv,
+  withOwnedManagedUpdateEnv,
+} from "../cli/update-cli/update-command-service-env.js";
 import { resolveUnsafeUpdateRecoveryGuidance } from "../cli/update-cli/update-recovery-guidance.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { isDefaultInstallIdentity, resolveStateDir } from "../config/paths.js";

--- a/src/infra/update-triage.ts
+++ b/src/infra/update-triage.ts
@@ -2,12 +2,12 @@ import fs from "node:fs/promises";
 import { z } from "zod";
 import { formatInstallationTargetCommand } from "../cli/installation-target-format.js";
 import { resolveSubprocessExitCode } from "../cli/subprocess-exit-code.js";
-import { withOwnedManagedUpdateEnv } from "../cli/update-cli/update-command-managed-context.js";
 import {
   disableUpdatedPackageCompileCacheEnv,
   resolveServiceRefreshEnv,
   resolveUpdateTargetEnv,
   stripGatewayServiceMarkerEnv,
+  withOwnedManagedUpdateEnv,
 } from "../cli/update-cli/update-command-service-env.js";
 import { writeTriageUpdateFailure, type TriageUpdateFailure } from "../commands/triage-update.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where loading the source-mode update repair command also loads schema-preflight and plugin-index machinery solely to obtain its environment-scoping helper.

## Why This Change Was Made

Move `withOwnedManagedUpdateEnv` unchanged into the existing update environment owner. Context capture and database admission remain in their current owner; all internal callers use the environment module and the old internal export is removed. The helper's body and comments are byte-for-byte unchanged, including live `process.env` alias handling, absent selectors and restoration after errors.

## User Impact

Less source-loading work in source-mode repair and its tests, with unchanged environment, authority, validation and repair behavior. No new configuration, cache, worker, timeout or shard policy.

## Evidence

Controlled original/candidate/restored-original runs used the same healthy repair case, assertions and temporary import diagnostics:

| Measurement | Original | Candidate | Restored original |
| --- | ---: | ---: | ---: |
| Three source imports | 10.890s | 7.846s | 9.992s |
| Repository modules loaded | 1,118 | 975 | 1,118 |

The candidate removes exactly 143 modules from the observed import graph and adds none. This measures the startup phase, not a guaranteed whole-case or workflow saving. Whole-case durations varied across the runs. Temporary instrumentation was removed before final validation.

Production delta is +6 lines from import regrouping around a pure function move; no executable body or branch was added. Test/support changes only update import paths. The single canonical environment helper remains distinct from the existing partial-key update-in-progress helper.

All 38 focused environment/lifecycle, recovery, execution and real repair-authority cases passed. The normal `pnpm build`, complete selected changed-file checks, and independent P2 review passed. Exact-head CI remains required before landing.

## Review follow-up

The data-model compatibility checklist was triggered by the names of the repair and doctor files. Both files change imports only. No schema, version, stored representation, migration, backfill, SQL, admission rule, or repair operation changes. The moved helper body is identical, and all callers retain their previous environment producers and restoration semantics. The existing pending-recovery, execution and validating/verifying repair cases passed. No additional migration is applicable to this relocation.

The scanner comment on the moved process.env assignment describes skill environment overrides. This helper consumes the existing update/service environment, not skill overrides; its assignment and caller authority are unchanged. The complete environment owner, managed-context owner, repair owner and caller paths were inspected. No new input path or authority is introduced.
