### PR TITLE
perf(ui): keep transcript history cached during worker setup

### DIFF
--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -123,6 +123,32 @@ describe("server-owned pending input display", () => {
     );
   });
 
+  it.each([
+    { state: "queued", runId: undefined, notice: undefined },
+    {
+      state: "interrupted",
+      runId: "run-queued",
+      notice:
+        "Interrupted before the agent started it. It will not run automatically; copy it and send again.",
+    },
+    {
+      state: "cancelled",
+      runId: "run-queued",
+      notice:
+        "Cancelled before the agent started it. It will not run automatically; copy it and send again.",
+    },
+  ] as const)(
+    "keeps $state custody out of the worker-setup notice without eligible execution",
+    ({ state, runId, notice }) => {
+      const items = buildPendingInputItems([{ ...input, state, runId }], undefined, [], [], true);
+
+      expect(items.filter((item) => item.kind === "notice").map((item) => item.text)).toEqual(
+        notice ? [notice] : [],
+      );
+      expect(items.some((item) => item.kind === "message")).toBe(true);
+    },
+  );
+
   it("keeps cached local submissions available after pane remount", async () => {
     const host = makeChatHost({ sessionKey, currentSessionId: sessionId, requestHandlers: {} });
     const runId = "cached-delivery";

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -36,7 +36,7 @@ export function buildPendingInputItems(
   searchQuery?: string,
   browserInputs: readonly ChatQueueItem[] = [],
   workspaceSyncPendingRunIds: readonly string[] = [],
-  workerSetupPendingRunIds: readonly string[] = [],
+  workerSetupPending = false,
 ): ChatItem[] {
   // Custody records stay outside active-run ordering until the writer promotes them.
   const items: ChatItem[] = [];
@@ -55,16 +55,13 @@ export function buildPendingInputItems(
       ),
     );
     if (input.state === "queued") {
-      const waitingForSetup = Boolean(
-        input.runId && workerSetupPendingRunIds.includes(input.runId),
-      );
-      if (input.runId && (waitingForSetup || workspaceSyncPendingRunIds.includes(input.runId))) {
+      if (input.runId && (workerSetupPending || workspaceSyncPendingRunIds.includes(input.runId))) {
         items.push({
           kind: "notice",
           key: `pending-input:${input.id}:workspace-sync`,
           timestamp: input.acceptedAt,
           text: t(
-            waitingForSetup
+            workerSetupPending
               ? "chat.pendingInputs.waitingForWorkerSetup"
               : "chat.pendingInputs.waitingForWorkspaceSync",
           ),

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -95,7 +95,7 @@ export type BuildChatItemsProps = {
   queue?: ChatQueueItem[];
   pendingInputs?: ChatPendingInputsPage["items"];
   workspaceSyncPendingRunIds?: readonly string[];
-  workerSetupPendingRunIds?: readonly string[];
+  workerSetupPending?: boolean;
   showToolCalls: boolean;
   persistCommentary?: boolean;
   /** True while the agent is visibly working (isChatRunWorking). */
@@ -322,7 +322,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     props.searchOpen ? props.searchQuery : undefined,
     props.queue,
     props.workspaceSyncPendingRunIds,
-    props.workerSetupPendingRunIds,
+    props.workerSetupPending,
   ).map((item) => ({ item }));
   if (compaction && compactionKey && !hasPersistedCompaction) {
     const timestamp = compaction.startedAt ?? compaction.completedAt ?? Date.now();

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -159,27 +159,26 @@ function toolMessage(
   return chatMessage("tool", content, timestamp, { toolCallId, toolName, ...overrides });
 }
 
-it.each(["workspaceSyncPendingRunIds", "workerSetupPendingRunIds"] as const)(
-  "invalidates cached custody notices when %s ownership changes",
-  (property) => {
-    const pendingInputs = [
-      {
-        acceptedAt: 1,
-        id: "pending-follow-up",
-        message: userMessage("continue", 1),
-        runId: "follow-up-run",
-        state: "queued" as const,
-      },
-    ];
-    const waiting = buildCachedChatItems(
-      createProps({ pendingInputs, [property]: ["follow-up-run"] }),
-    );
-    const active = buildCachedChatItems(createProps({ pendingInputs }));
+it("invalidates cached custody notices when workspace sync ownership changes", () => {
+  const pendingInputs = [
+    {
+      acceptedAt: 1,
+      id: "pending-follow-up",
+      message: userMessage("continue", 1),
+      runId: "follow-up-run",
+      state: "queued" as const,
+    },
+  ];
+  const input = createProps({ pendingInputs });
+  const waiting = buildCachedChatItems({
+    ...input,
+    workspaceSyncPendingRunIds: ["follow-up-run"],
+  });
+  const active = buildCachedChatItems(input);
 
-    expect(waiting.some((item) => item.kind === "notice")).toBe(true);
-    expect(active.some((item) => item.kind === "notice")).toBe(false);
-  },
-);
+  expect(waiting.some((item) => item.kind === "notice")).toBe(true);
+  expect(active.some((item) => item.kind === "notice")).toBe(false);
+});
 
 function queuedSend(
   id: string,

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -265,7 +265,7 @@ function sameChatItemsStructuralInput(
     previous.queue === next.queue &&
     previous.pendingInputs === next.pendingInputs &&
     previous.workspaceSyncPendingRunIds === next.workspaceSyncPendingRunIds &&
-    previous.workerSetupPendingRunIds === next.workerSetupPendingRunIds &&
+    previous.workerSetupPending === next.workerSetupPending &&
     previous.showToolCalls === next.showToolCalls &&
     previous.persistCommentary === next.persistCommentary &&
     previous.runWorking === next.runWorking &&

--- a/ui/src/pages/chat/components/chat-transcript-invalidation.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-invalidation.test.ts
@@ -318,6 +318,67 @@ describe("chat transcript invalidation", () => {
     expect(restoredItemsA.every((item, index) => item === itemsA[index])).toBe(true);
   });
 
+  it("keeps history cached during worker setup and clears its notice when placement becomes active", async () => {
+    const props = threadProps("pane-worker-setup", "agent:main:worker-setup", [
+      { role: "user", content: "Earlier request", timestamp: 1_000 },
+      { role: "assistant", content: "Earlier reply", timestamp: 2_000 },
+    ]);
+    props.pendingInputs = [
+      {
+        id: "queued-follow-up",
+        runId: "queued-run",
+        acceptedAt: 3_000,
+        state: "queued",
+        message: { role: "user", content: "Queued follow-up", timestamp: 3_000 },
+      },
+    ];
+    const timing = { generation: 1, createdAtMs: 1, updatedAtMs: 1, stateChangedAtMs: 1 };
+    props.selectedSession = {
+      key: props.sessionKey,
+      kind: "direct",
+      updatedAt: 1,
+      placement: { state: "requested", ...timing },
+    };
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const buildSpy = vi.spyOn(chatThreadBuild, "buildChatItems");
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    try {
+      rerender();
+      transcript.hostConnected();
+      await flushDeferredRowPrune();
+      expect(container.textContent).toContain("Received · waiting for worker setup");
+      expect(container.querySelectorAll('[data-message-text="Queued follow-up"]')).toHaveLength(1);
+      expect(buildSpy).toHaveBeenCalledOnce();
+
+      rerender();
+      expect(buildSpy).toHaveBeenCalledOnce();
+      expect(container.textContent).toContain("Received · waiting for worker setup");
+
+      props.selectedSession = {
+        ...props.selectedSession,
+        placement: {
+          state: "active",
+          ...timing,
+          environmentId: "worker:fixture",
+          activeOwnerEpoch: 1,
+          workerBundleHash: "a".repeat(64),
+          workspaceBaseManifestRef: "base-manifest",
+          remoteWorkspaceDir: "/worker/repo",
+        },
+      };
+      rerender();
+      expect(buildSpy).toHaveBeenCalledTimes(2);
+      expect(container.textContent).not.toContain("Received · waiting for worker setup");
+      expect(container.querySelectorAll('[data-message-text="Queued follow-up"]')).toHaveLength(1);
+    } finally {
+      transcript.hostDisconnected();
+    }
+  });
+
   it("keeps settled rows idle across session metadata updates but refreshes their identity gutter", () => {
     vi.spyOn(Date, "now").mockReturnValue(60_000);
     const props = threadProps("pane-session-metadata");

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -128,13 +128,9 @@ export function projectChatTranscript(
     streamStartedAt: props.streamStartedAt,
     queue: props.queue,
     pendingInputs: props.pendingInputs,
-    workerSetupPendingRunIds: ["requested", "provisioning", "syncing", "starting"].includes(
+    workerSetupPending: ["requested", "provisioning", "syncing", "starting"].includes(
       activeSession?.placement?.state ?? "",
-    )
-      ? props.pendingInputs?.flatMap((input) =>
-          input.state === "queued" && input.runId ? [input.runId] : [],
-        )
-      : undefined,
+    ),
     workspaceSyncPendingRunIds:
       (activeSession?.placement?.state === "active" ||
         activeSession?.placement?.state === "draining") &&


### PR DESCRIPTION
Closes #144384

## What Problem This Solves

An unchanged worker-setup projection creates a fresh setup-message array that invalidates the structural transcript cache. Repeated rendering therefore rebuilds history even when the relevant state has not changed.

## Why This Change Was Made

Carry the placement-derived setup boolean through the actual projector and cache. The queued-input owner retains run-ID/state eligibility, notice precedence and separate workspace-sync matching. Transitioning to active placement still invalidates the view, clears the notice and preserves the queued message.

## User Impact

Queued content and setup/status behavior remain unchanged while redundant historical rebuilding is avoided. Current plugin-icon propagation/dependencies and work-group behavior are preserved. The change removes seven production lines and adds 86 net test lines without a new public API, configuration or persistence contract.

## Evidence

The actual projector regression fails on the composed current-main baseline because unchanged setup calls the history builder twice instead of once. The candidate passes that regression and all 324 owner tests, including active transition, icon, grouping and custody controls. The full selected changed gate and fresh independent P2 review pass.

Both synthetic mock-Gateway browser arms show one queued message and the setup notice, then remove only the notice on active placement, with no page errors. The inspected stage-matched screenshots are byte-identical; the attached pair shows the same setup stage. No live worker provisioning, latency or heap-byte improvement is claimed.

![Before: synthetic behavior preservation](https://github.com/user-attachments/assets/120d60d0-7a8d-4321-98ef-4443e9f16efb)

![After: synthetic behavior preservation](https://github.com/user-attachments/assets/ebd591ff-44e4-4def-b871-572b8b061549)