### PR TITLE
refactor(tests): exercise real Twitch target utilities

### DIFF
--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -32,12 +32,6 @@ vi.mock("./send.js", () => ({
   sendMessageTwitchInternal: vi.fn(),
 }));
 
-vi.mock("./utils/twitch.js", () => ({
-  normalizeTwitchChannel: (channel: string) => channel.toLowerCase().replace(/^#/, ""),
-  missingTargetError: (channel: string, hint: string) =>
-    new Error(`Missing target for ${channel}. Provide ${hint}`),
-}));
-
 function assertResolvedTarget(
   result: ReturnType<NonNullable<typeof twitchOutbound.resolveTarget>>,
 ): string {
@@ -294,7 +288,7 @@ describe("outbound", () => {
           mode: "explicit",
           allowFrom: [],
         },
-        "Missing target",
+        "Delivering to Twitch requires target <channel-name>",
       );
     });
 
@@ -306,7 +300,7 @@ describe("outbound", () => {
           mode: "explicit",
           allowFrom: [],
         },
-        "Missing target",
+        "Delivering to Twitch requires target <channel-name>",
       );
     });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Twitch outbound tests checked a missing-target error invented by a mock instead of the message the real utility returns. The same mock also replaced the channel normalizer with a handwritten implementation.

## Why This Change Was Made

Remove that pure utility mock so the existing outbound tests exercise the real normalization and error owner. Update the two affected expectations to the complete actionable error message. Account-resolution and send mocks remain at their existing boundaries.

## User Impact

No production behavior changes. The tests now cover the real utility while retaining all target, allowlist, account, abort, receipt, no-send, and media cases. One test file loses six net lines; production code is unchanged.

## Evidence

- The complete outbound, send, and client-manager registry suites pass before and after: 38/38, with matching case inventories.
- Removing only the utility mock while retaining the old expectations produces exactly the two intended assertion failures: 24 pass, 2 fail. The corrected candidate passes all 38 cases.
- All 19 required changed-file checks pass, including types, lint, formatting, boundaries, and unused-export scans.
- Independent Codex review is clean through P2. These are synthetic adapter and fake-transport tests; no live Twitch message or real account was used.
