### PR TITLE
fix(macos): extract app bundle identifiers without full plist JSON

### DIFF
--- a/src/infra/installed-apps.test.ts
+++ b/src/infra/installed-apps.test.ts
@@ -1,10 +1,11 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { scanInstalledApps } from "./installed-apps.js";
 
-const tempRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function makeFixtureRoot(): Promise<{
   root: string;
@@ -12,9 +13,7 @@ async function makeFixtureRoot(): Promise<{
   userApplications: string;
   systemApplications: string;
 }> {
-  const raw = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-installed-apps-"));
-  const root = await fs.realpath(raw);
-  tempRoots.push(root);
+  const root = await fs.realpath(tempDirs.make("openclaw-installed-apps-"));
   const applications = path.join(root, "Applications");
   const userApplications = path.join(root, "UserApplications");
   const systemApplications = path.join(root, "SystemApplications");
@@ -26,64 +25,42 @@ async function makeFixtureRoot(): Promise<{
   return { root, applications, userApplications, systemApplications };
 }
 
-async function createApp(root: string, name: string, bundleId?: string): Promise<void> {
+async function createApp(root: string, name: string, plist?: string): Promise<string> {
   const contents = path.join(root, `${name}.app`, "Contents");
   await fs.mkdir(contents, { recursive: true });
-  if (!bundleId) {
-    return;
+  const plistPath = path.join(contents, "Info.plist");
+  if (plist !== undefined) {
+    await fs.writeFile(plistPath, plist);
   }
-  await fs.writeFile(
-    path.join(contents, "Info.plist"),
-    `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>${bundleId}</string></dict></plist>`,
-  );
+  return plistPath;
 }
-
-afterEach(async () => {
-  await Promise.all(
-    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
-});
 
 describe("scanInstalledApps", () => {
   it("scans app roots, filters copies and system apps, and sorts deterministically", async () => {
     const roots = await makeFixtureRoot();
     await Promise.all([
-      createApp(roots.applications, "Zulu", "com.example.zulu"),
-      createApp(roots.applications, "Alpha", "com.example.alpha"),
-      createApp(roots.applications, "Alpha previous", "com.example.previous"),
-      createApp(roots.applications, "Zulu-pre-update", "com.example.pre"),
+      createApp(roots.applications, "Zulu"),
+      createApp(roots.applications, "Alpha"),
+      createApp(roots.applications, "Alpha previous"),
+      createApp(roots.applications, "Zulu-pre-update"),
       createApp(roots.userApplications, "No Plist"),
-      createApp(roots.systemApplications, "Mail", "com.apple.mail"),
-      createApp(roots.systemApplications, "Calculator", "com.apple.calculator"),
+      createApp(roots.systemApplications, "Mail"),
+      createApp(roots.systemApplications, "Calculator"),
       fs.mkdir(path.join(roots.applications, "Not An App")),
     ]);
 
-    // The production reader shells out to macOS plutil; parse the XML fixture
-    // directly so this test also runs on Linux CI.
-    const readBundleId = async (appPath: string): Promise<string | undefined> => {
-      try {
-        const plist = await fs.readFile(path.join(appPath, "Contents", "Info.plist"), "utf8");
-        return /<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/.exec(plist)?.[1];
-      } catch {
-        return undefined;
-      }
-    };
-    const result = await scanInstalledApps({ platform: "darwin", roots, readBundleId });
+    const result = await scanInstalledApps({ platform: "darwin", roots });
 
     expect(result).toEqual({
       status: "ok",
       apps: [
         {
           label: "Alpha",
-          bundleId: "com.example.alpha",
           path: path.join(roots.applications, "Alpha.app"),
           system: false,
         },
         {
           label: "Mail",
-          bundleId: "com.apple.mail",
           path: path.join(roots.systemApplications, "Mail.app"),
           system: true,
         },
@@ -94,7 +71,6 @@ describe("scanInstalledApps", () => {
         },
         {
           label: "Zulu",
-          bundleId: "com.example.zulu",
           path: path.join(roots.applications, "Zulu.app"),
           system: false,
         },
@@ -104,13 +80,12 @@ describe("scanInstalledApps", () => {
 
   it("includes symlinked app bundles", async () => {
     const roots = await makeFixtureRoot();
-    await createApp(roots.applications, "RealTarget", "com.example.symlinked");
+    await createApp(roots.applications, "RealTarget");
     await fs.symlink(
       path.join(roots.applications, "RealTarget.app"),
       path.join(roots.userApplications, "Linked.app"),
     );
-    const readBundleId = async () => "com.example.symlinked";
-    const result = await scanInstalledApps({ platform: "darwin", roots, readBundleId });
+    const result = await scanInstalledApps({ platform: "darwin", roots });
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.apps.map((app) => app.label)).toContain("Linked");
@@ -124,4 +99,98 @@ describe("scanInstalledApps", () => {
       apps: [],
     });
   });
+
+  it.runIf(process.platform === "darwin")(
+    "reads only nonempty string identifiers from native plists and retains apps with invalid metadata",
+    async () => {
+      const roots = await makeFixtureRoot();
+      const fixtures: Array<{
+        name: string;
+        value?: string;
+        extra?: string;
+        bundleId?: string;
+        binary?: boolean;
+      }> = [
+        {
+          name: "XML",
+          value: "<string> \tcom.example.xml\n </string>",
+          bundleId: "com.example.xml",
+        },
+        {
+          name: "Binary",
+          value: "<string>com.example.binary</string>",
+          bundleId: "com.example.binary",
+          binary: true,
+        },
+        {
+          name: "Unrelated Date",
+          value: "<string>com.example.date</string>",
+          extra: "<key>BuildDate</key><date>2026-01-01T00:00:00Z</date>",
+          bundleId: "com.example.date",
+        },
+        {
+          name: "Large Unrelated Value",
+          value: "<string>com.example.large</string>",
+          extra: `<key>Unrelated</key><string>${"x".repeat(2 * 1024 * 1024)}</string>`,
+          bundleId: "com.example.large",
+        },
+        { name: "Numeric String", value: "<string>42</string>", bundleId: "42" },
+        { name: "Empty", value: "<string></string>" },
+        { name: "Whitespace", value: "<string> \t\n </string>" },
+        { name: "Missing Identifier" },
+        { name: "Integer", value: "<integer>42</integer>" },
+        { name: "Boolean", value: "<true/>" },
+        { name: "Array", value: "<array><string>com.example.array</string></array>" },
+        { name: "Dictionary", value: "<dict><key>id</key><string>example</string></dict>" },
+        { name: "Data", value: "<data>ZXhhbXBsZQ==</data>" },
+        { name: "Date Identifier", value: "<date>2026-01-01T00:00:00Z</date>" },
+        { name: "Oversized Identifier", value: `<string>${"x".repeat(2 * 1024 * 1024)}</string>` },
+      ];
+      for (const fixture of fixtures) {
+        const identifier =
+          fixture.value === undefined ? "" : `<key>CFBundleIdentifier</key>${fixture.value}`;
+        const plistPath = await createApp(
+          roots.applications,
+          fixture.name,
+          `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>${identifier}${fixture.extra ?? ""}</dict></plist>`,
+        );
+        if (fixture.binary) {
+          execFileSync("/usr/bin/plutil", ["-convert", "binary1", plistPath], { timeout: 2_000 });
+          expect((await fs.readFile(plistPath)).subarray(0, 8).toString()).toBe("bplist00");
+        }
+      }
+      await createApp(roots.applications, "Malformed", "not a property list");
+      await createApp(roots.applications, "No Plist");
+      const linkedPath = path.join(roots.userApplications, "Linked.app");
+      await fs.symlink(path.join(roots.applications, "XML.app"), linkedPath);
+
+      const result = await scanInstalledApps({ roots });
+
+      expect(result.status).toBe("ok");
+      if (result.status !== "ok") {
+        return;
+      }
+      expect(result.apps).toHaveLength(fixtures.length + 3);
+      const apps = new Map(result.apps.map((app) => [app.label, app]));
+      for (const fixture of [
+        ...fixtures,
+        { name: "Malformed", bundleId: undefined },
+        { name: "No Plist", bundleId: undefined },
+      ]) {
+        expect(apps.get(fixture.name), fixture.name).toEqual({
+          label: fixture.name,
+          ...(fixture.bundleId ? { bundleId: fixture.bundleId } : {}),
+          path: path.join(roots.applications, `${fixture.name}.app`),
+          system: false,
+        });
+      }
+      expect(apps.get("Linked")).toEqual({
+        label: "Linked",
+        bundleId: "com.example.xml",
+        path: linkedPath,
+        system: false,
+      });
+    },
+  );
 });

--- a/src/infra/installed-apps.ts
+++ b/src/infra/installed-apps.ts
@@ -5,7 +5,6 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import pLimit from "p-limit";
-import { z } from "zod";
 
 const execFileAsync = promisify(execFile);
 const PLIST_READ_CONCURRENCY = 8;
@@ -27,12 +26,6 @@ const SYSTEM_APP_NAMES = new Set([
   "Shortcuts",
 ]);
 
-const InfoPlistSchema = z
-  .object({
-    CFBundleIdentifier: z.string().trim().min(1).optional(),
-  })
-  .passthrough();
-
 export type InstalledApp = {
   label: string;
   bundleId?: string;
@@ -53,7 +46,6 @@ type InstalledAppRoots = {
 type ScanInstalledAppsOptions = {
   platform?: NodeJS.Platform;
   roots?: InstalledAppRoots;
-  readBundleId?: (appPath: string) => Promise<string | undefined>;
 };
 
 function defaultRoots(): InstalledAppRoots {
@@ -110,12 +102,13 @@ async function listAppPaths(
 
 async function readBundleIdWithPlutil(appPath: string): Promise<string | undefined> {
   try {
+    const plistPath = path.join(appPath, "Contents", "Info.plist");
     const { stdout } = await execFileAsync(
       "/usr/bin/plutil",
-      ["-convert", "json", "-o", "-", path.join(appPath, "Contents", "Info.plist")],
+      ["-extract", "CFBundleIdentifier", "raw", "-expect", "string", plistPath],
       { encoding: "utf8", maxBuffer: 1024 * 1024, timeout: PLIST_READ_TIMEOUT_MS },
     );
-    return InfoPlistSchema.parse(JSON.parse(stdout)).CFBundleIdentifier;
+    return stdout.trim() || undefined;
   } catch {
     return undefined;
   }
@@ -137,12 +130,11 @@ export async function scanInstalledApps(
       listAppPaths(roots.systemApplications, true),
     ])
   ).flat();
-  const readBundleId = options.readBundleId ?? readBundleIdWithPlutil;
   const limit = pLimit(PLIST_READ_CONCURRENCY);
   const apps = await Promise.all(
     appPaths.map((entry) =>
       limit(async (): Promise<InstalledApp> => {
-        const bundleId = await readBundleId(entry.path);
+        const bundleId = await readBundleIdWithPlutil(entry.path);
         return {
           label: path.basename(entry.path, ".app"),
           ...(bundleId ? { bundleId } : {}),


### PR DESCRIPTION
Closes #144380

## What Problem This Solves

Mac app discovery converts an entire Info.plist to JSON just to read CFBundleIdentifier. An unrelated Date value can make that conversion fail, and a large unrelated value can exceed the subprocess output limit, leaving a valid identifier missing.

## Why This Change Was Made

Ask native plutil to extract the identifier as a string, then retain the existing trim/empty handling. Remove whole-document JSON parsing and the test-only reader injection; tests use isolated native plist fixtures instead.

## User Impact

Valid identifiers are recovered despite unrelated Date or large metadata values. App filtering, ordering, symlinks, error omission, the 2-second timeout, 1 MiB capture limit and eight-reader concurrency remain unchanged. Device-app sharing and onboarding callers retain their contracts; no configuration or storage migration is introduced.

## Evidence

The actual owner matches 18 synthetic native outcomes before and after; only the intended Date and large-unrelated-value cases improve. Owner/device-app suites pass (five tests before, six afterward), and the new native regression fails against the original reader at the missing Date identifier. An evidence guard initially held restoration because JSON abbreviated the assertion; the full text and process cleanup were checked, then exact candidate bytes restored without rerunning the test.

For one synthetic 512 KiB unrelated value, subprocess stdout shrinks from 524,346 to 23 bytes with the same identifier. This measures representation size, not allocation, RSS, latency or timeout cancellation. No real application inventory was read. The full selected changed gate and independent P2 review pass.
