### PR TITLE
fix(docs): restore the complete Show widget reference

### DIFF
--- a/scripts/lib/docs-markdown.mjs
+++ b/scripts/lib/docs-markdown.mjs
@@ -241,8 +241,13 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() }, firstLin
   };
   const jsxComments = new Set();
   let text = new DocsSource(input, firstLine).replace(
-    /<!--[^]*?-->|\{\/\*[^]*?\*\/\}|<(pre|code|script|style|textarea)\b[^>]*>[^]*?<\/\1\s*>/g,
+    /(`+)(?:(?!\n(?:[ \t]*\r?\n|[ \t]*<(?:pre|script|style|textarea)\b))[^])*?\1|<!--[^]*?-->|\{\/\*[^]*?\*\/\}|<(pre|code|script|style|textarea)\b[^>]*>[^]*?<\/\2\s*>/g,
     (value) => {
+      // Code spans cannot cross a blank line or a raw HTML block boundary.
+      // Skip them before raw HTML matching can consume later examples.
+      if (value.startsWith("`")) {
+        return value;
+      }
       if (value.startsWith("{/*")) {
         jsxComments.add(saved.length);
       }

--- a/test/scripts/docs-markdown.test.ts
+++ b/test/scripts/docs-markdown.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createDocsMarkdown, parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
+
+describe("docs Markdown rendering", () => {
+  it.each(["pre", "code", "script", "style", "textarea"])(
+    "keeps inline <%s> examples literal before a later HTML example",
+    (tag) => {
+      const source = [
+        `Intro with \`<${tag}>\`.`,
+        "",
+        '<ParamField path="source" type="string">',
+        `  Pass \`<${tag}>\` or \`\`<${tag}> with a \` backtick\`\`.`,
+        `  Or \`<${tag}>\n  attributes\`.`,
+        "</ParamField>",
+        "",
+        "```html",
+        `<${tag}>example</${tag}>`,
+        "```",
+        "",
+        "## After the example",
+        "",
+        "[Related](/related)",
+      ].join("\n");
+      const md = createDocsMarkdown();
+      const document = parseDocsDocument(source, md);
+      const html = md.renderer.render(document.tokens, md.options, document.env);
+      expect(html).toContain(`<code>&lt;${tag}&gt;</code>`);
+      expect(html).toContain(`<code>&lt;${tag}&gt; with a \` backtick</code>`);
+      expect(html).toContain(`<code>&lt;${tag}&gt; attributes</code>`);
+      expect(html).toContain(`&lt;${tag}&gt;example&lt;/${tag}&gt;`);
+      expect(html).not.toContain("<ParamField");
+      expect(document.ids).toContain("param-source");
+      expect(document.ids).toContain("after-the-example");
+      expect(document.links).toEqual(["/related"]);
+    },
+  );
+
+  it.each(["", "Unmatched `\n", "Unmatched `\n\n"])(
+    "preserves raw HTML containing backticks after %j",
+    (prefix) => {
+      const literal = '<script>const example = `<Card href="/hidden" />`;</script>';
+      const md = createDocsMarkdown();
+      const document = parseDocsDocument(`${prefix}${literal}\n\n[Visible](/visible)`, md);
+      const html = md.renderer.render(document.tokens, md.options, document.env);
+      expect(html).toContain(literal);
+      expect(html).not.toContain("OPENCLAW_DOCS_MARKER");
+      expect(document.links).toEqual(["/visible"]);
+    },
+  );
+
+  it("preserves raw HTML after an unmatched backtick and a CRLF blank line", () => {
+    const literal = '<code>const example = `<Card href="/hidden" />`;</code>';
+    const md = createDocsMarkdown();
+    const document = parseDocsDocument(
+      `Unmatched \`\r\n\r\n${literal}\r\n\r\n[Visible](/visible)`,
+      md,
+    );
+    const html = md.renderer.render(document.tokens, md.options, document.env);
+    expect(html).toContain(
+      "<code>const example = <code>&lt;Card href=&quot;/hidden&quot; /&gt;</code>;</code>",
+    );
+    expect(html).not.toContain("OPENCLAW_DOCS_MARKER");
+    expect(document.links).toEqual(["/visible"]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of [Show widget](https://docs.openclaw.ai/tools/show-widget#use-the-tool) lose the rest of the reference halfway through “Use the tool.” An inline `<script>` example is treated as raw HTML, hiding the remaining content in the browser.

## Why This Change Was Made

Keep backtick code spans out of the initial raw-HTML capture in the shared documentation parser. Respect Markdown block boundaries so an unmatched backtick cannot swallow an actual script block. The publishing repository receives the parser through docs sync.

## User Impact

The widget parameters, examples, related links, and source link remain readable through the end of the page. Authored raw HTML remains intact.

## Evidence

- Five regression cases fail on the original parser; all nine cases pass after the fix, including genuine raw-HTML siblings, unmatched backticks, and CRLF paragraph boundaries.
- Compared rendered HTML, anchors, and links for all 1,289 English Markdown sources. Only `docs/tools/show-widget.md` changes: its raw script tag disappears and the missing parameter anchors and link return.
- Focused syntax, formatting, lint, and `git diff --check` passed.
- The real publisher preview restores the complete reference and its Edit source link.

The installed Vitest is older than the current default configuration, so the test file ran with an external minimal configuration. The default runner fails before collection (`defineCacheKeyGenerator is not a function`); that gate is not claimed as passing.

Before and after below use the real `openclaw/docs` publisher in a local four-page preview. This is focused rendering proof, not a full site build or a deployed fix.

Before:

![Before](https://github.com/user-attachments/assets/4b07a4bd-c82d-49a1-98c3-d1134a05f0a2)

After:

![After](https://github.com/user-attachments/assets/ef1930ec-9e72-494a-9ed2-6273cbd0cc49)
