### PR TITLE
docs: restore the skill creation tutorial steps

### DIFF
--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -36,7 +36,7 @@ OpenClaw loads skills from several roots in a defined [precedence order](/tools/
   <Step title="Write SKILL.md">
     The frontmatter defines metadata; the body gives the agent instructions.
 
-    ```markdown
+    ````markdown
     ---
     name: hello-world
     description: A simple skill that prints a greeting.
@@ -49,7 +49,7 @@ OpenClaw loads skills from several roots in a defined [precedence order](/tools/
     ```bash
     echo "Hello from your custom skill!"
     ```
-    ```
+    ````
 
     Naming rules:
     - Use lowercase letters, digits, and hyphens for `name`.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers following [Creating skills](https://docs.openclaw.ai/tools/creating-skills#create-your-first-skill) see step tags and naming rules inside a code block, and the verification step disappears.

## Why This Change Was Made

Use a four-backtick outer fence around the SKILL.md example so its nested Bash fence remains literal. The change belongs in the English source; the publishing repository receives it through docs sync.

## User Impact

Readers can copy the full skill example and follow the separate verification and test steps.

## Evidence

`node scripts/check-docs-mdx.mjs docs/tools/creating-skills.md` and `git diff --check` passed. The real publishing renderer reproduces the missing verification heading before the change and restores it afterward, without leaked Step markup.

Before and after below use the real `openclaw/docs` publisher in a local four-page preview. This is focused rendering proof, not a full site build or a deployed fix.

Before:

![Before](https://github.com/user-attachments/assets/1144fe14-b840-4fd7-8a2f-1e0859747d9d)

After:

![After](https://github.com/user-attachments/assets/afb2a833-bd36-42f8-abf1-645eb1be60c8)
