### PR TITLE
fix(docs): restore literal text in expandable titles

### DIFF
--- a/scripts/lib/docs-markdown.mjs
+++ b/scripts/lib/docs-markdown.mjs
@@ -119,24 +119,26 @@ class DocsSource {
   }
 }
 
-function preprocess(input) {
+function preprocess(input, restore) {
   let out = input.replace(/\r\n/g, "\n").replace(/^import\s+.+?;?\s*$/gm, "");
   out = out.replace(
     /<Mermaid\b[^>]*>([\s\S]*?)<\/Mermaid>/g,
-    (_, body) => `\n${marker("mermaidBlock", body)}\n`,
+    (_, body) => `\n${marker("mermaidBlock", restore(body))}\n`,
   );
   out = out.replace(
     /<Chart\b([^>]*)\/>/g,
-    (_, attrs) => `\n${marker("chart", JSON.stringify({ attrs, body: "" }))}\n`,
+    (_, attrs) => `\n${marker("chart", JSON.stringify({ attrs: restore(attrs), body: "" }))}\n`,
   );
   out = out.replace(
     /<Chart\b([^>]*)>([\s\S]*?)<\/Chart>/g,
-    (_, attrs, body) => `\n${marker("chart", JSON.stringify({ attrs, body }))}\n`,
+    (_, attrs, body) =>
+      `\n${marker("chart", JSON.stringify({ attrs: restore(attrs), body: restore(body) }))}\n`,
   );
   out = out.replace(/<br\s*\/?>/gi, "\n");
   return out.replace(componentTag, (tag, closing, name, attrs) => {
     let kind;
-    let value = closing ? "" : attrs;
+    // Restore literal attributes before encoding hides their placeholders.
+    let value = closing ? "" : restore(attrs);
     if (gridComponents.has(name) || knownBlocks.has(name)) {
       kind = closing ? "blockClose" : "blockOpen";
       value = gridComponents.has(name) ? cardGridClass(attrs) : knownBlocks.get(name)[0];
@@ -334,7 +336,7 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() }, firstLin
       false,
     );
   }
-  text = preprocess(text);
+  text = preprocess(text, restore);
   return text.replace(placeholder, (_, index) => saved[Number(index)], false);
 }
 

--- a/test/scripts/docs-component-literals.test.ts
+++ b/test/scripts/docs-component-literals.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  inlineMarkerPrefix,
+  markerPrefix,
+  parseDocsDocument,
+} from "../../scripts/lib/docs-markdown.mjs";
+
+describe("docs component literal attributes", () => {
+  it.each([
+    [
+      "Accordion",
+      "accordionOpen",
+      "Registered recall tools return `status=policy-disabled`",
+      "registered-recall-tools-return-status-policy-disabled",
+    ],
+    [
+      "Expandable",
+      "accordionOpen",
+      "First recall returns `status=timeout`",
+      "first-recall-returns-status-timeout",
+    ],
+    ["Step", "stepOpen", "Run `openclaw status`", "run-%60openclaw-status%60"],
+    ["Tab", "tabOpen", "Use `default`", "use-%60default%60"],
+    ["Card", "cardOpen", "Inspect `config`", undefined],
+    ["Tooltip", "tooltipOpen", "The `config` value", undefined],
+  ])("preserves inline code in %s attributes before publishing", (name, kind, title, id) => {
+    const document = parseDocsDocument(`<${name} title="${title}">Body.</${name}>`);
+    const token = document.tokens.find(
+      (entry) => entry.type === "inline" && entry.content.includes(`:${kind}:`),
+    );
+    const prefix = name === "Tooltip" ? inlineMarkerPrefix : markerPrefix;
+    const encoded = token?.content.match(new RegExp(`${prefix}:${kind}:([A-Za-z0-9_-]+)`))?.[1];
+    expect(encoded).toBeDefined();
+    expect(Buffer.from(encoded!, "base64url").toString("utf8")).toBe(` title="${title}"`);
+    expect(document.ids).toEqual(id ? [id] : []);
+  });
+
+  it.each([
+    ['<Mermaid>graph LR\nA["`value`"]</Mermaid>', "mermaidBlock", 'graph LR\nA["`value`"]'],
+    ['<Chart title="A `value`" />', "chart", '{"attrs":" title=\\"A `value`\\" ","body":""}'],
+    [
+      '<Chart title="A `value`">{"label":"`value`"}</Chart>',
+      "chart",
+      '{"attrs":" title=\\"A `value`\\"","body":"{\\"label\\":\\"`value`\\"}"}',
+    ],
+  ])("restores literal data in the %s publishing payload", (source, kind, payload) => {
+    const document = parseDocsDocument(source);
+    const token = document.tokens.find(
+      (entry) => entry.type === "inline" && entry.content.startsWith(`${markerPrefix}:${kind}:`),
+    );
+    expect(Buffer.from(token!.content.split(":")[2], "base64url").toString("utf8")).toBe(payload);
+  });
+
+  it("keeps placeholder-shaped author text and component examples literal", () => {
+    const source = [
+      "```md",
+      '<Accordion title="Do not render `this`" id="example">',
+      "OPENCLAWVERBATIM0END $&",
+      "{/* retain this comment */}",
+      "</Accordion>",
+      "```",
+      "",
+      '`<Badge id="inline-example" />`',
+      "",
+      '<Accordion title="Keep `OPENCLAWVERBATIM0END $&` and `status=timeout`">',
+      "Visible body.",
+      "</Accordion>",
+    ].join("\n");
+    const document = parseDocsDocument(source);
+    expect(document.tokens.find((token) => token.type === "fence")?.content).toBe(
+      '<Accordion title="Do not render `this`" id="example">\nOPENCLAWVERBATIM0END $&\n{/* retain this comment */}\n</Accordion>\n',
+    );
+    expect(document.ids).toEqual(["keep-openclawverbatim0end-and-and-status-timeout"]);
+    expect(
+      document.tokens
+        .flatMap((token) => token.children ?? [])
+        .find((token) => token.type === "code_inline")?.content,
+    ).toBe('<Badge id="inline-example" />');
+  });
+});

--- a/test/scripts/docs-component-literals.test.ts
+++ b/test/scripts/docs-component-literals.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 import {
   inlineMarkerPrefix,
   markerPrefix,
@@ -48,7 +48,9 @@ describe("docs component literal attributes", () => {
     const token = document.tokens.find(
       (entry) => entry.type === "inline" && entry.content.startsWith(`${markerPrefix}:${kind}:`),
     );
-    expect(Buffer.from(token!.content.split(":")[2], "base64url").toString("utf8")).toBe(payload);
+    const encoded = token?.content.split(":")[2];
+    assert.isDefined(encoded);
+    expect(Buffer.from(encoded, "base64url").toString("utf8")).toBe(payload);
   });
 
   it("keeps placeholder-shaped author text and component examples literal", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where [Active memory troubleshooting](https://docs.openclaw.ai/concepts/active-memory/troubleshooting#common-issues) displays internal `OPENCLAWVERBATIM...END` placeholders instead of the documented status values in expandable titles.

## Why This Change Was Made

Restore protected literal content before the shared parser serializes component attributes and Chart/Mermaid payloads. This repairs the producer used by the publishing repository while preserving literal examples and placeholder-shaped author text.

## User Impact

Troubleshooting titles show `status=policy-disabled` and `status=timeout` again. Other affected Accordion, Step, Tab, Card, and Tooltip attributes also retain their original text.

## Evidence

Ten regression cases fail on the original parser and pass with the fix; two existing source-anchor tests also pass. Eight affected titles across five actual documents were checked. Syntax, formatting, and `git diff --check` passed.

The initial workstation used an older Vitest and required an external minimal configuration. During CI repair, a clean isolated checkout with the locked dependencies passed all 12 focused cases through the normal repository runner (Vitest 5.0.0).

The original [check-test-types failure](https://github.com/openclaw/openclaw/actions/runs/34526417551/job/103036730102) was deterministic: an indexed marker payload was typed `string | undefined` when passed to `Buffer.from`. A runtime assertion now validates and narrows that payload before decoding, while preserving the exact payload comparison. The focused typecheck reproduced TS2769 before the change and passed afterward. Scoped lint, formatting, and `git diff --check` also passed. No autoreview was run, per maintainer instruction; [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34530577355) passed on `70b04fee3ed6a28a5b580c2e265e191aa2861e01`, including `check-test-types` and required `openclaw/ci-gate`. The checks watcher exited successfully with 49 passing checks and none failed or pending.

Before and after below use the real `openclaw/docs` publisher in a local four-page preview. This is focused rendering proof, not a full site build or a deployed fix.

Before:

![Before](https://github.com/user-attachments/assets/f70e05ce-4d5d-498d-972e-bbbc7438d738)

After:

![After](https://github.com/user-attachments/assets/98d73c5b-6972-4973-9c50-491500a7907a)

