### PR TITLE
fix(docs): render parameter labels containing angle brackets

### DIFF
--- a/scripts/lib/docs-markdown.mjs
+++ b/scripts/lib/docs-markdown.mjs
@@ -55,7 +55,12 @@ const components = new Map([
 ]);
 const inlineComponents = new Set(["Badge", "Tooltip"]);
 const gridComponents = new Set(["CardGroup", "Columns"]);
-const componentTag = /<(\/)?([A-Z][A-Za-z0-9_.-]*)\b([^>]*)>/g;
+// Quoted values can contain placeholders such as <section>; only unquoted > closes a tag.
+const componentAttrsPattern = String.raw`(?:"[^"]*"|'[^']*'|[^'">])*`;
+const componentTag = new RegExp(
+  String.raw`<(\/)?([A-Z][A-Za-z0-9_.-]*)\b(${componentAttrsPattern})>`,
+  "g",
+);
 
 // Track source lines through the existing rewrites; inserted snippet content has
 // no location in the including file. This metadata never enters rendered tokens.
@@ -122,15 +127,15 @@ class DocsSource {
 function preprocess(input, restore) {
   let out = input.replace(/\r\n/g, "\n").replace(/^import\s+.+?;?\s*$/gm, "");
   out = out.replace(
-    /<Mermaid\b[^>]*>([\s\S]*?)<\/Mermaid>/g,
+    new RegExp(String.raw`<Mermaid\b${componentAttrsPattern}>([\s\S]*?)<\/Mermaid>`, "g"),
     (_, body) => `\n${marker("mermaidBlock", restore(body))}\n`,
   );
   out = out.replace(
-    /<Chart\b([^>]*)\/>/g,
+    new RegExp(String.raw`<Chart\b(${componentAttrsPattern})\/>`, "g"),
     (_, attrs) => `\n${marker("chart", JSON.stringify({ attrs: restore(attrs), body: "" }))}\n`,
   );
   out = out.replace(
-    /<Chart\b([^>]*)>([\s\S]*?)<\/Chart>/g,
+    new RegExp(String.raw`<Chart\b(${componentAttrsPattern})>([\s\S]*?)<\/Chart>`, "g"),
     (_, attrs, body) =>
       `\n${marker("chart", JSON.stringify({ attrs: restore(attrs), body: restore(body) }))}\n`,
   );
@@ -318,7 +323,7 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() }, firstLin
   );
   if (sourceFile) {
     text = text.replace(
-      /<Snippet\b([^>]*)\/>/g,
+      new RegExp(String.raw`<Snippet\b(${componentAttrsPattern})\/>`, "g"),
       (_, rawAttrs) => {
         const attrs = parseAttrs(rawAttrs);
         const ref = attrs.file ?? attrs.src;

--- a/test/scripts/docs-component-attributes.test.ts
+++ b/test/scripts/docs-component-attributes.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -8,10 +9,11 @@ function componentPayload(source: string, kind: string) {
   const token = document.tokens.find((entry) =>
     entry.content.startsWith(`${markerPrefix}:${kind}:`),
   );
-  expect(token, `Missing ${kind} renderer token`).toBeDefined();
+  const encodedPayload = token?.content.split(":")[2];
+  assert.ok(encodedPayload !== undefined, `Missing ${kind} renderer payload`);
   return {
     document,
-    payload: Buffer.from(token!.content.split(":")[2], "base64url").toString(),
+    payload: Buffer.from(encodedPayload, "base64url").toString(),
   };
 }
 

--- a/test/scripts/docs-component-attributes.test.ts
+++ b/test/scripts/docs-component-attributes.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { markerPrefix, parseAttrs, parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
+
+function componentPayload(source: string, kind: string) {
+  const document = parseDocsDocument(source);
+  const token = document.tokens.find((entry) =>
+    entry.content.startsWith(`${markerPrefix}:${kind}:`),
+  );
+  expect(token, `Missing ${kind} renderer token`).toBeDefined();
+  return {
+    document,
+    payload: Buffer.from(token!.content.split(":")[2], "base64url").toString(),
+  };
+}
+
+function componentAttrs(source: string, kind: string) {
+  const { document, payload } = componentPayload(source, kind);
+  return { document, attrs: parseAttrs(payload) };
+}
+
+describe("docs component attribute boundaries", () => {
+  it.each([
+    [
+      '<ParamField path="--section <section>" type="string">Filter.</ParamField>',
+      { path: "--section <section>", type: "string" },
+    ],
+    [
+      "<ResponseField name='--key <key>' type='string > null'>Value.</ResponseField>",
+      { name: "--key <key>", type: "string > null" },
+    ],
+  ])("preserves parameter labels and types in %s", (source, expected) => {
+    const { document, attrs } = componentAttrs(source, "paramOpen");
+    expect(attrs).toEqual(expected);
+    expect(
+      document.tokens
+        .filter((token) => token.type === "inline" && !token.content.startsWith(markerPrefix))
+        .map((token) => token.content),
+    ).toEqual([source.includes("Filter.") ? "Filter." : "Value."]);
+  });
+
+  it.each([
+    ['<Chart title="A > B" type="bar" />', ""],
+    ["<Chart title='A > B' type='bar'>chart data</Chart>", "chart data"],
+  ])("preserves chart attributes and body in %s", (source, body) => {
+    const { payload } = componentPayload(source, "chart");
+    const chart = JSON.parse(payload);
+    expect(parseAttrs(chart.attrs)).toEqual({ title: "A > B", type: "bar" });
+    expect(chart.body).toBe(body);
+  });
+
+  it("starts Mermaid content after the complete opening tag", () => {
+    expect(
+      componentPayload('<Mermaid title="A > B">graph LR; A-->B</Mermaid>', "mermaidBlock").payload,
+    ).toBe("graph LR; A-->B");
+  });
+
+  it("expands snippets with quoted angle brackets before the file attribute", () => {
+    const root = path.resolve(import.meta.dirname, "../../docs");
+    const file = "snippets/plugin-publish/minimal-package.json";
+    const document = parseDocsDocument(`<Snippet title="Use <key>" file="${file}" />`, undefined, {
+      sourceFile: path.join(root, "index.md"),
+      root,
+    });
+    const expected = parseDocsDocument(fs.readFileSync(path.join(root, file), "utf8"));
+    expect(document.tokens.map((token) => [token.type, token.content])).toEqual(
+      expected.tokens.map((token) => [token.type, token.content]),
+    );
+  });
+
+  it("preserves sibling titles, links, self-closing tags and source locations", () => {
+    const source = '<Card title="Use <key> > default" href="/cli/config#root-options" />';
+    const { attrs } = componentAttrs(source, "cardSelf");
+    expect(attrs).toMatchObject({ title: "Use <key> > default", href: "/cli/config#root-options" });
+    expect(
+      parseDocsDocument(source, undefined, {
+        mapLink: (href: string, line: number | undefined) => ({ href, line }),
+      }).links,
+    ).toEqual([{ href: "/cli/config#root-options", line: 1 }]);
+  });
+
+  it("keeps indented content and component anchors after a quoted closing angle bracket", () => {
+    const source = '<Steps>\n  <Step title="A > B">\n    [Guide](/cli/config)\n  </Step>\n</Steps>';
+    const { document, attrs } = componentAttrs(source, "stepOpen");
+    expect(attrs.title).toBe("A > B");
+    expect(document.links).toEqual(["/cli/config"]);
+    expect(document.ids).toContain("a-%3E-b");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Config root options](https://docs.openclaw.ai/cli/config#root-options) see a truncated parameter name and raw attributes instead of `--section <section>` and its type.

## Why This Change Was Made

Teach the shared documentation parser to close a component tag only at an unquoted `>`. Reuse that boundary for ordinary components, Chart, Mermaid, and Snippet while preserving the existing literal-text restoration; the publisher consumes this source through docs sync.

## User Impact

Parameter labels, types, and component titles containing angle brackets render completely. The existing `root-options` section anchor remains intact.

## Evidence

Eight regression cases fail on the original parser and pass with the fix; two existing source-anchor tests also pass. Syntax, formatting, and `git diff --check` passed. The actual publisher preview renders the full parameter and its type.

The CI follow-up fixes TS2769 in the new test helper by asserting that the encoded renderer payload is present before decoding it. This was a deterministic type error in this PR, not a flaky check. The fix preserves the literal restoration from #144389. All 29 focused component, literal-text, Markdown, and anchor tests pass through the normal repository runner; root-test typing also passes on the rebased head. Targeted lint, formatting, syntax, and `git diff --check` also pass. The [complete CI run for the final head](https://github.com/openclaw/openclaw/actions/runs/34532421643) passed, including test typing and the required CI gate. The full link-audit suite and a full site build were not run locally.

Before and after below use the real `openclaw/docs` publisher in a local four-page preview. This is focused rendering proof, not a full site build or a deployed fix.

Before:

![Before](https://github.com/user-attachments/assets/fadb1cec-2f72-4122-a86f-d998c1d5dfc1)

After:

![After](https://github.com/user-attachments/assets/588d7a29-a740-494b-99b3-2d186025fd0a)

