### PR TITLE
refactor(ui): remove duplicate NO_REPLY test

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2668,16 +2668,6 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatRunError).toEqual({ summary: "chat error", runId: "run-failed-before-start" });
   });
 
-  it("drops NO_REPLY final payload from another run", () => {
-    const state = createActiveStreamingState();
-    const payload = createOtherRunNoReplyFinalPayload();
-
-    expect(handleChatGatewayEvent(state, payload)).toBe("final");
-    expect(state.chatMessages).toStrictEqual([]);
-    expect(state.chatRunId).toBe("run-user");
-    expect(state.chatStream).toBe("Working...");
-  });
-
   it("drops NO_REPLY final payload from own run", () => {
     const state = createState({
       sessionKey: "main",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/139428

## What Problem This Solves

Chat Gateway tests repeat the other-run `NO_REPLY` final-event scenario without checking an additional behavior.

## Why This Change Was Made

Remove the weaker duplicate. The retained case uses the same fresh state and event, keeps every removed assertion, and additionally verifies that the active stream's start timestamp is preserved. All other token, ownership, retry, and history cases remain unchanged.

## User Impact

No runtime or visual behavior change. This maintainer-requested test audit removes one redundant case and 10 test lines; production code, helpers, and imports are unchanged.

## Evidence

- Full ordered `ui/src/pages/chat/chat-gateway.test.ts` run through the normal root wrapper: 182 actual passes, zero skips, including the stronger retained case.
- Targeted formatting and diff checks passed; all 18 selected changed checks passed.
- One scoped P2 review found no actionable findings.

The existing Node test environment was preserved. No live Gateway, browser, performance, packaging, or full-repository test-suite proof is claimed.
